### PR TITLE
fix(runner): strip runtime-only `.with`/`.bind` from `moduleToJSON` output

### DIFF
--- a/packages/runner/src/builder/json-utils.ts
+++ b/packages/runner/src/builder/json-utils.ts
@@ -304,11 +304,23 @@ function itemsSchemaFromArray(
 
 export function moduleToJSON(module: Module) {
   const frame = getTopFrame();
+  // Destructure-and-drop the runtime-only methods that handler modules
+  // attach for the in-builder ergonomics (`mod.with(...)`/`mod.bind(...)`).
+  // They are not part of the serialized contract — under the legacy
+  // data-model layer they were silently omitted by `JSON.stringify`-style
+  // semantics; under modern they would surface as
+  // `Cannot store function per se`.
   const {
     implementation: _implementation,
-    toJSON: _,
+    toJSON: _toJSON,
+    with: _with,
+    bind: _bind,
     ...rest
-  } = module as Module & { toJSON: () => any };
+  } = module as Module & {
+    toJSON: () => any;
+    with?: unknown;
+    bind?: unknown;
+  };
   let implementation = module.implementation;
 
   // CT-1230 WORKAROUND: Preserve pattern structure when serializing pattern modules.


### PR DESCRIPTION
Prep PR for the modern-data-model flag flip (PR #3569). Fixes one of the two remaining test failures that surface when `modernDataModel` is on by default; no-op under legacy.

## The bug

Handler-style modules built in `packages/runner/src/builder/module.ts` carry two builder-time convenience methods on the module object:

* `with: (inputs) => factory(inputs)` — used as `someHandler.with({...})` in pattern bodies.
* `bind: (inputs) => factory(inputs)` — same shape, present so `Function.prototype.bind` doesn't get hit on the underlying callable module.

`moduleToJSON()` destructures out `implementation` and `toJSON` before spreading the rest into the serialized form — but it leaves `.with` and `.bind` in `rest`. Under the legacy fabric-value layer, `JSON.stringify`-style semantics silently omit function properties on storage, so the bare arrows disappeared on the way to memory. Under modern, the fabric-value layer rejects function-without-`toJSON()` ("death before confusion"), and the leak surfaces as:

```
Error: Cannot store function per se (needs to have a `toJSON()` method)
```

Empirically traced (via diagnostic logging) to a path like:

```
$UI.children.0.children.0.children.1.children.0.nodes.1.module.implementation.nodes.1.module.with
```

— the leaking `.with` is the bare arrow from `module.ts:377`.

## The fix

Add `with` and `bind` to the destructure-and-drop list in `moduleToJSON`. The serialized form now has no trace of these runtime-only methods.

Grepped — no production reader pulls `.with`/`.bind` off a serialized module. They exist only for the in-builder ergonomics on the live runtime-side object.

## Why not match legacy's lenient behavior in the data-model layer?

(Background: this came up in an earlier discussion on PR #3590.) Legacy's silent function-drop was an accidental consequence of using `JSON.stringify` conventions, not a deliberate design that callers should be allowed to lean on. Production patterns never put raw functions into result projections — they use `handler()` (~176 uses) or `action()` (~68 uses). Modern's strict rejection is exposing a real upstream bug (a runtime-only method leaking into the serialized form), and the right fix is to plug the leak, not weaken the layer that caught it.

## Tests fixed

Verified locally with the modern default temporarily flipped:

- `packages/patterns/cfc-trusted-component-examples/main.test.tsx` — was failing under PR #3569's `Pattern Unit Tests (2/5)` with the same "Cannot store function per se" error.

After this fix, the remaining modern-on runner failures from PR #3569's CI are:

- `fetch-data mutex mechanism` (2 steps) — idempotency-key hashing under modern.
- `generateObject with tools` (1 step) — InjectionSafe label dedup under modern.

Both are out of scope for this PR.

## Test plan

- [x] `deno task check` — passes.
- [x] `deno task test` (workspace-wide) under `modernDataModel = false` (current default on `main`): all green.
- [x] `deno task test` (workspace-wide) under `modernDataModel = true` (post-flip): the cfc-trusted failure clears; only the two unrelated known root causes remain.
- [ ] Manual: not needed; the change is internal to the serialization helper and verified by the cited test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strips runtime-only `.with` and `.bind` from `moduleToJSON()` so function values don’t leak into serialized modules under the modern data model. Fixes the modern-on failure while keeping legacy behavior unchanged.

- **Bug Fixes**
  - Exclude `with`/`bind` during serialization in `packages/runner/src/builder/json-utils.ts` to avoid `Cannot store function per se (needs to have a toJSON() method)`.
  - Unblocks `packages/patterns/cfc-trusted-component-examples/main.test.tsx` with `modernDataModel` enabled; no-op under legacy.

<sup>Written for commit 7b2c094a833cdd39ab077107853cde41a03b9f29. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Performance Baseline

There's no way this very small (both code and running time) change could have materially affected the performance numbers, so the following accounts for a spurious failure:

NEW_PERF_BASELINE: job: Package Integration Tests (background-charm-service) = 54s

