### PR TITLE
refactor(runner/scheduler): extract execution phase helpers

### DIFF
--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -91,6 +91,15 @@ import { breakCyclesIfNeeded } from "./scheduler/cycle-break.ts";
 import { applyExecuteContinuation } from "./scheduler/continuation.ts";
 import type { CycleBreakState } from "./scheduler/cycle-break.ts";
 import type { ExecuteContinuationState } from "./scheduler/continuation.ts";
+import {
+  canAutomaticallyDebounce as canAutomaticallyDebounceState,
+  getNextDebounceRunTime as getNextDebounceRunTimeState,
+  isDebouncedComputationWaiting as isDebouncedComputationWaitingState,
+  maybeAutoDebounce as maybeAutoDebounceState,
+  scheduleComputationDebounce as scheduleComputationDebounceState,
+  type SchedulerDelayControlState,
+  scheduleWithDebounce as scheduleWithDebounceState,
+} from "./scheduler/delay-control.ts";
 import { SchedulerDelays } from "./scheduler/delays.ts";
 import { processStorageNotification } from "./scheduler/notifications.ts";
 import {
@@ -280,6 +289,18 @@ export class Scheduler {
     actionStats: this.actionStats,
     getActionId: (action) => this.getActionId(action),
   });
+  private delayControlState: SchedulerDelayControlState = {
+    delays: this.delays,
+    computations: this.computations,
+    effects: this.effects,
+    dirty: this.staleness.dirty,
+    pending: this.pending,
+    getPullMode: () => this.pullMode,
+    isPullDemandRootEffect: (action) => this.isPullDemandRootEffect(action),
+    queueExecution: () => this.queueExecution(),
+    logDebounce: (message) =>
+      logger.debug("schedule-debounce", () => [message]),
+  };
   private inFlightSourceState: InFlightSourceState = {
     inFlightSources: new WeakMap<Action, Set<IStorageTransaction>>(),
   };
@@ -1377,11 +1398,7 @@ export class Scheduler {
   }
 
   private canAutomaticallyDebounce(action: Action): boolean {
-    return this.delays.canAutomaticallyDebounce(action, {
-      effects: this.effects,
-      isPullDemandRootEffect: (candidate) =>
-        this.isPullDemandRootEffect(candidate),
-    });
+    return canAutomaticallyDebounceState(this.delayControlState, action);
   }
 
   private shouldRunFirstPullComputationInDemandContext(
@@ -1592,47 +1609,15 @@ export class Scheduler {
   }
 
   private getNextDebounceRunTime(action: Action): number | undefined {
-    return this.delays.getNextDebounceRunTime(
-      action,
-      {
-        pullMode: this.pullMode,
-        computations: this.computations,
-        effects: this.effects,
-        dirty: this.staleness.dirty,
-      },
-    );
+    return getNextDebounceRunTimeState(this.delayControlState, action);
   }
 
   private isDebouncedComputationWaiting(action: Action): boolean {
-    return this.delays.isDebouncedComputationWaiting(
-      action,
-      {
-        pullMode: this.pullMode,
-        computations: this.computations,
-        effects: this.effects,
-        dirty: this.staleness.dirty,
-        pending: this.pending,
-        queueExecution: () => this.queueExecution(),
-        logDebounce: (message) =>
-          logger.debug("schedule-debounce", () => [message]),
-      },
-    );
+    return isDebouncedComputationWaitingState(this.delayControlState, action);
   }
 
   private scheduleComputationDebounce(action: Action): void {
-    this.delays.scheduleComputationDebounce(
-      action,
-      {
-        pullMode: this.pullMode,
-        computations: this.computations,
-        effects: this.effects,
-        dirty: this.staleness.dirty,
-        pending: this.pending,
-        queueExecution: () => this.queueExecution(),
-        logDebounce: (message) =>
-          logger.debug("schedule-debounce", () => [message]),
-      },
-    );
+    scheduleComputationDebounceState(this.delayControlState, action);
   }
 
   /**
@@ -1641,15 +1626,7 @@ export class Scheduler {
    * Otherwise, it's added immediately.
    */
   private scheduleWithDebounce(action: Action): void {
-    this.delays.scheduleWithDebounce(
-      action,
-      {
-        pending: this.pending,
-        queueExecution: () => this.queueExecution(),
-        logDebounce: (message) =>
-          logger.debug("schedule-debounce", () => [message]),
-      },
-    );
+    scheduleWithDebounceState(this.delayControlState, action);
   }
 
   /**
@@ -1658,10 +1635,7 @@ export class Scheduler {
    * Auto-debounce is enabled by default; use noDebounce to opt out.
    */
   private maybeAutoDebounce(action: Action): void {
-    const update = this.delays.maybeAutoDebounce(action, {
-      canAutomaticallyDebounce: (candidate) =>
-        this.canAutomaticallyDebounce(candidate),
-    });
+    const update = maybeAutoDebounceState(this.delayControlState, action);
     if (update) {
       logger.debug("schedule-debounce", () => [
         `[AUTO-DEBOUNCE] Action ${update.actionId} ` +

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -176,6 +176,17 @@ const logger = getLogger("scheduler", {
   level: "warn",
 });
 
+type PendingPullRunnableState = Parameters<typeof isPendingPullActionRunnable>[
+  0
+];
+type DirtyPullRunnableState = Parameters<typeof isDirtyPullActionRunnable>[0];
+type DirtyPullRunnableStateWithDebounce = DirtyPullRunnableState & {
+  readonly isDebouncedComputationWaiting: (action: Action) => boolean;
+};
+type PendingDependencyCollectionState =
+  SchedulerSubscribeActionState["pendingDependencyCollectionState"];
+type FilterStatsState = { filtered: number; executed: number };
+
 // Re-export types that tests expect from scheduler
 export type { ErrorWithContext };
 export type {
@@ -294,79 +305,22 @@ export class Scheduler {
     timestamp: number;
   }[] = [];
   private changeGroupToActionId = new Map<ChangeGroup, string>();
-  private diagnosisControlState: SchedulerDiagnosisControlState = {
-    getDiagnosisEnabled: () => this.diagnosisEnabled,
-    setDiagnosisEnabled: (enabled) => {
-      this.diagnosisEnabled = enabled;
-    },
-    getDiagnosisTimeout: () => this.diagnosisTimeout,
-    setDiagnosisTimeout: (timeout) => {
-      this.diagnosisTimeout = timeout;
-    },
-    getDiagnosisStartTime: () => this.diagnosisStartTime,
-    setDiagnosisStartTime: (time) => {
-      this.diagnosisStartTime = time;
-    },
-    getDiagnosisBusyTime: () => this.diagnosisBusyTime,
-    setDiagnosisBusyTime: (time) => {
-      this.diagnosisBusyTime = time;
-    },
-    getDiagnosisResolve: () => this.diagnosisResolve,
-    setDiagnosisResolve: (resolve) => {
-      this.diagnosisResolve = resolve;
-    },
-    diagnosisHistory: this.diagnosisHistory,
-    diagnosisNonIdempotent: this.diagnosisNonIdempotent,
-    causalEdges: this.causalEdges,
-    idempotencyViolations: this.idempotencyViolations,
-    computations: this.computations,
-    setIdempotencyCheckMode: (enabled) => {
-      this.idempotencyCheckMode = enabled;
-    },
-    runAction: (action) => this.run(action),
-  };
+  private diagnosisControlState!: SchedulerDiagnosisControlState;
 
   // Debounce infrastructure for throttling slow actions
   private pendingQueueTaskTimer: ReturnType<typeof setTimeout> | null = null;
-  private eventQueueWakeState: EventQueueWakeState = {
-    timer: null,
-    wakeAt: null,
-    eventQueue: this.eventQueue,
-    isDisposed: () => this.disposed,
-    queueExecution: () => this.queueExecution(),
-  };
+  private eventQueueWakeState!: EventQueueWakeState;
   private eventQueueState!: SchedulerEventQueueState;
   private delays = new SchedulerDelays({
     actionStats: this.actionStats,
     getActionId: (action) => this.getActionId(action),
   });
-  private delayControlState: SchedulerDelayControlState = {
-    delays: this.delays,
-    computations: this.computations,
-    effects: this.effects,
-    dirty: this.staleness.dirty,
-    pending: this.pending,
-    getPullMode: () => this.pullMode,
-    isPullDemandRootEffect: (action) =>
-      isPullDemandRootEffect(this.pullDemandState, action),
-    queueExecution: () => this.queueExecution(),
-    logDebounce: (message) =>
-      logger.debug("schedule-debounce", () => [message]),
-  };
+  private delayControlState!: SchedulerDelayControlState;
   private inFlightSourceState: InFlightSourceState = {
     inFlightSources: new WeakMap<Action, Set<IStorageTransaction>>(),
   };
 
-  private schedulingWriteState: SchedulingWriteState = {
-    // Current-known writes are rebuilt on each dependency update from actual
-    // writes plus declared/potential writes. This is the default scheduling view.
-    currentKnownWrites: new WeakMap<Action, IMemorySpaceAddress[]>(),
-    // Historical writes preserve the legacy cumulative union and are only used
-    // when the experimental historical-write mode is enabled.
-    historicalMightWrite: new WeakMap<Action, IMemorySpaceAddress[]>(),
-    useHistoricalMightWrite: () =>
-      this.runtime.experimental.schedulerHistoricalMightWrite === true,
-  };
+  private schedulingWriteState!: SchedulingWriteState;
   private writerIndexState: WriterIndexState = {
     // Index: entity -> actions that write to it (for fast dependency lookup).
     // Updated from the active scheduling write set.
@@ -374,25 +328,11 @@ export class Scheduler {
     // Reverse index: action -> entities it writes to (for cleanup)
     actionWriteEntities: new WeakMap<Action, Set<SpaceScopeAndURI>>(),
   };
-  private dirtyDependencyCollectionState: DirtyDependencyCollectionState = {
-    collectStack: this.collectStack,
-    getTrace: () => this.dirtyDependencyTraceContext,
-    dirty: this.staleness.dirty,
-    pending: this.pending,
-    computations: this.computations,
-    reverseDependencies: this.reverseDependencies,
-    dependencies: this.dependencies,
-    writersByEntity: this.writerIndexState.writersByEntity,
-    effects: this.effects,
-    isStale: (target) => this.staleness.isStale(target),
-    getSchedulingWrites: (target) =>
-      getSchedulingWritesFromState(this.schedulingWriteState, target),
-    getActionId: (target) => this.getActionId(target),
-  };
+  private dirtyDependencyCollectionState!: DirtyDependencyCollectionState;
   // Track actions scheduled for first time (bypass filter)
   private scheduledFirstTime = new Set<Action>();
   // Filter stats for diagnostics
-  private filterStats = { filtered: 0, executed: 0 };
+  private filterStats: FilterStatsState = { filtered: 0, executed: 0 };
 
   // Settle stats for performance analysis (opt-in via enableSettleStats())
   private collectSettleStats = false;
@@ -405,35 +345,7 @@ export class Scheduler {
   private eventPreflightTelemetryEnabled = false;
   private changedWritesHistory: IMemorySpaceAddress[] = [];
   private conditionallyScheduledEffects = new Map<Action, number>();
-  private storageNotificationState: StorageNotificationState = {
-    triggers: this.triggerIndexState.triggers,
-    nonRecursiveTriggers: this.triggerIndexState.nonRecursiveTriggers,
-    getPullMode: () => this.pullMode,
-    getDiagnosisEnabled: () => this.diagnosisEnabled,
-    getCollectTriggerTrace: () => this.collectTriggerTrace,
-    changeGroupToActionId: this.changeGroupToActionId,
-    recordCausalEdge: (edge) => {
-      this.causalEdges.push(edge);
-    },
-    actionChangeGroups: this.actionChangeGroups,
-    effects: this.effects,
-    pending: this.pending,
-    dirty: this.staleness.dirty,
-    inFlightSources: this.inFlightSourceState.inFlightSources,
-    conditionallyScheduledEffects: this.conditionallyScheduledEffects,
-    getActionId: (target) => this.getActionId(target),
-    recordCellUpdate: (change) =>
-      this.runtime.telemetry.submit({
-        type: "cell.update",
-        change,
-      }),
-    recordTriggerTrace: (entry) =>
-      recordTriggerTraceState({ triggerTrace: this.triggerTrace }, entry),
-    scheduleWithDebounce: (target) => this.scheduleWithDebounce(target),
-    markDirty: (target) =>
-      markSchedulerDirty(this.dirtySchedulingState, target),
-    scheduleAffectedEffects: (target) => this.scheduleAffectedEffects(target),
-  };
+  private storageNotificationState!: StorageNotificationState;
 
   // Parent-child action tracking for proper execution ordering
   // When a child action is created during parent execution, parent must run first
@@ -441,117 +353,17 @@ export class Scheduler {
   currentActionId?: string;
   private actionParent = new WeakMap<Action, Action>();
   private actionChildren = new WeakMap<Action, Set<Action>>();
-  private pullDemandState: PullDemandState = {
-    getPullMode: () => this.pullMode,
-    computations: this.computations,
-    effects: this.effects,
-    dependents: this.dependents,
-    dependencies: this.dependencies,
-    actionParent: this.actionParent,
-    isEffectAction: this.isEffectAction,
-    pullDemandedFirstRunComputations: this.pullDemandedFirstRunComputations,
-    hasActionRun: (action) => this.delays.hasActionRun(action),
-    getSchedulingWrites: (action) =>
-      getSchedulingWritesFromState(this.schedulingWriteState, action),
-  };
-  private dependencyGraphState: DependencyGraphState = {
-    triggers: this.triggerIndexState.triggers,
-    nonRecursiveTriggers: this.triggerIndexState.nonRecursiveTriggers,
-    writersByEntity: this.writerIndexState.writersByEntity,
-    dependencies: this.dependencies,
-    dependents: this.dependents,
-    reverseDependencies: this.reverseDependencies,
-    staleness: this.staleness,
-    getSchedulingWrites: (action) =>
-      getSchedulingWritesFromState(this.schedulingWriteState, action),
-    isStale: (action) => this.staleness.isStale(action),
-    isDemandedPullComputation: (action) =>
-      isDemandedPullComputation(this.pullDemandState, action),
-    queueExecution: () => this.queueExecution(),
-  };
-  private dependencyUpdateState: DependencyUpdateState = {
-    writersByEntity: this.writerIndexState.writersByEntity,
-    actionWriteEntities: this.writerIndexState.actionWriteEntities,
-    dependencies: this.dependencies,
-    currentKnownWrites: this.schedulingWriteState.currentKnownWrites,
-    historicalMightWrite: this.schedulingWriteState.historicalMightWrite,
-    dependencyGraph: this.dependencyGraphState,
-    useHistoricalMightWrite: this.schedulingWriteState.useHistoricalMightWrite,
-    isPullMode: () => this.pullMode,
-  };
-  private triggerSubscriptionState: TriggerSubscriptionState = {
-    triggers: this.triggerIndexState.triggers,
-    nonRecursiveTriggers: this.triggerIndexState.nonRecursiveTriggers,
-    cancels: this.cancels,
-    getActionId: (action) => this.getActionId(action),
-    onTriggerUnsubscribe: (actionId, entityCount) => {
-      logger.debug("schedule-unsubscribe", () => [
-        `Action: ${actionId}`,
-        `Entities: ${entityCount}`,
-      ]);
-    },
-  };
-  private dirtySchedulingState: DirtySchedulingState = {
-    staleness: this.staleness,
-    computations: this.computations,
-    scheduleComputationDebounce: (action) =>
-      this.scheduleComputationDebounce(action),
-    clearComputationDebounceState: (action) =>
-      this.delays.clearComputationDebounceState(action),
-    isDemandedPullComputation: (action) =>
-      isDemandedPullComputation(this.pullDemandState, action),
-    queueExecution: () => this.queueExecution(),
-  };
-  private pendingPullRunnableState = {
-    effects: this.effects,
-    isDemandedPullComputation: (action: Action) =>
-      isDemandedPullComputation(this.pullDemandState, action),
-    shouldRunFirstPullComputationInDemandContext: (action: Action) =>
-      shouldRunFirstPullComputationInDemandContext(
-        this.pullDemandState,
-        action,
-      ),
-  };
-  private dirtyPullRunnableState = {
-    effects: this.effects,
-    isDemandedPullComputation: (action: Action) =>
-      isDemandedPullComputation(this.pullDemandState, action),
-    isThrottled: (action: Action) => this.delays.isThrottled(action),
-  };
-  private dirtyPullRunnableStateWithDebounce = {
-    ...this.dirtyPullRunnableState,
-    isDebouncedComputationWaiting: (action: Action) =>
-      this.isDebouncedComputationWaiting(action),
-  };
-  private writePropagationState: WritePropagationState = {
-    triggers: this.triggerIndexState.triggers,
-    nonRecursiveTriggers: this.triggerIndexState.nonRecursiveTriggers,
-    changedWritesHistory: this.changedWritesHistory,
-    effects: this.effects,
-    computations: this.computations,
-    conditionallyScheduledEffects: this.conditionallyScheduledEffects,
-    isPullMode: () => this.pullMode,
-    scheduleWithDebounce: (action) => this.scheduleWithDebounce(action),
-    markDirty: (action) =>
-      markSchedulerDirty(this.dirtySchedulingState, action),
-    scheduleAffectedEffects: (action) => {
-      this.scheduleAffectedEffects(action);
-    },
-  };
-  private subscriptionState: SchedulerSubscriptionState = {
-    actionChangeGroups: this.actionChangeGroups,
-    changeGroupToActionId: this.changeGroupToActionId,
-    isEffectAction: this.isEffectAction,
-    effects: this.effects,
-    computations: this.computations,
-    getPullMode: () => this.pullMode,
-    getIdempotencyCheckMode: () => this.idempotencyCheckMode,
-    queueExecution: () => this.queueExecution(),
-    getActionId: (target) => this.getActionId(target),
-    getExecutingAction: () => this.executingAction,
-    actionParent: this.actionParent,
-    actionChildren: this.actionChildren,
-  };
+  private pullDemandState!: PullDemandState;
+  private dependencyGraphState!: DependencyGraphState;
+  private dependencyUpdateState!: DependencyUpdateState;
+  private triggerSubscriptionState!: TriggerSubscriptionState;
+  private dirtySchedulingState!: DirtySchedulingState;
+  private pendingPullRunnableState!: PendingPullRunnableState;
+  private dirtyPullRunnableState!: DirtyPullRunnableState;
+  private dirtyPullRunnableStateWithDebounce!:
+    DirtyPullRunnableStateWithDebounce;
+  private writePropagationState!: WritePropagationState;
+  private subscriptionState!: SchedulerSubscriptionState;
 
   /**
    * Temporarily set the executing action so that any child actions created
@@ -576,54 +388,9 @@ export class Scheduler {
   >();
   // Actions that need dependency population before first run
   private pendingDependencyCollection = new Set<Action>();
-  private pendingDependencyCollectionState = {
-    pendingDependencyCollection: this.pendingDependencyCollection,
-    effects: this.effects,
-    isThrottled: (action: Action) => this.delays.isThrottled(action),
-    getSchedulingWrites: (action: Action) =>
-      getSchedulingWritesFromState(this.schedulingWriteState, action),
-    hasDependentPath: (from: Action, to: Action) =>
-      hasDependentPath(this.pullDemandState, from, to),
-  };
+  private pendingDependencyCollectionState!: PendingDependencyCollectionState;
   private dependencyCollectionState!: DependencyCollectionState;
-  private subscribeActionState: SchedulerSubscribeActionState = {
-    subscriptionState: this.subscriptionState,
-    dependencyUpdateState: this.dependencyUpdateState,
-    triggerSubscriptionState: this.triggerSubscriptionState,
-    pendingDependencyCollectionState: this.pendingDependencyCollectionState,
-    populateDependenciesCallbacks: this.populateDependenciesCallbacks,
-    pendingDependencyCollection: this.pendingDependencyCollection,
-    activePullDemandActions: this.activePullDemandActions,
-    pullDemandedFirstRunComputations: this.pullDemandedFirstRunComputations,
-    actionParent: this.actionParent,
-    pending: this.pending,
-    scheduledFirstTime: this.scheduledFirstTime,
-    effects: this.effects,
-    dirty: this.staleness.dirty,
-    stale: this.staleness.stale,
-    writersByEntity: this.writerIndexState.writersByEntity,
-    getPullMode: () => this.pullMode,
-    setDebounce: (action, ms) => this.setDebounce(action, ms),
-    setNoDebounce: (action, optOut) => this.setNoDebounce(action, optOut),
-    setThrottle: (action, ms) => this.setThrottle(action, ms),
-    getSchedulingWrites: (action) =>
-      getSchedulingWritesFromState(this.schedulingWriteState, action),
-    isThrottled: (action) => this.delays.isThrottled(action),
-    isStale: (action) => this.staleness.isStale(action),
-    markDirectDirty: (action) => {
-      this.staleness.markDirectDirty(action);
-    },
-    markEffectConditionallyScheduled: (action) =>
-      this.markEffectConditionallyScheduled(action),
-    updateDependents: (action, log) => this.updateDependents(action, log),
-    scheduleAffectedEffects: (action) => this.scheduleAffectedEffects(action),
-    queueExecution: () => this.queueExecution(),
-    getActionId: (action) => this.getActionId(action),
-    unsubscribe: (action) => this.unsubscribe(action),
-    submitSubscribeTelemetry: (event) => {
-      this.runtime.telemetry.submit(event);
-    },
-  };
+  private subscribeActionState!: SchedulerSubscribeActionState;
 
   private idlePromises: (() => void)[] = [];
   private backgroundTasks = new Set<Promise<unknown>>();
@@ -634,110 +401,9 @@ export class Scheduler {
   private scheduled = false;
   private disposed = false;
   private actionRunState!: SchedulerActionRunState;
-  private cycleBreakState: CycleBreakState = {
-    getPullMode: () => this.pullMode,
-    dirty: this.staleness.dirty,
-    effects: this.effects,
-    runsThisExecute: this.runsThisExecute,
-    pending: this.pending,
-    isThrottled: (action) => this.delays.isThrottled(action),
-    clearDirty: (action) =>
-      clearSchedulerDirty(this.dirtySchedulingState, action),
-    unsubscribe: (action) => this.unsubscribe(action),
-    recordExecuted: () => {
-      this.filterStats.executed++;
-    },
-    getActionId: (action) => this.getActionId(action),
-    runAction: (action) => this.run(action),
-  };
-  private settleLoopState: SchedulerSettleLoopState = {
-    getPullMode: () => this.pullMode,
-    getCollectSettleStats: () => this.collectSettleStats,
-    pendingDependencyCollection: this.pendingDependencyCollection,
-    populateDependenciesCallbacks: this.populateDependenciesCallbacks,
-    effects: this.effects,
-    computations: this.computations,
-    pending: this.pending,
-    dirty: this.staleness.dirty,
-    dependencies: this.dependencies,
-    actionParent: this.actionParent,
-    dependents: this.dependents,
-    conditionallyScheduledEffects: this.conditionallyScheduledEffects,
-    filterStats: this.filterStats,
-    getLoopCounter: () => this.loopCounter,
-    runsThisExecute: this.runsThisExecute,
-    activePullDemandActions: this.activePullDemandActions,
-    getSchedulingWrites: (action) =>
-      getSchedulingWritesFromState(this.schedulingWriteState, action),
-    getSchedulingWritesMap: () =>
-      getSchedulingWritesMapFromState(this.schedulingWriteState),
-    collectDependenciesForAction: (action, populateDependencies, options) =>
-      this.collectDependenciesForAction(
-        action,
-        populateDependencies,
-        options,
-      ),
-    collectPullIterationSeeds: (seeds) => this.collectPullIterationSeeds(seeds),
-    collectDirtyDependencies: (seed, targetWorkSet, memo) =>
-      this.collectDirtyDependencies(seed, targetWorkSet, memo),
-    getActionId: (action) => this.getActionId(action),
-    clearDirty: (action) =>
-      clearSchedulerDirty(this.dirtySchedulingState, action),
-    markDirectDirty: (action) => this.staleness.markDirectDirty(action),
-    isThrottled: (action) => this.delays.isThrottled(action),
-    isDebouncedComputationWaiting: (action) =>
-      this.isDebouncedComputationWaiting(action),
-    clearComputationDebounceState: (action) =>
-      this.delays.clearComputationDebounceState(action),
-    conditionalEffectHasChangedInputs: (action) =>
-      this.conditionalEffectHasChangedInputs(action),
-    isPullDemandRootEffect: (action) =>
-      isPullDemandRootEffect(this.pullDemandState, action),
-    handleError: (error, action) => this.handleError(error, action),
-    runAction: (action) => this.run(action),
-  };
-  private executeContinuationState: ExecuteContinuationState = {
-    getPullMode: () => this.pullMode,
-    pending: this.pending,
-    dirty: this.staleness.dirty,
-    effects: this.effects,
-    eventQueue: this.eventQueue,
-    eventQueueWakeState: this.eventQueueWakeState,
-    idlePromises: this.idlePromises,
-    scheduledFirstTime: this.scheduledFirstTime,
-    conditionallyScheduledEffects: this.conditionallyScheduledEffects,
-    changedWritesHistory: this.changedWritesHistory,
-    consumeRerunAfterCurrentExecute: () => {
-      const shouldRerun = this.rerunAfterCurrentExecute;
-      this.rerunAfterCurrentExecute = false;
-      return shouldRerun;
-    },
-    isDemandedPullComputation: (action) =>
-      isDemandedPullComputation(this.pullDemandState, action),
-    shouldRunFirstPullComputationInDemandContext: (action) =>
-      shouldRunFirstPullComputationInDemandContext(
-        this.pullDemandState,
-        action,
-      ),
-    isDebouncedComputationWaiting: (action) =>
-      this.isDebouncedComputationWaiting(action),
-    getNextDebounceRunTime: (action) => this.getNextDebounceRunTime(action),
-    getNextEligibleRunTime: (action) =>
-      this.delays.getNextEligibleRunTime(action),
-    resetLoopCounter: () => {
-      this.loopCounter = new WeakMap();
-    },
-    setScheduled: (scheduled) => {
-      this.scheduled = scheduled;
-    },
-    resetSettlingTracker: () => {
-      this.settlingTracker = createSettlingTracker();
-    },
-    setPendingQueueTaskTimer: (timer) => {
-      this.pendingQueueTaskTimer = timer;
-    },
-    execute: () => this.execute(),
-  };
+  private cycleBreakState!: CycleBreakState;
+  private settleLoopState!: SchedulerSettleLoopState;
+  private executeContinuationState!: ExecuteContinuationState;
 
   get runningPromise(): Promise<unknown> | undefined {
     return this._running;
@@ -761,7 +427,500 @@ export class Scheduler {
     consoleHandler?: ConsoleHandler,
     errorHandlers?: ErrorHandler[],
   ) {
-    this.eventQueueState = {
+    this.initializeSchedulerState();
+
+    this.consoleHandler = consoleHandler ||
+      function (data) {
+        // Default console handler returns arguments unaffected.
+        return data.args;
+      };
+
+    if (errorHandlers) {
+      errorHandlers.forEach((handler) => this.errorHandlers.add(handler));
+    }
+
+    // Subscribe to storage notifications
+    this.runtime.storageManager.subscribe(
+      createStorageSubscription(this.storageNotificationState),
+    );
+
+    // Set up harness event listeners
+    this.runtime.harness.addEventListener("console", (e: Event) => {
+      // Called synchronously when `console` methods are
+      // called within the runtime.
+      const { method, args } = e as ConsoleEvent;
+      const metadata = getPieceMetadataFromFrame();
+      const result = this.consoleHandler({ metadata, method, args });
+      console[method].apply(console, result);
+    });
+  }
+
+  // Keep state-bundle wiring explicit without making the field declarations
+  // read like one large object graph.
+  private initializeSchedulerState(): void {
+    this.diagnosisControlState = this.createDiagnosisControlState();
+    this.eventQueueWakeState = this.createEventQueueWakeState();
+    this.schedulingWriteState = this.createSchedulingWriteState();
+    this.pullDemandState = this.createPullDemandState();
+    this.delayControlState = this.createDelayControlState();
+    this.dirtyDependencyCollectionState = this
+      .createDirtyDependencyCollectionState();
+    this.dependencyGraphState = this.createDependencyGraphState();
+    this.dependencyUpdateState = this.createDependencyUpdateState();
+    this.triggerSubscriptionState = this.createTriggerSubscriptionState();
+    this.dirtySchedulingState = this.createDirtySchedulingState();
+    this.storageNotificationState = this.createStorageNotificationState();
+    this.pendingPullRunnableState = this.createPendingPullRunnableState();
+    this.dirtyPullRunnableState = this.createDirtyPullRunnableState();
+    this.dirtyPullRunnableStateWithDebounce = this
+      .createDirtyPullRunnableStateWithDebounce();
+    this.writePropagationState = this.createWritePropagationState();
+    this.subscriptionState = this.createSubscriptionState();
+    this.pendingDependencyCollectionState = this
+      .createPendingDependencyCollectionState();
+    this.subscribeActionState = this.createSubscribeActionState();
+    this.cycleBreakState = this.createCycleBreakState();
+    this.settleLoopState = this.createSettleLoopState();
+    this.executeContinuationState = this.createExecuteContinuationState();
+    this.eventQueueState = this.createEventQueueState();
+    this.dependencyCollectionState = this.createDependencyCollectionState();
+    this.actionRunState = this.createActionRunState();
+  }
+
+  private createDiagnosisControlState(): SchedulerDiagnosisControlState {
+    return {
+      getDiagnosisEnabled: () => this.diagnosisEnabled,
+      setDiagnosisEnabled: (enabled) => {
+        this.diagnosisEnabled = enabled;
+      },
+      getDiagnosisTimeout: () => this.diagnosisTimeout,
+      setDiagnosisTimeout: (timeout) => {
+        this.diagnosisTimeout = timeout;
+      },
+      getDiagnosisStartTime: () => this.diagnosisStartTime,
+      setDiagnosisStartTime: (time) => {
+        this.diagnosisStartTime = time;
+      },
+      getDiagnosisBusyTime: () => this.diagnosisBusyTime,
+      setDiagnosisBusyTime: (time) => {
+        this.diagnosisBusyTime = time;
+      },
+      getDiagnosisResolve: () => this.diagnosisResolve,
+      setDiagnosisResolve: (resolve) => {
+        this.diagnosisResolve = resolve;
+      },
+      diagnosisHistory: this.diagnosisHistory,
+      diagnosisNonIdempotent: this.diagnosisNonIdempotent,
+      causalEdges: this.causalEdges,
+      idempotencyViolations: this.idempotencyViolations,
+      computations: this.computations,
+      setIdempotencyCheckMode: (enabled) => {
+        this.idempotencyCheckMode = enabled;
+      },
+      runAction: (action) => this.run(action),
+    };
+  }
+
+  private createEventQueueWakeState(): EventQueueWakeState {
+    return {
+      timer: null,
+      wakeAt: null,
+      eventQueue: this.eventQueue,
+      isDisposed: () => this.disposed,
+      queueExecution: () => this.queueExecution(),
+    };
+  }
+
+  private createSchedulingWriteState(): SchedulingWriteState {
+    return {
+      // Current-known writes are rebuilt on each dependency update from actual
+      // writes plus declared/potential writes. This is the default scheduling view.
+      currentKnownWrites: new WeakMap<Action, IMemorySpaceAddress[]>(),
+      // Historical writes preserve the legacy cumulative union and are only used
+      // when the experimental historical-write mode is enabled.
+      historicalMightWrite: new WeakMap<Action, IMemorySpaceAddress[]>(),
+      useHistoricalMightWrite: () =>
+        this.runtime.experimental.schedulerHistoricalMightWrite === true,
+    };
+  }
+
+  private createPullDemandState(): PullDemandState {
+    return {
+      getPullMode: () => this.pullMode,
+      computations: this.computations,
+      effects: this.effects,
+      dependents: this.dependents,
+      dependencies: this.dependencies,
+      actionParent: this.actionParent,
+      isEffectAction: this.isEffectAction,
+      pullDemandedFirstRunComputations: this.pullDemandedFirstRunComputations,
+      hasActionRun: (action) => this.delays.hasActionRun(action),
+      getSchedulingWrites: (action) =>
+        getSchedulingWritesFromState(this.schedulingWriteState, action),
+    };
+  }
+
+  private createDelayControlState(): SchedulerDelayControlState {
+    return {
+      delays: this.delays,
+      computations: this.computations,
+      effects: this.effects,
+      dirty: this.staleness.dirty,
+      pending: this.pending,
+      getPullMode: () => this.pullMode,
+      isPullDemandRootEffect: (action) =>
+        isPullDemandRootEffect(this.pullDemandState, action),
+      queueExecution: () => this.queueExecution(),
+      logDebounce: (message) =>
+        logger.debug("schedule-debounce", () => [message]),
+    };
+  }
+
+  private createDirtyDependencyCollectionState(): DirtyDependencyCollectionState {
+    return {
+      collectStack: this.collectStack,
+      getTrace: () => this.dirtyDependencyTraceContext,
+      dirty: this.staleness.dirty,
+      pending: this.pending,
+      computations: this.computations,
+      reverseDependencies: this.reverseDependencies,
+      dependencies: this.dependencies,
+      writersByEntity: this.writerIndexState.writersByEntity,
+      effects: this.effects,
+      isStale: (target) => this.staleness.isStale(target),
+      getSchedulingWrites: (target) =>
+        getSchedulingWritesFromState(this.schedulingWriteState, target),
+      getActionId: (target) => this.getActionId(target),
+    };
+  }
+
+  private createDependencyGraphState(): DependencyGraphState {
+    return {
+      triggers: this.triggerIndexState.triggers,
+      nonRecursiveTriggers: this.triggerIndexState.nonRecursiveTriggers,
+      writersByEntity: this.writerIndexState.writersByEntity,
+      dependencies: this.dependencies,
+      dependents: this.dependents,
+      reverseDependencies: this.reverseDependencies,
+      staleness: this.staleness,
+      getSchedulingWrites: (action) =>
+        getSchedulingWritesFromState(this.schedulingWriteState, action),
+      isStale: (action) => this.staleness.isStale(action),
+      isDemandedPullComputation: (action) =>
+        isDemandedPullComputation(this.pullDemandState, action),
+      queueExecution: () => this.queueExecution(),
+    };
+  }
+
+  private createDependencyUpdateState(): DependencyUpdateState {
+    return {
+      writersByEntity: this.writerIndexState.writersByEntity,
+      actionWriteEntities: this.writerIndexState.actionWriteEntities,
+      dependencies: this.dependencies,
+      currentKnownWrites: this.schedulingWriteState.currentKnownWrites,
+      historicalMightWrite: this.schedulingWriteState.historicalMightWrite,
+      dependencyGraph: this.dependencyGraphState,
+      useHistoricalMightWrite:
+        this.schedulingWriteState.useHistoricalMightWrite,
+      isPullMode: () => this.pullMode,
+    };
+  }
+
+  private createTriggerSubscriptionState(): TriggerSubscriptionState {
+    return {
+      triggers: this.triggerIndexState.triggers,
+      nonRecursiveTriggers: this.triggerIndexState.nonRecursiveTriggers,
+      cancels: this.cancels,
+      getActionId: (action) => this.getActionId(action),
+      onTriggerUnsubscribe: (actionId, entityCount) => {
+        logger.debug("schedule-unsubscribe", () => [
+          `Action: ${actionId}`,
+          `Entities: ${entityCount}`,
+        ]);
+      },
+    };
+  }
+
+  private createDirtySchedulingState(): DirtySchedulingState {
+    return {
+      staleness: this.staleness,
+      computations: this.computations,
+      scheduleComputationDebounce: (action) =>
+        this.scheduleComputationDebounce(action),
+      clearComputationDebounceState: (action) =>
+        this.delays.clearComputationDebounceState(action),
+      isDemandedPullComputation: (action) =>
+        isDemandedPullComputation(this.pullDemandState, action),
+      queueExecution: () => this.queueExecution(),
+    };
+  }
+
+  private createStorageNotificationState(): StorageNotificationState {
+    return {
+      triggers: this.triggerIndexState.triggers,
+      nonRecursiveTriggers: this.triggerIndexState.nonRecursiveTriggers,
+      getPullMode: () => this.pullMode,
+      getDiagnosisEnabled: () => this.diagnosisEnabled,
+      getCollectTriggerTrace: () => this.collectTriggerTrace,
+      changeGroupToActionId: this.changeGroupToActionId,
+      recordCausalEdge: (edge) => {
+        this.causalEdges.push(edge);
+      },
+      actionChangeGroups: this.actionChangeGroups,
+      effects: this.effects,
+      pending: this.pending,
+      dirty: this.staleness.dirty,
+      inFlightSources: this.inFlightSourceState.inFlightSources,
+      conditionallyScheduledEffects: this.conditionallyScheduledEffects,
+      getActionId: (target) => this.getActionId(target),
+      recordCellUpdate: (change) =>
+        this.runtime.telemetry.submit({
+          type: "cell.update",
+          change,
+        }),
+      recordTriggerTrace: (entry) =>
+        recordTriggerTraceState({ triggerTrace: this.triggerTrace }, entry),
+      scheduleWithDebounce: (target) => this.scheduleWithDebounce(target),
+      markDirty: (target) =>
+        markSchedulerDirty(this.dirtySchedulingState, target),
+      scheduleAffectedEffects: (target) => this.scheduleAffectedEffects(target),
+    };
+  }
+
+  private createPendingPullRunnableState(): PendingPullRunnableState {
+    return {
+      effects: this.effects,
+      isDemandedPullComputation: (action) =>
+        isDemandedPullComputation(this.pullDemandState, action),
+      shouldRunFirstPullComputationInDemandContext: (action) =>
+        shouldRunFirstPullComputationInDemandContext(
+          this.pullDemandState,
+          action,
+        ),
+    };
+  }
+
+  private createDirtyPullRunnableState(): DirtyPullRunnableState {
+    return {
+      effects: this.effects,
+      isDemandedPullComputation: (action) =>
+        isDemandedPullComputation(this.pullDemandState, action),
+      isThrottled: (action) => this.delays.isThrottled(action),
+    };
+  }
+
+  private createDirtyPullRunnableStateWithDebounce(): DirtyPullRunnableStateWithDebounce {
+    return {
+      ...this.dirtyPullRunnableState,
+      isDebouncedComputationWaiting: (action) =>
+        this.isDebouncedComputationWaiting(action),
+    };
+  }
+
+  private createWritePropagationState(): WritePropagationState {
+    return {
+      triggers: this.triggerIndexState.triggers,
+      nonRecursiveTriggers: this.triggerIndexState.nonRecursiveTriggers,
+      changedWritesHistory: this.changedWritesHistory,
+      effects: this.effects,
+      computations: this.computations,
+      conditionallyScheduledEffects: this.conditionallyScheduledEffects,
+      isPullMode: () => this.pullMode,
+      scheduleWithDebounce: (action) => this.scheduleWithDebounce(action),
+      markDirty: (action) =>
+        markSchedulerDirty(this.dirtySchedulingState, action),
+      scheduleAffectedEffects: (action) => {
+        this.scheduleAffectedEffects(action);
+      },
+    };
+  }
+
+  private createSubscriptionState(): SchedulerSubscriptionState {
+    return {
+      actionChangeGroups: this.actionChangeGroups,
+      changeGroupToActionId: this.changeGroupToActionId,
+      isEffectAction: this.isEffectAction,
+      effects: this.effects,
+      computations: this.computations,
+      getPullMode: () => this.pullMode,
+      getIdempotencyCheckMode: () => this.idempotencyCheckMode,
+      queueExecution: () => this.queueExecution(),
+      getActionId: (target) => this.getActionId(target),
+      getExecutingAction: () => this.executingAction,
+      actionParent: this.actionParent,
+      actionChildren: this.actionChildren,
+    };
+  }
+
+  private createPendingDependencyCollectionState(): PendingDependencyCollectionState {
+    return {
+      pendingDependencyCollection: this.pendingDependencyCollection,
+      effects: this.effects,
+      isThrottled: (action) => this.delays.isThrottled(action),
+      getSchedulingWrites: (action) =>
+        getSchedulingWritesFromState(this.schedulingWriteState, action),
+      hasDependentPath: (from, to) =>
+        hasDependentPath(this.pullDemandState, from, to),
+    };
+  }
+
+  private createSubscribeActionState(): SchedulerSubscribeActionState {
+    return {
+      subscriptionState: this.subscriptionState,
+      dependencyUpdateState: this.dependencyUpdateState,
+      triggerSubscriptionState: this.triggerSubscriptionState,
+      pendingDependencyCollectionState: this.pendingDependencyCollectionState,
+      populateDependenciesCallbacks: this.populateDependenciesCallbacks,
+      pendingDependencyCollection: this.pendingDependencyCollection,
+      activePullDemandActions: this.activePullDemandActions,
+      pullDemandedFirstRunComputations: this.pullDemandedFirstRunComputations,
+      actionParent: this.actionParent,
+      pending: this.pending,
+      scheduledFirstTime: this.scheduledFirstTime,
+      effects: this.effects,
+      dirty: this.staleness.dirty,
+      stale: this.staleness.stale,
+      writersByEntity: this.writerIndexState.writersByEntity,
+      getPullMode: () => this.pullMode,
+      setDebounce: (action, ms) => this.setDebounce(action, ms),
+      setNoDebounce: (action, optOut) => this.setNoDebounce(action, optOut),
+      setThrottle: (action, ms) => this.setThrottle(action, ms),
+      getSchedulingWrites: (action) =>
+        getSchedulingWritesFromState(this.schedulingWriteState, action),
+      isThrottled: (action) => this.delays.isThrottled(action),
+      isStale: (action) => this.staleness.isStale(action),
+      markDirectDirty: (action) => {
+        this.staleness.markDirectDirty(action);
+      },
+      markEffectConditionallyScheduled: (action) =>
+        this.markEffectConditionallyScheduled(action),
+      updateDependents: (action, log) => this.updateDependents(action, log),
+      scheduleAffectedEffects: (action) => this.scheduleAffectedEffects(action),
+      queueExecution: () => this.queueExecution(),
+      getActionId: (action) => this.getActionId(action),
+      unsubscribe: (action) => this.unsubscribe(action),
+      submitSubscribeTelemetry: (event) => {
+        this.runtime.telemetry.submit(event);
+      },
+    };
+  }
+
+  private createCycleBreakState(): CycleBreakState {
+    return {
+      getPullMode: () => this.pullMode,
+      dirty: this.staleness.dirty,
+      effects: this.effects,
+      runsThisExecute: this.runsThisExecute,
+      pending: this.pending,
+      isThrottled: (action) => this.delays.isThrottled(action),
+      clearDirty: (action) =>
+        clearSchedulerDirty(this.dirtySchedulingState, action),
+      unsubscribe: (action) => this.unsubscribe(action),
+      recordExecuted: () => {
+        this.filterStats.executed++;
+      },
+      getActionId: (action) => this.getActionId(action),
+      runAction: (action) => this.run(action),
+    };
+  }
+
+  private createSettleLoopState(): SchedulerSettleLoopState {
+    return {
+      getPullMode: () => this.pullMode,
+      getCollectSettleStats: () => this.collectSettleStats,
+      pendingDependencyCollection: this.pendingDependencyCollection,
+      populateDependenciesCallbacks: this.populateDependenciesCallbacks,
+      effects: this.effects,
+      computations: this.computations,
+      pending: this.pending,
+      dirty: this.staleness.dirty,
+      dependencies: this.dependencies,
+      actionParent: this.actionParent,
+      dependents: this.dependents,
+      conditionallyScheduledEffects: this.conditionallyScheduledEffects,
+      filterStats: this.filterStats,
+      getLoopCounter: () => this.loopCounter,
+      runsThisExecute: this.runsThisExecute,
+      activePullDemandActions: this.activePullDemandActions,
+      getSchedulingWrites: (action) =>
+        getSchedulingWritesFromState(this.schedulingWriteState, action),
+      getSchedulingWritesMap: () =>
+        getSchedulingWritesMapFromState(this.schedulingWriteState),
+      collectDependenciesForAction: (action, populateDependencies, options) =>
+        this.collectDependenciesForAction(
+          action,
+          populateDependencies,
+          options,
+        ),
+      collectPullIterationSeeds: (seeds) =>
+        this.collectPullIterationSeeds(seeds),
+      collectDirtyDependencies: (seed, targetWorkSet, memo) =>
+        this.collectDirtyDependencies(seed, targetWorkSet, memo),
+      getActionId: (action) => this.getActionId(action),
+      clearDirty: (action) =>
+        clearSchedulerDirty(this.dirtySchedulingState, action),
+      markDirectDirty: (action) => this.staleness.markDirectDirty(action),
+      isThrottled: (action) => this.delays.isThrottled(action),
+      isDebouncedComputationWaiting: (action) =>
+        this.isDebouncedComputationWaiting(action),
+      clearComputationDebounceState: (action) =>
+        this.delays.clearComputationDebounceState(action),
+      conditionalEffectHasChangedInputs: (action) =>
+        this.conditionalEffectHasChangedInputs(action),
+      isPullDemandRootEffect: (action) =>
+        isPullDemandRootEffect(this.pullDemandState, action),
+      handleError: (error, action) => this.handleError(error, action),
+      runAction: (action) => this.run(action),
+    };
+  }
+
+  private createExecuteContinuationState(): ExecuteContinuationState {
+    return {
+      getPullMode: () => this.pullMode,
+      pending: this.pending,
+      dirty: this.staleness.dirty,
+      effects: this.effects,
+      eventQueue: this.eventQueue,
+      eventQueueWakeState: this.eventQueueWakeState,
+      idlePromises: this.idlePromises,
+      scheduledFirstTime: this.scheduledFirstTime,
+      conditionallyScheduledEffects: this.conditionallyScheduledEffects,
+      changedWritesHistory: this.changedWritesHistory,
+      consumeRerunAfterCurrentExecute: () => {
+        const shouldRerun = this.rerunAfterCurrentExecute;
+        this.rerunAfterCurrentExecute = false;
+        return shouldRerun;
+      },
+      isDemandedPullComputation: (action) =>
+        isDemandedPullComputation(this.pullDemandState, action),
+      shouldRunFirstPullComputationInDemandContext: (action) =>
+        shouldRunFirstPullComputationInDemandContext(
+          this.pullDemandState,
+          action,
+        ),
+      isDebouncedComputationWaiting: (action) =>
+        this.isDebouncedComputationWaiting(action),
+      getNextDebounceRunTime: (action) => this.getNextDebounceRunTime(action),
+      getNextEligibleRunTime: (action) =>
+        this.delays.getNextEligibleRunTime(action),
+      resetLoopCounter: () => {
+        this.loopCounter = new WeakMap();
+      },
+      setScheduled: (scheduled) => {
+        this.scheduled = scheduled;
+      },
+      resetSettlingTracker: () => {
+        this.settlingTracker = createSettlingTracker();
+      },
+      setPendingQueueTaskTimer: (timer) => {
+        this.pendingQueueTaskTimer = timer;
+      },
+      execute: () => this.execute(),
+    };
+  }
+
+  private createEventQueueState(): SchedulerEventQueueState {
+    return {
       runtime: this.runtime,
       eventHandlers: this.eventHandlers,
       eventQueue: this.eventQueue,
@@ -782,15 +941,19 @@ export class Scheduler {
           targetDoNotLoad,
         ),
     };
+  }
 
-    this.dependencyCollectionState = {
+  private createDependencyCollectionState(): DependencyCollectionState {
+    return {
       runtime: this.runtime,
       dependencyUpdateState: this.dependencyUpdateState,
       triggerSubscriptionState: this.triggerSubscriptionState,
       updateDependents: (action, log) => this.updateDependents(action, log),
     };
+  }
 
-    this.actionRunState = {
+  private createActionRunState(): SchedulerActionRunState {
+    return {
       runtime: this.runtime,
       actionChangeGroups: this.actionChangeGroups,
       inFlightSourceState: this.inFlightSourceState,
@@ -836,31 +999,6 @@ export class Scheduler {
         this.currentActionId = undefined;
       },
     };
-
-    this.consoleHandler = consoleHandler ||
-      function (data) {
-        // Default console handler returns arguments unaffected.
-        return data.args;
-      };
-
-    if (errorHandlers) {
-      errorHandlers.forEach((handler) => this.errorHandlers.add(handler));
-    }
-
-    // Subscribe to storage notifications
-    this.runtime.storageManager.subscribe(
-      createStorageSubscription(this.storageNotificationState),
-    );
-
-    // Set up harness event listeners
-    this.runtime.harness.addEventListener("console", (e: Event) => {
-      // Called synchronously when `console` methods are
-      // called within the runtime.
-      const { method, args } = e as ConsoleEvent;
-      const metadata = getPieceMetadataFromFrame();
-      const result = this.consoleHandler({ metadata, method, args });
-      console[method].apply(console, result);
-    });
   }
 
   /**

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -52,15 +52,16 @@ import {
   getSchedulingWrites as getSchedulingWritesFromState,
   getSchedulingWritesMap as getSchedulingWritesMapFromState,
   readsOverlapWrites,
-  replaceActionTriggerPaths,
   type SchedulingWriteState,
-  setCancelForTriggerEntities,
-  setSchedulerDependencies,
   type TriggerIndexState,
   type TriggerSubscriptionState,
   updateDependentEdgesForLog,
   type WriterIndexState,
 } from "./scheduler/dependency-index.ts";
+import {
+  collectDependenciesForAction as collectDependenciesForActionState,
+  type DependencyCollectionState,
+} from "./scheduler/dependency-collection.ts";
 import {
   collectDirtyDependencies as collectDirtyDependenciesState,
   collectDirtyDependenciesForLog as collectDirtyDependenciesForLogState,
@@ -68,6 +69,7 @@ import {
 import {
   type InFlightSourceState,
   runSchedulerAction,
+  type SchedulerActionRunState,
 } from "./scheduler/action-run.ts";
 import {
   buildPullInitialSeeds,
@@ -81,6 +83,7 @@ import {
   pushBoundedHistory,
   recordExecuteEnd,
   runSchedulerSettleLoop,
+  type SchedulerSettleLoopState,
   type SchedulerSettleResult,
   type SettlingTracker,
 } from "./scheduler/execution.ts";
@@ -109,7 +112,6 @@ import {
   type ActionTimingState,
   getActionStats as getActionStatsFromState,
 } from "./scheduler/timing.ts";
-import { txToReactivityLog } from "./scheduler/reactivity.ts";
 import {
   addSchedulerEventHandler,
   cancelEventQueueWake as cancelEventQueueWakeState,
@@ -450,6 +452,7 @@ export class Scheduler {
     hasDependentPath: (from: Action, to: Action) =>
       this.hasDependentPath(from, to),
   };
+  private dependencyCollectionState!: DependencyCollectionState;
   private subscribeActionState: SchedulerSubscribeActionState = {
     subscriptionState: this.subscriptionState,
     dependencyUpdateState: this.dependencyUpdateState,
@@ -497,6 +500,7 @@ export class Scheduler {
   private _running: Promise<unknown> | undefined = undefined;
   private scheduled = false;
   private disposed = false;
+  private actionRunState!: SchedulerActionRunState;
   private cycleBreakState: CycleBreakState = {
     getPullMode: () => this.pullMode,
     dirty: this.staleness.dirty,
@@ -511,6 +515,51 @@ export class Scheduler {
       this.filterStats.executed++;
     },
     getActionId: (action) => this.getActionId(action),
+    runAction: (action) => this.run(action),
+  };
+  private settleLoopState: SchedulerSettleLoopState = {
+    getPullMode: () => this.pullMode,
+    getCollectSettleStats: () => this.collectSettleStats,
+    pendingDependencyCollection: this.pendingDependencyCollection,
+    populateDependenciesCallbacks: this.populateDependenciesCallbacks,
+    effects: this.effects,
+    computations: this.computations,
+    pending: this.pending,
+    dirty: this.staleness.dirty,
+    dependencies: this.dependencies,
+    actionParent: this.actionParent,
+    dependents: this.dependents,
+    conditionallyScheduledEffects: this.conditionallyScheduledEffects,
+    filterStats: this.filterStats,
+    getLoopCounter: () => this.loopCounter,
+    runsThisExecute: this.runsThisExecute,
+    activePullDemandActions: this.activePullDemandActions,
+    getSchedulingWrites: (action) =>
+      getSchedulingWritesFromState(this.schedulingWriteState, action),
+    getSchedulingWritesMap: () =>
+      getSchedulingWritesMapFromState(this.schedulingWriteState),
+    collectDependenciesForAction: (action, populateDependencies, options) =>
+      this.collectDependenciesForAction(
+        action,
+        populateDependencies,
+        options,
+      ),
+    collectPullIterationSeeds: (seeds) => this.collectPullIterationSeeds(seeds),
+    collectDirtyDependencies: (seed, targetWorkSet, memo) =>
+      this.collectDirtyDependencies(seed, targetWorkSet, memo),
+    getActionId: (action) => this.getActionId(action),
+    clearDirty: (action) =>
+      clearSchedulerDirty(this.dirtySchedulingState, action),
+    markDirectDirty: (action) => this.staleness.markDirectDirty(action),
+    isThrottled: (action) => this.delays.isThrottled(action),
+    isDebouncedComputationWaiting: (action) =>
+      this.isDebouncedComputationWaiting(action),
+    clearComputationDebounceState: (action) =>
+      this.delays.clearComputationDebounceState(action),
+    conditionalEffectHasChangedInputs: (action) =>
+      this.conditionalEffectHasChangedInputs(action),
+    isPullDemandRootEffect: (action) => this.isPullDemandRootEffect(action),
+    handleError: (error, action) => this.handleError(error, action),
     runAction: (action) => this.run(action),
   };
   private executeContinuationState: ExecuteContinuationState = {
@@ -575,6 +624,60 @@ export class Scheduler {
     consoleHandler?: ConsoleHandler,
     errorHandlers?: ErrorHandler[],
   ) {
+    this.dependencyCollectionState = {
+      runtime: this.runtime,
+      dependencyUpdateState: this.dependencyUpdateState,
+      triggerSubscriptionState: this.triggerSubscriptionState,
+      updateDependents: (action, log) => this.updateDependents(action, log),
+    };
+
+    this.actionRunState = {
+      runtime: this.runtime,
+      actionChangeGroups: this.actionChangeGroups,
+      inFlightSourceState: this.inFlightSourceState,
+      actionTimingState: this.actionTimingState,
+      pullDemandedFirstRunComputations: this.pullDemandedFirstRunComputations,
+      retries: this.retries,
+      pending: this.pending,
+      actionRunTrace: this.actionRunTrace,
+      actionParent: this.actionParent,
+      isEffectAction: this.isEffectAction,
+      diagnosisHistory: this.diagnosisHistory,
+      diagnosisNonIdempotent: this.diagnosisNonIdempotent,
+      idempotencyViolations: this.idempotencyViolations,
+      writePropagationState: this.writePropagationState,
+      computations: this.computations,
+      getRunningPromise: () => this.runningPromise,
+      setRunningPromise: (promise) => {
+        this.runningPromise = promise;
+      },
+      getPullMode: () => this.pullMode,
+      getCollectActionRunTrace: () => this.collectActionRunTrace,
+      getDiagnosisEnabled: () => this.diagnosisEnabled,
+      getIdempotencyCheckMode: () => this.idempotencyCheckMode,
+      getActionId: (target) => this.getActionId(target),
+      getActionTelemetryInfo: (target) =>
+        getSchedulerActionTelemetryInfo(target),
+      getSchedulingWrites: (target) =>
+        getSchedulingWritesFromState(this.schedulingWriteState, target),
+      maybeAutoDebounce: (target) => this.maybeAutoDebounce(target),
+      markActionHasRun: (target) => this.delays.markActionHasRun(target),
+      handleError: (error, target) => this.handleError(error, target),
+      resubscribe: (target, log) => this.resubscribe(target, log),
+      markDirectDirty: (target) => this.staleness.markDirectDirty(target),
+      clearDirectDirty: (target) =>
+        clearSchedulerDirectDirty(this.dirtySchedulingState, target),
+      queueExecution: () => this.queueExecution(),
+      setExecutingAction: (target, targetActionId) => {
+        this.executingAction = target;
+        this.currentActionId = targetActionId;
+      },
+      clearExecutingAction: () => {
+        this.executingAction = null;
+        this.currentActionId = undefined;
+      },
+    };
+
     this.consoleHandler = consoleHandler ||
       function (data) {
         // Default console handler returns arguments unaffected.
@@ -612,7 +715,7 @@ export class Scheduler {
 
   enableIdempotencyCheck(): void {
     this.idempotencyCheckMode = true;
-    this.idempotencyViolations = [];
+    this.idempotencyViolations.length = 0;
     if (this.pullMode) {
       this.queueExecution();
     }
@@ -724,52 +827,7 @@ export class Scheduler {
   }
 
   async run(action: Action): Promise<any> {
-    return await runSchedulerAction({
-      runtime: this.runtime,
-      actionChangeGroups: this.actionChangeGroups,
-      inFlightSourceState: this.inFlightSourceState,
-      actionTimingState: this.actionTimingState,
-      pullDemandedFirstRunComputations: this.pullDemandedFirstRunComputations,
-      retries: this.retries,
-      pending: this.pending,
-      actionRunTrace: this.actionRunTrace,
-      actionParent: this.actionParent,
-      isEffectAction: this.isEffectAction,
-      diagnosisHistory: this.diagnosisHistory,
-      diagnosisNonIdempotent: this.diagnosisNonIdempotent,
-      idempotencyViolations: this.idempotencyViolations,
-      writePropagationState: this.writePropagationState,
-      computations: this.computations,
-      getRunningPromise: () => this.runningPromise,
-      setRunningPromise: (promise) => {
-        this.runningPromise = promise;
-      },
-      getPullMode: () => this.pullMode,
-      getCollectActionRunTrace: () => this.collectActionRunTrace,
-      getDiagnosisEnabled: () => this.diagnosisEnabled,
-      getIdempotencyCheckMode: () => this.idempotencyCheckMode,
-      getActionId: (target) => this.getActionId(target),
-      getActionTelemetryInfo: (target) =>
-        getSchedulerActionTelemetryInfo(target),
-      getSchedulingWrites: (target) =>
-        getSchedulingWritesFromState(this.schedulingWriteState, target),
-      maybeAutoDebounce: (target) => this.maybeAutoDebounce(target),
-      markActionHasRun: (target) => this.delays.markActionHasRun(target),
-      handleError: (error, target) => this.handleError(error, target),
-      resubscribe: (target, log) => this.resubscribe(target, log),
-      markDirectDirty: (target) => this.staleness.markDirectDirty(target),
-      clearDirectDirty: (target) =>
-        clearSchedulerDirectDirty(this.dirtySchedulingState, target),
-      queueExecution: () => this.queueExecution(),
-      setExecutingAction: (target, targetActionId) => {
-        this.executingAction = target;
-        this.currentActionId = targetActionId;
-      },
-      clearExecutingAction: () => {
-        this.executingAction = null;
-        this.currentActionId = undefined;
-      },
-    }, action);
+    return await runSchedulerAction(this.actionRunState, action);
   }
 
   idle(): Promise<void> {
@@ -939,50 +997,12 @@ export class Scheduler {
       useRawReadsForTriggers?: boolean;
     },
   ): { log: ReactivityLog; entities: Set<SpaceScopeAndURI> } {
-    let log: ReactivityLog;
-    if (typeof populateDependencies === "function") {
-      const depTx = this.runtime.edit();
-      try {
-        logger.timeStart("collectDependencies", "populate");
-        try {
-          populateDependencies(depTx);
-        } finally {
-          logger.timeEnd("collectDependencies", "populate");
-        }
-      } catch (error) {
-        logger.debug(options.errorLogLabel, () => [
-          options.errorMessage(action, error),
-        ]);
-      }
-      log = txToReactivityLog(depTx);
-      depTx.abort();
-    } else {
-      log = populateDependencies;
-    }
-
-    const { reads, shallowReads, log: schedulingLog } =
-      setSchedulerDependencies(this.dependencyUpdateState, action, log);
-    if (options.updateDependents ?? true) {
-      this.updateDependents(action, schedulingLog);
-    }
-
-    const readsForTriggers = options.useRawReadsForTriggers ? log.reads : reads;
-    const shallowReadsForTriggers = options.useRawReadsForTriggers
-      ? log.shallowReads
-      : shallowReads;
-    const { entities } = replaceActionTriggerPaths(
-      this.triggerSubscriptionState,
+    return collectDependenciesForActionState(
+      this.dependencyCollectionState,
       action,
-      readsForTriggers,
-      shallowReadsForTriggers,
+      populateDependencies,
+      options,
     );
-    setCancelForTriggerEntities(
-      this.triggerSubscriptionState,
-      action,
-      entities,
-    );
-
-    return { log, entities };
   }
 
   /**
@@ -1705,7 +1725,8 @@ export class Scheduler {
    * Resets filter statistics.
    */
   resetFilterStats(): void {
-    this.filterStats = { filtered: 0, executed: 0 };
+    this.filterStats.filtered = 0;
+    this.filterStats.executed = 0;
   }
 
   /**
@@ -1749,7 +1770,7 @@ export class Scheduler {
   setActionRunTraceEnabled(enabled: boolean): void {
     this.collectActionRunTrace = enabled;
     if (!enabled) {
-      this.actionRunTrace = [];
+      this.actionRunTrace.length = 0;
     }
   }
 
@@ -1814,7 +1835,7 @@ export class Scheduler {
     this.diagnosisStartTime = performance.now();
     this.diagnosisBusyTime = 0;
     this.diagnosisHistory.clear();
-    this.diagnosisNonIdempotent = [];
+    this.diagnosisNonIdempotent.length = 0;
     this.causalEdges = [];
 
     this.diagnosisTimeout = setTimeout(() => {
@@ -1879,7 +1900,7 @@ export class Scheduler {
    * automatically gets a second synchronous run for comparison.
    */
   async runIdempotencyCheck(): Promise<SchedulerDiagnosisResult> {
-    this.idempotencyViolations = [];
+    this.idempotencyViolations.length = 0;
     this.idempotencyCheckMode = true;
 
     try {
@@ -2048,52 +2069,10 @@ export class Scheduler {
   private async runSettleLoop(
     initialSeeds: ReadonlySet<Action>,
   ): Promise<SchedulerSettleResult> {
-    const settleResult = await runSchedulerSettleLoop({
-      pullMode: this.pullMode,
-      collectSettleStats: this.collectSettleStats,
-      pendingDependencyCollection: this.pendingDependencyCollection,
-      populateDependenciesCallbacks: this.populateDependenciesCallbacks,
-      effects: this.effects,
-      computations: this.computations,
-      pending: this.pending,
-      dirty: this.staleness.dirty,
-      dependencies: this.dependencies,
-      actionParent: this.actionParent,
-      dependents: this.dependents,
-      conditionallyScheduledEffects: this.conditionallyScheduledEffects,
-      filterStats: this.filterStats,
-      loopCounter: this.loopCounter,
-      runsThisExecute: this.runsThisExecute,
-      activePullDemandActions: this.activePullDemandActions,
-      getSchedulingWrites: (action) =>
-        getSchedulingWritesFromState(this.schedulingWriteState, action),
-      getSchedulingWritesMap: () =>
-        getSchedulingWritesMapFromState(this.schedulingWriteState),
-      collectDependenciesForAction: (action, populateDependencies, options) =>
-        this.collectDependenciesForAction(
-          action,
-          populateDependencies,
-          options,
-        ),
-      collectPullIterationSeeds: (seeds) =>
-        this.collectPullIterationSeeds(seeds),
-      collectDirtyDependencies: (seed, targetWorkSet, memo) =>
-        this.collectDirtyDependencies(seed, targetWorkSet, memo),
-      getActionId: (action) => this.getActionId(action),
-      clearDirty: (action) =>
-        clearSchedulerDirty(this.dirtySchedulingState, action),
-      markDirectDirty: (action) => this.staleness.markDirectDirty(action),
-      isThrottled: (action) => this.delays.isThrottled(action),
-      isDebouncedComputationWaiting: (action) =>
-        this.isDebouncedComputationWaiting(action),
-      clearComputationDebounceState: (action) =>
-        this.delays.clearComputationDebounceState(action),
-      conditionalEffectHasChangedInputs: (action) =>
-        this.conditionalEffectHasChangedInputs(action),
-      isPullDemandRootEffect: (action) => this.isPullDemandRootEffect(action),
-      handleError: (error, action) => this.handleError(error, action),
-      runAction: (action) => this.run(action),
-    }, initialSeeds);
+    const settleResult = await runSchedulerSettleLoop(
+      this.settleLoopState,
+      initialSeeds,
+    );
 
     if (settleResult.settleStats) {
       this.lastSettleStats = settleResult.settleStats;

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -42,8 +42,12 @@ import {
   type SchedulerActionIdentityState,
 } from "./scheduler/diagnostics.ts";
 import {
-  detectCausalCycles,
   type DiagnosisRecord,
+  runSchedulerDiagnosis,
+  runSchedulerIdempotencyCheck,
+  type SchedulerDiagnosisControlState,
+  startSchedulerDiagnosis,
+  stopSchedulerDiagnosis,
 } from "./scheduler/diagnosis.ts";
 import {
   type DependencyGraphState,
@@ -278,6 +282,37 @@ export class Scheduler {
     timestamp: number;
   }[] = [];
   private changeGroupToActionId = new Map<ChangeGroup, string>();
+  private diagnosisControlState: SchedulerDiagnosisControlState = {
+    getDiagnosisEnabled: () => this.diagnosisEnabled,
+    setDiagnosisEnabled: (enabled) => {
+      this.diagnosisEnabled = enabled;
+    },
+    getDiagnosisTimeout: () => this.diagnosisTimeout,
+    setDiagnosisTimeout: (timeout) => {
+      this.diagnosisTimeout = timeout;
+    },
+    getDiagnosisStartTime: () => this.diagnosisStartTime,
+    setDiagnosisStartTime: (time) => {
+      this.diagnosisStartTime = time;
+    },
+    getDiagnosisBusyTime: () => this.diagnosisBusyTime,
+    setDiagnosisBusyTime: (time) => {
+      this.diagnosisBusyTime = time;
+    },
+    getDiagnosisResolve: () => this.diagnosisResolve,
+    setDiagnosisResolve: (resolve) => {
+      this.diagnosisResolve = resolve;
+    },
+    diagnosisHistory: this.diagnosisHistory,
+    diagnosisNonIdempotent: this.diagnosisNonIdempotent,
+    causalEdges: this.causalEdges,
+    idempotencyViolations: this.idempotencyViolations,
+    computations: this.computations,
+    setIdempotencyCheckMode: (enabled) => {
+      this.idempotencyCheckMode = enabled;
+    },
+    runAction: (action) => this.run(action),
+  };
 
   // Debounce infrastructure for throttling slow actions
   private pendingQueueTaskTimer: ReturnType<typeof setTimeout> | null = null;
@@ -1799,53 +1834,14 @@ export class Scheduler {
    * Automatically stops after durationMs.
    */
   private startDiagnosis(durationMs = 5000): void {
-    if (this.diagnosisEnabled) return;
-
-    this.diagnosisEnabled = true;
-    this.diagnosisStartTime = performance.now();
-    this.diagnosisBusyTime = 0;
-    this.diagnosisHistory.clear();
-    this.diagnosisNonIdempotent.length = 0;
-    this.causalEdges = [];
-
-    this.diagnosisTimeout = setTimeout(() => {
-      this.stopDiagnosis();
-    }, durationMs);
+    startSchedulerDiagnosis(this.diagnosisControlState, durationMs);
   }
 
   /**
    * Stops diagnosis mode and finalizes results.
    */
   private stopDiagnosis(): void {
-    if (!this.diagnosisEnabled) return;
-
-    this.diagnosisEnabled = false;
-    if (this.diagnosisTimeout) {
-      clearTimeout(this.diagnosisTimeout);
-      this.diagnosisTimeout = null;
-    }
-
-    const duration = performance.now() - this.diagnosisStartTime;
-
-    // Detect cycles from causal edges
-    const cycles = detectCausalCycles(this.causalEdges);
-
-    const result: SchedulerDiagnosisResult = {
-      nonIdempotent: this.diagnosisNonIdempotent,
-      cycles,
-      duration,
-      busyTime: this.diagnosisBusyTime,
-    };
-
-    // Clean up
-    this.diagnosisHistory.clear();
-    this.causalEdges = [];
-
-    // Resolve the promise if someone is waiting
-    if (this.diagnosisResolve) {
-      this.diagnosisResolve(result);
-      this.diagnosisResolve = null;
-    }
+    stopSchedulerDiagnosis(this.diagnosisControlState);
   }
 
   /**
@@ -1853,15 +1849,7 @@ export class Scheduler {
    * This is the main entry point for external callers (IPC, console).
    */
   runDiagnosis(durationMs = 5000): Promise<SchedulerDiagnosisResult> {
-    // If already running, stop and start fresh
-    if (this.diagnosisEnabled) {
-      this.stopDiagnosis();
-    }
-
-    return new Promise<SchedulerDiagnosisResult>((resolve) => {
-      this.diagnosisResolve = resolve;
-      this.startDiagnosis(durationMs);
-    });
+    return runSchedulerDiagnosis(this.diagnosisControlState, durationMs);
   }
 
   /**
@@ -1870,25 +1858,7 @@ export class Scheduler {
    * automatically gets a second synchronous run for comparison.
    */
   async runIdempotencyCheck(): Promise<SchedulerDiagnosisResult> {
-    this.idempotencyViolations.length = 0;
-    this.idempotencyCheckMode = true;
-
-    try {
-      // Snapshot computations to avoid iterating a live Set
-      const computationsSnapshot = [...this.computations];
-      for (const action of computationsSnapshot) {
-        await this.run(action);
-      }
-    } finally {
-      this.idempotencyCheckMode = false;
-    }
-
-    return {
-      nonIdempotent: [...this.idempotencyViolations],
-      cycles: [],
-      duration: 0,
-      busyTime: 0,
-    };
+    return await runSchedulerIdempotencyCheck(this.diagnosisControlState);
   }
 
   private handleError(error: Error, action: any) {

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -47,7 +47,6 @@ import {
   type DiagnosisRecord,
 } from "./scheduler/diagnosis.ts";
 import {
-  collectDirectWritersForLog,
   type DependencyGraphState,
   type DependencyUpdateState,
   getSchedulingWrites as getSchedulingWritesFromState,
@@ -64,6 +63,10 @@ import {
   updateDependentEdgesForLog,
   type WriterIndexState,
 } from "./scheduler/dependency-index.ts";
+import {
+  collectDirtyDependencies as collectDirtyDependenciesState,
+  collectDirtyDependenciesForLog as collectDirtyDependenciesForLogState,
+} from "./scheduler/dirty-dependencies.ts";
 import {
   type InFlightSourceState,
   runSchedulerAction,
@@ -1405,121 +1408,12 @@ export class Scheduler {
     workSet: Set<Action>,
     memo = new Map<Action, boolean>(),
   ): boolean {
-    const collectStart = performance.now();
-    let addedToStack = false;
-    const trace = this.dirtyDependencyTraceContext;
-
-    try {
-      if (trace) {
-        trace.visitCount++;
-        trace.maxDepth = Math.max(trace.maxDepth, trace.depth);
-        const actionSummary = this.getTraceActionSummary(trace, action);
-        actionSummary.visitCount++;
-        if (this.staleness.dirty.has(action)) {
-          trace.dirtyInputCount++;
-          actionSummary.dirtyInputCount++;
-        }
-      }
-
-      const cached = memo.get(action);
-      if (cached !== undefined) {
-        if (trace) {
-          trace.memoHitCount++;
-          this.getTraceActionSummary(trace, action).memoHitCount++;
-        }
-        if (
-          cached && this.staleness.dirty.has(action) &&
-          this.computations.has(action)
-        ) {
-          if (!workSet.has(action) && trace) trace.workSetAddCount++;
-          workSet.add(action);
-        }
-        return cached;
-      }
-
-      if (!this.staleness.isStale(action)) {
-        memo.set(action, false);
-        return false;
-      }
-
-      if (this.collectStack.has(action)) {
-        if (trace) trace.cycleHitCount++;
-        const cycleResult = this.staleness.isStale(action) ||
-          workSet.has(action);
-        memo.set(action, cycleResult);
-        return cycleResult;
-      }
-
-      this.collectStack.add(action);
-      addedToStack = true;
-
-      let actionNeedsRun = this.staleness.isStale(action);
-      const directWriters = this.reverseDependencies.get(action);
-      if (directWriters) {
-        if (trace) {
-          trace.reverseDependencyActionCount++;
-          trace.reverseDependencyEdgeCount += directWriters.size;
-          const actionSummary = this.getTraceActionSummary(trace, action);
-          actionSummary.reverseDependencyEdgeCount += directWriters.size;
-          actionSummary.maxDirectWriterCount = Math.max(
-            actionSummary.maxDirectWriterCount,
-            directWriters.size,
-          );
-        }
-        for (const writer of directWriters) {
-          if (!this.staleness.isStale(writer)) {
-            memo.set(writer, false);
-            continue;
-          }
-          if (trace) trace.depth++;
-          let writerNeedsRun: boolean;
-          try {
-            writerNeedsRun = this.collectDirtyDependencies(
-              writer,
-              workSet,
-              memo,
-            );
-          } finally {
-            if (trace) trace.depth--;
-          }
-          if (writerNeedsRun) {
-            actionNeedsRun = true;
-          }
-        }
-      } else {
-        if (trace) trace.logFallbackCount++;
-        const log = this.dependencies.get(action);
-        if (log) {
-          if (this.collectDirtyDependenciesForLog(log, workSet, memo)) {
-            actionNeedsRun = true;
-          }
-        }
-      }
-
-      if (
-        this.staleness.dirty.has(action) && this.computations.has(action)
-      ) {
-        if (!workSet.has(action) && trace) trace.workSetAddCount++;
-        workSet.add(action);
-      }
-
-      if (actionNeedsRun && trace) {
-        trace.resultTrueCount++;
-        this.getTraceActionSummary(trace, action).resultTrueCount++;
-      }
-      memo.set(action, actionNeedsRun);
-      return actionNeedsRun;
-    } finally {
-      if (addedToStack) {
-        this.collectStack.delete(action);
-      }
-      logger.time(
-        collectStart,
-        "scheduler",
-        "execute",
-        "collectDirtyDependencies",
-      );
-    }
+    return collectDirtyDependenciesState(
+      this.dirtyDependencyCollectionState(),
+      action,
+      workSet,
+      memo,
+    );
   }
 
   private hasDependentPath(
@@ -1665,65 +1559,32 @@ export class Scheduler {
     workSet: Set<Action>,
     memo = new Map<Action, boolean>(),
   ): boolean {
-    const lookupStart = performance.now();
-    const trace = this.dirtyDependencyTraceContext;
-    let directWriters: Set<Action>;
-    try {
-      directWriters = collectDirectWritersForLog({
-        writersByEntity: this.writerIndexState.writersByEntity,
-        effects: this.effects,
-        getSchedulingWrites: (writer) =>
-          getSchedulingWritesFromState(this.schedulingWriteState, writer),
-        trace,
-      }, log);
-    } finally {
-      logger.time(
-        lookupStart,
-        "scheduler",
-        "execute",
-        "collectDirtyDependencies",
-        "writerLookup",
-      );
-    }
+    return collectDirtyDependenciesForLogState(
+      this.dirtyDependencyCollectionState(),
+      log,
+      workSet,
+      memo,
+    );
+  }
 
-    if (trace) trace.directWriterCount += directWriters.size;
-    if (trace && trace.depth === 0) {
-      for (const writer of directWriters) {
-        trace.rootDirectWriterActions.add(writer);
-        this.getTraceActionSummary(trace, writer);
-      }
-    }
-
-    let hasDirtyDependencies = false;
-    for (const writer of directWriters) {
-      if (!this.staleness.isStale(writer)) {
-        memo.set(writer, false);
-        continue;
-      }
-
-      if (trace) trace.depth++;
-      let writerNeedsRun: boolean;
-      try {
-        writerNeedsRun = this.collectDirtyDependencies(
-          writer,
-          workSet,
-          memo,
-        );
-      } finally {
-        if (trace) trace.depth--;
-      }
-      if (writerNeedsRun) {
-        hasDirtyDependencies = true;
-        if (
-          this.staleness.dirty.has(writer) && this.computations.has(writer)
-        ) {
-          if (!workSet.has(writer) && trace) trace.workSetAddCount++;
-          workSet.add(writer);
-        }
-      }
-    }
-
-    return hasDirtyDependencies;
+  private dirtyDependencyCollectionState() {
+    return {
+      collectStack: this.collectStack,
+      trace: this.dirtyDependencyTraceContext,
+      dirty: this.staleness.dirty,
+      computations: this.computations,
+      reverseDependencies: this.reverseDependencies,
+      dependencies: this.dependencies,
+      writersByEntity: this.writerIndexState.writersByEntity,
+      effects: this.effects,
+      isStale: (target: Action) => this.staleness.isStale(target),
+      getSchedulingWrites: (target: Action) =>
+        getSchedulingWritesFromState(this.schedulingWriteState, target),
+      getTraceActionSummary: (
+        trace: DirtyDependencyTraceContext,
+        target: Action,
+      ) => this.getTraceActionSummary(trace, target),
+    };
   }
 
   /**

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -14,7 +14,6 @@ import type {
   IMemorySpaceAddress,
   IStorageTransaction,
 } from "./storage/interface.ts";
-import type { SortedAndCompactPaths } from "./reactive-dependencies.ts";
 import {
   allowMutableTransactionRead,
   ignoreReadForScheduling,
@@ -53,14 +52,12 @@ import {
 } from "./scheduler/dependency-graph.ts";
 import { type DependencyUpdateState } from "./scheduler/dependency-updates.ts";
 import {
-  getSchedulingWrites as getSchedulingWritesFromState,
-  getSchedulingWritesMap as getSchedulingWritesMapFromState,
   readsOverlapWrites,
-  type SchedulingWriteState,
-  type WriterIndexState,
+  SchedulerWriteIndex,
 } from "./scheduler/scheduling-writes.ts";
 import {
-  type TriggerIndexState,
+  SchedulerTriggerIndex,
+  SchedulerTriggerSubscriptions,
   type TriggerSubscriptionState,
 } from "./scheduler/trigger-index.ts";
 import {
@@ -131,6 +128,7 @@ import {
   resubscribeSchedulerAction,
   type SchedulerSubscribeActionState,
   type SchedulerSubscriptionState,
+  type SchedulerUnsubscribeActionState,
   subscribeSchedulerAction,
   unsubscribeSchedulerAction,
 } from "./scheduler/subscriptions.ts";
@@ -150,7 +148,10 @@ import {
   scheduleEventQueueWake as scheduleEventQueueWakeState,
   type SchedulerEventQueueState,
 } from "./scheduler/events.ts";
-import { buildSchedulerGraphSnapshot } from "./scheduler/graph-snapshot.ts";
+import {
+  buildSchedulerGraphSnapshot,
+  type SchedulerGraphSnapshotState,
+} from "./scheduler/graph-snapshot.ts";
 import { collectTransitiveEffects } from "./scheduler/topology.ts";
 import type {
   Action,
@@ -225,16 +226,7 @@ export class Scheduler {
   private pending = new Set<Action>();
   private dependencies = new WeakMap<Action, ReactivityLog>();
   private cancels = new WeakMap<Action, Cancel>();
-  private triggerIndexState: TriggerIndexState = {
-    triggers: new Map<
-      SpaceScopeAndURI,
-      Map<Action, SortedAndCompactPaths>
-    >(),
-    nonRecursiveTriggers: new Map<
-      SpaceScopeAndURI,
-      Map<Action, SortedAndCompactPaths>
-    >(),
-  };
+  private triggerIndex = new SchedulerTriggerIndex();
   private actionChangeGroups = new WeakMap<Action, ChangeGroup>();
   private retries = new WeakMap<Action, number>();
 
@@ -320,14 +312,7 @@ export class Scheduler {
     inFlightSources: new WeakMap<Action, Set<IStorageTransaction>>(),
   };
 
-  private schedulingWriteState!: SchedulingWriteState;
-  private writerIndexState: WriterIndexState = {
-    // Index: entity -> actions that write to it (for fast dependency lookup).
-    // Updated from the active scheduling write set.
-    writersByEntity: new Map<SpaceScopeAndURI, Set<Action>>(),
-    // Reverse index: action -> entities it writes to (for cleanup)
-    actionWriteEntities: new WeakMap<Action, Set<SpaceScopeAndURI>>(),
-  };
+  private writeIndex!: SchedulerWriteIndex;
   private dirtyDependencyCollectionState!: DirtyDependencyCollectionState;
   // Track actions scheduled for first time (bypass filter)
   private scheduledFirstTime = new Set<Action>();
@@ -391,6 +376,7 @@ export class Scheduler {
   private pendingDependencyCollectionState!: PendingDependencyCollectionState;
   private dependencyCollectionState!: DependencyCollectionState;
   private subscribeActionState!: SchedulerSubscribeActionState;
+  private unsubscribeState!: SchedulerUnsubscribeActionState;
 
   private idlePromises: (() => void)[] = [];
   private backgroundTasks = new Set<Promise<unknown>>();
@@ -401,6 +387,7 @@ export class Scheduler {
   private scheduled = false;
   private disposed = false;
   private actionRunState!: SchedulerActionRunState;
+  private graphSnapshotState!: SchedulerGraphSnapshotState;
   private cycleBreakState!: CycleBreakState;
   private settleLoopState!: SchedulerSettleLoopState;
   private executeContinuationState!: ExecuteContinuationState;
@@ -460,7 +447,7 @@ export class Scheduler {
   private initializeSchedulerState(): void {
     this.diagnosisControlState = this.createDiagnosisControlState();
     this.eventQueueWakeState = this.createEventQueueWakeState();
-    this.schedulingWriteState = this.createSchedulingWriteState();
+    this.writeIndex = this.createWriteIndex();
     this.pullDemandState = this.createPullDemandState();
     this.delayControlState = this.createDelayControlState();
     this.dirtyDependencyCollectionState = this
@@ -479,12 +466,14 @@ export class Scheduler {
     this.pendingDependencyCollectionState = this
       .createPendingDependencyCollectionState();
     this.subscribeActionState = this.createSubscribeActionState();
+    this.unsubscribeState = this.createUnsubscribeState();
     this.cycleBreakState = this.createCycleBreakState();
     this.settleLoopState = this.createSettleLoopState();
     this.executeContinuationState = this.createExecuteContinuationState();
     this.eventQueueState = this.createEventQueueState();
     this.dependencyCollectionState = this.createDependencyCollectionState();
     this.actionRunState = this.createActionRunState();
+    this.graphSnapshotState = this.createGraphSnapshotState();
   }
 
   private createDiagnosisControlState(): SchedulerDiagnosisControlState {
@@ -531,17 +520,11 @@ export class Scheduler {
     };
   }
 
-  private createSchedulingWriteState(): SchedulingWriteState {
-    return {
-      // Current-known writes are rebuilt on each dependency update from actual
-      // writes plus declared/potential writes. This is the default scheduling view.
-      currentKnownWrites: new WeakMap<Action, IMemorySpaceAddress[]>(),
-      // Historical writes preserve the legacy cumulative union and are only used
-      // when the experimental historical-write mode is enabled.
-      historicalMightWrite: new WeakMap<Action, IMemorySpaceAddress[]>(),
+  private createWriteIndex(): SchedulerWriteIndex {
+    return new SchedulerWriteIndex({
       useHistoricalMightWrite: () =>
         this.runtime.experimental.schedulerHistoricalMightWrite === true,
-    };
+    });
   }
 
   private createPullDemandState(): PullDemandState {
@@ -556,7 +539,7 @@ export class Scheduler {
       pullDemandedFirstRunComputations: this.pullDemandedFirstRunComputations,
       hasActionRun: (action) => this.delays.hasActionRun(action),
       getSchedulingWrites: (action) =>
-        getSchedulingWritesFromState(this.schedulingWriteState, action),
+        this.writeIndex.getSchedulingWrites(action),
     };
   }
 
@@ -585,26 +568,25 @@ export class Scheduler {
       computations: this.computations,
       reverseDependencies: this.reverseDependencies,
       dependencies: this.dependencies,
-      writersByEntity: this.writerIndexState.writersByEntity,
+      writersByEntity: this.writeIndex.writersByEntity,
       effects: this.effects,
       isStale: (target) => this.staleness.isStale(target),
       getSchedulingWrites: (target) =>
-        getSchedulingWritesFromState(this.schedulingWriteState, target),
+        this.writeIndex.getSchedulingWrites(target),
       getActionId: (target) => this.getActionId(target),
     };
   }
 
   private createDependencyGraphState(): DependencyGraphState {
     return {
-      triggers: this.triggerIndexState.triggers,
-      nonRecursiveTriggers: this.triggerIndexState.nonRecursiveTriggers,
-      writersByEntity: this.writerIndexState.writersByEntity,
+      triggerIndex: this.triggerIndex,
+      writersByEntity: this.writeIndex.writersByEntity,
       dependencies: this.dependencies,
       dependents: this.dependents,
       reverseDependencies: this.reverseDependencies,
       staleness: this.staleness,
       getSchedulingWrites: (action) =>
-        getSchedulingWritesFromState(this.schedulingWriteState, action),
+        this.writeIndex.getSchedulingWrites(action),
       isStale: (action) => this.staleness.isStale(action),
       isDemandedPullComputation: (action) =>
         isDemandedPullComputation(this.pullDemandState, action),
@@ -614,22 +596,16 @@ export class Scheduler {
 
   private createDependencyUpdateState(): DependencyUpdateState {
     return {
-      writersByEntity: this.writerIndexState.writersByEntity,
-      actionWriteEntities: this.writerIndexState.actionWriteEntities,
+      writeIndex: this.writeIndex,
       dependencies: this.dependencies,
-      currentKnownWrites: this.schedulingWriteState.currentKnownWrites,
-      historicalMightWrite: this.schedulingWriteState.historicalMightWrite,
       dependencyGraph: this.dependencyGraphState,
-      useHistoricalMightWrite:
-        this.schedulingWriteState.useHistoricalMightWrite,
       isPullMode: () => this.pullMode,
     };
   }
 
   private createTriggerSubscriptionState(): TriggerSubscriptionState {
-    return {
-      triggers: this.triggerIndexState.triggers,
-      nonRecursiveTriggers: this.triggerIndexState.nonRecursiveTriggers,
+    return new SchedulerTriggerSubscriptions({
+      triggerIndex: this.triggerIndex,
       cancels: this.cancels,
       getActionId: (action) => this.getActionId(action),
       onTriggerUnsubscribe: (actionId, entityCount) => {
@@ -638,7 +614,7 @@ export class Scheduler {
           `Entities: ${entityCount}`,
         ]);
       },
-    };
+    });
   }
 
   private createDirtySchedulingState(): DirtySchedulingState {
@@ -657,8 +633,7 @@ export class Scheduler {
 
   private createStorageNotificationState(): StorageNotificationState {
     return {
-      triggers: this.triggerIndexState.triggers,
-      nonRecursiveTriggers: this.triggerIndexState.nonRecursiveTriggers,
+      triggerIndex: this.triggerIndex,
       getPullMode: () => this.pullMode,
       getDiagnosisEnabled: () => this.diagnosisEnabled,
       getCollectTriggerTrace: () => this.collectTriggerTrace,
@@ -719,8 +694,7 @@ export class Scheduler {
 
   private createWritePropagationState(): WritePropagationState {
     return {
-      triggers: this.triggerIndexState.triggers,
-      nonRecursiveTriggers: this.triggerIndexState.nonRecursiveTriggers,
+      triggerIndex: this.triggerIndex,
       changedWritesHistory: this.changedWritesHistory,
       effects: this.effects,
       computations: this.computations,
@@ -758,7 +732,7 @@ export class Scheduler {
       effects: this.effects,
       isThrottled: (action) => this.delays.isThrottled(action),
       getSchedulingWrites: (action) =>
-        getSchedulingWritesFromState(this.schedulingWriteState, action),
+        this.writeIndex.getSchedulingWrites(action),
       hasDependentPath: (from, to) =>
         hasDependentPath(this.pullDemandState, from, to),
     };
@@ -780,13 +754,13 @@ export class Scheduler {
       effects: this.effects,
       dirty: this.staleness.dirty,
       stale: this.staleness.stale,
-      writersByEntity: this.writerIndexState.writersByEntity,
+      writeIndex: this.writeIndex,
       getPullMode: () => this.pullMode,
       setDebounce: (action, ms) => this.setDebounce(action, ms),
       setNoDebounce: (action, optOut) => this.setNoDebounce(action, optOut),
       setThrottle: (action, ms) => this.setThrottle(action, ms),
       getSchedulingWrites: (action) =>
-        getSchedulingWritesFromState(this.schedulingWriteState, action),
+        this.writeIndex.getSchedulingWrites(action),
       isThrottled: (action) => this.delays.isThrottled(action),
       isStale: (action) => this.staleness.isStale(action),
       markDirectDirty: (action) => {
@@ -802,6 +776,32 @@ export class Scheduler {
       submitSubscribeTelemetry: (event) => {
         this.runtime.telemetry.submit(event);
       },
+    };
+  }
+
+  private createUnsubscribeState(): SchedulerUnsubscribeActionState {
+    return {
+      cancels: this.cancels,
+      dependencies: this.dependencies,
+      actionChangeGroups: this.actionChangeGroups,
+      changeGroupToActionId: this.changeGroupToActionId,
+      pending: this.pending,
+      conditionallyScheduledEffects: this.conditionallyScheduledEffects,
+      reverseDependencies: this.reverseDependencies,
+      dependents: this.dependents,
+      effects: this.effects,
+      computations: this.computations,
+      pullDemandedFirstRunComputations: this.pullDemandedFirstRunComputations,
+      writeIndex: this.writeIndex,
+      populateDependenciesCallbacks: this.populateDependenciesCallbacks,
+      pendingDependencyCollection: this.pendingDependencyCollection,
+      getActionId: (target) => this.getActionId(target),
+      clearDirectDirty: (target) =>
+        clearSchedulerDirectDirty(this.dirtySchedulingState, target),
+      forceClearStale: (target) => this.staleness.forceClearStale(target),
+      cancelDebounceTimer: (target) => this.delays.cancelDebounceTimer(target),
+      clearComputationDebounceState: (target, targetOptions) =>
+        this.delays.clearComputationDebounceState(target, targetOptions),
     };
   }
 
@@ -843,9 +843,8 @@ export class Scheduler {
       runsThisExecute: this.runsThisExecute,
       activePullDemandActions: this.activePullDemandActions,
       getSchedulingWrites: (action) =>
-        getSchedulingWritesFromState(this.schedulingWriteState, action),
-      getSchedulingWritesMap: () =>
-        getSchedulingWritesMapFromState(this.schedulingWriteState),
+        this.writeIndex.getSchedulingWrites(action),
+      getSchedulingWritesMap: () => this.writeIndex.getSchedulingWritesMap(),
       collectDependenciesForAction: (action, populateDependencies, options) =>
         this.collectDependenciesForAction(
           action,
@@ -981,7 +980,7 @@ export class Scheduler {
       getActionTelemetryInfo: (target) =>
         getSchedulerActionTelemetryInfo(target),
       getSchedulingWrites: (target) =>
-        getSchedulingWritesFromState(this.schedulingWriteState, target),
+        this.writeIndex.getSchedulingWrites(target),
       maybeAutoDebounce: (target) => this.maybeAutoDebounce(target),
       markActionHasRun: (target) => this.delays.markActionHasRun(target),
       handleError: (error, target) => this.handleError(error, target),
@@ -997,6 +996,46 @@ export class Scheduler {
       clearExecutingAction: () => {
         this.executingAction = null;
         this.currentActionId = undefined;
+      },
+    };
+  }
+
+  private createGraphSnapshotState(): SchedulerGraphSnapshotState {
+    const getPullMode = () => this.pullMode;
+    return {
+      get pullMode() {
+        return getPullMode();
+      },
+      effects: this.effects,
+      computations: this.computations,
+      pending: this.pending,
+      dirty: this.staleness.dirty,
+      conditionallyScheduledEffects: this.conditionallyScheduledEffects,
+      dependencies: this.dependencies,
+      dependents: this.dependents,
+      actionParent: this.actionParent,
+      actionChildren: this.actionChildren,
+      actionStats: this.actionStats,
+      getDebounce: (action) => this.delays.getDebounce(action),
+      getThrottle: (action) => this.delays.getThrottle(action),
+      hasActiveDebounceTimer: (action) =>
+        this.delays.hasActiveDebounceTimer(action),
+      getActionId: (action) => this.getActionId(action),
+      getSchedulingWrites: (action) =>
+        this.writeIndex.getSchedulingWrites(action),
+      getNextDebounceRunTime: (action) => this.getNextDebounceRunTime(action),
+      getNextEligibleRunTime: (action) =>
+        this.delays.getNextEligibleRunTime(action),
+      isDemandedPullComputation: (action) =>
+        isDemandedPullComputation(this.pullDemandState, action),
+      isLiveEffect: (action) => isLiveEffect(this.pullDemandState, action),
+      isPullDemandRootEffect: (action) =>
+        isPullDemandRootEffect(this.pullDemandState, action),
+      getPatternId: (action) => {
+        const annotated = action as Partial<TelemetryAnnotations>;
+        return annotated.pattern
+          ? this.runtime.patternManager.getPatternId(annotated.pattern)
+          : undefined;
       },
     };
   }
@@ -1094,35 +1133,7 @@ export class Scheduler {
     action: Action,
     options: { preserveChangeGroup?: boolean } = {},
   ): void {
-    unsubscribeSchedulerAction(
-      {
-        cancels: this.cancels,
-        dependencies: this.dependencies,
-        actionChangeGroups: this.actionChangeGroups,
-        changeGroupToActionId: this.changeGroupToActionId,
-        pending: this.pending,
-        conditionallyScheduledEffects: this.conditionallyScheduledEffects,
-        reverseDependencies: this.reverseDependencies,
-        dependents: this.dependents,
-        effects: this.effects,
-        computations: this.computations,
-        pullDemandedFirstRunComputations: this.pullDemandedFirstRunComputations,
-        actionWriteEntities: this.writerIndexState.actionWriteEntities,
-        writersByEntity: this.writerIndexState.writersByEntity,
-        populateDependenciesCallbacks: this.populateDependenciesCallbacks,
-        pendingDependencyCollection: this.pendingDependencyCollection,
-        getActionId: (target) => this.getActionId(target),
-        clearDirectDirty: (target) =>
-          clearSchedulerDirectDirty(this.dirtySchedulingState, target),
-        forceClearStale: (target) => this.staleness.forceClearStale(target),
-        cancelDebounceTimer: (target) =>
-          this.delays.cancelDebounceTimer(target),
-        clearComputationDebounceState: (target, targetOptions) =>
-          this.delays.clearComputationDebounceState(target, targetOptions),
-      },
-      action,
-      options,
-    );
+    unsubscribeSchedulerAction(this.unsubscribeState, action, options);
   }
 
   async run(action: Action): Promise<any> {
@@ -1303,40 +1314,7 @@ export class Scheduler {
    * Uses getActionId for the identifier (includes code location).
    */
   getGraphSnapshot(): SchedulerGraphSnapshot {
-    return buildSchedulerGraphSnapshot({
-      pullMode: this.pullMode,
-      effects: this.effects,
-      computations: this.computations,
-      pending: this.pending,
-      dirty: this.staleness.dirty,
-      conditionallyScheduledEffects: this.conditionallyScheduledEffects,
-      dependencies: this.dependencies,
-      dependents: this.dependents,
-      actionParent: this.actionParent,
-      actionChildren: this.actionChildren,
-      actionStats: this.actionStats,
-      getDebounce: (action) => this.delays.getDebounce(action),
-      getThrottle: (action) => this.delays.getThrottle(action),
-      hasActiveDebounceTimer: (action) =>
-        this.delays.hasActiveDebounceTimer(action),
-      getActionId: (action) => this.getActionId(action),
-      getSchedulingWrites: (action) =>
-        getSchedulingWritesFromState(this.schedulingWriteState, action),
-      getNextDebounceRunTime: (action) => this.getNextDebounceRunTime(action),
-      getNextEligibleRunTime: (action) =>
-        this.delays.getNextEligibleRunTime(action),
-      isDemandedPullComputation: (action) =>
-        isDemandedPullComputation(this.pullDemandState, action),
-      isLiveEffect: (action) => isLiveEffect(this.pullDemandState, action),
-      isPullDemandRootEffect: (action) =>
-        isPullDemandRootEffect(this.pullDemandState, action),
-      getPatternId: (action) => {
-        const annotated = action as Partial<TelemetryAnnotations>;
-        return annotated.pattern
-          ? this.runtime.patternManager.getPatternId(annotated.pattern)
-          : undefined;
-      },
-    });
+    return buildSchedulerGraphSnapshot(this.graphSnapshotState);
   }
 
   /**
@@ -1704,7 +1682,7 @@ export class Scheduler {
    * cumulative legacy view instead.
    */
   getMightWrite(action: Action): IMemorySpaceAddress[] | undefined {
-    return getSchedulingWritesFromState(this.schedulingWriteState, action);
+    return this.writeIndex.getSchedulingWrites(action);
   }
 
   /**
@@ -1902,7 +1880,7 @@ export class Scheduler {
       populateDependenciesCallbacks: this.populateDependenciesCallbacks,
       effects: this.effects,
       getSchedulingWrites: (action) =>
-        getSchedulingWritesFromState(this.schedulingWriteState, action),
+        this.writeIndex.getSchedulingWrites(action),
       collectDependenciesForAction: (action, populateDependencies, options) =>
         this.collectDependenciesForAction(
           action,
@@ -1970,7 +1948,7 @@ export class Scheduler {
       populateDependenciesCallbacks: this.populateDependenciesCallbacks,
       effects: this.effects,
       getSchedulingWrites: (action) =>
-        getSchedulingWritesFromState(this.schedulingWriteState, action),
+        this.writeIndex.getSchedulingWrites(action),
       collectDependenciesForAction: (action, populateDependencies, options) =>
         this.collectDependenciesForAction(
           action,

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -352,21 +352,6 @@ export class Scheduler {
   private writePropagationState!: WritePropagationState;
   private subscriptionState!: SchedulerSubscriptionState;
 
-  /**
-   * Temporarily set the executing action so that any child actions created
-   * during `fn` are registered as children of `action`. Restores the previous
-   * executing action afterwards (stack-like nesting).
-   */
-  withExecutingAction<T>(action: Action, fn: () => T): T {
-    const prev = this.executingAction;
-    this.executingAction = action;
-    try {
-      return fn();
-    } finally {
-      this.executingAction = prev;
-    }
-  }
-
   // Dependency population callbacks for first-time subscriptions
   // Called in execute() to discover what cells the action will read
   private populateDependenciesCallbacks = new WeakMap<
@@ -394,22 +379,9 @@ export class Scheduler {
   private settleLoopState!: SchedulerSettleLoopState;
   private executeContinuationState!: ExecuteContinuationState;
 
-  get runningPromise(): Promise<unknown> | undefined {
-    return this._running;
-  }
-
-  set runningPromise(promise: Promise<unknown> | undefined) {
-    if (this._running !== undefined) {
-      throw new Error(
-        "Cannot set running while another promise is in progress",
-      );
-    }
-    if (promise !== undefined) {
-      this._running = promise.finally(() => {
-        this._running = undefined;
-      });
-    }
-  }
+  // ============================================================
+  // Public API
+  // ============================================================
 
   constructor(
     readonly runtime: Runtime,
@@ -443,6 +415,838 @@ export class Scheduler {
       console[method].apply(console, result);
     });
   }
+
+  get runningPromise(): Promise<unknown> | undefined {
+    return this._running;
+  }
+
+  set runningPromise(promise: Promise<unknown> | undefined) {
+    if (this._running !== undefined) {
+      throw new Error(
+        "Cannot set running while another promise is in progress",
+      );
+    }
+    if (promise !== undefined) {
+      this._running = promise.finally(() => {
+        this._running = undefined;
+      });
+    }
+  }
+
+  /**
+   * Temporarily set the executing action so that any child actions created
+   * during `fn` are registered as children of `action`. Restores the previous
+   * executing action afterwards (stack-like nesting).
+   */
+  withExecutingAction<T>(action: Action, fn: () => T): T {
+    const prev = this.executingAction;
+    this.executingAction = action;
+    try {
+      return fn();
+    } finally {
+      this.executingAction = prev;
+    }
+  }
+
+  /**
+   * Subscribes an action to run when its dependencies change.
+   *
+   * The action will be scheduled to run immediately. Before running, the
+   * populateDependencies callback will be called to discover what cells the
+   * action will read. After running, the scheduler automatically re-subscribes
+   * using the reactivity log from the run.
+   *
+   * @param action The action to subscribe
+   * @param populateDependencies Callback to discover the action's read dependencies,
+   *   or a ReactivityLog for backwards compatibility (deprecated)
+   * @param options Configuration options for the subscription
+   * @returns A cancel function to unsubscribe
+   */
+  subscribe(
+    action: Action,
+    populateDependencies: PopulateDependencies | ReactivityLog,
+    options: {
+      isEffect?: boolean;
+      debounce?: number;
+      noDebounce?: boolean;
+      throttle?: number;
+      changeGroup?: ChangeGroup;
+    } = {},
+  ): Cancel {
+    return subscribeSchedulerAction(
+      this.subscribeActionState,
+      action,
+      populateDependencies,
+      options,
+    );
+  }
+
+  /**
+   * Re-subscribes an action after it has already run, using the reactivity log
+   * from the completed run. This sets up triggers for future changes without
+   * scheduling the action to run immediately.
+   *
+   * Use this method when:
+   * - An action has just completed running and you have its reactivity log
+   * - You want to register triggers for future changes
+   *
+   * @param action The action to re-subscribe
+   * @param log The reactivity log from the action's previous run
+   * @param options Optional configuration (e.g., isEffect to mark as side-effectful)
+   */
+  resubscribe(
+    action: Action,
+    log: ReactivityLog,
+    options: {
+      isEffect?: boolean;
+      changeGroup?: ChangeGroup;
+    } = {},
+  ): void {
+    resubscribeSchedulerAction(
+      this.subscribeActionState,
+      action,
+      log,
+      options,
+    );
+  }
+
+  unsubscribe(
+    action: Action,
+    options: { preserveChangeGroup?: boolean } = {},
+  ): void {
+    unsubscribeSchedulerAction(this.unsubscribeState, action, options);
+  }
+
+  async run(action: Action): Promise<any> {
+    return await runSchedulerAction(this.actionRunState, action);
+  }
+
+  idle(): Promise<void> {
+    return new Promise<void>((resolve) => {
+      if (this.runningPromise) {
+        // Something is currently running - wait for it then check again
+        this.runningPromise.then(() => this.idle().then(resolve));
+      } else if (this.backgroundTasks.size > 0) {
+        // Async scheduler work, such as event-triggered auto-start, is still in
+        // flight. Wait for it to settle and then re-check the scheduler state.
+        Promise.allSettled([...this.backgroundTasks]).then(() =>
+          this.idle().then(resolve)
+        );
+      } else if (
+        hasEventQueueWakeTimer(this.eventQueueWakeState) &&
+        ((this.eventQueue.length > 0 &&
+          isHeadEventParkedState(this.eventQueueWakeState)) ||
+          this.hasDeferredDirtyEffectWork())
+      ) {
+        // A queued event is parked behind a throttled dependency. Wait for the
+        // wake timer to re-schedule the queue and then re-check.
+        this.idlePromises.push(resolve);
+      } else if (!this.scheduled) {
+        if (this.pullMode && this.hasRunnablePullWork()) {
+          this.queueExecution();
+          this.idlePromises.push(resolve);
+          return;
+        }
+        // Nothing is scheduled to run - we're idle.
+        // In pull mode, pending computations won't run without an effect to pull them,
+        // so we don't wait for them.
+        resolve();
+      } else {
+        // Execution is scheduled - wait for it to complete
+        this.idlePromises.push(resolve);
+      }
+    });
+  }
+
+  queueExecution(): void {
+    if (this.disposed) return;
+    if (this.scheduled) {
+      if (this.pendingQueueTaskTimer === null) {
+        this.rerunAfterCurrentExecute = true;
+      }
+      return;
+    }
+    this.pendingQueueTaskTimer = queueTask(() => {
+      this.pendingQueueTaskTimer = null;
+      this.execute();
+    });
+    this.scheduled = true;
+  }
+
+  queueEvent(
+    eventLink: NormalizedFullLink,
+    event: any,
+    retries: number = DEFAULT_RETRIES_FOR_EVENTS,
+    // Internal-only commit callback. This runs after the final commit result,
+    // including exhausted failure, so it must not perform external side
+    // effects. Use the post-commit outbox for success-only effect release.
+    onCommit?: (tx: IExtendedStorageTransaction) => void,
+    doNotLoadPieceIfNotRunning: boolean = false,
+  ): void {
+    queueSchedulerEvent(this.eventQueueState, {
+      eventLink,
+      event,
+      retries,
+      onCommit,
+      doNotLoadPieceIfNotRunning,
+    });
+  }
+
+  addEventHandler(
+    handler: EventHandler,
+    ref: NormalizedFullLink,
+    populateDependencies?: (
+      tx: IExtendedStorageTransaction,
+      event: any,
+    ) => void,
+  ): Cancel {
+    return addSchedulerEventHandler({
+      eventHandlers: this.eventHandlers,
+    }, {
+      handler,
+      ref,
+      populateDependencies,
+    });
+  }
+
+  onConsole(fn: ConsoleHandler): void {
+    this.consoleHandler = fn;
+  }
+
+  onError(fn: ErrorHandler): void {
+    this.errorHandlers.add(fn);
+  }
+
+  setEventPreflightTelemetryEnabled(enabled: boolean): void {
+    this.eventPreflightTelemetryEnabled = enabled;
+  }
+
+  isEventPreflightTelemetryEnabled(): boolean {
+    return this.eventPreflightTelemetryEnabled;
+  }
+
+  // ============================================================
+  // Pull-based scheduling methods
+  // ============================================================
+
+  /**
+   * Enables pull-based scheduling mode.
+   * In pull mode, only effects are scheduled; computations are marked dirty
+   * and pulled on demand when effects need their values.
+   */
+  enablePullMode(): void {
+    this.pullMode = true;
+    this.staleness.stale.clear();
+    this.staleness.resetUpstreamStaleState();
+
+    // Rebuild reverse dependency graph (dependents map) from current dependencies.
+    // In push mode, processRun() doesn't update dependents, so the map may be stale.
+    // We need accurate dependents for markDirty() propagation and scheduleAffectedEffects().
+    for (const action of [...this.effects, ...this.computations]) {
+      const log = this.dependencies.get(action);
+      if (log) {
+        this.updateDependents(action, log);
+      }
+    }
+    for (const action of this.staleness.dirty) {
+      this.staleness.setStaleFromInputs(action);
+    }
+
+    this.runtime.telemetry.submit({
+      type: "scheduler.mode.change",
+      pullMode: true,
+    });
+    this.queueExecution();
+  }
+
+  /**
+   * Disables pull-based scheduling mode (returns to push mode).
+   */
+  disablePullMode(): void {
+    this.pullMode = false;
+    // Clear dirty set when switching back to push mode
+    this.staleness.clearAll();
+    this.runtime.telemetry.submit({
+      type: "scheduler.mode.change",
+      pullMode: false,
+    });
+    this.queueExecution();
+  }
+
+  /**
+   * Returns whether pull mode is enabled.
+   */
+  isPullModeEnabled(): boolean {
+    return this.pullMode;
+  }
+
+  // ============================================================
+  // Debounce infrastructure for throttling slow actions
+  // ============================================================
+
+  /**
+   * Sets a debounce delay for an action.
+   * When the action is triggered, it will wait for the specified delay before running.
+   * If triggered again during the delay, the timer resets.
+   */
+  setDebounce(action: Action, ms: number): void {
+    this.delays.setDebounce(action, ms);
+  }
+
+  /**
+   * Gets the current debounce delay for an action, if set.
+   */
+  getDebounce(action: Action): number | undefined {
+    return this.delays.getDebounce(action);
+  }
+
+  /**
+   * Clears the debounce setting for an action.
+   */
+  clearDebounce(action: Action): void {
+    this.delays.clearDebounce(action);
+  }
+
+  /**
+   * Enables or disables auto-debounce detection for an action.
+   * When set to true, this action opts OUT of auto-debounce.
+   * By default, slow actions (> 50ms avg after 3 runs) will automatically get debounced.
+   */
+  setNoDebounce(action: Action, optOut: boolean): void {
+    this.delays.setNoDebounce(action, optOut);
+  }
+
+  // ============================================================
+  // Throttle infrastructure - "value can be stale by T ms"
+  // ============================================================
+
+  /**
+   * Sets a throttle period for an action.
+   * The action won't run if it ran within the last `ms` milliseconds.
+   * Unlike debounce, throttled actions stay dirty and will be pulled
+   * by effects when the throttle period expires. Event handlers whose head
+   * dependencies are throttled are parked until the earliest eligible wake time.
+   */
+  setThrottle(action: Action, ms: number): void {
+    this.delays.setThrottle(action, ms);
+  }
+
+  /**
+   * Gets the current throttle period for an action, if set.
+   */
+  getThrottle(action: Action): number | undefined {
+    return this.delays.getThrottle(action);
+  }
+
+  /**
+   * Clears the throttle setting for an action.
+   */
+  clearThrottle(action: Action): void {
+    this.delays.clearThrottle(action);
+  }
+
+  /**
+   * Set action IDs that should trigger a debugger breakpoint before execution.
+   */
+  setBreakpoints(actionIds: string[]): void {
+    this.breakpoints.clear();
+    for (const id of actionIds) {
+      this.breakpoints.add(id);
+    }
+  }
+
+  /**
+   * Get currently set breakpoint action IDs.
+   */
+  getBreakpoints(): string[] {
+    return Array.from(this.breakpoints);
+  }
+
+  /**
+   * Check if an action ID has a breakpoint set.
+   */
+  hasBreakpoint(actionId: string): boolean {
+    return this.breakpoints.has(actionId);
+  }
+
+  /**
+   * Returns diagnostic statistics about the scheduler state.
+   * Useful for debugging and monitoring pull-based scheduling behavior.
+   */
+  getStats(): { effects: number; computations: number; pending: number } {
+    return {
+      effects: this.effects.size,
+      computations: this.computations.size,
+      pending: this.pending.size,
+    };
+  }
+
+  /**
+   * Returns whether an action is registered as an effect.
+   */
+  isEffect(action: Action): boolean {
+    return this.effects.has(action);
+  }
+
+  /**
+   * Returns whether an action is registered as a computation.
+   */
+  isComputation(action: Action): boolean {
+    return this.computations.has(action);
+  }
+
+  /**
+   * Returns whether an action is marked as dirty.
+   */
+  isDirty(action: Action): boolean {
+    return this.staleness.dirty.has(action);
+  }
+
+  /**
+   * Returns the set of actions that depend on this action's output.
+   */
+  getDependents(action: Action): Set<Action> {
+    return this.dependents.get(action) ?? new Set();
+  }
+
+  /**
+   * Returns a snapshot of the current dependency graph for visualization.
+   * Uses getActionId for the identifier (includes code location).
+   */
+  getGraphSnapshot(): SchedulerGraphSnapshot {
+    return buildSchedulerGraphSnapshot(this.graphSnapshotState);
+  }
+
+  // ============================================================
+  // Push-triggered filtering
+  // ============================================================
+
+  /**
+   * Returns the active scheduling write set for an action. By default this is
+   * the current-known write set; experimental historical mode returns the
+   * cumulative legacy view instead.
+   */
+  getMightWrite(action: Action): IMemorySpaceAddress[] | undefined {
+    return this.writeIndex.getSchedulingWrites(action);
+  }
+
+  // ============================================================
+  // Compute time tracking for cycle-aware scheduling
+  // ============================================================
+
+  /**
+   * Returns the execution statistics for an action, if available.
+   * Useful for diagnostics and determining cycle convergence strategy.
+   * Accepts either an Action or an action ID string.
+   */
+  getActionStats(action: Action | string): ActionStats | undefined {
+    return getActionStatsFromState(this.actionTimingState, action);
+  }
+
+  /**
+   * Returns filter statistics for the current/last execution cycle.
+   */
+  getFilterStats(): { filtered: number; executed: number } {
+    return { ...this.filterStats };
+  }
+
+  /**
+   * Resets filter statistics.
+   */
+  resetFilterStats(): void {
+    this.filterStats.filtered = 0;
+    this.filterStats.executed = 0;
+  }
+
+  /**
+   * Enables collection of per-iteration settle stats during execute().
+   * Call this once before running patterns to opt in to the overhead.
+   */
+  enableSettleStats(): void {
+    this.setSettleStatsEnabled(true);
+  }
+
+  /**
+   * Enables or disables collection of per-iteration settle stats during execute().
+   * Disabling also clears the last collected stats to avoid stale reads.
+   */
+  setSettleStatsEnabled(enabled: boolean): void {
+    this.collectSettleStats = enabled;
+    if (!enabled) {
+      this.lastSettleStats = null;
+      this.settleStatsHistory = [];
+    }
+  }
+
+  /**
+   * Returns settle stats from the last execute() call, or null if not enabled/collected.
+   */
+  getSettleStats(): SettleStats | null {
+    return this.lastSettleStats;
+  }
+
+  /**
+   * Returns recent settle stats history from execute() calls, oldest first.
+   */
+  getSettleStatsHistory(): SettleStatsHistoryEntry[] {
+    return [...this.settleStatsHistory];
+  }
+
+  /**
+   * Enables or disables collection of exact action-run history.
+   * Disabling clears the current ring buffer to avoid stale reads.
+   */
+  setActionRunTraceEnabled(enabled: boolean): void {
+    this.collectActionRunTrace = enabled;
+    if (!enabled) {
+      this.actionRunTrace.length = 0;
+    }
+  }
+
+  /**
+   * Returns recent exact action-run history, oldest first.
+   */
+  getActionRunTrace(): ActionRunTraceEntry[] {
+    return [...this.actionRunTrace];
+  }
+
+  /**
+   * Enables or disables collection of structured trigger-trace entries.
+   * Disabling clears the current ring buffer to avoid stale reads.
+   */
+  setTriggerTraceEnabled(enabled: boolean): void {
+    this.collectTriggerTrace = enabled;
+    if (!enabled) {
+      this.triggerTrace = [];
+    }
+  }
+
+  /**
+   * Returns recent structured trigger-trace entries, oldest first.
+   */
+  getTriggerTrace(): TriggerTraceEntry[] {
+    return [...this.triggerTrace];
+  }
+
+  // ============================================================
+  // Non-settling detection API
+  // ============================================================
+
+  /**
+   * Returns whether the scheduler has detected a non-settling condition.
+   * This means execute() is consuming a high fraction of wall-clock time,
+   * indicating the system is churning.
+   */
+  isNonSettling(): boolean {
+    return this.settlingTracker.nonSettlingDetected;
+  }
+
+  /**
+   * Enables or disables automatic triggering of diagnosis when non-settling
+   * is detected. Off by default.
+   */
+  setAutoTriggerDiagnosis(enabled: boolean): void {
+    this.autoTriggerDiagnosis = enabled;
+  }
+
+  /**
+   * Runs a diagnosis for the specified duration and returns the result.
+   * This is the main entry point for external callers (IPC, console).
+   */
+  runDiagnosis(durationMs = 5000): Promise<SchedulerDiagnosisResult> {
+    return runSchedulerDiagnosis(this.diagnosisControlState, durationMs);
+  }
+
+  // ── Inline idempotency check mode ──────────────────────────────────
+
+  enableIdempotencyCheck(): void {
+    this.idempotencyCheckMode = true;
+    this.idempotencyViolations.length = 0;
+    if (this.pullMode) {
+      this.queueExecution();
+    }
+  }
+
+  disableIdempotencyCheck(): void {
+    this.idempotencyCheckMode = false;
+  }
+
+  getIdempotencyViolations(): NonIdempotentReport[] {
+    return [...this.idempotencyViolations];
+  }
+
+  /**
+   * Checks all computations for idempotency by enabling inline mode
+   * and force-running each computation through run(). Each run()
+   * automatically gets a second synchronous run for comparison.
+   */
+  async runIdempotencyCheck(): Promise<SchedulerDiagnosisResult> {
+    return await runSchedulerIdempotencyCheck(this.diagnosisControlState);
+  }
+
+  /**
+   * Clean up all pending timers and resources.
+   * Should be called when the scheduler is being torn down.
+   */
+  dispose(): void {
+    this.disposed = true;
+    // Clear all active debounce timers
+    this.delays.clearActiveDebounceTimers();
+    if (this.pendingQueueTaskTimer !== null) {
+      clearTimeout(this.pendingQueueTaskTimer);
+      this.pendingQueueTaskTimer = null;
+    }
+    cancelEventQueueWakeState(this.eventQueueWakeState);
+    // Clean up diagnosis state
+    if (this.diagnosisTimeout) {
+      clearTimeout(this.diagnosisTimeout);
+      this.diagnosisTimeout = null;
+    }
+    this.diagnosisEnabled = false;
+  }
+
+  // ============================================================
+  // Execution orchestration
+  // ============================================================
+
+  private handleError(error: Error, action: any) {
+    handleSchedulerError(
+      {
+        errorHandlers: this.errorHandlers,
+        parseStack: (stack) => this.runtime.harness.parseStack(stack),
+      },
+      error,
+      action,
+    );
+  }
+
+  private async execute(): Promise<void> {
+    if (this.disposed) return;
+    logger.timeStart("scheduler", "execute");
+
+    // In case a directly invoked `run` is still running, wait for it to finish.
+    if (this.runningPromise) await this.runningPromise;
+
+    this.beginExecuteCycle();
+    const { newActionsWithoutDependencies } = this
+      .collectInitialExecuteDependencies();
+    const eventBlockingDeps = await this.processExecuteEventPhase();
+    this.collectPostEventDependencies();
+    const initialSeeds = this.buildInitialExecuteSeeds(
+      newActionsWithoutDependencies,
+      eventBlockingDeps,
+    );
+
+    const settleResult = await this.runSettleLoop(initialSeeds);
+    await breakCyclesIfNeeded(this.cycleBreakState, settleResult);
+    this.applyAdaptiveCycleDebounce();
+    this.recordExecuteEndTelemetry();
+    applyExecuteContinuation(this.executeContinuationState);
+    logger.timeEnd("scheduler", "execute");
+  }
+
+  private beginExecuteCycle(): void {
+    // Track timing for cycle-aware debounce
+    this.executeStartTime = performance.now();
+    this.runsThisExecute.clear();
+
+    // Non-settling heuristic: record execute() start
+    markExecuteStart(this.settlingTracker);
+  }
+
+  private collectInitialExecuteDependencies(): {
+    newActionsWithoutDependencies: Action[];
+  } {
+    return collectInitialExecuteDependenciesState({
+      pendingDependencyCollection: this.pendingDependencyCollection,
+      populateDependenciesCallbacks: this.populateDependenciesCallbacks,
+      effects: this.effects,
+      getSchedulingWrites: (action) =>
+        this.writeIndex.getSchedulingWrites(action),
+      collectDependenciesForAction: (action, populateDependencies, options) =>
+        this.collectDependenciesForAction(
+          action,
+          populateDependencies,
+          options,
+        ),
+      getActionId: (action) => this.getActionId(action),
+      scheduleAffectedEffects: (action) => this.scheduleAffectedEffects(action),
+    });
+  }
+
+  private async processExecuteEventPhase(): Promise<Set<Action>> {
+    // Track dirty dependencies that block events - these must be added to workSet
+    const eventBlockingDeps = new Set<Action>();
+
+    logger.timeStart("scheduler", "execute", "event");
+    try {
+      await processQueuedEventDuringExecute(
+        this.eventExecutionState,
+        eventBlockingDeps,
+      );
+      return eventBlockingDeps;
+    } finally {
+      logger.timeEnd("scheduler", "execute", "event");
+    }
+  }
+
+  private collectPostEventDependencies(): void {
+    collectPostEventDependenciesState({
+      pendingDependencyCollection: this.pendingDependencyCollection,
+      populateDependenciesCallbacks: this.populateDependenciesCallbacks,
+      effects: this.effects,
+      getSchedulingWrites: (action) =>
+        this.writeIndex.getSchedulingWrites(action),
+      collectDependenciesForAction: (action, populateDependencies, options) =>
+        this.collectDependenciesForAction(
+          action,
+          populateDependencies,
+          options,
+        ),
+      getActionId: (action) => this.getActionId(action),
+    });
+  }
+
+  private buildInitialExecuteSeeds(
+    newActionsWithoutDependencies: Iterable<Action>,
+    eventBlockingDeps: Iterable<Action>,
+  ): Set<Action> {
+    // Build initial seeds for pull mode (effects + special actions).
+    return buildPullInitialSeeds({
+      pullMode: this.pullMode,
+      pending: this.pending,
+      dirty: this.staleness.dirty,
+      effects: this.effects,
+      newActionsWithoutDependencies,
+      eventBlockingDeps,
+      computationDebounceFlushSeeds: this.delays.computationDebounceFlushSeeds,
+    });
+  }
+
+  private async runSettleLoop(
+    initialSeeds: ReadonlySet<Action>,
+  ): Promise<SchedulerSettleResult> {
+    const settleResult = await runSchedulerSettleLoop(
+      this.settleLoopState,
+      initialSeeds,
+    );
+
+    if (settleResult.settleStats) {
+      this.lastSettleStats = settleResult.settleStats;
+      pushBoundedHistory(
+        this.settleStatsHistory,
+        { recordedAt: performance.now(), stats: settleResult.settleStats },
+        MAX_SETTLE_STATS_HISTORY,
+      );
+    }
+
+    return settleResult;
+  }
+
+  private applyAdaptiveCycleDebounce(): void {
+    // Apply cycle-aware debounce to effects that ran multiple times this execute().
+    // Pull computations are already demand-gated; debouncing them can leave a
+    // live renderer observing stale materialized data until an arbitrary timer
+    // fires.
+    const cycleDebouncePlan = planAdaptiveCycleDebounce({
+      pullMode: this.pullMode,
+      executeStartTime: this.executeStartTime,
+      runsThisExecute: this.runsThisExecute,
+      canAutomaticallyDebounce: (action) =>
+        this.canAutomaticallyDebounce(
+          action,
+        ),
+      getCurrentDebounce: (action) => this.delays.getDebounce(action),
+    });
+    for (
+      const { action, runs, delayMs } of cycleDebouncePlan.updates
+    ) {
+      this.delays.setDebounce(action, delayMs);
+      logger.debug("schedule-cycle-debounce", () => [
+        `[CYCLE-DEBOUNCE] Action ${this.getActionId(action)} ` +
+        `ran ${runs}x in ${cycleDebouncePlan.elapsedMs.toFixed(1)}ms, ` +
+        `setting debounce to ${delayMs}ms`,
+      ]);
+    }
+  }
+
+  private recordExecuteEndTelemetry(): void {
+    // Non-settling heuristic: accumulate busy time at end of execute()
+    const executeEnd = recordExecuteEnd(this.settlingTracker);
+    if (this.diagnosisEnabled) {
+      this.diagnosisBusyTime += executeEnd.diagnosisBusyTimeMs;
+    }
+    if (executeEnd.nonSettlingTelemetry) {
+      this.runtime.telemetry.submit({
+        type: "scheduler.non-settling",
+        ...executeEnd.nonSettlingTelemetry,
+      });
+      // Auto-trigger diagnosis if enabled
+      if (this.autoTriggerDiagnosis && !this.diagnosisEnabled) {
+        this.startDiagnosis();
+      }
+    }
+  }
+
+  // ============================================================
+  // Idempotency diagnosis API (Phase 2 + 3)
+  // ============================================================
+
+  /**
+   * Starts diagnosis mode: captures read/write values and causal edges.
+   * Automatically stops after durationMs.
+   */
+  private startDiagnosis(durationMs = 5000): void {
+    startSchedulerDiagnosis(this.diagnosisControlState, durationMs);
+  }
+
+  /**
+   * Stops diagnosis mode and finalizes results.
+   */
+  private stopDiagnosis(): void {
+    stopSchedulerDiagnosis(this.diagnosisControlState);
+  }
+
+  private collectDependenciesForAction(
+    action: Action,
+    populateDependencies: PopulateDependenciesEntry,
+    options: {
+      errorLogLabel: string;
+      errorMessage: (action: Action, error: unknown) => string;
+      updateDependents?: boolean;
+      useRawReadsForTriggers?: boolean;
+    },
+  ): { log: ReactivityLog; entities: Set<SpaceScopeAndURI> } {
+    return collectDependenciesForActionState(
+      this.dependencyCollectionState,
+      action,
+      populateDependencies,
+      options,
+    );
+  }
+
+  /**
+   * Updates the reverse dependency graph (dependents map).
+   * For each action that writes to paths this action reads, add this action as a dependent.
+   */
+  private updateDependents(action: Action, log: ReactivityLog): void {
+    const actionId = this.getActionId(action);
+    updateDependentEdgesForLog(this.dependencyGraphState, action, log);
+
+    // Emit telemetry for dependency updates
+    this.runtime.telemetry.submit({
+      type: "scheduler.dependencies.update",
+      actionId,
+      reads: [...log.reads, ...log.shallowReads].map((r) =>
+        `${r.space}/${r.id}/${r.path.join("/")}`
+      ),
+      writes: log.writes.map((w) => `${w.space}/${w.id}/${w.path.join("/")}`),
+    });
+  }
+
+  // ============================================================
+  // State wiring
+  // ============================================================
 
   // Keep state-bundle wiring explicit without making the field declarations
   // read like one large object graph.
@@ -1110,6 +1914,10 @@ export class Scheduler {
     };
   }
 
+  // ============================================================
+  // Private forwarding helpers
+  // ============================================================
+
   /**
    * Gets a stable identifier for an action based on its source location.
    * Prefers .src (set as backup) over .name, falls back to a generated ID.
@@ -1117,365 +1925,6 @@ export class Scheduler {
    */
   private getActionId(action: Action | EventHandler): string {
     return getSchedulerActionId(this.actionIdentityState, action);
-  }
-
-  // ── Inline idempotency check mode ──────────────────────────────────
-
-  enableIdempotencyCheck(): void {
-    this.idempotencyCheckMode = true;
-    this.idempotencyViolations.length = 0;
-    if (this.pullMode) {
-      this.queueExecution();
-    }
-  }
-
-  disableIdempotencyCheck(): void {
-    this.idempotencyCheckMode = false;
-  }
-
-  getIdempotencyViolations(): NonIdempotentReport[] {
-    return [...this.idempotencyViolations];
-  }
-
-  /**
-   * Subscribes an action to run when its dependencies change.
-   *
-   * The action will be scheduled to run immediately. Before running, the
-   * populateDependencies callback will be called to discover what cells the
-   * action will read. After running, the scheduler automatically re-subscribes
-   * using the reactivity log from the run.
-   *
-   * @param action The action to subscribe
-   * @param populateDependencies Callback to discover the action's read dependencies,
-   *   or a ReactivityLog for backwards compatibility (deprecated)
-   * @param options Configuration options for the subscription
-   * @returns A cancel function to unsubscribe
-   */
-  subscribe(
-    action: Action,
-    populateDependencies: PopulateDependencies | ReactivityLog,
-    options: {
-      isEffect?: boolean;
-      debounce?: number;
-      noDebounce?: boolean;
-      throttle?: number;
-      changeGroup?: ChangeGroup;
-    } = {},
-  ): Cancel {
-    return subscribeSchedulerAction(
-      this.subscribeActionState,
-      action,
-      populateDependencies,
-      options,
-    );
-  }
-
-  /**
-   * Re-subscribes an action after it has already run, using the reactivity log
-   * from the completed run. This sets up triggers for future changes without
-   * scheduling the action to run immediately.
-   *
-   * Use this method when:
-   * - An action has just completed running and you have its reactivity log
-   * - You want to register triggers for future changes
-   *
-   * @param action The action to re-subscribe
-   * @param log The reactivity log from the action's previous run
-   * @param options Optional configuration (e.g., isEffect to mark as side-effectful)
-   */
-  resubscribe(
-    action: Action,
-    log: ReactivityLog,
-    options: {
-      isEffect?: boolean;
-      changeGroup?: ChangeGroup;
-    } = {},
-  ): void {
-    resubscribeSchedulerAction(
-      this.subscribeActionState,
-      action,
-      log,
-      options,
-    );
-  }
-
-  unsubscribe(
-    action: Action,
-    options: { preserveChangeGroup?: boolean } = {},
-  ): void {
-    unsubscribeSchedulerAction(this.unsubscribeState, action, options);
-  }
-
-  async run(action: Action): Promise<any> {
-    return await runSchedulerAction(this.actionRunState, action);
-  }
-
-  idle(): Promise<void> {
-    return new Promise<void>((resolve) => {
-      if (this.runningPromise) {
-        // Something is currently running - wait for it then check again
-        this.runningPromise.then(() => this.idle().then(resolve));
-      } else if (this.backgroundTasks.size > 0) {
-        // Async scheduler work, such as event-triggered auto-start, is still in
-        // flight. Wait for it to settle and then re-check the scheduler state.
-        Promise.allSettled([...this.backgroundTasks]).then(() =>
-          this.idle().then(resolve)
-        );
-      } else if (
-        hasEventQueueWakeTimer(this.eventQueueWakeState) &&
-        ((this.eventQueue.length > 0 &&
-          isHeadEventParkedState(this.eventQueueWakeState)) ||
-          this.hasDeferredDirtyEffectWork())
-      ) {
-        // A queued event is parked behind a throttled dependency. Wait for the
-        // wake timer to re-schedule the queue and then re-check.
-        this.idlePromises.push(resolve);
-      } else if (!this.scheduled) {
-        if (this.pullMode && this.hasRunnablePullWork()) {
-          this.queueExecution();
-          this.idlePromises.push(resolve);
-          return;
-        }
-        // Nothing is scheduled to run - we're idle.
-        // In pull mode, pending computations won't run without an effect to pull them,
-        // so we don't wait for them.
-        resolve();
-      } else {
-        // Execution is scheduled - wait for it to complete
-        this.idlePromises.push(resolve);
-      }
-    });
-  }
-
-  queueEvent(
-    eventLink: NormalizedFullLink,
-    event: any,
-    retries: number = DEFAULT_RETRIES_FOR_EVENTS,
-    // Internal-only commit callback. This runs after the final commit result,
-    // including exhausted failure, so it must not perform external side
-    // effects. Use the post-commit outbox for success-only effect release.
-    onCommit?: (tx: IExtendedStorageTransaction) => void,
-    doNotLoadPieceIfNotRunning: boolean = false,
-  ): void {
-    queueSchedulerEvent(this.eventQueueState, {
-      eventLink,
-      event,
-      retries,
-      onCommit,
-      doNotLoadPieceIfNotRunning,
-    });
-  }
-
-  addEventHandler(
-    handler: EventHandler,
-    ref: NormalizedFullLink,
-    populateDependencies?: (
-      tx: IExtendedStorageTransaction,
-      event: any,
-    ) => void,
-  ): Cancel {
-    return addSchedulerEventHandler({
-      eventHandlers: this.eventHandlers,
-    }, {
-      handler,
-      ref,
-      populateDependencies,
-    });
-  }
-
-  onConsole(fn: ConsoleHandler): void {
-    this.consoleHandler = fn;
-  }
-
-  onError(fn: ErrorHandler): void {
-    this.errorHandlers.add(fn);
-  }
-
-  queueExecution(): void {
-    if (this.disposed) return;
-    if (this.scheduled) {
-      if (this.pendingQueueTaskTimer === null) {
-        this.rerunAfterCurrentExecute = true;
-      }
-      return;
-    }
-    this.pendingQueueTaskTimer = queueTask(() => {
-      this.pendingQueueTaskTimer = null;
-      this.execute();
-    });
-    this.scheduled = true;
-  }
-
-  private collectDependenciesForAction(
-    action: Action,
-    populateDependencies: PopulateDependenciesEntry,
-    options: {
-      errorLogLabel: string;
-      errorMessage: (action: Action, error: unknown) => string;
-      updateDependents?: boolean;
-      useRawReadsForTriggers?: boolean;
-    },
-  ): { log: ReactivityLog; entities: Set<SpaceScopeAndURI> } {
-    return collectDependenciesForActionState(
-      this.dependencyCollectionState,
-      action,
-      populateDependencies,
-      options,
-    );
-  }
-
-  /**
-   * Updates the reverse dependency graph (dependents map).
-   * For each action that writes to paths this action reads, add this action as a dependent.
-   */
-  private updateDependents(action: Action, log: ReactivityLog): void {
-    const actionId = this.getActionId(action);
-    updateDependentEdgesForLog(this.dependencyGraphState, action, log);
-
-    // Emit telemetry for dependency updates
-    this.runtime.telemetry.submit({
-      type: "scheduler.dependencies.update",
-      actionId,
-      reads: [...log.reads, ...log.shallowReads].map((r) =>
-        `${r.space}/${r.id}/${r.path.join("/")}`
-      ),
-      writes: log.writes.map((w) => `${w.space}/${w.id}/${w.path.join("/")}`),
-    });
-  }
-
-  /**
-   * Returns diagnostic statistics about the scheduler state.
-   * Useful for debugging and monitoring pull-based scheduling behavior.
-   */
-  getStats(): { effects: number; computations: number; pending: number } {
-    return {
-      effects: this.effects.size,
-      computations: this.computations.size,
-      pending: this.pending.size,
-    };
-  }
-
-  /**
-   * Set action IDs that should trigger a debugger breakpoint before execution.
-   */
-  setBreakpoints(actionIds: string[]): void {
-    this.breakpoints.clear();
-    for (const id of actionIds) {
-      this.breakpoints.add(id);
-    }
-  }
-
-  /**
-   * Get currently set breakpoint action IDs.
-   */
-  getBreakpoints(): string[] {
-    return Array.from(this.breakpoints);
-  }
-
-  /**
-   * Check if an action ID has a breakpoint set.
-   */
-  hasBreakpoint(actionId: string): boolean {
-    return this.breakpoints.has(actionId);
-  }
-
-  /**
-   * Returns a snapshot of the current dependency graph for visualization.
-   * Uses getActionId for the identifier (includes code location).
-   */
-  getGraphSnapshot(): SchedulerGraphSnapshot {
-    return buildSchedulerGraphSnapshot(this.graphSnapshotState);
-  }
-
-  /**
-   * Returns whether an action is registered as an effect.
-   */
-  isEffect(action: Action): boolean {
-    return this.effects.has(action);
-  }
-
-  /**
-   * Returns whether an action is registered as a computation.
-   */
-  isComputation(action: Action): boolean {
-    return this.computations.has(action);
-  }
-
-  /**
-   * Returns the set of actions that depend on this action's output.
-   */
-  getDependents(action: Action): Set<Action> {
-    return this.dependents.get(action) ?? new Set();
-  }
-
-  // ============================================================
-  // Pull-based scheduling methods
-  // ============================================================
-
-  /**
-   * Enables pull-based scheduling mode.
-   * In pull mode, only effects are scheduled; computations are marked dirty
-   * and pulled on demand when effects need their values.
-   */
-  enablePullMode(): void {
-    this.pullMode = true;
-    this.staleness.stale.clear();
-    this.staleness.resetUpstreamStaleState();
-
-    // Rebuild reverse dependency graph (dependents map) from current dependencies.
-    // In push mode, processRun() doesn't update dependents, so the map may be stale.
-    // We need accurate dependents for markDirty() propagation and scheduleAffectedEffects().
-    for (const action of [...this.effects, ...this.computations]) {
-      const log = this.dependencies.get(action);
-      if (log) {
-        this.updateDependents(action, log);
-      }
-    }
-    for (const action of this.staleness.dirty) {
-      this.staleness.setStaleFromInputs(action);
-    }
-
-    this.runtime.telemetry.submit({
-      type: "scheduler.mode.change",
-      pullMode: true,
-    });
-    this.queueExecution();
-  }
-
-  /**
-   * Disables pull-based scheduling mode (returns to push mode).
-   */
-  disablePullMode(): void {
-    this.pullMode = false;
-    // Clear dirty set when switching back to push mode
-    this.staleness.clearAll();
-    this.runtime.telemetry.submit({
-      type: "scheduler.mode.change",
-      pullMode: false,
-    });
-    this.queueExecution();
-  }
-
-  /**
-   * Returns whether pull mode is enabled.
-   */
-  isPullModeEnabled(): boolean {
-    return this.pullMode;
-  }
-
-  setEventPreflightTelemetryEnabled(enabled: boolean): void {
-    this.eventPreflightTelemetryEnabled = enabled;
-  }
-
-  isEventPreflightTelemetryEnabled(): boolean {
-    return this.eventPreflightTelemetryEnabled;
-  }
-
-  /**
-   * Returns whether an action is marked as dirty.
-   */
-  isDirty(action: Action): boolean {
-    return this.staleness.dirty.has(action);
   }
 
   /**
@@ -1499,6 +1948,19 @@ export class Scheduler {
     );
   }
 
+  private collectDirtyDependenciesForLog(
+    log: ReactivityLog,
+    workSet: Set<Action>,
+    memo = new Map<Action, boolean>(),
+  ): boolean {
+    return collectDirtyDependenciesForLogState(
+      this.dirtyDependencyCollectionState,
+      log,
+      workSet,
+      memo,
+    );
+  }
+
   private canAutomaticallyDebounce(action: Action): boolean {
     return canAutomaticallyDebounceState(this.delayControlState, action);
   }
@@ -1514,19 +1976,6 @@ export class Scheduler {
     );
   }
 
-  private collectDirtyDependenciesForLog(
-    log: ReactivityLog,
-    workSet: Set<Action>,
-    memo = new Map<Action, boolean>(),
-  ): boolean {
-    return collectDirtyDependenciesForLogState(
-      this.dirtyDependencyCollectionState,
-      log,
-      workSet,
-      memo,
-    );
-  }
-
   private collectPullIterationSeeds(workSet: Set<Action>): void {
     collectPullIterationSeedsState(this.pullSchedulingState, workSet);
   }
@@ -1534,6 +1983,7 @@ export class Scheduler {
   private hasRunnablePullWork(): boolean {
     return hasRunnablePullWorkState(this.pullSchedulingState);
   }
+
   private hasDeferredDirtyEffectWork(): boolean {
     return hasDeferredDirtyEffectWorkState(this.pullSchedulingState);
   }
@@ -1542,55 +1992,6 @@ export class Scheduler {
     computation: Action,
   ): TriggerTraceScheduledEffect[] {
     return scheduleAffectedEffectsState(this.pullSchedulingState, computation);
-  }
-
-  // ============================================================
-  // Compute time tracking for cycle-aware scheduling
-  // ============================================================
-
-  /**
-   * Returns the execution statistics for an action, if available.
-   * Useful for diagnostics and determining cycle convergence strategy.
-   * Accepts either an Action or an action ID string.
-   */
-  getActionStats(action: Action | string): ActionStats | undefined {
-    return getActionStatsFromState(this.actionTimingState, action);
-  }
-
-  // ============================================================
-  // Debounce infrastructure for throttling slow actions
-  // ============================================================
-
-  /**
-   * Sets a debounce delay for an action.
-   * When the action is triggered, it will wait for the specified delay before running.
-   * If triggered again during the delay, the timer resets.
-   */
-  setDebounce(action: Action, ms: number): void {
-    this.delays.setDebounce(action, ms);
-  }
-
-  /**
-   * Gets the current debounce delay for an action, if set.
-   */
-  getDebounce(action: Action): number | undefined {
-    return this.delays.getDebounce(action);
-  }
-
-  /**
-   * Clears the debounce setting for an action.
-   */
-  clearDebounce(action: Action): void {
-    this.delays.clearDebounce(action);
-  }
-
-  /**
-   * Enables or disables auto-debounce detection for an action.
-   * When set to true, this action opts OUT of auto-debounce.
-   * By default, slow actions (> 50ms avg after 3 runs) will automatically get debounced.
-   */
-  setNoDebounce(action: Action, optOut: boolean): void {
-    this.delays.setNoDebounce(action, optOut);
   }
 
   private getNextDebounceRunTime(action: Action): number | undefined {
@@ -1629,389 +2030,5 @@ export class Scheduler {
         }ms >= ${update.thresholdMs}ms)`,
       ]);
     }
-  }
-
-  // ============================================================
-  // Throttle infrastructure - "value can be stale by T ms"
-  // ============================================================
-
-  /**
-   * Sets a throttle period for an action.
-   * The action won't run if it ran within the last `ms` milliseconds.
-   * Unlike debounce, throttled actions stay dirty and will be pulled
-   * by effects when the throttle period expires. Event handlers whose head
-   * dependencies are throttled are parked until the earliest eligible wake time.
-   */
-  setThrottle(action: Action, ms: number): void {
-    this.delays.setThrottle(action, ms);
-  }
-
-  /**
-   * Gets the current throttle period for an action, if set.
-   */
-  getThrottle(action: Action): number | undefined {
-    return this.delays.getThrottle(action);
-  }
-
-  /**
-   * Clears the throttle setting for an action.
-   */
-  clearThrottle(action: Action): void {
-    this.delays.clearThrottle(action);
-  }
-
-  // ============================================================
-  // Push-triggered filtering
-  // ============================================================
-
-  /**
-   * Returns the active scheduling write set for an action. By default this is
-   * the current-known write set; experimental historical mode returns the
-   * cumulative legacy view instead.
-   */
-  getMightWrite(action: Action): IMemorySpaceAddress[] | undefined {
-    return this.writeIndex.getSchedulingWrites(action);
-  }
-
-  /**
-   * Returns filter statistics for the current/last execution cycle.
-   */
-  getFilterStats(): { filtered: number; executed: number } {
-    return { ...this.filterStats };
-  }
-
-  /**
-   * Resets filter statistics.
-   */
-  resetFilterStats(): void {
-    this.filterStats.filtered = 0;
-    this.filterStats.executed = 0;
-  }
-
-  /**
-   * Enables collection of per-iteration settle stats during execute().
-   * Call this once before running patterns to opt in to the overhead.
-   */
-  enableSettleStats(): void {
-    this.setSettleStatsEnabled(true);
-  }
-
-  /**
-   * Enables or disables collection of per-iteration settle stats during execute().
-   * Disabling also clears the last collected stats to avoid stale reads.
-   */
-  setSettleStatsEnabled(enabled: boolean): void {
-    this.collectSettleStats = enabled;
-    if (!enabled) {
-      this.lastSettleStats = null;
-      this.settleStatsHistory = [];
-    }
-  }
-
-  /**
-   * Returns settle stats from the last execute() call, or null if not enabled/collected.
-   */
-  getSettleStats(): SettleStats | null {
-    return this.lastSettleStats;
-  }
-
-  /**
-   * Returns recent settle stats history from execute() calls, oldest first.
-   */
-  getSettleStatsHistory(): SettleStatsHistoryEntry[] {
-    return [...this.settleStatsHistory];
-  }
-
-  /**
-   * Enables or disables collection of exact action-run history.
-   * Disabling clears the current ring buffer to avoid stale reads.
-   */
-  setActionRunTraceEnabled(enabled: boolean): void {
-    this.collectActionRunTrace = enabled;
-    if (!enabled) {
-      this.actionRunTrace.length = 0;
-    }
-  }
-
-  /**
-   * Returns recent exact action-run history, oldest first.
-   */
-  getActionRunTrace(): ActionRunTraceEntry[] {
-    return [...this.actionRunTrace];
-  }
-
-  /**
-   * Enables or disables collection of structured trigger-trace entries.
-   * Disabling clears the current ring buffer to avoid stale reads.
-   */
-  setTriggerTraceEnabled(enabled: boolean): void {
-    this.collectTriggerTrace = enabled;
-    if (!enabled) {
-      this.triggerTrace = [];
-    }
-  }
-
-  /**
-   * Returns recent structured trigger-trace entries, oldest first.
-   */
-  getTriggerTrace(): TriggerTraceEntry[] {
-    return [...this.triggerTrace];
-  }
-
-  // ============================================================
-  // Non-settling detection API
-  // ============================================================
-
-  /**
-   * Returns whether the scheduler has detected a non-settling condition.
-   * This means execute() is consuming a high fraction of wall-clock time,
-   * indicating the system is churning.
-   */
-  isNonSettling(): boolean {
-    return this.settlingTracker.nonSettlingDetected;
-  }
-
-  /**
-   * Enables or disables automatic triggering of diagnosis when non-settling
-   * is detected. Off by default.
-   */
-  setAutoTriggerDiagnosis(enabled: boolean): void {
-    this.autoTriggerDiagnosis = enabled;
-  }
-
-  // ============================================================
-  // Idempotency diagnosis API (Phase 2 + 3)
-  // ============================================================
-
-  /**
-   * Starts diagnosis mode: captures read/write values and causal edges.
-   * Automatically stops after durationMs.
-   */
-  private startDiagnosis(durationMs = 5000): void {
-    startSchedulerDiagnosis(this.diagnosisControlState, durationMs);
-  }
-
-  /**
-   * Stops diagnosis mode and finalizes results.
-   */
-  private stopDiagnosis(): void {
-    stopSchedulerDiagnosis(this.diagnosisControlState);
-  }
-
-  /**
-   * Runs a diagnosis for the specified duration and returns the result.
-   * This is the main entry point for external callers (IPC, console).
-   */
-  runDiagnosis(durationMs = 5000): Promise<SchedulerDiagnosisResult> {
-    return runSchedulerDiagnosis(this.diagnosisControlState, durationMs);
-  }
-
-  /**
-   * Checks all computations for idempotency by enabling inline mode
-   * and force-running each computation through run(). Each run()
-   * automatically gets a second synchronous run for comparison.
-   */
-  async runIdempotencyCheck(): Promise<SchedulerDiagnosisResult> {
-    return await runSchedulerIdempotencyCheck(this.diagnosisControlState);
-  }
-
-  private handleError(error: Error, action: any) {
-    handleSchedulerError(
-      {
-        errorHandlers: this.errorHandlers,
-        parseStack: (stack) => this.runtime.harness.parseStack(stack),
-      },
-      error,
-      action,
-    );
-  }
-
-  private async execute(): Promise<void> {
-    if (this.disposed) return;
-    logger.timeStart("scheduler", "execute");
-
-    // In case a directly invoked `run` is still running, wait for it to finish.
-    if (this.runningPromise) await this.runningPromise;
-
-    this.beginExecuteCycle();
-    const { newActionsWithoutDependencies } = this
-      .collectInitialExecuteDependencies();
-    const eventBlockingDeps = await this.processExecuteEventPhase();
-    this.collectPostEventDependencies();
-    const initialSeeds = this.buildInitialExecuteSeeds(
-      newActionsWithoutDependencies,
-      eventBlockingDeps,
-    );
-
-    const settleResult = await this.runSettleLoop(initialSeeds);
-    await breakCyclesIfNeeded(this.cycleBreakState, settleResult);
-    this.applyAdaptiveCycleDebounce();
-    this.recordExecuteEndTelemetry();
-    applyExecuteContinuation(this.executeContinuationState);
-    logger.timeEnd("scheduler", "execute");
-  }
-
-  private beginExecuteCycle(): void {
-    // Track timing for cycle-aware debounce
-    this.executeStartTime = performance.now();
-    this.runsThisExecute.clear();
-
-    // Non-settling heuristic: record execute() start
-    markExecuteStart(this.settlingTracker);
-  }
-
-  private collectInitialExecuteDependencies(): {
-    newActionsWithoutDependencies: Action[];
-  } {
-    return collectInitialExecuteDependenciesState({
-      pendingDependencyCollection: this.pendingDependencyCollection,
-      populateDependenciesCallbacks: this.populateDependenciesCallbacks,
-      effects: this.effects,
-      getSchedulingWrites: (action) =>
-        this.writeIndex.getSchedulingWrites(action),
-      collectDependenciesForAction: (action, populateDependencies, options) =>
-        this.collectDependenciesForAction(
-          action,
-          populateDependencies,
-          options,
-        ),
-      getActionId: (action) => this.getActionId(action),
-      scheduleAffectedEffects: (action) => this.scheduleAffectedEffects(action),
-    });
-  }
-
-  private async processExecuteEventPhase(): Promise<Set<Action>> {
-    // Track dirty dependencies that block events - these must be added to workSet
-    const eventBlockingDeps = new Set<Action>();
-
-    logger.timeStart("scheduler", "execute", "event");
-    try {
-      await processQueuedEventDuringExecute(
-        this.eventExecutionState,
-        eventBlockingDeps,
-      );
-      return eventBlockingDeps;
-    } finally {
-      logger.timeEnd("scheduler", "execute", "event");
-    }
-  }
-
-  private collectPostEventDependencies(): void {
-    collectPostEventDependenciesState({
-      pendingDependencyCollection: this.pendingDependencyCollection,
-      populateDependenciesCallbacks: this.populateDependenciesCallbacks,
-      effects: this.effects,
-      getSchedulingWrites: (action) =>
-        this.writeIndex.getSchedulingWrites(action),
-      collectDependenciesForAction: (action, populateDependencies, options) =>
-        this.collectDependenciesForAction(
-          action,
-          populateDependencies,
-          options,
-        ),
-      getActionId: (action) => this.getActionId(action),
-    });
-  }
-
-  private buildInitialExecuteSeeds(
-    newActionsWithoutDependencies: Iterable<Action>,
-    eventBlockingDeps: Iterable<Action>,
-  ): Set<Action> {
-    // Build initial seeds for pull mode (effects + special actions).
-    return buildPullInitialSeeds({
-      pullMode: this.pullMode,
-      pending: this.pending,
-      dirty: this.staleness.dirty,
-      effects: this.effects,
-      newActionsWithoutDependencies,
-      eventBlockingDeps,
-      computationDebounceFlushSeeds: this.delays.computationDebounceFlushSeeds,
-    });
-  }
-
-  private async runSettleLoop(
-    initialSeeds: ReadonlySet<Action>,
-  ): Promise<SchedulerSettleResult> {
-    const settleResult = await runSchedulerSettleLoop(
-      this.settleLoopState,
-      initialSeeds,
-    );
-
-    if (settleResult.settleStats) {
-      this.lastSettleStats = settleResult.settleStats;
-      pushBoundedHistory(
-        this.settleStatsHistory,
-        { recordedAt: performance.now(), stats: settleResult.settleStats },
-        MAX_SETTLE_STATS_HISTORY,
-      );
-    }
-
-    return settleResult;
-  }
-
-  private applyAdaptiveCycleDebounce(): void {
-    // Apply cycle-aware debounce to effects that ran multiple times this execute().
-    // Pull computations are already demand-gated; debouncing them can leave a
-    // live renderer observing stale materialized data until an arbitrary timer
-    // fires.
-    const cycleDebouncePlan = planAdaptiveCycleDebounce({
-      pullMode: this.pullMode,
-      executeStartTime: this.executeStartTime,
-      runsThisExecute: this.runsThisExecute,
-      canAutomaticallyDebounce: (action) =>
-        this.canAutomaticallyDebounce(
-          action,
-        ),
-      getCurrentDebounce: (action) => this.delays.getDebounce(action),
-    });
-    for (
-      const { action, runs, delayMs } of cycleDebouncePlan.updates
-    ) {
-      this.delays.setDebounce(action, delayMs);
-      logger.debug("schedule-cycle-debounce", () => [
-        `[CYCLE-DEBOUNCE] Action ${this.getActionId(action)} ` +
-        `ran ${runs}x in ${cycleDebouncePlan.elapsedMs.toFixed(1)}ms, ` +
-        `setting debounce to ${delayMs}ms`,
-      ]);
-    }
-  }
-
-  private recordExecuteEndTelemetry(): void {
-    // Non-settling heuristic: accumulate busy time at end of execute()
-    const executeEnd = recordExecuteEnd(this.settlingTracker);
-    if (this.diagnosisEnabled) {
-      this.diagnosisBusyTime += executeEnd.diagnosisBusyTimeMs;
-    }
-    if (executeEnd.nonSettlingTelemetry) {
-      this.runtime.telemetry.submit({
-        type: "scheduler.non-settling",
-        ...executeEnd.nonSettlingTelemetry,
-      });
-      // Auto-trigger diagnosis if enabled
-      if (this.autoTriggerDiagnosis && !this.diagnosisEnabled) {
-        this.startDiagnosis();
-      }
-    }
-  }
-
-  /**
-   * Clean up all pending timers and resources.
-   * Should be called when the scheduler is being torn down.
-   */
-  dispose(): void {
-    this.disposed = true;
-    // Clear all active debounce timers
-    this.delays.clearActiveDebounceTimers();
-    if (this.pendingQueueTaskTimer !== null) {
-      clearTimeout(this.pendingQueueTaskTimer);
-      this.pendingQueueTaskTimer = null;
-    }
-    cancelEventQueueWakeState(this.eventQueueWakeState);
-    // Clean up diagnosis state
-    if (this.diagnosisTimeout) {
-      clearTimeout(this.diagnosisTimeout);
-      this.diagnosisTimeout = null;
-    }
-    this.diagnosisEnabled = false;
   }
 }

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -43,10 +43,8 @@ import {
   type SchedulerActionIdentityState,
 } from "./scheduler/diagnostics.ts";
 import {
-  captureDiagnosisRecord as captureDiagnosisRecordState,
   detectCausalCycles,
   type DiagnosisRecord,
-  runIdempotencyRecheck as runIdempotencyRecheckState,
 } from "./scheduler/diagnosis.ts";
 import {
   collectDirectWritersForLog,
@@ -67,13 +65,8 @@ import {
   type WriterIndexState,
 } from "./scheduler/dependency-index.ts";
 import {
-  addInFlightSource as addInFlightSourceState,
-  appendActionRunTrace,
   type InFlightSourceState,
-  invokeReactiveAction,
-  removeInFlightSource as removeInFlightSourceState,
-  startReactiveActionCommit,
-  watchReactiveActionCommit,
+  runSchedulerAction,
 } from "./scheduler/action-run.ts";
 import {
   buildPullInitialSeeds,
@@ -107,15 +100,10 @@ import {
   updateSchedulerActionChangeGroup,
   updateSchedulerActionType,
 } from "./scheduler/subscriptions.ts";
-import {
-  markReadersDirtyForChangedWrites as markReadersDirtyForChangedWritesState,
-  recordChangedComputationWrites as recordChangedComputationWritesState,
-  type WritePropagationState,
-} from "./scheduler/write-propagation.ts";
+import { type WritePropagationState } from "./scheduler/write-propagation.ts";
 import {
   type ActionTimingState,
   getActionStats as getActionStatsFromState,
-  recordActionTime as recordActionTimeState,
 } from "./scheduler/timing.ts";
 import { txToReactivityLog } from "./scheduler/reactivity.ts";
 import {
@@ -885,207 +873,52 @@ export class Scheduler {
   }
 
   async run(action: Action): Promise<any> {
-    logger.timeStart("scheduler", "run");
-    const actionId = this.getActionId(action);
-    this.runtime.telemetry.submit({
-      type: "scheduler.run",
-      actionId,
-      actionInfo: getSchedulerActionTelemetryInfo(action),
-    });
-
-    logger.debug("schedule-run-start", () => [
-      `[RUN] Starting action: ${actionId}`,
-      `Pull mode: ${this.pullMode}`,
-    ]);
-
-    if (this.runningPromise) await this.runningPromise;
-
-    const tx = this.runtime.edit({
-      changeGroup: this.actionChangeGroups.get(action),
-    });
-    (tx.tx as { debugActionId?: string }).debugActionId = actionId;
-    addInFlightSourceState(this.inFlightSourceState, action, tx.tx);
-    const actionStartTime = performance.now();
-
-    let result: any;
-    this.runningPromise = new Promise((resolve) => {
-      const finalizeAction = (error?: unknown) => {
-        // Record action execution time for cycle-aware scheduling
-        const elapsed = performance.now() - actionStartTime;
-        recordActionTimeState(this.actionTimingState, action, elapsed);
-        this.maybeAutoDebounce(action);
-        this.delays.markActionHasRun(action);
-        this.pullDemandedFirstRunComputations.delete(action);
-
-        try {
-          if (error) {
-            logger.error("schedule-error", () => [
-              `[RUN] Action failed: ${actionId}`,
-              `Error: ${error}`,
-            ]);
-            this.handleError(error as Error, action);
-          }
-        } finally {
-          // Set up new reactive subscriptions after the action runs
-
-          // Commit the transaction. The code continues synchronously after
-          // kicking off the commit, i.e. it assumes the commit will be
-          // successful. If it isn't, the data will be rolled back and all other
-          // reactive functions based on it will be retriggered. But also, the
-          // retry logic below will have re-scheduled this action, so
-          // topological sorting should move it before the dependencies.
-          const commitPromise = startReactiveActionCommit({
-            runtime: this.runtime,
-            tx,
-          });
-          const log = txToReactivityLog(tx);
-          watchReactiveActionCommit({
-            action,
-            tx,
-            log,
-            retries: this.retries,
-            pending: this.pending,
-            commitPromise,
-            resubscribe: (target, targetLog) =>
-              this.resubscribe(target, targetLog),
-            markDirectDirty: (target) => this.staleness.markDirectDirty(target),
-            queueExecution: () => this.queueExecution(),
-            removeInFlightSource: (target, source) =>
-              removeInFlightSourceState(
-                this.inFlightSourceState,
-                target,
-                source,
-              ),
-          });
-          const changedComputationWrites = recordChangedComputationWritesState(
-            this.writePropagationState,
-            action,
-            tx,
-            log,
-          );
-
-          logger.debug("schedule-run-complete", () => [
-            `[RUN] Action completed: ${actionId}`,
-            `Reads: ${log.reads.length}`,
-            `Writes: ${log.writes.length}`,
-            `Elapsed: ${elapsed.toFixed(2)}ms`,
-          ]);
-
-          if (this.collectActionRunTrace) {
-            appendActionRunTrace({
-              actionRunTrace: this.actionRunTrace,
-              actionParent: this.actionParent,
-              isEffectAction: this.isEffectAction,
-              getActionId: (target) => this.getActionId(target),
-              getSchedulingWrites: (target) =>
-                getSchedulingWritesFromState(
-                  this.schedulingWriteState,
-                  target,
-                ),
-            }, {
-              action,
-              actionId,
-              durationMs: elapsed,
-              log,
-            });
-          }
-
-          // Diagnosis capture: record read/write values for idempotency checking
-          if (this.diagnosisEnabled) {
-            captureDiagnosisRecordState({
-              diagnosisHistory: this.diagnosisHistory,
-              diagnosisNonIdempotent: this.diagnosisNonIdempotent,
-              createReadTx: () => this.runtime.edit(),
-              getActionTelemetryInfo: (target) =>
-                getSchedulerActionTelemetryInfo(target),
-            }, {
-              actionId,
-              action,
-              tx,
-              log,
-            });
-          }
-
-          // Inline idempotency re-run: when the mode is on, every
-          // computation gets a second synchronous run against post-commit
-          // state. An idempotent computation produces the same writes
-          // both times. Uses isEffectAction (persists past unsubscribe)
-          // since execute() calls unsubscribe() before run().
-          if (
-            this.idempotencyCheckMode &&
-            !this.isEffectAction.get(action)
-          ) {
-            logger.timeStart("scheduler", "run", "idempotencyRecheck");
-            try {
-              runIdempotencyRecheckState(
-                {
-                  idempotencyViolations: this.idempotencyViolations,
-                  createTx: () => this.runtime.edit(),
-                  invoke: (fn) => this.runtime.harness.invoke(fn),
-                  getActionId: (target) => this.getActionId(target),
-                  getActionTelemetryInfo: (target) =>
-                    getSchedulerActionTelemetryInfo(target),
-                },
-                action,
-                tx,
-                log,
-              );
-            } finally {
-              logger.timeEnd("scheduler", "run", "idempotencyRecheck");
-            }
-          }
-
-          logger.timeStart("scheduler", "run", "resubscribe");
-          try {
-            this.resubscribe(action, log);
-          } finally {
-            logger.timeEnd("scheduler", "run", "resubscribe");
-          }
-          if (this.pullMode && this.computations.has(action)) {
-            clearSchedulerDirectDirty(this.dirtySchedulingState, action);
-            markReadersDirtyForChangedWritesState(
-              this.writePropagationState,
-              action,
-              changedComputationWrites,
-            );
-          }
-          resolve(result);
-        }
-      };
-
-      invokeReactiveAction({
-        runtime: this.runtime,
-        setExecutingAction: (target, targetActionId) => {
-          this.executingAction = target;
-          this.currentActionId = targetActionId;
-        },
-        clearExecutingAction: () => {
-          this.executingAction = null;
-          this.currentActionId = undefined;
-        },
-      }, {
-        action,
-        actionId,
-        tx,
-        actionStartTime,
-      })
-        .then((invocation) => {
-          if (invocation.ok) {
-            result = invocation.result;
-            finalizeAction();
-          } else {
-            finalizeAction(invocation.error);
-          }
-        })
-        .catch((error) => {
-          finalizeAction(error);
-        });
-    });
-
-    return this.runningPromise.then((result) => {
-      logger.timeEnd("scheduler", "run");
-      return result;
-    });
+    return await runSchedulerAction({
+      runtime: this.runtime,
+      actionChangeGroups: this.actionChangeGroups,
+      inFlightSourceState: this.inFlightSourceState,
+      actionTimingState: this.actionTimingState,
+      pullDemandedFirstRunComputations: this.pullDemandedFirstRunComputations,
+      retries: this.retries,
+      pending: this.pending,
+      actionRunTrace: this.actionRunTrace,
+      actionParent: this.actionParent,
+      isEffectAction: this.isEffectAction,
+      diagnosisHistory: this.diagnosisHistory,
+      diagnosisNonIdempotent: this.diagnosisNonIdempotent,
+      idempotencyViolations: this.idempotencyViolations,
+      writePropagationState: this.writePropagationState,
+      computations: this.computations,
+      getRunningPromise: () => this.runningPromise,
+      setRunningPromise: (promise) => {
+        this.runningPromise = promise;
+      },
+      getPullMode: () => this.pullMode,
+      getCollectActionRunTrace: () => this.collectActionRunTrace,
+      getDiagnosisEnabled: () => this.diagnosisEnabled,
+      getIdempotencyCheckMode: () => this.idempotencyCheckMode,
+      getActionId: (target) => this.getActionId(target),
+      getActionTelemetryInfo: (target) =>
+        getSchedulerActionTelemetryInfo(target),
+      getSchedulingWrites: (target) =>
+        getSchedulingWritesFromState(this.schedulingWriteState, target),
+      maybeAutoDebounce: (target) => this.maybeAutoDebounce(target),
+      markActionHasRun: (target) => this.delays.markActionHasRun(target),
+      handleError: (error, target) => this.handleError(error, target),
+      resubscribe: (target, log) => this.resubscribe(target, log),
+      markDirectDirty: (target) => this.staleness.markDirectDirty(target),
+      clearDirectDirty: (target) =>
+        clearSchedulerDirectDirty(this.dirtySchedulingState, target),
+      queueExecution: () => this.queueExecution(),
+      setExecutingAction: (target, targetActionId) => {
+        this.executingAction = target;
+        this.currentActionId = targetActionId;
+      },
+      clearExecutingAction: () => {
+        this.executingAction = null;
+        this.currentActionId = undefined;
+      },
+    }, action);
   }
 
   idle(): Promise<void> {

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -7,7 +7,7 @@ import type {
   ErrorWithContext,
   Runtime,
 } from "./runtime.ts";
-import { type NormalizedFullLink, toMemorySpaceAddress } from "./link-utils.ts";
+import { type NormalizedFullLink } from "./link-utils.ts";
 import type {
   ChangeGroup,
   IExtendedStorageTransaction,
@@ -51,8 +51,6 @@ import {
   type DependencyUpdateState,
   getSchedulingWrites as getSchedulingWritesFromState,
   getSchedulingWritesMap as getSchedulingWritesMapFromState,
-  pendingDependencyCollectionMightAffect
-    as pendingDependencyCollectionMightAffectState,
   readsOverlapWrites,
   replaceActionTriggerPaths,
   type SchedulingWriteState,
@@ -100,11 +98,11 @@ import {
   SchedulerStaleness,
 } from "./scheduler/staleness.ts";
 import {
-  registerParentChildAction,
+  resubscribeSchedulerAction,
+  type SchedulerSubscribeActionState,
   type SchedulerSubscriptionState,
+  subscribeSchedulerAction,
   unsubscribeSchedulerAction,
-  updateSchedulerActionChangeGroup,
-  updateSchedulerActionType,
 } from "./scheduler/subscriptions.ts";
 import { type WritePropagationState } from "./scheduler/write-propagation.ts";
 import {
@@ -123,7 +121,6 @@ import {
   scheduleEventQueueWake as scheduleEventQueueWakeState,
 } from "./scheduler/events.ts";
 import { buildSchedulerGraphSnapshot } from "./scheduler/graph-snapshot.ts";
-import { entityKey } from "./scheduler/keys.ts";
 import { collectTransitiveEffects } from "./scheduler/topology.ts";
 import type {
   Action,
@@ -453,6 +450,44 @@ export class Scheduler {
     hasDependentPath: (from: Action, to: Action) =>
       this.hasDependentPath(from, to),
   };
+  private subscribeActionState: SchedulerSubscribeActionState = {
+    subscriptionState: this.subscriptionState,
+    dependencyUpdateState: this.dependencyUpdateState,
+    triggerSubscriptionState: this.triggerSubscriptionState,
+    pendingDependencyCollectionState: this.pendingDependencyCollectionState,
+    populateDependenciesCallbacks: this.populateDependenciesCallbacks,
+    pendingDependencyCollection: this.pendingDependencyCollection,
+    activePullDemandActions: this.activePullDemandActions,
+    pullDemandedFirstRunComputations: this.pullDemandedFirstRunComputations,
+    actionParent: this.actionParent,
+    pending: this.pending,
+    scheduledFirstTime: this.scheduledFirstTime,
+    effects: this.effects,
+    dirty: this.staleness.dirty,
+    stale: this.staleness.stale,
+    writersByEntity: this.writerIndexState.writersByEntity,
+    getPullMode: () => this.pullMode,
+    setDebounce: (action, ms) => this.setDebounce(action, ms),
+    setNoDebounce: (action, optOut) => this.setNoDebounce(action, optOut),
+    setThrottle: (action, ms) => this.setThrottle(action, ms),
+    getSchedulingWrites: (action) =>
+      getSchedulingWritesFromState(this.schedulingWriteState, action),
+    isThrottled: (action) => this.delays.isThrottled(action),
+    isStale: (action) => this.staleness.isStale(action),
+    markDirectDirty: (action) => {
+      this.staleness.markDirectDirty(action);
+    },
+    markEffectConditionallyScheduled: (action) =>
+      this.markEffectConditionallyScheduled(action),
+    updateDependents: (action, log) => this.updateDependents(action, log),
+    scheduleAffectedEffects: (action) => this.scheduleAffectedEffects(action),
+    queueExecution: () => this.queueExecution(),
+    getActionId: (action) => this.getActionId(action),
+    unsubscribe: (action) => this.unsubscribe(action),
+    submitSubscribeTelemetry: (event) => {
+      this.runtime.telemetry.submit(event);
+    },
+  };
 
   private idlePromises: (() => void)[] = [];
   private backgroundTasks = new Set<Promise<unknown>>();
@@ -616,146 +651,12 @@ export class Scheduler {
       changeGroup?: ChangeGroup;
     } = {},
   ): Cancel {
-    // Handle backwards-compatible ReactivityLog argument
-    let populateDependenciesEntry: PopulateDependenciesEntry;
-    let immediateLog: ReactivityLog | undefined;
-    if (typeof populateDependencies === "function") {
-      populateDependenciesEntry = populateDependencies;
-    } else {
-      // ReactivityLog provided directly - set up dependencies immediately
-      // (for backwards compatibility with code that passes reads/writes)
-      immediateLog = populateDependencies;
-      populateDependenciesEntry = immediateLog;
-    }
-    const {
-      isEffect = false,
-      debounce,
-      noDebounce,
-      throttle,
-    } = options;
-
-    updateSchedulerActionChangeGroup(this.subscriptionState, action, options);
-
-    // Apply debounce settings if provided
-    if (debounce !== undefined) {
-      this.setDebounce(action, debounce);
-    }
-    if (noDebounce !== undefined) {
-      this.setNoDebounce(action, noDebounce);
-    }
-    // Apply throttle setting if provided
-    if (throttle !== undefined) {
-      this.setThrottle(action, throttle);
-    }
-
-    const actionIsEffect = updateSchedulerActionType(
-      this.subscriptionState,
+    return subscribeSchedulerAction(
+      this.subscribeActionState,
       action,
-      isEffect,
-      {
-        queueExecution: true,
-      },
+      populateDependencies,
+      options,
     );
-
-    // Track parent-child relationship if action is created during another action's execution
-    registerParentChildAction(this.subscriptionState, action);
-    const parent = this.actionParent.get(action);
-    if (
-      this.pullMode &&
-      !actionIsEffect &&
-      parent &&
-      this.activePullDemandActions.has(parent)
-    ) {
-      this.pullDemandedFirstRunComputations.add(action);
-      this.queueExecution();
-    }
-
-    logger.debug(
-      "schedule",
-      () => [
-        "Subscribing to action:",
-        action,
-        actionIsEffect ? "effect" : "computation",
-      ],
-    );
-
-    // Store the populateDependencies callback for use in execute()
-    this.populateDependenciesCallbacks.set(action, populateDependenciesEntry);
-
-    // In pull mode, newly subscribed computations can be the replacement for an
-    // already-running child graph (for example after a $TYPE change). Seed any
-    // statically declared writes immediately so existing effects can discover
-    // the new writer before the first execute() cycle.
-    if (
-      this.pullMode &&
-      !actionIsEffect &&
-      !immediateLog
-    ) {
-      const declaredWrites = (action as Partial<TelemetryAnnotations>).writes;
-      if (declaredWrites && declaredWrites.length > 0) {
-        setSchedulerDependencies(
-          this.dependencyUpdateState,
-          action,
-          {
-            reads: [],
-            shallowReads: [],
-            writes: declaredWrites.map(toMemorySpaceAddress),
-          },
-        );
-      }
-    }
-
-    // If a ReactivityLog was provided directly, set up dependencies immediately.
-    // This ensures writes are tracked right away for reverse dependency graph.
-    if (immediateLog) {
-      const { reads, shallowReads, log: schedulingLog } =
-        setSchedulerDependencies(
-          this.dependencyUpdateState,
-          action,
-          immediateLog,
-        );
-      this.updateDependents(action, schedulingLog);
-      const { entities } = replaceActionTriggerPaths(
-        this.triggerSubscriptionState,
-        action,
-        reads,
-        shallowReads,
-      );
-
-      // Register the cancel function for the latest trigger set.
-      setCancelForTriggerEntities(
-        this.triggerSubscriptionState,
-        action,
-        entities,
-      );
-    } else {
-      // Mark action for dependency collection before first run
-      this.pendingDependencyCollection.add(action);
-    }
-
-    // Mark as dirty and pending for first-time execution
-    // In pull mode this still doesn't mean execution: There needs to be an effect to trigger it.
-    this.staleness.markDirectDirty(action);
-    this.pending.add(action);
-    this.scheduledFirstTime.add(action);
-
-    if (
-      this.pullMode &&
-      !actionIsEffect &&
-      getSchedulingWritesFromState(this.schedulingWriteState, action)?.length
-    ) {
-      this.scheduleAffectedEffects(action);
-    }
-
-    // Emit telemetry for new subscription
-    const actionId = this.getActionId(action);
-    this.runtime.telemetry.submit({
-      type: "scheduler.subscribe",
-      actionId,
-      isEffect: actionIsEffect,
-    });
-
-    return () => this.unsubscribe(action);
   }
 
   /**
@@ -779,123 +680,12 @@ export class Scheduler {
       changeGroup?: ChangeGroup;
     } = {},
   ): void {
-    const { isEffect } = options;
-
-    updateSchedulerActionChangeGroup(this.subscriptionState, action, options);
-
-    const { reads, shallowReads, log: schedulingLog } =
-      setSchedulerDependencies(this.dependencyUpdateState, action, log);
-
-    // Track action type for pull-based scheduling
-    // Once an action is marked as an effect, it stays an effect
-    const actionIsEffect = updateSchedulerActionType(
-      this.subscriptionState,
+    resubscribeSchedulerAction(
+      this.subscribeActionState,
       action,
-      isEffect,
+      log,
+      options,
     );
-    const actionId = this.getActionId(action);
-
-    // Update reverse dependency graph after the action type is restored. In
-    // pull mode, registering a new edge to a live effect can be the moment a
-    // stale upstream computation becomes demanded.
-    if (this.pullMode) this.updateDependents(action, schedulingLog);
-
-    // Track parent-child relationship if action is created during another action's execution
-    // Only set if not already set (resubscribe can be called multiple times)
-    registerParentChildAction(this.subscriptionState, action, {
-      allowExisting: false,
-    });
-
-    const { entities, triggerPathsByEntity } = replaceActionTriggerPaths(
-      this.triggerSubscriptionState,
-      action,
-      reads,
-      shallowReads,
-    );
-
-    logger.debug("schedule-resubscribe", () => [
-      `Action: ${actionId}`,
-      `Entities: ${triggerPathsByEntity.size}`,
-      `Reads: ${reads.length}`,
-    ]);
-
-    setCancelForTriggerEntities(
-      this.triggerSubscriptionState,
-      action,
-      entities,
-    );
-
-    // In pull mode: When an effect resubscribes, check if any non-throttled dirty
-    // computations write to what it reads. If so, mark the effect dirty so it can
-    // pull those computations and see fresh data.
-    // Skip throttled computations - they'll trigger via storage changes when unthrottled.
-    // Use isEffectAction instead of effects because unsubscribe() clears effects before run()
-    if (this.pullMode && actionIsEffect && this.staleness.stale.size > 0) {
-      const effectReads = reads;
-      const effectShallowReads = shallowReads;
-      let shouldMarkDirty = false;
-
-      // If there are pending computations whose dependencies haven't been
-      // collected yet, only fall back to conservatism for unknown writes or
-      // known writes that overlap what this effect reads.
-      if (
-        pendingDependencyCollectionMightAffectState(
-          this.pendingDependencyCollectionState,
-          action,
-          effectReads,
-          effectShallowReads,
-        )
-      ) {
-        shouldMarkDirty = true;
-      }
-
-      // Use writersByEntity index for efficient lookup
-      if (!shouldMarkDirty) {
-        const entities = new Set<SpaceScopeAndURI>();
-        for (const read of effectReads) {
-          entities.add(entityKey(read));
-        }
-        for (const read of effectShallowReads) {
-          entities.add(entityKey(read));
-        }
-
-        for (const entity of entities) {
-          const writers = this.writerIndexState.writersByEntity.get(entity);
-          if (!writers) continue;
-
-          for (const writer of writers) {
-            if (writer === action) continue;
-            if (!this.staleness.isStale(writer)) continue;
-            if (this.effects.has(writer)) continue; // Only check computations
-            if (this.delays.isThrottled(writer)) continue; // Skip throttled - they trigger via storage
-
-            // Check path overlap
-            const writerWrites =
-              getSchedulingWritesFromState(this.schedulingWriteState, writer) ??
-                [];
-            if (
-              readsOverlapWrites(
-                effectReads,
-                effectShallowReads,
-                writerWrites,
-              )
-            ) {
-              shouldMarkDirty = true;
-              break;
-            }
-            if (shouldMarkDirty) break;
-          }
-          if (shouldMarkDirty) break;
-        }
-      }
-
-      if (shouldMarkDirty && !this.staleness.dirty.has(action)) {
-        this.markEffectConditionallyScheduled(action);
-        this.staleness.markDirectDirty(action);
-        this.pending.add(action);
-        this.queueExecution();
-      }
-    }
   }
 
   unsubscribe(

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -24,8 +24,6 @@ import type {
   ActionStats,
   NonIdempotentReport,
   SchedulerDiagnosisResult,
-  SchedulerEventPreflightActionSummary,
-  SchedulerEventPreflightStats,
   SchedulerGraphSnapshot,
 } from "./telemetry.ts";
 import {
@@ -68,6 +66,8 @@ import {
 import {
   collectDirtyDependencies as collectDirtyDependenciesState,
   collectDirtyDependenciesForLog as collectDirtyDependenciesForLogState,
+  type DirtyDependencyCollectionState,
+  snapshotDirtyDependencyTraceContext,
 } from "./scheduler/dirty-dependencies.ts";
 import {
   type InFlightSourceState,
@@ -104,6 +104,14 @@ import {
   scheduleWithDebounce as scheduleWithDebounceState,
 } from "./scheduler/delay-control.ts";
 import { SchedulerDelays } from "./scheduler/delays.ts";
+import {
+  hasDependentPath,
+  isDemandedPullComputation,
+  isLiveEffect,
+  isPullDemandRootEffect,
+  type PullDemandState,
+  shouldRunFirstPullComputationInDemandContext,
+} from "./scheduler/demand.ts";
 import {
   createStorageSubscription,
   type StorageNotificationState,
@@ -335,7 +343,8 @@ export class Scheduler {
     dirty: this.staleness.dirty,
     pending: this.pending,
     getPullMode: () => this.pullMode,
-    isPullDemandRootEffect: (action) => this.isPullDemandRootEffect(action),
+    isPullDemandRootEffect: (action) =>
+      isPullDemandRootEffect(this.pullDemandState, action),
     queueExecution: () => this.queueExecution(),
     logDebounce: (message) =>
       logger.debug("schedule-debounce", () => [message]),
@@ -360,6 +369,21 @@ export class Scheduler {
     writersByEntity: new Map<SpaceScopeAndURI, Set<Action>>(),
     // Reverse index: action -> entities it writes to (for cleanup)
     actionWriteEntities: new WeakMap<Action, Set<SpaceScopeAndURI>>(),
+  };
+  private dirtyDependencyCollectionState: DirtyDependencyCollectionState = {
+    collectStack: this.collectStack,
+    getTrace: () => this.dirtyDependencyTraceContext,
+    dirty: this.staleness.dirty,
+    pending: this.pending,
+    computations: this.computations,
+    reverseDependencies: this.reverseDependencies,
+    dependencies: this.dependencies,
+    writersByEntity: this.writerIndexState.writersByEntity,
+    effects: this.effects,
+    isStale: (target) => this.staleness.isStale(target),
+    getSchedulingWrites: (target) =>
+      getSchedulingWritesFromState(this.schedulingWriteState, target),
+    getActionId: (target) => this.getActionId(target),
   };
   // Track actions scheduled for first time (bypass filter)
   private scheduledFirstTime = new Set<Action>();
@@ -413,6 +437,19 @@ export class Scheduler {
   currentActionId?: string;
   private actionParent = new WeakMap<Action, Action>();
   private actionChildren = new WeakMap<Action, Set<Action>>();
+  private pullDemandState: PullDemandState = {
+    getPullMode: () => this.pullMode,
+    computations: this.computations,
+    effects: this.effects,
+    dependents: this.dependents,
+    dependencies: this.dependencies,
+    actionParent: this.actionParent,
+    isEffectAction: this.isEffectAction,
+    pullDemandedFirstRunComputations: this.pullDemandedFirstRunComputations,
+    hasActionRun: (action) => this.delays.hasActionRun(action),
+    getSchedulingWrites: (action) =>
+      getSchedulingWritesFromState(this.schedulingWriteState, action),
+  };
   private dependencyGraphState: DependencyGraphState = {
     triggers: this.triggerIndexState.triggers,
     nonRecursiveTriggers: this.triggerIndexState.nonRecursiveTriggers,
@@ -425,7 +462,7 @@ export class Scheduler {
       getSchedulingWritesFromState(this.schedulingWriteState, action),
     isStale: (action) => this.staleness.isStale(action),
     isDemandedPullComputation: (action) =>
-      this.isDemandedPullComputation(action),
+      isDemandedPullComputation(this.pullDemandState, action),
     queueExecution: () => this.queueExecution(),
   };
   private dependencyUpdateState: DependencyUpdateState = {
@@ -458,20 +495,23 @@ export class Scheduler {
     clearComputationDebounceState: (action) =>
       this.delays.clearComputationDebounceState(action),
     isDemandedPullComputation: (action) =>
-      this.isDemandedPullComputation(action),
+      isDemandedPullComputation(this.pullDemandState, action),
     queueExecution: () => this.queueExecution(),
   };
   private pendingPullRunnableState = {
     effects: this.effects,
     isDemandedPullComputation: (action: Action) =>
-      this.isDemandedPullComputation(action),
+      isDemandedPullComputation(this.pullDemandState, action),
     shouldRunFirstPullComputationInDemandContext: (action: Action) =>
-      this.shouldRunFirstPullComputationInDemandContext(action),
+      shouldRunFirstPullComputationInDemandContext(
+        this.pullDemandState,
+        action,
+      ),
   };
   private dirtyPullRunnableState = {
     effects: this.effects,
     isDemandedPullComputation: (action: Action) =>
-      this.isDemandedPullComputation(action),
+      isDemandedPullComputation(this.pullDemandState, action),
     isThrottled: (action: Action) => this.delays.isThrottled(action),
   };
   private dirtyPullRunnableStateWithDebounce = {
@@ -539,7 +579,7 @@ export class Scheduler {
     getSchedulingWrites: (action: Action) =>
       getSchedulingWritesFromState(this.schedulingWriteState, action),
     hasDependentPath: (from: Action, to: Action) =>
-      this.hasDependentPath(from, to),
+      hasDependentPath(this.pullDemandState, from, to),
   };
   private dependencyCollectionState!: DependencyCollectionState;
   private subscribeActionState: SchedulerSubscribeActionState = {
@@ -647,7 +687,8 @@ export class Scheduler {
       this.delays.clearComputationDebounceState(action),
     conditionalEffectHasChangedInputs: (action) =>
       this.conditionalEffectHasChangedInputs(action),
-    isPullDemandRootEffect: (action) => this.isPullDemandRootEffect(action),
+    isPullDemandRootEffect: (action) =>
+      isPullDemandRootEffect(this.pullDemandState, action),
     handleError: (error, action) => this.handleError(error, action),
     runAction: (action) => this.run(action),
   };
@@ -668,9 +709,12 @@ export class Scheduler {
       return shouldRerun;
     },
     isDemandedPullComputation: (action) =>
-      this.isDemandedPullComputation(action),
+      isDemandedPullComputation(this.pullDemandState, action),
     shouldRunFirstPullComputationInDemandContext: (action) =>
-      this.shouldRunFirstPullComputationInDemandContext(action),
+      shouldRunFirstPullComputationInDemandContext(
+        this.pullDemandState,
+        action,
+      ),
     isDebouncedComputationWaiting: (action) =>
       this.isDebouncedComputationWaiting(action),
     getNextDebounceRunTime: (action) => this.getNextDebounceRunTime(action),
@@ -1140,9 +1184,10 @@ export class Scheduler {
       getNextEligibleRunTime: (action) =>
         this.delays.getNextEligibleRunTime(action),
       isDemandedPullComputation: (action) =>
-        this.isDemandedPullComputation(action),
-      isLiveEffect: (action) => this.isLiveEffect(action),
-      isPullDemandRootEffect: (action) => this.isPullDemandRootEffect(action),
+        isDemandedPullComputation(this.pullDemandState, action),
+      isLiveEffect: (action) => isLiveEffect(this.pullDemandState, action),
+      isPullDemandRootEffect: (action) =>
+        isPullDemandRootEffect(this.pullDemandState, action),
       getPatternId: (action) => {
         const annotated = action as Partial<TelemetryAnnotations>;
         return annotated.pattern
@@ -1236,77 +1281,6 @@ export class Scheduler {
     return this.eventPreflightTelemetryEnabled;
   }
 
-  private getTraceActionSummary(
-    trace: DirtyDependencyTraceContext,
-    action: Action,
-  ): SchedulerEventPreflightActionSummary {
-    let summary = trace.actionSummaries.get(action);
-    if (!summary) {
-      const log = this.dependencies.get(action);
-      const writes =
-        getSchedulingWritesFromState(this.schedulingWriteState, action) ?? [];
-      summary = {
-        actionId: this.getActionId(action),
-        actionType: this.effects.has(action)
-          ? "effect"
-          : this.computations.has(action)
-          ? "computation"
-          : "unknown",
-        visitCount: 0,
-        memoHitCount: 0,
-        dirtyInputCount: 0,
-        resultTrueCount: 0,
-        reverseDependencyEdgeCount: 0,
-        maxDirectWriterCount: 0,
-        dirty: this.staleness.dirty.has(action),
-        pending: this.pending.has(action),
-        readCount: log?.reads.length ?? 0,
-        shallowReadCount: log?.shallowReads.length ?? 0,
-        writeCount: writes.length,
-      };
-      trace.actionSummaries.set(action, summary);
-    } else {
-      summary.dirty ||= this.staleness.dirty.has(action);
-      summary.pending ||= this.pending.has(action);
-    }
-    return summary;
-  }
-
-  private snapshotDirtyDependencyTraceContext(
-    context: DirtyDependencyTraceContext,
-  ): SchedulerEventPreflightStats {
-    const {
-      depth: _depth,
-      actionSummaries,
-      rootDirectWriterActions,
-      ...stats
-    } = context;
-    const actionRows = [...actionSummaries.values()];
-    const topBy = (
-      rows: SchedulerEventPreflightActionSummary[],
-      key: "visitCount" | "reverseDependencyEdgeCount",
-    ) =>
-      rows
-        .filter((row) => row[key] > 0)
-        .sort((a, b) =>
-          b[key] - a[key] ||
-          b.visitCount - a.visitCount ||
-          a.actionId.localeCompare(b.actionId)
-        )
-        .slice(0, 12);
-
-    const rootDirectWriterRows = [...rootDirectWriterActions].map((action) =>
-      this.getTraceActionSummary(context, action)
-    );
-
-    return {
-      ...stats,
-      hotActions: topBy(actionRows, "visitCount"),
-      hotFanoutActions: topBy(actionRows, "reverseDependencyEdgeCount"),
-      rootDirectWriters: topBy(rootDirectWriterRows, "visitCount"),
-    };
-  }
-
   /**
    * Returns whether an action is marked as dirty.
    */
@@ -1328,123 +1302,15 @@ export class Scheduler {
     memo = new Map<Action, boolean>(),
   ): boolean {
     return collectDirtyDependenciesState(
-      this.dirtyDependencyCollectionState(),
+      this.dirtyDependencyCollectionState,
       action,
       workSet,
       memo,
     );
   }
 
-  private hasDependentPath(
-    from: Action,
-    to: Action,
-    visited = new Set<Action>(),
-  ): boolean {
-    if (from === to) return true;
-    if (visited.has(from)) return false;
-    visited.add(from);
-
-    const dependents = this.dependents.get(from);
-    if (!dependents) return false;
-
-    for (const dependent of dependents) {
-      if (this.hasDependentPath(dependent, to, visited)) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  private hasTransitiveEffectDependent(
-    action: Action,
-    visited = new Set<Action>(),
-  ): boolean {
-    if (visited.has(action)) return false;
-    visited.add(action);
-
-    const dependents = this.dependents.get(action);
-    if (!dependents) return false;
-
-    for (const dependent of dependents) {
-      if (this.isLiveEffect(dependent)) return true;
-      if (this.hasTransitiveEffectDependent(dependent, visited)) {
-        return true;
-      }
-    }
-
-    return false;
-  }
-
-  private isDemandedPullComputation(
-    action: Action,
-    visited = new Set<Action>(),
-  ): boolean {
-    if (
-      !this.pullMode ||
-      !this.computations.has(action) ||
-      this.isLiveEffect(action)
-    ) {
-      return false;
-    }
-    if (visited.has(action)) return false;
-    visited.add(action);
-
-    return this.hasTransitiveEffectDependent(action) ||
-      this.hasDemandedParentContext(action, visited);
-  }
-
-  private hasDemandedParentContext(
-    action: Action,
-    visited = new Set<Action>(),
-  ): boolean {
-    const parent = this.actionParent.get(action);
-    if (!parent) return false;
-
-    if (this.isLiveEffect(parent)) {
-      return (
-        getSchedulingWritesFromState(this.schedulingWriteState, parent)
-          ?.length ?? 0
-      ) === 0;
-    }
-
-    return this.isDemandedPullComputation(parent, visited);
-  }
-
-  private isLiveEffect(action: Action): boolean {
-    if (this.effects.has(action)) return true;
-
-    // During resubscribe, dependencies can be registered before all effect
-    // bookkeeping is restored. Treat only dependency-bearing historical effects
-    // as live so unsubscribed effects do not keep old pull graphs demanded.
-    return (this.isEffectAction.get(action) ?? false) &&
-      this.dependencies.has(action);
-  }
-
-  private isPullDemandRootEffect(action: Action): boolean {
-    return this.pullMode &&
-      this.effects.has(action) &&
-      (getSchedulingWritesFromState(this.schedulingWriteState, action)
-          ?.length ?? 0) === 0;
-  }
-
   private canAutomaticallyDebounce(action: Action): boolean {
     return canAutomaticallyDebounceState(this.delayControlState, action);
-  }
-
-  private shouldRunFirstPullComputationInDemandContext(
-    action: Action,
-  ): boolean {
-    if (
-      !this.pullMode ||
-      !this.computations.has(action) ||
-      this.effects.has(action) ||
-      this.delays.hasActionRun(action)
-    ) {
-      return false;
-    }
-
-    return this.pullDemandedFirstRunComputations.has(action);
   }
 
   private markEffectConditionallyScheduled(effect: Action): void {
@@ -1475,31 +1341,11 @@ export class Scheduler {
     memo = new Map<Action, boolean>(),
   ): boolean {
     return collectDirtyDependenciesForLogState(
-      this.dirtyDependencyCollectionState(),
+      this.dirtyDependencyCollectionState,
       log,
       workSet,
       memo,
     );
-  }
-
-  private dirtyDependencyCollectionState() {
-    return {
-      collectStack: this.collectStack,
-      trace: this.dirtyDependencyTraceContext,
-      dirty: this.staleness.dirty,
-      computations: this.computations,
-      reverseDependencies: this.reverseDependencies,
-      dependencies: this.dependencies,
-      writersByEntity: this.writerIndexState.writersByEntity,
-      effects: this.effects,
-      isStale: (target: Action) => this.staleness.isStale(target),
-      getSchedulingWrites: (target: Action) =>
-        getSchedulingWritesFromState(this.schedulingWriteState, target),
-      getTraceActionSummary: (
-        trace: DirtyDependencyTraceContext,
-        target: Action,
-      ) => this.getTraceActionSummary(trace, target),
-    };
   }
 
   /**
@@ -1965,7 +1811,10 @@ export class Scheduler {
         scheduleEventQueueWake: (notBefore) =>
           scheduleEventQueueWakeState(this.eventQueueWakeState, notBefore),
         snapshotDirtyDependencyTraceContext: (trace) =>
-          this.snapshotDirtyDependencyTraceContext(trace),
+          snapshotDirtyDependencyTraceContext(
+            this.dirtyDependencyCollectionState,
+            trace,
+          ),
       });
       return eventBlockingDeps;
     } finally {

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -80,14 +80,16 @@ import {
   isPendingPullActionRunnable,
   markExecuteStart,
   planAdaptiveCycleDebounce,
-  planCycleBreak,
-  planExecuteContinuation,
   pushBoundedHistory,
   recordExecuteEnd,
   runSchedulerSettleLoop,
   type SchedulerSettleResult,
   type SettlingTracker,
 } from "./scheduler/execution.ts";
+import { breakCyclesIfNeeded } from "./scheduler/cycle-break.ts";
+import { applyExecuteContinuation } from "./scheduler/continuation.ts";
+import type { CycleBreakState } from "./scheduler/cycle-break.ts";
+import type { ExecuteContinuationState } from "./scheduler/continuation.ts";
 import { SchedulerDelays } from "./scheduler/delays.ts";
 import { processStorageNotification } from "./scheduler/notifications.ts";
 import {
@@ -460,6 +462,61 @@ export class Scheduler {
   private _running: Promise<unknown> | undefined = undefined;
   private scheduled = false;
   private disposed = false;
+  private cycleBreakState: CycleBreakState = {
+    getPullMode: () => this.pullMode,
+    dirty: this.staleness.dirty,
+    effects: this.effects,
+    runsThisExecute: this.runsThisExecute,
+    pending: this.pending,
+    isThrottled: (action) => this.delays.isThrottled(action),
+    clearDirty: (action) =>
+      clearSchedulerDirty(this.dirtySchedulingState, action),
+    unsubscribe: (action) => this.unsubscribe(action),
+    recordExecuted: () => {
+      this.filterStats.executed++;
+    },
+    getActionId: (action) => this.getActionId(action),
+    runAction: (action) => this.run(action),
+  };
+  private executeContinuationState: ExecuteContinuationState = {
+    getPullMode: () => this.pullMode,
+    pending: this.pending,
+    dirty: this.staleness.dirty,
+    effects: this.effects,
+    eventQueue: this.eventQueue,
+    eventQueueWakeState: this.eventQueueWakeState,
+    idlePromises: this.idlePromises,
+    scheduledFirstTime: this.scheduledFirstTime,
+    conditionallyScheduledEffects: this.conditionallyScheduledEffects,
+    changedWritesHistory: this.changedWritesHistory,
+    consumeRerunAfterCurrentExecute: () => {
+      const shouldRerun = this.rerunAfterCurrentExecute;
+      this.rerunAfterCurrentExecute = false;
+      return shouldRerun;
+    },
+    isDemandedPullComputation: (action) =>
+      this.isDemandedPullComputation(action),
+    shouldRunFirstPullComputationInDemandContext: (action) =>
+      this.shouldRunFirstPullComputationInDemandContext(action),
+    isDebouncedComputationWaiting: (action) =>
+      this.isDebouncedComputationWaiting(action),
+    getNextDebounceRunTime: (action) => this.getNextDebounceRunTime(action),
+    getNextEligibleRunTime: (action) =>
+      this.delays.getNextEligibleRunTime(action),
+    resetLoopCounter: () => {
+      this.loopCounter = new WeakMap();
+    },
+    setScheduled: (scheduled) => {
+      this.scheduled = scheduled;
+    },
+    resetSettlingTracker: () => {
+      this.settlingTracker = createSettlingTracker();
+    },
+    setPendingQueueTaskTimer: (timer) => {
+      this.pendingQueueTaskTimer = timer;
+    },
+    execute: () => this.execute(),
+  };
 
   get runningPromise(): Promise<unknown> | undefined {
     return this._running;
@@ -2082,10 +2139,10 @@ export class Scheduler {
     );
 
     const settleResult = await this.runSettleLoop(initialSeeds);
-    await this.breakCyclesIfNeeded(settleResult);
+    await breakCyclesIfNeeded(this.cycleBreakState, settleResult);
     this.applyAdaptiveCycleDebounce();
     this.recordExecuteEndTelemetry();
-    this.applyExecuteContinuation();
+    applyExecuteContinuation(this.executeContinuationState);
     logger.timeEnd("scheduler", "execute");
   }
 
@@ -2260,56 +2317,6 @@ export class Scheduler {
     return settleResult;
   }
 
-  private async breakCyclesIfNeeded(
-    settleResult: SchedulerSettleResult,
-  ): Promise<void> {
-    // If we hit max iterations without settling, break the cycle:
-    // 1. Clear dirty/pending for computations that were in early iterations AND still in last workSet
-    // 2. Run all remaining dirty effects so they don't get lost
-    const cycleBreakPlan = planCycleBreak({
-      pullMode: this.pullMode,
-      settledEarly: settleResult.settledEarly,
-      lastWorkSet: settleResult.lastWorkSet,
-      earlyIterationComputations: settleResult.earlyIterationComputations,
-      dirty: this.staleness.dirty,
-      effects: this.effects,
-      runsThisExecute: this.runsThisExecute,
-      isThrottled: (action) => this.delays.isThrottled(action),
-    });
-    if (!cycleBreakPlan.shouldBreak) return;
-
-    logger.debug("schedule-cycle", () => [
-      `[CYCLE-BREAK] Hit max iterations (${settleResult.maxSettleIterations}), breaking cycle`,
-      `Early computations: ${settleResult.earlyIterationComputations.size}, Last workSet: ${settleResult.lastWorkSet.size}`,
-    ]);
-
-    // Clear computations that appear to be in the cycle
-    // (present in early iterations AND still in the last workSet)
-    // But don't clear throttled computations - they should stay dirty
-    for (const comp of cycleBreakPlan.computationsToClear) {
-      logger.debug("schedule-cycle", () => [
-        `[CYCLE-BREAK] Clearing cyclic computation: ${this.getActionId(comp)}`,
-      ]);
-      clearSchedulerDirty(this.dirtySchedulingState, comp);
-      this.pending.delete(comp);
-    }
-
-    // Run all remaining dirty effects - these shouldn't be lost
-    // But skip throttled effects - they should stay dirty for later
-    for (const effect of cycleBreakPlan.dirtyEffectsToRun) {
-      if (this.effects.has(effect) && this.staleness.dirty.has(effect)) {
-        logger.debug("schedule-cycle", () => [
-          `[CYCLE-BREAK] Running dirty effect: ${this.getActionId(effect)}`,
-        ]);
-        clearSchedulerDirty(this.dirtySchedulingState, effect);
-        this.pending.delete(effect);
-        this.unsubscribe(effect);
-        this.filterStats.executed++;
-        await this.run(effect);
-      }
-    }
-  }
-
   private applyAdaptiveCycleDebounce(): void {
     // Apply cycle-aware debounce to effects that ran multiple times this execute().
     // Pull computations are already demand-gated; debouncing them can leave a
@@ -2352,82 +2359,6 @@ export class Scheduler {
       if (this.autoTriggerDiagnosis && !this.diagnosisEnabled) {
         this.startDiagnosis();
       }
-    }
-  }
-
-  private applyExecuteContinuation(): void {
-    // In pull mode, we consider ourselves done when there are no effects or
-    // effect-demanded computations to execute.
-    const hasQueuedEventReadyNow = this.eventQueue.length > 0 &&
-      !isHeadEventParkedState(this.eventQueueWakeState);
-    const hasParkedHeadEvent = this.eventQueue.length > 0 &&
-      isHeadEventParkedState(this.eventQueueWakeState);
-    const shouldRerunAfterCurrentExecute = this.rerunAfterCurrentExecute;
-    this.rerunAfterCurrentExecute = false;
-
-    const continuation = planExecuteContinuation({
-      pullMode: this.pullMode,
-      pending: this.pending,
-      dirty: this.staleness.dirty,
-      effects: this.effects,
-      shouldRerunAfterCurrentExecute,
-      hasQueuedEventReadyNow,
-      hasParkedHeadEvent,
-      isDemandedPullComputation: (action) =>
-        this.isDemandedPullComputation(action),
-      shouldRunFirstPullComputationInDemandContext: (action) =>
-        this.shouldRunFirstPullComputationInDemandContext(action),
-      isDebouncedComputationWaiting: (action) =>
-        this.isDebouncedComputationWaiting(action),
-      getNextDebounceRunTime: (action) => this.getNextDebounceRunTime(action),
-      getNextEligibleRunTime: (action) =>
-        this.delays.getNextEligibleRunTime(action),
-    });
-
-    if (!continuation.shouldQueueAnotherTick) {
-      if (continuation.nextDirtyPullRunAt !== undefined) {
-        scheduleEventQueueWakeState(
-          this.eventQueueWakeState,
-          continuation.nextDirtyPullRunAt,
-        );
-        const promises = this.idlePromises;
-        if (
-          !continuation.hasParkedHeadEvent &&
-          !continuation.nextDirtyPullRunWaitsForIdle
-        ) {
-          for (const resolve of promises) resolve();
-          this.idlePromises.length = 0;
-        }
-        this.loopCounter = new WeakMap();
-        this.scheduled = false;
-      } else if (hasEventQueueWakeTimer(this.eventQueueWakeState)) {
-        this.loopCounter = new WeakMap();
-        this.scheduled = false;
-
-        // Waiting on a future wake is quiescent from the scheduler's
-        // perspective, so reset the non-settling tracker.
-        this.settlingTracker = createSettlingTracker();
-      } else {
-        const promises = this.idlePromises;
-        for (const resolve of promises) resolve();
-        this.idlePromises.length = 0;
-        this.loopCounter = new WeakMap();
-        this.scheduled = false;
-
-        // Reset settling tracker on idle
-        this.settlingTracker = createSettlingTracker();
-
-        this.scheduledFirstTime.clear();
-        if (this.conditionallyScheduledEffects.size === 0) {
-          this.changedWritesHistory.length = 0;
-        }
-      }
-    } else {
-      // Keep scheduled = true since we're queuing another execution
-      this.pendingQueueTaskTimer = queueTask(() => {
-        this.pendingQueueTaskTimer = null;
-        this.execute();
-      });
     }
   }
 

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -146,6 +146,7 @@ import {
   processQueuedEventDuringExecute,
   queueSchedulerEvent,
   scheduleEventQueueWake as scheduleEventQueueWakeState,
+  type SchedulerEventExecutionState,
   type SchedulerEventQueueState,
 } from "./scheduler/events.ts";
 import {
@@ -303,6 +304,7 @@ export class Scheduler {
   private pendingQueueTaskTimer: ReturnType<typeof setTimeout> | null = null;
   private eventQueueWakeState!: EventQueueWakeState;
   private eventQueueState!: SchedulerEventQueueState;
+  private eventExecutionState!: SchedulerEventExecutionState;
   private delays = new SchedulerDelays({
     actionStats: this.actionStats,
     getActionId: (action) => this.getActionId(action),
@@ -471,6 +473,7 @@ export class Scheduler {
     this.settleLoopState = this.createSettleLoopState();
     this.executeContinuationState = this.createExecuteContinuationState();
     this.eventQueueState = this.createEventQueueState();
+    this.eventExecutionState = this.createEventExecutionState();
     this.dependencyCollectionState = this.createDependencyCollectionState();
     this.actionRunState = this.createActionRunState();
     this.graphSnapshotState = this.createGraphSnapshotState();
@@ -938,6 +941,53 @@ export class Scheduler {
           targetRetries,
           targetOnCommit,
           targetDoNotLoad,
+        ),
+    };
+  }
+
+  private createEventExecutionState(): SchedulerEventExecutionState {
+    const getPullMode = () => this.pullMode;
+    const getEventPreflightTelemetryEnabled = () =>
+      this.eventPreflightTelemetryEnabled;
+    return {
+      runtime: this.runtime,
+      eventQueue: this.eventQueue,
+      get pullMode() {
+        return getPullMode();
+      },
+      dirty: this.staleness.dirty,
+      pending: this.pending,
+      get eventPreflightTelemetryEnabled() {
+        return getEventPreflightTelemetryEnabled();
+      },
+      setRunningPromise: (promise) => {
+        this.runningPromise = promise;
+      },
+      getActionId: (target) => this.getActionId(target),
+      getActionTelemetryInfo: (target) =>
+        getSchedulerActionTelemetryInfo(target),
+      handleError: (error, target) => this.handleError(error, target),
+      queueExecution: () => this.queueExecution(),
+      setDirtyDependencyTraceContext: (trace) => {
+        this.dirtyDependencyTraceContext = trace;
+      },
+      collectDirtyDependenciesForLog: (deps, dirtyDeps, dirtyDepMemo) =>
+        this.collectDirtyDependenciesForLog(
+          deps,
+          dirtyDeps,
+          dirtyDepMemo,
+        ),
+      isDebouncedComputationWaiting: (target) =>
+        this.isDebouncedComputationWaiting(target),
+      getNextDebounceRunTime: (target) => this.getNextDebounceRunTime(target),
+      getNextEligibleRunTime: (target) =>
+        this.delays.getNextEligibleRunTime(target),
+      scheduleEventQueueWake: (notBefore) =>
+        scheduleEventQueueWakeState(this.eventQueueWakeState, notBefore),
+      snapshotDirtyDependencyTraceContext: (trace) =>
+        snapshotDirtyDependencyTraceContext(
+          this.dirtyDependencyCollectionState,
+          trace,
         ),
     };
   }
@@ -1898,44 +1948,10 @@ export class Scheduler {
 
     logger.timeStart("scheduler", "execute", "event");
     try {
-      await processQueuedEventDuringExecute({
-        runtime: this.runtime,
-        eventQueue: this.eventQueue,
-        pullMode: this.pullMode,
-        dirty: this.staleness.dirty,
-        pending: this.pending,
+      await processQueuedEventDuringExecute(
+        this.eventExecutionState,
         eventBlockingDeps,
-        eventPreflightTelemetryEnabled: this.eventPreflightTelemetryEnabled,
-        setRunningPromise: (promise) => {
-          this.runningPromise = promise;
-        },
-        getActionId: (target) => this.getActionId(target),
-        getActionTelemetryInfo: (target) =>
-          getSchedulerActionTelemetryInfo(target),
-        handleError: (error, target) => this.handleError(error, target),
-        queueExecution: () => this.queueExecution(),
-        setDirtyDependencyTraceContext: (trace) => {
-          this.dirtyDependencyTraceContext = trace;
-        },
-        collectDirtyDependenciesForLog: (deps, dirtyDeps, dirtyDepMemo) =>
-          this.collectDirtyDependenciesForLog(
-            deps,
-            dirtyDeps,
-            dirtyDepMemo,
-          ),
-        isDebouncedComputationWaiting: (dep) =>
-          this.isDebouncedComputationWaiting(dep),
-        getNextDebounceRunTime: (dep) => this.getNextDebounceRunTime(dep),
-        getNextEligibleRunTime: (dep) =>
-          this.delays.getNextEligibleRunTime(dep),
-        scheduleEventQueueWake: (notBefore) =>
-          scheduleEventQueueWakeState(this.eventQueueWakeState, notBefore),
-        snapshotDirtyDependencyTraceContext: (trace) =>
-          snapshotDirtyDependencyTraceContext(
-            this.dirtyDependencyCollectionState,
-            trace,
-          ),
-      });
+      );
       return eventBlockingDeps;
     } finally {
       logger.timeEnd("scheduler", "execute", "event");

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -51,10 +51,7 @@ import {
   updateDependentEdgesForLog,
 } from "./scheduler/dependency-graph.ts";
 import { type DependencyUpdateState } from "./scheduler/dependency-updates.ts";
-import {
-  readsOverlapWrites,
-  SchedulerWriteIndex,
-} from "./scheduler/scheduling-writes.ts";
+import { SchedulerWriteIndex } from "./scheduler/scheduling-writes.ts";
 import {
   SchedulerTriggerIndex,
   SchedulerTriggerSubscriptions,
@@ -80,8 +77,6 @@ import {
   collectInitialExecuteDependencies as collectInitialExecuteDependenciesState,
   collectPostEventDependencies as collectPostEventDependenciesState,
   createSettlingTracker,
-  isDirtyPullActionRunnable,
-  isPendingPullActionRunnable,
   markExecuteStart,
   planAdaptiveCycleDebounce,
   pushBoundedHistory,
@@ -91,6 +86,18 @@ import {
   type SchedulerSettleResult,
   type SettlingTracker,
 } from "./scheduler/execution.ts";
+import {
+  collectPullIterationSeeds as collectPullIterationSeedsState,
+  conditionalEffectHasChangedInputs as conditionalEffectHasChangedInputsState,
+  type DirtyPullRunnableState,
+  type DirtyPullRunnableStateWithDebounce,
+  hasDeferredDirtyEffectWork as hasDeferredDirtyEffectWorkState,
+  hasRunnablePullWork as hasRunnablePullWorkState,
+  markEffectConditionallyScheduled as markEffectConditionallyScheduledState,
+  type PendingPullRunnableState,
+  type PullSchedulingState,
+  scheduleAffectedEffects as scheduleAffectedEffectsState,
+} from "./scheduler/pull-scheduling.ts";
 import { breakCyclesIfNeeded } from "./scheduler/cycle-break.ts";
 import { applyExecuteContinuation } from "./scheduler/continuation.ts";
 import type { CycleBreakState } from "./scheduler/cycle-break.ts";
@@ -153,7 +160,6 @@ import {
   buildSchedulerGraphSnapshot,
   type SchedulerGraphSnapshotState,
 } from "./scheduler/graph-snapshot.ts";
-import { collectTransitiveEffects } from "./scheduler/topology.ts";
 import type {
   Action,
   ActionRunTraceEntry,
@@ -178,13 +184,6 @@ const logger = getLogger("scheduler", {
   level: "warn",
 });
 
-type PendingPullRunnableState = Parameters<typeof isPendingPullActionRunnable>[
-  0
-];
-type DirtyPullRunnableState = Parameters<typeof isDirtyPullActionRunnable>[0];
-type DirtyPullRunnableStateWithDebounce = DirtyPullRunnableState & {
-  readonly isDebouncedComputationWaiting: (action: Action) => boolean;
-};
 type PendingDependencyCollectionState =
   SchedulerSubscribeActionState["pendingDependencyCollectionState"];
 type FilterStatsState = { filtered: number; executed: number };
@@ -349,6 +348,7 @@ export class Scheduler {
   private dirtyPullRunnableState!: DirtyPullRunnableState;
   private dirtyPullRunnableStateWithDebounce!:
     DirtyPullRunnableStateWithDebounce;
+  private pullSchedulingState!: PullSchedulingState;
   private writePropagationState!: WritePropagationState;
   private subscriptionState!: SchedulerSubscriptionState;
 
@@ -463,6 +463,7 @@ export class Scheduler {
     this.dirtyPullRunnableState = this.createDirtyPullRunnableState();
     this.dirtyPullRunnableStateWithDebounce = this
       .createDirtyPullRunnableStateWithDebounce();
+    this.pullSchedulingState = this.createPullSchedulingState();
     this.writePropagationState = this.createWritePropagationState();
     this.subscriptionState = this.createSubscriptionState();
     this.pendingDependencyCollectionState = this
@@ -692,6 +693,25 @@ export class Scheduler {
       ...this.dirtyPullRunnableState,
       isDebouncedComputationWaiting: (action) =>
         this.isDebouncedComputationWaiting(action),
+    };
+  }
+
+  private createPullSchedulingState(): PullSchedulingState {
+    return {
+      changedWritesHistory: this.changedWritesHistory,
+      conditionallyScheduledEffects: this.conditionallyScheduledEffects,
+      dependencies: this.dependencies,
+      pending: this.pending,
+      dirty: this.staleness.dirty,
+      effects: this.effects,
+      dependents: this.dependents,
+      pendingPullRunnableState: this.pendingPullRunnableState,
+      dirtyPullRunnableState: this.dirtyPullRunnableState,
+      dirtyPullRunnableStateWithDebounce: this
+        .dirtyPullRunnableStateWithDebounce,
+      getDebounce: (action) => this.delays.getDebounce(action),
+      scheduleWithDebounce: (action) => this.scheduleWithDebounce(action),
+      getActionId: (action) => this.getActionId(action),
     };
   }
 
@@ -1484,25 +1504,14 @@ export class Scheduler {
   }
 
   private markEffectConditionallyScheduled(effect: Action): void {
-    if (!this.conditionallyScheduledEffects.has(effect)) {
-      this.conditionallyScheduledEffects.set(
-        effect,
-        this.changedWritesHistory.length,
-      );
-    }
+    markEffectConditionallyScheduledState(this.pullSchedulingState, effect);
   }
 
   private conditionalEffectHasChangedInputs(effect: Action): boolean {
-    const changedWritesStart = this.conditionallyScheduledEffects.get(effect);
-    if (changedWritesStart === undefined) return true;
-
-    const changedWrites = this.changedWritesHistory.slice(changedWritesStart);
-    if (changedWrites.length === 0) return false;
-
-    const log = this.dependencies.get(effect);
-    if (!log) return false;
-
-    return readsOverlapWrites(log.reads, log.shallowReads, changedWrites);
+    return conditionalEffectHasChangedInputsState(
+      this.pullSchedulingState,
+      effect,
+    );
   }
 
   private collectDirtyDependenciesForLog(
@@ -1518,92 +1527,21 @@ export class Scheduler {
     );
   }
 
-  /**
-   * In pull mode, only effects are runnable seeds by default.
-   *
-   * Inline idempotency mode intentionally does not widen this to computations:
-   * it rechecks computations that already run due to explicit demand or an
-   * effect pull, rather than turning pull mode back into eager push mode.
-   */
   private collectPullIterationSeeds(workSet: Set<Action>): void {
-    for (const action of this.pending) {
-      if (isPendingPullActionRunnable(this.pendingPullRunnableState, action)) {
-        workSet.add(action);
-      }
-    }
-
-    for (const action of this.staleness.dirty) {
-      if (isDirtyPullActionRunnable(this.dirtyPullRunnableState, action)) {
-        this.pending.add(action);
-        workSet.add(action);
-      }
-    }
+    collectPullIterationSeedsState(this.pullSchedulingState, workSet);
   }
 
   private hasRunnablePullWork(): boolean {
-    for (const action of this.pending) {
-      if (isPendingPullActionRunnable(this.pendingPullRunnableState, action)) {
-        return true;
-      }
-    }
-
-    for (const action of this.staleness.dirty) {
-      if (
-        isDirtyPullActionRunnable(
-          this.dirtyPullRunnableStateWithDebounce,
-          action,
-        )
-      ) {
-        return true;
-      }
-    }
-
-    return false;
+    return hasRunnablePullWorkState(this.pullSchedulingState);
   }
   private hasDeferredDirtyEffectWork(): boolean {
-    for (const action of this.staleness.dirty) {
-      if (this.effects.has(action)) return true;
-    }
-    return false;
+    return hasDeferredDirtyEffectWorkState(this.pullSchedulingState);
   }
 
-  /**
-   * Finds and schedules all effects that transitively depend on the given computation.
-   */
   private scheduleAffectedEffects(
     computation: Action,
   ): TriggerTraceScheduledEffect[] {
-    const start = performance.now();
-    const scheduledEffects: TriggerTraceScheduledEffect[] = [];
-
-    try {
-      for (
-        const effect of collectTransitiveEffects(
-          { dependents: this.dependents, effects: this.effects },
-          computation,
-        )
-      ) {
-        const pendingBefore = this.pending.has(effect);
-        const dirtyBefore = this.staleness.dirty.has(effect);
-        const debounceMs = this.delays.getDebounce(effect);
-        if (
-          !pendingBefore && !dirtyBefore &&
-          !this.conditionallyScheduledEffects.has(effect)
-        ) {
-          this.markEffectConditionallyScheduled(effect);
-        }
-        this.scheduleWithDebounce(effect);
-        scheduledEffects.push({
-          actionId: this.getActionId(effect),
-          pendingBefore,
-          dirtyBefore,
-          debounceMs,
-        });
-      }
-    } finally {
-      logger.time(start, "scheduler", "scheduleAffectedEffects");
-    }
-    return scheduledEffects;
+    return scheduleAffectedEffectsState(this.pullSchedulingState, computation);
   }
 
   // ============================================================

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -1,5 +1,4 @@
 import { getLogger } from "@commonfabric/utils/logger";
-import { type Frame } from "./builder/types.ts";
 import type { Cancel } from "./cancel.ts";
 import { ConsoleEvent } from "./harness/console.ts";
 import type {
@@ -32,7 +31,6 @@ import type {
 } from "./telemetry.ts";
 import {
   DEFAULT_RETRIES_FOR_EVENTS,
-  MAX_ITERATIONS_PER_RUN,
   MAX_SETTLE_STATS_HISTORY,
 } from "./scheduler/constants.ts";
 import {
@@ -78,7 +76,6 @@ import {
   watchReactiveActionCommit,
 } from "./scheduler/action-run.ts";
 import {
-  buildIterationWorkSet,
   buildPullInitialSeeds,
   collectPendingDependencyActions,
   createSettlingTracker,
@@ -89,11 +86,10 @@ import {
   planCycleBreak,
   planExecuteContinuation,
   pushBoundedHistory,
-  recordEarlyIterationComputations,
   recordExecuteEnd,
+  runSchedulerSettleLoop,
+  type SchedulerSettleResult,
   type SettlingTracker,
-  summarizeSettleIteration,
-  summarizeSettleRun,
 } from "./scheduler/execution.ts";
 import { SchedulerDelays } from "./scheduler/delays.ts";
 import { processStorageNotification } from "./scheduler/notifications.ts";
@@ -134,10 +130,7 @@ import {
 } from "./scheduler/events.ts";
 import { buildSchedulerGraphSnapshot } from "./scheduler/graph-snapshot.ts";
 import { entityKey } from "./scheduler/keys.ts";
-import {
-  collectTransitiveEffects,
-  topologicalSort,
-} from "./scheduler/topology.ts";
+import { collectTransitiveEffects } from "./scheduler/topology.ts";
 import type {
   Action,
   ActionRunTraceEntry,
@@ -147,7 +140,6 @@ import type {
   PopulateDependenciesEntry,
   QueuedEvent,
   ReactivityLog,
-  SettleIterationStats,
   SettleStats,
   SettleStatsHistoryEntry,
   SpaceScopeAndURI,
@@ -192,13 +184,6 @@ export {
   allowMutableTransactionRead,
   ignoreReadForScheduling,
   markReadAsPotentialWrite,
-};
-
-type SchedulerSettleResult = {
-  settledEarly: boolean;
-  lastWorkSet: Set<Action>;
-  earlyIterationComputations: Set<Action>;
-  maxSettleIterations: number;
 };
 
 export class Scheduler {
@@ -2519,281 +2504,63 @@ export class Scheduler {
   private async runSettleLoop(
     initialSeeds: ReadonlySet<Action>,
   ): Promise<SchedulerSettleResult> {
-    // Settle loop: runs until no more dirty work is found.
-    // First iteration processes initial seeds + their dirty deps.
-    // Subsequent iterations process new subscriptions and re-collect dirty deps.
-    logger.timeStart("scheduler", "execute", "settle");
-    const maxSettleIterations = this.pullMode ? 10 : 10;
-    const EARLY_ITERATION_THRESHOLD = 5;
-    const earlyIterationComputations = new Set<Action>(); // Track computations in first N iterations
-    let lastWorkSet: Set<Action> = new Set();
-    let settledEarly = false;
-    const settleIterStats: SettleIterationStats[] | undefined =
-      this.collectSettleStats ? [] : undefined;
-    const settleStartTime = this.collectSettleStats ? performance.now() : 0;
-
-    for (let settleIter = 0; settleIter < maxSettleIterations; settleIter++) {
-      const iterStart = settleIterStats ? performance.now() : 0;
-      let iterActionsRun = 0;
-
-      // Process any newly subscribed actions from previous iteration.
-      // This sets up their dependencies so collectDirtyDependencies can find them.
-      if (this.pullMode && this.pendingDependencyCollection.size > 0) {
-        collectPendingDependencyActions({
-          pendingDependencyCollection: this.pendingDependencyCollection,
-          populateDependenciesCallbacks: this.populateDependenciesCallbacks,
-          effects: this.effects,
-          getSchedulingWrites: (action) =>
-            getSchedulingWritesFromState(this.schedulingWriteState, action),
-          collectDependenciesForAction: (action, populateDependencies) =>
-            this.collectDependenciesForAction(action, populateDependencies, {
-              errorLogLabel: "schedule-dep-error-pre-run",
-              errorMessage: (target, error) =>
-                `Error collecting deps for ${
-                  this.getActionId(target)
-                }: ${error}`,
-              useRawReadsForTriggers: true,
-            }),
-        });
-      }
-
-      // Build the work set for this iteration
-      const buildPullWorkSetStart = this.pullMode ? performance.now() : 0;
-      const { workSet, iterationSeeds, dirtyDependencyCount } =
-        buildIterationWorkSet({
-          pullMode: this.pullMode,
-          pending: this.pending,
-          initialSeeds,
-          settleIter,
-          collectPullIterationSeeds: (seeds) =>
-            this.collectPullIterationSeeds(seeds),
-          collectDirtyDependencies: (seed, targetWorkSet, memo) =>
-            this.collectDirtyDependencies(seed, targetWorkSet, memo),
-        });
-
-      if (this.pullMode) {
-        if (settleIter === 0) {
-          logger.debug("schedule-execute-pull", () => [
-            `Pull mode: Seeds: ${iterationSeeds.size}, Dirty deps added: ${dirtyDependencyCount}`,
-          ]);
-        }
-        logger.time(
-          buildPullWorkSetStart,
-          "scheduler",
-          "execute",
-          "buildPullWorkSet",
-        );
-      }
-
-      if (workSet.size === 0) {
-        settledEarly = true;
-        break;
-      }
-
-      recordEarlyIterationComputations({
-        pullMode: this.pullMode,
-        settleIter,
-        threshold: EARLY_ITERATION_THRESHOLD,
-        workSet,
-        effects: this.effects,
-        earlyIterationComputations,
-      });
-      lastWorkSet = workSet;
-
-      // Snapshot workSet size before topo sort (in push mode, workSet === this.pending
-      // which gets mutated during execution)
-      const iterWorkSetSize = workSet.size;
-
-      const topologicalSortStart = performance.now();
-      const order = topologicalSort(
-        workSet,
-        this.dependencies,
+    const settleResult = await runSchedulerSettleLoop({
+      pullMode: this.pullMode,
+      collectSettleStats: this.collectSettleStats,
+      pendingDependencyCollection: this.pendingDependencyCollection,
+      populateDependenciesCallbacks: this.populateDependenciesCallbacks,
+      effects: this.effects,
+      computations: this.computations,
+      pending: this.pending,
+      dirty: this.staleness.dirty,
+      dependencies: this.dependencies,
+      actionParent: this.actionParent,
+      dependents: this.dependents,
+      conditionallyScheduledEffects: this.conditionallyScheduledEffects,
+      filterStats: this.filterStats,
+      loopCounter: this.loopCounter,
+      runsThisExecute: this.runsThisExecute,
+      activePullDemandActions: this.activePullDemandActions,
+      getSchedulingWrites: (action) =>
+        getSchedulingWritesFromState(this.schedulingWriteState, action),
+      getSchedulingWritesMap: () =>
         getSchedulingWritesMapFromState(this.schedulingWriteState),
-        this.actionParent,
-        this.pullMode ? this.dependents : undefined,
-      );
-      logger.time(
-        topologicalSortStart,
-        "scheduler",
-        "execute",
-        "topologicalSort",
-      );
+      collectDependenciesForAction: (action, populateDependencies, options) =>
+        this.collectDependenciesForAction(
+          action,
+          populateDependencies,
+          options,
+        ),
+      collectPullIterationSeeds: (seeds) =>
+        this.collectPullIterationSeeds(seeds),
+      collectDirtyDependencies: (seed, targetWorkSet, memo) =>
+        this.collectDirtyDependencies(seed, targetWorkSet, memo),
+      getActionId: (action) => this.getActionId(action),
+      clearDirty: (action) =>
+        clearSchedulerDirty(this.dirtySchedulingState, action),
+      markDirectDirty: (action) => this.staleness.markDirectDirty(action),
+      isThrottled: (action) => this.delays.isThrottled(action),
+      isDebouncedComputationWaiting: (action) =>
+        this.isDebouncedComputationWaiting(action),
+      clearComputationDebounceState: (action) =>
+        this.delays.clearComputationDebounceState(action),
+      conditionalEffectHasChangedInputs: (action) =>
+        this.conditionalEffectHasChangedInputs(action),
+      isPullDemandRootEffect: (action) => this.isPullDemandRootEffect(action),
+      handleError: (error, action) => this.handleError(error, action),
+      runAction: (action) => this.run(action),
+    }, initialSeeds);
 
-      logger.debug("schedule-execute", () => [
-        `Running ${order.length} actions (settle iteration ${settleIter})`,
-      ]);
-
-      // Implicit cycle detection for effects:
-      // Clear dirty flags for all effects upfront. If an effect becomes dirty again
-      // by the time we run it, something in the execution re-dirtied it → cycle.
-      if (this.pullMode) {
-        for (const fn of order) {
-          if (this.effects.has(fn)) {
-            clearSchedulerDirty(this.dirtySchedulingState, fn);
-          }
-        }
-      }
-
-      // Run all functions. This will resubscribe actions with their new dependencies.
-      for (const fn of order) {
-        // Check if action is still scheduled (not unsubscribed during this tick).
-        // Running an action might unsubscribe other actions in the workSet.
-        const isStillScheduled = this.computations.has(fn) ||
-          this.effects.has(fn);
-        if (!isStillScheduled) continue;
-
-        // Check if action is still valid
-        // In pull mode, check both pending (effects) and dirty (computations)
-        const isInPending = this.pending.has(fn);
-        const isInDirty = this.staleness.dirty.has(fn);
-
-        if (this.pullMode) {
-          // For effects: we cleared dirty upfront, so check if re-dirtied (cycle)
-          if (this.effects.has(fn)) {
-            if (this.staleness.dirty.has(fn)) {
-              // Effect was re-dirtied during this tick → cycle detected
-              logger.debug("schedule-cycle", () => [
-                `[CYCLE] Effect ${
-                  this.getActionId(fn)
-                } re-dirtied, skipping (cycle detected)`,
-              ]);
-              // Skip this effect - it will run on a future tick after cycle settles
-              this.pending.delete(fn);
-              continue;
-            }
-            if (!isInPending) continue;
-          } else {
-            // For computations: must be pending or dirty
-            if (!isInPending && !isInDirty) continue;
-          }
-        } else {
-          // Push mode: action must be in pending
-          if (!isInPending) continue;
-        }
-
-        if (this.isDebouncedComputationWaiting(fn)) {
-          logger.debug("schedule-debounce", () => [
-            `[DEBOUNCE] Skipping debounced computation: ${
-              this.getActionId(fn)
-            }`,
-          ]);
-          this.filterStats.filtered++;
-          this.pending.delete(fn);
-          continue;
-        }
-
-        // Check throttle: skip recently-run actions but keep them dirty
-        // They'll be pulled next time an effect needs them (if throttle expired)
-        if (this.delays.isThrottled(fn)) {
-          logger.debug("schedule-throttle", () => [
-            `[THROTTLE] Skipping throttled action: ${this.getActionId(fn)}`,
-          ]);
-          this.filterStats.filtered++;
-          // Don't clear from pending or dirty - action stays in its current state
-          // but we remove from pending so it doesn't run this cycle
-          this.pending.delete(fn);
-          // Keep pull-mode effects dirty so they wake when the throttle expires.
-          if (this.pullMode && this.effects.has(fn)) {
-            this.staleness.markDirectDirty(fn);
-          }
-          continue;
-        }
-
-        if (
-          this.pullMode &&
-          this.effects.has(fn) &&
-          this.conditionallyScheduledEffects.has(fn) &&
-          !this.conditionalEffectHasChangedInputs(fn)
-        ) {
-          this.conditionallyScheduledEffects.delete(fn);
-          this.pending.delete(fn);
-          clearSchedulerDirty(this.dirtySchedulingState, fn);
-          this.filterStats.filtered++;
-          continue;
-        }
-
-        // Clean up from pending/dirty before running
-        this.pending.delete(fn);
-        this.conditionallyScheduledEffects.delete(fn);
-        if (this.computations.has(fn)) {
-          this.delays.clearComputationDebounceState(fn);
-        }
-        if (this.pullMode && this.effects.has(fn)) {
-          clearSchedulerDirty(this.dirtySchedulingState, fn);
-        }
-
-        this.filterStats.executed++;
-        iterActionsRun++;
-        this.loopCounter.set(fn, (this.loopCounter.get(fn) || 0) + 1);
-        // Track runs for cycle-aware debounce
-        this.runsThisExecute.set(fn, (this.runsThisExecute.get(fn) ?? 0) + 1);
-        if (this.loopCounter.get(fn)! > MAX_ITERATIONS_PER_RUN) {
-          const error = new Error(
-            `Too many iterations: ${this.loopCounter.get(fn)} ${
-              this.getActionId(fn)
-            }`,
-          );
-          // Attach the last frame from the action so handleError can
-          // extract piece/spell metadata (CT-1316: fixes message:null).
-          const lastFrame = (fn as Action & { lastFrame?: Frame }).lastFrame;
-          if (lastFrame) {
-            (error as Error & { frame?: Frame }).frame = lastFrame;
-          }
-          this.handleError(error, fn);
-        } else {
-          const activePullDemand = this.pullMode &&
-            (this.computations.has(fn) ||
-              this.isPullDemandRootEffect(fn));
-          if (activePullDemand) {
-            this.activePullDemandActions.add(fn);
-          }
-          try {
-            await this.run(fn);
-          } finally {
-            if (activePullDemand) {
-              this.activePullDemandActions.delete(fn);
-            }
-          }
-        }
-      }
-
-      // Capture per-iteration settle stats (only when enabled)
-      if (settleIterStats) {
-        settleIterStats.push(summarizeSettleIteration({
-          workSetSize: iterWorkSetSize,
-          order,
-          actionsRun: iterActionsRun,
-          durationMs: performance.now() - iterStart,
-          effects: this.effects,
-          getActionId: (action) => this.getActionId(action),
-        }));
-      }
-    }
-
-    // Store settle stats for external access (only when enabled)
-    if (settleIterStats) {
-      const settleStats = summarizeSettleRun({
-        iterations: settleIterStats,
-        totalDurationMs: performance.now() - settleStartTime,
-        settledEarly,
-        initialSeedCount: initialSeeds.size,
-      });
-      this.lastSettleStats = settleStats;
+    if (settleResult.settleStats) {
+      this.lastSettleStats = settleResult.settleStats;
       pushBoundedHistory(
         this.settleStatsHistory,
-        { recordedAt: performance.now(), stats: settleStats },
+        { recordedAt: performance.now(), stats: settleResult.settleStats },
         MAX_SETTLE_STATS_HISTORY,
       );
     }
 
-    logger.timeEnd("scheduler", "execute", "settle");
-
-    return {
-      settledEarly,
-      lastWorkSet,
-      earlyIterationComputations,
-      maxSettleIterations,
-    };
+    return settleResult;
   }
 
   private async breakCyclesIfNeeded(

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -70,7 +70,8 @@ import {
 } from "./scheduler/action-run.ts";
 import {
   buildPullInitialSeeds,
-  collectPendingDependencyActions,
+  collectInitialExecuteDependencies as collectInitialExecuteDependenciesState,
+  collectPostEventDependencies as collectPostEventDependenciesState,
   createSettlingTracker,
   isDirtyPullActionRunnable,
   isPendingPullActionRunnable,
@@ -2209,114 +2210,123 @@ export class Scheduler {
     // In case a directly invoked `run` is still running, wait for it to finish.
     if (this.runningPromise) await this.runningPromise;
 
+    this.beginExecuteCycle();
+    const { newActionsWithoutDependencies } = this
+      .collectInitialExecuteDependencies();
+    const eventBlockingDeps = await this.processExecuteEventPhase();
+    this.collectPostEventDependencies();
+    const initialSeeds = this.buildInitialExecuteSeeds(
+      newActionsWithoutDependencies,
+      eventBlockingDeps,
+    );
+
+    const settleResult = await this.runSettleLoop(initialSeeds);
+    await this.breakCyclesIfNeeded(settleResult);
+    this.applyAdaptiveCycleDebounce();
+    this.recordExecuteEndTelemetry();
+    this.applyExecuteContinuation();
+    logger.timeEnd("scheduler", "execute");
+  }
+
+  private beginExecuteCycle(): void {
     // Track timing for cycle-aware debounce
     this.executeStartTime = performance.now();
     this.runsThisExecute.clear();
 
     // Non-settling heuristic: record execute() start
     markExecuteStart(this.settlingTracker);
+  }
 
-    logger.timeStart("scheduler", "execute", "depCollect");
-    // Find computation actions whose writes are still unknown. We run them on
-    // the first cycle to capture writes that cannot be inferred from declared
-    // outputs or populateDependencies() potential writes.
-    //
-    // TODO(seefeld): Once we more reliably capture what they can write via
-    // WriteableCell or so, then we can treat this more deliberately via the
-    // dependency collection process above. We'll have to re-run it whenever
-    // inputs change, as they might change what they can write to. We hope that
-    // for now this will be sufficiently captured in mightWrite.
-    const { newActionsWithoutDependencies } = collectPendingDependencyActions({
+  private collectInitialExecuteDependencies(): {
+    newActionsWithoutDependencies: Action[];
+  } {
+    return collectInitialExecuteDependenciesState({
       pendingDependencyCollection: this.pendingDependencyCollection,
       populateDependenciesCallbacks: this.populateDependenciesCallbacks,
       effects: this.effects,
       getSchedulingWrites: (action) =>
         getSchedulingWritesFromState(this.schedulingWriteState, action),
-      collectDependenciesForAction: (action, populateDependencies) =>
-        this.collectDependenciesForAction(action, populateDependencies, {
-          errorLogLabel: "schedule-dep-error",
-          errorMessage: (target, error) =>
-            `Error populating dependencies for ${
-              this.getActionId(target)
-            }: ${error}`,
-        }),
-      onCollected: (action, { log, entities }) =>
-        logger.debug("schedule-dep-collect", () => [
-          `Collected dependencies for ${
-            this.getActionId(action)
-          }: ${log.reads.length} reads, ${log.writes.length} writes, ${entities.size} entities`,
-        ]),
+      collectDependenciesForAction: (action, populateDependencies, options) =>
+        this.collectDependenciesForAction(
+          action,
+          populateDependencies,
+          options,
+        ),
+      getActionId: (action) => this.getActionId(action),
       scheduleAffectedEffects: (action) => this.scheduleAffectedEffects(action),
     });
-    logger.timeEnd("scheduler", "execute", "depCollect");
+  }
 
+  private async processExecuteEventPhase(): Promise<Set<Action>> {
     // Track dirty dependencies that block events - these must be added to workSet
     const eventBlockingDeps = new Set<Action>();
 
     logger.timeStart("scheduler", "execute", "event");
-    await processQueuedEventDuringExecute({
-      runtime: this.runtime,
-      eventQueue: this.eventQueue,
-      pullMode: this.pullMode,
-      dirty: this.staleness.dirty,
-      pending: this.pending,
-      eventBlockingDeps,
-      eventPreflightTelemetryEnabled: this.eventPreflightTelemetryEnabled,
-      setRunningPromise: (promise) => {
-        this.runningPromise = promise;
-      },
-      getActionId: (target) => this.getActionId(target),
-      getActionTelemetryInfo: (target) =>
-        getSchedulerActionTelemetryInfo(target),
-      handleError: (error, target) => this.handleError(error, target),
-      queueExecution: () => this.queueExecution(),
-      setDirtyDependencyTraceContext: (trace) => {
-        this.dirtyDependencyTraceContext = trace;
-      },
-      collectDirtyDependenciesForLog: (deps, dirtyDeps, dirtyDepMemo) =>
-        this.collectDirtyDependenciesForLog(
-          deps,
-          dirtyDeps,
-          dirtyDepMemo,
-        ),
-      isDebouncedComputationWaiting: (dep) =>
-        this.isDebouncedComputationWaiting(dep),
-      getNextDebounceRunTime: (dep) => this.getNextDebounceRunTime(dep),
-      getNextEligibleRunTime: (dep) => this.delays.getNextEligibleRunTime(dep),
-      scheduleEventQueueWake: (notBefore) =>
-        scheduleEventQueueWakeState(this.eventQueueWakeState, notBefore),
-      snapshotDirtyDependencyTraceContext: (trace) =>
-        this.snapshotDirtyDependencyTraceContext(trace),
-    });
-    logger.timeEnd("scheduler", "execute", "event");
-
-    // Process any newly subscribed actions that were added during event handling.
-    // This handles cases like event handlers that create sub-patterns whose
-    // computations need their dependencies discovered before we build the workSet.
-    if (this.pendingDependencyCollection.size > 0) {
-      collectPendingDependencyActions({
-        pendingDependencyCollection: this.pendingDependencyCollection,
-        populateDependenciesCallbacks: this.populateDependenciesCallbacks,
-        effects: this.effects,
-        getSchedulingWrites: (action) =>
-          getSchedulingWritesFromState(this.schedulingWriteState, action),
-        collectDependenciesForAction: (action, populateDependencies) =>
-          this.collectDependenciesForAction(action, populateDependencies, {
-            errorLogLabel: "schedule-dep-error-post-event",
-            errorMessage: (target, error) =>
-              `Error populating dependencies for ${
-                this.getActionId(target)
-              }: ${error}`,
-          }),
-        onCollected: (action) =>
-          logger.debug("schedule-dep-collect-post-event", () => [
-            `Collected dependencies for ${this.getActionId(action)}`,
-          ]),
+    try {
+      await processQueuedEventDuringExecute({
+        runtime: this.runtime,
+        eventQueue: this.eventQueue,
+        pullMode: this.pullMode,
+        dirty: this.staleness.dirty,
+        pending: this.pending,
+        eventBlockingDeps,
+        eventPreflightTelemetryEnabled: this.eventPreflightTelemetryEnabled,
+        setRunningPromise: (promise) => {
+          this.runningPromise = promise;
+        },
+        getActionId: (target) => this.getActionId(target),
+        getActionTelemetryInfo: (target) =>
+          getSchedulerActionTelemetryInfo(target),
+        handleError: (error, target) => this.handleError(error, target),
+        queueExecution: () => this.queueExecution(),
+        setDirtyDependencyTraceContext: (trace) => {
+          this.dirtyDependencyTraceContext = trace;
+        },
+        collectDirtyDependenciesForLog: (deps, dirtyDeps, dirtyDepMemo) =>
+          this.collectDirtyDependenciesForLog(
+            deps,
+            dirtyDeps,
+            dirtyDepMemo,
+          ),
+        isDebouncedComputationWaiting: (dep) =>
+          this.isDebouncedComputationWaiting(dep),
+        getNextDebounceRunTime: (dep) => this.getNextDebounceRunTime(dep),
+        getNextEligibleRunTime: (dep) =>
+          this.delays.getNextEligibleRunTime(dep),
+        scheduleEventQueueWake: (notBefore) =>
+          scheduleEventQueueWakeState(this.eventQueueWakeState, notBefore),
+        snapshotDirtyDependencyTraceContext: (trace) =>
+          this.snapshotDirtyDependencyTraceContext(trace),
       });
+      return eventBlockingDeps;
+    } finally {
+      logger.timeEnd("scheduler", "execute", "event");
     }
+  }
 
+  private collectPostEventDependencies(): void {
+    collectPostEventDependenciesState({
+      pendingDependencyCollection: this.pendingDependencyCollection,
+      populateDependenciesCallbacks: this.populateDependenciesCallbacks,
+      effects: this.effects,
+      getSchedulingWrites: (action) =>
+        getSchedulingWritesFromState(this.schedulingWriteState, action),
+      collectDependenciesForAction: (action, populateDependencies, options) =>
+        this.collectDependenciesForAction(
+          action,
+          populateDependencies,
+          options,
+        ),
+      getActionId: (action) => this.getActionId(action),
+    });
+  }
+
+  private buildInitialExecuteSeeds(
+    newActionsWithoutDependencies: Iterable<Action>,
+    eventBlockingDeps: Iterable<Action>,
+  ): Set<Action> {
     // Build initial seeds for pull mode (effects + special actions).
-    const initialSeeds = buildPullInitialSeeds({
+    return buildPullInitialSeeds({
       pullMode: this.pullMode,
       pending: this.pending,
       dirty: this.staleness.dirty,
@@ -2325,13 +2335,6 @@ export class Scheduler {
       eventBlockingDeps,
       computationDebounceFlushSeeds: this.delays.computationDebounceFlushSeeds,
     });
-
-    const settleResult = await this.runSettleLoop(initialSeeds);
-    await this.breakCyclesIfNeeded(settleResult);
-    this.applyAdaptiveCycleDebounce();
-    this.recordExecuteEndTelemetry();
-    this.applyExecuteContinuation();
-    logger.timeEnd("scheduler", "execute");
   }
 
   private async runSettleLoop(

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -49,16 +49,20 @@ import {
 } from "./scheduler/diagnosis.ts";
 import {
   type DependencyGraphState,
-  type DependencyUpdateState,
+  updateDependentEdgesForLog,
+} from "./scheduler/dependency-graph.ts";
+import { type DependencyUpdateState } from "./scheduler/dependency-updates.ts";
+import {
   getSchedulingWrites as getSchedulingWritesFromState,
   getSchedulingWritesMap as getSchedulingWritesMapFromState,
   readsOverlapWrites,
   type SchedulingWriteState,
+  type WriterIndexState,
+} from "./scheduler/scheduling-writes.ts";
+import {
   type TriggerIndexState,
   type TriggerSubscriptionState,
-  updateDependentEdgesForLog,
-  type WriterIndexState,
-} from "./scheduler/dependency-index.ts";
+} from "./scheduler/trigger-index.ts";
 import {
   collectDependenciesForAction as collectDependenciesForActionState,
   type DependencyCollectionState,

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -12,7 +12,6 @@ import type {
   ChangeGroup,
   IExtendedStorageTransaction,
   IMemorySpaceAddress,
-  IStorageSubscription,
   IStorageTransaction,
 } from "./storage/interface.ts";
 import type { SortedAndCompactPaths } from "./reactive-dependencies.ts";
@@ -101,7 +100,10 @@ import {
   scheduleWithDebounce as scheduleWithDebounceState,
 } from "./scheduler/delay-control.ts";
 import { SchedulerDelays } from "./scheduler/delays.ts";
-import { processStorageNotification } from "./scheduler/notifications.ts";
+import {
+  createStorageSubscription,
+  type StorageNotificationState,
+} from "./scheduler/notifications.ts";
 import {
   clearSchedulerDirectDirty,
   clearSchedulerDirty,
@@ -130,6 +132,7 @@ import {
   processQueuedEventDuringExecute,
   queueSchedulerEvent,
   scheduleEventQueueWake as scheduleEventQueueWakeState,
+  type SchedulerEventQueueState,
 } from "./scheduler/events.ts";
 import { buildSchedulerGraphSnapshot } from "./scheduler/graph-snapshot.ts";
 import { collectTransitiveEffects } from "./scheduler/topology.ts";
@@ -285,6 +288,7 @@ export class Scheduler {
     isDisposed: () => this.disposed,
     queueExecution: () => this.queueExecution(),
   };
+  private eventQueueState!: SchedulerEventQueueState;
   private delays = new SchedulerDelays({
     actionStats: this.actionStats,
     getActionId: (action) => this.getActionId(action),
@@ -338,6 +342,35 @@ export class Scheduler {
   private eventPreflightTelemetryEnabled = false;
   private changedWritesHistory: IMemorySpaceAddress[] = [];
   private conditionallyScheduledEffects = new Map<Action, number>();
+  private storageNotificationState: StorageNotificationState = {
+    triggers: this.triggerIndexState.triggers,
+    nonRecursiveTriggers: this.triggerIndexState.nonRecursiveTriggers,
+    getPullMode: () => this.pullMode,
+    getDiagnosisEnabled: () => this.diagnosisEnabled,
+    getCollectTriggerTrace: () => this.collectTriggerTrace,
+    changeGroupToActionId: this.changeGroupToActionId,
+    recordCausalEdge: (edge) => {
+      this.causalEdges.push(edge);
+    },
+    actionChangeGroups: this.actionChangeGroups,
+    effects: this.effects,
+    pending: this.pending,
+    dirty: this.staleness.dirty,
+    inFlightSources: this.inFlightSourceState.inFlightSources,
+    conditionallyScheduledEffects: this.conditionallyScheduledEffects,
+    getActionId: (target) => this.getActionId(target),
+    recordCellUpdate: (change) =>
+      this.runtime.telemetry.submit({
+        type: "cell.update",
+        change,
+      }),
+    recordTriggerTrace: (entry) =>
+      recordTriggerTraceState({ triggerTrace: this.triggerTrace }, entry),
+    scheduleWithDebounce: (target) => this.scheduleWithDebounce(target),
+    markDirty: (target) =>
+      markSchedulerDirty(this.dirtySchedulingState, target),
+    scheduleAffectedEffects: (target) => this.scheduleAffectedEffects(target),
+  };
 
   // Parent-child action tracking for proper execution ordering
   // When a child action is created during parent execution, parent must run first
@@ -645,6 +678,28 @@ export class Scheduler {
     consoleHandler?: ConsoleHandler,
     errorHandlers?: ErrorHandler[],
   ) {
+    this.eventQueueState = {
+      runtime: this.runtime,
+      eventHandlers: this.eventHandlers,
+      eventQueue: this.eventQueue,
+      backgroundTasks: this.backgroundTasks,
+      queueExecution: () => this.queueExecution(),
+      queueEvent: (
+        targetEventLink,
+        targetEvent,
+        targetRetries,
+        targetOnCommit,
+        targetDoNotLoad,
+      ) =>
+        this.queueEvent(
+          targetEventLink,
+          targetEvent,
+          targetRetries,
+          targetOnCommit,
+          targetDoNotLoad,
+        ),
+    };
+
     this.dependencyCollectionState = {
       runtime: this.runtime,
       dependencyUpdateState: this.dependencyUpdateState,
@@ -710,7 +765,9 @@ export class Scheduler {
     }
 
     // Subscribe to storage notifications
-    this.runtime.storageManager.subscribe(this.createStorageSubscription());
+    this.runtime.storageManager.subscribe(
+      createStorageSubscription(this.storageNotificationState),
+    );
 
     // Set up harness event listeners
     this.runtime.harness.addEventListener("console", (e: Event) => {
@@ -898,27 +955,7 @@ export class Scheduler {
     onCommit?: (tx: IExtendedStorageTransaction) => void,
     doNotLoadPieceIfNotRunning: boolean = false,
   ): void {
-    queueSchedulerEvent({
-      runtime: this.runtime,
-      eventHandlers: this.eventHandlers,
-      eventQueue: this.eventQueue,
-      backgroundTasks: this.backgroundTasks,
-      queueExecution: () => this.queueExecution(),
-      queueEvent: (
-        targetEventLink,
-        targetEvent,
-        targetRetries,
-        targetOnCommit,
-        targetDoNotLoad,
-      ) =>
-        this.queueEvent(
-          targetEventLink,
-          targetEvent,
-          targetRetries,
-          targetOnCommit,
-          targetDoNotLoad,
-        ),
-    }, {
+    queueSchedulerEvent(this.eventQueueState, {
       eventLink,
       event,
       retries,
@@ -950,47 +987,6 @@ export class Scheduler {
 
   onError(fn: ErrorHandler): void {
     this.errorHandlers.add(fn);
-  }
-
-  /**
-   * Creates and returns a new storage subscription that can be used to receive storage notifications.
-   *
-   * @returns A new IStorageSubscription instance
-   */
-  private createStorageSubscription(): IStorageSubscription {
-    return {
-      next: (notification) => {
-        processStorageNotification({
-          triggers: this.triggerIndexState.triggers,
-          nonRecursiveTriggers: this.triggerIndexState.nonRecursiveTriggers,
-          pullMode: this.pullMode,
-          diagnosisEnabled: this.diagnosisEnabled,
-          collectTriggerTrace: this.collectTriggerTrace,
-          changeGroupToActionId: this.changeGroupToActionId,
-          causalEdges: this.causalEdges,
-          actionChangeGroups: this.actionChangeGroups,
-          effects: this.effects,
-          pending: this.pending,
-          dirty: this.staleness.dirty,
-          inFlightSources: this.inFlightSourceState.inFlightSources,
-          conditionallyScheduledEffects: this.conditionallyScheduledEffects,
-          getActionId: (target) => this.getActionId(target),
-          recordCellUpdate: (change) =>
-            this.runtime.telemetry.submit({
-              type: "cell.update",
-              change,
-            }),
-          recordTriggerTrace: (entry) =>
-            recordTriggerTraceState({ triggerTrace: this.triggerTrace }, entry),
-          scheduleWithDebounce: (target) => this.scheduleWithDebounce(target),
-          markDirty: (target) =>
-            markSchedulerDirty(this.dirtySchedulingState, target),
-          scheduleAffectedEffects: (target) =>
-            this.scheduleAffectedEffects(target),
-        }, notification);
-        return { done: false };
-      },
-    } satisfies IStorageSubscription;
   }
 
   queueExecution(): void {

--- a/packages/runner/src/scheduler/action-run.ts
+++ b/packages/runner/src/scheduler/action-run.ts
@@ -355,11 +355,15 @@ function finalizeSchedulerAction(
         `[RUN] Action failed: ${args.actionId}`,
         `Error: ${args.error}`,
       ]);
-      state.handleError(args.error as Error, args.action);
+      state.handleError(normalizeThrownError(args.error), args.action);
     }
   } finally {
     finalizeReactiveActionCommit(state, args, elapsed);
   }
+}
+
+function normalizeThrownError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
 }
 
 function finalizeReactiveActionCommit(

--- a/packages/runner/src/scheduler/action-run.ts
+++ b/packages/runner/src/scheduler/action-run.ts
@@ -1,6 +1,7 @@
 import { getLogger } from "@commonfabric/utils/logger";
 import type { Runtime } from "../runtime.ts";
 import type {
+  ChangeGroup,
   IExtendedStorageTransaction,
   IMemorySpaceAddress,
   IStorageTransaction,
@@ -10,13 +11,26 @@ import {
   MAX_ACTION_RUN_TRACE_HISTORY,
   MAX_RETRIES_FOR_REACTIVE,
 } from "./constants.ts";
+import {
+  captureDiagnosisRecord,
+  type DiagnosisRecord,
+  runIdempotencyRecheck,
+} from "./diagnosis.ts";
 import { toActionRunTraceAddress } from "./diagnostics.ts";
+import { txToReactivityLog } from "./reactivity.ts";
+import { type ActionTimingState, recordActionTime } from "./timing.ts";
 import type {
   Action,
   ActionRunTraceEntry,
   EventHandler,
   ReactivityLog,
 } from "./types.ts";
+import {
+  markReadersDirtyForChangedWrites,
+  recordChangedComputationWrites,
+  type WritePropagationState,
+} from "./write-propagation.ts";
+import type { NonIdempotentReport, SchedulerActionInfo } from "../telemetry.ts";
 
 const logger = getLogger("scheduler", {
   enabled: true,
@@ -202,5 +216,291 @@ export function appendActionRunTrace(state: {
       (args.maxHistory ?? MAX_ACTION_RUN_TRACE_HISTORY)
   ) {
     state.actionRunTrace.shift();
+  }
+}
+
+export interface SchedulerActionRunState {
+  readonly runtime: Runtime;
+  readonly actionChangeGroups: WeakMap<Action, ChangeGroup>;
+  readonly inFlightSourceState: InFlightSourceState;
+  readonly actionTimingState: ActionTimingState;
+  readonly pullDemandedFirstRunComputations: WeakSet<Action>;
+  readonly retries: WeakMap<Action, number>;
+  readonly pending: Set<Action>;
+  readonly actionRunTrace: ActionRunTraceEntry[];
+  readonly actionParent: WeakMap<Action, Action>;
+  readonly isEffectAction: WeakMap<Action, boolean>;
+  readonly diagnosisHistory: Map<string, DiagnosisRecord[]>;
+  readonly diagnosisNonIdempotent: NonIdempotentReport[];
+  readonly idempotencyViolations: NonIdempotentReport[];
+  readonly writePropagationState: WritePropagationState;
+  readonly computations: ReadonlySet<Action>;
+  readonly getRunningPromise: () => Promise<unknown> | undefined;
+  readonly setRunningPromise: (promise: Promise<unknown>) => void;
+  readonly getPullMode: () => boolean;
+  readonly getCollectActionRunTrace: () => boolean;
+  readonly getDiagnosisEnabled: () => boolean;
+  readonly getIdempotencyCheckMode: () => boolean;
+  readonly getActionId: (action: Action | EventHandler) => string;
+  readonly getActionTelemetryInfo: (
+    action: Action | EventHandler,
+  ) => SchedulerActionInfo | undefined;
+  readonly getSchedulingWrites: (
+    action: Action,
+  ) => readonly IMemorySpaceAddress[] | undefined;
+  readonly maybeAutoDebounce: (action: Action) => void;
+  readonly markActionHasRun: (action: Action) => void;
+  readonly handleError: (error: Error, action: Action) => void;
+  readonly resubscribe: (action: Action, log: ReactivityLog) => void;
+  readonly markDirectDirty: (action: Action) => void;
+  readonly clearDirectDirty: (action: Action) => void;
+  readonly queueExecution: () => void;
+  readonly setExecutingAction: (action: Action, actionId: string) => void;
+  readonly clearExecutingAction: () => void;
+}
+
+export async function runSchedulerAction(
+  state: SchedulerActionRunState,
+  action: Action,
+): Promise<any> {
+  logger.timeStart("scheduler", "run");
+  const actionId = state.getActionId(action);
+  state.runtime.telemetry.submit({
+    type: "scheduler.run",
+    actionId,
+    actionInfo: state.getActionTelemetryInfo(action),
+  });
+
+  logger.debug("schedule-run-start", () => [
+    `[RUN] Starting action: ${actionId}`,
+    `Pull mode: ${state.getPullMode()}`,
+  ]);
+
+  const runningPromise = state.getRunningPromise();
+  if (runningPromise) await runningPromise;
+
+  const tx = state.runtime.edit({
+    changeGroup: state.actionChangeGroups.get(action),
+  });
+  (tx.tx as { debugActionId?: string }).debugActionId = actionId;
+  addInFlightSource(state.inFlightSourceState, action, tx.tx);
+  const actionStartTime = performance.now();
+
+  let result: any;
+  const nextRunningPromise = new Promise((resolve) => {
+    const finalizeAction = (error?: unknown) => {
+      finalizeSchedulerAction(state, {
+        action,
+        actionId,
+        tx,
+        actionStartTime,
+        result,
+        error,
+        resolve,
+      });
+    };
+
+    invokeReactiveAction({
+      runtime: state.runtime,
+      setExecutingAction: state.setExecutingAction,
+      clearExecutingAction: state.clearExecutingAction,
+    }, {
+      action,
+      actionId,
+      tx,
+      actionStartTime,
+    })
+      .then((invocation) => {
+        if (invocation.ok) {
+          result = invocation.result;
+          finalizeAction();
+        } else {
+          finalizeAction(invocation.error);
+        }
+      })
+      .catch((error) => {
+        finalizeAction(error);
+      });
+  });
+  state.setRunningPromise(nextRunningPromise);
+
+  return nextRunningPromise.then((result) => {
+    logger.timeEnd("scheduler", "run");
+    return result;
+  });
+}
+
+function finalizeSchedulerAction(
+  state: SchedulerActionRunState,
+  args: {
+    readonly action: Action;
+    readonly actionId: string;
+    readonly tx: IExtendedStorageTransaction;
+    readonly actionStartTime: number;
+    readonly result: unknown;
+    readonly error?: unknown;
+    readonly resolve: (value: unknown) => void;
+  },
+): void {
+  // Record action execution time for cycle-aware scheduling
+  const elapsed = performance.now() - args.actionStartTime;
+  recordActionTime(state.actionTimingState, args.action, elapsed);
+  state.maybeAutoDebounce(args.action);
+  state.markActionHasRun(args.action);
+  state.pullDemandedFirstRunComputations.delete(args.action);
+
+  try {
+    if (args.error) {
+      logger.error("schedule-error", () => [
+        `[RUN] Action failed: ${args.actionId}`,
+        `Error: ${args.error}`,
+      ]);
+      state.handleError(args.error as Error, args.action);
+    }
+  } finally {
+    finalizeReactiveActionCommit(state, args, elapsed);
+  }
+}
+
+function finalizeReactiveActionCommit(
+  state: SchedulerActionRunState,
+  args: {
+    readonly action: Action;
+    readonly actionId: string;
+    readonly tx: IExtendedStorageTransaction;
+    readonly result: unknown;
+    readonly resolve: (value: unknown) => void;
+  },
+  elapsed: number,
+): void {
+  // Set up new reactive subscriptions after the action runs
+
+  // Commit the transaction. The code continues synchronously after
+  // kicking off the commit, i.e. it assumes the commit will be
+  // successful. If it isn't, the data will be rolled back and all other
+  // reactive functions based on it will be retriggered. But also, the
+  // retry logic below will have re-scheduled this action, so
+  // topological sorting should move it before the dependencies.
+  const commitPromise = startReactiveActionCommit({
+    runtime: state.runtime,
+    tx: args.tx,
+  });
+  const log = txToReactivityLog(args.tx);
+  watchReactiveActionCommit({
+    action: args.action,
+    tx: args.tx,
+    log,
+    retries: state.retries,
+    pending: state.pending,
+    commitPromise,
+    resubscribe: state.resubscribe,
+    markDirectDirty: state.markDirectDirty,
+    queueExecution: state.queueExecution,
+    removeInFlightSource: (target, source) =>
+      removeInFlightSource(
+        state.inFlightSourceState,
+        target,
+        source,
+      ),
+  });
+  const changedComputationWrites = recordChangedComputationWrites(
+    state.writePropagationState,
+    args.action,
+    args.tx,
+    log,
+  );
+
+  logger.debug("schedule-run-complete", () => [
+    `[RUN] Action completed: ${args.actionId}`,
+    `Reads: ${log.reads.length}`,
+    `Writes: ${log.writes.length}`,
+    `Elapsed: ${elapsed.toFixed(2)}ms`,
+  ]);
+
+  recordOptionalActionRunDiagnostics(state, args, log, elapsed);
+
+  logger.timeStart("scheduler", "run", "resubscribe");
+  try {
+    state.resubscribe(args.action, log);
+  } finally {
+    logger.timeEnd("scheduler", "run", "resubscribe");
+  }
+  if (state.getPullMode() && state.computations.has(args.action)) {
+    state.clearDirectDirty(args.action);
+    markReadersDirtyForChangedWrites(
+      state.writePropagationState,
+      args.action,
+      changedComputationWrites,
+    );
+  }
+  args.resolve(args.result);
+}
+
+function recordOptionalActionRunDiagnostics(
+  state: SchedulerActionRunState,
+  args: {
+    readonly action: Action;
+    readonly actionId: string;
+    readonly tx: IExtendedStorageTransaction;
+  },
+  log: ReactivityLog,
+  elapsed: number,
+): void {
+  if (state.getCollectActionRunTrace()) {
+    appendActionRunTrace({
+      actionRunTrace: state.actionRunTrace,
+      actionParent: state.actionParent,
+      isEffectAction: state.isEffectAction,
+      getActionId: state.getActionId,
+      getSchedulingWrites: state.getSchedulingWrites,
+    }, {
+      action: args.action,
+      actionId: args.actionId,
+      durationMs: elapsed,
+      log,
+    });
+  }
+
+  // Diagnosis capture: record read/write values for idempotency checking
+  if (state.getDiagnosisEnabled()) {
+    captureDiagnosisRecord({
+      diagnosisHistory: state.diagnosisHistory,
+      diagnosisNonIdempotent: state.diagnosisNonIdempotent,
+      createReadTx: () => state.runtime.edit(),
+      getActionTelemetryInfo: state.getActionTelemetryInfo,
+    }, {
+      actionId: args.actionId,
+      action: args.action,
+      tx: args.tx,
+      log,
+    });
+  }
+
+  // Inline idempotency re-run: when the mode is on, every
+  // computation gets a second synchronous run against post-commit
+  // state. An idempotent computation produces the same writes
+  // both times. Uses isEffectAction (persists past unsubscribe)
+  // since execute() calls unsubscribe() before run().
+  if (
+    state.getIdempotencyCheckMode() &&
+    !state.isEffectAction.get(args.action)
+  ) {
+    logger.timeStart("scheduler", "run", "idempotencyRecheck");
+    try {
+      runIdempotencyRecheck(
+        {
+          idempotencyViolations: state.idempotencyViolations,
+          createTx: () => state.runtime.edit(),
+          invoke: (fn) => state.runtime.harness.invoke(fn),
+          getActionId: state.getActionId,
+          getActionTelemetryInfo: state.getActionTelemetryInfo,
+        },
+        args.action,
+        args.tx,
+        log,
+      );
+    } finally {
+      logger.timeEnd("scheduler", "run", "idempotencyRecheck");
+    }
   }
 }

--- a/packages/runner/src/scheduler/continuation.ts
+++ b/packages/runner/src/scheduler/continuation.ts
@@ -1,0 +1,128 @@
+import { queueTask } from "./diagnostics.ts";
+import { planExecuteContinuation } from "./execution.ts";
+import {
+  type EventQueueWakeState,
+  hasEventQueueWakeTimer,
+  isHeadEventParked,
+  scheduleEventQueueWake,
+} from "./events.ts";
+import type { Action, QueuedEvent } from "./types.ts";
+
+export interface ExecuteContinuationState {
+  readonly getPullMode: () => boolean;
+  readonly pending: ReadonlySet<Action>;
+  readonly dirty: ReadonlySet<Action>;
+  readonly effects: ReadonlySet<Action>;
+  readonly eventQueue: readonly QueuedEvent[];
+  readonly eventQueueWakeState: EventQueueWakeState;
+  readonly idlePromises: (() => void)[];
+  readonly scheduledFirstTime: Set<Action>;
+  readonly conditionallyScheduledEffects: ReadonlyMap<Action, number>;
+  readonly changedWritesHistory: unknown[];
+  readonly consumeRerunAfterCurrentExecute: () => boolean;
+  readonly isDemandedPullComputation: (action: Action) => boolean;
+  readonly shouldRunFirstPullComputationInDemandContext: (
+    action: Action,
+  ) => boolean;
+  readonly isDebouncedComputationWaiting: (action: Action) => boolean;
+  readonly getNextDebounceRunTime: (action: Action) => number | undefined;
+  readonly getNextEligibleRunTime: (action: Action) => number | undefined;
+  readonly resetLoopCounter: () => void;
+  readonly setScheduled: (scheduled: boolean) => void;
+  readonly resetSettlingTracker: () => void;
+  readonly setPendingQueueTaskTimer: (
+    timer: ReturnType<typeof setTimeout> | null,
+  ) => void;
+  readonly execute: () => void;
+}
+
+export function applyExecuteContinuation(
+  state: ExecuteContinuationState,
+): void {
+  // In pull mode, we consider ourselves done when there are no effects or
+  // effect-demanded computations to execute.
+  const hasQueuedEventReadyNow = state.eventQueue.length > 0 &&
+    !isHeadEventParked(state.eventQueueWakeState);
+  const hasParkedHeadEvent = state.eventQueue.length > 0 &&
+    isHeadEventParked(state.eventQueueWakeState);
+  const shouldRerunAfterCurrentExecute = state
+    .consumeRerunAfterCurrentExecute();
+
+  const continuation = planExecuteContinuation({
+    pullMode: state.getPullMode(),
+    pending: state.pending,
+    dirty: state.dirty,
+    effects: state.effects,
+    shouldRerunAfterCurrentExecute,
+    hasQueuedEventReadyNow,
+    hasParkedHeadEvent,
+    isDemandedPullComputation: state.isDemandedPullComputation,
+    shouldRunFirstPullComputationInDemandContext:
+      state.shouldRunFirstPullComputationInDemandContext,
+    isDebouncedComputationWaiting: state.isDebouncedComputationWaiting,
+    getNextDebounceRunTime: state.getNextDebounceRunTime,
+    getNextEligibleRunTime: state.getNextEligibleRunTime,
+  });
+
+  if (!continuation.shouldQueueAnotherTick) {
+    applyQuiescentContinuation(state, continuation);
+    return;
+  }
+
+  // Keep scheduled = true since we're queuing another execution.
+  const timer = queueTask(() => {
+    state.setPendingQueueTaskTimer(null);
+    state.execute();
+  });
+  state.setPendingQueueTaskTimer(timer);
+}
+
+function applyQuiescentContinuation(
+  state: ExecuteContinuationState,
+  continuation: ReturnType<typeof planExecuteContinuation>,
+): void {
+  if (continuation.nextDirtyPullRunAt !== undefined) {
+    scheduleEventQueueWake(
+      state.eventQueueWakeState,
+      continuation.nextDirtyPullRunAt,
+    );
+    if (
+      !continuation.hasParkedHeadEvent &&
+      !continuation.nextDirtyPullRunWaitsForIdle
+    ) {
+      resolveIdlePromises(state.idlePromises);
+    }
+    markNotScheduled(state);
+    return;
+  }
+
+  if (hasEventQueueWakeTimer(state.eventQueueWakeState)) {
+    markNotScheduled(state);
+
+    // Waiting on a future wake is quiescent from the scheduler's perspective,
+    // so reset the non-settling tracker.
+    state.resetSettlingTracker();
+    return;
+  }
+
+  resolveIdlePromises(state.idlePromises);
+  markNotScheduled(state);
+
+  // Reset settling tracker on idle.
+  state.resetSettlingTracker();
+
+  state.scheduledFirstTime.clear();
+  if (state.conditionallyScheduledEffects.size === 0) {
+    state.changedWritesHistory.length = 0;
+  }
+}
+
+function markNotScheduled(state: ExecuteContinuationState): void {
+  state.resetLoopCounter();
+  state.setScheduled(false);
+}
+
+function resolveIdlePromises(promises: (() => void)[]): void {
+  for (const resolve of promises) resolve();
+  promises.length = 0;
+}

--- a/packages/runner/src/scheduler/cycle-break.ts
+++ b/packages/runner/src/scheduler/cycle-break.ts
@@ -1,0 +1,73 @@
+import { getLogger } from "@commonfabric/utils/logger";
+import { planCycleBreak, type SchedulerSettleResult } from "./execution.ts";
+import type { Action } from "./types.ts";
+
+const logger = getLogger("scheduler", {
+  enabled: true,
+  level: "warn",
+});
+
+export interface CycleBreakState {
+  readonly getPullMode: () => boolean;
+  readonly dirty: ReadonlySet<Action>;
+  readonly effects: ReadonlySet<Action>;
+  readonly runsThisExecute: ReadonlyMap<Action, number>;
+  readonly pending: Set<Action>;
+  readonly isThrottled: (action: Action) => boolean;
+  readonly clearDirty: (action: Action) => void;
+  readonly unsubscribe: (action: Action) => void;
+  readonly recordExecuted: () => void;
+  readonly getActionId: (action: Action) => string;
+  readonly runAction: (action: Action) => Promise<unknown>;
+}
+
+export async function breakCyclesIfNeeded(
+  state: CycleBreakState,
+  settleResult: SchedulerSettleResult,
+): Promise<void> {
+  // If we hit max iterations without settling, break the cycle:
+  // 1. Clear dirty/pending for computations that were in early iterations AND still in last workSet
+  // 2. Run all remaining dirty effects so they don't get lost
+  const cycleBreakPlan = planCycleBreak({
+    pullMode: state.getPullMode(),
+    settledEarly: settleResult.settledEarly,
+    lastWorkSet: settleResult.lastWorkSet,
+    earlyIterationComputations: settleResult.earlyIterationComputations,
+    dirty: state.dirty,
+    effects: state.effects,
+    runsThisExecute: state.runsThisExecute,
+    isThrottled: state.isThrottled,
+  });
+  if (!cycleBreakPlan.shouldBreak) return;
+
+  logger.debug("schedule-cycle", () => [
+    `[CYCLE-BREAK] Hit max iterations (${settleResult.maxSettleIterations}), breaking cycle`,
+    `Early computations: ${settleResult.earlyIterationComputations.size}, Last workSet: ${settleResult.lastWorkSet.size}`,
+  ]);
+
+  // Clear computations that appear to be in the cycle
+  // (present in early iterations AND still in the last workSet)
+  // But don't clear throttled computations - they should stay dirty
+  for (const comp of cycleBreakPlan.computationsToClear) {
+    logger.debug("schedule-cycle", () => [
+      `[CYCLE-BREAK] Clearing cyclic computation: ${state.getActionId(comp)}`,
+    ]);
+    state.clearDirty(comp);
+    state.pending.delete(comp);
+  }
+
+  // Run all remaining dirty effects - these shouldn't be lost
+  // But skip throttled effects - they should stay dirty for later
+  for (const effect of cycleBreakPlan.dirtyEffectsToRun) {
+    if (state.effects.has(effect) && state.dirty.has(effect)) {
+      logger.debug("schedule-cycle", () => [
+        `[CYCLE-BREAK] Running dirty effect: ${state.getActionId(effect)}`,
+      ]);
+      state.clearDirty(effect);
+      state.pending.delete(effect);
+      state.unsubscribe(effect);
+      state.recordExecuted();
+      await state.runAction(effect);
+    }
+  }
+}

--- a/packages/runner/src/scheduler/delay-control.ts
+++ b/packages/runner/src/scheduler/delay-control.ts
@@ -1,0 +1,102 @@
+import type { SchedulerDelays } from "./delays.ts";
+import type { Action } from "./types.ts";
+
+export interface SchedulerDelayControlState {
+  readonly delays: SchedulerDelays;
+  readonly computations: ReadonlySet<Action>;
+  readonly effects: ReadonlySet<Action>;
+  readonly dirty: ReadonlySet<Action>;
+  readonly pending: Set<Action>;
+  readonly getPullMode: () => boolean;
+  readonly isPullDemandRootEffect: (action: Action) => boolean;
+  readonly queueExecution: () => void;
+  readonly logDebounce: (message: string) => void;
+}
+
+export function canAutomaticallyDebounce(
+  state: SchedulerDelayControlState,
+  action: Action,
+): boolean {
+  return state.delays.canAutomaticallyDebounce(action, {
+    effects: state.effects,
+    isPullDemandRootEffect: state.isPullDemandRootEffect,
+  });
+}
+
+export function getNextDebounceRunTime(
+  state: SchedulerDelayControlState,
+  action: Action,
+): number | undefined {
+  return state.delays.getNextDebounceRunTime(
+    action,
+    {
+      pullMode: state.getPullMode(),
+      computations: state.computations,
+      effects: state.effects,
+      dirty: state.dirty,
+    },
+  );
+}
+
+export function isDebouncedComputationWaiting(
+  state: SchedulerDelayControlState,
+  action: Action,
+): boolean {
+  return state.delays.isDebouncedComputationWaiting(
+    action,
+    debouncedComputationContext(state),
+  );
+}
+
+export function scheduleComputationDebounce(
+  state: SchedulerDelayControlState,
+  action: Action,
+): void {
+  state.delays.scheduleComputationDebounce(
+    action,
+    debouncedComputationContext(state),
+  );
+}
+
+export function scheduleWithDebounce(
+  state: SchedulerDelayControlState,
+  action: Action,
+): void {
+  state.delays.scheduleWithDebounce(
+    action,
+    {
+      pending: state.pending,
+      queueExecution: state.queueExecution,
+      logDebounce: state.logDebounce,
+    },
+  );
+}
+
+export function maybeAutoDebounce(
+  state: SchedulerDelayControlState,
+  action: Action,
+):
+  | {
+    actionId: string;
+    averageTime: number;
+    delayMs: number;
+    thresholdMs: number;
+  }
+  | undefined {
+  return state.delays.maybeAutoDebounce(action, {
+    canAutomaticallyDebounce: (candidate) =>
+      canAutomaticallyDebounce(state, candidate),
+  });
+}
+
+function debouncedComputationContext(state: SchedulerDelayControlState) {
+  return {
+    pullMode: state.getPullMode(),
+    computations: state.computations,
+    effects: state.effects,
+    dirty: state.dirty,
+    pending: state.pending,
+    queueExecution: state.queueExecution,
+    logDebounce: state.logDebounce,
+  };
+}

--- a/packages/runner/src/scheduler/demand.ts
+++ b/packages/runner/src/scheduler/demand.ts
@@ -1,0 +1,145 @@
+import type { IMemorySpaceAddress } from "../storage/interface.ts";
+import type { Action, ReactivityLog } from "./types.ts";
+
+export interface PullDemandState {
+  readonly getPullMode: () => boolean;
+  readonly computations: ReadonlySet<Action>;
+  readonly effects: ReadonlySet<Action>;
+  readonly dependents: WeakMap<Action, Set<Action>>;
+  readonly dependencies: WeakMap<Action, ReactivityLog>;
+  readonly actionParent: WeakMap<Action, Action>;
+  readonly isEffectAction: WeakMap<Action, boolean>;
+  readonly pullDemandedFirstRunComputations: WeakSet<Action>;
+  readonly hasActionRun: (action: Action) => boolean;
+  readonly getSchedulingWrites: (
+    action: Action,
+  ) => readonly IMemorySpaceAddress[] | undefined;
+}
+
+export function hasDependentPath(
+  state: Pick<PullDemandState, "dependents">,
+  from: Action,
+  to: Action,
+  visited = new Set<Action>(),
+): boolean {
+  if (from === to) return true;
+  if (visited.has(from)) return false;
+  visited.add(from);
+
+  const dependents = state.dependents.get(from);
+  if (!dependents) return false;
+
+  for (const dependent of dependents) {
+    if (hasDependentPath(state, dependent, to, visited)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function isDemandedPullComputation(
+  state: PullDemandState,
+  action: Action,
+  visited = new Set<Action>(),
+): boolean {
+  if (
+    !state.getPullMode() ||
+    !state.computations.has(action) ||
+    isLiveEffect(state, action)
+  ) {
+    return false;
+  }
+  if (visited.has(action)) return false;
+  visited.add(action);
+
+  return hasTransitiveEffectDependent(state, action) ||
+    hasDemandedParentContext(state, action, visited);
+}
+
+export function isLiveEffect(
+  state: Pick<
+    PullDemandState,
+    "effects" | "isEffectAction" | "dependencies"
+  >,
+  action: Action,
+): boolean {
+  if (state.effects.has(action)) return true;
+
+  // During resubscribe, dependencies can be registered before all effect
+  // bookkeeping is restored. Treat only dependency-bearing historical effects
+  // as live so unsubscribed effects do not keep old pull graphs demanded.
+  return (state.isEffectAction.get(action) ?? false) &&
+    state.dependencies.has(action);
+}
+
+export function isPullDemandRootEffect(
+  state: Pick<
+    PullDemandState,
+    "getPullMode" | "effects" | "getSchedulingWrites"
+  >,
+  action: Action,
+): boolean {
+  return state.getPullMode() &&
+    state.effects.has(action) &&
+    (state.getSchedulingWrites(action)?.length ?? 0) === 0;
+}
+
+export function shouldRunFirstPullComputationInDemandContext(
+  state: Pick<
+    PullDemandState,
+    | "getPullMode"
+    | "computations"
+    | "effects"
+    | "hasActionRun"
+    | "pullDemandedFirstRunComputations"
+  >,
+  action: Action,
+): boolean {
+  if (
+    !state.getPullMode() ||
+    !state.computations.has(action) ||
+    state.effects.has(action) ||
+    state.hasActionRun(action)
+  ) {
+    return false;
+  }
+
+  return state.pullDemandedFirstRunComputations.has(action);
+}
+
+function hasTransitiveEffectDependent(
+  state: PullDemandState,
+  action: Action,
+  visited = new Set<Action>(),
+): boolean {
+  if (visited.has(action)) return false;
+  visited.add(action);
+
+  const dependents = state.dependents.get(action);
+  if (!dependents) return false;
+
+  for (const dependent of dependents) {
+    if (isLiveEffect(state, dependent)) return true;
+    if (hasTransitiveEffectDependent(state, dependent, visited)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function hasDemandedParentContext(
+  state: PullDemandState,
+  action: Action,
+  visited = new Set<Action>(),
+): boolean {
+  const parent = state.actionParent.get(action);
+  if (!parent) return false;
+
+  if (isLiveEffect(state, parent)) {
+    return (state.getSchedulingWrites(parent)?.length ?? 0) === 0;
+  }
+
+  return isDemandedPullComputation(state, parent, visited);
+}

--- a/packages/runner/src/scheduler/dependency-collection.ts
+++ b/packages/runner/src/scheduler/dependency-collection.ts
@@ -3,11 +3,13 @@ import type { Runtime } from "../runtime.ts";
 import { txToReactivityLog } from "./reactivity.ts";
 import {
   type DependencyUpdateState,
+  setSchedulerDependencies,
+} from "./dependency-updates.ts";
+import {
   replaceActionTriggerPaths,
   setCancelForTriggerEntities,
-  setSchedulerDependencies,
   type TriggerSubscriptionState,
-} from "./dependency-index.ts";
+} from "./trigger-index.ts";
 import type {
   Action,
   PopulateDependenciesEntry,

--- a/packages/runner/src/scheduler/dependency-collection.ts
+++ b/packages/runner/src/scheduler/dependency-collection.ts
@@ -1,0 +1,104 @@
+import { getLogger } from "@commonfabric/utils/logger";
+import type { Runtime } from "../runtime.ts";
+import { txToReactivityLog } from "./reactivity.ts";
+import {
+  type DependencyUpdateState,
+  replaceActionTriggerPaths,
+  setCancelForTriggerEntities,
+  setSchedulerDependencies,
+  type TriggerSubscriptionState,
+} from "./dependency-index.ts";
+import type {
+  Action,
+  PopulateDependenciesEntry,
+  ReactivityLog,
+  SpaceScopeAndURI,
+} from "./types.ts";
+
+const logger = getLogger("scheduler", {
+  enabled: true,
+  level: "warn",
+});
+
+export interface DependencyCollectionState {
+  readonly runtime: Runtime;
+  readonly dependencyUpdateState: DependencyUpdateState;
+  readonly triggerSubscriptionState: TriggerSubscriptionState;
+  readonly updateDependents: (action: Action, log: ReactivityLog) => void;
+}
+
+export interface CollectDependenciesOptions {
+  readonly errorLogLabel: string;
+  readonly errorMessage: (action: Action, error: unknown) => string;
+  readonly updateDependents?: boolean;
+  readonly useRawReadsForTriggers?: boolean;
+}
+
+export function collectDependenciesForAction(
+  state: DependencyCollectionState,
+  action: Action,
+  populateDependencies: PopulateDependenciesEntry,
+  options: CollectDependenciesOptions,
+): { log: ReactivityLog; entities: Set<SpaceScopeAndURI> } {
+  const log = resolveDependencyLog(
+    state,
+    action,
+    populateDependencies,
+    options,
+  );
+
+  const { reads, shallowReads, log: schedulingLog } = setSchedulerDependencies(
+    state.dependencyUpdateState,
+    action,
+    log,
+  );
+  if (options.updateDependents ?? true) {
+    state.updateDependents(action, schedulingLog);
+  }
+
+  const readsForTriggers = options.useRawReadsForTriggers ? log.reads : reads;
+  const shallowReadsForTriggers = options.useRawReadsForTriggers
+    ? log.shallowReads
+    : shallowReads;
+  const { entities } = replaceActionTriggerPaths(
+    state.triggerSubscriptionState,
+    action,
+    readsForTriggers,
+    shallowReadsForTriggers,
+  );
+  setCancelForTriggerEntities(
+    state.triggerSubscriptionState,
+    action,
+    entities,
+  );
+
+  return { log, entities };
+}
+
+function resolveDependencyLog(
+  state: DependencyCollectionState,
+  action: Action,
+  populateDependencies: PopulateDependenciesEntry,
+  options: CollectDependenciesOptions,
+): ReactivityLog {
+  if (typeof populateDependencies !== "function") {
+    return populateDependencies;
+  }
+
+  const depTx = state.runtime.edit();
+  try {
+    logger.timeStart("collectDependencies", "populate");
+    try {
+      populateDependencies(depTx);
+    } finally {
+      logger.timeEnd("collectDependencies", "populate");
+    }
+  } catch (error) {
+    logger.debug(options.errorLogLabel, () => [
+      options.errorMessage(action, error),
+    ]);
+  }
+  const log = txToReactivityLog(depTx);
+  depTx.abort();
+  return log;
+}

--- a/packages/runner/src/scheduler/dependency-graph.ts
+++ b/packages/runner/src/scheduler/dependency-graph.ts
@@ -2,10 +2,7 @@ import type { IMemorySpaceAddress } from "../storage/interface.ts";
 import { entityKey } from "./keys.ts";
 import { readsOverlapWrites } from "./scheduling-writes.ts";
 import type { SchedulerStaleness } from "./staleness.ts";
-import {
-  collectReadersForWrite,
-  type TriggerIndexState,
-} from "./trigger-index.ts";
+import type { TriggerIndexState } from "./trigger-index.ts";
 import type {
   Action,
   DirtyDependencyTraceContext,
@@ -13,7 +10,8 @@ import type {
   SpaceScopeAndURI,
 } from "./types.ts";
 
-export interface DependencyGraphState extends TriggerIndexState {
+export interface DependencyGraphState {
+  readonly triggerIndex: TriggerIndexState;
   readonly writersByEntity: Map<SpaceScopeAndURI, Set<Action>>;
   readonly dependencies: WeakMap<Action, ReactivityLog>;
   readonly dependents: WeakMap<Action, Set<Action>>;
@@ -230,7 +228,7 @@ export function backfillDependentsForNewWrites(
   if (writes.length === 0) return;
   const readers = new Set<Action>();
   for (const write of writes) {
-    for (const action of collectReadersForWrite(state, write)) {
+    for (const action of state.triggerIndex.collectReadersForWrite(write)) {
       readers.add(action);
     }
   }

--- a/packages/runner/src/scheduler/dependency-index.ts
+++ b/packages/runner/src/scheduler/dependency-index.ts
@@ -1,4 +1,0 @@
-export * from "./dependency-graph.ts";
-export * from "./dependency-updates.ts";
-export * from "./scheduling-writes.ts";
-export * from "./trigger-index.ts";

--- a/packages/runner/src/scheduler/dependency-updates.ts
+++ b/packages/runner/src/scheduler/dependency-updates.ts
@@ -11,14 +11,12 @@ import {
   buildKnownSchedulingWrites,
   diffSchedulingWrites,
   pruneStructuralAncestorWrites,
-  type SchedulingWriteState,
-  updateWriterIndex,
-  type WriterIndexState,
+  type SchedulerWriteIndex,
 } from "./scheduling-writes.ts";
 import type { Action, ReactivityLog, TelemetryAnnotations } from "./types.ts";
 
-export interface DependencyUpdateState
-  extends WriterIndexState, SchedulingWriteState {
+export interface DependencyUpdateState {
+  readonly writeIndex: SchedulerWriteIndex;
   readonly dependencies: WeakMap<Action, ReactivityLog>;
   readonly dependencyGraph: DependencyGraphState;
   readonly isPullMode: () => boolean;
@@ -65,13 +63,14 @@ export function setSchedulerDependencies(
   // Rebuild the current scheduling view from the latest writes plus
   // declared/potential writes. Keep the cumulative legacy union separately
   // so it can be enabled behind an experimental flag.
-  const rawExistingCurrentWrites = state.currentKnownWrites.get(action) ?? [];
+  const rawExistingCurrentWrites =
+    state.writeIndex.currentKnownWrites.get(action) ?? [];
   const existingCurrentWrites = filterIgnoredAddresses(
     rawExistingCurrentWrites,
     ignoredSchedulingWrites,
   );
   const existingHistoricalWrites = filterIgnoredAddresses(
-    state.historicalMightWrite.get(action) ?? [],
+    state.writeIndex.historicalMightWrite.get(action) ?? [],
     ignoredSchedulingWrites,
   );
   const { newCurrentKnownWrites, newHistoricalMightWrite } =
@@ -82,13 +81,13 @@ export function setSchedulerDependencies(
       existingCurrentWrites,
       existingHistoricalWrites,
     });
-  state.currentKnownWrites.set(action, newCurrentKnownWrites);
-  state.historicalMightWrite.set(action, newHistoricalMightWrite);
+  state.writeIndex.currentKnownWrites.set(action, newCurrentKnownWrites);
+  state.writeIndex.historicalMightWrite.set(action, newHistoricalMightWrite);
 
-  const previousSchedulingWrites = state.useHistoricalMightWrite()
+  const previousSchedulingWrites = state.writeIndex.useHistoricalMightWrite()
     ? existingHistoricalWrites
     : existingCurrentWrites;
-  const nextSchedulingWrites = state.useHistoricalMightWrite()
+  const nextSchedulingWrites = state.writeIndex.useHistoricalMightWrite()
     ? newHistoricalMightWrite
     : newCurrentKnownWrites;
 
@@ -97,7 +96,7 @@ export function setSchedulerDependencies(
     nextSchedulingWrites,
   );
 
-  updateWriterIndex(state, action, nextSchedulingWrites);
+  state.writeIndex.updateWriterIndex(action, nextSchedulingWrites);
 
   if (removedWrites.length > 0) {
     pruneDependentsForCurrentWrites(

--- a/packages/runner/src/scheduler/diagnosis.ts
+++ b/packages/runner/src/scheduler/diagnosis.ts
@@ -10,6 +10,7 @@ import type {
   CycleReport,
   NonIdempotentReport,
   SchedulerActionInfo,
+  SchedulerDiagnosisResult,
 } from "../telemetry.ts";
 import { txToReactivityLog } from "./reactivity.ts";
 import { mapsEqual } from "./topology.ts";
@@ -20,6 +21,39 @@ export type DiagnosisRecord = {
   writeValues: Map<string, unknown>;
   timestamp: number;
 };
+
+export type CausalEdge = {
+  writer: string;
+  cell: string;
+  triggered: string;
+  timestamp: number;
+};
+
+export interface SchedulerDiagnosisControlState {
+  readonly getDiagnosisEnabled: () => boolean;
+  readonly setDiagnosisEnabled: (enabled: boolean) => void;
+  readonly getDiagnosisTimeout: () => ReturnType<typeof setTimeout> | null;
+  readonly setDiagnosisTimeout: (
+    timeout: ReturnType<typeof setTimeout> | null,
+  ) => void;
+  readonly getDiagnosisStartTime: () => number;
+  readonly setDiagnosisStartTime: (time: number) => void;
+  readonly getDiagnosisBusyTime: () => number;
+  readonly setDiagnosisBusyTime: (time: number) => void;
+  readonly getDiagnosisResolve: () =>
+    | ((result: SchedulerDiagnosisResult) => void)
+    | null;
+  readonly setDiagnosisResolve: (
+    resolve: ((result: SchedulerDiagnosisResult) => void) | null,
+  ) => void;
+  readonly diagnosisHistory: Map<string, DiagnosisRecord[]>;
+  readonly diagnosisNonIdempotent: NonIdempotentReport[];
+  readonly causalEdges: CausalEdge[];
+  readonly idempotencyViolations: NonIdempotentReport[];
+  readonly computations: ReadonlySet<Action>;
+  readonly setIdempotencyCheckMode: (enabled: boolean) => void;
+  readonly runAction: (action: Action) => Promise<unknown>;
+}
 
 export function makeAddressKey(addr: IMemorySpaceAddress): string {
   return `${addr.space}/${addr.id}/${addr.path.join("/")}`;
@@ -270,8 +304,98 @@ export function captureDiagnosisRecord(state: {
   });
 }
 
+export function startSchedulerDiagnosis(
+  state: SchedulerDiagnosisControlState,
+  durationMs = 5000,
+): void {
+  if (state.getDiagnosisEnabled()) return;
+
+  state.setDiagnosisEnabled(true);
+  state.setDiagnosisStartTime(performance.now());
+  state.setDiagnosisBusyTime(0);
+  state.diagnosisHistory.clear();
+  state.diagnosisNonIdempotent.length = 0;
+  state.causalEdges.length = 0;
+
+  state.setDiagnosisTimeout(
+    setTimeout(() => {
+      stopSchedulerDiagnosis(state);
+    }, durationMs),
+  );
+}
+
+export function stopSchedulerDiagnosis(
+  state: SchedulerDiagnosisControlState,
+): void {
+  if (!state.getDiagnosisEnabled()) return;
+
+  state.setDiagnosisEnabled(false);
+  const diagnosisTimeout = state.getDiagnosisTimeout();
+  if (diagnosisTimeout) {
+    clearTimeout(diagnosisTimeout);
+    state.setDiagnosisTimeout(null);
+  }
+
+  const duration = performance.now() - state.getDiagnosisStartTime();
+  const cycles = detectCausalCycles(state.causalEdges);
+
+  const result: SchedulerDiagnosisResult = {
+    nonIdempotent: state.diagnosisNonIdempotent,
+    cycles,
+    duration,
+    busyTime: state.getDiagnosisBusyTime(),
+  };
+
+  state.diagnosisHistory.clear();
+  state.causalEdges.length = 0;
+
+  const resolve = state.getDiagnosisResolve();
+  if (resolve) {
+    resolve(result);
+    state.setDiagnosisResolve(null);
+  }
+}
+
+export function runSchedulerDiagnosis(
+  state: SchedulerDiagnosisControlState,
+  durationMs = 5000,
+): Promise<SchedulerDiagnosisResult> {
+  if (state.getDiagnosisEnabled()) {
+    stopSchedulerDiagnosis(state);
+  }
+
+  return new Promise<SchedulerDiagnosisResult>((resolve) => {
+    state.setDiagnosisResolve(resolve);
+    startSchedulerDiagnosis(state, durationMs);
+  });
+}
+
+export async function runSchedulerIdempotencyCheck(
+  state: SchedulerDiagnosisControlState,
+): Promise<SchedulerDiagnosisResult> {
+  state.idempotencyViolations.length = 0;
+  state.setIdempotencyCheckMode(true);
+
+  try {
+    // Snapshot computations to avoid iterating a live Set.
+    const computationsSnapshot = [...state.computations];
+    for (const action of computationsSnapshot) {
+      await state.runAction(action);
+    }
+  } finally {
+    state.setIdempotencyCheckMode(false);
+  }
+
+  return {
+    nonIdempotent: [...state.idempotencyViolations],
+    cycles: [],
+    duration: 0,
+    busyTime: 0,
+  };
+}
+
 export function detectCausalCycles(
-  causalEdges: readonly { writer: string; triggered: string; cell: string }[],
+  causalEdges: readonly Pick<CausalEdge, "writer" | "triggered" | "cell">[],
 ): CycleReport[] {
   // Build adjacency list: writer -> [{ triggered, cell }]
   const adj = new Map<string, { triggered: string; cell: string }[]>();

--- a/packages/runner/src/scheduler/dirty-dependencies.ts
+++ b/packages/runner/src/scheduler/dirty-dependencies.ts
@@ -4,7 +4,7 @@ import type {
   SchedulerEventPreflightActionSummary,
   SchedulerEventPreflightStats,
 } from "../telemetry.ts";
-import { collectDirectWritersForLog } from "./dependency-index.ts";
+import { collectDirectWritersForLog } from "./dependency-graph.ts";
 import type {
   Action,
   DirtyDependencyTraceContext,

--- a/packages/runner/src/scheduler/dirty-dependencies.ts
+++ b/packages/runner/src/scheduler/dirty-dependencies.ts
@@ -1,6 +1,9 @@
 import { getLogger } from "@commonfabric/utils/logger";
 import type { IMemorySpaceAddress } from "../storage/interface.ts";
-import type { SchedulerEventPreflightActionSummary } from "../telemetry.ts";
+import type {
+  SchedulerEventPreflightActionSummary,
+  SchedulerEventPreflightStats,
+} from "../telemetry.ts";
 import { collectDirectWritersForLog } from "./dependency-index.ts";
 import type {
   Action,
@@ -16,8 +19,9 @@ const logger = getLogger("scheduler", {
 
 export interface DirtyDependencyCollectionState {
   readonly collectStack: Set<Action>;
-  readonly trace?: DirtyDependencyTraceContext;
+  readonly getTrace: () => DirtyDependencyTraceContext | undefined;
   readonly dirty: ReadonlySet<Action>;
+  readonly pending: ReadonlySet<Action>;
   readonly computations: ReadonlySet<Action>;
   readonly reverseDependencies: WeakMap<Action, Set<Action>>;
   readonly dependencies: WeakMap<Action, ReactivityLog>;
@@ -27,10 +31,7 @@ export interface DirtyDependencyCollectionState {
   readonly getSchedulingWrites: (
     action: Action,
   ) => readonly IMemorySpaceAddress[] | undefined;
-  readonly getTraceActionSummary: (
-    trace: DirtyDependencyTraceContext,
-    action: Action,
-  ) => SchedulerEventPreflightActionSummary;
+  readonly getActionId: (action: Action) => string;
 }
 
 /**
@@ -49,13 +50,13 @@ export function collectDirtyDependencies(
 ): boolean {
   const collectStart = performance.now();
   let addedToStack = false;
-  const trace = state.trace;
+  const trace = state.getTrace();
 
   try {
     if (trace) {
       trace.visitCount++;
       trace.maxDepth = Math.max(trace.maxDepth, trace.depth);
-      const actionSummary = state.getTraceActionSummary(trace, action);
+      const actionSummary = getTraceActionSummary(state, trace, action);
       actionSummary.visitCount++;
       if (state.dirty.has(action)) {
         trace.dirtyInputCount++;
@@ -67,7 +68,7 @@ export function collectDirtyDependencies(
     if (cached !== undefined) {
       if (trace) {
         trace.memoHitCount++;
-        state.getTraceActionSummary(trace, action).memoHitCount++;
+        getTraceActionSummary(state, trace, action).memoHitCount++;
       }
       if (cached && state.dirty.has(action) && state.computations.has(action)) {
         if (!workSet.has(action) && trace) trace.workSetAddCount++;
@@ -133,7 +134,7 @@ export function collectDirtyDependencies(
 
     if (actionNeedsRun && trace) {
       trace.resultTrueCount++;
-      state.getTraceActionSummary(trace, action).resultTrueCount++;
+      getTraceActionSummary(state, trace, action).resultTrueCount++;
     }
     memo.set(action, actionNeedsRun);
     return actionNeedsRun;
@@ -155,12 +156,12 @@ function recordReverseDependencyTrace(
   action: Action,
   directWriters: Set<Action>,
 ): void {
-  const trace = state.trace;
+  const trace = state.getTrace();
   if (!trace) return;
 
   trace.reverseDependencyActionCount++;
   trace.reverseDependencyEdgeCount += directWriters.size;
-  const actionSummary = state.getTraceActionSummary(trace, action);
+  const actionSummary = getTraceActionSummary(state, trace, action);
   actionSummary.reverseDependencyEdgeCount += directWriters.size;
   actionSummary.maxDirectWriterCount = Math.max(
     actionSummary.maxDirectWriterCount,
@@ -175,7 +176,7 @@ export function collectDirtyDependenciesForLog(
   memo = new Map<Action, boolean>(),
 ): boolean {
   const lookupStart = performance.now();
-  const trace = state.trace;
+  const trace = state.getTrace();
   let directWriters: Set<Action>;
   try {
     directWriters = collectDirectWritersForLog({
@@ -198,7 +199,7 @@ export function collectDirtyDependenciesForLog(
   if (trace && trace.depth === 0) {
     for (const writer of directWriters) {
       trace.rootDirectWriterActions.add(writer);
-      state.getTraceActionSummary(trace, writer);
+      getTraceActionSummary(state, trace, writer);
     }
   }
 
@@ -231,4 +232,76 @@ export function collectDirtyDependenciesForLog(
   }
 
   return hasDirtyDependencies;
+}
+
+export function snapshotDirtyDependencyTraceContext(
+  state: DirtyDependencyCollectionState,
+  context: DirtyDependencyTraceContext,
+): SchedulerEventPreflightStats {
+  const {
+    depth: _depth,
+    actionSummaries,
+    rootDirectWriterActions,
+    ...stats
+  } = context;
+  const actionRows = [...actionSummaries.values()];
+  const topBy = (
+    rows: SchedulerEventPreflightActionSummary[],
+    key: "visitCount" | "reverseDependencyEdgeCount",
+  ) =>
+    rows
+      .filter((row) => row[key] > 0)
+      .sort((a, b) =>
+        b[key] - a[key] ||
+        b.visitCount - a.visitCount ||
+        a.actionId.localeCompare(b.actionId)
+      )
+      .slice(0, 12);
+
+  const rootDirectWriterRows = [...rootDirectWriterActions].map((action) =>
+    getTraceActionSummary(state, context, action)
+  );
+
+  return {
+    ...stats,
+    hotActions: topBy(actionRows, "visitCount"),
+    hotFanoutActions: topBy(actionRows, "reverseDependencyEdgeCount"),
+    rootDirectWriters: topBy(rootDirectWriterRows, "visitCount"),
+  };
+}
+
+function getTraceActionSummary(
+  state: DirtyDependencyCollectionState,
+  trace: DirtyDependencyTraceContext,
+  action: Action,
+): SchedulerEventPreflightActionSummary {
+  let summary = trace.actionSummaries.get(action);
+  if (!summary) {
+    const log = state.dependencies.get(action);
+    const writes = state.getSchedulingWrites(action) ?? [];
+    summary = {
+      actionId: state.getActionId(action),
+      actionType: state.effects.has(action)
+        ? "effect"
+        : state.computations.has(action)
+        ? "computation"
+        : "unknown",
+      visitCount: 0,
+      memoHitCount: 0,
+      dirtyInputCount: 0,
+      resultTrueCount: 0,
+      reverseDependencyEdgeCount: 0,
+      maxDirectWriterCount: 0,
+      dirty: state.dirty.has(action),
+      pending: state.pending.has(action),
+      readCount: log?.reads.length ?? 0,
+      shallowReadCount: log?.shallowReads.length ?? 0,
+      writeCount: writes.length,
+    };
+    trace.actionSummaries.set(action, summary);
+  } else {
+    summary.dirty ||= state.dirty.has(action);
+    summary.pending ||= state.pending.has(action);
+  }
+  return summary;
 }

--- a/packages/runner/src/scheduler/dirty-dependencies.ts
+++ b/packages/runner/src/scheduler/dirty-dependencies.ts
@@ -1,0 +1,234 @@
+import { getLogger } from "@commonfabric/utils/logger";
+import type { IMemorySpaceAddress } from "../storage/interface.ts";
+import type { SchedulerEventPreflightActionSummary } from "../telemetry.ts";
+import { collectDirectWritersForLog } from "./dependency-index.ts";
+import type {
+  Action,
+  DirtyDependencyTraceContext,
+  ReactivityLog,
+  SpaceScopeAndURI,
+} from "./types.ts";
+
+const logger = getLogger("scheduler", {
+  enabled: true,
+  level: "warn",
+});
+
+export interface DirtyDependencyCollectionState {
+  readonly collectStack: Set<Action>;
+  readonly trace?: DirtyDependencyTraceContext;
+  readonly dirty: ReadonlySet<Action>;
+  readonly computations: ReadonlySet<Action>;
+  readonly reverseDependencies: WeakMap<Action, Set<Action>>;
+  readonly dependencies: WeakMap<Action, ReactivityLog>;
+  readonly writersByEntity: Map<SpaceScopeAndURI, Set<Action>>;
+  readonly effects: ReadonlySet<Action>;
+  readonly isStale: (action: Action) => boolean;
+  readonly getSchedulingWrites: (
+    action: Action,
+  ) => readonly IMemorySpaceAddress[] | undefined;
+  readonly getTraceActionSummary: (
+    trace: DirtyDependencyTraceContext,
+    action: Action,
+  ) => SchedulerEventPreflightActionSummary;
+}
+
+/**
+ * Collects computations that must run before `action` can observe up-to-date
+ * values. This includes explicitly dirty computations and clean intermediates
+ * whose own inputs flow from dirty upstream computations.
+ *
+ * Returns whether `action` itself is stale with respect to the current dirty
+ * set.
+ */
+export function collectDirtyDependencies(
+  state: DirtyDependencyCollectionState,
+  action: Action,
+  workSet: Set<Action>,
+  memo = new Map<Action, boolean>(),
+): boolean {
+  const collectStart = performance.now();
+  let addedToStack = false;
+  const trace = state.trace;
+
+  try {
+    if (trace) {
+      trace.visitCount++;
+      trace.maxDepth = Math.max(trace.maxDepth, trace.depth);
+      const actionSummary = state.getTraceActionSummary(trace, action);
+      actionSummary.visitCount++;
+      if (state.dirty.has(action)) {
+        trace.dirtyInputCount++;
+        actionSummary.dirtyInputCount++;
+      }
+    }
+
+    const cached = memo.get(action);
+    if (cached !== undefined) {
+      if (trace) {
+        trace.memoHitCount++;
+        state.getTraceActionSummary(trace, action).memoHitCount++;
+      }
+      if (cached && state.dirty.has(action) && state.computations.has(action)) {
+        if (!workSet.has(action) && trace) trace.workSetAddCount++;
+        workSet.add(action);
+      }
+      return cached;
+    }
+
+    if (!state.isStale(action)) {
+      memo.set(action, false);
+      return false;
+    }
+
+    if (state.collectStack.has(action)) {
+      if (trace) trace.cycleHitCount++;
+      const cycleResult = state.isStale(action) || workSet.has(action);
+      memo.set(action, cycleResult);
+      return cycleResult;
+    }
+
+    state.collectStack.add(action);
+    addedToStack = true;
+
+    let actionNeedsRun = state.isStale(action);
+    const directWriters = state.reverseDependencies.get(action);
+    if (directWriters) {
+      recordReverseDependencyTrace(state, action, directWriters);
+      for (const writer of directWriters) {
+        if (!state.isStale(writer)) {
+          memo.set(writer, false);
+          continue;
+        }
+        if (trace) trace.depth++;
+        let writerNeedsRun: boolean;
+        try {
+          writerNeedsRun = collectDirtyDependencies(
+            state,
+            writer,
+            workSet,
+            memo,
+          );
+        } finally {
+          if (trace) trace.depth--;
+        }
+        if (writerNeedsRun) {
+          actionNeedsRun = true;
+        }
+      }
+    } else {
+      if (trace) trace.logFallbackCount++;
+      const log = state.dependencies.get(action);
+      if (log) {
+        if (collectDirtyDependenciesForLog(state, log, workSet, memo)) {
+          actionNeedsRun = true;
+        }
+      }
+    }
+
+    if (state.dirty.has(action) && state.computations.has(action)) {
+      if (!workSet.has(action) && trace) trace.workSetAddCount++;
+      workSet.add(action);
+    }
+
+    if (actionNeedsRun && trace) {
+      trace.resultTrueCount++;
+      state.getTraceActionSummary(trace, action).resultTrueCount++;
+    }
+    memo.set(action, actionNeedsRun);
+    return actionNeedsRun;
+  } finally {
+    if (addedToStack) {
+      state.collectStack.delete(action);
+    }
+    logger.time(
+      collectStart,
+      "scheduler",
+      "execute",
+      "collectDirtyDependencies",
+    );
+  }
+}
+
+function recordReverseDependencyTrace(
+  state: DirtyDependencyCollectionState,
+  action: Action,
+  directWriters: Set<Action>,
+): void {
+  const trace = state.trace;
+  if (!trace) return;
+
+  trace.reverseDependencyActionCount++;
+  trace.reverseDependencyEdgeCount += directWriters.size;
+  const actionSummary = state.getTraceActionSummary(trace, action);
+  actionSummary.reverseDependencyEdgeCount += directWriters.size;
+  actionSummary.maxDirectWriterCount = Math.max(
+    actionSummary.maxDirectWriterCount,
+    directWriters.size,
+  );
+}
+
+export function collectDirtyDependenciesForLog(
+  state: DirtyDependencyCollectionState,
+  log: ReactivityLog,
+  workSet: Set<Action>,
+  memo = new Map<Action, boolean>(),
+): boolean {
+  const lookupStart = performance.now();
+  const trace = state.trace;
+  let directWriters: Set<Action>;
+  try {
+    directWriters = collectDirectWritersForLog({
+      writersByEntity: state.writersByEntity,
+      effects: state.effects,
+      getSchedulingWrites: state.getSchedulingWrites,
+      trace,
+    }, log);
+  } finally {
+    logger.time(
+      lookupStart,
+      "scheduler",
+      "execute",
+      "collectDirtyDependencies",
+      "writerLookup",
+    );
+  }
+
+  if (trace) trace.directWriterCount += directWriters.size;
+  if (trace && trace.depth === 0) {
+    for (const writer of directWriters) {
+      trace.rootDirectWriterActions.add(writer);
+      state.getTraceActionSummary(trace, writer);
+    }
+  }
+
+  let hasDirtyDependencies = false;
+  for (const writer of directWriters) {
+    if (!state.isStale(writer)) {
+      memo.set(writer, false);
+      continue;
+    }
+
+    if (trace) trace.depth++;
+    let writerNeedsRun: boolean;
+    try {
+      writerNeedsRun = collectDirtyDependencies(
+        state,
+        writer,
+        workSet,
+        memo,
+      );
+    } finally {
+      if (trace) trace.depth--;
+    }
+    if (writerNeedsRun) {
+      hasDirtyDependencies = true;
+      if (state.dirty.has(writer) && state.computations.has(writer)) {
+        if (!workSet.has(writer) && trace) trace.workSetAddCount++;
+        workSet.add(writer);
+      }
+    }
+  }
+
+  return hasDirtyDependencies;
+}

--- a/packages/runner/src/scheduler/events.ts
+++ b/packages/runner/src/scheduler/events.ts
@@ -97,7 +97,7 @@ export interface EventDependencyPreflightResult {
   preflightStats: DirtyDependencyTraceContext;
 }
 
-export function queueSchedulerEvent(state: {
+export interface SchedulerEventQueueState {
   readonly runtime: Runtime;
   readonly eventHandlers: readonly [NormalizedFullLink, EventHandler][];
   readonly eventQueue: QueuedEvent[];
@@ -110,7 +110,9 @@ export function queueSchedulerEvent(state: {
     onCommit: QueuedEvent["onCommit"] | undefined,
     doNotLoadPieceIfNotRunning: boolean,
   ) => void;
-}, args: {
+}
+
+export function queueSchedulerEvent(state: SchedulerEventQueueState, args: {
   readonly eventLink: NormalizedFullLink;
   readonly event: unknown;
   readonly retries: number;

--- a/packages/runner/src/scheduler/events.ts
+++ b/packages/runner/src/scheduler/events.ts
@@ -182,13 +182,12 @@ export function addSchedulerEventHandler(state: {
   };
 }
 
-export async function processQueuedEventDuringExecute(state: {
+export interface SchedulerEventExecutionState {
   readonly runtime: Runtime;
   readonly eventQueue: QueuedEvent[];
   readonly pullMode: boolean;
   readonly dirty: ReadonlySet<Action>;
   readonly pending: Set<Action>;
-  readonly eventBlockingDeps: Set<Action>;
   readonly eventPreflightTelemetryEnabled: boolean;
   readonly setRunningPromise: (promise: Promise<unknown>) => void;
   readonly getActionId: (action: Action | EventHandler) => string;
@@ -215,7 +214,12 @@ export async function processQueuedEventDuringExecute(state: {
   readonly snapshotDirtyDependencyTraceContext: (
     trace: DirtyDependencyTraceContext,
   ) => SchedulerEventPreflightStats;
-}): Promise<void> {
+}
+
+export async function processQueuedEventDuringExecute(
+  state: SchedulerEventExecutionState,
+  eventBlockingDeps: Set<Action>,
+): Promise<void> {
   // Process next event from the event queue.
   const queuedEvent = state.eventQueue[0];
   if (!queuedEvent) return;
@@ -242,7 +246,7 @@ export async function processQueuedEventDuringExecute(state: {
       dirty: state.dirty,
       pending: state.pending,
       pendingActions: state.pending,
-      eventBlockingDeps: state.eventBlockingDeps,
+      eventBlockingDeps,
       handleError: (error, target) => state.handleError(error, target),
       setDirtyDependencyTraceContext: (trace) => {
         state.setDirtyDependencyTraceContext(trace);

--- a/packages/runner/src/scheduler/execution.ts
+++ b/packages/runner/src/scheduler/execution.ts
@@ -448,11 +448,12 @@ export async function runSchedulerSettleLoop(
     }
 
     lastWorkSet = iteration.workSet;
+    const iterationWorkSetSize = iteration.workSet.size;
     const iterActionsRun = await runSettleOrder(state, iteration.order);
 
     if (settleIterStats) {
       settleIterStats.push(summarizeSettleIteration({
-        workSetSize: iteration.workSet.size,
+        workSetSize: iterationWorkSetSize,
         order: iteration.order,
         actionsRun: iterActionsRun,
         durationMs: performance.now() - iterStart,

--- a/packages/runner/src/scheduler/execution.ts
+++ b/packages/runner/src/scheduler/execution.ts
@@ -137,6 +137,100 @@ export function buildPullInitialSeeds(state: {
   return initialSeeds;
 }
 
+export interface ExecuteDependencyCollectionState {
+  readonly pendingDependencyCollection: Set<Action>;
+  readonly populateDependenciesCallbacks: WeakMap<
+    Action,
+    PopulateDependenciesEntry
+  >;
+  readonly effects: ReadonlySet<Action>;
+  readonly getSchedulingWrites: (
+    action: Action,
+  ) => readonly unknown[] | undefined;
+  readonly collectDependenciesForAction: (
+    action: Action,
+    populateDependencies: PopulateDependenciesEntry,
+    options: {
+      readonly errorLogLabel: string;
+      readonly errorMessage: (target: Action, error: unknown) => string;
+      readonly useRawReadsForTriggers?: boolean;
+    },
+  ) => { log: ReactivityLog; entities: Set<SpaceScopeAndURI> };
+  readonly getActionId: (action: Action) => string;
+  readonly scheduleAffectedEffects?: (action: Action) => void;
+}
+
+export function collectInitialExecuteDependencies(
+  state: ExecuteDependencyCollectionState,
+): {
+  collectedActions: Action[];
+  newActionsWithoutDependencies: Action[];
+} {
+  logger.timeStart("scheduler", "execute", "depCollect");
+  try {
+    // Find computation actions whose writes are still unknown. We run them on
+    // the first cycle to capture writes that cannot be inferred from declared
+    // outputs or populateDependencies() potential writes.
+    //
+    // TODO(seefeld): Once we more reliably capture what they can write via
+    // WriteableCell or so, then we can treat this more deliberately via the
+    // dependency collection process above. We'll have to re-run it whenever
+    // inputs change, as they might change what they can write to. We hope that
+    // for now this will be sufficiently captured in mightWrite.
+    return collectPendingDependencyActions({
+      pendingDependencyCollection: state.pendingDependencyCollection,
+      populateDependenciesCallbacks: state.populateDependenciesCallbacks,
+      effects: state.effects,
+      getSchedulingWrites: state.getSchedulingWrites,
+      collectDependenciesForAction: (action, populateDependencies) =>
+        state.collectDependenciesForAction(action, populateDependencies, {
+          errorLogLabel: "schedule-dep-error",
+          errorMessage: (target, error) =>
+            `Error populating dependencies for ${
+              state.getActionId(target)
+            }: ${error}`,
+        }),
+      onCollected: (action, { log, entities }) =>
+        logger.debug("schedule-dep-collect", () => [
+          `Collected dependencies for ${
+            state.getActionId(action)
+          }: ${log.reads.length} reads, ${log.writes.length} writes, ${entities.size} entities`,
+        ]),
+      scheduleAffectedEffects: state.scheduleAffectedEffects,
+    });
+  } finally {
+    logger.timeEnd("scheduler", "execute", "depCollect");
+  }
+}
+
+export function collectPostEventDependencies(
+  state: ExecuteDependencyCollectionState,
+): void {
+  // Process any newly subscribed actions that were added during event handling.
+  // This handles cases like event handlers that create sub-patterns whose
+  // computations need their dependencies discovered before we build the workSet.
+  if (state.pendingDependencyCollection.size === 0) return;
+
+  collectPendingDependencyActions({
+    pendingDependencyCollection: state.pendingDependencyCollection,
+    populateDependenciesCallbacks: state.populateDependenciesCallbacks,
+    effects: state.effects,
+    getSchedulingWrites: state.getSchedulingWrites,
+    collectDependenciesForAction: (action, populateDependencies) =>
+      state.collectDependenciesForAction(action, populateDependencies, {
+        errorLogLabel: "schedule-dep-error-post-event",
+        errorMessage: (target, error) =>
+          `Error populating dependencies for ${
+            state.getActionId(target)
+          }: ${error}`,
+      }),
+    onCollected: (action) =>
+      logger.debug("schedule-dep-collect-post-event", () => [
+        `Collected dependencies for ${state.getActionId(action)}`,
+      ]),
+  });
+}
+
 export function collectPendingDependencyActions(state: {
   readonly pendingDependencyCollection: Set<Action>;
   readonly populateDependenciesCallbacks: WeakMap<

--- a/packages/runner/src/scheduler/execution.ts
+++ b/packages/runner/src/scheduler/execution.ts
@@ -1,8 +1,13 @@
+import { getLogger } from "@commonfabric/utils/logger";
+import { type Frame } from "../builder/types.ts";
+import type { IMemorySpaceAddress } from "../storage/interface.ts";
 import {
   CYCLE_DEBOUNCE_MIN_RUNS,
   CYCLE_DEBOUNCE_MULTIPLIER,
   CYCLE_DEBOUNCE_THRESHOLD_MS,
+  MAX_ITERATIONS_PER_RUN,
 } from "./constants.ts";
+import { topologicalSort } from "./topology.ts";
 import type {
   Action,
   PopulateDependenciesEntry,
@@ -11,6 +16,11 @@ import type {
   SettleStats,
   SpaceScopeAndURI,
 } from "./types.ts";
+
+const logger = getLogger("scheduler", {
+  enabled: true,
+  level: "warn",
+});
 
 export interface SettlingTracker {
   windowStart: number;
@@ -243,6 +253,398 @@ export function buildIterationWorkSet(state: {
     iterationSeeds,
     dirtyDependencyCount: workSet.size - iterationSeeds.size,
   };
+}
+
+export type SchedulerSettleResult = {
+  settledEarly: boolean;
+  lastWorkSet: Set<Action>;
+  earlyIterationComputations: Set<Action>;
+  maxSettleIterations: number;
+  settleStats?: SettleStats;
+};
+
+export interface SchedulerSettleLoopState {
+  readonly pullMode: boolean;
+  readonly collectSettleStats: boolean;
+  readonly pendingDependencyCollection: Set<Action>;
+  readonly populateDependenciesCallbacks: WeakMap<
+    Action,
+    PopulateDependenciesEntry
+  >;
+  readonly effects: ReadonlySet<Action>;
+  readonly computations: ReadonlySet<Action>;
+  readonly pending: Set<Action>;
+  readonly dirty: ReadonlySet<Action>;
+  readonly dependencies: WeakMap<Action, ReactivityLog>;
+  readonly actionParent: WeakMap<Action, Action>;
+  readonly dependents: WeakMap<Action, Set<Action>>;
+  readonly conditionallyScheduledEffects: Map<Action, number>;
+  readonly filterStats: { filtered: number; executed: number };
+  readonly loopCounter: WeakMap<Action, number>;
+  readonly runsThisExecute: Map<Action, number>;
+  readonly activePullDemandActions: WeakSet<Action>;
+  readonly getSchedulingWrites: (
+    action: Action,
+  ) => readonly IMemorySpaceAddress[] | undefined;
+  readonly getSchedulingWritesMap: () => WeakMap<
+    Action,
+    IMemorySpaceAddress[]
+  >;
+  readonly collectDependenciesForAction: (
+    action: Action,
+    populateDependencies: PopulateDependenciesEntry,
+    options: {
+      readonly errorLogLabel: string;
+      readonly errorMessage: (target: Action, error: unknown) => string;
+      readonly useRawReadsForTriggers?: boolean;
+    },
+  ) => { log: ReactivityLog; entities: Set<SpaceScopeAndURI> };
+  readonly collectPullIterationSeeds: (seeds: Set<Action>) => void;
+  readonly collectDirtyDependencies: (
+    seed: Action,
+    targetWorkSet: Set<Action>,
+    memo: Map<Action, boolean>,
+  ) => boolean;
+  readonly getActionId: (action: Action) => string;
+  readonly clearDirty: (action: Action) => void;
+  readonly markDirectDirty: (action: Action) => void;
+  readonly isThrottled: (action: Action) => boolean;
+  readonly isDebouncedComputationWaiting: (action: Action) => boolean;
+  readonly clearComputationDebounceState: (action: Action) => void;
+  readonly conditionalEffectHasChangedInputs: (action: Action) => boolean;
+  readonly isPullDemandRootEffect: (action: Action) => boolean;
+  readonly handleError: (error: Error, action: Action) => void;
+  readonly runAction: (action: Action) => Promise<unknown>;
+}
+
+export async function runSchedulerSettleLoop(
+  state: SchedulerSettleLoopState,
+  initialSeeds: ReadonlySet<Action>,
+): Promise<SchedulerSettleResult> {
+  // Settle loop: runs until no more dirty work is found.
+  // First iteration processes initial seeds + their dirty deps.
+  // Subsequent iterations process new subscriptions and re-collect dirty deps.
+  logger.timeStart("scheduler", "execute", "settle");
+  const maxSettleIterations = state.pullMode ? 10 : 10;
+  const EARLY_ITERATION_THRESHOLD = 5;
+  const earlyIterationComputations = new Set<Action>(); // Track computations in first N iterations
+  let lastWorkSet: Set<Action> = new Set();
+  let settledEarly = false;
+  const settleIterStats: SettleIterationStats[] | undefined =
+    state.collectSettleStats ? [] : undefined;
+  const settleStartTime = state.collectSettleStats ? performance.now() : 0;
+
+  for (let settleIter = 0; settleIter < maxSettleIterations; settleIter++) {
+    const iterStart = settleIterStats ? performance.now() : 0;
+
+    collectSettlePreRunDependencies(state);
+    const iteration = prepareSettleIteration(
+      state,
+      initialSeeds,
+      settleIter,
+      EARLY_ITERATION_THRESHOLD,
+      earlyIterationComputations,
+    );
+
+    if (iteration.settled) {
+      settledEarly = true;
+      break;
+    }
+
+    lastWorkSet = iteration.workSet;
+    const iterActionsRun = await runSettleOrder(state, iteration.order);
+
+    if (settleIterStats) {
+      settleIterStats.push(summarizeSettleIteration({
+        workSetSize: iteration.workSet.size,
+        order: iteration.order,
+        actionsRun: iterActionsRun,
+        durationMs: performance.now() - iterStart,
+        effects: state.effects,
+        getActionId: (action) => state.getActionId(action),
+      }));
+    }
+  }
+
+  const settleStats = settleIterStats
+    ? summarizeSettleRun({
+      iterations: settleIterStats,
+      totalDurationMs: performance.now() - settleStartTime,
+      settledEarly,
+      initialSeedCount: initialSeeds.size,
+    })
+    : undefined;
+
+  logger.timeEnd("scheduler", "execute", "settle");
+
+  return {
+    settledEarly,
+    lastWorkSet,
+    earlyIterationComputations,
+    maxSettleIterations,
+    ...(settleStats ? { settleStats } : {}),
+  };
+}
+
+function collectSettlePreRunDependencies(
+  state: SchedulerSettleLoopState,
+): void {
+  // Process any newly subscribed actions from previous iteration.
+  // This sets up their dependencies so collectDirtyDependencies can find them.
+  if (!state.pullMode || state.pendingDependencyCollection.size === 0) return;
+
+  collectPendingDependencyActions({
+    pendingDependencyCollection: state.pendingDependencyCollection,
+    populateDependenciesCallbacks: state.populateDependenciesCallbacks,
+    effects: state.effects,
+    getSchedulingWrites: state.getSchedulingWrites,
+    collectDependenciesForAction: (action, populateDependencies) =>
+      state.collectDependenciesForAction(action, populateDependencies, {
+        errorLogLabel: "schedule-dep-error-pre-run",
+        errorMessage: (target, error) =>
+          `Error collecting deps for ${state.getActionId(target)}: ${error}`,
+        useRawReadsForTriggers: true,
+      }),
+  });
+}
+
+function prepareSettleIteration(
+  state: SchedulerSettleLoopState,
+  initialSeeds: ReadonlySet<Action>,
+  settleIter: number,
+  earlyIterationThreshold: number,
+  earlyIterationComputations: Set<Action>,
+): { settled: true } | {
+  settled: false;
+  workSet: Set<Action>;
+  order: Action[];
+} {
+  // Build the work set for this iteration
+  const buildPullWorkSetStart = state.pullMode ? performance.now() : 0;
+  const { workSet, iterationSeeds, dirtyDependencyCount } =
+    buildIterationWorkSet({
+      pullMode: state.pullMode,
+      pending: state.pending,
+      initialSeeds,
+      settleIter,
+      collectPullIterationSeeds: state.collectPullIterationSeeds,
+      collectDirtyDependencies: state.collectDirtyDependencies,
+    });
+
+  if (state.pullMode) {
+    if (settleIter === 0) {
+      logger.debug("schedule-execute-pull", () => [
+        `Pull mode: Seeds: ${iterationSeeds.size}, Dirty deps added: ${dirtyDependencyCount}`,
+      ]);
+    }
+    logger.time(
+      buildPullWorkSetStart,
+      "scheduler",
+      "execute",
+      "buildPullWorkSet",
+    );
+  }
+
+  if (workSet.size === 0) {
+    return { settled: true };
+  }
+
+  recordEarlyIterationComputations({
+    pullMode: state.pullMode,
+    settleIter,
+    threshold: earlyIterationThreshold,
+    workSet,
+    effects: state.effects,
+    earlyIterationComputations,
+  });
+
+  const topologicalSortStart = performance.now();
+  const order = topologicalSort(
+    workSet,
+    state.dependencies,
+    state.getSchedulingWritesMap(),
+    state.actionParent,
+    state.pullMode ? state.dependents : undefined,
+  );
+  logger.time(
+    topologicalSortStart,
+    "scheduler",
+    "execute",
+    "topologicalSort",
+  );
+
+  logger.debug("schedule-execute", () => [
+    `Running ${order.length} actions (settle iteration ${settleIter})`,
+  ]);
+
+  // Implicit cycle detection for effects:
+  // Clear dirty flags for all effects upfront. If an effect becomes dirty again
+  // by the time we run it, something in the execution re-dirtied it → cycle.
+  if (state.pullMode) {
+    for (const fn of order) {
+      if (state.effects.has(fn)) {
+        state.clearDirty(fn);
+      }
+    }
+  }
+
+  return { settled: false, workSet, order };
+}
+
+async function runSettleOrder(
+  state: SchedulerSettleLoopState,
+  order: readonly Action[],
+): Promise<number> {
+  let actionsRun = 0;
+  for (const fn of order) {
+    actionsRun += await runSettleAction(state, fn);
+  }
+  return actionsRun;
+}
+
+async function runSettleAction(
+  state: SchedulerSettleLoopState,
+  fn: Action,
+): Promise<number> {
+  // Check if action is still scheduled (not unsubscribed during this tick).
+  // Running an action might unsubscribe other actions in the workSet.
+  const isStillScheduled = state.computations.has(fn) || state.effects.has(fn);
+  if (!isStillScheduled) return 0;
+
+  if (!isSettleActionStillRunnable(state, fn)) return 0;
+  if (skipDelayedSettleAction(state, fn)) return 0;
+  if (skipUnchangedConditionalEffect(state, fn)) return 0;
+
+  // Clean up from pending/dirty before running
+  state.pending.delete(fn);
+  state.conditionallyScheduledEffects.delete(fn);
+  if (state.computations.has(fn)) {
+    state.clearComputationDebounceState(fn);
+  }
+  if (state.pullMode && state.effects.has(fn)) {
+    state.clearDirty(fn);
+  }
+
+  state.filterStats.executed++;
+  state.loopCounter.set(fn, (state.loopCounter.get(fn) || 0) + 1);
+  // Track runs for cycle-aware debounce
+  state.runsThisExecute.set(fn, (state.runsThisExecute.get(fn) ?? 0) + 1);
+  if (state.loopCounter.get(fn)! > MAX_ITERATIONS_PER_RUN) {
+    const error = new Error(
+      `Too many iterations: ${state.loopCounter.get(fn)} ${
+        state.getActionId(fn)
+      }`,
+    );
+    // Attach the last frame from the action so handleError can
+    // extract piece/spell metadata (CT-1316: fixes message:null).
+    const lastFrame = (fn as Action & { lastFrame?: Frame }).lastFrame;
+    if (lastFrame) {
+      (error as Error & { frame?: Frame }).frame = lastFrame;
+    }
+    state.handleError(error, fn);
+    return 1;
+  }
+
+  const activePullDemand = state.pullMode &&
+    (state.computations.has(fn) || state.isPullDemandRootEffect(fn));
+  if (activePullDemand) {
+    state.activePullDemandActions.add(fn);
+  }
+  try {
+    await state.runAction(fn);
+  } finally {
+    if (activePullDemand) {
+      state.activePullDemandActions.delete(fn);
+    }
+  }
+  return 1;
+}
+
+function isSettleActionStillRunnable(
+  state: SchedulerSettleLoopState,
+  fn: Action,
+): boolean {
+  // Check if action is still valid
+  // In pull mode, check both pending (effects) and dirty (computations)
+  const isInPending = state.pending.has(fn);
+  const isInDirty = state.dirty.has(fn);
+
+  if (!state.pullMode) {
+    // Push mode: action must be in pending
+    return isInPending;
+  }
+
+  // For effects: we cleared dirty upfront, so check if re-dirtied (cycle)
+  if (state.effects.has(fn)) {
+    if (state.dirty.has(fn)) {
+      // Effect was re-dirtied during this tick → cycle detected
+      logger.debug("schedule-cycle", () => [
+        `[CYCLE] Effect ${
+          state.getActionId(fn)
+        } re-dirtied, skipping (cycle detected)`,
+      ]);
+      // Skip this effect - it will run on a future tick after cycle settles
+      state.pending.delete(fn);
+      return false;
+    }
+    return isInPending;
+  }
+
+  // For computations: must be pending or dirty
+  return isInPending || isInDirty;
+}
+
+function skipDelayedSettleAction(
+  state: SchedulerSettleLoopState,
+  fn: Action,
+): boolean {
+  if (state.isDebouncedComputationWaiting(fn)) {
+    logger.debug("schedule-debounce", () => [
+      `[DEBOUNCE] Skipping debounced computation: ${state.getActionId(fn)}`,
+    ]);
+    state.filterStats.filtered++;
+    state.pending.delete(fn);
+    return true;
+  }
+
+  // Check throttle: skip recently-run actions but keep them dirty
+  // They'll be pulled next time an effect needs them (if throttle expired)
+  if (state.isThrottled(fn)) {
+    logger.debug("schedule-throttle", () => [
+      `[THROTTLE] Skipping throttled action: ${state.getActionId(fn)}`,
+    ]);
+    state.filterStats.filtered++;
+    // Don't clear from pending or dirty - action stays in its current state
+    // but we remove from pending so it doesn't run this cycle
+    state.pending.delete(fn);
+    // Keep pull-mode effects dirty so they wake when the throttle expires.
+    if (state.pullMode && state.effects.has(fn)) {
+      state.markDirectDirty(fn);
+    }
+    return true;
+  }
+
+  return false;
+}
+
+function skipUnchangedConditionalEffect(
+  state: SchedulerSettleLoopState,
+  fn: Action,
+): boolean {
+  if (
+    !state.pullMode ||
+    !state.effects.has(fn) ||
+    !state.conditionallyScheduledEffects.has(fn) ||
+    state.conditionalEffectHasChangedInputs(fn)
+  ) {
+    return false;
+  }
+
+  state.conditionallyScheduledEffects.delete(fn);
+  state.pending.delete(fn);
+  state.clearDirty(fn);
+  state.filterStats.filtered++;
+  return true;
 }
 
 export function recordEarlyIterationComputations(state: {

--- a/packages/runner/src/scheduler/execution.ts
+++ b/packages/runner/src/scheduler/execution.ts
@@ -358,8 +358,8 @@ export type SchedulerSettleResult = {
 };
 
 export interface SchedulerSettleLoopState {
-  readonly pullMode: boolean;
-  readonly collectSettleStats: boolean;
+  readonly getPullMode: () => boolean;
+  readonly getCollectSettleStats: () => boolean;
   readonly pendingDependencyCollection: Set<Action>;
   readonly populateDependenciesCallbacks: WeakMap<
     Action,
@@ -374,7 +374,7 @@ export interface SchedulerSettleLoopState {
   readonly dependents: WeakMap<Action, Set<Action>>;
   readonly conditionallyScheduledEffects: Map<Action, number>;
   readonly filterStats: { filtered: number; executed: number };
-  readonly loopCounter: WeakMap<Action, number>;
+  readonly getLoopCounter: () => WeakMap<Action, number>;
   readonly runsThisExecute: Map<Action, number>;
   readonly activePullDemandActions: WeakSet<Action>;
   readonly getSchedulingWrites: (
@@ -419,14 +419,16 @@ export async function runSchedulerSettleLoop(
   // First iteration processes initial seeds + their dirty deps.
   // Subsequent iterations process new subscriptions and re-collect dirty deps.
   logger.timeStart("scheduler", "execute", "settle");
-  const maxSettleIterations = state.pullMode ? 10 : 10;
+  const maxSettleIterations = state.getPullMode() ? 10 : 10;
   const EARLY_ITERATION_THRESHOLD = 5;
   const earlyIterationComputations = new Set<Action>(); // Track computations in first N iterations
   let lastWorkSet: Set<Action> = new Set();
   let settledEarly = false;
-  const settleIterStats: SettleIterationStats[] | undefined =
-    state.collectSettleStats ? [] : undefined;
-  const settleStartTime = state.collectSettleStats ? performance.now() : 0;
+  const collectSettleStats = state.getCollectSettleStats();
+  const settleIterStats: SettleIterationStats[] | undefined = collectSettleStats
+    ? []
+    : undefined;
+  const settleStartTime = collectSettleStats ? performance.now() : 0;
 
   for (let settleIter = 0; settleIter < maxSettleIterations; settleIter++) {
     const iterStart = settleIterStats ? performance.now() : 0;
@@ -485,7 +487,9 @@ function collectSettlePreRunDependencies(
 ): void {
   // Process any newly subscribed actions from previous iteration.
   // This sets up their dependencies so collectDirtyDependencies can find them.
-  if (!state.pullMode || state.pendingDependencyCollection.size === 0) return;
+  if (!state.getPullMode() || state.pendingDependencyCollection.size === 0) {
+    return;
+  }
 
   collectPendingDependencyActions({
     pendingDependencyCollection: state.pendingDependencyCollection,
@@ -514,10 +518,11 @@ function prepareSettleIteration(
   order: Action[];
 } {
   // Build the work set for this iteration
-  const buildPullWorkSetStart = state.pullMode ? performance.now() : 0;
+  const pullMode = state.getPullMode();
+  const buildPullWorkSetStart = pullMode ? performance.now() : 0;
   const { workSet, iterationSeeds, dirtyDependencyCount } =
     buildIterationWorkSet({
-      pullMode: state.pullMode,
+      pullMode,
       pending: state.pending,
       initialSeeds,
       settleIter,
@@ -525,7 +530,7 @@ function prepareSettleIteration(
       collectDirtyDependencies: state.collectDirtyDependencies,
     });
 
-  if (state.pullMode) {
+  if (pullMode) {
     if (settleIter === 0) {
       logger.debug("schedule-execute-pull", () => [
         `Pull mode: Seeds: ${iterationSeeds.size}, Dirty deps added: ${dirtyDependencyCount}`,
@@ -544,7 +549,7 @@ function prepareSettleIteration(
   }
 
   recordEarlyIterationComputations({
-    pullMode: state.pullMode,
+    pullMode,
     settleIter,
     threshold: earlyIterationThreshold,
     workSet,
@@ -558,7 +563,7 @@ function prepareSettleIteration(
     state.dependencies,
     state.getSchedulingWritesMap(),
     state.actionParent,
-    state.pullMode ? state.dependents : undefined,
+    pullMode ? state.dependents : undefined,
   );
   logger.time(
     topologicalSortStart,
@@ -574,7 +579,7 @@ function prepareSettleIteration(
   // Implicit cycle detection for effects:
   // Clear dirty flags for all effects upfront. If an effect becomes dirty again
   // by the time we run it, something in the execution re-dirtied it → cycle.
-  if (state.pullMode) {
+  if (pullMode) {
     for (const fn of order) {
       if (state.effects.has(fn)) {
         state.clearDirty(fn);
@@ -615,19 +620,18 @@ async function runSettleAction(
   if (state.computations.has(fn)) {
     state.clearComputationDebounceState(fn);
   }
-  if (state.pullMode && state.effects.has(fn)) {
+  if (state.getPullMode() && state.effects.has(fn)) {
     state.clearDirty(fn);
   }
 
   state.filterStats.executed++;
-  state.loopCounter.set(fn, (state.loopCounter.get(fn) || 0) + 1);
+  const loopCounter = state.getLoopCounter();
+  loopCounter.set(fn, (loopCounter.get(fn) || 0) + 1);
   // Track runs for cycle-aware debounce
   state.runsThisExecute.set(fn, (state.runsThisExecute.get(fn) ?? 0) + 1);
-  if (state.loopCounter.get(fn)! > MAX_ITERATIONS_PER_RUN) {
+  if (loopCounter.get(fn)! > MAX_ITERATIONS_PER_RUN) {
     const error = new Error(
-      `Too many iterations: ${state.loopCounter.get(fn)} ${
-        state.getActionId(fn)
-      }`,
+      `Too many iterations: ${loopCounter.get(fn)} ${state.getActionId(fn)}`,
     );
     // Attach the last frame from the action so handleError can
     // extract piece/spell metadata (CT-1316: fixes message:null).
@@ -639,7 +643,7 @@ async function runSettleAction(
     return 1;
   }
 
-  const activePullDemand = state.pullMode &&
+  const activePullDemand = state.getPullMode() &&
     (state.computations.has(fn) || state.isPullDemandRootEffect(fn));
   if (activePullDemand) {
     state.activePullDemandActions.add(fn);
@@ -663,7 +667,7 @@ function isSettleActionStillRunnable(
   const isInPending = state.pending.has(fn);
   const isInDirty = state.dirty.has(fn);
 
-  if (!state.pullMode) {
+  if (!state.getPullMode()) {
     // Push mode: action must be in pending
     return isInPending;
   }
@@ -712,7 +716,7 @@ function skipDelayedSettleAction(
     // but we remove from pending so it doesn't run this cycle
     state.pending.delete(fn);
     // Keep pull-mode effects dirty so they wake when the throttle expires.
-    if (state.pullMode && state.effects.has(fn)) {
+    if (state.getPullMode() && state.effects.has(fn)) {
       state.markDirectDirty(fn);
     }
     return true;
@@ -726,7 +730,7 @@ function skipUnchangedConditionalEffect(
   fn: Action,
 ): boolean {
   if (
-    !state.pullMode ||
+    !state.getPullMode() ||
     !state.effects.has(fn) ||
     !state.conditionallyScheduledEffects.has(fn) ||
     state.conditionalEffectHasChangedInputs(fn)

--- a/packages/runner/src/scheduler/notifications.ts
+++ b/packages/runner/src/scheduler/notifications.ts
@@ -7,7 +7,7 @@ import type {
   IStorageTransaction,
   StorageNotification,
 } from "../storage/interface.ts";
-import type { TriggerIndexState } from "./dependency-index.ts";
+import type { TriggerIndexState } from "./trigger-index.ts";
 import { summarizeTriggerTraceValue } from "./diagnostics.ts";
 import { entityKey } from "./keys.ts";
 import type {

--- a/packages/runner/src/scheduler/notifications.ts
+++ b/packages/runner/src/scheduler/notifications.ts
@@ -3,6 +3,7 @@ import { determineTriggeredActions } from "../reactive-dependencies.ts";
 import type {
   ChangeGroup,
   IMemoryChange,
+  IStorageSubscription,
   IStorageTransaction,
   StorageNotification,
 } from "../storage/interface.ts";
@@ -180,19 +181,21 @@ export function shouldRecordTriggerTraceEntry(
   return entry.triggered.length > 0 || entry.matchedActionCount > 0;
 }
 
-export function processStorageNotification(state: {
+interface CausalEdge {
+  writer: string;
+  cell: string;
+  triggered: string;
+  timestamp: number;
+}
+
+export interface StorageNotificationState {
   readonly triggers: TriggerIndexState["triggers"];
   readonly nonRecursiveTriggers: TriggerIndexState["nonRecursiveTriggers"];
-  readonly pullMode: boolean;
-  readonly diagnosisEnabled: boolean;
-  readonly collectTriggerTrace: boolean;
+  readonly getPullMode: () => boolean;
+  readonly getDiagnosisEnabled: () => boolean;
+  readonly getCollectTriggerTrace: () => boolean;
   readonly changeGroupToActionId: Map<ChangeGroup, string>;
-  readonly causalEdges: {
-    writer: string;
-    cell: string;
-    triggered: string;
-    timestamp: number;
-  }[];
+  readonly recordCausalEdge: (edge: CausalEdge) => void;
   readonly actionChangeGroups: WeakMap<Action, ChangeGroup>;
   readonly effects: ReadonlySet<Action>;
   readonly pending: ReadonlySet<Action>;
@@ -207,7 +210,23 @@ export function processStorageNotification(state: {
   readonly scheduleAffectedEffects: (
     action: Action,
   ) => TriggerTraceScheduledEffect[];
-}, notification: StorageNotification): void {
+}
+
+export function createStorageSubscription(
+  state: StorageNotificationState,
+): IStorageSubscription {
+  return {
+    next: (notification) => {
+      processStorageNotification(state, notification);
+      return { done: false };
+    },
+  };
+}
+
+export function processStorageNotification(
+  state: StorageNotificationState,
+  notification: StorageNotification,
+): void {
   const space = notification.space;
 
   if (!("changes" in notification)) {
@@ -219,6 +238,9 @@ export function processStorageNotification(state: {
     : undefined;
   const hasSourceChangeGroup = notification.type === "commit" &&
     sourceChangeGroup !== undefined;
+  const pullMode = state.getPullMode();
+  const collectTriggerTrace = state.getCollectTriggerTrace();
+  const diagnosisEnabled = state.getDiagnosisEnabled();
 
   let changeIndex = 0;
   for (const change of notification.changes) {
@@ -255,30 +277,29 @@ export function processStorageNotification(state: {
         sourceChangeGroup !== undefined
       ? state.changeGroupToActionId.get(sourceChangeGroup)
       : undefined;
-    const triggerTraceEntry: TriggerTraceEntry | null =
-      state.collectTriggerTrace
-        ? createTriggerTraceEntry({
-          notificationType: notification.type,
-          changeIndex,
-          matchedActionCount: triggeredActions.length,
-          pullMode: state.pullMode,
-          writerActionId,
-          space,
-          change,
-        })
-        : null;
+    const triggerTraceEntry: TriggerTraceEntry | null = collectTriggerTrace
+      ? createTriggerTraceEntry({
+        notificationType: notification.type,
+        changeIndex,
+        matchedActionCount: triggeredActions.length,
+        pullMode,
+        writerActionId,
+        space,
+        change,
+      })
+      : null;
 
     for (const action of triggeredActions) {
       // Causal edge tracking for diagnosis.
       if (
-        state.diagnosisEnabled && hasSourceChangeGroup &&
+        diagnosisEnabled && hasSourceChangeGroup &&
         sourceChangeGroup !== undefined
       ) {
         const writerActionId = state.changeGroupToActionId.get(
           sourceChangeGroup,
         );
         if (writerActionId) {
-          state.causalEdges.push({
+          state.recordCausalEdge({
             writer: writerActionId,
             cell: spaceAndURI,
             triggered: state.getActionId(action),
@@ -297,7 +318,7 @@ export function processStorageNotification(state: {
         notification.source !== undefined &&
         state.inFlightSources.get(action)?.has(notification.source) === true;
       const plan = planTriggeredAction({
-        pullMode: state.pullMode,
+        pullMode,
         isEffect: actionIsEffect,
         dirtyBefore,
         isOwnCommitSource,
@@ -308,7 +329,7 @@ export function processStorageNotification(state: {
       let scheduledEffects: TriggerTraceScheduledEffect[] = [];
 
       if (plan.operation === "schedule") {
-        if (state.pullMode && actionIsEffect) {
+        if (pullMode && actionIsEffect) {
           state.conditionallyScheduledEffects.delete(action);
         }
         state.scheduleWithDebounce(action);
@@ -321,7 +342,7 @@ export function processStorageNotification(state: {
         createTriggerTraceActionRecord({
           actionId,
           actionType,
-          pullMode: state.pullMode,
+          pullMode,
           decision: plan.decision,
           pendingBefore,
           pendingAfter: state.pending.has(action),

--- a/packages/runner/src/scheduler/notifications.ts
+++ b/packages/runner/src/scheduler/notifications.ts
@@ -1,5 +1,4 @@
 import type { MemorySpace } from "@commonfabric/memory/interface";
-import { determineTriggeredActions } from "../reactive-dependencies.ts";
 import type {
   ChangeGroup,
   IMemoryChange,
@@ -9,7 +8,6 @@ import type {
 } from "../storage/interface.ts";
 import type { TriggerIndexState } from "./trigger-index.ts";
 import { summarizeTriggerTraceValue } from "./diagnostics.ts";
-import { entityKey } from "./keys.ts";
 import type {
   Action,
   SpaceScopeAndURI,
@@ -27,7 +25,7 @@ export function schedulerMode(pullMode: boolean): SchedulerMode {
 export function hasRegisteredTriggers(
   state: TriggerIndexState,
 ): boolean {
-  return state.triggers.size > 0 || state.nonRecursiveTriggers.size > 0;
+  return state.hasRegisteredTriggers();
 }
 
 export function collectTriggeredActionsForChange(
@@ -39,50 +37,7 @@ export function collectTriggeredActionsForChange(
   hasMatchingTriggerPaths: boolean;
   triggeredActions: Action[];
 } {
-  const entity = entityKey({ ...change.address, space });
-  const paths = state.triggers.get(entity);
-  const nonRecursivePaths = state.nonRecursiveTriggers.get(entity);
-
-  if (!paths && !nonRecursivePaths) {
-    return {
-      entity,
-      hasMatchingTriggerPaths: false,
-      triggeredActions: [],
-    };
-  }
-
-  const triggeredActionSet = new Set<Action>();
-  if (paths) {
-    for (
-      const action of determineTriggeredActions(
-        paths,
-        change.before,
-        change.after,
-        change.address.path,
-      )
-    ) {
-      triggeredActionSet.add(action);
-    }
-  }
-  if (nonRecursivePaths) {
-    for (
-      const action of determineTriggeredActions(
-        nonRecursivePaths,
-        change.before,
-        change.after,
-        change.address.path,
-        { nonRecursive: true },
-      )
-    ) {
-      triggeredActionSet.add(action);
-    }
-  }
-
-  return {
-    entity,
-    hasMatchingTriggerPaths: true,
-    triggeredActions: [...triggeredActionSet],
-  };
+  return state.collectTriggeredActionsForChange(space, change);
 }
 
 export function createTriggerTraceEntry(state: {
@@ -189,8 +144,7 @@ interface CausalEdge {
 }
 
 export interface StorageNotificationState {
-  readonly triggers: TriggerIndexState["triggers"];
-  readonly nonRecursiveTriggers: TriggerIndexState["nonRecursiveTriggers"];
+  readonly triggerIndex: TriggerIndexState;
   readonly getPullMode: () => boolean;
   readonly getDiagnosisEnabled: () => boolean;
   readonly getCollectTriggerTrace: () => boolean;
@@ -248,10 +202,7 @@ export function processStorageNotification(
     state.recordCellUpdate(change);
 
     if (
-      !hasRegisteredTriggers({
-        triggers: state.triggers,
-        nonRecursiveTriggers: state.nonRecursiveTriggers,
-      })
+      !hasRegisteredTriggers(state.triggerIndex)
     ) {
       continue;
     }
@@ -261,10 +212,7 @@ export function processStorageNotification(
       hasMatchingTriggerPaths,
       triggeredActions,
     } = collectTriggeredActionsForChange(
-      {
-        triggers: state.triggers,
-        nonRecursiveTriggers: state.nonRecursiveTriggers,
-      },
+      state.triggerIndex,
       space,
       change,
     );

--- a/packages/runner/src/scheduler/pull-scheduling.ts
+++ b/packages/runner/src/scheduler/pull-scheduling.ts
@@ -1,0 +1,171 @@
+import { getLogger } from "@commonfabric/utils/logger";
+import type { IMemorySpaceAddress } from "../storage/interface.ts";
+import {
+  isDirtyPullActionRunnable,
+  isPendingPullActionRunnable,
+} from "./execution.ts";
+import { readsOverlapWrites } from "./scheduling-writes.ts";
+import { collectTransitiveEffects } from "./topology.ts";
+import type {
+  Action,
+  ReactivityLog,
+  TriggerTraceScheduledEffect,
+} from "./types.ts";
+
+const logger = getLogger("scheduler", {
+  enabled: true,
+  level: "warn",
+});
+
+export type PendingPullRunnableState = Parameters<
+  typeof isPendingPullActionRunnable
+>[0];
+export type DirtyPullRunnableState = Parameters<
+  typeof isDirtyPullActionRunnable
+>[0];
+export type DirtyPullRunnableStateWithDebounce = DirtyPullRunnableState & {
+  readonly isDebouncedComputationWaiting: (action: Action) => boolean;
+};
+
+export interface ConditionalEffectState {
+  readonly changedWritesHistory: readonly IMemorySpaceAddress[];
+  readonly conditionallyScheduledEffects: Map<Action, number>;
+  readonly dependencies: WeakMap<Action, ReactivityLog>;
+}
+
+export interface PullSchedulingState extends ConditionalEffectState {
+  readonly pending: Set<Action>;
+  readonly dirty: ReadonlySet<Action>;
+  readonly effects: ReadonlySet<Action>;
+  readonly dependents: WeakMap<Action, Set<Action>>;
+  readonly pendingPullRunnableState: PendingPullRunnableState;
+  readonly dirtyPullRunnableState: DirtyPullRunnableState;
+  readonly dirtyPullRunnableStateWithDebounce:
+    DirtyPullRunnableStateWithDebounce;
+  readonly getDebounce: (action: Action) => number | undefined;
+  readonly scheduleWithDebounce: (action: Action) => void;
+  readonly getActionId: (action: Action) => string;
+}
+
+export function markEffectConditionallyScheduled(
+  state: ConditionalEffectState,
+  effect: Action,
+): void {
+  if (!state.conditionallyScheduledEffects.has(effect)) {
+    state.conditionallyScheduledEffects.set(
+      effect,
+      state.changedWritesHistory.length,
+    );
+  }
+}
+
+export function conditionalEffectHasChangedInputs(
+  state: ConditionalEffectState,
+  effect: Action,
+): boolean {
+  const changedWritesStart = state.conditionallyScheduledEffects.get(effect);
+  if (changedWritesStart === undefined) return true;
+
+  const changedWrites = state.changedWritesHistory.slice(changedWritesStart);
+  if (changedWrites.length === 0) return false;
+
+  const log = state.dependencies.get(effect);
+  if (!log) return false;
+
+  return readsOverlapWrites(log.reads, log.shallowReads, changedWrites);
+}
+
+/**
+ * In pull mode, only effects are runnable seeds by default.
+ *
+ * Inline idempotency mode intentionally does not widen this to computations:
+ * it rechecks computations that already run due to explicit demand or an
+ * effect pull, rather than turning pull mode back into eager push mode.
+ */
+export function collectPullIterationSeeds(
+  state: PullSchedulingState,
+  workSet: Set<Action>,
+): void {
+  for (const action of state.pending) {
+    if (isPendingPullActionRunnable(state.pendingPullRunnableState, action)) {
+      workSet.add(action);
+    }
+  }
+
+  for (const action of state.dirty) {
+    if (isDirtyPullActionRunnable(state.dirtyPullRunnableState, action)) {
+      state.pending.add(action);
+      workSet.add(action);
+    }
+  }
+}
+
+export function hasRunnablePullWork(state: PullSchedulingState): boolean {
+  for (const action of state.pending) {
+    if (isPendingPullActionRunnable(state.pendingPullRunnableState, action)) {
+      return true;
+    }
+  }
+
+  for (const action of state.dirty) {
+    if (
+      isDirtyPullActionRunnable(
+        state.dirtyPullRunnableStateWithDebounce,
+        action,
+      )
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function hasDeferredDirtyEffectWork(
+  state: PullSchedulingState,
+): boolean {
+  for (const action of state.dirty) {
+    if (state.effects.has(action)) return true;
+  }
+  return false;
+}
+
+/**
+ * Finds and schedules all effects that transitively depend on the given computation.
+ */
+export function scheduleAffectedEffects(
+  state: PullSchedulingState,
+  computation: Action,
+): TriggerTraceScheduledEffect[] {
+  const start = performance.now();
+  const scheduledEffects: TriggerTraceScheduledEffect[] = [];
+
+  try {
+    for (
+      const effect of collectTransitiveEffects(
+        { dependents: state.dependents, effects: state.effects },
+        computation,
+      )
+    ) {
+      const pendingBefore = state.pending.has(effect);
+      const dirtyBefore = state.dirty.has(effect);
+      const debounceMs = state.getDebounce(effect);
+      if (
+        !pendingBefore && !dirtyBefore &&
+        !state.conditionallyScheduledEffects.has(effect)
+      ) {
+        markEffectConditionallyScheduled(state, effect);
+      }
+      state.scheduleWithDebounce(effect);
+      scheduledEffects.push({
+        actionId: state.getActionId(effect),
+        pendingBefore,
+        dirtyBefore,
+        debounceMs,
+      });
+    }
+  } finally {
+    logger.time(start, "scheduler", "scheduleAffectedEffects");
+  }
+  return scheduledEffects;
+}

--- a/packages/runner/src/scheduler/scheduling-writes.ts
+++ b/packages/runner/src/scheduler/scheduling-writes.ts
@@ -14,29 +14,139 @@ import type { Action, SpaceScopeAndURI } from "./types.ts";
 export interface WriterIndexState {
   readonly writersByEntity: Map<SpaceScopeAndURI, Set<Action>>;
   readonly actionWriteEntities: WeakMap<Action, Set<SpaceScopeAndURI>>;
+  updateWriterIndex(
+    action: Action,
+    nextSchedulingWrites: readonly IMemorySpaceAddress[],
+  ): {
+    nextEntities: Set<SpaceScopeAndURI>;
+    addedEntities: Set<SpaceScopeAndURI>;
+    removedEntities: Set<SpaceScopeAndURI>;
+  };
+  clearAction(action: Action): void;
 }
 
 export interface SchedulingWriteState {
   readonly currentKnownWrites: WeakMap<Action, IMemorySpaceAddress[]>;
   readonly historicalMightWrite: WeakMap<Action, IMemorySpaceAddress[]>;
   readonly useHistoricalMightWrite: () => boolean;
+  getSchedulingWrites(action: Action): IMemorySpaceAddress[] | undefined;
+  getSchedulingWritesMap(): WeakMap<Action, IMemorySpaceAddress[]>;
+}
+
+export class SchedulerWriteIndex
+  implements WriterIndexState, SchedulingWriteState {
+  // Current-known writes are rebuilt on each dependency update from actual
+  // writes plus declared/potential writes. This is the default scheduling view.
+  readonly currentKnownWrites = new WeakMap<Action, IMemorySpaceAddress[]>();
+  // Historical writes preserve the legacy cumulative union and are only used
+  // when the experimental historical-write mode is enabled.
+  readonly historicalMightWrite = new WeakMap<Action, IMemorySpaceAddress[]>();
+  // Index: entity -> actions that write to it (for fast dependency lookup).
+  // Updated from the active scheduling write set.
+  readonly writersByEntity = new Map<SpaceScopeAndURI, Set<Action>>();
+  // Reverse index: action -> entities it writes to (for cleanup).
+  readonly actionWriteEntities = new WeakMap<
+    Action,
+    Set<SpaceScopeAndURI>
+  >();
+
+  constructor(
+    private readonly state: {
+      readonly useHistoricalMightWrite: () => boolean;
+    },
+  ) {}
+
+  useHistoricalMightWrite(): boolean {
+    return this.state.useHistoricalMightWrite();
+  }
+
+  getSchedulingWrites(action: Action): IMemorySpaceAddress[] | undefined {
+    return this.useHistoricalMightWrite()
+      ? this.historicalMightWrite.get(action)
+      : this.currentKnownWrites.get(action);
+  }
+
+  getSchedulingWritesMap(): WeakMap<Action, IMemorySpaceAddress[]> {
+    return this.useHistoricalMightWrite()
+      ? this.historicalMightWrite
+      : this.currentKnownWrites;
+  }
+
+  updateWriterIndex(
+    action: Action,
+    nextSchedulingWrites: readonly IMemorySpaceAddress[],
+  ): {
+    nextEntities: Set<SpaceScopeAndURI>;
+    addedEntities: Set<SpaceScopeAndURI>;
+    removedEntities: Set<SpaceScopeAndURI>;
+  } {
+    const existingEntities = this.actionWriteEntities.get(action) ?? new Set();
+    const nextEntities = new Set<SpaceScopeAndURI>();
+    const addedEntities = new Set<SpaceScopeAndURI>();
+    const removedEntities = new Set<SpaceScopeAndURI>();
+
+    for (const write of nextSchedulingWrites) {
+      const entity = entityKey(write);
+      nextEntities.add(entity);
+      if (!existingEntities.has(entity)) {
+        addedEntities.add(entity);
+      }
+    }
+
+    for (const entity of existingEntities) {
+      if (!nextEntities.has(entity)) {
+        removedEntities.add(entity);
+      }
+    }
+
+    for (const entity of removedEntities) {
+      const writers = this.writersByEntity.get(entity);
+      writers?.delete(action);
+      if (writers && writers.size === 0) {
+        this.writersByEntity.delete(entity);
+      }
+    }
+
+    for (const entity of addedEntities) {
+      let writers = this.writersByEntity.get(entity);
+      if (!writers) {
+        writers = new Set();
+        this.writersByEntity.set(entity, writers);
+      }
+      writers.add(action);
+    }
+
+    this.actionWriteEntities.set(action, nextEntities);
+    return { nextEntities, addedEntities, removedEntities };
+  }
+
+  clearAction(action: Action): void {
+    const writeEntities = this.actionWriteEntities.get(action);
+    if (!writeEntities) return;
+
+    for (const entity of writeEntities) {
+      const writers = this.writersByEntity.get(entity);
+      writers?.delete(action);
+      if (writers && writers.size === 0) {
+        this.writersByEntity.delete(entity);
+      }
+    }
+    // Clear actionWriteEntities so resubscribe will re-register the action.
+    this.actionWriteEntities.delete(action);
+  }
 }
 
 export function getSchedulingWrites(
   state: SchedulingWriteState,
   action: Action,
 ): IMemorySpaceAddress[] | undefined {
-  return state.useHistoricalMightWrite()
-    ? state.historicalMightWrite.get(action)
-    : state.currentKnownWrites.get(action);
+  return state.getSchedulingWrites(action);
 }
 
 export function getSchedulingWritesMap(
   state: SchedulingWriteState,
 ): WeakMap<Action, IMemorySpaceAddress[]> {
-  return state.useHistoricalMightWrite()
-    ? state.historicalMightWrite
-    : state.currentKnownWrites;
+  return state.getSchedulingWritesMap();
 }
 
 export function updateWriterIndex(
@@ -48,44 +158,7 @@ export function updateWriterIndex(
   addedEntities: Set<SpaceScopeAndURI>;
   removedEntities: Set<SpaceScopeAndURI>;
 } {
-  const existingEntities = state.actionWriteEntities.get(action) ?? new Set();
-  const nextEntities = new Set<SpaceScopeAndURI>();
-  const addedEntities = new Set<SpaceScopeAndURI>();
-  const removedEntities = new Set<SpaceScopeAndURI>();
-
-  for (const write of nextSchedulingWrites) {
-    const entity = entityKey(write);
-    nextEntities.add(entity);
-    if (!existingEntities.has(entity)) {
-      addedEntities.add(entity);
-    }
-  }
-
-  for (const entity of existingEntities) {
-    if (!nextEntities.has(entity)) {
-      removedEntities.add(entity);
-    }
-  }
-
-  for (const entity of removedEntities) {
-    const writers = state.writersByEntity.get(entity);
-    writers?.delete(action);
-    if (writers && writers.size === 0) {
-      state.writersByEntity.delete(entity);
-    }
-  }
-
-  for (const entity of addedEntities) {
-    let writers = state.writersByEntity.get(entity);
-    if (!writers) {
-      writers = new Set();
-      state.writersByEntity.set(entity, writers);
-    }
-    writers.add(action);
-  }
-
-  state.actionWriteEntities.set(action, nextEntities);
-  return { nextEntities, addedEntities, removedEntities };
+  return state.updateWriterIndex(action, nextSchedulingWrites);
 }
 
 export function buildKnownSchedulingWrites(state: {

--- a/packages/runner/src/scheduler/subscriptions.ts
+++ b/packages/runner/src/scheduler/subscriptions.ts
@@ -1,11 +1,31 @@
+import { getLogger } from "@commonfabric/utils/logger";
 import type { Cancel } from "../cancel.ts";
+import { toMemorySpaceAddress } from "../link-utils.ts";
+import type { IMemorySpaceAddress } from "../storage/interface.ts";
 import type { ChangeGroup } from "../storage/interface.ts";
+import {
+  type DependencyUpdateState,
+  pendingDependencyCollectionMightAffect,
+  readsOverlapWrites,
+  replaceActionTriggerPaths,
+  setCancelForTriggerEntities,
+  setSchedulerDependencies,
+  type TriggerSubscriptionState,
+} from "./dependency-index.ts";
+import { entityKey } from "./keys.ts";
 import type {
   Action,
+  PopulateDependencies,
   PopulateDependenciesEntry,
   ReactivityLog,
   SpaceScopeAndURI,
+  TelemetryAnnotations,
 } from "./types.ts";
+
+const logger = getLogger("scheduler", {
+  enabled: true,
+  level: "warn",
+});
 
 type SchedulerActionTypeState = {
   readonly isEffectAction: WeakMap<Action, boolean>;
@@ -32,6 +52,365 @@ export type SchedulerSubscriptionState =
   & SchedulerActionTypeState
   & SchedulerActionChangeGroupState
   & SchedulerParentChildState;
+
+export interface SchedulerSubscribeOptions {
+  isEffect?: boolean;
+  debounce?: number;
+  noDebounce?: boolean;
+  throttle?: number;
+  changeGroup?: ChangeGroup;
+}
+
+export interface SchedulerResubscribeOptions {
+  isEffect?: boolean;
+  changeGroup?: ChangeGroup;
+}
+
+export interface SchedulerSubscribeActionState {
+  readonly subscriptionState: SchedulerSubscriptionState;
+  readonly dependencyUpdateState: DependencyUpdateState;
+  readonly triggerSubscriptionState: TriggerSubscriptionState;
+  readonly pendingDependencyCollectionState: {
+    readonly pendingDependencyCollection: ReadonlySet<Action>;
+    readonly effects: ReadonlySet<Action>;
+    readonly isThrottled: (action: Action) => boolean;
+    readonly getSchedulingWrites: (
+      action: Action,
+    ) => readonly IMemorySpaceAddress[] | undefined;
+    readonly hasDependentPath: (from: Action, to: Action) => boolean;
+  };
+  readonly populateDependenciesCallbacks: WeakMap<
+    Action,
+    PopulateDependenciesEntry
+  >;
+  readonly pendingDependencyCollection: Set<Action>;
+  readonly activePullDemandActions: WeakSet<Action>;
+  readonly pullDemandedFirstRunComputations: WeakSet<Action>;
+  readonly actionParent: WeakMap<Action, Action>;
+  readonly pending: Set<Action>;
+  readonly scheduledFirstTime: Set<Action>;
+  readonly effects: ReadonlySet<Action>;
+  readonly dirty: ReadonlySet<Action>;
+  readonly stale: ReadonlySet<Action>;
+  readonly writersByEntity: Map<SpaceScopeAndURI, Set<Action>>;
+  readonly getPullMode: () => boolean;
+  readonly setDebounce: (action: Action, ms: number) => void;
+  readonly setNoDebounce: (action: Action, optOut: boolean) => void;
+  readonly setThrottle: (action: Action, ms: number) => void;
+  readonly getSchedulingWrites: (
+    action: Action,
+  ) => readonly IMemorySpaceAddress[] | undefined;
+  readonly isThrottled: (action: Action) => boolean;
+  readonly isStale: (action: Action) => boolean;
+  readonly markDirectDirty: (action: Action) => void;
+  readonly markEffectConditionallyScheduled: (action: Action) => void;
+  readonly updateDependents: (action: Action, log: ReactivityLog) => void;
+  readonly scheduleAffectedEffects: (action: Action) => void;
+  readonly queueExecution: () => void;
+  readonly getActionId: (action: Action) => string;
+  readonly unsubscribe: (action: Action) => void;
+  readonly submitSubscribeTelemetry: (
+    event: {
+      type: "scheduler.subscribe";
+      actionId: string;
+      isEffect: boolean;
+    },
+  ) => void;
+}
+
+export function subscribeSchedulerAction(
+  state: SchedulerSubscribeActionState,
+  action: Action,
+  populateDependencies: PopulateDependencies | ReactivityLog,
+  options: SchedulerSubscribeOptions = {},
+): Cancel {
+  // Handle backwards-compatible ReactivityLog argument
+  let populateDependenciesEntry: PopulateDependenciesEntry;
+  let immediateLog: ReactivityLog | undefined;
+  if (typeof populateDependencies === "function") {
+    populateDependenciesEntry = populateDependencies;
+  } else {
+    // ReactivityLog provided directly - set up dependencies immediately
+    // (for backwards compatibility with code that passes reads/writes)
+    immediateLog = populateDependencies;
+    populateDependenciesEntry = immediateLog;
+  }
+  const {
+    isEffect = false,
+    debounce,
+    noDebounce,
+    throttle,
+  } = options;
+
+  updateSchedulerActionChangeGroup(
+    state.subscriptionState,
+    action,
+    options,
+  );
+
+  // Apply debounce settings if provided
+  if (debounce !== undefined) {
+    state.setDebounce(action, debounce);
+  }
+  if (noDebounce !== undefined) {
+    state.setNoDebounce(action, noDebounce);
+  }
+  // Apply throttle setting if provided
+  if (throttle !== undefined) {
+    state.setThrottle(action, throttle);
+  }
+
+  const actionIsEffect = updateSchedulerActionType(
+    state.subscriptionState,
+    action,
+    isEffect,
+    {
+      queueExecution: true,
+    },
+  );
+
+  // Track parent-child relationship if action is created during another action's execution
+  registerParentChildAction(state.subscriptionState, action);
+  const parent = state.actionParent.get(action);
+  if (
+    state.getPullMode() &&
+    !actionIsEffect &&
+    parent &&
+    state.activePullDemandActions.has(parent)
+  ) {
+    state.pullDemandedFirstRunComputations.add(action);
+    state.queueExecution();
+  }
+
+  logger.debug(
+    "schedule",
+    () => [
+      "Subscribing to action:",
+      action,
+      actionIsEffect ? "effect" : "computation",
+    ],
+  );
+
+  // Store the populateDependencies callback for use in execute()
+  state.populateDependenciesCallbacks.set(action, populateDependenciesEntry);
+
+  // In pull mode, newly subscribed computations can be the replacement for an
+  // already-running child graph (for example after a $TYPE change). Seed any
+  // statically declared writes immediately so existing effects can discover
+  // the new writer before the first execute() cycle.
+  if (
+    state.getPullMode() &&
+    !actionIsEffect &&
+    !immediateLog
+  ) {
+    const declaredWrites = (action as Partial<TelemetryAnnotations>).writes;
+    if (declaredWrites && declaredWrites.length > 0) {
+      setSchedulerDependencies(
+        state.dependencyUpdateState,
+        action,
+        {
+          reads: [],
+          shallowReads: [],
+          writes: declaredWrites.map(toMemorySpaceAddress),
+        },
+      );
+    }
+  }
+
+  // If a ReactivityLog was provided directly, set up dependencies immediately.
+  // This ensures writes are tracked right away for reverse dependency graph.
+  if (immediateLog) {
+    const { reads, shallowReads, log: schedulingLog } =
+      setSchedulerDependencies(
+        state.dependencyUpdateState,
+        action,
+        immediateLog,
+      );
+    state.updateDependents(action, schedulingLog);
+    const { entities } = replaceActionTriggerPaths(
+      state.triggerSubscriptionState,
+      action,
+      reads,
+      shallowReads,
+    );
+
+    // Register the cancel function for the latest trigger set.
+    setCancelForTriggerEntities(
+      state.triggerSubscriptionState,
+      action,
+      entities,
+    );
+  } else {
+    // Mark action for dependency collection before first run
+    state.pendingDependencyCollection.add(action);
+  }
+
+  // Mark as dirty and pending for first-time execution
+  // In pull mode this still doesn't mean execution: There needs to be an effect to trigger it.
+  state.markDirectDirty(action);
+  state.pending.add(action);
+  state.scheduledFirstTime.add(action);
+
+  if (
+    state.getPullMode() &&
+    !actionIsEffect &&
+    state.getSchedulingWrites(action)?.length
+  ) {
+    state.scheduleAffectedEffects(action);
+  }
+
+  // Emit telemetry for new subscription
+  const actionId = state.getActionId(action);
+  state.submitSubscribeTelemetry({
+    type: "scheduler.subscribe",
+    actionId,
+    isEffect: actionIsEffect,
+  });
+
+  return () => state.unsubscribe(action);
+}
+
+export function resubscribeSchedulerAction(
+  state: SchedulerSubscribeActionState,
+  action: Action,
+  log: ReactivityLog,
+  options: SchedulerResubscribeOptions = {},
+): void {
+  const { isEffect } = options;
+
+  updateSchedulerActionChangeGroup(
+    state.subscriptionState,
+    action,
+    options,
+  );
+
+  const { reads, shallowReads, log: schedulingLog } = setSchedulerDependencies(
+    state.dependencyUpdateState,
+    action,
+    log,
+  );
+
+  // Track action type for pull-based scheduling
+  // Once an action is marked as an effect, it stays an effect
+  const actionIsEffect = updateSchedulerActionType(
+    state.subscriptionState,
+    action,
+    isEffect,
+  );
+  const actionId = state.getActionId(action);
+
+  // Update reverse dependency graph after the action type is restored. In
+  // pull mode, registering a new edge to a live effect can be the moment a
+  // stale upstream computation becomes demanded.
+  if (state.getPullMode()) state.updateDependents(action, schedulingLog);
+
+  // Track parent-child relationship if action is created during another action's execution
+  // Only set if not already set (resubscribe can be called multiple times)
+  registerParentChildAction(state.subscriptionState, action, {
+    allowExisting: false,
+  });
+
+  const { entities, triggerPathsByEntity } = replaceActionTriggerPaths(
+    state.triggerSubscriptionState,
+    action,
+    reads,
+    shallowReads,
+  );
+
+  logger.debug("schedule-resubscribe", () => [
+    `Action: ${actionId}`,
+    `Entities: ${triggerPathsByEntity.size}`,
+    `Reads: ${reads.length}`,
+  ]);
+
+  setCancelForTriggerEntities(
+    state.triggerSubscriptionState,
+    action,
+    entities,
+  );
+
+  markEffectDirtyIfStaleInputs(
+    state,
+    action,
+    actionIsEffect,
+    reads,
+    shallowReads,
+  );
+}
+
+function markEffectDirtyIfStaleInputs(
+  state: SchedulerSubscribeActionState,
+  action: Action,
+  actionIsEffect: boolean,
+  reads: readonly IMemorySpaceAddress[],
+  shallowReads: readonly IMemorySpaceAddress[],
+): void {
+  // In pull mode: When an effect resubscribes, check if any non-throttled dirty
+  // computations write to what it reads. If so, mark the effect dirty so it can
+  // pull those computations and see fresh data.
+  // Skip throttled computations - they'll trigger via storage changes when unthrottled.
+  // Use isEffectAction instead of effects because unsubscribe() clears effects before run()
+  if (!state.getPullMode() || !actionIsEffect || state.stale.size === 0) {
+    return;
+  }
+
+  const shouldMarkDirty = pendingDependencyCollectionMightAffect(
+    state.pendingDependencyCollectionState,
+    action,
+    reads,
+    shallowReads,
+  ) ||
+    hasStaleWriterForEffectReads(state, action, reads, shallowReads);
+
+  if (shouldMarkDirty && !state.dirty.has(action)) {
+    state.markEffectConditionallyScheduled(action);
+    state.markDirectDirty(action);
+    state.pending.add(action);
+    state.queueExecution();
+  }
+}
+
+function hasStaleWriterForEffectReads(
+  state: SchedulerSubscribeActionState,
+  action: Action,
+  effectReads: readonly IMemorySpaceAddress[],
+  effectShallowReads: readonly IMemorySpaceAddress[],
+): boolean {
+  // Use writersByEntity index for efficient lookup.
+  const entities = new Set<SpaceScopeAndURI>();
+  for (const read of effectReads) {
+    entities.add(entityKey(read));
+  }
+  for (const read of effectShallowReads) {
+    entities.add(entityKey(read));
+  }
+
+  for (const entity of entities) {
+    const writers = state.writersByEntity.get(entity);
+    if (!writers) continue;
+
+    for (const writer of writers) {
+      if (writer === action) continue;
+      if (!state.isStale(writer)) continue;
+      if (state.effects.has(writer)) continue; // Only check computations
+      if (state.isThrottled(writer)) continue; // Skip throttled - they trigger via storage
+
+      // Check path overlap.
+      const writerWrites = state.getSchedulingWrites(writer) ?? [];
+      if (
+        readsOverlapWrites(
+          effectReads,
+          effectShallowReads,
+          writerWrites,
+        )
+      ) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
 
 export function updateSchedulerActionType(
   state: SchedulerActionTypeState,

--- a/packages/runner/src/scheduler/subscriptions.ts
+++ b/packages/runner/src/scheduler/subscriptions.ts
@@ -8,7 +8,10 @@ import {
   type DependencyUpdateState,
   setSchedulerDependencies,
 } from "./dependency-updates.ts";
-import { readsOverlapWrites } from "./scheduling-writes.ts";
+import {
+  readsOverlapWrites,
+  type WriterIndexState,
+} from "./scheduling-writes.ts";
 import {
   replaceActionTriggerPaths,
   setCancelForTriggerEntities,
@@ -94,7 +97,7 @@ export interface SchedulerSubscribeActionState {
   readonly effects: ReadonlySet<Action>;
   readonly dirty: ReadonlySet<Action>;
   readonly stale: ReadonlySet<Action>;
-  readonly writersByEntity: Map<SpaceScopeAndURI, Set<Action>>;
+  readonly writeIndex: WriterIndexState;
   readonly getPullMode: () => boolean;
   readonly setDebounce: (action: Action, ms: number) => void;
   readonly setNoDebounce: (action: Action, optOut: boolean) => void;
@@ -388,7 +391,7 @@ function hasStaleWriterForEffectReads(
   }
 
   for (const entity of entities) {
-    const writers = state.writersByEntity.get(entity);
+    const writers = state.writeIndex.writersByEntity.get(entity);
     if (!writers) continue;
 
     for (const writer of writers) {
@@ -492,7 +495,7 @@ export function registerParentChildAction(
   children.add(action);
 }
 
-interface SchedulerUnsubscribeActionState {
+export interface SchedulerUnsubscribeActionState {
   readonly cancels: WeakMap<Action, Cancel>;
   readonly dependencies: WeakMap<Action, ReactivityLog>;
   readonly actionChangeGroups: WeakMap<Action, ChangeGroup>;
@@ -504,8 +507,7 @@ interface SchedulerUnsubscribeActionState {
   readonly effects: Set<Action>;
   readonly computations: Set<Action>;
   readonly pullDemandedFirstRunComputations: WeakSet<Action>;
-  readonly actionWriteEntities: WeakMap<Action, Set<SpaceScopeAndURI>>;
-  readonly writersByEntity: Map<SpaceScopeAndURI, Set<Action>>;
+  readonly writeIndex: WriterIndexState;
   readonly populateDependenciesCallbacks: WeakMap<
     Action,
     PopulateDependenciesEntry
@@ -613,18 +615,7 @@ function removeActionWriteIndexes(
   state: SchedulerUnsubscribeActionState,
   action: Action,
 ): void {
-  const writeEntities = state.actionWriteEntities.get(action);
-  if (writeEntities) {
-    for (const entity of writeEntities) {
-      const writers = state.writersByEntity.get(entity);
-      writers?.delete(action);
-      if (writers && writers.size === 0) {
-        state.writersByEntity.delete(entity);
-      }
-    }
-    // Clear actionWriteEntities so resubscribe will re-register the action.
-    state.actionWriteEntities.delete(action);
-  }
+  state.writeIndex.clearAction(action);
 }
 
 function clearActionDelayState(

--- a/packages/runner/src/scheduler/subscriptions.ts
+++ b/packages/runner/src/scheduler/subscriptions.ts
@@ -3,15 +3,17 @@ import type { Cancel } from "../cancel.ts";
 import { toMemorySpaceAddress } from "../link-utils.ts";
 import type { IMemorySpaceAddress } from "../storage/interface.ts";
 import type { ChangeGroup } from "../storage/interface.ts";
+import { pendingDependencyCollectionMightAffect } from "./dependency-graph.ts";
 import {
   type DependencyUpdateState,
-  pendingDependencyCollectionMightAffect,
-  readsOverlapWrites,
+  setSchedulerDependencies,
+} from "./dependency-updates.ts";
+import { readsOverlapWrites } from "./scheduling-writes.ts";
+import {
   replaceActionTriggerPaths,
   setCancelForTriggerEntities,
-  setSchedulerDependencies,
   type TriggerSubscriptionState,
-} from "./dependency-index.ts";
+} from "./trigger-index.ts";
 import { entityKey } from "./keys.ts";
 import type {
   Action,

--- a/packages/runner/src/scheduler/subscriptions.ts
+++ b/packages/runner/src/scheduler/subscriptions.ts
@@ -490,61 +490,100 @@ export function registerParentChildAction(
   children.add(action);
 }
 
+interface SchedulerUnsubscribeActionState {
+  readonly cancels: WeakMap<Action, Cancel>;
+  readonly dependencies: WeakMap<Action, ReactivityLog>;
+  readonly actionChangeGroups: WeakMap<Action, ChangeGroup>;
+  readonly changeGroupToActionId: Map<ChangeGroup, string>;
+  readonly pending: Set<Action>;
+  readonly conditionallyScheduledEffects: Map<Action, number>;
+  readonly reverseDependencies: WeakMap<Action, Set<Action>>;
+  readonly dependents: WeakMap<Action, Set<Action>>;
+  readonly effects: Set<Action>;
+  readonly computations: Set<Action>;
+  readonly pullDemandedFirstRunComputations: WeakSet<Action>;
+  readonly actionWriteEntities: WeakMap<Action, Set<SpaceScopeAndURI>>;
+  readonly writersByEntity: Map<SpaceScopeAndURI, Set<Action>>;
+  readonly populateDependenciesCallbacks: WeakMap<
+    Action,
+    PopulateDependenciesEntry
+  >;
+  readonly pendingDependencyCollection: Set<Action>;
+  readonly getActionId: (action: Action) => string;
+  readonly clearDirectDirty: (action: Action) => void;
+  readonly forceClearStale: (action: Action) => void;
+  readonly cancelDebounceTimer: (action: Action) => void;
+  readonly clearComputationDebounceState: (
+    action: Action,
+    options?: { cancelTimer?: boolean },
+  ) => void;
+}
+
 export function unsubscribeSchedulerAction(
-  state: {
-    readonly cancels: WeakMap<Action, Cancel>;
-    readonly dependencies: WeakMap<Action, ReactivityLog>;
-    readonly actionChangeGroups: WeakMap<Action, ChangeGroup>;
-    readonly changeGroupToActionId: Map<ChangeGroup, string>;
-    readonly pending: Set<Action>;
-    readonly conditionallyScheduledEffects: Map<Action, number>;
-    readonly reverseDependencies: WeakMap<Action, Set<Action>>;
-    readonly dependents: WeakMap<Action, Set<Action>>;
-    readonly effects: Set<Action>;
-    readonly computations: Set<Action>;
-    readonly pullDemandedFirstRunComputations: WeakSet<Action>;
-    readonly actionWriteEntities: WeakMap<Action, Set<SpaceScopeAndURI>>;
-    readonly writersByEntity: Map<SpaceScopeAndURI, Set<Action>>;
-    readonly populateDependenciesCallbacks: WeakMap<
-      Action,
-      PopulateDependenciesEntry
-    >;
-    readonly pendingDependencyCollection: Set<Action>;
-    readonly getActionId: (action: Action) => string;
-    readonly clearDirectDirty: (action: Action) => void;
-    readonly forceClearStale: (action: Action) => void;
-    readonly cancelDebounceTimer: (action: Action) => void;
-    readonly clearComputationDebounceState: (
-      action: Action,
-      options?: { cancelTimer?: boolean },
-    ) => void;
-  },
+  state: SchedulerUnsubscribeActionState,
   action: Action,
   options: {
     preserveChangeGroup?: boolean;
   } = {},
 ): void {
   const { preserveChangeGroup = false } = options;
+  cancelActionSubscription(state, action);
+  state.dependencies.delete(action);
+  clearActionChangeGroup(state, action, preserveChangeGroup);
+  clearActionSchedulingState(state, action);
+  removeReverseDependencyEdges(state, action);
+  clearActionTypeTracking(state, action);
+  removeActionWriteIndexes(state, action);
+  // NOTE: We intentionally keep parent-child relationships intact.
+  // They're needed for cycle detection (identifying obsolete children
+  // when parent is re-running). They'll be cleaned up when parent is
+  // garbage collected (WeakMap).
+  clearActionDelayState(state, action);
+  clearDependencyCollectionState(state, action);
+}
+
+function cancelActionSubscription(
+  state: SchedulerUnsubscribeActionState,
+  action: Action,
+): void {
   state.cancels.get(action)?.();
   state.cancels.delete(action);
-  state.dependencies.delete(action);
-  if (!preserveChangeGroup) {
-    const changeGroup = state.actionChangeGroups.get(action);
-    const actionId = state.getActionId(action);
-    if (
-      changeGroup !== undefined &&
-      state.changeGroupToActionId.get(changeGroup) === actionId
-    ) {
-      state.changeGroupToActionId.delete(changeGroup);
-    }
-    state.actionChangeGroups.delete(action);
+}
+
+function clearActionChangeGroup(
+  state: SchedulerUnsubscribeActionState,
+  action: Action,
+  preserveChangeGroup: boolean,
+): void {
+  if (preserveChangeGroup) return;
+
+  const changeGroup = state.actionChangeGroups.get(action);
+  const actionId = state.getActionId(action);
+  if (
+    changeGroup !== undefined &&
+    state.changeGroupToActionId.get(changeGroup) === actionId
+  ) {
+    state.changeGroupToActionId.delete(changeGroup);
   }
+  state.actionChangeGroups.delete(action);
+}
+
+function clearActionSchedulingState(
+  state: SchedulerUnsubscribeActionState,
+  action: Action,
+): void {
   state.pending.delete(action);
   state.conditionallyScheduledEffects.delete(action);
   // Clear direct/stale state before removing outgoing edges so downstream
   // stale counts are decremented through normal propagation.
   state.clearDirectDirty(action);
   state.forceClearStale(action);
+}
+
+function removeReverseDependencyEdges(
+  state: SchedulerUnsubscribeActionState,
+  action: Action,
+): void {
   const dependencies = state.reverseDependencies.get(action);
   if (dependencies) {
     for (const dependency of dependencies) {
@@ -557,11 +596,21 @@ export function unsubscribeSchedulerAction(
     state.reverseDependencies.delete(action);
   }
   state.dependents.delete(action);
-  // Clean up effect/computation tracking.
+}
+
+function clearActionTypeTracking(
+  state: SchedulerUnsubscribeActionState,
+  action: Action,
+): void {
   state.effects.delete(action);
   state.computations.delete(action);
   state.pullDemandedFirstRunComputations.delete(action);
-  // Clean up writersByEntity index.
+}
+
+function removeActionWriteIndexes(
+  state: SchedulerUnsubscribeActionState,
+  action: Action,
+): void {
   const writeEntities = state.actionWriteEntities.get(action);
   if (writeEntities) {
     for (const entity of writeEntities) {
@@ -574,13 +623,20 @@ export function unsubscribeSchedulerAction(
     // Clear actionWriteEntities so resubscribe will re-register the action.
     state.actionWriteEntities.delete(action);
   }
-  // NOTE: We intentionally keep parent-child relationships intact.
-  // They're needed for cycle detection (identifying obsolete children
-  // when parent is re-running). They'll be cleaned up when parent is
-  // garbage collected (WeakMap).
+}
+
+function clearActionDelayState(
+  state: SchedulerUnsubscribeActionState,
+  action: Action,
+): void {
   state.cancelDebounceTimer(action);
   state.clearComputationDebounceState(action, { cancelTimer: false });
-  // Clean up dependency collection tracking.
+}
+
+function clearDependencyCollectionState(
+  state: SchedulerUnsubscribeActionState,
+  action: Action,
+): void {
   state.populateDependenciesCallbacks.delete(action);
   state.pendingDependencyCollection.delete(action);
 }

--- a/packages/runner/src/scheduler/trigger-index.ts
+++ b/packages/runner/src/scheduler/trigger-index.ts
@@ -1,11 +1,16 @@
 import {
   addressesToPathByEntity,
   arraysOverlap,
+  determineTriggeredActions,
   nonRecursiveReadMayOverlapWrite,
   type SortedAndCompactPaths,
 } from "../reactive-dependencies.ts";
 import type { Cancel } from "../cancel.ts";
-import type { IMemorySpaceAddress } from "../storage/interface.ts";
+import type { MemorySpace } from "@commonfabric/memory/interface";
+import type {
+  IMemoryChange,
+  IMemorySpaceAddress,
+} from "../storage/interface.ts";
 import { entityKey } from "./keys.ts";
 import type { Action, SpaceScopeAndURI } from "./types.ts";
 
@@ -18,6 +23,28 @@ export interface TriggerIndexState {
     SpaceScopeAndURI,
     Map<Action, SortedAndCompactPaths>
   >;
+  addActionReads(
+    action: Action,
+    reads: IMemorySpaceAddress[],
+    shallowReads: IMemorySpaceAddress[],
+  ): {
+    entities: Set<SpaceScopeAndURI>;
+    triggerPathsByEntity: Map<SpaceScopeAndURI, SortedAndCompactPaths>;
+  };
+  removeActionFromEntities(
+    action: Action,
+    entities: Iterable<SpaceScopeAndURI>,
+  ): void;
+  collectReadersForWrite(write: IMemorySpaceAddress): Set<Action>;
+  hasRegisteredTriggers(): boolean;
+  collectTriggeredActionsForChange(
+    space: MemorySpace,
+    change: IMemoryChange,
+  ): {
+    entity: SpaceScopeAndURI;
+    hasMatchingTriggerPaths: boolean;
+    triggeredActions: Action[];
+  };
 }
 
 export interface TriggerSubscriptionState extends TriggerIndexState {
@@ -29,6 +56,230 @@ export interface TriggerSubscriptionState extends TriggerIndexState {
   ) => void;
 }
 
+export class SchedulerTriggerSubscriptions implements TriggerSubscriptionState {
+  constructor(
+    private readonly state: {
+      readonly triggerIndex: TriggerIndexState;
+      readonly cancels: WeakMap<Action, Cancel>;
+      readonly getActionId: (action: Action) => string;
+      readonly onTriggerUnsubscribe?: (
+        actionId: string,
+        entityCount: number,
+      ) => void;
+    },
+  ) {}
+
+  get triggers(): TriggerIndexState["triggers"] {
+    return this.state.triggerIndex.triggers;
+  }
+
+  get nonRecursiveTriggers(): TriggerIndexState["nonRecursiveTriggers"] {
+    return this.state.triggerIndex.nonRecursiveTriggers;
+  }
+
+  get cancels(): WeakMap<Action, Cancel> {
+    return this.state.cancels;
+  }
+
+  get getActionId(): (action: Action) => string {
+    return this.state.getActionId;
+  }
+
+  get onTriggerUnsubscribe():
+    | ((actionId: string, entityCount: number) => void)
+    | undefined {
+    return this.state.onTriggerUnsubscribe;
+  }
+
+  addActionReads(
+    action: Action,
+    reads: IMemorySpaceAddress[],
+    shallowReads: IMemorySpaceAddress[],
+  ): {
+    entities: Set<SpaceScopeAndURI>;
+    triggerPathsByEntity: Map<SpaceScopeAndURI, SortedAndCompactPaths>;
+  } {
+    return this.state.triggerIndex.addActionReads(action, reads, shallowReads);
+  }
+
+  removeActionFromEntities(
+    action: Action,
+    entities: Iterable<SpaceScopeAndURI>,
+  ): void {
+    this.state.triggerIndex.removeActionFromEntities(action, entities);
+  }
+
+  collectReadersForWrite(write: IMemorySpaceAddress): Set<Action> {
+    return this.state.triggerIndex.collectReadersForWrite(write);
+  }
+
+  hasRegisteredTriggers(): boolean {
+    return this.state.triggerIndex.hasRegisteredTriggers();
+  }
+
+  collectTriggeredActionsForChange(
+    space: MemorySpace,
+    change: IMemoryChange,
+  ): {
+    entity: SpaceScopeAndURI;
+    hasMatchingTriggerPaths: boolean;
+    triggeredActions: Action[];
+  } {
+    return this.state.triggerIndex.collectTriggeredActionsForChange(
+      space,
+      change,
+    );
+  }
+}
+
+export class SchedulerTriggerIndex implements TriggerIndexState {
+  readonly triggers = new Map<
+    SpaceScopeAndURI,
+    Map<Action, SortedAndCompactPaths>
+  >();
+  readonly nonRecursiveTriggers = new Map<
+    SpaceScopeAndURI,
+    Map<Action, SortedAndCompactPaths>
+  >();
+
+  addActionReads(
+    action: Action,
+    reads: IMemorySpaceAddress[],
+    shallowReads: IMemorySpaceAddress[],
+  ): {
+    entities: Set<SpaceScopeAndURI>;
+    triggerPathsByEntity: Map<SpaceScopeAndURI, SortedAndCompactPaths>;
+  } {
+    const pathsByEntity = addressesToPathByEntity(reads);
+    const nonRecursivePathsByEntity = addressesToPathByEntity(shallowReads);
+    const entities = new Set<SpaceScopeAndURI>();
+    const triggerPathsByEntity = new Map<
+      SpaceScopeAndURI,
+      SortedAndCompactPaths
+    >();
+
+    for (const [spaceAndURI, paths] of pathsByEntity) {
+      entities.add(spaceAndURI);
+      let pathsByAction = this.triggers.get(spaceAndURI);
+      if (!pathsByAction) {
+        pathsByAction = new Map();
+        this.triggers.set(spaceAndURI, pathsByAction);
+      }
+      pathsByAction.set(action, paths);
+      triggerPathsByEntity.set(spaceAndURI, paths);
+    }
+
+    for (const [spaceAndURI, paths] of nonRecursivePathsByEntity) {
+      entities.add(spaceAndURI);
+      let pathsByAction = this.nonRecursiveTriggers.get(spaceAndURI);
+      if (!pathsByAction) {
+        pathsByAction = new Map();
+        this.nonRecursiveTriggers.set(spaceAndURI, pathsByAction);
+      }
+      pathsByAction.set(action, paths);
+    }
+
+    return { entities, triggerPathsByEntity };
+  }
+
+  removeActionFromEntities(
+    action: Action,
+    entities: Iterable<SpaceScopeAndURI>,
+  ): void {
+    for (const spaceAndURI of entities) {
+      this.triggers.get(spaceAndURI)?.delete(action);
+      this.nonRecursiveTriggers.get(spaceAndURI)?.delete(action);
+    }
+  }
+
+  collectReadersForWrite(write: IMemorySpaceAddress): Set<Action> {
+    const entity = entityKey(write);
+    const readers = new Set<Action>();
+
+    const recursiveReaders = this.triggers.get(entity);
+    if (recursiveReaders) {
+      for (const [action, paths] of recursiveReaders) {
+        if (paths.some((path) => arraysOverlap(write.path, path))) {
+          readers.add(action);
+        }
+      }
+    }
+
+    const nonRecursiveReaders = this.nonRecursiveTriggers.get(entity);
+    if (nonRecursiveReaders) {
+      for (const [action, reads] of nonRecursiveReaders) {
+        if (
+          reads.some((read) =>
+            nonRecursiveReadMayOverlapWrite(read, write.path)
+          )
+        ) {
+          readers.add(action);
+        }
+      }
+    }
+
+    return readers;
+  }
+
+  hasRegisteredTriggers(): boolean {
+    return this.triggers.size > 0 || this.nonRecursiveTriggers.size > 0;
+  }
+
+  collectTriggeredActionsForChange(
+    space: MemorySpace,
+    change: IMemoryChange,
+  ): {
+    entity: SpaceScopeAndURI;
+    hasMatchingTriggerPaths: boolean;
+    triggeredActions: Action[];
+  } {
+    const entity = entityKey({ ...change.address, space });
+    const paths = this.triggers.get(entity);
+    const nonRecursivePaths = this.nonRecursiveTriggers.get(entity);
+
+    if (!paths && !nonRecursivePaths) {
+      return {
+        entity,
+        hasMatchingTriggerPaths: false,
+        triggeredActions: [],
+      };
+    }
+
+    const triggeredActionSet = new Set<Action>();
+    if (paths) {
+      for (
+        const action of determineTriggeredActions(
+          paths,
+          change.before,
+          change.after,
+          change.address.path,
+        )
+      ) {
+        triggeredActionSet.add(action);
+      }
+    }
+    if (nonRecursivePaths) {
+      for (
+        const action of determineTriggeredActions(
+          nonRecursivePaths,
+          change.before,
+          change.after,
+          change.address.path,
+          { nonRecursive: true },
+        )
+      ) {
+        triggeredActionSet.add(action);
+      }
+    }
+
+    return {
+      entity,
+      hasMatchingTriggerPaths: true,
+      triggeredActions: [...triggeredActionSet],
+    };
+  }
+}
+
 export function addTriggerPathsToIndex(
   state: TriggerIndexState,
   action: Action,
@@ -38,36 +289,7 @@ export function addTriggerPathsToIndex(
   entities: Set<SpaceScopeAndURI>;
   triggerPathsByEntity: Map<SpaceScopeAndURI, SortedAndCompactPaths>;
 } {
-  const pathsByEntity = addressesToPathByEntity(reads);
-  const nonRecursivePathsByEntity = addressesToPathByEntity(shallowReads);
-  const entities = new Set<SpaceScopeAndURI>();
-  const triggerPathsByEntity = new Map<
-    SpaceScopeAndURI,
-    SortedAndCompactPaths
-  >();
-
-  for (const [spaceAndURI, paths] of pathsByEntity) {
-    entities.add(spaceAndURI);
-    let pathsByAction = state.triggers.get(spaceAndURI);
-    if (!pathsByAction) {
-      pathsByAction = new Map();
-      state.triggers.set(spaceAndURI, pathsByAction);
-    }
-    pathsByAction.set(action, paths);
-    triggerPathsByEntity.set(spaceAndURI, paths);
-  }
-
-  for (const [spaceAndURI, paths] of nonRecursivePathsByEntity) {
-    entities.add(spaceAndURI);
-    let pathsByAction = state.nonRecursiveTriggers.get(spaceAndURI);
-    if (!pathsByAction) {
-      pathsByAction = new Map();
-      state.nonRecursiveTriggers.set(spaceAndURI, pathsByAction);
-    }
-    pathsByAction.set(action, paths);
-  }
-
-  return { entities, triggerPathsByEntity };
+  return state.addActionReads(action, reads, shallowReads);
 }
 
 export function replaceActionTriggerPaths(
@@ -102,7 +324,7 @@ export function setCancelForTriggerEntities(
   const actionId = state.getActionId(action);
   state.cancels.set(action, () => {
     state.onTriggerUnsubscribe?.(actionId, entities.size);
-    removeActionFromTriggerIndex(state, action, entities);
+    state.removeActionFromEntities(action, entities);
   });
 }
 
@@ -111,38 +333,12 @@ export function removeActionFromTriggerIndex(
   action: Action,
   entities: Iterable<SpaceScopeAndURI>,
 ): void {
-  for (const spaceAndURI of entities) {
-    state.triggers.get(spaceAndURI)?.delete(action);
-    state.nonRecursiveTriggers.get(spaceAndURI)?.delete(action);
-  }
+  state.removeActionFromEntities(action, entities);
 }
 
 export function collectReadersForWrite(
   state: TriggerIndexState,
   write: IMemorySpaceAddress,
 ): Set<Action> {
-  const entity = entityKey(write);
-  const readers = new Set<Action>();
-
-  const recursiveReaders = state.triggers.get(entity);
-  if (recursiveReaders) {
-    for (const [action, paths] of recursiveReaders) {
-      if (paths.some((path) => arraysOverlap(write.path, path))) {
-        readers.add(action);
-      }
-    }
-  }
-
-  const nonRecursiveReaders = state.nonRecursiveTriggers.get(entity);
-  if (nonRecursiveReaders) {
-    for (const [action, reads] of nonRecursiveReaders) {
-      if (
-        reads.some((read) => nonRecursiveReadMayOverlapWrite(read, write.path))
-      ) {
-        readers.add(action);
-      }
-    }
-  }
-
-  return readers;
+  return state.collectReadersForWrite(write);
 }

--- a/packages/runner/src/scheduler/write-propagation.ts
+++ b/packages/runner/src/scheduler/write-propagation.ts
@@ -8,7 +8,7 @@ import { getTransactionWriteDetails } from "../storage/transaction-inspection.ts
 import {
   collectReadersForWrite,
   type TriggerIndexState,
-} from "./dependency-index.ts";
+} from "./trigger-index.ts";
 import type { Action, ReactivityLog } from "./types.ts";
 
 export interface WritePropagationState extends TriggerIndexState {

--- a/packages/runner/src/scheduler/write-propagation.ts
+++ b/packages/runner/src/scheduler/write-propagation.ts
@@ -5,13 +5,11 @@ import type {
   IMemorySpaceAddress,
 } from "../storage/interface.ts";
 import { getTransactionWriteDetails } from "../storage/transaction-inspection.ts";
-import {
-  collectReadersForWrite,
-  type TriggerIndexState,
-} from "./trigger-index.ts";
+import type { TriggerIndexState } from "./trigger-index.ts";
 import type { Action, ReactivityLog } from "./types.ts";
 
-export interface WritePropagationState extends TriggerIndexState {
+export interface WritePropagationState {
+  readonly triggerIndex: TriggerIndexState;
   readonly changedWritesHistory: IMemorySpaceAddress[];
   readonly effects: ReadonlySet<Action>;
   readonly computations: ReadonlySet<Action>;
@@ -57,7 +55,7 @@ export function markReadersDirtyForChangedWrites(
 
   const readers = new Set<Action>();
   for (const write of sortAndCompactPaths([...changedWrites])) {
-    for (const reader of collectReadersForWrite(state, write)) {
+    for (const reader of state.triggerIndex.collectReadersForWrite(write)) {
       if (reader !== sourceAction) {
         readers.add(reader);
       }

--- a/packages/runner/test/scheduler-core.test.ts
+++ b/packages/runner/test/scheduler-core.test.ts
@@ -136,6 +136,56 @@ describe("scheduler", () => {
     expect(c.get()).toBe(4);
   });
 
+  it("records push-mode settle work-set size before actions mutate pending", async () => {
+    runtime.scheduler.enableSettleStats();
+
+    let runCount = 0;
+    const actionA: Action = () => {
+      runCount++;
+    };
+    const actionB: Action = () => {
+      runCount++;
+    };
+
+    const emptyLog = {
+      reads: [],
+      shallowReads: [],
+      writes: [],
+    };
+    runtime.scheduler.subscribe(actionA, emptyLog);
+    runtime.scheduler.subscribe(actionB, emptyLog);
+
+    await runtime.scheduler.idle();
+
+    const stats = runtime.scheduler.getSettleStats();
+    expect(runCount).toBe(2);
+    expect(stats?.iterations[0]?.workSetSize).toBe(2);
+    expect(stats?.iterations[0]?.actionsRun).toBe(2);
+  });
+
+  it("normalizes non-Error action throws before error handlers", async () => {
+    const errors: Error[] = [];
+    runtime.scheduler.onError((error) => {
+      errors.push(error);
+    });
+
+    const throwingAction: Action = () => {
+      throw "boom";
+    };
+
+    runtime.scheduler.subscribe(throwingAction, {
+      reads: [],
+      shallowReads: [],
+      writes: [],
+    });
+
+    await runtime.scheduler.idle();
+
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toBeInstanceOf(Error);
+    expect(errors[0].message).toBe("boom");
+  });
+
   it("should re-run an async read-only effect when invalidated while paused", async () => {
     const source = runtime.getCell<number>(
       space,

--- a/packages/runner/test/scheduler-test-utils.ts
+++ b/packages/runner/test/scheduler-test-utils.ts
@@ -17,6 +17,10 @@ import {
 } from "../src/scheduler.ts";
 import { setSchedulerDependencies } from "../src/scheduler/dependency-index.ts";
 import {
+  isDemandedPullComputation,
+  type PullDemandState,
+} from "../src/scheduler/demand.ts";
+import {
   clearSchedulerDirectDirty,
   getUpstreamStaleCount as getUpstreamStaleCountFromState,
   isActionStale,
@@ -119,7 +123,7 @@ function getStaleSchedulerInternals(
     dirtySchedulingState: Parameters<typeof markSchedulerDirty>[0];
     dependencyUpdateState: Parameters<typeof setSchedulerDependencies>[0];
     isEffectAction: WeakMap<Action, boolean>;
-    isDemandedPullComputation: (action: Action) => boolean;
+    pullDemandState: PullDemandState;
     updateDependents: StaleSchedulerInternals["updateDependents"];
     collectDirtyDependencies: StaleSchedulerInternals[
       "collectDirtyDependencies"
@@ -132,7 +136,7 @@ function getStaleSchedulerInternals(
     dirty: internal.staleness.dirty,
     isStale: (action) => isActionStale(internal.staleness, action),
     isDemandedPullComputation: (action) =>
-      internal.isDemandedPullComputation(action),
+      isDemandedPullComputation(internal.pullDemandState, action),
     getUpstreamStaleCount: (action) =>
       getUpstreamStaleCountFromState(internal.staleness, action),
     clearDirectDirty: (action) =>

--- a/packages/runner/test/scheduler-test-utils.ts
+++ b/packages/runner/test/scheduler-test-utils.ts
@@ -15,7 +15,7 @@ import {
   ignoreReadForScheduling,
   txToReactivityLog,
 } from "../src/scheduler.ts";
-import { setSchedulerDependencies } from "../src/scheduler/dependency-index.ts";
+import { setSchedulerDependencies } from "../src/scheduler/dependency-updates.ts";
 import {
   isDemandedPullComputation,
   type PullDemandState,


### PR DESCRIPTION
## Summary
- Extract scheduler settle-loop, action-run, subscription, dirty dependency, cycle-break, continuation, dependency-collection, delay-control, event-notification, diagnosis-control, pull-demand, event-execution, and pull-scheduling work into focused helper modules.
- Keep scheduler.ts closer to a high-level execution outline with explicit state bundles passed to helper functions.
- Centralize scheduler state initialization behind named state factories so field wiring is easier to audit.
- Reify trigger and scheduling-write indexes as classes, with their core mutation/query behavior living with the owned maps.
- Reorder Scheduler class members so fields, constructor/public API, execution orchestration, state wiring, and forwarding helpers appear in a reader-friendly outline.
- Address review feedback for settle telemetry in push mode and non-Error action throws.

## Size
- scheduler.ts before: 2990 lines on origin/main
- scheduler.ts after: 2034 lines

## Performance baseline
NEW_PERF_BASELINE: job: Test = 124s
NEW_PERF_BASELINE: job: Package Integration Tests (shell) = 91s

## Validation
- deno fmt --check packages/runner/src/scheduler.ts
- deno lint packages/runner/src/scheduler.ts
- deno check packages/runner/src/scheduler.ts
- HEADLESS=1 deno test -A packages/runner/test/scheduler-*.test.ts
- HEADLESS=1 deno task check
- HEADLESS=1 deno task test in packages/runner
