### PR TITLE
Track CFC model context labels

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -436,6 +436,12 @@ records the observed output labels in run state and merges those confidentiality
 labels into later model-authored invocation inputs. Opaque and denied outputs
 are not added to this model-context accumulator.
 
+The persisted model-context accumulator is sensitive retained run metadata. It
+does not store raw stdout/stderr bytes, but its labels and observation refs can
+still disclose which confidential sources influenced model-visible context.
+Handle it under the same access and retention boundary as transcripts, tool
+outputs, run state, and CFC policy traces.
+
 On Docker Desktop for macOS, use the host path for `cf-harness` and the
 `/host_mnt/...` projection for Docker's runtime args. The gVisor
 `docker-desktop-cfc-setup` helper defaults to:

--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -431,7 +431,10 @@ When a trusted prompt-slot binding is present, `cf-harness` also derives
 confidentiality-only prompt influence labels for model-authored invocation
 inputs such as shell commands, structured file-tool arguments, and stdin
 payloads. These labels are taint evidence, not integrity or authorization
-claims.
+claims. When CFC-mediated bash output is released to the model, `cf-harness`
+records the observed output labels in run state and merges those confidentiality
+labels into later model-authored invocation inputs. Opaque and denied outputs
+are not added to this model-context accumulator.
 
 On Docker Desktop for macOS, use the host path for `cf-harness` and the
 `/host_mnt/...` projection for Docker's runtime args. The gVisor

--- a/packages/cf-harness/src/contracts/cfc-invocation-context.ts
+++ b/packages/cf-harness/src/contracts/cfc-invocation-context.ts
@@ -3,6 +3,10 @@ import type {
   CfcLabelView,
 } from "@commonfabric/runner/cfc";
 import { mergeCfcLabelViews } from "@commonfabric/runner/cfc";
+import {
+  createHarnessCfcModelContextInputLabels,
+  type HarnessCfcModelContext,
+} from "./cfc-model-context.ts";
 import type { PromptSlotBinding, PromptSlotRole } from "./prompt-slot.ts";
 import type { HarnessRunManifest } from "./run-manifest.ts";
 import type { BuiltinToolId } from "./tool-descriptor.ts";
@@ -115,6 +119,7 @@ export interface CreateHarnessCfcInvocationContextOptions {
   env?: Record<string, string>;
   cfcInputLabels?: CfcLabelView;
   cfcInputLabelPaths?: readonly HarnessCfcInvocationInputLabelPath[];
+  cfcModelContext?: HarnessCfcModelContext;
 }
 
 const textEncoder = new TextEncoder();
@@ -281,6 +286,10 @@ export const createHarnessCfcInvocationContext = async (
     createHarnessPromptSlotInfluenceLabels({
       promptSlot: options.promptSlot,
       runManifest: options.runManifest,
+      paths: options.cfcInputLabelPaths,
+    }),
+    createHarnessCfcModelContextInputLabels({
+      modelContext: options.cfcModelContext,
       paths: options.cfcInputLabelPaths,
     }),
   ]);

--- a/packages/cf-harness/src/contracts/cfc-model-context.ts
+++ b/packages/cf-harness/src/contracts/cfc-model-context.ts
@@ -29,6 +29,11 @@ export interface HarnessCfcModelContextObservationInput {
   truncated?: boolean;
 }
 
