### PR TITLE
feat(data-model): ReconstructionContext.shouldDeepFreeze output-contract directive (U3 split-PR)

### DIFF
--- a/packages/data-model/base-reconstruction-context.ts
+++ b/packages/data-model/base-reconstruction-context.ts
@@ -1,0 +1,39 @@
+/**
+ * Base class for `ReconstructionContext` implementations. Centralizes the
+ * `shouldDeepFreeze` getter so every context declares the (required) member
+ * via a single shared implementation instead of repeating it.
+ */
+
+import type { FabricInstance, ReconstructionContext } from "./interface.ts";
+
+/**
+ * Abstract base that supplies the `shouldDeepFreeze` getter from a
+ * constructor argument. Subclasses implement `getCell()` for their own
+ * boundary semantics; they inherit `shouldDeepFreeze` for free.
+ *
+ * The `shouldDeepFreeze` argument defaults to `true`, mirroring
+ * `cloneIfNecessary()`'s `frozen` option (see `value-clone.ts`): the
+ * deep-frozen result is the safe default, and `shouldDeepFreeze === true`
+ * corresponds to `cloneIfNecessary(value, { frozen: true })`.
+ */
+export abstract class BaseReconstructionContext
+  implements ReconstructionContext {
+  readonly #shouldDeepFreeze: boolean;
+
+  constructor(shouldDeepFreeze: boolean = true) {
+    this.#shouldDeepFreeze = shouldDeepFreeze;
+  }
+
+  /**
+   * Whether a reconstruction call should produce a deep-frozen result. See
+   * `ReconstructionContext.shouldDeepFreeze`.
+   */
+  get shouldDeepFreeze(): boolean {
+    return this.#shouldDeepFreeze;
+  }
+
+  /** Resolves a cell reference. Subclass-specific. */
+  abstract getCell(
+    ref: { id: string; path: string[]; space: string },
+  ): FabricInstance;
+}

--- a/packages/data-model/deno.json
+++ b/packages/data-model/deno.json
@@ -24,6 +24,7 @@
     "./base-reconstruction-context": "./base-reconstruction-context.ts",
     "./bigint-encoding": "./bigint-encoding.ts",
     "./deep-freeze": "./deep-freeze.ts",
+    "./empty-reconstruction-context": "./empty-reconstruction-context.ts",
     "./explicit-tag-value": "./explicit-tag-value.ts",
     "./fabric-bytes": "./fabric-bytes.ts",
     "./fabric-epoch": "./fabric-epoch.ts",

--- a/packages/data-model/deno.json
+++ b/packages/data-model/deno.json
@@ -21,6 +21,7 @@
   },
   "exports": {
     "./array-utils": "./array-utils.ts",
+    "./base-reconstruction-context": "./base-reconstruction-context.ts",
     "./bigint-encoding": "./bigint-encoding.ts",
     "./deep-freeze": "./deep-freeze.ts",
     "./explicit-tag-value": "./explicit-tag-value.ts",

--- a/packages/data-model/empty-reconstruction-context.ts
+++ b/packages/data-model/empty-reconstruction-context.ts
@@ -22,4 +22,8 @@ export const EMPTY_RECONSTRUCTION_CONTEXT: ReconstructionContext = Object
         `Cannot reconstruct cell reference \`${ref.id}\`: no runtime context provided.`,
       );
     },
+
+    // The deep-frozen result is the safe default (mirrors
+    // `cloneIfNecessary`'s `frozen` defaulting to `true`).
+    shouldDeepFreeze: true,
   });

--- a/packages/data-model/empty-reconstruction-context.ts
+++ b/packages/data-model/empty-reconstruction-context.ts
@@ -11,13 +11,28 @@ import { BaseReconstructionContext } from "./base-reconstruction-context.ts";
 /**
  * `ReconstructionContext` whose `getCell()` always throws. `shouldDeepFreeze`
  * is inherited from `BaseReconstructionContext` (defaults to `true`).
+ *
+ * Both constructor arguments are optional and default so that
+ * `new EmptyReconstructionContext()` is byte-identical to the historical
+ * singleton: `shouldDeepFreeze` defaults to `true` (via the base class) and
+ * the `getCell()` throw message defaults to the original literal. Callers
+ * that need a different frozenness intent (e.g. a clone path that owns its
+ * own freeze decision) or a situation-appropriate throw message pass them
+ * explicitly.
  */
