### PR TITLE
Proper deep-frozen `FabricValue` type guard; partial `FabricInstance` deep clone

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1795,7 +1795,6 @@
     },
     "uuid@9.0.1": {
       "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": true,
       "bin": true
     },
     "w3c-keyname@2.2.8": {

--- a/packages/data-model/deep-freeze.ts
+++ b/packages/data-model/deep-freeze.ts
@@ -1,15 +1,4 @@
-/**
- * Recursively freeze an object tree in place. Primitives pass through
- * unchanged. Arrays and plain objects are frozen after their children are
- * recursively frozen.
- *
- * Objects already confirmed as deep-frozen (present in the cache) are
- * returned immediately. Otherwise, already-frozen objects are still recursed
- * into (their children may not be frozen). After freezing, the result is
- * recorded in the cache so subsequent calls return in O(1).
- *
- * Handles sparse arrays correctly (only visits populated indices).
- */
+import { FabricInstance, FabricPrimitive } from "./interface.ts";
 
 /**
  * Cache of confirmed deep-frozen objects.
@@ -147,4 +136,38 @@ export function deepFreeze<T>(value: T): T {
   if (!alreadyFrozen) Object.freeze(value);
   addToDeepFrozenCache(value as object);
   return value;
+}
+
+/**
+ * Indicates whether the value is a deep-frozen `FabricValue`. Returns `true` if
+ * the value is a primitive, or a frozen object/array whose children are all
+ * also deep-frozen `FabricValue`s.
+ */
+export function isDeepFrozenFabricValue(value: unknown): boolean {
+  if (value === null || (typeof value !== "object")) return true; // primitives
+  if (!Object.isFrozen(value)) return false;
+
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      if (i in value && !isDeepFrozenFabricValue(value[i])) return false;
+    }
+    return true;
+  }
+
+  // `FabricPrimitive`s are by definition frozen and have no outbound
+  // references.
+  if (value instanceof FabricPrimitive) return true;
+
+  // `FabricInstance`s might have references, but -- TODO(@danfuzz) -- we have
+  // no way of handling them yet.
+  if (value instanceof FabricInstance) {
+    throw new Error(
+      `Cannot yet handle instance of class ${value.constructor.name}`,
+    );
+  }
+
+  for (const v of Object.values(value)) {
+    if (!isDeepFrozenFabricValue(v)) return false;
+  }
+  return true;
 }

--- a/packages/data-model/deep-freeze.ts
+++ b/packages/data-model/deep-freeze.ts
@@ -184,12 +184,12 @@ export function isDeepFrozenFabricValue(value: unknown): value is FabricValue {
       );
     } else if (Array.isArray(item)) {
       for (let i = 0; i <= item.length; i++) {
-        if (i in item && !isDeepFrozenFabricValue(item[i])) return false;
+        if (i in item && !checkValue(item[i])) return false;
       }
       return true;
     } else {
       for (const v of Object.values(item)) {
-        if (!isDeepFrozenFabricValue(v)) return false;
+        if (!checkValue(v)) return false;
       }
       return true;
     }

--- a/packages/data-model/deep-freeze.ts
+++ b/packages/data-model/deep-freeze.ts
@@ -3,6 +3,7 @@ import {
   FabricPrimitive,
   FabricValue,
 } from "./interface.ts";
+import { isPlainObject } from "@commonfabric/utils/types";
 
 /**
  * Cache of confirmed deep-frozen objects.
@@ -187,11 +188,15 @@ export function isDeepFrozenFabricValue(value: unknown): value is FabricValue {
         if (i in item && !checkValue(item[i])) return false;
       }
       return true;
-    } else {
+    } else if (isPlainObject(item)) {
       for (const v of Object.values(item)) {
         if (!checkValue(v)) return false;
       }
       return true;
+    } else {
+      // It's an instance of a class that isn't covered by the `FabricValue`
+      // type definition.
+      return false;
     }
   };
 

--- a/packages/data-model/deep-freeze.ts
+++ b/packages/data-model/deep-freeze.ts
@@ -151,12 +151,27 @@ export function isDeepFrozenFabricValue(value: unknown): value is FabricValue {
   // only does a single layer check, and (b) is only ever exercised in unit
   // tests, so it should be safe to replace it.
 
-  if (value === null || (typeof value !== "object")) {
-    // It's a primitive. Return here for efficiency, rather than do the
-    // heavyweight setup for recursive tracing.
-    return true;
-  } else if (!isDeepFrozen(value)) {
-    return false;
+  switch (typeof value) {
+    case 'function': {
+      return false;
+    }
+
+    case 'object': {
+      if (value === null) {
+        return true;
+      } else if (!isDeepFrozen(value)) {
+        return false;
+      }
+
+      // Continue below the `switch`.
+      break;
+    }
+
+    default: {
+      // It's a primitive. Return here for efficiency, rather than do the
+      // heavyweight setup for recursive tracing.
+      return true;
+    }
   }
 
   // At this point, it's known to be a deep-frozen value with internal

--- a/packages/data-model/deep-freeze.ts
+++ b/packages/data-model/deep-freeze.ts
@@ -1,4 +1,8 @@
-import { FabricInstance, FabricPrimitive } from "./interface.ts";
+import {
+  FabricInstance,
+  FabricPrimitive,
+  FabricValue,
+} from "./interface.ts";
 
 /**
  * Cache of confirmed deep-frozen objects.
@@ -143,7 +147,7 @@ export function deepFreeze<T>(value: T): T {
  * the value is a primitive, or a frozen object/array whose children are all
  * also deep-frozen `FabricValue`s.
  */
