### PR TITLE
feat(memory): suppress own watch echoes

### DIFF
--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -357,6 +357,7 @@ export async function executeResolvedCallable(
 
   let outputValue: unknown;
   try {
+    await resolved.manager.runtime.idle();
     resolved.manager.runtime.prepareTxForCommit?.(tx);
     if (typeof tx.commit !== "function") {
       throw new Error("Callable runtime transaction is not committable");

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -6,6 +6,7 @@ import {
 import type { ExecCommandSpec } from "./exec-schema.ts";
 
 export const CF_RUNTIME_ERROR_LOG = Symbol.for("cf.cli.runtimeErrorLog");
+const DEFAULT_TOOL_RESULT_TIMEOUT_MS = 15_000;
 
 export interface CliRuntimeErrorRecord {
   message: string;
@@ -361,11 +362,12 @@ export async function executeResolvedCallable(
       throw new Error("Callable runtime transaction is not committable");
     }
     await tx.commit();
+    const waitForResult = deps.waitForResult ?? defaultWaitForResult;
+    const timeoutMs = deps.timeoutMs ?? DEFAULT_TOOL_RESULT_TIMEOUT_MS;
+
     await resolved.manager.runtime.idle();
     await resolved.manager.synced();
-    const waitForResult = deps.waitForResult ?? defaultWaitForResult;
-    const timeoutMs = deps.timeoutMs ?? 5000;
-
+    await resolved.manager.runtime.storageManager?.synced();
     await waitForResult(resultCell, timeoutMs);
     await resolved.manager.runtime.storageManager?.synced();
     outputValue = await waitForResult(resultCell, timeoutMs);

--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -351,8 +351,15 @@ export async function executeResolvedCallable(
     mergeToolInput(input, extraParams),
     resultCell,
   );
+  let sinkValue: unknown;
+  let hasSinkValue = false;
   const cancelSink = typeof running?.sink === "function"
-    ? running.sink(() => {})
+    ? running.sink((value) => {
+      if (value !== undefined) {
+        sinkValue = value;
+        hasSinkValue = true;
+      }
+    })
     : undefined;
 
   let outputValue: unknown;
@@ -369,9 +376,13 @@ export async function executeResolvedCallable(
     await resolved.manager.runtime.idle();
     await resolved.manager.synced();
     await resolved.manager.runtime.storageManager?.synced();
-    await waitForResult(resultCell, timeoutMs);
-    await resolved.manager.runtime.storageManager?.synced();
-    outputValue = await waitForResult(resultCell, timeoutMs);
+    if (hasSinkValue) {
+      outputValue = sinkValue;
+    } else {
+      await waitForResult(resultCell, timeoutMs);
+      await resolved.manager.runtime.storageManager?.synced();
+      outputValue = await waitForResult(resultCell, timeoutMs);
+    }
   } finally {
     cancelSink?.();
   }

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -1445,7 +1445,7 @@ describe("mounted callable resolution and execution", () => {
     });
   });
 
-  it("syncs storage before waiting for mounted tool results with a longer default timeout", async () => {
+  it("idles before committing mounted tool results and syncs before waiting", async () => {
     const mountpoint = join(tmpDir, "mount");
     const filePath = await createMountedFile(mountpoint, {
       relativePath: "home/pieces/notes-2/result/search.tool",
@@ -1491,10 +1491,10 @@ describe("mounted callable resolution and execution", () => {
         loadManager: () => Promise.resolve(harness.manager),
         loadPiece: () => Promise.resolve(harness.piece),
         uuid: () => "tool-result-id",
-        waitForResult: async (_cell, timeoutMs) => {
+        waitForResult: (_cell, timeoutMs) => {
           harness.tracker.events.push("wait");
           timeouts.push(timeoutMs);
-          return { echoed: "tea" };
+          return Promise.resolve({ echoed: "tea" });
         },
       },
     );
@@ -1502,6 +1502,7 @@ describe("mounted callable resolution and execution", () => {
     expect(timeouts).toEqual([15_000, 15_000]);
     expect(harness.tracker.events).toEqual([
       "run",
+      "idle",
       "commit",
       "idle",
       "manager.synced",
@@ -2181,19 +2182,22 @@ function createExecHarness(options: {
 
   const manager = {
     getSpace: () => options.managerSpace ?? "home",
-    synced: async () => {
+    synced: () => {
       tracker.events.push("manager.synced");
+      return Promise.resolve();
     },
     runtime: {
       [CF_RUNTIME_ERROR_LOG]: runtimeErrors,
       storageManager: {
-        synced: async () => {
+        synced: () => {
           tracker.events.push("storage.synced");
+          return Promise.resolve();
         },
       },
       edit: () => ({
-        commit: async () => {
+        commit: () => {
           tracker.events.push("commit");
+          return Promise.resolve();
         },
       }),
       getCell: (
@@ -2220,8 +2224,9 @@ function createExecHarness(options: {
           sink: () => () => {},
         };
       },
-      idle: async () => {
+      idle: () => {
         tracker.events.push("idle");
+        return Promise.resolve();
       },
     },
   };

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -1514,6 +1514,70 @@ describe("mounted callable resolution and execution", () => {
     expect(JSON.parse(result.outputText!)).toEqual({ echoed: "tea" });
   });
 
+  it("uses mounted tool sink output after a successful commit", async () => {
+    const mountpoint = join(tmpDir, "mount");
+    const filePath = await createMountedFile(mountpoint, {
+      relativePath: "home/pieces/notes-2/result/search.tool",
+      pieceId: "of:piece-123",
+    });
+    const harness = createExecHarness({
+      callableKind: "tool",
+      cellProp: "result",
+      cellKey: "search",
+      pieceId: "of:piece-123",
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: { type: "string" },
+        },
+        required: ["query"],
+      },
+      pattern: {
+        argumentSchema: {
+          type: "object",
+          properties: {
+            query: { type: "string" },
+          },
+          required: ["query"],
+        },
+        resultSchema: {
+          type: "object",
+          properties: {
+            echoed: { type: "string" },
+          },
+        },
+      },
+      toolSinkValue: { echoed: "from-sink" },
+    });
+
+    await writeLiveMountState(stateDir, mountpoint);
+
+    const result = await executeMountedCallableFile(
+      filePath,
+      ["--query", "tea"],
+      {
+        stateDir,
+        loadManager: () => Promise.resolve(harness.manager),
+        loadPiece: () => Promise.resolve(harness.piece),
+        uuid: () => "tool-result-id",
+        waitForResult: () => {
+          throw new Error("waitForResult should not be used");
+        },
+      },
+    );
+
+    expect(harness.tracker.events).toEqual([
+      "run",
+      "sink",
+      "idle",
+      "commit",
+      "idle",
+      "manager.synced",
+      "storage.synced",
+    ]);
+    expect(JSON.parse(result.outputText!)).toEqual({ echoed: "from-sink" });
+  });
+
   it("pulls mounted tool result cells before serializing output", async () => {
     const mountpoint = join(tmpDir, "mount");
     const filePath = await createMountedFile(mountpoint, {
@@ -2056,6 +2120,7 @@ function createExecHarness(options: {
   toolResult?: unknown;
   toolResultGetValue?: unknown;
   toolResultPullValue?: unknown;
+  toolSinkValue?: unknown;
   handlerFailureMessage?: string;
   handlerSendRequiresReceiver?: boolean;
   sparseHandlerCell?: boolean;
@@ -2221,7 +2286,13 @@ function createExecHarness(options: {
         state.getValue = options.toolResultGetValue ?? options.toolResult;
         state.pullValue = options.toolResultPullValue ?? options.toolResult;
         return {
-          sink: () => () => {},
+          sink: (callback: (value: unknown) => void) => {
+            if (options.toolSinkValue !== undefined) {
+              tracker.events.push("sink");
+              callback(options.toolSinkValue);
+            }
+            return () => {};
+          },
         };
       },
       idle: () => {

--- a/packages/cli/test/exec.test.ts
+++ b/packages/cli/test/exec.test.ts
@@ -1445,6 +1445,74 @@ describe("mounted callable resolution and execution", () => {
     });
   });
 
+  it("syncs storage before waiting for mounted tool results with a longer default timeout", async () => {
+    const mountpoint = join(tmpDir, "mount");
+    const filePath = await createMountedFile(mountpoint, {
+      relativePath: "home/pieces/notes-2/result/search.tool",
+      pieceId: "of:piece-123",
+    });
+    const harness = createExecHarness({
+      callableKind: "tool",
+      cellProp: "result",
+      cellKey: "search",
+      pieceId: "of:piece-123",
+      inputSchema: {
+        type: "object",
+        properties: {
+          query: { type: "string" },
+        },
+        required: ["query"],
+      },
+      pattern: {
+        argumentSchema: {
+          type: "object",
+          properties: {
+            query: { type: "string" },
+          },
+          required: ["query"],
+        },
+        resultSchema: {
+          type: "object",
+          properties: {
+            echoed: { type: "string" },
+          },
+        },
+      },
+    });
+    const timeouts: number[] = [];
+
+    await writeLiveMountState(stateDir, mountpoint);
+
+    const result = await executeMountedCallableFile(
+      filePath,
+      ["--query", "tea"],
+      {
+        stateDir,
+        loadManager: () => Promise.resolve(harness.manager),
+        loadPiece: () => Promise.resolve(harness.piece),
+        uuid: () => "tool-result-id",
+        waitForResult: async (_cell, timeoutMs) => {
+          harness.tracker.events.push("wait");
+          timeouts.push(timeoutMs);
+          return { echoed: "tea" };
+        },
+      },
+    );
+
+    expect(timeouts).toEqual([15_000, 15_000]);
+    expect(harness.tracker.events).toEqual([
+      "run",
+      "commit",
+      "idle",
+      "manager.synced",
+      "storage.synced",
+      "wait",
+      "storage.synced",
+      "wait",
+    ]);
+    expect(JSON.parse(result.outputText!)).toEqual({ echoed: "tea" });
+  });
+
   it("pulls mounted tool result cells before serializing output", async () => {
     const mountpoint = join(tmpDir, "mount");
     const filePath = await createMountedFile(mountpoint, {
@@ -1992,6 +2060,7 @@ function createExecHarness(options: {
   sparseHandlerCell?: boolean;
 }) {
   const tracker = {
+    events: [] as string[],
     asSchemaFromLinksCalls: 0,
     handlerWrites: [] as Array<{
       cellProp: "input" | "result";
@@ -2112,14 +2181,20 @@ function createExecHarness(options: {
 
   const manager = {
     getSpace: () => options.managerSpace ?? "home",
-    synced: async () => {},
+    synced: async () => {
+      tracker.events.push("manager.synced");
+    },
     runtime: {
       [CF_RUNTIME_ERROR_LOG]: runtimeErrors,
       storageManager: {
-        synced: async () => {},
+        synced: async () => {
+          tracker.events.push("storage.synced");
+        },
       },
       edit: () => ({
-        commit: async () => {},
+        commit: async () => {
+          tracker.events.push("commit");
+        },
       }),
       getCell: (
         space: string,
@@ -2136,6 +2211,7 @@ function createExecHarness(options: {
         input: unknown,
         _result: unknown,
       ) => {
+        tracker.events.push("run");
         tracker.toolRunInput = input;
         state.value = options.toolResult;
         state.getValue = options.toolResultGetValue ?? options.toolResult;
@@ -2144,7 +2220,9 @@ function createExecHarness(options: {
           sink: () => () => {},
         };
       },
-      idle: async () => {},
+      idle: async () => {
+        tracker.events.push("idle");
+      },
     },
   };
 

--- a/packages/memory/test/v2-server-test.ts
+++ b/packages/memory/test/v2-server-test.ts
@@ -770,13 +770,28 @@ Deno.test("memory v2 server rejects legacy live graph.query subscriptions", asyn
 Deno.test("memory v2 server watch sets expand to previously hidden nodes after retargets", async () => {
   const server = createServer("memory://memory-v2-server-watch-expansion");
   const messages: ServerMessage[] = [];
+  const writerMessages: ServerMessage[] = [];
   const connection = server.connect((message) => messages.push(message));
+  const writer = server.connect((message) => writerMessages.push(message));
   const space = "did:key:z6Mk-memory-v2-server-watch-expansion";
   const fixture = createGraphFixture(space);
 
   try {
-    await connection.receive(encodeMemoryBoundary(HELLO));
+    for (const client of [connection, writer]) {
+      await client.receive(encodeMemoryBoundary(HELLO));
+    }
     shiftMessage(messages);
+    shiftMessage(writerMessages);
+
+    await writer.receive(encodeMemoryBoundary({
+      type: "session.open",
+      requestId: "writer-open",
+      space,
+      session: {},
+    }));
+    const writerSessionId = assertResponse<{ sessionId: string }>(
+      shiftMessage(writerMessages),
+    ).ok!.sessionId;
 
     await connection.receive(encodeMemoryBoundary({
       type: "session.open",
@@ -789,11 +804,11 @@ Deno.test("memory v2 server watch sets expand to previously hidden nodes after r
     );
     const sessionId = opened.ok!.sessionId;
 
-    await connection.receive(encodeMemoryBoundary({
+    await writer.receive(encodeMemoryBoundary({
       type: "transact",
       requestId: "seed",
       space,
-      sessionId,
+      sessionId: writerSessionId,
       commit: {
         localSeq: 1,
         reads: { confirmed: [], pending: [] },
@@ -804,7 +819,10 @@ Deno.test("memory v2 server watch sets expand to previously hidden nodes after r
         })),
       },
     }));
-    assertEquals(assertResponse<any>(shiftMessage(messages)).requestId, "seed");
+    assertEquals(
+      assertResponse<any>(shiftMessage(writerMessages)).requestId,
+      "seed",
+    );
 
     await connection.receive(encodeMemoryBoundary({
       type: "session.watch.set",
@@ -838,7 +856,7 @@ Deno.test("memory v2 server watch sets expand to previously hidden nodes after r
       space,
       sessionId,
       commit: {
-        localSeq: 2,
+        localSeq: 1,
         reads: { confirmed: [], pending: [] },
         operations: [{
           op: "set",
@@ -855,7 +873,6 @@ Deno.test("memory v2 server watch sets expand to previously hidden nodes after r
     await tick();
     const effect = assertEffect(shiftMessage(messages));
     const expectedUpdatedIds = [
-      fixture.rootId,
       ...fixture.expandedReachableIds.filter((id) =>
         !fixture.initialReachableIds.includes(id)
       ),
@@ -877,7 +894,9 @@ Deno.test("memory v2 server does not emit delayed exact-reconcile removes after 
     0,
   );
   const messages: ServerMessage[] = [];
+  const writerMessages: ServerMessage[] = [];
   const connection = server.connect((message) => messages.push(message));
+  const writer = server.connect((message) => writerMessages.push(message));
   const space = "did:key:z6Mk-memory-v2-server-watch-shrink-no-reconcile";
   const fixture = createGraphFixture(space);
   const expandedDocs = fixture.docs.map((doc) => ({
@@ -889,8 +908,21 @@ Deno.test("memory v2 server does not emit delayed exact-reconcile removes after 
   assertExists(initialRoot);
 
   try {
-    await connection.receive(encodeMemoryBoundary(HELLO));
+    for (const client of [connection, writer]) {
+      await client.receive(encodeMemoryBoundary(HELLO));
+    }
     shiftMessage(messages);
+    shiftMessage(writerMessages);
+
+    await writer.receive(encodeMemoryBoundary({
+      type: "session.open",
+      requestId: "writer-open",
+      space,
+      session: {},
+    }));
+    const writerSessionId = assertResponse<{ sessionId: string }>(
+      shiftMessage(writerMessages),
+    ).ok!.sessionId;
 
     await connection.receive(encodeMemoryBoundary({
       type: "session.open",
@@ -903,11 +935,11 @@ Deno.test("memory v2 server does not emit delayed exact-reconcile removes after 
     );
     const sessionId = opened.ok!.sessionId;
 
-    await connection.receive(encodeMemoryBoundary({
+    await writer.receive(encodeMemoryBoundary({
       type: "transact",
       requestId: "seed",
       space,
-      sessionId,
+      sessionId: writerSessionId,
       commit: {
         localSeq: 1,
         reads: { confirmed: [], pending: [] },
@@ -918,7 +950,10 @@ Deno.test("memory v2 server does not emit delayed exact-reconcile removes after 
         })),
       },
     }));
-    assertEquals(assertResponse<any>(shiftMessage(messages)).requestId, "seed");
+    assertEquals(
+      assertResponse<any>(shiftMessage(writerMessages)).requestId,
+      "seed",
+    );
 
     await connection.receive(encodeMemoryBoundary({
       type: "session.watch.set",
@@ -946,11 +981,11 @@ Deno.test("memory v2 server does not emit delayed exact-reconcile removes after 
     );
     assertEquals(watch.ok?.sync.removes, []);
 
-    await connection.receive(encodeMemoryBoundary({
+    await writer.receive(encodeMemoryBoundary({
       type: "transact",
       requestId: "shrink",
       space,
-      sessionId,
+      sessionId: writerSessionId,
       commit: {
         localSeq: 2,
         reads: { confirmed: [], pending: [] },
@@ -962,7 +997,7 @@ Deno.test("memory v2 server does not emit delayed exact-reconcile removes after 
       },
     }));
     assertEquals(
-      assertResponse<any>(shiftMessage(messages)).requestId,
+      assertResponse<any>(shiftMessage(writerMessages)).requestId,
       "shrink",
     );
 
@@ -1037,12 +1072,27 @@ Deno.test("memory v2 server does not send watch effects after a connection close
 Deno.test("memory v2 server refreshes watched docs by syncing only the touched entity", async () => {
   const server = createServer("memory://memory-v2-server-incremental-watch");
   const messages: ServerMessage[] = [];
+  const writerMessages: ServerMessage[] = [];
   const connection = server.connect((message) => messages.push(message));
+  const writer = server.connect((message) => writerMessages.push(message));
   const space = "did:key:z6Mk-memory-v2-server-incremental-watch";
 
   try {
-    await connection.receive(encodeMemoryBoundary(HELLO));
+    for (const client of [connection, writer]) {
+      await client.receive(encodeMemoryBoundary(HELLO));
+    }
     shiftMessage(messages);
+    shiftMessage(writerMessages);
+
+    await writer.receive(encodeMemoryBoundary({
+      type: "session.open",
+      requestId: "writer-open",
+      space,
+      session: {},
+    }));
+    const writerSessionId = assertResponse<{ sessionId: string }>(
+      shiftMessage(writerMessages),
+    ).ok!.sessionId;
 
     await connection.receive(encodeMemoryBoundary({
       type: "session.open",
@@ -1055,11 +1105,11 @@ Deno.test("memory v2 server refreshes watched docs by syncing only the touched e
     );
     const sessionId = opened.ok!.sessionId;
 
-    await connection.receive(encodeMemoryBoundary({
+    await writer.receive(encodeMemoryBoundary({
       type: "transact",
       requestId: "seed",
       space,
-      sessionId,
+      sessionId: writerSessionId,
       commit: {
         localSeq: 1,
         reads: { confirmed: [], pending: [] },
@@ -1074,7 +1124,10 @@ Deno.test("memory v2 server refreshes watched docs by syncing only the touched e
         }],
       },
     }));
-    assertEquals(assertResponse<any>(shiftMessage(messages)).requestId, "seed");
+    assertEquals(
+      assertResponse<any>(shiftMessage(writerMessages)).requestId,
+      "seed",
+    );
 
     await connection.receive(encodeMemoryBoundary({
       type: "session.watch.set",
@@ -1112,11 +1165,11 @@ Deno.test("memory v2 server refreshes watched docs by syncing only the touched e
       "watch-1",
     );
 
-    await connection.receive(encodeMemoryBoundary({
+    await writer.receive(encodeMemoryBoundary({
       type: "transact",
       requestId: "update",
       space,
-      sessionId,
+      sessionId: writerSessionId,
       commit: {
         localSeq: 2,
         reads: { confirmed: [], pending: [] },
@@ -1128,7 +1181,7 @@ Deno.test("memory v2 server refreshes watched docs by syncing only the touched e
       },
     }));
     assertEquals(
-      assertResponse<any>(shiftMessage(messages)).requestId,
+      assertResponse<any>(shiftMessage(writerMessages)).requestId,
       "update",
     );
 
@@ -1748,6 +1801,108 @@ Deno.test("memory v2 server watch set replacement emits removes for entities tha
   }
 });
 
+Deno.test("memory v2 server does not echo same-session operation docs through watches", async () => {
+  const server = createServer("memory://memory-v2-server-suppress-own-watch");
+  const writerMessages: ServerMessage[] = [];
+  const observerMessages: ServerMessage[] = [];
+  const writer = server.connect((message) => writerMessages.push(message));
+  const observer = server.connect((message) => observerMessages.push(message));
+  const space = "did:key:z6Mk-memory-v2-suppress-own-watch";
+
+  try {
+    for (const connection of [writer, observer]) {
+      await connection.receive(encodeMemoryBoundary(HELLO));
+    }
+    shiftMessage(writerMessages);
+    shiftMessage(observerMessages);
+
+    await writer.receive(encodeMemoryBoundary({
+      type: "session.open",
+      requestId: "writer-open",
+      space,
+      session: {},
+    }));
+    const writerSessionId = assertResponse<{ sessionId: string }>(
+      shiftMessage(writerMessages),
+    ).ok!.sessionId;
+
+    await observer.receive(encodeMemoryBoundary({
+      type: "session.open",
+      requestId: "observer-open",
+      space,
+      session: {},
+    }));
+    const observerSessionId = assertResponse<{ sessionId: string }>(
+      shiftMessage(observerMessages),
+    ).ok!.sessionId;
+
+    for (
+      const [connection, sessionId, requestId, messages] of [
+        [writer, writerSessionId, "writer-watch", writerMessages],
+        [observer, observerSessionId, "observer-watch", observerMessages],
+      ] as const
+    ) {
+      await connection.receive(encodeMemoryBoundary({
+        type: "session.watch.set",
+        requestId,
+        space,
+        sessionId,
+        watches: [{
+          id: "root",
+          kind: "graph",
+          query: {
+            roots: [{
+              id: "of:doc:1",
+              selector: {
+                path: [],
+                schema: false,
+              },
+            }],
+          },
+        }],
+      }));
+      shiftMessage(messages);
+    }
+
+    await writer.receive(encodeMemoryBoundary({
+      type: "transact",
+      requestId: "writer-tx",
+      space,
+      sessionId: writerSessionId,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "of:doc:1",
+          value: { value: { version: 1 } },
+        }],
+      },
+    }));
+    const committed = assertResponse<any>(shiftMessage(writerMessages));
+    assertEquals(committed.requestId, "writer-tx");
+    assertEquals(committed.ok?.seq, 1);
+
+    await server.flushSessions([space]);
+
+    assertEquals(writerMessages, []);
+    const observerEffect = assertEffect(shiftMessage(observerMessages));
+    assertEquals(observerEffect.effect.upserts, [{
+      branch: "",
+      id: "of:doc:1",
+      scope: "space",
+      seq: 1,
+      doc: {
+        value: { version: 1 },
+      },
+    }]);
+    assertEquals(observerEffect.effect.removes, []);
+    assertEquals(observerMessages, []);
+  } finally {
+    await server.close();
+  }
+});
+
 Deno.test("memory v2 server flushes session sync before returning conflicts", async () => {
   const server = createServer("memory://memory-v2-server-conflict-flush", 20);
   const messages: ServerMessage[] = [];
@@ -2031,7 +2186,9 @@ Deno.test("memory v2 server waits for queued receives before rerunning scheduled
     1,
   );
   const messages: ServerMessage[] = [];
+  const writerMessages: ServerMessage[] = [];
   const connection = server.connect((message) => messages.push(message));
+  const writer = server.connect((message) => writerMessages.push(message));
   const space = "did:key:z6Mk-memory-v2-server-refresh-after-queue-drain";
   const originalSync = server.syncSessionForConnection.bind(server);
   const originalTransact = server.transact.bind(server);
@@ -2063,8 +2220,21 @@ Deno.test("memory v2 server waits for queued receives before rerunning scheduled
   };
 
   try {
-    await connection.receive(encodeMemoryBoundary(HELLO));
+    for (const client of [connection, writer]) {
+      await client.receive(encodeMemoryBoundary(HELLO));
+    }
     shiftMessage(messages);
+    shiftMessage(writerMessages);
+
+    await writer.receive(encodeMemoryBoundary({
+      type: "session.open",
+      requestId: "writer-open",
+      space,
+      session: {},
+    }));
+    const writerSessionId = assertResponse<{ sessionId: string }>(
+      shiftMessage(writerMessages),
+    ).ok!.sessionId;
 
     await connection.receive(encodeMemoryBoundary({
       type: "session.open",
@@ -2113,11 +2283,11 @@ Deno.test("memory v2 server waits for queued receives before rerunning scheduled
     }));
     shiftMessage(messages);
 
-    await connection.receive(encodeMemoryBoundary({
+    await writer.receive(encodeMemoryBoundary({
       type: "transact",
       requestId: "tx-1",
       space,
-      sessionId,
+      sessionId: writerSessionId,
       commit: {
         localSeq: 1,
         reads: { confirmed: [], pending: [] },
@@ -2128,16 +2298,19 @@ Deno.test("memory v2 server waits for queued receives before rerunning scheduled
         }],
       },
     }));
-    assertEquals(assertResponse<any>(shiftMessage(messages)).requestId, "tx-1");
+    assertEquals(
+      assertResponse<any>(shiftMessage(writerMessages)).requestId,
+      "tx-1",
+    );
 
     await time.tickAsync(1);
     await time.tickAsync(0);
 
-    await connection.receive(encodeMemoryBoundary({
+    await writer.receive(encodeMemoryBoundary({
       type: "transact",
       requestId: "tx-2",
       space,
-      sessionId,
+      sessionId: writerSessionId,
       commit: {
         localSeq: 2,
         reads: { confirmed: [], pending: [] },
@@ -2148,13 +2321,16 @@ Deno.test("memory v2 server waits for queued receives before rerunning scheduled
         }],
       },
     }));
-    assertEquals(assertResponse<any>(shiftMessage(messages)).requestId, "tx-2");
+    assertEquals(
+      assertResponse<any>(shiftMessage(writerMessages)).requestId,
+      "tx-2",
+    );
 
-    const tx3 = connection.receive(encodeMemoryBoundary({
+    const tx3 = writer.receive(encodeMemoryBoundary({
       type: "transact",
       requestId: "tx-3",
       space,
-      sessionId,
+      sessionId: writerSessionId,
       commit: {
         localSeq: 3,
         reads: { confirmed: [], pending: [] },
@@ -2187,7 +2363,10 @@ Deno.test("memory v2 server waits for queued receives before rerunning scheduled
     await tx3;
     await time.tickAsync(0);
 
-    assertEquals(assertResponse<any>(shiftMessage(messages)).requestId, "tx-3");
+    assertEquals(
+      assertResponse<any>(shiftMessage(writerMessages)).requestId,
+      "tx-3",
+    );
     const secondEffect = assertEffect(shiftMessage(messages));
     assertEquals(secondEffect.effect.toSeq, 3);
     assertEquals(secondEffect.effect.upserts, [{
@@ -2221,7 +2400,9 @@ Deno.test("memory v2 server reruns scheduled watch refresh after max deferral", 
     1,
   );
   const messages: ServerMessage[] = [];
+  const writerMessages: ServerMessage[] = [];
   const connection = server.connect((message) => messages.push(message));
+  const writer = server.connect((message) => writerMessages.push(message));
   const space = "did:key:z6Mk-memory-v2-server-refresh-max-deferral";
   const originalSync = server.syncSessionForConnection.bind(server);
   const originalTransact = server.transact.bind(server);
@@ -2253,8 +2434,21 @@ Deno.test("memory v2 server reruns scheduled watch refresh after max deferral", 
   };
 
   try {
-    await connection.receive(encodeMemoryBoundary(HELLO));
+    for (const client of [connection, writer]) {
+      await client.receive(encodeMemoryBoundary(HELLO));
+    }
     shiftMessage(messages);
+    shiftMessage(writerMessages);
+
+    await writer.receive(encodeMemoryBoundary({
+      type: "session.open",
+      requestId: "writer-open",
+      space,
+      session: {},
+    }));
+    const writerSessionId = assertResponse<{ sessionId: string }>(
+      shiftMessage(writerMessages),
+    ).ok!.sessionId;
 
     await connection.receive(encodeMemoryBoundary({
       type: "session.open",
@@ -2303,11 +2497,11 @@ Deno.test("memory v2 server reruns scheduled watch refresh after max deferral", 
     }));
     shiftMessage(messages);
 
-    await connection.receive(encodeMemoryBoundary({
+    await writer.receive(encodeMemoryBoundary({
       type: "transact",
       requestId: "tx-1",
       space,
-      sessionId,
+      sessionId: writerSessionId,
       commit: {
         localSeq: 1,
         reads: { confirmed: [], pending: [] },
@@ -2318,16 +2512,19 @@ Deno.test("memory v2 server reruns scheduled watch refresh after max deferral", 
         }],
       },
     }));
-    assertEquals(assertResponse<any>(shiftMessage(messages)).requestId, "tx-1");
+    assertEquals(
+      assertResponse<any>(shiftMessage(writerMessages)).requestId,
+      "tx-1",
+    );
 
     await time.tickAsync(1);
     await time.tickAsync(0);
 
-    await connection.receive(encodeMemoryBoundary({
+    await writer.receive(encodeMemoryBoundary({
       type: "transact",
       requestId: "tx-2",
       space,
-      sessionId,
+      sessionId: writerSessionId,
       commit: {
         localSeq: 2,
         reads: { confirmed: [], pending: [] },
@@ -2338,13 +2535,16 @@ Deno.test("memory v2 server reruns scheduled watch refresh after max deferral", 
         }],
       },
     }));
-    assertEquals(assertResponse<any>(shiftMessage(messages)).requestId, "tx-2");
+    assertEquals(
+      assertResponse<any>(shiftMessage(writerMessages)).requestId,
+      "tx-2",
+    );
 
-    const tx3 = connection.receive(encodeMemoryBoundary({
+    const tx3 = writer.receive(encodeMemoryBoundary({
       type: "transact",
       requestId: "tx-3",
       space,
-      sessionId,
+      sessionId: writerSessionId,
       commit: {
         localSeq: 3,
         reads: { confirmed: [], pending: [] },
@@ -2394,6 +2594,10 @@ Deno.test("memory v2 server reruns scheduled watch refresh after max deferral", 
 
     releaseTx3.resolve();
     await tx3;
+    assertEquals(
+      assertResponse<any>(shiftMessage(writerMessages)).requestId,
+      "tx-3",
+    );
   } finally {
     await server.close();
     time.restore();

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -138,6 +138,11 @@ type SessionHandle = {
   sessionId: string;
 };
 
+type DirtyOrigin = {
+  sessionId: string;
+  seq: number;
+};
+
 class Connection {
   #ready = false;
   #closed = false;
@@ -365,6 +370,7 @@ class Connection {
   async refreshDirty(
     space: string,
     dirtyIds?: ReadonlySet<string>,
+    dirtyOrigins?: ReadonlyMap<string, DirtyOrigin>,
   ): Promise<void> {
     if (this.#closed) {
       return;
@@ -378,6 +384,7 @@ class Connection {
         space,
         sessionId,
         dirtyIds,
+        dirtyOrigins,
       );
       if (this.#closed) {
         return;
@@ -409,6 +416,7 @@ export class Server {
   #directLocalSeq = 0;
   #dirtySpaces = new Set<string>();
   #dirtyDocsBySpace = new Map<string, Set<string>>();
+  #dirtyOriginsBySpace = new Map<string, Map<string, DirtyOrigin>>();
   #refreshTimer: ReturnType<typeof setTimeout> | null = null;
   #refreshing: Promise<void> | null = null;
   #lastRefreshDurationMs = 0;
@@ -616,6 +624,10 @@ export class Server {
         message.commit.operations.map((operation) =>
           toDirtyKey(operation.id, declaredScope(operation.scope))
         ),
+        {
+          sessionId: message.sessionId,
+          seq: commit.seq,
+        },
       );
       return {
         type: "response",
@@ -980,6 +992,7 @@ export class Server {
     space: string,
     sessionId: string,
     dirtyIds?: ReadonlySet<string>,
+    dirtyOrigins?: ReadonlyMap<string, DirtyOrigin>,
   ): Promise<SessionEffectMessage | null> {
     const session = this.#sessions.get(space, sessionId);
     if (session === null || session.watches.length === 0) {
@@ -1037,7 +1050,15 @@ export class Server {
           toDirtyKey(entry.id, declaredScope(entry.scope)),
         );
         if (!sameSnapshot(previous, entry)) {
-          upserts.push(entry);
+          const dirtyKey = toDirtyKey(entry.id, declaredScope(entry.scope));
+          const origin = dirtyOrigins?.get(dirtyKey);
+          if (
+            origin === undefined ||
+            origin.sessionId !== sessionId ||
+            origin.seq !== entry.seq
+          ) {
+            upserts.push(entry);
+          }
         }
       }
       const toSeq = Engine.serverSeq(engine);
@@ -1095,15 +1116,32 @@ export class Server {
     };
   }
 
-  markSpaceDirty(space: string, dirtyIds?: Iterable<string>): void {
+  markSpaceDirty(
+    space: string,
+    dirtyIds?: Iterable<string>,
+    origin?: DirtyOrigin,
+  ): void {
     if (dirtyIds !== undefined) {
       let ids = this.#dirtyDocsBySpace.get(space);
       if (ids === undefined) {
         ids = new Set();
         this.#dirtyDocsBySpace.set(space, ids);
       }
+      let origins = this.#dirtyOriginsBySpace.get(space);
+      if (origin !== undefined && origins === undefined) {
+        origins = new Map();
+        this.#dirtyOriginsBySpace.set(space, origins);
+      }
       for (const id of dirtyIds) {
         ids.add(id);
+        if (origin === undefined) {
+          origins?.delete(id);
+        } else {
+          origins?.set(id, origin);
+        }
+      }
+      if (origins?.size === 0) {
+        this.#dirtyOriginsBySpace.delete(space);
       }
     }
     this.#dirtySpaces.add(space);
@@ -1214,6 +1252,7 @@ export class Server {
     if (this.#connections.size === 0) {
       this.#dirtySpaces.clear();
       this.#dirtyDocsBySpace.clear();
+      this.#dirtyOriginsBySpace.clear();
     }
   }
 
@@ -1243,8 +1282,12 @@ export class Server {
         if (dirtyIds !== undefined) {
           this.#dirtyDocsBySpace.delete(space);
         }
+        const dirtyOrigins = this.#dirtyOriginsBySpace.get(space);
+        if (dirtyOrigins !== undefined) {
+          this.#dirtyOriginsBySpace.delete(space);
+        }
         for (const connection of this.#connections.values()) {
-          await connection.refreshDirty(space, dirtyIds);
+          await connection.refreshDirty(space, dirtyIds, dirtyOrigins);
         }
       }
 

--- a/packages/runner/test/memory-v2-reconnect-race.test.ts
+++ b/packages/runner/test/memory-v2-reconnect-race.test.ts
@@ -519,6 +519,52 @@ Deno.test("memory v2 runner restores watched graph state after reconnect and kee
   }
 });
 
+Deno.test("memory v2 runner confirms its own watched commit without an integrate echo", async () => {
+  const storageManager = CutoverStorageManager.emulate({
+    as: signer,
+  });
+  const notifications = new NotificationRecorder();
+  const provider = storageManager.open(space) as TestProvider;
+  const uri = `of:memory-v2-own-commit-${crypto.randomUUID()}` as URI;
+  const address = { id: uri, type: DOCUMENT_MIME as MIME };
+
+  storageManager.subscribe(notifications);
+
+  try {
+    await provider.sync(uri);
+    await storageManager.synced();
+    notifications.clear();
+
+    const result = await provider.send([{
+      uri,
+      value: { value: { version: 1 } },
+    }]);
+    assertEquals(result, { ok: {} });
+    await storageManager.synced();
+
+    const candidate = storageManager as unknown as {
+      server?: () => MemoryV2Server.Server;
+    };
+    if (typeof candidate.server !== "function") {
+      throw new Error("Expected a memory/v2 emulated storage manager");
+    }
+    await candidate.server().idle();
+
+    const state = provider.replica.get(address) as
+      | { since?: number }
+      | undefined;
+    assertEquals(provider.get(uri), { value: { version: 1 } });
+    assertEquals(state?.since, 1);
+
+    const notificationTypes = notifications.notifications.map((
+      notification,
+    ) => notification.type);
+    assertEquals(notificationTypes, ["commit"]);
+  } finally {
+    await storageManager.close();
+  }
+});
+
 Deno.test("memory v2 runner can retry immediately after a conflict revert", async () => {
   const storageManager = CutoverStorageManager.emulate({
     as: signer,


### PR DESCRIPTION
## Summary
- Track dirty document origins by session and committed seq in the memory v2 server.
- Suppress same-session watch upserts for documents the transaction just committed while still sending full effects to other clients.
- Add memory and runner regressions for own-write suppression, multi-client watch delivery, and commit confirmation without integrate echoes.

## Validation
- deno fmt --check packages/memory/v2/server.ts packages/memory/test/v2-server-test.ts packages/runner/test/memory-v2-reconnect-race.test.ts
- deno test -A packages/memory/test/v2-server-test.ts packages/runner/test/memory-v2-reconnect-race.test.ts
- deno test -A packages/memory/test/v2-client-test.ts packages/memory/test/v2-client-watch-test.ts packages/memory/test/v2-watch-sync-test.ts
- deno test -A packages/runner/test/memory-v2-watch-refresh-race.test.ts packages/runner/test/memory-v2-confirm-pending.test.ts packages/runner/test/memory-v2-stacked-commit.test.ts
- deno task check
- deno task test (packages/memory)
- deno task test (packages/runner)
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppress same-session watch echoes in the `memory` v2 server so writers don’t receive upserts for their own commits; other clients still get the effects. Improve `cli` mounted tool execution by idling before commit, syncing before waiting, using sink output when present, and increasing the default wait to 15s.

- **Bug Fixes**
  - Track dirty origins (sessionId + seq), propagate through refresh, and filter same-session upserts in `syncSession`; clear state when idle.
  - `cli`: idle before committing mounted tool results; sync runtime/manager/storage before waiting; prefer sink output after a successful commit; increase default result timeout to 15s.
  - Add tests for writer/observer own-write suppression, `runner` commit confirmation without integrate echoes, and `cli` sink/idle/sync/timeout behavior.

<sup>Written for commit fa7188fbc39ecb0231e530f24c0240d29b96cf25. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3622?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