+/**
+ * Sensitive retained run metadata. Even without raw stdout/stderr bytes, these
+ * labels and observation refs can reveal which confidential sources influenced
+ * model-visible context, so treat this at least like transcript metadata.
+ */
 export interface HarnessCfcModelContext {
   type: "cf-harness.cfc-model-context";
   version: 1;

--- a/packages/cf-harness/src/contracts/cfc-model-context.ts
+++ b/packages/cf-harness/src/contracts/cfc-model-context.ts
@@ -1,0 +1,182 @@
+import type { CfcLabelView, IFCLabel } from "@commonfabric/runner/cfc";
+import type { HarnessCfcInvocationInputLabelPath } from "./cfc-invocation-context.ts";
+import type { ToolOutputId } from "./tool-result.ts";
+
+export type HarnessCfcModelContextChannel =
+  | "stdout"
+  | "stderr"
+  | "exitCode";
+
+export interface HarnessCfcModelContextObservation {
+  type: "cf-harness.cfc-model-context-observation";
+  sequence: number;
+  at: string;
+  toolCallId: string;
+  toolId: string;
+  outputId: ToolOutputId;
+  channels: readonly HarnessCfcModelContextChannel[];
+  policy: "observed";
+  label: IFCLabel;
+  truncated?: boolean;
+}
+
+export interface HarnessCfcModelContextObservationInput {
+  toolCallId: string;
+  toolId: string;
+  outputId: ToolOutputId;
+  channels: readonly HarnessCfcModelContextChannel[];
+  label: IFCLabel;
+  truncated?: boolean;
+}
+
+export interface HarnessCfcModelContext {
+  type: "cf-harness.cfc-model-context";
+  version: 1;
+  updatedAt: string;
+  label: IFCLabel;
+  observations: readonly HarnessCfcModelContextObservation[];
+}
+
+const cloneJsonValue = <T>(value: T): T => structuredClone(value);
+
+export const cloneIfcLabel = (label: IFCLabel): IFCLabel => {
+  const cloned: IFCLabel = {};
+  if (
+    Array.isArray(label.confidentiality) &&
+    label.confidentiality.length > 0
+  ) {
+    cloned.confidentiality = cloneJsonValue(label.confidentiality);
+  }
+  if (Array.isArray(label.integrity) && label.integrity.length > 0) {
+    cloned.integrity = cloneJsonValue(label.integrity);
+  }
+  return cloned;
+};
+
+export const confidentialityOnlyIfcLabel = (
+  label: IFCLabel,
+): IFCLabel | undefined => {
+  if (
+    !Array.isArray(label.confidentiality) ||
+    label.confidentiality.length === 0
+  ) {
+    return undefined;
+  }
+  return { confidentiality: cloneJsonValue(label.confidentiality) };
+};
+
+const labelValueKey = (value: unknown): string => {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+};
+
+export const mergeConfidentialityOnlyLabels = (
+  labels: readonly (IFCLabel | undefined)[],
+): IFCLabel | undefined => {
+  const confidentiality: unknown[] = [];
+  const seen = new Set<string>();
+  for (const label of labels) {
+    const confidentialityOnly = label === undefined
+      ? undefined
+      : confidentialityOnlyIfcLabel(label);
+    for (const value of confidentialityOnly?.confidentiality ?? []) {
+      const key = labelValueKey(value);
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+      confidentiality.push(cloneJsonValue(value));
+    }
+  }
+  return confidentiality.length > 0 ? { confidentiality } : undefined;
+};
+
+export const createHarnessCfcModelContextObservation = (
+  input: HarnessCfcModelContextObservationInput & {
+    sequence: number;
+    at: string;
+  },
+): HarnessCfcModelContextObservation | undefined => {
+  const label = confidentialityOnlyIfcLabel(input.label);
+  if (label === undefined || input.channels.length === 0) {
+    return undefined;
+  }
+  return {
+    type: "cf-harness.cfc-model-context-observation",
+    sequence: input.sequence,
+    at: input.at,
+    toolCallId: input.toolCallId,
+    toolId: input.toolId,
+    outputId: input.outputId,
+    channels: [...input.channels],
+    policy: "observed",
+    label,
+    ...(input.truncated === true ? { truncated: true } : {}),
+  };
+};
+
+export const appendHarnessCfcModelContextObservations = (
+  context: HarnessCfcModelContext | undefined,
+  inputs: readonly HarnessCfcModelContextObservationInput[],
+  at: string,
+): HarnessCfcModelContext | undefined => {
+  if (inputs.length === 0) {
+    return context;
+  }
+  const existingObservations = [...(context?.observations ?? [])];
+  const newObservations: HarnessCfcModelContextObservation[] = [];
+  for (const input of inputs) {
+    const observation = createHarnessCfcModelContextObservation({
+      ...input,
+      sequence: existingObservations.length + newObservations.length + 1,
+      at,
+    });
+    if (observation !== undefined) {
+      newObservations.push(observation);
+    }
+  }
+  if (newObservations.length === 0) {
+    return context;
+  }
+  const label = mergeConfidentialityOnlyLabels([
+    context?.label,
+    ...newObservations.map((observation) => observation.label),
+  ]);
+  if (label === undefined) {
+    return context;
+  }
+  return {
+    type: "cf-harness.cfc-model-context",
+    version: 1,
+    updatedAt: at,
+    label,
+    observations: [...existingObservations, ...newObservations],
+  };
+};
+
+export const createHarnessCfcModelContextInputLabels = (options: {
+  modelContext?: HarnessCfcModelContext;
+  paths?: readonly HarnessCfcInvocationInputLabelPath[];
+}): CfcLabelView | undefined => {
+  if (
+    options.modelContext === undefined ||
+    options.paths === undefined ||
+    options.paths.length === 0
+  ) {
+    return undefined;
+  }
+  const label = confidentialityOnlyIfcLabel(options.modelContext.label);
+  if (label === undefined) {
+    return undefined;
+  }
+  return {
+    version: 1,
+    entries: options.paths.map((path) => ({
+      path: [...path],
+      label: cloneIfcLabel(label),
+    })),
+  };
+};

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -9,6 +9,7 @@ import {
 } from "./artifacts.ts";
 import {
   appendHarnessCfcInvocationContext,
+  appendHarnessCfcModelContextObservations,
   appendHarnessFailureRecord,
   appendHarnessPolicyDecision,
   appendHarnessPolicyEvent,
@@ -30,6 +31,7 @@ import {
   setHarnessSkillResourceReads,
   setHarnessTranscriptPath,
 } from "./run-state.ts";
+import type { HarnessCfcModelContextObservationInput } from "./contracts/cfc-model-context.ts";
 import {
   classifyBuiltinToolFailure,
   classifyHarnessPolicyEventFailure,
@@ -420,6 +422,18 @@ export class CfHarnessEngine {
       this.#runState,
       policyDecision,
       now,
+    );
+    await this.persistRunState();
+    return this.getRunState();
+  }
+
+  async recordCfcModelContextObservations(
+    observations: readonly HarnessCfcModelContextObservationInput[],
+  ): Promise<HarnessRunState> {
+    this.#runState = appendHarnessCfcModelContextObservations(
+      this.#runState,
+      observations,
+      this.#now(),
     );
     await this.persistRunState();
     return this.getRunState();
@@ -1004,6 +1018,9 @@ export class CfHarnessEngine {
         : {}),
       ...(options.cfcInputLabelPaths !== undefined
         ? { cfcInputLabelPaths: options.cfcInputLabelPaths }
+        : {}),
+      ...(this.#runState.cfcModelContext !== undefined
+        ? { cfcModelContext: this.#runState.cfcModelContext }
         : {}),
     });
     this.#runState = appendHarnessCfcInvocationContext(

--- a/packages/cf-harness/src/index.ts
+++ b/packages/cf-harness/src/index.ts
@@ -10,6 +10,7 @@ export * from "./gateway/openai-client.ts";
 export * from "./contracts/image.ts";
 export * from "./contracts/prompt-slot.ts";
 export * from "./contracts/cfc-invocation-context.ts";
+export * from "./contracts/cfc-model-context.ts";
 export * from "./contracts/cfc-policy-snapshot.ts";
 export * from "./contracts/run-manifest.ts";
 export * from "./contracts/observation.ts";

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -32,6 +32,7 @@ import {
   type HarnessParentToolAllowance,
   type HarnessPromptSlotBindingSource,
 } from "./contracts/cfc-policy-snapshot.ts";
+import type { HarnessCfcModelContextObservationInput } from "./contracts/cfc-model-context.ts";
 import type {
   HarnessAssistantTranscriptMessage,
   HarnessToolCall,
@@ -916,6 +917,14 @@ const MODEL_FACING_BASH_STREAM_MAX_CHARS = MODEL_FACING_BASH_STREAM_HEAD_CHARS +
 interface InvokedToolCallMessages {
   toolMessage: HarnessToolTranscriptMessage;
   followupMessages?: readonly HarnessTranscriptMessage[];
+  cfcModelContextObservations?:
+    readonly HarnessCfcModelContextObservationInput[];
+}
+
+interface ModelFacingToolOutputResult {
+  output: ModelFacingToolOutput;
+  cfcModelContextObservations?:
+    readonly HarnessCfcModelContextObservationInput[];
 }
 
 interface CfcSandboxResultCarrier {
@@ -1153,11 +1162,50 @@ const summarizeCfcSandboxResult = (result: CfcSandboxResult) => ({
     : {}),
 });
 
+const modelContextObservationForStream = (
+  observation: CfcStreamObservation,
+  resultRef: ToolResultRef,
+  toolCallId: string,
+  modelTruncated?: boolean,
+): HarnessCfcModelContextObservationInput | undefined => {
+  if (observation.policy !== "observed") {
+    return undefined;
+  }
+  return {
+    toolCallId,
+    toolId: resultRef.toolId,
+    outputId: resultRef.outputId,
+    channels: [observation.channel],
+    label: observation.label,
+    ...(observation.truncated === true || modelTruncated === true
+      ? { truncated: true }
+      : {}),
+  };
+};
+
+const modelContextObservationForExitCode = (
+  observation: CfcSandboxExitCodeObservation,
+  resultRef: ToolResultRef,
+  toolCallId: string,
+): HarnessCfcModelContextObservationInput | undefined => {
+  if (observation.policy !== "observed") {
+    return undefined;
+  }
+  return {
+    toolCallId,
+    toolId: resultRef.toolId,
+    outputId: resultRef.outputId,
+    channels: ["exitCode"],
+    label: observation.label,
+  };
+};
+
 const renderMediatedBashOutput = (
   output: Record<string, unknown>,
   cfcResult: CfcSandboxResult,
   resultRef: ToolResultRef,
-): ModelFacingToolOutput => {
+  toolCallId: string,
+): ModelFacingToolOutputResult => {
   const stdout = truncateModelFacingBashStream(
     stripBashCwdMarker(
       renderStreamObservation(cfcResult.stdout, resultRef),
@@ -1171,24 +1219,50 @@ const renderMediatedBashOutput = (
     "stderr",
     resultRef,
   );
+  const observations = [
+    modelContextObservationForStream(
+      cfcResult.stdout,
+      resultRef,
+      toolCallId,
+      stdout.truncated,
+    ),
+    modelContextObservationForStream(
+      cfcResult.stderr,
+      resultRef,
+      toolCallId,
+      stderr.truncated,
+    ),
+    modelContextObservationForExitCode(
+      cfcResult.exitCode,
+      resultRef,
+      toolCallId,
+    ),
+  ].filter((observation) =>
+    observation !== undefined
+  ) as HarnessCfcModelContextObservationInput[];
   return {
-    outputId: output.outputId,
-    stdout: stdout.value,
-    stderr: stderr.value,
-    exitCode: renderExitCodeObservation(cfcResult.exitCode, resultRef),
-    cwd: output.cwd,
-    cfc: summarizeCfcSandboxResult(cfcResult),
-    ...(stdout.truncated === true
-      ? {
-        stdoutTruncated: true,
-        stdoutOriginalLength: stdout.originalLength,
-      }
-      : {}),
-    ...(stderr.truncated === true
-      ? {
-        stderrTruncated: true,
-        stderrOriginalLength: stderr.originalLength,
-      }
+    output: {
+      outputId: output.outputId,
+      stdout: stdout.value,
+      stderr: stderr.value,
+      exitCode: renderExitCodeObservation(cfcResult.exitCode, resultRef),
+      cwd: output.cwd,
+      cfc: summarizeCfcSandboxResult(cfcResult),
+      ...(stdout.truncated === true
+        ? {
+          stdoutTruncated: true,
+          stdoutOriginalLength: stdout.originalLength,
+        }
+        : {}),
+      ...(stderr.truncated === true
+        ? {
+          stderrTruncated: true,
+          stderrOriginalLength: stderr.originalLength,
+        }
+        : {}),
+    },
+    ...(observations.length > 0
+      ? { cfcModelContextObservations: observations }
       : {}),
   };
 };
@@ -1542,6 +1616,8 @@ export class CfHarnessPromptLoop {
           };
         }
         const followupMessages: HarnessTranscriptMessage[] = [];
+        const pendingCfcModelContextObservations:
+          HarnessCfcModelContextObservationInput[] = [];
         for (const toolCall of toolCalls) {
           const invokedToolCall = await this.#invokeToolCall(
             toolCall,
@@ -1566,6 +1642,11 @@ export class CfHarnessPromptLoop {
           if (invokedToolCall.followupMessages !== undefined) {
             followupMessages.push(...invokedToolCall.followupMessages);
           }
+          if (invokedToolCall.cfcModelContextObservations !== undefined) {
+            pendingCfcModelContextObservations.push(
+              ...invokedToolCall.cfcModelContextObservations,
+            );
+          }
         }
         for (const followupMessage of followupMessages) {
           transcript.push(followupMessage);
@@ -1580,6 +1661,11 @@ export class CfHarnessPromptLoop {
             message: followupMessage,
             transcript,
           });
+        }
+        if (pendingCfcModelContextObservations.length > 0) {
+          await this.engine.recordCfcModelContextObservations(
+            pendingCfcModelContextObservations,
+          );
         }
       }
     } catch (error) {
@@ -1934,13 +2020,14 @@ export class CfHarnessPromptLoop {
       });
       throw error;
     }
-    const modelOutput = await this.#modelFacingToolOutput(
+    const modelOutputResult = await this.#modelFacingToolOutput(
       toolCall.function.name,
       result.output,
       result.resultRef,
       toolCall.id,
       recordPolicyEvent,
     );