-class EmptyReconstructionContext extends BaseReconstructionContext {
+export class EmptyReconstructionContext extends BaseReconstructionContext {
+  readonly #getCellMessage: string;
+
+  constructor(shouldDeepFreeze?: boolean, getCellMessage?: string) {
+    super(shouldDeepFreeze);
+    this.#getCellMessage = getCellMessage ?? "no runtime context provided.";
+  }
+
   override getCell(
     ref: { id: string; path: string[]; space: string },
   ): FabricInstance {
     throw new Error(
-      `Cannot reconstruct cell reference \`${ref.id}\`: no runtime context provided.`,
+      `Cannot reconstruct cell reference \`${ref.id}\`: ${this.#getCellMessage}`,
     );
   }
 }

--- a/packages/data-model/empty-reconstruction-context.ts
+++ b/packages/data-model/empty-reconstruction-context.ts
@@ -6,6 +6,21 @@
  */
 
 import type { FabricInstance, ReconstructionContext } from "./interface.ts";
+import { BaseReconstructionContext } from "./base-reconstruction-context.ts";
+
+/**
+ * `ReconstructionContext` whose `getCell()` always throws. `shouldDeepFreeze`
+ * is inherited from `BaseReconstructionContext` (defaults to `true`).
+ */
+class EmptyReconstructionContext extends BaseReconstructionContext {
+  override getCell(
+    ref: { id: string; path: string[]; space: string },
+  ): FabricInstance {
+    throw new Error(
+      `Cannot reconstruct cell reference \`${ref.id}\`: no runtime context provided.`,
+    );
+  }
+}
 
 /**
  * Shared `ReconstructionContext` instance whose `getCell()` always throws.
@@ -14,16 +29,4 @@ import type { FabricInstance, ReconstructionContext } from "./interface.ts";
  * unexpected reconstruction obvious instead of silent.
  */
 export const EMPTY_RECONSTRUCTION_CONTEXT: ReconstructionContext = Object
-  .freeze({
-    getCell(
-      ref: { id: string; path: string[]; space: string },
-    ): FabricInstance {
-      throw new Error(
-        `Cannot reconstruct cell reference \`${ref.id}\`: no runtime context provided.`,
-      );
-    },
-
-    // The deep-frozen result is the safe default (mirrors
-    // `cloneIfNecessary`'s `frozen` defaulting to `true`).
-    shouldDeepFreeze: true,
-  });
+  .freeze(new EmptyReconstructionContext());

--- a/packages/data-model/fabric-native-instances.ts
+++ b/packages/data-model/fabric-native-instances.ts
@@ -11,9 +11,7 @@ import { deepFreeze, isDeepFrozen } from "./deep-freeze.ts";
 import { NATIVE_TAGS, tagFromNativeValue } from "./native-type-tags.ts";
 import { TAGS } from "./fabric-type-tags.ts";
 import { FrozenMap, FrozenSet } from "./frozen-builtins.ts";
-import {
-  EMPTY_RECONSTRUCTION_CONTEXT,
-} from "./empty-reconstruction-context.ts";
+import { EmptyReconstructionContext } from "./empty-reconstruction-context.ts";
 
 // ---------------------------------------------------------------------------
 // Utility: native-instance type guard
@@ -316,11 +314,13 @@ export class FabricError extends FabricNativeWrapper<Error> {
     // `[RECONSTRUCT]` now honors `context.shouldDeepFreeze`. This clone path
     // owns its own frozenness decision (the `frozen ? deepFreeze : result`
     // below), so it must NOT have `[RECONSTRUCT]` pre-freeze: pass a context
-    // whose `shouldDeepFreeze` matches this clone's `frozen` intent.
-    const reconstructContext: ReconstructionContext = {
-      getCell: EMPTY_RECONSTRUCTION_CONTEXT.getCell,
-      shouldDeepFreeze: frozen,
-    };
+    // whose `shouldDeepFreeze` matches this clone's `frozen` intent. The first
+    // ctor arg MUST be `frozen` (not defaulted) so the context's frozenness
+    // tracks this clone's intent rather than defaulting to `true`.
+    const reconstructContext = new EmptyReconstructionContext(
+      frozen,
+      "no runtime context (FabricError deep-clone path).",
+    );
     const result = FabricError[RECONSTRUCT](state, reconstructContext);
 
     return frozen ? deepFreeze(result) : result;

--- a/packages/data-model/fabric-native-instances.ts
+++ b/packages/data-model/fabric-native-instances.ts
@@ -313,10 +313,15 @@ export class FabricError extends FabricNativeWrapper<Error> {
       }
     }
 
-    const result = FabricError[RECONSTRUCT](
-      state,
-      EMPTY_RECONSTRUCTION_CONTEXT,
-    );
+    // `[RECONSTRUCT]` now honors `context.shouldDeepFreeze`. This clone path
+    // owns its own frozenness decision (the `frozen ? deepFreeze : result`
+    // below), so it must NOT have `[RECONSTRUCT]` pre-freeze: pass a context
+    // whose `shouldDeepFreeze` matches this clone's `frozen` intent.
+    const reconstructContext: ReconstructionContext = {
+      getCell: EMPTY_RECONSTRUCTION_CONTEXT.getCell,
+      shouldDeepFreeze: frozen,
+    };
+    const result = FabricError[RECONSTRUCT](state, reconstructContext);
 
     return frozen ? deepFreeze(result) : result;
   }
@@ -329,7 +334,7 @@ export class FabricError extends FabricNativeWrapper<Error> {
    */
   static [RECONSTRUCT](
     state: FabricValue,
-    _context: ReconstructionContext,
+    context: ReconstructionContext,
   ): FabricError {
     const s = state as Record<string, FabricValue>;
     const type = (s.type as string) ?? (s.name as string) ?? "Error";
@@ -361,7 +366,12 @@ export class FabricError extends FabricNativeWrapper<Error> {
       }
     }
 
-    return new FabricError(error);
+    const result = new FabricError(error);
+    // Honor `shouldDeepFreeze`: produce the type's correct deep-frozen form
+    // via its `[DEEP_FREEZE]` member (recursing through `deepFreeze`).
+    return context.shouldDeepFreeze
+      ? result[DEEP_FREEZE]((v) => deepFreeze(v)) as unknown as FabricError
+      : result;
   }
 }
 
@@ -594,13 +604,18 @@ export class FabricRegExp extends FabricNativeWrapper<RegExp> {
    */
   static [RECONSTRUCT](
     state: FabricValue,
-    _context: ReconstructionContext,
+    context: ReconstructionContext,
   ): FabricRegExp {
     const s = state as Record<string, FabricValue>;
     const source = (s.source as string) ?? "";
     const flags = (s.flags as string) ?? "";
     const flavor = (s.flavor as string) ?? "es2025";
-    return new FabricRegExp(new RegExp(source, flags), flavor);
+    const result = new FabricRegExp(new RegExp(source, flags), flavor);
+    // Honor `shouldDeepFreeze`: produce the type's correct deep-frozen form
+    // via its `[DEEP_FREEZE]` member (recursing through `deepFreeze`).
+    return context.shouldDeepFreeze
+      ? result[DEEP_FREEZE]((v) => deepFreeze(v)) as unknown as FabricRegExp
+      : result;
   }
 }
 

--- a/packages/data-model/interface.ts
+++ b/packages/data-model/interface.ts
@@ -338,12 +338,14 @@ export interface ReconstructionContext {
    * free by extending `BaseReconstructionContext`, which centralizes the
    * getter; the `cloneIfNecessary`-style `true` default lives there.
    *
-   * Scope note: this declares the signal and its default. The `[RECONSTRUCT]`
-   * implementations do not yet consult it — query-and-abide enforcement at
-   * the reconstruction sites is the arm-2 / class-registry follow-on's
-   * responsibility and is intentionally NOT provided here. Until that lands,
-   * a `[RECONSTRUCT]` impl that ignores this signal is over-conservative
-   * (the default is `true` ⇒ the safe, deep-frozen outcome), never wrong.
+   * Enforcement: the concrete `[RECONSTRUCT]` implementations query this and
+   * abide by it — they produce a deep-frozen result when it is `true`. The
+   * one place this is *not* applied is the class-registry fallback
+   * call-site wrap (`json-encoding-context.ts`'s `cls[RECONSTRUCT]` path);
+   * that call-site deep-freeze is a separate follow-on's responsibility and
+   * is intentionally NOT covered here. The per-implementation honoring is
+   * sufficient for correctness regardless: each impl freezes its own output
+   * when asked.
    */
   readonly shouldDeepFreeze: boolean;
 }

--- a/packages/data-model/interface.ts
+++ b/packages/data-model/interface.ts
@@ -327,18 +327,23 @@ export interface ReconstructionContext {
   ): FabricInstance;
 
   /**
-   * Whether a reconstruction call should produce a deep-frozen result.
-   * `[RECONSTRUCT]` implementations query this and abide by it: when `true`,
-   * the reconstructed value they return must be deep-frozen; when `false`, a
-   * mutable result is acceptable.
-   *
-   * This is the same contract as `frozen` passed to `cloneIfNecessary()`
-   * (see `value-clone.ts`): `shouldDeepFreeze === true` corresponds to
+   * Signals whether a reconstruction call should produce a deep-frozen
+   * result: `true` means the reconstructed value should be deep-frozen,
+   * `false` means a mutable result is acceptable. Same contract as `frozen`
+   * passed to `cloneIfNecessary()` (see `value-clone.ts`):
+   * `shouldDeepFreeze === true` corresponds to
    * `cloneIfNecessary(value, { frozen: true })`.
    *
-   * Required (not optional): every context declares it. Implementations get
-   * it for free by extending `BaseReconstructionContext`, which centralizes
-   * the getter; the `cloneIfNecessary`-style `true` default lives there.
+   * Required (not optional): every context declares it. Contexts get it for
+   * free by extending `BaseReconstructionContext`, which centralizes the
+   * getter; the `cloneIfNecessary`-style `true` default lives there.
+   *
+   * Scope note: this declares the signal and its default. The `[RECONSTRUCT]`
+   * implementations do not yet consult it — query-and-abide enforcement at
+   * the reconstruction sites is the arm-2 / class-registry follow-on's
+   * responsibility and is intentionally NOT provided here. Until that lands,
+   * a `[RECONSTRUCT]` impl that ignores this signal is over-conservative
+   * (the default is `true` ⇒ the safe, deep-frozen outcome), never wrong.
    */
   readonly shouldDeepFreeze: boolean;
 }

