### PR TITLE
Consistency of `hashString` vs. `taggedHashString`.

### DIFF
--- a/packages/data-model/fabric-hash.ts
+++ b/packages/data-model/fabric-hash.ts
@@ -79,9 +79,21 @@ export class FabricHash extends FabricPrimitive implements ApiFabricHash {
     return this.#tag;
   }
 
-  /** String form of the hash _without_ an algorithm tag. */
+  /**
+   * String form of the hash _without_ an algorithm tag. The hash is in unpadded
+   * base64url form.
+   */
   get hashString(): string {
     return this.#justHashString;
+  }
+
+  /**
+   * String form of the hash _with_ an algorithm tag. The form is
+   * `<tag>:<base64urlHash>`, where the hash portion is in an unpadded base64url
+   * string.
+   */
+  get taggedHashString(): string {
+    return this.#fullStringForm;
   }
 
   /** Copies the hash bytes into `target` starting at offset 0. Returns `target`. */
@@ -90,7 +102,7 @@ export class FabricHash extends FabricPrimitive implements ApiFabricHash {
     return target;
   }
 
-  /** Returns `<tag>:<base64urlHash>` (unpadded base64url). */
+  /** Returns the tagged hash string, same as `.taggedHashString`. */
   override toString(): string {
     return this.#fullStringForm;
   }

--- a/packages/data-model/schema-and-hash.ts
+++ b/packages/data-model/schema-and-hash.ts
@@ -40,8 +40,11 @@ export class SchemaAndHash {
     return this.#hash;
   }
 
-  /** The hash as a string (delegates to `FabricHash.toString()`). */
-  get hashString(): string {
-    return this.#hash.toString();
+  /**
+   * The hash as a string. This is just a convenient shorthand for
+   * `this.hash.taggedHashString`.
+   */
+  get taggedHashString(): string {
+    return this.#hash.taggedHashString;
   }
 }