+    const modelOutput = modelOutputResult.output;
     const policyEvents = this.engine.getRunState().policyEvents;
     let activityPolicyDecision: HarnessToolPolicyDecision = policyDecision;
     for (const index of policyEventIndexes) {
@@ -1978,7 +2065,15 @@ export class CfHarnessPromptLoop {
         }],
       };
     }
-    return { toolMessage };
+    return {
+      toolMessage,
+      ...(modelOutputResult.cfcModelContextObservations !== undefined
+        ? {
+          cfcModelContextObservations:
+            modelOutputResult.cfcModelContextObservations,
+        }
+        : {}),
+    };
   }
 
   async #modelFacingToolOutput(
@@ -1987,34 +2082,38 @@ export class CfHarnessPromptLoop {
     resultRef: ToolResultRef,
     toolCallId: string,
     recordPolicyEvent?: RecordHarnessPolicyEvent,
-  ): Promise<ModelFacingToolOutput> {
+  ): Promise<ModelFacingToolOutputResult> {
     const writePolicyEvent = recordPolicyEvent ??
       ((event) => this.engine.recordPolicyEvent(event));
     const mode = this.engine.getRunState().cfcEnforcementMode;
     const cfcResult = cfcResultFromOutput(output);
     if (toolId === "view_image" && isViewImageToolSuccessOutput(output)) {
       return {
-        outputId: output.outputId,
-        path: output.path,
-        mediaType: output.mediaType,
-        bytes: output.bytes,
-        digest: output.digest,
-        imageAttached: true,
+        output: {
+          outputId: output.outputId,
+          path: output.path,
+          mediaType: output.mediaType,
+          bytes: output.bytes,
+          digest: output.digest,
+          imageAttached: true,
+        },
       };
     }
     if (!toolOutputNeedsSandboxMediation(toolId)) {
-      return stripInternalCfcFields(output);
+      return { output: stripInternalCfcFields(output) };
     }
     if (cfcResult === undefined) {
       const detail =
         `${toolId} output did not include trusted CFC mediation metadata`;
       if (mode === "disabled") {
-        return toolId === "bash"
-          ? truncateModelFacingBashOutput(
-            stripInternalCfcFields(output),
-            resultRef,
-          )
-          : stripInternalCfcFields(output);
+        return {
+          output: toolId === "bash"
+            ? truncateModelFacingBashOutput(
+              stripInternalCfcFields(output),
+              resultRef,
+            )
+            : stripInternalCfcFields(output),
+        };
       }
       if (mode === "observe") {
         await writePolicyEvent({
@@ -2025,12 +2124,14 @@ export class CfHarnessPromptLoop {
           detail:
             `${detail}; raw output was exposed because CFC is in observe mode`,
         });
-        return toolId === "bash"
-          ? truncateModelFacingBashOutput(
-            stripInternalCfcFields(output),
-            resultRef,
-          )
-          : stripInternalCfcFields(output);
+        return {
+          output: toolId === "bash"
+            ? truncateModelFacingBashOutput(
+              stripInternalCfcFields(output),
+              resultRef,
+            )
+            : stripInternalCfcFields(output),
+        };
       }
       const denial = makeObservationDenied("not-observable", {
         detail,
@@ -2044,12 +2145,12 @@ export class CfHarnessPromptLoop {
         detail,
         observationDenied: denial,
       });
-      return denial;
+      return { output: denial };
     }
     if (toolId === "bash" && isObjectRecord(output)) {
-      return renderMediatedBashOutput(output, cfcResult, resultRef);
+      return renderMediatedBashOutput(output, cfcResult, resultRef, toolCallId);
     }
-    return stripInternalCfcFields(output);
+    return { output: stripInternalCfcFields(output) };
   }
 
   async #invokeBuiltinTool<TToolId extends BuiltinToolId>(

--- a/packages/cf-harness/src/run-state.ts
+++ b/packages/cf-harness/src/run-state.ts
@@ -1,5 +1,10 @@
 import type { CfcEnforcementMode } from "@commonfabric/runner/cfc";
 import type { HarnessCfcInvocationContext } from "./contracts/cfc-invocation-context.ts";
+import {
+  appendHarnessCfcModelContextObservations as appendCfcModelContextObservations,
+  type HarnessCfcModelContext,
+  type HarnessCfcModelContextObservationInput,
+} from "./contracts/cfc-model-context.ts";
 import type { HarnessCfcPolicySnapshot } from "./contracts/cfc-policy-snapshot.ts";
 import type { HarnessPolicyEvent } from "./contracts/policy.ts";
 import type {
@@ -63,6 +68,7 @@ export interface HarnessRunState {
   cfcPolicySnapshotPath?: string;
   policyTrace?: HarnessPolicyTrace;
   policyTracePath?: string;
+  cfcModelContext?: HarnessCfcModelContext;
   cfcInvocationContexts?: HarnessCfcInvocationContext[];
   policyEvents: HarnessPolicyEvent[];
   policyDecisions?: HarnessPolicyDecisionRecord[];
@@ -98,6 +104,7 @@ export interface CreateHarnessRunStateOptions {
   cfcPolicySnapshotPath?: string;
   policyTrace?: HarnessPolicyTrace;
   policyTracePath?: string;
+  cfcModelContext?: HarnessCfcModelContext;
   cfcInvocationContexts?: HarnessCfcInvocationContext[];
   policyDecisions?: HarnessPolicyDecisionRecord[];
   subagentRuns?: HarnessSubagentRunRef[];
@@ -175,6 +182,9 @@ export const createHarnessRunState = (
       : {}),
     ...(options.policyTracePath !== undefined
       ? { policyTracePath: options.policyTracePath }
+      : {}),
+    ...(options.cfcModelContext !== undefined
+      ? { cfcModelContext: structuredClone(options.cfcModelContext) }
       : {}),
     ...(options.cfcInvocationContexts !== undefined
       ? { cfcInvocationContexts: [...options.cfcInvocationContexts] }
@@ -258,6 +268,26 @@ export const appendHarnessCfcInvocationContext = (
   updatedAt: now,
   cfcInvocationContexts: [...(state.cfcInvocationContexts ?? []), context],
 });
+
+export const appendHarnessCfcModelContextObservations = (
+  state: HarnessRunState,
+  observations: readonly HarnessCfcModelContextObservationInput[],
+  now = new Date().toISOString(),
+): HarnessRunState => {
+  const cfcModelContext = appendCfcModelContextObservations(
+    state.cfcModelContext,
+    observations,
+    now,
+  );
+  if (cfcModelContext === state.cfcModelContext) {
+    return state;
+  }
+  return {
+    ...state,
+    updatedAt: now,
+    ...(cfcModelContext !== undefined ? { cfcModelContext } : {}),
+  };
+};
 
 export const appendHarnessSubagentRun = (
   state: HarnessRunState,

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -207,34 +207,40 @@ const observedCfcResult = (
     stderrPolicy?: "observed" | "denied";
     stderr?: string;
     exitCode?: number;
+    stdoutLabel?: CfcSandboxResult["stdout"]["label"];
+    stderrLabel?: CfcSandboxResult["stderr"]["label"];
+    exitCodeLabel?: CfcSandboxResult["exitCode"]["label"];
   } = {},
 ): CfcSandboxResult => ({
   version: 1,
   stdout: {
     channel: "stdout",
     policy: "observed",
-    label: { confidentiality: ["public"] },
-    segments: [{ text: stdout, label: { confidentiality: ["public"] } }],
+    label: options.stdoutLabel ?? { confidentiality: ["public"] },
+    segments: [{
+      text: stdout,
+      label: options.stdoutLabel ?? { confidentiality: ["public"] },
+    }],
   },
   stderr: options.stderrPolicy === "denied"
     ? {
       channel: "stderr",
       policy: "denied",
-      label: { confidentiality: ["secret"] },
+      label: options.stderrLabel ?? { confidentiality: ["secret"] },
       reason: "stderr release denied",
     }
     : {
       channel: "stderr",
       policy: "observed",
-      label: { confidentiality: ["public"] },
+      label: options.stderrLabel ?? { confidentiality: ["public"] },
       segments: [{
         text: options.stderr ?? "",
-        label: { confidentiality: ["public"] },
+        label: options.stderrLabel ?? { confidentiality: ["public"] },
       }],
     },
   exitCode: {
     policy: "observed",
-    label: { confidentiality: ["public"] },
+    label: options.exitCodeLabel ?? { confidentiality: ["public"] },
     value: options.exitCode ?? 0,
   },
 });
@@ -3292,6 +3298,363 @@ Deno.test("CfHarnessPromptLoop exposes mediated bash output instead of raw stdou
   assertEquals(content.exitCode, 0);
   assertEquals(content.cfc.stdout.policy, "observed");
   assertEquals(content.cfc.stderr.policy, "denied");
+});
+
+const labelHasConfidentialityValue = (
+  label: unknown,
+  value: unknown,
+): boolean =>
+  typeof label === "object" &&
+  label !== null &&
+  "confidentiality" in label &&
+  Array.isArray(label.confidentiality) &&
+  label.confidentiality.some((entry) =>
+    JSON.stringify(entry) === JSON.stringify(value)
+  );
+
+const invocationInputLabelContains = (
+  runState: HarnessRunState,
+  invocationIndex: number,
+  pathRoot: string,
+  value: unknown,
+): boolean => {
+  const labels = runState.cfcInvocationContexts?.[invocationIndex]
+    ?.cfcInputLabels;
+  const entry = labels?.entries.find((entry) =>
+    entry.path.length === 1 && entry.path[0] === pathRoot
+  );
+  return labelHasConfidentialityValue(entry?.label, value);
+};
+
+Deno.test("CfHarnessPromptLoop accumulates observed CFC labels for the next model turn", async () => {
+  const fetchCalls: RequestInit[] = [];
+  const secretLabel = "did:key:alice";
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime([
+        {
+          stdout: "raw secret\n",
+          stderr: "",
+          exitCode: 0,
+          cfcResult: observedCfcResult("released secret\n", {
+            stderrPolicy: "denied",
+            stdoutLabel: { confidentiality: [secretLabel] },
+            exitCodeLabel: { confidentiality: [secretLabel] },
+          }),
+        },
+        {
+          stdout: "second\n",
+          stderr: "",
+          exitCode: 0,
+          cfcResult: observedCfcResult("second released\n"),
+        },
+      ]),
+      runId: "run-cfc-model-context",
+      model: "gpt-5.4",
+      cfcEnforcementMode: "enforce-explicit",
+    }),
+    fetchFn: (_input, init) => {
+      fetchCalls.push(init ?? {});
+      const payload = fetchCalls.length === 1
+        ? {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "",
+              tool_calls: [{
+                id: "call-read-secret",
+                type: "function",
+                function: {
+                  name: "bash",
+                  arguments: JSON.stringify({ command: "cat secret.txt" }),
+                },
+              }],
+            },
+          }],
+        }
+        : fetchCalls.length === 2
+        ? {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "",
+              tool_calls: [{
+                id: "call-use-secret",
+                type: "function",
+                function: {
+                  name: "bash",
+                  arguments: JSON.stringify({ command: "printf done" }),
+                },
+              }],
+            },
+          }],
+        }
+        : {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "Done.",
+            },
+          }],
+        };
+      return Promise.resolve(
+        new Response(JSON.stringify(payload), { status: 200 }),
+      );
+    },
+  });
+
+  const result = await loop.runPrompt({
+    prompt: "Run a direct command.",
+    promptSlotBinding: directPromptSlotBinding,
+  });
+
+  assertEquals(
+    labelHasConfidentialityValue(
+      result.runState.cfcModelContext?.label,
+      secretLabel,
+    ),
+    true,
+  );
+  assertEquals(
+    result.runState.cfcModelContext?.observations.some((observation) =>
+      observation.toolCallId === "call-read-secret" &&
+      observation.channels.includes("stdout") &&
+      labelHasConfidentialityValue(observation.label, secretLabel)
+    ),
+    true,
+  );
+  assertEquals(
+    invocationInputLabelContains(result.runState, 1, "command", secretLabel),
+    true,
+  );
+});
+
+Deno.test("CfHarnessPromptLoop does not taint sibling tool calls from one assistant message", async () => {
+  const fetchCalls: RequestInit[] = [];
+  const siblingLabel = "did:key:sibling";
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime([
+        {
+          stdout: "first raw\n",
+          stderr: "",
+          exitCode: 0,
+          cfcResult: observedCfcResult("first released\n", {
+            stderrPolicy: "denied",
+            stdoutLabel: { confidentiality: [siblingLabel] },
+            exitCodeLabel: { confidentiality: [siblingLabel] },
+          }),
+        },
+        {
+          stdout: "second raw\n",
+          stderr: "",
+          exitCode: 0,
+          cfcResult: observedCfcResult("second released\n"),
+        },
+        {
+          stdout: "third raw\n",
+          stderr: "",
+          exitCode: 0,
+          cfcResult: observedCfcResult("third released\n"),
+        },
+      ]),
+      runId: "run-cfc-model-context-siblings",
+      model: "gpt-5.4",
+      cfcEnforcementMode: "enforce-explicit",
+    }),
+    fetchFn: (_input, init) => {
+      fetchCalls.push(init ?? {});
+      const payload = fetchCalls.length === 1
+        ? {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "",
+              tool_calls: [{
+                id: "call-sibling-first",
+                type: "function",
+                function: {
+                  name: "bash",
+                  arguments: JSON.stringify({ command: "cat secret.txt" }),
+                },
+              }, {
+                id: "call-sibling-second",
+                type: "function",
+                function: {
+                  name: "bash",
+                  arguments: JSON.stringify({ command: "printf sibling" }),
+                },
+              }],
+            },
+          }],
+        }
+        : fetchCalls.length === 2
+        ? {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "",
+              tool_calls: [{
+                id: "call-after-siblings",
+                type: "function",
+                function: {
+                  name: "bash",
+                  arguments: JSON.stringify({ command: "printf later" }),
+                },
+              }],
+            },
+          }],
+        }
+        : {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "Done.",
+            },
+          }],
+        };
+      return Promise.resolve(
+        new Response(JSON.stringify(payload), { status: 200 }),
+      );
+    },
+  });
+
+  const result = await loop.runPrompt({
+    prompt: "Run direct commands.",
+    promptSlotBinding: directPromptSlotBinding,
+  });
+
+  assertEquals(
+    invocationInputLabelContains(result.runState, 1, "command", siblingLabel),
+    false,
+  );
+  assertEquals(
+    invocationInputLabelContains(result.runState, 2, "command", siblingLabel),
+    true,
+  );
+});
+
+Deno.test("CfHarnessPromptLoop ignores opaque and denied CFC observations for model context", async () => {
+  const fetchCalls: RequestInit[] = [];
+  const opaqueLabel = "did:key:opaque";
+  const opaqueResult: CfcSandboxResult = {
+    version: 1,
+    stdout: {
+      channel: "stdout",
+      policy: "opaque",
+      label: { confidentiality: [opaqueLabel] },
+      byteLength: 32,
+    },
+    stderr: {
+      channel: "stderr",
+      policy: "denied",
+      label: { confidentiality: [opaqueLabel] },
+      reason: "stderr denied",
+    },
+    exitCode: {
+      policy: "denied",
+      label: { confidentiality: [opaqueLabel] },
+      reason: "exit denied",
+    },
+  };
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime([
+        {
+          stdout: "hidden\n",
+          stderr: "hidden stderr\n",
+          exitCode: 1,
+          cfcResult: opaqueResult,
+        },
+        {
+          stdout: "second raw\n",
+          stderr: "",
+          exitCode: 0,
+          cfcResult: observedCfcResult("second released\n"),
+        },
+      ]),
+      runId: "run-cfc-model-context-opaque",
+      model: "gpt-5.4",
+      cfcEnforcementMode: "enforce-explicit",
+    }),
+    fetchFn: (_input, init) => {
+      fetchCalls.push(init ?? {});
+      const payload = fetchCalls.length === 1
+        ? {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "",
+              tool_calls: [{
+                id: "call-opaque",
+                type: "function",
+                function: {
+                  name: "bash",
+                  arguments: JSON.stringify({ command: "cat opaque.txt" }),
+                },
+              }],
+            },
+          }],
+        }
+        : fetchCalls.length === 2
+        ? {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "",
+              tool_calls: [{
+                id: "call-after-opaque",
+                type: "function",
+                function: {
+                  name: "bash",
+                  arguments: JSON.stringify({ command: "printf done" }),
+                },
+              }],
+            },
+          }],
+        }
+        : {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "Done.",
+            },
+          }],
+        };
+      return Promise.resolve(
+        new Response(JSON.stringify(payload), { status: 200 }),
+      );
+    },
+  });
+
+  const result = await loop.runPrompt({
+    prompt: "Run a direct command.",
+    promptSlotBinding: directPromptSlotBinding,
+  });
+
+  assertEquals(
+    invocationInputLabelContains(result.runState, 1, "command", opaqueLabel),
+    false,
+  );
+  assertEquals(
+    labelHasConfidentialityValue(
+      result.runState.cfcModelContext?.label,
+      opaqueLabel,
+    ),
+    false,
+  );
 });
 
 Deno.test("CfHarnessPromptLoop returns observation-denied tool content in enforce-explicit mode", async () => {


### PR DESCRIPTION
## Summary

- add a persisted `cf-harness.cfc-model-context` run-state accumulator for CFC-observed model context
- record labels from CFC-mediated bash stdout/stderr/exitCode only when those channels are released to the model
- merge accumulated confidentiality labels into later model-authored invocation inputs, while preserving sibling tool-call turn boundaries
- document the model-context continuity behavior in the cf-harness README

## Tests

- `/Users/gideonwald/.deno/bin/deno check packages/cf-harness/src/contracts/cfc-model-context.ts packages/cf-harness/src/contracts/cfc-invocation-context.ts packages/cf-harness/src/run-state.ts packages/cf-harness/src/engine.ts packages/cf-harness/src/prompt-loop.ts packages/cf-harness/test/prompt-loop.test.ts`
- `/Users/gideonwald/.deno/bin/deno test --allow-env --allow-read --allow-run --allow-write packages/cf-harness/test/prompt-loop.test.ts packages/cf-harness/test/engine.test.ts packages/cf-harness/test/cfc-invocation-context.test.ts`
- `/Users/gideonwald/.deno/bin/deno task test` in `packages/cf-harness`
- `git diff --cached --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds model-context label tracking to `cf-harness`. When CFC-mediated bash output is released to the model, observed confidentiality labels are persisted and applied to later model-authored tool inputs; opaque/denied outputs are ignored.

- **New Features**
  - Added `cf-harness.cfc-model-context` run-state accumulator with an observation log and merged confidentiality-only label.
  - Captures labels from CFC-observed `stdout`/`stderr`/`exitCode` only when those channels are exposed to the model; tracks truncation.
  - Merges accumulated labels into subsequent invocation `cfcInputLabels` via `cfc-invocation-context`, without crossing sibling tool-call boundaries in the same assistant turn.
  - Exposed `engine.recordCfcModelContextObservations`, new helpers and types in `contracts/cfc-model-context.ts`, and wired them through the engine, prompt loop, and `createHarnessCfcInvocationContext`.
  - Updated README to document continuity and note the model-context accumulator is sensitive metadata (labels/refs only, no raw bytes).

<sup>Written for commit 3e68dc48da5b5139d2f32d54aaf9952d074c6848. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

