### PR TITLE
fix(github-actions): fix perf check PR body refresh

### DIFF
--- a/tasks/perf-check.ts
+++ b/tasks/perf-check.ts
@@ -29,8 +29,8 @@ import {
   extractMetrics,
   extractTestFileMetrics,
   fetchArtifactsForRun,
+  fetchCurrentPRBody,
   fetchJobsForRun,
-  fetchPRBody,
   fetchPRForCommit,
   formatMetricValue,
   formatOverrideSuggestion,
@@ -63,16 +63,6 @@ const BASELINE_RUNS = 20;
 
 /** Recent completed workflow runs to scan for fallback backfill artifacts. */
 const BACKFILL_SOURCE_RUNS = 20;
-
-function pullRequestBodyFromEvent(
-  event: object | undefined,
-): string | undefined {
-  const pullRequest =
-    (event as { pull_request?: { body?: unknown } } | undefined)
-      ?.pull_request;
-  if (!pullRequest || !("body" in pullRequest)) return undefined;
-  return typeof pullRequest.body === "string" ? pullRequest.body : "";
-}
 
 function currentWorkflowRunFromEvent(
   event: object | undefined,
@@ -165,19 +155,20 @@ async function main() {
   // 1. Check PR description for overrides, if there's a PR to check.
   let prOverrides;
   if (prNumber) {
-    let prBody = pullRequestBodyFromEvent(event);
-    if (prBody === undefined) {
-      console.log(`Fetching PR #${prNumber} description...`);
-      try {
-        prBody = await fetchPRBody(parseInt(prNumber));
-      } catch (error) {
-        console.warn(`  Warning: could not fetch PR body: ${error}`);
-        prBody = "";
-      }
+    console.log(`Fetching live PR #${prNumber} description...`);
+    const prBody = await fetchCurrentPRBody(parseInt(prNumber), event);
+    if (prBody.source === "live") {
+      console.log("Using live PR description from GitHub API.");
+    } else if (prBody.source === "event-fallback") {
+      console.warn(
+        `  Warning: could not fetch live PR body; using pull_request event payload: ${prBody.errorMessage}`,
+      );
     } else {
-      console.log("Using PR description from pull_request event payload.");
+      console.warn(
+        `  Warning: could not fetch live PR body and no pull_request event body was available: ${prBody.errorMessage}`,
+      );
     }
-    prOverrides = parseBaselineOverrides(prBody);
+    prOverrides = parseBaselineOverrides(prBody.body);
   } else {
     prOverrides = { metrics: new Map() };
   }

--- a/tasks/perf-lib.test.ts
+++ b/tasks/perf-lib.test.ts
@@ -3,6 +3,7 @@ import {
   computeBaseline,
   computeCiWallTimeRevisitSignals,
   extractMetrics,
+  fetchCurrentPRBody,
   fetchPRBody,
   githubGet,
   type Job,
@@ -594,6 +595,50 @@ Deno.test("fetchPRBody reads the live pull request body from the GitHub API", as
     assertEquals(
       requestedUrl,
       "https://api.github.com/repos/commontoolsinc/labs/pulls/3427",
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("fetchCurrentPRBody prefers the live pull request body over stale event payloads", async () => {
+  const originalFetch = globalThis.fetch;
+  try {
+    globalThis.fetch = ((_input, _init) =>
+      Promise.resolve(
+        new Response(JSON.stringify({ body: "LIVE PR BODY" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      )) as typeof fetch;
+
+    const result = await fetchCurrentPRBody(3427, {
+      pull_request: { body: "STALE EVENT BODY" },
+    });
+
+    assertEquals(result, { body: "LIVE PR BODY", source: "live" });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("fetchCurrentPRBody falls back to the event body if the live request fails", async () => {
+  const originalFetch = globalThis.fetch;
+  try {
+    globalThis.fetch = ((_input, _init) =>
+      Promise.resolve(
+        new Response("rate limited", { status: 429 }),
+      )) as typeof fetch;
+
+    const result = await fetchCurrentPRBody(3427, {
+      pull_request: { body: "EVENT BODY" },
+    });
+
+    assertEquals(result.body, "EVENT BODY");
+    assertEquals(result.source, "event-fallback");
+    assertEquals(
+      result.errorMessage?.includes("GitHub API 429:"),
+      true,
     );
   } finally {
     globalThis.fetch = originalFetch;

--- a/tasks/perf-lib.ts
+++ b/tasks/perf-lib.ts
@@ -173,6 +173,12 @@ export interface PRInfo {
   merged_at: string | null;
 }
 
+export interface CurrentPRBody {
+  body: string;
+  source: "live" | "event-fallback" | "empty-fallback";
+  errorMessage?: string;
+}
+
 export interface BaselineOverrides {
   /** Metric name -> value in the metric's native unit (seconds or nanoseconds). */
   metrics: Map<string, number>;
@@ -1319,6 +1325,32 @@ export async function fetchPRBody(prNumber: number): Promise<string> {
     `/repos/${REPO}/pulls/${prNumber}`,
   );
   return pr.body ?? "";
+}
+
+export function pullRequestBodyFromEvent(
+  event: object | undefined,
+): string | undefined {
+  const pullRequest =
+    (event as { pull_request?: { body?: unknown } } | undefined)
+      ?.pull_request;
+  if (!pullRequest || !("body" in pullRequest)) return undefined;
+  return typeof pullRequest.body === "string" ? pullRequest.body : "";
+}
+
+export async function fetchCurrentPRBody(
+  prNumber: number,
+  event: object | undefined,
+): Promise<CurrentPRBody> {
+  try {
+    return { body: await fetchPRBody(prNumber), source: "live" };
+  } catch (error) {
+    const eventBody = pullRequestBodyFromEvent(event);
+    return {
+      body: eventBody ?? "",
+      source: eventBody === undefined ? "empty-fallback" : "event-fallback",
+      errorMessage: error instanceof Error ? error.message : String(error),
+    };
+  }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fetch the current PR description from the GitHub API before parsing `NEW_PERF_BASELINE` overrides.
- Keep the existing pull request event payload as a fallback only when the live fetch fails.
- Add regression coverage proving live PR bodies win over stale event payloads on reruns.

## Root cause

The PR performance check parsed `github.event.pull_request.body` first. On a GitHub Actions rerun, that event payload can remain the original webhook payload, so edits to the PR description were not reliably picked up unless a new workflow run was triggered.

## Validation

- `deno test --allow-net --allow-env --allow-read --allow-run --allow-write tasks/perf-lib.test.ts`
- `deno fmt --check tasks/perf-check.ts tasks/perf-lib.ts tasks/perf-lib.test.ts`
- `deno task check`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale PR body reads in the performance check by fetching the live PR description from the GitHub API on each run. Edits to `NEW_PERF_BASELINE` in the PR body now apply on reruns without requiring a new workflow.

- Bug Fixes
  - Added `fetchCurrentPRBody(prNumber, event)` to prefer the live PR body; falls back to the `pull_request` event body or empty when the API call fails.
  - Updated `perf-check.ts` to use the new helper and log which source was used.
  - Added tests covering live-preferred and event-fallback behavior.

<sup>Written for commit dbc94e1bcbfd43efcca2ebbbc5b02f60f8b9ebc6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

