### PR TITLE
fix(ts-transformers): preserve stream capability when narrowing

### DIFF
--- a/packages/ts-transformers/src/transformers/schema-injection.ts
+++ b/packages/ts-transformers/src/transformers/schema-injection.ts
@@ -37,9 +37,11 @@ import {
   type CapabilitySummaryApplicationMode,
   containsAnyOrUnknownTypeNode,
   isCellLikeTypeNode,
+  isStreamTypeNode,
   printTypeNode,
 } from "./type-shrinking.ts";
 import { isPatternFactoryCalleeExpression } from "./structural-reactive-factory.ts";
+import { getCellKind } from "./opaque-ref/opaque-ref.ts";
 
 type UiContractHint = NonNullable<SchemaHint["cfcUiContract"]>;
 type CellScope = "space" | "user" | "session";
@@ -130,6 +132,13 @@ function extractCellLikeInnerTypeNode(
   if (!ts.isTypeReferenceNode(node)) return undefined;
   if (!node.typeArguments || node.typeArguments.length === 0) return undefined;
   return node.typeArguments[0];
+}
+
+function isStreamCellType(
+  type: ts.Type | undefined,
+  checker: ts.TypeChecker,
+): boolean {
+  return !!type && getCellKind(type, checker) === "stream";
 }
 
 function parameterUsesCellLikeMethods(
@@ -252,6 +261,8 @@ function applyCapabilitySummaryToArgument(
       sourceFile,
     );
   const shouldWrap = !!innerTypeNode;
+  const preserveStreamWrapper = shouldWrap &&
+    (isStreamTypeNode(argumentNode) || isStreamCellType(argumentType, checker));
   const baseTypeNode = innerTypeNode ?? argumentNode;
   let baseType = shouldWrap && argumentType
     ? (unwrapCellLikeType(argumentType, checker) ?? argumentType)
@@ -277,6 +288,7 @@ function applyCapabilitySummaryToArgument(
     mode === "defaults_only" ? "opaque" : paramSummary.capability,
     context,
     fnNode ?? fn,
+    preserveStreamWrapper,
   );
 }
 
@@ -309,6 +321,9 @@ function applyCapabilitySummaryToParameter(
 
   const innerTypeNode = extractCellLikeInnerTypeNode(parameterNode);
   const shouldWrap = !!innerTypeNode;
+  const preserveStreamWrapper = shouldWrap &&
+    (isStreamTypeNode(parameterNode) ||
+      isStreamCellType(parameterType, checker));
   const baseTypeNode = innerTypeNode ?? parameterNode;
   let baseType = shouldWrap && parameterType
     ? (unwrapCellLikeType(parameterType, checker) ?? parameterType)
@@ -334,6 +349,7 @@ function applyCapabilitySummaryToParameter(
     paramSummary.capability,
     context,
     fnNode ?? fn,
+    preserveStreamWrapper,
   );
 }
 

--- a/packages/ts-transformers/src/transformers/type-shrinking.ts
+++ b/packages/ts-transformers/src/transformers/type-shrinking.ts
@@ -17,6 +17,7 @@ import {
   typeToSchemaTypeNode,
   unwrapCellLikeType,
 } from "../ast/mod.ts";
