### PR TITLE
fix(ts-transformers): lower property access in module-extracted callbacks (CT-1587)

### DIFF
--- a/packages/ts-transformers/src/ast/call-kind.ts
+++ b/packages/ts-transformers/src/ast/call-kind.ts
@@ -75,8 +75,8 @@ const CELL_FACTORY_NAMES = new Set(["of"]);
 const CELL_FOR_NAMES = new Set(["for"]);
 const COMMONFABRIC_CALL_NAMES = COMMONFABRIC_CALL_EXPORT_NAMES;
 const WILDCARD_OBJECT_METHOD_NAMES = new Set(["keys", "values", "entries"]);
-const SYNTHETIC_MODULE_CALLBACK_PREFIX = "__cfModuleCallback";
-const FUNCTION_HARDENING_HELPER_PREFIX = "__cfHardenFn";
+export const SYNTHETIC_MODULE_CALLBACK_PREFIX = "__cfModuleCallback";
+export const FUNCTION_HARDENING_HELPER_PREFIX = "__cfHardenFn";
 
 export type ArrayMethodFamilyName = "map" | "filter" | "flatMap";
 

--- a/packages/ts-transformers/src/ast/mod.ts
+++ b/packages/ts-transformers/src/ast/mod.ts
@@ -16,6 +16,7 @@ export {
   classifyWildcardTraversalCall,
   detectCallKind,
   detectDirectBuilderCall,
+  FUNCTION_HARDENING_HELPER_PREFIX,
   getCapabilitySummaryCallbackArgument,
   getDeriveInputAndCallbackArgument,
   getLoweredArrayMethodName,
@@ -28,6 +29,7 @@ export {
   isReactiveValueSymbol,
   isSimpleReactiveAccessExpression,
   isWildcardTraversalCall,
+  SYNTHETIC_MODULE_CALLBACK_PREFIX,
 } from "./call-kind.ts";
 export * from "./dataflow.ts";
 export {

--- a/packages/ts-transformers/src/transformers/pattern-callback-lowering.ts
+++ b/packages/ts-transformers/src/transformers/pattern-callback-lowering.ts
@@ -1,8 +1,10 @@
 import ts from "typescript";
 import {
   classifyArrayMethodCall,
+  FUNCTION_HARDENING_HELPER_PREFIX,
   getCapabilitySummaryCallbackArgument,
   getPatternBuilderCallbackArgument,
+  SYNTHETIC_MODULE_CALLBACK_PREFIX,
   visitEachChildWithJsx,
 } from "../ast/mod.ts";
 import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
@@ -14,6 +16,8 @@ import {
   addBindingTargetSymbols,
   isOpaqueSourceExpression,
 } from "./opaque-roots.ts";
+import { rewritePatternCallbackBody } from "./pattern-body-reactive-root-lowering.ts";
+import { unwrapExpression } from "../utils/expression.ts";
 
 interface PatternScopeInfo {
   opaqueNames: Set<string>;
@@ -244,10 +248,143 @@ export class PatternCallbackLoweringTransformer extends HelpersOnlyTransformer {
       return visitedNode;
     };
 
-    return visitEachChildWithJsx(
+    const mainPass = visitEachChildWithJsx(
       context.sourceFile,
       visit,
       context.tsContext,
     ) as ts.SourceFile;
+
+    // ── Module-extracted callback post-pass ────────────────────────────
+    // ClosureTransformer hoists reactive callback bodies (from
+    // `computed(...)`, `derive(...)`, etc.) into top-level
+    // `const __cfModuleCallback_N = (() => { ... })` declarations. The
+    // main pass above only walks INSIDE pattern callbacks, so those
+    // module-level bodies never receive the reactive-root lowering pass
+    // and end up with shapes like `const foo = wish(...).result!` un-
+    // lowered. Walk them now with empty pattern-scope, applying the
+    // same body rewrite the inline case gets.
+    return rewriteModuleExtractedCallbackBodies(mainPass, context);
   }
+}
+
+function rewriteModuleExtractedCallbackBodies(
+  sourceFile: ts.SourceFile,
+  context: TransformationContext,
+): ts.SourceFile {
+  const { factory } = context;
+  let changed = false;
+  const newStatements = sourceFile.statements.map((statement) => {
+    if (!ts.isVariableStatement(statement)) return statement;
+    if ((statement.declarationList.flags & ts.NodeFlags.Const) === 0) {
+      return statement;
+    }
+    let declChanged = false;
+    const newDeclarations = statement.declarationList.declarations.map(
+      (declaration) => {
+        if (
+          !ts.isIdentifier(declaration.name) ||
+          !declaration.name.text.startsWith(SYNTHETIC_MODULE_CALLBACK_PREFIX) ||
+          !declaration.initializer
+        ) {
+          return declaration;
+        }
+        const updated = rewriteModuleCallbackInitializer(
+          declaration.initializer,
+          context,
+        );
+        if (updated === declaration.initializer) return declaration;
+        declChanged = true;
+        return factory.updateVariableDeclaration(
+          declaration,
+          declaration.name,
+          declaration.exclamationToken,
+          declaration.type,
+          updated,
+        );
+      },
+    );
+    if (!declChanged) return statement;
+    changed = true;
+    return factory.updateVariableStatement(
+      statement,
+      statement.modifiers,
+      factory.updateVariableDeclarationList(
+        statement.declarationList,
+        newDeclarations,
+      ),
+    );
+  });
+  if (!changed) return sourceFile;
+  return factory.updateSourceFile(sourceFile, newStatements);
+}
+
+// Unwrap `__cfHardenFn(<fn>)` if present, walk the underlying function's
+// body with `rewritePatternCallbackBody` (empty pattern scope), and re-wrap
+// when needed. Returns the original initializer if nothing changed.
+function rewriteModuleCallbackInitializer(
+  initializer: ts.Expression,
+  context: TransformationContext,
+): ts.Expression {
+  const { factory } = context;
+  const unwrapped = unwrapExpression(initializer);
+  // Form 1: bare arrow / function expression.
+  if (ts.isArrowFunction(unwrapped) || ts.isFunctionExpression(unwrapped)) {
+    const newFn = rewriteModuleCallbackFunction(unwrapped, context);
+    return newFn === unwrapped ? initializer : newFn;
+  }
+  // Form 2: `__cfHardenFn(<fn>)` wrapper around the function.
+  if (
+    ts.isCallExpression(unwrapped) &&
+    unwrapped.arguments.length === 1 &&
+    ts.isIdentifier(unwrapped.expression) &&
+    unwrapped.expression.text.startsWith(FUNCTION_HARDENING_HELPER_PREFIX)
+  ) {
+    const inner = unwrapped.arguments[0];
+    if (ts.isArrowFunction(inner) || ts.isFunctionExpression(inner)) {
+      const newFn = rewriteModuleCallbackFunction(inner, context);
+      if (newFn === inner) return initializer;
+      return factory.updateCallExpression(
+        unwrapped,
+        unwrapped.expression,
+        unwrapped.typeArguments,
+        [newFn],
+      );
+    }
+  }
+  return initializer;
+}
+
+function rewriteModuleCallbackFunction(
+  fn: ts.ArrowFunction | ts.FunctionExpression,
+  context: TransformationContext,
+): ts.ArrowFunction | ts.FunctionExpression {
+  const newBody = rewritePatternCallbackBody(
+    fn.body,
+    new Set<string>(),
+    new Set<ts.Symbol>(),
+    context,
+  );
+  if (newBody === fn.body) return fn;
+  const { factory } = context;
+  if (ts.isArrowFunction(fn)) {
+    return factory.updateArrowFunction(
+      fn,
+      fn.modifiers,
+      fn.typeParameters,
+      fn.parameters,
+      fn.type,
+      fn.equalsGreaterThanToken,
+      newBody,
+    );
+  }
+  return factory.updateFunctionExpression(
+    fn,
+    fn.modifiers,
+    fn.asteriskToken,
+    fn.name,
+    fn.typeParameters,
+    fn.parameters,
+    fn.type,
+    newBody as ts.Block,
+  );
 }

--- a/packages/ts-transformers/test/fixtures/closures/computed-in-computed-property-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-in-computed-property-access.expected.jsx
@@ -24,7 +24,7 @@ const __cfModuleCallback_1 = __cfHardenFn(() => {
         },
         required: ["bar"]
     } as const satisfies __cfHelpers.JSONSchema, {}, () => ({ bar: 1 })).for("foo", true);
-    return foo.bar;
+    return foo.key("bar");
 });
 // FIXTURE: computed-in-computed-property-access
 // Verifies: property access on a computed() result declared INSIDE another computed()

