### PR TITLE
Add runsc CFC read_file integration smoke

### DIFF
--- a/packages/cf-harness/integration/engine.integration.test.ts
+++ b/packages/cf-harness/integration/engine.integration.test.ts
@@ -1,5 +1,5 @@
 import { assert, assertEquals, assertStringIncludes } from "@std/assert";
-import { fromFileUrl } from "@std/path";
+import { fromFileUrl, join } from "@std/path";
 import type {
   CfcEnforcementMode,
   CfcLabelView,
@@ -7,6 +7,10 @@ import type {
 } from "@commonfabric/runner/cfc";
 import { CfHarnessEngine } from "../src/engine.ts";
 import { CfHarnessPromptLoop } from "../src/prompt-loop.ts";
+import {
+  readHarnessRunState,
+  readHarnessTranscript,
+} from "../src/artifacts.ts";
 import {
   CFC_INVOCATION_CONTEXT_DIR_ENV,
   CFC_RESULT_DIR_ENV,
@@ -86,6 +90,8 @@ const labsRootPath = (): Promise<string> =>
 
 interface WithHarnessOptions {
   cfcEnforcementMode?: CfcEnforcementMode;
+  artifactRoot?: string;
+  model?: string;
   configureSandbox?: (
     workspaceHostPath: string,
   ) => Partial<Parameters<typeof resolveDockerRunscSandboxConfig>[0]>;
@@ -231,9 +237,13 @@ const withHarness = async (
     await assertRunscRuntimeAvailable();
     const engine = new CfHarnessEngine({
       runId,
+      ...(options.artifactRoot !== undefined
+        ? { artifactRoot: options.artifactRoot }
+        : {}),
       ...(options.cfcEnforcementMode !== undefined
         ? { cfcEnforcementMode: options.cfcEnforcementMode }
         : {}),
+      ...(options.model !== undefined ? { model: options.model } : {}),
       sandbox: resolveDockerRunscSandboxConfig({
         workspaceHostPath,
         runtimeName: DOCKER_RUNTIME,
@@ -612,6 +622,213 @@ Deno.test({
       );
     } finally {
       await Deno.remove(secretsHostPath, { recursive: true });
+    }
+  },
+});
+
+Deno.test({
+  name:
+    "cf-harness integration: prompt loop mediates read_file output through runsc-cfc",
+  ignore: !INTEGRATION || !CFC_RESULT_DIR_CONFIGURED ||
+    !CFC_INVOCATION_CONTEXT_DIR_CONFIGURED,
+  permissions: { env: true, read: true, run: true, write: true },
+  async fn() {
+    const artifactRoot = await makeIntegrationTempDir(
+      "cf-harness-read-file-cfc-artifacts-",
+    );
+    const fileContent = "workspace read through runsc CFC\n";
+    try {
+      await withHarness(
+        "integration-read-file-cfc-prompt-loop",
+        async (engine, hostPath) => {
+          assertEquals(
+            engine.sandbox.describe?.().cfc?.invocationContextTransport,
+            "sidecar",
+          );
+          await Deno.mkdir(`${hostPath}/notes`, { recursive: true });
+          await Deno.writeTextFile(`${hostPath}/notes/public.txt`, fileContent);
+
+          const requests: Array<{
+            messages: Array<{
+              role: string;
+              tool_call_id?: string;
+              content?: string;
+            }>;
+          }> = [];
+          const loop = new CfHarnessPromptLoop({
+            apiKey: "test-key",
+            engine,
+            maxModelTurns: 3,
+            fetchFn: (_input, init) => {
+              const request = JSON.parse(String(init?.body ?? "{}")) as {
+                messages: Array<{
+                  role: string;
+                  tool_call_id?: string;
+                  content?: string;
+                }>;
+              };
+              requests.push(request);
+              const toolResponseCount = request.messages.filter((message) =>
+                message.role === "tool"
+              ).length;
+              const payload = toolResponseCount === 0
+                ? {
+                  choices: [{
+                    index: 0,
+                    message: {
+                      role: "assistant",
+                      content: "",
+                      tool_calls: [{
+                        id: "call-read-file",
+                        type: "function",
+                        function: {
+                          name: "read_file",
+                          arguments: JSON.stringify({
+                            path: "notes/public.txt",
+                          }),
+                        },
+                      }],
+                    },
+                  }],
+                }
+                : toolResponseCount === 1
+                ? {
+                  choices: [{
+                    index: 0,
+                    message: {
+                      role: "assistant",
+                      content: "",
+                      tool_calls: [{
+                        id: "call-followup-bash",
+                        type: "function",
+                        function: {
+                          name: "bash",
+                          arguments: JSON.stringify({
+                            command: "printf followup",
+                          }),
+                        },
+                      }],
+                    },
+                  }],
+                }
+                : {
+                  choices: [{
+                    index: 0,
+                    message: {
+                      role: "assistant",
+                      content: "read_file runtime CFC smoke complete.",
+                    },
+                  }],
+                };
+              return Promise.resolve(
+                new Response(JSON.stringify(payload), { status: 200 }),
+              );
+            },
+          });
+
+          const promptSlotBinding = {
+            type: CFC_PROMPT_SLOT_BOUND_ATOM_TYPE,
+            source: {
+              type: "cf-harness.integration.prompt-slot",
+              subject: "read-file-cfc",
+            },
+            role: "direct-command",
+            kernelName: "integration",
+            surface: "cli",
+          } as const;
+          const result = await loop.runPrompt({
+            model: "gpt-5.4",
+            prompt: "Read the workspace file, then run a followup command.",
+            promptSlotBinding,
+          });
+
+          assertEquals(
+            result.finalAssistantText,
+            "read_file runtime CFC smoke complete.",
+          );
+          assertEquals(requests.length, 3);
+          const readToolMessage = requests[1].messages.at(-1);
+          assertEquals(readToolMessage?.role, "tool");
+          assertEquals(readToolMessage?.tool_call_id, "call-read-file");
+          const readToolContent = JSON.parse(
+            readToolMessage?.content ?? "{}",
+          ) as {
+            content?: unknown;
+            cfc?: {
+              stdout?: { policy?: string };
+              stderr?: { policy?: string };
+              exitCode?: { policy?: string; value?: number };
+              diagnostics?: unknown[];
+            };
+          };
+          assertEquals(readToolContent.content, fileContent);
+          assertEquals(readToolContent.cfc?.stdout?.policy, "observed");
+          assertEquals(readToolContent.cfc?.stderr?.policy, "observed");
+          assertEquals(readToolContent.cfc?.exitCode?.policy, "observed");
+          assertEquals(readToolContent.cfc?.exitCode?.value, 0);
+          assertStringIncludes(
+            JSON.stringify(readToolContent.cfc?.diagnostics ?? []),
+            "runsc_cfc_result",
+          );
+
+          const runRoot = join(
+            artifactRoot,
+            "integration-read-file-cfc-prompt-loop",
+          );
+          const persistedState = await readHarnessRunState(
+            join(runRoot, "run-state.json"),
+          );
+          const persistedTranscript = await readHarnessTranscript(
+            join(runRoot, "transcript.json"),
+          );
+          assertEquals(persistedTranscript, result.transcript);
+          assertEquals(
+            persistedState.toolOutputs.map((ref) => ref.toolId),
+            ["read_file", "bash"],
+          );
+          assertEquals(
+            persistedState.cfcInvocationContexts?.map((context) =>
+              context.toolId
+            ),
+            ["read_file", "bash"],
+          );
+          assertEquals(
+            persistedState.cfcInvocationContexts?.[0].runManifest.present,
+            false,
+          );
+          const readOutputArtifactPath = persistedState.toolOutputs[0]
+            ?.artifactPath;
+          assert(
+            readOutputArtifactPath !== undefined,
+            "read_file output artifact path was not retained",
+          );
+          const readOutputArtifact = JSON.parse(
+            await Deno.readTextFile(readOutputArtifactPath),
+          ) as {
+            content?: unknown;
+            cfcResult?: {
+              stdout?: { policy?: string };
+              diagnostics?: unknown[];
+            };
+          };
+          assertEquals(readOutputArtifact.content, fileContent);
+          assertEquals(
+            readOutputArtifact.cfcResult?.stdout?.policy,
+            "observed",
+          );
+          assertStringIncludes(
+            JSON.stringify(readOutputArtifact.cfcResult?.diagnostics ?? []),
+            "runsc_cfc_result",
+          );
+        },
+        {
+          artifactRoot,
+          cfcEnforcementMode: "enforce-explicit",
+          model: "gpt-5.4",
+        },
+      );
+    } finally {
+      await Deno.remove(artifactRoot, { recursive: true });
     }
   },
 });

--- a/packages/cf-harness/src/contracts/cfc-invocation-context.ts
+++ b/packages/cf-harness/src/contracts/cfc-invocation-context.ts
@@ -119,6 +119,9 @@ export interface CreateHarnessCfcInvocationContextOptions {
   env?: Record<string, string>;
   cfcInputLabels?: CfcLabelView;
   cfcInputLabelPaths?: readonly HarnessCfcInvocationInputLabelPath[];
+  cfcPromptSlotInputLabelPaths?: readonly HarnessCfcInvocationInputLabelPath[];
+  cfcModelContextInputLabelPaths?:
+    readonly HarnessCfcInvocationInputLabelPath[];
   cfcModelContext?: HarnessCfcModelContext;
 }
 
@@ -281,16 +284,20 @@ export const createHarnessCfcInvocationContext = async (
     ? undefined
     : await summarizeCfcInvocationText(options.stdinText);
   const env = summarizeCfcInvocationEnv(options.env);
+  const promptSlotInputLabelPaths = options.cfcPromptSlotInputLabelPaths ??
+    options.cfcInputLabelPaths;
+  const modelContextInputLabelPaths = options.cfcModelContextInputLabelPaths ??
+    options.cfcInputLabelPaths;
   const cfcInputLabels = mergeCfcLabelViews([
     options.cfcInputLabels,
     createHarnessPromptSlotInfluenceLabels({
       promptSlot: options.promptSlot,
       runManifest: options.runManifest,
-      paths: options.cfcInputLabelPaths,
+      paths: promptSlotInputLabelPaths,
     }),
     createHarnessCfcModelContextInputLabels({
       modelContext: options.cfcModelContext,
-      paths: options.cfcInputLabelPaths,
+      paths: modelContextInputLabelPaths,
     }),
   ]);
 

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -986,6 +986,10 @@ export class CfHarnessEngine {
     env?: Record<string, string>;
     cfcInputLabels?: CfcLabelView;
     cfcInputLabelPaths?: readonly HarnessCfcInvocationInputLabelPath[];
+    cfcPromptSlotInputLabelPaths?:
+      readonly HarnessCfcInvocationInputLabelPath[];
+    cfcModelContextInputLabelPaths?:
+      readonly HarnessCfcInvocationInputLabelPath[];
   }): Promise<HarnessCfcInvocationContext> {
     const now = this.#now();
     const invocation = await createHarnessCfcInvocationContext({
@@ -1018,6 +1022,15 @@ export class CfHarnessEngine {
         : {}),
       ...(options.cfcInputLabelPaths !== undefined
         ? { cfcInputLabelPaths: options.cfcInputLabelPaths }
+        : {}),
+      ...(options.cfcPromptSlotInputLabelPaths !== undefined
+        ? { cfcPromptSlotInputLabelPaths: options.cfcPromptSlotInputLabelPaths }
+        : {}),
+      ...(options.cfcModelContextInputLabelPaths !== undefined
+        ? {
+          cfcModelContextInputLabelPaths:
+            options.cfcModelContextInputLabelPaths,
+        }
         : {}),
       ...(this.#runState.cfcModelContext !== undefined
         ? { cfcModelContext: this.#runState.cfcModelContext }
@@ -1088,6 +1101,10 @@ export class CfHarnessEngine {
         env?: Record<string, string>;
         cfcInputLabels?: CfcLabelView;
         cfcInputLabelPaths?: readonly HarnessCfcInvocationInputLabelPath[];
+        cfcPromptSlotInputLabelPaths?:
+          readonly HarnessCfcInvocationInputLabelPath[];
+        cfcModelContextInputLabelPaths?:
+          readonly HarnessCfcInvocationInputLabelPath[];
       }) => this.#createCfcInvocationContext(options),
     };
   }

--- a/packages/cf-harness/src/tools/read-file.ts
+++ b/packages/cf-harness/src/tools/read-file.ts
@@ -135,7 +135,11 @@ export const readFileTool: HarnessToolDefinition<
         cwd: context.currentDir,
         command,
         args,
-        cfcInputLabelPaths: [["args"]],
+        // read_file is a trusted selector: successful file bytes are mediated
+        // by their own CFC result, not by direct prompt influence on the path.
+        // If prior observed output influenced the model's selected path, carry
+        // that accumulated model-context label onto the invocation args.
+        cfcModelContextInputLabelPaths: [["args"]],
       }),
     });
     if (result.exitCode !== 0) {

--- a/packages/cf-harness/src/tools/types.ts
+++ b/packages/cf-harness/src/tools/types.ts
@@ -55,6 +55,10 @@ export interface HarnessToolContext {
     env?: Record<string, string>;
     cfcInputLabels?: CfcLabelView;
     cfcInputLabelPaths?: readonly HarnessCfcInvocationInputLabelPath[];
+    cfcPromptSlotInputLabelPaths?:
+      readonly HarnessCfcInvocationInputLabelPath[];
+    cfcModelContextInputLabelPaths?:
+      readonly HarnessCfcInvocationInputLabelPath[];
   }): Promise<HarnessCfcInvocationContext>;
 }
 

--- a/packages/cf-harness/test/cfc-invocation-context.test.ts
+++ b/packages/cf-harness/test/cfc-invocation-context.test.ts
@@ -191,6 +191,68 @@ Deno.test("createHarnessCfcInvocationContext derives prompt-slot influence label
   }
 });
 