--- a/packages/data-model/interface.ts
+++ b/packages/data-model/interface.ts
@@ -328,18 +328,19 @@ export interface ReconstructionContext {
 
   /**
    * Whether a reconstruction call should produce a deep-frozen result.
-   * `[RECONSTRUCT]` implementations are expected to query this and abide by
-   * it: when `true`, the reconstructed value they return must be deep-frozen;
-   * when `false`, a mutable result is acceptable.
+   * `[RECONSTRUCT]` implementations query this and abide by it: when `true`,
+   * the reconstructed value they return must be deep-frozen; when `false`, a
+   * mutable result is acceptable.
    *
    * This is the same contract as `frozen` passed to `cloneIfNecessary()`
    * (see `value-clone.ts`): `shouldDeepFreeze === true` corresponds to
-   * `cloneIfNecessary(value, { frozen: true })`. Like that option, it
-   * defaults to `true` when not provided — the deep-frozen result is the
-   * safe default, so an implementation that does not yet consult this
-   * signal still behaves correctly (over-conservatively), never wrongly.
+   * `cloneIfNecessary(value, { frozen: true })`.
+   *
+   * Required (not optional): every context declares it. Implementations get
+   * it for free by extending `BaseReconstructionContext`, which centralizes
+   * the getter; the `cloneIfNecessary`-style `true` default lives there.
    */
-  readonly shouldDeepFreeze?: boolean;
+  readonly shouldDeepFreeze: boolean;
 }
 
 /**

--- a/packages/data-model/interface.ts
+++ b/packages/data-model/interface.ts
@@ -325,6 +325,21 @@ export interface ReconstructionContext {
   getCell(
     ref: { id: string; path: string[]; space: string },
   ): FabricInstance;
+
+  /**
+   * Whether a reconstruction call should produce a deep-frozen result.
+   * `[RECONSTRUCT]` implementations are expected to query this and abide by
+   * it: when `true`, the reconstructed value they return must be deep-frozen;
+   * when `false`, a mutable result is acceptable.
+   *
+   * This is the same contract as `frozen` passed to `cloneIfNecessary()`
+   * (see `value-clone.ts`): `shouldDeepFreeze === true` corresponds to
+   * `cloneIfNecessary(value, { frozen: true })`. Like that option, it
+   * defaults to `true` when not provided — the deep-frozen result is the
+   * safe default, so an implementation that does not yet consult this
+   * signal still behaves correctly (over-conservatively), never wrongly.
+   */
+  readonly shouldDeepFreeze?: boolean;
 }
 
 /**

--- a/packages/data-model/json-encoding.ts
+++ b/packages/data-model/json-encoding.ts
@@ -1,11 +1,27 @@
 import { isInstance } from "@commonfabric/utils/types";
 import type { FabricValue } from "./fabric-value.ts";
 import type { ReconstructionContext } from "./fabric-value.ts";
-import { EMPTY_RECONSTRUCTION_CONTEXT } from "./empty-reconstruction-context.ts";
+import { EmptyReconstructionContext } from "./empty-reconstruction-context.ts";
 import { JsonEncodingContext } from "./json-encoding-context.ts";
 
 /** Shared JSON encoding context. */
 const jsonEncodingContext = new JsonEncodingContext();
