### PR TITLE
test(runner): bifurcate `recursivelyAddIDIfNeeded` identity tests by data-model flag

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -222,9 +222,6 @@ export type IsThisArray =
 export interface IAnyCell<T> {}
 
 /**
- * Readable cells can retrieve their current value.
- */
-/**
  * Readable cells provide a view onto stored data.
  *
  * **Frozenness contract (modern data model only):** `get()` and `sample()`

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -224,12 +224,35 @@ export interface IAnyCell<T> {}
 /**
  * Readable cells can retrieve their current value.
  */
+/**
+ * Readable cells provide a view onto stored data.
+ *
+ * **Frozenness contract (modern data model only):** `get()` and `sample()`
+ * return a JS Proxy over the stored value. Writes through the proxy are
+ * rejected with a "read-only" runtime error under both flag states (this
+ * is independent of the data-model flag — the proxy itself enforces
+ * non-mutation). Under `modernDataModel: true`, the underlying stored
+ * data is additionally a deep-frozen `FabricValue` tree, so callers that
+ * escape the proxy (e.g. via `getRaw()`) see frozen data without an
+ * extra clone. Under `modernDataModel: false` (legacy), only the proxy
+ * trap protects against mutation; the underlying data may be unfrozen.
+ *
+ * Note: `Object.isFrozen(proxy)` reports `false` regardless of the
+ * underlying state — that's a property of how JS Proxy reports
+ * extensibility, not a statement about mutability.
+ */
 export interface IReadable<T> {
+  /**
+   * Read the cell's current value as a Proxy view. See the
+   * {@link IReadable} interface docs for the modern-mode frozenness
+   * contract.
+   */
   get(options?: { traverseCells?: boolean }): Readonly<StripDefaultBrand<T>>;
   /**
    * Read the cell's current value without creating a reactive dependency.
    * Unlike `get()`, calling `sample()` inside a lift won't cause the lift
-   * to re-run when this cell's value changes.
+   * to re-run when this cell's value changes. The same frozenness
+   * contract from {@link IReadable} applies.
    */
   sample(): Readonly<StripDefaultBrand<T>>;
 }

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -236,13 +236,36 @@ export interface IReadable<T> {
 
 /**
  * Writable cells can update their value.
+ *
+ * **Frozenness contract (modern data model only):** Values passed into
+ * `set()`, `update()`, and `push()` flow through a write-boundary
+ * normalization step that — under `modernDataModel: true` — shallowly
+ * freezes any plain unfrozen Object/Array levels it visits. Inputs that
+ * are already deep-frozen valid `FabricValue` trees are accepted
+ * identity-preservingly with no further cloning. Under
+ * `modernDataModel: false` (legacy), no freezing happens at the write
+ * boundary; storage handles its own frozenness invariants on commit.
  */
 export interface IWritable<T, C extends AnyBrandedCell<any>> {
+  /**
+   * Set the cell's value. See the {@link IWritable} interface docs for
+   * the modern-mode frozenness contract on the input.
+   */
   set(value: T | AnyCellWrapping<T>): C;
+  /**
+   * Merge a partial object value into the cell. Implemented as a
+   * per-key `set()`, so the same frozenness contract applies. See
+   * {@link IWritable}.
+   */
   update<V extends (Partial<T> | AnyCellWrapping<Partial<T>>)>(
     this: IsThisObject,
     values: V extends object ? AnyCellWrapping<V> : never,
   ): C;
+  /**
+   * Append one or more values to an array cell. See the
+   * {@link IWritable} interface docs for the modern-mode frozenness
+   * contract on the inputs.
+   */
   push(
     this: IsThisArray,
     ...value: T extends (infer U)[] ? (U | AnyCellWrapping<U>)[] : never

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1378,10 +1378,27 @@ export class CellImpl<T extends FabricValue>
     }) as SigilWriteRedirectLink;
   }
 
