### PR TITLE
Clean up type casts

### DIFF
--- a/packages/data-model/fabric-value-modern.ts
+++ b/packages/data-model/fabric-value-modern.ts
@@ -293,7 +293,7 @@ function fabricFromNativeValueModernInternal(
     if (isOriginalRecord) {
       converted.set(original, value);
     }
-    return value as FabricValue;
+    return value;
   }
 
   // TODO(danfuzz): Look into avoiding this special case for `FabricError`.
@@ -317,7 +317,7 @@ function fabricFromNativeValueModernInternal(
     if (isOriginalRecord) {
       converted.set(original, result);
     }
-    return result as FabricValue;
+    return result;
   }
 
   // `FabricSpecialObject` (primitives and protocol types) -- pass through

--- a/packages/data-model/fabric-value-modern.ts
+++ b/packages/data-model/fabric-value-modern.ts
@@ -647,7 +647,7 @@ export function nativeFromFabricValueModern(
         result.length = i + 1;
       } else {
         result[i] = nativeFromFabricValueModern(
-          value[i] as FabricValue,
+          value[i],
           frozen,
         );
       }
@@ -659,10 +659,7 @@ export function nativeFromFabricValueModern(
   const result: Record<string, unknown> = {};
   for (const [key, val] of Object.entries(value)) {
     if (!UNSAFE_KEYS.has(key)) {
-      result[key] = nativeFromFabricValueModern(
-        val as FabricValue,
-        frozen,
-      );
+      result[key] = nativeFromFabricValueModern(val, frozen);
     }
   }
   if (frozen) Object.freeze(result);

--- a/packages/data-model/fabric-value-modern.ts
+++ b/packages/data-model/fabric-value-modern.ts
@@ -240,13 +240,13 @@ export function fabricFromNativeValueModern(
   // Identity optimization: if the value is already a deep-frozen
   // `FabricValue`, return it without copying.
   if (freeze && isDeepFrozenFabricValue(value)) {
-    return value as FabricValue;
+    return value;
   }
   return fabricFromNativeValueModernInternal(
     value,
     new Map(),
     freeze,
-  ) as FabricValue;
+  );
 }
 
 /**

--- a/packages/data-model/fabric-value-modern.ts
+++ b/packages/data-model/fabric-value-modern.ts
@@ -327,7 +327,7 @@ function fabricFromNativeValueModernInternal(
     if (isOriginalRecord) {
       converted.set(original, value);
     }
-    return value as FabricValue;
+    return value;
   }
 
   let result: FabricValue;
@@ -349,7 +349,7 @@ function fabricFromNativeValueModernInternal(
       }
     }
     if (freeze) Object.freeze(resultArray);
-    result = resultArray as FabricValue;
+    result = resultArray;
   } else {
     // Recurse into object properties. Preserve `undefined`-valued properties.
     // Use `Object.create()` to preserve null prototypes (`Object.fromEntries()`

--- a/packages/data-model/fabric-value-modern.ts
+++ b/packages/data-model/fabric-value-modern.ts
@@ -258,7 +258,7 @@ export function fabricFromNativeValueModern(
  */
 function fabricFromNativeValueModernInternal(
   original: unknown,
-  converted: Map<object, unknown>,
+  converted: Map<object, FabricValue>,
   freeze: boolean,
 ): FabricValue {
   const isOriginalRecord = isRecord(original);
@@ -268,7 +268,7 @@ function fabricFromNativeValueModernInternal(
     if (cached === PROCESSING) {
       throw new Error("Cannot store circular reference");
     }
-    return cached as FabricValue;
+    return cached;
   }
 
   if (isOriginalRecord) {
@@ -385,7 +385,7 @@ function fabricFromNativeValueModernInternal(
  */
 function convertErrorInternals(
   error: Error,
-  converted: Map<object, unknown>,
+  converted: Map<object, FabricValue>,
   freeze: boolean,
 ): Error {
   // Construct the same `Error` subclass.


### PR DESCRIPTION
This is just a small PR to remove type casts that are now, or in many cases were never, necessary.

## Performance baseline

This PR is type-annotations only, so the following accounts for a spurious perf check failure:

NEW_PERF_BASELINE: step: runtime-client integration = 61s


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unnecessary type casts and tightened generics (e.g., Map<object, FabricValue>) in the fabric value conversion code in `data-model`. Improves type safety and readability with no runtime changes.

<sup>Written for commit b9a8aac1c597d1ff6fcea4b31be7018e7c7f5799. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3611?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

