### PR TITLE
fix(runner): atomic `FabricInstance` traversal + bifurcate Cell/proxy tests by data-model flag

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -2212,13 +2212,15 @@ export function recursivelyAddIDIfNeeded<T>(
   // they remain unused.
   if (value instanceof FabricInstance) {
     seen.set(value, value);
+    let state: FabricValue | undefined;
     try {
-      const state = value[DECONSTRUCT]();
-      if (isRecord(state) || Array.isArray(state)) {
-        recursivelyAddIDIfNeeded(state, frame, seen);
-      }
+      state = value[DECONSTRUCT]();
     } catch {
-      // `[DECONSTRUCT]` not yet implemented for this subclass.
+      // `[DECONSTRUCT]` not yet implemented for this subclass
+      // (`FabricMap`, `FabricSet`); skip the side-effect traversal.
+    }
+    if (state !== undefined && (isRecord(state) || Array.isArray(state))) {
+      recursivelyAddIDIfNeeded(state, frame, seen);
     }
     return value;
   }

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -2197,18 +2197,19 @@ export function recursivelyAddIDIfNeeded<T>(
     return value;
   }
 
-  // `FabricInstance` values (`FabricError`, `FabricEpochNsec`, etc.) are
-  // immutable wrappers with class-defined identity. Their own-enumerable
-  // properties are implementation details (e.g., `FabricError.error` is the
-  // wrapped native `Error`), not user-visible structure; iterating them
-  // would re-wrap the embedded native value on each pass and recurse
-  // forever. Instead, walk the observable internal structure via
-  // `[DECONSTRUCT]()` (the same mechanism the serialization system uses)
-  // for side effects only — tracking shared references in `seen` and
-  // populating `frame.generatedIdCounter` for any objects-in-arrays nested
-  // inside — then return the original instance unchanged. Subclasses
-  // without `[DECONSTRUCT]` yet (`FabricMap`, `FabricSet`) skip the
-  // side-effect traversal; that's acceptable while they remain unused.
+  // `FabricInstance` values (`FabricError`, `FabricMap`, `FabricSet`,
+  // `FabricRegExp`) are immutable wrappers with class-defined identity.
+  // Their own-enumerable properties are implementation details (e.g.,
+  // `FabricError.error` is the wrapped native `Error`), not user-visible
+  // structure; iterating them would re-wrap the embedded native value on
+  // each pass and recurse forever. Instead, walk the observable internal
+  // structure via `[DECONSTRUCT]()` (the same mechanism the serialization
+  // system uses) for side effects only — tracking shared references in
+  // `seen` and populating `frame.generatedIdCounter` for any
+  // objects-in-arrays nested inside — then return the original instance
+  // unchanged. Subclasses without `[DECONSTRUCT]` yet (`FabricMap`,
+  // `FabricSet`) skip the side-effect traversal; that's acceptable while
+  // they remain unused.
   if (value instanceof FabricInstance) {
     seen.set(value, value);
     try {

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -6,6 +6,8 @@ import {
 } from "@commonfabric/utils/types";
 import {
   cloneIfNecessary,
+  DECONSTRUCT,
+  FabricInstance,
   type FabricValue,
   isArrayIndexPropertyName,
   shallowFabricFromNativeValue,
@@ -2192,6 +2194,31 @@ export function recursivelyAddIDIfNeeded<T>(
 
   // Cell links pass through unchanged.
   if (isCellLink(value)) {
+    return value;
+  }
+
+  // `FabricInstance` values (`FabricError`, `FabricEpochNsec`, etc.) are
+  // immutable wrappers with class-defined identity. Their own-enumerable
+  // properties are implementation details (e.g., `FabricError.error` is the
+  // wrapped native `Error`), not user-visible structure; iterating them
+  // would re-wrap the embedded native value on each pass and recurse
+  // forever. Instead, walk the observable internal structure via
+  // `[DECONSTRUCT]()` (the same mechanism the serialization system uses)
+  // for side effects only — tracking shared references in `seen` and
+  // populating `frame.generatedIdCounter` for any objects-in-arrays nested
+  // inside — then return the original instance unchanged. Subclasses
+  // without `[DECONSTRUCT]` yet (`FabricMap`, `FabricSet`) skip the
+  // side-effect traversal; that's acceptable while they remain unused.
+  if (value instanceof FabricInstance) {
+    seen.set(value, value);
+    try {
+      const state = value[DECONSTRUCT]();
+      if (isRecord(state) || Array.isArray(state)) {
+        recursivelyAddIDIfNeeded(state, frame, seen);
+      }
+    } catch {
+      // `[DECONSTRUCT]` not yet implemented for this subclass.
+    }
     return value;
   }
 

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -2208,9 +2208,8 @@ export function recursivelyAddIDIfNeeded<T>(
   // `seen` and populating `frame.generatedIdCounter` for any
   // objects-in-arrays nested inside — then return the original instance
   // unchanged. Subclasses that haven't implemented `[DECONSTRUCT]` yet
-  // (`FabricMap`, `FabricSet`) will throw from this path; that's
-  // intentional — those classes aren't yet in use, and a thrown error is
-  // the right signal the moment they start seeing traffic.
+  // will throw from this path; that's the right signal the moment they
+  // start seeing traffic.
   if (value instanceof FabricInstance) {
     seen.set(value, value);
     const state = value[DECONSTRUCT]();

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -2215,9 +2215,15 @@ export function recursivelyAddIDIfNeeded<T>(
     let state: FabricValue | undefined;
     try {
       state = value[DECONSTRUCT]();
-    } catch {
-      // `[DECONSTRUCT]` not yet implemented for this subclass
-      // (`FabricMap`, `FabricSet`); skip the side-effect traversal.
+    } catch (e) {
+      // `[DECONSTRUCT]` not yet implemented for this subclass (e.g.,
+      // `FabricMap`, `FabricSet`); skip the side-effect traversal. Log
+      // so the gap surfaces if/when these classes start to see traffic.
+      logger.warn(
+        "fabric-instance-deconstruct-skip",
+        `recursivelyAddIDIfNeeded: skipping ${value.constructor.name} (no [DECONSTRUCT])`,
+        e,
+      );
     }
     if (state !== undefined && (isRecord(state) || Array.isArray(state))) {
       recursivelyAddIDIfNeeded(state, frame, seen);

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -2207,25 +2207,14 @@ export function recursivelyAddIDIfNeeded<T>(
   // system uses) for side effects only — tracking shared references in
   // `seen` and populating `frame.generatedIdCounter` for any
   // objects-in-arrays nested inside — then return the original instance
-  // unchanged. Subclasses without `[DECONSTRUCT]` yet (`FabricMap`,
-  // `FabricSet`) skip the side-effect traversal; that's acceptable while
-  // they remain unused.
+  // unchanged. Subclasses that haven't implemented `[DECONSTRUCT]` yet
+  // (`FabricMap`, `FabricSet`) will throw from this path; that's
+  // intentional — those classes aren't yet in use, and a thrown error is
+  // the right signal the moment they start seeing traffic.
   if (value instanceof FabricInstance) {
     seen.set(value, value);
-    let state: FabricValue | undefined;
-    try {
-      state = value[DECONSTRUCT]();
-    } catch (e) {
-      // `[DECONSTRUCT]` not yet implemented for this subclass (e.g.,
-      // `FabricMap`, `FabricSet`); skip the side-effect traversal. Log
-      // so the gap surfaces if/when these classes start to see traffic.
-      logger.warn(
-        "fabric-instance-deconstruct-skip",
-        `recursivelyAddIDIfNeeded: skipping ${value.constructor.name} (no [DECONSTRUCT])`,
-        e,
-      );
-    }
-    if (state !== undefined && (isRecord(state) || Array.isArray(state))) {
+    const state = value[DECONSTRUCT]();
+    if (isRecord(state) || Array.isArray(state)) {
       recursivelyAddIDIfNeeded(state, frame, seen);
     }
     return value;

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -348,23 +348,6 @@ export function normalizeAndDiff(
     newValue = new CellImpl(runtime, tx, seen.get(newValue)!);
   }
 
-  // `FabricInstance` values (`FabricError`, `FabricMap`, `FabricSet`,
-  // `FabricRegExp`) are atomic from this layer's perspective: their
-  // own-enumerable properties are implementation details, not
-  // user-visible structure, and iterating them would re-wrap embedded
-  // native values (e.g., `FabricError.error` is a native `Error`) on
-  // each pass, recursing forever. Emit a single change at this link with
-  // the wrapper as the value — the storage layer's JSON encoding handles
-  // serialization via `[DECONSTRUCT]`/`[RECONSTRUCT]`.
-  if (newValue instanceof FabricInstance) {
-    diffLogger.debug(
-      "diff",
-      () => `[BRANCH_FABRIC_INSTANCE] Atomic FabricInstance at path=${pathStr}`,
-    );
-    changes.push({ location: link, value: newValue as FabricValue });
-    return changes;
-  }
-
   // ID_FIELD redirects to an existing field and we do something like DOM
   // diffing with it: We look at sibling entries and their value for that field,
   // and if we find a match, we reuse that document. Otherwise we create a new
@@ -779,6 +762,26 @@ export function normalizeAndDiff(
       });
     }
 
+    return changes;
+  }
+
+  // `FabricInstance` values (`FabricError`, `FabricMap`, `FabricSet`,
+  // `FabricRegExp`) are atomic from this layer's perspective: their
+  // own-enumerable properties are implementation details, not
+  // user-visible structure, and iterating them via the generic
+  // `isRecord` branch below would re-wrap embedded native values (e.g.,
+  // `FabricError.error` is a native `Error`) on each pass, recursing
+  // forever. Emit a single change at this link with the wrapper as the
+  // value — the storage layer's JSON encoding handles serialization via
+  // `[DECONSTRUCT]`/`[RECONSTRUCT]`. Placed after the write-redirect
+  // resolution above so writes through a redirect land on the target,
+  // not on the redirect itself.
+  if (newValue instanceof FabricInstance) {
+    diffLogger.debug(
+      "diff",
+      () => `[BRANCH_FABRIC_INSTANCE] Atomic FabricInstance at path=${pathStr}`,
+    );
+    changes.push({ location: link, value: newValue as FabricValue });
     return changes;
   }
 

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -1,5 +1,6 @@
 import { isRecord } from "@commonfabric/utils/types";
 import {
+  FabricInstance,
   type FabricObject,
   type FabricValue,
   isArrayIndexPropertyName,
@@ -345,6 +346,23 @@ export function normalizeAndDiff(
         `[SEEN_CHECK] Already seen object at path=${pathStr}, converting to cell`,
     );
     newValue = new CellImpl(runtime, tx, seen.get(newValue)!);
+  }
+
+  // `FabricInstance` values (`FabricError`, `FabricEpochNsec`, etc.) are
+  // atomic from this layer's perspective: their own-enumerable properties
+  // are implementation details, not user-visible structure, and iterating
+  // them would re-wrap embedded native values (e.g., `FabricError.error`
+  // is a native `Error`) on each pass, recursing forever. Emit a single
+  // change at this link with the wrapper as the value — the storage
+  // layer's JSON encoding handles serialization via
+  // `[DECONSTRUCT]`/`[RECONSTRUCT]`.
+  if (newValue instanceof FabricInstance) {
+    diffLogger.debug(
+      "diff",
+      () => `[BRANCH_FABRIC_INSTANCE] Atomic FabricInstance at path=${pathStr}`,
+    );
+    changes.push({ location: link, value: newValue as FabricValue });
+    return changes;
   }
 
   // ID_FIELD redirects to an existing field and we do something like DOM

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -348,14 +348,14 @@ export function normalizeAndDiff(
     newValue = new CellImpl(runtime, tx, seen.get(newValue)!);
   }
 
-  // `FabricInstance` values (`FabricError`, `FabricEpochNsec`, etc.) are
-  // atomic from this layer's perspective: their own-enumerable properties
-  // are implementation details, not user-visible structure, and iterating
-  // them would re-wrap embedded native values (e.g., `FabricError.error`
-  // is a native `Error`) on each pass, recursing forever. Emit a single
-  // change at this link with the wrapper as the value — the storage
-  // layer's JSON encoding handles serialization via
-  // `[DECONSTRUCT]`/`[RECONSTRUCT]`.
+  // `FabricInstance` values (`FabricError`, `FabricMap`, `FabricSet`,
+  // `FabricRegExp`) are atomic from this layer's perspective: their
+  // own-enumerable properties are implementation details, not
+  // user-visible structure, and iterating them would re-wrap embedded
+  // native values (e.g., `FabricError.error` is a native `Error`) on
+  // each pass, recursing forever. Emit a single change at this link with
+  // the wrapper as the value — the storage layer's JSON encoding handles
+  // serialization via `[DECONSTRUCT]`/`[RECONSTRUCT]`.
   if (newValue instanceof FabricInstance) {
     diffLogger.debug(
       "diff",

--- a/packages/runner/test/cell-core.test.ts
+++ b/packages/runner/test/cell-core.test.ts
@@ -75,36 +75,89 @@ describe("Cell", () => {
     expect(c.get()).toBe(20);
   });
 
-  it("should convert Error instances to @Error wrapper on set", () => {
-    const c = runtime.getCell<unknown>(
+  it("should convert Error instances to @Error wrapper on set (legacy)", async () => {
+    const sm = StorageManager.emulate({ as: signer });
+    const rt = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm,
+      experimental: { modernDataModel: false },
+    });
+    const localTx = rt.edit();
+    const c = rt.getCell<unknown>(
       space,
-      "should convert Error instances to @Error wrapper on set",
+      "should convert Error instances to @Error wrapper on set (legacy)",
       undefined,
-      tx,
+      localTx,
     );
     const error = new TypeError("something went wrong");
     c.set(error);
 
-    // Error should be converted to @Error wrapper during set
+    // Legacy path: error should be converted to the `@Error` wrapper.
     const result = c.get() as { "@Error": Record<string, unknown> } | undefined;
     expect(result).toHaveProperty("@Error");
     expect(result!["@Error"].name).toBe("TypeError");
     expect(result!["@Error"].message).toBe("something went wrong");
     expect(typeof result!["@Error"].stack).toBe("string");
+    await localTx.commit();
+    await rt.dispose();
+    await sm.close();
   });
 
-  it("should preserve Error cause property on set", () => {
-    const c = runtime.getCell<unknown>(
+  it("should wrap Error instances in FabricError on set (modern)", async () => {
+    const sm = StorageManager.emulate({ as: signer });
+    const rt = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm,
+      experimental: { modernDataModel: true },
+    });
+    const localTx = rt.edit();
+    const c = rt.getCell<unknown>(
       space,
-      "should preserve Error cause property on set",
+      "should wrap Error instances in FabricError on set (modern)",
       undefined,
-      tx,
+      localTx,
+    );
+    const error = new TypeError("something went wrong");
+    c.set(error);
+
+    // Modern path: error is stored as a `FabricError`-shaped value rather
+    // than the legacy `@Error` wrapper. `c.get()` returns a proxy view of
+    // the stored wrapper — its `error` slot exposes the wrapped Error's
+    // observable fields (`message`, `stack`), and its `typeTag` is
+    // `"Error"` (`FabricError`'s tag).
+    const result = c.get() as {
+      error: { message: string; stack: string };
+      typeTag: string;
+      "@Error"?: unknown;
+    };
+    expect(result["@Error"]).toBeUndefined();
+    expect(result.typeTag).toBe("Error@1");
+    expect(result.error.message).toBe("something went wrong");
+    expect(typeof result.error.stack).toBe("string");
+    await localTx.commit();
+    await rt.dispose();
+    await sm.close();
+  });
+
+  it("should preserve Error cause property on set (legacy)", async () => {
+    const sm = StorageManager.emulate({ as: signer });
+    const rt = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm,
+      experimental: { modernDataModel: false },
+    });
+    const localTx = rt.edit();
+    const c = rt.getCell<unknown>(
+      space,
+      "should preserve Error cause property on set (legacy)",
+      undefined,
+      localTx,
     );
     const cause = new Error("root cause");
     const error = new Error("wrapper error", { cause });
     c.set(error);
 
-    // Error cause should be recursively converted to @Error wrapper
+    // Legacy path: error cause is recursively converted to `@Error` wrapper.
     const result = c.get() as { "@Error": Record<string, unknown> } | undefined;
     expect(result).toHaveProperty("@Error");
     expect(result!["@Error"].message).toBe("wrapper error");
@@ -113,6 +166,45 @@ describe("Cell", () => {
     };
     expect(causeWrapper).toHaveProperty("@Error");
     expect(causeWrapper["@Error"].message).toBe("root cause");
+    await localTx.commit();
+    await rt.dispose();
+    await sm.close();
+  });
+
+  it("should preserve Error cause property on set (modern)", async () => {
+    const sm = StorageManager.emulate({ as: signer });
+    const rt = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm,
+      experimental: { modernDataModel: true },
+    });
+    const localTx = rt.edit();
+    const c = rt.getCell<unknown>(
+      space,
+      "should preserve Error cause property on set (modern)",
+      undefined,
+      localTx,
+    );
+    const cause = new Error("root cause");
+    const error = new Error("wrapper error", { cause });
+    c.set(error);
+
+    // Modern path: outer error is a `FabricError`-shaped value; its cause
+    // is also `FabricError`-shaped (recursively wrapped at conversion
+    // time), not a legacy `@Error` wrapper.
+    const result = c.get() as {
+      error: { message: string; cause: { message: string; stack: string } };
+      typeTag: string;
+      "@Error"?: unknown;
+    };
+    expect(result["@Error"]).toBeUndefined();
+    expect(result.typeTag).toBe("Error@1");
+    expect(result.error.message).toBe("wrapper error");
+    expect(result.error.cause.message).toBe("root cause");
+    expect(typeof result.error.cause.stack).toBe("string");
+    await localTx.commit();
+    await rt.dispose();
+    await sm.close();
   });
 
   it("should call toJSON() on plain objects during set", () => {

--- a/packages/runner/test/cell-core.test.ts
+++ b/packages/runner/test/cell-core.test.ts
@@ -207,6 +207,57 @@ describe("Cell", () => {
     await sm.close();
   });
 
+  it("Error set through a nested write-redirect lands on the target (modern)", async () => {
+    const sm = StorageManager.emulate({ as: signer });
+    const rt = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm,
+      experimental: { modernDataModel: true },
+    });
+    const localTx = rt.edit();
+
+    const target = rt.getCell<unknown>(
+      space,
+      "nested redirect target (modern Error)",
+      undefined,
+      localTx,
+    );
+    target.set("initial");
+
+    // `parent.slot` holds a write-redirect that aliases writes to `target`.
+    // `Cell.set` pre-resolves its top-level link, so to exercise
+    // `normalizeAndDiff`'s redirect-resolution branch we need the redirect
+    // at a nested key — that's the path it actually fires on, during the
+    // per-key recursion in the `isRecord(newValue)` branch.
+    const parent = rt.getCell<{ slot: unknown }>(
+      space,
+      "nested redirect parent (modern Error)",
+      undefined,
+      localTx,
+    );
+    parent.setRawUntyped({
+      slot: target.getAsWriteRedirectLink(),
+    } as unknown as FabricValue);
+
+    // Writing a `FabricInstance` (here, a native `Error` that gets wrapped
+    // into `FabricError`) through the redirect must land at the target,
+    // not clobber the redirect link at `parent.slot`. Target started as
+    // `"initial"`; under the bug, target stays as `"initial"` because the
+    // FabricError clobbered the redirect at `parent.slot`.
+    parent.set({ slot: new TypeError("through nested redirect") });
+
+    const targetResult = target.get() as {
+      error: { message: string };
+      typeTag: string;
+    };
+    expect(targetResult.typeTag).toBe("Error@1");
+    expect(targetResult.error.message).toBe("through nested redirect");
+
+    await localTx.commit();
+    await rt.dispose();
+    await sm.close();
+  });
+
   it("should call toJSON() on plain objects during set", () => {
     const c = runtime.getCell<unknown>(
       space,

--- a/packages/runner/test/frozen-proxy-target.test.ts
+++ b/packages/runner/test/frozen-proxy-target.test.ts
@@ -521,7 +521,7 @@ describe("frozen proxy target: v2 committed reads with richStorableValues ON", (
   });
 });
 
-describe("frozen proxy target: committed reads with richStorableValues OFF", () => {
+describe("frozen proxy target: committed reads with richStorableValues OFF (legacy)", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
   let tx: IExtendedStorageTransaction;
@@ -530,10 +530,12 @@ describe("frozen proxy target: committed reads with richStorableValues OFF", () 
     storageManager = StorageManager.emulate({
       as: signer,
     });
-    // No experimental flags -- richStorableValues defaults to false.
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
+      experimental: {
+        modernDataModel: false,
+      },
     });
     tx = runtime.edit();
   });
@@ -544,7 +546,7 @@ describe("frozen proxy target: committed reads with richStorableValues OFF", () 
     await storageManager?.close();
   });
 
-  it("returns unfrozen committed objects when richStorableValues is OFF", async () => {
+  it("returns unfrozen committed objects when richStorableValues is OFF (legacy)", async () => {
     const link = writeCell(runtime, tx, "legacy-frozen-raw", {
       a: 1,
       b: 2,
@@ -553,6 +555,54 @@ describe("frozen proxy target: committed reads with richStorableValues OFF", () 
     tx = await commitAndReopen(runtime, tx);
     const rawValue = tx.readValueOrThrow(link);
     expect(Object.isFrozen(rawValue)).toBe(false);
+
+    const result = createQueryResultProxy<{ a: number; b: number }>(
+      runtime,
+      tx,
+      link,
+      0,
+      false,
+    );
+
+    expect(Number(result.a)).toBe(1);
+    expect(Number(result.b)).toBe(2);
+  });
+});
+
+describe("frozen proxy target: committed reads under modernDataModel", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({
+      as: signer,
+    });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      experimental: {
+        modernDataModel: true,
+      },
+    });
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("returns frozen committed objects under modernDataModel", async () => {
+    const link = writeCell(runtime, tx, "modern-frozen-raw", {
+      a: 1,
+      b: 2,
+    });
+
+    tx = await commitAndReopen(runtime, tx);
+    const rawValue = tx.readValueOrThrow(link);
+    expect(Object.isFrozen(rawValue)).toBe(true);
 
     const result = createQueryResultProxy<{ a: number; b: number }>(
       runtime,


### PR DESCRIPTION
## Summary

Two preparatory tasks for the modern data model flag flip (PR #3569):

* **Fix:** treat `FabricInstance` values as atomic terminals in
  `recursivelyAddIDIfNeeded()` (`cell.ts`) and `normalizeAndDiff()`
  (`data-updating.ts`). Without this, `Cell.set(new Error(...))` under
  modern wraps the native `Error` in a `FabricError` whose
  own-enumerable `error` slot points back at the native — recursing
  forever and blowing the stack. The fix walks the observable internal
  structure via `[DECONSTRUCT]()` for side-effect-only ID assignment
  (`cell.ts`), and emits a single change for the wrapper
  (`data-updating.ts`).
* **Test bifurcation:** split `cell-core.test.ts`'s two
  `Error`-on-set tests into `(legacy)` and `(modern)` variants with
  explicit `experimental.modernDataModel`; pin
  `frozen-proxy-target.test.ts`'s `richStorableValues OFF` test to
  legacy and add a paired "committed reads under modernDataModel"
  describe.

Both states (`modernDataModelEnabled = false` and `= true`) pass the
full runner suite and the full workspace test suite.

## Notes

* `FabricInstance` subclasses without `[DECONSTRUCT]` yet (`FabricMap`,
  `FabricSet`) silently skip the `cell.ts` side-effect traversal.
  That's acceptable while those classes remain unused; once they are,
  they'll need to implement `[DECONSTRUCT]`.
* The modern variant of the `cell-core` Error tests asserts structural
  shape (`typeTag` is `"Error@1"`, observable `error.message` slot, no
  legacy `@Error` key) rather than `instanceof FabricError`, because
  `c.get()` returns a proxy view of the stored wrapper, not a live
  `FabricError` instance. Reaching for `c.getRaw()` would trip an
  unrelated `isDeepFrozenFabricValue` TODO for `FabricInstance`
  handling — deferred.

## Test plan

- [x] `packages/runner` tests pass under `modernDataModelEnabled = false`
- [x] `packages/runner` tests pass under `modernDataModelEnabled = true`
- [x] Full workspace `deno task test` passes on the branch default

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat `FabricInstance` values as atomic during `Cell` traversal and diff to prevent recursion when `Error` is wrapped as `FabricError` under the modern model. Also ensure nested write-redirects are followed so `FabricInstance` writes land on the target; tests are split into legacy vs modern, and `[DECONSTRUCT]()` is required and will throw if missing.

- **Bug Fixes**
  - Handle `FabricInstance` atomically in `recursivelyAddIDIfNeeded()` and `normalizeAndDiff()`; walk `[DECONSTRUCT]()` for side-effect ID tracking and emit a single change for the wrapper. Place the terminal after write-redirect resolution so writes like `{ slot: new Error(...) }` update the redirect target, not the redirect link; adds a regression test.
  - Split `Error`-on-set tests into legacy and modern; pin the "richStorableValues OFF" committed-read test to legacy and add modern coverage (committed objects are frozen).

- **Refactors**
  - Clarified comments for `[DECONSTRUCT]` handling and removed explicit class lists to avoid drift.

<sup>Written for commit 5ee2829fa1b753435535b6d61d06d61bbf30c87f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Performance baseline

This PR only does anything particularly different when encountering `FabricInstance`s, which more or less doesn't happen right now. So, the following accounts for what seems to be a spurious perf check failure:

NEW_PERF_BASELINE: job: Runner Tests (4/4) = 84s

