### PR TITLE
Mediate read_file outputs through CFC

### DIFF
--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -85,6 +85,7 @@ import {
   cwdMarkerForOutput,
   extractFinalWorkingDirectory,
 } from "./tools/shell-cwd.ts";
+import { isReadFileToolSuccessOutput } from "./tools/read-file.ts";
 import { isViewImageToolSuccessOutput } from "./tools/view-image.ts";
 import type { HarnessFailureRecord } from "./diagnostics.ts";
 import { DEFAULT_PARENT_TOOL_IDS as DEFAULT_PROMPT_LOOP_TOOL_IDS } from "./contracts/tool-descriptor.ts";
@@ -954,8 +955,12 @@ const stripInternalCfcFields = (output: unknown): unknown => {
   return publicOutput;
 };
 
-const toolOutputNeedsSandboxMediation = (toolId: BuiltinToolId): boolean =>
-  toolId === "bash";
+const toolOutputNeedsSandboxMediation = (
+  toolId: BuiltinToolId,
+  output: unknown,
+): boolean =>
+  toolId === "bash" ||
+  (toolId === "read_file" && isReadFileToolSuccessOutput(output));
 
 const createOutputHandle = (
   resultRef: ToolResultRef,
@@ -1070,6 +1075,30 @@ const truncateModelFacingBashOutput = (
       ? {
         stderrTruncated: true,
         stderrOriginalLength: stderr.originalLength,
+      }
+      : {}),
+  };
+};
+
+const truncateModelFacingReadFileOutput = (
+  output: unknown,
+  resultRef: ToolResultRef,
+): unknown => {
+  if (!isObjectRecord(output)) {
+    return output;
+  }
+  const content = truncateModelFacingBashStream(
+    typeof output.content === "string" ? output.content : "",
+    "stdout",
+    resultRef,
+  );
+  return {
+    ...output,
+    content: content.value,
+    ...(content.truncated === true
+      ? {
+        contentTruncated: true,
+        contentOriginalLength: content.originalLength,
       }
       : {}),
   };
@@ -1263,6 +1292,42 @@ const renderMediatedBashOutput = (
     },
     ...(observations.length > 0
       ? { cfcModelContextObservations: observations }
+      : {}),
+  };
+};
+
+const renderMediatedReadFileOutput = (
+  output: Record<string, unknown>,
+  cfcResult: CfcSandboxResult,
+  resultRef: ToolResultRef,
+  toolCallId: string,
+): ModelFacingToolOutputResult => {
+  const content = truncateModelFacingBashStream(
+    renderStreamObservation(cfcResult.stdout, resultRef),
+    "stdout",
+    resultRef,
+  );
+  const observation = modelContextObservationForStream(
+    cfcResult.stdout,
+    resultRef,
+    toolCallId,
+    content.truncated,
+  );
+  return {
+    output: {
+      outputId: output.outputId,
+      path: output.path,
+      content: content.value,
+      cfc: summarizeCfcSandboxResult(cfcResult),
+      ...(content.truncated === true
+        ? {
+          contentTruncated: true,
+          contentOriginalLength: content.originalLength,
+        }
+        : {}),
+    },
+    ...(observation !== undefined
+      ? { cfcModelContextObservations: [observation] }
       : {}),
   };
 };
@@ -2099,7 +2164,7 @@ export class CfHarnessPromptLoop {
         },
       };
     }
