### PR TITLE
Derive prompt-slot CFC input labels

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -427,6 +427,11 @@ payload contains audit/provenance context plus optional trusted `cfcInputLabels`
 for supported startup inputs (`command`, `argv`, `args`, `env`, `cwd`, and
 `stdin`). `stdin` labels are modeled as labels on the stdin source and taint
 only after the sandbox reads or maps fd 0, not as automatic startup task taint.
+When a trusted prompt-slot binding is present, `cf-harness` also derives
+confidentiality-only prompt influence labels for model-authored invocation
+inputs such as shell commands, structured file-tool arguments, and stdin
+payloads. These labels are taint evidence, not integrity or authorization
+claims.
 
 On Docker Desktop for macOS, use the host path for `cf-harness` and the
 `/host_mnt/...` projection for Docker's runtime args. The gVisor

--- a/packages/cf-harness/src/contracts/cfc-invocation-context.ts
+++ b/packages/cf-harness/src/contracts/cfc-invocation-context.ts
@@ -2,12 +2,46 @@ import type {
   CfcEnforcementMode,
   CfcLabelView,
 } from "@commonfabric/runner/cfc";
-import type { PromptSlotBinding } from "./prompt-slot.ts";
+import { mergeCfcLabelViews } from "@commonfabric/runner/cfc";
+import type { PromptSlotBinding, PromptSlotRole } from "./prompt-slot.ts";
 import type { HarnessRunManifest } from "./run-manifest.ts";
 import type { BuiltinToolId } from "./tool-descriptor.ts";
 import type { ToolOutputId } from "./tool-result.ts";
 
 export type HarnessCfcInvocationOperation = "command" | "shell";
+export type HarnessCfcInvocationInputLabelRoot =
+  | "command"
+  | "argv"
+  | "args"
+  | "env"
+  | "cwd"
+  | "stdin";
+export type HarnessCfcInvocationInputLabelPath = readonly [
+  HarnessCfcInvocationInputLabelRoot,
+  ...string[],
+];
+
+export const CF_HARNESS_PROMPT_SLOT_INFLUENCE_ATOM_TYPE =
+  "cf-harness.cfc/PromptSlotInfluence" as const;
+
+export interface HarnessPromptSlotInfluenceAtom {
+  type: typeof CF_HARNESS_PROMPT_SLOT_INFLUENCE_ATOM_TYPE;
+  version: 1;
+  role: PromptSlotRole;
+  kernelName: string;
+  surface: string;
+  subject?: string;
+  eventId?: string;
+  valueDigest?: string;
+  slotDigest?: string;
+  snapshotDigest?: string;
+  targetPath?: string;
+  runManifest?: {
+    source?: string;
+    wishId?: string;
+    dispatchClass?: string;
+  };
+}
 
 export interface HarnessCfcRedactedTextSummary {
   type: "cf-harness.redacted-text-summary";
@@ -80,6 +114,7 @@ export interface CreateHarnessCfcInvocationContextOptions {
   stdinText?: string;
   env?: Record<string, string>;
   cfcInputLabels?: CfcLabelView;
+  cfcInputLabelPaths?: readonly HarnessCfcInvocationInputLabelPath[];
 }
 
 const textEncoder = new TextEncoder();
@@ -159,6 +194,72 @@ export const summarizeCfcInvocationRunManifest = (
     : {}),
 });
 