+  /**
+   * Read the cell's value at the fabric layer (no native unwrapping, no
+   * Proxy wrapping). By default returns a deep-frozen `FabricValue`
+   * snapshot; pass `{ frozen: false }` for a mutable deep copy.
+   *
+   * **Frozenness contract:** Defaults to `{ frozen: true }` regardless
+   * of the data-model flag, returning a deep-frozen `FabricValue`
+   * snapshot via `cloneIfNecessary()`. Under `modernDataModel: true`
+   * the underlying storage already holds a deep-frozen tree, so the
+   * clone is typically a no-op. Under `modernDataModel: false` (legacy)
+   * the snapshot is freshly frozen at read time. The `{ frozen: false }`
+   * variant returns a fresh mutable deep copy and never aliases storage
+   * state.
+   */
   getRaw(options?: IReadOptions): Immutable<T> | undefined {
     return this.getRawUntyped(options) as Immutable<T> | undefined;
   }
 
+  /**
+   * Untyped variant of `getRaw()`; same frozenness contract.
+   */
   getRawUntyped(
     options?: IReadOptions & { frozen?: true },
   ): Immutable<FabricValue>;
@@ -2201,6 +2218,10 @@ export function recursivelyAddIDIfNeeded<T>(
   // Can't add IDs without frame.
   if (!frame) return value;
 
+  // Snapshot the modern-data-model flag once; used below at the freshly-
+  // built-container freeze points.
+  const modern = getDataModelConfig();
+
   // Already seen, return previously annotated result. Check this before
   // shallowFabricFromNativeValue() to handle circular references properly.
   if (seen.has(value)) return seen.get(value) as T;
@@ -2272,7 +2293,7 @@ export function recursivelyAddIDIfNeeded<T>(
         const withId = { [ID]: frame.generatedIdCounter++, ...v };
         // Under modern, the ID-wrapped object is a freshly-built
         // container that must also be deep-frozen.
-        if (getDataModelConfig()) Object.freeze(withId);
+        if (modern) Object.freeze(withId);
         result[i] = withId;
       } else {
         if (!Object.is(v, el)) {
@@ -2291,7 +2312,7 @@ export function recursivelyAddIDIfNeeded<T>(
     // expects deep-frozen `FabricValue` trees. Children are already frozen
     // by `shallowFabricFromNativeValue()` above; freeze the freshly-built
     // top-level container so the returned tree is deep-frozen as a whole.
-    if (getDataModelConfig()) Object.freeze(result);
+    if (modern) Object.freeze(result);
     return result as T;
   } else {
     // At this point we know `value` is a non-array record (we returned early
@@ -2325,7 +2346,7 @@ export function recursivelyAddIDIfNeeded<T>(
     }
 
     // See array-branch comment above re: modern freeze.
-    if (getDataModelConfig()) Object.freeze(result);
+    if (modern) Object.freeze(result);
     return result as T;
   }
 }

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -2173,6 +2173,18 @@ function validateStaticData(value: unknown): void {
  * This ensures that mutable arrays only consist of links to documents, at least
  * when written to only via .set, .update and .push above.
  *
+ * **Frozenness contract (modern data model only):** This function sits at
+ * the write boundary into runner/memory storage. Under
+ * `modernDataModel: true`, the shallow fabric conversion that happens
+ * here additionally produces frozen shallow clones for any plain
+ * unfrozen Object/Array level it visits — so the returned tree's
+ * already-processed sub-trees are deep-frozen `FabricValue`s. If the
+ * input is already a deep-frozen valid `FabricValue`, the shallow
+ * conversion returns it as-is and reference identity is preserved
+ * end-to-end. Under `modernDataModel: false` (legacy), no freezing
+ * happens here at all and the legacy "preserve identity when there's
+ * nothing to do" optimization applies regardless of input frozenness.
+ *
  * TODO(seefeld): When an array has default entries and is rewritten as [...old,
  * new], this will still break, because the previous entries will point back to
  * the array itself instead of being new entries.

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -9,6 +9,7 @@ import {
   DECONSTRUCT,
   FabricInstance,
   type FabricValue,
+  getDataModelConfig,
   isArrayIndexPropertyName,
   shallowFabricFromNativeValue,
 } from "@commonfabric/data-model/fabric-value";
@@ -2175,15 +2176,15 @@ function validateStaticData(value: unknown): void {
  *
  * **Frozenness contract (modern data model only):** This function sits at
  * the write boundary into runner/memory storage. Under
- * `modernDataModel: true`, the shallow fabric conversion that happens
- * here additionally produces frozen shallow clones for any plain
- * unfrozen Object/Array level it visits — so the returned tree's
- * already-processed sub-trees are deep-frozen `FabricValue`s. If the
- * input is already a deep-frozen valid `FabricValue`, the shallow
- * conversion returns it as-is and reference identity is preserved
- * end-to-end. Under `modernDataModel: false` (legacy), no freezing
- * happens here at all and the legacy "preserve identity when there's
- * nothing to do" optimization applies regardless of input frozenness.
+ * `modernDataModel: true`, the returned tree is always a valid
+ * deep-frozen `FabricValue`: the shallow fabric conversion freezes the
+ * sub-trees it visits, and the function freezes the freshly-built
+ * top-level container before returning. If the input is already a
+ * deep-frozen valid `FabricValue`, the shallow conversion returns it
+ * as-is and reference identity is preserved end-to-end. Under
+ * `modernDataModel: false` (legacy), no freezing happens here at all
+ * and the legacy "preserve identity when there's nothing to do"
+ * optimization applies regardless of input frozenness.
  *
  * TODO(seefeld): When an array has default entries and is rewritten as [...old,
  * new], this will still break, because the previous entries will point back to
@@ -2268,7 +2269,11 @@ export function recursivelyAddIDIfNeeded<T>(
         isObject(v) && !isCellLink(v) && !(ID in v)
       ) {
         changed = true;
-        result[i] = { [ID]: frame.generatedIdCounter++, ...v };
+        const withId = { [ID]: frame.generatedIdCounter++, ...v };
+        // Under modern, the ID-wrapped object is a freshly-built
+        // container that must also be deep-frozen.
+        if (getDataModelConfig()) Object.freeze(withId);
+        result[i] = withId;
       } else {
         if (!Object.is(v, el)) {
           changed = true;
@@ -2282,6 +2287,11 @@ export function recursivelyAddIDIfNeeded<T>(
       return value;
     }
 
+    // Under the modern data model, the value enters a write-boundary that
+    // expects deep-frozen `FabricValue` trees. Children are already frozen
+    // by `shallowFabricFromNativeValue()` above; freeze the freshly-built
+    // top-level container so the returned tree is deep-frozen as a whole.
+    if (getDataModelConfig()) Object.freeze(result);
     return result as T;
   } else {
     // At this point we know `value` is a non-array record (we returned early
@@ -2314,6 +2324,8 @@ export function recursivelyAddIDIfNeeded<T>(
       return value;
     }
 
+    // See array-branch comment above re: modern freeze.
+    if (getDataModelConfig()) Object.freeze(result);
     return result as T;
   }
 }

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -120,6 +120,20 @@ const arrayMethods: { [key: string]: ArrayMethodType } = {
   toLocaleString: ArrayMethodType.ReadOnly,
 };
 
+/**
+ * Builds a JS proxy view over a stored cell. Read traps resolve links
+ * and wrap nested values; write-side array mutators (`push`, `splice`,
+ * `unshift`, etc.) route through the same write-boundary normalization
+ * as `Cell.set()` / `Cell.push()`.
+ *
+ * **Frozenness contract (modern data model only):** Values handed to
+ * the write-side array mutators flow through `recursivelyAddIDIfNeeded`
+ * and so inherit its modern-mode contract: plain unfrozen Object/Array
+ * inputs get shallowly frozen at each visited level; already-deep-
+ * frozen valid `FabricValue` inputs are accepted identity-preservingly.
+ * Under `modernDataModel: false` (legacy), no freezing happens at the
+ * write boundary.
+ */
 export function createQueryResultProxy<T>(
   runtime: Runtime,
   tx: IExtendedStorageTransaction | undefined,

--- a/packages/runner/test/cell-core.test.ts
+++ b/packages/runner/test/cell-core.test.ts
@@ -8,6 +8,10 @@ import "@commonfabric/utils/equal-ignoring-symbols";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import type { FabricValue } from "@commonfabric/memory/interface";
+import {
+  getDataModelConfig,
+  setDataModelConfig,
+} from "@commonfabric/data-model/fabric-value";
 import { isCell, recursivelyAddIDIfNeeded } from "../src/cell.ts";
 import { LINK_V1_TAG } from "../src/sigil-types.ts";
 import { isCellResult } from "../src/query-result-proxy.ts";
@@ -366,45 +370,127 @@ describe("Cell", () => {
     await sm.close();
   });
 
-  it("preserves identity when recursivelyAddIDIfNeeded has nothing to do", () => {
-    const frame: Frame = {
-      generatedIdCounter: 0,
-      opaqueRefs: new Set(),
-    };
-    const interests = ["coding", "reading"];
-    const value = {
-      firstName: "Ada",
-      lastName: "Lovelace",
-      interests,
-      stable: { nested: true },
-    };
+  // `recursivelyAddIDIfNeeded()` has a legacy "preserve reference identity
+  // when there's nothing to do" optimization. Under the modern data model
+  // (`modernDataModel: true`), every conversion step produces a frozen
+  // shallow clone, so reference identity inherently isn't preserved — the
+  // result is structurally equal but a fresh deep-frozen tree. These two
+  // pairs of tests pin the legacy invariant explicitly and assert the
+  // modern shape separately. (Direct unit tests of
+  // `recursivelyAddIDIfNeeded` don't go through a `Runtime`, so flag
+  // control happens via `setDataModelConfig()` rather than runtime
+  // construction.)
 
-    const result = recursivelyAddIDIfNeeded(value, frame);
+  it("preserves identity when recursivelyAddIDIfNeeded has nothing to do (legacy)", () => {
+    const savedFlag = getDataModelConfig();
+    setDataModelConfig(false);
+    try {
+      const frame: Frame = {
+        generatedIdCounter: 0,
+        opaqueRefs: new Set(),
+      };
+      const interests = ["coding", "reading"];
+      const value = {
+        firstName: "Ada",
+        lastName: "Lovelace",
+        interests,
+        stable: { nested: true },
+      };
 
-    expect(result).toBe(value);
-    expect(result.interests).toBe(interests);
-    expect(result.stable).toBe(value.stable);
+      const result = recursivelyAddIDIfNeeded(value, frame);
+
+      expect(result).toBe(value);
+      expect(result.interests).toBe(interests);
+      expect(result.stable).toBe(value.stable);
+    } finally {
+      setDataModelConfig(savedFlag);
+    }
   });
 
-  it("only clones branches that need generated IDs", () => {
-    const frame: Frame = {
-      generatedIdCounter: 0,
-      opaqueRefs: new Set(),
-    };
-    const stable = { nested: true };
-    const value = {
-      stable,
-      list: [{ name: "Ada" }, "plain"],
-    };
+  it("returns a structural copy when recursivelyAddIDIfNeeded has nothing to do (modern)", () => {
+    const savedFlag = getDataModelConfig();
+    setDataModelConfig(true);
+    try {
+      const frame: Frame = {
+        generatedIdCounter: 0,
+        opaqueRefs: new Set(),
+      };
+      const interests = ["coding", "reading"];
+      const value = {
+        firstName: "Ada",
+        lastName: "Lovelace",
+        interests,
+        stable: { nested: true },
+      };
 
-    const result = recursivelyAddIDIfNeeded(value, frame) as typeof value;
+      const result = recursivelyAddIDIfNeeded(value, frame);
 
-    expect(result).not.toBe(value);
-    expect(result.stable).toBe(stable);
-    expect(result.list).not.toBe(value.list);
-    expect(result.list[0]).not.toBe(value.list[0]);
-    expect((result.list[0] as Record<PropertyKey, unknown>)[ID]).toBe(0);
-    expect(result.list[1]).toBe(value.list[1]);
+      // Modern: shallow fabric conversion at each level produces fresh
+      // (frozen) sub-trees, so the legacy "preserve identity when nothing
+      // to do" optimization no longer applies. The function still returns
+      // a structurally equivalent value.
+      expect(result).not.toBe(value);
+      expect(result).toEqual(value);
+    } finally {
+      setDataModelConfig(savedFlag);
+    }
+  });
+
+  it("only clones branches that need generated IDs (legacy)", () => {
+    const savedFlag = getDataModelConfig();
+    setDataModelConfig(false);
+    try {
+      const frame: Frame = {
+        generatedIdCounter: 0,
+        opaqueRefs: new Set(),
+      };
+      const stable = { nested: true };
+      const value = {
+        stable,
+        list: [{ name: "Ada" }, "plain"],
+      };
+
+      const result = recursivelyAddIDIfNeeded(value, frame) as typeof value;
+
+      expect(result).not.toBe(value);
+      expect(result.stable).toBe(stable);
+      expect(result.list).not.toBe(value.list);
+      expect(result.list[0]).not.toBe(value.list[0]);
+      expect((result.list[0] as Record<PropertyKey, unknown>)[ID]).toBe(0);
+      expect(result.list[1]).toBe(value.list[1]);
+    } finally {
+      setDataModelConfig(savedFlag);
+    }
+  });
+
+  it("adds generated IDs to objects in arrays regardless of clone depth (modern)", () => {
+    const savedFlag = getDataModelConfig();
+    setDataModelConfig(true);
+    try {
+      const frame: Frame = {
+        generatedIdCounter: 0,
+        opaqueRefs: new Set(),
+      };
+      const stable = { nested: true };
+      const value = {
+        stable,
+        list: [{ name: "Ada" }, "plain"],
+      };
+
+      const result = recursivelyAddIDIfNeeded(value, frame) as typeof value;
+
+      // Modern: shallow fabric conversion clones at each level, so no
+      // sub-branch is reference-preserved. The core invariants that
+      // remain: ID assignment for objects-in-arrays still fires, and
+      // primitive list elements still pass through unchanged.
+      expect(result).not.toBe(value);
+      expect(result.stable).not.toBe(stable);
+      expect(result.stable).toEqual(stable);
+      expect((result.list[0] as Record<PropertyKey, unknown>)[ID]).toBe(0);
+      expect(result.list[1]).toBe("plain");
+    } finally {
+      setDataModelConfig(savedFlag);
+    }
   });
 
   it("should preserve holes and add IDs to objects in sparse arrays", () => {

--- a/packages/runner/test/cell-core.test.ts
+++ b/packages/runner/test/cell-core.test.ts
@@ -372,14 +372,17 @@ describe("Cell", () => {
 
   // `recursivelyAddIDIfNeeded()` has a legacy "preserve reference identity
   // when there's nothing to do" optimization. Under the modern data model
-  // (`modernDataModel: true`), every conversion step produces a frozen
-  // shallow clone, so reference identity inherently isn't preserved — the
-  // result is structurally equal but a fresh deep-frozen tree. These two
-  // pairs of tests pin the legacy invariant explicitly and assert the
-  // modern shape separately. (Direct unit tests of
-  // `recursivelyAddIDIfNeeded` don't go through a `Runtime`, so flag
-  // control happens via `setDataModelConfig()` rather than runtime
-  // construction.)
+  // (`modernDataModel: true`), the shallow fabric conversion eagerly
+  // freezes plain unfrozen Object/Array inputs by producing a frozen
+  // shallow clone — so reference identity isn't preserved for unfrozen
+  // inputs even when no IDs need to be generated. However, when the
+  // input is *already* deep-frozen (a valid `FabricValue`), the shallow
+  // conversion returns it as-is, so identity *is* preserved. The pairs
+  // below pin the legacy invariant explicitly and assert the modern
+  // shape (both sides: unfrozen vs. already-frozen) separately. (Direct
+  // unit tests of `recursivelyAddIDIfNeeded` don't go through a
+  // `Runtime`, so flag control happens via `setDataModelConfig()`
+  // rather than runtime construction.)
 
   it("preserves identity when recursivelyAddIDIfNeeded has nothing to do (legacy)", () => {
     const savedFlag = getDataModelConfig();
@@ -407,7 +410,7 @@ describe("Cell", () => {
     }
   });
 
-  it("returns a structural copy when recursivelyAddIDIfNeeded has nothing to do (modern)", () => {
+  it("returns a structural copy when recursivelyAddIDIfNeeded has nothing to do (modern, unfrozen input)", () => {
     const savedFlag = getDataModelConfig();
     setDataModelConfig(true);
     try {
@@ -425,12 +428,44 @@ describe("Cell", () => {
 
       const result = recursivelyAddIDIfNeeded(value, frame);
 
-      // Modern: shallow fabric conversion at each level produces fresh
-      // (frozen) sub-trees, so the legacy "preserve identity when nothing
-      // to do" optimization no longer applies. The function still returns
-      // a structurally equivalent value.
+      // Modern: shallow fabric conversion eagerly freezes unfrozen plain
+      // Object/Array inputs (producing a fresh frozen clone at the level
+      // it visits), so the legacy "preserve identity when nothing to do"
+      // optimization doesn't apply for unfrozen inputs. The function
+      // still returns a structurally equivalent value.
       expect(result).not.toBe(value);
       expect(result).toEqual(value);
+    } finally {
+      setDataModelConfig(savedFlag);
+    }
+  });
+
+  it("preserves identity when input is already deep-frozen (modern)", () => {
+    const savedFlag = getDataModelConfig();
+    setDataModelConfig(true);
+    try {
+      const frame: Frame = {
+        generatedIdCounter: 0,
+        opaqueRefs: new Set(),
+      };
+      // Deep-freeze before passing in. Under modern, an already-frozen
+      // plain Object/Array is a valid `FabricValue` and shallow fabric
+      // conversion returns it as-is, so reference identity survives all
+      // the way out.
+      const interests = Object.freeze(["coding", "reading"]);
+      const stable = Object.freeze({ nested: true });
+      const value = Object.freeze({
+        firstName: "Ada",
+        lastName: "Lovelace",
+        interests,
+        stable,
+      });
+
+      const result = recursivelyAddIDIfNeeded(value, frame);
+
+      expect(result).toBe(value);
+      expect(result.interests).toBe(interests);
+      expect(result.stable).toBe(stable);
     } finally {
       setDataModelConfig(savedFlag);
     }

--- a/packages/runner/test/cell-core.test.ts
+++ b/packages/runner/test/cell-core.test.ts
@@ -372,15 +372,15 @@ describe("Cell", () => {
 
   // `recursivelyAddIDIfNeeded()` has a legacy "preserve reference identity
   // when there's nothing to do" optimization. Under the modern data model
-  // (`modernDataModel: true`), the shallow fabric conversion eagerly
-  // freezes plain unfrozen Object/Array inputs by producing a frozen
-  // shallow clone — so reference identity isn't preserved for unfrozen
-  // inputs even when no IDs need to be generated. However, when the
-  // input is *already* deep-frozen (a valid `FabricValue`), the shallow
-  // conversion returns it as-is, so identity *is* preserved. The pairs
-  // below pin the legacy invariant explicitly and assert the modern
-  // shape (both sides: unfrozen vs. already-frozen) separately. (Direct
-  // unit tests of `recursivelyAddIDIfNeeded` don't go through a
+  // (`modernDataModel: true`), the function instead guarantees a
+  // deep-frozen `FabricValue` result for unfrozen inputs: shallow fabric
+  // conversion freezes the visited sub-trees and the function freezes
+  // the freshly-built top-level container. However, when the input is
+  // *already* deep-frozen (a valid `FabricValue`), the shallow
+  // conversion returns it as-is, so identity *is* preserved end-to-end.
+  // The pairs below pin the legacy invariant explicitly and assert the
+  // modern shape (both sides: unfrozen vs. already-frozen) separately.
+  // (Direct unit tests of `recursivelyAddIDIfNeeded` don't go through a
   // `Runtime`, so flag control happens via `setDataModelConfig()`
   // rather than runtime construction.)
 
@@ -410,7 +410,7 @@ describe("Cell", () => {
     }
   });
 
-  it("returns a structural copy when recursivelyAddIDIfNeeded has nothing to do (modern, unfrozen input)", () => {
+  it("returns a deep-frozen structural copy when recursivelyAddIDIfNeeded has nothing to do (modern, unfrozen input)", () => {
     const savedFlag = getDataModelConfig();
     setDataModelConfig(true);
     try {
@@ -428,13 +428,15 @@ describe("Cell", () => {
 
       const result = recursivelyAddIDIfNeeded(value, frame);
 
-      // Modern: shallow fabric conversion eagerly freezes unfrozen plain
-      // Object/Array inputs (producing a fresh frozen clone at the level
-      // it visits), so the legacy "preserve identity when nothing to do"
-      // optimization doesn't apply for unfrozen inputs. The function
-      // still returns a structurally equivalent value.
+      // Modern: the legacy "preserve identity when nothing to do"
+      // optimization doesn't apply for unfrozen inputs. Instead the
+      // function returns a structurally equivalent, deep-frozen tree
+      // (top-level included).
       expect(result).not.toBe(value);
       expect(result).toEqual(value);
+      expect(Object.isFrozen(result)).toBe(true);
+      expect(Object.isFrozen(result.interests)).toBe(true);
+      expect(Object.isFrozen(result.stable)).toBe(true);
     } finally {
       setDataModelConfig(savedFlag);
     }
@@ -517,12 +519,16 @@ describe("Cell", () => {
       // Modern: shallow fabric conversion clones at each level, so no
       // sub-branch is reference-preserved. The core invariants that
       // remain: ID assignment for objects-in-arrays still fires, and
-      // primitive list elements still pass through unchanged.
+      // primitive list elements still pass through unchanged. The
+      // returned tree is deep-frozen as a whole (top-level + sub-trees).
       expect(result).not.toBe(value);
       expect(result.stable).not.toBe(stable);
       expect(result.stable).toEqual(stable);
       expect((result.list[0] as Record<PropertyKey, unknown>)[ID]).toBe(0);
       expect(result.list[1]).toBe("plain");
+      expect(Object.isFrozen(result)).toBe(true);
+      expect(Object.isFrozen(result.list)).toBe(true);
+      expect(Object.isFrozen(result.list[0])).toBe(true);
     } finally {
       setDataModelConfig(savedFlag);
     }


### PR DESCRIPTION
## Summary

Prep PR for the modern-data-model flag flip (PR #3569).

Two `cell-core.test.ts` tests assert reference-equality contracts that
only hold under legacy:

* `preserves identity when recursivelyAddIDIfNeeded has nothing to do`
* `only clones branches that need generated IDs`

Under `modernDataModel: true`, each level of `recursivelyAddIDIfNeeded`
calls `shallowFabricFromNativeValue()`, which produces a fresh frozen
shallow clone — so reference identity isn't preserved at any depth even
when no IDs need to be generated. The structural output is still equal
and the ID-assignment / primitive-passthrough invariants still hold.

Bifurcated each into `(legacy)` and `(modern)` variants pinned via
`setDataModelConfig()` with save/restore (these tests call
`recursivelyAddIDIfNeeded` as a unit-level function without going
through a `Runtime`, so flag control happens directly rather than via
runtime construction). Modern variants drop the reference-equality
assertions and assert the contracts that remain. Added a complementary
modern test that asserts the inverse: when the input is *already*
deep-frozen (a valid `FabricValue`), the shallow conversion returns it
as-is and reference identity *is* preserved end-to-end.

### Small non-test runtime change

While documenting the frozenness contract on the modern path, it
became clear `recursivelyAddIDIfNeeded()` was producing a
*partially* deep-frozen tree under modern — the visited sub-trees
were frozen (from shallow fabric conversion), but the freshly-built
top-level container and the ID-wrapped objects inside arrays were
unfrozen. The function sits at the write boundary into runner/memory
storage, where the contract is "modern values are deep-frozen
`FabricValue`s." Tightened the implementation to freeze those built
containers under modern; legacy is unchanged. Adjusted the modern
test titles and assertions to verify the now-complete deep-freeze
guarantee.

### Doc comments

Added doc comments documenting the modern-mode frozenness contract on:

* `recursivelyAddIDIfNeeded()` in `packages/runner/src/cell.ts`
* `IWritable` (and `set`/`update`/`push`) in `packages/api/index.ts`
* `createQueryResultProxy()` in `packages/runner/src/query-result-proxy.ts`

All caveat the contract with "modern data model only"; the legacy state
is noted.

## Triage context

I looked at the three failure categories the user flagged as
"probable test bugs" (cell-core identity tests, `toCell` circular,
`generateObject` InjectionSafe labels). Only the cell-core identity
tests turned out to be test bugs; the others are real bugs and remain
on the flag-flip branch for follow-up:

* `should translate circular references into links` (×2) — `RangeError:
  Maximum call stack size exceeded` in `recursivelyAddIDIfNeeded`. The
  identity-based caching no longer breaks cycles because modern shallow
  conversion always produces a new object, so cycles never hit the
  `seen` check on the original input. **Real bug.**
* `toCell ... should handle circular references gracefully` — same
  root cause as above. **Real bug.**
* `generateObject ... writes InjectionSafe labels only for
  instruction-inert result paths` — actual label arrays contain
  duplicated entries (`InjectionSafe` doubled, multiple identical
  `prompt-influence` Caveats), suggesting label normalization isn't
  deduping under the modern conversion path. **Real bug.**

Left for follow-up PRs.

## Test plan

- [x] `cd packages/runner && deno task test` passes under
  `modernDataModelEnabled = false` (main today) — 417 passed
- [x] Under `modernDataModelEnabled = true` (flag-flip branch state),
  the 5 bifurcated tests all pass; only the 5 real bugs above remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