-    if (!toolOutputNeedsSandboxMediation(toolId)) {
+    if (!toolOutputNeedsSandboxMediation(toolId, output)) {
       return { output: stripInternalCfcFields(output) };
     }
     if (cfcResult === undefined) {
@@ -2109,6 +2174,11 @@ export class CfHarnessPromptLoop {
         return {
           output: toolId === "bash"
             ? truncateModelFacingBashOutput(
+              stripInternalCfcFields(output),
+              resultRef,
+            )
+            : toolId === "read_file"
+            ? truncateModelFacingReadFileOutput(
               stripInternalCfcFields(output),
               resultRef,
             )
@@ -2127,6 +2197,11 @@ export class CfHarnessPromptLoop {
         return {
           output: toolId === "bash"
             ? truncateModelFacingBashOutput(
+              stripInternalCfcFields(output),
+              resultRef,
+            )
+            : toolId === "read_file"
+            ? truncateModelFacingReadFileOutput(
               stripInternalCfcFields(output),
               resultRef,
             )
@@ -2149,6 +2224,14 @@ export class CfHarnessPromptLoop {
     }
     if (toolId === "bash" && isObjectRecord(output)) {
       return renderMediatedBashOutput(output, cfcResult, resultRef, toolCallId);
+    }
+    if (toolId === "read_file" && isObjectRecord(output)) {
+      return renderMediatedReadFileOutput(
+        output,
+        cfcResult,
+        resultRef,
+        toolCallId,
+      );
     }
     return { output: stripInternalCfcFields(output) };
   }

--- a/packages/cf-harness/src/tools/read-file.ts
+++ b/packages/cf-harness/src/tools/read-file.ts
@@ -1,4 +1,5 @@
 import type { JSONSchema } from "@commonfabric/api";
+import type { CfcSandboxResult } from "@commonfabric/runner/cfc";
 import type { HarnessToolDescriptor } from "../contracts/tool-descriptor.ts";
 import type { HarnessToolDefinition } from "./types.ts";
 import {
@@ -25,6 +26,7 @@ export interface ReadFileToolSuccessOutput {
   outputId: string;
   path: string;
   content: string;
+  cfcResult?: CfcSandboxResult;
 }
 
 export type ReadFileToolOutput =
@@ -54,6 +56,7 @@ export const readFileToolDescriptor: HarnessToolDescriptor = {
         outputId: { type: "string" },
         path: { type: "string" },
         content: { type: "string" },
+        cfcResult: { type: "object" },
       },
       required: ["outputId", "path", "content"],
       additionalProperties: false,
@@ -61,6 +64,18 @@ export const readFileToolDescriptor: HarnessToolDescriptor = {
   } satisfies JSONSchema,
   tags: ["file", "read", "vm"],
 };
+
+export const isReadFileToolSuccessOutput = (
+  output: unknown,
+): output is ReadFileToolSuccessOutput =>
+  typeof output === "object" &&
+  output !== null &&
+  "outputId" in output &&
+  typeof output.outputId === "string" &&
+  "path" in output &&
+  typeof output.path === "string" &&
+  "content" in output &&
+  typeof output.content === "string";
 
 export const readFileTool: HarnessToolDefinition<
   ReadFileToolInput,
@@ -135,6 +150,9 @@ export const readFileTool: HarnessToolDefinition<
       outputId: context.nextOutputId("read_file"),
       path: resolvedPath,
       content: result.stdout,
+      ...(result.cfcResult !== undefined
+        ? { cfcResult: result.cfcResult }
+        : {}),
     };
   },
 };

--- a/packages/cf-harness/test/artifacts.test.ts
+++ b/packages/cf-harness/test/artifacts.test.ts
@@ -389,7 +389,12 @@ Deno.test({
         engine: new CfHarnessEngine({
           artifactRoot,
           sandboxRuntime: new FakeSandboxRuntime([
-            { stdout: "hello from file", stderr: "", exitCode: 0 },
+            {
+              stdout: "hello from file",
+              stderr: "",
+              exitCode: 0,
+              cfcResult: observedCfcResult("hello from file"),
+            },
           ]),
           runId: "run-loop-persisted",
           model: "gpt-5.4",

--- a/packages/cf-harness/test/docker-runsc-sandbox.test.ts
+++ b/packages/cf-harness/test/docker-runsc-sandbox.test.ts
@@ -450,6 +450,32 @@ Deno.test("DockerRunscSandboxRuntime attaches observed CFC sidecar output", asyn
   }
 });
 
+Deno.test("DockerRunscSandboxRuntime leaves output unmediated when CFC sidecar is missing", async () => {
+  const cfcResultDir = await Deno.makeTempDir();
+  try {
+    const runner = new FakeProcessRunner(
+      dockerLifecycleResults({ stdout: "raw without sidecar\n" }),
+    );
+    const runtime = new DockerRunscSandboxRuntime(
+      resolveDockerRunscSandboxConfig({
+        workspaceHostPath: "/host/project",
+        cfcResultDir,
+      }),
+      runner,
+    );
+
+    const result = await runtime.run({ argv: ["/bin/echo", "public"] });
+
+    assertEquals(result, {
+      stdout: "raw without sidecar\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  } finally {
+    await Deno.remove(cfcResultDir, { recursive: true });
+  }
+});
+
 Deno.test("DockerRunscSandboxRuntime makes tainted sidecar output opaque", async () => {
   const cfcResultDir = await Deno.makeTempDir();
   try {

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -255,6 +255,7 @@ Deno.test("CfHarnessPromptLoop runs a tool call and returns the final assistant 
       ]),
       runId: "run-loop",
       model: "gpt-5.4",
+      cfcEnforcementMode: "disabled",
       now: (() => {
         const timestamps = [
           "2026-04-15T20:00:00.000Z",
@@ -2184,7 +2185,12 @@ Deno.test("CfHarnessPromptLoop reports child run failures through delegate_task 
     apiKey: "test-key",
     engine: new CfHarnessEngine({
       sandboxRuntime: new FakeSandboxRuntime([
-        { stdout: "child file", stderr: "", exitCode: 0 },
+        {
+          stdout: "child file",
+          stderr: "",
+          exitCode: 0,
+          cfcResult: observedCfcResult("child file"),
+        },
       ]),
       runId: "run-delegate-child-failure",
       model: "gpt-5.4",
@@ -2824,6 +2830,7 @@ Deno.test("CfHarnessPromptLoop fails when the model exceeds the configured turn 
       ]),
       runId: "run-max-turns",
       model: "gpt-5.4",
+      cfcEnforcementMode: "disabled",
     }),
     maxModelTurns: 1,
     fetchFn: () =>
@@ -3325,6 +3332,185 @@ const invocationInputLabelContains = (
   );
   return labelHasConfidentialityValue(entry?.label, value);
 };
+
+Deno.test("CfHarnessPromptLoop denies read_file content without CFC metadata in enforce mode", async () => {
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime([
+        { stdout: "secret from file\n", stderr: "", exitCode: 0 },
+      ]),
+      runId: "run-read-file-missing-cfc-result",
+      model: "gpt-5.4",
+      cfcEnforcementMode: "enforce-explicit",
+    }),
+    fetchFn: (() => {
+      let callCount = 0;
+      return () => {
+        callCount += 1;
+        const payload = callCount === 1
+          ? {
+            choices: [{
+              index: 0,
+              message: {
+                role: "assistant",
+                content: "",
+                tool_calls: [{
+                  id: "call-read-missing-cfc-result",
+                  type: "function",
+                  function: {
+                    name: "read_file",
+                    arguments: JSON.stringify({ path: "secret.txt" }),
+                  },
+                }],
+              },
+            }],
+          }
+          : {
+            choices: [{
+              index: 0,
+              message: {
+                role: "assistant",
+                content: "Handled denied file output.",
+              },
+            }],
+          };
+        return Promise.resolve(
+          new Response(JSON.stringify(payload), { status: 200 }),
+        );
+      };
+    })(),
+  });
+
+  const result = await loop.runPrompt({
+    prompt: "Read a file.",
+  });
+
+  const toolMessage = result.transcript.at(-2);
+  assert(toolMessage !== undefined && toolMessage.role === "tool");
+  assert(!toolMessage.content.includes("secret from file"));
+  assertEquals(JSON.parse(toolMessage.content), {
+    type: "cf-harness.observation-denied",
+    reason: "not-observable",
+    detail: "read_file output did not include trusted CFC mediation metadata",
+    handle: {
+      type: "cf-harness.opaque-handle",
+      handleId: "run-read-file-missing-cfc-result:read_file:1:output",
+      scope: "run",
+      createdAt: JSON.parse(toolMessage.content).handle.createdAt,
+    },
+  });
+  assertEquals(result.runState.policyEvents.at(-1)?.severity, "denied");
+});
+
+Deno.test("CfHarnessPromptLoop exposes mediated read_file content and tracks model context", async () => {
+  const fetchCalls: RequestInit[] = [];
+  const secretLabel = "did:key:read-file-secret";
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime([
+        {
+          stdout: "raw file secret\n",
+          stderr: "",
+          exitCode: 0,
+          cfcResult: observedCfcResult("released file secret\n", {
+            stdoutLabel: { confidentiality: [secretLabel] },
+          }),
+        },
+        {
+          stdout: "second\n",
+          stderr: "",
+          exitCode: 0,
+          cfcResult: observedCfcResult("second released\n"),
+        },
+      ]),
+      runId: "run-read-file-cfc-model-context",
+      model: "gpt-5.4",
+      cfcEnforcementMode: "enforce-explicit",
+    }),
+    fetchFn: (_input, init) => {
+      fetchCalls.push(init ?? {});
+      const payload = fetchCalls.length === 1
+        ? {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "",
+              tool_calls: [{
+                id: "call-read-secret-file",
+                type: "function",
+                function: {
+                  name: "read_file",
+                  arguments: JSON.stringify({ path: "secret.txt" }),
+                },
+              }],
+            },
+          }],
+        }
+        : fetchCalls.length === 2
+        ? {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "",
+              tool_calls: [{
+                id: "call-use-file-secret",
+                type: "function",
+                function: {
+                  name: "bash",
+                  arguments: JSON.stringify({ command: "printf done" }),
+                },
+              }],
+            },
+          }],
+        }
+        : {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "Done.",
+            },
+          }],
+        };
+      return Promise.resolve(
+        new Response(JSON.stringify(payload), { status: 200 }),
+      );
+    },
+  });
+
+  const result = await loop.runPrompt({
+    prompt: "Read a file, then run a direct command.",
+    promptSlotBinding: directPromptSlotBinding,
+  });
+
+  const readFileToolMessage = result.transcript.find((message) =>
+    message.role === "tool" && message.toolName === "read_file"
+  );
+  assert(readFileToolMessage !== undefined);
+  assert(!readFileToolMessage.content.includes("raw file secret"));
+  const content = JSON.parse(readFileToolMessage.content);
+  assertEquals(content.outputId, "run-read-file-cfc-model-context:read_file:1");
+  assertEquals(content.path, "/workspace/secret.txt");
+  assertEquals(content.content, "released file secret\n");
+  assertEquals(content.cfc.stdout.policy, "observed");
+  assertEquals(
+    result.runState.cfcModelContext?.observations.some((observation) =>
+      observation.toolCallId === "call-read-secret-file" &&
+      observation.toolId === "read_file" &&
+      observation.channels.includes("stdout") &&
+      labelHasConfidentialityValue(observation.label, secretLabel)
+    ),
+    true,
+  );
+  assertEquals(
+    invocationInputLabelContains(result.runState, 1, "command", secretLabel),
+    true,
+  );
+});
 
 Deno.test("CfHarnessPromptLoop accumulates observed CFC labels for the next model turn", async () => {
   const fetchCalls: RequestInit[] = [];

--- a/packages/cf-harness/test/tools-execution.test.ts
+++ b/packages/cf-harness/test/tools-execution.test.ts
@@ -687,6 +687,27 @@ Deno.test("read_file tool resolves relative paths from the session currentDir", 
   );
 });
 
