### PR TITLE
Redact failed read_file status observations

### DIFF
--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -86,6 +86,7 @@ import {
   extractFinalWorkingDirectory,
 } from "./tools/shell-cwd.ts";
 import { isReadFileToolSuccessOutput } from "./tools/read-file.ts";
+import { isStructuredFileToolErrorOutput } from "./tools/file-errors.ts";
 import { isViewImageToolSuccessOutput } from "./tools/view-image.ts";
 import type { HarnessFailureRecord } from "./diagnostics.ts";
 import { DEFAULT_PARENT_TOOL_IDS as DEFAULT_PROMPT_LOOP_TOOL_IDS } from "./contracts/tool-descriptor.ts";
@@ -914,6 +915,13 @@ const MODEL_FACING_BASH_STREAM_HEAD_CHARS = 60_000;
 const MODEL_FACING_BASH_STREAM_TAIL_CHARS = 20_000;
 const MODEL_FACING_BASH_STREAM_MAX_CHARS = MODEL_FACING_BASH_STREAM_HEAD_CHARS +
   MODEL_FACING_BASH_STREAM_TAIL_CHARS;
+const REDACTED_READ_FILE_ERROR_PATH = "[redacted]";
+const REDACTED_READ_FILE_ERROR_MESSAGE =
+  "read_file failed: filesystem status not observable under CFC policy";
+const REDACTED_READ_FILE_ERROR_DETAIL =
+  "Filesystem status details were redacted by CFC policy.";
+const READ_FILE_STATUS_OBSERVATION_DETAIL =
+  "read_file failure may reveal filesystem path/status observations";
 
 interface InvokedToolCallMessages {
   toolMessage: HarnessToolTranscriptMessage;
@@ -961,6 +969,40 @@ const toolOutputNeedsSandboxMediation = (
 ): boolean =>
   toolId === "bash" ||
   (toolId === "read_file" && isReadFileToolSuccessOutput(output));
+
+const isReadFileStatusObservationError = (output: unknown): boolean =>
+  isStructuredFileToolErrorOutput(output) &&
+  output.error.exitCode !== undefined &&
+  (
+    output.error.code === "file_not_found" ||
+    output.error.code === "not_a_file" ||
+    output.error.code === "permission_denied" ||
+    output.error.code === "unknown"
+  );
+
+const redactReadFileStatusObservationError = (
+  output: unknown,
+  resultRef: ToolResultRef,
+): unknown => {
+  if (!isStructuredFileToolErrorOutput(output)) {
+    return output;
+  }
+  const outputId = typeof output.outputId === "string"
+    ? output.outputId
+    : resultRef.outputId;
+  return {
+    outputId,
+    path: REDACTED_READ_FILE_ERROR_PATH,
+    ok: false,
+    error: {
+      type: "cf-harness.structured-file-tool-error",
+      code: "unknown",
+      message: REDACTED_READ_FILE_ERROR_MESSAGE,
+      path: REDACTED_READ_FILE_ERROR_PATH,
+      detail: REDACTED_READ_FILE_ERROR_DETAIL,
+    },
+  };
+};
 
 const createOutputHandle = (
   resultRef: ToolResultRef,
@@ -2162,6 +2204,38 @@ export class CfHarnessPromptLoop {
           digest: output.digest,
           imageAttached: true,
         },
+      };
+    }
+    if (toolId === "read_file" && isReadFileStatusObservationError(output)) {
+      if (mode === "disabled") {
+        return { output: stripInternalCfcFields(output) };
+      }
+      if (mode === "observe") {
+        await writePolicyEvent({
+          severity: "warning",
+          mode,
+          toolId,
+          toolCallId,
+          detail:
+            `${READ_FILE_STATUS_OBSERVATION_DETAIL}; raw error was exposed because CFC is in observe mode`,
+        });
+        return { output: stripInternalCfcFields(output) };
+      }
+      const denial = makeObservationDenied("not-observable", {
+        detail: READ_FILE_STATUS_OBSERVATION_DETAIL,
+        handle: createOutputHandle(resultRef, "error"),
+      });
+      await writePolicyEvent({
+        severity: "denied",
+        mode,
+        toolId,
+        toolCallId,
+        detail:
+          `${READ_FILE_STATUS_OBSERVATION_DETAIL}; raw error details were redacted`,
+        observationDenied: denial,
+      });
+      return {
+        output: redactReadFileStatusObservationError(output, resultRef),
       };
     }
     if (!toolOutputNeedsSandboxMediation(toolId, output)) {

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -684,6 +684,7 @@ Deno.test("CfHarnessPromptLoop surfaces recoverable file-tool failures to the mo
       ]),
       runId: "run-recoverable-file-error",
       model: "gpt-5.4",