-export function isDeepFrozenFabricValue(value: unknown): boolean {
+export function isDeepFrozenFabricValue(value: unknown): value is FabricValue {
   // TODO(@danfuzz): A function `isFabricValue()` should ultimately get
   // extracted from this function, which does just the recursive type check.
   // Note that, as of this writing, the existing function with that name (a)

--- a/packages/data-model/deep-freeze.ts
+++ b/packages/data-model/deep-freeze.ts
@@ -156,7 +156,8 @@ export function isDeepFrozenFabricValue(value: unknown): value is FabricValue {
   // tests, so it should be safe to replace it.
 
   if (value === null || (typeof value !== "object")) {
-    // It's a primitive.
+    // It's a primitive. Return here for efficiency, rather than do the
+    // heavyweight setup for recursive tracing.
     return true;
   } else if (!isDeepFrozen(value)) {
     return false;
@@ -166,8 +167,11 @@ export function isDeepFrozenFabricValue(value: unknown): value is FabricValue {
   // structure, but we don't know if it's actually a `FabricValue`.
 
   const seen = new Set();
-  const checkValue = (item: object) => {
-    if (seen.has(item)) {
+  const checkValue = (item: unknown): boolean => {
+    if (item === null || (typeof item !== "object")) {
+      // It's a primitive.
+      return true;
+    } else if (seen.has(item)) {
       return true;
     }
 

--- a/packages/data-model/deep-freeze.ts
+++ b/packages/data-model/deep-freeze.ts
@@ -1,8 +1,4 @@
-import {
-  FabricInstance,
-  FabricPrimitive,
-  FabricValue,
-} from "./interface.ts";
+import { FabricInstance, FabricPrimitive, FabricValue } from "./interface.ts";
 import { isPlainObject } from "@commonfabric/utils/types";
 
 /**

--- a/packages/data-model/deep-freeze.ts
+++ b/packages/data-model/deep-freeze.ts
@@ -152,11 +152,11 @@ export function isDeepFrozenFabricValue(value: unknown): value is FabricValue {
   // tests, so it should be safe to replace it.
 
   switch (typeof value) {
-    case 'function': {
+    case "function": {
       return false;
     }
 
-    case 'object': {
+    case "object": {
       if (value === null) {
         return true;
       } else if (!isDeepFrozen(value)) {

--- a/packages/data-model/deep-freeze.ts
+++ b/packages/data-model/deep-freeze.ts
@@ -144,30 +144,52 @@ export function deepFreeze<T>(value: T): T {
  * also deep-frozen `FabricValue`s.
  */
 export function isDeepFrozenFabricValue(value: unknown): boolean {
-  if (value === null || (typeof value !== "object")) return true; // primitives
-  if (!Object.isFrozen(value)) return false;
+  // TODO(@danfuzz): A function `isFabricValue()` should ultimately get
+  // extracted from this function, which does just the recursive type check.
+  // Note that, as of this writing, the existing function with that name (a)
+  // only does a single layer check, and (b) is only ever exercised in unit
+  // tests, so it should be safe to replace it.
 
-  if (Array.isArray(value)) {
-    for (let i = 0; i < value.length; i++) {
-      if (i in value && !isDeepFrozenFabricValue(value[i])) return false;
-    }
+  if (value === null || (typeof value !== "object")) {
+    // It's a primitive.
     return true;
+  } else if (!isDeepFrozen(value)) {
+    return false;
   }
 
-  // `FabricPrimitive`s are by definition frozen and have no outbound
-  // references.
-  if (value instanceof FabricPrimitive) return true;
+  // At this point, it's known to be a deep-frozen value with internal
+  // structure, but we don't know if it's actually a `FabricValue`.
 
-  // `FabricInstance`s might have references, but -- TODO(@danfuzz) -- we have
-  // no way of handling them yet.
-  if (value instanceof FabricInstance) {
-    throw new Error(
-      `Cannot yet handle instance of class ${value.constructor.name}`,
-    );
-  }
+  const seen = new Set();
+  const checkValue = (item: object) => {
+    if (seen.has(item)) {
+      return true;
+    }
 
-  for (const v of Object.values(value)) {
-    if (!isDeepFrozenFabricValue(v)) return false;
-  }
-  return true;
+    seen.add(item);
+
+    if (item instanceof FabricPrimitive) {
+      // `FabricPrimitive`s are by definition frozen and have no outbound
+      // references.
+      return true;
+    } else if (item instanceof FabricInstance) {
+      // `FabricInstance`s might have references, but -- TODO(@danfuzz) -- we
+      // have no way of handling them yet.
+      throw new Error(
+        `Cannot yet handle instance of class ${item.constructor.name}`,
+      );
+    } else if (Array.isArray(item)) {
+      for (let i = 0; i <= item.length; i++) {
+        if (i in item && !isDeepFrozenFabricValue(item[i])) return false;
+      }
+      return true;
+    } else {
+      for (const v of Object.values(item)) {
+        if (!isDeepFrozenFabricValue(v)) return false;
+      }
+      return true;
+    }
+  };
+
+  return checkValue(value);
 }

--- a/packages/data-model/fabric-native-instances.ts
+++ b/packages/data-model/fabric-native-instances.ts
@@ -5,10 +5,13 @@ import {
   RECONSTRUCT,
   type ReconstructionContext,
 } from "./interface.ts";
-
+import { isDeepFrozen, deepFreeze } from "./deep-freeze.ts";
 import { NATIVE_TAGS, tagFromNativeValue } from "./native-type-tags.ts";
 import { TAGS } from "./fabric-type-tags.ts";
 import { FrozenMap, FrozenSet } from "./frozen-builtins.ts";
+import {
+  EMPTY_RECONSTRUCTION_CONTEXT,
+} from "./empty-reconstruction-context.ts";
 
 // ---------------------------------------------------------------------------
 // Utility: native-instance type guard
@@ -140,6 +143,11 @@ export abstract class FabricNativeWrapper<T extends object>
     if (frozen === Object.isFrozen(value)) return value;
     return frozen ? this.toNativeFrozen() : this.toNativeThawed();
   }
+
+  /** @inheritDoc */
+  deepClone(frozen: boolean): FabricInstance {
+    throw new Error(`Cannot yet handle deep cloning of \`${this.constructor.name}\`.`);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -219,6 +227,36 @@ export class FabricError extends FabricNativeWrapper<Error> {
   /** @inheritDoc */
   protected toNativeThawed(): Error {
     return copyError(this.error);
+  }
+
+  /** @inheritDoc */
+  override deepClone(frozen: boolean): FabricError {
+    // TODO(danfuzz): This is a partial implementation, meant to keep thins
+    // working well enough as the modern data model gets fleshed out.
+    // Ultimately, concrete classes should not have to implement this method at
+    // all.
+
+    if (frozen && isDeepFrozen(this)) {
+      return this;
+    }
+
+    // This makes a result that just has the  string properties of the original.
+
+    const state: Record<string, unknown> =
+      this[DECONSTRUCT]() as Record<string, unknown>;
+
+    for (const key in state) {
+      if (typeof state[key] !== "string") {
+        delete state[key];
+      }
+    }
+
+    const result =
+      FabricError[RECONSTRUCT](state, EMPTY_RECONSTRUCTION_CONTEXT);
+
+    return frozen
+      ? Object.freeze(result) as FabricError
+      : result;
   }
 
   /**

--- a/packages/data-model/fabric-native-instances.ts
+++ b/packages/data-model/fabric-native-instances.ts
@@ -5,7 +5,7 @@ import {
   RECONSTRUCT,
   type ReconstructionContext,
 } from "./interface.ts";
-import { isDeepFrozen, deepFreeze } from "./deep-freeze.ts";
+import { deepFreeze, isDeepFrozen } from "./deep-freeze.ts";
 import { NATIVE_TAGS, tagFromNativeValue } from "./native-type-tags.ts";
 import { TAGS } from "./fabric-type-tags.ts";
 import { FrozenMap, FrozenSet } from "./frozen-builtins.ts";
@@ -146,7 +146,9 @@ export abstract class FabricNativeWrapper<T extends object>
 
   /** @inheritDoc */
   deepClone(frozen: boolean): FabricInstance {
-    throw new Error(`Cannot yet handle deep cloning of \`${this.constructor.name}\`.`);
+    throw new Error(
+      `Cannot yet handle deep cloning of \`${this.constructor.name}\`.`,
+    );
   }
 }
 
@@ -242,8 +244,10 @@ export class FabricError extends FabricNativeWrapper<Error> {
 
     // This makes a result that just has the  string properties of the original.
 
-    const state: Record<string, unknown> =
-      this[DECONSTRUCT]() as Record<string, unknown>;
+    const state: Record<string, unknown> = this[DECONSTRUCT]() as Record<
+      string,
+      unknown
+    >;
 
     for (const key in state) {
       if (typeof state[key] !== "string") {
@@ -251,12 +255,12 @@ export class FabricError extends FabricNativeWrapper<Error> {
       }
     }
 
-    const result =
-      FabricError[RECONSTRUCT](state, EMPTY_RECONSTRUCTION_CONTEXT);
+    const result = FabricError[RECONSTRUCT](
+      state,
+      EMPTY_RECONSTRUCTION_CONTEXT,
+    );
 
-    return frozen
-      ? Object.freeze(result) as FabricError
-      : result;
+    return frozen ? Object.freeze(result) as FabricError : result;
   }
 
   /**

--- a/packages/data-model/fabric-native-instances.ts
+++ b/packages/data-model/fabric-native-instances.ts
@@ -5,7 +5,7 @@ import {
   RECONSTRUCT,
   type ReconstructionContext,
 } from "./interface.ts";
-import { deepFreeze, isDeepFrozen } from "./deep-freeze.ts";
+import { isDeepFrozen } from "./deep-freeze.ts";
 import { NATIVE_TAGS, tagFromNativeValue } from "./native-type-tags.ts";
 import { TAGS } from "./fabric-type-tags.ts";
 import { FrozenMap, FrozenSet } from "./frozen-builtins.ts";
@@ -145,7 +145,7 @@ export abstract class FabricNativeWrapper<T extends object>
   }
 
   /** @inheritDoc */
-  deepClone(frozen: boolean): FabricInstance {
+  deepClone(_frozen: boolean): FabricInstance {
     throw new Error(
       `Cannot yet handle deep cloning of \`${this.constructor.name}\`.`,
     );

--- a/packages/data-model/fabric-native-instances.ts
+++ b/packages/data-model/fabric-native-instances.ts
@@ -5,7 +5,7 @@ import {
   RECONSTRUCT,
   type ReconstructionContext,
 } from "./interface.ts";
-import { isDeepFrozen } from "./deep-freeze.ts";
+import { deepFreeze, isDeepFrozen } from "./deep-freeze.ts";
 import { NATIVE_TAGS, tagFromNativeValue } from "./native-type-tags.ts";
 import { TAGS } from "./fabric-type-tags.ts";
 import { FrozenMap, FrozenSet } from "./frozen-builtins.ts";
@@ -260,7 +260,7 @@ export class FabricError extends FabricNativeWrapper<Error> {
       EMPTY_RECONSTRUCTION_CONTEXT,
     );
 
-    return frozen ? Object.freeze(result) as FabricError : result;
+    return frozen ? deepFreeze(result) : result;
   }
 
   /**

--- a/packages/data-model/fabric-value-modern.ts
+++ b/packages/data-model/fabric-value-modern.ts
@@ -633,9 +633,9 @@ function cloneHelper(
       if (canReturnAsIs(value)) {
         return value;
       } else if (deep) {
-        throw new Error("Cannot yet handle deep cloning of `FabricInstance`s.");
+        return (value as FabricInstance).deepClone(frozen);
       } else {
-        return (value as FabricInstance).shallowClone(frozen) as FabricValue;
+        return (value as FabricInstance).shallowClone(frozen);
       }
     }
 

--- a/packages/data-model/fabric-value-modern.ts
+++ b/packages/data-model/fabric-value-modern.ts
@@ -2,7 +2,6 @@ import { isInstance, isRecord } from "@commonfabric/utils/types";
 import {
   FabricInstance,
   type FabricNativeObject,
-  FabricPrimitive,
   FabricSpecialObject,
   type FabricValue,
   type FabricValueLayer,
@@ -629,10 +628,16 @@ function cloneHelper(
     case NATIVE_TAGS.FabricBytes:
       return value;
 
-    case NATIVE_TAGS.FabricInstance:
+    case NATIVE_TAGS.FabricInstance: {
       // Identity optimization: already-correct frozenness needs no clone.
-      if (canReturnAsIs(value)) return value;
-      return (value as FabricInstance).shallowClone(frozen) as FabricValue;
+      if (canReturnAsIs(value)) {
+        return value;
+      } else if (deep) {
+        throw new Error("Cannot yet handle deep cloning of `FabricInstance`s.");
+      } else {
+        return (value as FabricInstance).shallowClone(frozen) as FabricValue;
+      }
+    }
 
     case NATIVE_TAGS.Array: {
       if (canReturnAsIs(value)) return value;

--- a/packages/data-model/fabric-value-modern.ts
+++ b/packages/data-model/fabric-value-modern.ts
@@ -18,6 +18,7 @@ import {
 import { FabricBytes } from "./fabric-bytes.ts";
 import { NATIVE_TAGS, tagFromNativeValue } from "./native-type-tags.ts";
 import { isArrayWithOnlyIndexProperties } from "./array-utils.ts";
+import { isDeepFrozenFabricValue } from "./deep-freeze.ts";
 
 /**
  * Helper for `shallowFabricFromNativeValueModern()`, which rejects native
@@ -247,41 +248,6 @@ export function fabricFromNativeValueModern(
     new Map(),
     freeze,
   ) as FabricValue;
-}
-
-/**
- * Helper for `fabricFromNativeValueModern()` and `cloneHelper()`, which
- * indicates whether the value is a deep-frozen `FabricValue` (naive recursive
- * check). Returns `true` if the value is a primitive, or a frozen
- * object/array whose children are all also deep-frozen `FabricValue`s.
- */
-function isDeepFrozenFabricValue(value: unknown): boolean {
-  if (value === null || (typeof value !== "object")) return true; // primitives
-  if (!Object.isFrozen(value)) return false;
-
-  if (Array.isArray(value)) {
-    for (let i = 0; i < value.length; i++) {
-      if (i in value && !isDeepFrozenFabricValue(value[i])) return false;
-    }
-    return true;
-  }
-
-  // `FabricPrimitive`s are by definition frozen and have no outbound
-  // references.
-  if (value instanceof FabricPrimitive) return true;
-
-  // `FabricInstance`s might have references, but -- TODO(@danfuzz) -- we have
-  // no way of handling them yet.
-  if (value instanceof FabricInstance) {
-    throw new Error(
-      `Cannot yet handle instance of class ${value.constructor.name}`,
-    );
-  }
-
-  for (const v of Object.values(value)) {
-    if (!isDeepFrozenFabricValue(v)) return false;
-  }
-  return true;
 }
 
 /**
@@ -640,8 +606,9 @@ function cloneHelper(
   seen: Set<object> | null,
 ): FabricValue {
   // Identity optimization: when `force` is off, check if the value's frozenness
-  // already matches the requested state. Deep mode uses `isDeepFrozenFabricValue()`;
-  // shallow mode uses `Object.isFrozen(v) === frozen`.
+  // already matches the requested state. Deep mode uses
+  // `isDeepFrozenFabricValue()`; shallow mode uses `Object.isFrozen(v) ===
+  // frozen`.
   function canReturnAsIs(v: FabricValue): boolean {
     if (force) return false;
     if (deep) {

--- a/packages/data-model/interface.ts
+++ b/packages/data-model/interface.ts
@@ -46,16 +46,9 @@ export const RECONSTRUCT: unique symbol = Symbol.for("common.reconstruct");
  * Abstract base class for values that participate in the fabric protocol.
  * See Section 2.3 of the formal spec.
  *
- * Subclasses must implement:
- * - `[DECONSTRUCT]()` -- returns essential state for serialization.
- * - `shallowUnfrozenClone()` -- returns a new unfrozen copy of this instance.
- *
- * `shallowClone(frozen)` is an effectively-final method that manages the
- * frozenness contract:
- * - `shallowClone(true)` on a frozen instance returns `this` (identity).
- * - `shallowClone(true)` on an unfrozen instance returns a frozen clone.
- * - `shallowClone(false)` always returns a new unfrozen clone -- even if the
- *   instance is already unfrozen. The caller gets a distinct, mutable object.
+ * Subclasses must implement `[DECONSTRUCT]()`, `deepClone()`, and
+ * `shallowUnfrozenClone()`. * Subclasses must also define a static member
+ * `[RECONSTRUCT]()`.
  */
 export abstract class FabricInstance extends FabricSpecialObject {
   /**
@@ -64,6 +57,19 @@ export abstract class FabricInstance extends FabricSpecialObject {
    * serialization system handles that.
    */
   abstract [DECONSTRUCT](): FabricValue;
+
+  /**
+   * Returns a new deep clone of this instance with equivalent data but no
+   * shared structure for any unfrozen data in the original. When `frozen ===
+   * true`, produces a frozen instance with maximal structural sharing, including
+   * returning `this` if it is already deep-frozen. When `frozen === false`,
+   * produces a deeply-mutable instance with no visible shared reference
+   * structure with the original.
+   *
+   * TODO(danfuzz): This method should have a base implementation which defers
+   * to a _different_ `protected abstract` method.
+   */
+  abstract deepClone(frozen: boolean): FabricInstance;
 
   /**
    * Returns a new unfrozen copy of this instance with the same data. Called

--- a/packages/data-model/problematic-value.ts
+++ b/packages/data-model/problematic-value.ts
@@ -27,7 +27,7 @@ export class ProblematicValue extends ExplicitTagValue {
   }
 
   /** @inheritDoc */
-  deepClone(frozen: boolean): ProblematicValue {
+  deepClone(_frozen: boolean): ProblematicValue {
     throw new Error("Cannot yet handle deep cloning of `ProblematicValue`.");
   }
 

--- a/packages/data-model/problematic-value.ts
+++ b/packages/data-model/problematic-value.ts
@@ -26,6 +26,11 @@ export class ProblematicValue extends ExplicitTagValue {
     return { type: this.typeTag, state: this.state, error: this.error };
   }
 
+  /** @inheritDoc */
+  deepClone(frozen: boolean): ProblematicValue {
+    throw new Error("Cannot yet handle deep cloning of `ProblematicValue`.");
+  }
+
   protected shallowUnfrozenClone(): ProblematicValue {
     return new ProblematicValue(this.typeTag, this.state, this.error);
   }

--- a/packages/data-model/test/clone-if-necessary.test.ts
+++ b/packages/data-model/test/clone-if-necessary.test.ts
@@ -246,40 +246,51 @@ describe("cloneIfNecessary", () => {
     describe(`FabricInstance (${label} path)`, () => {
       beforeEach(() => setDataModelConfig(modernMode));
 
-      it("frozen `FabricError` cannot yet be cloned", () => {
+      it("deep-clones a frozen `FabricError` (partial)", () => {
+        // Deep cloning of `FabricInstance` is now (partially) supported: the
+        // `FabricError` is rebuilt from its string-valued state, so the
+        // result is a fresh frozen `FabricError` preserving `message`.
         const error = new FabricError(new Error("test"));
         Object.freeze(error);
-        const func = () => cloneIfNecessary(error);
-        expect(func).toThrow(/Cannot yet handle/);
+        const result = cloneIfNecessary(error);
+        expect(result).toBeInstanceOf(FabricError);
+        expect(result).not.toBe(error); // rebuilt (inner Error was not frozen)
+        expect(Object.isFrozen(result)).toBe(true);
+        expect((result as FabricError).error.message).toBe("test");
       });
 
-      it("produces mutable FabricError clone (shallow, frozen=false)", () => {
-        // A *deep* clone of a `FabricInstance` now throws (we can't yet
-        // traverse its internals), so the only way to get a mutable clone is
-        // a shallow one: `deep: false` yields a `shallowClone()`.
+      it("produces a mutable FabricError clone (deep, frozen=false)", () => {
+        // Deep clone with `frozen: false` yields a fresh *mutable*
+        // `FabricError` (rebuilt from string state, not frozen).
         const error = new FabricError(new Error("test"));
         Object.freeze(error);
         const result = cloneIfNecessary(
           error as unknown as FabricValue,
-          { frozen: false, deep: false },
+          { frozen: false },
         );
         expect(result).toBeInstanceOf(FabricError);
         expect(result).not.toBe(error);
         expect(Object.isFrozen(result)).toBe(false);
+        expect((result as FabricError).error.message).toBe("test");
       });
 
-      it("cannot yet deep-clone a FabricError nested in an object", () => {
-        // The can't-handle guard fires for *nested* `FabricInstance`s too,
-        // not just a top-level one.
+      it("deep-clones a FabricError nested in an object (partial)", () => {
+        // Nested `FabricInstance`s are deep-cloned too, not shared: each is
+        // rebuilt from its string state.
         const error = new FabricError(new Error("nested"));
         const value = { err: error, x: 42 } as FabricValue;
-        expect(() => cloneIfNecessary(value)).toThrow(/Cannot yet handle/);
+        const result = cloneIfNecessary(value) as Record<string, unknown>;
+        expect(result).not.toBe(value);
+        expect(Object.isFrozen(result)).toBe(true);
+        expect(result.err).toBeInstanceOf(FabricError);
+        expect(result.err).not.toBe(error); // deep-cloned, not shared
+        expect((result.err as FabricError).error.message).toBe("nested");
+        expect(result.x).toBe(42);
       });
 
       it("shallow-clones an object containing a FabricError (deep=false)", () => {
-        // The guard is specifically about *deep* traversal: a shallow clone
-        // of a container is fine -- the nested instance is shared by
-        // reference, never traversed.
+        // Shallow clone of a container shares the nested instance by
+        // reference -- it is never traversed or rebuilt.
         const error = new FabricError(new Error("nested"));
         const value = { err: error, x: 42 } as FabricValue;
         const result = cloneIfNecessary(value, { deep: false }) as Record<

--- a/packages/data-model/test/clone-if-necessary.test.ts
+++ b/packages/data-model/test/clone-if-necessary.test.ts
@@ -253,24 +253,42 @@ describe("cloneIfNecessary", () => {
         expect(func).toThrow(/Cannot yet handle/);
       });
 
-      it("produces mutable FabricError clone when frozen=false", () => {
+      it("produces mutable FabricError clone (shallow, frozen=false)", () => {
+        // A *deep* clone of a `FabricInstance` now throws (we can't yet
+        // traverse its internals), so the only way to get a mutable clone is
+        // a shallow one: `deep: false` yields a `shallowClone()`.
         const error = new FabricError(new Error("test"));
         Object.freeze(error);
         const result = cloneIfNecessary(
           error as unknown as FabricValue,
-          { frozen: false },
+          { frozen: false, deep: false },
         );
         expect(result).toBeInstanceOf(FabricError);
         expect(result).not.toBe(error);
         expect(Object.isFrozen(result)).toBe(false);
       });
 
-      it("handles FabricError nested in an object", () => {
+      it("cannot yet deep-clone a FabricError nested in an object", () => {
+        // The can't-handle guard fires for *nested* `FabricInstance`s too,
+        // not just a top-level one.
         const error = new FabricError(new Error("nested"));
         const value = { err: error, x: 42 } as FabricValue;
-        const result = cloneIfNecessary(value) as Record<string, unknown>;
+        expect(() => cloneIfNecessary(value)).toThrow(/Cannot yet handle/);
+      });
+
+      it("shallow-clones an object containing a FabricError (deep=false)", () => {
+        // The guard is specifically about *deep* traversal: a shallow clone
+        // of a container is fine -- the nested instance is shared by
+        // reference, never traversed.
+        const error = new FabricError(new Error("nested"));
+        const value = { err: error, x: 42 } as FabricValue;
+        const result = cloneIfNecessary(value, { deep: false }) as Record<
+          string,
+          unknown
+        >;
+        expect(result).not.toBe(value);
         expect(Object.isFrozen(result)).toBe(true);
-        expect(result.err).toBeInstanceOf(FabricError);
+        expect(result.err).toBe(error);
         expect(result.x).toBe(42);
       });
     });

--- a/packages/data-model/test/fabric-native-instances.test.ts
+++ b/packages/data-model/test/fabric-native-instances.test.ts
@@ -838,6 +838,9 @@ describe("fabric-native-instances", () => {
         [DECONSTRUCT](): FabricValue {
           return { value: 42 };
         }
+        deepClone(_frozen: boolean): CustomFabInst {
+          return new CustomFabInst();
+        }
         protected shallowUnfrozenClone(): CustomFabInst {
           return new CustomFabInst();
         }

--- a/packages/data-model/unknown-value.ts
+++ b/packages/data-model/unknown-value.ts
@@ -23,7 +23,7 @@ export class UnknownValue extends ExplicitTagValue {
   }
 
   /** @inheritDoc */
-  deepClone(frozen: boolean): UnknownValue {
+  deepClone(_frozen: boolean): UnknownValue {
     throw new Error("Cannot yet handle deep cloning of `UnknownValue`.");
   }
 

--- a/packages/data-model/unknown-value.ts
+++ b/packages/data-model/unknown-value.ts
@@ -22,6 +22,11 @@ export class UnknownValue extends ExplicitTagValue {
     return { type: this.typeTag, state: this.state };
   }
 
+  /** @inheritDoc */
+  deepClone(frozen: boolean): UnknownValue {
+    throw new Error("Cannot yet handle deep cloning of `UnknownValue`.");
+  }
+
   protected shallowUnfrozenClone(): UnknownValue {
     return new UnknownValue(this.typeTag, this.state);
   }

--- a/packages/utils/src/strip-undefined-props.ts
+++ b/packages/utils/src/strip-undefined-props.ts
@@ -1,3 +1,5 @@
+import { isPlainObject } from "./types.ts";
+
 /**
  * Returns a copy of `value` with `undefined`-valued properties removed,
  * recursively through plain-object values. Non-plain-object values
@@ -32,10 +34,4 @@ export function stripUndefinedProps(
     });
   }
   return out;
-}
-
-function isPlainObject(value: unknown): boolean {
-  if (value === null || typeof value !== "object") return false;
-  const proto = Object.getPrototypeOf(value);
-  return proto === Object.prototype || proto === null;
 }

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -74,6 +74,17 @@ export function isFiniteNumber(value: unknown): boolean {
 }
 
 /**
+ * Check whether a value is a plain object.
+ * @param value - The value to check
+ * @returns True if the value is a plain object
+ */
+export function isPlainObject(value: unknown): boolean {
+  if (value === null || typeof value !== "object") return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+/**
  * Predicate for narrowing a `string` type.
  * @param value - The value to check
  * @returns True if the value is a string

--- a/packages/utils/test/types.test.ts
+++ b/packages/utils/test/types.test.ts
@@ -7,6 +7,7 @@ import {
   isInstance,
   isNumber,
   isObject,
+  isPlainObject,
   isRecord,
   isString,
   Mutable,
@@ -195,6 +196,39 @@ describe("types", () => {
 
     it("returns false for functions", () => {
       expect(isObject(() => {})).toBe(false);
+    });
+  });
+
+  describe("isPlainObject", () => {
+    it("returns true for object literals", () => {
+      expect(isPlainObject({})).toBe(true);
+      expect(isPlainObject({ a: 1 })).toBe(true);
+      expect(isPlainObject(new Object())).toBe(true);
+    });
+
+    it("returns true for null-prototype objects", () => {
+      expect(isPlainObject(Object.create(null))).toBe(true);
+    });
+
+    it("returns false for arrays and class instances", () => {
+      class MyClass {}
+      expect(isPlainObject([])).toBe(false);
+      expect(isPlainObject([1, 2, 3])).toBe(false);
+      expect(isPlainObject(new Date())).toBe(false);
+      expect(isPlainObject(new Map())).toBe(false);
+      expect(isPlainObject(/regex/)).toBe(false);
+      expect(isPlainObject(new MyClass())).toBe(false);
+      expect(isPlainObject(Object.create({}))).toBe(false);
+    });
+
+    it("returns false for null, primitives, and functions", () => {
+      expect(isPlainObject(null)).toBe(false);
+      expect(isPlainObject(undefined)).toBe(false);
+      expect(isPlainObject(42)).toBe(false);
+      expect(isPlainObject("string")).toBe(false);
+      expect(isPlainObject(true)).toBe(false);
+      expect(isPlainObject(Symbol("test"))).toBe(false);
+      expect(isPlainObject(() => {})).toBe(false);
     });
   });
 


### PR DESCRIPTION
## What

Reworks `isDeepFrozenFabricValue()` and lays the groundwork (with a
minimal implementation) for `FabricInstance`s flowing through the modern
data model.

- **Relocates + rewrites `isDeepFrozenFabricValue()`** into
  `deep-freeze.ts` (next to `isDeepFrozen()` / `deepFreeze()`) and makes
  it a real TypeScript type guard (`value is FabricValue`). It delegates
  the deep-frozen check to the shared `isDeepFrozen()` (cycle detection +
  cache) and does the recursive `FabricValue` *type* check via an internal
  `checkValue()` walk (primitive base case, `isPlainObject()` rejection of
  non-`FabricValue` class instances, cycle-safe).
- **Separates two concerns** the old single-pass function quietly
  conflated: *"is this a deep-frozen `FabricValue`?"* (the predicate) vs.
  *"is it safe to clone?"* — the latter now lives explicitly in
  `cloneHelper()`.
- **Adds a minimal / partial `FabricInstance.deepClone(frozen)`**,
  implemented for `FabricError` (rebuild from the string-valued
  `[DECONSTRUCT]()` state via `[RECONSTRUCT]()`; identity fast-path when
  already deep-frozen). Other `FabricInstance` subclasses still throw an
  explicit `Cannot yet handle deep cloning of ...`.
- **Extracts `isPlainObject()`** into `@commonfabric/utils/types` (+ unit
  tests).

## Why

The old predicate did double duty: it `throw`-aborted on a
`FabricInstance` as a de-facto "unsafe to clone" assert, invisibly, at the
call site. Pulling that apart surfaced a real latent bug — deep-cloning a
`FabricInstance` silently produced an *incorrect shallow* clone that
ignored the requested depth. That was masked in the runner storage path
(`applyPendingVersion`) only because the very next call was `deepFreeze()`,
which happened to salvage the result.

Under `modernDataModel: true`, setting an `Error` into a cell wraps it as
a `FabricError` (a `FabricInstance`) that flows through that storage path —
so this is an exercised path, not a test-only fixture. The partial
`deepClone()` keeps that path correct (and explicit) instead of
accidentally-correct.

## Behavioral change — please note

Deep-cloning a `FabricInstance`:

- `FabricError`: now produces a correct fresh clone preserving its
  string-valued state (`message`, etc.). **Non-string state (e.g. `cause`)
  is dropped** — this is the documented partial limitation.
- Other subclasses: now throw an *explicit*
  `Cannot yet handle deep cloning of \`<Class>\`.` (previously a silent,
  incorrect shallow clone).

## Tests

- `data-model` `clone-if-necessary.test.ts`: the `FabricError` cases were
  iterated to the final contract — frozen/mutable deep clones now assert a
  successful rebuilt clone with `message` preserved; a shallow-clone
  companion pins the reference-sharing path.
- `utils` `types.test.ts`: new `isPlainObject` coverage.
- `data-model` and `runner` suites verified green locally (`runner`'s
  `cell-core.test.ts` — the modern `Error`-in-cell path — passes). Full
  repo run in progress.

## Known follow-ups (deferred)

- `FabricError.deepClone()` is partial (string state only); other
  `FabricInstance` subclasses unimplemented.
- The `deepClone()` `already-deep-frozen → this` identity fast-path is
  currently shadowed when reached via `cloneIfNecessary` (the predicate's
  `checkValue()` still throws on a descended `FabricInstance` first); not
  hit by the `frozen: false` storage path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `isDeepFrozenFabricValue()` a proper type guard and adds partial deep cloning for `FabricInstance` (implemented for `FabricError`) to prevent deep clones from becoming shallow.

- **New Features**
  - Moved and rewrote `isDeepFrozenFabricValue()` in `deep-freeze.ts`; delegates to `isDeepFrozen()`, walks `FabricValue` safely with cycle detection, and rejects functions and non-plain objects.
  - Extracted `isPlainObject()` to `@commonfabric/utils/types`; used in `deep-freeze.ts` and `strip-undefined-props.ts`.
  - Added `FabricInstance.deepClone(frozen)`; default throws. `FabricError` is rebuilt from string-only state, deep-freezes when `frozen === true`, and returns `this` when already deep-frozen.

- **Bug Fixes**
  - Fixed `cloneIfNecessary()` so deep-cloning a `FabricInstance` calls `deepClone()` instead of producing a shallow clone; nested `FabricError` clones preserve `message`, while shallow clones keep references.

<sup>Written for commit c705ee67a614b6b2c28baf05624994c6ba25c2ea. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3604?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