+import { getCellKind } from "./opaque-ref/opaque-ref.ts";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -498,11 +499,7 @@ function findPropertySymbol(
 
 export function isCellLikeTypeNode(node: ts.TypeNode): boolean {
   if (!ts.isTypeReferenceNode(node)) return false;
-  const name = ts.isIdentifier(node.typeName)
-    ? node.typeName.text
-    : ts.isQualifiedName(node.typeName)
-    ? node.typeName.right.text
-    : undefined;
+  const name = getTypeReferenceNodeName(node);
   if (!name) return false;
   return name === "Cell" ||
     name === "Writable" ||
@@ -512,6 +509,28 @@ export function isCellLikeTypeNode(node: ts.TypeNode): boolean {
     name === "ReadonlyCell" ||
     name === "WriteonlyCell" ||
     name === "Stream";
+}
+
+function getTypeReferenceNodeName(
+  node: ts.TypeReferenceNode,
+): string | undefined {
+  return ts.isIdentifier(node.typeName)
+    ? node.typeName.text
+    : ts.isQualifiedName(node.typeName)
+    ? node.typeName.right.text
+    : undefined;
+}
+
+export function isStreamTypeNode(node: ts.TypeNode): boolean {
+  return ts.isTypeReferenceNode(node) &&
+    getTypeReferenceNodeName(node) === "Stream";
+}
+
+function isStreamCellType(
+  type: ts.Type | undefined,
+  checker: ts.TypeChecker,
+): boolean {
+  return !!type && getCellKind(type, checker) === "stream";
 }
 
 export function printTypeNode(
@@ -1656,6 +1675,25 @@ export function wrapTypeNodeWithCapability(
     ? "Writable"
     : "OpaqueCell";
 
+  return createHelperWrapperTypeNode(node, wrapperName, factory);
+}
+
+function wrapTypeNodeWithCapabilityOrStream(
+  node: ts.TypeNode,
+  capability: ReactiveCapability,
+  factory: ts.NodeFactory,
+  preserveStream: boolean,
+): ts.TypeNode {
+  return preserveStream
+    ? createHelperWrapperTypeNode(node, "Stream", factory)
+    : wrapTypeNodeWithCapability(node, capability, factory);
+}
+
+function createHelperWrapperTypeNode(
+  node: ts.TypeNode,
+  wrapperName: string,
+  factory: ts.NodeFactory,
+): ts.TypeNode {
   return factory.createTypeReferenceNode(
     factory.createQualifiedName(
       factory.createIdentifier("__cfHelpers"),
@@ -1868,7 +1906,13 @@ function applyCellCapabilityPathsToTypeNode(
     if (inner) {
       const capability = selectCellPathCapability(childPaths);
       if (capability) {
-        updated = wrapTypeNodeWithCapability(inner, capability, factory);
+        updated = wrapTypeNodeWithCapabilityOrStream(
+          inner,
+          capability,
+          factory,
+          isStreamTypeNode(updated) ||
+            isStreamCellType(memberSemanticType, checker),
+        );
         if (typeRegistry && isCellLikeType(memberSemanticType, checker)) {
           typeRegistry.set(updated, memberSemanticType);
         }
@@ -1926,10 +1970,11 @@ function createIdentityOnlyReplacementTypeNode(
     isCellLikeTypeNode(node) ||
     isCellLikeType(resolvedType, checker)
   ) {
-    const wrappedNode = wrapTypeNodeWithCapability(
+    const wrappedNode = wrapTypeNodeWithCapabilityOrStream(
       unknownNode,
       forceComparable ? "comparable" : "opaque",
       factory,
+      isStreamTypeNode(node) || isStreamCellType(resolvedType, checker),
     );
     const wrappedType = resolveIdentitySemanticType(
       wrappedNode,
@@ -2684,6 +2729,7 @@ export function applyShrinkAndWrap(
   wrapCapability: ReactiveCapability = paramSummary.capability,
   context?: TransformationContext,
   fnNode?: ts.Node,
+  preserveStreamWrapper = false,
 ): ts.TypeNode {
   const shrinkPlan = deriveCapabilityShrinkPlan(paramSummary);
   const {
@@ -2747,7 +2793,12 @@ export function applyShrinkAndWrap(
     if (!shouldWrap) {
       return next;
     }
-    return wrapTypeNodeWithCapability(next, wrapCapability, factory);
+    return wrapTypeNodeWithCapabilityOrStream(
+      next,
+      wrapCapability,
+      factory,
+      preserveStreamWrapper,
+    );
   }
 
   let next = identityOnlyRoot
@@ -2905,5 +2956,10 @@ export function applyShrinkAndWrap(
   if (!shouldWrap) {
     return next;
   }
-  return wrapTypeNodeWithCapability(next, wrapCapability, factory);
+  return wrapTypeNodeWithCapabilityOrStream(
+    next,
+    wrapCapability,
+    factory,
+    preserveStreamWrapper,
+  );
 }

--- a/packages/ts-transformers/test/fixtures/closures/action-in-ternary-with-explicit-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-in-ternary-with-explicit-computed.expected.jsx
@@ -86,7 +86,7 @@ export default pattern((__cf_pattern_input) => {
                         required: ["description"]
                     },
                     startEditing: {
-                        asCell: ["readonly", "opaque"]
+                        asCell: ["stream", "opaque"]
                     }
                 },
                 required: ["card", "startEditing"]

--- a/packages/ts-transformers/test/fixtures/closures/helper-owned-handler-nested-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/helper-owned-handler-nested-captures.expected.jsx
@@ -95,7 +95,7 @@ export default pattern((__cf_pattern_input) => {
                     }
                 },
                 required: ["fileId", "content"],
-                asCell: ["readonly"]
+                asCell: ["stream"]
             }
         },
         required: ["timer", "fileId", "content", "savedContent", "onSaveFile"]

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-captures.expected.jsx
@@ -201,7 +201,7 @@ export default pattern((__cf_pattern_input) => {
                                     }
                                 },
                                 required: ["name"],
-                                asCell: ["readonly"]
+                                asCell: ["stream"]
                             },
                             entry: {
                                 type: "object",
@@ -239,7 +239,7 @@ export default pattern((__cf_pattern_input) => {
                                         }
                                     },
                                     required: ["name"],
-                                    asCell: ["readonly"]
+                                    asCell: ["stream"]
                                 }
                             },
                             required: ["pushPath"]

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-default-input-local-chain-map-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-default-input-local-chain-map-capture.expected.jsx
@@ -315,7 +315,7 @@ export default pattern((__cf_pattern_input) => {
                                             }
                                         },
                                         required: ["name"],
-                                        asCell: ["readonly"]
+                                        asCell: ["stream"]
                                     },
                                     item: {
                                         type: "object",
@@ -347,7 +347,7 @@ export default pattern((__cf_pattern_input) => {
                                             }
                                         },
                                         required: ["item"],
-                                        asCell: ["readonly"]
+                                        asCell: ["stream"]
                                     },
                                     item: {
                                         $ref: "#/$defs/Entry"
@@ -406,7 +406,7 @@ export default pattern((__cf_pattern_input) => {
                                         }
                                     },
                                     required: ["name"],
-                                    asCell: ["readonly"]
+                                    asCell: ["stream"]
                                 },
                                 handleOpenFile: {
                                     type: "object",
@@ -416,7 +416,7 @@ export default pattern((__cf_pattern_input) => {
                                         }
                                     },
                                     required: ["item"],
-                                    asCell: ["readonly"]
+                                    asCell: ["stream"]
                                 }
                             },
                             required: ["handleNavigateInto", "handleOpenFile"]

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-local-initializer-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-local-initializer-captures.expected.jsx
@@ -261,7 +261,7 @@ export default pattern((__cf_pattern_input) => {
                                     }
                                 },
                                 required: ["name"],
-                                asCell: ["readonly"]
+                                asCell: ["stream"]
                             },
                             item: {
                                 type: "object",
@@ -299,7 +299,7 @@ export default pattern((__cf_pattern_input) => {
                                         }
                                     },
                                     required: ["name"],
-                                    asCell: ["readonly"]
+                                    asCell: ["stream"]
                                 }
                             },
                             required: ["pushPath"]


### PR DESCRIPTION
## Summary

- Preserve `Stream<T>` when capability shrinking rebuilds synthetic wrapper type nodes.
- Keep stream captures from being emitted as readonly/writeonly/opaque cells after narrowing.
- Update affected ts-transformers fixture goldens to expect `asCell: ["stream"]`.

## Root Cause

The new narrowing pass reused the generic cell capability wrapper for all cell-like inputs. That let semantic streams be reconstructed as `ReadonlyCell<unknown>` in handler/map capture schemas, even though streams are their own `.send()`-only capability surface.

## Validation

- `FIXTURE=map-conditional-inline-handler-send deno test --allow-read --allow-write --allow-env test/fixture-based.test.ts`
- `deno task test` in `packages/ts-transformers`
- `deno task check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves `Stream<T>` when narrowing cell-like types so streams aren’t rewritten as readonly/opaque cells. Fixes capture schemas to keep stream send-only semantics and updates fixtures to expect `asCell: ["stream"]`.

- **Bug Fixes**
  - Detect streams via `isStreamTypeNode` and `getCellKind(...)= "stream"`.
  - Keep `Stream` wrapper during shrink/wrap using `wrapTypeNodeWithCapabilityOrStream` instead of generic cell wrappers.
  - Preserve stream wrappers in schema injection for parameters/arguments; update affected `packages/ts-transformers` fixtures to `asCell: ["stream"]`.

<sup>Written for commit a2e33986026b9111d2316866528ca57aacc2060a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

NEW_PERF_BASELINE: job: CLI Integration Tests (fuse) = 131s