+const createPromptSlotInfluenceAtom = (
+  promptSlot: PromptSlotBinding,
+  runManifest: HarnessCfcInvocationRunManifestSummary,
+): HarnessPromptSlotInfluenceAtom => ({
+  type: CF_HARNESS_PROMPT_SLOT_INFLUENCE_ATOM_TYPE,
+  version: 1,
+  role: promptSlot.role,
+  kernelName: promptSlot.kernelName,
+  surface: promptSlot.surface,
+  ...(promptSlot.subject !== undefined ? { subject: promptSlot.subject } : {}),
+  ...(promptSlot.eventId !== undefined ? { eventId: promptSlot.eventId } : {}),
+  ...(promptSlot.valueDigest !== undefined
+    ? { valueDigest: promptSlot.valueDigest }
+    : {}),
+  ...(promptSlot.slotDigest !== undefined
+    ? { slotDigest: promptSlot.slotDigest }
+    : {}),
+  ...(promptSlot.snapshotDigest !== undefined
+    ? { snapshotDigest: promptSlot.snapshotDigest }
+    : {}),
+  ...(promptSlot.targetPath !== undefined
+    ? { targetPath: promptSlot.targetPath }
+    : {}),
+  ...(runManifest.source !== undefined ||
+      runManifest.wishId !== undefined ||
+      runManifest.dispatchClass !== undefined
+    ? {
+      runManifest: {
+        ...(runManifest.source !== undefined
+          ? { source: runManifest.source }
+          : {}),
+        ...(runManifest.wishId !== undefined
+          ? { wishId: runManifest.wishId }
+          : {}),
+        ...(runManifest.dispatchClass !== undefined
+          ? { dispatchClass: runManifest.dispatchClass }
+          : {}),
+      },
+    }
+    : {}),
+});
+
+export const createHarnessPromptSlotInfluenceLabels = (options: {
+  promptSlot?: PromptSlotBinding;
+  runManifest: HarnessCfcInvocationRunManifestSummary;
+  paths?: readonly HarnessCfcInvocationInputLabelPath[];
+}): CfcLabelView | undefined => {
+  if (options.promptSlot === undefined || options.paths === undefined) {
+    return undefined;
+  }
+  if (options.paths.length === 0) {
+    return undefined;
+  }
+  const atom = createPromptSlotInfluenceAtom(
+    options.promptSlot,
+    options.runManifest,
+  );
+  return {
+    version: 1,
+    entries: options.paths.map((path) => ({
+      path: [...path],
+      label: { confidentiality: [atom] },
+    })),
+  };
+};
+
 export const createHarnessCfcInvocationContext = async (
   options: CreateHarnessCfcInvocationContextOptions,
 ): Promise<HarnessCfcInvocationContext> => {
@@ -175,6 +276,14 @@ export const createHarnessCfcInvocationContext = async (
     ? undefined
     : await summarizeCfcInvocationText(options.stdinText);
   const env = summarizeCfcInvocationEnv(options.env);
+  const cfcInputLabels = mergeCfcLabelViews([
+    options.cfcInputLabels,
+    createHarnessPromptSlotInfluenceLabels({
+      promptSlot: options.promptSlot,
+      runManifest: options.runManifest,
+      paths: options.cfcInputLabelPaths,
+    }),
+  ]);
 
   return {
     type: "cf-harness.cfc-invocation-context",
@@ -200,8 +309,6 @@ export const createHarnessCfcInvocationContext = async (
       ...(stdin !== undefined ? { stdin } : {}),
       ...(env !== undefined ? { env } : {}),
     },
-    ...(options.cfcInputLabels !== undefined
-      ? { cfcInputLabels: options.cfcInputLabels }
-      : {}),
+    ...(cfcInputLabels !== undefined ? { cfcInputLabels } : {}),
   };
 };

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -46,6 +46,7 @@ import {
 import {
   createHarnessCfcInvocationContext,
   type HarnessCfcInvocationContext,
+  type HarnessCfcInvocationInputLabelPath,
   type HarnessCfcInvocationOperation,
   summarizeCfcInvocationRunManifest,
 } from "./contracts/cfc-invocation-context.ts";
@@ -970,6 +971,7 @@ export class CfHarnessEngine {
     stdinText?: string;
     env?: Record<string, string>;
     cfcInputLabels?: CfcLabelView;
+    cfcInputLabelPaths?: readonly HarnessCfcInvocationInputLabelPath[];
   }): Promise<HarnessCfcInvocationContext> {
     const now = this.#now();
     const invocation = await createHarnessCfcInvocationContext({
@@ -999,6 +1001,9 @@ export class CfHarnessEngine {
       ...(options.env !== undefined ? { env: options.env } : {}),
       ...(options.cfcInputLabels !== undefined
         ? { cfcInputLabels: options.cfcInputLabels }
+        : {}),
+      ...(options.cfcInputLabelPaths !== undefined
+        ? { cfcInputLabelPaths: options.cfcInputLabelPaths }
         : {}),
     });
     this.#runState = appendHarnessCfcInvocationContext(
@@ -1065,6 +1070,7 @@ export class CfHarnessEngine {
         stdinText?: string;
         env?: Record<string, string>;
         cfcInputLabels?: CfcLabelView;
+        cfcInputLabelPaths?: readonly HarnessCfcInvocationInputLabelPath[];
       }) => this.#createCfcInvocationContext(options),
     };
   }

