### PR TITLE
CT-1600: Fix typed wish writable projections

### DIFF
--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -882,7 +882,10 @@ function projectWishCellValue(
   schema: unknown,
 ): unknown {
   if (schema === undefined) return cell;
-  return cell.asSchema(schema as JSONSchema).getAsLink({ includeSchema: true });
+  return cell.asSchema(schema as JSONSchema).getAsLink({
+    includeSchema: true,
+    keepAsCell: true,
+  });
 }
 
 function createWishCandidatesCell(
@@ -898,20 +901,10 @@ function createWishCandidatesCell(
   return runtime.getImmutableCell(space, values, undefined, tx);
 }
 
-function schemaAsCell(schema: unknown): JSONSchema {
-  if (schema && typeof schema === "object") {
-    return {
-      ...(JSON.parse(JSON.stringify(schema)) as Record<string, unknown>),
-      asCell: ["cell"],
-    };
-  }
-  return { asCell: ["cell"] };
-}
-
 function wishStateSchemaForResult(schema: unknown): JSONSchema | undefined {
   if (schema === undefined) return undefined;
-  const resultSchema = schemaAsCell(schema);
-  const candidateSchema = schemaAsCell(schema);
+  const resultSchema = JSON.parse(JSON.stringify(schema)) as JSONSchema;
+  const candidateSchema = JSON.parse(JSON.stringify(schema)) as JSONSchema;
   return internSchema({
     type: "object",
     properties: {
@@ -982,7 +975,10 @@ function sharedWishCellValue(
 ): unknown {
   const wishStateSchema = wishStateSchemaForResult(schema);
   if (!wishStateSchema) return cell;
-  return cell.asSchema(wishStateSchema).getAsLink({ includeSchema: true });
+  return cell.asSchema(wishStateSchema).getAsLink({
+    includeSchema: true,
+    keepAsCell: true,
+  });
 }
 
 const TARGET_SCHEMA = internSchema(

--- a/packages/runner/test/wish.test.ts
+++ b/packages/runner/test/wish.test.ts
@@ -240,6 +240,173 @@ describe("wish built-in", () => {
     expect(result.key("firstMentionable").get()?.result).toEqual("Alpha");
   });
 
+  it("preserves writable cells in typed #mentionable wish projections", async () => {
+    const spaceCell = runtime.getCell(space, space).withTx(tx);
+    const defaultPatternCell = runtime.getCell(space, "default-pattern").withTx(
+      tx,
+    );
+    defaultPatternCell.set({
+      backlinksIndex: {
+        mentionable: [
+          { [NAME]: "Alpha", summary: "First summary" },
+          { [NAME]: "Beta", summary: "Second summary" },
+        ],
+      },
+    });
+    (spaceCell as any).key("defaultPattern").set(defaultPatternCell);
+
+    await tx.commit();
+    await runtime.idle();
+    tx = runtime.edit();
+
+    const program = {
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/main.tsx",
+          contents: [
+            "import { computed, Default, NAME, pattern, wish, Writable } from 'commonfabric';",
+            "type Piece = { [NAME]?: string; summary?: string };",
+            "export default pattern<{}>(() => {",
+            "  const plain = wish<Piece[]>({ query: '#mentionable' }).result;",
+            "  const writableArray = wish<Writable<Piece>[]>({ query: '#mentionable' }).result;",
+            "  const writableDefault = wish<Writable<Piece>[] | Default<[]>>({ query: '#mentionable' }).result;",
+            "  const writableItem = wish<Writable<Piece>>({ query: '#mentionable/0' }).result;",
+            "  const checks = computed(() => {",
+            "    const firstPlain = Array.isArray(plain) ? plain[0] : undefined;",
+            "    const firstWritable = Array.isArray(writableArray) ? writableArray[0] : undefined;",
+            "    const firstDefault = Array.isArray(writableDefault) ? writableDefault[0] : undefined;",
+            "    return {",
+            "      plainIsArray: Array.isArray(plain),",
+            "      plainFirstHasGet: typeof (firstPlain as any)?.get === 'function',",
+            "      plainFirstName: firstPlain?.[NAME],",
+            "      writableArrayIsArray: Array.isArray(writableArray),",
+            "      writableFirstHasGet: typeof firstWritable?.get === 'function',",
+            "      writableFirstName: firstWritable?.get?.()?.[NAME],",
+            "      defaultUnionIsArray: Array.isArray(writableDefault),",
+            "      defaultUnionFirstHasGet: typeof firstDefault?.get === 'function',",
+            "      defaultUnionFirstName: firstDefault?.get?.()?.[NAME],",
+            "      itemHasGet: typeof writableItem?.get === 'function',",
+            "      itemName: writableItem?.get?.()?.[NAME],",
+            "    };",
+            "  });",
+            "  return { checks };",
+            "});",
+          ].join("\n"),
+        },
+      ],
+    };
+
+    const compiled = await runtime.patternManager.compilePattern(program);
+    const patternId = runtime.patternManager.registerPattern(compiled, program);
+    const loadedPattern = await runtime.patternManager.loadPattern(
+      patternId,
+      space,
+      tx,
+    );
+
+    const resultCell = runtime.getCell<{ checks?: Record<string, unknown> }>(
+      space,
+      "wish typed mentionable result",
+      undefined,
+      tx,
+    );
+    const result = runtime.run(tx, loadedPattern, {}, resultCell);
+    await tx.commit();
+    tx = runtime.edit();
+
+    await result.pull();
+
+    expect(result.key("checks").get()).toEqual({
+      plainIsArray: true,
+      plainFirstHasGet: false,
+      plainFirstName: "Alpha",
+      writableArrayIsArray: true,
+      writableFirstHasGet: true,
+      writableFirstName: "Alpha",
+      defaultUnionIsArray: true,
+      defaultUnionFirstHasGet: true,
+      defaultUnionFirstName: "Alpha",
+      itemHasGet: true,
+      itemName: "Alpha",
+    });
+  });
+
+  it("supports SummaryIndex-style iteration over writable mentionable wishes", async () => {
+    const spaceCell = runtime.getCell(space, space).withTx(tx);
+    const defaultPatternCell = runtime.getCell(space, "default-pattern").withTx(
+      tx,
+    );
+    defaultPatternCell.set({
+      backlinksIndex: {
+        mentionable: [
+          { [NAME]: "Alpha", summary: "First summary" },
+          { [NAME]: "Beta" },
+          { [NAME]: "Gamma", summary: "Third summary" },
+        ],
+      },
+    });
+    (spaceCell as any).key("defaultPattern").set(defaultPatternCell);
+
+    await tx.commit();
+    await runtime.idle();
+    tx = runtime.edit();
+
+    const program = {
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/main.tsx",
+          contents: [
+            "import { computed, Default, NAME, pattern, wish, Writable } from 'commonfabric';",
+            "type Piece = { [NAME]?: string; summary?: string };",
+            "export default pattern<{}>(() => {",
+            "  const mentionable = wish<Writable<Piece>[] | Default<[]>>({ query: '#mentionable' }).result;",
+            "  const entries = computed(() => {",
+            "    const result: { name: string; summary: string }[] = [];",
+            "    for (const piece of (Array.isArray(mentionable) ? mentionable : [])) {",
+            "      if (!piece) continue;",
+            "      const value = piece.get();",
+            "      if (!value.summary) continue;",
+            "      result.push({ name: (value[NAME] ?? '').toString(), summary: value.summary });",
+            "    }",
+            "    return result;",
+            "  });",
+            "  return { entries };",
+            "});",
+          ].join("\n"),
+        },
+      ],
+    };
+
+    const compiled = await runtime.patternManager.compilePattern(program);
+    const patternId = runtime.patternManager.registerPattern(compiled, program);
+    const loadedPattern = await runtime.patternManager.loadPattern(
+      patternId,
+      space,
+      tx,
+    );
+
+    const resultCell = runtime.getCell<{
+      entries?: { name: string; summary: string }[];
+    }>(
+      space,
+      "wish summary-index iteration result",
+      undefined,
+      tx,
+    );
+    const result = runtime.run(tx, loadedPattern, {}, resultCell);
+    await tx.commit();
+    tx = runtime.edit();
+
+    await result.pull();
+
+    expect(result.key("entries").get()).toEqual([
+      { name: "Alpha", summary: "First summary" },
+      { name: "Gamma", summary: "Third summary" },
+    ]);
+  });
+
   it("resolves recent pieces via #recent", async () => {
     const spaceCell = runtime.getCell(space, space).withTx(tx);
     const recentPiecesCell = runtime.getCell(space, "recent-pieces", {


### PR DESCRIPTION
## Summary

Fixes CT-1600 by restoring the typed `wish` contract for writable results. When a pattern asks for `wish<Writable<T>>`, `wish<Cell<T>>`, or arrays of those types, the projected result now preserves the schema `asCell` markers so callers receive cell handles instead of plain snapshots.

This keeps `#mentionable` producer semantics unchanged. `BacklinksIndex` can still expose plain mentionable data; the conversion to writable cell handles happens at the typed wish projection boundary.

## Why this regressed

Typed wish results were serialized with schema, but `getAsLink({ includeSchema: true })` sanitized away `asCell` markers by default. That meant a consumer like `SummaryIndex` could correctly ask for `Writable<SummarizablePiece>[]`, but the runtime delivered plain objects, revealing the crash as `piece.get is not a function`.

The wish-state schema also wrapped the whole `result` as a cell, which hid array-shaped results at the wrong layer. The fix preserves cell markers on the result links and describes the requested result shape directly in the wish-state schema.

## Changes

- Preserve `asCell` markers when serializing typed wish result links.
- Apply the same preservation to shared/headless wish-state serialization.
- Stop wrapping typed wish-state `result` and `candidates` in an extra outer cell schema.
- Add compiled-pattern regressions covering writable mentionable arrays, default-union arrays, plain arrays, single writable results, and SummaryIndex-style iteration.

## Validation

- `deno test --allow-ffi --allow-env --allow-read --allow-write=/tmp,/var/folders --allow-run=git packages/runner/test/wish.test.ts`
- `deno task cf check packages/patterns/system/summary-index.tsx`
- Pre-commit `deno fmt` and `deno lint`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CT-1600 by restoring typed `wish` projections so `wish<Writable<T>>`, `wish<Cell<T>>`, and array forms return cell handles, not plain snapshots. Prevents crashes in consumers like SummaryIndex by preserving `asCell` markers and describing the result shape correctly.

- **Bug Fixes**
  - Preserve cell handles in typed wish links via `keepAsCell: true` in `getAsLink` for both result and shared wish-state serialization.
  - Remove the extra outer cell wrapper from wish-state `result` and `candidates`; use the requested schema directly.
  - Add regression tests for writable arrays, default-union arrays, single writable results, and SummaryIndex-style iteration.

<sup>Written for commit 42a1efbe647880813445d206d8063f6423c8806c. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3621?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

