### PR TITLE
Make `JsonWireValue` be deep-frozen

### DIFF
--- a/packages/data-model/json-encoding-context.ts
+++ b/packages/data-model/json-encoding-context.ts
@@ -65,14 +65,19 @@ function isQuoteSafe(v: JsonWireValue): boolean {
  * literal and must not be recursed into.
  */
 function unquote(v: JsonWireValue): JsonWireValue {
-  if (v === null || typeof v !== "object") return v;
-  if (Array.isArray(v)) return v.map(unquote) as JsonWireValue;
-  if (isEncodedInstance(v) && Object.keys(v)[0] === "/quote") {
+  if (v === null || typeof v !== "object") {
+    return v;
+  } else if (Array.isArray(v)) {
+    const result = v.map(unquote) as JsonWireValue;
+    return Object.freeze(result);
+  } else if (isEncodedInstance(v) && Object.keys(v)[0] === "/quote") {
     return (v as Record<string, JsonWireValue>)["/quote"];
+  } else {
+    const result = Object.fromEntries(
+      Object.entries(v).map(([k, val]) => [k, unquote(val as JsonWireValue)]),
+    ) as JsonWireValue;
+    return Object.freeze(result);
   }
-  return Object.fromEntries(
-    Object.entries(v).map(([k, val]) => [k, unquote(val as JsonWireValue)]),
-  ) as JsonWireValue;
 }
 
 /**
@@ -217,7 +222,7 @@ export class JsonEncodingContext implements SerializationContext<string> {
    * tag to produce the JSON key. See Section 5.2 of the formal spec.
    */
   private wrapTag(tag: string, state: JsonWireValue): JsonWireValue {
-    return { [`/${tag}`]: state } as JsonWireValue;
+    return Object.freeze({ [`/${tag}`]: state } as JsonWireValue);
   }
 
   /**
@@ -255,7 +260,8 @@ export class JsonEncodingContext implements SerializationContext<string> {
 
   /** Parses UTF-8-encoded JSON bytes back into a wire-format tree. */
   private fromBytes(bytes: Uint8Array): JsonWireValue {
-    return JSON.parse(new TextDecoder().decode(bytes)) as JsonWireValue;
+    const result = JSON.parse(new TextDecoder().decode(bytes)) as JsonWireValue;
+    return deepFreeze(result);
   }
 
   // -------------------------------------------------------------------------
@@ -362,8 +368,10 @@ export class JsonEncodingContext implements SerializationContext<string> {
     const keys = Object.keys(result);
     if (keys.some((k) => k.startsWith("/"))) {
       if (Object.values(result).every((v) => isQuoteSafe(v))) {
-        const unquoted = Object.fromEntries(
-          Object.entries(result).map(([k, v]) => [k, unquote(v)]),
+        const unquoted = deepFreeze(
+          Object.fromEntries(
+            Object.entries(result).map(([k, v]) => [k, unquote(v)]),
+          ),
         );
         return this.wrapTag(TAGS.quote, unquoted) as JsonWireValue;
       }

--- a/packages/data-model/json-encoding-context.ts
+++ b/packages/data-model/json-encoding-context.ts
@@ -153,7 +153,7 @@ export class JsonEncodingContext implements SerializationContext<string> {
     }
 
     const json = data.slice(ENCODING_PREFIX_TAG.length);
-    const parsed = JSON.parse(json) as JsonWireValue;
+    const parsed = deepFreeze(JSON.parse(json) as JsonWireValue);
     return this.deserialize(parsed, runtime);
   }
 

--- a/packages/data-model/json-encoding-context.ts
+++ b/packages/data-model/json-encoding-context.ts
@@ -368,7 +368,7 @@ export class JsonEncodingContext implements SerializationContext<string> {
     const keys = Object.keys(result);
     if (keys.some((k) => k.startsWith("/"))) {
       if (Object.values(result).every((v) => isQuoteSafe(v))) {
-        const unquoted = deepFreeze(
+        const unquoted = Object.freeze(
           Object.fromEntries(
             Object.entries(result).map(([k, v]) => [k, unquote(v)]),
           ),

--- a/packages/data-model/json-encoding-context.ts
+++ b/packages/data-model/json-encoding-context.ts
@@ -227,7 +227,10 @@ export class JsonEncodingContext implements SerializationContext<string> {
 
   /**
    * Unwraps a wire representation. Detects single-key objects with `/`-prefixed
-   * keys. Returns `{ tag, state }` or `null` if not a tagged value.
+   * keys. Returns `{ tag, state }` or `null` if not a tagged value. The
+   * returned `state` is extracted directly from `data`, so if `data` is
+   * deep-frozen (as it should be) then `state` will be too.
+   *
    * See Section 5.4 of the formal spec.
    */
   private unwrapTag(
@@ -427,7 +430,7 @@ export class JsonEncodingContext implements SerializationContext<string> {
 
       // `TAGS.quote` literal handling (Section 5.6).
       if (tag === TAGS.quote) {
-        return deepFreeze(state) as FabricValue;
+        return state as FabricValue;
       }
 
       // --- Type handler dispatch ---

--- a/packages/data-model/json-encoding-context.ts
+++ b/packages/data-model/json-encoding-context.ts
@@ -33,6 +33,12 @@ import { utf8SortedKeysOf } from "@commonfabric/utils/utf8";
  */
 const ENCODING_PREFIX_TAG = "fvj1:";
 
+/** Shared text encoder, created once. */
+const textEncoder = new TextEncoder();
+
+/** Shared text decoder, created once. */
+const textDecoder = new TextDecoder();
+
 /** Shared default handler registry, created once. */
 const defaultRegistry: TypeHandlerRegistry = createDefaultRegistry();
 
@@ -153,7 +159,7 @@ export class JsonEncodingContext implements SerializationContext<string> {
     }
 
     const json = data.slice(ENCODING_PREFIX_TAG.length);
-    const parsed = deepFreeze(JSON.parse(json) as JsonWireValue);
+    const parsed = JsonEncodingContext.#parseWireText(json);
     return this.deserialize(parsed, runtime);
   }
 
@@ -258,13 +264,13 @@ export class JsonEncodingContext implements SerializationContext<string> {
 
   /** Converts a wire-format tree to UTF-8-encoded JSON bytes. */
   private toBytes(data: JsonWireValue): Uint8Array {
-    return new TextEncoder().encode(JSON.stringify(data));
+    return textEncoder.encode(JSON.stringify(data));
   }
 
   /** Parses UTF-8-encoded JSON bytes back into a wire-format tree. */
   private fromBytes(bytes: Uint8Array): JsonWireValue {
-    const result = JSON.parse(new TextDecoder().decode(bytes)) as JsonWireValue;
-    return deepFreeze(result);
+    const json = textDecoder.decode(bytes);
+    return JsonEncodingContext.#parseWireText(json);
   }
 
   // -------------------------------------------------------------------------
@@ -550,5 +556,12 @@ export class JsonEncodingContext implements SerializationContext<string> {
       result[key] = this.deserialize(val, runtime, registry);
     }
     return Object.freeze(result);
+  }
+
+  /**
+   * Parses the JSON-text wire form, _without_ a tag prefix.
+   */
+  static #parseWireText(jsonText: string): JsonWireValue {
+    return deepFreeze(JSON.parse(jsonText) as JsonWireValue);
   }
 }

--- a/packages/data-model/json-type-handlers.ts
+++ b/packages/data-model/json-type-handlers.ts
@@ -22,6 +22,8 @@ import {
  * JSON-compatible wire format value. This is the intermediate tree
  * representation used during serialization tree walking -- NOT the final
  * serialized form (which is `string`). Internal to the JSON implementation.
+ * Immediately after construction, all instances of this type are expected to be
+ * deep-frozen.
  */
 export type JsonWireValue =
   | null

--- a/packages/data-model/json-type-handlers.ts
+++ b/packages/data-model/json-type-handlers.ts
@@ -6,19 +6,6 @@ import {
 } from "./interface.ts";
 import { ExplicitTagValue } from "./explicit-tag-value.ts";
 import { ProblematicValue } from "./problematic-value.ts";
-
-/**
- * JSON-compatible wire format value. This is the intermediate tree
- * representation used during serialization tree walking -- NOT the final
- * serialized form (which is `string`). Internal to the JSON implementation.
- */
-export type JsonWireValue =
-  | null
-  | boolean
-  | number
-  | string
-  | JsonWireValue[]
-  | { [key: string]: JsonWireValue };
 import { FabricEpochDays, FabricEpochNsec } from "./fabric-epoch.ts";
 import { FabricBytes } from "./fabric-bytes.ts";
 import { TAGS } from "./fabric-type-tags.ts";
@@ -30,6 +17,19 @@ import {
   bigintFromMinimalTwosComplement,
   bigintToMinimalTwosComplement,
 } from "./bigint-encoding.ts";
+
+/**
+ * JSON-compatible wire format value. This is the intermediate tree
+ * representation used during serialization tree walking -- NOT the final
+ * serialized form (which is `string`). Internal to the JSON implementation.
+ */
+export type JsonWireValue =
+  | null
+  | boolean
+  | number
+  | string
+  | readonly JsonWireValue[]
+  | { [key: string]: JsonWireValue };
 
 /**
  * Narrow interface for what type handlers need from the encoding context

--- a/packages/data-model/json-type-handlers.ts
+++ b/packages/data-model/json-type-handlers.ts
@@ -22,8 +22,17 @@ import {
  * JSON-compatible wire format value. This is the intermediate tree
  * representation used during serialization tree walking -- NOT the final
  * serialized form (which is `string`). Internal to the JSON implementation.
- * Immediately after construction, all instances of this type are expected to be
- * deep-frozen.
+ *
+ * Deep-frozen invariant: every wire tree that *enters deserialization* is
+ * deep-frozen. This is enforced at the two construction sites that feed
+ * `deserialize()` -- `decode()` and `fromBytes()`, unified in
+ * `#parseWireText()` -- and is what lets `unwrapTag()` / the `/quote` arm
+ * hand back extracted sub-trees directly (see their contracts). The transient
+ * trees built on the *serialize* side are not covered by this invariant: they
+ * are `JSON.stringify`-ed and discarded by `encode()` / `encodeToBytes()` and
+ * never reach a caller. (The serialize-side `/quote` form happens to be
+ * deep-frozen as a side effect of `unquote()`'s recursive rebuild, but no
+ * other serialize output is, and none needs to be.)
  */
 export type JsonWireValue =
   | null

--- a/packages/data-model/test/json-encoding-context.test.ts
+++ b/packages/data-model/test/json-encoding-context.test.ts
@@ -1706,6 +1706,156 @@ describe("JsonEncodingContext", () => {
   });
 
   // --------------------------------------------------------------------------
+  // Deep-frozen wire invariant: decode() / decodeFromBytes() symmetry
+  // --------------------------------------------------------------------------
+
+  describe("deep-frozen wire invariant (decode/decodeFromBytes symmetry)", () => {
+    // Every `JsonWireValue` handed to `deserialize()` must be deep-frozen, so
+    // both `deserialize()` entry points must produce equally deep-frozen
+    // results: `decode()` (string path) and `decodeFromBytes()` (bytes path
+    // via `fromBytes()`).
+    //
+    // Regression guard: the `/quote` arm does `return state`, handing back a
+    // node lifted straight out of the parsed wire tree (see `unwrapTag`'s
+    // contract). That shortcut is only sound because the parsed tree is
+    // deep-frozen at construction. `fromBytes()` has always done this;
+    // `decode()` once did NOT (it parsed inline without `deepFreeze()`), so a
+    // tweak that removed the `/quote` arm's own `deepFreeze()` made
+    // string-path `/quote` results come back mutable. These tests pin the
+    // symmetry so neither construction site can silently drop the guarantee.
+
+    /**
+     * Decodes the same wire tree both ways. The string path needs the
+     * encoding prefix; the bytes path does not (it does not strip one).
+     */
+    function decodeBothPaths(
+      data: JsonWireValue,
+    ): { viaString: FabricValue; viaBytes: FabricValue } {
+      const { context, runtime } = makeTestContext();
+      const json = JSON.stringify(data);
+      const viaString = context.decode(ENCODING_PREFIX + json, runtime);
+      const viaBytes = context.decodeFromBytes(
+        new TextEncoder().encode(json),
+        runtime,
+      );
+      return { viaString, viaBytes };
+    }
+
+    const cases: Array<[string, JsonWireValue]> = [
+      ["plain nested object + array", { a: { b: [1, 2, { c: 3 }] } }],
+      ["/quote literal with nested object and array", {
+        "/quote": { x: [1, { y: 2 }], z: { w: [3, 4] } },
+      }],
+      ["/quote literal whose top value is an array", {
+        "/quote": [[1, 2], { a: 1 }, [{ b: 2 }]],
+      }],
+      ["/object-wrapped object with a /-prefixed key", {
+        "/object": { "/k": { nested: [1, 2] } },
+      }],
+      ["tagged handler value (EpochNsec, arm-1 contract)", {
+        "/EpochNsec@1": "AA",
+      }],
+      ["mixed: a /quote value beside a normal array", {
+        meta: [1, 2],
+        lit: { "/quote": { deep: { deeper: [9] } } },
+      }],
+    ];
+
+    for (const [name, wire] of cases) {
+      it(`both paths yield a deep-frozen, equal result: ${name}`, () => {
+        const { viaString, viaBytes } = decodeBothPaths(wire);
+        expect(isDeepFrozen(viaString)).toBe(true);
+        expect(isDeepFrozen(viaBytes)).toBe(true);
+        expect(viaString).toEqual(viaBytes);
+      });
+    }
+
+    it("string path deep-freezes /quote content at every depth (regression for decode() vs fromBytes())", () => {
+      const wire = {
+        "/quote": { outer: { inner: [1, 2] } },
+      } as JsonWireValue;
+      const { context, runtime } = makeTestContext();
+      const result = context.decode(
+        ENCODING_PREFIX + JSON.stringify(wire),
+        runtime,
+      ) as Record<string, Record<string, FabricValue[]>>;
+
+      expect(isDeepFrozen(result)).toBe(true);
+      expect(Object.isFrozen(result.outer)).toBe(true);
+      expect(Object.isFrozen(result.outer.inner)).toBe(true);
+      expect(() => {
+        (result.outer.inner as unknown as number[])[0] = 99;
+      }).toThrow();
+      expect(() => {
+        (result.outer as Record<string, unknown>).added = true;
+      }).toThrow();
+    });
+
+    it("bytes path deep-freezes /quote content at every depth", () => {
+      const wire = {
+        "/quote": { outer: { inner: [{ deep: 1 }] } },
+      } as JsonWireValue;
+      const { context, runtime } = makeTestContext();
+      const result = context.decodeFromBytes(
+        new TextEncoder().encode(JSON.stringify(wire)),
+        runtime,
+      ) as Record<string, Record<string, Array<Record<string, FabricValue>>>>;
+
+      expect(isDeepFrozen(result)).toBe(true);
+      expect(Object.isFrozen(result.outer.inner[0])).toBe(true);
+      expect(() => {
+        (result.outer.inner[0] as Record<string, unknown>).deep = 2;
+      }).toThrow();
+    });
+
+    it("serialize() output for /quote-routed values is itself deep-frozen (flat and nested)", () => {
+      // White-box: the serialized /quote tree is transient -- encode() and
+      // encodeToBytes() immediately JSON.stringify it and discard it -- so
+      // its frozen-ness is not observable via the public API. Reach into the
+      // private serializer to pin the guarantee directly.
+      //
+      // It holds because `unquote()` rebuilds + recursively freezes every
+      // array/object, so each member handed to the container's shallow
+      // `Object.freeze` is itself already deep-frozen. A future change to
+      // `unquote()` that stopped rebuilding (or stopped freezing) would
+      // silently break this; this test is the guard. NOTE: the non-/quote
+      // serialize outputs (bare objects/arrays, /object-wrapped, handler
+      // state) are intentionally NOT asserted here -- that throwaway tree is
+      // out of scope and is not deep-frozen.
+      const { context } = makeTestContext();
+      const serialize = (context as unknown as {
+        serialize(v: FabricValue): JsonWireValue;
+      }).serialize.bind(context);
+
+      const flat = serialize(
+        { "/a": 1, "/b": { plain: [1, 2] } } as unknown as FabricValue,
+      );
+      const nested = serialize(
+        { "/a": { "/b": { c: [1, { d: 2 }] } } } as unknown as FabricValue,
+      );
+
+      expect(flat).toEqual({
+        "/quote": { "/a": 1, "/b": { plain: [1, 2] } },
+      });
+      expect(isDeepFrozen(flat)).toBe(true);
+      expect(isDeepFrozen(nested)).toBe(true);
+    });
+
+    it("serialize→/quote→decode round-trip is deep-frozen end-to-end", () => {
+      // An object whose keys are all /-prefixed but whose values are all
+      // quote-safe routes through the serialize-side /quote path, then back
+      // through the deserialize /quote `return state` arm.
+      const value = {
+        "/a": 1,
+        "/b": { plain: [1, 2] },
+      } as unknown as FabricValue;
+      const result = roundTrip(value);
+      expect(isDeepFrozen(result)).toBe(true);
+      expect(result).toEqual({ "/a": 1, "/b": { plain: [1, 2] } });
+    });
+  });
+
+  // --------------------------------------------------------------------------
   // JsonEncodingContext public API
   // --------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR tweaks the type of `JsonWireValue` to be more `readonly` and changes the places where instances of it are constructed to make them be consistently deep-frozen.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deep-freezes `JsonWireValue` trees at deserialization entry (`decode()` and `decodeFromBytes()`) to guarantee immutability and decode-path symmetry; arrays are `readonly`. Serialize-side trees remain transient (except the `/quote` rebuild) and are not part of the invariant.

- **Refactors**
  - Deep-freeze parsed JSON in `#parseWireText()` for both string/bytes decode; `/quote` unwrap returns `state` directly.
  - Freeze `unquote()` results and `wrapTag()` objects; make array form of `JsonWireValue` `readonly`.
  - Remove redundant `deepFreeze()` in `/quote` decode; reuse shared `TextEncoder`/`TextDecoder`.
  - Add tests pinning the deep-frozen invariant, decode/decodeFromBytes symmetry, `/quote` depth guarantees, and the serialize-side `/quote` tree freeze.

- **Migration**
  - Do not mutate a `JsonWireValue`; create a new value instead.
  - If you modified decoded results in place, clone first (e.g., `structuredClone`).

<sup>Written for commit a4c666fb387bdd566262e0fedfaf3f15f4d146ef. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3619?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