+
+/**
+ * Shared empty `ReconstructionContext` used when a JSON decode is requested
+ * without a runtime context. Behaviorally identical to the bare empty
+ * singleton (`shouldDeepFreeze` is `true`); only the `getCell()` throw
+ * message is decode-framed, so an unexpected cell reference during a
+ * context-less decode produces a message that names the situation. This
+ * single instance covers both public entry points (`valueFromJson()` and
+ * `plainObjectFromJson()`, the latter delegating to the former).
+ */
+const JSON_DECODE_EMPTY_CONTEXT = Object.freeze(
+  new EmptyReconstructionContext(
+    true,
+    "no runtime context (JSON decode); a cell reference cannot be reconstructed.",
+  ),
+);
 
 /**
  * Encodes a fabric value to a JSON string in the standard `FabricValue`
@@ -18,8 +34,9 @@ export function jsonFromValue(value: FabricValue): string {
 /**
  * Decodes a string in the `FabricValue` JSON-embedded encoding format, which is
  * expected to be a plain object. Throws if it turns out to be something else.
- * If `runtime` is omitted, the shared `EMPTY_RECONSTRUCTION_CONTEXT` is
- * substituted, which throws if any reconstruction is needed.
+ * If `runtime` is omitted, a shared decode-framed empty context is
+ * substituted (via `valueFromJson()`), which throws if any reconstruction
+ * is needed.
  */
 export function plainObjectFromJson<T extends object = object>(
   json: string,
@@ -54,8 +71,9 @@ export function seemsLikeJsonEncodedFabricValue(value: string): boolean {
 
 /**
  * Decodes a string in the `FabricValue` JSON-embedded encoding format. If
- * `runtime` is omitted, the shared `EMPTY_RECONSTRUCTION_CONTEXT` is
- * substituted, which throws if any reconstruction is needed.
+ * `runtime` is omitted, the shared decode-framed empty context
+ * (`JSON_DECODE_EMPTY_CONTEXT`) is substituted, which throws if any
+ * reconstruction is needed.
  */
 export function valueFromJson(
   json: string,
@@ -63,6 +81,6 @@ export function valueFromJson(
 ): FabricValue {
   return jsonEncodingContext.decode(
     json,
-    runtime ?? EMPTY_RECONSTRUCTION_CONTEXT,
+    runtime ?? JSON_DECODE_EMPTY_CONTEXT,
   );
 }

--- a/packages/data-model/problematic-value.ts
+++ b/packages/data-model/problematic-value.ts
@@ -7,6 +7,7 @@ import {
   type ReconstructionContext,
 } from "./interface.ts";
 import { ExplicitTagValue } from "./explicit-tag-value.ts";
+import { deepFreeze } from "./deep-freeze.ts";
 
 /**
  * Container for a value whose deconstruction or reconstruction failed.
@@ -61,8 +62,13 @@ export class ProblematicValue extends ExplicitTagValue {
 
   static [RECONSTRUCT](
     state: { type: string; state: FabricValue; error: string },
-    _context: ReconstructionContext,
+    context: ReconstructionContext,
   ): ProblematicValue {
-    return new ProblematicValue(state.type, state.state, state.error);
+    const result = new ProblematicValue(state.type, state.state, state.error);
+    // Honor `shouldDeepFreeze`: produce the type's correct deep-frozen form
+    // via its `[DEEP_FREEZE]` member (recursing through `deepFreeze`).
+    return context.shouldDeepFreeze
+      ? result[DEEP_FREEZE]((v) => deepFreeze(v)) as unknown as ProblematicValue
+      : result;
   }
 }

--- a/packages/data-model/test/empty-reconstruction-context.test.ts
+++ b/packages/data-model/test/empty-reconstruction-context.test.ts
@@ -32,4 +32,8 @@ describe("EMPTY_RECONSTRUCTION_CONTEXT", () => {
   it("is frozen (cannot have getCell replaced)", () => {
     expect(Object.isFrozen(EMPTY_RECONSTRUCTION_CONTEXT)).toBe(true);
   });
+
+  it("shouldDeepFreeze is true (the safe default, mirrors cloneIfNecessary frozen)", () => {
+    expect(EMPTY_RECONSTRUCTION_CONTEXT.shouldDeepFreeze).toBe(true);
+  });
 });

--- a/packages/data-model/test/empty-reconstruction-context.test.ts
+++ b/packages/data-model/test/empty-reconstruction-context.test.ts
@@ -1,6 +1,9 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { EMPTY_RECONSTRUCTION_CONTEXT } from "../empty-reconstruction-context.ts";
+import {
+  EMPTY_RECONSTRUCTION_CONTEXT,
+  EmptyReconstructionContext,
+} from "../empty-reconstruction-context.ts";
 
 describe("EMPTY_RECONSTRUCTION_CONTEXT", () => {
   it("is a singleton (re-import yields the same instance)", async () => {
@@ -35,5 +38,38 @@ describe("EMPTY_RECONSTRUCTION_CONTEXT", () => {
 
   it("shouldDeepFreeze is true (the safe default, mirrors cloneIfNecessary frozen)", () => {
     expect(EMPTY_RECONSTRUCTION_CONTEXT.shouldDeepFreeze).toBe(true);
+  });
+});
+
+describe("EmptyReconstructionContext (exported class)", () => {
+  it("default ctor: shouldDeepFreeze true + the historical verbatim throw message", () => {
+    const ctx = new EmptyReconstructionContext();
+    expect(ctx.shouldDeepFreeze).toBe(true);
+    expect(() =>
+      ctx.getCell({ id: "of:bafyDEFAULT", path: [], space: "did:key:z1" })
+    ).toThrow(
+      "Cannot reconstruct cell reference `of:bafyDEFAULT`: no runtime context provided.",
+    );
+  });
+
+  it("shouldDeepFreeze arg is forwarded (false stays false)", () => {
+    expect(new EmptyReconstructionContext(false).shouldDeepFreeze).toBe(false);
+    expect(new EmptyReconstructionContext(true).shouldDeepFreeze).toBe(true);
+  });
+
+  it("getCellMessage arg parameterizes only the after-colon clause", () => {
+    const ctx = new EmptyReconstructionContext(true, "custom");
+    expect(() =>
+      ctx.getCell({ id: "of:bafyCUSTOM", path: [], space: "did:key:z1" })
+    ).toThrow("Cannot reconstruct cell reference `of:bafyCUSTOM`: custom");
+  });
+
+  it("the two args are independent (frozen-intent context with a situation message)", () => {
+    const ctx = new EmptyReconstructionContext(false, "deep-clone path.");
+    expect(ctx.shouldDeepFreeze).toBe(false);
+    expect(() => ctx.getCell({ id: "of:bafyX", path: [], space: "did:key:z1" }))
+      .toThrow(
+        "Cannot reconstruct cell reference `of:bafyX`: deep-clone path.",
+      );
   });
 });

--- a/packages/data-model/test/fabric-native-instances.test.ts
+++ b/packages/data-model/test/fabric-native-instances.test.ts
@@ -7,8 +7,8 @@ import {
   type FabricValue,
   IS_DEEP_FROZEN,
   RECONSTRUCT,
-  type ReconstructionContext,
 } from "../interface.ts";
+import { BaseReconstructionContext } from "../base-reconstruction-context.ts";
 import {
   FabricError,
   FabricMap,
@@ -30,11 +30,12 @@ import { ExplicitTagValue } from "../explicit-tag-value.ts";
 import { deepFreeze, isDeepFrozen } from "../deep-freeze.ts";
 
 /** Dummy reconstruction context for tests. */
-const dummyContext: ReconstructionContext = {
-  getCell(_ref) {
+class DummyReconstructionContext extends BaseReconstructionContext {
+  override getCell(): never {
     throw new Error("getCell not implemented in test");
-  },
-};
+  }
+}
+const dummyContext = new DummyReconstructionContext();
 
 // ============================================================================
 // Tests

--- a/packages/data-model/test/fabric-native-instances.test.ts
+++ b/packages/data-model/test/fabric-native-instances.test.ts
@@ -1080,4 +1080,61 @@ describe("fabric-native-instances", () => {
       });
     });
   });
+
+  // --------------------------------------------------------------------------
+  // [RECONSTRUCT] honors ReconstructionContext.shouldDeepFreeze
+  // --------------------------------------------------------------------------
+
+  describe("[RECONSTRUCT] honors shouldDeepFreeze", () => {
+    const frozenCtx = new DummyReconstructionContext(true);
+    const mutableCtx = new DummyReconstructionContext(false);
+
+    it("FabricError: shouldDeepFreeze true => deep-frozen, false => mutable", () => {
+      const state = {
+        type: "Error",
+        name: null,
+        message: "boom",
+      } as unknown as FabricValue;
+      const frozen = FabricError[RECONSTRUCT](state, frozenCtx);
+      expect(isDeepFrozen(frozen)).toBe(true);
+      const mutable = FabricError[RECONSTRUCT](state, mutableCtx);
+      expect(Object.isFrozen(mutable)).toBe(false);
+    });
+
+    it("FabricRegExp: shouldDeepFreeze true => deep-frozen, false => mutable", () => {
+      const state = {
+        source: "abc",
+        flags: "g",
+        flavor: "es2025",
+      } as unknown as FabricValue;
+      const frozen = FabricRegExp[RECONSTRUCT](state, frozenCtx);
+      expect(isDeepFrozen(frozen)).toBe(true);
+      expect(Object.isFrozen(frozen.regex)).toBe(true);
+      const mutable = FabricRegExp[RECONSTRUCT](state, mutableCtx);
+      expect(Object.isFrozen(mutable)).toBe(false);
+    });
+
+    it("ProblematicValue: shouldDeepFreeze true => deep-frozen, false => mutable", () => {
+      const state = {
+        type: "Bad@1",
+        state: { x: 1 },
+        error: "oops",
+      } as unknown as { type: string; state: FabricValue; error: string };
+      const frozen = ProblematicValue[RECONSTRUCT](state, frozenCtx);
+      expect(isDeepFrozen(frozen)).toBe(true);
+      const mutable = ProblematicValue[RECONSTRUCT](state, mutableCtx);
+      expect(Object.isFrozen(mutable)).toBe(false);
+    });
+
+    it("UnknownValue: shouldDeepFreeze true => deep-frozen, false => mutable", () => {
+      const state = { type: "Fancy@3", state: { y: 2 } } as unknown as {
+        type: string;
+        state: FabricValue;
+      };
+      const frozen = UnknownValue[RECONSTRUCT](state, frozenCtx);
+      expect(isDeepFrozen(frozen)).toBe(true);
+      const mutable = UnknownValue[RECONSTRUCT](state, mutableCtx);
+      expect(Object.isFrozen(mutable)).toBe(false);
+    });
+  });
 });

