### PR TITLE
fix(runner): split attempted writes from materializers

### DIFF
--- a/docs/development/debugging/README.md
+++ b/docs/development/debugging/README.md
@@ -31,6 +31,7 @@ Quick error reference and debugging workflows. For detailed explanations, see li
 | "lift() should not be immediately invoked inside a pattern" | `lift(...)(args)` inside pattern | Use `computed()` instead, or define lift() at module scope ([gotchas/handler-inside-pattern](gotchas/handler-inside-pattern.md)) |
 | Click handler does nothing, ID lookup fails silently | Using custom `id` property for lookups | Use `equals()` for identity, not custom IDs ([gotchas/custom-id-property-pitfall](gotchas/custom-id-property-pitfall.md)) |
 | Selection overwrites item data, `.set()` changes wrong value | Storing Cell reference directly | Box the reference: `{ item }` instead of `item` ([gotchas/cell-reference-overwrite](gotchas/cell-reference-overwrite.md)) |
+| Writable-input computed causes churn or stale fan-out | Computed writes through a `Writable<>` input while also participating in reactive scheduling | Treat it as effectful and check for cycles. Pull mode materializes stable side writes through idle materializers, so actual changed paths should drive downstream updates instead of broad fan-out. |
 
 ---
 

--- a/docs/plans/runner_cfc_implementation.md
+++ b/docs/plans/runner_cfc_implementation.md
@@ -133,13 +133,13 @@ last-write-wins compaction.
 Phase 1 does not require that precision. It uses two deterministic transaction
 views:
 
-- `potentialWrites`: the maybe-write target set, sourced from tx
-  `markReadAsPotentialWrite` reads performed while deciding whether a diff
+- `attemptedWrites`: the maybe-write target set, sourced from tx
+  `markReadAsAttemptedWrite` reads performed while deciding whether a diff
   results in a write
 - `writes`: the actual changed/final write set sourced from v2 transaction
   internals
 
-Boundary checking uses `potentialWrites ∪ writes` as the target set for
+Boundary checking uses `attemptedWrites ∪ writes` as the target set for
 relevance and conservative target-side policy checks. Persisted output label-map
 updates and metadata updates are derived from `writes` only. If later rules
 need per-write provenance or exact attempt order, we can add dedicated
@@ -147,11 +147,11 @@ write-attempt logging as a follow-on precision optimization.
 
 Phase-1 invariant: direct `tx.write*()` usage remains internal-only runner API.
 No-op attempted-target coverage depends on higher-level diff paths performing
-`markReadAsPotentialWrite` reads before deciding whether to write. That
+`markReadAsAttemptedWrite` reads before deciding whether to write. That
 assumption should be documented explicitly on the transaction write APIs and
 covered by guardrail tests. This is not just theoretical: current v2 writes
 short-circuit same-value writes before recording write activity, so no-op
-attempted-target coverage must come from `markReadAsPotentialWrite` or a future
+attempted-target coverage must come from `markReadAsAttemptedWrite` or a future
 explicit attempted-write API.
 
 ### Write-Policy Input
@@ -215,7 +215,7 @@ handler has produced its reads and writes but before commit succeeds.
 
 Prepare:
 
-- gathers consumed reads, canonical `potentialWrites`, canonical `writes`, and
+- gathers consumed reads, canonical `attemptedWrites`, canonical `writes`, and
   canonical write-policy inputs
 - evaluates schema and policy obligations
 - computes output label maps and metadata
@@ -226,7 +226,7 @@ Prepare:
 The prepared digest is a stable hash of:
 
 - canonical consumed reads
-- canonical `potentialWrites`
+- canonical `attemptedWrites`
 - canonical `writes`
 - canonical write-policy inputs
 - implementation identity
@@ -538,15 +538,15 @@ Primary files:
 Tasks:
 
 - [x] Build a canonical extractor over the v2 inspection APIs
-- [x] Surface tx `potentialWrites` as the phase-1 maybe-write target set
+- [x] Surface tx `attemptedWrites` as the phase-1 maybe-write target set
 - [x] Produce a deterministic final-per-path `writes` set for phase 1
-- [x] Preserve no-op attempted-target coverage through `potentialWrites`
+- [x] Preserve no-op attempted-target coverage through `attemptedWrites`
 - [x] Add JSDoc and guardrails on internal `tx.write*` APIs explaining that
       phase-1 no-op attempted-target coverage relies on higher-level diff paths
-      using `markReadAsPotentialWrite`; blind same-value direct writes are not
-      surfaced through `potentialWrites`
+      using `markReadAsAttemptedWrite`; blind same-value direct writes are not
+      surfaced through `attemptedWrites`
 - [x] Audit existing internal direct `tx.write*` / `writeValueOrThrow()` call
-      sites and either ensure they establish `potentialWrites` coverage before
+      sites and either ensure they establish `attemptedWrites` coverage before
       same-value short-circuiting or explicitly keep them out of phase-1 CFC
       scope
 - [x] Add explicit APIs to record canonical `WritePolicyInput` entries at
@@ -556,20 +556,20 @@ Tasks:
 - [x] Exclude only `internalVerifierRead` from the consumed-read set
 - [x] Make the phase-1 prepare engine free to pessimistically treat all
       consumed reads as influencing all target paths in
-      `potentialWrites ∪ writes`
+      `attemptedWrites ∪ writes`
 - [x] Defer exact ordered write-attempt logging to a follow-up precision slice
       if later rules need it
 
 Acceptance:
 
 - [x] Canonical path handling strips the `value` wrapper consistently
-- [x] Phase-1 canonical `potentialWrites` extraction is deterministic across
+- [x] Phase-1 canonical `attemptedWrites` extraction is deterministic across
       runs
 - [x] Phase-1 canonical `writes` extraction is deterministic across runs
 - [x] Canonical `WritePolicyInput` capture is deterministic across runs
 - [x] Internal verifier reads remain visible for diagnostics but not policy
 - [x] Final-per-path view is deterministic
-- [x] Same-value direct writes are either covered by `potentialWrites` or
+- [x] Same-value direct writes are either covered by `attemptedWrites` or
       explicitly out of phase-1 scope
 
 ### 4. Relevance Detection
@@ -589,7 +589,7 @@ Tasks:
 - [x] Mark write-only transactions relevant when the target path carries CFC
       obligations even if no read happened first
 - [x] Treat attempted no-op writes as relevant when they appear in
-      `potentialWrites` for a path carrying CFC obligations
+      `attemptedWrites` for a path carrying CFC obligations
 - [x] Ensure dependency-discovery transactions and other non-committing
       inspection transactions do not trigger prepare
 - [x] Audit helper reads that should be tagged `internalVerifierRead`
@@ -670,7 +670,7 @@ Tasks:
       `requiredIntegrity`, and `maxConfidentiality`
 - [x] Implement `writeAuthorizedBy`, `exactCopyOf`, `projection`, and
       collection-derived transition checks where they can be evaluated from
-      consumed reads plus `potentialWrites`/`writes` plus explicit write-policy
+      consumed reads plus `attemptedWrites`/`writes` plus explicit write-policy
       inputs; otherwise fail closed or remain conservative
 - [x] Until stable implementation identities and trust snapshots land, treat
       trust-sensitive claims such as `writeAuthorizedBy` as non-enforceable:
@@ -679,8 +679,8 @@ Tasks:
 - [x] Persist only concrete evidence in stored metadata; derived trust closure
       remains runtime-only
 - [x] In phase 1, allow a conservative all-consumed-reads-to-all-targets
-      influence model over `potentialWrites ∪ writes`
-- [x] Use `potentialWrites ∪ writes` for target-side enforcement and use
+      influence model over `attemptedWrites ∪ writes`
+- [x] Use `attemptedWrites ∪ writes` for target-side enforcement and use
       `writes` only for persisted output metadata
 - [x] If a target entity has no stored `schemaHash`, seed it from the first
       canonical `SchemaAndHash` and persist or reuse `cid:<hash>`; if merge
@@ -1120,7 +1120,7 @@ Land the work in mergeable vertical slices:
 1. [x] Types, canonical path helpers, write-policy input helpers, and digest
        helpers
 2. [x] Transaction CFC state and rollout modes with observe-mode prepare
-3. [x] V2 consumed-read, `potentialWrites`, compact final-write extraction, and
+3. [x] V2 consumed-read, `attemptedWrites`, compact final-write extraction, and
        write-policy input capture APIs
 4. [x] Relevance detection and merged-schema envelope implementation
 5. [x] Embedded v2 CFC metadata persistence, `cid:<hash>` schema-document

--- a/docs/specs/pull-based-scheduler/README.md
+++ b/docs/specs/pull-based-scheduler/README.md
@@ -82,7 +82,9 @@ else cellB.set(x);
 
 By default the scheduler uses the latest known writes rather than cumulative
 history, so stale branches can disappear when an action changes what it writes.
-The old cumulative `mightWrite` behavior is retained behind the experimental
+The public diagnostic API still uses the older name `getMightWrite()`, but it
+returns this active scheduling write set by default. The old cumulative
+write-history behavior is retained behind the experimental
 `schedulerHistoricalMightWrite` flag.
 
 ### Materializer Write Envelopes
@@ -92,6 +94,11 @@ Computations that write through writable inputs are not indexed from transaction
 resolvable, it is represented as a normal declared write. Broad or dynamic
 writable-input targets are represented as `materializerWriteEnvelopes`, a
 separate pull-mode index.
+
+The materializer index is owned by `SchedulerMaterializers` and exposed to
+scheduler helper modules through the `MaterializerIndexState` interface. That
+index owns both membership checks and write-envelope lookup; consumers do not
+thread separate `isMaterializer` callbacks through scheduler state.
 
 When a materializer's inputs change, dirtying stops at the materializer. It is
 queued for the idle pull loop, coalescing repeated source changes and honoring
