### PR TITLE
fix(memory): preserve FabricInstance wrappers through patch application

### DIFF
--- a/packages/memory/test/v2-patch-test.ts
+++ b/packages/memory/test/v2-patch-test.ts
@@ -1,5 +1,141 @@
-import { assertEquals, assertStrictEquals } from "@std/assert";
+import { assert, assertEquals, assertStrictEquals } from "@std/assert";
 import { applyPatch } from "../v2/patch.ts";
+import { FabricError } from "@commonfabric/data-model/fabric-native-instances";
+import { FabricInstance } from "@commonfabric/data-model/interface";
+import { FabricBytes } from "@commonfabric/data-model/fabric-bytes";
+import { FabricEpochNsec } from "@commonfabric/data-model/fabric-epoch";
+
+// `patch.ts` deep-clones incoming op values for isolation. It MUST preserve
+// fabric wrapper classes: it previously used `structuredClone()`, which
+// silently demotes class instances to plain objects, so a `FabricError`
+// (or any `FabricInstance`/`FabricPrimitive`) round-tripped through a patch
+// op came back as a plain object and was then serialized lossily (PR #3613).
+// These tests pin the property directly at the `patch.ts` layer, exercising
+// every op that clones a value (`replace`, `add`, `splice`, and the
+// `add`-via-`move` path), plus a second `applyPatch` pass to mimic the
+// engine replaying a stored patch sequence over an already-deep-frozen base.
+
+Deno.test("memory v2 patch preserves `FabricInstance` values with full fidelity", () => {
+  const placements = [
+    () =>
+      applyPatch({ a: { x: 1 } }, [
+        {
+          op: "replace",
+          path: "/a",
+          value: new FabricError(new Error("boom")),
+        },
+      ]) as { a: unknown },
+    () =>
+      applyPatch({}, [
+        { op: "add", path: "/a", value: new FabricError(new Error("boom")) },
+      ]) as { a: unknown },
+    () =>
+      applyPatch({ a: ["keep"] }, [
+        {
+          op: "splice",
+          path: "/a",
+          index: 1,
+          remove: 0,
+          add: [new FabricError(new Error("boom"))],
+        },
+      ]) as { a: unknown[] },
+  ];
+  const reads: Array<(r: any) => unknown> = [
+    (r) => r.a,
+    (r) => r.a,
+    (r) => r.a[1],
+  ];
+
+  placements.forEach((place, i) => {
+    const out = reads[i]!(place()) as FabricError;
+    assert(out instanceof FabricError, `placement ${i}: not a FabricError`);
+    assertEquals(out.error.message, "boom");
+    assertEquals(typeof out.error.stack, "string");
+  });
+});
+
+Deno.test("memory v2 patch keeps `FabricInstance` values as `FabricInstance`s (not demoted to plain objects)", () => {
+  const patched = applyPatch({}, [
+    { op: "add", path: "/e", value: new FabricError(new Error("boom")) },
+  ]) as { e: unknown };
+  const out = patched.e;
+
+  // The structuredClone-regression guard: a demoted value would be a plain
+  // object (`Object.prototype`), failing every check below.
+  assert(out instanceof FabricInstance);
+  assert(out instanceof FabricError);
+  assertEquals(Object.getPrototypeOf(out) === Object.prototype, false);
+});
+
+Deno.test("memory v2 patch round-trips `FabricInstance` values across replayed patch passes", () => {
+  const first = applyPatch({ box: {} }, [
+    { op: "add", path: "/box/err", value: new FabricError(new Error("boom")) },
+  ]);
+  // `first` is deep-frozen by applyPatch; a second pass mimics the engine
+  // replaying a stored patch sequence (here `move` -> `add`-clones the
+  // already-deep-frozen FabricInstance).
+  const second = applyPatch(first, [
+    { op: "move", from: "/box/err", path: "/moved" },
+  ]) as { moved: unknown };
+  const out = second.moved as FabricError;
+
+  assert(out instanceof FabricError);
+  assertEquals(out.error.message, "boom");
+  assertEquals(typeof out.error.stack, "string");
+});
+
+Deno.test("memory v2 patch preserves `FabricPrimitive` values with full fidelity", () => {
+  const bytes = new Uint8Array([1, 2, 3, 4]);
+  const patchedBytes = applyPatch({ a: ["keep"] }, [
+    {
+      op: "splice",
+      path: "/a",
+      index: 0,
+      remove: 0,
+      add: [new FabricBytes(bytes)],
+    },
+  ]) as { a: unknown[] };
+  const outBytes = patchedBytes.a[0] as FabricBytes;
+  assert(outBytes instanceof FabricBytes);
+  assertEquals(outBytes.length, 4);
+  assertEquals([...outBytes.slice()], [1, 2, 3, 4]);
+
+  const patchedEpoch = applyPatch({}, [
+    { op: "add", path: "/ts", value: new FabricEpochNsec(1_234n) },
+  ]) as { ts: unknown };
+  const outEpoch = patchedEpoch.ts as FabricEpochNsec;
+  assert(outEpoch instanceof FabricEpochNsec);
+  assertEquals(outEpoch.value, 1_234n);
+});
+
+Deno.test("memory v2 patch keeps `FabricPrimitive` values as `FabricPrimitive`s (not demoted to plain objects)", () => {
+  const patched = applyPatch({}, [
+    { op: "add", path: "/b", value: new FabricBytes(new Uint8Array([9, 9])) },
+  ]) as { b: unknown };
+  const out = patched.b;
+
+  assert(out instanceof FabricBytes);
+  assertEquals(Object.getPrototypeOf(out) === Object.prototype, false);
+  // structuredClone would have dropped the private `#bytes` entirely.
+  assertEquals((out as FabricBytes).length, 2);
+});
+
+Deno.test("memory v2 patch round-trips `FabricPrimitive` values across replayed patch passes", () => {
+  const first = applyPatch({ box: {} }, [
+    {
+      op: "add",
+      path: "/box/b",
+      value: new FabricBytes(new Uint8Array([7, 8, 9])),
+    },
+  ]);
+  const second = applyPatch(first, [
+    { op: "move", from: "/box/b", path: "/moved" },
+  ]) as { moved: unknown };
+  const out = second.moved as FabricBytes;
+
+  assert(out instanceof FabricBytes);
+  assertEquals([...out.slice()], [7, 8, 9]);
+});
 
 Deno.test("memory v2 patch applies multiple operations without mutating the input", () => {
   const original = {

--- a/packages/memory/v2/patch.ts
+++ b/packages/memory/v2/patch.ts
@@ -20,13 +20,13 @@ const MAX_ARRAY_INDEX = 2 ** 32 - 2;
  * generically and its wrapped native `Error` -- whose `message`/`stack`
  * are non-enumerable -- collapses to `{}`, losing the error entirely.
  *
- * `cloneIfNecessary({ frozen: true })` deep-clones via the fabric value
- * machinery (`FabricInstance.deepClone()` for wrappers), preserving the
- * class. The frozen result is consistent with `applyPatch`'s deep-freeze
- * contract, and already-deep-frozen inputs are returned as-is.
+ * `cloneIfNecessary()`'s defaults are exactly right here: it deep-clones
+ * via the fabric value machinery (`FabricInstance.deepClone()` for
+ * wrappers), preserving the class; the deep-frozen result matches
+ * `applyPatch`'s deep-freeze contract; and an already-deep-frozen input
+ * is returned as-is (immutable, so no isolation copy is needed).
  */
-const cloneValue = (value: FabricValue): FabricValue =>
-  cloneIfNecessary(value, { frozen: true });
+const cloneValue = (value: FabricValue): FabricValue => cloneIfNecessary(value);
 
 /**
  * Applies a sequence of RFC 6902 JSON Patch operations (`replace`, `add`,

--- a/packages/memory/v2/patch.ts
+++ b/packages/memory/v2/patch.ts
@@ -32,7 +32,7 @@ const MAX_ARRAY_INDEX = 2 ** 32 - 2;
  * that re-clones a frozen subtree holding a `FabricError`). `force`
  * short-circuits the identity check before that throw. The result is
  * still deep-frozen: `applyPatch` deep-freezes the assembled tree at its
- * boundary regardless. (TODO: once `checkValue()`/`isDeepFrozenFabricValue`
+ * boundary regardless. (TODO(@danfuzz): once `checkValue()`/`isDeepFrozenFabricValue`
  * handle `FabricInstance`, the default could be used and would also reuse
  * already-frozen inputs identity-preservingly.)
  */

--- a/packages/memory/v2/patch.ts
+++ b/packages/memory/v2/patch.ts
@@ -20,13 +20,24 @@ const MAX_ARRAY_INDEX = 2 ** 32 - 2;
  * generically and its wrapped native `Error` -- whose `message`/`stack`
  * are non-enumerable -- collapses to `{}`, losing the error entirely.
  *
- * `cloneIfNecessary()`'s defaults are exactly right here: it deep-clones
- * via the fabric value machinery (`FabricInstance.deepClone()` for
- * wrappers), preserving the class; the deep-frozen result matches
- * `applyPatch`'s deep-freeze contract; and an already-deep-frozen input
- * is returned as-is (immutable, so no isolation copy is needed).
+ * `cloneIfNecessary()` deep-clones via the fabric value machinery
+ * (`FabricInstance.deepClone()` for wrappers), preserving the class.
+ *
+ * `{ frozen: false }` (which implies `force: true`) is required, NOT the
+ * `{ frozen: true }` default: with the default, `cloneIfNecessary`'s
+ * identity check calls `isDeepFrozenFabricValue()`, whose `checkValue()`
+ * currently THROWS on a `FabricInstance` ("Cannot yet handle instance of
+ * class ..."). That path is hit whenever the engine replays a stored
+ * patch sequence over an already-deep-frozen tree (e.g. a `move`/`add`
+ * that re-clones a frozen subtree holding a `FabricError`). `force`
+ * short-circuits the identity check before that throw. The result is
+ * still deep-frozen: `applyPatch` deep-freezes the assembled tree at its
+ * boundary regardless. (TODO: once `checkValue()`/`isDeepFrozenFabricValue`
+ * handle `FabricInstance`, the default could be used and would also reuse
+ * already-frozen inputs identity-preservingly.)
  */
-const cloneValue = (value: FabricValue): FabricValue => cloneIfNecessary(value);
+const cloneValue = (value: FabricValue): FabricValue =>
+  cloneIfNecessary(value, { frozen: false });
 
 /**
  * Applies a sequence of RFC 6902 JSON Patch operations (`replace`, `add`,

--- a/packages/memory/v2/patch.ts
+++ b/packages/memory/v2/patch.ts
@@ -1,5 +1,6 @@
 import type { FabricValue } from "../interface.ts";
 import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
+import { cloneIfNecessary } from "@commonfabric/data-model/fabric-value";
 import { isInstance, isObject } from "@commonfabric/utils/types";
 import type { PatchOp } from "../v2.ts";
 import { encodePointer, parsePointer } from "./path.ts";
@@ -7,6 +8,25 @@ import { encodePointer, parsePointer } from "./path.ts";
 type PatchObject = Record<string, FabricValue>;
 type PatchContainer = PatchObject | FabricValue[];
 const MAX_ARRAY_INDEX = 2 ** 32 - 2;
+
+/**
+ * Deep-clones an incoming patch value for isolation, preserving
+ * `FabricInstance` wrappers (e.g. `FabricError`, `FabricMap`).
+ *
+ * `structuredClone()` MUST NOT be used here: it silently demotes class
+ * instances to plain objects. A demoted `FabricError` then fails the
+ * `value instanceof FabricInstance` check in the wire/persistence codec
+ * (`jsonFromValue`/`FabricInstanceHandler`), so it is serialized
+ * generically and its wrapped native `Error` -- whose `message`/`stack`
+ * are non-enumerable -- collapses to `{}`, losing the error entirely.
+ *
+ * `cloneIfNecessary({ frozen: true })` deep-clones via the fabric value
+ * machinery (`FabricInstance.deepClone()` for wrappers), preserving the
+ * class. The frozen result is consistent with `applyPatch`'s deep-freeze
+ * contract, and already-deep-frozen inputs are returned as-is.
+ */
+const cloneValue = (value: FabricValue): FabricValue =>
+  cloneIfNecessary(value, { frozen: true });
 
 /**
  * Applies a sequence of RFC 6902 JSON Patch operations (`replace`, `add`,
@@ -68,14 +88,14 @@ const replaceAtPath = (
   fullPath: string[] = path,
 ): FabricValue => {
   if (path.length === 0) {
-    return structuredClone(value);
+    return cloneValue(value);
   }
 
   if (Array.isArray(root)) {
     const index = requireExistingArrayIndex(root, path[0]!, fullPath);
     const next = shallowCloneContainer(root) as FabricValue[];
     if (path.length === 1) {
-      next[index] = structuredClone(value);
+      next[index] = cloneValue(value);
       return next;
     }
 
@@ -94,7 +114,7 @@ const replaceAtPath = (
   const next = shallowCloneContainer(root) as PatchObject;
   const key = path[0]!;
   if (path.length === 1) {
-    next[key] = structuredClone(value);
+    next[key] = cloneValue(value);
     return next;
   }
 
@@ -117,7 +137,7 @@ const addAtPath = (
   fullPath: string[] = path,
 ): FabricValue => {
   if (path.length === 0) {
-    return structuredClone(value);
+    return cloneValue(value);
   }
 
   if (Array.isArray(root)) {
@@ -125,10 +145,10 @@ const addAtPath = (
     const segment = path[0]!;
     if (path.length === 1) {
       if (segment === "-") {
-        next.push(structuredClone(value));
+        next.push(cloneValue(value));
       } else {
         const index = parseArrayInsertIndex(segment, root.length);
-        next.splice(index, 0, structuredClone(value));
+        next.splice(index, 0, cloneValue(value));
       }
       return next;
     }
@@ -149,7 +169,7 @@ const addAtPath = (
   const next = shallowCloneContainer(root) as PatchObject;
   const key = path[0]!;
   if (path.length === 1) {
-    next[key] = structuredClone(value);
+    next[key] = cloneValue(value);
     return next;
   }
 
@@ -249,7 +269,7 @@ const spliceAtPath = (
       throw new Error(`invalid splice at ${encodePointer(fullPath)}`);
     }
     const next = shallowCloneContainer(root) as FabricValue[];
-    next.splice(index, remove, ...add.map((value) => structuredClone(value)));
+    next.splice(index, remove, ...add.map((value) => cloneValue(value)));
     return next;
   }
 

--- a/packages/runner/test/fetch-data-mutex.test.ts
+++ b/packages/runner/test/fetch-data-mutex.test.ts
@@ -451,40 +451,58 @@ describe("fetch-data mutex mechanism", () => {
     globalThis.fetch = slowFetch;
   });
 
-  it("should handle fetch errors gracefully", async () => {
-    // Mock fetch to return an error
+  // Bifurcated by data model: the legacy fabric-value layer converts a
+  // thrown `Error` to the `{ "@Error": { name, message, stack } }` wrapper;
+  // the modern layer wraps it as a `FabricError`-shaped value (`typeTag`
+  // "Error@1", observable fields under `.error`). Each variant pins its
+  // own `Runtime` with an explicit `experimental.modernDataModel` (the
+  // constructor snapshots the flag at construction time), per the
+  // `cell-core.test.ts` Error-bifurcation pattern.
+  const error404Fetch = () => {
     globalThis.fetch = async () => {
       await new Promise((resolve) => setTimeout(resolve, 10));
       return new Response("Not Found", { status: 404 });
     };
+  };
 
-    const fetchData = byRef("fetchData");
-    const testPattern = pattern<{ url: string }>(
+  it("should handle fetch errors gracefully (legacy)", async () => {
+    error404Fetch();
+    const sm = StorageManager.emulate({ as: signer });
+    const rt = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm,
+      experimental: { modernDataModel: false },
+    });
+    const localTx = rt.edit();
+    const { commonfabric } = createTrustedBuilder(rt);
+    const fetchData = commonfabric.byRef("fetchData");
+    const testPattern = commonfabric.pattern<{ url: string }>(
       ({ url }) => fetchData({ url, mode: "json" }),
     );
 
-    const resultCell = runtime.getCell(space, "error-test", undefined, tx);
-    const result = runtime.run(
-      tx,
+    const resultCell = rt.getCell(
+      space,
+      "error-test-legacy",
+      undefined,
+      localTx,
+    );
+    const result = rt.run(
+      localTx,
       testPattern,
       { url: "/api/error" },
       resultCell,
     );
-    tx.commit();
+    localTx.commit();
 
-    // Pull first to trigger computation (starts the fetch)
     await result.pull();
-
-    // Wait for async work
     await new Promise((resolve) => setTimeout(resolve, 200));
 
     const data = (await result.pull()) as {
       error?: unknown;
-      result?: unknown;
       pending?: boolean;
     };
 
-    // Should have an error with proper @Error wrapper structure
+    // Legacy path: error is the `@Error` wrapper.
     expect(data.error).toBeDefined();
     expect(data.error).toHaveProperty("@Error");
     const errorInfo =
@@ -492,6 +510,70 @@ describe("fetch-data mutex mechanism", () => {
     expect(errorInfo.name).toBe("Error");
     expect(errorInfo.message).toMatch(/HTTP 404/);
     expect(data.pending).toBe(false);
+
+    await localTx.commit();
+    await rt.dispose();
+    await sm.close();
+  });
+
+  it("should handle fetch errors gracefully (modern)", async () => {
+    error404Fetch();
+    const sm = StorageManager.emulate({ as: signer });
+    const rt = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm,
+      experimental: { modernDataModel: true },
+    });
+    const localTx = rt.edit();
+    const { commonfabric } = createTrustedBuilder(rt);
+    const fetchData = commonfabric.byRef("fetchData");
+    const testPattern = commonfabric.pattern<{ url: string }>(
+      ({ url }) => fetchData({ url, mode: "json" }),
+    );
+
+    const resultCell = rt.getCell(
+      space,
+      "error-test-modern",
+      undefined,
+      localTx,
+    );
+    const result = rt.run(
+      localTx,
+      testPattern,
+      { url: "/api/error" },
+      resultCell,
+    );
+    localTx.commit();
+
+    await result.pull();
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
+    const data = (await result.pull()) as {
+      error?: unknown;
+      pending?: boolean;
+    };
+
+    // Modern path: error is a `FabricError`-shaped value (`typeTag`
+    // "Error@1"), not the legacy `@Error` wrapper; its `.error` slot
+    // exposes the wrapped Error's observable fields. Regression guard for
+    // the `memory/v2/patch.ts` `structuredClone()` class-stripping bug,
+    // which made errors round-trip back as `{ error: {}, typeTag:
+    // "Error@1" }` with message/stack lost.
+    expect(data.error).toBeDefined();
+    expect((data.error as { "@Error"?: unknown })["@Error"]).toBeUndefined();
+    const fe = data.error as {
+      typeTag: string;
+      error: { name: string; message: string; stack: string };
+    };
+    expect(fe.typeTag).toBe("Error@1");
+    expect(fe.error.name).toBe("Error");
+    expect(fe.error.message).toMatch(/HTTP 404/);
+    expect(typeof fe.error.stack).toBe("string");
+    expect(data.pending).toBe(false);
+
+    await localTx.commit();
+    await rt.dispose();
+    await sm.close();
   });
 
   it("should abort and clear state if URL becomes empty while waiting for mutex", async () => {


### PR DESCRIPTION
### Problem

Under the modern data model, a fetched error round-trips back as
`{ error: {}, typeTag: "Error@1" }` -- `message`/`stack`/`name` lost.
Surfaced by `fetch-data-mutex.test.ts` "should handle fetch errors
gracefully" on the modern-data-model flag-flip branch (#3569).

### Root cause

`packages/memory/v2/patch.ts` deep-cloned incoming patch values with
**`structuredClone()`**, which silently demotes class instances to plain
objects. On the server-side patch-reconstruction path
(`engine.ts` -> `applyPatch`), a `FabricError` (any `FabricInstance`
wrapper) loses its class. The declassed value then fails the
`value instanceof FabricInstance` check in the wire/persistence codec
(`jsonFromValue` / `FabricInstanceHandler`, which *is* FabricInstance-aware
via `createDefaultRegistry()`), so it is serialized **generically** and its
wrapped native `Error` -- whose `message`/`stack` are non-enumerable --
collapses to `{}`.

`structuredClone()` was harmless when all stored values were plain JSON;
the modern data model's `FabricInstance` wrappers break that assumption.

### Fix

Replace every `structuredClone(value)` in `patch.ts` with a `cloneValue()`
helper delegating to `cloneIfNecessary(value, { frozen: true })` (from
`@commonfabric/data-model/fabric-value`). It deep-clones via the fabric
value machinery, preserving `FabricInstance` wrappers, and yields a frozen
result consistent with `applyPatch`'s existing deep-freeze contract. No-op
for legacy plain-JSON values.

Also bifurcate `fetch-data-mutex.test.ts` "should handle fetch errors
gracefully" into explicit `(legacy)` (`@Error` wrapper) / `(modern)`
(`typeTag: "Error@1"`, `.error.message` ~ `/HTTP 404/`) variants, each
pinning its own `Runtime` `experimental.modernDataModel`. The `(modern)`
variant is a regression guard for this bug.

### Scope

Standalone prep fix: correct independent of the modern-data-model flag,
flag-default-agnostic test, lands on `main` before/independent of the flag
flip (keeps the flag-flip PR a true one-line edit).

Verified green on **both** flag defaults: `data-model` (57 / 1289 steps),
`memory` (113), full `runner` unit suite (452 / 2443 steps),
`fetch-data-mutex` both variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves `FabricInstance` wrappers during patch application and fixes a replay crash, so modern-model errors keep their `message`/`stack` and patches remain safe on frozen trees.

- **Bug Fixes**
  - In `packages/memory/v2/patch.ts`, replaced `structuredClone()` with a `cloneValue()` helper that calls `cloneIfNecessary(value, { frozen: false })` from `@commonfabric/data-model/fabric-value`. This preserves wrappers (`FabricError`, `FabricBytes`, `FabricEpochNsec`) and avoids a `checkValue()` throw when replaying patches over deep-frozen trees; `applyPatch` still deep-freezes the final result.
  - Keeps `FabricInstance` types intact through patch reconstruction; no-op for plain JSON.

- **Tests**
  - Added `packages/memory/test/v2-patch-test.ts` to pin wrapper fidelity across `replace`/`add`/`splice` and `move` replay, including class identity and content checks for `FabricError`, `FabricBytes`, and `FabricEpochNsec`.
  - Split `packages/runner/test/fetch-data-mutex.test.ts` into legacy and modern variants; modern asserts `typeTag: "Error@1"` with populated `error.message/stack`, legacy asserts the `@Error` wrapper.

<sup>Written for commit 6098049a1b5d7ed090ec8e3cfb4fbaa240829478. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3613?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