+Deno.test("createHarnessCfcInvocationContext can label prompt-slot and model-context inputs separately", async () => {
+  const promptSlot = {
+    type: CFC_PROMPT_SLOT_BOUND_ATOM_TYPE,
+    source: { type: "cf-harness.test-input", surface: "cli" },
+    role: "direct-command",
+    kernelName: "cf-harness",
+    surface: "cli",
+  } as const;
+  const observedSecret = {
+    type: "test.cfc/ObservedOutput",
+    subject: "did:key:observed-secret",
+  };
+
+  const context = await createHarnessCfcInvocationContext({
+    sequence: 3,
+    runId: "run-split-label-paths",
+    createdAt: "2026-05-18T22:01:00.000Z",
+    toolId: "read_file",
+    operation: "shell",
+    cfcEnforcementMode: "enforce-explicit",
+    cwd: "/workspace",
+    promptSlot,
+    runManifest: { present: false },
+    command: 'cat "$1"',
+    args: ["/workspace/notes/public.txt"],
+    cfcPromptSlotInputLabelPaths: [["command"]],
+    cfcModelContextInputLabelPaths: [["args"]],
+    cfcModelContext: {
+      type: "cf-harness.cfc-model-context",
+      version: 1,
+      updatedAt: "2026-05-18T22:00:00.000Z",
+      label: {
+        confidentiality: [observedSecret],
+        integrity: [{ type: "test.cfc/ShouldNotFlow" }],
+      },
+      observations: [],
+    },
+  });
+
+  assertEquals(context.cfcInputLabels, {
+    version: 1,
+    entries: [
+      {
+        path: ["args"],
+        label: { confidentiality: [observedSecret] },
+      },
+      {
+        path: ["command"],
+        label: {
+          confidentiality: [{
+            type: CF_HARNESS_PROMPT_SLOT_INFLUENCE_ATOM_TYPE,
+            version: 1,
+            role: "direct-command",
+            kernelName: "cf-harness",
+            surface: "cli",
+          }],
+        },
+      },
+    ],
+  });
+});
+
 Deno.test("createHarnessCfcInvocationContext merges explicit trusted labels with derived prompt-slot labels", async () => {
   const explicitAtom = {
     type: "test.cfc/ExplicitTrustedInput",

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -3498,6 +3498,10 @@ Deno.test("CfHarnessPromptLoop exposes mediated read_file content and tracks mod
   assertEquals(content.content, "released file secret\n");
   assertEquals(content.cfc.stdout.policy, "observed");
   assertEquals(
+    result.runState.cfcInvocationContexts?.[0]?.cfcInputLabels,
+    undefined,
+  );
+  assertEquals(
     result.runState.cfcModelContext?.observations.some((observation) =>
       observation.toolCallId === "call-read-secret-file" &&
       observation.toolId === "read_file" &&


### PR DESCRIPTION
## Summary
- Add an env-gated Docker/runsc CFC prompt-loop integration smoke for the `read_file` mediation path.
- Keep the target to Wilk's first gate: `/workspace` only, no `/fabric` or FUSE.
- Split CFC invocation input-label derivation so trusted `read_file` path selection does not get direct prompt-slot taint, while prior observed model-context labels still flow onto model-selected read paths.
- Assert real runsc sidecar metadata reaches model-facing `read_file` output and retained tool artifacts.

## Notes
- #3606 is now merged; this PR is rebased onto `main` and contains only the integration smoke plus the selector-label adjustment required for the real runsc path.
- The smoke is skipped unless `CF_HARNESS_INTEGRATION=1`, `CF_HARNESS_RUNSC_CFC_RESULT_DIR`, and `CF_HARNESS_RUNSC_CFC_INVOCATION_CONTEXT_DIR` are configured.
- This keeps `read_file` aligned with the trusted-selector interpretation: successful file bytes are mediated by the file read's CFC result, not by direct prompt influence on the path string. If the model selected the path based on previously observed CFC-mediated output, that accumulated model-context label is still carried into the invocation sidecar.

## Tests
- `deno test -A packages/cf-harness/test/cfc-invocation-context.test.ts packages/cf-harness/test/prompt-loop.test.ts packages/cf-harness/test/tools-execution.test.ts`
- `CF_HARNESS_INTEGRATION=1 CF_HARNESS_RUNSC_CFC_RESULT_DIR="$HOME/.local/share/runsc-cfc/cfc-results" CF_HARNESS_RUNSC_CFC_INVOCATION_CONTEXT_DIR="$HOME/.local/share/runsc-cfc/cfc-invocations" deno test -A --filter "prompt loop mediates read_file output through runsc-cfc" packages/cf-harness/integration/engine.integration.test.ts`
- `cd packages/cf-harness && deno task test`
- `git diff --check`
