### PR TITLE
fix(patterns): emit mentionable cells for summary index

### DIFF
--- a/packages/patterns/system/backlinks-index.tsx
+++ b/packages/patterns/system/backlinks-index.tsx
@@ -26,20 +26,22 @@ export type MentionablePiece = {
   mentionable?: MentionablePiece[] | { get?: () => MentionablePiece[] };
 };
 
+export type MentionableCell = Writable<MentionablePiece>;
+
 export type WritableBacklinks = {
-  mentioned?: WritableBacklinks[];
-  backlinks?: Writable<WritableBacklinks[]>;
+  mentioned?: MentionableCell[];
+  backlinks?: Writable<MentionableCell[]>;
 };
 
 type Input = {
-  allPieces: MentionablePiece[];
+  allPieces: MentionableCell[];
 };
 
 type Output = {
-  mentionable: MentionablePiece[];
+  mentionable: MentionableCell[];
 };
 
-const computeIndex = lift<{ allPieces: WritableBacklinks[] | undefined }, void>(
+const computeIndex = lift<{ allPieces: MentionableCell[] | undefined }, void>(
   ({ allPieces }) => {
     const cs = allPieces ?? [];
 
@@ -49,16 +51,21 @@ const computeIndex = lift<{ allPieces: WritableBacklinks[] | undefined }, void>(
     // Also skip undefined/null entries that may exist in the array.
     for (const c of cs) {
       if (!c) continue;
-      c.backlinks?.set?.([]);
+      const value = c.get();
+      if (!value || !("backlinks" in value)) continue;
+      c.key("backlinks").set([]);
     }
 
     // Populate backlinks from mentioned references.
     // Again, use optional chaining since not all pieces support backlinks.
     for (const c of cs) {
       if (!c) continue;
-      const mentions = c.mentioned ?? [];
-      for (const m of mentions) {
-        m?.backlinks?.push?.(c);
+      const mentions = c.key("mentioned").get() ?? [];
+      for (let i = 0; i < mentions.length; i++) {
+        const m = c.key("mentioned").key(i);
+        const target = m?.get();
+        if (!target || !("backlinks" in target)) continue;
+        m.key("backlinks").push(c);
       }
     }
   },
@@ -83,33 +90,31 @@ const computeIndex = lift<{ allPieces: WritableBacklinks[] | undefined }, void>(
 const MAX_MENTIONABLE_DEPTH = 5;
 
 const computeMentionable = lift<
-  { allPieces: MentionablePiece[] },
-  MentionablePiece[]
+  { allPieces: MentionableCell[] },
+  MentionableCell[]
 >(({ allPieces: pieceList }) => {
   const cs = pieceList ?? [];
-  const out: MentionablePiece[] = [];
+  const out: MentionableCell[] = [];
 
-  function isVisited(piece: MentionablePiece): boolean {
+  function isVisited(piece: MentionableCell): boolean {
     return out.some((other) => equals(piece, other));
   }
 
-  function collect(piece: MentionablePiece, depth: number) {
-    if (!piece || piece.isMentionable === false) return;
+  function collect(piece: MentionableCell, depth: number) {
+    if (!piece) return;
+    const value = piece.get();
+    if (!value || value.isMentionable === false) return;
     if (isVisited(piece)) return;
     out.push(piece);
 
     if (depth >= MAX_MENTIONABLE_DEPTH) return;
 
-    const exported = piece.mentionable;
-    let items: MentionablePiece[] = [];
-    if (Array.isArray(exported)) {
-      items = exported;
-    } else if (exported && typeof (exported as any).get === "function") {
-      items = (exported as { get: () => MentionablePiece[] }).get() ?? [];
-    }
-
-    for (const m of items) {
-      collect(m, depth + 1);
+    const mentionable = piece.key("mentionable");
+    const items = mentionable.get() ?? [];
+    if (Array.isArray(items)) {
+      for (let i = 0; i < items.length; i++) {
+        collect(mentionable.key(i), depth + 1);
+      }
     }
   }
 
@@ -121,9 +126,9 @@ const computeMentionable = lift<
 });
 
 type Entry = {
-  piece: any;
+  piece: MentionableCell;
   name: string;
-  backlinks: any[];
+  backlinks: MentionableCell[];
 };
 
 /** Sub-pattern to render a single entry row with its backlinks. */
@@ -151,10 +156,14 @@ const EntryRow = pattern<Entry, { [UI]: VNode }>(({ piece, backlinks }) => {
 });
 
 const BacklinksIndex = pattern<Input, Output>(({ allPieces }) => {
-  computeIndex({ allPieces } as { allPieces: WritableBacklinks[] });
+  const allPieceCells = allPieces as MentionableCell[];
+
+  computeIndex({ allPieces: allPieceCells });
 
   // Compute mentionable list from allPieces reactively
-  const mentionable = computeMentionable({ allPieces });
+  const mentionable = computeMentionable({
+    allPieces: allPieceCells,
+  }) as MentionableCell[];
 
   const query = Writable.of("");
 
@@ -164,9 +173,15 @@ const BacklinksIndex = pattern<Input, Output>(({ allPieces }) => {
     const result: Entry[] = [];
     for (const piece of items) {
       if (!piece) continue;
-      const name = (piece[NAME] ?? "").toString();
-      const bl = Array.isArray(piece.backlinks) ? piece.backlinks : [];
-      result.push({ piece, name, backlinks: bl });
+      const value = piece.get();
+      const name = (value?.[NAME] ?? "").toString();
+      const backlinks = piece.key("backlinks");
+      const bl = backlinks.get() ?? [];
+      result.push({
+        piece,
+        name,
+        backlinks: Array.isArray(bl) ? bl.map((_, i) => backlinks.key(i)) : [],
+      });
     }
     return result;
   });

--- a/packages/patterns/system/summary-index.tsx
+++ b/packages/patterns/system/summary-index.tsx
@@ -12,9 +12,10 @@ import {
 import { type MentionablePiece } from "./backlinks-index.tsx";
 
 export type SummarizablePiece = MentionablePiece & { summary?: string };
+type MaybeWritable<T> = T | { get: () => T };
 
 export type SummaryIndexEntry = {
-  piece: Writable<SummarizablePiece>;
+  piece: MaybeWritable<SummarizablePiece>;
   summary: string;
   name: string;
 };
@@ -26,11 +27,20 @@ type Output = {
   search: PatternToolResult<{ entries: SummaryIndexEntry[] }>;
 };
 
+function isCellLike<T>(value: unknown): value is { get: () => T } {
+  return !!value && typeof value === "object" &&
+    typeof (value as { get?: unknown }).get === "function";
+}
+
+function getCellValue<T>(value: MaybeWritable<T>): T {
+  return isCellLike<T>(value) ? value.get() : value;
+}
+
 function extractSummary(piece: any): string | undefined {
   const summary = piece?.summary;
   if (!summary) return undefined;
 
-  if (typeof summary === "object" && "get" in summary) {
+  if (isCellLike<string>(summary)) {
     const value = summary.get();
     return typeof value === "string" && value.trim() ? value : undefined;
   }
@@ -61,7 +71,7 @@ export const searchPattern = pattern<
 });
 
 const SummaryIndex = pattern<Input, Output>(() => {
-  const mentionable = wish<Writable<SummarizablePiece>[] | Default<[]>>({
+  const mentionable = wish<MaybeWritable<SummarizablePiece>[] | Default<[]>>({
     query: "#mentionable",
   }).result;
 
@@ -71,7 +81,7 @@ const SummaryIndex = pattern<Input, Output>(() => {
     const result: SummaryIndexEntry[] = [];
     for (const piece of (Array.isArray(mentionable) ? mentionable : [])) {
       if (!piece) continue;
-      const value = piece.get();
+      const value = getCellValue(piece);
       const summary = extractSummary(value);
       if (!summary) continue;
       const name = (value[NAME] ?? "").toString();

--- a/packages/patterns/system/summary-index.tsx
+++ b/packages/patterns/system/summary-index.tsx
@@ -12,10 +12,9 @@ import {
 import { type MentionablePiece } from "./backlinks-index.tsx";
 
 export type SummarizablePiece = MentionablePiece & { summary?: string };
-type MaybeWritable<T> = T | { get: () => T };
 
 export type SummaryIndexEntry = {
-  piece: MaybeWritable<SummarizablePiece>;
+  piece: Writable<SummarizablePiece>;
   summary: string;
   name: string;
 };
@@ -30,10 +29,6 @@ type Output = {
 function isCellLike<T>(value: unknown): value is { get: () => T } {
   return !!value && typeof value === "object" &&
     typeof (value as { get?: unknown }).get === "function";
-}
-
-function getCellValue<T>(value: MaybeWritable<T>): T {
-  return isCellLike<T>(value) ? value.get() : value;
 }
 
 function extractSummary(piece: any): string | undefined {
@@ -71,7 +66,7 @@ export const searchPattern = pattern<
 });
 
 const SummaryIndex = pattern<Input, Output>(() => {
-  const mentionable = wish<MaybeWritable<SummarizablePiece>[] | Default<[]>>({
+  const mentionable = wish<Default<Writable<SummarizablePiece>[], []>>({
     query: "#mentionable",
   }).result;
 
@@ -81,7 +76,7 @@ const SummaryIndex = pattern<Input, Output>(() => {
     const result: SummaryIndexEntry[] = [];
     for (const piece of (Array.isArray(mentionable) ? mentionable : [])) {
       if (!piece) continue;
-      const value = getCellValue(piece);
+      const value = piece.get();
       const summary = extractSummary(value);
       if (!summary) continue;
       const name = (value[NAME] ?? "").toString();


### PR DESCRIPTION
## Summary
- Make `BacklinksIndex` publish `#mentionable` as writable cell refs instead of plain mentionable values.
- Keep `SummaryIndexEntry.piece` strict as `Writable<SummarizablePiece>`.
- Wish for `Default<Writable<SummarizablePiece>[], []>` so the list defaults to `[]` while every present item still lowers with `asCell: ["cell"]`.

## Validation
- `deno fmt packages/patterns/system/backlinks-index.tsx packages/patterns/system/summary-index.tsx`
- `deno task cf check packages/patterns/system/summary-index.tsx --no-run`
- `deno task cf check packages/patterns/system/backlinks-index.tsx --no-run`
- `deno task cf check packages/patterns/examples/summary-index-tester.tsx --root packages/patterns --no-run`
- `deno task cf check packages/patterns/system/default-app.tsx --no-run`
- Live smoke: deployed `summary-index-tester.tsx` to `summary-index-default-cell-20260519`; `piece inspect --summary` no longer emits `piece.get is not a function`.