--- a/packages/data-model/test/fabric-regexp.test.ts
+++ b/packages/data-model/test/fabric-regexp.test.ts
@@ -5,8 +5,8 @@ import {
   FabricInstance,
   type FabricValue,
   RECONSTRUCT,
-  type ReconstructionContext,
 } from "../interface.ts";
+import { BaseReconstructionContext } from "../base-reconstruction-context.ts";
 import {
   FabricNativeWrapper,
   FabricRegExp,
@@ -26,11 +26,12 @@ import {
 import { hashOf } from "../value-hash.ts";
 
 /** Dummy reconstruction context for tests. */
-const dummyContext: ReconstructionContext = {
-  getCell(_ref) {
+class DummyReconstructionContext extends BaseReconstructionContext {
+  override getCell(): never {
     throw new Error("getCell not implemented in test");
-  },
-};
+  }
+}
+const dummyContext = new DummyReconstructionContext();
 
 // ============================================================================
 // Tests

--- a/packages/data-model/test/json-encoding-context.test.ts
+++ b/packages/data-model/test/json-encoding-context.test.ts
@@ -1,27 +1,35 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { JsonEncodingContext } from "../json-encoding-context.ts";
-import type { FabricValue, ReconstructionContext } from "../interface.ts";
+import type { FabricValue } from "../interface.ts";
 import type { JsonWireValue } from "../json-type-handlers.ts";
 import { UnknownValue } from "../unknown-value.ts";
 import { ProblematicValue } from "../problematic-value.ts";
 import { FabricEpochDays, FabricEpochNsec } from "../fabric-epoch.ts";
 import { FabricError } from "../fabric-native-instances.ts";
 import { isDeepFrozen } from "../deep-freeze.ts";
+import { BaseReconstructionContext } from "../base-reconstruction-context.ts";
 import {
   resetDataModelConfig,
   setDataModelConfig,
   shallowFabricFromNativeValue,
 } from "../fabric-value.ts";
 
+/**
+ * Shared test `ReconstructionContext`: `getCell()` always throws (no test
+ * here reaches it); `shouldDeepFreeze` is inherited from
+ * `BaseReconstructionContext` (defaults to `true`).
+ */
+class TestReconstructionContext extends BaseReconstructionContext {
+  override getCell(): never {
+    throw new Error("getCell not implemented in test runtime");
+  }
+}
+
 /** Creates a standard test context (non-lenient) and a mock runtime. */
 function makeTestContext() {
   const context = new JsonEncodingContext();
-  const runtime: ReconstructionContext = {
-    getCell(_ref) {
-      throw new Error("getCell not implemented in test runtime");
-    },
-  };
+  const runtime = new TestReconstructionContext();
   return { context, runtime };
 }
 
@@ -491,11 +499,7 @@ describe("JsonEncodingContext", () => {
 
     it("non-string state -> ProblematicValue (lenient)", () => {
       const ctx = new JsonEncodingContext({ lenient: true });
-      const runtime: ReconstructionContext = {
-        getCell(_ref) {
-          throw new Error("getCell not implemented in test runtime");
-        },
-      };
+      const runtime = new TestReconstructionContext();
       const encoded = ENCODING_PREFIX +
         JSON.stringify({ "/SpecialNumber@1": 0 });
       const result = ctx.decode(encoded, runtime);
@@ -507,11 +511,7 @@ describe("JsonEncodingContext", () => {
 
     it("unknown literal -> ProblematicValue (lenient)", () => {
       const ctx = new JsonEncodingContext({ lenient: true });
-      const runtime: ReconstructionContext = {
-        getCell(_ref) {
-          throw new Error("getCell not implemented in test runtime");
-        },
-      };
+      const runtime = new TestReconstructionContext();
       const encoded = ENCODING_PREFIX +
         JSON.stringify({ "/SpecialNumber@1": "Infinity" }); // missing leading +
       const result = ctx.decode(encoded, runtime);
@@ -589,11 +589,7 @@ describe("JsonEncodingContext", () => {
 
     it("non-string state -> ProblematicValue (lenient)", () => {
       const ctx = new JsonEncodingContext({ lenient: true });
-      const runtime: ReconstructionContext = {
-        getCell(_ref) {
-          throw new Error("getCell not implemented in test runtime");
-        },
-      };
+      const runtime = new TestReconstructionContext();
       const encodedJson = ENCODING_PREFIX +
         JSON.stringify({ "/Symbol@1": 42 });
       const result = ctx.decode(encodedJson, runtime);
@@ -1560,11 +1556,7 @@ describe("JsonEncodingContext", () => {
 
     it("lenient mode wraps failed handler reconstruction", () => {
       const context = new JsonEncodingContext({ lenient: true });
-      const runtime: ReconstructionContext = {
-        getCell(_ref) {
-          throw new Error("not available");
-        },
-      };
+      const runtime = new TestReconstructionContext();
 
       // BigInt@1 with a non-string state produces ProblematicValue
       // in lenient mode because the handler validates the state type.
@@ -1580,11 +1572,7 @@ describe("JsonEncodingContext", () => {
 
     it("lenient mode wraps failed class-registry reconstruction", () => {
       const context = new JsonEncodingContext({ lenient: true });
-      const runtime: ReconstructionContext = {
-        getCell(_ref) {
-          throw new Error("not available");
-        },
-      };
+      const runtime = new TestReconstructionContext();
 
       // Map@1 always throws on RECONSTRUCT ("not yet implemented"),
       // triggering lenient wrapping.
@@ -1683,11 +1671,7 @@ describe("JsonEncodingContext", () => {
       // so the contract deep-freezes it (not a crash: it is the value
       // lenient mode produces precisely to avoid crashing).
       const ctx = new JsonEncodingContext({ lenient: true });
-      const runtime: ReconstructionContext = {
-        getCell(_ref) {
-          throw new Error("not available");
-        },
-      };
+      const runtime = new TestReconstructionContext();
       const result = ctx.decode(
         ENCODING_PREFIX + JSON.stringify({ "/BigInt@1": 42 }),
         runtime,
@@ -1720,22 +1704,14 @@ describe("JsonEncodingContext", () => {
 
     it("decode parses a prefixed JSON string back to a value", () => {
       const ctx = new JsonEncodingContext();
-      const runtime: ReconstructionContext = {
-        getCell(_ref) {
-          throw new Error("not implemented");
-        },
-      };
+      const runtime = new TestReconstructionContext();
       const result = ctx.decode(ENCODING_PREFIX + "42", runtime);
       expect(result).toBe(42);
     });
 
     it("encode/decode round-trip for tagged types", () => {
       const ctx = new JsonEncodingContext();
-      const runtime: ReconstructionContext = {
-        getCell(_ref) {
-          throw new Error("not implemented");
-        },
-      };
+      const runtime = new TestReconstructionContext();
       const se = new FabricError(new Error("test"));
       const encoded = ctx.encode(se as FabricValue);
       const decoded = ctx.decode(encoded, runtime);
@@ -1745,11 +1721,7 @@ describe("JsonEncodingContext", () => {
 
     it("encodeToBytes/decodeFromBytes round-trip", () => {
       const ctx = new JsonEncodingContext();
-      const runtime: ReconstructionContext = {
-        getCell(_ref) {
-          throw new Error("not implemented");
-        },
-      };
+      const runtime = new TestReconstructionContext();
       const data = {
         name: "test",
         error: new FabricError(new Error("fail")),

--- a/packages/data-model/test/json-encoding.test.ts
+++ b/packages/data-model/test/json-encoding.test.ts
@@ -254,6 +254,23 @@ describe("json-encoding", () => {
     it("explicit `undefined` runtime is equivalent to omission", () => {
       expect(valueFromJson('fvj1:{"a":1}', undefined)).toEqual({ a: 1 });
     });
+
+    // (B) fold-in: the no-runtime fallback is a decode-framed empty context
+    // (`JSON_DECODE_EMPTY_CONTEXT`) instead of the bare singleton. This is
+    // message-only and behavior-preserving: every no-cell-ref decode above
+    // must still succeed unchanged (covered by the cases in this describe),
+    // and the round-trip with a runtime is unaffected. The decode-framed
+    // throw message itself is asserted on the exported class (see
+    // `EmptyReconstructionContext (exported class)` below) since a cell-ref
+    // decode requires runner-owned wire machinery not available here.
+    it("(B) no-runtime decode behavior is unchanged (round-trips, no cell ref)", () => {
+      // Same payloads as above, asserted as a single behavior-preservation
+      // checkpoint tied to the (B) fold-in.
+      expect(valueFromJson("fvj1:42")).toBe(42);
+      expect(valueFromJson('fvj1:{"a":1}')).toEqual({ a: 1 });
+      expect(valueFromJson('fvj1:{"\/Undefined@1":null}')).toBe(undefined);
+      expect(roundTrip(7 as FabricValue)).toBe(7);
+    });
   });
 
   describe("plainObjectFromJson", () => {

--- a/packages/data-model/test/json-encoding.test.ts
+++ b/packages/data-model/test/json-encoding.test.ts
@@ -7,15 +7,16 @@ import {
   valueFromJson,
 } from "../json-encoding.ts";
 import { FabricError } from "../fabric-native-instances.ts";
-import type { ReconstructionContext } from "../fabric-value.ts";
 import type { FabricValue } from "../fabric-value.ts";
+import { BaseReconstructionContext } from "../base-reconstruction-context.ts";
 
 /** Mock runtime for deserialization calls. */
-const mockRuntime: ReconstructionContext = {
-  getCell(_ref) {
+class MockRuntime extends BaseReconstructionContext {
+  override getCell(): never {
     throw new Error("getCell not implemented in test runtime");
-  },
-};
+  }
+}
+const mockRuntime = new MockRuntime();
 
 /** Encode then decode a value through the current dispatch configuration. */
 function roundTrip(value: FabricValue): FabricValue {

--- a/packages/data-model/unknown-value.ts
+++ b/packages/data-model/unknown-value.ts
@@ -7,6 +7,7 @@ import {
   type ReconstructionContext,
 } from "./interface.ts";
 import { ExplicitTagValue } from "./explicit-tag-value.ts";
+import { deepFreeze } from "./deep-freeze.ts";
 
 /**
  * Container for an unrecognized type's data, used for round-tripping. When
@@ -57,8 +58,13 @@ export class UnknownValue extends ExplicitTagValue {
 
   static [RECONSTRUCT](
     state: { type: string; state: FabricValue },
-    _context: ReconstructionContext,
+    context: ReconstructionContext,
   ): UnknownValue {
-    return new UnknownValue(state.type, state.state);
+    const result = new UnknownValue(state.type, state.state);
+    // Honor `shouldDeepFreeze`: produce the type's correct deep-frozen form
+    // via its `[DEEP_FREEZE]` member (recursing through `deepFreeze`).
+    return context.shouldDeepFreeze
+      ? result[DEEP_FREEZE]((v) => deepFreeze(v)) as unknown as UnknownValue
+      : result;
   }
 }

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -5,7 +5,7 @@ import {
 } from "@commonfabric/data-model/json-encoding";
 import { internPathSelector } from "@commonfabric/data-model/schema-utils";
 import type { FabricValue, SchemaPathSelector } from "./interface.ts";
-import { BaseReconstructionContext } from "@commonfabric/data-model/base-reconstruction-context";
+import { EmptyReconstructionContext } from "@commonfabric/data-model/empty-reconstruction-context";
 import { isObject, isRecord } from "@commonfabric/utils/types";
 
 export const MEMORY_PROTOCOL = "memory" as const;
@@ -352,15 +352,10 @@ export type ServerMessage =
   | SessionEffectMessage
   | SessionRevokedMessage;
 
-class MemoryReconstructionContext extends BaseReconstructionContext {
-  override getCell(): never {
-    throw new Error(
-      "getCell is not available at the memory boundary",
-    );
-  }
-}
-
-const memoryReconstructionContext = new MemoryReconstructionContext();
+const memoryReconstructionContext = new EmptyReconstructionContext(
+  true,
+  "no cell reconstruction at the memory boundary",
+);
 
 export const getMemoryProtocolFlags = (): MemoryProtocolFlags => ({
   modernDataModel: getDataModelConfig(),

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -5,7 +5,7 @@ import {
 } from "@commonfabric/data-model/json-encoding";
 import { internPathSelector } from "@commonfabric/data-model/schema-utils";
 import type { FabricValue, SchemaPathSelector } from "./interface.ts";
-import type { ReconstructionContext } from "@commonfabric/data-model/interface";
+import { BaseReconstructionContext } from "@commonfabric/data-model/base-reconstruction-context";
 import { isObject, isRecord } from "@commonfabric/utils/types";
 
 export const MEMORY_PROTOCOL = "memory" as const;
@@ -352,13 +352,15 @@ export type ServerMessage =
   | SessionEffectMessage
   | SessionRevokedMessage;
 
-const memoryReconstructionContext: ReconstructionContext = {
-  getCell() {
+class MemoryReconstructionContext extends BaseReconstructionContext {
+  override getCell(): never {
     throw new Error(
       "getCell is not available at the memory boundary",
     );
-  },
-};
+  }
+}
+
+const memoryReconstructionContext = new MemoryReconstructionContext();
 
 export const getMemoryProtocolFlags = (): MemoryProtocolFlags => ({
   modernDataModel: getDataModelConfig(),

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -20,7 +20,7 @@ import {
   getMemoryProtocolFlags,
   type PatchOp,
 } from "@commonfabric/memory/v2";
-import type { ReconstructionContext } from "@commonfabric/data-model/interface";
+import { BaseReconstructionContext } from "@commonfabric/data-model/base-reconstruction-context";
 import type {
   ClientCommit,
   ConfirmedRead,
@@ -53,11 +53,12 @@ const helloOk = () => ({
   protocol: "memory",
   flags: getMemoryProtocolFlags(),
 } as const);
-const testReconstructionContext: ReconstructionContext = {
-  getCell() {
+class TestReconstructionContext extends BaseReconstructionContext {
+  override getCell(): never {
     throw new Error("getCell is not available in stacked commit transport");
-  },
-};
+  }
+}
+const testReconstructionContext = new TestReconstructionContext();
 const DOCS = {
   A: "of:memory-v2-stacked-A" as URI,
   B: "of:memory-v2-stacked-B" as URI,

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -20,7 +20,7 @@ import {
   getMemoryProtocolFlags,
   type PatchOp,
 } from "@commonfabric/memory/v2";
-import { BaseReconstructionContext } from "@commonfabric/data-model/base-reconstruction-context";
+import { EmptyReconstructionContext } from "@commonfabric/data-model/empty-reconstruction-context";
 import type {
   ClientCommit,
   ConfirmedRead,
@@ -53,12 +53,10 @@ const helloOk = () => ({
   protocol: "memory",
   flags: getMemoryProtocolFlags(),
 } as const);
-class TestReconstructionContext extends BaseReconstructionContext {
-  override getCell(): never {
-    throw new Error("getCell is not available in stacked commit transport");
-  }
-}
-const testReconstructionContext = new TestReconstructionContext();
+const testReconstructionContext = new EmptyReconstructionContext(
+  true,
+  "no cell reconstruction in stacked commit transport",
+);
 const DOCS = {
   A: "of:memory-v2-stacked-A" as URI,
   B: "of:memory-v2-stacked-B" as URI,

--- a/packages/toolshed/routes/blobs/blobs.index.ts
+++ b/packages/toolshed/routes/blobs/blobs.index.ts
@@ -8,7 +8,7 @@ import { isDID } from "@commonfabric/identity";
 import { FabricBytes } from "@commonfabric/data-model/fabric-bytes";
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import { JsonEncodingContext } from "@commonfabric/data-model/json-encoding-context";
-import type { ReconstructionContext } from "@commonfabric/data-model/fabric-value";
+import { BaseReconstructionContext } from "@commonfabric/data-model/base-reconstruction-context";
 import {
   decodeMemoryBoundary,
   encodeMemoryBoundary,
@@ -17,11 +17,13 @@ import type { Context } from "@hono/hono";
 
 const router = createRouter();
 const blobUploadEncoding = new JsonEncodingContext();
-const blobReconstructionContext: ReconstructionContext = {
-  getCell() {
+class BlobReconstructionContext extends BaseReconstructionContext {
+  override getCell(): never {
     throw new Error("Blob upload payloads cannot contain cell references");
-  },
-};
+  }
+}
+
+const blobReconstructionContext = new BlobReconstructionContext();
 
 type BlobContents = {
   type: string;

--- a/packages/toolshed/routes/blobs/blobs.index.ts
+++ b/packages/toolshed/routes/blobs/blobs.index.ts
@@ -8,7 +8,7 @@ import { isDID } from "@commonfabric/identity";
 import { FabricBytes } from "@commonfabric/data-model/fabric-bytes";
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import { JsonEncodingContext } from "@commonfabric/data-model/json-encoding-context";
-import { BaseReconstructionContext } from "@commonfabric/data-model/base-reconstruction-context";
+import { EmptyReconstructionContext } from "@commonfabric/data-model/empty-reconstruction-context";
 import {
   decodeMemoryBoundary,
   encodeMemoryBoundary,
@@ -17,13 +17,10 @@ import type { Context } from "@hono/hono";
 
 const router = createRouter();
 const blobUploadEncoding = new JsonEncodingContext();
-class BlobReconstructionContext extends BaseReconstructionContext {
-  override getCell(): never {
-    throw new Error("Blob upload payloads cannot contain cell references");
-  }
-}
-
-const blobReconstructionContext = new BlobReconstructionContext();
+const blobReconstructionContext = new EmptyReconstructionContext(
+  true,
+  "blob upload payloads cannot contain cell references",
+);
 
 type BlobContents = {
   type: string;


### PR DESCRIPTION
## Summary

Adds `ReconstructionContext.shouldDeepFreeze` — a **required** interface
member that `[RECONSTRUCT]` implementations query and are obligated to
abide: `shouldDeepFreeze === true` means the call **must** produce a
deep-frozen result (it corresponds to `cloneIfNecessary(value, { frozen:
true })`). This resolves Dan's PR #3612 review comment #5
(`json-encoding-context.ts:452`, verbatim: *"Suggest: Add a task to put
a `shouldDeepFreeze` getter on `ReconstructionContext`, which
`[RECONSTRUCT]` methods are expected to query and abide by."*), which
Dan subsequently upgraded from a filed task to this implemented PR.

**Semantic (Dan-direct, the corrected reading):** `shouldDeepFreeze` is
an **output-contract directive** — "an indication of whether or not the
call should produce a deep-frozen result" — NOT an efficiency-skip hint.
A `[RECONSTRUCT]` that ignores a `true` directive is incorrect, not
merely non-optimal; the query-and-abide wiring is part of the
correctness contract.

This is **U3 / split-PR#3** of the F1 deep-freeze arc. Scope is
**Dan-ratified, triple-confirmed**: *no more and no less than* (a) each
concrete `[RECONSTRUCT]` impl queries `context.shouldDeepFreeze` and
produces the type-correct deep-frozen form impl-internal; (b) edit
consumers if they break (bounded — exactly one broke; see below). See
**Sequencing**.

## What this does

* **`interface.ts`** — `readonly shouldDeepFreeze: boolean` added to
  `ReconstructionContext` as a **required** member (every context
  declares it; not optional), documented as the
  `cloneIfNecessary({frozen:true})` correspondence + the abide
  obligation.
* **`base-reconstruction-context.ts`** (new) — `BaseReconstructionContext`
  supplies the member so the ~16 concrete reconstruction-context
  providers get it via the base (elements 1–3).
* **`empty-reconstruction-context.ts`** — the empty/default context
  carries the member.
* **Element-4** — the 4 concrete `[RECONSTRUCT]` impls (`FabricError`,
  `FabricRegExp`, `ProblematicValue`, `UnknownValue`) now query
  `context.shouldDeepFreeze` and produce the type-correct deep-frozen
  form **impl-internal** when directed.
* **Bounded (b)-consumer-fix (one site).** Honoring `shouldDeepFreeze`
  broke exactly one consumer — `FabricError.deepClone` was passing an
  always-`shouldDeepFreeze:true` `EMPTY_RECONSTRUCTION_CONTEXT`. Fixed
  in-PR at that one site: it now passes `{shouldDeepFreeze: frozen}` so
  the existing `frozen ? deepFreeze : result` stays the single freeze
  authority — **restores the exact prior behavior-contract**, not a
  cascade (matches Dan's predicted "mostly straightforward").
* Consumer-edits in `packages/memory/v2.ts`, `packages/runner`,
  `packages/toolshed/routes/blobs` are the provider/contract propagation
  (the ~16-provider + required-member surface), no behavior change.

**Arm-2 explicitly NOT in U3.** The class-registry call-site wrap
(`json-encoding-context.ts:468/:480`) is a separately-fenced follow-on
unit — `json-encoding-context.ts` source is **byte-untouched** by this
PR (verified at-source).

## Independently safe + correct to land (named acceptance criterion)

* **Safe.** `deno fmt`/`lint`/`check` clean; data-model `deno task test`
  57 passed (1317 steps) / 0 failed (incl. 4 new element-4 tests + the
  previously-failing clone test now passing); cross-package compile
  clean (`memory`/`toolshed`/`runner`); runner 44/0. No dangling
  reference to an unmerged sibling — the protocol pieces U3 leans on
  (`[DEEP_FREEZE]`, merged U1) are on `main`.
* **Correct (semantically complete as landed, not a partial contract).**
  The contract is *fulfilled within the data-model*: the required member
  is declared by every context, and the 4 concrete `[RECONSTRUCT]` impls
  query-and-abide it impl-internal — so a `true` directive produces
  deep-frozen output as landed, not "documented but unwired." The
  bounded (b)-fix restores the one affected consumer's exact prior
  contract. Nothing is sometimes-wrong-until-later.

(This named safe+correct attestation is the binding per-unit review
criterion; the at-source basis is above. Same per-unit-attestation
shape as U1 #3614 / U2 #3616. reviewer-flux: APPROVE, no blocking
findings — independent at-source, all 3 named checks ✓ + the
(b)-consumer-fix independently confirmed correct+complete.)

## Deliberate post-R6 follow-up (stated transparently, not debt)

Element-4's impls use the per-type `result[DEEP_FREEZE]((v) =>
deepFreeze(v))` form rather than a bare unified `deepFreeze()` call,
**because `deep-freeze.ts` has no `instanceof FabricInstance` arm on
this base yet** — that arm is the unmerged U4/R3 residual. `[DEEP_FREEZE]`
(merged via U1) is the authored-correct form for the *current* base;
this is intentional and correct as landed, NOT debt. A unified-
`deepFreeze()` rework is a deliberate Dan-requested follow-up scheduled
**post-R6** (tracked separately). The body states this so the form is
understood as a sequenced follow-up, not an oversight.

## Sequencing

This is **U3** of the Dan-directed 5-unit F1 chain:

* **U1** — `[DEEP_FREEZE]`/`[IS_DEEP_FROZEN]` protocol. **MERGED**.
* **U2** — `TypeHandler.deserialize()` arm-1 contractual deep-frozen
  (Dan's #4, NARROW). **READY/handed to Dan**.
* **U3 (this PR)** — `ReconstructionContext.shouldDeepFreeze`
  output-contract directive + 4 `[RECONSTRUCT]` impls query-and-abide
  (Dan's #5). Leans on U1's merged protocol; arm-2 fenced out.
* **U4** — residual integration (`deepFreeze()` arm-3 dispatch +
  `isDeepFrozenFabricValue` type-guard + R6 throw-retirement).
* **U5** — Dan re-evaluation checkpoint.

Then the post-R6 unified-`deepFreeze()` rework + the arm-2/fallback-path
follow-on + Stage 2 (freeze-clone collapse + #3588 perf-baseline
re-measurement).

**Base note:** branch base `f35e9bc4d`; `main` has since advanced
(`#3606`/`#3609` — read-file-CFC + runner/scheduler refactor, zero U3
data-model overlap; `git merge-tree` clean, no conflicts). A merge-sync
to current `main` is land-prep hygiene done before merge, NOT a
review-blocker and NOT a precondition for this PR's readiness.

## Validation (standalone)

- [x] `deno fmt` — clean
- [x] `deno lint` — clean
- [x] `deno check` — clean (data-model + cross-package memory/toolshed/runner)
- [x] data-model `deno task test` — 57 passed (1317 steps), 0 failed
  (incl. 4 new element-4 tests + the previously-failing clone test now
  passing)
- [x] runner `deno task test` — 44 passed / 0 failed

Co-Authored-By: coder-colt (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a required ReconstructionContext.shouldDeepFreeze directive and wires [RECONSTRUCT] to honor it, returning deep-frozen results when requested. Also switches JSON decode’s no-runtime fallback to a decode-framed empty context for clearer errors, with no behavior change.

- New Features
  - Required `shouldDeepFreeze: boolean` on `ReconstructionContext` (default `true`) via `BaseReconstructionContext`.
  - `[RECONSTRUCT]` for `FabricError`, `FabricRegExp`, `ProblematicValue`, and `UnknownValue` deep-freezes when `shouldDeepFreeze` is `true` using `[DEEP_FREEZE]` + `deepFreeze`.
  - Exported `EmptyReconstructionContext` with optional `(shouldDeepFreeze?, getCellMessage?)`; JSON decode without a runtime now uses a shared decode-framed instance for better error messages.

- Refactors
  - Collapsed bespoke `ReconstructionContext` classes in `@commonfabric/memory`, `@commonfabric/toolshed`, and `@commonfabric/runner` to `EmptyReconstructionContext`; added `./empty-reconstruction-context` to package exports for cross-package use.
  - `FabricError.deepClone` now passes `new EmptyReconstructionContext(frozen, "no runtime context (FabricError deep-clone path).")` so `frozen` controls the result, preserving prior behavior.

<sup>Written for commit 24baa3879cbaf98eda8d9d70693f0b27f7fffc53. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3620?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