--- a/packages/data-model/schema-hash.ts
+++ b/packages/data-model/schema-hash.ts
@@ -252,6 +252,6 @@ export function isInternedSchema(schema: JSONSchema): boolean {
  * names the operation and avoids the non-obvious `true` (`wantSchemaAndHash`)
  * argument at call sites.
  */
-export function internSchemaAsHashString(schema: JSONSchema): string {
+export function internSchemaAsTaggedHashString(schema: JSONSchema): string {
   return internSchema(schema, true).taggedHashString;
 }

--- a/packages/data-model/schema-hash.ts
+++ b/packages/data-model/schema-hash.ts
@@ -64,8 +64,8 @@ const schemaFinalizer = new FinalizationRegistry<string>((hashStr) => {
 });
 
 // Seeds `hashToRef` with intern records for `boolean` schemas.
-hashToRef.set(booleanInterns.true.hashString, true);
-hashToRef.set(booleanInterns.false.hashString, false);
+hashToRef.set(booleanInterns.true.taggedHashString, true);
+hashToRef.set(booleanInterns.false.taggedHashString, false);
 
 /**
  * Helper for `internSchema()`, which always returns a `SchemaAndHash`.
@@ -248,10 +248,10 @@ export function isInternedSchema(schema: JSONSchema): boolean {
 
 /**
  * Interns (and thus deep-freezes) the given schema, returning its hash
- * string. Equivalent to `internSchema(schema, true).hashString`, but names
- * the operation and avoids the non-obvious `true` (`wantSchemaAndHash`)
+ * string. Equivalent to `internSchema(schema, true).taggedHashString`, but
+ * names the operation and avoids the non-obvious `true` (`wantSchemaAndHash`)
  * argument at call sites.
  */
 export function internSchemaAsHashString(schema: JSONSchema): string {
-  return internSchema(schema, true).hashString;
+  return internSchema(schema, true).taggedHashString;
 }

--- a/packages/data-model/schema-utils.ts
+++ b/packages/data-model/schema-utils.ts
@@ -13,7 +13,7 @@ import { deepFreeze, isDeepFrozen } from "./deep-freeze.ts";
 import { cloneIfNecessary } from "./fabric-value.ts";
 import {
   internSchema,
-  internSchemaAsHashString,
+  internSchemaAsTaggedHashString,
   isInternedSchema,
 } from "./schema-hash.ts";
 import { type FabricValue } from "./interface.ts";
@@ -371,5 +371,5 @@ export const DEFAULT_SELECTOR: SchemaPathSelector = Object.freeze({
  * for the motivating regression.
  */
 export function internSchemaPairAsKey(a: JSONSchema, b: JSONSchema): string {
-  return `${internSchemaAsHashString(a)}|${internSchemaAsHashString(b)}`;
+  return `${internSchemaAsTaggedHashString(a)}|${internSchemaAsTaggedHashString(b)}`;
 }

--- a/packages/data-model/schema-utils.ts
+++ b/packages/data-model/schema-utils.ts
@@ -371,5 +371,7 @@ export const DEFAULT_SELECTOR: SchemaPathSelector = Object.freeze({
  * for the motivating regression.
  */
 export function internSchemaPairAsKey(a: JSONSchema, b: JSONSchema): string {
-  return `${internSchemaAsTaggedHashString(a)}|${internSchemaAsTaggedHashString(b)}`;
+  return `${internSchemaAsTaggedHashString(a)}|${
+    internSchemaAsTaggedHashString(b)
+  }`;
 }

--- a/packages/data-model/test/fabric-hash.test.ts
+++ b/packages/data-model/test/fabric-hash.test.ts
@@ -100,11 +100,7 @@ describe("FabricHash", () => {
   });
 });
 
-// -----------------------------------------------------------------
-// Tests of things in `value-hash.ts` that end up in `FabricHash`
-// -----------------------------------------------------------------
-
-describe("stuff from value-hash.ts", () => {
+describe("static methods", () => {
   it("FabricHash.fromJson() works on the result of instance method FabricHash.toJSON()", () => {
     const original = new FabricHash(SAMPLE_HASH, "fid1");
     const json = original.toJSON();

--- a/packages/data-model/test/fabric-hash.test.ts
+++ b/packages/data-model/test/fabric-hash.test.ts
@@ -21,6 +21,12 @@ describe("FabricHash", () => {
     expect(str.startsWith("fid1:")).toBe(true);
   });
 
+  it("`.taggedHashString` produces fid1:<base64> format", () => {
+    const cid = new FabricHash(SAMPLE_HASH, "fid1");
+    const str = cid.taggedHashString;
+    expect(str.startsWith("fid1:")).toBe(true);
+  });
+
   it("toJSON() produces { '/': 'fid1:<base64>' }", () => {
     const cid = new FabricHash(SAMPLE_HASH, "fid1");
     const json = cid.toJSON();

--- a/packages/data-model/test/schema-and-hash.test.ts
+++ b/packages/data-model/test/schema-and-hash.test.ts
@@ -35,21 +35,21 @@ describe("constructor", () => {
   });
 });
 
-describe("hashString getter", () => {
+describe("`.taggedHashString` getter", () => {
   it("returns a string", () => {
     const sah = new SchemaAndHash(true, HASH_A);
-    expect(typeof sah.hashString).toBe("string");
+    expect(typeof sah.taggedHashString).toBe("string");
   });
 
-  it("matches hash.toString()", () => {
+  it("matches hash.taggedHashString", () => {
     const sah = new SchemaAndHash(true, HASH_A);
-    expect(sah.hashString).toBe(sah.hash.toString());
+    expect(sah.taggedHashString).toBe(sah.hash.taggedHashString);
   });
 
-  it("different hashes produce different hashStrings", () => {
+  it("different hashes produce different results", () => {
     const sahA = new SchemaAndHash(true, HASH_A);
     const sahB = new SchemaAndHash(true, HASH_B);
-    expect(sahA.hashString).not.toBe(sahB.hashString);
+    expect(sahA.taggedHashString).not.toBe(sahB.taggedHashString);
   });
 });
 

--- a/packages/data-model/test/schema-hash.test.ts
+++ b/packages/data-model/test/schema-hash.test.ts
@@ -313,7 +313,9 @@ describe("schema-hash dispatch", () => {
         type: "object",
         properties: { x: { type: "string" } },
       };
-      expect(internSchemaAsTaggedHashString(a)).toBe(internSchemaAsTaggedHashString(b));
+      expect(internSchemaAsTaggedHashString(a)).toBe(
+        internSchemaAsTaggedHashString(b),
+      );
     });
 
     it("produces different strings for different schemas", () => {

--- a/packages/data-model/test/schema-hash.test.ts
+++ b/packages/data-model/test/schema-hash.test.ts
@@ -265,7 +265,7 @@ describe("schema-hash dispatch", () => {
             },
             true,
           );
-          const found = callFind(sah.hashString);
+          const found = callFind(sah.taggedHashString);
           expectSame(found, sah);
         });
 
@@ -288,19 +288,19 @@ describe("schema-hash dispatch", () => {
   });
 
   describe("internSchemaAsHashString()", () => {
-    it("returns the interned schema's hashString for an object", () => {
+    it("returns the interned schema's `.taggedHashString` for an object", () => {
       const schema: JSONSchema = { type: "number" };
       const sah = internSchema(schema, true);
-      expect(internSchemaAsHashString(schema)).toBe(sah.hashString);
+      expect(internSchemaAsHashString(schema)).toBe(sah.taggedHashString);
     });
 
-    it("returns the boolean schema's prefab hashString for `true`", () => {
-      const expected = internSchema(true, true).hashString;
+    it("returns the boolean schema's prefab `.taggedHashString` for `true`", () => {
+      const expected = internSchema(true, true).taggedHashString;
       expect(internSchemaAsHashString(true)).toBe(expected);
     });
 
-    it("returns the boolean schema's prefab hashString for `false`", () => {
-      const expected = internSchema(false, true).hashString;
+    it("returns the boolean schema's prefab `.taggedHashString` for `false`", () => {
+      const expected = internSchema(false, true).taggedHashString;
       expect(internSchemaAsHashString(false)).toBe(expected);
     });
 

--- a/packages/data-model/test/schema-hash.test.ts
+++ b/packages/data-model/test/schema-hash.test.ts
@@ -5,7 +5,7 @@ import {
   findInternedSchema,
   hashSchema,
   internSchema,
-  internSchemaAsHashString,
+  internSchemaAsTaggedHashString,
   isInternedSchema,
 } from "../schema-hash.ts";
 import { SchemaAndHash } from "../schema-and-hash.ts";
@@ -287,21 +287,21 @@ describe("schema-hash dispatch", () => {
     }
   });
 
-  describe("internSchemaAsHashString()", () => {
+  describe("internSchemaAsTaggedHashString()", () => {
     it("returns the interned schema's `.taggedHashString` for an object", () => {
       const schema: JSONSchema = { type: "number" };
       const sah = internSchema(schema, true);
-      expect(internSchemaAsHashString(schema)).toBe(sah.taggedHashString);
+      expect(internSchemaAsTaggedHashString(schema)).toBe(sah.taggedHashString);
     });
 
     it("returns the boolean schema's prefab `.taggedHashString` for `true`", () => {
       const expected = internSchema(true, true).taggedHashString;
-      expect(internSchemaAsHashString(true)).toBe(expected);
+      expect(internSchemaAsTaggedHashString(true)).toBe(expected);
     });
 
     it("returns the boolean schema's prefab `.taggedHashString` for `false`", () => {
       const expected = internSchema(false, true).taggedHashString;
-      expect(internSchemaAsHashString(false)).toBe(expected);
+      expect(internSchemaAsTaggedHashString(false)).toBe(expected);
     });
 
     it("produces matching strings for structurally-equal objects", () => {
@@ -313,15 +313,15 @@ describe("schema-hash dispatch", () => {
         type: "object",
         properties: { x: { type: "string" } },
       };
-      expect(internSchemaAsHashString(a)).toBe(internSchemaAsHashString(b));
+      expect(internSchemaAsTaggedHashString(a)).toBe(internSchemaAsTaggedHashString(b));
     });
 
     it("produces different strings for different schemas", () => {
-      expect(internSchemaAsHashString({ type: "number" })).not.toEqual(
-        internSchemaAsHashString({ type: "string" }),
+      expect(internSchemaAsTaggedHashString({ type: "number" })).not.toEqual(
+        internSchemaAsTaggedHashString({ type: "string" }),
       );
-      expect(internSchemaAsHashString(true)).not.toEqual(
-        internSchemaAsHashString(false),
+      expect(internSchemaAsTaggedHashString(true)).not.toEqual(
+        internSchemaAsTaggedHashString(false),
       );
     });
 
@@ -333,15 +333,15 @@ describe("schema-hash dispatch", () => {
         title: `schemaHashTestAt${Date.now()}-${Math.random()}`,
       };
       expect(isInternedSchema(schema)).toBe(false);
-      internSchemaAsHashString(schema);
+      internSchemaAsTaggedHashString(schema);
       expect(isInternedSchema(schema)).toBe(true);
       assert(isDeepFrozen(schema));
     });
 
     it("is idempotent on already-interned schemas", () => {
       const schema: JSONSchema = { type: "number" };
-      const first = internSchemaAsHashString(schema);
-      const second = internSchemaAsHashString(schema);
+      const first = internSchemaAsTaggedHashString(schema);
+      const second = internSchemaAsTaggedHashString(schema);
       expect(first).toBe(second);
     });
   });

--- a/packages/data-model/test/schema-utils.test.ts
+++ b/packages/data-model/test/schema-utils.test.ts
@@ -853,19 +853,19 @@ describe("emptySchemaObject", () => {
 });
 
 describe("internSchemaPairAsKey()", () => {
-  it("composes the two interned `hashString`s with `|`", () => {
+  it("composes the two interned `.taggedHashString`s with `|`", () => {
     const a: JSONSchema = { type: "number" };
     const b: JSONSchema = { type: "string" };
-    const aHash = internSchema(a, true).hashString;
-    const bHash = internSchema(b, true).hashString;
+    const aHash = internSchema(a, true).taggedHashString;
+    const bHash = internSchema(b, true).taggedHashString;
     expect(internSchemaPairAsKey(a, b)).toBe(`${aHash}|${bHash}`);
   });
 
   it("handles boolean schemas on either side", () => {
     const obj: JSONSchema = { type: "number" };
-    const objHash = internSchema(obj, true).hashString;
-    const trueHash = internSchema(true, true).hashString;
-    const falseHash = internSchema(false, true).hashString;
+    const objHash = internSchema(obj, true).taggedHashString;
+    const trueHash = internSchema(true, true).taggedHashString;
+    const falseHash = internSchema(false, true).taggedHashString;
     expect(internSchemaPairAsKey(true, obj)).toBe(`${trueHash}|${objHash}`);
     expect(internSchemaPairAsKey(obj, false)).toBe(`${objHash}|${falseHash}`);
     expect(internSchemaPairAsKey(true, false)).toBe(

--- a/packages/memory/v2/server-sync.ts
+++ b/packages/memory/v2/server-sync.ts
@@ -1,4 +1,4 @@
-import { internSchemaAsHashString } from "@commonfabric/data-model/schema-hash";
+import { internSchemaAsTaggedHashString } from "@commonfabric/data-model/schema-hash";
 import {
   type CellScope,
   type EntitySnapshot,
@@ -111,7 +111,7 @@ const watchRootIdentity = (root: GraphQuery["roots"][number]): string =>
     root.selector.path,
     root.selector.schema === undefined
       ? ""
-      : internSchemaAsHashString(root.selector.schema),
+      : internSchemaAsTaggedHashString(root.selector.schema),
   ]);
 
 const watchQueryIdentity = (watch: WatchSpec): string =>

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -156,7 +156,7 @@ const recordSchemaWritePolicyInput = (
       scope: link.scope,
       path: [...link.path],
     },
-    schemaHash: schemaAndHash.hashString,
+    schemaHash: schemaAndHash.taggedHashString,
     schema: schemaAndHash.schema,
   });
 };

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1275,12 +1275,12 @@ export const prepareBoundaryCommit = (
     ensureSchemaDocument(
       tx,
       space,
-      schemaAndHash.hashString,
+      schemaAndHash.taggedHashString,
       schemaAndHash.schema,
     );
     const metadata: CfcMetadata = {
       version: 1,
-      schemaHash: schemaAndHash.hashString,
+      schemaHash: schemaAndHash.taggedHashString,
       labelMap: {
         version: 1,
         entries: coalescedLabelEntries,

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -3,7 +3,7 @@ import { hashOf, hashStringOf } from "@commonfabric/data-model/value-hash";
 import {
   hashSchema,
   internSchema,
-  internSchemaAsHashString,
+  internSchemaAsTaggedHashString,
 } from "@commonfabric/data-model/schema-hash";
 import { MIME } from "@commonfabric/memory/interface";
 import type { JSONSchemaObj } from "@commonfabric/api";
@@ -384,7 +384,7 @@ export class CycleTracker<K> {
  *
  * Identity check on `partialKey`, structural check on `extraKey` via
  * the interned hash string of `extraKey`: the inner per-partialKey map
- * is keyed on `internSchemaAsHashString(extraKey ?? true)`, so repeat
+ * is keyed on `internSchemaAsTaggedHashString(extraKey ?? true)`, so repeat
  * calls with a structurally-equal schema re-lookup the same entry in
  * O(1) without re-hashing — the intern cache's WeakMap returns the
  * canonical hash string without invoking `hashStringOf()` on
@@ -419,7 +419,7 @@ export class CompoundCycleTracker<
       existing = new Map();
       this.partial.set(partialKey, existing);
     }
-    const hash = internSchemaAsHashString(extraKey ?? true);
+    const hash = internSchemaAsTaggedHashString(extraKey ?? true);
     if (existing.has(hash)) {
       return null;
     }
@@ -443,7 +443,7 @@ export class CompoundCycleTracker<
     if (existing === undefined) {
       return undefined;
     }
-    const hash = internSchemaAsHashString(extraKey ?? true);
+    const hash = internSchemaAsTaggedHashString(extraKey ?? true);
     return existing.get(hash);
   }
 }
@@ -3415,8 +3415,8 @@ export function mergeAnyOfBranchSchemas(
   // Interning each input stabilizes its identity so downstream callers
   // hit the hash-cache fast path; `||` separates outer from branches,
   // `|` separates branches.
-  const key = `${internSchemaAsHashString(outerSchema)}||` +
-    branches.map(internSchemaAsHashString).join("|");
+  const key = `${internSchemaAsTaggedHashString(outerSchema)}||` +
+    branches.map(internSchemaAsTaggedHashString).join("|");
   const cached = _mergeAnyOfBranchCache.get(key);
   if (cached !== undefined) return cached;
 
@@ -3500,7 +3500,7 @@ function _mergeAnyOfBranchSchemasUncached(
     // identities for any downstream caller that re-hashes them.
     const uniqueHashes = new Map<string, JSONSchema>();
     for (const s of schemas) {
-      uniqueHashes.set(internSchemaAsHashString(s), s);
+      uniqueHashes.set(internSchemaAsTaggedHashString(s), s);
     }
     if (uniqueHashes.size === 1) {
       // All branches agree on this property's schema

--- a/packages/runner/test/cfc-boundary.test.ts
+++ b/packages/runner/test/cfc-boundary.test.ts
@@ -2161,7 +2161,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
         value: { linked: null },
         cfc: {
           version: 1,
-          schemaHash: guardedSchema.hashString,
+          schemaHash: guardedSchema.taggedHashString,
           labelMap: {
             version: 1,
             entries: [{ path: ["linked"], label: {} }],
@@ -2171,7 +2171,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
       targetSeed.writeOrThrow({
         space: signer.did(),
         scope: "space",
-        id: `cid:${guardedSchema.hashString}`,
+        id: `cid:${guardedSchema.taggedHashString}`,
         path: [],
       }, {
         value: guardedSchema.schema,
@@ -2261,7 +2261,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
         value: { items: [null] },
         cfc: {
           version: 1,
-          schemaHash: guardedSchema.hashString,
+          schemaHash: guardedSchema.taggedHashString,
           labelMap: {
             version: 1,
             entries: [{ path: ["items", "*"], label: {} }],
@@ -2271,7 +2271,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
       targetSeed.writeOrThrow({
         space: signer.did(),
         scope: "space",
-        id: `cid:${guardedSchema.hashString}`,
+        id: `cid:${guardedSchema.taggedHashString}`,
         path: [],
       }, {
         value: guardedSchema.schema,
@@ -2689,7 +2689,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
         },
         cfc: {
           version: 1,
-          schemaHash: existingSchemaAndHash.hashString,
+          schemaHash: existingSchemaAndHash.taggedHashString,
           labelMap: {
             version: 1,
             entries: [
@@ -2702,7 +2702,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
       seed.writeOrThrow({
         space: signer.did(),
         scope: "space",
-        id: `cid:${existingSchemaAndHash.hashString}`,
+        id: `cid:${existingSchemaAndHash.taggedHashString}`,
         type,
         path: [],
       }, {
@@ -2733,7 +2733,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
           id: documentId,
           path: ["internal", "stage"],
         },
-        schemaHash: stageSchemaAndHash.hashString,
+        schemaHash: stageSchemaAndHash.taggedHashString,
         schema: stageSchemaAndHash.schema,
       });
 


### PR DESCRIPTION
This PR makes it so that the term `hashString` in names of functions, members, etc. consistently means an _untagged_ hash string, whereas `taggedHashString` — unsurprisingly! — means a _tagged_ hash string.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes naming: `hashString` now always means an untagged base64url hash, and `taggedHashString` means `<tag>:<hash>`. This aligns APIs across `@commonfabric/data-model`, `@commonfabric/runner`, and `@commonfabric/memory` with no behavior changes.

- **Refactors**
  - Added `FabricHash.taggedHashString` (same as `toString()`).
  - Renamed `SchemaAndHash.hashString` → `SchemaAndHash.taggedHashString`.
  - Renamed `internSchemaAsHashString()` → `internSchemaAsTaggedHashString()`.
  - Updated all call sites and tests.

- **Migration**
  - Use `SchemaAndHash.taggedHashString` instead of `.hashString`.
  - Use `internSchemaAsTaggedHashString(...)` instead of `internSchemaAsHashString(...)`.
  - For untagged strings, use `FabricHash.hashString`.

<sup>Written for commit 1f89a1999e86de50d41329c84a18dd1ec327611e. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3617?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

## Performance Baseline

This PR only renames things, so the following accounts for a spurious perf check failure:

NEW_PERF_BASELINE: job: CLI Integration Tests (fuse) = 161s

