### PR TITLE
refactor(utils): move `bigint-encoding` from `data-model` to `utils` as `bigint`

### DIFF
--- a/packages/data-model/deno.json
+++ b/packages/data-model/deno.json
@@ -22,7 +22,6 @@
   "exports": {
     "./array-utils": "./array-utils.ts",
     "./base-reconstruction-context": "./base-reconstruction-context.ts",
-    "./bigint-encoding": "./bigint-encoding.ts",
     "./deep-freeze": "./deep-freeze.ts",
     "./empty-reconstruction-context": "./empty-reconstruction-context.ts",
     "./explicit-tag-value": "./explicit-tag-value.ts",

--- a/packages/data-model/json-type-handlers.ts
+++ b/packages/data-model/json-type-handlers.ts
@@ -16,7 +16,7 @@ import {
 import {
   bigintFromMinimalTwosComplement,
   bigintToMinimalTwosComplement,
-} from "./bigint-encoding.ts";
+} from "@commonfabric/utils/bigint";
 
 /**
  * JSON-compatible wire format value. This is the intermediate tree

--- a/packages/data-model/value-hash.ts
+++ b/packages/data-model/value-hash.ts
@@ -19,7 +19,7 @@ import { DECONSTRUCT, type FabricInstance } from "./interface.ts";
 import { shallowFabricFromNativeValueModern } from "./fabric-value-modern.ts";
 import { NATIVE_TAGS, tagFromNativeValue } from "./native-type-tags.ts";
 import { encodeULEB128 } from "@commonfabric/leb128";
-import { bigintToMinimalTwosComplement } from "./bigint-encoding.ts";
+import { bigintToMinimalTwosComplement } from "@commonfabric/utils/bigint";
 import { LRUCache } from "@commonfabric/utils/cache";
 import { utf8SortedKeysOf } from "@commonfabric/utils/utf8";
 

--- a/packages/utils/bench/bigint.bench.ts
+++ b/packages/utils/bench/bigint.bench.ts
@@ -26,13 +26,13 @@
  * bigints, so the encode and decode benchmarks for a given (size, sign)
  * exercise inverse operations on matching data.
  *
- * Run with: deno bench --no-check test/bigint-encoding.bench.ts
+ * Run with: deno bench --no-check bench/bigint.bench.ts
  */
 
 import {
   bigintFromMinimalTwosComplement,
   bigintToMinimalTwosComplement,
-} from "../bigint-encoding.ts";
+} from "@commonfabric/utils/bigint";
 
 const BATCH = 64;
 

--- a/packages/utils/deno.json
+++ b/packages/utils/deno.json
@@ -1,11 +1,16 @@
 {
   "name": "@commonfabric/utils",
   "tasks": {
-    "test": "deno test"
+    "test": "deno test",
+    "bench": {
+      "description": "Run benchmarks",
+      "command": "deno bench"
+    }
   },
   "exports": {
     ".": "./src/index.ts",
     "./base64url": "./src/base64url.ts",
+    "./bigint": "./src/bigint.ts",
     "./cache": "./src/cache.ts",
     "./deep-equal": "./src/deep-equal.ts",
     "./defer": "./src/defer.ts",

--- a/packages/utils/src/bigint.ts
+++ b/packages/utils/src/bigint.ts
@@ -1,7 +1,6 @@
 /**
- * Shared BigInt two's-complement big-endian encoding, and base64url helpers for
- * the JSON wire format. Used by both `value-hash.ts` (byte-level hashing)
- * and `json-type-handlers.ts` (JSON serialization).
+ * Shared `bigint` two's-complement big-endian encoding and decoding. Used for
+ * byte-level value hashing and JSON wire-format (de)serialization.
  *
  * The two's-complement encoding is minimal: no unnecessary leading 0x00 bytes
  * for positive values, no unnecessary leading 0xFF bytes for negative values,

--- a/packages/utils/test/bigint.test.ts
+++ b/packages/utils/test/bigint.test.ts
@@ -3,7 +3,7 @@ import { expect } from "@std/expect";
 import {
   bigintFromMinimalTwosComplement,
   bigintToMinimalTwosComplement,
-} from "../bigint-encoding.ts";
+} from "@commonfabric/utils/bigint";
 import {
   fromBase64url,
   toUnpaddedBase64url,


### PR DESCRIPTION
## What

Moves the self-contained `bigint` two's-complement big-endian codec from
`@commonfabric/data-model` down to `@commonfabric/utils`, renaming
`bigint-encoding.ts` → `bigint.ts`.

## Why

The codec has **no imports of its own**, and `data-model` already depended on
`@commonfabric/utils`. So this only pushes code *down* the pace-layer stack
(foundation layer) — never sideways or up. No package outside `data-model`
referenced the old export path, so there are no external consumers to migrate.

## Changes

- `data-model/bigint-encoding.ts` → `utils/src/bigint.ts` (history preserved)
- tests → `utils/test/bigint.test.ts`
- bench → its own `utils/bench/` directory (mirroring the `content-hash`
  layout, which keeps benchmarks out of `deno test` discovery), plus a
  `bench` task in `utils/deno.json`
- export maps: added `@commonfabric/utils/bigint`, removed
  `@commonfabric/data-model/bigint-encoding`
- retargeted the two importers (`value-hash.ts`, `json-type-handlers.ts`)
- moved test/bench switched to the `@commonfabric/utils/bigint`
  self-reference convention used elsewhere in `utils`
- generalized the module doc, which had named higher-layer files by bare
  filename and referenced a non-existent base64url helper

## Testing

- `utils` and `data-model` package suites green (incl. `bigint.test.ts`
  18/18; `data-model` 40 / 1297 steps); `bigint.bench.ts` type-checks in
  its new location; `deno test` correctly ignores `bench/`
- **Full repo suite green**: "All tests passing!", 85s wall time

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the two’s-complement big-endian `bigint` codec from `@commonfabric/data-model` to `@commonfabric/utils` as `bigint` to centralize low-level utilities. No known external consumers of the old path; internal imports updated.

- **Refactors**
  - Move `data-model/bigint-encoding.ts` → `utils/src/bigint.ts` (renamed to `bigint.ts`).
  - Update exports: add `@commonfabric/utils/bigint`, remove `@commonfabric/data-model/bigint-encoding`.
  - Retarget `value-hash.ts` and `json-type-handlers.ts` to `@commonfabric/utils/bigint`.
  - Relocate tests and bench to `utils`; add `bench` task in `@commonfabric/utils`; bench path now `bench/bigint.bench.ts` and excluded from `deno test`.

<sup>Written for commit 2f4b5dc49943f7a3e580d7587d59910000fabfa2. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3623?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

