### PR TITLE
fix(cli): propagate caller identity into piece inspect scope context (CT-1598)

### DIFF
--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -831,6 +831,43 @@ export async function generateSpaceMap(
   return formatSpaceMap(connections, format);
 }
 
+/**
+ * Read a cell's value with per-property scope awareness.
+ *
+ * `cell.get()` on a top-level cell returns whatever is stored *inline* in the
+ * underlying document at the cell's effective scope. For per-property scoped
+ * fields (e.g. `PerUser<string>` on an otherwise space-scoped argument), the
+ * inline value is the default (e.g. `""`); the real per-user value lives in a
+ * separate scoped instance and is only resolved when the read traverses through
+ * a per-property link.
+ *
+ * `cell.key(prop)` constructs a child cell that inherits the property schema's
+ * declared scope (see `cell.ts` Cell.key()), so calling `.get()` on the child
+ * cell correctly reaches the scoped storage instance.
+ *
+ * For `cf piece inspect`, we want the caller to see the values they would see
+ * as if they were running the pattern (per-user fields resolved against the
+ * caller's identity). So we read top-level object properties via `cell.key()`
+ * rather than using the parent's flat `.get()` value directly. See CT-1598.
+ */
+export function readWithPropertyScope(cell: Cell<unknown>): unknown {
+  const value = cell.get();
+  if (
+    value === null || value === undefined || typeof value !== "object" ||
+    Array.isArray(value)
+  ) {
+    return value;
+  }
+  const out: Record<string, unknown> = {};
+  for (const propKey of Object.keys(value as Record<string, unknown>)) {
+    const childCell = (cell as Cell<Record<string, unknown>>).key(
+      propKey as keyof Record<string, unknown>,
+    ) as Cell<unknown>;
+    out[propKey] = childCell.get();
+  }
+  return out;
+}
+
 export async function inspectPiece(config: PieceConfig): Promise<{
   id: string;
   name?: string;
@@ -847,8 +884,15 @@ export async function inspectPiece(config: PieceConfig): Promise<{
   const id = piece.id;
   const name = piece.name();
   const patternName = (await piece.getPatternMeta()).patternName;
-  const source = (await piece.input.get()) as Readonly<unknown>;
-  const result = (await piece.result.get()) as Readonly<unknown>;
+
+  const sourceCell = await piece.input.getCell();
+  await sourceCell.pull();
+  const source = readWithPropertyScope(sourceCell) as Readonly<unknown>;
+
+  const resultCell = await piece.result.getCell();
+  await resultCell.pull();
+  const result = readWithPropertyScope(resultCell) as Readonly<unknown>;
+
   const readingFrom = (await piece.readingFrom()).map((piece) => ({
     id: piece.id,
     name: piece.name(),

--- a/packages/cli/test/piece-inspect.test.ts
+++ b/packages/cli/test/piece-inspect.test.ts
@@ -1,0 +1,109 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { readWithPropertyScope } from "../lib/piece.ts";
+
+/**
+ * Unit tests for `readWithPropertyScope`, the helper used by
+ * `cf piece inspect` to read top-level object properties via `cell.key()`
+ * rather than via the parent's flat `.get()` value.
+ *
+ * The fix this exercises (CT-1598): when a pattern declares a property as
+ * `PerUser<…>` (or any other scope-shifted shape), the value stored inline in
+ * the parent space-scoped document is the default — the per-user value lives
+ * in a separate scoped instance. `cell.key(prop).get()` carries the property
+ * schema's scope into the read and resolves the scoped instance; the parent
+ * `cell.get()` does not. So `inspectPiece` descends one level via `cell.key()`
+ * so the caller sees their own per-user values.
+ *
+ * These tests model just enough of the `Cell` interface to verify the
+ * descent contract.
+ */
+
+interface FakeCell {
+  get(): unknown;
+  key(prop: string | number): FakeCell;
+}
+
+function makeFakeCell(opts: {
+  parentValue: unknown;
+  childValues?: Record<string, unknown>;
+}): FakeCell {
+  return {
+    get: () => opts.parentValue,
+    key: (prop) => {
+      const k = String(prop);
+      // Override values for children when supplied — this models the runtime
+      // behavior where `cell.key(prop)` returns a child cell whose `.get()`
+      // resolves the property at the property schema's scope (which can
+      // differ from the parent's flat inline value).
+      const override = opts.childValues?.[k];
+      return makeFakeCell({ parentValue: override });
+    },
+  };
+}
+
+describe("readWithPropertyScope", () => {
+  it("returns primitive values unchanged", () => {
+    const cell = makeFakeCell({ parentValue: "hello" });
+    expect(readWithPropertyScope(cell as never)).toBe("hello");
+  });
+
+  it("returns null/undefined unchanged", () => {
+    expect(readWithPropertyScope(
+      makeFakeCell({ parentValue: null }) as never,
+    )).toBe(null);
+    expect(readWithPropertyScope(
+      makeFakeCell({ parentValue: undefined }) as never,
+    )).toBe(undefined);
+  });
+
+  it("returns arrays unchanged (no per-element descent)", () => {
+    const arr = [1, 2, 3];
+    const cell = makeFakeCell({ parentValue: arr });
+    expect(readWithPropertyScope(cell as never)).toEqual(arr);
+  });
+
+  it("reads each top-level property via cell.key() (CT-1598)", () => {
+    // Models the cozy-poll-scoped argument document, where myName is declared
+    // PerUser<string> — the inline value at scope=space is the default "",
+    // but the per-user instance contains the actual value.
+    const cell = makeFakeCell({
+      parentValue: {
+        adminName: "Alex",
+        myName: "", // inline value at scope=space (the default)
+        users: [{ name: "Alex" }],
+      },
+      childValues: {
+        // What cell.key(prop).get() would return for each property — for
+        // PerUser fields this differs from the inline parent value.
+        adminName: "Alex",
+        myName: "Alex", // resolved per-user value
+        users: [{ name: "Alex" }],
+      },
+    });
+
+    const out = readWithPropertyScope(cell as never) as Record<string, unknown>;
+    expect(out.adminName).toBe("Alex");
+    expect(out.myName).toBe("Alex");
+    expect(out.users).toEqual([{ name: "Alex" }]);
+  });
+
+  it("different identities see different per-user values", () => {
+    const cellAsAlex = makeFakeCell({
+      parentValue: { myName: "", adminName: "Alex" },
+      childValues: { myName: "Alex", adminName: "Alex" },
+    });
+    const cellAsBeth = makeFakeCell({
+      parentValue: { myName: "", adminName: "Alex" },
+      childValues: { myName: "Beth", adminName: "Alex" },
+    });
+    expect(
+      (readWithPropertyScope(cellAsAlex as never) as Record<string, unknown>)
+        .myName,
+    ).toBe("Alex");
+    expect(
+      (readWithPropertyScope(cellAsBeth as never) as Record<string, unknown>)
+        .myName,
+    ).toBe("Beth");
+  });
+});


### PR DESCRIPTION
## Summary

`cf piece inspect --identity <key>` was reading `PerUser`/`PerSession` fields as the default (e.g. `""`) regardless of which identity ran the inspect, even when handlers had clearly written per-user values via `cf piece call`. The caller's identity was used to authenticate the connection but never reached per-property scope resolution.

**Root cause:** `inspectPiece` in `packages/cli/lib/piece.ts` read each top-level field via `piece.input.get()` / `piece.result.get()`, which returns whatever is stored *inline* in the parent document at the cell's effective scope. For per-property-scoped fields on an otherwise space-scoped argument, the inline value is the default — the real per-user value lives in a separate scoped storage instance (`scope_key = "user:<DID>"`).

**Fix:** Descend one level via `cell.key(prop)` per top-level property. `cell.key()` already carries the property schema's declared scope into the child cell (see `Cell.key()` in `packages/runner/src/cell.ts:1171-1173`), so calling `.get()` on the child cell correctly resolves the scoped storage instance for the active identity.

## Why this is small

- One helper (`readWithPropertyScope`) of ~15 lines plus two call sites swapped over.
- Pure read-side change in the CLI. No protocol or schema changes.
- Same scope-aware behavior the runtime already uses when handlers access bound cells in their context maps.

## Verified against `packages/patterns/cozy-poll-scoped/main.tsx`

- **Before:** `myName: ""` for every identity.
- **After:** `myName: "Alex"` when inspecting as the Alex identity, `myName: "Beth"` as the Beth identity — matching the values the handlers wrote.

Reproduction in CT-1598. Regular (non-scoped) pieces continue to inspect identically (verified against `packages/patterns/notes/note.tsx`).

## Test plan

- [x] New unit tests in `packages/cli/test/piece-inspect.test.ts` (primitives, null/undefined, arrays, top-level descent, per-identity divergence).
- [x] All existing CLI tests still pass (`cd packages/cli && deno task test` — 36 passed, 1 ignored).
- [x] All runner tests still pass (`cd packages/runner && deno task test` — 451 passed).
- [x] End-to-end repro against a live toolshed (`cozy-poll-scoped` pattern, two identities, two voters).
- [ ] CI green.

Refs: CT-1598

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `cf piece inspect --identity` so `PerUser`/`PerSession` fields resolve using the caller’s identity, matching what handlers wrote. Aligns CLI inspect with runtime scope resolution and addresses CT-1598.

- **Bug Fixes**
  - Added `readWithPropertyScope` to read top-level object fields via `cell.key(prop).get()`.
  - Updated `inspectPiece` to use `getCell().pull()` and scope-aware reads for `input` and `result`.
  - Added unit tests in `packages/cli/test/piece-inspect.test.ts` covering primitives and per-identity divergence.

<sup>Written for commit 570448bd400684a16cfb135c190bba1e8ae49a1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