--- a/packages/cf-harness/src/tools/bash.ts
+++ b/packages/cf-harness/src/tools/bash.ts
@@ -110,7 +110,9 @@ export const bashTool: HarnessToolDefinition<BashToolInput, BashToolOutput> = {
         ...(input.cfcInputLabels !== undefined
           ? { cfcInputLabels: input.cfcInputLabels }
           : {}),
-        cfcInputLabelPaths: [["command"]],
+        cfcInputLabelPaths: input.cwd !== undefined
+          ? [["command"], ["cwd"]]
+          : [["command"]],
       }),
     });
     const mayTrustCwdMarker = context.cfcEnforcementMode === "disabled" ||

--- a/packages/cf-harness/src/tools/bash.ts
+++ b/packages/cf-harness/src/tools/bash.ts
@@ -110,6 +110,7 @@ export const bashTool: HarnessToolDefinition<BashToolInput, BashToolOutput> = {
         ...(input.cfcInputLabels !== undefined
           ? { cfcInputLabels: input.cfcInputLabels }
           : {}),
+        cfcInputLabelPaths: [["command"]],
       }),
     });
     const mayTrustCwdMarker = context.cfcEnforcementMode === "disabled" ||

--- a/packages/cf-harness/src/tools/edit-file.ts
+++ b/packages/cf-harness/src/tools/edit-file.ts
@@ -559,6 +559,7 @@ export const editFileTool: HarnessToolDefinition<
         cwd: context.currentDir,
         command: READ_FILE_COMMAND,
         args: readArgs,
+        cfcInputLabelPaths: [["args"]],
       }),
     });
     if (readResult.exitCode !== 0) {
@@ -608,6 +609,7 @@ export const editFileTool: HarnessToolDefinition<
         command: WRITE_FILE_COMMAND,
         args: writeArgs,
         stdinText: edited.content,
+        cfcInputLabelPaths: [["args"], ["stdin"]],
       }),
     });
     if (writeResult.exitCode !== 0) {
@@ -629,6 +631,7 @@ export const editFileTool: HarnessToolDefinition<
         cwd: context.currentDir,
         command: READ_FILE_COMMAND,
         args: readArgs,
+        cfcInputLabelPaths: [["args"]],
       }),
     });
     if (verifyResult.exitCode !== 0) {

--- a/packages/cf-harness/src/tools/read-file.ts
+++ b/packages/cf-harness/src/tools/read-file.ts
@@ -120,6 +120,7 @@ export const readFileTool: HarnessToolDefinition<
         cwd: context.currentDir,
         command,
         args,
+        cfcInputLabelPaths: [["args"]],
       }),
     });
     if (result.exitCode !== 0) {

--- a/packages/cf-harness/src/tools/types.ts
+++ b/packages/cf-harness/src/tools/types.ts
@@ -4,6 +4,7 @@ import type {
 } from "@commonfabric/runner/cfc";
 import type {
   HarnessCfcInvocationContext,
+  HarnessCfcInvocationInputLabelPath,
   HarnessCfcInvocationOperation,
 } from "../contracts/cfc-invocation-context.ts";
 import type {
@@ -53,6 +54,7 @@ export interface HarnessToolContext {
     stdinText?: string;
     env?: Record<string, string>;
     cfcInputLabels?: CfcLabelView;
+    cfcInputLabelPaths?: readonly HarnessCfcInvocationInputLabelPath[];
   }): Promise<HarnessCfcInvocationContext>;
 }
 

