### PR TITLE
fix(runner): make `computeInputHashFromValue()` strip undefined props directly

### DIFF
--- a/packages/runner/src/builtins/fetch-utils.ts
+++ b/packages/runner/src/builtins/fetch-utils.ts
@@ -1,4 +1,4 @@
-import { hashOf } from "@commonfabric/data-model/value-hash";
+import { hashStringOf } from "@commonfabric/data-model/value-hash";
 import { stripUndefinedProps } from "@commonfabric/utils/strip-undefined-props";
 import { type Cell } from "../cell.ts";
 import type { Runtime } from "../runtime.ts";
@@ -42,8 +42,8 @@ export const internalSchema = internSchema(
  *     function must do the normalization itself to stay
  *     data-model-flag-agnostic.
  *
- * `hashOf()` itself is happy to hash `undefined` values; no normalization
- * for hashability per se is needed.
+ * `hashStringOf()` itself is happy to hash `undefined` values; no
+ * normalization for hashability per se is needed.
  */
 export function computeInputHashFromValue<T extends Record<string, any>>(
   inputs: T | undefined,
@@ -52,7 +52,7 @@ export function computeInputHashFromValue<T extends Record<string, any>>(
     string,
     unknown
   >;
-  return hashOf(stripUndefinedProps(inputsOnly)).toString();
+  return hashStringOf(stripUndefinedProps(inputsOnly));
 }
 
 export function computeInputHash<T extends Record<string, any>>(

--- a/packages/runner/src/builtins/fetch-utils.ts
+++ b/packages/runner/src/builtins/fetch-utils.ts
@@ -1,5 +1,5 @@
 import { hashOf } from "@commonfabric/data-model/value-hash";
-import { fabricFromNativeValue } from "@commonfabric/data-model/fabric-value";
+import { stripUndefinedProps } from "@commonfabric/utils/strip-undefined-props";
 import { type Cell } from "../cell.ts";
 import type { Runtime } from "../runtime.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
@@ -22,22 +22,37 @@ export const internalSchema = internSchema(
 );
 
 /**
- * Computes a hash of inputs for comparison.
- * Excludes the 'result' field which is used only as a TypeScript type hint,
- * not as an actual input parameter.
+ * Computes a stable string hash of fetch-style inputs, suitable for use as
+ * a comparison key (e.g. an idempotency key or mutex identifier).
+ *
+ * Two normalizations are applied before hashing:
+ *
+ * (1) The top-level `result` property is dropped. It exists only as a
+ *     TypeScript type hint at call sites, never as a real fetch parameter,
+ *     and so must not influence the hash.
+ *
+ * (2) `undefined`-valued object properties are dropped, recursively.
+ *     Callers commonly materialize snapshots via unconditional object
+ *     construction (e.g. `{ url, mode, options }`, or one level deeper
+ *     `{ method, body }`), and the resulting hash needs to be the same
+ *     regardless of whether an absent field is omitted entirely or
+ *     present-but-`undefined`. This matches the JSON-style normalization
+ *     that the legacy fabric-value layer applied implicitly; under the
+ *     modern layer `undefined` properties are preserved, so this
+ *     function must do the normalization itself to stay
+ *     data-model-flag-agnostic.
+ *
+ * `hashOf()` itself is happy to hash `undefined` values; no normalization
+ * for hashability per se is needed.
  */
 export function computeInputHashFromValue<T extends Record<string, any>>(
   inputs: T | undefined,
 ): string {
-  const safeInputs = inputs ?? {};
-  // Exclude 'result' type hint from the hash - only hash actual fetch parameters
-  const inputsOnly = { ...(safeInputs as Record<string, unknown>) };
-  delete (inputsOnly as Record<string, unknown>).result;
-  // hashOf() cannot hash undefined values; normalize to a deep fabric shape
-  // (omits undefined object props, converts undefined array elements to null).
-  const fabricInputs = fabricFromNativeValue(inputsOnly);
-  const normalized = fabricInputs === undefined ? {} : fabricInputs;
-  return hashOf(normalized as Record<string, unknown>).toString();
+  const { result: _result, ...inputsOnly } = (inputs ?? {}) as Record<
+    string,
+    unknown
+  >;
+  return hashOf(stripUndefinedProps(inputsOnly)).toString();
 }
 
 export function computeInputHash<T extends Record<string, any>>(

--- a/packages/runner/test/fetch-utils.test.ts
+++ b/packages/runner/test/fetch-utils.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  resetDataModelConfig,
+  setDataModelConfig,
+} from "@commonfabric/data-model/fabric-value";
+import { computeInputHashFromValue } from "../src/builtins/fetch-utils.ts";
+
+// ============================================================================
+// Tests
+// ============================================================================
+//
+// `computeInputHashFromValue()` must produce a stable hash across legacy and
+// modern fabric-value-layer states. In particular, callers commonly build
+// snapshots via unconditional object construction, so omitted-key versus
+// present-but-`undefined` must hash identically -- a property the legacy
+// layer used to provide implicitly, and which the function now normalizes
+// directly.
+
+describe("computeInputHashFromValue", () => {
+  afterEach(() => {
+    resetDataModelConfig();
+  });
+
+  for (const modernMode of [false, true]) {
+    const label = modernMode ? "modern" : "legacy";
+
+    describe(`(${label} path)`, () => {
+      beforeEach(() => setDataModelConfig(modernMode));
+
+      it("drops the top-level `result` type-hint field", () => {
+        const a = computeInputHashFromValue({ url: "x", mode: "json" });
+        const b = computeInputHashFromValue({
+          url: "x",
+          mode: "json",
+          result: "ignored type hint",
+        });
+        expect(a).toBe(b);
+      });
+
+      it("treats omitted vs `undefined` top-level properties identically", () => {
+        const a = computeInputHashFromValue({ url: "x", mode: "json" });
+        const b = computeInputHashFromValue({
+          url: "x",
+          mode: "json",
+          options: undefined,
+        });
+        expect(a).toBe(b);
+      });
+
+      it("treats omitted vs `undefined` nested properties identically", () => {
+        const a = computeInputHashFromValue({
+          url: "x",
+          options: { method: "GET" },
+        });
+        const b = computeInputHashFromValue({
+          url: "x",
+          options: { method: "GET", body: undefined },
+        });
+        expect(a).toBe(b);
+      });
+
+      it("distinguishes inputs that differ in non-`undefined` content", () => {
+        const a = computeInputHashFromValue({ url: "x", mode: "json" });
+        const b = computeInputHashFromValue({ url: "y", mode: "json" });
+        expect(a).not.toBe(b);
+      });
+
+      it("treats `undefined` inputs as the empty object", () => {
+        const a = computeInputHashFromValue(undefined);
+        const b = computeInputHashFromValue({});
+        expect(a).toBe(b);
+      });
+    });
+  }
+
+  describe("(flag-independent output)", () => {
+    afterEach(() => {
+      resetDataModelConfig();
+    });
+
+    it("produces the same hash under legacy and modern for the same inputs", () => {
+      const inputs = {
+        url: "http://example/api",
+        mode: "json" as const,
+        options: { method: "GET", body: undefined },
+      };
+      setDataModelConfig(false);
+      const legacyHash = computeInputHashFromValue(inputs);
+      setDataModelConfig(true);
+      const modernHash = computeInputHashFromValue(inputs);
+      expect(modernHash).toBe(legacyHash);
+    });
+  });
+});

--- a/packages/utils/deno.json
+++ b/packages/utils/deno.json
@@ -16,6 +16,7 @@
     "./logger": "./src/logger.ts",
     "./sandbox-contract": "./src/sandbox-contract.ts",
     "./sleep": "./src/sleep.ts",
+    "./strip-undefined-props": "./src/strip-undefined-props.ts",
     "./types": "./src/types.ts",
     "./utf8": "./src/utf8.ts",
     "./zod-utils": "./src/zod-utils.ts"

--- a/packages/utils/src/strip-undefined-props.ts
+++ b/packages/utils/src/strip-undefined-props.ts
@@ -1,0 +1,32 @@
+/**
+ * Returns a copy of `value` with `undefined`-valued properties removed,
+ * recursively through plain-object values. Non-plain-object values
+ * (primitives, arrays, class instances) are returned as-is; only own
+ * enumerable string-keyed properties of plain objects are walked.
+ *
+ * Intended use is to canonicalize an object shape for stable comparison
+ * (e.g. content-hashing), where a property that's present-but-`undefined`
+ * should be treated the same as an omitted property. This matches the
+ * JSON-style normalization that the legacy fabric-value layer applied
+ * implicitly; under the modern layer, `undefined`-valued properties are
+ * preserved, so callers that need this normalization must apply it
+ * directly.
+ */
+export function stripUndefinedProps(
+  value: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(value)) {
+    if (val === undefined) continue;
+    out[key] = isPlainObject(val)
+      ? stripUndefinedProps(val as Record<string, unknown>)
+      : val;
+  }
+  return out;
+}
+
+function isPlainObject(value: unknown): boolean {
+  if (value === null || typeof value !== "object") return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}

--- a/packages/utils/src/strip-undefined-props.ts
+++ b/packages/utils/src/strip-undefined-props.ts
@@ -18,9 +18,18 @@ export function stripUndefinedProps(
   const out: Record<string, unknown> = {};
   for (const [key, val] of Object.entries(value)) {
     if (val === undefined) continue;
-    out[key] = isPlainObject(val)
-      ? stripUndefinedProps(val as Record<string, unknown>)
-      : val;
+    // Use `defineProperty` rather than `out[key] = ...` so that a special
+    // key like `"__proto__"` is written as a plain own data property
+    // rather than triggering the prototype setter on `out` (which would
+    // pollute the prototype chain of the returned object).
+    Object.defineProperty(out, key, {
+      value: isPlainObject(val)
+        ? stripUndefinedProps(val as Record<string, unknown>)
+        : val,
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
   }
   return out;
 }

--- a/packages/utils/test/strip-undefined-props.test.ts
+++ b/packages/utils/test/strip-undefined-props.test.ts
@@ -1,0 +1,67 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { stripUndefinedProps } from "@commonfabric/utils/strip-undefined-props";
+
+describe("stripUndefinedProps", () => {
+  it("returns an empty object given an empty object", () => {
+    expect(stripUndefinedProps({})).toEqual({});
+  });
+
+  it("returns a shallow copy when no properties are undefined", () => {
+    const input = { a: 1, b: "two", c: true, d: null };
+    const out = stripUndefinedProps(input);
+    expect(out).toEqual(input);
+    expect(out).not.toBe(input);
+  });
+
+  it("drops undefined-valued top-level properties", () => {
+    expect(stripUndefinedProps({ a: 1, b: undefined, c: 3 })).toEqual({
+      a: 1,
+      c: 3,
+    });
+  });
+
+  it("drops undefined-valued properties at nested depths", () => {
+    expect(stripUndefinedProps({
+      a: 1,
+      b: { c: undefined, d: 4, e: { f: undefined, g: 7 } },
+    })).toEqual({
+      a: 1,
+      b: { d: 4, e: { g: 7 } },
+    });
+  });
+
+  it("preserves `null` properties", () => {
+    expect(stripUndefinedProps({ a: null, b: undefined })).toEqual({ a: null });
+  });
+
+  it("preserves empty nested objects", () => {
+    expect(stripUndefinedProps({ a: {}, b: { c: undefined } })).toEqual({
+      a: {},
+      b: {},
+    });
+  });
+
+  it("leaves array values intact, including any `undefined` elements", () => {
+    const input = { xs: [1, undefined, 3], ys: undefined };
+    const out = stripUndefinedProps(input);
+    expect(out).toEqual({ xs: [1, undefined, 3] });
+    expect(out.xs).toBe(input.xs);
+  });
+
+  it("does not walk into class instances", () => {
+    class Tag {
+      constructor(public name: string, public maybe: string | undefined) {}
+    }
+    const tag = new Tag("t", undefined);
+    const out = stripUndefinedProps({ tag, dropped: undefined });
+    expect(out).toEqual({ tag });
+    expect(out.tag).toBe(tag);
+  });
+
+  it("does not mutate the input object", () => {
+    const input = { a: 1, b: undefined, c: { d: undefined, e: 5 } };
+    stripUndefinedProps(input);
+    expect(input).toEqual({ a: 1, b: undefined, c: { d: undefined, e: 5 } });
+  });
+});

--- a/packages/utils/test/strip-undefined-props.test.ts
+++ b/packages/utils/test/strip-undefined-props.test.ts
@@ -64,4 +64,23 @@ describe("stripUndefinedProps", () => {
     stripUndefinedProps(input);
     expect(input).toEqual({ a: 1, b: undefined, c: { d: undefined, e: 5 } });
   });
+
+  it("copies a `__proto__` own property as an own data property, not as a prototype", () => {
+    // `JSON.parse()` produces an object with an *own* `__proto__` property
+    // (it does not invoke the `__proto__` setter), so callers feeding
+    // parsed JSON in could reach this code with that shape. A naive
+    // assignment-based copy would invoke the setter on the output and
+    // pollute its prototype chain.
+    const input = JSON.parse('{"__proto__": {"polluted": true}, "x": 1}');
+    const out = stripUndefinedProps(input);
+    expect(Object.getPrototypeOf(out)).toBe(Object.prototype);
+    expect(({} as { polluted?: boolean }).polluted).toBeUndefined();
+    expect(Object.getOwnPropertyDescriptor(out, "__proto__")).toEqual({
+      value: { polluted: true },
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+    expect(out.x).toBe(1);
+  });
 });


### PR DESCRIPTION
Prep PR for the modern-data-model flag flip (PR #3569). Clears both remaining `fetch-data mutex mechanism` failures under `modernDataModel = true`; no-op under legacy. After this, the only modern-on runner failures from PR #3569's CI should be gone — the burndown is done.

## The bug

`computeInputHashFromValue()` in `packages/runner/src/builtins/fetch-utils.ts` was routing inputs through `fabricFromNativeValue()` before hashing, with a comment claiming the step was needed to make `hashOf()` happy with `undefined` values. That claim is false (`hashOf()` is happy to hash `undefined` per se). What the step *actually* did was inherit the legacy fabric-value layer's JSON-style coercion, which silently dropped `undefined`-valued object properties.

Under modern, `undefined`-valued properties are preserved, so that implicit normalization disappeared and hashes diverged between otherwise-equivalent input shapes.

## Concrete failure on PR #3569

Two failing steps under `Runner Tests (3/4)` → `fetch-data mutex mechanism`:

- `"uses a stable fetchData idempotency key for identical inputs"` (line 208) — direct hash mismatch.
- `"should handle fetch errors gracefully"` (line 489) — downstream effect: with the mutex stuck unclaimable, the fetch never completes and `data.error` stays `undefined`, so the `expect(data.error).toHaveProperty("@Error")` assertion fails too.

Mechanism:

- `snapshotFetchDataInputs()` builds `{ url, mode, options }` where `options` is `undefined` when the user passed no options. Test computes the expected hash from `{ url, mode }` (no `options` key at all).
- Under legacy, the legacy fabric-value layer drops the `options: undefined` key before hashing → 2-key shape on both sides → match.
- Under modern, the key is preserved → 3-key system-side vs 2-key test-side → mismatch.

## The fix

Make `computeInputHashFromValue()` strip undefined properties itself, in a flag-agnostic way. Factored the stripping into a new utility `stripUndefinedProps()` in `@commonfabric/utils/strip-undefined-props`, which recursively drops `undefined`-valued properties from plain-object values (other shapes — primitives, arrays, class instances — pass through unchanged).

Audit of all `computeInputHashFromValue()` call sites confirmed that fetch-style input shapes use plain objects only — no arrays, no class instances at any depth — so the helper's contract is scoped tightly to plain objects. (No undefined-element-to-null array handling needed.)

Side cleanups in `computeInputHashFromValue()`:

- Modernized the `result` type-hint stripping from `delete inputsOnly.result` to the destructuring form `{ result: _result, ...inputsOnly } = ...`.
- Replaced the stale doc comment (incorrect claim about `hashOf()` + thin description) with one that describes both normalizations the function actually performs.

## Tests fixed

Verified locally with the modern default temporarily flipped:

- `packages/runner/test/fetch-data-mutex.test.ts > fetch-data mutex mechanism > "uses a stable fetchData idempotency key for identical inputs"` — passes under both flag states.
- `packages/runner/test/fetch-data-mutex.test.ts > fetch-data mutex mechanism > "should handle fetch errors gracefully"` — passes under both flag states (was a downstream effect of the same root cause).

## Tests added

- `packages/utils/test/strip-undefined-props.test.ts` — 9 sub-tests covering empty/no-strip, top-level and nested stripping, null preservation, empty nested objects, arrays-passed-through, class-instances-not-walked, no-mutation. One of these caught a real discrepancy between an early draft and its doc comment: the obvious `typeof val === "object" && !Array.isArray(val)` predicate also walks into class instances, so the implementation was tightened to a proper `isPlainObject` check (`proto === Object.prototype || proto === null`).
- `packages/runner/test/fetch-utils.test.ts` — flag-bifurcated tests for `computeInputHashFromValue()` (legacy path, modern path, and a flag-independence assertion), covering the `result` strip, top-level and nested `undefined` normalization, distinguishing-real-content, and the `undefined`-vs-`{}` input case.

## Test plan

- [x] `deno task check` — passes.
- [x] `deno task test` (workspace-wide) under `modernDataModel = false` (current default on `main`): all green.
- [x] `deno task test` (runner package) under `modernDataModel = true` (post-flip): the two `fetch-data mutex` failures clear.
- [ ] Manual: not needed; the change is internal to a hashing helper and verified by the cited tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize fetch input hashing by stripping `undefined` props and dropping the top-level `result` hint so `fetchData` idempotency keys stay stable across legacy and modern data models. Switch to `hashStringOf()` (no `fid1:`) and harden copying to prevent `__proto__` pollution, clearing the last modern fetch-data mutex test failures.

- **Bug Fixes**
  - Replaced `fabricFromNativeValue()` with `stripUndefinedProps()` in `computeInputHashFromValue()` to drop `undefined` props recursively on plain objects and ignore the top-level `result` field.
  - Wrote keys via `Object.defineProperty()` to keep `"__proto__"` as an own data property for safety; added `@commonfabric/utils/strip-undefined-props`.

- **Refactors**
  - Switched to `hashStringOf()` for input hashes, changing `fetchData:fid1:<base64>` to `fetchData:<base64>`; format change only triggers a benign first re-fetch.

<sup>Written for commit 9683468906e58af08e4fdce68dbc743db21575e6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

