### PR TITLE
test(runner): drop spurious anon function from cross-space wish test fixture

### DIFF
--- a/packages/runner/test/wish.test.ts
+++ b/packages/runner/test/wish.test.ts
@@ -2499,15 +2499,12 @@ describe("wish built-in", () => {
     });
 
     it("starts piece automatically when accessed via cross-space wish", async () => {
-      // Setup 1: Create a simple counter pattern/piece
+      // Setup 1: Create a simple piece. The actual returned shape doesn't
+      // matter for this test — we only care that the piece can be started
+      // and that its result is reachable through a cross-space wish.
       const counterPattern = pattern<{ count: number }>(() => {
         const count = 0;
-        return {
-          count,
-          increment: () => {
-            return count + 1;
-          },
-        };
+        return { count };
       });
 
       // Setup 2: Store the piece in home space
@@ -2562,10 +2559,9 @@ describe("wish built-in", () => {
       expect(pieceData).toBeDefined();
       expect(typeof pieceData).toBe("object");
 
-      // The piece should be running and have its state accessible
-      // Note: This test may need adjustment based on actual piece startup behavior
+      // The piece should be running and have its state accessible.
       if (typeof pieceData === "object" && pieceData !== null) {
-        expect("count" in pieceData || "increment" in pieceData).toBe(true);
+        expect("count" in pieceData).toBe(true);
       }
     });
   });


### PR DESCRIPTION
Prep PR for the modern-data-model flag flip (PR #3569). Cleans one of the test fixtures that fails under `modernDataModel: true`; no-op under legacy.

## What was happening

The `counterPattern` fixture in `wish.test.ts` > `"starts piece automatically when accessed via cross-space wish"` returned:

```typescript
const counterPattern = pattern<{ count: number }>(() => {
  const count = 0;
  return {
    count,
    increment: () => {
      return count + 1;
    },
  };
});
```

- `count` is a plain JS `const 0`, not a `Writable`.
- `increment` is a closure over that const — would return `1` every time, never actually invoked.
- Neither the function nor any reactive plumbing was being tested.

Under the legacy data-model layer, this fixture worked because legacy follows `JSON.stringify` semantics: a function in an object property is silently omitted. So `pieceData` ended up as `{ count: 0 }` regardless. The original assertion (`"count" in pieceData || "increment" in pieceData`) was permissive enough that the missing `increment` didn't matter.

Confirmed empirically — running the original fixture under legacy default with diagnostic logging:

```
DIAG pieceData keys: [ "count" ]
DIAG count present: true
DIAG increment present: false
DIAG increment value: undefined
```

Under modern, the data-model layer is strict — a function-without-`toJSON()` in a stored value is rejected ("death before confusion"). The test then fails with `Cannot store function per se (needs to have a toJSON() method)`.

## Why I didn't just match legacy's behavior

The legacy semantics here were an accident of using `JSON.stringify` conventions, not a deliberate design that patterns are supposed to lean on. Surveying production patterns confirms this: `handler()` is used ~176×, `action()` ~68×, and raw functions returned in pattern result projections appear ~zero times outside this test fixture. Functions in pattern results are anti-idiomatic; legacy's silent drop was hiding latent data-loss, not enabling a feature.

So rather than weaken the modern data-model contract to preserve the accidental tolerance, drop the function from the fixture. The test is about cross-space wish auto-start; the fixture only needs to be *a piece that can be started and whose result is reachable*.

## Changes

- Drop the `increment` property from the `counterPattern` fixture return value.
- Tighten the assertion to `"count" in pieceData` (no `|| "increment"`).
- Comment that the returned shape doesn't matter for what this test exercises.

## Test plan

- [x] `wish.test.ts` passes locally under `modernDataModel = false` (current default on `main`).
- [x] `wish.test.ts` passes locally under `modernDataModel = true` (post-flip).
- [x] Empirical confirmation that legacy was silently dropping `increment` (diagnostic logging above).
- [ ] Manual: not needed; pure test fixture cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned the cross-space wish test by removing the unused function from the `counterPattern` result to avoid storing a raw function under `modernDataModel: true`. Tightened the assertion to only check `"count"` and added a brief comment; legacy behavior is unchanged.

<sup>Written for commit a67481d86f50d4293c69de3ce76c01b3350ef950. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