--- a/packages/cf-harness/src/tools/write-file.ts
+++ b/packages/cf-harness/src/tools/write-file.ts
@@ -137,6 +137,7 @@ export const writeFileTool: HarnessToolDefinition<
         command,
         args,
         stdinText: input.content,
+        cfcInputLabelPaths: [["args"], ["stdin"]],
       }),
     });
     if (result.exitCode !== 0) {

--- a/packages/cf-harness/test/cfc-invocation-context.test.ts
+++ b/packages/cf-harness/test/cfc-invocation-context.test.ts
@@ -1,5 +1,6 @@
 import { assertEquals } from "@std/assert";
 import {
+  CF_HARNESS_PROMPT_SLOT_INFLUENCE_ATOM_TYPE,
   createHarnessCfcInvocationContext,
   summarizeCfcInvocationSequence,
   summarizeCfcInvocationText,
@@ -33,18 +34,18 @@ Deno.test("createHarnessCfcInvocationContext summarizes measured invocation inpu
         },
       },
       {
-        path: ["env", "SECRET_TOKEN"],
-        label: {
-          confidentiality: [
-            { type: "test.cfc/User", subject: "did:key:env-reader" },
-          ],
-        },
-      },
-      {
         path: ["cwd"],
         label: {
           confidentiality: [
             { type: "test.cfc/Workspace", subject: "workspace-secret" },
+          ],
+        },
+      },
+      {
+        path: ["env", "SECRET_TOKEN"],
+        label: {
+          confidentiality: [
+            { type: "test.cfc/User", subject: "did:key:env-reader" },
           ],
         },
       },
@@ -115,4 +116,131 @@ Deno.test("createHarnessCfcInvocationContext summarizes measured invocation inpu
       `sidecar leaked raw invocation input ${rawValue}`,
     );
   }
+});
+
+Deno.test("createHarnessCfcInvocationContext derives prompt-slot influence labels for selected invocation inputs", async () => {
+  const promptSlot = {
+    type: CFC_PROMPT_SLOT_BOUND_ATOM_TYPE,
+    source: { type: "cf-harness.test-input", surface: "cli" },
+    role: "direct-command",
+    kernelName: "cf-harness",
+    surface: "cli",
+    subject: "did:key:user",
+    eventId: "evt-1",
+    valueDigest: "sha256:value",
+    slotDigest: "sha256:slot",
+    snapshotDigest: "sha256:snapshot",
+    targetPath: "/workspace/request.md",
+  } as const;
+
+  const context = await createHarnessCfcInvocationContext({
+    sequence: 1,
+    runId: "run-labels",
+    createdAt: "2026-05-14T17:00:00.000Z",
+    toolId: "bash",
+    operation: "shell",
+    cfcEnforcementMode: "enforce-explicit",
+    cwd: "/workspace",
+    promptSlot,
+    runManifest: {
+      present: true,
+      source: "loom",
+      wishId: "W-534",
+      dispatchClass: "gtd-ops",
+      promptSlotPresent: true,
+    },
+    command: "printf hello",
+    stdinText: "model-authored stdin",
+    cfcInputLabelPaths: [["command"], ["stdin"]],
+  });
+
+  const expectedAtom = {
+    type: CF_HARNESS_PROMPT_SLOT_INFLUENCE_ATOM_TYPE,
+    version: 1,
+    role: "direct-command",
+    kernelName: "cf-harness",
+    surface: "cli",
+    subject: "did:key:user",
+    eventId: "evt-1",
+    valueDigest: "sha256:value",
+    slotDigest: "sha256:slot",
+    snapshotDigest: "sha256:snapshot",
+    targetPath: "/workspace/request.md",
+    runManifest: {
+      source: "loom",
+      wishId: "W-534",
+      dispatchClass: "gtd-ops",
+    },
+  };
+
+  assertEquals(context.cfcInputLabels, {
+    version: 1,
+    entries: [
+      {
+        path: ["command"],
+        label: { confidentiality: [expectedAtom] },
+      },
+      {
+        path: ["stdin"],
+        label: { confidentiality: [expectedAtom] },
+      },
+    ],
+  });
+  for (const entry of context.cfcInputLabels?.entries ?? []) {
+    assertEquals(entry.label.integrity, undefined);
+  }
+});
+
+Deno.test("createHarnessCfcInvocationContext merges explicit trusted labels with derived prompt-slot labels", async () => {
+  const explicitAtom = {
+    type: "test.cfc/ExplicitTrustedInput",
+    subject: "trusted-sidecar",
+  };
+  const promptSlot = {
+    type: CFC_PROMPT_SLOT_BOUND_ATOM_TYPE,
+    source: { type: "cf-harness.test-input", surface: "cli" },
+    role: "context",
+    kernelName: "cf-harness",
+    surface: "cli",
+  } as const;
+
+  const context = await createHarnessCfcInvocationContext({
+    sequence: 2,
+    runId: "run-merged-labels",
+    createdAt: "2026-05-14T17:01:00.000Z",
+    toolId: "read_file",
+    operation: "shell",
+    cfcEnforcementMode: "observe",
+    cwd: "/workspace",
+    promptSlot,
+    runManifest: { present: false },
+    args: ["/workspace/notes.md"],
+    cfcInputLabels: {
+      version: 1,
+      entries: [{
+        path: ["args"],
+        label: { confidentiality: [explicitAtom] },
+      }],
+    },
+    cfcInputLabelPaths: [["args"]],
+  });
+
+  assertEquals(context.cfcInputLabels, {
+    version: 1,
+    entries: [{
+      path: ["args"],
+      label: {
+        confidentiality: [
+          explicitAtom,
+          {
+            type: CF_HARNESS_PROMPT_SLOT_INFLUENCE_ATOM_TYPE,
+            version: 1,
+            role: "context",
+            kernelName: "cf-harness",
+            surface: "cli",
+          },
+        ],
+      },
+    }],
+  });
 });

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertRejects, assertThrows } from "@std/assert";
 import { normalize } from "@std/path/posix";
 import type { HarnessArtifactStore } from "../src/artifacts.ts";
