### PR TITLE
fix(runner): structural dedup of CFC label atoms (not reference-set)

### DIFF
--- a/packages/runner/src/cfc/label-view-core.ts
+++ b/packages/runner/src/cfc/label-view-core.ts
@@ -1,4 +1,5 @@
 import { encodePointer } from "../../../memory/v2/path.ts";
+import { uniqueCfcAtoms } from "./observation.ts";
 
 export type IFCLabel = {
   confidentiality?: unknown[];
@@ -74,7 +75,15 @@ const mergeLabel = (
       ...(Array.isArray(left?.[key]) ? left[key] : []),
       ...(Array.isArray(right[key]) ? right[key] : []),
     ];
-    const unique = [...new Set(values)];
+    // Dedup structurally via `uniqueCfcAtoms()` rather than by reference
+    // (`new Set()`). Atoms can be fabric-converted clones (each call to
+    // `cloneIfNecessary()` produces a fresh frozen object), so two
+    // logically-identical caveats may not share a JS reference. The
+    // reference-keyed approach would leave duplicates that callers
+    // observe as both `confidentiality` bloat and -- since downstream
+    // entry-merging compares labels structurally -- as label entries
+    // failing to coalesce at the right path.
+    const unique = uniqueCfcAtoms(values);
     if (unique.length > 0) {
       merged[key] = unique;
     }

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -26,6 +26,7 @@ import {
 import { getValueAtPath } from "../path-utils.ts";
 import { encodePointer } from "../../../memory/v2/path.ts";
 import { canonicalizeLogicalPath } from "./canonical.ts";
+import { uniqueCfcAtoms } from "./observation.ts";
 import { mergeCfcSchemaEnvelopes } from "./schema-merge.ts";
 import {
   CFC_STRUCTURAL_PROVENANCE_SETUP_PROJECTION,
@@ -80,11 +81,13 @@ const labelAtPath = (
 const mergeLabelValues = (
   ...sources: Array<readonly unknown[] | undefined>
 ) => {
-  const merged = [
-    ...new Set(
-      sources.flatMap((source) => source ? [...source] : []),
-    ),
-  ];
+  // Structural dedup via `uniqueCfcAtoms()` rather than reference dedup
+  // via `new Set()`. Atoms can be fabric-converted clones (each
+  // `cloneIfNecessary()` produces a fresh frozen object), so two
+  // logically-identical caveats may not share a JS reference.
+  const merged = uniqueCfcAtoms(
+    sources.flatMap((source) => source ? [...source] : []),
+  );
   return merged.length > 0 ? merged : undefined;
 };
 


### PR DESCRIPTION
Prep PR for the modern-data-model flag flip (PR #3569). Fixes one of the two remaining test failures that surface when `modernDataModel` is on by default; no-op under legacy.

## The bug

Two helpers in the CFC label machinery were deduplicating atom arrays by JS reference identity (`[...new Set(values)]`):

- `mergeLabel()` in `packages/runner/src/cfc/label-view-core.ts`
- `mergeLabelValues()` in `packages/runner/src/cfc/prepare.ts`

That happened to work under the legacy fabric-value layer because atoms tended to flow through the system as shared references. Under modern, `cloneIfNecessary()` produces a fresh frozen object on every conversion, so two logically-identical caveats (same `type`, `kind`, `source`) no longer share a reference. `new Set()` then leaves duplicates in place.

The concrete symptom on PR #3569 (`Runner Tests (2/4)` → `generateObject with tools > "writes InjectionSafe labels only for instruction-inert result paths"`):

- Test expects per-property entries (`["action"]`, `["approved"]`, `["confidence"]`, `["reasoning"]`), each with a deduplicated `confidentiality` list.
- Under modern the actual result is a single root entry at `path: []` whose `confidentiality` is `[promptRisk, promptInfluence, promptRisk, promptInfluence]` — each atom appearing twice — because the downstream "merge entries that share a path" step compares labels structurally and these no-longer-equal duplicated arrays prevent the per-path coalescence.

Diagnostic confirmation (side-by-side `[...new Set(values)]` vs `uniqueCfcAtoms(values)` inside `mergeLabel()`): repeated `ref-unique=4 / struct-unique=2 / input=4` mismatches throughout the test run.

## The fix

Route both call sites through the existing structural-dedup helper `uniqueCfcAtoms()` (which compares atoms with `deepEqual()`). Legacy behavior is unchanged in practice — shared references happen to match structurally too — but the layer no longer depends on reference-identity-as-equality, which is the kind of accidental coupling the modern data-model is exposing.

## Perf note

`uniqueCfcAtoms()` is O(N²) on the input length with `deepEqual()` as the inner comparison, so it's worth checking whether routing both call sites through it introduces a meaningful cost. Measured locally with diagnostic instrumentation in `mergeLabel`/`mergeLabelValues` over a full runner test pass (450 tests, ~65 s wall):

- `mergeLabel`: 1,526 calls; avg N=1.18, p99=4, max=5; 96% of calls have N≤2; Σ N² ≈ 3,168.
- `mergeLabelValues`: 464 calls; avg N=0.58, p99=2, max=4; 99.4% of calls have N≤2; Σ N² ≈ 386.

Combined ≈3,554 `deepEqual` invocations across the entire runner test pass, each on a 3–5-field atom. Sub-millisecond total cost — no content-hashing optimization needed.

## Tests fixed

Verified locally with the modern default temporarily flipped:

- `packages/runner/test/generate-object-tools.test.ts > generateObject with tools > "writes InjectionSafe labels only for instruction-inert result paths"` — passes under both flag states.

After this lands, the only modern-on runner failure remaining from PR #3569's CI should be `fetch-data mutex mechanism` (2 steps), which is a separate root cause and out of scope for this PR.

## Test plan

- [x] `deno task check` — passes.
- [x] `deno task test` (workspace-wide) under `modernDataModel = false` (current default on `main`): all green.
- [x] `deno task test` (runner package) under `modernDataModel = true` (post-flip): the InjectionSafe failure clears; only the `fetch-data mutex` root cause remains.
- [ ] Manual: not needed; the change is internal to the CFC label-merge helpers and verified by the cited test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
