### PR TITLE
fix(patterns): clear typecheck errors in chat-note and email-task-engine

### DIFF
--- a/packages/patterns/experimental/chat-note.tsx
+++ b/packages/patterns/experimental/chat-note.tsx
@@ -347,11 +347,12 @@ const ChatNote = pattern<Input, Output>(
     model,
     [SELF]: self,
   }) => {
-    const { allPieces } =
-      wish<{ allPieces: MinimalPiece[] | Default<[]> }>({ query: "/" }).result;
-    const { result: mentionable } = wish<MentionablePiece[] | Default<[]>>({
+    const { allPieces } = wish<{ allPieces: MinimalPiece[] | Default<[]> }>({
+      query: "/",
+    }).result!;
+    const mentionable = wish<MentionablePiece[] | Default<[]>>({
       query: "#mentionable",
-    });
+    }).result!;
     const mentioned = Writable.of<MentionablePiece[]>([]);
     const backlinks = Writable.of<MentionablePiece[]>([]);
 

--- a/packages/patterns/experimental/email-task-engine.tsx
+++ b/packages/patterns/experimental/email-task-engine.tsx
@@ -25,6 +25,7 @@ import {
   handler,
   ifElse,
   NAME,
+  type Opaque,
   pattern,
   Stream,
   UI,
@@ -74,7 +75,7 @@ interface SuggestionResult {
 
 interface TaskAnalysis {
   email: TaskEmail;
-  result: SuggestionResult | null;
+  result: SuggestionResult | undefined;
   pending: boolean;
   error?: unknown;
 }
@@ -457,8 +458,8 @@ export default pattern<PatternInput, PatternOutput>(({ overrideAuth }) => {
   const sortNewestFirst = Writable.of(true).for("sortNewestFirst");
 
   // Get all pieces for note discovery
-  const { allPieces } =
-    wish<{ allPieces: NotePiece[] }>({ query: "#default" }).result;
+  const { allPieces } = wish<{ allPieces: NotePiece[] }>({ query: "#default" })
+    .result!;
 
   // Use createGoogleAuth for scopes that include gmailModify
   const {
@@ -554,7 +555,9 @@ export default pattern<PatternInput, PatternOutput>(({ overrideAuth }) => {
       const notes = availableNotes || [];
       const notesContext = notes.length === 0
         ? "No existing notes found."
-        : notes.map((n) => `- "${n.title}": ${n.contentPreview}`).join("\n");
+        : notes.map((n: { title: string; contentPreview: string }) =>
+          `- "${n.title}": ${n.contentPreview}`
+        ).join("\n");
 
       return `You are analyzing an email to suggest an action. The email has been labeled "task-current" indicating the user wants to take action on it.
 
@@ -584,7 +587,7 @@ Respond with the most appropriate action.`;
     });
 
     const llmAnalysis = generateObject<SuggestionResult>({
-      prompt,
+      prompt: prompt as Opaque<string>,
       schema: SUGGESTION_SCHEMA,
       model: "anthropic:claude-sonnet-4-5",
     });
@@ -605,7 +608,7 @@ Respond with the most appropriate action.`;
   );
   const completedCount = computed(
     () =>
-      analyses?.filter((a) => !a?.pending && a?.result !== null)?.length ||
+      analyses?.filter((a) => !a?.pending && a?.result !== undefined)?.length ||
       0,
   );
 


### PR DESCRIPTION
## Summary

Two experimental patterns were failing `cf check --no-run` on `main`. This PR clears those errors with minimal, targeted source changes — no transformer changes.

### chat-note.tsx

- `const { allPieces } = wish<{...}>(...).result` destructured directly off the wish's `T | undefined` result type. Add `.result!` so the destructure sees `T`.
- `const { result: mentionable } = wish<...>(...)` left `mentionable` typed as `T | undefined`, failing downstream at `<cf-code-editor $mentionable={mentionable}>` which expects `Opaque<T[]>`. Flatten to `const mentionable = wish(...).result!`.

### email-task-engine.tsx

- Same `wish().result` destructure fix.
- `TaskAnalysis.result` was typed `SuggestionResult | null` but the code actually produces `| undefined` (from `generateObject(...).result` while pending). Switch the field to `| undefined`; update the one `result !== null` filter to match.
- `notes.map((n) => ...)` had implicit `any` parameter — explicit annotation.
- `generateObject({ prompt, ... })` got `string | undefined` for `prompt` because the surrounding `computed(() => ...)` returns `undefined` for emails without a subject. Cast at the call site via `Opaque<string>` — runtime already handles the undefined case downstream via `result: undefined`.

## Test plan

- [x] `cf check --no-run packages/patterns/experimental/chat-note.tsx` — clean
- [x] `cf check --no-run packages/patterns/experimental/email-task-engine.tsx` — clean
- [x] Broader pattern sample (chatbot, omnibox-fab, space-overview, quick-capture, suggestion, record-backup, annotation, notes/note, gmail-importer, etc.) — clean, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes typecheck errors in `packages/patterns/experimental/chat-note.tsx` and `packages/patterns/experimental/email-task-engine.tsx` so `cf check --no-run` is clean on `main`.

- **Bug Fixes**
  - `chat-note.tsx`: use `.result!` when reading `wish` results; flatten `mentionable` to `wish(...).result!` to satisfy the editor’s `Opaque<T[]>` prop.
  - `email-task-engine.tsx`: use `.result!` on `wish` destructure; change `TaskAnalysis.result` to `SuggestionResult | undefined` and update the filter; add explicit types in `notes.map`; cast `prompt` to `Opaque<string>` for `generateObject`.

<sup>Written for commit 38ec2a2ae5310fc66b49b9f86fd2ea30915b764a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

