### PR TITLE
feat(cli): Add scoped cf cell reference syntax

### DIFF
--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -592,6 +592,8 @@ well-known IDs. See docs/common/concepts/well-known-ids.md for IDs and usage.`,
         {
           start: options.start,
           allowNonExisting: !!(options as any).allowNonExisting,
+          sourceScope: source.scope,
+          targetScope: target.scope,
         },
       );
     } catch (error) {

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -29,6 +29,7 @@ import { render, safeStringify } from "../lib/render.ts";
 import { decode } from "@commonfabric/utils/encoding";
 import { cliText } from "../lib/cli-name.ts";
 import { absPath } from "../lib/utils.ts";
+import type { CellScope } from "@commonfabric/api";
 import { parseCellPath } from "@commonfabric/runner";
 import { UI } from "@commonfabric/runner";
 import ports from "@commonfabric/ports" with { type: "json" };
@@ -874,6 +875,27 @@ interface PieceCLIOptions {
   url?: string;
 }
 
+const CELL_SCOPE_VALUES = new Set(["space", "user", "session"]);
+
+function parseScopedIdSegment(id: string): {
+  id: string;
+  scope?: CellScope;
+} {
+  const scopeSeparator = id.lastIndexOf("@");
+  if (scopeSeparator === -1) return { id };
+
+  const scope = id.slice(scopeSeparator + 1);
+  const scopedId = id.slice(0, scopeSeparator);
+  if (!scopedId || !CELL_SCOPE_VALUES.has(scope)) {
+    throw new ValidationError(
+      `Invalid scope suffix "@${scope}". Expected @space, @user, or @session.`,
+      { exitCode: 1 },
+    );
+  }
+
+  return { id: scopedId, scope: scope as CellScope };
+}
+
 function parseSetHomeOptions(
   input: PieceCLIOptions,
 ): Omit<SpaceConfig, "space"> {
@@ -930,10 +952,11 @@ export function parseSpaceOptions(
   };
 
   if (input.url) {
-    const { apiUrl, space, piece } = parseUrl(input.url);
+    const { apiUrl, space, piece, pieceScope } = parseUrl(input.url);
     output.apiUrl = apiUrl;
     output.space = space;
     output.piece = piece;
+    if (pieceScope) output.pieceScope = pieceScope;
     return output as PieceConfig;
   }
 
@@ -953,7 +976,9 @@ export function parseSpaceOptions(
   if (input.piece) {
     // Do not validate here -- piece is only
     // required via `parsePieceOptions`
-    output.piece = input.piece;
+    const parsedPiece = parseScopedIdSegment(input.piece);
+    output.piece = parsedPiece.id;
+    if (parsedPiece.scope) output.pieceScope = parsedPiece.scope;
   }
 
   output.apiUrl = input.apiUrl;
@@ -971,7 +996,7 @@ export function parseSpaceOptions(
 export function parseLink(
   ref: string,
   _options?: { allowWellKnown?: boolean },
-): { pieceId: string; path?: (string | number)[] } {
+): { pieceId: string; scope?: CellScope; path?: (string | number)[] } {
   const parts = ref.split("/");
   if (parts.length < 1) {
     throw new ValidationError(
@@ -980,21 +1005,26 @@ export function parseLink(
     );
   }
 
-  const pieceId = parts[0];
+  const parsedPiece = parseScopedIdSegment(parts[0]);
+  const pieceId = parsedPiece.id;
 
   if (parts.length === 1) {
     // If this is a well-known ID (no path) and allowWellKnown is not explicitly true,
     // we might want to handle it differently in the future
-    return { pieceId };
+    return { pieceId, ...(parsedPiece.scope && { scope: parsedPiece.scope }) };
   }
 
   const path = parseCellPath(parts.slice(1).join("/"));
-  return { pieceId, path };
+  return {
+    pieceId,
+    ...(parsedPiece.scope && { scope: parsedPiece.scope }),
+    path,
+  };
 }
 
 function parseUrl(
   input: string,
-): { apiUrl: string; space: string; piece?: string } {
+): { apiUrl: string; space: string; piece?: string; pieceScope?: CellScope } {
   let url;
   try {
     url = new URL(input);
@@ -1012,7 +1042,14 @@ function parseUrl(
       { exitCode: 1 },
     );
   }
-  return { apiUrl, space, piece };
+  if (!piece) return { apiUrl, space };
+  const parsedPiece = parseScopedIdSegment(piece);
+  return {
+    apiUrl,
+    space,
+    piece: parsedPiece.id,
+    ...(parsedPiece.scope && { pieceScope: parsedPiece.scope }),
+  };
 }
 
 // We use stdin for piece input which must be an `Object`

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -552,6 +552,12 @@ well-known IDs. See docs/common/concepts/well-known-ids.md for IDs and usage.`,
   )
   .example(
     cliText(
+      `cf piece link ${EX_ID} ${EX_COMP} bafypiece1@user/profile bafypiece2@session/currentProfile`,
+    ),
+    `Link scoped cell instances using @user or @session on the piece ID.`,
+  )
+  .example(
+    cliText(
       `cf piece link ${EX_ID} ${EX_COMP} baedreiahv63wxwgaem4hzjkizl4qncfgvca7pj5cvdon7cukumfon3ioye bafypiece1/allPieces`,
     ),
     `Link well-known "allPieces" list to a piece field.`,
@@ -626,6 +632,13 @@ PATH FORMAT: Use forward slashes and numeric indices for arrays.
       `cf piece get ${EX_ID} ${EX_COMP_PIECE} data/users/0/email --input`,
     ),
     `Get a nested field value from piece input "${RAW_EX_COMP.piece!}".`,
