### PR TITLE
chore(github-actions): Add perf metrics artifact backfill

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -508,6 +508,24 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: deno run --allow-net --allow-env --allow-read --allow-run --allow-write tasks/perf-check.ts
 
+      - name: 📤 Upload performance metrics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-metrics
+          path: perf-metrics.json
+          retention-days: 90
+          if-no-files-found: ignore
+
+      - name: 📤 Upload performance metrics backfill
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-metrics-backfill
+          path: perf-metrics-backfill.json
+          retention-days: 90
+          if-no-files-found: ignore
+
   attest-binaries:
     name: "Attest and Upload Binaries"
     if: github.ref == 'refs/heads/main'

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -19,10 +19,13 @@ import {
   addSample,
   API_CONCURRENCY,
   applyBaselineOverrides,
+  type Artifact,
   type BaselineOverrides,
   computeBaseline,
   computeCiWallTimeRevisitSignals,
   downloadAndParseJUnit,
+  downloadAndParsePerfMetrics,
+  downloadAndParsePerfMetricsBackfill,
   extractMetrics,
   extractTestFileMetrics,
   fetchArtifactsForRun,
@@ -38,6 +41,10 @@ import {
   MIN_REGRESSION_PCT,
   MIN_SAMPLES,
   parseBaselineOverrides,
+  PERF_METRICS_ARTIFACT_NAME,
+  PERF_METRICS_BACKFILL_ARTIFACT_NAME,
+  PERF_METRICS_BACKFILL_FILE,
+  PERF_METRICS_FILE,
   type PRInfo,
   readAndParseEvent,
   REPO,
@@ -47,10 +54,15 @@ import {
   TOKEN,
   WORKFLOW_FILE,
   type WorkflowRun,
+  writePerfMetricsBackfillFile,
+  writePerfMetricsFile,
 } from "./perf-lib.ts";
 
 /** How many recent main-branch runs to use for baseline. */
 const BASELINE_RUNS = 20;
+
+/** Recent completed workflow runs to scan for fallback backfill artifacts. */
+const BACKFILL_SOURCE_RUNS = 20;
 
 /**
  * Metrics to exclude from regression checks because their aggregate values
@@ -139,6 +151,11 @@ async function main() {
     console.warn(`  Warning: could not fetch artifacts for current run: ${e}`);
   }
 
+  await writePerfMetricsFile(PERF_METRICS_FILE, currentMetrics);
+  console.log(
+    `Wrote ${PERF_METRICS_FILE} with ${currentMetrics.size} metrics.`,
+  );
+
   if (currentMetrics.size === 0) {
     console.log("No metrics extracted from current run. Nothing to check.");
     Deno.exit(0);
@@ -167,53 +184,151 @@ async function main() {
   const timelines = new Map<string, MetricTimeline>();
   const overridesBySha = new Map<string, BaselineOverrides>();
   const prInfoBySha = new Map<string, PRInfo>();
+  const newBackfills = new Map<number, Map<string, TimingSample>>();
 
-  await mapConcurrent(baselineRuns, API_CONCURRENCY, async (run) => {
-    const [jobs, pr] = await Promise.all([
-      fetchJobsForRun(run.id),
-      fetchPRForCommit(run.head_sha),
-    ]);
+  interface BaselineRunContext {
+    run: WorkflowRun;
+    artifacts: Artifact[];
+    pr: PRInfo | null;
+  }
+
+  const baselineContexts = await mapConcurrent(
+    baselineRuns,
+    API_CONCURRENCY,
+    async (run): Promise<BaselineRunContext> => {
+      const [artifacts, pr] = await Promise.all([
+        fetchArtifactsForRun(run.id),
+        fetchPRForCommit(run.head_sha),
+      ]);
+      return { run, artifacts, pr };
+    },
+  );
+
+  console.log("Fetching recent perf metric backfills...");
+  const backfillSourceData = await githubGet<{ workflow_runs: WorkflowRun[] }>(
+    `/repos/${REPO}/actions/workflows/${WORKFLOW_FILE}/runs?status=completed&per_page=${BACKFILL_SOURCE_RUNS}`,
+  );
+  const baselineRunIds = new Set(baselineRuns.map((run) => run.id));
+  const backfillSourceRuns = backfillSourceData.workflow_runs.filter((run) =>
+    !baselineRunIds.has(run.id) && run.id !== runIdNum
+  );
+  const extraBackfillContexts = await mapConcurrent(
+    backfillSourceRuns,
+    API_CONCURRENCY,
+    async (run): Promise<BaselineRunContext> => ({
+      run,
+      artifacts: await fetchArtifactsForRun(run.id),
+      pr: null,
+    }),
+  );
+
+  const backfilledMetricsByRunId = new Map<number, Map<string, TimingSample>>();
+  await mapConcurrent(
+    [...baselineContexts, ...extraBackfillContexts],
+    API_CONCURRENCY,
+    async ({ artifacts }) => {
+      const artifact = artifacts.find(
+        (a) => a.name === PERF_METRICS_BACKFILL_ARTIFACT_NAME && !a.expired,
+      );
+      if (!artifact) return;
+
+      const backfills = await downloadAndParsePerfMetricsBackfill(artifact.id);
+      if (!backfills) return;
+
+      for (const [backfilledRunId, metrics] of backfills) {
+        if (!backfilledMetricsByRunId.has(backfilledRunId)) {
+          backfilledMetricsByRunId.set(backfilledRunId, metrics);
+        }
+      }
+    },
+  );
+  if (backfilledMetricsByRunId.size > 0) {
+    console.log(
+      `Loaded perf metric backfills for ${backfilledMetricsByRunId.size} run(s).`,
+    );
+  }
+
+  await mapConcurrent(baselineContexts, API_CONCURRENCY, async (context) => {
+    const { run, artifacts, pr } = context;
 
     if (pr) {
       prInfoBySha.set(run.head_sha, pr);
+      const overrides = parseBaselineOverrides(pr.body ?? "");
+      if (overrides.metrics.size > 0) {
+        overridesBySha.set(run.head_sha, overrides);
+      }
     }
 
-    const metrics = extractMetrics(run, jobs);
+    const perfMetricsArtifact = artifacts.find(
+      (a) => a.name === PERF_METRICS_ARTIFACT_NAME && !a.expired,
+    );
+    if (perfMetricsArtifact) {
+      const metrics = await downloadAndParsePerfMetrics(
+        perfMetricsArtifact.id,
+      );
+      if (metrics) {
+        for (const [name, sample] of metrics) {
+          addSample(timelines, name, sample);
+        }
+        return;
+      }
+    }
+
+    const backfilledMetrics = backfilledMetricsByRunId.get(run.id);
+    if (backfilledMetrics) {
+      for (const [name, sample] of backfilledMetrics) {
+        addSample(timelines, name, sample);
+      }
+      return;
+    }
+
+    const jobs = await fetchJobsForRun(run.id);
+    const metrics = new Map(extractMetrics(run, jobs));
     for (const [name, sample] of metrics) {
       addSample(timelines, name, sample);
     }
 
     // Fetch per-test timing artifacts
+    let canBackfill = true;
     try {
-      const artifacts = await fetchArtifactsForRun(run.id);
       const timingArtifacts = artifacts.filter(
         (a) => a.name.startsWith("test-timing-") && !a.expired,
       );
       for (const artifact of timingArtifacts) {
         const suites = await downloadAndParseJUnit(artifact.id);
-        if (suites.length > 0) {
-          const testMetrics = extractTestFileMetrics(
-            run,
-            timingArtifactLabel(artifact.name),
-            suites,
-          );
-          for (const [name, sample] of testMetrics) {
-            addSample(timelines, name, sample);
-          }
+        if (suites.length === 0) {
+          canBackfill = false;
+          continue;
+        }
+        const testMetrics = extractTestFileMetrics(
+          run,
+          timingArtifactLabel(artifact.name),
+          suites,
+        );
+        for (const [name, sample] of testMetrics) {
+          metrics.set(name, sample);
+          addSample(timelines, name, sample);
         }
       }
     } catch {
       // Artifacts may not exist for older runs
+      canBackfill = false;
     }
 
-    // Check for baseline overrides in merged PRs
-    if (pr?.body) {
-      const overrides = parseBaselineOverrides(pr.body);
-      if (overrides.metrics.size > 0) {
-        overridesBySha.set(run.head_sha, overrides);
-      }
+    if (metrics.size > 0 && canBackfill) {
+      newBackfills.set(run.id, metrics);
     }
   });
+
+  if (newBackfills.size > 0) {
+    await writePerfMetricsBackfillFile(
+      PERF_METRICS_BACKFILL_FILE,
+      newBackfills,
+    );
+    console.log(
+      `Wrote ${PERF_METRICS_BACKFILL_FILE} for ${newBackfills.size} fallback run(s).`,
+    );
+  }
 
   // Sort timelines chronologically
   for (const timeline of timelines.values()) {

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -192,12 +192,25 @@ async function main() {
     pr: PRInfo | null;
   }
 
+  async function fetchArtifactsForRunBestEffort(
+    run: WorkflowRun,
+  ): Promise<Artifact[]> {
+    try {
+      return await fetchArtifactsForRun(run.id);
+    } catch (error) {
+      console.warn(
+        `  Warning: could not fetch artifacts for run ${run.id}: ${error}`,
+      );
+      return [];
+    }
+  }
+
   const baselineContexts = await mapConcurrent(
     baselineRuns,
     API_CONCURRENCY,
     async (run): Promise<BaselineRunContext> => {
       const [artifacts, pr] = await Promise.all([
-        fetchArtifactsForRun(run.id),
+        fetchArtifactsForRunBestEffort(run),
         fetchPRForCommit(run.head_sha),
       ]);
       return { run, artifacts, pr };
@@ -206,7 +219,7 @@ async function main() {
 
   console.log("Fetching recent perf metric backfills...");
   const backfillSourceData = await githubGet<{ workflow_runs: WorkflowRun[] }>(
-    `/repos/${REPO}/actions/workflows/${WORKFLOW_FILE}/runs?status=completed&per_page=${BACKFILL_SOURCE_RUNS}`,
+    `/repos/${REPO}/actions/workflows/${WORKFLOW_FILE}/runs?branch=main&event=push&status=success&per_page=${BACKFILL_SOURCE_RUNS}`,
   );
   const baselineRunIds = new Set(baselineRuns.map((run) => run.id));
   const backfillSourceRuns = backfillSourceData.workflow_runs.filter((run) =>
@@ -217,31 +230,40 @@ async function main() {
     API_CONCURRENCY,
     async (run): Promise<BaselineRunContext> => ({
       run,
-      artifacts: await fetchArtifactsForRun(run.id),
+      artifacts: await fetchArtifactsForRunBestEffort(run),
       pr: null,
     }),
   );
 
   const backfilledMetricsByRunId = new Map<number, Map<string, TimingSample>>();
-  await mapConcurrent(
-    [...baselineContexts, ...extraBackfillContexts],
+  const backfillSourceContexts = [
+    ...baselineContexts,
+    ...extraBackfillContexts,
+  ].sort((a, b) =>
+    b.run.created_at.localeCompare(a.run.created_at) || b.run.id - a.run.id
+  );
+  const parsedBackfillSources = await mapConcurrent(
+    backfillSourceContexts,
     API_CONCURRENCY,
     async ({ artifacts }) => {
       const artifact = artifacts.find(
         (a) => a.name === PERF_METRICS_BACKFILL_ARTIFACT_NAME && !a.expired,
       );
-      if (!artifact) return;
+      if (!artifact) return null;
 
-      const backfills = await downloadAndParsePerfMetricsBackfill(artifact.id);
-      if (!backfills) return;
-
-      for (const [backfilledRunId, metrics] of backfills) {
-        if (!backfilledMetricsByRunId.has(backfilledRunId)) {
-          backfilledMetricsByRunId.set(backfilledRunId, metrics);
-        }
-      }
+      return await downloadAndParsePerfMetricsBackfill(artifact.id);
     },
   );
+
+  for (const backfills of parsedBackfillSources) {
+    if (!backfills) continue;
+
+    for (const [backfilledRunId, metrics] of backfills) {
+      if (!backfilledMetricsByRunId.has(backfilledRunId)) {
+        backfilledMetricsByRunId.set(backfilledRunId, metrics);
+      }
+    }
+  }
   if (backfilledMetricsByRunId.size > 0) {
     console.log(
       `Loaded perf metric backfills for ${backfilledMetricsByRunId.size} run(s).`,

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -64,6 +64,16 @@ const BASELINE_RUNS = 20;
 /** Recent completed workflow runs to scan for fallback backfill artifacts. */
 const BACKFILL_SOURCE_RUNS = 20;
 
+function pullRequestBodyFromEvent(
+  event: object | undefined,
+): string | undefined {
+  const pullRequest =
+    (event as { pull_request?: { body?: unknown } } | undefined)
+      ?.pull_request;
+  if (!pullRequest || !("body" in pullRequest)) return undefined;
+  return typeof pullRequest.body === "string" ? pullRequest.body : "";
+}
+
 /**
  * Metrics to exclude from regression checks because their aggregate values
  * naturally grow as new tests are added.  Per-test timings from JUnit
@@ -93,16 +103,24 @@ async function main() {
     Deno.exit(1);
   }
 
-  console.log(
-    "::group::Triggered by event:\n%o\n::endgroup::",
-    await readAndParseEvent(),
-  );
+  const event = await readAndParseEvent();
+  console.log("::group::Triggered by event:\n%o\n::endgroup::", event);
 
   // 1. Check PR description for overrides, if there's a PR to check.
   let prOverrides;
   if (prNumber) {
-    console.log(`Fetching PR #${prNumber} description...`);
-    const prBody = await fetchPRBody(parseInt(prNumber));
+    let prBody = pullRequestBodyFromEvent(event);
+    if (prBody === undefined) {
+      console.log(`Fetching PR #${prNumber} description...`);
+      try {
+        prBody = await fetchPRBody(parseInt(prNumber));
+      } catch (error) {
+        console.warn(`  Warning: could not fetch PR body: ${error}`);
+        prBody = "";
+      }
+    } else {
+      console.log("Using PR description from pull_request event payload.");
+    }
     prOverrides = parseBaselineOverrides(prBody);
   } else {
     prOverrides = { metrics: new Map() };

--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -74,6 +74,62 @@ function pullRequestBodyFromEvent(
   return typeof pullRequest.body === "string" ? pullRequest.body : "";
 }
 
+function currentWorkflowRunFromEvent(
+  event: object | undefined,
+  runId: number,
+): WorkflowRun {
+  const payload = event as {
+    after?: unknown;
+    pull_request?: {
+      head?: { sha?: unknown };
+    };
+  } | undefined;
+
+  const headSha = typeof payload?.pull_request?.head?.sha === "string"
+    ? payload.pull_request.head.sha
+    : typeof payload?.after === "string"
+    ? payload.after
+    : Deno.env.get("GITHUB_SHA") ?? "";
+
+  return {
+    id: runId,
+    html_url: `https://github.com/${REPO}/actions/runs/${runId}`,
+    head_sha: headSha,
+    created_at: new Date().toISOString(),
+    conclusion: "",
+    event: Deno.env.get("GITHUB_EVENT_NAME") ?? "",
+  };
+}
+
+function isGitHubRateLimitError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /\b(rate limit|rate-limited|ratelimit)\b/i.test(message);
+}
+
+async function githubApiOrSkip<T>(
+  description: string,
+  operation: () => Promise<T>,
+  metricsForArtifact: Map<string, TimingSample>,
+): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (!isGitHubRateLimitError(error)) throw error;
+
+    console.warn(
+      `  Warning: GitHub API rate limit while ${description}: ${error}`,
+    );
+    await writePerfMetricsFile(PERF_METRICS_FILE, metricsForArtifact);
+    console.log(
+      `Wrote ${PERF_METRICS_FILE} with ${metricsForArtifact.size} metrics.`,
+    );
+    console.log(
+      "Skipping performance regression check because GitHub API rate limits prevent collecting required CI timing data.",
+    );
+    Deno.exit(0);
+  }
+}
+
 /**
  * Metrics to exclude from regression checks because their aggregate values
  * naturally grow as new tests are added.  Per-test timings from JUnit
@@ -135,13 +191,16 @@ async function main() {
   // 2. Get current run's job/step metrics and per-test timing artifacts
   console.log(`Fetching jobs for current run ${runId}...`);
   const runIdNum = parseInt(runId);
-  const currentJobs = await fetchJobsForRun(runIdNum);
-
-  // Build a minimal WorkflowRun for the current run to extract metrics
-  const currentRunInfo = await githubGet<WorkflowRun>(
-    `/repos/${REPO}/actions/runs/${runId}`,
-  );
   const currentMetrics = new Map<string, TimingSample>();
+  const currentJobs = await githubApiOrSkip(
+    `fetching jobs for current run ${runId}`,
+    () => fetchJobsForRun(runIdNum),
+    currentMetrics,
+  );
+
+  // The event payload has the metadata needed for samples, so avoid spending
+  // another API request on the current workflow run.
+  const currentRunInfo = currentWorkflowRunFromEvent(event, runIdNum);
 
   // Extract job/step metrics
   for (const [name, sample] of extractMetrics(currentRunInfo, currentJobs)) {
@@ -184,8 +243,13 @@ async function main() {
 
   // 3. Fetch recent main-branch push runs for baseline
   console.log("Fetching recent main-branch runs for baseline...");
-  const baselineData = await githubGet<{ workflow_runs: WorkflowRun[] }>(
-    `/repos/${REPO}/actions/workflows/${WORKFLOW_FILE}/runs?branch=main&status=success&event=push&per_page=${BASELINE_RUNS}`,
+  const baselineData = await githubApiOrSkip(
+    "fetching recent main-branch runs for baseline",
+    () =>
+      githubGet<{ workflow_runs: WorkflowRun[] }>(
+        `/repos/${REPO}/actions/workflows/${WORKFLOW_FILE}/runs?branch=main&status=success&event=push&per_page=${BASELINE_RUNS}`,
+      ),
+    currentMetrics,
   );
   const baselineRuns = baselineData.workflow_runs;
 
@@ -223,34 +287,49 @@ async function main() {
     }
   }
 
-  const baselineContexts = await mapConcurrent(
-    baselineRuns,
-    API_CONCURRENCY,
-    async (run): Promise<BaselineRunContext> => {
-      const [artifacts, pr] = await Promise.all([
-        fetchArtifactsForRunBestEffort(run),
-        fetchPRForCommit(run.head_sha),
-      ]);
-      return { run, artifacts, pr };
-    },
+  const baselineContexts = await githubApiOrSkip(
+    "fetching baseline run context",
+    () =>
+      mapConcurrent(
+        baselineRuns,
+        API_CONCURRENCY,
+        async (run): Promise<BaselineRunContext> => {
+          const [artifacts, pr] = await Promise.all([
+            fetchArtifactsForRunBestEffort(run),
+            fetchPRForCommit(run.head_sha),
+          ]);
+          return { run, artifacts, pr };
+        },
+      ),
+    currentMetrics,
   );
 
   console.log("Fetching recent perf metric backfills...");
-  const backfillSourceData = await githubGet<{ workflow_runs: WorkflowRun[] }>(
-    `/repos/${REPO}/actions/workflows/${WORKFLOW_FILE}/runs?branch=main&event=push&status=success&per_page=${BACKFILL_SOURCE_RUNS}`,
+  const backfillSourceData = await githubApiOrSkip(
+    "fetching recent perf metric backfill sources",
+    () =>
+      githubGet<{ workflow_runs: WorkflowRun[] }>(
+        `/repos/${REPO}/actions/workflows/${WORKFLOW_FILE}/runs?branch=main&event=push&status=success&per_page=${BACKFILL_SOURCE_RUNS}`,
+      ),
+    currentMetrics,
   );
   const baselineRunIds = new Set(baselineRuns.map((run) => run.id));
   const backfillSourceRuns = backfillSourceData.workflow_runs.filter((run) =>
     !baselineRunIds.has(run.id) && run.id !== runIdNum
   );
-  const extraBackfillContexts = await mapConcurrent(
-    backfillSourceRuns,
-    API_CONCURRENCY,
-    async (run): Promise<BaselineRunContext> => ({
-      run,
-      artifacts: await fetchArtifactsForRunBestEffort(run),
-      pr: null,
-    }),
+  const extraBackfillContexts = await githubApiOrSkip(
+    "fetching extra perf metric backfill context",
+    () =>
+      mapConcurrent(
+        backfillSourceRuns,
+        API_CONCURRENCY,
+        async (run): Promise<BaselineRunContext> => ({
+          run,
+          artifacts: await fetchArtifactsForRunBestEffort(run),
+          pr: null,
+        }),
+      ),
+    currentMetrics,
   );
 
   const backfilledMetricsByRunId = new Map<number, Map<string, TimingSample>>();
@@ -260,17 +339,22 @@ async function main() {
   ].sort((a, b) =>
     b.run.created_at.localeCompare(a.run.created_at) || b.run.id - a.run.id
   );
-  const parsedBackfillSources = await mapConcurrent(
-    backfillSourceContexts,
-    API_CONCURRENCY,
-    async ({ artifacts }) => {
-      const artifact = artifacts.find(
-        (a) => a.name === PERF_METRICS_BACKFILL_ARTIFACT_NAME && !a.expired,
-      );
-      if (!artifact) return null;
+  const parsedBackfillSources = await githubApiOrSkip(
+    "downloading perf metric backfills",
+    () =>
+      mapConcurrent(
+        backfillSourceContexts,
+        API_CONCURRENCY,
+        async ({ artifacts }) => {
+          const artifact = artifacts.find(
+            (a) => a.name === PERF_METRICS_BACKFILL_ARTIFACT_NAME && !a.expired,
+          );
+          if (!artifact) return null;
 
-      return await downloadAndParsePerfMetricsBackfill(artifact.id);
-    },
+          return await downloadAndParsePerfMetricsBackfill(artifact.id);
+        },
+      ),
+    currentMetrics,
   );
 
   for (const backfills of parsedBackfillSources) {
@@ -288,77 +372,82 @@ async function main() {
     );
   }
 
-  await mapConcurrent(baselineContexts, API_CONCURRENCY, async (context) => {
-    const { run, artifacts, pr } = context;
+  await githubApiOrSkip(
+    "building baseline timelines",
+    () =>
+      mapConcurrent(baselineContexts, API_CONCURRENCY, async (context) => {
+        const { run, artifacts, pr } = context;
 
-    if (pr) {
-      prInfoBySha.set(run.head_sha, pr);
-      const overrides = parseBaselineOverrides(pr.body ?? "");
-      if (overrides.metrics.size > 0) {
-        overridesBySha.set(run.head_sha, overrides);
-      }
-    }
+        if (pr) {
+          prInfoBySha.set(run.head_sha, pr);
+          const overrides = parseBaselineOverrides(pr.body ?? "");
+          if (overrides.metrics.size > 0) {
+            overridesBySha.set(run.head_sha, overrides);
+          }
+        }
 
-    const perfMetricsArtifact = artifacts.find(
-      (a) => a.name === PERF_METRICS_ARTIFACT_NAME && !a.expired,
-    );
-    if (perfMetricsArtifact) {
-      const metrics = await downloadAndParsePerfMetrics(
-        perfMetricsArtifact.id,
-      );
-      if (metrics) {
+        const perfMetricsArtifact = artifacts.find(
+          (a) => a.name === PERF_METRICS_ARTIFACT_NAME && !a.expired,
+        );
+        if (perfMetricsArtifact) {
+          const metrics = await downloadAndParsePerfMetrics(
+            perfMetricsArtifact.id,
+          );
+          if (metrics) {
+            for (const [name, sample] of metrics) {
+              addSample(timelines, name, sample);
+            }
+            return;
+          }
+        }
+
+        const backfilledMetrics = backfilledMetricsByRunId.get(run.id);
+        if (backfilledMetrics) {
+          for (const [name, sample] of backfilledMetrics) {
+            addSample(timelines, name, sample);
+          }
+          return;
+        }
+
+        const jobs = await fetchJobsForRun(run.id);
+        const metrics = new Map(extractMetrics(run, jobs));
         for (const [name, sample] of metrics) {
           addSample(timelines, name, sample);
         }
-        return;
-      }
-    }
 
-    const backfilledMetrics = backfilledMetricsByRunId.get(run.id);
-    if (backfilledMetrics) {
-      for (const [name, sample] of backfilledMetrics) {
-        addSample(timelines, name, sample);
-      }
-      return;
-    }
-
-    const jobs = await fetchJobsForRun(run.id);
-    const metrics = new Map(extractMetrics(run, jobs));
-    for (const [name, sample] of metrics) {
-      addSample(timelines, name, sample);
-    }
-
-    // Fetch per-test timing artifacts
-    let canBackfill = true;
-    try {
-      const timingArtifacts = artifacts.filter(
-        (a) => a.name.startsWith("test-timing-") && !a.expired,
-      );
-      for (const artifact of timingArtifacts) {
-        const suites = await downloadAndParseJUnit(artifact.id);
-        if (suites.length === 0) {
+        // Fetch per-test timing artifacts
+        let canBackfill = true;
+        try {
+          const timingArtifacts = artifacts.filter(
+            (a) => a.name.startsWith("test-timing-") && !a.expired,
+          );
+          for (const artifact of timingArtifacts) {
+            const suites = await downloadAndParseJUnit(artifact.id);
+            if (suites.length === 0) {
+              canBackfill = false;
+              continue;
+            }
+            const testMetrics = extractTestFileMetrics(
+              run,
+              timingArtifactLabel(artifact.name),
+              suites,
+            );
+            for (const [name, sample] of testMetrics) {
+              metrics.set(name, sample);
+              addSample(timelines, name, sample);
+            }
+          }
+        } catch {
+          // Artifacts may not exist for older runs
           canBackfill = false;
-          continue;
         }
-        const testMetrics = extractTestFileMetrics(
-          run,
-          timingArtifactLabel(artifact.name),
-          suites,
-        );
-        for (const [name, sample] of testMetrics) {
-          metrics.set(name, sample);
-          addSample(timelines, name, sample);
-        }
-      }
-    } catch {
-      // Artifacts may not exist for older runs
-      canBackfill = false;
-    }
 
-    if (metrics.size > 0 && canBackfill) {
-      newBackfills.set(run.id, metrics);
-    }
-  });
+        if (metrics.size > 0 && canBackfill) {
+          newBackfills.set(run.id, metrics);
+        }
+      }),
+    currentMetrics,
+  );
 
   if (newBackfills.size > 0) {
     await writePerfMetricsBackfillFile(

--- a/tasks/perf-lib.test.ts
+++ b/tasks/perf-lib.test.ts
@@ -6,6 +6,10 @@ import {
   fetchPRBody,
   githubGet,
   type Job,
+  parsePerfMetricsBackfillFile,
+  parsePerfMetricsFile,
+  serializePerfMetrics,
+  serializePerfMetricsBackfill,
   type Step,
   timingArtifactLabel,
   type WorkflowRun,
@@ -362,6 +366,71 @@ Deno.test("timingArtifactLabel normalizes matrix shard artifacts", () => {
   assertEquals(
     timingArtifactLabel("test-timing-package-integration"),
     "package-integration",
+  );
+});
+
+Deno.test("perf metrics files round-trip stable metric samples", () => {
+  const metrics = new Map([
+    [
+      "step: Type check",
+      {
+        runId: 123,
+        runUrl: "https://example.test/run/123",
+        sha: "abc123",
+        createdAt: "2026-01-01T00:00:00Z",
+        durationSeconds: 42.5,
+      },
+    ],
+    [
+      "job: Check",
+      {
+        runId: 123,
+        runUrl: "https://example.test/run/123",
+        sha: "abc123",
+        createdAt: "2026-01-01T00:00:00Z",
+        durationSeconds: 60,
+      },
+    ],
+  ]);
+
+  const serialized = serializePerfMetrics(metrics);
+  assertEquals(
+    serialized.metrics.map((metric) => metric.name),
+    ["job: Check", "step: Type check"],
+  );
+
+  assertEquals(
+    parsePerfMetricsFile(JSON.stringify(serialized)),
+    metrics,
+  );
+});
+
+Deno.test("perf metrics backfill files round-trip run-keyed samples", () => {
+  const runMetrics = new Map([
+    [
+      123,
+      new Map([
+        [
+          "job: Check",
+          {
+            runId: 123,
+            runUrl: "https://example.test/run/123",
+            sha: "abc123",
+            createdAt: "2026-01-01T00:00:00Z",
+            durationSeconds: 60,
+          },
+        ],
+      ]),
+    ],
+  ]);
+
+  const serialized = serializePerfMetricsBackfill(runMetrics);
+  assertEquals(serialized.runs.map((run) => run.runId), [123]);
+  assertEquals(serialized.runs[0].metrics[0].name, "job: Check");
+
+  assertEquals(
+    parsePerfMetricsBackfillFile(JSON.stringify(serialized)),
+    runMetrics,
   );
 });
 

--- a/tasks/perf-lib.ts
+++ b/tasks/perf-lib.ts
@@ -13,6 +13,10 @@
 export const REPO = Deno.env.get("GITHUB_REPOSITORY") ?? "commontoolsinc/labs";
 export const TOKEN = Deno.env.get("GITHUB_TOKEN");
 export const WORKFLOW_FILE = "deno.yml";
+export const PERF_METRICS_ARTIFACT_NAME = "perf-metrics";
+export const PERF_METRICS_FILE = "perf-metrics.json";
+export const PERF_METRICS_BACKFILL_ARTIFACT_NAME = "perf-metrics-backfill";
+export const PERF_METRICS_BACKFILL_FILE = "perf-metrics-backfill.json";
 
 /** Minimum number of historical samples before we compute a baseline. */
 export const MIN_SAMPLES = 5;
@@ -87,6 +91,27 @@ export interface TimingSample {
   sha: string;
   createdAt: string;
   durationSeconds: number;
+}
+
+export interface PerfMetricRecord extends TimingSample {
+  name: string;
+}
+
+export interface PerfMetricsFile {
+  version: 1;
+  generatedAt: string;
+  metrics: PerfMetricRecord[];
+}
+
+export interface PerfMetricsBackfillRun {
+  runId: number;
+  metrics: PerfMetricRecord[];
+}
+
+export interface PerfMetricsBackfillFile {
+  version: 1;
+  generatedAt: string;
+  runs: PerfMetricsBackfillRun[];
 }
 
 export interface MetricTimeline {
@@ -361,6 +386,191 @@ export async function downloadAndParseJUnit(
       }
     }
     return suites;
+  } finally {
+    try {
+      await Deno.remove(tmpDir, { recursive: true });
+    } catch { /* ignore cleanup errors */ }
+  }
+}
+
+export function serializePerfMetrics(
+  metrics: Map<string, TimingSample>,
+): PerfMetricsFile {
+  return {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    metrics: metricsToRecords(metrics),
+  };
+}
+
+function metricsToRecords(
+  metrics: Map<string, TimingSample>,
+): PerfMetricRecord[] {
+  return [...metrics.entries()]
+    .map(([name, sample]) => ({ name, ...sample }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function parsePerfMetricsFile(
+  content: string,
+): Map<string, TimingSample> {
+  const parsed = JSON.parse(content) as Partial<PerfMetricsFile>;
+  if (parsed.version !== 1 || !Array.isArray(parsed.metrics)) {
+    throw new Error("Unsupported perf metrics file format.");
+  }
+
+  const metrics = new Map<string, TimingSample>();
+  for (const metric of parsed.metrics) {
+    if (
+      typeof metric.name !== "string" ||
+      typeof metric.runId !== "number" ||
+      typeof metric.runUrl !== "string" ||
+      typeof metric.sha !== "string" ||
+      typeof metric.createdAt !== "string" ||
+      typeof metric.durationSeconds !== "number"
+    ) {
+      throw new Error("Invalid perf metric record.");
+    }
+
+    metrics.set(metric.name, {
+      runId: metric.runId,
+      runUrl: metric.runUrl,
+      sha: metric.sha,
+      createdAt: metric.createdAt,
+      durationSeconds: metric.durationSeconds,
+    });
+  }
+  return metrics;
+}
+
+export function serializePerfMetricsBackfill(
+  metricsByRunId: Map<number, Map<string, TimingSample>>,
+): PerfMetricsBackfillFile {
+  return {
+    version: 1,
+    generatedAt: new Date().toISOString(),
+    runs: [...metricsByRunId.entries()]
+      .map(([runId, metrics]) => ({
+        runId,
+        metrics: metricsToRecords(metrics),
+      }))
+      .sort((a, b) => a.runId - b.runId),
+  };
+}
+
+export function parsePerfMetricsBackfillFile(
+  content: string,
+): Map<number, Map<string, TimingSample>> {
+  const parsed = JSON.parse(content) as Partial<PerfMetricsBackfillFile>;
+  if (parsed.version !== 1 || !Array.isArray(parsed.runs)) {
+    throw new Error("Unsupported perf metrics backfill file format.");
+  }
+
+  const metricsByRunId = new Map<number, Map<string, TimingSample>>();
+  for (const run of parsed.runs) {
+    if (typeof run.runId !== "number" || !Array.isArray(run.metrics)) {
+      throw new Error("Invalid perf metrics backfill run.");
+    }
+
+    metricsByRunId.set(
+      run.runId,
+      parsePerfMetricsFile(JSON.stringify({
+        version: 1,
+        generatedAt: parsed.generatedAt ?? "",
+        metrics: run.metrics,
+      })),
+    );
+  }
+  return metricsByRunId;
+}
+
+export async function writePerfMetricsFile(
+  path: string,
+  metrics: Map<string, TimingSample>,
+): Promise<void> {
+  await Deno.writeTextFile(
+    path,
+    `${JSON.stringify(serializePerfMetrics(metrics), null, 2)}\n`,
+  );
+}
+
+export async function writePerfMetricsBackfillFile(
+  path: string,
+  metricsByRunId: Map<number, Map<string, TimingSample>>,
+): Promise<void> {
+  await Deno.writeTextFile(
+    path,
+    `${
+      JSON.stringify(serializePerfMetricsBackfill(metricsByRunId), null, 2)
+    }\n`,
+  );
+}
+
+export async function downloadAndParsePerfMetrics(
+  artifactId: number,
+): Promise<Map<string, TimingSample> | null> {
+  const resp = await fetch(
+    `https://api.github.com/repos/${REPO}/actions/artifacts/${artifactId}/zip`,
+    { headers: apiHeaders() },
+  );
+  if (!resp.ok) return null;
+
+  const tmpDir = await Deno.makeTempDir({ prefix: "perf-metrics-" });
+  const zipPath = `${tmpDir}/artifact.zip`;
+
+  try {
+    const data = new Uint8Array(await resp.arrayBuffer());
+    await Deno.writeFile(zipPath, data);
+
+    const unzip = new Deno.Command("unzip", {
+      args: ["-o", zipPath, "-d", tmpDir],
+      stdout: "null",
+      stderr: "null",
+    });
+    const result = await unzip.output();
+    if (!result.success) return null;
+
+    const jsonPath = `${tmpDir}/${PERF_METRICS_FILE}`;
+    const content = await Deno.readTextFile(jsonPath);
+    return parsePerfMetricsFile(content);
+  } catch {
+    return null;
+  } finally {
+    try {
+      await Deno.remove(tmpDir, { recursive: true });
+    } catch { /* ignore cleanup errors */ }
+  }
+}
+
+export async function downloadAndParsePerfMetricsBackfill(
+  artifactId: number,
+): Promise<Map<number, Map<string, TimingSample>> | null> {
+  const resp = await fetch(
+    `https://api.github.com/repos/${REPO}/actions/artifacts/${artifactId}/zip`,
+    { headers: apiHeaders() },
+  );
+  if (!resp.ok) return null;
+
+  const tmpDir = await Deno.makeTempDir({ prefix: "perf-metrics-backfill-" });
+  const zipPath = `${tmpDir}/artifact.zip`;
+
+  try {
+    const data = new Uint8Array(await resp.arrayBuffer());
+    await Deno.writeFile(zipPath, data);
+
+    const unzip = new Deno.Command("unzip", {
+      args: ["-o", zipPath, "-d", tmpDir],
+      stdout: "null",
+      stderr: "null",
+    });
+    const result = await unzip.output();
+    if (!result.success) return null;
+
+    const jsonPath = `${tmpDir}/${PERF_METRICS_BACKFILL_FILE}`;
+    const content = await Deno.readTextFile(jsonPath);
+    return parsePerfMetricsBackfillFile(content);
+  } catch {
+    return null;
   } finally {
     try {
       await Deno.remove(tmpDir, { recursive: true });

--- a/tasks/perf-regression.ts
+++ b/tasks/perf-regression.ts
@@ -27,6 +27,7 @@ import {
   computeBaseline,
   type DenoBenchResult,
   downloadAndParseJUnit,
+  downloadAndParsePerfMetrics,
   escapeTableCell,
   extractBenchMetrics,
   extractMetrics,
@@ -53,6 +54,7 @@ import {
   normalizeName,
   parseBaselineOverrides,
   parseDenoTestLog,
+  PERF_METRICS_ARTIFACT_NAME,
   type PRInfo,
   RECENT_THRESHOLD,
   RECENT_WINDOW,
@@ -442,6 +444,7 @@ async function main() {
   // TODO(perf): Remove log-parsing fallback after 2026-03-19.
   console.log("Fetching test timing artifacts...");
   let artifactRunsProcessed = 0;
+  let perfMetricRunsProcessed = 0;
   let logParseRunsProcessed = 0;
   await mapConcurrent(
     [...jobsByRun],
@@ -449,6 +452,24 @@ async function main() {
     async ({ run, jobs }) => {
       try {
         const artifacts = await fetchArtifactsForRun(run.id);
+        const perfMetricsArtifact = artifacts.find(
+          (a) => a.name === PERF_METRICS_ARTIFACT_NAME && !a.expired,
+        );
+        if (perfMetricsArtifact) {
+          const metrics = await downloadAndParsePerfMetrics(
+            perfMetricsArtifact.id,
+          );
+          if (metrics) {
+            for (const [name, sample] of metrics) {
+              if (name.startsWith("test:") || name.startsWith("subtest:")) {
+                addSample(timelines, name, sample);
+              }
+            }
+            perfMetricRunsProcessed++;
+            return;
+          }
+        }
+
         const timingArtifacts = artifacts.filter(
           (a) => a.name.startsWith("test-timing-") && !a.expired,
         );
@@ -504,7 +525,7 @@ async function main() {
   );
 
   console.log(
-    `Processed ${timelines.size} metrics across ${runs.length} runs (${artifactRunsProcessed} with JUnit artifacts, ${logParseRunsProcessed} via log parsing).`,
+    `Processed ${timelines.size} metrics across ${runs.length} runs (${perfMetricRunsProcessed} with perf metrics, ${artifactRunsProcessed} with JUnit artifacts, ${logParseRunsProcessed} via log parsing).`,
   );
 
   // Fetch benchmark results from the Benchmarks workflow

--- a/tasks/perf-regression.ts
+++ b/tasks/perf-regression.ts
@@ -460,13 +460,17 @@ async function main() {
             perfMetricsArtifact.id,
           );
           if (metrics) {
+            let hasTestMetrics = false;
             for (const [name, sample] of metrics) {
               if (name.startsWith("test:") || name.startsWith("subtest:")) {
+                hasTestMetrics = true;
                 addSample(timelines, name, sample);
               }
             }
-            perfMetricRunsProcessed++;
-            return;
+            if (hasTestMetrics) {
+              perfMetricRunsProcessed++;
+              return;
+            }
           }
         }
 


### PR DESCRIPTION
## Summary
- write a consolidated perf-metrics.json artifact from the Performance Check job
- prefer perf-metrics artifacts for baseline reads, with fallback to legacy timing artifacts
- backfill legacy fallback results into perf-metrics-backfill artifacts for later runs
- teach the scheduled perf regression job to use perf-metrics when available

## Validation
- deno test -A tasks/perf-lib.test.ts
- deno check tasks/perf-lib.ts tasks/perf-check.ts tasks/perf-regression.ts
- deno fmt --check tasks/perf-lib.ts tasks/perf-check.ts tasks/perf-regression.ts tasks/perf-lib.test.ts .github/workflows/deno.yml
- deno task check
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit a single `perf-metrics.json` artifact and use it across perf checks and regression for consistent metrics. Backfill legacy timing data so future runs can read perf metrics even when older runs lacked them.

- **New Features**
  - Performance Check writes `perf-metrics.json` and `perf-metrics-backfill.json`, uploaded as `perf-metrics` and `perf-metrics-backfill` via `actions/upload-artifact@v4` (90-day retention).
  - Baseline building prefers `perf-metrics`; otherwise loads `perf-metrics-backfill` from recent runs, then falls back to legacy JUnit timings and emits new backfill. Reads PR overrides from the pull_request event payload (API lookup as fallback).
  - Scheduled perf regression prefers `perf-metrics` for test/subtest timings, with JUnit and log parsing as fallbacks; backfilled metrics are consumed automatically.
  - Added typed serializers/parsers and artifact download helpers, plus round-trip tests for both files.

- **Bug Fixes**
  - Hardened against GitHub rate limits: use event payload to reduce API calls; if rate-limited, write `perf-metrics.json` and skip the check without failing the job.

<sup>Written for commit f7760600d16d4fd7fa270a3991605c419021b43a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

NEW_PERF_BASELINE: step: runner tests = 73s