+Deno.test("read_file tool preserves CFC result on success", async () => {
+  const cfcResult = observedCfcResult("released file");
+  const sandbox = new FakeSandboxRuntime([{
+    stdout: "raw file",
+    stderr: "",
+    exitCode: 0,
+    cfcResult,
+  }]);
+
+  const output = await readFileTool.invoke(createContext(sandbox), {
+    path: "notes/todo.txt",
+  });
+
+  assertEquals(output, {
+    outputId: "run-1:read_file:1",
+    path: "/workspace/notes/todo.txt",
+    content: "raw file",
+    cfcResult,
+  });
+});
+
 Deno.test("read_file tool rejects non-integer maxBytes", async () => {
   const sandbox = new FakeSandboxRuntime();
 


### PR DESCRIPTION
## Summary
- Preserve trusted `cfcResult` metadata on successful `read_file` tool outputs.
- Treat successful `read_file` output as CFC-mediated before it reaches the model, while preserving structured file-tool failures as recoverable operational outputs.
- Record observed read content labels into `cfcModelContext` so later model-authored sandbox inputs carry the influence label.

## Tests
- `deno fmt packages/cf-harness/src/tools/read-file.ts packages/cf-harness/src/prompt-loop.ts packages/cf-harness/test/tools-execution.test.ts packages/cf-harness/test/prompt-loop.test.ts packages/cf-harness/test/artifacts.test.ts`
- `deno test --allow-env --allow-read --allow-run --allow-write packages/cf-harness/test/tools-execution.test.ts packages/cf-harness/test/prompt-loop.test.ts packages/cf-harness/test/artifacts.test.ts packages/cf-harness/test/cfc-invocation-context.test.ts`
- `cd packages/cf-harness && deno task test`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mediates `read_file` outputs through CFC so the model only sees observed content with trusted metadata. Also propagates observed content labels into `cfcModelContext` and denies unmediated reads when enforcement is on.

- **New Features**
  - Treat successful `read_file` results as CFC-mediated; include summarized CFC info and truncate long content in model-facing output.
  - Preserve trusted `cfcResult` on `read_file` success and add `isReadFileToolSuccessOutput` for detection.
  - Deny `read_file` outputs without CFC metadata in `enforce-explicit` mode (observation-denied handle); otherwise pass through truncated content.
  - Record observed `read_file` stdout labels into `cfcModelContext` so later tool inputs (e.g., `bash`) carry the influence label.
  - Prompt loop only mediates `bash` and successful `read_file` outputs; Docker runsc leaves output unmediated when the CFC sidecar is missing.

<sup>Written for commit 7ad9bb18a5d24fa0bc61a2a34c01e6cd9a0fd5b6. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3606?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

