### PR TITLE
CT-1599: Fix tab focus order for form controls

### DIFF
--- a/docs/development/UI_TESTING.md
+++ b/docs/development/UI_TESTING.md
@@ -88,8 +88,8 @@ const button = await page.$("[data-cf-button]", {
 
 Playwright's `fill()` requires a native `<input>` or `<textarea>`. Since
 `cf-input` and `cf-textarea` are custom elements, use
-`pressSequentially()` on the locator instead — `delegatesFocus` forwards
-focus to the inner native input automatically:
+`pressSequentially()` on the locator instead. The custom element host is the
+semantic tab stop and forwards focus to the inner native input automatically:
 
 ```typescript
 const input = page.getByRole("textbox", { name: "Email" });

--- a/packages/patterns/factory-outputs/parking-coordinator/main.tsx
+++ b/packages/patterns/factory-outputs/parking-coordinator/main.tsx
@@ -252,7 +252,11 @@ export const DEFAULT_SPOTS: ParkingSpot[] = [
 // ============================================================
 
 export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
-  ({ spots, people, requests }) => {
+  ({ spots: inputSpots, people: inputPeople, requests: inputRequests }) => {
+    const spots = inputSpots ?? Writable.perSpace.of(DEFAULT_SPOTS);
+    const people = inputPeople ?? Writable.perSpace.of<Person[]>([]);
+    const requests = inputRequests ?? Writable.perSpace.of<SpotRequest[]>([]);
+
     const nowTimestamp = wish<number>({ query: "#now" });
     const todayStr = computed(() =>
       toLocalDateStr(nowTimestamp.result || safeDateNow())
@@ -1694,6 +1698,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                                   <cf-input
                                     $value={newPersonName}
                                     placeholder="Full name"
+                                    timingStrategy="immediate"
                                     style="width: 100%;"
                                   />
                                 </cf-vstack>
@@ -1707,6 +1712,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                                   <cf-input
                                     $value={newPersonEmail}
                                     placeholder="email@company.com"
+                                    timingStrategy="immediate"
                                     style="width: 100%;"
                                   />
                                 </cf-vstack>
@@ -1730,6 +1736,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                                     $value={newPersonPriority}
                                     type="number"
                                     placeholder="1"
+                                    timingStrategy="immediate"
                                     style="width: 5rem;"
                                   />
                                 </cf-vstack>
@@ -1759,6 +1766,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                                 <cf-input
                                   $value={newPersonPreferences}
                                   placeholder="e.g. 1, 5"
+                                  timingStrategy="immediate"
                                   style="width: 100%;"
                                 />
                               </cf-vstack>

--- a/packages/ui/src/v2/components/cf-host-accessibility.browser.test.ts
+++ b/packages/ui/src/v2/components/cf-host-accessibility.browser.test.ts
@@ -74,3 +74,21 @@ Deno.test("form control host focus forwards to native shadow controls", async ()
   textarea.remove();
   select.remove();
 });
+
+Deno.test("cf-input preserves early programmatic focus before first render", async () => {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const input = document.createElement("cf-input") as CFInput;
+  document.body.append(input);
+
+  input.focus();
+  assertEquals(document.activeElement, input);
+
+  await input.updateComplete;
+  await nextFrame();
+  assertEquals(input.shadowRoot?.activeElement?.tagName, "INPUT");
+
+  input.remove();
+});

--- a/packages/ui/src/v2/components/cf-host-accessibility.browser.test.ts
+++ b/packages/ui/src/v2/components/cf-host-accessibility.browser.test.ts
@@ -1,6 +1,11 @@
 import { assertEquals, assertInstanceOf } from "@std/assert";
 import { CFButton } from "./cf-button/cf-button.ts";
 import { CFInput } from "./cf-input/cf-input.ts";
+import { CFSelect } from "./cf-select/cf-select.ts";
+import { CFTextarea } from "./cf-textarea/cf-textarea.ts";
+
+const nextFrame = () =>
+  new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
 
 Deno.test("cf-button and cf-input can be created by document.createElement", async () => {
   if (typeof document === "undefined") {
@@ -23,4 +28,49 @@ Deno.test("cf-button and cf-input can be created by document.createElement", asy
 
   button.remove();
   input.remove();
+});
+
+Deno.test("form control host focus forwards to native shadow controls", async () => {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const input = document.createElement("cf-input") as CFInput;
+  const textarea = document.createElement("cf-textarea") as CFTextarea;
+  const select = document.createElement("cf-select") as CFSelect;
+  select.items = [{ label: "One", value: "one" }];
+
+  document.body.append(input, textarea, select);
+  assertInstanceOf(input, CFInput);
+  assertInstanceOf(textarea, CFTextarea);
+  assertInstanceOf(select, CFSelect);
+
+  await Promise.all([
+    input.updateComplete,
+    textarea.updateComplete,
+    select.updateComplete,
+  ]);
+
+  input.focus();
+  await nextFrame();
+  assertEquals(input.shadowRoot?.activeElement?.tagName, "INPUT");
+
+  textarea.focus();
+  await nextFrame();
+  assertEquals(textarea.shadowRoot?.activeElement?.tagName, "TEXTAREA");
+
+  select.focus();
+  await nextFrame();
+  assertEquals(select.shadowRoot?.activeElement?.tagName, "SELECT");
+
+  input.disabled = true;
+  await input.updateComplete;
+  input.blur();
+  input.focus();
+  await nextFrame();
+  assertEquals(input.shadowRoot?.activeElement, null);
+
+  input.remove();
+  textarea.remove();
+  select.remove();
 });

--- a/packages/ui/src/v2/components/cf-input/cf-input.test.ts
+++ b/packages/ui/src/v2/components/cf-input/cf-input.test.ts
@@ -131,8 +131,8 @@ describe("CFInput", () => {
     expect(CFInput.formAssociated).toBe(true);
   });
 
-  it("should delegate focus into the shadow input", () => {
-    expect(CFInput.shadowRootOptions.delegatesFocus).toBe(true);
+  it("should not rely on delegatesFocus for keyboard navigation", () => {
+    expect(CFInput.shadowRootOptions?.delegatesFocus).not.toBe(true);
   });
 
   it("should accept a CellHandle as value property", () => {

--- a/packages/ui/src/v2/components/cf-input/cf-input.ts
+++ b/packages/ui/src/v2/components/cf-input/cf-input.ts
@@ -658,6 +658,8 @@ export class CFInput extends BaseElement {
         // The host element carries the ARIA role and tabindex for accessibility.
         // The inner input is removed from the sequential tab order; when the host
         // receives focus, we forward focus here so typing and selection work.
+        // Avoid delegatesFocus: it can make the shadow control appear to be the
+        // active tab stop instead of the host that owns the ARIA surface.
         return html`
           <input
             type="${this.type}"
@@ -766,8 +768,8 @@ export class CFInput extends BaseElement {
         }
       }
 
-      private _forwardFocusToInput = (event: FocusEvent) => {
-        if (event.target !== this || this.disabled) return;
+      private _forwardFocusToInput = () => {
+        if (this.disabled) return;
         this.input?.focus();
       };
 
@@ -909,6 +911,7 @@ export class CFInput extends BaseElement {
       }
 
       override focus(options?: FocusOptions): void {
+        if (this.disabled) return;
         this.input?.focus(options);
       }
 

--- a/packages/ui/src/v2/components/cf-input/cf-input.ts
+++ b/packages/ui/src/v2/components/cf-input/cf-input.ts
@@ -1,4 +1,4 @@
-import { css, html, LitElement } from "lit";
+import { css, html } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { property } from "lit/decorators.js";
 import { BaseElement } from "../../core/base-element.ts";
@@ -126,10 +126,6 @@ export const INPUT_PATTERNS = {
 
 export class CFInput extends BaseElement {
   static formAssociated = true;
-  static override shadowRootOptions = {
-    ...LitElement.shadowRootOptions,
-    delegatesFocus: true,
-  };
 
   static override styles = css`
     :host {
@@ -483,6 +479,7 @@ export class CFInput extends BaseElement {
         this.showValidation = false;
         this.timingStrategy = "debounce";
         this.timingDelay = 300;
+        this.addEventListener("focus", this._forwardFocusToInput);
       }
 
       // Theme consumption
@@ -659,10 +656,8 @@ export class CFInput extends BaseElement {
         const inputValue = this.type === "file" ? undefined : this.getValue();
 
         // The host element carries the ARIA role and tabindex for accessibility.
-        // delegatesFocus: true routes focus to the inner <input>, so aria-hidden
-        // must NOT be set on it — browsers refuse to apply aria-hidden on focused
-        // elements. The tabindex="-1" keeps it out of the tab sequence (the host
-        // is the tab stop); the host ARIA attributes are the a11y surface.
+        // The inner input is removed from the sequential tab order; when the host
+        // receives focus, we forward focus here so typing and selection work.
         return html`
           <input
             type="${this.type}"
@@ -770,6 +765,11 @@ export class CFInput extends BaseElement {
           });
         }
       }
+
+      private _forwardFocusToInput = (event: FocusEvent) => {
+        if (event.target !== this || this.disabled) return;
+        this.input?.focus();
+      };
 
       private _handleInvalid(event: Event) {
         event.preventDefault(); // Prevent browser's default validation UI
@@ -908,7 +908,9 @@ export class CFInput extends BaseElement {
         }
       }
 
-      // focus() is handled by delegatesFocus on the shadow root.
+      override focus(options?: FocusOptions): void {
+        this.input?.focus(options);
+      }
 
       /**
        * Blur the input programmatically

--- a/packages/ui/src/v2/components/cf-input/cf-input.ts
+++ b/packages/ui/src/v2/components/cf-input/cf-input.ts
@@ -912,7 +912,21 @@ export class CFInput extends BaseElement {
 
       override focus(options?: FocusOptions): void {
         if (this.disabled) return;
-        this.input?.focus(options);
+        const input = this.input;
+        if (input) {
+          input.focus(options);
+          return;
+        }
+
+        // If focus is requested before the first render, keep focus on the
+        // semantic host now, then forward it once the native input exists.
+        super.focus(options);
+        void this.updateComplete.then(() => {
+          if (this.disabled || this.ownerDocument.activeElement !== this) {
+            return;
+          }
+          this.input?.focus(options);
+        });
       }
 
       /**

--- a/packages/ui/src/v2/components/cf-select/cf-select.ts
+++ b/packages/ui/src/v2/components/cf-select/cf-select.ts
@@ -324,6 +324,9 @@ export class CFSelect extends BaseElement {
   /* ---------- Render ---------- */
   override render() {
     return html`
+      <!-- The host owns role and tabindex; focus is forwarded to this native
+        select instead of using delegatesFocus so keyboard tab order follows the
+        host's ARIA surface. -->
       <select
         ?disabled="${this.disabled}"
         ?multiple="${this.multiple}"
@@ -433,6 +436,7 @@ export class CFSelect extends BaseElement {
 
   /* ---------- Public API ---------- */
   override focus(options?: FocusOptions) {
+    if (this.disabled) return;
     this._select?.focus(options);
   }
 
@@ -450,8 +454,8 @@ export class CFSelect extends BaseElement {
 
   private _lastGeneratedRole: string | null = null;
 
-  private _forwardFocusToSelect = (event: FocusEvent) => {
-    if (event.target !== this || this.disabled) return;
+  private _forwardFocusToSelect = () => {
+    if (this.disabled) return;
     this._select?.focus();
   };
 

--- a/packages/ui/src/v2/components/cf-select/cf-select.ts
+++ b/packages/ui/src/v2/components/cf-select/cf-select.ts
@@ -1,4 +1,4 @@
-import { css, html, LitElement, nothing } from "lit";
+import { css, html, nothing } from "lit";
 import { property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { BaseElement } from "../../core/base-element.ts";
@@ -61,11 +61,6 @@ export interface SelectItem {
 }
 
 export class CFSelect extends BaseElement {
-  static override shadowRootOptions = {
-    ...LitElement.shadowRootOptions,
-    delegatesFocus: true,
-  };
-
   /* ---------- Styles ---------- */
   static override styles = [
     BaseElement.baseStyles,
@@ -259,6 +254,7 @@ export class CFSelect extends BaseElement {
     this.placeholder = "";
     this.items = [];
     this.value = this.multiple ? [] : undefined;
+    this.addEventListener("focus", this._forwardFocusToSelect);
   }
 
   /* ---------- Lifecycle ---------- */
@@ -436,8 +432,8 @@ export class CFSelect extends BaseElement {
   }
 
   /* ---------- Public API ---------- */
-  override focus() {
-    this._select?.focus();
+  override focus(options?: FocusOptions) {
+    this._select?.focus(options);
   }
 
   override blur() {
@@ -453,6 +449,11 @@ export class CFSelect extends BaseElement {
   }
 
   private _lastGeneratedRole: string | null = null;
+
+  private _forwardFocusToSelect = (event: FocusEvent) => {
+    if (event.target !== this || this.disabled) return;
+    this._select?.focus();
+  };
 
   /* ---------- Accessibility ---------- */
   private _updateAccessibilityAttributes() {

--- a/packages/ui/src/v2/components/cf-textarea/cf-textarea.test.ts
+++ b/packages/ui/src/v2/components/cf-textarea/cf-textarea.test.ts
@@ -105,8 +105,8 @@ describe("CFTextarea", () => {
     expect(CFTextarea.formAssociated).toBe(true);
   });
 
-  it("should delegate focus into the shadow textarea", () => {
-    expect(CFTextarea.shadowRootOptions.delegatesFocus).toBe(true);
+  it("should not rely on delegatesFocus for keyboard navigation", () => {
+    expect(CFTextarea.shadowRootOptions?.delegatesFocus).not.toBe(true);
   });
 
   it("should not set attributes in constructor (custom element spec)", () => {

--- a/packages/ui/src/v2/components/cf-textarea/cf-textarea.ts
+++ b/packages/ui/src/v2/components/cf-textarea/cf-textarea.ts
@@ -518,7 +518,9 @@ export class CFTextarea extends BaseElement {
 
           // The host carries the ARIA role and tabindex. The inner textarea is
           // removed from sequential tab order; host focus forwards here so
-          // typing and selection work.
+          // typing and selection work. Avoid delegatesFocus: it can make the
+          // shadow control appear to be the active tab stop instead of the host
+          // that owns the ARIA surface.
           return html`
             <textarea
               class="${this.error ? "error" : ""}"
@@ -613,8 +615,8 @@ export class CFTextarea extends BaseElement {
           }
         }
 
-        private _forwardFocusToTextarea = (event: FocusEvent) => {
-          if (event.target !== this || this.disabled) return;
+        private _forwardFocusToTextarea = () => {
+          if (this.disabled) return;
           this.textarea?.focus();
         };
 
@@ -696,6 +698,7 @@ export class CFTextarea extends BaseElement {
         }
 
         override focus(options?: FocusOptions): void {
+          if (this.disabled) return;
           this.textarea?.focus(options);
         }
 

--- a/packages/ui/src/v2/components/cf-textarea/cf-textarea.ts
+++ b/packages/ui/src/v2/components/cf-textarea/cf-textarea.ts
@@ -1,4 +1,4 @@
-import { css, html, LitElement } from "lit";
+import { css, html } from "lit";
 import { property } from "lit/decorators.js";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { BaseElement } from "../../core/base-element.ts";
@@ -56,10 +56,6 @@ export type TimingStrategy = "immediate" | "debounce" | "throttle" | "blur";
 
 export class CFTextarea extends BaseElement {
   static formAssociated = true;
-  static override shadowRootOptions = {
-    ...LitElement.shadowRootOptions,
-    delegatesFocus: true,
-  };
 
   static override properties = {
     placeholder: { type: String },
@@ -378,6 +374,7 @@ export class CFTextarea extends BaseElement {
           this.timingStrategy = "debounce";
           this.timingDelay = 300;
           this.size = "md";
+          this.addEventListener("focus", this._forwardFocusToTextarea);
         }
 
         private getValue(): string {
@@ -519,10 +516,9 @@ export class CFTextarea extends BaseElement {
             ? "resize: none;"
             : `resize: ${this.resize};`;
 
-          // The host carries the ARIA role and tabindex. delegatesFocus: true
-          // routes focus to the inner <textarea>, so aria-hidden must NOT be set
-          // on it — browsers refuse to apply aria-hidden on focused elements.
-          // tabindex="-1" keeps it out of the tab sequence (the host is the tab stop).
+          // The host carries the ARIA role and tabindex. The inner textarea is
+          // removed from sequential tab order; host focus forwards here so
+          // typing and selection work.
           return html`
             <textarea
               class="${this.error ? "error" : ""}"
@@ -617,6 +613,11 @@ export class CFTextarea extends BaseElement {
           }
         }
 
+        private _forwardFocusToTextarea = (event: FocusEvent) => {
+          if (event.target !== this || this.disabled) return;
+          this.textarea?.focus();
+        };
+
         private _updateAccessibilityAttributes() {
           // Respect author-provided role; only set our generated role when none exists
           if (!this.hasAttribute("role")) {
@@ -694,7 +695,9 @@ export class CFTextarea extends BaseElement {
             `${newHeight}px`;
         }
 
-        // focus() is handled by delegatesFocus on the shadow root.
+        override focus(options?: FocusOptions): void {
+          this.textarea?.focus(options);
+        }
 
         /**
          * Blur the textarea programmatically


### PR DESCRIPTION
## Summary
- move cf-input, cf-textarea, and cf-select away from delegatesFocus so their hosts remain reliable keyboard tab stops
- add Parking Coordinator fallback cells for optional spots/people/requests inputs to avoid undefined collection crashes
- keep Add Person text fields immediate to avoid blur-time reactive updates during Tab navigation
- update UI testing docs for the host-owned focus behavior

## Verification
- deno test --allow-env --allow-ffi --allow-read --allow-write --allow-run packages/ui/src/v2/components/cf-input/cf-input.test.ts packages/ui/src/v2/components/cf-textarea/cf-textarea.test.ts
- deno check packages/ui/src/v2/components/cf-select/cf-select.ts packages/ui/src/v2/components/cf-input/cf-input.ts packages/ui/src/v2/components/cf-textarea/cf-textarea.ts
- deno fmt --check docs/development/UI_TESTING.md packages/ui/src/v2/components/cf-input/cf-input.ts packages/ui/src/v2/components/cf-textarea/cf-textarea.ts packages/ui/src/v2/components/cf-select/cf-select.ts packages/ui/src/v2/components/cf-input/cf-input.test.ts packages/ui/src/v2/components/cf-textarea/cf-textarea.test.ts packages/patterns/factory-outputs/parking-coordinator/main.tsx
- deno task cf check packages/patterns/factory-outputs/parking-coordinator/main.tsx --no-run
- deno task cf test packages/patterns/factory-outputs/parking-coordinator/main.test.tsx
- manual browser retest in local piece confirmed initial fix

Linear: CT-1599

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes keyboard tab order for `cf-input`, `cf-textarea`, and `cf-select` by making the host the tab stop and forwarding focus to the native control (Linear CT-1599). Also fixes early programmatic focus in `cf-input`, adds safe fallbacks in Parking Coordinator, and updates docs/tests.

- **Bug Fixes**
  - Removed `delegatesFocus`; host forwards focus to the native control. Overrode `focus()` (respects `disabled`) and preserved early programmatic focus in `cf-input`.
  - Parking Coordinator: default `spots` to `DEFAULT_SPOTS`; `people`/`requests` to empty `Writable` cells; set `timingStrategy="immediate"` on "Add Person" inputs.
  - Updated UI testing docs and added browser tests for host-owned focus, disabled behavior, and early focus in `cf-input`.

<sup>Written for commit 211a96b11a9176f18909a3824933988be8d739a3. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3629?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