+      cfcEnforcementMode: "disabled",
       now: (() => {
         const timestamps = [
           "2026-04-15T20:05:00.000Z",
@@ -3401,6 +3402,162 @@ Deno.test("CfHarnessPromptLoop denies read_file content without CFC metadata in 
     },
   });
   assertEquals(result.runState.policyEvents.at(-1)?.severity, "denied");
+});
+
+Deno.test("CfHarnessPromptLoop redacts read_file filesystem-status failures in enforce mode", async () => {
+  const sensitivePath = "/workspace/personal/health/condition-7.md";
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime([
+        {
+          stdout: "",
+          stderr: `file not found: ${sensitivePath}`,
+          exitCode: 10,
+        },
+      ]),
+      runId: "run-read-file-status-redacted",
+      model: "gpt-5.4",
+      cfcEnforcementMode: "enforce-explicit",
+    }),
+    fetchFn: (() => {
+      let callCount = 0;
+      return () => {
+        callCount += 1;
+        const payload = callCount === 1
+          ? {
+            choices: [{
+              index: 0,
+              message: {
+                role: "assistant",
+                content: "",
+                tool_calls: [{
+                  id: "call-read-file-status-redacted",
+                  type: "function",
+                  function: {
+                    name: "read_file",
+                    arguments: JSON.stringify({ path: sensitivePath }),
+                  },
+                }],
+              },
+            }],
+          }
+          : {
+            choices: [{
+              index: 0,
+              message: {
+                role: "assistant",
+                content: "Handled redacted file status.",
+              },
+            }],
+          };
+        return Promise.resolve(
+          new Response(JSON.stringify(payload), { status: 200 }),
+        );
+      };
+    })(),
+  });
+
+  const result = await loop.runPrompt({
+    prompt: "Read a possible private file.",
+  });
+
+  const toolMessage = result.transcript.find((message) =>
+    message.role === "tool" && message.toolName === "read_file"
+  );
+  assert(toolMessage !== undefined);
+  assert(!toolMessage.content.includes("condition-7"));
+  assert(!toolMessage.content.includes("file_not_found"));
+  assert(!toolMessage.content.includes("file not found"));
+  assertEquals(JSON.parse(toolMessage.content), {
+    outputId: createToolOutputId(
+      "run-read-file-status-redacted",
+      "read_file",
+      1,
+    ),
+    path: "[redacted]",
+    ok: false,
+    error: {
+      type: "cf-harness.structured-file-tool-error",
+      code: "unknown",
+      message:
+        "read_file failed: filesystem status not observable under CFC policy",
+      path: "[redacted]",
+      detail: "Filesystem status details were redacted by CFC policy.",
+    },
+  });
+
+  const policyEvent = result.runState.policyEvents.at(-1);
+  assertEquals(policyEvent?.severity, "denied");
+  assertEquals(policyEvent?.observationDenied?.reason, "not-observable");
+});
+
+Deno.test("CfHarnessPromptLoop warns but exposes read_file filesystem-status failures in observe mode", async () => {
+  const path = "/workspace/personal/health/condition-8.md";
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime([
+        {
+          stdout: "",
+          stderr: `file not found: ${path}`,
+          exitCode: 10,
+        },
+      ]),
+      runId: "run-read-file-status-observe",
+      model: "gpt-5.4",
+      cfcEnforcementMode: "observe",
+    }),
+    fetchFn: (() => {
+      let callCount = 0;
+      return () => {
+        callCount += 1;
+        const payload = callCount === 1
+          ? {
+            choices: [{
+              index: 0,
+              message: {
+                role: "assistant",
+                content: "",
+                tool_calls: [{
+                  id: "call-read-file-status-observe",
+                  type: "function",
+                  function: {
+                    name: "read_file",
+                    arguments: JSON.stringify({ path }),
+                  },
+                }],
+              },
+            }],
+          }
+          : {
+            choices: [{
+              index: 0,
+              message: {
+                role: "assistant",
+                content: "Handled observed file status.",
+              },
+            }],
+          };
+        return Promise.resolve(
+          new Response(JSON.stringify(payload), { status: 200 }),
+        );
+      };
+    })(),
+  });
+
+  const result = await loop.runPrompt({
+    prompt: "Read a possible private file.",
+  });
+
+  const toolMessage = result.transcript.find((message) =>
+    message.role === "tool" && message.toolName === "read_file"
+  );
+  assert(toolMessage !== undefined);
+  assert(toolMessage.content.includes("condition-8"));
+  assert(toolMessage.content.includes("file_not_found"));
+  assert(toolMessage.content.includes("file not found"));
+  assertEquals(result.runState.policyEvents.at(-1)?.severity, "warning");
 });
 
 Deno.test("CfHarnessPromptLoop exposes mediated read_file content and tracks model context", async () => {


### PR DESCRIPTION
## Summary
- redact model-facing read_file filesystem-status failures in CFC enforce modes
- keep disabled behavior unchanged and emit observe-mode warnings while exposing raw errors
- add prompt-loop coverage for enforce redaction and observe warning behavior

## Testing
- /Users/gideonwald/.deno/bin/deno test -A packages/cf-harness/test/prompt-loop.test.ts packages/cf-harness/test/tools-execution.test.ts packages/cf-harness/test/artifacts.test.ts
- cd packages/cf-harness && /Users/gideonwald/.deno/bin/deno task test
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts read_file filesystem-status failures under CFC enforce modes to prevent leaking path/status observations to the model. Observe mode warns but exposes the raw error; disabled mode remains unchanged.

- **New Features**
  - Enforce modes: redact read_file status errors (e.g., file_not_found, not_a_file, permission_denied, unknown) with a generic message and path set to "[redacted]"; emit a "denied" policy event with reason "not-observable".
  - Observe mode: pass through the raw error and emit a "warning" policy event.
  - Disabled mode: pass through the raw error with no policy event changes.
  - Added prompt-loop tests covering enforce redaction and observe warnings.

<sup>Written for commit 6be39e920d99fd15a40b6c0db8098b5985c26d05. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3627?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

