### PR TITLE
feat(data-model): `[DEEP_FREEZE]`/`[IS_DEEP_FROZEN]` protocol — defs, impls, stubs (U1 pre-PR)

### DIFF
--- a/packages/data-model/fabric-native-instances.ts
+++ b/packages/data-model/fabric-native-instances.ts
@@ -245,21 +245,21 @@ export class FabricError extends FabricNativeWrapper<Error> {
    * deep-frozen. Never throws.
    */
   [IS_DEEP_FROZEN](
-    isSubDeepFrozen: (value: FabricValue) => boolean,
+    subIsDeepFrozen: (value: FabricValue) => boolean,
   ): boolean {
     if (!Object.isFrozen(this) || !Object.isFrozen(this.error)) {
       return false;
     }
     if (
       this.error.cause !== undefined &&
-      !isSubDeepFrozen(this.error.cause as FabricValue)
+      !subIsDeepFrozen(this.error.cause as FabricValue)
     ) {
       return false;
     }
     for (const key of Object.keys(this.error)) {
       if (UNSAFE_KEYS.has(key) || key === "cause") continue;
       if (
-        !isSubDeepFrozen(
+        !subIsDeepFrozen(
           (this.error as unknown as Record<string, FabricValue>)[key],
         )
       ) {
@@ -402,7 +402,7 @@ export class FabricMap
    * `[DEEP_FREEZE]` above.
    */
   [IS_DEEP_FROZEN](
-    _isSubDeepFrozen: (value: FabricValue) => boolean,
+    _subIsDeepFrozen: (value: FabricValue) => boolean,
   ): boolean {
     throw new Error("FabricMap: not yet implemented");
   }
@@ -467,7 +467,7 @@ export class FabricSet extends FabricNativeWrapper<Set<FabricValue>> {
    * `[DEEP_FREEZE]` above.
    */
   [IS_DEEP_FROZEN](
-    _isSubDeepFrozen: (value: FabricValue) => boolean,
+    _subIsDeepFrozen: (value: FabricValue) => boolean,
   ): boolean {
     throw new Error("FabricSet: not yet implemented");
   }
@@ -559,7 +559,7 @@ export class FabricRegExp extends FabricNativeWrapper<RegExp> {
    * never throws.
    */
   [IS_DEEP_FROZEN](
-    _isSubDeepFrozen: (value: FabricValue) => boolean,
+    _subIsDeepFrozen: (value: FabricValue) => boolean,
   ): boolean {
     return Object.isFrozen(this) && Object.isFrozen(this.regex);
   }

--- a/packages/data-model/fabric-native-instances.ts
+++ b/packages/data-model/fabric-native-instances.ts
@@ -1,7 +1,9 @@
 import {
   DECONSTRUCT,
+  DEEP_FREEZE,
   FabricInstance,
   type FabricValue,
+  IS_DEEP_FROZEN,
   RECONSTRUCT,
   type ReconstructionContext,
 } from "./interface.ts";
@@ -211,6 +213,62 @@ export class FabricError extends FabricNativeWrapper<Error> {
     return state as FabricValue;
   }
 
+  /**
+   * Deep-freezes in place. `Object.freeze` on the wrapped `Error` covers the
+   * standard non-enumerable slots (`message`, `name`, `stack`); the only
+   * deep-freeze gap is the (`FabricValue`-typed, per the `[DECONSTRUCT]`
+   * invariant) `cause` and any custom enumerable own properties, which are
+   * recursed via `subFreeze`. This freezes the existing instance -- it does
+   * NOT rebuild and does NOT narrow to string-valued state (that narrowing
+   * is a `deepClone()` stop-gap detail, not a `[DEEP_FREEZE]` requirement).
+   */
+  [DEEP_FREEZE](
+    subFreeze: (value: FabricValue) => FabricValue,
+  ): FabricValue {
+    if (this.error.cause !== undefined) {
+      subFreeze(this.error.cause as FabricValue);
+    }
+    for (const key of Object.keys(this.error)) {
+      if (UNSAFE_KEYS.has(key) || key === "cause") continue;
+      subFreeze(
+        (this.error as unknown as Record<string, FabricValue>)[key],
+      );
+    }
+    Object.freeze(this.error);
+    return Object.freeze(this) as unknown as FabricValue;
+  }
+
+  /**
+   * Side-effect-free check mirroring `[DEEP_FREEZE]`'s canonical form: this
+   * wrapper and its wrapped `Error` are frozen, and the (`FabricValue`-typed)
+   * `cause` plus any custom enumerable own properties are recursively
+   * deep-frozen. Never throws.
+   */
+  [IS_DEEP_FROZEN](
+    isSubDeepFrozen: (value: FabricValue) => boolean,
+  ): boolean {
+    if (!Object.isFrozen(this) || !Object.isFrozen(this.error)) {
+      return false;
+    }
+    if (
+      this.error.cause !== undefined &&
+      !isSubDeepFrozen(this.error.cause as FabricValue)
+    ) {
+      return false;
+    }
+    for (const key of Object.keys(this.error)) {
+      if (UNSAFE_KEYS.has(key) || key === "cause") continue;
+      if (
+        !isSubDeepFrozen(
+          (this.error as unknown as Record<string, FabricValue>)[key],
+        )
+      ) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   /** @inheritDoc */
   protected shallowUnfrozenClone(): FabricError {
     return new FabricError(this.error);
@@ -328,6 +386,27 @@ export class FabricMap
     throw new Error("FabricMap: not yet implemented");
   }
 
+  /**
+   * Stub -- throws until `Map` support is fully implemented. `FabricMap` is
+   * not yet used and is being reworked separately; the protocol methods are
+   * deliberately left as throwing stubs (per Dan's PR #3612 review).
+   */
+  [DEEP_FREEZE](
+    _subFreeze: (value: FabricValue) => FabricValue,
+  ): FabricValue {
+    throw new Error("FabricMap: not yet implemented");
+  }
+
+  /**
+   * Stub -- throws until `Map` support is fully implemented. See
+   * `[DEEP_FREEZE]` above.
+   */
+  [IS_DEEP_FROZEN](
+    _isSubDeepFrozen: (value: FabricValue) => boolean,
+  ): boolean {
+    throw new Error("FabricMap: not yet implemented");
+  }
+
   /** @inheritDoc */
   protected shallowUnfrozenClone(): FabricMap {
     return new FabricMap(this.map);
@@ -369,6 +448,27 @@ export class FabricSet extends FabricNativeWrapper<Set<FabricValue>> {
   }
 
   [DECONSTRUCT](): FabricValue {
+    throw new Error("FabricSet: not yet implemented");
+  }
+
+  /**
+   * Stub -- throws until `Set` support is fully implemented. `FabricSet` is
+   * not yet used and is being reworked separately; the protocol methods are
+   * deliberately left as throwing stubs (per Dan's PR #3612 review).
+   */
+  [DEEP_FREEZE](
+    _subFreeze: (value: FabricValue) => FabricValue,
+  ): FabricValue {
+    throw new Error("FabricSet: not yet implemented");
+  }
+
+  /**
+   * Stub -- throws until `Set` support is fully implemented. See
+   * `[DEEP_FREEZE]` above.
+   */
+  [IS_DEEP_FROZEN](
+    _isSubDeepFrozen: (value: FabricValue) => boolean,
+  ): boolean {
     throw new Error("FabricSet: not yet implemented");
   }
 
@@ -432,6 +532,36 @@ export class FabricRegExp extends FabricNativeWrapper<RegExp> {
       flags: this.regex.flags,
       flavor: this.flavor,
     } as FabricValue;
+  }
+
+  /**
+   * Deep-freezes in place. The deep-frozen form of a `FabricRegExp` is one
+   * whose wrapped `RegExp` is frozen (an immutable `.lastIndex`, so stateful
+   * methods won't mutate it -- matching `toNativeFrozen()`'s semantics).
+   * `Object.freeze` fully immutabilizes a `RegExp` in place (unlike `Map` /
+   * `Set`, whose mutating methods bypass property descriptors), so this
+   * freezes `this.regex` directly rather than requiring it pre-frozen --
+   * which lets a freshly-`[RECONSTRUCT]`ed `FabricRegExp` flow through the
+   * deserialize-boundary `deepFreeze()` wrap without a fix-up step. There
+   * are no `FabricValue` children to recurse.
+   */
+  [DEEP_FREEZE](
+    _subFreeze: (value: FabricValue) => FabricValue,
+  ): FabricValue {
+    Object.freeze(this.regex);
+    return Object.freeze(this) as unknown as FabricValue;
+  }
+
+  /**
+   * Side-effect-free check mirroring `[DEEP_FREEZE]`'s canonical form: this
+   * wrapper and its wrapped `RegExp` are frozen. There are no `FabricValue`
+   * children to recurse. An unfrozen wrapped `RegExp` answers `false` --
+   * never throws.
+   */
+  [IS_DEEP_FROZEN](
+    _isSubDeepFrozen: (value: FabricValue) => boolean,
+  ): boolean {
+    return Object.isFrozen(this) && Object.isFrozen(this.regex);
   }
 
   /** @inheritDoc */

--- a/packages/data-model/interface.ts
+++ b/packages/data-model/interface.ts
@@ -59,7 +59,7 @@ export const DEEP_FREEZE: unique symbol = Symbol.for("common.deepFreeze");
  * frozen, without mutating it. The sibling-of-`[DEEP_FREEZE]` *check*: it
  * verifies the instance's own internal slot(s) are in canonical deep-frozen
  * form and recurses into any nested `FabricValue`s via the provided
- * `isSubDeepFrozen` callback, returning the boolean conjunction. This is an
+ * `subIsDeepFrozen` callback, returning the boolean conjunction. This is an
  * abstract member of `FabricInstance`, so the generic deep-frozen type guard
  * operates on any `FabricInstance` by gating on `instanceof` against the
  * abstract base and invoking this member -- it does not enumerate concrete
@@ -109,7 +109,7 @@ export abstract class FabricInstance extends FabricSpecialObject {
    * Indicates whether this instance is already deeply frozen, without
    * mutating it. Checks this instance's own internal slot(s) are in
    * canonical deep-frozen form and recurses into each nested `FabricValue`
-   * via the provided `isSubDeepFrozen` callback, returning the boolean
+   * via the provided `subIsDeepFrozen` callback, returning the boolean
    * conjunction. Implementations must NOT import or call the deep-frozen
    * type guard directly -- recursion is handed through the callback,
    * mirroring `[DEEP_FREEZE]`'s callback shape and avoiding an import cycle.
@@ -118,7 +118,7 @@ export abstract class FabricInstance extends FabricSpecialObject {
    * canonical deep-frozen form returns `false`.
    */
   abstract [IS_DEEP_FROZEN](
-    isSubDeepFrozen: (value: FabricValue) => boolean,
+    subIsDeepFrozen: (value: FabricValue) => boolean,
   ): boolean;
 
   /**

--- a/packages/data-model/interface.ts
+++ b/packages/data-model/interface.ts
@@ -43,12 +43,44 @@ export const DECONSTRUCT: unique symbol = Symbol.for("common.deconstruct");
 export const RECONSTRUCT: unique symbol = Symbol.for("common.reconstruct");
 
 /**
+ * Well-known symbol for deeply freezing a fabric instance in place. The method
+ * freezes the instance's own internal slot(s) and recurses into any nested
+ * `FabricValue`s via the provided `subFreeze` callback. This is an abstract
+ * member of `FabricInstance`, so the generic `deepFreeze()` operates on any
+ * `FabricInstance` by gating on `instanceof` against the abstract base and
+ * invoking this member -- it does not enumerate concrete subclasses.
+ * Distinct from `deepClone()`: `[DEEP_FREEZE]` freezes the existing instance
+ * in place; `deepClone()` constructs a new instance.
+ */
+export const DEEP_FREEZE: unique symbol = Symbol.for("common.deepFreeze");
+
+/**
+ * Well-known symbol for checking whether a fabric instance is already deeply
+ * frozen, without mutating it. The sibling-of-`[DEEP_FREEZE]` *check*: it
+ * verifies the instance's own internal slot(s) are in canonical deep-frozen
+ * form and recurses into any nested `FabricValue`s via the provided
+ * `isSubDeepFrozen` callback, returning the boolean conjunction. This is an
+ * abstract member of `FabricInstance`, so the generic deep-frozen type guard
+ * operates on any `FabricInstance` by gating on `instanceof` against the
+ * abstract base and invoking this member -- it does not enumerate concrete
+ * subclasses.
+ *
+ * Unlike `[DEEP_FREEZE]`, this method is side-effect-free and never throws:
+ * a not-in-canonical-deep-frozen-form instance answers `false`, it does not
+ * crash. (`[DEEP_FREEZE]` is a mutator and uses "death before confusion" on
+ * a malformed internal slot; a status check must not.)
+ */
+export const IS_DEEP_FROZEN: unique symbol = Symbol.for(
+  "common.isDeepFrozen",
+);
+
+/**
  * Abstract base class for values that participate in the fabric protocol.
  * See Section 2.3 of the formal spec.
  *
- * Subclasses must implement `[DECONSTRUCT]()`, `deepClone()`, and
- * `shallowUnfrozenClone()`. * Subclasses must also define a static member
- * `[RECONSTRUCT]()`.
+ * Subclasses must implement `[DECONSTRUCT]()`, `[DEEP_FREEZE]()`,
+ * `[IS_DEEP_FROZEN]()`, `deepClone()`, and `shallowUnfrozenClone()`.
+ * Subclasses must also define a static member `[RECONSTRUCT]()`.
  */
 export abstract class FabricInstance extends FabricSpecialObject {
   /**
@@ -57,6 +89,37 @@ export abstract class FabricInstance extends FabricSpecialObject {
    * serialization system handles that.
    */
   abstract [DECONSTRUCT](): FabricValue;
+
+  /**
+   * Deeply freezes this instance in place: freezes this instance's own
+   * internal slot(s) and recurses into each nested `FabricValue` by calling
+   * the provided `subFreeze` callback on it. Implementations must NOT import
+   * or call `deepFreeze()` directly -- recursion is handed through the
+   * callback so that the freeze utility's caching / cycle-detection
+   * bookkeeping is preserved and no import cycle is introduced.
+   *
+   * Returns the (now deeply-frozen) value. Freeze-in-place implementations
+   * return `this`.
+   */
+  abstract [DEEP_FREEZE](
+    subFreeze: (value: FabricValue) => FabricValue,
+  ): FabricValue;
+
+  /**
+   * Indicates whether this instance is already deeply frozen, without
+   * mutating it. Checks this instance's own internal slot(s) are in
+   * canonical deep-frozen form and recurses into each nested `FabricValue`
+   * via the provided `isSubDeepFrozen` callback, returning the boolean
+   * conjunction. Implementations must NOT import or call the deep-frozen
+   * type guard directly -- recursion is handed through the callback,
+   * mirroring `[DEEP_FREEZE]`'s callback shape and avoiding an import cycle.
+   *
+   * Side-effect-free and must not throw: an instance that is not in
+   * canonical deep-frozen form returns `false`.
+   */
+  abstract [IS_DEEP_FROZEN](
+    isSubDeepFrozen: (value: FabricValue) => boolean,
+  ): boolean;
 
   /**
    * Returns a new deep clone of this instance with equivalent data but no

--- a/packages/data-model/problematic-value.ts
+++ b/packages/data-model/problematic-value.ts
@@ -45,9 +45,9 @@ export class ProblematicValue extends ExplicitTagValue {
    * wrapper is frozen and `state` is recursively deep-frozen. Never throws.
    */
   [IS_DEEP_FROZEN](
-    isSubDeepFrozen: (value: FabricValue) => boolean,
+    subIsDeepFrozen: (value: FabricValue) => boolean,
   ): boolean {
-    return Object.isFrozen(this) && isSubDeepFrozen(this.state);
+    return Object.isFrozen(this) && subIsDeepFrozen(this.state);
   }
 
   /** @inheritDoc */

--- a/packages/data-model/problematic-value.ts
+++ b/packages/data-model/problematic-value.ts
@@ -1,6 +1,8 @@
 import {
   DECONSTRUCT,
+  DEEP_FREEZE,
   type FabricValue,
+  IS_DEEP_FROZEN,
   RECONSTRUCT,
   type ReconstructionContext,
 } from "./interface.ts";
@@ -24,6 +26,28 @@ export class ProblematicValue extends ExplicitTagValue {
 
   [DECONSTRUCT](): FabricValue {
     return { type: this.typeTag, state: this.state, error: this.error };
+  }
+
+  /**
+   * Deep-freezes in place. `typeTag` and `error` are immutable strings; the
+   * only `FabricValue`-typed slot is `state`, which is recursed via
+   * `subFreeze` before the wrapper itself is frozen.
+   */
+  [DEEP_FREEZE](
+    subFreeze: (value: FabricValue) => FabricValue,
+  ): FabricValue {
+    subFreeze(this.state);
+    return Object.freeze(this) as unknown as FabricValue;
+  }
+
+  /**
+   * Side-effect-free check mirroring `[DEEP_FREEZE]`'s canonical form: this
+   * wrapper is frozen and `state` is recursively deep-frozen. Never throws.
+   */
+  [IS_DEEP_FROZEN](
+    isSubDeepFrozen: (value: FabricValue) => boolean,
+  ): boolean {
+    return Object.isFrozen(this) && isSubDeepFrozen(this.state);
   }
 
   /** @inheritDoc */

--- a/packages/data-model/test/fabric-native-instances.test.ts
+++ b/packages/data-model/test/fabric-native-instances.test.ts
@@ -2,8 +2,10 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
   DECONSTRUCT,
+  DEEP_FREEZE,
   FabricInstance,
   type FabricValue,
+  IS_DEEP_FROZEN,
   RECONSTRUCT,
   type ReconstructionContext,
 } from "../interface.ts";
@@ -11,6 +13,7 @@ import {
   FabricError,
   FabricMap,
   FabricNativeWrapper,
+  FabricRegExp,
   FabricSet,
   isConvertibleNativeInstance,
 } from "../fabric-native-instances.ts";
@@ -24,6 +27,7 @@ import {
 import { UnknownValue } from "../unknown-value.ts";
 import { ProblematicValue } from "../problematic-value.ts";
 import { ExplicitTagValue } from "../explicit-tag-value.ts";
+import { deepFreeze, isDeepFrozen } from "../deep-freeze.ts";
 
 /** Dummy reconstruction context for tests. */
 const dummyContext: ReconstructionContext = {
@@ -838,6 +842,16 @@ describe("fabric-native-instances", () => {
         [DECONSTRUCT](): FabricValue {
           return { value: 42 };
         }
+        [DEEP_FREEZE](
+          _subFreeze: (value: FabricValue) => FabricValue,
+        ): FabricValue {
+          return this as unknown as FabricValue;
+        }
+        [IS_DEEP_FROZEN](
+          _isSubDeepFrozen: (value: FabricValue) => boolean,
+        ): boolean {
+          return Object.isFrozen(this);
+        }
         deepClone(_frozen: boolean): CustomFabInst {
           return new CustomFabInst();
         }
@@ -924,6 +938,145 @@ describe("fabric-native-instances", () => {
       );
       expect(ps.typeTag).toBe("Bad@1");
       expect(ps.state).toBe("data");
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // [DEEP_FREEZE] / [IS_DEEP_FROZEN] protocol (F1)
+  // --------------------------------------------------------------------------
+
+  // These exercise the `[DEEP_FREEZE]` / `[IS_DEEP_FROZEN]` protocol members
+  // DIRECTLY (invoking them on the instance with a recursion callback),
+  // rather than through `deepFreeze()` / `isDeepFrozenFabricValue()`. That
+  // dispatch layer (`deep-freeze.ts` arm-3 / type-guard) is a separate
+  // (follow-on) unit; this unit ships only the protocol defs/impls/stubs, so
+  // its coverage must not depend on the dispatcher. The callbacks below use
+  // the existing `deepFreeze` / `isDeepFrozen` only as recursion helpers on
+  // the nested (plain) sub-values -- never as the entry point for the
+  // instance itself.
+  describe("[DEEP_FREEZE] / [IS_DEEP_FROZEN] protocol", () => {
+    const subFreeze = (v: FabricValue): FabricValue => deepFreeze(v);
+    const isSubDeepFrozen = (v: FabricValue): boolean => isDeepFrozen(v);
+
+    describe("FabricError", () => {
+      it("[DEEP_FREEZE] freezes wrapper + Error + recurses cause", () => {
+        const inner = new Error("cause");
+        const fe = new FabricError(new Error("outer", { cause: inner }));
+        const result = fe[DEEP_FREEZE](subFreeze);
+        expect(result).toBe(fe); // freeze-in-place identity
+        expect(Object.isFrozen(fe)).toBe(true);
+        expect(Object.isFrozen(fe.error)).toBe(true);
+        expect(Object.isFrozen(inner)).toBe(true);
+      });
+
+      it("[DEEP_FREEZE] recurses enumerable custom props, no string-narrow", () => {
+        const err = new Error("e");
+        const childObj = { nested: 1 };
+        (err as unknown as Record<string, unknown>).custom = childObj;
+        const fe = new FabricError(err);
+        fe[DEEP_FREEZE](subFreeze);
+        // Non-string custom state is preserved AND deep-frozen (it must not
+        // be dropped -- that narrowing is a deepClone stop-gap, not this).
+        expect((fe.error as unknown as Record<string, unknown>).custom)
+          .toBe(childObj);
+        expect(Object.isFrozen(childObj)).toBe(true);
+      });
+
+      it("[IS_DEEP_FROZEN] true only when wrapper + Error frozen", () => {
+        const fe = new FabricError(new Error("test"));
+        expect(fe[IS_DEEP_FROZEN](isSubDeepFrozen)).toBe(false);
+        Object.freeze(fe); // wrapper only; inner Error still mutable
+        expect(fe[IS_DEEP_FROZEN](isSubDeepFrozen)).toBe(false);
+        fe[DEEP_FREEZE](subFreeze);
+        expect(fe[IS_DEEP_FROZEN](isSubDeepFrozen)).toBe(true);
+      });
+    });
+
+    // FabricMap/FabricSet deliberately keep throwing stubs for the protocol
+    // methods (per Dan's PR #3612 review: not yet used, reworked separately).
+    describe("FabricMap (throwing stub)", () => {
+      it("[DEEP_FREEZE] throws not-yet-implemented", () => {
+        const fm = new FabricMap(
+          new FrozenMap<FabricValue, FabricValue>([["a", 1]]),
+        );
+        expect(() => fm[DEEP_FREEZE](subFreeze)).toThrow(
+          "FabricMap: not yet implemented",
+        );
+      });
+
+      it("[IS_DEEP_FROZEN] throws not-yet-implemented", () => {
+        const fm = new FabricMap(
+          new FrozenMap<FabricValue, FabricValue>([["a", 1]]),
+        );
+        Object.freeze(fm);
+        expect(() => fm[IS_DEEP_FROZEN](isSubDeepFrozen)).toThrow(
+          "FabricMap: not yet implemented",
+        );
+      });
+    });
+
+    describe("FabricSet (throwing stub)", () => {
+      it("[DEEP_FREEZE] throws not-yet-implemented", () => {
+        const fs = new FabricSet(new FrozenSet<FabricValue>([1, 2]));
+        expect(() => fs[DEEP_FREEZE](subFreeze)).toThrow(
+          "FabricSet: not yet implemented",
+        );
+      });
+
+      it("[IS_DEEP_FROZEN] throws not-yet-implemented", () => {
+        const fs = new FabricSet(new FrozenSet<FabricValue>([1, 2]));
+        Object.freeze(fs);
+        expect(() => fs[IS_DEEP_FROZEN](isSubDeepFrozen)).toThrow(
+          "FabricSet: not yet implemented",
+        );
+      });
+    });
+
+    describe("FabricRegExp", () => {
+      it("[DEEP_FREEZE] freezes the wrapped RegExp in place", () => {
+        const fr = new FabricRegExp(/abc/g);
+        expect(Object.isFrozen(fr.regex)).toBe(false);
+        const result = fr[DEEP_FREEZE](subFreeze);
+        expect(result).toBe(fr);
+        expect(Object.isFrozen(fr)).toBe(true);
+        expect(Object.isFrozen(fr.regex)).toBe(true);
+      });
+
+      it("[IS_DEEP_FROZEN] true only when wrapper + RegExp frozen", () => {
+        const fr = new FabricRegExp(/abc/g);
+        expect(fr[IS_DEEP_FROZEN](isSubDeepFrozen)).toBe(false);
+        fr[DEEP_FREEZE](subFreeze);
+        expect(fr[IS_DEEP_FROZEN](isSubDeepFrozen)).toBe(true);
+      });
+    });
+
+    describe("ExplicitTagValue subclasses", () => {
+      it("ProblematicValue [DEEP_FREEZE] recurses state, freezes in place", () => {
+        const child = { x: 1 };
+        const pv = new ProblematicValue(
+          "Bad@1",
+          child as unknown as FabricValue,
+          "oops",
+        );
+        const result = pv[DEEP_FREEZE](subFreeze);
+        expect(result).toBe(pv);
+        expect(Object.isFrozen(pv)).toBe(true);
+        expect(Object.isFrozen(child)).toBe(true);
+        expect(pv[IS_DEEP_FROZEN](isSubDeepFrozen)).toBe(true);
+      });
+
+      it("UnknownValue [DEEP_FREEZE] recurses state, freezes in place", () => {
+        const child = { y: 2 };
+        const uv = new UnknownValue(
+          "Fancy@3",
+          child as unknown as FabricValue,
+        );
+        const result = uv[DEEP_FREEZE](subFreeze);
+        expect(result).toBe(uv);
+        expect(Object.isFrozen(uv)).toBe(true);
+        expect(Object.isFrozen(child)).toBe(true);
+        expect(uv[IS_DEEP_FROZEN](isSubDeepFrozen)).toBe(true);
+      });
     });
   });
 });

--- a/packages/data-model/test/fabric-native-instances.test.ts
+++ b/packages/data-model/test/fabric-native-instances.test.ts
@@ -848,7 +848,7 @@ describe("fabric-native-instances", () => {
           return this as unknown as FabricValue;
         }
         [IS_DEEP_FROZEN](
-          _isSubDeepFrozen: (value: FabricValue) => boolean,
+          _subIsDeepFrozen: (value: FabricValue) => boolean,
         ): boolean {
           return Object.isFrozen(this);
         }
@@ -956,7 +956,7 @@ describe("fabric-native-instances", () => {
   // instance itself.
   describe("[DEEP_FREEZE] / [IS_DEEP_FROZEN] protocol", () => {
     const subFreeze = (v: FabricValue): FabricValue => deepFreeze(v);
-    const isSubDeepFrozen = (v: FabricValue): boolean => isDeepFrozen(v);
+    const subIsDeepFrozen = (v: FabricValue): boolean => isDeepFrozen(v);
 
     describe("FabricError", () => {
       it("[DEEP_FREEZE] freezes wrapper + Error + recurses cause", () => {
@@ -984,11 +984,11 @@ describe("fabric-native-instances", () => {
 
       it("[IS_DEEP_FROZEN] true only when wrapper + Error frozen", () => {
         const fe = new FabricError(new Error("test"));
-        expect(fe[IS_DEEP_FROZEN](isSubDeepFrozen)).toBe(false);
+        expect(fe[IS_DEEP_FROZEN](subIsDeepFrozen)).toBe(false);
         Object.freeze(fe); // wrapper only; inner Error still mutable
-        expect(fe[IS_DEEP_FROZEN](isSubDeepFrozen)).toBe(false);
+        expect(fe[IS_DEEP_FROZEN](subIsDeepFrozen)).toBe(false);
         fe[DEEP_FREEZE](subFreeze);
-        expect(fe[IS_DEEP_FROZEN](isSubDeepFrozen)).toBe(true);
+        expect(fe[IS_DEEP_FROZEN](subIsDeepFrozen)).toBe(true);
       });
     });
 
@@ -1009,7 +1009,7 @@ describe("fabric-native-instances", () => {
           new FrozenMap<FabricValue, FabricValue>([["a", 1]]),
         );
         Object.freeze(fm);
-        expect(() => fm[IS_DEEP_FROZEN](isSubDeepFrozen)).toThrow(
+        expect(() => fm[IS_DEEP_FROZEN](subIsDeepFrozen)).toThrow(
           "FabricMap: not yet implemented",
         );
       });
@@ -1026,7 +1026,7 @@ describe("fabric-native-instances", () => {
       it("[IS_DEEP_FROZEN] throws not-yet-implemented", () => {
         const fs = new FabricSet(new FrozenSet<FabricValue>([1, 2]));
         Object.freeze(fs);
-        expect(() => fs[IS_DEEP_FROZEN](isSubDeepFrozen)).toThrow(
+        expect(() => fs[IS_DEEP_FROZEN](subIsDeepFrozen)).toThrow(
           "FabricSet: not yet implemented",
         );
       });
@@ -1044,9 +1044,9 @@ describe("fabric-native-instances", () => {
 
       it("[IS_DEEP_FROZEN] true only when wrapper + RegExp frozen", () => {
         const fr = new FabricRegExp(/abc/g);
-        expect(fr[IS_DEEP_FROZEN](isSubDeepFrozen)).toBe(false);
+        expect(fr[IS_DEEP_FROZEN](subIsDeepFrozen)).toBe(false);
         fr[DEEP_FREEZE](subFreeze);
-        expect(fr[IS_DEEP_FROZEN](isSubDeepFrozen)).toBe(true);
+        expect(fr[IS_DEEP_FROZEN](subIsDeepFrozen)).toBe(true);
       });
     });
 
@@ -1062,7 +1062,7 @@ describe("fabric-native-instances", () => {
         expect(result).toBe(pv);
         expect(Object.isFrozen(pv)).toBe(true);
         expect(Object.isFrozen(child)).toBe(true);
-        expect(pv[IS_DEEP_FROZEN](isSubDeepFrozen)).toBe(true);
+        expect(pv[IS_DEEP_FROZEN](subIsDeepFrozen)).toBe(true);
       });
 
       it("UnknownValue [DEEP_FREEZE] recurses state, freezes in place", () => {
@@ -1075,7 +1075,7 @@ describe("fabric-native-instances", () => {
         expect(result).toBe(uv);
         expect(Object.isFrozen(uv)).toBe(true);
         expect(Object.isFrozen(child)).toBe(true);
-        expect(uv[IS_DEEP_FROZEN](isSubDeepFrozen)).toBe(true);
+        expect(uv[IS_DEEP_FROZEN](subIsDeepFrozen)).toBe(true);
       });
     });
   });

--- a/packages/data-model/unknown-value.ts
+++ b/packages/data-model/unknown-value.ts
@@ -41,9 +41,9 @@ export class UnknownValue extends ExplicitTagValue {
    * wrapper is frozen and `state` is recursively deep-frozen. Never throws.
    */
   [IS_DEEP_FROZEN](
-    isSubDeepFrozen: (value: FabricValue) => boolean,
+    subIsDeepFrozen: (value: FabricValue) => boolean,
   ): boolean {
-    return Object.isFrozen(this) && isSubDeepFrozen(this.state);
+    return Object.isFrozen(this) && subIsDeepFrozen(this.state);
   }
 
   /** @inheritDoc */

--- a/packages/data-model/unknown-value.ts
+++ b/packages/data-model/unknown-value.ts
@@ -1,6 +1,8 @@
 import {
   DECONSTRUCT,
+  DEEP_FREEZE,
   type FabricValue,
+  IS_DEEP_FROZEN,
   RECONSTRUCT,
   type ReconstructionContext,
 } from "./interface.ts";
@@ -20,6 +22,28 @@ export class UnknownValue extends ExplicitTagValue {
 
   [DECONSTRUCT](): FabricValue {
     return { type: this.typeTag, state: this.state };
+  }
+
+  /**
+   * Deep-freezes in place. `typeTag` is an immutable string; the only
+   * `FabricValue`-typed slot is `state`, which is recursed via `subFreeze`
+   * before the wrapper itself is frozen.
+   */
+  [DEEP_FREEZE](
+    subFreeze: (value: FabricValue) => FabricValue,
+  ): FabricValue {
+    subFreeze(this.state);
+    return Object.freeze(this) as unknown as FabricValue;
+  }
+
+  /**
+   * Side-effect-free check mirroring `[DEEP_FREEZE]`'s canonical form: this
+   * wrapper is frozen and `state` is recursively deep-frozen. Never throws.
+   */
+  [IS_DEEP_FROZEN](
+    isSubDeepFrozen: (value: FabricValue) => boolean,
+  ): boolean {
+    return Object.isFrozen(this) && isSubDeepFrozen(this.state);
   }
 
   /** @inheritDoc */


### PR DESCRIPTION
## Summary

Adds the `[DEEP_FREEZE]` / `[IS_DEEP_FROZEN]` symbol-protocol **definition
layer** to the data model: the two new well-known symbols, their abstract
members on `FabricInstance`, the concrete per-class implementations
(`FabricError`, `FabricRegExp`, `ProblematicValue`, `UnknownValue`), and
deliberate throwing stubs (`FabricMap`, `FabricSet`). This is an **inert
layer** — no caller dispatches to the new members yet (the dispatch/use
layer is a separate follow-on unit).

This is **U1 (pre-PR#1)** of the split F1 deep-freeze protocol work
(`coordination/docs/2026-05-14-deep-freeze-discipline-audit.md` §3.7 /
§10; `tasks.md` #56 "Consolidated 5-unit structure"). **The split into
units was directed by Dan directly** (relayed for the record — meta-repo
git metadata does not carry who-decided): the F1 work is delivered as a
landed-in-order chain rather than one PR. See **Sequencing** below.

## Independently safe + correct to land (named acceptance criterion)

This PR is safe and correct to land on its own — it is an **inert
definition layer**. (This is the foreman's named blocking review
criterion for each split unit; the at-source basis:)

* **Safe (gates green standalone, no dangling sibling reference).** Built
  off `origin/main`; `deno fmt`/`lint`/`check` clean and the data-model +
  runner suites pass on this branch alone (see Validation). It references
  no symbol or code that exists only in a not-yet-landed sibling unit.
* **Correct (semantically complete as landed, not a partial contract).**
  Verified at-source: `origin/main` `deep-freeze.ts` references neither
  `DEEP_FREEZE` nor `IS_DEEP_FROZEN`, and the *only* dispatcher to these
  members is `deep-freeze.ts` (arm-3 / type-guard) — which stays at
  `origin/main` in this PR (it is the follow-on unit). So **nothing
  dispatches to the new members** once this lands: the abstract members
  force every `FabricInstance` subclass to implement them (all such
  subclasses are in this PR's file-set, so the contract is satisfied
  within the PR and it compiles), and no caller invokes them, so there is
  no partial/sometimes-wrong behavior. Adding an abstract member only
  constrains subclasses, not consumers, so `deep-freeze.ts` (and every
  other consumer) compiles unchanged. The per-class impls are tested
  directly (callback-driven), so they are exercised and correct as
  shipped.

Same precedent shape as the session-2026-072 prep-PR (inert definition
layer landed ahead of its use).

## Changes

* **`interface.ts`** — R1: `DEEP_FREEZE`
  (`Symbol.for("common.deepFreeze")`) and `IS_DEEP_FROZEN`
  (`Symbol.for("common.isDeepFrozen")`), exported adjacent to
  `DECONSTRUCT`/`RECONSTRUCT`. R2: abstract
  `[DEEP_FREEZE](subFreeze: (v: FabricValue) => FabricValue): FabricValue`
  and `[IS_DEEP_FROZEN](isSubDeepFrozen: (v: FabricValue) => boolean):
  boolean` on `FabricInstance`, class docstring updated. The symbol
  docstrings describe the dispatch as **base-class-`instanceof` +
  abstract-protocol-member** — the corrected principle: `deepFreeze()` /
  the type guard operate generically via the abstract base
  (`instanceof FabricInstance`, like the rest of the package), do **not**
  enumerate concrete classes, and do **not** duck-type method-sniff. (This
  is Dan's correction-of-framing — the earlier "no class names" /
  "duck-typed" framing was a prior-session relay-compression misframing;
  durable at `tasks.md` #56. The dispatch code itself lands in the
  follow-on unit; this PR carries the corrected `interface.ts`
  docstrings.)
* **`fabric-native-instances.ts`** — `FabricError` and `FabricRegExp`
  concrete `[DEEP_FREEZE]`/`[IS_DEEP_FROZEN]` (freeze-in-place; for
  `FabricError`, recurse `cause` + enumerable own custom props via the
  callback, no string-narrowing; for `FabricRegExp`, `Object.freeze` the
  wrapped `RegExp` in place). `FabricMap` and `FabricSet` carry
  **deliberate throwing stubs** (`"Fabric{Map,Set}: not yet implemented"`,
  matching their existing `[DECONSTRUCT]`/`[RECONSTRUCT]` stub idiom) per
  Dan's PR #3612 review — those classes are not yet used and are being
  reworked separately. `FabricNativeWrapper` (abstract) carries no member.
* **`problematic-value.ts` / `unknown-value.ts`** — real
  `[DEEP_FREEZE]`/`[IS_DEEP_FROZEN]` (recurse `state` via the callback,
  freeze the wrapper in place; `typeTag`/`error` are immutable strings).
* **`test/fabric-native-instances.test.ts`** — per-class coverage that
  invokes the protocol members **directly** with a recursion callback,
  deliberately *not* through `deepFreeze()`/`isDeepFrozenFabricValue()`
  (that dispatch is the follow-on unit; this unit's coverage must not
  depend on it). The in-test `CustomFabInst` stub gains both abstract
  members.

## Design choices (audit §3.7.5, "coder's call")

* **R2 callback return type → `FabricValue`** (convention-match with
  `deepFreeze<T>(value: T): T`; chain-friendly; `return this` for
  freeze-in-place).
* **Q-3.7-B option 3** (verify frozen-variant internal) — now moot for
  `FabricMap`/`FabricSet` since they are stubbed per Dan's review;
  preserved as the intended shape for the eventual rework.
* **Q-3.7-C** — `FabricError` recurses `cause` + custom enumerable props
  with no string-narrowing (that narrowing is a `deepClone()` stop-gap
  detail, not a `[DEEP_FREEZE]` requirement); `FabricRegExp`
  freeze-in-place (`Object.freeze` fully immutabilizes a `RegExp`).

## Sequencing

This is **U1** of the Dan-directed 5-unit F1 chain (`tasks.md` #56):

* **U1 (this PR)** — protocol definition layer (symbols + abstract
  members + per-class impls + stubs). Inert; lands first.
* **U2** — `TypeHandler.deserialize()` contractual deep-frozen guarantee.
* **U3** — `ReconstructionContext.shouldDeepFreeze` getter.
* **U4** — residual integration on the original branch (the
  `deepFreeze()` arm-3 dispatch + the `isDeepFrozenFabricValue`
  type-guard delegation + the `deep-freeze.ts` half of the duck-typing
  doc sweep).
* **U5** — Dan re-evaluation checkpoint (terminal; not auto-proceed).

Order is U1 → U2 → U3 → U4 → U5, then Stage 2 (the freeze-clone
collapse + #3588 perf-baseline re-measurement). U1 hard-precedes the
others; it does not depend on any of them and stands on its own.

## Validation (standalone, off `origin/main`)

- [x] `deno fmt` — clean
- [x] `deno lint` — clean
- [x] `deno check` — clean (data-model)
- [x] data-model `deno task test` — 57 passed (1306 steps), 0 failed
- [x] runner `deno task test` — 452 passed (2442 steps), 0 failed

Co-Authored-By: coder-colt (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `DEEP_FREEZE`/`IS_DEEP_FROZEN` protocol as an inert definition layer: new symbols, abstract members on `FabricInstance`, and per-class implementations. No dispatcher yet, so no runtime behavior change.

- **New Features**
  - Added `DEEP_FREEZE` and `IS_DEEP_FROZEN` symbols and abstract methods on `FabricInstance` (docstrings clarify base-class `instanceof` dispatch; no duck-typing).
  - Implemented for `FabricError` (freeze in place; recurse `cause` and enumerable own props), `FabricRegExp` (freeze wrapped `RegExp` in place), `ProblematicValue` and `UnknownValue` (recurse `state`, then freeze).
  - Added deliberate throwing stubs for `FabricMap` and `FabricSet`.
  - Added tests that call the protocol members directly with recursion callbacks (`deepFreeze`/`isDeepFrozen` only for nested values).

- **Refactors**
  - Renamed `[IS_DEEP_FROZEN]` callback param to `subIsDeepFrozen` across interface, implementations, and tests (consistency with `subFreeze`; no behavior change).

<sup>Written for commit ea52bc51a3ce76f0404d79cfcb19dea6b4ca5369. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3614?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