--- a/packages/ts-transformers/test/fixtures/closures/computed-in-computed-scoped-no-false-rewrite.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-in-computed-scoped-no-false-rewrite.expected.jsx
@@ -26,7 +26,7 @@ const __cfModuleCallback_1 = __cfHardenFn(() => {
             },
             required: ["bar"]
         } as const satisfies __cfHelpers.JSONSchema, {}, () => ({ bar: 1 })).for("config", true);
-        return config.bar;
+        return config.key("bar");
     }
     return config.bar;
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-regains-reactive-aliases.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-regains-reactive-aliases.expected.jsx
@@ -12,14 +12,14 @@ const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const __cfModuleCallback_1 = __cfHardenFn(() => {
-    const foo = wish<Default<string[], [
+    const __cf_destructure_1 = wish<Default<string[], [
     ]>>({ query: "#items" }, {
         type: "array",
         items: {
             type: "string"
         },
         "default": []
-    } as const satisfies __cfHelpers.JSONSchema).result!;
+    } as const satisfies __cfHelpers.JSONSchema), foo = __cf_destructure_1.key("result").for("foo", true);
     return foo.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
         const item = __cf_pattern_input.key("element");
         return item + "!";

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-local-var.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-local-var.expected.jsx
@@ -59,8 +59,8 @@ const __cfModuleCallback_1 = __cfHardenFn(({ language, content }: {
     } as const satisfies __cfHelpers.JSONSchema, {
         type: ["string", "undefined"]
     } as const satisfies __cfHelpers.JSONSchema, { genResult: {
-            pending: genResult.pending,
-            result: genResult.result
+            pending: genResult.key("pending"),
+            result: genResult.key("result")
         } }, ({ genResult }) => {
         if (genResult.pending)
             return undefined;

--- a/packages/ts-transformers/test/validation.test.ts
+++ b/packages/ts-transformers/test/validation.test.ts
@@ -3427,3 +3427,49 @@ Deno.test("Inline reactive-root chain rewrite", async (t) => {
     },
   );
 });
+
+Deno.test("Module-extracted reactive callback bodies (CT-1587)", async (t) => {
+  // ClosureTransformer hoists reactive callback bodies (computed/derive/etc.)
+  // into top-level `const __cfModuleCallback_N = ...` declarations. Those
+  // bodies must still receive the reactive-root lowering pass so chains like
+  // `cell.result` get lowered to `cell.key("result")` — otherwise the access
+  // stays as plain JS and unwraps the cell at runtime.
+  await t.step(
+    "lowers property access on opaque roots inside computed() bodies",
+    async () => {
+      const source = `
+        import { computed, Default, pattern, wish } from "commonfabric";
+
+        export default pattern<Record<string, never>>(() => {
+          const result = computed(() => {
+            const fooWish = wish<Default<string[], []>>({ query: "#items" });
+            const foo = fooWish.result!;
+            return foo[0];
+          });
+          return { result };
+        });
+      `;
+      const { diagnostics, output } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      assertEquals(
+        errors.length,
+        0,
+        `Should produce clean output (got: ${
+          errors.map((e) => e.message).join("; ")
+        })`,
+      );
+      assertStringIncludes(
+        output,
+        'fooWish.key("result")',
+        'fooWish.result! inside computed() should lower to fooWish.key("result")',
+      );
+      assertStringIncludes(
+        output,
+        'foo.key("0")',
+        'foo[0] inside computed() should lower to foo.key("0")',
+      );
+    },
+  );
+});


### PR DESCRIPTION
## Summary

Closes [CT-1587](https://linear.app/common-tools/issue/CT-1587/transformer-nested-computed-callbacks-dont-lower-property-access-on).

`ClosureTransformer` hoists reactive callback bodies (from `computed()`, nested `derive()`, etc.) into top-level `const __cfModuleCallback_N = (() => { ... })` declarations before `PatternCallbackLoweringTransformer` runs. The main pattern-body lowering pass only walks **inside** the pattern callback, so those module-extracted bodies never received the reactive-root lowering. Shapes like `const foo = wish(...).result!` survived un-lowered — at runtime `.result` unwrapped the cell to plain JS, defeating reactivity for any chained access (`foo[0]`, `foo.bar`, etc.).

## Why the existing nested-derive walker missed them

`rewriteNestedDeriveCallbackBodies` resolves the derive call's callback argument through `resolveCallbackFunctionExpression` and IS able to follow `__cfModuleCallback_N` identifiers back to the module-level arrow function. But the walker then tries to substitute the rewritten arrow inline via `args.indexOf(callbackArg)` — which returns `-1` because the resolved arrow isn't structurally one of the call's arguments (the Identifier is). The update silently no-ops.

## Fix

Add a post-pass at the source-file level in `PatternCallbackLoweringTransformer` that finds top-level `__cfModuleCallback_*` declarations, unwraps any `__cfHardenFn(...)` guard, and runs `rewritePatternCallbackBody` on the underlying arrow's body with empty pattern scope. Module-extracted callbacks now receive the same chain-rewrite + opaque-root tracking + nested-derive recursion the inline case gets.

## Fixture updates (4)

- `closures/map-regains-reactive-aliases` — the fixture CT-1587 cites as the visible instance. `const foo = wish(...).result!` now goes through the inline-chain pre-pass and emits as the destructure form with `.for("foo", true)` attached.
- `closures/computed-in-computed-property-access` — `foo.bar` inside a nested `computed()` now correctly lowers to `foo.key("bar")`. The fixture's stated intent (`"Verifies: foo.bar → foo.key(\"bar\")"`) was previously aspirational; the golden now matches.
- `closures/computed-in-computed-scoped-no-false-rewrite` — the inner-scope `config.bar` lowers (`config` is a local OpaqueRef from `computed()`) while the outer-scope `config.bar` stays unchanged (`config` is a module-level plain object). Confirms scope tracking still gates the rewrite correctly.
- `closures/patternTool-local-var` — `genResult.pending` and `genResult.result` inside a `computed()` capture wiring now lower to `.key("pending")` / `.key("result")`.

New test: `Module-extracted reactive callback bodies (CT-1587)` in `test/validation.test.ts` — asserts that property access on opaque roots inside `computed()` bodies lowers to `.key(...)`.

## Test plan

- [x] `deno task test` in `packages/ts-transformers/` — 260/259 tests passing (+1 new behavior-asserting test)
- [x] `cf check --no-run` clean on broad production-pattern sample (chatbot, omnibox-fab, knowledge-graph, summary-index, record-backup, annotation, gmail-importer, chat-note, email-task-engine, etc.)
- [x] 4 fixture goldens updated reflecting the corrected lowering

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CT-1587: property access inside module-extracted reactive callbacks was not lowered, breaking reactivity. Adds a post-pass so hoisted `computed/derive` bodies lower to `.key(...)` like inline callbacks.

- **Bug Fixes**
  - Add a source-file post-pass in `PatternCallbackLoweringTransformer` to rewrite top-level `__cfModuleCallback_*` declarations: unwrap `__cfHardenFn(...)`, run `rewritePatternCallbackBody`, and rewrap if needed.
  - Export `SYNTHETIC_MODULE_CALLBACK_PREFIX` and `FUNCTION_HARDENING_HELPER_PREFIX` from `call-kind.ts` and re-export via `ast/mod.ts` for use in the post-pass.
  - Update 4 fixtures to reflect `.key(...)` lowering and add a validation test ensuring `computed()` bodies correctly lower `foo.result` → `foo.key("result")` and `foo[0]` → `foo.key("0")`.

<sup>Written for commit 634becf5b0b5ef0821d3d4e97bb369bd9ca99054. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