+import { CF_HARNESS_PROMPT_SLOT_INFLUENCE_ATOM_TYPE } from "../src/contracts/cfc-invocation-context.ts";
 import { createHarnessCfcPolicySnapshot } from "../src/contracts/cfc-policy-snapshot.ts";
 import { createHarnessPolicyEvent } from "../src/contracts/policy.ts";
 import { CFC_PROMPT_SLOT_BOUND_ATOM_TYPE } from "../src/contracts/prompt-slot.ts";
@@ -368,6 +369,86 @@ Deno.test("CfHarnessEngine records prompt slot binding into run state", () => {
 
   assertEquals(engine.getRunState().promptSlotBinding, promptSlotBinding);
   assertEquals(engine.getRunState().updatedAt, "2026-04-17T19:00:01.000Z");
+});
+
+Deno.test("CfHarnessEngine derives prompt-slot labels for model-authored sandbox invocation inputs", async () => {
+  const promptSlotBinding = {
+    type: CFC_PROMPT_SLOT_BOUND_ATOM_TYPE,
+    source: { type: "test.prompt-slot", subject: "engine-label-test" },
+    role: "direct-command",
+    kernelName: "cf-harness",
+    surface: "test",
+    eventId: "event-engine-label",
+  } as const;
+  const sandbox = new FakeSandboxRuntime([
+    { stdout: "", stderr: "", exitCode: 0 },
+    { stdout: "", stderr: "", exitCode: 0 },
+  ]);
+  const engine = new CfHarnessEngine({
+    sandboxRuntime: sandbox,
+    runId: "run-prompt-slot-labels",
+    cfcEnforcementMode: "observe",
+    now: (() => {
+      const timestamps = [
+        "2026-04-17T19:05:00.000Z",
+        "2026-04-17T19:05:01.000Z",
+        "2026-04-17T19:05:02.000Z",
+        "2026-04-17T19:05:03.000Z",
+        "2026-04-17T19:05:04.000Z",
+      ];
+      return () => timestamps.shift() ?? "2026-04-17T19:05:05.000Z";
+    })(),
+  });
+
+  engine.setPromptSlotBinding(promptSlotBinding);
+  await engine.invokeBuiltinTool("bash", { command: "printf hello" });
+  await engine.invokeBuiltinTool("write_file", {
+    path: "notes.md",
+    content: "hello from prompt",
+  });
+
+  const expectedAtom = {
+    type: CF_HARNESS_PROMPT_SLOT_INFLUENCE_ATOM_TYPE,
+    version: 1,
+    role: "direct-command",
+    kernelName: "cf-harness",
+    surface: "test",
+    eventId: "event-engine-label",
+  };
+  assertEquals(
+    engine.getRunState().cfcInvocationContexts?.map((context) => ({
+      toolId: context.toolId,
+      labels: context.cfcInputLabels,
+    })),
+    [
+      {
+        toolId: "bash",
+        labels: {
+          version: 1,
+          entries: [{
+            path: ["command"],
+            label: { confidentiality: [expectedAtom] },
+          }],
+        },
+      },
+      {
+        toolId: "write_file",
+        labels: {
+          version: 1,
+          entries: [
+            {
+              path: ["args"],
+              label: { confidentiality: [expectedAtom] },
+            },
+            {
+              path: ["stdin"],
+              label: { confidentiality: [expectedAtom] },
+            },
+          ],
+        },
+      },
+    ],
+  );
 });
 
 Deno.test("CfHarnessEngine stamps policy snapshot state changes with mutation time", async () => {

--- a/packages/cf-harness/test/engine.test.ts
+++ b/packages/cf-harness/test/engine.test.ts
@@ -401,7 +401,10 @@ Deno.test("CfHarnessEngine derives prompt-slot labels for model-authored sandbox
   });
 
   engine.setPromptSlotBinding(promptSlotBinding);
-  await engine.invokeBuiltinTool("bash", { command: "printf hello" });
+  await engine.invokeBuiltinTool("bash", {
+    command: "printf hello",
+    cwd: "task-dir",
+  });
   await engine.invokeBuiltinTool("write_file", {
     path: "notes.md",
     content: "hello from prompt",
@@ -425,10 +428,16 @@ Deno.test("CfHarnessEngine derives prompt-slot labels for model-authored sandbox
         toolId: "bash",
         labels: {
           version: 1,
-          entries: [{
-            path: ["command"],
-            label: { confidentiality: [expectedAtom] },
-          }],
+          entries: [
+            {
+              path: ["command"],
+              label: { confidentiality: [expectedAtom] },
+            },
+            {
+              path: ["cwd"],
+              label: { confidentiality: [expectedAtom] },
+            },
+          ],
         },
       },
       {


### PR DESCRIPTION
## Summary
- derive confidentiality-only prompt-slot influence labels into cf-harness invocation contexts
- let tools declare which invocation input paths are model/prompt-influenced (`command`, `args`, `stdin`)
- merge derived labels with explicit trusted `cfcInputLabels` and document the behavior

## Notes
- These are taint/influence labels, not integrity or authorization claims. The merged gVisor side rejects integrity claims in `cfcInputLabels`.
- Docker/runsc sidecar-before-start transport is covered by the merged invocation-context work. The remaining runtime/Fabric gap is durable sandbox-to-FUSE write/readback via trusted prepare/finalize metadata and its atomicity semantics.

## Tests
- `/Users/gideonwald/.deno/bin/deno check packages/cf-harness/src/contracts/cfc-invocation-context.ts packages/cf-harness/src/engine.ts packages/cf-harness/src/tools/bash.ts packages/cf-harness/src/tools/read-file.ts packages/cf-harness/src/tools/write-file.ts packages/cf-harness/src/tools/edit-file.ts packages/cf-harness/test/cfc-invocation-context.test.ts packages/cf-harness/test/engine.test.ts`
- `/Users/gideonwald/.deno/bin/deno test --allow-env --allow-read --allow-run --allow-write packages/cf-harness/test/cfc-invocation-context.test.ts packages/cf-harness/test/engine.test.ts`
- `(cd packages/cf-harness && /Users/gideonwald/.deno/bin/deno task test)`
- `git diff --check`