@@ -175,10 +182,10 @@ Actions are sorted so dependencies run before dependents:
 function topologicalSort(
   actions,
   dependencies,
-  mightWrite,
+  schedulingWrites,
   actionParent,
   dependents,
-  getAdditionalWrites, // materializer envelopes in pull mode
+  getAdditionalWrites, // materializer-index envelopes in pull mode
 ) {
   // Build graph: action A → action B if A writes something B reads
   // In pull mode, prefer the incrementally maintained dependents graph.
@@ -440,7 +447,7 @@ The active scheduling write set is current-known by default:
 - Add parent writes for dynamic collection items when an actual child write
   falls under a declared collection write.
 
-The legacy cumulative `mightWrite` behavior is still kept in
+The legacy cumulative write-history behavior is still kept in
 `historicalMightWrite` and selected only when the
 `schedulerHistoricalMightWrite` experimental option is enabled.
 
@@ -452,6 +459,16 @@ The writer index maintains:
 
 When an action gains writes, existing readers are backfilled into the dependents
 graph. When it loses writes, stale dependents edges are pruned.
+
+The materializer index is separate from the writer index. It maintains:
+
+- `materializersByEntity`: entity -> materializer computations whose envelopes
+  may write it.
+- Action-local compacted materializer write envelopes.
+
+Materializer envelopes are used for pull-mode dirty dependency discovery and
+work-set ordering. They are not inserted into the normal writer index and do
+not create broad dependents edges by themselves.
 
 ### Trigger Index and Storage Notifications
 
@@ -865,6 +882,7 @@ class Scheduler {
   private reverseDependencies = new WeakMap<Action, Set<Action>>();
   private triggerIndex = new SchedulerTriggerIndex();
   private writeIndex = new SchedulerWriteIndex(...);
+  private materializers = new SchedulerMaterializers(...);
 
   // Parent-child relationships for nested patterns
   private actionParent = new WeakMap<Action, Action>();
@@ -901,6 +919,8 @@ modules under `packages/runner/src/scheduler/`, including:
 - `pull-execution.ts` and `push-execution.ts` for mode-specific settle loops
 - `pull-scheduling.ts` for demand-root and affected-effect scheduling
 - `events.ts`, `pull-events.ts`, and `push-events.ts` for queued handlers
+- `materializers.ts` for the pull-mode materializer index and write-envelope
+  lookup
 - `scheduling-writes.ts`, `trigger-index.ts`, and `dependency-graph.ts` for
   dependency indexes
 - `delays.ts` and `delay-control.ts` for debounce/throttle state
@@ -1094,7 +1114,7 @@ scheduler.isEffect(action)
 scheduler.isComputation(action)
 scheduler.isDirty(action)
 scheduler.getDependents(action)
-scheduler.getMightWrite(action)
+scheduler.getMightWrite(action)    // Active scheduling writes despite legacy name
 scheduler.getActionStats(actionOrId)
 scheduler.getFilterStats()
 scheduler.resetFilterStats()

--- a/docs/specs/pull-based-scheduler/README.md
+++ b/docs/specs/pull-based-scheduler/README.md
@@ -161,6 +161,12 @@ when the demand root is merely pending rather than stale, because a pending
 effect or event can read a materialized target before normal stale propagation
 has an exact edge.
 
+Initial demand roots are runnable only on the first settle iteration. On later
+iterations they remain traversal seeds so newly created or newly dirtied
+dependencies can be pulled through the same demand path before `pull()` returns,
+without rerunning the demand root unless normal scheduling also marks it
+pending.
+
 ### 4. Topological Sort
 
 Actions are sorted so dependencies run before dependents:
@@ -500,6 +506,8 @@ Runnable pull seeds include:
 - Computations whose debounce trailing flush has become ready.
 - Computations demanded through a live effect, a demanded parent context, or
   `pullDemandedFirstRunComputations`.
+- Computations marked as pull-demand continuations after a child computation
+  writes data that an ancestor read earlier in the same pull.
 
 A computation is demanded when it has a transitive live-effect dependent or is
 inside a demanded parent context. An effect with no scheduling writes is a pull
@@ -521,6 +529,9 @@ Pull mode:
 - Collects dependency logs for newly subscribed actions before each iteration.
 - Builds an iteration seed set, then recursively pulls dirty computations needed
   by those seeds.
+- Keeps initial demand roots as traversal-only seeds after the first iteration
+  so dynamic child computations can trigger ancestor continuations before the
+  original pull resolves.
 - Topologically sorts the work set using dependencies, current scheduling
   writes, parent-child edges, the dependents graph, and pull-only materializer
   envelope edges for the current work set.

--- a/docs/specs/pull-based-scheduler/README.md
+++ b/docs/specs/pull-based-scheduler/README.md
@@ -57,9 +57,13 @@ handlers are queued separately and run through the event path.
 In pull mode, when a cell changes:
 - Effects → added to `pending`
 - Computations → marked `dirty`/`stale`, and downstream effects are scheduled
+  unless the computation is a materializer
 
 A computation stays dirty until an effect, event preflight, or explicit
 `cell.pull()` needs it. If nothing ever observes it, it never runs.
+Materializers are the exception: broad or dynamic writable-input computations
+are dirty-coalesced and run from the idle pull loop so their actual changed
+writes can drive precise downstream propagation.
 
 In push mode, triggered effects and computations are both scheduled in
 `pending`.
@@ -67,7 +71,7 @@ In push mode, triggered effects and computations are both scheduled in
 ### Current-Known Writes
 
 Each action tracks its current known write set from the latest run plus
-declared/potential writes. This keeps the dependency graph precise while still
+declared writes. This keeps the dependency graph precise while still
 handling no-op runs and declared outputs:
 
 ```typescript
@@ -80,6 +84,22 @@ By default the scheduler uses the latest known writes rather than cumulative
 history, so stale branches can disappear when an action changes what it writes.
 The old cumulative `mightWrite` behavior is retained behind the experimental
 `schedulerHistoricalMightWrite` flag.
+
+### Materializer Write Envelopes
+
+Computations that write through writable inputs are not indexed from transaction
+`attemptedWrites`. If the write target is statically simple and safely
+resolvable, it is represented as a normal declared write. Broad or dynamic
+writable-input targets are represented as `materializerWriteEnvelopes`, a
+separate pull-mode index.
+
+When a materializer's inputs change, dirtying stops at the materializer. It is
+queued for the idle pull loop, coalescing repeated source changes and honoring
+manual debounce/throttle settings. If an effect, event preflight, or explicit
+demand reads a path overlapping a dirty materializer envelope before idle runs,
+that materializer is promoted into the same settle pass and ordered before the
+reader. After it runs, only actual changed writes are propagated to downstream
+readers.
 
 ## Execution Flow
 
@@ -380,9 +400,13 @@ dependency transaction for reactive actions, and installs:
 - Shallow reads, which only invalidate on same-path, ancestor-path, or direct
   child writes.
 - Actual writes from the transaction.
-- Potential writes, for APIs that read and may later write the same location.
 - Declared writes from action telemetry annotations.
+- Materializer write envelopes from action telemetry annotations.
 - Ignored scheduling writes from telemetry annotations.
+
+Transaction `attemptedWrites` remain a storage/CFC concept for APIs that read a
+path while deciding whether to write it. They are included in CFC target-side
+prepare/digest inputs, but are explicitly not scheduler dependency evidence.
 
 `setSchedulerDependencies()` sorts and compacts reads and writes, filters
 ignored scheduling writes, and prunes structural ancestor writes so unrelated
@@ -393,7 +417,6 @@ The active scheduling write set is current-known by default:
 - Use actual writes from the latest run when they exist.
 - Otherwise keep the existing current-known writes if present.
 - Otherwise seed from declared writes.
-- Add potential writes.
 - Add parent writes for dynamic collection items when an actual child write
   falls under a declared collection write.
 
@@ -820,7 +843,10 @@ interface ReactivityLog {
   reads: Address[];
   shallowReads: Address[];
   writes: Address[];
-  potentialWrites?: Address[];  // For diffAndUpdate pattern
+}
+
+interface TransactionReactivityLog extends ReactivityLog {
+  attemptedWrites?: Address[];  // CFC/security target evidence, not scheduling evidence
 }
 
 interface ActionStats {
@@ -1094,7 +1120,7 @@ The scheduler module also re-exports:
 txToReactivityLog
 allowMutableTransactionRead
 ignoreReadForScheduling
-markReadAsPotentialWrite
+markReadAsAttemptedWrite
 ```
 
 ## Tests

--- a/docs/specs/pull-based-scheduler/README.md
+++ b/docs/specs/pull-based-scheduler/README.md
@@ -507,7 +507,11 @@ Runnable pull seeds include:
 - Computations demanded through a live effect, a demanded parent context, or
   `pullDemandedFirstRunComputations`.
 - Computations marked as pull-demand continuations after a child computation
-  writes data that an ancestor read earlier in the same pull.
+  writes data that a scheduler-parent ancestor read earlier in the same pull.
+  This is deliberately based on `actionParent`, not arbitrary dependency edges:
+  normal reader/writer edges already schedule downstream readers, while
+  continuations let an already-run parent converge when its dynamically created
+  child produces data the parent sampled.
 
 A computation is demanded when it has a transitive live-effect dependent or is
 inside a demanded parent context. An effect with no scheduling writes is a pull

--- a/docs/specs/pull-based-scheduler/README.md
+++ b/docs/specs/pull-based-scheduler/README.md
@@ -115,6 +115,7 @@ Find actions that read X (via trigger index)
 For each triggered action:
     Effect → add to pending, queue execution
     Computation → mark dirty, propagate to dependents, schedule affected effects
+    Materializer computation → mark dirty and queue idle pull work
 ```
 
 The trigger index groups actions by the cells they read, so finding affected
@@ -154,16 +155,29 @@ for (const effect of workSet) {
 }
 ```
 
-The `collectDirtyDependencies` function finds dirty computations that write to cells the action reads.
+The `collectDirtyDependencies` function finds dirty computations that write to
+cells the action reads. It also consults the materializer envelope index even
+when the demand root is merely pending rather than stale, because a pending
+effect or event can read a materialized target before normal stale propagation
+has an exact edge.
 
 ### 4. Topological Sort
 
 Actions are sorted so dependencies run before dependents:
 
 ```typescript
-function topologicalSort(actions, dependencies, mightWrite, actionParent, dependents) {
+function topologicalSort(
+  actions,
+  dependencies,
+  mightWrite,
+  actionParent,
+  dependents,
+  getAdditionalWrites, // materializer envelopes in pull mode
+) {
   // Build graph: action A → action B if A writes something B reads
   // In pull mode, prefer the incrementally maintained dependents graph.
+  // Add materializer-envelope edges for this work set without mutating the
+  // normal writer/dependent indexes.
   // Add parent → child edges only when they do not oppose data dependencies.
   // Kahn's algorithm with cycle handling
 }
@@ -455,6 +469,8 @@ Push mode schedules every remaining triggered action with debounce. Pull mode:
 - Marks triggered computations dirty/stale.
 - Schedules downstream effects that transitively depend on the dirty
   computation.
+- For materializer computations, stops at the materializer and queues execution
+  instead of scheduling downstream effects from the broad envelope.
 
 When trigger tracing is enabled, each matched change records a bounded
 `TriggerTraceEntry` with the notification type, change index, before/after value
@@ -506,9 +522,13 @@ Pull mode:
 - Builds an iteration seed set, then recursively pulls dirty computations needed
   by those seeds.
 - Topologically sorts the work set using dependencies, current scheduling
-  writes, parent-child edges, and the dependents graph.
+  writes, parent-child edges, the dependents graph, and pull-only materializer
+  envelope edges for the current work set.
 - Clears dirty flags for effects up front; if an effect is re-dirtied before it
   runs, it is treated as part of a cycle and skipped until a future tick.
+- Before an effect runs, rechecks for dirty materializer dependencies that may
+  have appeared after the work set was built. If any overlap the effect reads,
+  the effect remains pending and the materializer is run first.
 - Skips unsubscribed actions, non-runnable pull actions, debounced computations,
   throttled actions, and conditionally scheduled effects whose inputs did not
   actually change.
@@ -583,7 +603,9 @@ When computations write changed data, the scheduler records the changed write
 addresses in `changedWritesHistory`. After the run, the scheduler finds readers
 of those changed writes through the trigger index. Reader effects are scheduled
 directly. Reader computations are marked dirty and their affected downstream
-effects are scheduled.
+effects are scheduled. If a reader computation is itself a materializer,
+dirtying stops there and it is queued/coalesced instead of scheduling
+downstream effects from its envelope.
 
 Pull-mode storage notification handling can also conditionally schedule
 downstream effects and remember the history index at which the effect was

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -1,5 +1,6 @@
 import { isRecord } from "@commonfabric/utils/types";
 import type { PatternBuilder } from "./pattern.ts";
+import type { NormalizedFullLink } from "../link-types.ts";
 
 import type {
   ActionFunction,
@@ -194,6 +195,8 @@ declare module "@commonfabric/api" {
     noDebounce?: boolean;
     /** Optional scheduler throttle period in milliseconds */
     throttle?: number;
+    /** Pull-mode write envelopes for broad/dynamic writable-input materializers */
+    materializerWriteEnvelopes?: readonly NormalizedFullLink[];
   }
 }
 

--- a/packages/runner/src/cfc/canonical.ts
+++ b/packages/runner/src/cfc/canonical.ts
@@ -199,7 +199,7 @@ export const canonicalizePreparedDigestInput = (
   consumedReads: [...input.consumedReads].map(canonicalizeConsumedRead).sort(
     compareAddress,
   ),
-  potentialWrites: [...input.potentialWrites].map(canonicalizeAttemptedWrite)
+  attemptedWrites: [...input.attemptedWrites].map(canonicalizeAttemptedWrite)
     .sort(compareAddress),
   writes: [...input.writes].map(canonicalizeAttemptedWrite).sort(
     compareAddress,

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1279,7 +1279,7 @@ const ifcEntryAppliesToAttemptedWrite = (
 
   const exactAttemptedPaths = [
     ...(tx.getReactivityLog?.().writes ?? []),
-    ...(tx.getReactivityLog?.().potentialWrites ?? []),
+    ...(tx.getReactivityLog?.().attemptedWrites ?? []),
   ].map((write) => ({
     write,
     path: canonicalizeLogicalPath(write.path),

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -709,7 +709,7 @@ const valueWriteTargets = (
   >();
   const log = tx.getReactivityLog?.();
   const seenWriteSpaces = new Set<MemorySpace>(
-    [...(log?.writes ?? []), ...(log?.potentialWrites ?? [])].map((write) =>
+    [...(log?.writes ?? []), ...(log?.attemptedWrites ?? [])].map((write) =>
       write.space
     ),
   );

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -216,7 +216,7 @@ export type WritePolicyInput =
 
 export type PreparedDigestInput = {
   readonly consumedReads: readonly ConsumedRead[];
-  readonly potentialWrites: readonly AttemptedWrite[];
+  readonly attemptedWrites: readonly AttemptedWrite[];
   readonly writes: readonly AttemptedWrite[];
   readonly dereferenceTraces: readonly CfcDereferenceTrace[];
   readonly writePolicyInputs: readonly WritePolicyInput[];

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -42,7 +42,7 @@ import { type Runtime } from "./runtime.ts";
 import { toURI } from "./uri-utils.ts";
 import {
   allowMutableTransactionRead,
-  markReadAsPotentialWrite,
+  markReadAsAttemptedWrite,
 } from "./scheduler.ts";
 import {
   readStoredCfcMetadata,
@@ -274,7 +274,7 @@ export function diffAndUpdate(
     ...options,
     meta: {
       ...options?.meta,
-      ...markReadAsPotentialWrite,
+      ...markReadAsAttemptedWrite,
       ...allowMutableTransactionRead,
     },
   };
@@ -1032,7 +1032,7 @@ export function applyChangeSet(
   }
   for (const change of changes) {
     // `diffAndUpdate()` establishes attempted-target coverage before we get
-    // here, so these direct writes preserve the phase-1 `potentialWrites` view.
+    // here, so these direct writes preserve the phase-1 `attemptedWrites` view.
     tx.writeValueOrThrow(change.location, change.value);
   }
 }

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1862,6 +1862,9 @@ export class Runner {
     tx: IExtendedStorageTransaction,
     outputCells: readonly NormalizedFullLink[],
   ): NormalizedFullLink[] {
+    // Write redirects are the static writable-output form: resolving them here
+    // lets pull-mode indexing treat the resolved target like a normal declared
+    // write. Dynamic writable-input writes use materializer envelopes instead.
     if (!outputCells.some((link) => link.overwrite === "redirect")) {
       return [];
     }
@@ -1877,9 +1880,14 @@ export class Runner {
           "writeRedirect",
         );
         targets.push(target);
-      } catch {
-        // The populateDependencies fallback will collect runtime evidence after
-        // the process cell is fully materialized.
+      } catch (error) {
+        // Some setup paths have not fully materialized process-cell redirects
+        // yet. Leave those to runtime dependency collection after the action
+        // has run, but keep debug context for unexpected resolution failures.
+        logger.debug("static-redirect-write-target", () => [
+          "Unable to resolve static redirect write target",
+          { output, error },
+        ]);
       }
     }
     return dedupeNormalizedLinks(targets);

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -2652,6 +2652,9 @@ export class Runner {
     const wrappedAction = Object.assign(action, {
       reads,
       writes,
+      ...(module.materializerWriteEnvelopes
+        ? { materializerWriteEnvelopes: module.materializerWriteEnvelopes }
+        : {}),
       module,
       pattern,
     });
@@ -2953,6 +2956,9 @@ export class Runner {
     Object.assign(action, builtinAction, {
       reads: inputCells,
       writes: outputCells,
+      ...(module.materializerWriteEnvelopes
+        ? { materializerWriteEnvelopes: module.materializerWriteEnvelopes }
+        : {}),
       module,
       pattern,
     });

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -40,6 +40,7 @@ import {
 } from "./pattern-binding.ts";
 import { resolveLink } from "./link-resolution.ts";
 import {
+  areNormalizedLinksSame,
   createSigilLinkFromParsedLink,
   isCellLink,
   isSigilLink,
@@ -441,6 +442,19 @@ type JavaScriptNodeContext = BoundNodeIO & {
 type JavaScriptActionResultCells = {
   byScope: Map<CellScope, Cell<any>>;
 };
+
+function dedupeNormalizedLinks(
+  links: readonly NormalizedFullLink[],
+): NormalizedFullLink[] {
+  const deduped: NormalizedFullLink[] = [];
+  for (const link of links) {
+    if (deduped.some((existing) => areNormalizedLinksSame(existing, link))) {
+      continue;
+    }
+    deduped.push(link);
+  }
+  return deduped;
+}
 
 export class Runner {
   readonly cancels = new Map<`${MemorySpace}/${URI}`, Cancel>();
@@ -1844,6 +1858,33 @@ export class Runner {
     };
   }
 
+  private collectStaticRedirectWriteTargets(
+    tx: IExtendedStorageTransaction,
+    outputCells: readonly NormalizedFullLink[],
+  ): NormalizedFullLink[] {
+    if (!outputCells.some((link) => link.overwrite === "redirect")) {
+      return [];
+    }
+
+    const targets: NormalizedFullLink[] = [];
+    for (const output of outputCells) {
+      if (output.overwrite !== "redirect") continue;
+      try {
+        const { overwrite: _overwrite, ...target } = resolveLink(
+          this.runtime,
+          tx,
+          output,
+          "writeRedirect",
+        );
+        targets.push(target);
+      } catch {
+        // The populateDependencies fallback will collect runtime evidence after
+        // the process cell is fully materialized.
+      }
+    }
+    return dedupeNormalizedLinks(targets);
+  }
+
   private resolveJavaScriptFunction(
     module: Module,
     pattern: Pattern,
@@ -2649,9 +2690,16 @@ export class Runner {
       setRunnableName(action, `action:${name}`, { setSrc: true });
     }
 
+    const staticRedirectWriteTargets = module.materializerWriteEnvelopes
+      ? []
+      : this.collectStaticRedirectWriteTargets(tx, writes);
+    const schedulingWrites = dedupeNormalizedLinks([
+      ...writes,
+      ...staticRedirectWriteTargets,
+    ]);
     const wrappedAction = Object.assign(action, {
       reads,
-      writes,
+      writes: schedulingWrites,
       ...(module.materializerWriteEnvelopes
         ? { materializerWriteEnvelopes: module.materializerWriteEnvelopes }
         : {}),
@@ -2953,9 +3001,16 @@ export class Runner {
 
     // Seed raw actions with their pattern/module/write metadata so pull-mode
     // scheduling can discover pending computations before their first run.
+    const staticRedirectWriteTargets = module.materializerWriteEnvelopes
+      ? []
+      : this.collectStaticRedirectWriteTargets(tx, outputCells);
+    const schedulingWrites = dedupeNormalizedLinks([
+      ...outputCells,
+      ...staticRedirectWriteTargets,
+    ]);
     Object.assign(action, builtinAction, {
       reads: inputCells,
-      writes: outputCells,
+      writes: schedulingWrites,
       ...(module.materializerWriteEnvelopes
         ? { materializerWriteEnvelopes: module.materializerWriteEnvelopes }
         : {}),

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -61,7 +61,7 @@ import type {
 import { TransactionWrapper } from "./storage/extended-storage-transaction.ts";
 import {
   ignoreReadForScheduling,
-  markReadAsPotentialWrite,
+  markReadAsAttemptedWrite,
 } from "./scheduler.ts";
 import { internalVerifierRead } from "./storage/reactivity-log.ts";
 import { FunctionCache } from "./function-cache.ts";
@@ -2677,7 +2677,7 @@ export class Runner {
 
         for (const output of writes) {
           this.runtime.getCellFromLink(output, undefined, depTx)?.getRaw({
-            meta: markReadAsPotentialWrite,
+            meta: markReadAsAttemptedWrite,
           });
         }
       } finally {
@@ -2980,11 +2980,11 @@ export class Runner {
             this.runtime.getCellFromLink(input, undefined, depTx)?.get();
           }
         }
-        // Always capture write dependencies by marking outputs as potential writes
+        // Always capture write dependencies by marking outputs as attempted writes
         for (const output of outputCells) {
-          // Reading with markReadAsPotentialWrite registers this as a write dependency
+          // Reading with markReadAsAttemptedWrite registers this as a write dependency
           this.runtime.getCellFromLink(output, undefined, depTx)?.getRaw({
-            meta: markReadAsPotentialWrite,
+            meta: markReadAsAttemptedWrite,
           });
         }
       } finally {

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -68,6 +68,8 @@ import {
 import {
   collectDirtyDependencies as collectDirtyDependenciesState,
   collectDirtyDependenciesForLog as collectDirtyDependenciesForLogState,
+  collectDirtyDependenciesFromTraversalRoot
+    as collectDirtyDependenciesFromTraversalRootState,
   type DirtyDependencyCollectionState,
   snapshotDirtyDependencyTraceContext,
 } from "./scheduler/dirty-dependencies.ts";
@@ -1500,8 +1502,7 @@ export class Scheduler {
         this.delays.clearComputationDebounceState(action),
       isDemandedPullComputation: (action) =>
         this.isDemandedPullComputation(action),
-      isIdleRunnableComputation: (action) =>
-        this.materializers.isMaterializer(action),
+      materializerIndex: this.materializers,
       queueExecution: () => this.queueExecution(),
     };
   }
@@ -1532,7 +1533,7 @@ export class Scheduler {
       scheduleWithDebounce: (target) => this.scheduleWithDebounce(target),
       markDirty: (target) =>
         markSchedulerDirty(this.dirtySchedulingState, target),
-      isMaterializer: (target) => this.materializers.isMaterializer(target),
+      materializerIndex: this.materializers,
       queueExecution: () => this.queueExecution(),
       scheduleAffectedEffects: (target) => this.scheduleAffectedEffects(target),
     };
@@ -1593,7 +1594,7 @@ export class Scheduler {
       pending: this.pending,
       dirty: this.staleness.dirty,
       effects: this.effects,
-      isMaterializer: (action) => this.materializers.isMaterializer(action),
+      materializerIndex: this.materializers,
       dependents: this.dependents,
       pendingPullRunnableState: this.pendingPullRunnableState,
       dirtyPullRunnableState: this.dirtyPullRunnableState,
@@ -1619,7 +1620,7 @@ export class Scheduler {
       scheduleWithDebounce: (action) => this.scheduleWithDebounce(action),
       markDirty: (action) =>
         markSchedulerDirty(this.dirtySchedulingState, action),
-      isMaterializer: (action) => this.materializers.isMaterializer(action),
+      materializerIndex: this.materializers,
       scheduleAffectedEffects: (action) => {
         this.scheduleAffectedEffects(action);
       },
@@ -1758,12 +1759,10 @@ export class Scheduler {
       getLoopCounter: () => this.loopCounter,
       runsThisExecute: this.runsThisExecute,
       activePullDemandActions: this.activePullDemandActions,
-      isMaterializer: (action) => this.materializers.isMaterializer(action),
+      materializerIndex: this.materializers,
       getSchedulingWrites: (action) =>
         this.writeIndex.getSchedulingWrites(action),
       getSchedulingWritesMap: () => this.writeIndex.getSchedulingWritesMap(),
-      getMaterializerWriteEnvelopes: (action) =>
-        this.materializers.getMaterializerWriteEnvelopes(action),
       collectDependenciesForAction: (action, populateDependencies, options) =>
         this.collectDependenciesForAction(
           action,
@@ -1772,8 +1771,18 @@ export class Scheduler {
         ),
       collectPullIterationSeeds: (seeds) =>
         this.collectPullIterationSeeds(seeds),
-      collectDirtyDependencies: (seed, targetWorkSet, memo, options) =>
-        this.collectDirtyDependencies(seed, targetWorkSet, memo, options),
+      collectDirtyDependencies: (seed, targetWorkSet, memo) =>
+        this.collectDirtyDependencies(seed, targetWorkSet, memo),
+      collectDirtyDependenciesFromTraversalRoot: (
+        seed,
+        targetWorkSet,
+        memo,
+      ) =>
+        this.collectDirtyDependenciesFromTraversalRoot(
+          seed,
+          targetWorkSet,
+          memo,
+        ),
       getActionId: (action) => this.getActionId(action),
       clearDirty: (action) =>
         clearSchedulerDirty(this.dirtySchedulingState, action),
@@ -1809,7 +1818,7 @@ export class Scheduler {
       },
       isDemandedPullComputation: (action) =>
         this.isDemandedPullComputation(action),
-      isMaterializer: (action) => this.materializers.isMaterializer(action),
+      materializerIndex: this.materializers,
       shouldRunFirstPullComputationInDemandContext: (action) =>
         this.shouldRunFirstPullComputationInDemandContext(action),
       isDebouncedComputationWaiting: (action) =>
@@ -2058,14 +2067,25 @@ export class Scheduler {
     action: Action,
     workSet: Set<Action>,
     memo = new Map<Action, boolean>(),
-    options: { forceTraverseCleanAction?: boolean } = {},
   ): boolean {
     return collectDirtyDependenciesState(
       this.dirtyDependencyCollectionState,
       action,
       workSet,
       memo,
-      options,
+    );
+  }
+
+  private collectDirtyDependenciesFromTraversalRoot(
+    action: Action,
+    workSet: Set<Action>,
+    memo = new Map<Action, boolean>(),
+  ): boolean {
+    return collectDirtyDependenciesFromTraversalRootState(
+      this.dirtyDependencyCollectionState,
+      action,
+      workSet,
+      memo,
     );
   }
 

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -255,6 +255,7 @@ export class Scheduler {
   private reverseDependencies = new WeakMap<Action, Set<Action>>();
   private activePullDemandActions = new WeakSet<Action>();
   private pullDemandedFirstRunComputations = new WeakSet<Action>();
+  private pullDemandedContinuationComputations = new WeakSet<Action>();
   // Track which actions are effects persistently (survives unsubscribe/re-subscribe)
   private isEffectAction = new WeakMap<Action, boolean>();
   // In pull mode, `dirty` means direct dirty. `stale` additionally includes
@@ -1401,6 +1402,8 @@ export class Scheduler {
       actionParent: this.actionParent,
       isEffectAction: this.isEffectAction,
       pullDemandedFirstRunComputations: this.pullDemandedFirstRunComputations,
+      pullDemandedContinuationComputations: this
+        .pullDemandedContinuationComputations,
       hasActionRun: (action) => this.delays.hasActionRun(action),
       getSchedulingWrites: (action) =>
         this.writeIndex.getSchedulingWrites(action),
@@ -1609,6 +1612,10 @@ export class Scheduler {
       effects: this.effects,
       computations: this.computations,
       conditionallyScheduledEffects: this.conditionallyScheduledEffects,
+      actionParent: this.actionParent,
+      pending: this.pending,
+      markPullDemandContinuation: (action) =>
+        this.pullDemandedContinuationComputations.add(action),
       scheduleWithDebounce: (action) => this.scheduleWithDebounce(action),
       markDirty: (action) =>
         markSchedulerDirty(this.dirtySchedulingState, action),
@@ -1616,6 +1623,7 @@ export class Scheduler {
       scheduleAffectedEffects: (action) => {
         this.scheduleAffectedEffects(action);
       },
+      queueExecution: () => this.queueExecution(),
     };
   }
 
@@ -1762,8 +1770,8 @@ export class Scheduler {
         ),
       collectPullIterationSeeds: (seeds) =>
         this.collectPullIterationSeeds(seeds),
-      collectDirtyDependencies: (seed, targetWorkSet, memo) =>
-        this.collectDirtyDependencies(seed, targetWorkSet, memo),
+      collectDirtyDependencies: (seed, targetWorkSet, memo, options) =>
+        this.collectDirtyDependencies(seed, targetWorkSet, memo, options),
       getActionId: (action) => this.getActionId(action),
       clearDirty: (action) =>
         clearSchedulerDirty(this.dirtySchedulingState, action),
@@ -1906,6 +1914,8 @@ export class Scheduler {
       inFlightSourceState: this.inFlightSourceState,
       actionTimingState: this.actionTimingState,
       pullDemandedFirstRunComputations: this.pullDemandedFirstRunComputations,
+      pullDemandedContinuationComputations: this
+        .pullDemandedContinuationComputations,
       retries: this.retries,
       pending: this.pending,
       actionRunTrace: this.actionRunTrace,
@@ -2046,12 +2056,14 @@ export class Scheduler {
     action: Action,
     workSet: Set<Action>,
     memo = new Map<Action, boolean>(),
+    options: { forceTraverseCleanAction?: boolean } = {},
   ): boolean {
     return collectDirtyDependenciesState(
       this.dirtyDependencyCollectionState,
       action,
       workSet,
       memo,
+      options,
     );
   }
 

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -1748,6 +1748,7 @@ export class Scheduler {
       getLoopCounter: () => this.loopCounter,
       runsThisExecute: this.runsThisExecute,
       activePullDemandActions: this.activePullDemandActions,
+      isMaterializer: (action) => this.materializers.isMaterializer(action),
       getSchedulingWrites: (action) =>
         this.writeIndex.getSchedulingWrites(action),
       getSchedulingWritesMap: () => this.writeIndex.getSchedulingWritesMap(),

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -1708,6 +1708,8 @@ export class Scheduler {
       effects: this.effects,
       computations: this.computations,
       pullDemandedFirstRunComputations: this.pullDemandedFirstRunComputations,
+      pullDemandedContinuationComputations: this
+        .pullDemandedContinuationComputations,
       writeIndex: this.writeIndex,
       populateDependenciesCallbacks: this.populateDependenciesCallbacks,
       pendingDependencyCollection: this.pendingDependencyCollection,

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -19,7 +19,7 @@ import type {
 import {
   allowMutableTransactionRead,
   ignoreReadForScheduling,
-  markReadAsPotentialWrite,
+  markReadAsAttemptedWrite,
 } from "./storage/reactivity-log.ts";
 import type {
   ActionStats,
@@ -53,6 +53,7 @@ import {
   type DependencyGraphState,
   updateDependentEdgesForLog,
 } from "./scheduler/dependency-graph.ts";
+import { SchedulerMaterializers } from "./scheduler/materializers.ts";
 import { type DependencyUpdateState } from "./scheduler/dependency-updates.ts";
 import { SchedulerWriteIndex } from "./scheduler/scheduling-writes.ts";
 import {
@@ -233,7 +234,7 @@ export { txToReactivityLog } from "./scheduler/reactivity.ts";
 export {
   allowMutableTransactionRead,
   ignoreReadForScheduling,
-  markReadAsPotentialWrite,
+  markReadAsAttemptedWrite,
 };
 
 export class Scheduler {
@@ -331,6 +332,7 @@ export class Scheduler {
   };
 
   private writeIndex!: SchedulerWriteIndex;
+  private materializers = new SchedulerMaterializers(this.effects);
   private dirtyDependencyCollectionState!: DirtyDependencyCollectionState;
   // Track actions scheduled for first time (bypass filter)
   private scheduledFirstTime = new Set<Action>();
@@ -490,6 +492,7 @@ export class Scheduler {
       changeGroup?: ChangeGroup;
     } = {},
   ): Cancel {
+    this.updateMaterializerRegistration(action);
     if (this.pullMode) {
       return subscribePullSchedulerAction(
         this.subscribeActionState,
@@ -527,6 +530,7 @@ export class Scheduler {
       changeGroup?: ChangeGroup;
     } = {},
   ): void {
+    this.updateMaterializerRegistration(action);
     if (this.pullMode) {
       resubscribePullSchedulerAction(
         this.subscribeActionState,
@@ -548,6 +552,7 @@ export class Scheduler {
     action: Action,
     options: { preserveChangeGroup?: boolean } = {},
   ): void {
+    this.materializers.clearAction(action);
     unsubscribeSchedulerAction(this.unsubscribeState, action, options);
   }
 
@@ -1427,6 +1432,7 @@ export class Scheduler {
       dependencies: this.dependencies,
       writersByEntity: this.writeIndex.writersByEntity,
       effects: this.effects,
+      materializerIndex: this.materializers,
       isStale: (target) => this.staleness.isStale(target),
       getSchedulingWrites: (target) =>
         this.writeIndex.getSchedulingWrites(target),
@@ -1491,6 +1497,8 @@ export class Scheduler {
         this.delays.clearComputationDebounceState(action),
       isDemandedPullComputation: (action) =>
         this.isDemandedPullComputation(action),
+      isIdleRunnableComputation: (action) =>
+        this.materializers.isMaterializer(action),
       queueExecution: () => this.queueExecution(),
     };
   }
@@ -1521,6 +1529,8 @@ export class Scheduler {
       scheduleWithDebounce: (target) => this.scheduleWithDebounce(target),
       markDirty: (target) =>
         markSchedulerDirty(this.dirtySchedulingState, target),
+      isMaterializer: (target) => this.materializers.isMaterializer(target),
+      queueExecution: () => this.queueExecution(),
       scheduleAffectedEffects: (target) => this.scheduleAffectedEffects(target),
     };
   }
@@ -1580,6 +1590,7 @@ export class Scheduler {
       pending: this.pending,
       dirty: this.staleness.dirty,
       effects: this.effects,
+      isMaterializer: (action) => this.materializers.isMaterializer(action),
       dependents: this.dependents,
       pendingPullRunnableState: this.pendingPullRunnableState,
       dirtyPullRunnableState: this.dirtyPullRunnableState,
@@ -1601,6 +1612,7 @@ export class Scheduler {
       scheduleWithDebounce: (action) => this.scheduleWithDebounce(action),
       markDirty: (action) =>
         markSchedulerDirty(this.dirtySchedulingState, action),
+      isMaterializer: (action) => this.materializers.isMaterializer(action),
       scheduleAffectedEffects: (action) => {
         this.scheduleAffectedEffects(action);
       },
@@ -1739,6 +1751,8 @@ export class Scheduler {
       getSchedulingWrites: (action) =>
         this.writeIndex.getSchedulingWrites(action),
       getSchedulingWritesMap: () => this.writeIndex.getSchedulingWritesMap(),
+      getMaterializerWriteEnvelopes: (action) =>
+        this.materializers.getMaterializerWriteEnvelopes(action),
       collectDependenciesForAction: (action, populateDependencies, options) =>
         this.collectDependenciesForAction(
           action,
@@ -1784,6 +1798,7 @@ export class Scheduler {
       },
       isDemandedPullComputation: (action) =>
         this.isDemandedPullComputation(action),
+      isMaterializer: (action) => this.materializers.isMaterializer(action),
       shouldRunFirstPullComputationInDemandContext: (action) =>
         this.shouldRunFirstPullComputationInDemandContext(action),
       isDebouncedComputationWaiting: (action) =>
@@ -2083,6 +2098,13 @@ export class Scheduler {
     computation: Action,
   ): TriggerTraceScheduledEffect[] {
     return scheduleAffectedEffectsState(this.pullSchedulingState, computation);
+  }
+
+  private updateMaterializerRegistration(action: Action): void {
+    this.materializers.register(
+      action,
+      (action as Partial<TelemetryAnnotations>).materializerWriteEnvelopes,
+    );
   }
 
   private getNextDebounceRunTime(action: Action): number | undefined {

--- a/packages/runner/src/scheduler/action-run.ts
+++ b/packages/runner/src/scheduler/action-run.ts
@@ -220,6 +220,7 @@ export interface SchedulerActionRunState {
   readonly inFlightSourceState: InFlightSourceState;
   readonly actionTimingState: ActionTimingState;
   readonly pullDemandedFirstRunComputations: WeakSet<Action>;
+  readonly pullDemandedContinuationComputations: WeakSet<Action>;
   readonly retries: WeakMap<Action, number>;
   readonly pending: Set<Action>;
   readonly actionRunTrace: ActionRunTraceEntry[];
@@ -349,6 +350,7 @@ function finalizeSchedulerAction(
   state.maybeAutoDebounce(args.action);
   state.markActionHasRun(args.action);
   state.pullDemandedFirstRunComputations.delete(args.action);
+  state.pullDemandedContinuationComputations.delete(args.action);
 
   try {
     if (args.error) {

--- a/packages/runner/src/scheduler/continuation.ts
+++ b/packages/runner/src/scheduler/continuation.ts
@@ -18,6 +18,7 @@ export interface ExecuteContinuationState {
   readonly changedWritesHistory: unknown[];
   readonly consumeRerunAfterCurrentExecute: () => boolean;
   readonly isDemandedPullComputation: (action: Action) => boolean;
+  readonly isMaterializer: (action: Action) => boolean;
   readonly shouldRunFirstPullComputationInDemandContext: (
     action: Action,
   ) => boolean;

--- a/packages/runner/src/scheduler/continuation.ts
+++ b/packages/runner/src/scheduler/continuation.ts
@@ -4,6 +4,7 @@ import {
   hasEventQueueWakeTimer,
   scheduleEventQueueWake,
 } from "./events.ts";
+import type { MaterializerIndexState } from "./materializers.ts";
 import type { Action, QueuedEvent } from "./types.ts";
 
 export interface ExecuteContinuationState {
@@ -18,7 +19,7 @@ export interface ExecuteContinuationState {
   readonly changedWritesHistory: unknown[];
   readonly consumeRerunAfterCurrentExecute: () => boolean;
   readonly isDemandedPullComputation: (action: Action) => boolean;
-  readonly isMaterializer: (action: Action) => boolean;
+  readonly materializerIndex: MaterializerIndexState;
   readonly shouldRunFirstPullComputationInDemandContext: (
     action: Action,
   ) => boolean;

--- a/packages/runner/src/scheduler/demand.ts
+++ b/packages/runner/src/scheduler/demand.ts
@@ -9,6 +9,7 @@ export interface PullDemandState {
   readonly actionParent: WeakMap<Action, Action>;
   readonly isEffectAction: WeakMap<Action, boolean>;
   readonly pullDemandedFirstRunComputations: WeakSet<Action>;
+  readonly pullDemandedContinuationComputations: WeakSet<Action>;
   readonly hasActionRun: (action: Action) => boolean;
   readonly getSchedulingWrites: (
     action: Action,
@@ -88,16 +89,16 @@ export function shouldRunFirstPullComputationInDemandContext(
     | "effects"
     | "hasActionRun"
     | "pullDemandedFirstRunComputations"
+    | "pullDemandedContinuationComputations"
   >,
   action: Action,
 ): boolean {
-  if (
-    !state.computations.has(action) ||
-    state.effects.has(action) ||
-    state.hasActionRun(action)
-  ) {
+  if (!state.computations.has(action) || state.effects.has(action)) {
     return false;
   }
+
+  if (state.pullDemandedContinuationComputations.has(action)) return true;
+  if (state.hasActionRun(action)) return false;
 
   return state.pullDemandedFirstRunComputations.has(action);
 }

--- a/packages/runner/src/scheduler/dependency-updates.ts
+++ b/packages/runner/src/scheduler/dependency-updates.ts
@@ -43,9 +43,6 @@ export function setSchedulerDependencies(
       false,
     ),
   );
-  const potentialWrites = sortAndCompactPaths(
-    filterIgnoredAddresses(log.potentialWrites, ignoredSchedulingWrites),
-  );
   const declaredWrites = sortAndCompactPaths(
     filterIgnoredAddresses(
       ((action as Partial<TelemetryAnnotations>).writes ?? []).map(
@@ -58,12 +55,11 @@ export function setSchedulerDependencies(
     reads,
     shallowReads,
     writes,
-    ...(potentialWrites.length > 0 ? { potentialWrites } : {}),
   };
   state.dependencies.set(action, schedulingLog);
 
   // Rebuild the current scheduling view from the latest writes plus
-  // declared/potential writes. Keep the cumulative legacy union separately
+  // declared writes. Keep the cumulative legacy union separately
   // so it can be enabled behind an experimental flag.
   const rawExistingCurrentWrites =
     state.writeIndex.currentKnownWrites.get(action) ?? [];
@@ -78,7 +74,6 @@ export function setSchedulerDependencies(
   const { newCurrentKnownWrites, newHistoricalMightWrite } =
     buildKnownSchedulingWrites({
       writes,
-      potentialWrites,
       declaredWrites,
       existingCurrentWrites,
       existingHistoricalWrites,

--- a/packages/runner/src/scheduler/dirty-dependencies.ts
+++ b/packages/runner/src/scheduler/dirty-dependencies.ts
@@ -52,7 +52,25 @@ export function collectDirtyDependencies(
   action: Action,
   workSet: Set<Action>,
   memo = new Map<Action, boolean>(),
-  options: { forceTraverseCleanAction?: boolean } = {},
+): boolean {
+  return collectDirtyDependenciesInternal(state, action, workSet, memo, false);
+}
+
+export function collectDirtyDependenciesFromTraversalRoot(
+  state: DirtyDependencyCollectionState,
+  action: Action,
+  workSet: Set<Action>,
+  memo = new Map<Action, boolean>(),
+): boolean {
+  return collectDirtyDependenciesInternal(state, action, workSet, memo, true);
+}
+
+function collectDirtyDependenciesInternal(
+  state: DirtyDependencyCollectionState,
+  action: Action,
+  workSet: Set<Action>,
+  memo: Map<Action, boolean>,
+  traverseCleanRoot: boolean,
 ): boolean {
   const collectStart = performance.now();
   let addedToStack = false;
@@ -92,7 +110,7 @@ export function collectDirtyDependencies(
 
     if (
       !state.isStale(action) && !hasStaleMaterializerWriter &&
-      !options.forceTraverseCleanAction
+      !traverseCleanRoot
     ) {
       memo.set(action, false);
       return false;

--- a/packages/runner/src/scheduler/dirty-dependencies.ts
+++ b/packages/runner/src/scheduler/dirty-dependencies.ts
@@ -69,6 +69,13 @@ export function collectDirtyDependencies(
       }
     }
 
+    const directWriters = collectDirectWritersForAction(state, action);
+    const hasStaleMaterializerWriter = [...directWriters.writers].some(
+      (writer) =>
+        state.materializerIndex.isMaterializer(writer) &&
+        state.isStale(writer),
+    );
+
     const cached = memo.get(action);
     if (cached !== undefined) {
       if (trace) {
@@ -82,7 +89,7 @@ export function collectDirtyDependencies(
       return cached;
     }
 
-    if (!state.isStale(action)) {
+    if (!state.isStale(action) && !hasStaleMaterializerWriter) {
       memo.set(action, false);
       return false;
     }
@@ -97,8 +104,7 @@ export function collectDirtyDependencies(
     state.collectStack.add(action);
     addedToStack = true;
 
-    let actionNeedsRun = state.isStale(action);
-    const directWriters = collectDirectWritersForAction(state, action);
+    let actionNeedsRun = state.isStale(action) || hasStaleMaterializerWriter;
     if (directWriters.usedLogFallback && trace) trace.logFallbackCount++;
     if (directWriters.writers.size > 0) {
       recordReverseDependencyTrace(state, action, directWriters.writers);

--- a/packages/runner/src/scheduler/dirty-dependencies.ts
+++ b/packages/runner/src/scheduler/dirty-dependencies.ts
@@ -70,13 +70,6 @@ export function collectDirtyDependencies(
       }
     }
 
-    const directWriters = collectDirectWritersForAction(state, action);
-    const hasStaleMaterializerWriter = [...directWriters.writers].some(
-      (writer) =>
-        state.materializerIndex.isMaterializer(writer) &&
-        state.isStale(writer),
-    );
-
     const cached = memo.get(action);
     if (cached !== undefined) {
       if (trace) {
@@ -89,6 +82,13 @@ export function collectDirtyDependencies(
       }
       return cached;
     }
+
+    const directWriters = collectDirectWritersForAction(state, action);
+    const hasStaleMaterializerWriter = [...directWriters.writers].some(
+      (writer) =>
+        state.materializerIndex.isMaterializer(writer) &&
+        state.isStale(writer),
+    );
 
     if (
       !state.isStale(action) && !hasStaleMaterializerWriter &&
@@ -114,10 +114,6 @@ export function collectDirtyDependencies(
       recordReverseDependencyTrace(state, action, directWriters.writers);
     }
     for (const writer of directWriters.writers) {
-      if (!state.isStale(writer)) {
-        memo.set(writer, false);
-        continue;
-      }
       if (trace) trace.depth++;
       let writerNeedsRun: boolean;
       try {

--- a/packages/runner/src/scheduler/dirty-dependencies.ts
+++ b/packages/runner/src/scheduler/dirty-dependencies.ts
@@ -5,6 +5,10 @@ import type {
   SchedulerEventPreflightStats,
 } from "../telemetry.ts";
 import { collectDirectWritersForLog } from "./dependency-graph.ts";
+import {
+  collectMaterializerWritersForLog,
+  type MaterializerIndexState,
+} from "./materializers.ts";
 import type {
   Action,
   DirtyDependencyTraceContext,
@@ -27,6 +31,7 @@ export interface DirtyDependencyCollectionState {
   readonly dependencies: WeakMap<Action, ReactivityLog>;
   readonly writersByEntity: Map<SpaceScopeAndURI, Set<Action>>;
   readonly effects: ReadonlySet<Action>;
+  readonly materializerIndex: MaterializerIndexState;
   readonly isStale: (action: Action) => boolean;
   readonly getSchedulingWrites: (
     action: Action,
@@ -93,37 +98,30 @@ export function collectDirtyDependencies(
     addedToStack = true;
 
     let actionNeedsRun = state.isStale(action);
-    const directWriters = state.reverseDependencies.get(action);
-    if (directWriters) {
-      recordReverseDependencyTrace(state, action, directWriters);
-      for (const writer of directWriters) {
-        if (!state.isStale(writer)) {
-          memo.set(writer, false);
-          continue;
-        }
-        if (trace) trace.depth++;
-        let writerNeedsRun: boolean;
-        try {
-          writerNeedsRun = collectDirtyDependencies(
-            state,
-            writer,
-            workSet,
-            memo,
-          );
-        } finally {
-          if (trace) trace.depth--;
-        }
-        if (writerNeedsRun) {
-          actionNeedsRun = true;
-        }
+    const directWriters = collectDirectWritersForAction(state, action);
+    if (directWriters.usedLogFallback && trace) trace.logFallbackCount++;
+    if (directWriters.writers.size > 0) {
+      recordReverseDependencyTrace(state, action, directWriters.writers);
+    }
+    for (const writer of directWriters.writers) {
+      if (!state.isStale(writer)) {
+        memo.set(writer, false);
+        continue;
       }
-    } else {
-      if (trace) trace.logFallbackCount++;
-      const log = state.dependencies.get(action);
-      if (log) {
-        if (collectDirtyDependenciesForLog(state, log, workSet, memo)) {
-          actionNeedsRun = true;
-        }
+      if (trace) trace.depth++;
+      let writerNeedsRun: boolean;
+      try {
+        writerNeedsRun = collectDirtyDependencies(
+          state,
+          writer,
+          workSet,
+          memo,
+        );
+      } finally {
+        if (trace) trace.depth--;
+      }
+      if (writerNeedsRun) {
+        actionNeedsRun = true;
       }
     }
 
@@ -149,6 +147,43 @@ export function collectDirtyDependencies(
       "collectDirtyDependencies",
     );
   }
+}
+
+function collectDirectWritersForAction(
+  state: DirtyDependencyCollectionState,
+  action: Action,
+): { writers: Set<Action>; usedLogFallback: boolean } {
+  const writers = new Set(state.reverseDependencies.get(action) ?? []);
+  const log = state.dependencies.get(action);
+  let usedLogFallback = false;
+
+  if (writers.size === 0 && log) {
+    usedLogFallback = true;
+    for (
+      const writer of collectDirectWritersForLog({
+        writersByEntity: state.writersByEntity,
+        effects: state.effects,
+        getSchedulingWrites: state.getSchedulingWrites,
+        trace: state.getTrace(),
+      }, log)
+    ) {
+      writers.add(writer);
+    }
+  }
+
+  if (log) {
+    for (
+      const materializer of collectMaterializerWritersForLog(
+        state.materializerIndex,
+        log,
+        { exclude: action },
+      )
+    ) {
+      writers.add(materializer);
+    }
+  }
+
+  return { writers, usedLogFallback };
 }
 
 function recordReverseDependencyTrace(
@@ -185,6 +220,14 @@ export function collectDirtyDependenciesForLog(
       getSchedulingWrites: state.getSchedulingWrites,
       trace,
     }, log);
+    for (
+      const materializer of collectMaterializerWritersForLog(
+        state.materializerIndex,
+        log,
+      )
+    ) {
+      directWriters.add(materializer);
+    }
   } finally {
     logger.time(
       lookupStart,

--- a/packages/runner/src/scheduler/dirty-dependencies.ts
+++ b/packages/runner/src/scheduler/dirty-dependencies.ts
@@ -52,6 +52,7 @@ export function collectDirtyDependencies(
   action: Action,
   workSet: Set<Action>,
   memo = new Map<Action, boolean>(),
+  options: { forceTraverseCleanAction?: boolean } = {},
 ): boolean {
   const collectStart = performance.now();
   let addedToStack = false;
@@ -89,7 +90,10 @@ export function collectDirtyDependencies(
       return cached;
     }
 
-    if (!state.isStale(action) && !hasStaleMaterializerWriter) {
+    if (
+      !state.isStale(action) && !hasStaleMaterializerWriter &&
+      !options.forceTraverseCleanAction
+    ) {
       memo.set(action, false);
       return false;
     }

--- a/packages/runner/src/scheduler/execution.ts
+++ b/packages/runner/src/scheduler/execution.ts
@@ -341,6 +341,7 @@ export interface SchedulerSettleLoopState {
     seed: Action,
     targetWorkSet: Set<Action>,
     memo: Map<Action, boolean>,
+    options?: { forceTraverseCleanAction?: boolean },
   ) => boolean;
   readonly getActionId: (action: Action) => string;
   readonly clearDirty: (action: Action) => void;

--- a/packages/runner/src/scheduler/execution.ts
+++ b/packages/runner/src/scheduler/execution.ts
@@ -167,7 +167,7 @@ export function collectInitialExecuteDependencies(
   try {
     // Find computation actions whose writes are still unknown. We run them on
     // the first cycle to capture writes that cannot be inferred from declared
-    // outputs or populateDependencies() potential writes.
+    // outputs.
     //
     // TODO(seefeld): Once we more reliably capture what they can write via
     // WriteableCell or so, then we can treat this more deliberately via the
@@ -323,6 +323,9 @@ export interface SchedulerSettleLoopState {
     Action,
     IMemorySpaceAddress[]
   >;
+  readonly getMaterializerWriteEnvelopes: (
+    action: Action,
+  ) => readonly IMemorySpaceAddress[] | undefined;
   readonly collectDependenciesForAction: (
     action: Action,
     populateDependencies: PopulateDependenciesEntry,
@@ -603,6 +606,7 @@ export function planPullExecuteContinuation(state: {
   readonly pending: ReadonlySet<Action>;
   readonly dirty: ReadonlySet<Action>;
   readonly effects: ReadonlySet<Action>;
+  readonly isMaterializer: (action: Action) => boolean;
   readonly shouldRerunAfterCurrentExecute: boolean;
   readonly hasQueuedEventReadyNow: boolean;
   readonly hasParkedHeadEvent: boolean;
@@ -618,6 +622,7 @@ export function planPullExecuteContinuation(state: {
   const now = state.now ?? performance.now();
   const hasPendingPullWork = [...state.pending].some((action) =>
     state.effects.has(action) ||
+    state.isMaterializer(action) ||
     state.isDemandedPullComputation(action) ||
     state.shouldRunFirstPullComputationInDemandContext(action)
   );
@@ -627,7 +632,8 @@ export function planPullExecuteContinuation(state: {
   const hasDirtyPullWork = [...state.dirty].some((action) => {
     if (
       !state.effects.has(action) &&
-      !state.isDemandedPullComputation(action)
+      !state.isDemandedPullComputation(action) &&
+      !state.isMaterializer(action)
     ) {
       return false;
     }
@@ -639,7 +645,8 @@ export function planPullExecuteContinuation(state: {
           nextDirtyPullRunAt,
           nextDebounceAt,
         );
-        nextDirtyPullRunWaitsForIdle ||= state.effects.has(action);
+        nextDirtyPullRunWaitsForIdle ||= state.effects.has(action) ||
+          state.isMaterializer(action);
       }
       return false;
     }
@@ -647,7 +654,8 @@ export function planPullExecuteContinuation(state: {
     const nextEligibleAt = state.getNextEligibleRunTime(action);
     if (nextEligibleAt !== undefined && nextEligibleAt > now) {
       nextDirtyPullRunAt = minDefined(nextDirtyPullRunAt, nextEligibleAt);
-      nextDirtyPullRunWaitsForIdle ||= state.effects.has(action);
+      nextDirtyPullRunWaitsForIdle ||= state.effects.has(action) ||
+        state.isMaterializer(action);
       return false;
     }
 

--- a/packages/runner/src/scheduler/execution.ts
+++ b/packages/runner/src/scheduler/execution.ts
@@ -7,6 +7,7 @@ import {
   CYCLE_DEBOUNCE_THRESHOLD_MS,
   MAX_ITERATIONS_PER_RUN,
 } from "./constants.ts";
+import type { MaterializerIndexState } from "./materializers.ts";
 import type {
   Action,
   PopulateDependenciesEntry,
@@ -316,7 +317,7 @@ export interface SchedulerSettleLoopState {
   readonly getLoopCounter: () => WeakMap<Action, number>;
   readonly runsThisExecute: Map<Action, number>;
   readonly activePullDemandActions: WeakSet<Action>;
-  readonly isMaterializer: (action: Action) => boolean;
+  readonly materializerIndex: MaterializerIndexState;
   readonly getSchedulingWrites: (
     action: Action,
   ) => readonly IMemorySpaceAddress[] | undefined;
@@ -324,9 +325,6 @@ export interface SchedulerSettleLoopState {
     Action,
     IMemorySpaceAddress[]
   >;
-  readonly getMaterializerWriteEnvelopes: (
-    action: Action,
-  ) => readonly IMemorySpaceAddress[] | undefined;
   readonly collectDependenciesForAction: (
     action: Action,
     populateDependencies: PopulateDependenciesEntry,
@@ -341,7 +339,11 @@ export interface SchedulerSettleLoopState {
     seed: Action,
     targetWorkSet: Set<Action>,
     memo: Map<Action, boolean>,
-    options?: { forceTraverseCleanAction?: boolean },
+  ) => boolean;
+  readonly collectDirtyDependenciesFromTraversalRoot: (
+    seed: Action,
+    targetWorkSet: Set<Action>,
+    memo: Map<Action, boolean>,
   ) => boolean;
   readonly getActionId: (action: Action) => string;
   readonly clearDirty: (action: Action) => void;
@@ -608,7 +610,7 @@ export function planPullExecuteContinuation(state: {
   readonly pending: ReadonlySet<Action>;
   readonly dirty: ReadonlySet<Action>;
   readonly effects: ReadonlySet<Action>;
-  readonly isMaterializer: (action: Action) => boolean;
+  readonly materializerIndex: MaterializerIndexState;
   readonly shouldRerunAfterCurrentExecute: boolean;
   readonly hasQueuedEventReadyNow: boolean;
   readonly hasParkedHeadEvent: boolean;
@@ -624,7 +626,7 @@ export function planPullExecuteContinuation(state: {
   const now = state.now ?? performance.now();
   const hasPendingPullWork = [...state.pending].some((action) =>
     state.effects.has(action) ||
-    state.isMaterializer(action) ||
+    state.materializerIndex.isMaterializer(action) ||
     state.isDemandedPullComputation(action) ||
     state.shouldRunFirstPullComputationInDemandContext(action)
   );
@@ -635,7 +637,7 @@ export function planPullExecuteContinuation(state: {
     if (
       !state.effects.has(action) &&
       !state.isDemandedPullComputation(action) &&
-      !state.isMaterializer(action)
+      !state.materializerIndex.isMaterializer(action)
     ) {
       return false;
     }
@@ -648,7 +650,7 @@ export function planPullExecuteContinuation(state: {
           nextDebounceAt,
         );
         nextDirtyPullRunWaitsForIdle ||= state.effects.has(action) ||
-          state.isMaterializer(action);
+          state.materializerIndex.isMaterializer(action);
       }
       return false;
     }
@@ -657,7 +659,7 @@ export function planPullExecuteContinuation(state: {
     if (nextEligibleAt !== undefined && nextEligibleAt > now) {
       nextDirtyPullRunAt = minDefined(nextDirtyPullRunAt, nextEligibleAt);
       nextDirtyPullRunWaitsForIdle ||= state.effects.has(action) ||
-        state.isMaterializer(action);
+        state.materializerIndex.isMaterializer(action);
       return false;
     }
 

--- a/packages/runner/src/scheduler/execution.ts
+++ b/packages/runner/src/scheduler/execution.ts
@@ -316,6 +316,7 @@ export interface SchedulerSettleLoopState {
   readonly getLoopCounter: () => WeakMap<Action, number>;
   readonly runsThisExecute: Map<Action, number>;
   readonly activePullDemandActions: WeakSet<Action>;
+  readonly isMaterializer: (action: Action) => boolean;
   readonly getSchedulingWrites: (
     action: Action,
   ) => readonly IMemorySpaceAddress[] | undefined;

--- a/packages/runner/src/scheduler/materializers.ts
+++ b/packages/runner/src/scheduler/materializers.ts
@@ -12,6 +12,7 @@ export interface MaterializerIndexState {
   getMaterializerWriteEnvelopes(
     action: Action,
   ): readonly IMemorySpaceAddress[] | undefined;
+  isMaterializer(action: Action): boolean;
 }
 
 export class SchedulerMaterializers implements MaterializerIndexState {

--- a/packages/runner/src/scheduler/materializers.ts
+++ b/packages/runner/src/scheduler/materializers.ts
@@ -1,0 +1,108 @@
+import { sortAndCompactPaths } from "../reactive-dependencies.ts";
+import type { NormalizedFullLink } from "../link-utils.ts";
+import { toMemorySpaceAddress } from "../link-utils.ts";
+import type { IMemorySpaceAddress } from "../storage/interface.ts";
+import { entityKey } from "./keys.ts";
+import { readsOverlapWrites } from "./scheduling-writes.ts";
+import type { Action, ReactivityLog, SpaceScopeAndURI } from "./types.ts";
+
+export interface MaterializerIndexState {
+  readonly materializersByEntity: Map<SpaceScopeAndURI, Set<Action>>;
+  readonly effects: ReadonlySet<Action>;
+  getMaterializerWriteEnvelopes(
+    action: Action,
+  ): readonly IMemorySpaceAddress[] | undefined;
+}
+
+export class SchedulerMaterializers implements MaterializerIndexState {
+  readonly materializers = new Set<Action>();
+  readonly materializersByEntity = new Map<SpaceScopeAndURI, Set<Action>>();
+  private readonly writeEnvelopes = new WeakMap<
+    Action,
+    IMemorySpaceAddress[]
+  >();
+  private readonly actionEntities = new WeakMap<
+    Action,
+    Set<SpaceScopeAndURI>
+  >();
+
+  constructor(
+    readonly effects: ReadonlySet<Action>,
+  ) {}
+
+  register(
+    action: Action,
+    envelopes: readonly NormalizedFullLink[] | undefined,
+  ): void {
+    this.clearAction(action);
+    if (!envelopes || envelopes.length === 0) return;
+
+    const writes = sortAndCompactPaths(envelopes.map(toMemorySpaceAddress));
+    if (writes.length === 0) return;
+
+    this.materializers.add(action);
+    this.writeEnvelopes.set(action, writes);
+
+    const entities = new Set<SpaceScopeAndURI>();
+    for (const write of writes) {
+      const entity = entityKey(write);
+      entities.add(entity);
+      let materializers = this.materializersByEntity.get(entity);
+      if (!materializers) {
+        materializers = new Set<Action>();
+        this.materializersByEntity.set(entity, materializers);
+      }
+      materializers.add(action);
+    }
+    this.actionEntities.set(action, entities);
+  }
+
+  clearAction(action: Action): void {
+    this.materializers.delete(action);
+    this.writeEnvelopes.delete(action);
+    const entities = this.actionEntities.get(action);
+    if (!entities) return;
+
+    for (const entity of entities) {
+      const materializers = this.materializersByEntity.get(entity);
+      materializers?.delete(action);
+      if (materializers && materializers.size === 0) {
+        this.materializersByEntity.delete(entity);
+      }
+    }
+    this.actionEntities.delete(action);
+  }
+
+  isMaterializer(action: Action): boolean {
+    return this.materializers.has(action);
+  }
+
+  getMaterializerWriteEnvelopes(
+    action: Action,
+  ): readonly IMemorySpaceAddress[] | undefined {
+    return this.writeEnvelopes.get(action);
+  }
+}
+
+export function collectMaterializerWritersForLog(
+  state: MaterializerIndexState,
+  log: ReactivityLog,
+  options: { exclude?: Action } = {},
+): Set<Action> {
+  const writers = new Set<Action>();
+  const reads = [...log.reads, ...log.shallowReads];
+  for (const read of reads) {
+    const candidates = state.materializersByEntity.get(entityKey(read));
+    if (!candidates) continue;
+
+    for (const candidate of candidates) {
+      if (candidate === options.exclude) continue;
+      if (state.effects.has(candidate)) continue;
+      const envelopes = state.getMaterializerWriteEnvelopes(candidate) ?? [];
+      if (readsOverlapWrites(log.reads, log.shallowReads, envelopes)) {
+        writers.add(candidate);
+      }
+    }
+  }
+  return writers;
+}

--- a/packages/runner/src/scheduler/notifications.ts
+++ b/packages/runner/src/scheduler/notifications.ts
@@ -5,6 +5,7 @@ import type {
   IStorageTransaction,
 } from "../storage/interface.ts";
 import type { TriggerIndexState } from "./trigger-index.ts";
+import type { MaterializerIndexState } from "./materializers.ts";
 import { summarizeTriggerTraceValue } from "./diagnostics.ts";
 import type {
   Action,
@@ -172,7 +173,7 @@ export function applyPullTriggeredActionPlan(
 
   if (plan.operation === "mark-dirty") {
     state.markDirty(action);
-    if (state.isMaterializer(action)) {
+    if (state.materializerIndex.isMaterializer(action)) {
       state.queueExecution();
       return [];
     }
@@ -206,7 +207,7 @@ export interface StorageNotificationState {
   readonly recordTriggerTrace: (entry: TriggerTraceEntry) => void;
   readonly scheduleWithDebounce: (action: Action) => void;
   readonly markDirty: (action: Action) => void;
-  readonly isMaterializer: (action: Action) => boolean;
+  readonly materializerIndex: MaterializerIndexState;
   readonly queueExecution: () => void;
   readonly scheduleAffectedEffects: (
     action: Action,

--- a/packages/runner/src/scheduler/notifications.ts
+++ b/packages/runner/src/scheduler/notifications.ts
@@ -172,6 +172,10 @@ export function applyPullTriggeredActionPlan(
 
   if (plan.operation === "mark-dirty") {
     state.markDirty(action);
+    if (state.isMaterializer(action)) {
+      state.queueExecution();
+      return [];
+    }
     return state.scheduleAffectedEffects(action);
   }
 
@@ -202,6 +206,8 @@ export interface StorageNotificationState {
   readonly recordTriggerTrace: (entry: TriggerTraceEntry) => void;
   readonly scheduleWithDebounce: (action: Action) => void;
   readonly markDirty: (action: Action) => void;
+  readonly isMaterializer: (action: Action) => boolean;
+  readonly queueExecution: () => void;
   readonly scheduleAffectedEffects: (
     action: Action,
   ) => TriggerTraceScheduledEffect[];

--- a/packages/runner/src/scheduler/pull-continuation.ts
+++ b/packages/runner/src/scheduler/pull-continuation.ts
@@ -26,7 +26,7 @@ export function applyPullExecuteContinuation(
     hasQueuedEventReadyNow,
     hasParkedHeadEvent,
     isDemandedPullComputation: state.isDemandedPullComputation,
-    isMaterializer: state.isMaterializer,
+    materializerIndex: state.materializerIndex,
     shouldRunFirstPullComputationInDemandContext:
       state.shouldRunFirstPullComputationInDemandContext,
     isDebouncedComputationWaiting: state.isDebouncedComputationWaiting,

--- a/packages/runner/src/scheduler/pull-continuation.ts
+++ b/packages/runner/src/scheduler/pull-continuation.ts
@@ -26,6 +26,7 @@ export function applyPullExecuteContinuation(
     hasQueuedEventReadyNow,
     hasParkedHeadEvent,
     isDemandedPullComputation: state.isDemandedPullComputation,
+    isMaterializer: state.isMaterializer,
     shouldRunFirstPullComputationInDemandContext:
       state.shouldRunFirstPullComputationInDemandContext,
     isDebouncedComputationWaiting: state.isDebouncedComputationWaiting,

--- a/packages/runner/src/scheduler/pull-execution.ts
+++ b/packages/runner/src/scheduler/pull-execution.ts
@@ -33,17 +33,17 @@ function buildPullIterationWorkSet(state: {
   const workSet = new Set<Action>();
   const iterationSeeds = new Set<Action>();
 
-  // Every iteration needs to consider newly created pending effects.
-  // Without this, nested/recursive patterns can stall after creating
-  // new demand-root effects in an earlier iteration.
-  state.collectPullIterationSeeds(iterationSeeds);
-
   // On first iteration, add special-case seeds discovered before settle.
   if (state.settleIter === 0) {
     for (const seed of state.initialSeeds) {
       iterationSeeds.add(seed);
     }
   }
+
+  // Every iteration needs to consider newly created pending effects.
+  // Without this, nested/recursive patterns can stall after creating
+  // new demand-root effects in an earlier iteration.
+  state.collectPullIterationSeeds(iterationSeeds);
 
   for (const seed of iterationSeeds) {
     workSet.add(seed);
@@ -210,6 +210,7 @@ function preparePullSettleIteration(
     state.getSchedulingWritesMap(),
     state.actionParent,
     state.dependents,
+    state.getMaterializerWriteEnvelopes,
   );
   logger.time(
     topologicalSortStart,

--- a/packages/runner/src/scheduler/pull-execution.ts
+++ b/packages/runner/src/scheduler/pull-execution.ts
@@ -24,7 +24,11 @@ function buildPullIterationWorkSet(state: {
     seed: Action,
     workSet: Set<Action>,
     memo: Map<Action, boolean>,
-    options?: { forceTraverseCleanAction?: boolean },
+  ) => boolean;
+  readonly collectDirtyDependenciesFromTraversalRoot: (
+    seed: Action,
+    workSet: Set<Action>,
+    memo: Map<Action, boolean>,
   ) => boolean;
 }): {
   workSet: Set<Action>;
@@ -58,10 +62,15 @@ function buildPullIterationWorkSet(state: {
   // Pull in dirty computations that feed the currently runnable seeds.
   const dirtyDependencyMemo = new Map<Action, boolean>();
   for (const seed of traversalSeeds) {
-    state.collectDirtyDependencies(seed, workSet, dirtyDependencyMemo, {
-      forceTraverseCleanAction: state.settleIter > 0 &&
-        state.initialSeeds.has(seed),
-    });
+    if (state.settleIter > 0 && state.initialSeeds.has(seed)) {
+      state.collectDirtyDependenciesFromTraversalRoot(
+        seed,
+        workSet,
+        dirtyDependencyMemo,
+      );
+      continue;
+    }
+    state.collectDirtyDependencies(seed, workSet, dirtyDependencyMemo);
   }
 
   return {
@@ -186,6 +195,8 @@ function preparePullSettleIteration(
       settleIter,
       collectPullIterationSeeds: state.collectPullIterationSeeds,
       collectDirtyDependencies: state.collectDirtyDependencies,
+      collectDirtyDependenciesFromTraversalRoot:
+        state.collectDirtyDependenciesFromTraversalRoot,
     });
 
   if (settleIter === 0) {
@@ -219,7 +230,7 @@ function preparePullSettleIteration(
     state.getSchedulingWritesMap(),
     state.actionParent,
     state.dependents,
-    state.getMaterializerWriteEnvelopes,
+    (action) => state.materializerIndex.getMaterializerWriteEnvelopes(action),
   );
   logger.time(
     topologicalSortStart,
@@ -333,7 +344,7 @@ function deferEffectForLateMaterializerDependency(
   const dirtyDeps = new Set<Action>();
   state.collectDirtyDependencies(fn, dirtyDeps, new Map());
   const materializers = [...dirtyDeps].filter((dep) =>
-    state.isMaterializer(dep) && state.dirty.has(dep)
+    state.materializerIndex.isMaterializer(dep) && state.dirty.has(dep)
   );
   if (materializers.length === 0) return false;
 

--- a/packages/runner/src/scheduler/pull-execution.ts
+++ b/packages/runner/src/scheduler/pull-execution.ts
@@ -24,6 +24,7 @@ function buildPullIterationWorkSet(state: {
     seed: Action,
     workSet: Set<Action>,
     memo: Map<Action, boolean>,
+    options?: { forceTraverseCleanAction?: boolean },
   ) => boolean;
 }): {
   workSet: Set<Action>;
@@ -32,10 +33,14 @@ function buildPullIterationWorkSet(state: {
 } {
   const workSet = new Set<Action>();
   const iterationSeeds = new Set<Action>();
+  const traversalSeeds = new Set<Action>();
 
-  // On first iteration, add special-case seeds discovered before settle.
-  if (state.settleIter === 0) {
-    for (const seed of state.initialSeeds) {
+  for (const seed of state.initialSeeds) {
+    traversalSeeds.add(seed);
+    // On the first iteration, initial seeds are runnable work. On later
+    // iterations they remain demand roots for newly dirtied dependencies, but
+    // should not be rerun unless normal scheduling also marks them pending.
+    if (state.settleIter === 0) {
       iterationSeeds.add(seed);
     }
   }
@@ -47,12 +52,16 @@ function buildPullIterationWorkSet(state: {
 
   for (const seed of iterationSeeds) {
     workSet.add(seed);
+    traversalSeeds.add(seed);
   }
 
   // Pull in dirty computations that feed the currently runnable seeds.
   const dirtyDependencyMemo = new Map<Action, boolean>();
-  for (const seed of iterationSeeds) {
-    state.collectDirtyDependencies(seed, workSet, dirtyDependencyMemo);
+  for (const seed of traversalSeeds) {
+    state.collectDirtyDependencies(seed, workSet, dirtyDependencyMemo, {
+      forceTraverseCleanAction: state.settleIter > 0 &&
+        state.initialSeeds.has(seed),
+    });
   }
 
   return {

--- a/packages/runner/src/scheduler/pull-execution.ts
+++ b/packages/runner/src/scheduler/pull-execution.ts
@@ -16,6 +16,12 @@ const logger = getLogger("scheduler", {
   level: "warn",
 });
 
+type PullSettleIteration = { settled: true } | {
+  settled: false;
+  workSet: Set<Action>;
+  order: Action[];
+};
+
 function buildPullIterationWorkSet(state: {
   readonly initialSeeds: ReadonlySet<Action>;
   readonly settleIter: number;
@@ -182,33 +188,11 @@ function preparePullSettleIteration(
   settleIter: number,
   earlyIterationThreshold: number,
   earlyIterationComputations: Set<Action>,
-): { settled: true } | {
-  settled: false;
-  workSet: Set<Action>;
-  order: Action[];
-} {
-  // Build the work set for this iteration
-  const buildPullWorkSetStart = performance.now();
-  const { workSet, iterationSeeds, dirtyDependencyCount } =
-    buildPullIterationWorkSet({
-      initialSeeds,
-      settleIter,
-      collectPullIterationSeeds: state.collectPullIterationSeeds,
-      collectDirtyDependencies: state.collectDirtyDependencies,
-      collectDirtyDependenciesFromTraversalRoot:
-        state.collectDirtyDependenciesFromTraversalRoot,
-    });
-
-  if (settleIter === 0) {
-    logger.debug("schedule-execute-pull", () => [
-      `Pull mode: Seeds: ${iterationSeeds.size}, Dirty deps added: ${dirtyDependencyCount}`,
-    ]);
-  }
-  logger.time(
-    buildPullWorkSetStart,
-    "scheduler",
-    "execute",
-    "buildPullWorkSet",
+): PullSettleIteration {
+  const { workSet } = buildAndLogPullIterationWorkSet(
+    state,
+    initialSeeds,
+    settleIter,
   );
 
   if (workSet.size === 0) {
@@ -223,6 +207,51 @@ function preparePullSettleIteration(
     earlyIterationComputations,
   });
 
+  const order = orderPullWorkSet(state, workSet, settleIter);
+  clearPullEffectsBeforeRun(state, order);
+
+  return { settled: false, workSet, order };
+}
+
+function buildAndLogPullIterationWorkSet(
+  state: SchedulerSettleLoopState,
+  initialSeeds: ReadonlySet<Action>,
+  settleIter: number,
+): {
+  workSet: Set<Action>;
+  iterationSeeds: Set<Action>;
+  dirtyDependencyCount: number;
+} {
+  const buildPullWorkSetStart = performance.now();
+  const result = buildPullIterationWorkSet({
+    initialSeeds,
+    settleIter,
+    collectPullIterationSeeds: state.collectPullIterationSeeds,
+    collectDirtyDependencies: state.collectDirtyDependencies,
+    collectDirtyDependenciesFromTraversalRoot:
+      state.collectDirtyDependenciesFromTraversalRoot,
+  });
+
+  if (settleIter === 0) {
+    logger.debug("schedule-execute-pull", () => [
+      `Pull mode: Seeds: ${result.iterationSeeds.size}, Dirty deps added: ${result.dirtyDependencyCount}`,
+    ]);
+  }
+  logger.time(
+    buildPullWorkSetStart,
+    "scheduler",
+    "execute",
+    "buildPullWorkSet",
+  );
+
+  return result;
+}
+
+function orderPullWorkSet(
+  state: SchedulerSettleLoopState,
+  workSet: Set<Action>,
+  settleIter: number,
+): Action[] {
   const topologicalSortStart = performance.now();
   const order = topologicalSort(
     workSet,
@@ -243,6 +272,13 @@ function preparePullSettleIteration(
     `Running ${order.length} actions (settle iteration ${settleIter})`,
   ]);
 
+  return order;
+}
+
+function clearPullEffectsBeforeRun(
+  state: SchedulerSettleLoopState,
+  order: readonly Action[],
+): void {
   // Implicit cycle detection for effects:
   // Clear dirty flags for all effects upfront. If an effect becomes dirty again
   // by the time we run it, something in the execution re-dirtied it -> cycle.
@@ -251,8 +287,6 @@ function preparePullSettleIteration(
       state.clearDirty(fn);
     }
   }
-
-  return { settled: false, workSet, order };
 }
 
 async function runPullSettleOrder(

--- a/packages/runner/src/scheduler/pull-execution.ts
+++ b/packages/runner/src/scheduler/pull-execution.ts
@@ -256,6 +256,7 @@ async function runPullSettleAction(
   if (!isStillScheduled) return 0;
 
   if (!isPullSettleActionStillRunnable(state, fn)) return 0;
+  if (deferEffectForLateMaterializerDependency(state, fn)) return 0;
   if (skipPullDelayedSettleAction(state, fn)) return 0;
   if (skipUnchangedConditionalEffect(state, fn)) return 0;
 
@@ -312,6 +313,26 @@ function isPullSettleActionStillRunnable(
 
   // For computations: must be pending or dirty
   return isInPending || isInDirty;
+}
+
+function deferEffectForLateMaterializerDependency(
+  state: SchedulerSettleLoopState,
+  fn: Action,
+): boolean {
+  if (!state.effects.has(fn)) return false;
+
+  const dirtyDeps = new Set<Action>();
+  state.collectDirtyDependencies(fn, dirtyDeps, new Map());
+  const materializers = [...dirtyDeps].filter((dep) =>
+    state.isMaterializer(dep) && state.dirty.has(dep)
+  );
+  if (materializers.length === 0) return false;
+
+  for (const materializer of materializers) {
+    state.pending.add(materializer);
+  }
+  state.pending.add(fn);
+  return true;
 }
 
 function skipPullDelayedSettleAction(

--- a/packages/runner/src/scheduler/pull-scheduling.ts
+++ b/packages/runner/src/scheduler/pull-scheduling.ts
@@ -78,7 +78,9 @@ export function conditionalEffectHasChangedInputs(
 }
 
 /**
- * In pull mode, only effects are runnable seeds by default.
+ * In pull mode, effects and demanded computations are primary runnable seeds.
+ * Materializers are idle work and only become seeds once the primary work set
+ * for this iteration is empty.
  *
  * Inline idempotency mode intentionally does not widen this to computations:
  * it rechecks computations that already run due to explicit demand or an
@@ -89,6 +91,19 @@ export function collectPullIterationSeeds(
   workSet: Set<Action>,
 ): void {
   const initialSize = workSet.size;
+  collectPrimaryPullIterationSeeds(state, workSet);
+
+  if (workSet.size > initialSize || initialSize > 0) {
+    return;
+  }
+
+  collectIdleMaterializerSeeds(state, workSet);
+}
+
+function collectPrimaryPullIterationSeeds(
+  state: PullSchedulingState,
+  workSet: Set<Action>,
+): void {
   for (const action of state.pending) {
     if (isPendingPullActionRunnable(state.pendingPullRunnableState, action)) {
       workSet.add(action);
@@ -101,25 +116,20 @@ export function collectPullIterationSeeds(
       workSet.add(action);
     }
   }
+}
 
-  if (workSet.size > initialSize || initialSize > 0) {
-    return;
-  }
-
+function collectIdleMaterializerSeeds(
+  state: PullSchedulingState,
+  workSet: Set<Action>,
+): void {
   for (const action of state.pending) {
-    if (
-      state.materializerIndex.isMaterializer(action) &&
-      isMaterializerRunnable(state, action)
-    ) {
+    if (isIdleMaterializerRunnable(state, action)) {
       workSet.add(action);
     }
   }
 
   for (const action of state.dirty) {
-    if (
-      state.materializerIndex.isMaterializer(action) &&
-      isMaterializerRunnable(state, action)
-    ) {
+    if (isIdleMaterializerRunnable(state, action)) {
       state.pending.add(action);
       workSet.add(action);
     }
@@ -127,12 +137,13 @@ export function collectPullIterationSeeds(
 }
 
 export function hasRunnablePullWork(state: PullSchedulingState): boolean {
+  return hasRunnablePrimaryPullWork(state) ||
+    hasRunnableIdleMaterializerWork(state);
+}
+
+function hasRunnablePrimaryPullWork(state: PullSchedulingState): boolean {
   for (const action of state.pending) {
-    if (
-      isPendingPullActionRunnable(state.pendingPullRunnableState, action) ||
-      (state.materializerIndex.isMaterializer(action) &&
-        isMaterializerRunnable(state, action))
-    ) {
+    if (isPendingPullActionRunnable(state.pendingPullRunnableState, action)) {
       return true;
     }
   }
@@ -142,15 +153,39 @@ export function hasRunnablePullWork(state: PullSchedulingState): boolean {
       isDirtyPullActionRunnable(
         state.dirtyPullRunnableStateWithDebounce,
         action,
-      ) ||
-      (state.materializerIndex.isMaterializer(action) &&
-        isMaterializerRunnable(state, action))
+      )
     ) {
       return true;
     }
   }
 
   return false;
+}
+
+function hasRunnableIdleMaterializerWork(
+  state: PullSchedulingState,
+): boolean {
+  for (const action of state.pending) {
+    if (isIdleMaterializerRunnable(state, action)) {
+      return true;
+    }
+  }
+
+  for (const action of state.dirty) {
+    if (isIdleMaterializerRunnable(state, action)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function isIdleMaterializerRunnable(
+  state: PullSchedulingState,
+  action: Action,
+): boolean {
+  return state.materializerIndex.isMaterializer(action) &&
+    isMaterializerRunnable(state, action);
 }
 
 function isMaterializerRunnable(

--- a/packages/runner/src/scheduler/pull-scheduling.ts
+++ b/packages/runner/src/scheduler/pull-scheduling.ts
@@ -6,6 +6,7 @@ import {
 } from "./execution.ts";
 import { readsOverlapWrites } from "./scheduling-writes.ts";
 import { collectTransitiveEffects } from "./topology.ts";
+import type { MaterializerIndexState } from "./materializers.ts";
 import type {
   Action,
   ReactivityLog,
@@ -37,7 +38,7 @@ export interface PullSchedulingState extends ConditionalEffectState {
   readonly pending: Set<Action>;
   readonly dirty: ReadonlySet<Action>;
   readonly effects: ReadonlySet<Action>;
-  readonly isMaterializer: (action: Action) => boolean;
+  readonly materializerIndex: MaterializerIndexState;
   readonly dependents: WeakMap<Action, Set<Action>>;
   readonly pendingPullRunnableState: PendingPullRunnableState;
   readonly dirtyPullRunnableState: DirtyPullRunnableState;
@@ -107,7 +108,7 @@ export function collectPullIterationSeeds(
 
   for (const action of state.pending) {
     if (
-      state.isMaterializer(action) &&
+      state.materializerIndex.isMaterializer(action) &&
       isMaterializerRunnable(state, action)
     ) {
       workSet.add(action);
@@ -116,7 +117,7 @@ export function collectPullIterationSeeds(
 
   for (const action of state.dirty) {
     if (
-      state.isMaterializer(action) &&
+      state.materializerIndex.isMaterializer(action) &&
       isMaterializerRunnable(state, action)
     ) {
       state.pending.add(action);
@@ -129,7 +130,8 @@ export function hasRunnablePullWork(state: PullSchedulingState): boolean {
   for (const action of state.pending) {
     if (
       isPendingPullActionRunnable(state.pendingPullRunnableState, action) ||
-      (state.isMaterializer(action) && isMaterializerRunnable(state, action))
+      (state.materializerIndex.isMaterializer(action) &&
+        isMaterializerRunnable(state, action))
     ) {
       return true;
     }
@@ -141,7 +143,8 @@ export function hasRunnablePullWork(state: PullSchedulingState): boolean {
         state.dirtyPullRunnableStateWithDebounce,
         action,
       ) ||
-      (state.isMaterializer(action) && isMaterializerRunnable(state, action))
+      (state.materializerIndex.isMaterializer(action) &&
+        isMaterializerRunnable(state, action))
     ) {
       return true;
     }

--- a/packages/runner/src/scheduler/pull-scheduling.ts
+++ b/packages/runner/src/scheduler/pull-scheduling.ts
@@ -37,6 +37,7 @@ export interface PullSchedulingState extends ConditionalEffectState {
   readonly pending: Set<Action>;
   readonly dirty: ReadonlySet<Action>;
   readonly effects: ReadonlySet<Action>;
+  readonly isMaterializer: (action: Action) => boolean;
   readonly dependents: WeakMap<Action, Set<Action>>;
   readonly pendingPullRunnableState: PendingPullRunnableState;
   readonly dirtyPullRunnableState: DirtyPullRunnableState;
@@ -86,6 +87,7 @@ export function collectPullIterationSeeds(
   state: PullSchedulingState,
   workSet: Set<Action>,
 ): void {
+  const initialSize = workSet.size;
   for (const action of state.pending) {
     if (isPendingPullActionRunnable(state.pendingPullRunnableState, action)) {
       workSet.add(action);
@@ -98,11 +100,37 @@ export function collectPullIterationSeeds(
       workSet.add(action);
     }
   }
+
+  if (workSet.size > initialSize || initialSize > 0) {
+    return;
+  }
+
+  for (const action of state.pending) {
+    if (
+      state.isMaterializer(action) &&
+      isMaterializerRunnable(state, action)
+    ) {
+      workSet.add(action);
+    }
+  }
+
+  for (const action of state.dirty) {
+    if (
+      state.isMaterializer(action) &&
+      isMaterializerRunnable(state, action)
+    ) {
+      state.pending.add(action);
+      workSet.add(action);
+    }
+  }
 }
 
 export function hasRunnablePullWork(state: PullSchedulingState): boolean {
   for (const action of state.pending) {
-    if (isPendingPullActionRunnable(state.pendingPullRunnableState, action)) {
+    if (
+      isPendingPullActionRunnable(state.pendingPullRunnableState, action) ||
+      (state.isMaterializer(action) && isMaterializerRunnable(state, action))
+    ) {
       return true;
     }
   }
@@ -112,13 +140,24 @@ export function hasRunnablePullWork(state: PullSchedulingState): boolean {
       isDirtyPullActionRunnable(
         state.dirtyPullRunnableStateWithDebounce,
         action,
-      )
+      ) ||
+      (state.isMaterializer(action) && isMaterializerRunnable(state, action))
     ) {
       return true;
     }
   }
 
   return false;
+}
+
+function isMaterializerRunnable(
+  state: PullSchedulingState,
+  action: Action,
+): boolean {
+  return !state.effects.has(action) &&
+    !state.dirtyPullRunnableStateWithDebounce.isThrottled(action) &&
+    state.dirtyPullRunnableStateWithDebounce
+        .isDebouncedComputationWaiting(action) !== true;
 }
 
 export function hasDeferredDirtyEffectWork(

--- a/packages/runner/src/scheduler/reactivity.ts
+++ b/packages/runner/src/scheduler/reactivity.ts
@@ -8,6 +8,7 @@ import { normalizeCellScope } from "../scope.ts";
 import type {
   IExtendedStorageTransaction,
   IMemorySpaceAddress,
+  TransactionReactivityLog,
 } from "../storage/interface.ts";
 import { reactivityLogFromActivities } from "../storage/reactivity-log.ts";
 import {
@@ -74,8 +75,13 @@ export function trustedEventWriteCandidatesFromTransaction(
     }
   }
 
-  const log = txToReactivityLog(tx);
-  for (const write of [...log.writes, ...(log.potentialWrites ?? [])]) {
+  const transactionLog = txToTransactionReactivityLog(tx);
+  for (
+    const write of [
+      ...transactionLog.writes,
+      ...(transactionLog.attemptedWrites ?? []),
+    ]
+  ) {
     addCandidate(write);
     detailSpaces.add(write.space);
   }
@@ -128,9 +134,25 @@ export function filterIgnoredAddresses(
 export function txToReactivityLog(
   tx: IExtendedStorageTransaction,
 ): ReactivityLog {
+  return toSchedulerReactivityLog(txToTransactionReactivityLog(tx));
+}
+
+function txToTransactionReactivityLog(
+  tx: IExtendedStorageTransaction,
+): TransactionReactivityLog {
   const direct = getDirectTransactionReactivityLog(tx);
   if (direct) {
     return direct;
   }
   return reactivityLogFromActivities(tx.journal.activity());
+}
+
+function toSchedulerReactivityLog(
+  log: TransactionReactivityLog,
+): ReactivityLog {
+  return {
+    reads: log.reads,
+    shallowReads: log.shallowReads,
+    writes: log.writes,
+  };
 }

--- a/packages/runner/src/scheduler/scheduling-writes.ts
+++ b/packages/runner/src/scheduler/scheduling-writes.ts
@@ -292,6 +292,8 @@ export function deriveDynamicCollectionParentWrites(
         declaredWrite.space !== write.space ||
         declaredWrite.id !== write.id ||
         declaredWrite.type !== write.type ||
+        normalizeCellScope(declaredWrite.scope) !==
+          normalizeCellScope(write.scope) ||
         declaredWrite.path.length >= write.path.length ||
         !arraysOverlap(declaredWrite.path, write.path)
       ) {
@@ -318,6 +320,8 @@ export function deriveDeclaredAncestorWrites(
         declaredWrite.space === write.space &&
         declaredWrite.id === write.id &&
         declaredWrite.type === write.type &&
+        normalizeCellScope(declaredWrite.scope) ===
+          normalizeCellScope(write.scope) &&
         declaredWrite.path.length < write.path.length &&
         arraysOverlap(declaredWrite.path, write.path)
       ) {

--- a/packages/runner/src/scheduler/scheduling-writes.ts
+++ b/packages/runner/src/scheduler/scheduling-writes.ts
@@ -285,45 +285,39 @@ export function deriveDynamicCollectionParentWrites(
   writes: readonly IMemorySpaceAddress[],
   declaredWrites: readonly IMemorySpaceAddress[],
 ): IMemorySpaceAddress[] {
-  const parentWrites: IMemorySpaceAddress[] = [];
-  for (const declaredWrite of declaredWrites) {
-    for (const write of writes) {
-      if (
-        declaredWrite.space !== write.space ||
-        declaredWrite.id !== write.id ||
-        declaredWrite.type !== write.type ||
-        normalizeCellScope(declaredWrite.scope) !==
-          normalizeCellScope(write.scope) ||
-        declaredWrite.path.length >= write.path.length ||
-        !arraysOverlap(declaredWrite.path, write.path)
-      ) {
-        continue;
-      }
-
-      const dynamicSegment = write.path[declaredWrite.path.length];
-      if (isDynamicCollectionSegment(dynamicSegment)) {
-        parentWrites.push(declaredWrite);
-      }
-    }
-  }
-  return parentWrites;
+  return deriveDeclaredAncestorWritesMatching(
+    writes,
+    declaredWrites,
+    (declaredWrite, write) =>
+      isDynamicCollectionSegment(write.path[declaredWrite.path.length]),
+  );
 }
 
 export function deriveDeclaredAncestorWrites(
   writes: readonly IMemorySpaceAddress[],
   declaredWrites: readonly IMemorySpaceAddress[],
 ): IMemorySpaceAddress[] {
+  return deriveDeclaredAncestorWritesMatching(
+    writes,
+    declaredWrites,
+    () => true,
+  );
+}
+
+function deriveDeclaredAncestorWritesMatching(
+  writes: readonly IMemorySpaceAddress[],
+  declaredWrites: readonly IMemorySpaceAddress[],
+  predicate: (
+    declaredWrite: IMemorySpaceAddress,
+    write: IMemorySpaceAddress,
+  ) => boolean,
+): IMemorySpaceAddress[] {
   const ancestorWrites: IMemorySpaceAddress[] = [];
   for (const declaredWrite of declaredWrites) {
     for (const write of writes) {
       if (
-        declaredWrite.space === write.space &&
-        declaredWrite.id === write.id &&
-        declaredWrite.type === write.type &&
-        normalizeCellScope(declaredWrite.scope) ===
-          normalizeCellScope(write.scope) &&
-        declaredWrite.path.length < write.path.length &&
-        arraysOverlap(declaredWrite.path, write.path)
+        declaredWriteIsAncestorOfWrite(declaredWrite, write) &&
+        predicate(declaredWrite, write)
       ) {
         ancestorWrites.push(declaredWrite);
         break;
@@ -331,6 +325,19 @@ export function deriveDeclaredAncestorWrites(
     }
   }
   return ancestorWrites;
+}
+
+function declaredWriteIsAncestorOfWrite(
+  declaredWrite: IMemorySpaceAddress,
+  write: IMemorySpaceAddress,
+): boolean {
+  return declaredWrite.space === write.space &&
+    declaredWrite.id === write.id &&
+    declaredWrite.type === write.type &&
+    normalizeCellScope(declaredWrite.scope) ===
+      normalizeCellScope(write.scope) &&
+    declaredWrite.path.length < write.path.length &&
+    arraysOverlap(declaredWrite.path, write.path);
 }
 
 function isDynamicCollectionSegment(

--- a/packages/runner/src/scheduler/scheduling-writes.ts
+++ b/packages/runner/src/scheduler/scheduling-writes.ts
@@ -179,9 +179,14 @@ export function buildKnownSchedulingWrites(state: {
     state.writes,
     state.declaredWrites,
   );
+  const declaredAncestorWrites = deriveDeclaredAncestorWrites(
+    state.writes,
+    state.declaredWrites,
+  );
   const newCurrentKnownWrites = sortAndCompactPaths([
     ...currentSeedWrites,
     ...dynamicParentWrites,
+    ...declaredAncestorWrites,
   ]);
   const newHistoricalMightWrite = sortAndCompactPaths([
     ...state.existingHistoricalWrites,
@@ -300,6 +305,28 @@ export function deriveDynamicCollectionParentWrites(
     }
   }
   return parentWrites;
+}
+
+export function deriveDeclaredAncestorWrites(
+  writes: readonly IMemorySpaceAddress[],
+  declaredWrites: readonly IMemorySpaceAddress[],
+): IMemorySpaceAddress[] {
+  const ancestorWrites: IMemorySpaceAddress[] = [];
+  for (const declaredWrite of declaredWrites) {
+    for (const write of writes) {
+      if (
+        declaredWrite.space === write.space &&
+        declaredWrite.id === write.id &&
+        declaredWrite.type === write.type &&
+        declaredWrite.path.length < write.path.length &&
+        arraysOverlap(declaredWrite.path, write.path)
+      ) {
+        ancestorWrites.push(declaredWrite);
+        break;
+      }
+    }
+  }
+  return ancestorWrites;
 }
 
 function isDynamicCollectionSegment(

--- a/packages/runner/src/scheduler/scheduling-writes.ts
+++ b/packages/runner/src/scheduler/scheduling-writes.ts
@@ -36,7 +36,7 @@ export interface SchedulingWriteState {
 export class SchedulerWriteIndex
   implements WriterIndexState, SchedulingWriteState {
   // Current-known writes are rebuilt on each dependency update from actual
-  // writes plus declared/potential writes. This is the default scheduling view.
+  // writes plus declared writes. This is the default scheduling view.
   readonly currentKnownWrites = new WeakMap<Action, IMemorySpaceAddress[]>();
   // Historical writes preserve the legacy cumulative union and are only used
   // when the experimental historical-write mode is enabled.
@@ -163,7 +163,6 @@ export function updateWriterIndex(
 
 export function buildKnownSchedulingWrites(state: {
   readonly writes: readonly IMemorySpaceAddress[];
-  readonly potentialWrites: readonly IMemorySpaceAddress[];
   readonly declaredWrites: readonly IMemorySpaceAddress[];
   readonly existingCurrentWrites: readonly IMemorySpaceAddress[];
   readonly existingHistoricalWrites: readonly IMemorySpaceAddress[];
@@ -183,7 +182,6 @@ export function buildKnownSchedulingWrites(state: {
   const newCurrentKnownWrites = sortAndCompactPaths([
     ...currentSeedWrites,
     ...dynamicParentWrites,
-    ...state.potentialWrites,
   ]);
   const newHistoricalMightWrite = sortAndCompactPaths([
     ...state.existingHistoricalWrites,

--- a/packages/runner/src/scheduler/staleness.ts
+++ b/packages/runner/src/scheduler/staleness.ts
@@ -1,4 +1,5 @@
 import type { Action } from "./types.ts";
+import type { MaterializerIndexState } from "./materializers.ts";
 
 export class SchedulerStaleness {
   readonly dirty = new Set<Action>();
@@ -120,7 +121,7 @@ export interface DirtySchedulingState {
   readonly scheduleComputationDebounce: (action: Action) => void;
   readonly clearComputationDebounceState: (action: Action) => void;
   readonly isDemandedPullComputation: (action: Action) => boolean;
-  readonly isIdleRunnableComputation?: (action: Action) => boolean;
+  readonly materializerIndex: MaterializerIndexState;
   readonly queueExecution: () => void;
 }
 
@@ -153,7 +154,7 @@ export function markSchedulerDirty(
   state.scheduleComputationDebounce(action);
   if (
     state.isDemandedPullComputation(action) ||
-    state.isIdleRunnableComputation?.(action) === true
+    state.materializerIndex.isMaterializer(action)
   ) {
     state.queueExecution();
   }

--- a/packages/runner/src/scheduler/staleness.ts
+++ b/packages/runner/src/scheduler/staleness.ts
@@ -120,6 +120,7 @@ export interface DirtySchedulingState {
   readonly scheduleComputationDebounce: (action: Action) => void;
   readonly clearComputationDebounceState: (action: Action) => void;
   readonly isDemandedPullComputation: (action: Action) => boolean;
+  readonly isIdleRunnableComputation?: (action: Action) => boolean;
   readonly queueExecution: () => void;
 }
 
@@ -150,7 +151,10 @@ export function markSchedulerDirty(
 ): void {
   state.staleness.markDirectDirty(action);
   state.scheduleComputationDebounce(action);
-  if (state.isDemandedPullComputation(action)) {
+  if (
+    state.isDemandedPullComputation(action) ||
+    state.isIdleRunnableComputation?.(action) === true
+  ) {
     state.queueExecution();
   }
 }

--- a/packages/runner/src/scheduler/subscriptions.ts
+++ b/packages/runner/src/scheduler/subscriptions.ts
@@ -269,6 +269,7 @@ export interface SchedulerUnsubscribeActionState {
   readonly effects: Set<Action>;
   readonly computations: Set<Action>;
   readonly pullDemandedFirstRunComputations: WeakSet<Action>;
+  readonly pullDemandedContinuationComputations: WeakSet<Action>;
   readonly writeIndex: WriterIndexState;
   readonly populateDependenciesCallbacks: WeakMap<
     Action,
@@ -371,6 +372,7 @@ function clearActionTypeTracking(
   state.effects.delete(action);
   state.computations.delete(action);
   state.pullDemandedFirstRunComputations.delete(action);
+  state.pullDemandedContinuationComputations.delete(action);
 }
 
 function removeActionWriteIndexes(

--- a/packages/runner/src/scheduler/topology.ts
+++ b/packages/runner/src/scheduler/topology.ts
@@ -50,6 +50,9 @@ export function topologicalSort(
   mightWrite: WeakMap<Action, IMemorySpaceAddress[]>,
   actionParent?: WeakMap<Action, Action>,
   dependents?: WeakMap<Action, Set<Action>>,
+  getAdditionalWrites?: (
+    action: Action,
+  ) => readonly IMemorySpaceAddress[] | undefined,
 ): Action[] {
   const graph = new Map<Action, Set<Action>>();
   const inDegree = new Map<Action, number>();
@@ -106,6 +109,16 @@ export function topologicalSort(
         }
       }
     }
+  }
+
+  if (getAdditionalWrites) {
+    addAdditionalWriteEdges({
+      actions,
+      dependencies,
+      graph,
+      inDegree,
+      getAdditionalWrites,
+    });
   }
 
   // Add parent-child edges only when no opposing data dependency exists.
@@ -180,4 +193,47 @@ export function topologicalSort(
   }
 
   return result;
+}
+
+function addAdditionalWriteEdges(state: {
+  readonly actions: Set<Action>;
+  readonly dependencies: WeakMap<Action, ReactivityLog>;
+  readonly graph: Map<Action, Set<Action>>;
+  readonly inDegree: Map<Action, number>;
+  readonly getAdditionalWrites: (
+    action: Action,
+  ) => readonly IMemorySpaceAddress[] | undefined;
+}): void {
+  for (const actionA of state.actions) {
+    const writes = state.getAdditionalWrites(actionA) ?? [];
+    if (writes.length === 0) continue;
+
+    const graphA = state.graph.get(actionA)!;
+    for (const actionB of state.actions) {
+      if (actionA === actionB || graphA.has(actionB)) continue;
+      const logB = state.dependencies.get(actionB);
+      if (!logB) continue;
+      if (
+        logB.reads.some(
+          (addr) =>
+            writes.some((write) =>
+              addr.space === write.space &&
+              addr.id === write.id &&
+              arraysOverlap(write.path, addr.path)
+            ),
+        ) ||
+        logB.shallowReads.some(
+          (addr) =>
+            writes.some((write) =>
+              addr.space === write.space &&
+              addr.id === write.id &&
+              nonRecursiveReadMayOverlapWrite(addr.path, write.path)
+            ),
+        )
+      ) {
+        graphA.add(actionB);
+        state.inDegree.set(actionB, (state.inDegree.get(actionB) || 0) + 1);
+      }
+    }
+  }
 }

--- a/packages/runner/src/scheduler/topology.ts
+++ b/packages/runner/src/scheduler/topology.ts
@@ -3,6 +3,7 @@ import {
   arraysOverlap,
   nonRecursiveReadMayOverlapWrite,
 } from "../reactive-dependencies.ts";
+import { normalizeCellScope } from "../scope.ts";
 import type { IMemorySpaceAddress } from "../storage/interface.ts";
 import type { Action, ReactivityLog } from "./types.ts";
 
@@ -91,14 +92,12 @@ export function topologicalSort(
             if (
               logB.reads.some(
                 (addr) =>
-                  addr.space === write.space &&
-                  addr.id === write.id &&
+                  addressesShareEntity(addr, write) &&
                   arraysOverlap(write.path, addr.path),
               ) ||
               logB.shallowReads.some(
                 (addr) =>
-                  addr.space === write.space &&
-                  addr.id === write.id &&
+                  addressesShareEntity(addr, write) &&
                   nonRecursiveReadMayOverlapWrite(addr.path, write.path),
               )
             ) {
@@ -217,16 +216,14 @@ function addAdditionalWriteEdges(state: {
         logB.reads.some(
           (addr) =>
             writes.some((write) =>
-              addr.space === write.space &&
-              addr.id === write.id &&
+              addressesShareEntity(addr, write) &&
               arraysOverlap(write.path, addr.path)
             ),
         ) ||
         logB.shallowReads.some(
           (addr) =>
             writes.some((write) =>
-              addr.space === write.space &&
-              addr.id === write.id &&
+              addressesShareEntity(addr, write) &&
               nonRecursiveReadMayOverlapWrite(addr.path, write.path)
             ),
         )
@@ -236,4 +233,13 @@ function addAdditionalWriteEdges(state: {
       }
     }
   }
+}
+
+function addressesShareEntity(
+  a: IMemorySpaceAddress,
+  b: IMemorySpaceAddress,
+): boolean {
+  return a.space === b.space &&
+    a.id === b.id &&
+    normalizeCellScope(a.scope) === normalizeCellScope(b.scope);
 }

--- a/packages/runner/src/scheduler/types.ts
+++ b/packages/runner/src/scheduler/types.ts
@@ -16,6 +16,7 @@ export interface TelemetryAnnotations {
   module: Module;
   reads: NormalizedFullLink[];
   writes: NormalizedFullLink[];
+  materializerWriteEnvelopes?: NormalizedFullLink[];
   ignoredSchedulingWrites?: NormalizedFullLink[];
 }
 
@@ -59,8 +60,6 @@ export type ReactivityLog = {
   /** Reads that should not invalidate on child writes unless they add a new key */
   shallowReads: IMemorySpaceAddress[];
   writes: IMemorySpaceAddress[];
-  /** Reads marked as potential writes (e.g., for diffAndUpdate which reads then conditionally writes) */
-  potentialWrites?: IMemorySpaceAddress[];
 };
 
 export type PopulateDependenciesEntry = PopulateDependencies | ReactivityLog;

--- a/packages/runner/src/scheduler/write-propagation.ts
+++ b/packages/runner/src/scheduler/write-propagation.ts
@@ -5,6 +5,7 @@ import type {
   IMemorySpaceAddress,
 } from "../storage/interface.ts";
 import { getTransactionWriteDetails } from "../storage/transaction-inspection.ts";
+import type { MaterializerIndexState } from "./materializers.ts";
 import type { TriggerIndexState } from "./trigger-index.ts";
 import type { Action, ReactivityLog } from "./types.ts";
 
@@ -19,7 +20,7 @@ export interface WritePropagationState {
   readonly markPullDemandContinuation: (action: Action) => void;
   readonly scheduleWithDebounce: (action: Action) => void;
   readonly markDirty: (action: Action) => void;
-  readonly isMaterializer: (action: Action) => boolean;
+  readonly materializerIndex: MaterializerIndexState;
   readonly scheduleAffectedEffects: (action: Action) => void;
   readonly queueExecution: () => void;
 }
@@ -81,7 +82,7 @@ export function markReadersDirtyForChangedWrites(
         state.pending.add(reader);
         state.queueExecution();
       }
-      if (!state.isMaterializer(reader)) {
+      if (!state.materializerIndex.isMaterializer(reader)) {
         state.scheduleAffectedEffects(reader);
       }
     }

--- a/packages/runner/src/scheduler/write-propagation.ts
+++ b/packages/runner/src/scheduler/write-propagation.ts
@@ -73,6 +73,10 @@ export function markReadersDirtyForChangedWrites(
     } else if (state.computations.has(reader)) {
       state.markDirty(reader);
       if (isAncestorAction(state.actionParent, sourceAction, reader)) {
+        // Continuations are only for actions in the scheduler parent chain.
+        // Dependency edges already schedule ordinary downstream readers; this
+        // handles the narrower case where a child created during a pull writes
+        // something its already-run parent read.
         state.markPullDemandContinuation(reader);
         state.pending.add(reader);
         state.queueExecution();

--- a/packages/runner/src/scheduler/write-propagation.ts
+++ b/packages/runner/src/scheduler/write-propagation.ts
@@ -16,6 +16,7 @@ export interface WritePropagationState {
   readonly conditionallyScheduledEffects: Map<Action, number>;
   readonly scheduleWithDebounce: (action: Action) => void;
   readonly markDirty: (action: Action) => void;
+  readonly isMaterializer: (action: Action) => boolean;
   readonly scheduleAffectedEffects: (action: Action) => void;
 }
 
@@ -67,7 +68,9 @@ export function markReadersDirtyForChangedWrites(
       state.scheduleWithDebounce(reader);
     } else if (state.computations.has(reader)) {
       state.markDirty(reader);
-      state.scheduleAffectedEffects(reader);
+      if (!state.isMaterializer(reader)) {
+        state.scheduleAffectedEffects(reader);
+      }
     }
   }
 }

--- a/packages/runner/src/scheduler/write-propagation.ts
+++ b/packages/runner/src/scheduler/write-propagation.ts
@@ -14,10 +14,14 @@ export interface WritePropagationState {
   readonly effects: ReadonlySet<Action>;
   readonly computations: ReadonlySet<Action>;
   readonly conditionallyScheduledEffects: Map<Action, number>;
+  readonly actionParent: WeakMap<Action, Action>;
+  readonly pending: Set<Action>;
+  readonly markPullDemandContinuation: (action: Action) => void;
   readonly scheduleWithDebounce: (action: Action) => void;
   readonly markDirty: (action: Action) => void;
   readonly isMaterializer: (action: Action) => boolean;
   readonly scheduleAffectedEffects: (action: Action) => void;
+  readonly queueExecution: () => void;
 }
 
 export function recordChangedComputationWrites(
@@ -68,9 +72,27 @@ export function markReadersDirtyForChangedWrites(
       state.scheduleWithDebounce(reader);
     } else if (state.computations.has(reader)) {
       state.markDirty(reader);
+      if (isAncestorAction(state.actionParent, sourceAction, reader)) {
+        state.markPullDemandContinuation(reader);
+        state.pending.add(reader);
+        state.queueExecution();
+      }
       if (!state.isMaterializer(reader)) {
         state.scheduleAffectedEffects(reader);
       }
     }
   }
+}
+
+function isAncestorAction(
+  actionParent: WeakMap<Action, Action>,
+  sourceAction: Action,
+  candidateAncestor: Action,
+): boolean {
+  let parent = actionParent.get(sourceAction);
+  while (parent) {
+    if (parent === candidateAncestor) return true;
+    parent = actionParent.get(parent);
+  }
+  return false;
 }

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -232,7 +232,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     }
 
     const log = this.getReactivityLog();
-    const potentialWrites: AttemptedWrite[] = (log.potentialWrites ?? []).map(
+    const attemptedWrites: AttemptedWrite[] = (log.attemptedWrites ?? []).map(
       (address) =>
         deepFreeze({
           ...address,
@@ -257,7 +257,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
 
     return {
       consumedReads,
-      potentialWrites,
+      attemptedWrites,
       writes,
       dereferenceTraces: [...this.cfcState.dereferenceTraces],
       writePolicyInputs: [...this.cfcState.writePolicyInputs],

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -745,7 +745,7 @@ export interface IExtendedStorageTransaction extends IStorageTransaction {
    * Internal runner API. Phase-1 CFC no-op attempted-target coverage is not
    * derived from blind direct `write*()` calls. Callers that need attempted
    * target coverage before same-value short-circuiting must first establish it
-   * through a higher-level diff path such as `markReadAsPotentialWrite`.
+   * through a higher-level diff path such as `markReadAsAttemptedWrite`.
    * Runner-owned system metadata writes may also use this directly when they
    * are intentionally out of phase-1 value-surface CFC scope.
    *
@@ -767,7 +767,7 @@ export interface IExtendedStorageTransaction extends IStorageTransaction {
    * Internal runner API with the same phase-1 CFC caveat as `writeOrThrow()`:
    * blind same-value direct writes do not by themselves establish attempted
    * target coverage. Use higher-level diff paths when no-op attempted writes
-   * need to appear in `potentialWrites`.
+   * need to appear in `attemptedWrites`.
    *
    * @param address - Memory address to write to.
    * @param value - Value to write.
@@ -1074,7 +1074,7 @@ export interface TransactionReactivityLog {
   reads: IMemorySpaceAddress[];
   shallowReads: IMemorySpaceAddress[];
   writes: IMemorySpaceAddress[];
-  potentialWrites?: IMemorySpaceAddress[];
+  attemptedWrites?: IMemorySpaceAddress[];
 }
 
 export interface TransactionWriteDetail {

--- a/packages/runner/src/storage/reactivity-log.ts
+++ b/packages/runner/src/storage/reactivity-log.ts
@@ -10,8 +10,8 @@ const ignoreReadForSchedulingMarker: unique symbol = Symbol(
   "ignoreReadForSchedulingMarker",
 );
 
-const markReadAsPotentialWriteMarker: unique symbol = Symbol(
-  "markReadAsPotentialWriteMarker",
+const markReadAsAttemptedWriteMarker: unique symbol = Symbol(
+  "markReadAsAttemptedWriteMarker",
 );
 
 const allowMutableTransactionReadMarker: unique symbol = Symbol(
@@ -26,8 +26,8 @@ export const ignoreReadForScheduling: Metadata = {
   [ignoreReadForSchedulingMarker]: true,
 };
 
-export const markReadAsPotentialWrite: Metadata = {
-  [markReadAsPotentialWriteMarker]: true,
+export const markReadAsAttemptedWrite: Metadata = {
+  [markReadAsAttemptedWriteMarker]: true,
 };
 
 export const allowMutableTransactionRead: Metadata = {
@@ -42,8 +42,8 @@ export function isReadIgnoredForScheduling(meta?: Metadata): boolean {
   return meta?.[ignoreReadForSchedulingMarker] === true;
 }
 
-export function isReadMarkedAsPotentialWrite(meta?: Metadata): boolean {
-  return meta?.[markReadAsPotentialWriteMarker] === true;
+export function isReadMarkedAsAttemptedWrite(meta?: Metadata): boolean {
+  return meta?.[markReadAsAttemptedWriteMarker] === true;
 }
 
 export function isMutableTransactionReadAllowed(meta?: Metadata): boolean {
@@ -78,9 +78,9 @@ export function reactivityLogFromActivities(
       } else {
         log.reads.push(address);
       }
-      if (isReadMarkedAsPotentialWrite(activity.read.meta)) {
-        log.potentialWrites ??= [];
-        log.potentialWrites.push(address);
+      if (isReadMarkedAsAttemptedWrite(activity.read.meta)) {
+        log.attemptedWrites ??= [];
+        log.attemptedWrites.push(address);
       }
       continue;
     }

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -63,7 +63,7 @@ import {
 import {
   isMutableTransactionReadAllowed,
   isReadIgnoredForScheduling,
-  isReadMarkedAsPotentialWrite,
+  isReadMarkedAsAttemptedWrite,
 } from "./reactivity-log.ts";
 import {
   createPathContainer,
@@ -1668,7 +1668,7 @@ export class V2StorageTransaction implements IStorageTransaction {
   private buildReactivityLog(): TransactionReactivityLog {
     const reads: IMemorySpaceAddress[] = [];
     const shallowReads: IMemorySpaceAddress[] = [];
-    let potentialWrites: IMemorySpaceAddress[] | undefined;
+    let attemptedWrites: IMemorySpaceAddress[] | undefined;
 
     for (const read of this.#readActivities) {
       const meta = read.meta ?? EMPTY_META;
@@ -1689,9 +1689,9 @@ export class V2StorageTransaction implements IStorageTransaction {
         reads.push(address);
       }
 
-      if (isReadMarkedAsPotentialWrite(meta)) {
-        potentialWrites ??= [];
-        potentialWrites.push(address);
+      if (isReadMarkedAsAttemptedWrite(meta)) {
+        attemptedWrites ??= [];
+        attemptedWrites.push(address);
       }
     }
 
@@ -1733,8 +1733,8 @@ export class V2StorageTransaction implements IStorageTransaction {
       reads,
       shallowReads,
       writes,
-      ...(potentialWrites && potentialWrites.length > 0
-        ? { potentialWrites }
+      ...(attemptedWrites && attemptedWrites.length > 0
+        ? { attemptedWrites }
         : {}),
     };
   }

--- a/packages/runner/test/cfc-boundary.test.ts
+++ b/packages/runner/test/cfc-boundary.test.ts
@@ -1585,14 +1585,14 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     }
   });
 
-  it("keeps no-op attempted targets in potentialWrites for labeled paths", async () => {
+  it("keeps no-op attempted targets in attemptedWrites for labeled paths", async () => {
     const { runtime, storageManager } = createRuntime();
     try {
       const seed = runtime.edit();
       seed.setCfcEnforcementMode("enforce-explicit");
       const seededCell = runtime.getCell(
         signer.did(),
-        "cfc-noop-potential-write",
+        "cfc-noop-attempted-write",
         {
           type: "object",
           properties: {
@@ -1615,7 +1615,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
       tx.setCfcEnforcementMode("enforce-explicit");
       const cell = runtime.getCell(
         signer.did(),
-        "cfc-noop-potential-write",
+        "cfc-noop-attempted-write",
         {
           type: "object",
           properties: {
@@ -1634,7 +1634,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
       const digestInput = (
         tx as unknown as {
           buildPreparedDigestInput(): {
-            potentialWrites: Array<{
+            attemptedWrites: Array<{
               space: string;
               scope: "space";
               id: string;
@@ -1645,7 +1645,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
           };
         }
       ).buildPreparedDigestInput();
-      expect(digestInput.potentialWrites).toContainEqual({
+      expect(digestInput.attemptedWrites).toContainEqual({
         space: signer.did(),
         scope: "space",
         id: seededId,

--- a/packages/runner/test/cfc-boundary.test.ts
+++ b/packages/runner/test/cfc-boundary.test.ts
@@ -115,7 +115,7 @@ describe("CFC canonicalization helpers", () => {
         id: "of:doc",
         path: ["value", "a"],
       }],
-      potentialWrites: [],
+      attemptedWrites: [],
       writes: [],
       dereferenceTraces: [],
       writePolicyInputs: [{

--- a/packages/runner/test/cfc-canonicalize.bench.ts
+++ b/packages/runner/test/cfc-canonicalize.bench.ts
@@ -56,7 +56,7 @@ const warm = (input: PreparedDigestInput): PreparedDigestInput => {
     deepFreeze({ ...a, path: canonicalizeLogicalPath(a.path) });
   return deepFreeze({
     consumedReads: input.consumedReads.map(warmAddr),
-    potentialWrites: input.potentialWrites.map(warmAddr),
+    attemptedWrites: input.attemptedWrites.map(warmAddr),
     writes: input.writes.map(warmAddr),
     dereferenceTraces: input.dereferenceTraces.map((t) =>
       deepFreeze({
@@ -79,7 +79,7 @@ const SMALL_INPUT: PreparedDigestInput = {
     makeAddress("a", "items"),
     makeAddress("b", "title"),
   ],
-  potentialWrites: [
+  attemptedWrites: [
     makeAddress("a", "items", 0),
   ],
   writes: [
@@ -105,7 +105,7 @@ const LARGE_INPUT: PreparedDigestInput = {
     { length: 12 },
     (_, i) => makeAddress(`r${i}`, "field", i),
   ),
-  potentialWrites: Array.from(
+  attemptedWrites: Array.from(
     { length: 4 },
     (_, i) => makeAddress(`w${i}`, "out", i),
   ),
@@ -160,7 +160,7 @@ const LARGE_INPUT: PreparedDigestInput = {
 // any future regression in the cache-eligibility pathway.
 const TIEBREAK_HEAVY_INPUT: PreparedDigestInput = {
   consumedReads: [],
-  potentialWrites: [],
+  attemptedWrites: [],
   writes: [],
   dereferenceTraces: [],
   writePolicyInputs: freezePolicies(
@@ -190,7 +190,7 @@ const PATH_HEAVY_INPUT: PreparedDigestInput = {
     scope: "space" as const,
     path: ["value", "items", String(i), "field", String(i)],
   })),
-  potentialWrites: Array.from({ length: 4 }, (_, i) => ({
+  attemptedWrites: Array.from({ length: 4 }, (_, i) => ({
     space: SPACE,
     id: "of:doc-shared",
     scope: "space" as const,

--- a/packages/runner/test/scheduler-core.test.ts
+++ b/packages/runner/test/scheduler-core.test.ts
@@ -1072,11 +1072,11 @@ describe("scheduler", () => {
     expect(resultCell.get()).toEqual({ count: 2, version: 1 });
   });
 
-  it("should track potentialWrites via Cell.set on nested path", async () => {
+  it("should track attemptedWrites via Cell.set on nested path", async () => {
     // Create a cell with nested structure
     const testCell = runtime.getCell<{ nested: { a: number; b: string } }>(
       space,
-      "potential-writes-cell-set-test",
+      "attempted-writes-cell-set-test",
       undefined,
       tx,
     );
@@ -1090,11 +1090,17 @@ describe("scheduler", () => {
 
     const log = txToReactivityLog(setTx);
 
-    // key("nested").set() reads the nested object to compare
-    // The "nested" path should appear in potentialWrites
-    expect(log.potentialWrites).toBeDefined();
+    // key("nested").set() reads the nested object to compare.
+    // The "nested" path should appear in attemptedWrites for CFC/security,
+    // but scheduler-facing potentialWrites should no longer exist.
+    const logWithAttemptedWrites = log as typeof log & {
+      attemptedWrites?: typeof log.writes;
+      potentialWrites?: typeof log.writes;
+    };
+    expect(logWithAttemptedWrites.attemptedWrites).toBeDefined();
+    expect(logWithAttemptedWrites.potentialWrites).toBeUndefined();
     expect(
-      log.potentialWrites!.some((addr) =>
+      logWithAttemptedWrites.attemptedWrites!.some((addr) =>
         addr.path[0] === "value" && addr.path[1] === "nested"
       ),
     ).toBe(true);
@@ -1115,13 +1121,13 @@ describe("scheduler", () => {
     await setTx.commit();
   });
 
-  it("should include nested path in potentialWrites when using key().set()", async () => {
+  it("should include nested path in attemptedWrites when using key().set()", async () => {
     // Create a cell with nested structure
     const testCell = runtime.getCell<{
       data: { unchanged: number; changed: number };
     }>(
       space,
-      "diff-update-potential-writes-cell",
+      "diff-update-attempted-writes-cell",
       undefined,
       tx,
     );
@@ -1135,11 +1141,16 @@ describe("scheduler", () => {
 
     const log = txToReactivityLog(setTx);
 
-    // The "data" path should be in potentialWrites because diffAndUpdate
-    // reads the nested object to compare
-    expect(log.potentialWrites).toBeDefined();
+    // The "data" path should be in attemptedWrites because diffAndUpdate
+    // reads the nested object to compare.
+    const logWithAttemptedWrites = log as typeof log & {
+      attemptedWrites?: typeof log.writes;
+      potentialWrites?: typeof log.writes;
+    };
+    expect(logWithAttemptedWrites.attemptedWrites).toBeDefined();
+    expect(logWithAttemptedWrites.potentialWrites).toBeUndefined();
     expect(
-      log.potentialWrites!.some((addr) =>
+      logWithAttemptedWrites.attemptedWrites!.some((addr) =>
         addr.path[0] === "value" && addr.path[1] === "data"
       ),
     ).toBe(true);
@@ -1162,10 +1173,10 @@ describe("scheduler", () => {
     await setTx.commit();
   });
 
-  it("should not have potentialWrites when using getRaw without metadata", async () => {
+  it("should not have attemptedWrites when using getRaw without metadata", async () => {
     const testCell = runtime.getCell<{ value: number }>(
       space,
-      "no-potential-writes-cell",
+      "no-attempted-writes-cell",
       undefined,
       tx,
     );
@@ -1173,15 +1184,20 @@ describe("scheduler", () => {
     tx.commit();
     tx = runtime.edit();
 
-    // getRaw without metadata should not create potentialWrites
+    // getRaw without metadata should not create attemptedWrites
     const readTx = runtime.edit();
     testCell.withTx(readTx).key("value").getRaw();
 
     const log = txToReactivityLog(readTx);
 
-    // Should have reads but no potentialWrites
+    // Should have reads but no attemptedWrites
+    const logWithAttemptedWrites = log as typeof log & {
+      attemptedWrites?: typeof log.writes;
+      potentialWrites?: typeof log.writes;
+    };
     expect(log.reads.length).toBeGreaterThanOrEqual(1);
-    expect(log.potentialWrites).toBeUndefined();
+    expect(logWithAttemptedWrites.attemptedWrites).toBeUndefined();
+    expect(logWithAttemptedWrites.potentialWrites).toBeUndefined();
 
     await readTx.commit();
   });

--- a/packages/runner/test/scheduler-core.test.ts
+++ b/packages/runner/test/scheduler-core.test.ts
@@ -23,6 +23,7 @@ import type {
   IExtendedStorageTransaction,
   SchedulerTestStorageManager,
 } from "./scheduler-test-utils.ts";
+import { getDirectTransactionReactivityLog } from "../src/storage/transaction-inspection.ts";
 
 describe("scheduler", () => {
   let storageManager: SchedulerTestStorageManager;
@@ -1088,32 +1089,34 @@ describe("scheduler", () => {
     const setTx = runtime.edit();
     testCell.withTx(setTx).key("nested").set({ a: 1, b: "world" });
 
-    const log = txToReactivityLog(setTx);
+    const storageLog = getDirectTransactionReactivityLog(setTx)!;
+    const schedulerLog = txToReactivityLog(setTx);
 
     // key("nested").set() reads the nested object to compare.
     // The "nested" path should appear in attemptedWrites for CFC/security,
-    // but scheduler-facing potentialWrites should no longer exist.
-    const logWithAttemptedWrites = log as typeof log & {
-      attemptedWrites?: typeof log.writes;
-      potentialWrites?: typeof log.writes;
-    };
-    expect(logWithAttemptedWrites.attemptedWrites).toBeDefined();
-    expect(logWithAttemptedWrites.potentialWrites).toBeUndefined();
+    // but scheduler-facing ReactivityLog should not expose attemptedWrites.
+    const schedulerLogWithAttemptedWrites = schedulerLog as
+      & typeof schedulerLog
+      & {
+        attemptedWrites?: typeof schedulerLog.writes;
+      };
+    expect(storageLog.attemptedWrites).toBeDefined();
+    expect(schedulerLogWithAttemptedWrites.attemptedWrites).toBeUndefined();
     expect(
-      logWithAttemptedWrites.attemptedWrites!.some((addr) =>
+      storageLog.attemptedWrites!.some((addr) =>
         addr.path[0] === "value" && addr.path[1] === "nested"
       ),
     ).toBe(true);
 
     // Only `b` changed within nested, so nested.b should be in writes
     expect(
-      log.writes.some((w) =>
+      schedulerLog.writes.some((w) =>
         w.path[0] === "value" && w.path[1] === "nested" && w.path[2] === "b"
       ),
     ).toBe(true);
     // nested.a should NOT be in writes (value didn't change)
     expect(
-      log.writes.some((w) =>
+      schedulerLog.writes.some((w) =>
         w.path[0] === "value" && w.path[1] === "nested" && w.path[2] === "a"
       ),
     ).toBe(false);
@@ -1139,32 +1142,34 @@ describe("scheduler", () => {
     const setTx = runtime.edit();
     testCell.withTx(setTx).key("data").set({ unchanged: 42, changed: 999 });
 
-    const log = txToReactivityLog(setTx);
+    const storageLog = getDirectTransactionReactivityLog(setTx)!;
+    const schedulerLog = txToReactivityLog(setTx);
 
     // The "data" path should be in attemptedWrites because diffAndUpdate
     // reads the nested object to compare.
-    const logWithAttemptedWrites = log as typeof log & {
-      attemptedWrites?: typeof log.writes;
-      potentialWrites?: typeof log.writes;
-    };
-    expect(logWithAttemptedWrites.attemptedWrites).toBeDefined();
-    expect(logWithAttemptedWrites.potentialWrites).toBeUndefined();
+    const schedulerLogWithAttemptedWrites = schedulerLog as
+      & typeof schedulerLog
+      & {
+        attemptedWrites?: typeof schedulerLog.writes;
+      };
+    expect(storageLog.attemptedWrites).toBeDefined();
+    expect(schedulerLogWithAttemptedWrites.attemptedWrites).toBeUndefined();
     expect(
-      logWithAttemptedWrites.attemptedWrites!.some((addr) =>
+      storageLog.attemptedWrites!.some((addr) =>
         addr.path[0] === "value" && addr.path[1] === "data"
       ),
     ).toBe(true);
 
     // Only changed property within data should be in writes
     expect(
-      log.writes.some((w) =>
+      schedulerLog.writes.some((w) =>
         w.path[0] === "value" && w.path[1] === "data" &&
         w.path[2] === "changed"
       ),
     ).toBe(true);
     // unchanged property should NOT be in writes (value didn't change)
     expect(
-      log.writes.some((w) =>
+      schedulerLog.writes.some((w) =>
         w.path[0] === "value" && w.path[1] === "data" &&
         w.path[2] === "unchanged"
       ),
@@ -1188,16 +1193,18 @@ describe("scheduler", () => {
     const readTx = runtime.edit();
     testCell.withTx(readTx).key("value").getRaw();
 
-    const log = txToReactivityLog(readTx);
+    const storageLog = getDirectTransactionReactivityLog(readTx)!;
+    const schedulerLog = txToReactivityLog(readTx);
 
     // Should have reads but no attemptedWrites
-    const logWithAttemptedWrites = log as typeof log & {
-      attemptedWrites?: typeof log.writes;
-      potentialWrites?: typeof log.writes;
-    };
-    expect(log.reads.length).toBeGreaterThanOrEqual(1);
-    expect(logWithAttemptedWrites.attemptedWrites).toBeUndefined();
-    expect(logWithAttemptedWrites.potentialWrites).toBeUndefined();
+    const schedulerLogWithAttemptedWrites = schedulerLog as
+      & typeof schedulerLog
+      & {
+        attemptedWrites?: typeof schedulerLog.writes;
+      };
+    expect(schedulerLog.reads.length).toBeGreaterThanOrEqual(1);
+    expect(storageLog.attemptedWrites).toBeUndefined();
+    expect(schedulerLogWithAttemptedWrites.attemptedWrites).toBeUndefined();
 
     await readTx.commit();
   });

--- a/packages/runner/test/scheduler-effects.test.ts
+++ b/packages/runner/test/scheduler-effects.test.ts
@@ -16,6 +16,7 @@ import {
 } from "./scheduler-test-utils.ts";
 import type {
   Action,
+  EventHandler,
   IExtendedStorageTransaction,
   ReactivityLog,
   SchedulerTestStorageManager,
@@ -659,5 +660,351 @@ describe("effect/computation tracking", () => {
       .toBe(true);
     expect(runtime.scheduler.getDependents(materializer).has(stableEffect))
       .toBe(false);
+  });
+
+  it("should coalesce dirty materializer runs behind manual debounce", async () => {
+    runtime.scheduler.enablePullMode();
+
+    const source = runtime.getCell<number>(
+      space,
+      "materializer-debounce-source",
+      undefined,
+      tx,
+    );
+    const target = runtime.getCell<{ value: number }>(
+      space,
+      "materializer-debounce-target",
+      undefined,
+      tx,
+    );
+    source.set(0);
+    target.set({ value: 0 });
+    await tx.commit();
+    tx = runtime.edit();
+
+    let materializerRuns = 0;
+    const materializer = Object.assign(
+      (actionTx: IExtendedStorageTransaction) => {
+        materializerRuns++;
+        target.withTx(actionTx).set({ value: source.withTx(actionTx).get() });
+      },
+      {
+        materializerWriteEnvelopes: [target.getAsNormalizedFullLink()],
+      },
+    ) as Action & {
+      materializerWriteEnvelopes: ReturnType<
+        typeof target.getAsNormalizedFullLink
+      >[];
+    };
+
+    runtime.scheduler.subscribe(materializer, {
+      reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
+      shallowReads: [],
+      writes: [],
+    }, { debounce: 20 });
+    await runtime.idle();
+    expect(materializerRuns).toBe(1);
+
+    for (const value of [1, 2, 3]) {
+      const updateTx = runtime.edit();
+      source.withTx(updateTx).set(value);
+      await updateTx.commit();
+    }
+    await runtime.idle();
+
+    expect(materializerRuns).toBe(2);
+    expect(target.get()).toEqual({ value: 3 });
+  });
+
+  it("should fan out materializer changes only to actual changed readers", async () => {
+    runtime.scheduler.enablePullMode();
+
+    const source = runtime.getCell<number>(
+      space,
+      "materializer-precise-source",
+      undefined,
+      tx,
+    );
+    const target = runtime.getCell<Record<string, number>>(
+      space,
+      "materializer-precise-target",
+      undefined,
+      tx,
+    );
+    source.set(0);
+    target.set(Object.fromEntries(
+      Array.from({ length: 12 }, (_, index) => [`k${index}`, 0]),
+    ));
+    await tx.commit();
+    tx = runtime.edit();
+
+    let materializerRuns = 0;
+    const effectRuns = Array.from({ length: 12 }, () => 0);
+    const materializer = Object.assign(
+      (actionTx: IExtendedStorageTransaction) => {
+        materializerRuns++;
+        const next = { ...target.withTx(actionTx).get() };
+        next.k7 = source.withTx(actionTx).get();
+        target.withTx(actionTx).set(next);
+      },
+      {
+        materializerWriteEnvelopes: [target.getAsNormalizedFullLink()],
+      },
+    ) as Action & {
+      materializerWriteEnvelopes: ReturnType<
+        typeof target.getAsNormalizedFullLink
+      >[];
+    };
+
+    runtime.scheduler.subscribe(materializer, {
+      reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
+      shallowReads: [],
+      writes: [],
+    });
+    for (let index = 0; index < effectRuns.length; index++) {
+      const key = `k${index}`;
+      const effect: Action = (actionTx) => {
+        effectRuns[index]++;
+        target.withTx(actionTx).key(key).get();
+      };
+      runtime.scheduler.subscribe(effect, effect, { isEffect: true });
+    }
+    await runtime.idle();
+    materializerRuns = 0;
+    effectRuns.fill(0);
+
+    const updateTx = runtime.edit();
+    source.withTx(updateTx).set(7);
+    await updateTx.commit();
+    await runtime.idle();
+
+    expect(materializerRuns).toBe(1);
+    expect(effectRuns[7]).toBe(1);
+    expect(effectRuns.reduce((sum, count) => sum + count, 0)).toBe(1);
+  });
+
+  it("should promote dirty materializers before demand-root effects", async () => {
+    runtime.scheduler.enablePullMode();
+
+    const source = runtime.getCell<number>(
+      space,
+      "materializer-demand-source",
+      undefined,
+      tx,
+    );
+    const trigger = runtime.getCell<number>(
+      space,
+      "materializer-demand-trigger",
+      undefined,
+      tx,
+    );
+    const target = runtime.getCell<{ value: number }>(
+      space,
+      "materializer-demand-target",
+      undefined,
+      tx,
+    );
+    source.set(1);
+    trigger.set(0);
+    target.set({ value: 1 });
+    await tx.commit();
+    tx = runtime.edit();
+
+    const observed: number[] = [];
+    const materializer = Object.assign(
+      (actionTx: IExtendedStorageTransaction) => {
+        target.withTx(actionTx).set({ value: source.withTx(actionTx).get() });
+      },
+      {
+        materializerWriteEnvelopes: [target.getAsNormalizedFullLink()],
+      },
+    ) as Action & {
+      materializerWriteEnvelopes: ReturnType<
+        typeof target.getAsNormalizedFullLink
+      >[];
+    };
+    const effect: Action = (actionTx) => {
+      trigger.withTx(actionTx).get();
+      observed.push(target.withTx(actionTx).key("value").get());
+    };
+
+    runtime.scheduler.subscribe(materializer, {
+      reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
+      shallowReads: [],
+      writes: [],
+    });
+    runtime.scheduler.subscribe(effect, effect, { isEffect: true });
+    await runtime.idle();
+    observed.length = 0;
+
+    const sourceUpdateTx = runtime.edit();
+    source.withTx(sourceUpdateTx).set(2);
+    await sourceUpdateTx.commit();
+
+    const triggerUpdateTx = runtime.edit();
+    trigger.withTx(triggerUpdateTx).set(1);
+    await triggerUpdateTx.commit();
+    await runtime.idle();
+
+    expect(observed).toEqual([2]);
+  });
+
+  it("should promote dirty materializers before event preflight handlers", async () => {
+    runtime.scheduler.enablePullMode();
+
+    const eventStream = runtime.getCell<unknown>(
+      space,
+      "materializer-event-stream",
+      undefined,
+      tx,
+    );
+    const source = runtime.getCell<number>(
+      space,
+      "materializer-event-source",
+      undefined,
+      tx,
+    );
+    const target = runtime.getCell<{ value: number }>(
+      space,
+      "materializer-event-target",
+      undefined,
+      tx,
+    );
+    source.set(1);
+    target.set({ value: 1 });
+    await tx.commit();
+    tx = runtime.edit();
+
+    const observed: number[] = [];
+    const materializer = Object.assign(
+      (actionTx: IExtendedStorageTransaction) => {
+        target.withTx(actionTx).set({ value: source.withTx(actionTx).get() });
+      },
+      {
+        materializerWriteEnvelopes: [target.getAsNormalizedFullLink()],
+      },
+    ) as Action & {
+      materializerWriteEnvelopes: ReturnType<
+        typeof target.getAsNormalizedFullLink
+      >[];
+    };
+    const handler: EventHandler = (actionTx) => {
+      observed.push(target.withTx(actionTx).key("value").get());
+    };
+    handler.populateDependencies = (depTx) => {
+      target.withTx(depTx).key("value").get();
+    };
+
+    runtime.scheduler.subscribe(materializer, {
+      reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
+      shallowReads: [],
+      writes: [],
+    });
+    runtime.scheduler.addEventHandler(
+      handler,
+      eventStream.getAsNormalizedFullLink(),
+    );
+    await runtime.idle();
+
+    const updateTx = runtime.edit();
+    source.withTx(updateTx).set(2);
+    await updateTx.commit();
+    runtime.scheduler.queueEvent(eventStream.getAsNormalizedFullLink(), {});
+    await runtime.idle();
+
+    expect(observed).toEqual([2]);
+  });
+
+  it("should keep static declared writes demand-driven in pull mode", async () => {
+    runtime.scheduler.enablePullMode();
+
+    const source = runtime.getCell<number>(
+      space,
+      "static-declared-source",
+      undefined,
+      tx,
+    );
+    const target = runtime.getCell<number>(
+      space,
+      "static-declared-target",
+      undefined,
+      tx,
+    );
+    source.set(1);
+    target.set(0);
+    await tx.commit();
+    tx = runtime.edit();
+
+    let computationRuns = 0;
+    const computation: Action = (actionTx) => {
+      computationRuns++;
+      target.withTx(actionTx).set(source.withTx(actionTx).get());
+    };
+    runtime.scheduler.subscribe(computation, {
+      reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
+      shallowReads: [],
+      writes: [toMemorySpaceAddress(target.getAsNormalizedFullLink())],
+    });
+    await runtime.idle();
+    expect(computationRuns).toBe(0);
+
+    const effect: Action = (actionTx) => {
+      target.withTx(actionTx).get();
+    };
+    runtime.scheduler.subscribe(effect, effect, { isEffect: true });
+    await runtime.idle();
+    expect(computationRuns).toBe(1);
+  });
+
+  it("should keep push mode eager for materializer-annotated computations", async () => {
+    runtime.scheduler.disablePullMode();
+
+    const source = runtime.getCell<number>(
+      space,
+      "materializer-push-source",
+      undefined,
+      tx,
+    );
+    const target = runtime.getCell<{ value: number }>(
+      space,
+      "materializer-push-target",
+      undefined,
+      tx,
+    );
+    source.set(1);
+    target.set({ value: 0 });
+    await tx.commit();
+    tx = runtime.edit();
+
+    let runs = 0;
+    const materializer = Object.assign(
+      (actionTx: IExtendedStorageTransaction) => {
+        runs++;
+        target.withTx(actionTx).set({ value: source.withTx(actionTx).get() });
+      },
+      {
+        materializerWriteEnvelopes: [target.getAsNormalizedFullLink()],
+      },
+    ) as Action & {
+      materializerWriteEnvelopes: ReturnType<
+        typeof target.getAsNormalizedFullLink
+      >[];
+    };
+
+    runtime.scheduler.subscribe(materializer, {
+      reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
+      shallowReads: [],
+      writes: [],
+    });
+    await runtime.idle();
+    expect(runs).toBe(1);
+
+    const updateTx = runtime.edit();
+    source.withTx(updateTx).set(2);
+    await updateTx.commit();
+    await runtime.idle();
+
+    expect(runs).toBe(2);
+    expect(target.get()).toEqual({ value: 2 });
   });
 });

--- a/packages/runner/test/scheduler-effects.test.ts
+++ b/packages/runner/test/scheduler-effects.test.ts
@@ -549,4 +549,115 @@ describe("effect/computation tracking", () => {
 
     expect(runtime.scheduler.getDependents(computation).has(effect)).toBe(true);
   });
+
+  it("should run dirty materializer computations without downstream demand", async () => {
+    runtime.scheduler.enablePullMode();
+
+    const source = runtime.getCell<number>(
+      space,
+      "materializer-undemanded-source",
+      undefined,
+      tx,
+    );
+    const target = runtime.getCell<{ value: number; stable: number }>(
+      space,
+      "materializer-undemanded-target",
+      undefined,
+      tx,
+    );
+    source.set(1);
+    target.set({ value: 0, stable: 0 });
+    await tx.commit();
+    tx = runtime.edit();
+
+    let materializerRuns = 0;
+    const materializer = Object.assign(
+      (actionTx: IExtendedStorageTransaction) => {
+        materializerRuns++;
+        const value = source.withTx(actionTx).get();
+        target.withTx(actionTx).set({ value, stable: 0 });
+      },
+      {
+        materializerWriteEnvelopes: [target.getAsNormalizedFullLink()],
+      },
+    ) as Action & {
+      materializerWriteEnvelopes: ReturnType<
+        typeof target.getAsNormalizedFullLink
+      >[];
+    };
+
+    runtime.scheduler.subscribe(materializer, {
+      reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
+      shallowReads: [],
+      writes: [],
+    });
+    await runtime.idle();
+    expect(materializerRuns).toBe(1);
+    expect(target.get()).toEqual({ value: 1, stable: 0 });
+
+    const updateTx = runtime.edit();
+    source.withTx(updateTx).set(2);
+    await updateTx.commit();
+    await runtime.idle();
+
+    expect(materializerRuns).toBe(2);
+    expect(target.get()).toEqual({ value: 2, stable: 0 });
+  });
+
+  it("should not make broad attempted writes into materializer dependents", async () => {
+    runtime.scheduler.enablePullMode();
+
+    const source = runtime.getCell<number>(
+      space,
+      "materializer-fanout-source",
+      undefined,
+      tx,
+    );
+    const target = runtime.getCell<{ changed: number; stable: number }>(
+      space,
+      "materializer-fanout-target",
+      undefined,
+      tx,
+    );
+    source.set(1);
+    target.set({ changed: 0, stable: 0 });
+    await tx.commit();
+    tx = runtime.edit();
+
+    const materializer = Object.assign(
+      (actionTx: IExtendedStorageTransaction) => {
+        const changed = source.withTx(actionTx).get();
+        target.withTx(actionTx).set({ changed, stable: 0 });
+      },
+      {
+        materializerWriteEnvelopes: [target.getAsNormalizedFullLink()],
+      },
+    ) as Action & {
+      materializerWriteEnvelopes: ReturnType<
+        typeof target.getAsNormalizedFullLink
+      >[];
+    };
+    const changedEffect: Action = (actionTx) => {
+      target.withTx(actionTx).key("changed").get();
+    };
+    const stableEffect: Action = (actionTx) => {
+      target.withTx(actionTx).key("stable").get();
+    };
+
+    runtime.scheduler.subscribe(materializer, {
+      reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
+      shallowReads: [],
+      writes: [],
+    });
+    runtime.scheduler.subscribe(changedEffect, changedEffect, {
+      isEffect: true,
+    });
+    runtime.scheduler.subscribe(stableEffect, stableEffect, { isEffect: true });
+    await runtime.idle();
+
+    expect(runtime.scheduler.getDependents(materializer).has(changedEffect))
+      .toBe(true);
+    expect(runtime.scheduler.getDependents(materializer).has(stableEffect))
+      .toBe(false);
+  });
 });

--- a/packages/runner/test/scheduler-effects.test.ts
+++ b/packages/runner/test/scheduler-effects.test.ts
@@ -17,6 +17,7 @@ import {
 import type {
   Action,
   IExtendedStorageTransaction,
+  ReactivityLog,
   SchedulerTestStorageManager,
 } from "./scheduler-test-utils.ts";
 
@@ -510,12 +511,12 @@ describe("effect/computation tracking", () => {
     );
   });
 
-  it("should keep dependents for potential writes without relying on historical writes", async () => {
+  it("should ignore attemptedWrites as scheduler dependency evidence", async () => {
     runtime.scheduler.enablePullMode();
 
     const output = runtime.getCell<number>(
       space,
-      "potential-write-output",
+      "attempted-write-output",
       undefined,
       tx,
     );
@@ -535,19 +536,18 @@ describe("effect/computation tracking", () => {
       {
         reads: [],
         shallowReads: [],
-        writes: [toMemorySpaceAddress(output.getAsNormalizedFullLink())],
+        writes: [],
+        attemptedWrites: [
+          toMemorySpaceAddress(output.getAsNormalizedFullLink()),
+        ],
+      } as ReactivityLog & {
+        attemptedWrites: ReturnType<typeof toMemorySpaceAddress>[];
       },
-      {},
     );
 
-    runtime.scheduler.resubscribe(computation, {
-      reads: [],
-      shallowReads: [],
-      writes: [],
-      potentialWrites: [toMemorySpaceAddress(output.getAsNormalizedFullLink())],
-    });
-
-    expect(runtime.scheduler.getDependents(computation).has(effect)).toBe(true);
+    expect(runtime.scheduler.getDependents(computation).has(effect)).toBe(
+      false,
+    );
   });
 
   it("should run dirty materializer computations without downstream demand", async () => {

--- a/packages/runner/test/scheduler-materializer-fanout.bench.ts
+++ b/packages/runner/test/scheduler-materializer-fanout.bench.ts
@@ -1,0 +1,229 @@
+import type { Cell, JSONSchema } from "../src/builder/types.ts";
+import type { Action } from "../src/scheduler.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { toMemorySpaceAddress } from "../src/link-utils.ts";
+import {
+  benchOptions,
+  benchSpace,
+  cleanupSchedulerBenchEnv,
+  consumeNumber,
+  createSchedulerBenchEnv,
+  numberSchema,
+  runWithSchedulerTiming,
+  type SchedulerBenchEnv,
+} from "./scheduler-bench-helpers.ts";
+
+const FANOUT_SIZES = [100, 1000] as const;
+
+const recordNumberSchema = {
+  type: "object",
+  additionalProperties: numberSchema,
+} as const satisfies JSONSchema;
+
+type MaterializerFanoutGraph = {
+  env: SchedulerBenchEnv;
+  source: Cell<number>;
+  target: Cell<Record<string, number>>;
+  readerRuns: number[];
+  getMaterializerRuns: () => number;
+};
+
+async function setupMaterializerFanoutGraph(
+  prefix: string,
+  fanout: number,
+): Promise<MaterializerFanoutGraph> {
+  const env = createSchedulerBenchEnv(true);
+  const { runtime } = env;
+  const tx = runtime.edit();
+
+  const source = runtime.getCell<number>(
+    benchSpace,
+    `${prefix}:source`,
+    numberSchema,
+    tx,
+  );
+  source.set(0);
+
+  const target = runtime.getCell<Record<string, number>>(
+    benchSpace,
+    `${prefix}:target`,
+    recordNumberSchema,
+    tx,
+  );
+  target.set(Object.fromEntries(
+    Array.from({ length: fanout }, (_, index) => [`k${index}`, 0]),
+  ));
+  await tx.commit();
+
+  let materializerRuns = 0;
+  const materializer = Object.assign(
+    (actionTx: IExtendedStorageTransaction) => {
+      materializerRuns++;
+      const next = { ...target.withTx(actionTx).get() };
+      next.k0 = source.withTx(actionTx).get() ?? 0;
+      target.withTx(actionTx).set(next);
+    },
+    {
+      materializerWriteEnvelopes: [target.getAsNormalizedFullLink()],
+    },
+  ) as Action & {
+    materializerWriteEnvelopes: ReturnType<
+      typeof target.getAsNormalizedFullLink
+    >[];
+  };
+
+  runtime.scheduler.subscribe(materializer, {
+    reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
+    shallowReads: [],
+    writes: [],
+  });
+
+  const readerRuns = Array.from({ length: fanout }, () => 0);
+  for (let index = 0; index < fanout; index++) {
+    const key = `k${index}`;
+    const reader: Action = (actionTx) => {
+      readerRuns[index]++;
+      target.withTx(actionTx).key(key).get();
+    };
+    runtime.scheduler.subscribe(reader, reader, { isEffect: true });
+  }
+
+  await runtime.scheduler.idle();
+  materializerRuns = 0;
+  readerRuns.fill(0);
+
+  return {
+    env,
+    source,
+    target,
+    readerRuns,
+    getMaterializerRuns: () => materializerRuns,
+  };
+}
+
+type StaticWriteGraph = {
+  env: SchedulerBenchEnv;
+  source: Cell<number>;
+  target: Cell<number>;
+  effectRuns: { value: number };
+  getComputationRuns: () => number;
+};
+
+async function setupStaticWriteGraph(
+  prefix: string,
+): Promise<StaticWriteGraph> {
+  const env = createSchedulerBenchEnv(true);
+  const { runtime } = env;
+  const tx = runtime.edit();
+  const source = runtime.getCell<number>(
+    benchSpace,
+    `${prefix}:source`,
+    numberSchema,
+    tx,
+  );
+  source.set(0);
+  const target = runtime.getCell<number>(
+    benchSpace,
+    `${prefix}:target`,
+    numberSchema,
+    tx,
+  );
+  target.set(0);
+  await tx.commit();
+
+  let computationRuns = 0;
+  const computation: Action = (actionTx) => {
+    computationRuns++;
+    target.withTx(actionTx).set(source.withTx(actionTx).get() ?? 0);
+  };
+  runtime.scheduler.subscribe(computation, {
+    reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
+    shallowReads: [],
+    writes: [toMemorySpaceAddress(target.getAsNormalizedFullLink())],
+  });
+
+  const effectRuns = { value: 0 };
+  const effect: Action = (actionTx) => {
+    effectRuns.value++;
+    target.withTx(actionTx).get();
+  };
+  runtime.scheduler.subscribe(effect, effect, { isEffect: true });
+  await runtime.scheduler.idle();
+  computationRuns = 0;
+  effectRuns.value = 0;
+
+  return {
+    env,
+    source,
+    target,
+    effectRuns,
+    getComputationRuns: () => computationRuns,
+  };
+}
+
+async function updateSource(
+  env: SchedulerBenchEnv,
+  source: Cell<number>,
+  value: number,
+) {
+  const tx = env.runtime.edit();
+  source.withTx(tx).set(value);
+  await tx.commit();
+}
+
+for (const fanout of FANOUT_SIZES) {
+  Deno.bench(
+    `Scheduler materializer fanout - broad side write with ${fanout} readers`,
+    benchOptions("scheduler-materializer-fanout", fanout === FANOUT_SIZES[0]),
+    async () => {
+      await runWithSchedulerTiming(
+        `materializer fanout: ${fanout} narrow readers`,
+        async (resetMeasuredTiming) => {
+          const graph = await setupMaterializerFanoutGraph(
+            `materializer:${fanout}`,
+            fanout,
+          );
+
+          resetMeasuredTiming();
+          await updateSource(graph.env, graph.source, 1);
+          await graph.env.runtime.scheduler.idle();
+
+          const totalReaderRuns = graph.readerRuns.reduce(
+            (sum, count) => sum + count,
+            0,
+          );
+          console.log(
+            `materializer fanout ${fanout}: materializerRuns=${graph.getMaterializerRuns()}, readerRuns=${totalReaderRuns}`,
+          );
+          consumeNumber(graph.target.get().k0);
+
+          await cleanupSchedulerBenchEnv(graph.env);
+        },
+      );
+    },
+  );
+}
+
+Deno.bench(
+  "Scheduler materializer fanout - static declared write control",
+  benchOptions("scheduler-materializer-fanout"),
+  async () => {
+    await runWithSchedulerTiming(
+      "materializer fanout: static declared write control",
+      async (resetMeasuredTiming) => {
+        const graph = await setupStaticWriteGraph("materializer-static");
+
+        resetMeasuredTiming();
+        await updateSource(graph.env, graph.source, 1);
+        await graph.env.runtime.scheduler.idle();
+
+        console.log(
+          `static declared write: computationRuns=${graph.getComputationRuns()}, effectRuns=${graph.effectRuns.value}`,
+        );
+        consumeNumber(graph.target.get());
+
+        await cleanupSchedulerBenchEnv(graph.env);
+      },
+    );
+  },
+);

--- a/packages/runner/test/scheduler-ordering.test.ts
+++ b/packages/runner/test/scheduler-ordering.test.ts
@@ -17,6 +17,27 @@ import type {
   IExtendedStorageTransaction,
   SchedulerTestStorageManager,
 } from "./scheduler-test-utils.ts";
+import {
+  deriveDeclaredAncestorWrites,
+  deriveDynamicCollectionParentWrites,
+} from "../src/scheduler/scheduling-writes.ts";
+import { topologicalSort } from "../src/scheduler/topology.ts";
+import type { IMemorySpaceAddress } from "../src/storage/interface.ts";
+
+type SchedulerTestScope = "space" | "user" | "session";
+
+function scopedAddress(
+  scope: SchedulerTestScope | undefined,
+  path: readonly string[],
+): IMemorySpaceAddress {
+  return {
+    space,
+    id: "of:scheduler-scope-shared",
+    type: "application/json",
+    scope,
+    path,
+  };
+}
 
 describe("push-triggered filtering", () => {
   let storageManager: SchedulerTestStorageManager;
@@ -279,6 +300,53 @@ describe("push-triggered filtering", () => {
     expect(runtime.scheduler.getMightWrite(action)).not.toEqual([
       toMemorySpaceAddress(firstChild),
     ]);
+  });
+
+  it("should not derive declared ancestor writes across scopes", () => {
+    const spaceAncestor = scopedAddress("space", ["items"]);
+    const sessionChild = scopedAddress("session", ["items", "details"]);
+
+    expect(
+      deriveDeclaredAncestorWrites([sessionChild], [spaceAncestor]),
+    ).toEqual([]);
+  });
+
+  it("should not derive dynamic collection parent writes across scopes", () => {
+    const spaceCollection = scopedAddress("space", ["items"]);
+    const sessionItem = scopedAddress("session", ["items", "0"]);
+
+    expect(
+      deriveDynamicCollectionParentWrites([sessionItem], [spaceCollection]),
+    ).toEqual([]);
+  });
+
+  it("should not order materializer writes before readers in other scopes", () => {
+    const materializer: Action = () => {};
+    const reader: Action = () => {};
+    const order = topologicalSort(
+      new Set([reader, materializer]),
+      new WeakMap<Action, {
+        reads: IMemorySpaceAddress[];
+        shallowReads: IMemorySpaceAddress[];
+        writes: IMemorySpaceAddress[];
+      }>([
+        [reader, {
+          reads: [scopedAddress("space", ["value"])],
+          shallowReads: [],
+          writes: [],
+        }],
+        [materializer, { reads: [], shallowReads: [], writes: [] }],
+      ]),
+      new WeakMap<Action, IMemorySpaceAddress[]>(),
+      undefined,
+      undefined,
+      (action) =>
+        action === materializer
+          ? [scopedAddress("session", ["value"])]
+          : undefined,
+    );
+
+    expect(order).toEqual([reader, materializer]);
   });
 
   it("should track filter stats", async () => {

--- a/packages/runner/test/scheduler-pull.test.ts
+++ b/packages/runner/test/scheduler-pull.test.ts
@@ -846,6 +846,68 @@ describe("pull-based scheduling", () => {
     expect(effectResult.get()).toBe(11);
   });
 
+  it("should continue a parent pull when a child writes a parent read", async () => {
+    runtime.scheduler.enablePullMode();
+
+    const source = runtime.getCell<number>(
+      space,
+      "pull-continuation-source",
+      undefined,
+      tx,
+    );
+    source.set(3);
+    const childResult = runtime.getCell<number>(
+      space,
+      "pull-continuation-child-result",
+      undefined,
+      tx,
+    );
+    childResult.set(0);
+    const parentResult = runtime.getCell<number>(
+      space,
+      "pull-continuation-parent-result",
+      undefined,
+      tx,
+    );
+    parentResult.set(0);
+    await tx.commit();
+    tx = runtime.edit();
+
+    let childSubscribed = false;
+    let parentRuns = 0;
+    let childRuns = 0;
+
+    const child: Action = (actionTx) => {
+      childRuns++;
+      childResult.withTx(actionTx).send(source.withTx(actionTx).get() ?? 0);
+    };
+
+    const parent: Action = (actionTx) => {
+      parentRuns++;
+      if (!childSubscribed) {
+        childSubscribed = true;
+        runtime.scheduler.subscribe(child, {
+          reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
+          shallowReads: [],
+          writes: [toMemorySpaceAddress(childResult.getAsNormalizedFullLink())],
+        });
+      }
+      parentResult.withTx(actionTx).send(
+        (childResult.withTx(actionTx).get() ?? 0) + 1,
+      );
+    };
+
+    runtime.scheduler.subscribe(parent, {
+      reads: [toMemorySpaceAddress(childResult.getAsNormalizedFullLink())],
+      shallowReads: [],
+      writes: [toMemorySpaceAddress(parentResult.getAsNormalizedFullLink())],
+    });
+
+    expect(await parentResult.pull()).toBe(4);
+    expect(parentRuns).toBe(2);
+    expect(childRuns).toBe(1);
+  });
+
   it("should first-run child computations created by demand-root effects", async () => {
     runtime.scheduler.enablePullMode();
 

--- a/packages/runner/test/scheduler-pull.test.ts
+++ b/packages/runner/test/scheduler-pull.test.ts
@@ -908,6 +908,54 @@ describe("pull-based scheduling", () => {
     expect(childRuns).toBe(1);
   });
 
+  it("should clear pull continuation demand when unsubscribing", async () => {
+    runtime.scheduler.enablePullMode();
+
+    const source = runtime.getCell<number>(
+      space,
+      "pull-continuation-unsubscribe-source",
+      undefined,
+      tx,
+    );
+    source.set(2);
+    const result = runtime.getCell<number>(
+      space,
+      "pull-continuation-unsubscribe-result",
+      undefined,
+      tx,
+    );
+    result.set(0);
+    await tx.commit();
+    tx = runtime.edit();
+
+    let runs = 0;
+    const action: Action = (actionTx) => {
+      runs++;
+      result.withTx(actionTx).send(source.withTx(actionTx).get() ?? 0);
+    };
+    const log = {
+      reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
+      shallowReads: [],
+      writes: [toMemorySpaceAddress(result.getAsNormalizedFullLink())],
+    };
+
+    runtime.scheduler.subscribe(action, log);
+    await runtime.scheduler.idle();
+    expect(runs).toBe(0);
+
+    const schedulerInternals = runtime.scheduler as unknown as {
+      pullDemandedContinuationComputations: WeakSet<Action>;
+    };
+    schedulerInternals.pullDemandedContinuationComputations.add(action);
+
+    runtime.scheduler.unsubscribe(action);
+    runtime.scheduler.subscribe(action, log);
+    await runtime.scheduler.idle();
+
+    expect(runs).toBe(0);
+    expect(result.get()).toBe(0);
+  });
+
   it("should first-run child computations created by demand-root effects", async () => {
     runtime.scheduler.enablePullMode();
 

--- a/packages/runner/test/storage-reactivity-log.bench.ts
+++ b/packages/runner/test/storage-reactivity-log.bench.ts
@@ -3,7 +3,7 @@ import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
 import {
   ignoreReadForScheduling,
-  markReadAsPotentialWrite,
+  markReadAsAttemptedWrite,
 } from "../src/storage/reactivity-log.ts";
 import { txToReactivityLog } from "../src/scheduler.ts";
 
@@ -70,7 +70,7 @@ Deno.bench(
           scope: "space",
           id: "of:reactivity-log-bench",
           path: ["list"],
-        }, { meta: markReadAsPotentialWrite });
+        }, { meta: markReadAsAttemptedWrite });
         tx.writeValueOrThrow({
           space,
           scope: "space",


### PR DESCRIPTION
## Summary

- Rename transaction `potentialWrites` to `attemptedWrites` for storage/CFC and keep it out of scheduler dependency evidence.
- Add explicit pull-mode materializer handling for broad/dynamic writable-input writes, with idle/debounced execution, demand/event promotion, and precise downstream propagation from actual changed writes.
- Preserve static/simple declared-write behavior and push-mode eager behavior.
- Add regression coverage, materializer fanout benchmarks, and update the pull scheduler spec/debugging docs.

## Validation

- `deno test -A packages/runner/test/scheduler-*.test.ts`
- `deno test -A packages/runner/test/cfc-boundary.test.ts packages/runner/test/scheduler-core.test.ts packages/runner/test/scheduler-effects.test.ts`
- `deno bench -A packages/runner/test/scheduler-materializer-fanout.bench.ts`
- `HEADLESS=1 deno task test` in `packages/runner`
- `HEADLESS=1 deno task check`
- `rg "potentialWrites|markReadAsPotentialWrite" packages/runner/src docs/specs/pull-based-scheduler/README.md` has no matches

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Splits attempted writes from scheduler dependency evidence and adds pull‑mode materializers for broad/dynamic writable-input computations. Also preserves pull-demand continuation when a child writes a parent read, fixes declared‑ancestor write derivation across scopes, and clarifies pull scheduler phases.

- New Features
  - Pull-mode materializers with idle/debounced execution; dirtied materializers auto-queue in the idle pull loop to drive propagation.
  - Precise propagation from actual changed writes; push mode and static declared-write behavior unchanged.
  - `materializerWriteEnvelopes` to bound materializer outputs and guide scheduling.
  - Added tests, a materializer fanout benchmark, and expanded docs for pull scheduling and materializers.

- Migration
  - Rename API/metadata: `markReadAsPotentialWrite` → `markReadAsAttemptedWrite`.
  - Rename CFC/log fields: `potentialWrites` → `attemptedWrites`.
  - Scheduler no longer uses attempted writes as dependency evidence; it uses actual and declared writes.
  - If you use runner internals, update imports from `scheduler.ts` and `storage/reactivity-log.ts`.

<sup>Written for commit 48a91db70b4a34b4a703e196b2271ef790d987ff. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3631?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



NEW_PERF_BASELINE: job: Runner Tests (3/4) = 84s