+  )
+  .example(
+    cliText(
+      `cf piece get ${EX_ID} ${EX_COMP} --piece ${RAW_EX_COMP
+        .piece!}@session draft`,
+    ),
+    `Get a value from a session-scoped piece instance.`,
   )
   .example(
     cliText(`cf piece get ${EX_ID} ${EX_COMP_PIECE}`),

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -1,4 +1,4 @@
-import type { JSONSchema } from "@commonfabric/api";
+import type { CellScope, JSONSchema } from "@commonfabric/api";
 import {
   type CallableKind,
   classifyCallableEntry,
@@ -33,6 +33,7 @@ export interface CallableCellLike {
   asSchemaFromLinks?: () => CallableCellLike;
   key: (segment: string) => CallableCellLike;
   pull?: () => Promise<unknown>;
+  getAsNormalizedFullLink?: () => { scope?: CellScope };
   send?: (
     value: unknown,
     onCommit?: (tx: CallableTransactionLike) => void,
@@ -54,6 +55,7 @@ export interface CallableRuntimeLike {
     id: string,
     schema: JSONSchema | undefined,
     tx: CallableTransactionLike,
+    scope?: CellScope,
   ) => CallableCellLike;
   run: (
     tx: CallableTransactionLike,
@@ -334,11 +336,13 @@ export async function executeResolvedCallable(
     resolved.callableCell.key("extraParams").get?.(),
   );
   const tx = resolved.manager.runtime.edit();
+  const resultScope = resolved.callableCell.getAsNormalizedFullLink?.().scope;
   const resultCell = resolved.manager.runtime.getCell(
     resolved.space,
     deps.uuid?.() ?? crypto.randomUUID(),
     pattern?.resultSchema,
     tx,
+    resultScope,
   );
   const running = resolved.manager.runtime.run(
     tx,

--- a/packages/cli/lib/piece-render.ts
+++ b/packages/cli/lib/piece-render.ts
@@ -32,7 +32,12 @@ export async function renderPiece(
   // 2. Get piece controller to access the Cell
   const manager = await loadManager(config);
   const pieces = new PiecesController(manager);
-  const piece = await pieces.get(config.piece, options.start ?? true);
+  const piece = await pieces.get(
+    config.piece,
+    options.start ?? true,
+    undefined,
+    config.pieceScope,
+  );
   const cell = piece.getCell().asSchema({
     type: "object",
     properties: {

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -311,7 +311,12 @@ export async function setPiecePattern(
 ): Promise<void> {
   const manager = await loadManager(config);
   const pieces = new PiecesController(manager);
-  const piece = await pieces.get(config.piece, false, undefined, config.pieceScope);
+  const piece = await pieces.get(
+    config.piece,
+    false,
+    undefined,
+    config.pieceScope,
+  );
   await piece.setPattern(await getProgramFromFile(manager, entry));
 }
 
@@ -322,7 +327,12 @@ export async function savePiecePattern(
   await ensureDir(outPath);
   const manager = await loadManager(config);
   const pieces = new PiecesController(manager);
-  const piece = await pieces.get(config.piece, false, undefined, config.pieceScope);
+  const piece = await pieces.get(
+    config.piece,
+    false,
+    undefined,
+    config.pieceScope,
+  );
   const meta = await piece.getPatternMeta();
 
   if (meta.src) {
@@ -347,7 +357,12 @@ export async function savePiecePattern(
 export async function applyPieceInput(config: PieceConfig, input: object) {
   const manager = await loadManager(config);
   const pieces = new PiecesController(manager);
-  const piece = await pieces.get(config.piece, false, undefined, config.pieceScope);
+  const piece = await pieces.get(
+    config.piece,
+    false,
+    undefined,
+    config.pieceScope,
+  );
   await piece.setInput(input);
 }
 
@@ -512,7 +527,7 @@ async function resolvePieceCallable(
   }
 
   if (resolved.callableKind === "tool") {
-  const liveCallableCell = await tryResolveLivePieceToolCallable(
+    const liveCallableCell = await tryResolveLivePieceToolCallable(
       piece,
       manager,
       space,
@@ -856,7 +871,12 @@ export async function inspectPiece(config: PieceConfig): Promise<{
 }> {
   const manager = await loadManager(config);
   const pieces = new PiecesController(manager);
-  const piece = await pieces.get(config.piece, false, undefined, config.pieceScope);
+  const piece = await pieces.get(
+    config.piece,
+    false,
+    undefined,
+    config.pieceScope,
+  );
 
   const id = piece.id;
   const name = piece.name();
@@ -916,7 +936,12 @@ export async function getCellValue(
 ): Promise<unknown> {
   const manager = await loadManager(config);
   const pieces = new PiecesController(manager);
-  const piece = await pieces.get(config.piece, false, undefined, config.pieceScope);
+  const piece = await pieces.get(
+    config.piece,
+    false,
+    undefined,
+    config.pieceScope,
+  );
   if (options?.input) {
     return await piece.input.get(path);
   } else {
@@ -932,7 +957,12 @@ export async function setCellValue(
 ): Promise<void> {
   const manager = await loadManager(config);
   const pieces = new PiecesController(manager);
-  const piece = await pieces.get(config.piece, false, undefined, config.pieceScope);
+  const piece = await pieces.get(
+    config.piece,
+    false,
+    undefined,
+    config.pieceScope,
+  );
   if (options?.input) {
     await piece.input.set(value, path);
   } else {

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -61,7 +61,11 @@ export interface ResolvedPieceCallable extends CallableResolution {
 export interface PieceCallableDependencies extends CallableExecutionDeps {
   helpCommandPrefix?: string;
   loadManager?: (config: SpaceConfig) => Promise<any>;
-  loadPiece?: (manager: any, pieceId: string) => Promise<any>;
+  loadPiece?: (
+    manager: any,
+    pieceId: string,
+    scope?: PieceConfig["pieceScope"],
+  ) => Promise<any>;
   readJsonInput?: () => Promise<unknown>;
   readTextInput?: () => Promise<string>;
   readTextFile?: (path: string) => Promise<string>;
@@ -307,7 +311,7 @@ export async function setPiecePattern(
 ): Promise<void> {
   const manager = await loadManager(config);
   const pieces = new PiecesController(manager);
-  const piece = await pieces.get(config.piece, false);
+  const piece = await pieces.get(config.piece, false, undefined, config.pieceScope);
   await piece.setPattern(await getProgramFromFile(manager, entry));
 }
 
@@ -318,7 +322,7 @@ export async function savePiecePattern(
   await ensureDir(outPath);
   const manager = await loadManager(config);
   const pieces = new PiecesController(manager);
-  const piece = await pieces.get(config.piece, false);
+  const piece = await pieces.get(config.piece, false, undefined, config.pieceScope);
   const meta = await piece.getPatternMeta();
 
   if (meta.src) {
@@ -343,7 +347,7 @@ export async function savePiecePattern(
 export async function applyPieceInput(config: PieceConfig, input: object) {
   const manager = await loadManager(config);
   const pieces = new PiecesController(manager);
-  const piece = await pieces.get(config.piece, false);
+  const piece = await pieces.get(config.piece, false, undefined, config.pieceScope);
   await piece.setInput(input);
 }
 
@@ -428,6 +432,7 @@ async function tryResolveLivePieceToolCallable(
   manager: any,
   space: string,
   callableName: string,
+  pieceScope?: PieceConfig["pieceScope"],
 ): Promise<any | null> {
   if (
     typeof piece.getPattern !== "function" ||
@@ -444,6 +449,7 @@ async function tryResolveLivePieceToolCallable(
     crypto.randomUUID(),
     pattern?.resultSchema,
     tx,
+    pieceScope,
   );
   manager.runtime.run(tx, pattern, input, liveResult);
   manager.runtime.prepareTxForCommit?.(tx);
@@ -480,8 +486,8 @@ async function resolvePieceCallable(
 
   const piece =
     await (deps.loadPiece
-      ? deps.loadPiece(manager, config.piece)
-      : pieces.get(config.piece, true));
+      ? deps.loadPiece(manager, config.piece, config.pieceScope)
+      : pieces.get(config.piece, true, undefined, config.pieceScope));
   const space = manager.getSpace?.() ?? config.space;
 
   const resolved = (await tryResolvePieceCallableAt(
@@ -506,11 +512,12 @@ async function resolvePieceCallable(
   }
 
   if (resolved.callableKind === "tool") {
-    const liveCallableCell = await tryResolveLivePieceToolCallable(
+  const liveCallableCell = await tryResolveLivePieceToolCallable(
       piece,
       manager,
       space,
       callableName,
+      config.pieceScope,
     );
     if (liveCallableCell) {
       return {
@@ -554,7 +561,12 @@ export async function linkPieces(
   sourcePath: (string | number)[],
   targetPieceId: string,
   targetPath: (string | number)[],
-  options?: { start?: boolean; allowNonExisting?: boolean },
+  options?: {
+    start?: boolean;
+    allowNonExisting?: boolean;
+    sourceScope?: PieceConfig["pieceScope"];
+    targetScope?: PieceConfig["pieceScope"];
+  },
 ): Promise<void> {
   const manager = await timeCliPhase(
     "linkPieces.loadManager",
@@ -570,7 +582,7 @@ export async function linkPieces(
     // (i.e., was created via cf piece new, not just written to with cf piece set)
     const sourcePiece = await timeCliPhase(
       "linkPieces.getSourcePiece",
-      () => pieces.get(sourcePieceId, false),
+      () => pieces.get(sourcePieceId, false, undefined, options?.sourceScope),
     );
     const sourceHasProcess =
       sourcePiece.getCell().getSourceCell() !== undefined;
@@ -610,7 +622,7 @@ export async function linkPieces(
     // Check target piece exists by verifying it has a source/process cell
     const targetPiece = await timeCliPhase(
       "linkPieces.getTargetPiece",
-      () => pieces.get(targetPieceId, false),
+      () => pieces.get(targetPieceId, false, undefined, options?.targetScope),
     );
     const targetHasProcess =
       targetPiece.getCell().getSourceCell() !== undefined;
@@ -844,7 +856,7 @@ export async function inspectPiece(config: PieceConfig): Promise<{
 }> {
   const manager = await loadManager(config);
   const pieces = new PiecesController(manager);
-  const piece = await pieces.get(config.piece, false);
+  const piece = await pieces.get(config.piece, false, undefined, config.pieceScope);
 
   const id = piece.id;
   const name = piece.name();
@@ -904,7 +916,7 @@ export async function getCellValue(
 ): Promise<unknown> {
   const manager = await loadManager(config);
   const pieces = new PiecesController(manager);
-  const piece = await pieces.get(config.piece, false);
+  const piece = await pieces.get(config.piece, false, undefined, config.pieceScope);
   if (options?.input) {
     return await piece.input.get(path);
   } else {
@@ -920,7 +932,7 @@ export async function setCellValue(
 ): Promise<void> {
   const manager = await loadManager(config);
   const pieces = new PiecesController(manager);
-  const piece = await pieces.get(config.piece, false);
+  const piece = await pieces.get(config.piece, false, undefined, config.pieceScope);
   if (options?.input) {
     await piece.input.set(value, path);
   } else {
@@ -957,7 +969,7 @@ export async function stepPiece(config: PieceConfig): Promise<void> {
   const pieces = new PiecesController(manager);
   const piece = await timeCliPhase(
     "stepPiece.getPiece",
-    () => pieces.get(config.piece, true),
+    () => pieces.get(config.piece, true, undefined, config.pieceScope),
   );
   await timeCliPhase("stepPiece.pull", () => piece.getCell().pull());
   await timeCliPhase("stepPiece.manager.synced", () => manager.synced());

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -9,6 +9,7 @@ import {
   UI,
   VNode,
 } from "@commonfabric/runner";
+import type { CellScope } from "@commonfabric/api";
 import { StorageManager } from "@commonfabric/runner/storage/cache";
 import { pieceId, PieceManager } from "@commonfabric/piece";
 import { PiecesController } from "@commonfabric/piece/ops";
@@ -50,6 +51,7 @@ export interface SpaceConfig {
 
 export interface PieceConfig extends SpaceConfig {
   piece: string;
+  pieceScope?: CellScope;
 }
 
 export interface ResolvedPieceCallable extends CallableResolution {

--- a/packages/cli/test/charm.test.ts
+++ b/packages/cli/test/charm.test.ts
@@ -95,6 +95,31 @@ describe("cli piece parsing", () => {
       identity: ID,
     })).toMatchObject(expected);
   });
+
+  it("parsePieceOptions() parses scope suffixes from piece ids and urls", () => {
+    expect(parsePieceOptions({
+      apiUrl: API_URL,
+      space: SPACE,
+      identity: ID,
+      piece: `${PIECE}@user`,
+    })).toMatchObject({
+      apiUrl: API_URL,
+      space: SPACE,
+      identity: ID,
+      piece: PIECE,
+      pieceScope: "user",
+    });
+    expect(parsePieceOptions({
+      url: `${API_URL}/${SPACE}/${PIECE}@session`,
+      identity: ID,
+    })).toMatchObject({
+      apiUrl: API_URL,
+      space: SPACE,
+      identity: ID,
+      piece: PIECE,
+      pieceScope: "session",
+    });
+  });
   it("parsePieceOptions() throws on incomplete input", () => {
     expect(() =>
       parsePieceOptions({
@@ -208,6 +233,31 @@ describe("cli piece parsing", () => {
       expect(result.path).toBeUndefined();
     });
 
+    it("should parse scope suffixes on the piece ID segment", () => {
+      expect(parseLink("piece1@user")).toEqual({
+        pieceId: "piece1",
+        scope: "user",
+      });
+      expect(parseLink("piece1@session/path/0")).toEqual({
+        pieceId: "piece1",
+        scope: "session",
+        path: ["path", 0],
+      });
+      expect(parseLink("piece1@space/path")).toEqual({
+        pieceId: "piece1",
+        scope: "space",
+        path: ["path"],
+      });
+    });
+
+    it("should reject invalid scope suffixes on the piece ID segment", () => {
+      expect(() => parseLink("piece1@any")).toThrow(/Invalid scope suffix/);
+      expect(() => parseLink("piece1@inherit")).toThrow(
+        /Invalid scope suffix/,
+      );
+      expect(() => parseLink("piece1@")).toThrow(/Invalid scope suffix/);
+    });
+
     it("should parse simple paths correctly", () => {
       const result = parseLink("piece1/field");
       expect(result.pieceId).toBe("piece1");
@@ -230,6 +280,13 @@ describe("cli piece parsing", () => {
       const result = parseLink("piece/0/1/2");
       expect(result.pieceId).toBe("piece");
       expect(result.path).toEqual([0, 1, 2]);
+    });
+
+    it("should preserve @ in path segments after the piece ID", () => {
+      const result = parseLink("piece/user@email");
+      expect(result.pieceId).toBe("piece");
+      expect(result.path).toEqual(["user@email"]);
+      expect(result.scope).toBeUndefined();
     });
 
     it("should handle empty string after slash", () => {

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -630,10 +630,10 @@ function createPieceCallableHarness(options: {
       ...(options.callableKind === "handler"
         ? {
           send: (
-          value: unknown,
-          onCommit?: (
-            tx: { status: () => { status: string; error?: Error } },
-          ) => void,
+            value: unknown,
+            onCommit?: (
+              tx: { status: () => { status: string; error?: Error } },
+            ) => void,
           ) => {
             tracker.handlerWrites.push({
               cellProp: "result",

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -118,6 +118,86 @@ describe("executePieceCallable", () => {
     });
   });
 
+  it("passes the configured piece scope when resolving callables", async () => {
+    const harness = createPieceCallableHarness({
+      callableKind: "handler",
+      cellKey: "recordMessage",
+      inputSchema: {
+        type: "object",
+        properties: {
+          message: { type: "string" },
+        },
+        required: ["message"],
+      },
+    });
+    let resolvedScope: string | undefined;
+
+    await executePieceCallable(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "of:piece-123",
+        pieceScope: "session",
+        space: "home",
+      },
+      "recordMessage",
+      ["--message", "milk"],
+      {
+        loadManager: () => Promise.resolve(harness.manager),
+        loadPiece: (_manager, _pieceId, scope) => {
+          resolvedScope = scope;
+          return Promise.resolve(harness.piece);
+        },
+      },
+    );
+
+    expect(resolvedScope).toBe("session");
+  });
+
+  it("creates pattern tool result cells with the callable scope", async () => {
+    const harness = createPieceCallableHarness({
+      callableKind: "tool",
+      cellKey: "search",
+      callableScope: "user",
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: { type: "string" },
+        },
+        required: ["query"],
+      },
+      pattern: {
+        argumentSchema: {
+          type: "object",
+          properties: {
+            query: { type: "string" },
+          },
+          required: ["query"],
+        },
+        resultSchema: { type: "object" },
+      },
+      toolResult: { ok: true },
+    });
+
+    await executePieceCallable(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "of:piece-123",
+        space: "home",
+      },
+      "search",
+      ["--query", "tea"],
+      {
+        loadManager: () => Promise.resolve(harness.manager),
+        loadPiece: () => Promise.resolve(harness.piece),
+        uuid: () => "tool-result-id",
+      },
+    );
+
+    expect(harness.tracker.toolResultScope).toBe("user");
+  });
+
   it("reads primitive handler input from --value-file", async () => {
     const harness = createPieceCallableHarness({
       callableKind: "handler",
@@ -507,6 +587,7 @@ function createPieceCallableHarness(options: {
   extraParams?: Record<string, unknown>;
   toolResult?: unknown;
   handlerFailureMessage?: string;
+  callableScope?: "space" | "user" | "session";
 }) {
   const tracker = {
     handlerWrites: [] as Array<{
@@ -516,6 +597,7 @@ function createPieceCallableHarness(options: {
     }>,
     toolRunPattern: undefined as unknown,
     toolRunInput: undefined as unknown,
+    toolResultScope: undefined as string | undefined,
   };
 
   const callableSchema: JSONSchema = options.callableKind === "tool"
@@ -543,34 +625,37 @@ function createPieceCallableHarness(options: {
   const callableCell = createMockCell(
     callableValue,
     callableSchema,
-    options.callableKind === "handler"
-      ? {
-        send: (
+    {
+      scope: options.callableScope,
+      ...(options.callableKind === "handler"
+        ? {
+          send: (
           value: unknown,
           onCommit?: (
             tx: { status: () => { status: string; error?: Error } },
           ) => void,
-        ) => {
-          tracker.handlerWrites.push({
-            cellProp: "result",
-            path: [options.cellKey],
-            value,
-          });
-          if (options.handlerFailureMessage) {
-            runtimeErrors.push({ message: options.handlerFailureMessage });
-          }
-          onCommit?.({
-            status: () =>
-              options.handlerFailureMessage
-                ? {
-                  status: "error",
-                  error: new Error(options.handlerFailureMessage),
-                }
-                : { status: "done" },
-          });
-        },
-      }
-      : undefined,
+          ) => {
+            tracker.handlerWrites.push({
+              cellProp: "result",
+              path: [options.cellKey],
+              value,
+            });
+            if (options.handlerFailureMessage) {
+              runtimeErrors.push({ message: options.handlerFailureMessage });
+            }
+            onCommit?.({
+              status: () =>
+                options.handlerFailureMessage
+                  ? {
+                    status: "error",
+                    error: new Error(options.handlerFailureMessage),
+                  }
+                  : { status: "done" },
+            });
+          },
+        }
+        : {}),
+    },
   );
   const rootCell = createMockCell(
     {
@@ -635,7 +720,11 @@ function createPieceCallableHarness(options: {
         _id: string,
         _schema: JSONSchema | undefined,
         _tx: unknown,
-      ) => resultCell,
+        scope?: string,
+      ) => {
+        tracker.toolResultScope = scope;
+        return resultCell;
+      },
       run: (
         _tx: unknown,
         pattern: unknown,
@@ -667,6 +756,7 @@ function createMockCell(
         tx: { status: () => { status: string; error?: Error } },
       ) => void,
     ) => void;
+    scope?: "space" | "user" | "session";
   },
 ) {
   const cell = {
@@ -674,6 +764,7 @@ function createMockCell(
     get: () => value,
     getRaw: () => value,
     asSchemaFromLinks: () => cell,
+    getAsNormalizedFullLink: () => ({ scope: options?.scope }),
     send: options?.send,
     key: (key: string) => {
       if (options?.childOverrides?.[key]) {

--- a/packages/piece/src/manager.ts
+++ b/packages/piece/src/manager.ts
@@ -20,6 +20,7 @@ import {
   TYPE,
   URI,
 } from "@commonfabric/runner";
+import type { CellScope } from "@commonfabric/api";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { type Session } from "@commonfabric/identity";
 import { isRecord } from "@commonfabric/utils/types";
@@ -271,21 +272,31 @@ export class PieceManager {
     id: string | Cell<unknown>,
     runIt: boolean,
     asSchema: S,
+    scope?: CellScope,
   ): Promise<Cell<Schema<S>>>;
   async get<T = unknown>(
     id: string | Cell<unknown>,
     runIt?: boolean,
     asSchema?: JSONSchema,
+    scope?: CellScope,
   ): Promise<Cell<T>>;
   async get<T = unknown>(
     id: string | Cell<unknown>,
     runIt: boolean = false,
     asSchema?: JSONSchema,
+    scope?: CellScope,
   ): Promise<Cell<T>> {
     // Get the piece cell
     const piece: Cell<unknown> = isCell(id)
       ? id
-      : this.runtime.getCellFromEntityId(this.space, { "/": id });
+      : this.runtime.getCellFromEntityId(
+        this.space,
+        { "/": id },
+        [],
+        undefined,
+        undefined,
+        scope,
+      );
 
     if (runIt) {
       // start() handles sync, pattern loading, and running
@@ -712,12 +723,15 @@ export class PieceManager {
     id: EntityId | string,
     path: string[] = [],
     schema?: JSONSchema,
+    scope?: CellScope,
   ): Promise<Cell<T>> {
     const cell = this.runtime.getCellFromEntityId<T>(
       this.space,
       id,
       path,
       schema,
+      undefined,
+      scope,
     );
     await cell.sync();
     return cell;
@@ -956,12 +970,21 @@ export class PieceManager {
     linkPath: (string | number)[],
     targetPieceId: string,
     targetPath: (string | number)[],
-    options?: { start?: boolean },
+    options?: {
+      start?: boolean;
+      sourceScope?: CellScope;
+      targetScope?: CellScope;
+    },
   ): Promise<void> {
     const start = options?.start ?? true;
-    let linkCell = this.runtime.getCellFromEntityId(this.space, {
-      "/": linkPieceId,
-    });
+    let linkCell = this.runtime.getCellFromEntityId(
+      this.space,
+      { "/": linkPieceId },
+      [],
+      undefined,
+      undefined,
+      options?.sourceScope,
+    );
     await linkCell.sync();
     linkCell = linkCell.asSchemaFromLinks(); // Make sure we have the full schema
     linkCell = linkCell.key(...linkPath);
@@ -1013,20 +1036,33 @@ async function getCellByIdOrPiece(
   manager: PieceManager,
   cellId: string,
   label: string,
-  options?: { start?: boolean },
+  options?: { start?: boolean; targetScope?: CellScope },
 ): Promise<{ cell: Cell<unknown>; isPiece: boolean }> {
   const start = options?.start ?? true;
   try {
     // Try to get as a piece first
-    const piece = await manager.get(cellId, start);
+    const piece = await manager.get(
+      cellId,
+      start,
+      undefined,
+      options?.targetScope,
+    );
     if (!piece) {
       throw new Error(`Piece ${cellId} not found`);
+    }
+    if (!piece.getSourceCell()) {
+      throw new Error(`Piece ${cellId} has no source cell`);
     }
     return { cell: piece, isPiece: true };
   } catch (_) {
     // If manager.get() fails (e.g., "patternId is required"), try as arbitrary cell ID
     try {
-      const cell = await manager.getCellById({ "/": cellId });
+      const cell = await manager.getCellById(
+        { "/": cellId },
+        [],
+        undefined,
+        options?.targetScope,
+      );
 
       // Check if this cell is actually a piece by looking at the pieces list
       const piecesCell = await manager.getPieces();

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -5,6 +5,7 @@ import {
   RuntimeProgram,
   type Schema,
 } from "@commonfabric/runner";
+import type { CellScope } from "@commonfabric/api";
 import { StorageManager } from "@commonfabric/runner/storage/cache";
 import { type NameSchema, nameSchema } from "@commonfabric/runner/schemas";
 import { PieceManager } from "../index.ts";
@@ -78,19 +79,23 @@ export class PiecesController<T = unknown> {
     pieceId: string,
     runIt: boolean,
     schema: S,
+    scope?: CellScope,
   ): Promise<PieceController<Schema<S>>>;
   async get<T = unknown>(
     pieceId: string,
     runIt?: boolean,
     schema?: JSONSchema,
+    scope?: CellScope,
   ): Promise<PieceController<T>>;
   async get(
     pieceId: string,
     runIt: boolean = false,
     schema?: JSONSchema,
+    scope?: CellScope,
   ): Promise<PieceController> {
     this.disposeCheck();
-    const cell = await (await this.#manager.get(pieceId, runIt, schema)).sync();
+    const cell = await (await this.#manager.get(pieceId, runIt, schema, scope))
+      .sync();
     return new PieceController(this.#manager, cell);
   }
 

--- a/packages/piece/test/link-reactivity.test.ts
+++ b/packages/piece/test/link-reactivity.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { resolveCellPath, Runtime } from "@commonfabric/runner";
+import { parseLink, resolveCellPath, Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { createSession, Identity } from "@commonfabric/identity";
 import { PieceManager } from "../src/manager.ts";
@@ -121,6 +121,39 @@ describe("PieceManager.link() reactivity", () => {
     });
     await runtime.idle();
     expect(targetCell.key("linked").get()).toBe("updated");
+  });
+
+  it("links scoped source cells into scoped target cells", async () => {
+    const sourceCell = runtime.getCellFromLink({
+      id: "of:scoped-source",
+      path: [],
+      space: manager.getSpace(),
+      scope: "user",
+    });
+    const targetCell = runtime.getCellFromLink({
+      id: "of:scoped-target",
+      path: [],
+      space: manager.getSpace(),
+      scope: "session",
+    });
+
+    await runtime.editWithRetry((tx) => {
+      sourceCell.withTx(tx).set({ data: "scoped value" });
+      targetCell.withTx(tx).set({ linked: null });
+    });
+    await runtime.idle();
+
+    await manager.link(
+      "scoped-source",
+      ["data"],
+      "scoped-target",
+      ["linked"],
+      { start: false, sourceScope: "user", targetScope: "session" },
+    );
+
+    const rawLink = targetCell.key("linked").getRaw();
+    expect(parseLink(rawLink, targetCell)?.scope).toBe("user");
+    expect(targetCell.key("linked").get()).toBe("scoped value");
   });
 
   it("should link through exposed cell-valued source fields", async () => {

--- a/packages/piece/test/link-reactivity.test.ts
+++ b/packages/piece/test/link-reactivity.test.ts
@@ -150,6 +150,7 @@ describe("PieceManager.link() reactivity", () => {
       ["linked"],
       { start: false, sourceScope: "user", targetScope: "session" },
     );
+    await targetCell.sync();
 
     const rawLink = targetCell.key("linked").getRaw();
     expect(parseLink(rawLink, targetCell)?.scope).toBe("user");

--- a/packages/runner/src/link-types.ts
+++ b/packages/runner/src/link-types.ts
@@ -20,6 +20,26 @@ import type {
   MemoryAddressPathComponent,
 } from "./storage/interface.ts";
 
+const CELL_SCOPE_VALUES = new Set(["space", "user", "session"]);
+
+function parseScopedIdSegment(idSegment: string): {
+  id: string;
+  scope?: CellScope;
+} {
+  const scopeSeparator = idSegment.lastIndexOf("@");
+  if (scopeSeparator === -1) return { id: idSegment };
+
+  const id = idSegment.slice(0, scopeSeparator);
+  const scope = idSegment.slice(scopeSeparator + 1);
+  if (!id || !CELL_SCOPE_VALUES.has(scope)) {
+    throw new Error(
+      `Invalid scope suffix "@${scope}" in link handle. Expected @space, @user, or @session.`,
+    );
+  }
+
+  return { id, scope: scope as CellScope };
+}
+
 /**
  * Normalized link structure returned by parsers
  */
@@ -349,6 +369,8 @@ export function parseLLMFriendlyLink(
     id = firstSegment;
     path = rest;
   }
+  const scopedId = parseScopedIdSegment(id);
+  id = scopedId.id;
 
   // Check if first segment looks like a CID/handle by length
   //
@@ -371,6 +393,7 @@ export function parseLLMFriendlyLink(
     id: id as `${string}:${string}`,
     path,
     ...(space && { space }),
+    ...(scopedId.scope && { scope: scopedId.scope }),
   };
 }
 
@@ -387,9 +410,12 @@ export function createLLMFriendlyLink(
   link: NormalizedFullLink,
   contextSpace?: MemorySpace,
 ): string {
+  const id = link.scope && link.scope !== "space"
+    ? `${link.id}@${link.scope}`
+    : link.id;
   // If contextSpace provided and differs, include space in link
   if (contextSpace && link.space && link.space !== contextSpace) {
-    return encodeJsonPointer(["", `@${link.space}`, link.id, ...link.path]);
+    return encodeJsonPointer(["", `@${link.space}`, id, ...link.path]);
   }
-  return encodeJsonPointer(["", link.id, ...link.path]);
+  return encodeJsonPointer(["", id, ...link.path]);
 }

--- a/packages/runner/src/link-types.ts
+++ b/packages/runner/src/link-types.ts
@@ -356,7 +356,7 @@ export function parseLLMFriendlyLink(
   }
 
   // Check if first segment is a space DID (cross-space link)
-  let id: string;
+  let id: string | undefined;
   let path: string[];
   const spaceMatch = firstSegment?.match(matchSpacePrefix);
   if (spaceMatch) {
@@ -368,6 +368,11 @@ export function parseLLMFriendlyLink(
     // Standard format: /of:bafyabc123/path
     id = firstSegment;
     path = rest;
+  }
+  if (id === undefined) {
+    throw new Error(
+      'Target must include a piece handle, e.g. "/of:bafyabc123/path".',
+    );
   }
   const scopedId = parseScopedIdSegment(id);
   id = scopedId.id;

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -754,6 +754,7 @@ export class Runtime {
     path?: readonly PropertyKey[],
     schema?: JSONSchema,
     tx?: IExtendedStorageTransaction,
+    scope?: NormalizedFullLink["scope"],
   ): Cell<T>;
   getCellFromEntityId<S extends JSONSchema = JSONSchema>(
     space: MemorySpace,
@@ -761,6 +762,7 @@ export class Runtime {
     path: readonly PropertyKey[],
     schema: S,
     tx?: IExtendedStorageTransaction,
+    scope?: NormalizedFullLink["scope"],
   ): Cell<Schema<S>>;
   getCellFromEntityId(
     space: MemorySpace,
@@ -768,13 +770,14 @@ export class Runtime {
     path: readonly PropertyKey[] = [],
     schema?: JSONSchema,
     tx?: IExtendedStorageTransaction,
+    scope: NormalizedFullLink["scope"] = "space",
   ): Cell<any> {
     return this.getCellFromLink(
       {
         id: toURI(entityId),
         path: path?.map(String) ?? [],
         space,
-        scope: "space",
+        scope,
       },
       schema,
       tx,

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -694,25 +694,28 @@ export class Runtime {
     cause: any,
     schema: S,
     tx?: IExtendedStorageTransaction,
+    scope?: NormalizedFullLink["scope"],
   ): Cell<Schema<S>>;
   getCell<T>(
     space: MemorySpace,
     cause: any,
     schema?: JSONSchema,
     tx?: IExtendedStorageTransaction,
+    scope?: NormalizedFullLink["scope"],
   ): Cell<T>;
   getCell(
     space: MemorySpace,
     cause: any,
     schema?: JSONSchema,
     tx?: IExtendedStorageTransaction,
+    scope: NormalizedFullLink["scope"] = "space",
   ): Cell<any> {
     return this.getCellFromLink(
       {
         id: toURI(createRef({}, cause)),
         path: [],
         space,
-        scope: "space",
+        scope,
       },
       schema,
       tx,

--- a/packages/runner/test/link-utils.test.ts
+++ b/packages/runner/test/link-utils.test.ts
@@ -1290,6 +1290,43 @@ describe("link-utils", () => {
       });
     });
 
+    it("should parse scope suffixes on the handle segment", () => {
+      const link = `/${longId}@user/path/to/cell`;
+      const result = parseLLMFriendlyLink(link, space);
+
+      expect(result).toEqual({
+        id: longId,
+        path: ["path", "to", "cell"],
+        space: space,
+        scope: "user",
+      });
+    });
+
+    it("should parse scope suffixes on cross-space handles", () => {
+      const otherSpace = "did:key:z6MkrX123abc";
+      const link = `/@${otherSpace}/${longId}@session/path`;
+      const result = parseLLMFriendlyLink(link, space);
+
+      expect(result).toEqual({
+        id: longId,
+        path: ["path"],
+        space: otherSpace,
+        scope: "session",
+      });
+    });
+
+    it("should reject invalid scope suffixes on the handle segment", () => {
+      expect(() => parseLLMFriendlyLink(`/${longId}@any/path`, space)).toThrow(
+        /Invalid scope suffix/,
+      );
+      expect(() =>
+        parseLLMFriendlyLink(`/${longId}@inherit/path`, space)
+      ).toThrow(/Invalid scope suffix/);
+      expect(() => parseLLMFriendlyLink(`/${longId}@/path`, space)).toThrow(
+        /Invalid scope suffix/,
+      );
+    });
+
     it("should parse link without space if optional", () => {
       const link = `/${longId}/path`;
       const result = parseLLMFriendlyLink(link);
@@ -1333,6 +1370,30 @@ describe("link-utils", () => {
       const result = createLLMFriendlyLink(link as any);
 
       expect(result).toBe(`/${longId}/path/to/cell`);
+    });
+
+    it("should create LLM friendly links with non-space scope suffixes", () => {
+      const link: NormalizedLink = {
+        id: longId,
+        path: ["path"],
+        space: space,
+        scope: "user",
+      };
+      const result = createLLMFriendlyLink(link as any);
+
+      expect(result).toBe(`/${longId}@user/path`);
+    });
+
+    it("should omit explicit space scope when creating LLM friendly links", () => {
+      const link: NormalizedLink = {
+        id: longId,
+        path: ["path"],
+        space: space,
+        scope: "space",
+      };
+      const result = createLLMFriendlyLink(link as any);
+
+      expect(result).toBe(`/${longId}/path`);
     });
 
     it("should handle empty path", () => {

--- a/packages/runner/test/link-utils.test.ts
+++ b/packages/runner/test/link-utils.test.ts
@@ -1337,9 +1337,8 @@ describe("link-utils", () => {
       expect(() => parseLLMFriendlyLink(`/${longId}@any/path`, space)).toThrow(
         /Invalid scope suffix/,
       );
-      expect(() =>
-        parseLLMFriendlyLink(`/${longId}@inherit/path`, space)
-      ).toThrow(/Invalid scope suffix/);
+      expect(() => parseLLMFriendlyLink(`/${longId}@inherit/path`, space))
+        .toThrow(/Invalid scope suffix/);
       expect(() => parseLLMFriendlyLink(`/${longId}@/path`, space)).toThrow(
         /Invalid scope suffix/,
       );

--- a/packages/runner/test/link-utils.test.ts
+++ b/packages/runner/test/link-utils.test.ts
@@ -211,6 +211,24 @@ describe("link-utils", () => {
   });
 
   describe("parseLink", () => {
+    it("runtime getCellFromEntityId should accept an explicit scope", () => {
+      const cell = runtime.getCellFromEntityId(
+        space,
+        { "/": "scoped-entity" },
+        [],
+        undefined,
+        undefined,
+        "user",
+      );
+
+      expect(cell.getAsNormalizedFullLink()).toMatchObject({
+        id: "of:scoped-entity",
+        path: [],
+        space,
+        scope: "user",
+      });
+    });
+
     it("should parse cells to normalized links", () => {
       const cell = runtime.getCell(space, "test", undefined, tx);
       cell.set({ value: 42 });

--- a/packages/runner/test/link-utils.test.ts
+++ b/packages/runner/test/link-utils.test.ts
@@ -1366,6 +1366,13 @@ describe("link-utils", () => {
       );
     });
 
+    it("should throw a controlled error if cross-space target omits handle", () => {
+      expect(() => parseLLMFriendlyLink("/@did:key:z6MkrX123abc", space))
+        .toThrow(
+          'Target must include a piece handle, e.g. "/of:bafyabc123/path".',
+        );
+    });
+
     it("should throw if handle is too short (human name)", () => {
       expect(() => parseLLMFriendlyLink("/of:short/path", space)).toThrow(
         'Piece references must use handles (e.g., "/of:bafyabc123/path"), not human names (e.g., "of:short").',


### PR DESCRIPTION
## Summary

Adds optional `@<scope>` suffixes to cell reference id segments used by `cf`, supporting `@space`, `@user`, and `@session` while preserving existing behavior when scope is omitted.

## Changes

- Parse scoped CLI refs and LLM-friendly refs such as `piece@user/path`, `/of:...@user/path`, and cross-space `/@did:key:.../of:...@session/path`.
- Reject invalid id suffixes early while preserving `@` inside path segments after the id.
- Thread scope through runtime entity access, piece manager/controller lookup, and piece linking.
- Apply scoped refs to `piece get`, `set`, `inspect`, `view`, `render`, `step`, `call`, and independent source/target scopes in `piece link`.
- Update compact help examples for scoped `piece get` and `piece link` usage.

## Validation

- `deno test --allow-ffi --allow-read --allow-write --allow-run --allow-env packages/cli/test/charm.test.ts`
- `ENV=test deno test --allow-ffi --allow-env --allow-read --allow-write=/tmp,/var/folders --allow-run=git packages/runner/test/link-utils.test.ts`
- `deno test --allow-ffi --allow-env --allow-read --allow-write=/tmp,/var/folders --allow-run=git packages/piece/test/link-reactivity.test.ts`
- `deno test --allow-ffi --allow-read --allow-write --allow-run --allow-env packages/cli/test/piece-call.test.ts`
- `deno task test` in `packages/cli`
- `deno task test` in `packages/piece`
- `deno task test` in `packages/runner`
- touched-file `deno fmt --check`
- `deno task check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional scope suffixes to cell reference IDs so users can target `@space`, `@user`, or `@session` instances in cf links. Also hardens link parsing with clearer errors for malformed cross-space links.

- **New Features**
  - Parse scoped refs in CLI args, `--url` inputs, and LLM-friendly links, e.g. `piece@user/path`, `/@otherSpace/handle@session/path`.
  - Apply scopes in `cf piece` commands: `get`, `set`, `inspect`, `view`, `render`, `step`, `call`, and `link` (independent `sourceScope`/`targetScope`).
  - Propagate scope through `packages/runner` (`getCell`, `getCellFromEntityId`, link parse/create), `packages/piece` (`PieceManager`, `PiecesController`), and CLI plumbing.
  - Create pattern tool result cells using the callable’s scope; add CLI help examples and tests across `packages/cli`, `packages/piece`, and `packages/runner`.

- **Bug Fixes**
  - Throw a clear error when a cross-space LLM-friendly link omits the handle (e.g., `/@did:key:...`), with guidance to include `/of:<handle>/...`.

<sup>Written for commit 28e88fac303baad6231baf85853b272b4c20d6c8. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3608?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

NEW_PERF_BASELINE: step: runner integration = 39s
