### PR TITLE
[codex] fix ts-transformers inline handler sends

### DIFF
--- a/packages/ts-transformers/src/closures/utils/capture-scaffold.ts
+++ b/packages/ts-transformers/src/closures/utils/capture-scaffold.ts
@@ -33,12 +33,16 @@ export function buildCapturedHandlerClosureCall(
   const builder = new PatternBuilder(context);
   builder.setCaptureTree(captureTree);
 
+  // The moved body keeps original parent links, so mark both callback nodes as
+  // safe handler contexts for later expression-site rewrites.
+  context.markAsSyntheticComputeCallback(callback);
   const handlerCallback = builder.buildHandlerCallback(
     callback,
     transformedBody,
     options?.eventParamName ?? "event",
     options?.paramsParamName ?? "params",
   );
+  context.markAsSyntheticComputeCallback(handlerCallback);
 
   const handlerCall = context.cfHelpers.createHelperCall(
     "handler",

--- a/packages/ts-transformers/test/fixtures/closures/map-conditional-inline-handler-send.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-conditional-inline-handler-send.expected.jsx
@@ -1,0 +1,322 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { Cell, handler, pattern, UI } from "commonfabric";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+interface Item {
+    id: string;
+    label: string;
+}
+interface VoteEvent {
+    id: string;
+    step: "single" | "double";
+}
+interface State {
+    items: Item[];
+    canVote: boolean;
+    votes: VoteEvent[];
+}
+const castVote = handler({
+    type: "unknown"
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        votes: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/VoteEvent"
+            },
+            asCell: ["cell"]
+        }
+    },
+    required: ["votes"],
+    $defs: {
+        VoteEvent: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                },
+                step: {
+                    "enum": ["single", "double"]
+                }
+            },
+            required: ["id", "step"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, (_event, { votes }) => {
+    votes.set([
+        ...votes.get(),
+        { id: "module", step: "single" },
+    ]);
+});
+// FIXTURE: map-conditional-inline-handler-send
+// Verifies: inline onClick handlers inside conditional JSX branches retain
+// imperative handler semantics when nested in reactive map callbacks.
+//   onClick={() => boundCastVote.send(...)} → bare handler callback body
+//   not derive(...boundCastVote.send(...))
+// Context: The conditional branch makes expression rewriting recurse into the
+// handler subtree; the authored handler arrow must be treated as safe context.
+export default pattern((state) => {
+    const boundCastVote = __cfHelpers.derive({
+        type: "object",
+        properties: {
+            castVote: {
+                type: "object",
+                properties: {
+                    type: {
+                        "enum": ["ref", "javascript", "pattern", "raw", "isolated", "passthrough"]
+                    },
+                    defaultScope: {
+                        $ref: "#/$defs/CellScope"
+                    },
+                    "with": {
+                        asStream: true
+                    }
+                },
+                required: ["type", "with"]
+            },
+            state: {
+                type: "object",
+                properties: {
+                    votes: {
+                        type: "array",
+                        items: {
+                            $ref: "#/$defs/VoteEvent"
+                        }
+                    }
+                },
+                required: ["votes"]
+            }
+        },
+        required: ["castVote", "state"],
+        $defs: {
+            VoteEvent: {
+                type: "object",
+                properties: {
+                    id: {
+                        type: "string"
+                    },
+                    step: {
+                        "enum": ["single", "double"]
+                    }
+                },
+                required: ["id", "step"]
+            },
+            CellScope: {
+                "enum": ["space", "user", "session"]
+            }
+        }
+    } as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema, {
+        castVote: castVote,
+        state: {
+            votes: state.key("votes")
+        }
+    }, ({ castVote, state }) => castVote({ votes: state.votes }).for({ stream: "boundCastVote" })).for({ stream: "boundCastVote" }, true);
+    return {
+        [UI]: (<div>
+        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
+                const item = __cf_pattern_input.key("element");
+                const state = __cf_pattern_input.key("params", "state");
+                const boundCastVote = __cf_pattern_input.key("params", "boundCastVote");
+                return (<div>
+              {__cfHelpers.when({
+                    type: "boolean"
+                } as const satisfies __cfHelpers.JSONSchema, {
+                    anyOf: [{}, {
+                            type: "object",
+                            properties: {}
+                        }]
+                } as const satisfies __cfHelpers.JSONSchema, {
+                    anyOf: [{
+                            type: "boolean"
+                        }, {}, {
+                            type: "object",
+                            properties: {}
+                        }]
+                } as const satisfies __cfHelpers.JSONSchema, state.key("canVote"), <button type="button" onClick={__cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+                    type: "object",
+                    properties: {
+                        boundCastVote: {
+                            type: "unknown",
+                            asCell: ["stream"]
+                        },
+                        item: {
+                            type: "object",
+                            properties: {
+                                id: {
+                                    type: "string"
+                                }
+                            },
+                            required: ["id"]
+                        }
+                    },
+                    required: ["boundCastVote", "item"]
+                } as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, { boundCastVote, item }) => boundCastVote.send({
+                    id: item.id,
+                    step: "single",
+                }))({
+                    boundCastVote: boundCastVote,
+                    item: {
+                        id: item.key("id")
+                    }
+                })}>
+                  {item.key("label")}
+                </button>)}
+            </div>);
+            }, {
+                type: "object",
+                properties: {
+                    element: {
+                        $ref: "#/$defs/Item"
+                    },
+                    params: {
+                        type: "object",
+                        properties: {
+                            state: {
+                                type: "object",
+                                properties: {
+                                    canVote: {
+                                        type: "boolean"
+                                    }
+                                },
+                                required: ["canVote"]
+                            },
+                            boundCastVote: {
+                                type: "unknown",
+                                asCell: ["stream"]
+                            }
+                        },
+                        required: ["state", "boundCastVote"]
+                    }
+                },
+                required: ["element", "params"],
+                $defs: {
+                    Item: {
+                        type: "object",
+                        properties: {
+                            id: {
+                                type: "string"
+                            },
+                            label: {
+                                type: "string"
+                            }
+                        },
+                        required: ["id", "label"]
+                    }
+                }
+            } as const satisfies __cfHelpers.JSONSchema, {
+                anyOf: [{
+                        $ref: "https://commonfabric.org/schemas/vnode.json"
+                    }, {
+                        $ref: "#/$defs/UIRenderable"
+                    }, {
+                        type: "object",
+                        properties: {}
+                    }],
+                $defs: {
+                    UIRenderable: {
+                        type: "object",
+                        properties: {
+                            $UI: {
+                                $ref: "https://commonfabric.org/schemas/vnode.json"
+                            }
+                        },
+                        required: ["$UI"]
+                    }
+                }
+            } as const satisfies __cfHelpers.JSONSchema), {
+                state: {
+                    canVote: state.key("canVote")
+                },
+                boundCastVote: boundCastVote
+            })}
+      </div>),
+    };
+}, {
+    type: "object",
+    properties: {
+        items: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Item"
+            }
+        },
+        canVote: {
+            type: "boolean"
+        },
+        votes: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/VoteEvent"
+            }
+        }
+    },
+    required: ["items", "canVote", "votes"],
+    $defs: {
+        VoteEvent: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                },
+                step: {
+                    "enum": ["single", "double"]
+                }
+            },
+            required: ["id", "step"]
+        },
+        Item: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                },
+                label: {
+                    type: "string"
+                }
+            },
+            required: ["id", "label"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        $UI: {
+            $ref: "#/$defs/JSXElement"
+        }
+    },
+    required: ["$UI"],
+    $defs: {
+        JSXElement: {
+            anyOf: [{
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }, {
+                    $ref: "#/$defs/UIRenderable"
+                }, {
+                    type: "object",
+                    properties: {}
+                }]
+        },
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-conditional-inline-handler-send.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-conditional-inline-handler-send.input.tsx
@@ -1,0 +1,64 @@
+import { Cell, handler, pattern, UI } from "commonfabric";
+
+interface Item {
+  id: string;
+  label: string;
+}
+
+interface VoteEvent {
+  id: string;
+  step: "single" | "double";
+}
+
+interface State {
+  items: Item[];
+  canVote: boolean;
+  votes: VoteEvent[];
+}
+
+const castVote = handler<unknown, { votes: Cell<VoteEvent[]> }>(
+  (_event, { votes }) => {
+    votes.set([
+      ...votes.get(),
+      { id: "module", step: "single" },
+    ]);
+  },
+);
+
+// FIXTURE: map-conditional-inline-handler-send
+// Verifies: inline onClick handlers inside conditional JSX branches retain
+// imperative handler semantics when nested in reactive map callbacks.
+//   onClick={() => boundCastVote.send(...)} → bare handler callback body
+//   not derive(...boundCastVote.send(...))
+// Context: The conditional branch makes expression rewriting recurse into the
+// handler subtree; the authored handler arrow must be treated as safe context.
+export default pattern<State>((state) => {
+  const boundCastVote = castVote({ votes: state.votes }).for(
+    { stream: "boundCastVote" },
+  );
+
+  return {
+    [UI]: (
+      <div>
+        {state.items.map((item) => {
+          return (
+            <div>
+              {state.canVote && (
+                <button
+                  type="button"
+                  onClick={() =>
+                    boundCastVote.send({
+                      id: item.id,
+                      step: "single",
+                    })}
+                >
+                  {item.label}
+                </button>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    ),
+  };
+});


### PR DESCRIPTION
## Summary

Fixes CT-1589 by preserving event-handler semantics for inline JSX handlers that call a bound stream `.send(...)` from inside reactive map/conditional JSX contexts.

The handler closure builder moves the authored handler body into a generated handler callback, but those body nodes can retain original parent links from the authored JSX arrow. Later expression-site rewriting could then classify the moved body as pattern-owned array-method computation and wrap `.send(...)` in `derive(...)`. This marks both the authored handler arrow and the generated handler callback as safe handler contexts, preventing that rewrite from treating handler bodies as reactive value expressions.

This PR is split directly off `main` so the normal `pull_request` CI trigger runs.

## Validation

- Added fixture `map-conditional-inline-handler-send` covering the failing shape.
- `FIXTURE=map-conditional-inline-handler-send deno test --allow-read --allow-write --allow-env test/fixture-based.test.ts`
- `deno task check` from `packages/ts-transformers`

Prior validation on the scoped repro branch also confirmed `cozy-poll-scoped` transformed output emits bare `bound*.send(...)` handler bodies and no `__cfModuleCallback` hits for the vote/remove buttons.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves inline JSX event handlers that call a bound stream `.send(...)` from being wrapped in `derive(...)` inside reactive map/conditional branches. Restores correct handler behavior and resolves Linear CT-1589.

- **Bug Fixes**
  - In `packages/ts-transformers/src/closures/utils/capture-scaffold.ts`, mark both the authored handler arrow and the generated handler callback as safe handler contexts to stop expression-site rewrites of `.send(...)`.
  - Added the `map-conditional-inline-handler-send` fixture (input + expected) to verify `.send(...)` remains a bare handler body inside conditional JSX within a map.

<sup>Written for commit 761deecccdbe3df7d7a7c268eb85604f166bfee1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

