### PR TITLE
docs(pattern-dev): add scoped pattern skill guidance

### DIFF
--- a/skills/pattern-critic/SKILL.md
+++ b/skills/pattern-critic/SKILL.md
@@ -98,6 +98,51 @@ export default pattern<Input>(({ deck }) => ({
 return <>{showDetails ? <div>Details content</div> : null}</>;
 ```
 
+### Scoped State Review
+
+Review whether each state field has the right sharing boundary. A useful test
+for UI state: if the user opens the same instance in a new tab, should this
+state carry over? If not, it is probably `PerSession<>`.
+
+| State                                                                                                     | Expected scope |
+| --------------------------------------------------------------------------------------------------------- | -------------- |
+| shared records, rooms, documents, canonical task lists                                                    | `PerSpace<>`   |
+| display name, user preference, personal draft, account-local setting                                      | `PerUser<>`    |
+| navigation, selected tab, selected item, selected room, modal/open state, local filter text, focused item | `PerSession<>` |
+
+Flag these issues:
+
+| Violation                                                      | Fix                                                                                                                                 |
+| -------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| transient UI state stored as unscoped or shared space state    | Use `PerSession<>`                                                                                                                  |
+| user-owned state stored as shared space state                  | Use `PerUser<>`                                                                                                                     |
+| shared canonical content stored per-session                    | Use `PerSpace<>` unless isolation is intentional                                                                                    |
+| user ids or session ids embedded in data to simulate isolation | Use scope wrappers                                                                                                                  |
+| `PerAny<>` used where the inner scope is known                 | Replace with the known scope; reserve `PerAny<>` for intentionally scope-polymorphic inner values under an outer `Per*` declaration |
+| scope used as an authorization boundary                        | Keep CFC/IFC/security policy separate                                                                                               |
+
+Accept either scoped authoring style:
+
+```ts
+// Plain data-shaped inputs.
+conversation?: PerSpace<Conversation | Default<typeof DEFAULT_CONVERSATION>>;
+name?: PerUser<string | Default<"">>;
+selectedRoom?: PerSession<SelectedRoom | Default<{}>>;
+
+// Writable aliases when handlers need stable cell handles.
+name?: PerUser<Writable<string | Default<"">>>;
+selectedRoom?: PerSession<Writable<SelectedRoom | Default<{}>>>;
+```
+
+`PerAny<>` should normally appear only as an inner override, for example:
+
+```ts
+type Selection = PerSession<{
+  item: PerUser<Item>;
+  attachment: PerAny<Attachment>;
+}>;
+```
+
 ### Visual Review Reminder
 
 When UI is important to the pattern, also look for:

--- a/skills/pattern-debug/SKILL.md
+++ b/skills/pattern-debug/SKILL.md
@@ -106,6 +106,35 @@ a function:**
 - Fix: use bare JSX ternaries, hoist `computed()` for data only
 - See `docs/common/concepts/computed/computed.md`
 
+**Transient UI state carries over when it should not:**
+
+- Check whether navigation, active tab, selected item, selected room, modal,
+  filter, or other ephemeral UI state is unscoped or space scoped.
+- Ask whether the state should carry over if the user opens the same instance in
+  a new tab. If not, it is probably session state.
+- Use `PerSession<>` for per-session UI state and `PerUser<>` for user-owned
+  durable state.
+- Use data-shaped scoped inputs for simple APIs. Use scoped `Writable` aliases
+  when handlers need stable cell handles, `.key(...)`, `.equals(...)`, or
+  per-item bindings.
+- Confirm the generated schema and transformed source with
+  `deno task cf check pattern.tsx --show-transformed`.
+- If a value unexpectedly becomes `undefined`, check for schema-scope traversal
+  restrictions: a narrower linked value may be unavailable to a broader declared
+  schema.
+- Scope is data scoping, not authorization; do not use it as a replacement for
+  CFC/IFC policy.
+
+**`PerAny<>` used to fix a scope issue:**
+
+- Treat `PerAny<>` as a rare inner override under an outer `Per*` declaration,
+  not as a fourth default scope.
+- Prefer the concrete inner scope when known:
+  `PerSession<{ item: PerUser<Item>; attachment: PerAny<Attachment> }>` is valid
+  when attachments intentionally may come from any scope.
+- If the inner scope is known, use `PerSpace<>`, `PerUser<>`, or `PerSession<>`
+  instead.
+
 ## Runtime Debugging (browser)
 
 When the pattern compiles but behaves wrong at runtime, use the browser console
@@ -140,6 +169,7 @@ When tests or CLI calls succeed but browser-visible UI stays stale:
 
 - inspect the live piece state first
 - confirm whether the handler actually wrote the expected value
+- inspect raw links or transformed schema when the bug could be a scope mismatch
 - only then decide whether the bug is in mutation semantics, rendering, or
   browser harness behavior
 

--- a/skills/pattern-dev/SKILL.md
+++ b/skills/pattern-dev/SKILL.md
@@ -18,6 +18,62 @@ debugging pattern state:
 These are required context for Common Fabric pattern work. TypeScript surface
 types can look like plain values even when runtime values are reactive cells.
 
+Decide each state field's sharing boundary before building the UI:
+
+- `PerSpace<T>`: shared durable state for everyone in the space.
+- `PerUser<T>`: state that follows one authenticated user across sessions.
+- `PerSession<T>`: ephemeral state for one session, such as navigation, selected
+  tab, selected room, selected item, local filter text, open modal, or focused
+  item.
+
+Default transient UI state to `PerSession<>` unless it intentionally needs to
+persist for the user across sessions. A useful test: if the user opens the same
+instance in a new tab, should this state carry over? If not, it is probably
+`PerSession<>`. Multi-user patterns make this boundary especially important, but
+the rule is about state lifetime, not only collaboration. Do not store user ids
+or session ids in ordinary data to simulate isolation; use scope wrappers on the
+relevant input and output types.
+
+Two common scoped authoring styles are useful:
+
+```ts
+// Plain-input style: public API looks like ordinary data.
+interface ChatInput {
+  conversation?: PerSpace<Conversation | Default<typeof DEFAULT_CONVERSATION>>;
+  name?: PerUser<string | Default<"">>;
+  selectedRoom?: PerSession<SelectedRoom | Default<EmptySelectedRoom>>;
+}
+
+// Writable-input style: handlers need stable writable cell handles.
+type NameCell = Writable<string | Default<"">>;
+type SelectedRoomCell = Writable<SelectedRoom | Default<EmptySelectedRoom>>;
+
+interface ChatInputWithCells {
+  name?: PerUser<NameCell>;
+  selectedRoom?: PerSession<SelectedRoomCell>;
+  conversation?: PerSpace<Writable<Conversation>>;
+}
+```
+
+Use the plain-input style when the pattern API should stay data-shaped. Use the
+writable-input style when handlers need `.key(...)`, `.equals(...)`, or stable
+cell bindings, especially in mutation-heavy multi-user UI.
+
+`PerAny<T>` is rare. Use it only when an inner value must override an outer
+scope declaration and may validly come from any concrete scope:
+
+```ts
+type Selection = PerSession<{
+  item: PerUser<Item>;
+  attachment: PerAny<Attachment>;
+}>;
+```
+
+Prefer `PerSpace<>`, `PerUser<>`, or `PerSession<>` whenever the inner value's
+scope is known. Do not directly stack scope wrappers on the same value, such as
+`PerUser<PerSession<T>>`; put the inner scoped declaration on the field or cell
+that actually has that scope.
+
 When working in a Pattern Factory Build workspace, also read:
 
 - `docs/common/ai/pattern-factory-build-guide.md`
@@ -29,6 +85,11 @@ When you're unsure whether a reactive expression site lowers the way you expect,
 inspect the emitted source directly with:
 
 - `deno task cf check <pattern>.tsx --show-transformed`
+
+Also inspect the emitted source when a composed pattern result is assigned to a
+`PerUser<>` or `PerSession<>` typed variable or output. Contextual scope types
+should lower into the factory call; if they do not, the pattern may instantiate
+state at the wrong sharing boundary.
 
 Current main handles plain ternaries well in normal pattern code. Prefer direct
 authored expressions first; if an unusual site seems ambiguous, inspect the

--- a/skills/pattern-implement/SKILL.md
+++ b/skills/pattern-implement/SKILL.md
@@ -78,6 +78,12 @@ local UI state, or draft/editing state:
 - Draft/editing state: create it from a static value, then copy from input state
   inside an `action()` or another valid event/reactive context.
 
+For transient UI state, prefer `PerSession<>` unless the state should persist
+across sessions. This includes active tab, selected item, selected room, local
+filter text, open modal, and focused item. A useful test: if the user opens the
+same instance in a new tab, should this state carry over? If not, it is probably
+`PerSession<>`.
+
 Use `safeDateNow()` and `nonPrivateRandom()` instead of ambient `Date.now()` and
 `Math.random()` when a pattern needs explicit time or randomness. If a control
 is already bound to a cell, usually via `$value` or `$checked`, let that binding

--- a/skills/pattern-ui/SKILL.md
+++ b/skills/pattern-ui/SKILL.md
@@ -42,11 +42,20 @@ Before touching JSX, decide all of the following:
 - **Tone**: Pick a concrete direction such as editorial, playful, luxurious,
   brutalist, retro-futurist, soft, or utilitarian.
 - **Hook**: What is the one visual idea someone will remember?
+- **State lifetime**: Which UI state is shared, user-specific, or session-only?
 - **Constraint strategy**: How will you get that look with `cf-*` components,
   local fonts, and public CSS custom properties?
 
 Do not drift into an undifferentiated default. Commit to a direction and execute
 it cleanly.
+
+Treat transient UI state as part of the design brief, not as incidental
+implementation detail. Active tab, selected item, selected room, open modal,
+local filter text, and focused item should usually be `PerSession<>`. A useful
+test: if the user opens the same instance in a new tab, should this state carry
+over? If not, it is probably `PerSession<>`. User preferences, display names,
+and personal drafts are usually `PerUser<>`. Shared records and canonical
+content are usually `PerSpace<>`.
 
 ## Theme-First Workflow
 
@@ -111,6 +120,20 @@ defaults, or layouts that read like a raw form dump.
 If a control is already bound to a cell, usually via `$value` or `$checked`, do
 not add a change handler that simply writes the same value back into that same
 cell. Use handlers only for dependent state updates or other side effects.
+
+**Scoped UI state:**
+
+```ts
+interface MultiUserUiState {
+  sharedBoard: PerSpace<Board>;
+  displayName: PerUser<string | Default<"">>;
+  selectedCard: PerSession<CardSelection | Default<{}>>;
+}
+```
+
+Use ordinary data-shaped inputs when the public API should stay simple. Use
+`Writable` cell aliases inside the scope wrapper when handlers need stable cell
+handles for `.key(...)`, `.equals(...)`, or per-item bindings.
 
 **Layout structure:**
 
@@ -178,3 +201,5 @@ domain flow, not as the first place to copy styling from.
 - the result has a clear visual idea rather than a generic default shell
 - full-height layouts use `cf-screen` (auto-scrolls); `cf-vscroll` only for
   chat/fade-edges
+- transient UI state has explicit scope; tab-local state is `PerSession<>`
+  unless cross-session persistence is intentional


### PR DESCRIPTION
## Summary
- Add scoped-state guidance to pattern development skills for multi-user patterns.
- Document when to use PerSpace, PerUser, and PerSession, with PerSession called out for ephemeral navigation-like UI state.
- Capture both plain-input and Writable-input authoring styles, plus the rare PerAny inner override case.

## Validation
- deno fmt --check skills/pattern-dev/SKILL.md skills/pattern-ui/SKILL.md skills/pattern-debug/SKILL.md skills/pattern-critic/SKILL.md
- git diff --check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds scoped-state guidance for multi-user patterns across the pattern dev, UI, implement, debug, and critic skills. Defaults transient UI to `PerSession` using the “open in a new tab” test, clarifies plain vs scoped `Writable` inputs, narrows `PerAny` to rare inner overrides, and notes contextual scope lowering and that scope is not auth.

- **New Guidance**
  - Dev/UI/implement: design with explicit state lifetimes; default navigation-like state to `PerSession`; avoid embedding user/session ids; pick plain inputs vs scoped `Writable` when handlers need stable cells or `.key()`/`.equals()`; don’t stack scopes; check contextual scope lowering in composed patterns.
  - Debug: find UI state that incorrectly carries over; use `PerSession` for ephemeral and `PerUser` for durable personal state; verify with `deno task cf check <pattern>.tsx --show-transformed`; watch for schema-scope traversal limits; inspect raw links/transformed schema on scope mismatches; scope is not authorization.
  - Critic: quick map of common state to `PerSpace`/`PerUser`/`PerSession`; violations-and-fixes table (e.g., don’t use `PerAny` when the inner scope is known); accept both data-shaped and scoped-`Writable` styles.

<sup>Written for commit a1c4cd1b0642221098590f09c2f84a6660f6c738. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



NEW_PERF_BASELINE: job: Runner Tests (3/4) = 79s
