### PR TITLE
fix(runner): pre-register `seen` for cycles when shallow conversion clones

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -2291,31 +2291,49 @@ export function recursivelyAddIDIfNeeded<T>(
   // - Objects/arrays with toJSON() methods
   // - Sparse arrays (densified with null in holes)
   const converted = shallowFabricFromNativeValue(value);
-  const convertedIsRecord = isRecord(converted);
 
-  // If conversion changed the value, cache the result so shared references
-  // are preserved and we avoid redundant toJSON() calls.
-  if (converted !== value) {
-    const result = convertedIsRecord
-      ? recursivelyAddIDIfNeeded(converted as T, frame, seen)
-      : converted as T;
-    seen.set(value, result);
-    return result;
-  }
-
-  // Primitives that didn't need conversion don't need further processing.
-  if (!convertedIsRecord) {
+  // `FabricInstance` returned by the conversion step (e.g. `FabricError`
+  // wrapping a native `Error`). Same handling as the up-front
+  // `FabricInstance` branch above: record identity, walk via
+  // `[DECONSTRUCT]()` for side effects, return the instance unchanged.
+  if (converted instanceof FabricInstance) {
+    seen.set(value, converted);
+    const state = converted[DECONSTRUCT]();
+    if (isRecord(state) || Array.isArray(state)) {
+      recursivelyAddIDIfNeeded(state, frame, seen);
+    }
     return converted as T;
   }
 
-  if (Array.isArray(value)) {
-    const result = new Array<unknown>(value.length);
-    let changed = false;
+  // Primitives need no further processing. Cache the conversion when it
+  // changed the value (e.g. `-0 → 0`) so callers see consistent results.
+  if (!isRecord(converted)) {
+    if (converted !== value) seen.set(value, converted);
+    return converted as T;
+  }
 
-    // Set before traversing, otherwise we'll infinite recurse.
+  // From here `converted` is an array or record. The result container is
+  // pre-registered in `seen` against the original `value` BEFORE descending
+  // into entries, so circular back-references to `value` resolve correctly
+  // even under modern, where shallow conversion allocates a fresh frozen
+  // clone whose own properties still point at the original (unfrozen)
+  // input. Without this, a cycle would re-enter
+  // `shallowFabricFromNativeValue(value)` on every pass and recurse
+  // forever.
+  const convertedDiffers = converted !== value;
+
+  if (Array.isArray(converted)) {
+    // Typed as `any[]` (not `unknown[]`) to preserve the original code's
+    // looser inference inside the iteration body, where `{...v}` and
+    // `ID in v` operate post-narrowing without explicit casts.
+    const sourceArray = converted as any[];
+    const result = new Array<unknown>(sourceArray.length);
+    let changed = convertedDiffers;
+
     seen.set(value, result);
+    if (convertedDiffers) seen.set(converted, result);
 
-    value.forEach((el, i) => {
+    sourceArray.forEach((el, i) => {
       const v = recursivelyAddIDIfNeeded(el, frame, seen);
       // For objects on arrays only: Add ID if not already present.
       if (
@@ -2347,16 +2365,14 @@ export function recursivelyAddIDIfNeeded<T>(
     if (modern) Object.freeze(result);
     return result as T;
   } else {
-    // At this point we know `value` is a non-array record (we returned early
-    // for primitives and `Array.isArray` was false).
-    const valueRecord = value as Record<string, unknown>;
+    const sourceRecord = converted as Record<string, unknown>;
     const result: Record<string, unknown> = {};
-    let changed = false;
+    let changed = convertedDiffers;
 
-    // Set before traversing, otherwise we'll infinite recurse.
     seen.set(value, result);
+    if (convertedDiffers) seen.set(converted, result);
 
-    Object.entries(valueRecord).forEach(([key, v]) => {
+    Object.entries(sourceRecord).forEach(([key, v]) => {
       const next = recursivelyAddIDIfNeeded(v, frame, seen);
       if (!Object.is(next, v)) {
         changed = true;
@@ -2364,13 +2380,18 @@ export function recursivelyAddIDIfNeeded<T>(
       result[key] = next;
     });
 
-    // Copy supported symbols from original value.
-    [ID, ID_FIELD].forEach((symbol) => {
-      if (symbol in valueRecord) {
-        (result as IDFields)[symbol as keyof IDFields] =
-          (valueRecord as IDFields)[symbol as keyof IDFields];
-      }
-    });
+    // Copy supported symbols from the original value. Symbols are not
+    // enumerable via `Object.entries()` and are not preserved by the
+    // shallow fabric conversion.
+    if (isRecord(value)) {
+      const valueRecord = value as Record<string, unknown>;
+      [ID, ID_FIELD].forEach((symbol) => {
+        if (symbol in valueRecord) {
+          (result as IDFields)[symbol as keyof IDFields] =
+            (valueRecord as IDFields)[symbol as keyof IDFields];
+        }
+      });
+    }
 
     if (!changed) {
       seen.set(value, value);

--- a/packages/runner/test/cell-core.test.ts
+++ b/packages/runner/test/cell-core.test.ts
@@ -10,6 +10,7 @@ import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import type { FabricValue } from "@commonfabric/memory/interface";
 import {
   getDataModelConfig,
+  resetDataModelConfig,
   setDataModelConfig,
 } from "@commonfabric/data-model/fabric-value";
 import { isCell, recursivelyAddIDIfNeeded } from "../src/cell.ts";
@@ -791,83 +792,121 @@ describe("Cell", () => {
     expect(final).toEqual({ output: 200 });
   });
 
-  it("should translate circular references into links", () => {
-    const schema = {
-      $ref: "#/$defs/Root",
-      $defs: {
-        Root: {
-          type: "object",
-          properties: {
-            x: { type: "number" },
-            y: { type: "number" },
-            z: { $ref: "#/$defs/Root" },
-          },
-          required: ["x", "y", "z"],
-        },
-      },
-    } as const satisfies JSONSchema;
-    const c = runtime.getCell(
-      space,
-      "should translate circular references into links",
-      schema,
-      tx,
-    );
-    const data: any = { x: 1, y: 2 };
-    data.z = data;
-    c.set(data);
+  // Cycle-resolution tests live in a separate `describe` below so they can be
+  // pinned to both `modernDataModel` flag states explicitly.
+});
 
-    const proxy = c.getAsQueryResult();
-    expect(proxy.z).toBe(proxy);
+// Cycle-resolution behavior should hold under both `modernDataModel` flag
+// states, so these tests are run twice, once per state. Modeled on
+// `packages/data-model/test/clone-if-necessary.test.ts`. The flag is set in
+// `beforeEach` BEFORE constructing the `Runtime`, so the runtime captures
+// the correct value (the `Runtime` constructor snapshots
+// `getDataModelConfig()` at construction time).
+describe("Cell circular references", () => {
+  for (const modernMode of [false, true]) {
+    const label = modernMode ? "modern" : "legacy";
 
-    const value = c.get();
-    expect(value.z.z.z).toBe(value.z.z);
+    describe(`(${label})`, () => {
+      let runtime: Runtime;
+      let storageManager: ReturnType<typeof StorageManager.emulate>;
+      let tx: IExtendedStorageTransaction;
 
-    const raw = c.getRaw();
-    expect(raw?.z).toMatchObject({ "/": { [LINK_V1_TAG]: { path: [] } } });
-  });
+      beforeEach(() => {
+        setDataModelConfig(modernMode);
+        storageManager = StorageManager.emulate({ as: signer });
+        runtime = new Runtime({
+          apiUrl: new URL(import.meta.url),
+          storageManager,
+        });
+        tx = runtime.edit();
+      });
 
-  it("should translate circular references into links across cells", () => {
-    const schema = {
-      $ref: "#/$defs/Root",
-      $defs: {
-        Root: {
-          type: "object",
-          properties: {
-            list: {
-              type: "array",
-              items: {
-                type: "object",
-                properties: { parent: { $ref: "#/$defs/Root" } },
-                asCell: true,
-                required: ["parent"],
+      afterEach(async () => {
+        await tx.commit();
+        await runtime?.dispose();
+        await storageManager?.close();
+        resetDataModelConfig();
+      });
+
+      it("should translate circular references into links", () => {
+        const schema = {
+          $ref: "#/$defs/Root",
+          $defs: {
+            Root: {
+              type: "object",
+              properties: {
+                x: { type: "number" },
+                y: { type: "number" },
+                z: { $ref: "#/$defs/Root" },
               },
+              required: ["x", "y", "z"],
             },
           },
-          required: ["list"],
-        },
-      },
-    } as const satisfies JSONSchema;
-    const c = runtime.getCell(
-      space,
-      "should translate circular references into links",
-      schema,
-      tx,
-    );
-    const inner: any = { [ID]: 1 }; // ID will turn this into a separate cell
-    const outer: any = { list: [inner] };
-    inner.parent = outer;
-    c.set(outer);
+        } as const satisfies JSONSchema;
+        const c = runtime.getCell(
+          space,
+          "should translate circular references into links",
+          schema,
+          tx,
+        );
+        const data: any = { x: 1, y: 2 };
+        data.z = data;
+        c.set(data);
 
-    const proxy = c.getAsQueryResult();
-    expect(proxy.list[0].parent).toBe(proxy);
+        const proxy = c.getAsQueryResult();
+        expect(proxy.z).toBe(proxy);
 
-    const { id } = c.getAsNormalizedFullLink();
-    const innerCell = c.get().list[0];
-    const raw = innerCell.getRaw();
-    expect(raw).toMatchObject({
-      parent: { "/": { [LINK_V1_TAG]: { id } } },
+        const value = c.get();
+        expect(value.z.z.z).toBe(value.z.z);
+
+        const raw = c.getRaw();
+        expect(raw?.z).toMatchObject({ "/": { [LINK_V1_TAG]: { path: [] } } });
+      });
+
+      it("should translate circular references into links across cells", () => {
+        const schema = {
+          $ref: "#/$defs/Root",
+          $defs: {
+            Root: {
+              type: "object",
+              properties: {
+                list: {
+                  type: "array",
+                  items: {
+                    type: "object",
+                    properties: { parent: { $ref: "#/$defs/Root" } },
+                    asCell: true,
+                    required: ["parent"],
+                  },
+                },
+              },
+              required: ["list"],
+            },
+          },
+        } as const satisfies JSONSchema;
+        const c = runtime.getCell(
+          space,
+          "should translate circular references into links",
+          schema,
+          tx,
+        );
+        const inner: any = { [ID]: 1 }; // ID will turn this into a separate cell
+        const outer: any = { list: [inner] };
+        inner.parent = outer;
+        c.set(outer);
+
+        const proxy = c.getAsQueryResult();
+        expect(proxy.list[0].parent).toBe(proxy);
+
+        const { id } = c.getAsNormalizedFullLink();
+        const innerCell = c.get().list[0];
+        const raw = innerCell.getRaw();
+        expect(raw).toMatchObject({
+          parent: { "/": { [LINK_V1_TAG]: { id } } },
+        });
+      });
     });
-  });
+  }
 });
 
 describe("Cell utility functions", () => {

--- a/packages/runner/test/cell-hooks.test.ts
+++ b/packages/runner/test/cell-hooks.test.ts
@@ -7,6 +7,10 @@ import "@commonfabric/utils/equal-ignoring-symbols";
 
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import {
+  resetDataModelConfig,
+  setDataModelConfig,
+} from "@commonfabric/data-model/fabric-value";
 import { isCell } from "../src/cell.ts";
 import { isCellResult } from "../src/query-result-proxy.ts";
 import { toCell } from "../src/back-to-cell.ts";
@@ -705,37 +709,76 @@ describe("toCell and toOpaqueRef hooks", () => {
       expect(deepCell.get().value).toBe(42);
     });
 
-    it("should handle circular references gracefully", () => {
-      const schema = {
-        $ref: "#/$defs/Root",
-        $defs: {
-          Root: {
-            type: "object",
-            properties: {
-              name: { type: "string" },
-              self: { $ref: "#/$defs/Root" },
+    // Cycle-handling test moved to a separate parameterized `describe`
+    // below so it can be pinned to both `modernDataModel` flag states.
+  });
+});
+
+// Run cycle-handling under both `modernDataModel` flag states explicitly.
+// Modeled on `packages/data-model/test/clone-if-necessary.test.ts`. The flag
+// is set in `beforeEach` BEFORE constructing the `Runtime`, so the runtime
+// captures the correct value (the `Runtime` constructor snapshots
+// `getDataModelConfig()` at construction time).
+describe("toCell and toOpaqueRef hooks: circular references", () => {
+  for (const modernMode of [false, true]) {
+    const label = modernMode ? "modern" : "legacy";
+
+    describe(`(${label})`, () => {
+      let runtime: Runtime;
+      let storageManager: ReturnType<typeof StorageManager.emulate>;
+      let tx: IExtendedStorageTransaction;
+
+      beforeEach(() => {
+        setDataModelConfig(modernMode);
+        storageManager = StorageManager.emulate({ as: signer });
+        runtime = new Runtime({
+          apiUrl: new URL(import.meta.url),
+          storageManager,
+        });
+        tx = runtime.edit();
+      });
+
+      afterEach(async () => {
+        await tx.commit();
+        await runtime?.dispose();
+        await storageManager?.close();
+        resetDataModelConfig();
+      });
+
+      it("should handle circular references gracefully", () => {
+        const schema = {
+          $ref: "#/$defs/Root",
+          $defs: {
+            Root: {
+              type: "object",
+              properties: {
+                name: { type: "string" },
+                self: { $ref: "#/$defs/Root" },
+              },
             },
           },
-        },
-      } as const satisfies JSONSchema;
+        } as const satisfies JSONSchema;
 
-      const c = runtime.getCell<any>(
-        space,
-        "hook-edge-circular",
-        schema,
-        tx,
-      );
+        const c = runtime.getCell<any>(
+          space,
+          "hook-edge-circular",
+          schema,
+          tx,
+        );
 
-      const data: any = { name: "circular" };
-      data.self = data;
-      c.set(data);
+        const data: any = { name: "circular" };
+        data.self = data;
+        c.set(data);
 
-      const result = c.get();
-      expect(toCell in result).toBe(true);
-      expect(result.name).toBe("circular");
-      // With circular references, the self reference points back to the same data
-      expect(result.self.name).toBe("circular");
-      expect(result.self.self.name).toBe("circular"); // Can navigate infinitely
+        const result = c.get();
+        expect(toCell in result).toBe(true);
+        expect(result.name).toBe("circular");
+        // With circular references, the self reference points back to the
+        // same data.
+        expect(result.self.name).toBe("circular");
+        // Can navigate infinitely.
+        expect(result.self.self.name).toBe("circular");
+      });
     });
-  });
+  }
 });


### PR DESCRIPTION
Prep PR for the modern-data-model flag flip (PR #3569). Fixes three test failures that surface when `modernDataModel` is on by default; no-op under legacy.

## The bug

`recursivelyAddIDIfNeeded()` is the write-boundary helper in `cell.ts` that walks an input tree and adds IDs to objects-in-arrays. It uses a `seen` map to break cycles — when a sub-tree references a value already seen, the registered result is returned instead of recursing.

Under modern, `shallowFabricFromNativeValue(value)` may allocate a fresh frozen container as the converted form, whose own properties still point at the original (unfrozen) input. In that case the prior "conversion changed the value" branch ran the recursive descent BEFORE registering `value` in `seen`. So a back-reference through the original `value` re-entered shallow conversion (allocating yet another frozen clone) and recursed forever:

```
RangeError: Maximum call stack size exceeded
```

Under legacy, `shallowFabricFromNativeValue()` returns the input as-is for plain objects/arrays, the "conversion changed" branch isn't taken, and the array/record paths register `seen.set(value, result)` up-front — so the bug doesn't manifest there.

## The fix

Restructure the function so that whenever `converted` is an array or record:

- The result container is allocated up-front.
- `seen.set(value, result)` is recorded BEFORE descending into entries (mirroring what the existing array/record branches already did when `converted === value`).
- When `converted` differs from `value`, both keys are registered against the same result container, so back-references through either reference resolve correctly.

Also handles the case where shallow conversion returns a `FabricInstance` (e.g. `FabricError` wrapping a native `Error`) — walks its internal `DECONSTRUCT` state the same way as the up-front `FabricInstance` branch above, instead of letting it fall through into the record path.

## Tests fixed

Verified locally by temporarily flipping the default to true and re-running the suite. These three modern-flag-on failures from PR #3569's CI now pass:

- `packages/runner/test/cell-core.test.ts > Cell > should translate circular references into links`
- `packages/runner/test/cell-core.test.ts > Cell > should translate circular references into links across cells`
- `packages/runner/test/cell-hooks.test.ts > toCell and toOpaqueRef hooks > Edge cases > should handle circular references gracefully`

The fix makes the existing tests flag-default-agnostic — they pass under both legacy and modern defaults — so PR #3569 (the one-line default flip) won't need to revisit them.

## Test plan

- [x] `deno task check` — passes.
- [x] `deno task test` (workspace-wide) under `modernDataModel = false` (current default on `main`): all green.
- [x] `deno task test` (workspace-wide) under `modernDataModel = true` (post-flip): the three circular-ref failures clear; the four unrelated known failures from PR #3569's CI (`fetch-data` mutex ×2, `generateObject` InjectionSafe, `wish` cross-space) remain and are out of scope for this PR.
- [ ] Manual: not needed; behavior is purely internal to the write-boundary helper and is covered by the cited unit tests.

## Perf-check note

Same wide-noise-floor situation as PR #3585 — the change is tests plus a write-boundary helper refactor, neither of which can plausibly add this many seconds of overhead to unrelated jobs. Accepting two distinct noise blips that surfaced across re-runs:

- `step: workspace tests`: 62s vs baseline median 53s, threshold 61s (baseline samples span 51s–56s).
- `job: Package Integration Tests (runtime-client)`: 1m 30s vs baseline median 1m 12s, threshold 1m 28s. The runtime-client package is unrelated to `recursivelyAddIDIfNeeded`.

NEW_PERF_BASELINE: step: workspace tests = 62s
NEW_PERF_BASELINE: job: Package Integration Tests (runtime-client) = 90s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cycle detection in `recursivelyAddIDIfNeeded()` under the modern data model by pre-registering `seen` when shallow conversion clones containers, and pins circular-reference tests to both `modernDataModel` states; legacy behavior is unchanged.

- **Bug Fixes**
  - Pre-register the result in `seen` before recursing for arrays/records; when `converted !== value`, register both `value` and `converted` to the same result.
  - Handle `FabricInstance` returned by shallow conversion by recording it in `seen`, walking `[DECONSTRUCT]()` for traversal, and returning it unchanged.
  - Resolves the modern-only failures for circular references in `cell-core` and `cell-hooks` tests.
  - Tests: Parameterize the three cycle tests to run under both legacy and modern via `setDataModelConfig()`/`resetDataModelConfig()` to keep coverage stable when the default flips.

<sup>Written for commit 6d8a68ba6246f20ec2b75ab9aac4801708e8e3ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


