### PR TITLE
feat(transformer): Narrow transformed cell capabilities

### DIFF
--- a/packages/schema-generator/src/formatters/common-fabric-formatter.ts
+++ b/packages/schema-generator/src/formatters/common-fabric-formatter.ts
@@ -261,6 +261,19 @@ export class CommonFabricFormatter implements TypeFormatter {
     }
 
     const wrapperInfo = getCellWrapperInfo(type, context.typeChecker);
+    if (
+      resolvedWrapper &&
+      resolvedWrapper.kind !== "Default" &&
+      wrapperInfo &&
+      wrapperInfo.kind !== resolvedWrapper.kind
+    ) {
+      return this.formatWrapperTypeFromNode(
+        resolvedWrapper.node,
+        context,
+        resolvedWrapper.kind,
+      );
+    }
+
     if (wrapperInfo && !(type.flags & ts.TypeFlags.Union)) {
       const nodeToPass = this.selectWrapperTypeNode(
         n,
@@ -338,9 +351,16 @@ export class CommonFabricFormatter implements TypeFormatter {
       throw new Error(`${wrapperKind}<T> requires type argument`);
     }
 
+    const registeredWrapperType = context.typeRegistry?.get(typeRefNode);
+    const registeredWrapperInfo = registeredWrapperType
+      ? getCellWrapperInfo(registeredWrapperType, context.typeChecker)
+      : undefined;
+
     let innerType: ts.Type;
     try {
-      innerType = context.typeChecker.getTypeFromTypeNode(innerTypeNode);
+      innerType = context.typeRegistry?.get(innerTypeNode) ??
+        registeredWrapperInfo?.typeRef.typeArguments?.[0] ??
+        context.typeChecker.getTypeFromTypeNode(innerTypeNode);
     } catch {
       innerType = context.typeChecker.getAnyType();
     }
@@ -405,7 +425,8 @@ export class CommonFabricFormatter implements TypeFormatter {
 
     let innerType: ts.Type;
     try {
-      innerType = context.typeChecker.getTypeFromTypeNode(innerTypeNode);
+      innerType = context.typeRegistry?.get(innerTypeNode) ??
+        context.typeChecker.getTypeFromTypeNode(innerTypeNode);
     } catch {
       innerType = context.typeChecker.getAnyType();
     }
@@ -487,7 +508,8 @@ export class CommonFabricFormatter implements TypeFormatter {
       innerTypeNode
     ) {
       try {
-        const fromNode = context.typeChecker.getTypeFromTypeNode(innerTypeNode);
+        const fromNode = context.typeRegistry?.get(innerTypeNode) ??
+          context.typeChecker.getTypeFromTypeNode(innerTypeNode);
         if (fromNode && !this.isUnusableInnerType(fromNode)) {
           innerType = fromNode;
         }
@@ -818,7 +840,8 @@ export class CommonFabricFormatter implements TypeFormatter {
       throw new Error("Default<T,V> type arguments cannot be undefined");
     }
     // Get the value type from the type nodes
-    const valueType = context.typeChecker.getTypeFromTypeNode(valueTypeNode);
+    const valueType = context.typeRegistry?.get(valueTypeNode) ??
+      context.typeChecker.getTypeFromTypeNode(valueTypeNode);
     if (typeArgs.length === 1 && this.isUndefinedType(valueType)) {
       throw new Error(
         "Default<undefined> is unsupported; use an optional field or a JSON value default.",
@@ -1573,7 +1596,8 @@ export class CommonFabricFormatter implements TypeFormatter {
       const lastTypeArg =
         typeNode.typeArguments[typeNode.typeArguments.length - 1];
       if (lastTypeArg) {
-        const lastType = context.typeChecker.getTypeFromTypeNode(lastTypeArg);
+        const lastType = context.typeRegistry?.get(lastTypeArg) ??
+          context.typeChecker.getTypeFromTypeNode(lastTypeArg);
         // If the value type is never, this represents an empty object
         if (lastType.flags & ts.TypeFlags.Never) {
           return {};
@@ -1624,7 +1648,8 @@ export class CommonFabricFormatter implements TypeFormatter {
     if (typeNode.kind === ts.SyntaxKind.UndefinedKeyword) return undefined;
 
     // Fallback: try to get the type and extract from it
-    const type = context.typeChecker.getTypeFromTypeNode(typeNode);
+    const type = context.typeRegistry?.get(typeNode) ??
+      context.typeChecker.getTypeFromTypeNode(typeNode);
     return this.extractDefaultValue(type, context);
   }
 

--- a/packages/schema-generator/src/formatters/common-fabric-formatter.ts
+++ b/packages/schema-generator/src/formatters/common-fabric-formatter.ts
@@ -265,7 +265,8 @@ export class CommonFabricFormatter implements TypeFormatter {
       resolvedWrapper &&
       resolvedWrapper.kind !== "Default" &&
       wrapperInfo &&
-      wrapperInfo.kind !== resolvedWrapper.kind
+      wrapperInfo.kind !== resolvedWrapper.kind &&
+      this.isSyntheticWrapperNode(resolvedWrapper.node)
     ) {
       return this.formatWrapperTypeFromNode(
         resolvedWrapper.node,
@@ -810,6 +811,10 @@ export class CommonFabricFormatter implements TypeFormatter {
       return resolvedWrapper.node;
     }
     return undefined;
+  }
+
+  private isSyntheticWrapperNode(node: ts.Node): boolean {
+    return node.pos < 0 || node.end < 0;
   }
 
   private getTypeRefIdentifierName(

--- a/packages/schema-generator/src/formatters/native-type-formatter.ts
+++ b/packages/schema-generator/src/formatters/native-type-formatter.ts
@@ -150,7 +150,8 @@ export class NativeTypeFormatter implements TypeFormatter {
       return fileName === "lib.d.ts" ||
         fileName.endsWith("/lib.d.ts") ||
         /(^|\/)lib\.[^/]+\.d\.ts$/i.test(fileName) ||
-        /(^|\/)(es\d+(?:\.[^/]+)?|dom|jsx)\.d\.ts$/i.test(fileName);
+        /(^|\/)(es\d+(?:\.[^/]+)?|dom|jsx)\.d\.ts$/i.test(fileName) ||
+        /(^|[\\/])node_modules[\\/]@types[\\/]node[\\/]/.test(fileName);
     }) ?? false;
   }
 

--- a/packages/schema-generator/src/formatters/native-type-formatter.ts
+++ b/packages/schema-generator/src/formatters/native-type-formatter.ts
@@ -28,6 +28,25 @@ const NATIVE_TYPE_SCHEMAS: Record<string, JSONSchemaMutable> = {
 };
 
 const NATIVE_TYPE_NAMES = new Set(Object.keys(NATIVE_TYPE_SCHEMAS));
+const LIB_DECLARED_NATIVE_TYPES = new Set([
+  "Date",
+  "URL",
+  "ArrayBuffer",
+  "ArrayBufferLike",
+  "SharedArrayBuffer",
+  "ArrayBufferView",
+  "Uint8Array",
+  "Uint8ClampedArray",
+  "Int8Array",
+  "Uint16Array",
+  "Int16Array",
+  "Uint32Array",
+  "Int32Array",
+  "Float32Array",
+  "Float64Array",
+  "BigInt64Array",
+  "BigUint64Array",
+]);
 
 /**
  * Formatter that replaces specific types with a manually specified schema
@@ -37,9 +56,17 @@ const NATIVE_TYPE_NAMES = new Set(Object.keys(NATIVE_TYPE_SCHEMAS));
  * for referencing embedded schema definitions.
  */
 export class NativeTypeFormatter implements TypeFormatter {
-  supportsType(type: ts.Type, _context: GenerationContext): boolean {
+  supportsType(type: ts.Type, context: GenerationContext): boolean {
     const typeName = NativeTypeFormatter.getTypeName(type);
-    return NativeTypeFormatter.isNativeType(typeName);
+    if (!NativeTypeFormatter.isNativeType(typeName)) {
+      return false;
+    }
+    if (
+      typeName !== undefined && LIB_DECLARED_NATIVE_TYPES.has(typeName)
+    ) {
+      return NativeTypeFormatter.hasLibraryDeclaration(type, context);
+    }
+    return true;
   }
 
   formatType(
@@ -89,6 +116,42 @@ export class NativeTypeFormatter implements TypeFormatter {
     }
 
     return name;
+  }
+
+  private static getTypeSymbol(type: ts.Type): ts.Symbol | undefined {
+    if (type.symbol) return type.symbol;
+
+    const objectFlags = (type as ts.ObjectType).objectFlags ?? 0;
+    if (objectFlags & ts.ObjectFlags.Reference) {
+      const ref = type as unknown as ts.TypeReference;
+      return ref.target?.symbol;
+    }
+
+    return type.aliasSymbol;
+  }
+
+  private static hasLibraryDeclaration(
+    type: ts.Type,
+    context: GenerationContext,
+  ): boolean {
+    const symbol = NativeTypeFormatter.getTypeSymbol(type);
+    return symbol?.declarations?.some((declaration) => {
+      const sourceFile = declaration.getSourceFile();
+      const program = (
+        context.typeChecker as ts.TypeChecker & {
+          getProgram?: () => ts.Program;
+        }
+      ).getProgram?.();
+      if (program?.isSourceFileDefaultLibrary(sourceFile)) {
+        return true;
+      }
+
+      const fileName = sourceFile.fileName;
+      return fileName === "lib.d.ts" ||
+        fileName.endsWith("/lib.d.ts") ||
+        /(^|\/)lib\.[^/]+\.d\.ts$/i.test(fileName) ||
+        /(^|\/)(es\d+(?:\.[^/]+)?|dom|jsx)\.d\.ts$/i.test(fileName);
+    }) ?? false;
   }
 
   // We expose this so type-utils can skip generating $defs for these

--- a/packages/schema-generator/src/interface.ts
+++ b/packages/schema-generator/src/interface.ts
@@ -36,6 +36,8 @@ export interface GenerationContext {
   typeNode?: ts.TypeNode;
   /** Source file name for authoring metadata that needs stable file identity */
   sourceFileName?: string;
+  /** Source file for resolving names from synthetic type nodes */
+  sourceFile?: ts.SourceFile;
   /** Optional type registry for synthetic nodes */
   typeRegistry?: WeakMap<ts.Node, ts.Type>;
   /** Widen literal types to base types during schema generation */
@@ -105,6 +107,7 @@ export interface SchemaGenerator {
         };
       }
     >,
+    sourceFile?: ts.SourceFile,
   ): SchemaDefinition;
 
   /**
@@ -135,5 +138,6 @@ export interface SchemaGenerator {
         };
       }
     >,
+    sourceFile?: ts.SourceFile,
   ): SchemaDefinition;
 }

--- a/packages/schema-generator/src/plugin.ts
+++ b/packages/schema-generator/src/plugin.ts
@@ -15,6 +15,7 @@ export function createSchemaTransformerV2() {
       typeArg?: ts.TypeNode,
       options?: { widenLiterals?: boolean },
       schemaHints?: WeakMap<ts.Node, { items?: unknown }>,
+      sourceFile?: ts.SourceFile,
     ) {
       return generator.generateSchema(
         type,
@@ -22,6 +23,7 @@ export function createSchemaTransformerV2() {
         typeArg,
         options,
         schemaHints,
+        sourceFile,
       );
     },
 
@@ -30,12 +32,14 @@ export function createSchemaTransformerV2() {
       checker: ts.TypeChecker,
       typeRegistry?: WeakMap<ts.Node, ts.Type>,
       schemaHints?: WeakMap<ts.Node, { items?: unknown }>,
+      sourceFile?: ts.SourceFile,
     ) {
       return generator.generateSchemaFromSyntheticTypeNode(
         typeNode,
         checker,
         typeRegistry,
         schemaHints,
+        sourceFile,
       );
     },
   };

--- a/packages/schema-generator/src/schema-generator.ts
+++ b/packages/schema-generator/src/schema-generator.ts
@@ -71,6 +71,7 @@ export class SchemaGenerator implements ISchemaGenerator {
         };
       }
     >,
+    sourceFile?: ts.SourceFile,
   ): JSONSchemaMutable {
     return this.generateSchemaInternal(
       type,
@@ -79,6 +80,7 @@ export class SchemaGenerator implements ISchemaGenerator {
       undefined,
       options,
       schemaHints,
+      sourceFile,
     );
   }
 
@@ -108,6 +110,7 @@ export class SchemaGenerator implements ISchemaGenerator {
         };
       }
     >,
+    sourceFile?: ts.SourceFile,
   ): JSONSchemaMutable {
     // Pass 'any' type with the typeNode - auto-detection will choose node-based analysis
     const anyType = checker.getAnyType();
@@ -118,6 +121,7 @@ export class SchemaGenerator implements ISchemaGenerator {
       typeRegistry,
       undefined,
       schemaHints,
+      sourceFile,
     );
   }
 
@@ -146,6 +150,7 @@ export class SchemaGenerator implements ISchemaGenerator {
         };
       }
     >,
+    sourceFile?: ts.SourceFile,
   ): JSONSchemaMutable {
     // Create unified context with all state
     const cycles = this.getCycles(type, checker);
@@ -167,6 +172,10 @@ export class SchemaGenerator implements ISchemaGenerator {
       ...(typeNode && { typeNode }),
       ...(typeNode?.getSourceFile()?.fileName && {
         sourceFileName: typeNode.getSourceFile().fileName,
+      }),
+      ...(sourceFile && {
+        sourceFile,
+        sourceFileName: sourceFile.fileName,
       }),
       ...(typeRegistry && { typeRegistry }),
       ...(options?.widenLiterals && { widenLiterals: true }),
@@ -794,7 +803,8 @@ export class SchemaGenerator implements ISchemaGenerator {
 
     // Handle ArrayTypeNode (e.g., number[], string[])
     if (ts.isArrayTypeNode(typeNode)) {
-      const elementType = checker.getTypeFromTypeNode(typeNode.elementType);
+      const elementType = typeRegistry?.get(typeNode.elementType) ??
+        checker.getTypeFromTypeNode(typeNode.elementType);
       const items = this.formatChildType(
         elementType,
         context,
@@ -824,6 +834,26 @@ export class SchemaGenerator implements ISchemaGenerator {
       if (filtered.length === 1) return filtered[0]!;
       return { anyOf: filtered as JSONSchemaObjMutable[] };
     }
+
+    if (ts.isLiteralTypeNode(typeNode)) {
+      const literal = typeNode.literal;
+      if (ts.isStringLiteral(literal)) {
+        return { type: "string", const: literal.text };
+      }
+      if (ts.isNumericLiteral(literal)) {
+        return { type: "number", const: Number(literal.text) };
+      }
+      if (literal.kind === ts.SyntaxKind.TrueKeyword) {
+        return { type: "boolean", const: true };
+      }
+      if (literal.kind === ts.SyntaxKind.FalseKeyword) {
+        return { type: "boolean", const: false };
+      }
+      if (literal.kind === ts.SyntaxKind.NullKeyword) {
+        return { type: "null" };
+      }
+    }
+
     // Synthetic TypeReferenceNodes may fail to bind in checker APIs directly.
     // Resolve by name from source scope as a fallback (e.g., CharmEntry in
     // Cell<CharmEntry[]>).
@@ -832,6 +862,12 @@ export class SchemaGenerator implements ISchemaGenerator {
         const wrapperType = typeRegistry?.get(typeNode) ??
           checker.getTypeFromTypeNode(typeNode);
         return this.formatChildType(wrapperType, context, typeNode);
+      }
+
+      if (
+        ts.isIdentifier(typeNode.typeName) && typeNode.typeName.text === "Date"
+      ) {
+        return { type: "string", format: "date-time" };
       }
 
       const resolved = this.resolveTypeReferenceFromScope(
@@ -898,7 +934,17 @@ export class SchemaGenerator implements ISchemaGenerator {
       }
     }
 
-    const scopeNode = context.typeNode?.getSourceFile?.() ??
+    const checkerWithProgram = checker as ts.TypeChecker & {
+      getProgram?: () => ts.Program;
+    };
+    const sourceFromContext = context.sourceFile ??
+      (context.sourceFileName
+        ? checkerWithProgram.getProgram?.().getSourceFile(
+          context.sourceFileName,
+        )
+        : undefined);
+    const scopeNode = sourceFromContext ??
+      context.typeNode?.getSourceFile?.() ??
       typeNode.getSourceFile?.();
     if (!scopeNode) return undefined;
 

--- a/packages/schema-generator/src/schema-generator.ts
+++ b/packages/schema-generator/src/schema-generator.ts
@@ -864,12 +864,6 @@ export class SchemaGenerator implements ISchemaGenerator {
         return this.formatChildType(wrapperType, context, typeNode);
       }
 
-      if (
-        ts.isIdentifier(typeNode.typeName) && typeNode.typeName.text === "Date"
-      ) {
-        return { type: "string", format: "date-time" };
-      }
-
       const resolved = this.resolveTypeReferenceFromScope(
         typeNode,
         checker,
@@ -877,6 +871,12 @@ export class SchemaGenerator implements ISchemaGenerator {
       );
       if (resolved) {
         return this.formatChildType(resolved, context, typeNode);
+      }
+
+      if (
+        ts.isIdentifier(typeNode.typeName) && typeNode.typeName.text === "Date"
+      ) {
+        return { type: "string", format: "date-time" };
       }
     }
 

--- a/packages/schema-generator/src/type-utils.ts
+++ b/packages/schema-generator/src/type-utils.ts
@@ -3,6 +3,7 @@ import ts from "typescript";
 import type { JSONSchemaMutable } from "@commonfabric/api";
 import { NativeTypeFormatter } from "./formatters/native-type-formatter.ts";
 import { getPropertyNameText } from "./typescript/property-name.ts";
+import type { CellWrapperKind } from "./typescript/cell-brand.ts";
 
 /**
  * Names that should be treated as Cell-like wrapper types.
@@ -13,11 +14,31 @@ const CELL_LIKE_WRAPPER_NAMES = new Set([
   "Writable",
   "ReadonlyCell",
   "WriteonlyCell",
+  "ComparableCell",
 ]);
 const OPAQUE_WRAPPER_NAMES = new Set(["OpaqueCell"]);
+type NodeWrapperKind = "Default" | CellWrapperKind;
 
 function getEntityNameText(name: ts.EntityName): string {
   return ts.isIdentifier(name) ? name.text : name.right.text;
+}
+
+function wrapperKindForName(name: string): NodeWrapperKind | undefined {
+  switch (name) {
+    case "Default":
+      return "Default";
+    case "Cell":
+    case "Writable":
+      return "Cell";
+    case "ReadonlyCell":
+    case "WriteonlyCell":
+    case "ComparableCell":
+    case "Stream":
+    case "OpaqueCell":
+      return name;
+    default:
+      return undefined;
+  }
 }
 
 export { getPropertyNameText };
@@ -726,7 +747,7 @@ export function isDefaultTypeRef(
 export function detectWrapperViaNode(
   typeNode: ts.TypeNode | undefined,
   typeChecker: ts.TypeChecker,
-): "Default" | "Cell" | "Stream" | "OpaqueRef" | undefined {
+): NodeWrapperKind | undefined {
   const result = resolveWrapperNode(typeNode, typeChecker);
   return result?.kind;
 }
@@ -739,7 +760,7 @@ export function resolveWrapperNode(
   typeNode: ts.TypeNode | undefined,
   typeChecker: ts.TypeChecker,
 ): {
-  kind: "Default" | "Cell" | "Stream" | "OpaqueRef";
+  kind: NodeWrapperKind;
   node: ts.TypeReferenceNode;
 } | undefined {
   if (!typeNode || !ts.isTypeReferenceNode(typeNode)) {
@@ -749,18 +770,10 @@ export function resolveWrapperNode(
   const literalName = getEntityNameText(typeNode.typeName);
 
   // Fast path: direct wrapper reference
-  if (
-    literalName === "Default" || CELL_LIKE_WRAPPER_NAMES.has(literalName) ||
-    literalName === "Stream" || OPAQUE_WRAPPER_NAMES.has(literalName)
-  ) {
-    // Normalize "Writable" to "Cell" for internal processing
-    const kind = CELL_LIKE_WRAPPER_NAMES.has(literalName)
-      ? "Cell"
-      : OPAQUE_WRAPPER_NAMES.has(literalName)
-      ? "OpaqueRef"
-      : literalName;
+  const directKind = wrapperKindForName(literalName);
+  if (directKind) {
     return {
-      kind: kind as "Default" | "Cell" | "Stream" | "OpaqueRef",
+      kind: directKind,
       node: typeNode,
     };
   }
@@ -781,7 +794,7 @@ function followAliasToWrapperNode(
   typeChecker: ts.TypeChecker,
   visited: Set<string>,
 ): {
-  kind: "Default" | "Cell" | "Stream" | "OpaqueRef";
+  kind: NodeWrapperKind;
   node: ts.TypeReferenceNode;
 } | undefined {
   if (!ts.isIdentifier(typeNode.typeName)) {
@@ -800,18 +813,10 @@ function followAliasToWrapperNode(
   visited.add(typeName);
 
   // Check if we've reached a wrapper type
-  if (
-    typeName === "Default" || CELL_LIKE_WRAPPER_NAMES.has(typeName) ||
-    typeName === "Stream" || OPAQUE_WRAPPER_NAMES.has(typeName)
-  ) {
-    // Normalize "Writable" to "Cell" for internal processing
-    const kind = CELL_LIKE_WRAPPER_NAMES.has(typeName)
-      ? "Cell"
-      : OPAQUE_WRAPPER_NAMES.has(typeName)
-      ? "OpaqueRef"
-      : typeName;
+  const directKind = wrapperKindForName(typeName);
+  if (directKind) {
     return {
-      kind: kind as "Default" | "Cell" | "Stream" | "OpaqueRef",
+      kind: directKind,
       node: typeNode,
     };
   }

--- a/packages/schema-generator/test/plugin.test.ts
+++ b/packages/schema-generator/test/plugin.test.ts
@@ -17,8 +17,8 @@ describe("Plugin Interface", () => {
     );
 
     // Verify generateSchema has the right number of parameters
-    // (type, checker, typeArg, options, schemaHints)
-    expect(transformer.generateSchema.length).toBe(5);
+    // (type, checker, typeArg, options, schemaHints, sourceFile)
+    expect(transformer.generateSchema.length).toBe(6);
   });
 
   it("transforms a simple object via plugin", async () => {

--- a/packages/schema-generator/test/schema-generator.test.ts
+++ b/packages/schema-generator/test/schema-generator.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import ts from "typescript";
 import { SchemaGenerator } from "../src/schema-generator.ts";
-import { getTypeFromCode } from "./utils.ts";
+import { createTestProgram, getTypeFromCode } from "./utils.ts";
 
 describe("SchemaGenerator", () => {
   describe("formatter chain", () => {
@@ -263,6 +263,56 @@ type Output = { [UI]: string; metadata: number };
         metadata: { type: "number" },
       });
       expect(schema.required).toEqual(["title", "metadata"]);
+    });
+
+    it("resolves local Date type references before applying native Date fallback", async () => {
+      const generator = new SchemaGenerator();
+      const code = `
+namespace Local {
+  export interface Date {
+    year: number;
+  }
+  export type Output = { createdAt: Date };
+}
+`;
+      const { checker, sourceFile } = await createTestProgram(code);
+      let outputNode: ts.TypeNode | undefined;
+      const visit = (node: ts.Node): void => {
+        if (
+          ts.isTypeAliasDeclaration(node) &&
+          node.name.text === "Output"
+        ) {
+          outputNode = node.type;
+          return;
+        }
+        ts.forEachChild(node, visit);
+      };
+      visit(sourceFile);
+      if (!outputNode) {
+        throw new Error("Expected Local.Output type node.");
+      }
+
+      const schema = generator.generateSchemaFromSyntheticTypeNode(
+        outputNode,
+        checker,
+        undefined,
+        undefined,
+        sourceFile,
+      ) as Record<string, unknown>;
+
+      expect(schema).toEqual({
+        type: "object",
+        properties: {
+          createdAt: {
+            type: "object",
+            properties: {
+              year: { type: "number" },
+            },
+            required: ["year"],
+          },
+        },
+        required: ["createdAt"],
+      });
     });
   });
 

--- a/packages/schema-generator/test/schema-generator.test.ts
+++ b/packages/schema-generator/test/schema-generator.test.ts
@@ -428,6 +428,82 @@ interface HasUrl {
       });
     });
 
+    it("formats URL from @types/node as string with uri format", () => {
+      const generator = new SchemaGenerator();
+      const sourceFiles = new Map([
+        [
+          "/test.ts",
+          ts.createSourceFile(
+            "/test.ts",
+            `
+interface HasNodeUrl {
+  homepage: URL;
+}`,
+            ts.ScriptTarget.ES2023,
+            true,
+          ),
+        ],
+        [
+          "/node_modules/@types/node/url.d.ts",
+          ts.createSourceFile(
+            "/node_modules/@types/node/url.d.ts",
+            `
+declare interface URL {
+  href: string;
+}`,
+            ts.ScriptTarget.ES2023,
+            true,
+          ),
+        ],
+      ]);
+      const compilerHost: ts.CompilerHost = {
+        getSourceFile: (fileName) => sourceFiles.get(fileName),
+        writeFile: () => {},
+        getCurrentDirectory: () => "/",
+        getDirectories: () => [],
+        fileExists: (fileName) => sourceFiles.has(fileName),
+        readFile: (fileName) => sourceFiles.get(fileName)?.text,
+        getCanonicalFileName: (fileName) => fileName,
+        useCaseSensitiveFileNames: () => true,
+        getNewLine: () => "\n",
+        getDefaultLibFileName: () => "lib.d.ts",
+      };
+      const program = ts.createProgram(
+        [...sourceFiles.keys()],
+        {
+          target: ts.ScriptTarget.ES2023,
+          module: ts.ModuleKind.ESNext,
+          noLib: true,
+          strict: true,
+        },
+        compilerHost,
+      );
+      const checker = program.getTypeChecker();
+      const sourceFile = program.getSourceFile("/test.ts");
+      if (!sourceFile) throw new Error("Expected test source file");
+      let foundType: ts.Type | undefined;
+      ts.forEachChild(sourceFile, (node) => {
+        if (
+          ts.isInterfaceDeclaration(node) && node.name.text === "HasNodeUrl"
+        ) {
+          const symbol = checker.getSymbolAtLocation(node.name);
+          if (symbol) foundType = checker.getDeclaredTypeOfSymbol(symbol);
+        }
+      });
+      if (!foundType) throw new Error("Expected HasNodeUrl type");
+
+      const schema = generator.generateSchema(foundType, checker);
+      const objectSchema = schema as Record<string, unknown>;
+      const props = objectSchema.properties as
+        | Record<string, Record<string, unknown>>
+        | undefined;
+
+      expect(props?.homepage).toEqual({
+        type: "string",
+        format: "uri",
+      });
+    });
+
     it("formats Uint8Array as permissive true schema", async () => {
       const generator = new SchemaGenerator();
       const code = `

--- a/packages/schema-generator/test/schema/capability-wrapper-types.test.ts
+++ b/packages/schema-generator/test/schema/capability-wrapper-types.test.ts
@@ -214,4 +214,81 @@ describe("Schema: Capability wrapper types", () => {
       asCell: ["cell"],
     });
   });
+
+  it("uses semantic wrapper kind when a non-synthetic type node disagrees", async () => {
+    const code = `
+      interface X {
+        authored: Cell<string>;
+        narrowed: ReadonlyCell<string>;
+      }
+    `;
+    const { checker, sourceFile } = await createTestProgram(code);
+    const symbol = checker.getSymbolsInScope(
+      sourceFile,
+      ts.SymbolFlags.Interface,
+    ).find((candidate) => candidate.name === "X");
+    if (!symbol) throw new Error("Interface X not found");
+
+    const type = checker.getDeclaredTypeOfSymbol(symbol);
+    const narrowed = type.getProperty("narrowed");
+    if (!narrowed) throw new Error("Property X.narrowed not found");
+    const narrowedType = checker.getTypeOfSymbolAtLocation(
+      narrowed,
+      sourceFile,
+    );
+    const authoredNode = findInterfaceMemberTypeNode(
+      sourceFile,
+      "X",
+      "authored",
+    );
+
+    const gen = createSchemaTransformerV2();
+    const result = gen.generateSchema(
+      narrowedType,
+      checker,
+      authoredNode,
+    ) as Record<string, any>;
+
+    expect(result).toEqual({ type: "string", asCell: ["readonly"] });
+  });
+
+  it("allows registered synthetic wrapper nodes to override semantic wrapper kind", async () => {
+    const code = `
+      interface X {
+        authored: Cell<string>;
+      }
+    `;
+    const { checker, sourceFile } = await createTestProgram(code);
+    const symbol = checker.getSymbolsInScope(
+      sourceFile,
+      ts.SymbolFlags.Interface,
+    ).find((candidate) => candidate.name === "X");
+    if (!symbol) throw new Error("Interface X not found");
+
+    const type = checker.getDeclaredTypeOfSymbol(symbol);
+    const authored = type.getProperty("authored");
+    if (!authored) throw new Error("Property X.authored not found");
+    const authoredType = checker.getTypeOfSymbolAtLocation(
+      authored,
+      sourceFile,
+    );
+    const syntheticNode = ts.factory.createTypeReferenceNode(
+      ts.factory.createQualifiedName(
+        ts.factory.createIdentifier("__cfHelpers"),
+        ts.factory.createIdentifier("WriteonlyCell"),
+      ),
+      [ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword)],
+    );
+    const typeRegistry = new WeakMap<ts.Node, ts.Type>();
+    typeRegistry.set(syntheticNode, authoredType);
+
+    const gen = createSchemaTransformerV2();
+    const result = gen.generateSchemaFromSyntheticTypeNode(
+      syntheticNode,
+      checker,
+      typeRegistry,
+    ) as Record<string, any>;
+
+    expect(result).toEqual({ type: "string", asCell: ["writeonly"] });
+  });
 });

--- a/packages/ts-transformers/src/closures/strategies/derive-strategy.ts
+++ b/packages/ts-transformers/src/closures/strategies/derive-strategy.ts
@@ -1,12 +1,19 @@
 import ts from "typescript";
-import type { TransformationContext } from "../../core/mod.ts";
+import type {
+  CapabilityParamSummary,
+  TransformationContext,
+} from "../../core/mod.ts";
 import type { ClosureTransformationStrategy } from "./strategy.ts";
 import {
   detectCallKind,
   getDeriveInputAndCallbackArgument,
+  getTypeFromTypeNodeWithFallback,
+  setParentPointers,
   unwrapOpaqueLikeType,
 } from "../../ast/mod.ts";
+import { analyzeFunctionCapabilities } from "../../policy/capability-analysis.ts";
 import { registerDeriveCallType } from "../../ast/type-inference.ts";
+import { applyShrinkAndWrap } from "../../transformers/type-shrinking.ts";
 import { getCellKind } from "../../transformers/opaque-ref/opaque-ref.ts";
 import type { CaptureTreeNode } from "../../utils/capture-tree.ts";
 import { buildCapturePropertyAssignments } from "../../utils/capture-tree.ts";
@@ -103,6 +110,22 @@ export function isDeriveCall(
 ): boolean {
   const callKind = detectCallKind(node, context.checker);
   return callKind?.kind === "derive";
+}
+
+function getFirstParameterCapabilitySummary(
+  callback: ts.ArrowFunction | ts.FunctionExpression,
+  checker: ts.TypeChecker,
+): CapabilityParamSummary | undefined {
+  const summary = analyzeFunctionCapabilities(callback, {
+    checker,
+    includeNestedCallbacks: true,
+  });
+  const parameter = callback.parameters[0];
+  if (!parameter) return undefined;
+  const parameterName = ts.isIdentifier(parameter.name)
+    ? parameter.name.text
+    : "__param0";
+  return summary.params.find((param) => param.name === parameterName);
 }
 
 /**
@@ -461,16 +484,40 @@ export function transformDeriveCall(
     null, // derive merges captures into top-level object
     hasExplicitReturnType ? resultTypeNode : null,
   );
+  setParentPointers(newCallback);
 
   // Build TypeNodes for schema generation
   const schemaFactory = new SchemaFactory(context);
-  const inputTypeNode = schemaFactory.createDeriveInputSchema(
+  let inputTypeNode = schemaFactory.createDeriveInputSchema(
     originalInputParamName,
     originalInput,
     captureTree,
     captureNameMap,
     hadZeroParameters,
   );
+  const inputParamSummary = getFirstParameterCapabilitySummary(
+    newCallback,
+    checker,
+  );
+  if (inputParamSummary) {
+    inputTypeNode = applyShrinkAndWrap(
+      inputParamSummary,
+      inputTypeNode,
+      getTypeFromTypeNodeWithFallback(
+        inputTypeNode,
+        checker,
+        options.typeRegistry,
+      ),
+      false,
+      checker,
+      context.sourceFile,
+      factory,
+      "full",
+      inputParamSummary.capability,
+      context,
+      newCallback,
+    );
+  }
 
   // Build the derive call expression
   const newDeriveCall = context.cfHelpers.createHelperCall(

--- a/packages/ts-transformers/src/core/transformers.ts
+++ b/packages/ts-transformers/src/core/transformers.ts
@@ -24,6 +24,7 @@ export interface SchemaHint {
 
 export type ReactiveCapability =
   | "opaque"
+  | "comparable"
   | "readonly"
   | "writeonly"
   | "writable";
@@ -44,6 +45,8 @@ export interface CapabilityParamSummary {
   readonly identityOnly?: boolean;
   readonly identityPaths?: readonly (readonly string[])[];
   readonly identityCellPaths?: readonly (readonly string[])[];
+  readonly comparablePaths?: readonly (readonly string[])[];
+  readonly comparableCellPaths?: readonly (readonly string[])[];
   readonly defaults?: readonly CapabilityParamDefault[];
 }
 

--- a/packages/ts-transformers/src/core/transformers.ts
+++ b/packages/ts-transformers/src/core/transformers.ts
@@ -40,6 +40,7 @@ export interface CapabilityParamSummary {
   readonly readPaths: readonly (readonly string[])[];
   readonly fullShapePaths?: readonly (readonly string[])[];
   readonly writePaths: readonly (readonly string[])[];
+  readonly opaquePaths?: readonly (readonly string[])[];
   readonly passthrough: boolean;
   readonly wildcard: boolean;
   readonly identityOnly?: boolean;

--- a/packages/ts-transformers/src/policy/capability-analysis.ts
+++ b/packages/ts-transformers/src/policy/capability-analysis.ts
@@ -36,6 +36,7 @@ interface MutableCapabilityState {
   readonly rawIdentityCellPaths: Set<string>;
   readonly rawComparablePaths: Set<string>;
   readonly rawComparableCellPaths: Set<string>;
+  readonly rawOpaquePaths: Set<string>;
   passthrough: boolean;
   wildcard: boolean;
   hasIdentityUse: boolean;
@@ -47,6 +48,7 @@ interface ObservedCapabilityUsage {
   readonly readPaths: readonly (readonly string[])[];
   readonly fullShapePaths: readonly (readonly string[])[];
   readonly writePaths: readonly (readonly string[])[];
+  readonly opaquePaths: readonly (readonly string[])[];
   readonly passthrough: boolean;
   readonly wildcard: boolean;
   readonly identityOnly: boolean;
@@ -985,6 +987,18 @@ function normalizeObservedCapabilityUsage(
   const readPaths = Array.from(state.reads).map(decodePath);
   const fullShapePaths = Array.from(state.fullShapeReads).map(decodePath);
   const writePaths = Array.from(state.writes).map(decodePath);
+  const opaquePaths = Array.from(state.rawOpaquePaths)
+    .map(decodePath)
+    .filter((opaquePath) =>
+      ![
+        ...readPaths,
+        ...fullShapePaths,
+        ...writePaths,
+      ].some((path) =>
+        path.length >= opaquePath.length &&
+        opaquePath.every((segment, index) => path[index] === segment)
+      )
+    );
   const identityPaths = Array.from(state.rawIdentityPaths)
     .map(decodePath)
     .filter((identityPath) => {
@@ -998,6 +1012,7 @@ function normalizeObservedCapabilityUsage(
         ...readPaths,
         ...fullShapePaths,
         ...writePaths,
+        ...opaquePaths,
       ].some((path) =>
         path.length >= identityPath.length &&
         identityPath.every((segment, index) => path[index] === segment)
@@ -1020,6 +1035,7 @@ function normalizeObservedCapabilityUsage(
     readPaths,
     fullShapePaths,
     writePaths,
+    opaquePaths,
     passthrough: state.passthrough,
     wildcard: state.wildcard,
     identityOnly: identityPaths.some((path) => path.length === 0) &&
@@ -1094,6 +1110,7 @@ export function analyzeFunctionCapabilities(
           rawIdentityCellPaths: new Set<string>(),
           rawComparablePaths: new Set<string>(),
           rawComparableCellPaths: new Set<string>(),
+          rawOpaquePaths: new Set<string>(),
           passthrough: false,
           wildcard: false,
           hasIdentityUse: false,
@@ -1156,6 +1173,18 @@ export function analyzeFunctionCapabilities(
 
     const markOpaqueUse = (name: string, path: readonly string[]): void => {
       const state = ensureState(name);
+      state.hasNonIdentityUse = true;
+      if (path.length === 0) {
+        state.hasNonIdentityRootUse = true;
+      }
+    };
+
+    const recordOpaquePath = (
+      name: string,
+      path: readonly string[],
+    ): void => {
+      const state = ensureState(name);
+      state.rawOpaquePaths.add(encodePath(path));
       state.hasNonIdentityUse = true;
       if (path.length === 0) {
         state.hasNonIdentityRootUse = true;
@@ -2334,6 +2363,12 @@ export function analyzeFunctionCapabilities(
             for (const writePath of paramSummary.writePaths) {
               trackWrite(source.root, [...source.path, ...writePath]);
             }
+            for (const opaquePath of paramSummary.opaquePaths ?? []) {
+              recordOpaquePath(source.root, [
+                ...source.path,
+                ...opaquePath,
+              ]);
+            }
 
             for (const identityPath of paramSummary.identityPaths ?? []) {
               if (source.dynamic) {
@@ -2474,7 +2509,7 @@ export function analyzeFunctionCapabilities(
               // results. Root receivers need no extra capability, but nested
               // receivers must still be retained in object-shaped inputs.
               if (receiver.path.length > 0) {
-                trackReadRef(receiver);
+                recordOpaquePath(receiver.root, receiver.path);
               } else {
                 markOpaqueUse(receiver.root, receiver.path);
               }

--- a/packages/ts-transformers/src/policy/capability-analysis.ts
+++ b/packages/ts-transformers/src/policy/capability-analysis.ts
@@ -973,7 +973,9 @@ function toCapability(state: MutableCapabilityState): ReactiveCapability {
   if (hasReads && hasWrites) return "writable";
   if (hasReads) return "readonly";
   if (hasWrites) return "writeonly";
-  if (state.rawComparablePaths.size > 0) return "comparable";
+  if (state.rawComparablePaths.size > 0 && !state.hasNonIdentityUse) {
+    return "comparable";
+  }
   return "opaque";
 }
 
@@ -1148,6 +1150,14 @@ export function analyzeFunctionCapabilities(
         state.hasIdentityUse = true;
       } else {
         state.hasNonIdentityUse = true;
+        state.hasNonIdentityRootUse = true;
+      }
+    };
+
+    const markOpaqueUse = (name: string, path: readonly string[]): void => {
+      const state = ensureState(name);
+      state.hasNonIdentityUse = true;
+      if (path.length === 0) {
         state.hasNonIdentityRootUse = true;
       }
     };
@@ -2465,6 +2475,8 @@ export function analyzeFunctionCapabilities(
               // receivers must still be retained in object-shaped inputs.
               if (receiver.path.length > 0) {
                 trackReadRef(receiver);
+              } else {
+                markOpaqueUse(receiver.root, receiver.path);
               }
             } else {
               // Unknown method call over a tracked source reads at least the receiver path.

--- a/packages/ts-transformers/src/policy/capability-analysis.ts
+++ b/packages/ts-transformers/src/policy/capability-analysis.ts
@@ -34,6 +34,8 @@ interface MutableCapabilityState {
   readonly writes: Set<string>;
   readonly rawIdentityPaths: Set<string>;
   readonly rawIdentityCellPaths: Set<string>;
+  readonly rawComparablePaths: Set<string>;
+  readonly rawComparableCellPaths: Set<string>;
   passthrough: boolean;
   wildcard: boolean;
   hasIdentityUse: boolean;
@@ -50,6 +52,8 @@ interface ObservedCapabilityUsage {
   readonly identityOnly: boolean;
   readonly identityPaths: readonly (readonly string[])[];
   readonly identityCellPaths: readonly (readonly string[])[];
+  readonly comparablePaths: readonly (readonly string[])[];
+  readonly comparableCellPaths: readonly (readonly string[])[];
 }
 
 interface AccessPathInfo {
@@ -104,6 +108,14 @@ const WRITER_METHODS = new Set(["set", "update"]);
 const ARRAY_IDENTITY_WRITER_METHODS = new Set(["push", "unshift", "splice"]);
 const ARRAY_IDENTITY_PRESERVING_CHAIN_METHODS = new Set(["slice"]);
 const READER_METHODS = new Set(["get"]);
+const OPAQUE_DERIVATION_METHODS = new Set([
+  "map",
+  "mapWithPattern",
+  "flatMap",
+  "flatMapWithPattern",
+  "filter",
+  "filterWithPattern",
+]);
 const FALLBACK_OPERATORS = new Set<ts.SyntaxKind>([
   ts.SyntaxKind.QuestionQuestionToken,
   ts.SyntaxKind.BarBarToken,
@@ -761,15 +773,18 @@ function isKnownIdentityEqualsCallee(
   const current = unwrapExpression(expr);
 
   if (ts.isIdentifier(current)) {
+    if (current.text !== "equals" && current.text !== "equalLinks") {
+      return false;
+    }
     if (!checker) {
-      return current.text === "equals";
+      return true;
     }
     const symbol = checker.getSymbolAtLocation(current);
-    return resolvesToCommonFabricSymbol(symbol, checker, "equals");
+    return resolvesToCommonFabricSymbol(symbol, checker, current.text);
   }
 
   if (ts.isPropertyAccessExpression(current)) {
-    if (current.name.text !== "equals") {
+    if (current.name.text !== "equals" && current.name.text !== "equalLinks") {
       return false;
     }
     return !checker ||
@@ -781,7 +796,8 @@ function isKnownIdentityEqualsCallee(
     current.argumentExpression &&
     isLiteralElement(current.argumentExpression)
   ) {
-    if (getLiteralElementText(current.argumentExpression) !== "equals") {
+    const methodName = getLiteralElementText(current.argumentExpression);
+    if (methodName !== "equals" && methodName !== "equalLinks") {
       return false;
     }
     return !checker ||
@@ -957,6 +973,7 @@ function toCapability(state: MutableCapabilityState): ReactiveCapability {
   if (hasReads && hasWrites) return "writable";
   if (hasReads) return "readonly";
   if (hasWrites) return "writeonly";
+  if (state.rawComparablePaths.size > 0) return "comparable";
   return "opaque";
 }
 
@@ -989,6 +1006,13 @@ function normalizeObservedCapabilityUsage(
   const identityCellPaths = Array.from(state.rawIdentityCellPaths)
     .filter((path) => keptIdentityPaths.has(path))
     .map(decodePath);
+  const comparablePaths = Array.from(state.rawComparablePaths)
+    .filter((path) => keptIdentityPaths.has(path))
+    .map(decodePath);
+  const keptComparablePaths = new Set(comparablePaths.map(encodePath));
+  const comparableCellPaths = Array.from(state.rawComparableCellPaths)
+    .filter((path) => keptComparablePaths.has(path))
+    .map(decodePath);
 
   return {
     readPaths,
@@ -1003,6 +1027,8 @@ function normalizeObservedCapabilityUsage(
       !state.wildcard,
     identityPaths,
     identityCellPaths,
+    comparablePaths,
+    comparableCellPaths,
   };
 }
 
@@ -1064,6 +1090,8 @@ export function analyzeFunctionCapabilities(
           writes: new Set<string>(),
           rawIdentityPaths: new Set<string>(),
           rawIdentityCellPaths: new Set<string>(),
+          rawComparablePaths: new Set<string>(),
+          rawComparableCellPaths: new Set<string>(),
           passthrough: false,
           wildcard: false,
           hasIdentityUse: false,
@@ -1136,6 +1164,20 @@ export function analyzeFunctionCapabilities(
         state.rawIdentityCellPaths.add(encoded);
       }
       state.hasIdentityUse = true;
+    };
+
+    const recordComparablePath = (
+      name: string,
+      path: readonly string[],
+      options?: { cellLike?: boolean },
+    ): void => {
+      recordIdentityPath(name, path, options);
+      const state = ensureState(name);
+      const encoded = encodePath(path);
+      state.rawComparablePaths.add(encoded);
+      if (options?.cellLike) {
+        state.rawComparableCellPaths.add(encoded);
+      }
     };
 
     const hasRecordedIdentityPath = (
@@ -1797,17 +1839,21 @@ export function analyzeFunctionCapabilities(
     const markIdentityUseRef = (
       ref: SourceRef,
       expr?: ts.Expression,
+      options?: { comparable?: boolean },
     ): void => {
       const cellLike = expr
         ? isCellLikeExpression(expr) || !isPrimitiveLikeExpression(expr)
         : false;
+      const record = options?.comparable
+        ? recordComparablePath
+        : recordIdentityPath;
       if (ref.dynamic) {
         markWildcard(ref.root);
       } else if (ref.path.length === 0) {
-        recordIdentityPath(ref.root, [], { cellLike });
+        record(ref.root, [], { cellLike });
         markPassthrough(ref.root, { identityOnly: true });
       } else {
-        recordIdentityPath(ref.root, ref.path, { cellLike });
+        record(ref.root, ref.path, { cellLike });
       }
     };
 
@@ -2283,7 +2329,17 @@ export function analyzeFunctionCapabilities(
               if (source.dynamic) {
                 markWildcard(source.root);
               } else {
-                recordIdentityPath(
+                const isComparablePath = (paramSummary.comparablePaths ?? [])
+                  .some((path) =>
+                    path.length === identityPath.length &&
+                    path.every((segment, index) =>
+                      segment === identityPath[index]
+                    )
+                  );
+                const recordPath = isComparablePath
+                  ? recordComparablePath
+                  : recordIdentityPath;
+                recordPath(
                   source.root,
                   [...source.path, ...identityPath],
                   {
@@ -2301,7 +2357,11 @@ export function analyzeFunctionCapabilities(
 
             if (paramSummary.passthrough && source.path.length === 0) {
               if (paramSummary.identityOnly) {
-                recordIdentityPath(source.root, []);
+                if (paramSummary.capability === "comparable") {
+                  recordComparablePath(source.root, []);
+                } else {
+                  recordIdentityPath(source.root, []);
+                }
               }
               markPassthrough(
                 source.root,
@@ -2361,7 +2421,9 @@ export function analyzeFunctionCapabilities(
                 }
               }
             } else if (identityEqualsCall) {
-              markIdentityUseRef(receiver, node.expression.expression);
+              markIdentityUseRef(receiver, node.expression.expression, {
+                comparable: true,
+              });
             } else if (WRITER_METHODS.has(methodName)) {
               trackWriteRef(receiver);
             } else if (ARRAY_IDENTITY_WRITER_METHODS.has(methodName)) {
@@ -2391,6 +2453,16 @@ export function analyzeFunctionCapabilities(
               if (!resolvedGetCalls.has(node)) {
                 trackReadRef(receiver);
               }
+            } else if (
+              OPAQUE_DERIVATION_METHODS.has(methodName) &&
+              (
+                !checker ||
+                isCellLikeExpression(node.expression.expression)
+              )
+            ) {
+              // These methods are available on opaque cells and return opaque
+              // results, so the receiver does not need read/write/comparable
+              // capabilities just because it is used as the derivation source.
             } else {
               // Unknown method call over a tracked source reads at least the receiver path.
               if (shouldTrackFullShape) {
@@ -2423,7 +2495,9 @@ export function analyzeFunctionCapabilities(
           for (const argument of node.arguments) {
             const source = resolveSourceRef(argument);
             if (source) {
-              markIdentityUseRef(source, argument);
+              markIdentityUseRef(source, argument, {
+                comparable: identityEqualsCall,
+              });
             }
           }
         }

--- a/packages/ts-transformers/src/policy/capability-analysis.ts
+++ b/packages/ts-transformers/src/policy/capability-analysis.ts
@@ -107,7 +107,12 @@ function extendSourceRef(
 const PARAMETER_SUMMARY_PREFIX = "__param";
 
 const WRITER_METHODS = new Set(["set", "update"]);
-const ARRAY_IDENTITY_WRITER_METHODS = new Set(["push", "unshift", "splice"]);
+const ARRAY_IDENTITY_WRITER_METHODS = new Set([
+  "push",
+  "unshift",
+  "splice",
+  "remove",
+]);
 const ARRAY_IDENTITY_PRESERVING_CHAIN_METHODS = new Set(["slice"]);
 const READER_METHODS = new Set(["get"]);
 const OPAQUE_DERIVATION_METHODS = new Set([
@@ -2506,9 +2511,11 @@ export function analyzeFunctionCapabilities(
               )
             ) {
               // These methods are available on opaque cells and return opaque
-              // results. Root receivers need no extra capability, but nested
-              // receivers must still be retained in object-shaped inputs.
-              if (receiver.path.length > 0) {
+              // results. Dynamic receivers can hide which branch is used, so
+              // they must disable shrinking for the root.
+              if (receiver.dynamic) {
+                markWildcard(receiver.root);
+              } else if (receiver.path.length > 0) {
                 recordOpaquePath(receiver.root, receiver.path);
               } else {
                 markOpaqueUse(receiver.root, receiver.path);

--- a/packages/ts-transformers/src/policy/capability-analysis.ts
+++ b/packages/ts-transformers/src/policy/capability-analysis.ts
@@ -112,6 +112,7 @@ const ARRAY_IDENTITY_WRITER_METHODS = new Set([
   "unshift",
   "splice",
   "remove",
+  "removeAll",
 ]);
 const ARRAY_IDENTITY_PRESERVING_CHAIN_METHODS = new Set(["slice"]);
 const READER_METHODS = new Set(["get"]);

--- a/packages/ts-transformers/src/policy/capability-analysis.ts
+++ b/packages/ts-transformers/src/policy/capability-analysis.ts
@@ -2461,8 +2461,11 @@ export function analyzeFunctionCapabilities(
               )
             ) {
               // These methods are available on opaque cells and return opaque
-              // results, so the receiver does not need read/write/comparable
-              // capabilities just because it is used as the derivation source.
+              // results. Root receivers need no extra capability, but nested
+              // receivers must still be retained in object-shaped inputs.
+              if (receiver.path.length > 0) {
+                trackReadRef(receiver);
+              }
             } else {
               // Unknown method call over a tracked source reads at least the receiver path.
               if (shouldTrackFullShape) {

--- a/packages/ts-transformers/src/policy/capability-analysis.ts
+++ b/packages/ts-transformers/src/policy/capability-analysis.ts
@@ -2375,6 +2375,15 @@ export function analyzeFunctionCapabilities(
                 ...opaquePath,
               ]);
             }
+            if (
+              paramSummary.capability === "opaque" &&
+              !paramSummary.passthrough &&
+              paramSummary.readPaths.length === 0 &&
+              paramSummary.writePaths.length === 0 &&
+              (paramSummary.opaquePaths?.length ?? 0) === 0
+            ) {
+              markOpaqueUse(source.root, source.path);
+            }
 
             for (const identityPath of paramSummary.identityPaths ?? []) {
               if (source.dynamic) {

--- a/packages/ts-transformers/src/transformers/schema-generator.ts
+++ b/packages/ts-transformers/src/transformers/schema-generator.ts
@@ -93,6 +93,7 @@ export class SchemaGeneratorTransformer extends HelpersOnlyTransformer {
             checker,
             typeRegistry,
             schemaHints,
+            sourceFile,
           );
         } else {
           // Normal Type path
@@ -102,6 +103,7 @@ export class SchemaGeneratorTransformer extends HelpersOnlyTransformer {
             schemaTypeArg,
             generationOptions,
             schemaHints,
+            sourceFile,
           );
         }
 

--- a/packages/ts-transformers/src/transformers/schema-injection.ts
+++ b/packages/ts-transformers/src/transformers/schema-injection.ts
@@ -639,13 +639,14 @@ function createToSchemaCall(
     "cfHelpers" | "factory"
   >,
   typeNode: ts.TypeNode,
-  options?: { widenLiterals?: boolean },
+  options?: SchemaCallOptions,
 ): ts.CallExpression {
   const expr = cfHelpers.getHelperExpr("toSchema");
 
-  // Build arguments array if options are provided
   const args: ts.Expression[] = [];
-  if (options?.widenLiterals) {
+  if (isSchemaCallOptionExpressions(options)) {
+    args.push(...options);
+  } else if (options?.widenLiterals) {
     args.push(
       factory.createObjectLiteralExpression([
         factory.createPropertyAssignment(
@@ -661,6 +662,14 @@ function createToSchemaCall(
     [typeNode],
     args,
   );
+}
+
+type SchemaCallOptions = { widenLiterals?: boolean } | readonly ts.Expression[];
+
+function isSchemaCallOptionExpressions(
+  options: SchemaCallOptions | undefined,
+): options is readonly ts.Expression[] {
+  return Array.isArray(options);
 }
 
 function isToSchemaCall(node: ts.Expression): node is ts.CallExpression {
@@ -897,7 +906,7 @@ function createSchemaCallWithRegistryTransfer(
   typeNode: ts.TypeNode,
   checker: ts.TypeChecker,
   typeRegistry?: TypeRegistry,
-  options?: { widenLiterals?: boolean },
+  options?: SchemaCallOptions,
   schemaHints?: TransformationContext["options"]["schemaHints"],
 ): ts.CallExpression {
   const emittedTypeNode = normalizeSchemaInjectionTypeNode(
@@ -3104,6 +3113,7 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
               narrowedArgumentType,
               checker,
               typeRegistry,
+              firstArgument.arguments,
             );
             if (narrowedArgumentTypeValue && typeRegistry) {
               typeRegistry.set(inputSchema, narrowedArgumentTypeValue);

--- a/packages/ts-transformers/src/transformers/schema-injection.ts
+++ b/packages/ts-transformers/src/transformers/schema-injection.ts
@@ -202,7 +202,9 @@ function findCapabilitySummaryForParameter(
     })
     : capabilityRegistry
     ? (capabilityRegistry.get(fn) ?? analyzeFunctionCapabilities(fn))
-    : undefined;
+    : analyzeFunctionCapabilities(fn, {
+      checker: options?.checker,
+    });
   if (!summary) return undefined;
   const parameter = fn.parameters[index];
   if (!parameter) return undefined;
@@ -241,8 +243,14 @@ function applyCapabilitySummaryToArgument(
   if (!paramSummary) {
     return argumentNode;
   }
-
-  const innerTypeNode = extractCellLikeInnerTypeNode(argumentNode);
+  const innerTypeNode = extractCellLikeInnerTypeNode(argumentNode) ??
+    typeToSchemaTypeNode(
+      argumentType && isCellLikeType(argumentType, checker)
+        ? unwrapCellLikeType(argumentType, checker)
+        : undefined,
+      checker,
+      sourceFile,
+    );
   const shouldWrap = !!innerTypeNode;
   const baseTypeNode = innerTypeNode ?? argumentNode;
   let baseType = shouldWrap && argumentType
@@ -653,6 +661,18 @@ function createToSchemaCall(
     [typeNode],
     args,
   );
+}
+
+function isToSchemaCall(node: ts.Expression): node is ts.CallExpression {
+  if (!ts.isCallExpression(node)) return false;
+  if (!node.typeArguments || node.typeArguments.length !== 1) return false;
+
+  if (ts.isIdentifier(node.expression)) {
+    return node.expression.text === "toSchema";
+  }
+
+  return ts.isPropertyAccessExpression(node.expression) &&
+    node.expression.name.text === "toSchema";
 }
 
 function createUnknownSchemaTypeNode(factory: ts.NodeFactory): ts.TypeNode {
@@ -3051,6 +3071,51 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
 
       if (callKind?.kind === "builder" && callKind.builderName === "lift") {
         const factory = transformation.factory;
+
+        const firstArgument = node.arguments[0];
+        if (firstArgument && isToSchemaCall(firstArgument)) {
+          const argumentType = firstArgument.typeArguments?.[0];
+          const liftCallback = resolveFunctionLikeExpression(
+            node.arguments[2],
+            checker,
+            sourceFile,
+          );
+          if (argumentType && liftCallback) {
+            const argumentTypeValue = getTypeFromTypeNodeWithFallback(
+              argumentType,
+              checker,
+              typeRegistry,
+            );
+            const {
+              argumentTypeNode: narrowedArgumentType,
+              argumentTypeValue: narrowedArgumentTypeValue,
+            } = applyCallbackBuilderArgumentCapabilitySummary(
+              liftCallback,
+              argumentType,
+              argumentTypeValue,
+              checker,
+              sourceFile,
+              factory,
+              capabilityRegistry,
+              context,
+            );
+            const inputSchema = createSchemaCallWithRegistryTransfer(
+              context,
+              narrowedArgumentType,
+              checker,
+              typeRegistry,
+            );
+            if (narrowedArgumentTypeValue && typeRegistry) {
+              typeRegistry.set(inputSchema, narrowedArgumentTypeValue);
+            }
+            const updated = factory.createCallExpression(
+              node.expression,
+              node.typeArguments,
+              [inputSchema, ...node.arguments.slice(1)],
+            );
+            return ts.visitEachChild(updated, visit, transformation);
+          }
+        }
 
         if (node.typeArguments && node.typeArguments.length >= 2) {
           const [argumentType, resultType] = node.typeArguments;

--- a/packages/ts-transformers/src/transformers/schema-injection.ts
+++ b/packages/ts-transformers/src/transformers/schema-injection.ts
@@ -1141,12 +1141,28 @@ function resolveDualSchemaBuilderTypes(
     isCellLikeType(options.fallbackArgumentType, checker) &&
     parameterUsesCellLikeMethods(callback, 0)
   ) {
-    argumentTypeValue = options.fallbackArgumentType;
-    argumentTypeNode = typeToSchemaTypeNode(
+    const fallbackArgumentNode = typeToSchemaTypeNode(
       options.fallbackArgumentType,
       checker,
       sourceFile,
-    ) ?? argumentTypeNode;
+    );
+    if (fallbackArgumentNode) {
+      ({
+        argumentTypeNode,
+        argumentTypeValue,
+      } = applyCallbackBuilderArgumentCapabilitySummary(
+        callback,
+        fallbackArgumentNode,
+        options.fallbackArgumentType,
+        checker,
+        sourceFile,
+        factory,
+        capabilityRegistry,
+        context,
+      ));
+    } else {
+      argumentTypeValue = options.fallbackArgumentType;
+    }
   }
 
   if (

--- a/packages/ts-transformers/src/transformers/type-shrinking.ts
+++ b/packages/ts-transformers/src/transformers/type-shrinking.ts
@@ -156,6 +156,12 @@ function shouldPreferNodeDrivenShrink(
   retainedPaths: readonly (readonly string[])[],
   checker: ts.TypeChecker,
 ): boolean {
+  if (
+    containsDefaultTypeNode(nodeDriven) && !containsDefaultTypeNode(typeDriven)
+  ) {
+    return true;
+  }
+
   const requestedHeads = getTopLevelRequestedHeads(retainedPaths);
   const typeDrivenCoverage = countRepresentedRequestedHeads(
     typeDriven,
@@ -184,6 +190,12 @@ function shouldPreferTypeDrivenShrink(
   checker: ts.TypeChecker,
   hasDirectAccess: boolean,
 ): boolean {
+  if (
+    containsDefaultTypeNode(nodeDriven) && !containsDefaultTypeNode(typeDriven)
+  ) {
+    return false;
+  }
+
   const requestedHeads = getTopLevelRequestedHeads(retainedPaths);
   const typeDrivenCoverage = countRepresentedRequestedHeads(
     typeDriven,
@@ -206,6 +218,27 @@ function shouldPreferTypeDrivenShrink(
       containsAnyOrUnknownTypeNode(nodeDriven) &&
       !containsAnyOrUnknownTypeNode(typeDriven)
     );
+}
+
+function containsDefaultTypeNode(node: ts.TypeNode): boolean {
+  let found = false;
+  const visit = (current: ts.Node) => {
+    if (found) return;
+    if (ts.isTypeReferenceNode(current)) {
+      const name = ts.isIdentifier(current.typeName)
+        ? current.typeName.text
+        : ts.isQualifiedName(current.typeName)
+        ? current.typeName.right.text
+        : undefined;
+      if (name === "Default") {
+        found = true;
+        return;
+      }
+    }
+    ts.forEachChild(current, visit);
+  };
+  visit(node);
+  return found;
 }
 
 function choosePreferredShrinkCandidate(
@@ -1643,22 +1676,38 @@ function extractCellLikeInnerTypeNode(
   sourceFile: ts.SourceFile,
   typeRegistry?: WeakMap<ts.Node, ts.Type>,
 ): ts.TypeNode | undefined {
-  if (
-    ts.isTypeReferenceNode(node) &&
-    isCellLikeTypeNode(node) &&
-    node.typeArguments?.[0]
-  ) {
-    return node.typeArguments[0];
-  }
   const semanticType = getTypeFromTypeNodeWithFallback(
     node,
     checker,
     typeRegistry,
   );
-  const innerType = semanticType && isCellLikeType(semanticType, checker)
+  const semanticInner = semanticType && isCellLikeType(semanticType, checker)
     ? unwrapCellLikeType(semanticType, checker)
     : undefined;
-  return typeToSchemaTypeNode(innerType, checker, sourceFile);
+  if (
+    ts.isTypeReferenceNode(node) &&
+    isCellLikeTypeNode(node) &&
+    node.typeArguments?.[0]
+  ) {
+    const inner = node.typeArguments[0];
+    const innerType = getTypeFromTypeNodeWithFallback(
+      inner,
+      checker,
+      typeRegistry,
+    );
+    const typeToRegister = semanticInner && !isAnyOrUnknownType(semanticInner)
+      ? semanticInner
+      : innerType;
+    if (typeToRegister) {
+      typeRegistry?.set(inner, typeToRegister);
+    }
+    return inner;
+  }
+  const innerNode = typeToSchemaTypeNode(semanticInner, checker, sourceFile);
+  if (innerNode && semanticInner) {
+    typeRegistry?.set(innerNode, semanticInner);
+  }
+  return innerNode;
 }
 
 function selectCellPathCapability(
@@ -1805,6 +1854,11 @@ function applyCellCapabilityPathsToTypeNode(
     }
 
     let updated = member.type;
+    const memberSemanticType = getTypeFromTypeNodeWithFallback(
+      updated,
+      checker,
+      typeRegistry,
+    );
     const inner = extractCellLikeInnerTypeNode(
       updated,
       checker,
@@ -1815,6 +1869,9 @@ function applyCellCapabilityPathsToTypeNode(
       const capability = selectCellPathCapability(childPaths);
       if (capability) {
         updated = wrapTypeNodeWithCapability(inner, capability, factory);
+        if (typeRegistry && isCellLikeType(memberSemanticType, checker)) {
+          typeRegistry.set(updated, memberSemanticType);
+        }
       }
     } else {
       const nested = childPaths.filter((entry) => entry.path.length > 0);
@@ -2813,14 +2870,6 @@ export function applyShrinkAndWrap(
     );
     shrunk = next;
   }
-  next = applyCellCapabilityPathsToTypeNode(
-    next,
-    cellCapabilityPaths,
-    factory,
-    checker,
-    sourceFile,
-    context?.options.typeRegistry,
-  );
   if (context && fnNode) {
     validateShrinkCoverage(
       paramSummary,
@@ -2843,6 +2892,14 @@ export function applyShrinkAndWrap(
     checker,
     sourceFile,
     factory,
+  );
+  next = applyCellCapabilityPathsToTypeNode(
+    next,
+    cellCapabilityPaths,
+    factory,
+    checker,
+    sourceFile,
+    context?.options.typeRegistry,
   );
 
   if (!shouldWrap) {

--- a/packages/ts-transformers/src/transformers/type-shrinking.ts
+++ b/packages/ts-transformers/src/transformers/type-shrinking.ts
@@ -120,6 +120,7 @@ function deriveCapabilityShrinkPlan(
   const paths = uniquePaths([
     ...paramSummary.readPaths,
     ...paramSummary.writePaths,
+    ...(paramSummary.opaquePaths ?? []),
   ]);
   const fullShapePaths = uniquePaths(paramSummary.fullShapePaths ?? []);
   const identityPaths = uniquePaths(paramSummary.identityPaths ?? []);
@@ -1631,6 +1632,220 @@ export function wrapTypeNodeWithCapability(
   );
 }
 
+interface CellCapabilityPath {
+  readonly path: readonly string[];
+  readonly capability: ReactiveCapability;
+}
+
+function extractCellLikeInnerTypeNode(
+  node: ts.TypeNode,
+  checker: ts.TypeChecker,
+  sourceFile: ts.SourceFile,
+  typeRegistry?: WeakMap<ts.Node, ts.Type>,
+): ts.TypeNode | undefined {
+  if (
+    ts.isTypeReferenceNode(node) &&
+    isCellLikeTypeNode(node) &&
+    node.typeArguments?.[0]
+  ) {
+    return node.typeArguments[0];
+  }
+  const semanticType = getTypeFromTypeNodeWithFallback(
+    node,
+    checker,
+    typeRegistry,
+  );
+  const innerType = semanticType && isCellLikeType(semanticType, checker)
+    ? unwrapCellLikeType(semanticType, checker)
+    : undefined;
+  return typeToSchemaTypeNode(innerType, checker, sourceFile);
+}
+
+function selectCellPathCapability(
+  entries: readonly CellCapabilityPath[],
+): ReactiveCapability | undefined {
+  let hasRead = false;
+  let hasWrite = false;
+  let hasOpaque = false;
+
+  for (const entry of entries) {
+    if (entry.capability === "writable") {
+      hasRead = true;
+      hasWrite = true;
+    } else if (entry.capability === "readonly") {
+      hasRead = true;
+    } else if (entry.capability === "writeonly") {
+      hasWrite = true;
+    } else if (entry.capability === "opaque") {
+      hasOpaque = true;
+    }
+  }
+
+  if (hasRead && hasWrite) return "writable";
+  if (hasRead) return "readonly";
+  if (hasWrite) return "writeonly";
+  if (hasOpaque) return "opaque";
+  return undefined;
+}
+
+function buildCellCapabilityPaths(
+  paramSummary: CapabilityParamSummary,
+): readonly CellCapabilityPath[] {
+  const byPath = new Map<
+    string,
+    {
+      path: readonly string[];
+      read: boolean;
+      write: boolean;
+      opaque: boolean;
+    }
+  >();
+  const ensure = (path: readonly string[]) => {
+    const key = JSON.stringify(path);
+    let entry = byPath.get(key);
+    if (!entry) {
+      entry = {
+        path,
+        read: false,
+        write: false,
+        opaque: false,
+      };
+      byPath.set(key, entry);
+    }
+    return entry;
+  };
+
+  for (const path of paramSummary.opaquePaths ?? []) {
+    if (path.length === 0) continue;
+    ensure(path).opaque = true;
+  }
+  for (const path of paramSummary.readPaths) {
+    if (path.length === 0) continue;
+    ensure(path).read = true;
+  }
+  for (const path of paramSummary.writePaths) {
+    if (path.length === 0) continue;
+    ensure(path).write = true;
+  }
+
+  return Array.from(byPath.values()).map((entry) => {
+    const capability = entry.read && entry.write
+      ? "writable"
+      : entry.read
+      ? "readonly"
+      : entry.write
+      ? "writeonly"
+      : "opaque";
+    return { path: entry.path, capability };
+  });
+}
+
+function groupCellCapabilityPathsByHead(
+  entries: readonly CellCapabilityPath[],
+): Map<string, CellCapabilityPath[]> {
+  const grouped = new Map<string, CellCapabilityPath[]>();
+  for (const entry of entries) {
+    if (entry.path.length === 0) continue;
+    const [head, ...tail] = entry.path;
+    if (!head) continue;
+    const existing = grouped.get(head);
+    const childEntry = { path: tail, capability: entry.capability };
+    if (existing) {
+      existing.push(childEntry);
+    } else {
+      grouped.set(head, [childEntry]);
+    }
+  }
+  return grouped;
+}
+
+function applyCellCapabilityPathsToTypeNode(
+  node: ts.TypeNode,
+  paths: readonly CellCapabilityPath[],
+  factory: ts.NodeFactory,
+  checker: ts.TypeChecker,
+  sourceFile: ts.SourceFile,
+  typeRegistry?: WeakMap<ts.Node, ts.Type>,
+): ts.TypeNode {
+  if (paths.length === 0) {
+    return node;
+  }
+
+  if (ts.isParenthesizedTypeNode(node)) {
+    const updated = applyCellCapabilityPathsToTypeNode(
+      node.type,
+      paths,
+      factory,
+      checker,
+      sourceFile,
+      typeRegistry,
+    );
+    return updated === node.type
+      ? node
+      : factory.updateParenthesizedType(node, updated);
+  }
+
+  if (!ts.isTypeLiteralNode(node)) {
+    return node;
+  }
+
+  const grouped = groupCellCapabilityPathsByHead(paths);
+  let changed = false;
+  const members = node.members.map((member) => {
+    if (!ts.isPropertySignature(member) || !member.type || !member.name) {
+      return member;
+    }
+    const propertyName = getRequestedPropertyNameText(member.name, checker);
+    if (!propertyName) {
+      return member;
+    }
+    const childPaths = grouped.get(propertyName);
+    if (!childPaths) {
+      return member;
+    }
+
+    let updated = member.type;
+    const inner = extractCellLikeInnerTypeNode(
+      updated,
+      checker,
+      sourceFile,
+      typeRegistry,
+    );
+    if (inner) {
+      const capability = selectCellPathCapability(childPaths);
+      if (capability) {
+        updated = wrapTypeNodeWithCapability(inner, capability, factory);
+      }
+    } else {
+      const nested = childPaths.filter((entry) => entry.path.length > 0);
+      if (nested.length > 0) {
+        updated = applyCellCapabilityPathsToTypeNode(
+          updated,
+          nested,
+          factory,
+          checker,
+          sourceFile,
+          typeRegistry,
+        );
+      }
+    }
+
+    if (updated === member.type) {
+      return member;
+    }
+    changed = true;
+    return factory.updatePropertySignature(
+      member,
+      member.modifiers,
+      member.name,
+      member.questionToken,
+      updated,
+    );
+  });
+
+  return changed ? factory.createTypeLiteralNode(members) : node;
+}
+
 function createIdentityOnlyReplacementTypeNode(
   node: ts.TypeNode,
   semanticType: ts.Type | undefined,
@@ -2423,6 +2638,7 @@ export function applyShrinkAndWrap(
     identityOnlyRoot,
     effectiveIdentityPaths,
   } = shrinkPlan;
+  const cellCapabilityPaths = buildCellCapabilityPaths(paramSummary);
   const appliedIdentityCellPaths = shouldWrap
     ? identityCellPaths.filter((path) => path.length > 0)
     : identityCellPaths;
@@ -2597,6 +2813,14 @@ export function applyShrinkAndWrap(
     );
     shrunk = next;
   }
+  next = applyCellCapabilityPathsToTypeNode(
+    next,
+    cellCapabilityPaths,
+    factory,
+    checker,
+    sourceFile,
+    context?.options.typeRegistry,
+  );
   if (context && fnNode) {
     validateShrinkCoverage(
       paramSummary,

--- a/packages/ts-transformers/src/transformers/type-shrinking.ts
+++ b/packages/ts-transformers/src/transformers/type-shrinking.ts
@@ -474,6 +474,7 @@ export function isCellLikeTypeNode(node: ts.TypeNode): boolean {
     name === "Writable" ||
     name === "OpaqueCell" ||
     name === "OpaqueRef" ||
+    name === "ComparableCell" ||
     name === "ReadonlyCell" ||
     name === "WriteonlyCell" ||
     name === "Stream";
@@ -2422,6 +2423,12 @@ export function applyShrinkAndWrap(
     identityOnlyRoot,
     effectiveIdentityPaths,
   } = shrinkPlan;
+  const appliedIdentityCellPaths = shouldWrap
+    ? identityCellPaths.filter((path) => path.length > 0)
+    : identityCellPaths;
+  const appliedComparableCellPaths = shouldWrap
+    ? comparableCellPaths.filter((path) => path.length > 0)
+    : comparableCellPaths;
 
   if (mode === "defaults_only") {
     if (context && fnNode) {
@@ -2441,8 +2448,8 @@ export function applyShrinkAndWrap(
       ? applyIdentityOnlyPathsToTypeNode(
         baseTypeNode,
         effectiveIdentityPaths,
-        identityCellPaths,
-        comparableCellPaths,
+        appliedIdentityCellPaths,
+        appliedComparableCellPaths,
         factory,
         checker,
         baseType,
@@ -2474,8 +2481,8 @@ export function applyShrinkAndWrap(
     ? applyIdentityOnlyPathsToTypeNode(
       baseTypeNode,
       effectiveIdentityPaths,
-      identityCellPaths,
-      comparableCellPaths,
+      appliedIdentityCellPaths,
+      appliedComparableCellPaths,
       factory,
       checker,
       baseType,
@@ -2485,8 +2492,8 @@ export function applyShrinkAndWrap(
     ? applyIdentityOnlyPathsToTypeNode(
       baseTypeNode,
       identityPaths,
-      identityCellPaths,
-      comparableCellPaths,
+      appliedIdentityCellPaths,
+      appliedComparableCellPaths,
       factory,
       checker,
       baseType,
@@ -2581,8 +2588,8 @@ export function applyShrinkAndWrap(
     next = applyIdentityOnlyPathsToTypeNode(
       next,
       identityPaths,
-      identityCellPaths,
-      comparableCellPaths,
+      appliedIdentityCellPaths,
+      appliedComparableCellPaths,
       factory,
       checker,
       baseType,

--- a/packages/ts-transformers/src/transformers/type-shrinking.ts
+++ b/packages/ts-transformers/src/transformers/type-shrinking.ts
@@ -29,6 +29,7 @@ interface CapabilityShrinkPlan {
   readonly fullShapePaths: readonly (readonly string[])[];
   readonly identityPaths: readonly (readonly string[])[];
   readonly identityCellPaths: readonly (readonly string[])[];
+  readonly comparableCellPaths: readonly (readonly string[])[];
   readonly identityOnlyRoot: boolean;
   readonly effectiveIdentityPaths: readonly (readonly string[])[];
 }
@@ -123,6 +124,10 @@ function deriveCapabilityShrinkPlan(
   const fullShapePaths = uniquePaths(paramSummary.fullShapePaths ?? []);
   const identityPaths = uniquePaths(paramSummary.identityPaths ?? []);
   const identityCellPaths = uniquePaths(paramSummary.identityCellPaths ?? []);
+  const comparableCellPaths = uniquePaths([
+    ...(paramSummary.comparableCellPaths ?? []),
+    ...(paramSummary.capability === "comparable" ? identityCellPaths : []),
+  ]);
   const retainedPaths = uniquePaths([...paths, ...identityPaths]);
   const identityOnlyRoot = !!paramSummary.identityOnly &&
     !paramSummary.wildcard &&
@@ -137,6 +142,7 @@ function deriveCapabilityShrinkPlan(
     fullShapePaths,
     identityPaths,
     identityCellPaths,
+    comparableCellPaths,
     identityOnlyRoot,
     effectiveIdentityPaths,
   };
@@ -1607,6 +1613,8 @@ export function wrapTypeNodeWithCapability(
 ): ts.TypeNode {
   const wrapperName = capability === "readonly"
     ? "ReadonlyCell"
+    : capability === "comparable"
+    ? "ComparableCell"
     : capability === "writeonly"
     ? "WriteonlyCell"
     : capability === "writable"
@@ -1626,6 +1634,7 @@ function createIdentityOnlyReplacementTypeNode(
   node: ts.TypeNode,
   semanticType: ts.Type | undefined,
   forceOpaque: boolean,
+  forceComparable: boolean,
   checker: ts.TypeChecker,
   factory: ts.NodeFactory,
   typeRegistry?: WeakMap<ts.Node, ts.Type>,
@@ -1646,7 +1655,7 @@ function createIdentityOnlyReplacementTypeNode(
   ) {
     const wrappedNode = wrapTypeNodeWithCapability(
       unknownNode,
-      "opaque",
+      forceComparable ? "comparable" : "opaque",
       factory,
     );
     const wrappedType = resolveIdentitySemanticType(
@@ -1688,6 +1697,7 @@ function createIdentityOnlyRootTypeNode(
   node: ts.TypeNode,
   semanticType: ts.Type | undefined,
   forceOpaque: boolean,
+  forceComparable: boolean,
   checker: ts.TypeChecker,
   factory: ts.NodeFactory,
   typeRegistry?: WeakMap<ts.Node, ts.Type>,
@@ -1700,6 +1710,7 @@ function createIdentityOnlyRootTypeNode(
       node,
       resolvedType,
       forceOpaque,
+      forceComparable,
       checker,
       factory,
       typeRegistry,
@@ -1735,6 +1746,7 @@ function createIdentityOnlyRootTypeNode(
           ) ?? factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword),
           memberType,
           forceOpaque,
+          forceComparable,
           checker,
           factory,
           typeRegistry,
@@ -1754,6 +1766,7 @@ function createIdentityOnlyRootTypeNode(
     node,
     resolvedType,
     forceOpaque,
+    forceComparable,
     checker,
     factory,
     typeRegistry,
@@ -1801,6 +1814,7 @@ function applyIdentityOnlyPathsToTypeNode(
   node: ts.TypeNode,
   paths: readonly (readonly string[])[],
   cellLikePaths: readonly (readonly string[])[],
+  comparableCellLikePaths: readonly (readonly string[])[],
   factory: ts.NodeFactory,
   checker: ts.TypeChecker,
   semanticType?: ts.Type,
@@ -1808,6 +1822,9 @@ function applyIdentityOnlyPathsToTypeNode(
 ): ts.TypeNode {
   const normalized = uniquePaths(paths);
   const normalizedCellLikePaths = uniquePaths(cellLikePaths);
+  const normalizedComparableCellLikePaths = uniquePaths(
+    comparableCellLikePaths,
+  );
   if (normalized.length === 0) {
     return node;
   }
@@ -1821,6 +1838,7 @@ function applyIdentityOnlyPathsToTypeNode(
       node,
       resolvedSemanticType,
       normalizedCellLikePaths.some((path) => path.length === 0),
+      normalizedComparableCellLikePaths.some((path) => path.length === 0),
       checker,
       factory,
       typeRegistry,
@@ -1832,6 +1850,7 @@ function applyIdentityOnlyPathsToTypeNode(
       node.type,
       normalized,
       normalizedCellLikePaths,
+      normalizedComparableCellLikePaths,
       factory,
       checker,
       resolvedSemanticType,
@@ -1844,6 +1863,9 @@ function applyIdentityOnlyPathsToTypeNode(
 
   const itemPaths = getArrayItemPaths(normalized);
   const itemCellLikePaths = getArrayItemPaths(normalizedCellLikePaths);
+  const itemComparableCellLikePaths = getArrayItemPaths(
+    normalizedComparableCellLikePaths,
+  );
   if (itemPaths.length > 0) {
     const itemSemanticType = resolvedSemanticType
       ? getArrayElementType(
@@ -1856,6 +1878,7 @@ function applyIdentityOnlyPathsToTypeNode(
         node.elementType,
         itemPaths,
         itemCellLikePaths,
+        itemComparableCellLikePaths,
         factory,
         checker,
         itemSemanticType,
@@ -1877,6 +1900,7 @@ function applyIdentityOnlyPathsToTypeNode(
         node.type.elementType,
         itemPaths,
         itemCellLikePaths,
+        itemComparableCellLikePaths,
         factory,
         checker,
         itemSemanticType,
@@ -1904,6 +1928,7 @@ function applyIdentityOnlyPathsToTypeNode(
         inner,
         itemPaths,
         itemCellLikePaths,
+        itemComparableCellLikePaths,
         factory,
         checker,
         itemSemanticType,
@@ -1924,6 +1949,9 @@ function applyIdentityOnlyPathsToTypeNode(
   if (ts.isTypeLiteralNode(node)) {
     const grouped = groupPathsByHead(normalized);
     const cellLikeGrouped = groupPathsByHead(normalizedCellLikePaths);
+    const comparableCellLikeGrouped = groupPathsByHead(
+      normalizedComparableCellLikePaths,
+    );
     let changed = false;
     const members = node.members.map((member) => {
       if (!ts.isPropertySignature(member) || !member.type || !member.name) {
@@ -1941,6 +1969,7 @@ function applyIdentityOnlyPathsToTypeNode(
         member.type,
         childPaths,
         cellLikeGrouped.get(propertyName) ?? [],
+        comparableCellLikeGrouped.get(propertyName) ?? [],
         factory,
         checker,
         getIdentityChildSemanticType(
@@ -1983,6 +2012,7 @@ function applyIdentityOnlyPathsToTypeNode(
       inner,
       normalized,
       normalizedCellLikePaths,
+      normalizedComparableCellLikePaths,
       factory,
       checker,
       unwrapCellLikeType(resolvedSemanticType, checker) ?? resolvedSemanticType,
@@ -2004,6 +2034,9 @@ function applyIdentityOnlyPathsToTypeNode(
     if (members) {
       const grouped = groupPathsByHead(normalized);
       const cellLikeGrouped = groupPathsByHead(normalizedCellLikePaths);
+      const comparableCellLikeGrouped = groupPathsByHead(
+        normalizedComparableCellLikePaths,
+      );
       let changed = false;
       const updatedMembers = members.map((member) => {
         if (!ts.isPropertySignature(member) || !member.type || !member.name) {
@@ -2021,6 +2054,7 @@ function applyIdentityOnlyPathsToTypeNode(
           member.type,
           childPaths,
           cellLikeGrouped.get(propertyName) ?? [],
+          comparableCellLikeGrouped.get(propertyName) ?? [],
           factory,
           checker,
           getIdentityChildSemanticType(
@@ -2061,6 +2095,7 @@ function applyIdentityOnlyPathsToTypeNode(
         member,
         normalized,
         normalizedCellLikePaths,
+        normalizedComparableCellLikePaths,
         factory,
         checker,
         resolvedSemanticType,
@@ -2383,6 +2418,7 @@ export function applyShrinkAndWrap(
     fullShapePaths,
     identityPaths,
     identityCellPaths,
+    comparableCellPaths,
     identityOnlyRoot,
     effectiveIdentityPaths,
   } = shrinkPlan;
@@ -2406,6 +2442,7 @@ export function applyShrinkAndWrap(
         baseTypeNode,
         effectiveIdentityPaths,
         identityCellPaths,
+        comparableCellPaths,
         factory,
         checker,
         baseType,
@@ -2438,6 +2475,7 @@ export function applyShrinkAndWrap(
       baseTypeNode,
       effectiveIdentityPaths,
       identityCellPaths,
+      comparableCellPaths,
       factory,
       checker,
       baseType,
@@ -2448,6 +2486,7 @@ export function applyShrinkAndWrap(
       baseTypeNode,
       identityPaths,
       identityCellPaths,
+      comparableCellPaths,
       factory,
       checker,
       baseType,
@@ -2543,6 +2582,7 @@ export function applyShrinkAndWrap(
       next,
       identityPaths,
       identityCellPaths,
+      comparableCellPaths,
       factory,
       checker,
       baseType,

--- a/packages/ts-transformers/test/fixtures/ast-transform/authored-ifelse-reactive-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/authored-ifelse-reactive-roots.expected.jsx
@@ -68,7 +68,7 @@ export default pattern((__cf_pattern_input) => {
             properties: {
                 cell: {
                     type: "number",
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["cell"]

--- a/packages/ts-transformers/test/fixtures/ast-transform/lift-explicit-toschema.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/lift-explicit-toschema.expected.jsx
@@ -47,11 +47,23 @@ const logCharmsList = lift({
     console.log("logCharmsList: ", charmsList.get());
     return charmsList;
 });
+const getStatus = lift({
+    type: "object",
+    properties: {
+        status: {
+            "enum": ["open", "closed"]
+        }
+    },
+    required: ["status"],
+    description: "Status input"
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "string"
+} as const satisfies __cfHelpers.JSONSchema, ({ status }) => status);
 // FIXTURE: lift-explicit-toschema
 // Verifies: lift() with explicit toSchema<T>() is replaced by the generated JSON schema
 //   lift(toSchema<{ charmsList: Cell<CharmEntry[]> }>(), undefined, fn) → lift(generatedSchema, undefined, fn)
 // Context: The toSchema() call is compiled away and replaced with the actual JSON schema object
-export default logCharmsList;
+export default __cfHelpers.__cf_data({ logCharmsList, getStatus });
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/lift-explicit-toschema.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/lift-explicit-toschema.expected.jsx
@@ -25,7 +25,7 @@ const logCharmsList = lift({
             items: {
                 $ref: "#/$defs/CharmEntry"
             },
-            asCell: ["cell"]
+            asCell: ["readonly"]
         }
     },
     required: ["charmsList"],

--- a/packages/ts-transformers/test/fixtures/ast-transform/lift-explicit-toschema.input.tsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/lift-explicit-toschema.input.tsx
@@ -16,8 +16,16 @@ const logCharmsList = lift(
   },
 );
 
+const getStatus = lift(
+  toSchema<{ status: "open" | "closed"; ignored: "draft" }>({
+    description: "Status input",
+  }),
+  toSchema<string>(),
+  ({ status }) => status,
+);
+
 // FIXTURE: lift-explicit-toschema
 // Verifies: lift() with explicit toSchema<T>() is replaced by the generated JSON schema
 //   lift(toSchema<{ charmsList: Cell<CharmEntry[]> }>(), undefined, fn) → lift(generatedSchema, undefined, fn)
 // Context: The toSchema() call is compiled away and replaced with the actual JSON schema object
-export default logCharmsList;
+export default { logCharmsList, getStatus };

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-array-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-array-map.expected.jsx
@@ -19,7 +19,7 @@ const adder = handler(false as const satisfies __cfHelpers.JSONSchema, {
             items: {
                 type: "string"
             },
-            asCell: ["cell"]
+            asCell: ["writeonly"]
         }
     },
     required: ["values"]

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-builders.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-builders.expected.jsx
@@ -33,7 +33,7 @@ const addTodo = handler({
             items: {
                 type: "string"
             },
-            asCell: ["cell"]
+            asCell: ["writeonly"]
         }
     },
     required: ["items"]

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-lift-cell-array.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-lift-cell-array.expected.jsx
@@ -29,7 +29,7 @@ const logCharmsList = lift({
             items: {
                 $ref: "#/$defs/CharmEntry"
             },
-            asCell: ["cell"]
+            asCell: ["readonly"]
         }
     },
     required: ["charmsList"],

--- a/packages/ts-transformers/test/fixtures/closures/action-generic-event.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-generic-event.expected.jsx
@@ -38,7 +38,7 @@ export default pattern((__cf_pattern_input) => {
             properties: {
                 value: {
                     type: "string",
-                    asCell: ["cell"]
+                    asCell: ["writeonly"]
                 }
             },
             required: ["value"]

--- a/packages/ts-transformers/test/fixtures/closures/action-in-ternary-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-in-ternary-branch.expected.jsx
@@ -41,7 +41,7 @@ export default pattern((__cf_pattern_input) => {
         properties: {
             isEditing: {
                 type: "boolean",
-                asCell: ["cell"]
+                asCell: ["writeonly"]
             }
         },
         required: ["isEditing"]

--- a/packages/ts-transformers/test/fixtures/closures/action-in-ternary-with-explicit-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-in-ternary-with-explicit-computed.expected.jsx
@@ -40,7 +40,7 @@ export default pattern((__cf_pattern_input) => {
         properties: {
             isEditing: {
                 type: "boolean",
-                asCell: ["cell"]
+                asCell: ["writeonly"]
             }
         },
         required: ["isEditing"]
@@ -86,7 +86,7 @@ export default pattern((__cf_pattern_input) => {
                         required: ["description"]
                     },
                     startEditing: {
-                        asCell: ["stream", "opaque"]
+                        asCell: ["readonly", "opaque"]
                     }
                 },
                 required: ["card", "startEditing"]

--- a/packages/ts-transformers/test/fixtures/closures/action-partial.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-partial.expected.jsx
@@ -29,8 +29,12 @@ export default pattern((__cf_pattern_input) => {
             type: "object",
             properties: {
                 a: {
-                    type: "string",
-                    asCell: ["cell"]
+                    anyOf: [{
+                            type: "string"
+                        }, {
+                            type: "undefined"
+                        }],
+                    asCell: ["readonly"]
                 }
             }
         } as const satisfies __cfHelpers.JSONSchema, (_, { a }) => console.log(a))({
@@ -40,8 +44,12 @@ export default pattern((__cf_pattern_input) => {
             type: "object",
             properties: {
                 b: {
-                    type: "number",
-                    asCell: ["cell"]
+                    anyOf: [{
+                            type: "number"
+                        }, {
+                            type: "undefined"
+                        }],
+                    asCell: ["readonly"]
                 }
             }
         } as const satisfies __cfHelpers.JSONSchema, (_, { b }) => console.log(b))({

--- a/packages/ts-transformers/test/fixtures/closures/action-required-partial.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-required-partial.expected.jsx
@@ -30,7 +30,7 @@ export default pattern((__cf_pattern_input) => {
             properties: {
                 a: {
                     type: "string",
-                    asCell: ["cell"]
+                    asCell: ["writeonly"]
                 }
             },
             required: ["a"]
@@ -42,7 +42,7 @@ export default pattern((__cf_pattern_input) => {
             properties: {
                 b: {
                     type: "number",
-                    asCell: ["cell"]
+                    asCell: ["writeonly"]
                 }
             },
             required: ["b"]

--- a/packages/ts-transformers/test/fixtures/closures/action-with-event.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-with-event.expected.jsx
@@ -37,7 +37,7 @@ export default pattern((__cf_pattern_input) => {
             properties: {
                 value: {
                     type: "string",
-                    asCell: ["cell"]
+                    asCell: ["writeonly"]
                 }
             },
             required: ["value"]

--- a/packages/ts-transformers/test/fixtures/closures/computed-basic-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-basic-capture.expected.jsx
@@ -27,11 +27,11 @@ export default pattern(() => {
         properties: {
             value: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             multiplier: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             }
         },
         required: ["value", "multiplier"]

--- a/packages/ts-transformers/test/fixtures/closures/computed-complex-expression.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-complex-expression.expected.jsx
@@ -30,15 +30,15 @@ export default pattern(() => {
         properties: {
             a: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             b: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             c: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             }
         },
         required: ["a", "b", "c"]

--- a/packages/ts-transformers/test/fixtures/closures/computed-conditional-expression.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-conditional-expression.expected.jsx
@@ -33,19 +33,19 @@ export default pattern(() => {
         properties: {
             value: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             threshold: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             a: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             b: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             }
         },
         required: ["value", "threshold", "a", "b"]

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-in-derived-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-in-derived-branch.expected.jsx
@@ -39,7 +39,7 @@ export default pattern((__cf_pattern_input) => {
                 items: {
                     $ref: "#/$defs/Person"
                 },
-                asCell: ["cell"]
+                asCell: ["readonly"]
             }
         },
         required: ["people"],
@@ -85,7 +85,7 @@ export default pattern((__cf_pattern_input) => {
                 items: {
                     type: "unknown"
                 },
-                asCell: ["cell"]
+                asCell: ["readonly"]
             }
         },
         required: ["people"]

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-in-ternary-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-in-ternary-branch.expected.jsx
@@ -40,7 +40,7 @@ export default pattern((__cf_pattern_input) => {
                 items: {
                     $ref: "#/$defs/Person"
                 },
-                asCell: ["cell"]
+                asCell: ["readonly"]
             }
         },
         required: ["people"],
@@ -86,7 +86,7 @@ export default pattern((__cf_pattern_input) => {
                 items: {
                     type: "unknown"
                 },
-                asCell: ["cell"]
+                asCell: ["readonly"]
             }
         },
         required: ["people"]

--- a/packages/ts-transformers/test/fixtures/closures/computed-multiple-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-multiple-captures.expected.jsx
@@ -30,15 +30,15 @@ export default pattern(() => {
         properties: {
             a: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             b: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             c: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             }
         },
         required: ["a", "b", "c"]

--- a/packages/ts-transformers/test/fixtures/closures/computed-nested-property.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-nested-property.expected.jsx
@@ -36,7 +36,7 @@ export default pattern(() => {
                     }
                 },
                 required: ["count"],
-                asCell: ["cell"]
+                asCell: ["readonly"]
             }
         },
         required: ["counter"]

--- a/packages/ts-transformers/test/fixtures/closures/computed-nested.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-nested.expected.jsx
@@ -29,11 +29,11 @@ export default pattern(() => {
         properties: {
             a: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             b: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             }
         },
         required: ["a", "b"]

--- a/packages/ts-transformers/test/fixtures/closures/computed-optional-chaining.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-optional-chaining.expected.jsx
@@ -41,6 +41,16 @@ export default pattern(() => {
                 asCell: ["readonly"]
             },
             config: {
+                anyOf: [{
+                        type: "object",
+                        properties: {
+                            multiplier: {
+                                type: "number"
+                            }
+                        }
+                    }, {
+                        type: "null"
+                    }],
                 asCell: ["readonly"]
             }
         },

--- a/packages/ts-transformers/test/fixtures/closures/computed-optional-chaining.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-optional-chaining.expected.jsx
@@ -38,20 +38,10 @@ export default pattern(() => {
         properties: {
             value: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             config: {
-                anyOf: [{
-                        type: "object",
-                        properties: {
-                            multiplier: {
-                                type: "number"
-                            }
-                        }
-                    }, {
-                        type: "null"
-                    }],
-                asCell: ["cell"]
+                asCell: ["readonly"]
             }
         },
         required: ["value", "config"]

--- a/packages/ts-transformers/test/fixtures/closures/computed-pattern-param-mixed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-pattern-param-mixed.expected.jsx
@@ -33,7 +33,7 @@ export default pattern((config: {
         properties: {
             value: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             config: {
                 type: "object",
@@ -52,7 +52,7 @@ export default pattern((config: {
             },
             threshold: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             }
         },
         required: ["value", "config", "offset", "threshold"]

--- a/packages/ts-transformers/test/fixtures/closures/computed-pattern-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-pattern-param.expected.jsx
@@ -28,7 +28,7 @@ export default pattern((config: {
         properties: {
             value: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             config: {
                 type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/computed-pattern-typed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-pattern-typed.expected.jsx
@@ -27,7 +27,7 @@ export default pattern((__cf_pattern_input) => {
         properties: {
             value: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             multiplier: {
                 type: "number"

--- a/packages/ts-transformers/test/fixtures/closures/computed-with-closed-over-cell-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-with-closed-over-cell-map.expected.jsx
@@ -39,11 +39,11 @@ export default pattern(() => {
                 items: {
                     type: "number"
                 },
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             multiplier: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             }
         },
         required: ["numbers", "multiplier"]
@@ -70,7 +70,7 @@ export default pattern(() => {
                 properties: {
                     multiplier: {
                         type: "number",
-                        asCell: ["cell"]
+                        asCell: ["readonly"]
                     }
                 },
                 required: ["multiplier"]

--- a/packages/ts-transformers/test/fixtures/closures/derive-4arg-form.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-4arg-form.expected.jsx
@@ -29,11 +29,11 @@ export default pattern(() => {
         properties: {
             value: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             multiplier: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             }
         },
         required: ["value", "multiplier"]

--- a/packages/ts-transformers/test/fixtures/closures/derive-all-literal-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-all-literal-types.expected.jsx
@@ -30,7 +30,7 @@ export default pattern(() => {
         properties: {
             value: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             numLiteral: {
                 type: "number"

--- a/packages/ts-transformers/test/fixtures/closures/derive-array-element-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-array-element-access.expected.jsx
@@ -25,7 +25,7 @@ export default pattern(() => {
         properties: {
             value: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             factors: {
                 type: "array",

--- a/packages/ts-transformers/test/fixtures/closures/derive-basic-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-basic-capture.expected.jsx
@@ -26,11 +26,11 @@ export default pattern(() => {
         properties: {
             value: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             multiplier: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             }
         },
         required: ["value", "multiplier"]

--- a/packages/ts-transformers/test/fixtures/closures/derive-collision-property.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-collision-property.expected.jsx
@@ -28,11 +28,11 @@ export default pattern(() => {
         properties: {
             multiplier_1: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             multiplier: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             }
         },
         required: ["multiplier_1", "multiplier"]

--- a/packages/ts-transformers/test/fixtures/closures/derive-collision-shorthand.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-collision-shorthand.expected.jsx
@@ -28,11 +28,11 @@ export default pattern(() => {
         properties: {
             multiplier: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             multiplier_1: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             }
         },
         required: ["multiplier", "multiplier_1"]

--- a/packages/ts-transformers/test/fixtures/closures/derive-complex-expression.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-complex-expression.expected.jsx
@@ -29,15 +29,15 @@ export default pattern(() => {
         properties: {
             a: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             b: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             c: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             }
         },
         required: ["a", "b", "c"]

--- a/packages/ts-transformers/test/fixtures/closures/derive-computed-property.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-computed-property.expected.jsx
@@ -26,7 +26,7 @@ export default pattern(() => {
         properties: {
             value: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             config: {
                 type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/derive-conditional-expression.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-conditional-expression.expected.jsx
@@ -29,15 +29,15 @@ export default pattern(() => {
         properties: {
             value: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             threshold: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             multiplier: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             }
         },
         required: ["value", "threshold", "multiplier"]

--- a/packages/ts-transformers/test/fixtures/closures/derive-destructured-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-destructured-param.expected.jsx
@@ -41,11 +41,11 @@ export default pattern(() => {
         properties: {
             point: {
                 $ref: "#/$defs/Point",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             multiplier: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             }
         },
         required: ["point", "multiplier"],

--- a/packages/ts-transformers/test/fixtures/closures/derive-empty-input-no-params.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-empty-input-no-params.expected.jsx
@@ -28,11 +28,11 @@ export default pattern(() => {
         properties: {
             a: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             b: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             }
         },
         required: ["a", "b"]

--- a/packages/ts-transformers/test/fixtures/closures/derive-local-variable.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-local-variable.expected.jsx
@@ -30,15 +30,15 @@ export default pattern(() => {
         properties: {
             a: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             b: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             c: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             }
         },
         required: ["a", "b", "c"]

--- a/packages/ts-transformers/test/fixtures/closures/derive-method-call-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-method-call-capture.expected.jsx
@@ -30,7 +30,7 @@ export default pattern((state: State) => {
         properties: {
             value: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             state: {
                 type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/derive-multiple-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-multiple-captures.expected.jsx
@@ -29,15 +29,15 @@ export default pattern(() => {
         properties: {
             value: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             multiplier: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             offset: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             }
         },
         required: ["value", "multiplier", "offset"]

--- a/packages/ts-transformers/test/fixtures/closures/derive-name-collision.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-name-collision.expected.jsx
@@ -26,11 +26,11 @@ export default pattern(() => {
         properties: {
             multiplier: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             multiplier_1: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             }
         },
         required: ["multiplier", "multiplier_1"]

--- a/packages/ts-transformers/test/fixtures/closures/derive-nested-callback.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-nested-callback.expected.jsx
@@ -30,19 +30,19 @@ export default pattern(() => {
     const result = __cfHelpers.derive({
         type: "object",
         properties: {
+            multiplier: {
+                type: "number",
+                asCell: ["readonly"]
+            },
             numbers: {
                 type: "array",
                 items: {
                     type: "number"
                 },
-                asCell: ["cell"]
-            },
-            multiplier: {
-                type: "number",
-                asCell: ["cell"]
+                asCell: ["opaque"]
             }
         },
-        required: ["numbers", "multiplier"]
+        required: ["multiplier", "numbers"]
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "array",
         items: {
@@ -66,7 +66,7 @@ export default pattern(() => {
                 properties: {
                     multiplier: {
                         type: "number",
-                        asCell: ["cell"]
+                        asCell: ["readonly"]
                     }
                 },
                 required: ["multiplier"]

--- a/packages/ts-transformers/test/fixtures/closures/derive-nested-property.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-nested-property.expected.jsx
@@ -29,7 +29,7 @@ export default pattern((state: State) => {
         properties: {
             value: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             state: {
                 type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/derive-no-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-no-captures.expected.jsx
@@ -22,7 +22,7 @@ export default pattern(() => {
     // No captures - should not be transformed
     const result = derive({
         type: "number",
-        asCell: ["cell"]
+        asCell: ["readonly"]
     } as const satisfies __cfHelpers.JSONSchema, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema, value, (v) => v.get() * 2).for("result", true);

--- a/packages/ts-transformers/test/fixtures/closures/derive-optional-chaining.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-optional-chaining.expected.jsx
@@ -27,7 +27,7 @@ export default pattern((config: Config) => {
         properties: {
             value: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             config: {
                 type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/derive-param-initializer.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-param-initializer.expected.jsx
@@ -29,7 +29,7 @@ export default pattern(() => {
             },
             multiplier: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             }
         },
         required: ["value", "multiplier"]

--- a/packages/ts-transformers/test/fixtures/closures/derive-reserved-names.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-reserved-names.expected.jsx
@@ -27,11 +27,11 @@ export default pattern(() => {
         properties: {
             value: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             __cf_reserved: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             }
         },
         required: ["value", "__cf_reserved"]

--- a/packages/ts-transformers/test/fixtures/closures/derive-template-literal.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-template-literal.expected.jsx
@@ -26,11 +26,11 @@ export default pattern(() => {
         properties: {
             prefix: {
                 type: "string",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             value: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             }
         },
         required: ["prefix", "value"]

--- a/packages/ts-transformers/test/fixtures/closures/derive-type-assertion.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-type-assertion.expected.jsx
@@ -27,11 +27,11 @@ export default pattern(() => {
         properties: {
             value: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             multiplier: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             }
         },
         required: ["value", "multiplier"]

--- a/packages/ts-transformers/test/fixtures/closures/derive-union-undefined.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/derive-union-undefined.expected.jsx
@@ -28,7 +28,7 @@ export default pattern((config: Config) => {
         properties: {
             value: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             config: {
                 type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/handler-destructured-params.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-destructured-params.expected.jsx
@@ -57,11 +57,11 @@ export default pattern((state) => {
                     properties: {
                         selectedValue: {
                             type: "string",
-                            asCell: ["cell"]
+                            asCell: ["writeonly"]
                         },
                         lastItems: {
                             type: "string",
-                            asCell: ["cell"]
+                            asCell: ["writeonly"]
                         }
                     },
                     required: ["selectedValue", "lastItems"]

--- a/packages/ts-transformers/test/fixtures/closures/handler-event-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-event-param.expected.jsx
@@ -48,7 +48,7 @@ export default pattern((state) => {
                         },
                         selectedValue: {
                             type: "string",
-                            asCell: ["cell"]
+                            asCell: ["writeonly"]
                         }
                     },
                     required: ["changeCount", "selectedValue"]

--- a/packages/ts-transformers/test/fixtures/closures/helper-owned-handler-nested-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/helper-owned-handler-nested-captures.expected.jsx
@@ -65,6 +65,11 @@ export default pattern((__cf_pattern_input) => {
         type: "object",
         properties: {
             timer: {
+                anyOf: [{
+                        type: "number"
+                    }, {
+                        type: "null"
+                    }],
                 asCell: ["cell"]
             },
             fileId: {

--- a/packages/ts-transformers/test/fixtures/closures/helper-owned-handler-nested-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/helper-owned-handler-nested-captures.expected.jsx
@@ -65,24 +65,19 @@ export default pattern((__cf_pattern_input) => {
         type: "object",
         properties: {
             timer: {
-                anyOf: [{
-                        type: "number"
-                    }, {
-                        type: "null"
-                    }],
                 asCell: ["cell"]
             },
             fileId: {
                 type: "string",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             content: {
                 type: "string",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             savedContent: {
                 type: "string",
-                asCell: ["cell"]
+                asCell: ["readonly"]
             },
             onSaveFile: {
                 type: "object",
@@ -95,7 +90,7 @@ export default pattern((__cf_pattern_input) => {
                     }
                 },
                 required: ["fileId", "content"],
-                asCell: ["stream"]
+                asCell: ["readonly"]
             }
         },
         required: ["timer", "fileId", "content", "savedContent", "onSaveFile"]

--- a/packages/ts-transformers/test/fixtures/closures/ifelse-factory-boundaries.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/ifelse-factory-boundaries.expected.jsx
@@ -38,7 +38,7 @@ const selectMessage = handler({
     properties: {
         selectedId: {
             type: "string",
-            asCell: ["cell"]
+            asCell: ["writeonly"]
         },
         msgId: {
             type: "string"
@@ -176,7 +176,7 @@ export default pattern((__cf_pattern_input) => {
                         properties: {
                             selectedId: {
                                 type: "string",
-                                asCell: ["cell"]
+                                asCell: ["readonly"]
                             }
                         },
                         required: ["selectedId"]

--- a/packages/ts-transformers/test/fixtures/closures/inline-action-in-ternary-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/inline-action-in-ternary-branch.expected.jsx
@@ -64,7 +64,7 @@ export default pattern((state) => {
                         properties: {
                             isEditing: {
                                 type: "boolean",
-                                asCell: ["cell"]
+                                asCell: ["readonly"]
                             }
                         },
                         required: ["isEditing"]
@@ -101,7 +101,7 @@ export default pattern((state) => {
                         properties: {
                             isEditing: {
                                 type: "boolean",
-                                asCell: ["cell"]
+                                asCell: ["writeonly"]
                             }
                         },
                         required: ["isEditing"]

--- a/packages/ts-transformers/test/fixtures/closures/map-and-handler.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-and-handler.expected.jsx
@@ -75,7 +75,7 @@ export default pattern((state) => {
                             properties: {
                                 selectedIndex: {
                                     type: "number",
-                                    asCell: ["cell"]
+                                    asCell: ["writeonly"]
                                 }
                             },
                             required: ["selectedIndex"]
@@ -117,7 +117,7 @@ export default pattern((state) => {
                                     },
                                     selectedIndex: {
                                         type: "number",
-                                        asCell: ["cell"]
+                                        asCell: ["readonly"]
                                     }
                                 },
                                 required: ["discount", "selectedIndex"]

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-cell-fn.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-cell-fn.expected.jsx
@@ -47,7 +47,7 @@ export default pattern((state) => {
                         properties: {
                             count: {
                                 type: "number",
-                                asCell: ["cell"]
+                                asCell: ["readonly"]
                             }
                         },
                         required: ["count"]

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-cell-of.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-cell-of.expected.jsx
@@ -47,7 +47,7 @@ export default pattern((state) => {
                         properties: {
                             counter: {
                                 type: "number",
-                                asCell: ["cell"]
+                                asCell: ["readonly"]
                             }
                         },
                         required: ["counter"]

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-writable-of.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-writable-of.expected.jsx
@@ -50,6 +50,11 @@ export default pattern((state) => {
                         type: "object",
                         properties: {
                             selected: {
+                                anyOf: [{
+                                        type: "string"
+                                    }, {
+                                        type: "null"
+                                    }],
                                 asCell: ["readonly"]
                             }
                         },

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-writable-of.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-writable-of.expected.jsx
@@ -50,12 +50,7 @@ export default pattern((state) => {
                         type: "object",
                         properties: {
                             selected: {
-                                anyOf: [{
-                                        type: "string"
-                                    }, {
-                                        type: "null"
-                                    }],
-                                asCell: ["cell"]
+                                asCell: ["readonly"]
                             }
                         },
                         required: ["selected"]

--- a/packages/ts-transformers/test/fixtures/closures/map-handler-reference-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-handler-reference-no-name.expected.jsx
@@ -69,7 +69,7 @@ export default pattern((state: State) => {
                                 properties: {
                                     count: {
                                         type: "number",
-                                        asCell: ["cell"]
+                                        asCell: ["readonly"]
                                     }
                                 },
                                 required: ["count"]

--- a/packages/ts-transformers/test/fixtures/closures/map-handler-reference-with-type-arg-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-handler-reference-with-type-arg-no-name.expected.jsx
@@ -69,7 +69,7 @@ export default pattern((state) => {
                                 properties: {
                                     count: {
                                         type: "number",
-                                        asCell: ["cell"]
+                                        asCell: ["readonly"]
                                     }
                                 },
                                 required: ["count"]

--- a/packages/ts-transformers/test/fixtures/closures/map-handler-reference.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-handler-reference.expected.jsx
@@ -69,7 +69,7 @@ export default pattern((state) => {
                                 properties: {
                                     count: {
                                         type: "number",
-                                        asCell: ["cell"]
+                                        asCell: ["readonly"]
                                     }
                                 },
                                 required: ["count"]

--- a/packages/ts-transformers/test/fixtures/closures/map-inside-ifelse-with-handler.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-inside-ifelse-with-handler.expected.jsx
@@ -25,13 +25,13 @@ const removeItem = handler({
             type: "array",
             items: {
                 type: "unknown",
-                asCell: ["opaque"]
+                asCell: ["comparable"]
             },
             asCell: ["cell"]
         },
         item: {
             type: "unknown",
-            asCell: ["opaque"]
+            asCell: ["comparable"]
         }
     },
     required: ["items", "item"]

--- a/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-alias-in-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-alias-in-computed.expected.jsx
@@ -113,7 +113,9 @@ export default pattern((__cf_pattern_input) => {
                         properties: {
                             logs: {
                                 type: "array",
-                                items: true,
+                                items: {
+                                    $ref: "#/$defs/HabitLog"
+                                },
                                 asCell: ["readonly"]
                             },
                             todayDate: {
@@ -125,6 +127,21 @@ export default pattern((__cf_pattern_input) => {
                 },
                 required: ["element", "params"],
                 $defs: {
+                    HabitLog: {
+                        type: "object",
+                        properties: {
+                            habitName: {
+                                type: "string"
+                            },
+                            date: {
+                                type: "string"
+                            },
+                            completed: {
+                                type: "boolean"
+                            }
+                        },
+                        required: ["habitName", "date", "completed"]
+                    },
                     Habit: {
                         type: "object",
                         properties: {

--- a/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-alias-in-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-alias-in-computed.expected.jsx
@@ -46,7 +46,7 @@ export default pattern((__cf_pattern_input) => {
                             items: {
                                 $ref: "#/$defs/HabitLog"
                             },
-                            asCell: ["cell"]
+                            asCell: ["readonly"]
                         },
                         habit: {
                             type: "object",
@@ -113,10 +113,8 @@ export default pattern((__cf_pattern_input) => {
                         properties: {
                             logs: {
                                 type: "array",
-                                items: {
-                                    $ref: "#/$defs/HabitLog"
-                                },
-                                asCell: ["cell"]
+                                items: true,
+                                asCell: ["readonly"]
                             },
                             todayDate: {
                                 type: "string"
@@ -127,21 +125,6 @@ export default pattern((__cf_pattern_input) => {
                 },
                 required: ["element", "params"],
                 $defs: {
-                    HabitLog: {
-                        type: "object",
-                        properties: {
-                            habitName: {
-                                type: "string"
-                            },
-                            date: {
-                                type: "string"
-                            },
-                            completed: {
-                                type: "boolean"
-                            }
-                        },
-                        required: ["habitName", "date", "completed"]
-                    },
                     Habit: {
                         type: "object",
                         properties: {

--- a/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-in-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-in-computed.expected.jsx
@@ -46,7 +46,7 @@ export default pattern((__cf_pattern_input) => {
                             items: {
                                 $ref: "#/$defs/HabitLog"
                             },
-                            asCell: ["cell"]
+                            asCell: ["readonly"]
                         },
                         habit: {
                             type: "object",
@@ -110,10 +110,8 @@ export default pattern((__cf_pattern_input) => {
                         properties: {
                             logs: {
                                 type: "array",
-                                items: {
-                                    $ref: "#/$defs/HabitLog"
-                                },
-                                asCell: ["cell"]
+                                items: true,
+                                asCell: ["readonly"]
                             },
                             todayDate: {
                                 type: "string"
@@ -124,21 +122,6 @@ export default pattern((__cf_pattern_input) => {
                 },
                 required: ["element", "params"],
                 $defs: {
-                    HabitLog: {
-                        type: "object",
-                        properties: {
-                            habitName: {
-                                type: "string"
-                            },
-                            date: {
-                                type: "string"
-                            },
-                            completed: {
-                                type: "boolean"
-                            }
-                        },
-                        required: ["habitName", "date", "completed"]
-                    },
                     Habit: {
                         type: "object",
                         properties: {

--- a/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-in-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-in-computed.expected.jsx
@@ -110,7 +110,9 @@ export default pattern((__cf_pattern_input) => {
                         properties: {
                             logs: {
                                 type: "array",
-                                items: true,
+                                items: {
+                                    $ref: "#/$defs/HabitLog"
+                                },
                                 asCell: ["readonly"]
                             },
                             todayDate: {
@@ -122,6 +124,21 @@ export default pattern((__cf_pattern_input) => {
                 },
                 required: ["element", "params"],
                 $defs: {
+                    HabitLog: {
+                        type: "object",
+                        properties: {
+                            habitName: {
+                                type: "string"
+                            },
+                            date: {
+                                type: "string"
+                            },
+                            completed: {
+                                type: "boolean"
+                            }
+                        },
+                        required: ["habitName", "date", "completed"]
+                    },
                     Habit: {
                         type: "object",
                         properties: {

--- a/packages/ts-transformers/test/fixtures/closures/map-ternary-inside-nested-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-ternary-inside-nested-map.expected.jsx
@@ -52,7 +52,7 @@ export default pattern((__cf_pattern_input) => {
                 items: {
                     type: "unknown"
                 },
-                asCell: ["cell"]
+                asCell: ["readonly"]
             }
         },
         required: ["items"]

--- a/packages/ts-transformers/test/fixtures/closures/map-wish-default-handler-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-wish-default-handler-capture.expected.jsx
@@ -28,7 +28,7 @@ const removeItem = handler({
                 $ref: "#/$defs/Item"
             },
             "default": [],
-            asCell: ["cell"]
+            asCell: ["readonly"]
         },
         item: {
             $ref: "#/$defs/Item"

--- a/packages/ts-transformers/test/fixtures/closures/map-wish-default-handler-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-wish-default-handler-capture.expected.jsx
@@ -28,7 +28,7 @@ const removeItem = handler({
                 $ref: "#/$defs/Item"
             },
             "default": [],
-            asCell: ["readonly"]
+            asCell: ["writeonly"]
         },
         item: {
             $ref: "#/$defs/Item"

--- a/packages/ts-transformers/test/fixtures/closures/nested-computed-in-ifelse.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/nested-computed-in-ifelse.expected.jsx
@@ -44,7 +44,7 @@ export default pattern(() => {
                 properties: {
                     secondToggle: {
                         type: "boolean",
-                        asCell: ["cell"]
+                        asCell: ["readonly"]
                     }
                 },
                 required: ["secondToggle"]
@@ -80,7 +80,7 @@ export default pattern(() => {
                     properties: {
                         secondToggle: {
                             type: "boolean",
-                            asCell: ["cell"]
+                            asCell: ["readonly"]
                         }
                     },
                     required: ["secondToggle"]

--- a/packages/ts-transformers/test/fixtures/closures/pattern-nested-jsx-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-nested-jsx-map.expected.jsx
@@ -53,7 +53,7 @@ export default pattern((__cf_pattern_input) => {
                 items: {
                     type: "unknown"
                 },
-                asCell: ["cell"]
+                asCell: ["readonly"]
             }
         },
         required: ["items"]

--- a/packages/ts-transformers/test/fixtures/closures/pattern-preserve-opaque-input.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-preserve-opaque-input.expected.jsx
@@ -28,7 +28,7 @@ export default pattern((input: Writable<State>) => {
             properties: {
                 input: {
                     $ref: "#/$defs/State",
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["input"],

--- a/packages/ts-transformers/test/fixtures/closures/writable-of-terminal-methods.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/writable-of-terminal-methods.expected.jsx
@@ -41,11 +41,11 @@ export default pattern((__cf_pattern_input) => {
         properties: {
             counter: {
                 type: "number",
-                asCell: ["cell"]
+                asCell: ["writeonly"]
             },
             label: {
                 type: "string",
-                asCell: ["cell"]
+                asCell: ["writeonly"]
             }
         },
         required: ["counter", "label"]

--- a/packages/ts-transformers/test/fixtures/handler-schema/array-cell-remove-intersection.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/array-cell-remove-intersection.expected.jsx
@@ -24,14 +24,27 @@ const removeItem = handler({
     properties: {
         items: {
             type: "array",
-            items: true,
+            items: {
+                $ref: "#/$defs/Item"
+            },
             asCell: ["cell"]
         },
         index: {
             type: "number"
         }
     },
-    required: ["items", "index"]
+    required: ["items", "index"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                text: {
+                    type: "string"
+                }
+            },
+            required: ["text"]
+        }
+    }
 } as const satisfies __cfHelpers.JSONSchema, (_, { items, index }) => {
     const next = items.get().slice();
     if (index >= 0 && index < next.length)
@@ -49,14 +62,27 @@ const removeItemAlias = handler({
     properties: {
         items: {
             type: "array",
-            items: true,
+            items: {
+                $ref: "#/$defs/Item"
+            },
             asCell: ["cell"]
         },
         index: {
             type: "number"
         }
     },
-    required: ["items", "index"]
+    required: ["items", "index"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                text: {
+                    type: "string"
+                }
+            },
+            required: ["text"]
+        }
+    }
 } as const satisfies __cfHelpers.JSONSchema, (_, { items, index }) => {
     const next = items.get().slice();
     if (index >= 0 && index < next.length)

--- a/packages/ts-transformers/test/fixtures/handler-schema/array-cell-remove-intersection.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/array-cell-remove-intersection.expected.jsx
@@ -24,27 +24,14 @@ const removeItem = handler({
     properties: {
         items: {
             type: "array",
-            items: {
-                $ref: "#/$defs/Item"
-            },
+            items: true,
             asCell: ["cell"]
         },
         index: {
             type: "number"
         }
     },
-    required: ["items", "index"],
-    $defs: {
-        Item: {
-            type: "object",
-            properties: {
-                text: {
-                    type: "string"
-                }
-            },
-            required: ["text"]
-        }
-    }
+    required: ["items", "index"]
 } as const satisfies __cfHelpers.JSONSchema, (_, { items, index }) => {
     const next = items.get().slice();
     if (index >= 0 && index < next.length)
@@ -62,27 +49,14 @@ const removeItemAlias = handler({
     properties: {
         items: {
             type: "array",
-            items: {
-                $ref: "#/$defs/Item"
-            },
+            items: true,
             asCell: ["cell"]
         },
         index: {
             type: "number"
         }
     },
-    required: ["items", "index"],
-    $defs: {
-        Item: {
-            type: "object",
-            properties: {
-                text: {
-                    type: "string"
-                }
-            },
-            required: ["text"]
-        }
-    }
+    required: ["items", "index"]
 } as const satisfies __cfHelpers.JSONSchema, (_, { items, index }) => {
     const next = items.get().slice();
     if (index >= 0 && index < next.length)

--- a/packages/ts-transformers/test/fixtures/handler-schema/complex-nested-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/complex-nested-types.expected.jsx
@@ -74,11 +74,11 @@ const userHandler = handler({
                 },
                 required: ["id", "name", "email"]
             },
-            asCell: ["cell"]
+            asCell: ["writeonly"]
         },
         lastAction: {
             type: "string",
-            asCell: ["cell"]
+            asCell: ["writeonly"]
         }
     },
     required: ["count", "users", "lastAction"]
@@ -118,7 +118,7 @@ const _updateTags = handler({
             items: {
                 type: "string"
             },
-            asCell: ["cell"]
+            asCell: ["writeonly"]
         }
     },
     required: ["tags"]

--- a/packages/ts-transformers/test/fixtures/handler-schema/date-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/date-types.expected.jsx
@@ -30,9 +30,7 @@ const timedHandler = handler({
     type: "object",
     properties: {
         lastUpdate: {
-            type: "string",
-            format: "date-time",
-            asCell: ["cell"]
+            asCell: ["writeonly"]
         }
     },
     required: ["lastUpdate"]

--- a/packages/ts-transformers/test/fixtures/handler-schema/date-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/date-types.expected.jsx
@@ -30,6 +30,8 @@ const timedHandler = handler({
     type: "object",
     properties: {
         lastUpdate: {
+            type: "string",
+            format: "date-time",
             asCell: ["writeonly"]
         }
     },

--- a/packages/ts-transformers/test/fixtures/handler-schema/identity-only-handler-payload.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/identity-only-handler-payload.expected.jsx
@@ -22,7 +22,7 @@ const addPiece = handler({
     properties: {
         piece: {
             type: "unknown",
-            asCell: ["opaque"]
+            asCell: ["comparable"]
         }
     },
     required: ["piece"]
@@ -33,7 +33,7 @@ const addPiece = handler({
             type: "array",
             items: {
                 type: "unknown",
-                asCell: ["opaque"]
+                asCell: ["comparable"]
             },
             asCell: ["cell"]
         }
@@ -53,7 +53,7 @@ const trackRecent = handler({
     properties: {
         piece: {
             type: "unknown",
-            asCell: ["opaque"]
+            asCell: ["comparable"]
         }
     },
     required: ["piece"]
@@ -64,7 +64,7 @@ const trackRecent = handler({
             type: "array",
             items: {
                 type: "unknown",
-                asCell: ["opaque"]
+                asCell: ["comparable"]
             },
             asCell: ["cell"]
         }

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/authored-ifelse-jsx-branches.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/authored-ifelse-jsx-branches.expected.jsx
@@ -126,7 +126,7 @@ export default pattern((__cf_pattern_input) => {
             properties: {
                 count: {
                     type: "number",
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["count"]

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/cell-get-in-ifelse-predicate.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/cell-get-in-ifelse-predicate.expected.jsx
@@ -44,7 +44,7 @@ export default pattern((__cf_pattern_input) => {
                 },
                 dismissedIndex: {
                     type: "number",
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["messageCount", "dismissedIndex"]

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/conditional-empty-check.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/conditional-empty-check.expected.jsx
@@ -47,7 +47,7 @@ export default pattern(() => {
                     items: {
                         type: "string"
                     },
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["items"]

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-both-opaque.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-both-opaque.expected.jsx
@@ -36,11 +36,11 @@ export default pattern((_state) => {
                     items: {
                         type: "string"
                     },
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 },
                 index: {
                     type: "number",
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["items", "index"]

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-captures.expected.jsx
@@ -143,7 +143,9 @@ export default pattern((__cf_pattern_input) => {
                     properties: {
                         entries: {
                             type: "array",
-                            items: true,
+                            items: {
+                                $ref: "#/$defs/Entry"
+                            },
                             asCell: ["readonly"]
                         },
                         p: {
@@ -153,7 +155,18 @@ export default pattern((__cf_pattern_input) => {
                             }
                         }
                     },
-                    required: ["entries", "p"]
+                    required: ["entries", "p"],
+                    $defs: {
+                        Entry: {
+                            type: "object",
+                            properties: {
+                                name: {
+                                    type: "string"
+                                }
+                            },
+                            required: ["name"]
+                        }
+                    }
                 } as const satisfies __cfHelpers.JSONSchema, {
                     type: "array",
                     items: {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-captures.expected.jsx
@@ -59,7 +59,7 @@ export default pattern((__cf_pattern_input) => {
                 items: {
                     type: "string"
                 },
-                asCell: ["cell"]
+                asCell: ["writeonly"]
             }
         },
         required: ["path"]
@@ -92,7 +92,7 @@ export default pattern((__cf_pattern_input) => {
                             items: {
                                 type: "string"
                             },
-                            asCell: ["cell"]
+                            asCell: ["readonly"]
                         }
                     },
                     required: ["path"]
@@ -128,7 +128,7 @@ export default pattern((__cf_pattern_input) => {
                             items: {
                                 type: "string"
                             },
-                            asCell: ["cell"]
+                            asCell: ["readonly"]
                         }
                     },
                     required: ["path"]
@@ -143,10 +143,8 @@ export default pattern((__cf_pattern_input) => {
                     properties: {
                         entries: {
                             type: "array",
-                            items: {
-                                $ref: "#/$defs/Entry"
-                            },
-                            asCell: ["cell"]
+                            items: true,
+                            asCell: ["readonly"]
                         },
                         p: {
                             type: "array",
@@ -155,18 +153,7 @@ export default pattern((__cf_pattern_input) => {
                             }
                         }
                     },
-                    required: ["entries", "p"],
-                    $defs: {
-                        Entry: {
-                            type: "object",
-                            properties: {
-                                name: {
-                                    type: "string"
-                                }
-                            },
-                            required: ["name"]
-                        }
-                    }
+                    required: ["entries", "p"]
                 } as const satisfies __cfHelpers.JSONSchema, {
                     type: "array",
                     items: {
@@ -201,7 +188,7 @@ export default pattern((__cf_pattern_input) => {
                                     }
                                 },
                                 required: ["name"],
-                                asCell: ["stream"]
+                                asCell: ["readonly"]
                             },
                             entry: {
                                 type: "object",
@@ -239,7 +226,7 @@ export default pattern((__cf_pattern_input) => {
                                         }
                                     },
                                     required: ["name"],
-                                    asCell: ["stream"]
+                                    asCell: ["readonly"]
                                 }
                             },
                             required: ["pushPath"]

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-default-input-local-chain-map-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-default-input-local-chain-map-capture.expected.jsx
@@ -67,7 +67,7 @@ export default pattern((__cf_pattern_input) => {
                 items: {
                     type: "string"
                 },
-                asCell: ["cell"]
+                asCell: ["writeonly"]
             }
         },
         required: ["path"]
@@ -206,7 +206,7 @@ export default pattern((__cf_pattern_input) => {
                             items: {
                                 type: "string"
                             },
-                            asCell: ["cell"]
+                            asCell: ["readonly"]
                         }
                     },
                     required: ["path"]
@@ -315,7 +315,7 @@ export default pattern((__cf_pattern_input) => {
                                             }
                                         },
                                         required: ["name"],
-                                        asCell: ["stream"]
+                                        asCell: ["readonly"]
                                     },
                                     item: {
                                         type: "object",
@@ -347,7 +347,7 @@ export default pattern((__cf_pattern_input) => {
                                             }
                                         },
                                         required: ["item"],
-                                        asCell: ["stream"]
+                                        asCell: ["readonly"]
                                     },
                                     item: {
                                         $ref: "#/$defs/Entry"
@@ -406,7 +406,7 @@ export default pattern((__cf_pattern_input) => {
                                         }
                                     },
                                     required: ["name"],
-                                    asCell: ["stream"]
+                                    asCell: ["readonly"]
                                 },
                                 handleOpenFile: {
                                     type: "object",
@@ -416,7 +416,7 @@ export default pattern((__cf_pattern_input) => {
                                         }
                                     },
                                     required: ["item"],
-                                    asCell: ["stream"]
+                                    asCell: ["readonly"]
                                 }
                             },
                             required: ["handleNavigateInto", "handleOpenFile"]

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-filter-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-filter-capture.expected.jsx
@@ -80,7 +80,9 @@ export default pattern((__cf_pattern_input) => {
                     properties: {
                         entries: {
                             type: "array",
-                            items: true,
+                            items: {
+                                $ref: "#/$defs/Entry"
+                            },
                             asCell: ["readonly"]
                         },
                         p: {
@@ -90,7 +92,18 @@ export default pattern((__cf_pattern_input) => {
                             }
                         }
                     },
-                    required: ["entries", "p"]
+                    required: ["entries", "p"],
+                    $defs: {
+                        Entry: {
+                            type: "object",
+                            properties: {
+                                name: {
+                                    type: "string"
+                                }
+                            },
+                            required: ["name"]
+                        }
+                    }
                 } as const satisfies __cfHelpers.JSONSchema, {
                     type: "array",
                     items: {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-filter-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-filter-capture.expected.jsx
@@ -65,7 +65,7 @@ export default pattern((__cf_pattern_input) => {
                             items: {
                                 type: "string"
                             },
-                            asCell: ["cell"]
+                            asCell: ["readonly"]
                         }
                     },
                     required: ["path"]
@@ -80,10 +80,8 @@ export default pattern((__cf_pattern_input) => {
                     properties: {
                         entries: {
                             type: "array",
-                            items: {
-                                $ref: "#/$defs/Entry"
-                            },
-                            asCell: ["cell"]
+                            items: true,
+                            asCell: ["readonly"]
                         },
                         p: {
                             type: "array",
@@ -92,18 +90,7 @@ export default pattern((__cf_pattern_input) => {
                             }
                         }
                     },
-                    required: ["entries", "p"],
-                    $defs: {
-                        Entry: {
-                            type: "object",
-                            properties: {
-                                name: {
-                                    type: "string"
-                                }
-                            },
-                            required: ["name"]
-                        }
-                    }
+                    required: ["entries", "p"]
                 } as const satisfies __cfHelpers.JSONSchema, {
                     type: "array",
                     items: {
@@ -141,7 +128,7 @@ export default pattern((__cf_pattern_input) => {
                             },
                             labelPrefix: {
                                 type: "string",
-                                asCell: ["cell"]
+                                asCell: ["readonly"]
                             }
                         },
                         required: ["entry", "labelPrefix"]
@@ -164,7 +151,7 @@ export default pattern((__cf_pattern_input) => {
                             properties: {
                                 labelPrefix: {
                                     type: "string",
-                                    asCell: ["cell"]
+                                    asCell: ["readonly"]
                                 }
                             },
                             required: ["labelPrefix"]

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-capture.expected.jsx
@@ -84,7 +84,9 @@ export default pattern((__cf_pattern_input) => {
                     properties: {
                         entries: {
                             type: "array",
-                            items: true,
+                            items: {
+                                $ref: "#/$defs/Entry"
+                            },
                             asCell: ["readonly"]
                         },
                         p: {
@@ -94,7 +96,18 @@ export default pattern((__cf_pattern_input) => {
                             }
                         }
                     },
-                    required: ["entries", "p"]
+                    required: ["entries", "p"],
+                    $defs: {
+                        Entry: {
+                            type: "object",
+                            properties: {
+                                name: {
+                                    type: "string"
+                                }
+                            },
+                            required: ["name"]
+                        }
+                    }
                 } as const satisfies __cfHelpers.JSONSchema, {
                     type: "array",
                     items: {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-capture.expected.jsx
@@ -69,7 +69,7 @@ export default pattern((__cf_pattern_input) => {
                             items: {
                                 type: "string"
                             },
-                            asCell: ["cell"]
+                            asCell: ["readonly"]
                         }
                     },
                     required: ["path"]
@@ -84,10 +84,8 @@ export default pattern((__cf_pattern_input) => {
                     properties: {
                         entries: {
                             type: "array",
-                            items: {
-                                $ref: "#/$defs/Entry"
-                            },
-                            asCell: ["cell"]
+                            items: true,
+                            asCell: ["readonly"]
                         },
                         p: {
                             type: "array",
@@ -96,18 +94,7 @@ export default pattern((__cf_pattern_input) => {
                             }
                         }
                     },
-                    required: ["entries", "p"],
-                    $defs: {
-                        Entry: {
-                            type: "object",
-                            properties: {
-                                name: {
-                                    type: "string"
-                                }
-                            },
-                            required: ["name"]
-                        }
-                    }
+                    required: ["entries", "p"]
                 } as const satisfies __cfHelpers.JSONSchema, {
                     type: "array",
                     items: {
@@ -145,7 +132,7 @@ export default pattern((__cf_pattern_input) => {
                             properties: {
                                 labelPrefix: {
                                     type: "string",
-                                    asCell: ["cell"]
+                                    asCell: ["readonly"]
                                 }
                             },
                             required: ["labelPrefix"]

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-local-initializer-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-local-initializer-captures.expected.jsx
@@ -116,7 +116,9 @@ export default pattern((__cf_pattern_input) => {
                     properties: {
                         tree: {
                             type: "array",
-                            items: true,
+                            items: {
+                                $ref: "#/$defs/Entry"
+                            },
                             asCell: ["readonly"]
                         },
                         p: {
@@ -126,7 +128,30 @@ export default pattern((__cf_pattern_input) => {
                             }
                         }
                     },
-                    required: ["tree", "p"]
+                    required: ["tree", "p"],
+                    $defs: {
+                        Entry: {
+                            type: "object",
+                            properties: {
+                                id: {
+                                    type: "string"
+                                },
+                                name: {
+                                    type: "string"
+                                },
+                                type: {
+                                    "enum": ["file", "folder"]
+                                },
+                                children: {
+                                    type: "array",
+                                    items: {
+                                        $ref: "#/$defs/Entry"
+                                    }
+                                }
+                            },
+                            required: ["id", "name", "type"]
+                        }
+                    }
                 } as const satisfies __cfHelpers.JSONSchema, {
                     type: "array",
                     items: {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-local-initializer-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-local-initializer-captures.expected.jsx
@@ -67,7 +67,7 @@ export default pattern((__cf_pattern_input) => {
                 items: {
                     type: "string"
                 },
-                asCell: ["cell"]
+                asCell: ["writeonly"]
             }
         },
         required: ["path"]
@@ -101,7 +101,7 @@ export default pattern((__cf_pattern_input) => {
                             items: {
                                 type: "string"
                             },
-                            asCell: ["cell"]
+                            asCell: ["readonly"]
                         }
                     },
                     required: ["path"]
@@ -115,8 +115,9 @@ export default pattern((__cf_pattern_input) => {
                     type: "object",
                     properties: {
                         tree: {
-                            $ref: "#/$defs/AnonymousType_1",
-                            asCell: ["cell"]
+                            type: "array",
+                            items: true,
+                            asCell: ["readonly"]
                         },
                         p: {
                             type: "array",
@@ -125,33 +126,7 @@ export default pattern((__cf_pattern_input) => {
                             }
                         }
                     },
-                    required: ["tree", "p"],
-                    $defs: {
-                        AnonymousType_1: {
-                            type: "array",
-                            items: {
-                                $ref: "#/$defs/Entry"
-                            }
-                        },
-                        Entry: {
-                            type: "object",
-                            properties: {
-                                id: {
-                                    type: "string"
-                                },
-                                name: {
-                                    type: "string"
-                                },
-                                type: {
-                                    "enum": ["file", "folder"]
-                                },
-                                children: {
-                                    $ref: "#/$defs/AnonymousType_1"
-                                }
-                            },
-                            required: ["id", "name", "type"]
-                        }
-                    }
+                    required: ["tree", "p"]
                 } as const satisfies __cfHelpers.JSONSchema, {
                     type: "array",
                     items: {
@@ -171,16 +146,13 @@ export default pattern((__cf_pattern_input) => {
                                     "enum": ["file", "folder"]
                                 },
                                 children: {
-                                    $ref: "#/$defs/AnonymousType_1"
+                                    type: "array",
+                                    items: {
+                                        $ref: "#/$defs/Entry"
+                                    }
                                 }
                             },
                             required: ["id", "name", "type"]
-                        },
-                        AnonymousType_1: {
-                            type: "array",
-                            items: {
-                                $ref: "#/$defs/Entry"
-                            }
                         }
                     }
                 } as const satisfies __cfHelpers.JSONSchema, {
@@ -212,16 +184,13 @@ export default pattern((__cf_pattern_input) => {
                                     "enum": ["file", "folder"]
                                 },
                                 children: {
-                                    $ref: "#/$defs/AnonymousType_1"
+                                    type: "array",
+                                    items: {
+                                        $ref: "#/$defs/Entry"
+                                    }
                                 }
                             },
                             required: ["id", "name", "type"]
-                        },
-                        AnonymousType_1: {
-                            type: "array",
-                            items: {
-                                $ref: "#/$defs/Entry"
-                            }
                         }
                     }
                 } as const satisfies __cfHelpers.JSONSchema, {
@@ -267,7 +236,7 @@ export default pattern((__cf_pattern_input) => {
                                     }
                                 },
                                 required: ["name"],
-                                asCell: ["stream"]
+                                asCell: ["readonly"]
                             },
                             item: {
                                 type: "object",
@@ -305,7 +274,7 @@ export default pattern((__cf_pattern_input) => {
                                         }
                                     },
                                     required: ["name"],
-                                    asCell: ["stream"]
+                                    asCell: ["readonly"]
                                 }
                             },
                             required: ["pushPath"]

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-and-non-jsx.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-and-non-jsx.expected.jsx
@@ -55,7 +55,7 @@ export default pattern((_state) => {
                         }
                     },
                     required: ["name", "age"],
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["user"]
@@ -75,7 +75,7 @@ export default pattern((_state) => {
                         }
                     },
                     required: ["name", "age"],
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["user"]
@@ -104,7 +104,7 @@ export default pattern((_state) => {
                         }
                     },
                     required: ["name", "age"],
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["user"]
@@ -124,7 +124,7 @@ export default pattern((_state) => {
                         }
                     },
                     required: ["name", "age"],
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["user"]

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-complex-expressions.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-complex-expressions.expected.jsx
@@ -53,11 +53,11 @@ export default pattern((_state) => {
                     items: {
                         type: "string"
                     },
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 },
                 isEnabled: {
                     type: "boolean",
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["items", "isEnabled"]
@@ -88,14 +88,14 @@ export default pattern((_state) => {
             properties: {
                 count: {
                     type: "number",
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 },
                 items: {
                     type: "array",
                     items: {
                         type: "string"
                     },
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["count", "items"]

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-mixed-and-or.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-mixed-and-or.expected.jsx
@@ -60,7 +60,7 @@ export default pattern((_state) => {
                         }
                     },
                     required: ["name", "age"],
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["user"]
@@ -76,7 +76,7 @@ export default pattern((_state) => {
             properties: {
                 defaultMessage: {
                     type: "string",
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["defaultMessage"]
@@ -105,7 +105,7 @@ export default pattern((_state) => {
                         }
                     },
                     required: ["name", "age"],
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["user"]
@@ -131,7 +131,7 @@ export default pattern((_state) => {
                         }
                     },
                     required: ["name", "age"],
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["user"]
@@ -161,7 +161,7 @@ export default pattern((_state) => {
                         }
                     },
                     required: ["name", "age"],
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["user"]

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-nullish-coalescing.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-nullish-coalescing.expected.jsx
@@ -74,7 +74,7 @@ export default pattern((_state) => {
                         }
                     },
                     required: ["timeout", "retries"],
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["config"]
@@ -107,7 +107,7 @@ export default pattern((_state) => {
                         }
                     },
                     required: ["timeout", "retries"],
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["config"]
@@ -131,7 +131,7 @@ export default pattern((_state) => {
                     items: {
                         type: "string"
                     },
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["items"]

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-or-unless.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-or-unless.expected.jsx
@@ -46,7 +46,7 @@ export default pattern((_state) => {
                     items: {
                         type: "string"
                     },
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["items"]

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-triple-and-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-triple-and-chain.expected.jsx
@@ -70,7 +70,7 @@ export default pattern((_state) => {
                         }
                     },
                     required: ["active", "verified", "name"],
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["user"]
@@ -93,7 +93,7 @@ export default pattern((_state) => {
                         }
                     },
                     required: ["active", "verified", "name"],
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["user"]

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-triple-or-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-triple-or-chain.expected.jsx
@@ -43,11 +43,11 @@ export default pattern((_state) => {
             properties: {
                 primary: {
                     type: "string",
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 },
                 secondary: {
                     type: "string",
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["primary", "secondary"]
@@ -73,7 +73,7 @@ export default pattern((_state) => {
                     items: {
                         type: "string"
                     },
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["items"]

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-array-length-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-array-length-conditional.expected.jsx
@@ -45,7 +45,7 @@ export default pattern((_state) => {
                     items: {
                         type: "string"
                     },
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["list"]

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-element-property-helper-comparison.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-element-property-helper-comparison.expected.jsx
@@ -54,7 +54,7 @@ export default pattern((__cf_pattern_input) => {
                         }
                     },
                     required: ["messages"],
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["selectedRoom"],
@@ -108,7 +108,7 @@ export default pattern((__cf_pattern_input) => {
                     },
                     name: {
                         type: "string",
-                        asCell: ["cell"]
+                        asCell: ["readonly"]
                     }
                 },
                 required: ["message", "name"]
@@ -170,7 +170,7 @@ export default pattern((__cf_pattern_input) => {
                     properties: {
                         name: {
                             type: "string",
-                            asCell: ["cell"]
+                            asCell: ["readonly"]
                         }
                     },
                     required: ["name"]

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-single-capture-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-single-capture-no-name.expected.jsx
@@ -67,7 +67,7 @@ export default pattern((_state: any) => {
                         },
                         required: ["id", "name"]
                     },
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["people"]

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-single-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-single-capture.expected.jsx
@@ -67,7 +67,7 @@ export default pattern((_state) => {
                         },
                         required: ["id", "name"]
                     },
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["people"]

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-cell-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-cell-map.expected.jsx
@@ -111,7 +111,7 @@ const createSimplePattern = handler({
         cellRef: {
             type: "array",
             items: true,
-            asCell: ["cell"]
+            asCell: ["readonly"]
         }
     },
     required: ["cellRef"]

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-operations.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-operations.expected.jsx
@@ -31,7 +31,7 @@ export default pattern((_state) => {
             properties: {
                 count: {
                     type: "number",
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["count"]
@@ -43,7 +43,7 @@ export default pattern((_state) => {
             properties: {
                 count: {
                     type: "number",
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["count"]
@@ -55,7 +55,7 @@ export default pattern((_state) => {
             properties: {
                 price: {
                     type: "number",
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["price"]

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/optional-element-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/optional-element-access.expected.jsx
@@ -48,14 +48,14 @@ export default pattern(() => {
             properties: {
                 list: {
                     anyOf: [{
-                            type: "undefined"
-                        }, {
                             type: "array",
                             items: {
                                 type: "string"
                             }
+                        }, {
+                            type: "undefined"
                         }],
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["list"]

--- a/packages/ts-transformers/test/fixtures/kitchensink/branch-lowered-capture-preservation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/branch-lowered-capture-preservation.expected.jsx
@@ -426,20 +426,32 @@ export default pattern((__cf_pattern_input) => {
                                 }
                             },
                             editingNoteIndex: {
-                                type: ["number", "undefined"],
-                                asCell: ["cell"]
+                                anyOf: [{
+                                        type: "number"
+                                    }, {
+                                        type: "undefined"
+                                    }],
+                                asCell: ["readonly"]
                             },
                             editingNoteText: {
                                 type: "string",
-                                asCell: ["cell"]
+                                asCell: ["readonly"]
                             },
                             settingsModuleIndex: {
-                                type: ["number", "undefined"],
-                                asCell: ["cell"]
+                                anyOf: [{
+                                        type: "number"
+                                    }, {
+                                        type: "undefined"
+                                    }],
+                                asCell: ["readonly"]
                             },
                             expandedIndex: {
-                                type: ["number", "undefined"],
-                                asCell: ["cell"]
+                                anyOf: [{
+                                        type: "number"
+                                    }, {
+                                        type: "undefined"
+                                    }],
+                                asCell: ["readonly"]
                             },
                             trashedSubPieces: {
                                 type: "array",

--- a/packages/ts-transformers/test/fixtures/kitchensink/helper-owned-compute-branches.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/helper-owned-compute-branches.expected.jsx
@@ -172,7 +172,7 @@ export default pattern((state) => {
                 items: {
                     type: "string"
                 },
-                asCell: ["cell"]
+                asCell: ["readonly"]
             }
         },
         required: ["visibleProjects", "state", "fallbackMembers"]

--- a/packages/ts-transformers/test/fixtures/kitchensink/nested-computed-output-maps.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/nested-computed-output-maps.expected.jsx
@@ -282,8 +282,12 @@ export default pattern((state) => {
                 }
             },
             selectedCommentId: {
-                type: ["string", "undefined"],
-                asCell: ["cell"]
+                anyOf: [{
+                        type: "string"
+                    }, {
+                        type: "undefined"
+                    }],
+                asCell: ["readonly"]
             },
             state: {
                 type: "object",

--- a/packages/ts-transformers/test/fixtures/kitchensink/nested-writable-pattern-branches.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/nested-writable-pattern-branches.expected.jsx
@@ -363,19 +363,11 @@ export default pattern((state) => {
                                     type: "object",
                                     properties: {
                                         selectedTaskId: {
-                                            anyOf: [{
-                                                    type: "string"
-                                                }, {
-                                                    type: "undefined"
-                                                }],
+                                            type: ["string", "undefined"],
                                             asCell: ["readonly"]
                                         },
                                         hoveredSectionId: {
-                                            anyOf: [{
-                                                    type: "string"
-                                                }, {
-                                                    type: "undefined"
-                                                }],
+                                            type: ["string", "undefined"],
                                             asCell: ["readonly"]
                                         },
                                         section: {
@@ -546,19 +538,11 @@ export default pattern((state) => {
                                 required: ["globalAccent", "showCompleted"]
                             },
                             selectedTaskId: {
-                                anyOf: [{
-                                        type: "string"
-                                    }, {
-                                        type: "undefined"
-                                    }],
+                                type: ["string", "undefined"],
                                 asCell: ["readonly"]
                             },
                             hoveredSectionId: {
-                                anyOf: [{
-                                        type: "string"
-                                    }, {
-                                        type: "undefined"
-                                    }],
+                                type: ["string", "undefined"],
                                 asCell: ["readonly"]
                             }
                         },

--- a/packages/ts-transformers/test/fixtures/kitchensink/nested-writable-pattern-branches.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/nested-writable-pattern-branches.expected.jsx
@@ -85,7 +85,7 @@ export default pattern((state) => {
                         items: {
                             type: "unknown"
                         },
-                        asCell: ["cell"]
+                        asCell: ["readonly"]
                     }
                 },
                 required: ["sections"]
@@ -363,12 +363,20 @@ export default pattern((state) => {
                                     type: "object",
                                     properties: {
                                         selectedTaskId: {
-                                            type: ["string", "undefined"],
-                                            asCell: ["cell"]
+                                            anyOf: [{
+                                                    type: "string"
+                                                }, {
+                                                    type: "undefined"
+                                                }],
+                                            asCell: ["readonly"]
                                         },
                                         hoveredSectionId: {
-                                            type: ["string", "undefined"],
-                                            asCell: ["cell"]
+                                            anyOf: [{
+                                                    type: "string"
+                                                }, {
+                                                    type: "undefined"
+                                                }],
+                                            asCell: ["readonly"]
                                         },
                                         section: {
                                             type: "object",
@@ -538,12 +546,20 @@ export default pattern((state) => {
                                 required: ["globalAccent", "showCompleted"]
                             },
                             selectedTaskId: {
-                                type: ["string", "undefined"],
-                                asCell: ["cell"]
+                                anyOf: [{
+                                        type: "string"
+                                    }, {
+                                        type: "undefined"
+                                    }],
+                                asCell: ["readonly"]
                             },
                             hoveredSectionId: {
-                                type: ["string", "undefined"],
-                                asCell: ["cell"]
+                                anyOf: [{
+                                        type: "string"
+                                    }, {
+                                        type: "undefined"
+                                    }],
+                                asCell: ["readonly"]
                             }
                         },
                         required: ["state", "selectedTaskId", "hoveredSectionId"]

--- a/packages/ts-transformers/test/fixtures/schema-injection/builder-input-full-shape-continuity.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/builder-input-full-shape-continuity.expected.jsx
@@ -22,7 +22,7 @@ const liftWrapped = lift({
         }
     },
     required: ["foo"],
-    asCell: ["cell"]
+    asCell: ["readonly"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, (input: Writable<{
@@ -126,7 +126,7 @@ const wildcardLift = lift({
         }
     },
     required: ["foo", "bar"],
-    asCell: ["cell"]
+    asCell: ["readonly"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, (input: Writable<{

--- a/packages/ts-transformers/test/fixtures/schema-injection/builder-input-path-shrink.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/builder-input-path-shrink.expected.jsx
@@ -18,7 +18,7 @@ const liftOptional = lift({
     type: "object",
     properties: {
         foo: {
-            type: ["string", "undefined"]
+            type: "string"
         }
     },
     asCell: ["readonly"]

--- a/packages/ts-transformers/test/fixtures/schema-injection/builder-input-path-shrink.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/builder-input-path-shrink.expected.jsx
@@ -21,7 +21,7 @@ const liftOptional = lift({
             type: ["string", "undefined"]
         }
     },
-    asCell: ["cell"]
+    asCell: ["readonly"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema, (input: Writable<{
@@ -40,7 +40,7 @@ const deriveObserved = __cfHelpers.__cf_data(derive({
         }
     },
     required: ["foo"],
-    asCell: ["cell"]
+    asCell: ["readonly"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, deriveInput, (input: Writable<{
@@ -55,7 +55,7 @@ const deriveExplicit = __cfHelpers.__cf_data(derive({
         }
     },
     required: ["foo"],
-    asCell: ["cell"]
+    asCell: ["readonly"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, deriveInput, (value) => value.key("foo").get()).for("deriveExplicit", true));
@@ -67,7 +67,7 @@ const handlerObserved = handler(false as const satisfies __cfHelpers.JSONSchema,
         }
     },
     required: ["foo"],
-    asCell: ["cell"]
+    asCell: ["readonly"]
 } as const satisfies __cfHelpers.JSONSchema, (_event: {
     id: string;
 }, state: Writable<{
@@ -98,7 +98,7 @@ const handlerExplicit = handler({
         }
     },
     required: ["foo"],
-    asCell: ["cell"]
+    asCell: ["readonly"]
 } as const satisfies __cfHelpers.JSONSchema, (event, state) => {
     event.detail.message;
     state.key("foo").get();
@@ -115,7 +115,7 @@ const liftInterprocedural = lift({
         }
     },
     required: ["foo"],
-    asCell: ["cell"]
+    asCell: ["readonly"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, (input: Writable<{
@@ -130,7 +130,7 @@ const liftWriteOnly = lift({
         }
     },
     required: ["foo"],
-    asCell: ["cell"]
+    asCell: ["writeonly"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, (input: Writable<{
@@ -148,7 +148,7 @@ const liftExplicit = lift({
         }
     },
     required: ["foo"],
-    asCell: ["cell"]
+    asCell: ["readonly"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, (input) => input.key("foo").get());

--- a/packages/ts-transformers/test/fixtures/schema-injection/builder-input-path-shrink.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/builder-input-path-shrink.expected.jsx
@@ -167,7 +167,7 @@ const actionPattern = pattern((input: Writable<{
                     }
                 },
                 required: ["foo"],
-                asCell: ["cell"]
+                asCell: ["readonly"]
             }
         },
         required: ["input"]

--- a/packages/ts-transformers/test/fixtures/schema-injection/capability-wrapper-narrowing.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/capability-wrapper-narrowing.expected.jsx
@@ -1,0 +1,196 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { lift, type Writable } from "commonfabric";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+type Profile = {
+    name: string;
+    email: string;
+};
+type Item = {
+    id: string;
+    label: string;
+};
+type State = {
+    foo: string;
+    profile: Profile;
+    items: Item[];
+    unused: string;
+};
+// FIXTURE: capability-wrapper-narrowing
+// Verifies: lift inputs narrow from Writable<> to the least capable cell
+// wrapper required by callback usage.
+const readOnly = lift({
+    type: "object",
+    properties: {
+        foo: {
+            type: "string"
+        }
+    },
+    required: ["foo"],
+    asCell: ["readonly"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "string"
+} as const satisfies __cfHelpers.JSONSchema, (input: Writable<State>) => input.key("foo").get());
+const setOnly = lift({
+    type: "object",
+    properties: {
+        foo: {
+            type: "string"
+        }
+    },
+    required: ["foo"],
+    asCell: ["writeonly"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "number"
+} as const satisfies __cfHelpers.JSONSchema, (input: Writable<State>) => {
+    input.key("foo").set("updated");
+    return 1;
+});
+const updateOnly = lift({
+    type: "object",
+    properties: {
+        profile: {
+            $ref: "#/$defs/Profile"
+        }
+    },
+    required: ["profile"],
+    asCell: ["writeonly"],
+    $defs: {
+        Profile: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                email: {
+                    type: "string"
+                }
+            },
+            required: ["name", "email"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "number"
+} as const satisfies __cfHelpers.JSONSchema, (input: Writable<State>) => {
+    input.key("profile").update({ name: "Ada" });
+    return 1;
+});
+const pushOnly = lift({
+    type: "object",
+    properties: {
+        items: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Item"
+            }
+        }
+    },
+    required: ["items"],
+    asCell: ["writeonly"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                },
+                label: {
+                    type: "string"
+                }
+            },
+            required: ["id", "label"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "number"
+} as const satisfies __cfHelpers.JSONSchema, (input: Writable<State>) => {
+    input.key("items").push({ id: "1", label: "First" });
+    return 1;
+});
+const readWrite = lift({
+    type: "object",
+    properties: {
+        foo: {
+            type: "string"
+        }
+    },
+    required: ["foo"],
+    asCell: ["cell"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "number"
+} as const satisfies __cfHelpers.JSONSchema, (input: Writable<State>) => {
+    input.key("foo").set(input.key("foo").get().toUpperCase());
+    return 1;
+});
+const comparable = lift({
+    type: "unknown",
+    asCell: ["comparable"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema, (input: Writable<State>) => input.equals(input));
+const opaqueMap = lift({
+    type: "array",
+    items: {
+        $ref: "#/$defs/Item"
+    },
+    asCell: ["opaque"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                },
+                label: {
+                    type: "string"
+                }
+            },
+            required: ["id", "label"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "array",
+    items: {
+        type: "string"
+    }
+} as const satisfies __cfHelpers.JSONSchema, (input: Writable<Item[]>) => input.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return item.key("id");
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                },
+                label: {
+                    type: "string"
+                }
+            },
+            required: ["id", "label"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "string"
+} as const satisfies __cfHelpers.JSONSchema), {}));
+export { comparable, opaqueMap, pushOnly, readOnly, readWrite, setOnly, updateOnly, };
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-injection/capability-wrapper-narrowing.input.tsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/capability-wrapper-narrowing.input.tsx
@@ -1,0 +1,60 @@
+import { lift, type Writable } from "commonfabric";
+
+type Profile = {
+  name: string;
+  email: string;
+};
+
+type Item = {
+  id: string;
+  label: string;
+};
+
+type State = {
+  foo: string;
+  profile: Profile;
+  items: Item[];
+  unused: string;
+};
+
+// FIXTURE: capability-wrapper-narrowing
+// Verifies: lift inputs narrow from Writable<> to the least capable cell
+// wrapper required by callback usage.
+
+const readOnly = lift((input: Writable<State>) => input.key("foo").get());
+
+const setOnly = lift((input: Writable<State>) => {
+  input.key("foo").set("updated");
+  return 1;
+});
+
+const updateOnly = lift((input: Writable<State>) => {
+  input.key("profile").update({ name: "Ada" });
+  return 1;
+});
+
+const pushOnly = lift((input: Writable<State>) => {
+  input.key("items").push({ id: "1", label: "First" });
+  return 1;
+});
+
+const readWrite = lift((input: Writable<State>) => {
+  input.key("foo").set(input.key("foo").get().toUpperCase());
+  return 1;
+});
+
+const comparable = lift((input: Writable<State>) => input.equals(input));
+
+const opaqueMap = lift((input: Writable<Item[]>) =>
+  input.map((item) => item.id)
+);
+
+export {
+  comparable,
+  opaqueMap,
+  pushOnly,
+  readOnly,
+  readWrite,
+  setOnly,
+  updateOnly,
+};

--- a/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection-shorthand.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection-shorthand.expected.jsx
@@ -16,11 +16,11 @@ const liftSummary = lift({
     properties: {
         primary: {
             type: "number",
-            asCell: ["cell"]
+            asCell: ["readonly"]
         },
         secondary: {
             type: "number",
-            asCell: ["cell"]
+            asCell: ["readonly"]
         }
     },
     required: ["primary", "secondary"]

--- a/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection.expected.jsx
@@ -16,11 +16,11 @@ const liftSummary = lift({
     properties: {
         primary: {
             type: "number",
-            asCell: ["cell"]
+            asCell: ["readonly"]
         },
         secondary: {
             type: "number",
-            asCell: ["cell"]
+            asCell: ["readonly"]
         }
     },
     required: ["primary", "secondary"]

--- a/packages/ts-transformers/test/fixtures/schema-transform/nested-default-optional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/nested-default-optional.expected.jsx
@@ -29,40 +29,26 @@ const increment = handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
         state: {
-            $ref: "#/$defs/NestedOptionalState",
-            asCell: ["cell"]
-        }
-    },
-    required: ["state"],
-    $defs: {
-        NestedOptionalState: {
             type: "object",
             properties: {
                 nested: {
-                    $ref: "#/$defs/OptionalNested"
+                    type: "object",
+                    properties: {
+                        branch: {
+                            type: "object",
+                            properties: {
+                                counter: {
+                                    type: "number"
+                                }
+                            }
+                        }
+                    }
                 }
-            }
-        },
-        OptionalNested: {
-            type: "object",
-            properties: {
-                branch: {
-                    $ref: "#/$defs/OptionalBranch"
-                }
-            }
-        },
-        OptionalBranch: {
-            type: "object",
-            properties: {
-                counter: {
-                    type: "number"
-                },
-                label: {
-                    type: "string"
-                }
-            }
+            },
+            asCell: ["cell"]
         }
-    }
+    },
+    required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, (_, context: {
     state: Cell<NestedOptionalState>;
 }) => {

--- a/packages/ts-transformers/test/fixtures/schema-transform/nested-default-optional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/nested-default-optional.expected.jsx
@@ -29,26 +29,40 @@ const increment = handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
         state: {
-            type: "object",
-            properties: {
-                nested: {
-                    type: "object",
-                    properties: {
-                        branch: {
-                            type: "object",
-                            properties: {
-                                counter: {
-                                    type: "number"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
+            $ref: "#/$defs/NestedOptionalState",
             asCell: ["cell"]
         }
     },
-    required: ["state"]
+    required: ["state"],
+    $defs: {
+        NestedOptionalState: {
+            type: "object",
+            properties: {
+                nested: {
+                    $ref: "#/$defs/OptionalNested"
+                }
+            }
+        },
+        OptionalNested: {
+            type: "object",
+            properties: {
+                branch: {
+                    $ref: "#/$defs/OptionalBranch"
+                }
+            }
+        },
+        OptionalBranch: {
+            type: "object",
+            properties: {
+                counter: {
+                    type: "number"
+                },
+                label: {
+                    type: "string"
+                }
+            }
+        }
+    }
 } as const satisfies __cfHelpers.JSONSchema, (_, context: {
     state: Cell<NestedOptionalState>;
 }) => {

--- a/packages/ts-transformers/test/fixtures/schema-transform/pattern-with-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/pattern-with-types.expected.jsx
@@ -113,7 +113,7 @@ const addItem = handler // <
             items: {
                 $ref: "#/$defs/Item"
             },
-            asCell: ["cell"]
+            asCell: ["writeonly"]
         }
     },
     required: ["items"],

--- a/packages/ts-transformers/test/fixtures/schema-transform/reactive-array-element-access-schema.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/reactive-array-element-access-schema.expected.jsx
@@ -33,11 +33,11 @@ export default pattern((_state) => {
                     items: {
                         type: "string"
                     },
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 },
                 index: {
                     type: "number",
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["items", "index"]

--- a/packages/ts-transformers/test/policy/capability-analysis.test.ts
+++ b/packages/ts-transformers/test/policy/capability-analysis.test.ts
@@ -497,6 +497,20 @@ Deno.test("Capability analysis classifies push-only usage as writeonly", () => {
   assertEquals(input.readPaths.length, 0);
 });
 
+Deno.test("Capability analysis classifies removeAll-only usage as writeonly", () => {
+  const fn = parseFirstCallback(
+    `const fn = (input, item) => {
+      input.key("items").removeAll(item);
+    };`,
+  );
+  const summary = analyzeFunctionCapabilities(fn);
+  const input = getPaths(summary, "input");
+
+  assertEquals(input.capability, "writeonly");
+  assert(input.writePaths.includes("items"));
+  assertEquals(input.readPaths.length, 0);
+});
+
 Deno.test("Capability analysis keeps opaque derivation methods opaque", () => {
   const fn = parseFirstCallback(
     `const fn = (input, mapper) => {

--- a/packages/ts-transformers/test/policy/capability-analysis.test.ts
+++ b/packages/ts-transformers/test/policy/capability-analysis.test.ts
@@ -515,6 +515,25 @@ Deno.test("Capability analysis keeps opaque derivation methods opaque", () => {
   assertEquals(input.wildcard, false);
 });
 
+Deno.test(
+  "Capability analysis keeps root derivation plus equality usage opaque",
+  () => {
+    const fn = parseFirstCallback(
+      `const fn = (input, mapper, other) => {
+        input.map(mapper);
+        return input.equals(other);
+      };`,
+    );
+    const summary = analyzeFunctionCapabilities(fn);
+    const input = getPaths(summary, "input");
+
+    assertEquals(input.capability, "opaque");
+    assertEquals(input.readPaths.length, 0);
+    assertEquals(input.writePaths.length, 0);
+    assertEquals(input.wildcard, false);
+  },
+);
+
 Deno.test("Capability analysis classifies pure passthrough as opaque", () => {
   const fn = parseFirstCallback(
     `const fn = (input) => {

--- a/packages/ts-transformers/test/policy/capability-analysis.test.ts
+++ b/packages/ts-transformers/test/policy/capability-analysis.test.ts
@@ -660,6 +660,36 @@ const fn = (input) => helper(input);`;
 );
 
 Deno.test(
+  "Capability analysis interprocedural propagation tracks root opaque use",
+  () => {
+    const source = `import { type Cell } from "commonfabric";
+const helper = (value: Cell<string[]>, mapper: (value: string) => string) => value.map(mapper);
+const fn = (input: Cell<string[]>, other: Cell<string[]>, mapper: (value: string) => string) => {
+  helper(input, mapper);
+  return input.equals(other);
+};`;
+    const { program, sourceFile } = createProgramWithFiles({
+      "/test.ts": source,
+      "/commonfabric.d.ts": COMMONFABRIC_TYPES["commonfabric.d.ts"]!,
+    });
+    const checker = program.getTypeChecker();
+    const fn = findArrowByVariableName(sourceFile, "fn");
+
+    const summary = analyzeFunctionCapabilities(fn, {
+      checker,
+      interprocedural: true,
+    });
+    const input = getPaths(summary, "input");
+
+    assertEquals(input.capability, "opaque");
+    assertEquals(input.readPaths.length, 0);
+    assertEquals(input.writePaths.length, 0);
+    assertEquals(input.wildcard, false);
+    assertEquals(input.identityOnly, false);
+  },
+);
+
+Deno.test(
   "Capability analysis without interprocedural propagation keeps conservative wildcard",
   () => {
     const source = `const helper = (value) => value.foo;

--- a/packages/ts-transformers/test/policy/capability-analysis.test.ts
+++ b/packages/ts-transformers/test/policy/capability-analysis.test.ts
@@ -537,6 +537,23 @@ Deno.test(
 );
 
 Deno.test(
+  "Capability analysis treats dynamic opaque derivation receivers as wildcard",
+  () => {
+    const fn = parseFirstCallback(
+      `const fn = (input, key) => {
+        return input.collections[key].map((item) => item.name);
+      };`,
+    );
+    const summary = analyzeFunctionCapabilities(fn);
+    const input = getPaths(summary, "input");
+
+    assertEquals(input.capability, "opaque");
+    assertEquals(input.wildcard, true);
+    assertEquals(input.opaquePaths.length, 0);
+  },
+);
+
+Deno.test(
   "Capability analysis keeps root derivation plus equality usage opaque",
   () => {
     const fn = parseFirstCallback(

--- a/packages/ts-transformers/test/policy/capability-analysis.test.ts
+++ b/packages/ts-transformers/test/policy/capability-analysis.test.ts
@@ -467,6 +467,54 @@ Deno.test("Capability analysis classifies read+write usage as writable", () => {
   assert(input.writePaths.includes("count"));
 });
 
+Deno.test("Capability analysis classifies update-only usage as writeonly", () => {
+  const fn = parseFirstCallback(
+    `const fn = (input) => {
+      input.key("profile").update({ name: "Ada" });
+    };`,
+  );
+  const summary = analyzeFunctionCapabilities(fn);
+  const input = getPaths(summary, "input");
+
+  assertEquals(input.capability, "writeonly");
+  assert(input.writePaths.includes("profile"));
+  assertEquals(input.readPaths.length, 0);
+});
+
+Deno.test("Capability analysis classifies push-only usage as writeonly", () => {
+  const fn = parseFirstCallback(
+    `const fn = (input) => {
+      input.key("items").push({ id: "1" });
+    };`,
+  );
+  const summary = analyzeFunctionCapabilities(fn);
+  const input = getPaths(summary, "input");
+
+  assertEquals(input.capability, "writeonly");
+  assert(input.writePaths.includes("items"));
+  assertEquals(input.readPaths.length, 0);
+});
+
+Deno.test("Capability analysis keeps opaque derivation methods opaque", () => {
+  const fn = parseFirstCallback(
+    `const fn = (input, mapper) => {
+      input.map(mapper);
+      input.flatMap(mapper);
+      input.filter(mapper);
+      input.mapWithPattern(mapper, {});
+      input.flatMapWithPattern(mapper, {});
+      input.filterWithPattern(mapper, {});
+    };`,
+  );
+  const summary = analyzeFunctionCapabilities(fn);
+  const input = getPaths(summary, "input");
+
+  assertEquals(input.capability, "opaque");
+  assertEquals(input.readPaths.length, 0);
+  assertEquals(input.writePaths.length, 0);
+  assertEquals(input.wildcard, false);
+});
+
 Deno.test("Capability analysis classifies pure passthrough as opaque", () => {
   const fn = parseFirstCallback(
     `const fn = (input) => {
@@ -1353,13 +1401,13 @@ Deno.test(
     const input = getPaths(summary, "input");
     const other = getPaths(summary, "other");
 
-    assertEquals(input.capability, "opaque");
+    assertEquals(input.capability, "comparable");
     assertEquals(input.passthrough, true);
     assertEquals(input.wildcard, false);
     assertEquals(input.identityOnly, true);
     assertEquals(input.readPaths.length, 0);
 
-    assertEquals(other.capability, "opaque");
+    assertEquals(other.capability, "comparable");
     assertEquals(other.passthrough, true);
     assertEquals(other.wildcard, false);
     assertEquals(other.identityOnly, true);
@@ -1379,13 +1427,39 @@ Deno.test(
     const input = getPaths(summary, "input");
     const other = getPaths(summary, "other");
 
-    assertEquals(input.capability, "opaque");
+    assertEquals(input.capability, "comparable");
     assertEquals(input.passthrough, true);
     assertEquals(input.wildcard, false);
     assertEquals(input.identityOnly, true);
     assertEquals(input.readPaths.length, 0);
 
-    assertEquals(other.capability, "opaque");
+    assertEquals(other.capability, "comparable");
+    assertEquals(other.passthrough, true);
+    assertEquals(other.wildcard, false);
+    assertEquals(other.identityOnly, true);
+    assertEquals(other.readPaths.length, 0);
+  },
+);
+
+Deno.test(
+  "Capability analysis treats .equalLinks() receiver and argument as comparable",
+  () => {
+    const fn = parseFirstCallback(
+      `const fn = (input, other) => {
+        return input.equalLinks(other);
+      };`,
+    );
+    const summary = analyzeFunctionCapabilities(fn);
+    const input = getPaths(summary, "input");
+    const other = getPaths(summary, "other");
+
+    assertEquals(input.capability, "comparable");
+    assertEquals(input.passthrough, true);
+    assertEquals(input.wildcard, false);
+    assertEquals(input.identityOnly, true);
+    assertEquals(input.readPaths.length, 0);
+
+    assertEquals(other.capability, "comparable");
     assertEquals(other.passthrough, true);
     assertEquals(other.wildcard, false);
     assertEquals(other.identityOnly, true);

--- a/packages/ts-transformers/test/policy/capability-analysis.test.ts
+++ b/packages/ts-transformers/test/policy/capability-analysis.test.ts
@@ -141,6 +141,7 @@ function getPaths(
   identityOnly: boolean;
   identityPaths: string[];
   identityCellPaths: string[];
+  opaquePaths: string[];
 } {
   const param = summary.params.find((entry) => entry.name === name);
   if (!param) {
@@ -158,6 +159,7 @@ function getPaths(
     identityCellPaths: (param.identityCellPaths ?? []).map((path) =>
       path.join(".")
     ),
+    opaquePaths: (param.opaquePaths ?? []).map((path) => path.join(".")),
   };
 }
 
@@ -514,6 +516,25 @@ Deno.test("Capability analysis keeps opaque derivation methods opaque", () => {
   assertEquals(input.writePaths.length, 0);
   assertEquals(input.wildcard, false);
 });
+
+Deno.test(
+  "Capability analysis records nested opaque derivation methods without reads",
+  () => {
+    const fn = parseFirstCallback(
+      `const fn = (input) => {
+        return input.items.map((item) => item.name);
+      };`,
+    );
+    const summary = analyzeFunctionCapabilities(fn);
+    const input = getPaths(summary, "input");
+
+    assertEquals(input.capability, "opaque");
+    assertEquals(input.readPaths.length, 0);
+    assertEquals(input.writePaths.length, 0);
+    assert(input.opaquePaths.includes("items"));
+    assertEquals(input.wildcard, false);
+  },
+);
 
 Deno.test(
   "Capability analysis keeps root derivation plus equality usage opaque",

--- a/packages/ts-transformers/test/schema-shrink-validation.test.ts
+++ b/packages/ts-transformers/test/schema-shrink-validation.test.ts
@@ -2003,7 +2003,7 @@ Deno.test("Schema Shrink Validation", async (t) => {
   );
 
   await t.step(
-    "derive shrinks equals-only cell inputs to opaque unknown cells",
+    "derive shrinks equals-only cell inputs to comparable unknown cells",
     async () => {
       const source = [
         "/// <cts-enable />",
@@ -2027,7 +2027,7 @@ Deno.test("Schema Shrink Validation", async (t) => {
         }`,
       );
       const inputSchema = extractSchemas(result.output)[0] ?? "";
-      assertStringIncludes(inputSchema, 'asCell: ["opaque"]');
+      assertStringIncludes(inputSchema, 'asCell: ["comparable"]');
       assertEquals(inputSchema.includes("name"), false);
       assertEquals(inputSchema.includes("extra"), false);
       assertEquals(inputSchema.includes("nested"), false);
@@ -2058,7 +2058,7 @@ Deno.test("Schema Shrink Validation", async (t) => {
       );
       const inputSchema = extractSchemas(result.output)[0] ?? "";
       assertStringIncludes(inputSchema, 'type: "undefined"');
-      assertStringIncludes(inputSchema, 'asCell: ["opaque"]');
+      assertStringIncludes(inputSchema, 'asCell: ["comparable"]');
     },
   );
 
@@ -2123,7 +2123,7 @@ Deno.test("Schema Shrink Validation", async (t) => {
           errors.map((e) => `${e.type}: ${e.message}`).join("; ")
         }`,
       );
-      assertStringIncludes(result.output, 'asCell: ["cell"]');
+      assertStringIncludes(result.output, 'asCell: ["readonly"]');
       assertStringIncludes(result.output, '"foo"');
       assertStringIncludes(result.output, '"bar"');
     },
@@ -2153,7 +2153,7 @@ Deno.test("Schema Shrink Validation", async (t) => {
           errors.map((e) => `${e.type}: ${e.message}`).join("; ")
         }`,
       );
-      assertStringIncludes(result.output, 'asCell: ["cell"]');
+      assertStringIncludes(result.output, 'asCell: ["readonly"]');
       assertStringIncludes(result.output, '"foo"');
       assertStringIncludes(result.output, '"bar"');
     },

--- a/packages/ts-transformers/test/schema-shrink-validation.test.ts
+++ b/packages/ts-transformers/test/schema-shrink-validation.test.ts
@@ -1771,7 +1771,7 @@ Deno.test("Schema Shrink Validation", async (t) => {
   );
 
   await t.step(
-    "derive preserves cell wrappers when callback uses .get() on inferred input",
+    "derive narrows cell wrappers when callback only uses .get() on inferred input",
     async () => {
       const source = [
         "/// <cts-enable />",
@@ -1793,13 +1793,13 @@ Deno.test("Schema Shrink Validation", async (t) => {
         }`,
       );
       const inputSchema = extractSchemas(result.output)[0] ?? "";
-      assertStringIncludes(inputSchema, 'asCell: ["cell"]');
+      assertStringIncludes(inputSchema, 'asCell: ["readonly"]');
       assertEquals(inputSchema.includes("asOpaque: true"), false);
     },
   );
 
   await t.step(
-    "derive preserves cell wrappers when expression-bodied callback is a direct .get() call",
+    "derive narrows cell wrappers when expression-bodied callback is a direct .get() call",
     async () => {
       const source = [
         "/// <cts-enable />",
@@ -1821,7 +1821,7 @@ Deno.test("Schema Shrink Validation", async (t) => {
         }`,
       );
       const inputSchema = extractSchemas(result.output)[0] ?? "";
-      assertStringIncludes(inputSchema, 'asCell: ["cell"]');
+      assertStringIncludes(inputSchema, 'asCell: ["readonly"]');
       assertEquals(inputSchema.includes("asOpaque: true"), false);
     },
   );

--- a/packages/ts-transformers/test/schema-shrink-validation.test.ts
+++ b/packages/ts-transformers/test/schema-shrink-validation.test.ts
@@ -2063,6 +2063,37 @@ Deno.test("Schema Shrink Validation", async (t) => {
   );
 
   await t.step(
+    "derive keeps root cell opaque when derivation and equality are both used",
+    async () => {
+      const source = [
+        "/// <cts-enable />",
+        'import { derive, type Writable } from "commonfabric";',
+        "const input = {} as Writable<number[]>;",
+        "const summary = derive(input, (input) => {",
+        "  input.map((value) => value);",
+        "  return input.equals(input);",
+        "});",
+      ].join("\n");
+
+      const result = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(result.diagnostics);
+
+      assertEquals(
+        errors.length,
+        0,
+        `expected no validation errors but got: ${
+          errors.map((e) => `${e.type}: ${e.message}`).join("; ")
+        }`,
+      );
+      const inputSchema = extractSchemas(result.output)[0] ?? "";
+      assertStringIncludes(inputSchema, 'asCell: ["opaque"]');
+      assertEquals(inputSchema.includes('asCell: ["comparable"]'), false);
+    },
+  );
+
+  await t.step(
     "derive keeps both array and index cells for dynamic element access",
     async () => {
       const source = [

--- a/packages/ts-transformers/test/type-shrinking.test.ts
+++ b/packages/ts-transformers/test/type-shrinking.test.ts
@@ -314,6 +314,33 @@ Deno.test("applyShrinkAndWrap turns identity-only wrapped inputs into OpaqueCell
   );
 });
 
+Deno.test("applyShrinkAndWrap turns comparable wrapped inputs into ComparableCell<unknown>", () => {
+  const { sourceFile, checker } = createProgram(`
+    type Item = { name: string; nested: { value: number } };
+  `);
+  const alias = findTypeAlias(sourceFile, "Item");
+  const baseType = checker.getTypeAtLocation(alias.type);
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      capability: "comparable",
+      identityOnly: true,
+      passthrough: true,
+    }),
+    ts.factory.createTypeReferenceNode("Input"),
+    baseType,
+    true,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  assertEquals(
+    printTypeNode(result, sourceFile),
+    "__cfHelpers.ComparableCell<unknown>",
+  );
+});
+
 Deno.test("applyShrinkAndWrap turns identity-only unwrapped inputs into unknown", () => {
   const { sourceFile, checker } = createProgram(`
     type Item = { name: string; nested: { value: number } };
@@ -367,6 +394,41 @@ Deno.test("applyShrinkAndWrap turns identity-only cell leaves into OpaqueCell<un
   const printed = printTypeNode(result, sourceFile);
   assertStringIncludes(printed, "left: __cfHelpers.OpaqueCell<unknown>");
   assertStringIncludes(printed, "right: __cfHelpers.OpaqueCell<unknown>");
+  assertEquals(printed.includes("name"), false);
+  assertEquals(printed.includes("nested"), false);
+});
+
+Deno.test("applyShrinkAndWrap turns comparable cell leaves into ComparableCell<unknown>", () => {
+  const { sourceFile, checker } = createProgram(`
+    declare namespace __cfHelpers {
+      export type Writable<T> = { readonly value?: T };
+      export type ComparableCell<T> = { readonly comparable?: T };
+    }
+    type Input = {
+      left: __cfHelpers.Writable<{ name: string; nested: { value: number } }>;
+      right: __cfHelpers.Writable<{ name: string; nested: { value: number } }>;
+    };
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      capability: "comparable",
+      identityPaths: [["left"], ["right"]],
+      identityCellPaths: [["left"], ["right"]],
+    }),
+    alias.type,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  const printed = printTypeNode(result, sourceFile);
+  assertStringIncludes(printed, "left: __cfHelpers.ComparableCell<unknown>");
+  assertStringIncludes(printed, "right: __cfHelpers.ComparableCell<unknown>");
   assertEquals(printed.includes("name"), false);
   assertEquals(printed.includes("nested"), false);
 });

--- a/packages/ts-transformers/test/type-shrinking.test.ts
+++ b/packages/ts-transformers/test/type-shrinking.test.ts
@@ -138,6 +138,7 @@ function createParamSummary(
     capability: "opaque",
     readPaths: [],
     writePaths: [],
+    opaquePaths: [],
     passthrough: false,
     wildcard: false,
     identityOnly: false,
@@ -396,6 +397,70 @@ Deno.test("applyShrinkAndWrap turns identity-only cell leaves into OpaqueCell<un
   assertStringIncludes(printed, "right: __cfHelpers.OpaqueCell<unknown>");
   assertEquals(printed.includes("name"), false);
   assertEquals(printed.includes("nested"), false);
+});
+
+Deno.test("applyShrinkAndWrap turns read-only cell leaves into ReadonlyCell", () => {
+  const { sourceFile, checker } = createProgram(`
+    declare namespace __cfHelpers {
+      export type Writable<T> = { readonly value?: T };
+      export type ReadonlyCell<T> = { readonly readonly?: T };
+    }
+    type Input = {
+      value: __cfHelpers.Writable<number>;
+      untouched: __cfHelpers.Writable<string>;
+    };
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      capability: "readonly",
+      readPaths: [["value"]],
+    }),
+    alias.type,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  const printed = printTypeNode(result, sourceFile);
+  assertStringIncludes(printed, "value: __cfHelpers.ReadonlyCell<number>");
+  assertEquals(printed.includes("untouched"), false);
+});
+
+Deno.test("applyShrinkAndWrap turns opaque derivation cell leaves into OpaqueCell", () => {
+  const { sourceFile, checker } = createProgram(`
+    declare namespace __cfHelpers {
+      export type Writable<T> = { readonly value?: T };
+      export type OpaqueCell<T> = { readonly opaque?: T };
+    }
+    type Input = {
+      items: __cfHelpers.Writable<{ name: string }[]>;
+      untouched: __cfHelpers.Writable<string>;
+    };
+  `);
+  const alias = findTypeAlias(sourceFile, "Input");
+  const baseType = checker.getTypeAtLocation(alias.type);
+
+  const result = applyShrinkAndWrap(
+    createParamSummary({
+      opaquePaths: [["items"]],
+    }),
+    alias.type,
+    baseType,
+    false,
+    checker,
+    sourceFile,
+    ts.factory,
+  );
+
+  const printed = printTypeNode(result, sourceFile);
+  assertStringIncludes(printed, "items: __cfHelpers.OpaqueCell");
+  assertStringIncludes(printed, "name: string");
+  assertEquals(printed.includes("untouched"), false);
 });
 
 Deno.test("applyShrinkAndWrap turns comparable cell leaves into ComparableCell<unknown>", () => {


### PR DESCRIPTION
## Summary

- infer narrower cell capabilities for transformed lifts, derives, and handlers, including readonly, writeonly, comparable, and opaque cells
- treat `.set`, `.update`, and `.push` as writes while keeping opaque-only derivation methods at opaque capability where possible
- preserve emitted wrapper schemas for `ReadonlyCell`, `WriteonlyCell`, `ComparableCell`, and `OpaqueCell`

## Validation

- `deno task test` in `packages/ts-transformers`
- `deno task check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Narrows transformed inputs, captured cells, and explicit `lift` schemas to the least capability needed. Adds `comparable`, keeps derivation roots opaque, and fixes wrapper resolution and schema emission to always use the correct kind.

- New Features
  - Capability analysis: infer `readonly`/`writeonly`/`writable`/`comparable`/`opaque`; treat `.set`/`.update`/`.push`/`.removeAll` as writes; keep `map`/`flatMap`/`filter` roots opaque while retaining nested receivers; mark `equals`/`equalLinks` as comparable-only; if derivation and equality touch the same root, stay opaque.
  - Type shrinking and schema emission: narrow captured cell and explicit `lift` schemas by usage (emit `asCell: ["readonly" | "writeonly" | "writable" | "comparable" | "opaque"]`); emit `ReadonlyCell`, `WriteonlyCell`, `ComparableCell`, and `OpaqueCell`; wrap identity-only leaves as `ComparableCell<unknown>`; apply capability summaries to builder fallback argument types.

- Bug Fixes
  - Wrapper resolution: prefer semantic wrapper kind when authored nodes disagree; use the synthetic node’s kind when the wrapper node is generated; resolve from the actual type when no inner node is present (including `typeRegistry` wrappers).
  - Schema generator: plumb `sourceFile` through the `schema-generator` plugin and generator to resolve names from synthetic nodes.
  - Native types: resolve local lib-declared names (e.g. `Date`) before applying native fallbacks, and recognize Node `URL` as a native type.

<sup>Written for commit 941c098a1833115b4b3e91c99bd1dfbec3713e29. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

