### PR TITLE
Add `Uint8Array.{to,from}Hex()`-based `bigint` encoding implementation

### DIFF
--- a/packages/utils/bench/bigint.bench.ts
+++ b/packages/utils/bench/bigint.bench.ts
@@ -2,13 +2,14 @@
  * BigInt encoding/decoding performance benchmarks.
  *
  * Measures `bigintToMinimalTwosComplement()` and
- * `bigintFromMinimalTwosComplement()` across the full byte-length spectrum,
- * with separate positive/negative tracks. Sizes 1-127 sweep in single-byte
- * steps so several discontinuities are visible: the 8-byte fast-path boundary
- * (both directions switch from a `DataView.{set,get}BigUint64()` fast path to
- * a per-byte fallback) and the 32-byte large-negative-decoder crossover.
- * Sizes 128, 256, 512 sample the deep-fallback regime; 1008..1039 brackets
- * 1024 to expose `partials` cost (`bytes.length & 7`) at very large sizes.
+ * `bigintFromMinimalTwosComplement()` using both implementations and across the
+ * full byte-length spectrum, with separate positive/negative tracks. Sizes
+ * 1-127 sweep in single-byte steps so several discontinuities are visible: the
+ * 8-byte fast-path boundary (both directions switch from a
+ * `DataView.{set,get}BigUint64()` fast path to a per-byte fallback) and the
+ * 32-byte large-negative-decoder crossover. Sizes 128, 256, 512 sample the
+ * deep-fallback regime; 1008..1039 brackets 1024 to expose `partials` cost
+ * (`bytes.length & 7`) at very large sizes.
  *
  * Each iteration of a benchmark function processes a fixed BATCH of values
  * pre-generated with a deterministic xorshift RNG, so JIT specialization on
@@ -30,9 +31,13 @@
  */
 
 import {
-  bigintFromMinimalTwosComplement,
-  bigintToMinimalTwosComplement,
-} from "@commonfabric/utils/bigint";
+  bigintFromMtcDirect,
+  bigintToMtcDirect,
+} from "../src/bigint-uint8-direct.ts";
+import {
+  bigintFromMtcHex,
+  bigintToMtcHex,
+} from "../src/bigint-uint8-hex-string.ts";
 
 const BATCH = 64;
 
@@ -92,75 +97,82 @@ function makeBatch(bytes: number, sign: 1n | -1n, seed: number): bigint[] {
   return out;
 }
 
-function encodeBatch(values: bigint[]): Uint8Array[] {
-  return values.map((v) => bigintToMinimalTwosComplement(v));
-}
+for (
+  const { biToMtc, biFromMtc } of [
+    { biToMtc: bigintToMtcDirect, biFromMtc: bigintFromMtcDirect },
+    { biToMtc: bigintToMtcHex, biFromMtc: bigintFromMtcHex },
+  ]
+) {
+  const encodeBatch = (values: bigint[]): Uint8Array[] => {
+    return values.map((v) => biToMtc(v));
+  };
 
-// Warm up both directions to avoid measuring JIT compilation in the first
-// reported bucket.
-{
-  const warmSmallVals = makeBatch(8, 1n, 1);
-  const warmLargeVals = makeBatch(64, -1n, 2);
-  const warmSmallBytes = encodeBatch(warmSmallVals);
-  const warmLargeBytes = encodeBatch(warmLargeVals);
-  for (let i = 0; i < 200; i++) {
-    for (const v of warmSmallVals) bigintToMinimalTwosComplement(v);
-    for (const v of warmLargeVals) bigintToMinimalTwosComplement(v);
-    for (const b of warmSmallBytes) bigintFromMinimalTwosComplement(b);
-    for (const b of warmLargeBytes) bigintFromMinimalTwosComplement(b);
+  // Warm up both directions to avoid measuring JIT compilation in the first
+  // reported bucket.
+  {
+    const warmSmallVals = makeBatch(8, 1n, 1);
+    const warmLargeVals = makeBatch(64, -1n, 2);
+    const warmSmallBytes = encodeBatch(warmSmallVals);
+    const warmLargeBytes = encodeBatch(warmLargeVals);
+    for (let i = 0; i < 200; i++) {
+      for (const v of warmSmallVals) biToMtc(v);
+      for (const v of warmLargeVals) biToMtc(v);
+      for (const b of warmSmallBytes) biFromMtc(b);
+      for (const b of warmLargeBytes) biFromMtc(b);
+    }
   }
-}
 
-for (const bytes of BYTE_SIZES) {
-  const positives = makeBatch(bytes, 1n, bytes * 31 + 1);
-  const negatives = makeBatch(bytes, -1n, bytes * 31 + 2);
-  const positiveBytes = encodeBatch(positives);
-  const negativeBytes = encodeBatch(negatives);
-  // Pad the group key so Deno bench's grouped output sorts in size order.
-  const groupKey = String(bytes).padStart(4, "0");
-  const encodeGroup = `encode-${groupKey}B`;
-  const decodeGroup = `decode-${groupKey}B`;
-  const label = `${bytes}B`;
+  for (const bytes of BYTE_SIZES) {
+    const positives = makeBatch(bytes, 1n, bytes * 31 + 1);
+    const negatives = makeBatch(bytes, -1n, bytes * 31 + 2);
+    const positiveBytes = encodeBatch(positives);
+    const negativeBytes = encodeBatch(negatives);
+    // Pad the group key so Deno bench's grouped output sorts in size order.
+    const groupKey = String(bytes).padStart(4, "0");
+    const encodeGroup = `encode-${groupKey}B`;
+    const decodeGroup = `decode-${groupKey}B`;
+    const label = `${bytes}B`;
 
-  Deno.bench({
-    name: `encode positive ${label} (${BATCH} ops)`,
-    group: encodeGroup,
-    baseline: true,
-    fn() {
-      for (let i = 0; i < BATCH; i++) {
-        bigintToMinimalTwosComplement(positives[i]);
-      }
-    },
-  });
+    Deno.bench({
+      name: `encode positive ${label} (${BATCH} ops)`,
+      group: encodeGroup,
+      baseline: true,
+      fn() {
+        for (let i = 0; i < BATCH; i++) {
+          biToMtc(positives[i]);
+        }
+      },
+    });
 
-  Deno.bench({
-    name: `encode negative ${label} (${BATCH} ops)`,
-    group: encodeGroup,
-    fn() {
-      for (let i = 0; i < BATCH; i++) {
-        bigintToMinimalTwosComplement(negatives[i]);
-      }
-    },
-  });
+    Deno.bench({
+      name: `encode negative ${label} (${BATCH} ops)`,
+      group: encodeGroup,
+      fn() {
+        for (let i = 0; i < BATCH; i++) {
+          biToMtc(negatives[i]);
+        }
+      },
+    });
 
-  Deno.bench({
-    name: `decode positive ${label} (${BATCH} ops)`,
-    group: decodeGroup,
-    baseline: true,
-    fn() {
-      for (let i = 0; i < BATCH; i++) {
-        bigintFromMinimalTwosComplement(positiveBytes[i]);
-      }
-    },
-  });
+    Deno.bench({
+      name: `decode positive ${label} (${BATCH} ops)`,
+      group: decodeGroup,
+      baseline: true,
+      fn() {
+        for (let i = 0; i < BATCH; i++) {
+          biFromMtc(positiveBytes[i]);
+        }
+      },
+    });
 
-  Deno.bench({
-    name: `decode negative ${label} (${BATCH} ops)`,
-    group: decodeGroup,
-    fn() {
-      for (let i = 0; i < BATCH; i++) {
-        bigintFromMinimalTwosComplement(negativeBytes[i]);
-      }
-    },
-  });
+    Deno.bench({
+      name: `decode negative ${label} (${BATCH} ops)`,
+      group: decodeGroup,
+      fn() {
+        for (let i = 0; i < BATCH; i++) {
+          biFromMtc(negativeBytes[i]);
+        }
+      },
+    });
+  }
 }

--- a/packages/utils/bench/bigint.bench.ts
+++ b/packages/utils/bench/bigint.bench.ts
@@ -97,12 +97,26 @@ function makeBatch(bytes: number, sign: 1n | -1n, seed: number): bigint[] {
   return out;
 }
 
-for (
-  const { biToMtc, biFromMtc } of [
-    { biToMtc: bigintToMtcDirect, biFromMtc: bigintFromMtcDirect },
-    { biToMtc: bigintToMtcHex, biFromMtc: bigintFromMtcHex },
-  ]
-) {
+const IMPLS: ReadonlyArray<{
+  readonly name: string;
+  readonly biToMtc: (value: bigint) => Uint8Array;
+  readonly biFromMtc: (bytes: Uint8Array) => bigint;
+}> = [
+  {
+    name: "direct",
+    biToMtc: bigintToMtcDirect,
+    biFromMtc: bigintFromMtcDirect,
+  },
+  {
+    name: "hex",
+    biToMtc: bigintToMtcHex,
+    biFromMtc: bigintFromMtcHex,
+  },
+];
+
+for (const { name: implName, biToMtc, biFromMtc } of IMPLS) {
+  const isBaselineImpl = implName === IMPLS[0].name;
+
   const encodeBatch = (values: bigint[]): Uint8Array[] => {
     return values.map((v) => biToMtc(v));
   };
@@ -134,9 +148,9 @@ for (
     const label = `${bytes}B`;
 
     Deno.bench({
-      name: `encode positive ${label} (${BATCH} ops)`,
+      name: `encode positive ${label} ${implName} (${BATCH} ops)`,
       group: encodeGroup,
-      baseline: true,
+      baseline: isBaselineImpl,
       fn() {
         for (let i = 0; i < BATCH; i++) {
           biToMtc(positives[i]);
@@ -145,7 +159,7 @@ for (
     });
 
     Deno.bench({
-      name: `encode negative ${label} (${BATCH} ops)`,
+      name: `encode negative ${label} ${implName} (${BATCH} ops)`,
       group: encodeGroup,
       fn() {
         for (let i = 0; i < BATCH; i++) {
@@ -155,9 +169,9 @@ for (
     });
 
     Deno.bench({
-      name: `decode positive ${label} (${BATCH} ops)`,
+      name: `decode positive ${label} ${implName} (${BATCH} ops)`,
       group: decodeGroup,
-      baseline: true,
+      baseline: isBaselineImpl,
       fn() {
         for (let i = 0; i < BATCH; i++) {
           biFromMtc(positiveBytes[i]);
@@ -166,7 +180,7 @@ for (
     });
 
     Deno.bench({
-      name: `decode negative ${label} (${BATCH} ops)`,
+      name: `decode negative ${label} ${implName} (${BATCH} ops)`,
       group: decodeGroup,
       fn() {
         for (let i = 0; i < BATCH; i++) {

--- a/packages/utils/src/bigint-shared-impl.ts
+++ b/packages/utils/src/bigint-shared-impl.ts
@@ -1,0 +1,83 @@
+/**
+ * Helpers for both `bigint` codec implementations.
+ */
+
+/**
+ * Shared 8-byte scratch buffer.
+ */
+const dv64Buf = new ArrayBuffer(8);
+
+/**
+ * `DataView` of `dv64buf`.
+ */
+const dv64View = new DataView(dv64Buf);
+
+/**
+ * `Uint8Array` view of `dv64buf`.
+ */
+const dv64Bytes = new Uint8Array(dv64Buf);
+
+/**
+ * Converts a hex digit at a particular index in a string to its 4-bit
+ * (nibble-sized) numeric value. Handles '0'-'9' (0x30-0x39) and 'a'-'f'
+ * (0x61-0x66).
+ */
+export function nibbleValueAt(hex: string, at: number): number {
+  const c = hex.charCodeAt(at);
+
+  // '0'-'9' = 0x30-0x39, 'a'-'f' = 0x61-0x66
+  return c < 0x3a ? c - 0x30 : c - 0x57;
+}
+
+/**
+ * Converts a pair of hex digits at a particular index in a string to its 8-bit
+ * (byte-sized) numeric value. Handles '0'-'9' (0x30-0x39) and 'a'-'f'
+ * (0x61-0x66).
+ */
+export function byteValueAt(hex: string, at: number): number {
+  return (nibbleValueAt(hex, at) << 4) | nibbleValueAt(hex, at + 1);
+}
+
+/**
+ * Converts a positive `bigint` to a hex string with an even number of digits,
+ * _and_ a leading `00` if it would otherwise be interpreted as a negative
+ * number in twos-complement.
+ */
+export function hexStringFromPositiveValue(value: bigint): string {
+  const hex = value.toString(16);
+  if ((hex.length & 1) === 1) {
+    // Round up to an even number of nibbles.
+    return "0" + hex;
+  } else if (nibbleValueAt(hex, 0) >= 8) {
+    // Add an extra `0x00` byte, because the high-order bit would otherwise
+    // be `1` and therefore the encoded result would be negative, which
+    // would be wrong.
+    return "00" + hex;
+  } else {
+    return hex;
+  }
+}
+
+/**
+ * Converts a value that fits into 64 bits and requires `length >= 5`.
+ */
+export function encode5To8Bytes(value: bigint, negative: boolean): Uint8Array {
+  const skipByte = negative ? 0xff : 0x00;
+  const signBit = skipByte & 0x80;
+
+  dv64View.setBigInt64(0, value, false); // `false` means big-endian.
+
+  // Note: Loop necessarily ends before running off the end of the array
+  // because by virtue of the caller's up-front check, there's definitely a
+  // non-skipped byte).
+  for (let i = 0; true; i++) {
+    const byte = dv64Bytes[i];
+    if (byte !== skipByte) {
+      // Adjust starting index backwards if the non-skipped byte would flip
+      // the sign of the result.
+      return ((byte & 0x80) === signBit)
+        ? dv64Bytes.slice(i)
+        : dv64Bytes.slice(i - 1);
+    }
+  }
+}

--- a/packages/utils/src/bigint-uint8-direct.ts
+++ b/packages/utils/src/bigint-uint8-direct.ts
@@ -3,86 +3,11 @@
  * parses `Uint8Array`s.
  */
 
-/**
- * Shared 8-byte scratch buffer.
- */
-const dv64Buf = new ArrayBuffer(8);
-
-/**
- * `DataView` of `dv64buf`.
- */
-const dv64View = new DataView(dv64Buf);
-
-/**
- * `Uint8Array` view of `dv64buf`.
- */
-const dv64Bytes = new Uint8Array(dv64Buf);
-
-/**
- * Helper for `bigintToMtcDirect()`, which converts a hex digit at a particular
- * index in a string to its 4-bit (nibble-sized) numeric value. Handles '0'-'9'
- * (0x30-0x39) and 'a'-'f' (0x61-0x66).
- */
-function nibbleValueAt(hex: string, at: number): number {
-  const c = hex.charCodeAt(at);
-
-  // '0'-'9' = 0x30-0x39, 'a'-'f' = 0x61-0x66
-  return c < 0x3a ? c - 0x30 : c - 0x57;
-}
-
-/**
- * Helper for `bigintToMtcDirect()`, which converts a pair of hex digits at a
- * particular index in a string to its 8-bit (byte-sized) numeric value. Handles
- * '0'-'9' (0x30-0x39) and 'a'-'f' (0x61-0x66).
- */
-function byteValueAt(hex: string, at: number): number {
-  return (nibbleValueAt(hex, at) << 4) | nibbleValueAt(hex, at + 1);
-}
-
-/**
- * Helper for `bigintToMtcDirect()`, which converts a positive `bigint` to a hex
- * string with an even number of digits, _and_ a leading `00` if it would
- * otherwise be interpreted as a negative number in twos-complement.
- */
-function hexStringFromPositiveValue(value: bigint): string {
-  const hex = value.toString(16);
-  if ((hex.length & 1) === 1) {
-    // Round up to an even number of nibbles.
-    return "0" + hex;
-  } else if (nibbleValueAt(hex, 0) >= 8) {
-    // Add an extra `0x00` byte, because the high-order bit would otherwise
-    // be `1` and therefore the encoded result would be negative, which
-    // would be wrong.
-    return "00" + hex;
-  } else {
-    return hex;
-  }
-}
-
-/**
- * Helper for `bigintToMtcDirect()`, which converts a value that fits into 64
- * bits and requires `length >= 5`.
- */
-function encode5To8Bytes(value: bigint, negative: boolean): Uint8Array {
-  const skipByte = negative ? 0xff : 0x00;
-  const signBit = skipByte & 0x80;
-
-  dv64View.setBigInt64(0, value, false); // `false` means big-endian.
-
-  // Note: Loop necessarily ends before running off the end of the array
-  // because by virtue of the caller's up-front check, there's definitely a
-  // non-skipped byte).
-  for (let i = 0; true; i++) {
-    const byte = dv64Bytes[i];
-    if (byte !== skipByte) {
-      // Adjust starting index backwards if the non-skipped byte would flip
-      // the sign of the result.
-      return ((byte & 0x80) === signBit)
-        ? dv64Bytes.slice(i)
-        : dv64Bytes.slice(i - 1);
-    }
-  }
-}
+import {
+  byteValueAt,
+  encode5To8Bytes,
+  hexStringFromPositiveValue,
+} from "./bigint-shared-impl.ts";
 
 /**
  * Direct-`Uint8Array`-construction version of

--- a/packages/utils/src/bigint-uint8-direct.ts
+++ b/packages/utils/src/bigint-uint8-direct.ts
@@ -1,0 +1,335 @@
+/**
+ * Implementation of `bigint.ts` which directly / algorithmically constructs and
+ * parses `Uint8Array`s.
+ */
+
+/**
+ * Shared 8-byte scratch buffer.
+ */
+const dv64Buf = new ArrayBuffer(8);
+
+/**
+ * `DataView` of `dv64buf`.
+ */
+const dv64View = new DataView(dv64Buf);
+
+/**
+ * `Uint8Array` view of `dv64buf`.
+ */
+const dv64Bytes = new Uint8Array(dv64Buf);
+
+/**
+ * Helper for `bigintToMtcDirect()`, which converts a hex digit at a particular
+ * index in a string to its 4-bit (nibble-sized) numeric value. Handles '0'-'9'
+ * (0x30-0x39) and 'a'-'f' (0x61-0x66).
+ */
+function nibbleValueAt(hex: string, at: number): number {
+  const c = hex.charCodeAt(at);
+
+  // '0'-'9' = 0x30-0x39, 'a'-'f' = 0x61-0x66
+  return c < 0x3a ? c - 0x30 : c - 0x57;
+}
+
+/**
+ * Helper for `bigintToMtcDirect()`, which converts a pair of hex digits at a
+ * particular index in a string to its 8-bit (byte-sized) numeric value. Handles
+ * '0'-'9' (0x30-0x39) and 'a'-'f' (0x61-0x66).
+ */
+function byteValueAt(hex: string, at: number): number {
+  return (nibbleValueAt(hex, at) << 4) | nibbleValueAt(hex, at + 1);
+}
+
+/**
+ * Helper for `bigintToMtcDirect()`, which converts a positive `bigint` to a hex
+ * string with an even number of digits, _and_ a leading `00` if it would
+ * otherwise be interpreted as a negative number in twos-complement.
+ */
+function hexStringFromPositiveValue(value: bigint): string {
+  const hex = value.toString(16);
+  if ((hex.length & 1) === 1) {
+    // Round up to an even number of nibbles.
+    return "0" + hex;
+  } else if (nibbleValueAt(hex, 0) >= 8) {
+    // Add an extra `0x00` byte, because the high-order bit would otherwise
+    // be `1` and therefore the encoded result would be negative, which
+    // would be wrong.
+    return "00" + hex;
+  } else {
+    return hex;
+  }
+}
+
+/**
+ * Helper for `bigintToMtcDirect()`, which converts a value that fits into 64
+ * bits and requires `length >= 5`.
+ */
+function encode5To8Bytes(value: bigint, negative: boolean): Uint8Array {
+  const skipByte = negative ? 0xff : 0x00;
+  const signBit = skipByte & 0x80;
+
+  dv64View.setBigInt64(0, value, false); // `false` means big-endian.
+
+  // Note: Loop necessarily ends before running off the end of the array
+  // because by virtue of the caller's up-front check, there's definitely a
+  // non-skipped byte).
+  for (let i = 0; true; i++) {
+    const byte = dv64Bytes[i];
+    if (byte !== skipByte) {
+      // Adjust starting index backwards if the non-skipped byte would flip
+      // the sign of the result.
+      return ((byte & 0x80) === signBit)
+        ? dv64Bytes.slice(i)
+        : dv64Bytes.slice(i - 1);
+    }
+  }
+}
+
+/**
+ * Direct-`Uint8Array`-construction version of
+ * `bigintToMinimalTwosComplement()`.
+ */
+export function bigintToMtcDirect(value: bigint): Uint8Array {
+  if (value >= 0n) {
+    if (value <= 0x7fff_ffffn) {
+      const num = Number(value);
+      if (num <= 0x7fff) {
+        if (num <= 0x7f) {
+          const result = new Uint8Array(1);
+          result[0] = num;
+          return result;
+        } else {
+          const result = new Uint8Array(2);
+          result[0] = num >> 8;
+          result[1] = num;
+          return result;
+        }
+      } else {
+        if (num <= 0x7f_ffff) {
+          const result = new Uint8Array(3);
+          result[0] = num >> 16;
+          result[1] = num >> 8;
+          result[2] = num;
+          return result;
+        } else {
+          const result = new Uint8Array(4);
+          result[0] = num >> 24;
+          result[1] = num >> 16;
+          result[2] = num >> 8;
+          result[3] = num;
+          return result;
+        }
+      }
+    } else if (value <= 0x7fff_ffff_ffff_ffffn) {
+      return encode5To8Bytes(value, false);
+    }
+
+    // Slow path for positive numbers: This stringifies and then parses back the
+    // `value`, to work around JS's very limited set of `bigint` functionality.
+    // If and when the TC39 BigInt Math proposal lands, this code could be
+    // reworked to be much more performant. See:
+    // <https://github.com/tc39/proposal-bigint-math>.
+
+    const hex = hexStringFromPositiveValue(value);
+
+    // Note: When it is widely-enough available, we will be able to say `return
+    // Uint8Array.fromHex(hex)` here and probably see a major performance
+    // improvement.
+
+    const bytes = new Uint8Array(hex.length >> 1);
+
+    for (let i = 0; i < bytes.length; i++) {
+      bytes[i] = byteValueAt(hex, i * 2);
+    }
+
+    return bytes;
+  } else {
+    if (value >= -0x8000_0000n) {
+      const num = Number(value);
+      if (num >= -0x8000) {
+        if (num >= -0x80) {
+          const result = new Uint8Array(1);
+          result[0] = num;
+          return result;
+        } else {
+          const result = new Uint8Array(2);
+          result[0] = num >> 8;
+          result[1] = num;
+          return result;
+        }
+      } else {
+        if (num >= -0x80_0000) {
+          const result = new Uint8Array(3);
+          result[0] = num >> 16;
+          result[1] = num >> 8;
+          result[2] = num;
+          return result;
+        } else {
+          const result = new Uint8Array(4);
+          result[0] = num >> 24;
+          result[1] = num >> 16;
+          result[2] = num >> 8;
+          result[3] = num;
+          return result;
+        }
+      }
+    } else if (value >= -0x8000_0000_0000_0000n) {
+      return encode5To8Bytes(value, true);
+    }
+
+    // Slow path for negative numbers. See above for details. The extra twist
+    // here is that we need to end up with a string that correctly represents
+    // `value` as a twos-complement negative value. The trick we do here is
+    // convert the _ones_-complement of `value` to a string, and then undo it
+    // byte-by-byte when storing the result.
+
+    const hex = hexStringFromPositiveValue(~value);
+    const bytes = new Uint8Array(hex.length >> 1);
+
+    for (let i = 0; i < bytes.length; i++) {
+      // `0xff ^ value` to undo the ones-complement in `~value` above.
+      bytes[i] = 0xff ^ byteValueAt(hex, i * 2);
+    }
+
+    return bytes;
+  }
+}
+
+/**
+ * Direct-`Uint8Array`-construction version of
+ * `bigintFromMinimalTwosComplement()`.
+ */
+export function bigintFromMtcDirect(bytes: Uint8Array): bigint {
+  switch (bytes.length) {
+    case 0: {
+      throw new Error("bigintFromMinimalTwosComplement: empty input");
+    }
+
+    case 1: {
+      // `(x << 24) >> 24` to sign extend. Similar below.
+      return BigInt((bytes[0] << 24) >> 24);
+    }
+
+    case 2: {
+      return BigInt(((bytes[0] << 24) | (bytes[1] << 16)) >> 16);
+    }
+
+    case 3: {
+      return BigInt(
+        ((bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8)) >> 8,
+      );
+    }
+
+    case 4: {
+      return BigInt(
+        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
+      );
+    }
+
+    case 5: {
+      const subResult1 = BigInt(
+        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
+      );
+      const subResult2 = BigInt(bytes[4]);
+      return (subResult1 << 8n) | subResult2;
+    }
+
+    case 6: {
+      const subResult1 = BigInt(
+        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
+      );
+      const subResult2 = BigInt((bytes[4] << 8) | bytes[5]);
+      return (subResult1 << 16n) | subResult2;
+    }
+
+    case 7: {
+      const subResult1 = BigInt(
+        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
+      );
+      const subResult2 = BigInt((bytes[4] << 16) | (bytes[5] << 8) | bytes[6]);
+      return (subResult1 << 24n) | subResult2;
+    }
+
+    case 8: {
+      const subResult1 = BigInt(
+        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
+      );
+      const subResult2 = BigInt(
+        (bytes[4] << 24) | (bytes[5] << 16) | (bytes[6] << 8) | bytes[7],
+      ) & 0xffff_ffffn;
+      return (subResult1 << 32n) | subResult2;
+    }
+  }
+
+  // Slow path.
+
+  // Determine sign from the high bit of the first byte.
+  const negative = (bytes[0]! & 0x80) !== 0;
+
+  // Count of partial-`int64` bytes.
+  const partials = bytes.length & 7;
+
+  let result;
+
+  // This calculates the high-order "partial" `int64`, if any. We waste a little
+  // bit of work in cases where the partial count isn't a multiple of `4`, but
+  // it's worth it for the simplicity (and is at worst negligible in time cost).
+  if (partials === 0) {
+    result = negative ? -1n : 0n;
+  } else if (partials <= 4) {
+    const partial = BigInt(
+      (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
+    );
+    result = partial >> BigInt(32 - (partials * 8));
+  } else {
+    const partial1 = BigInt(
+      (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
+    );
+    const partial2 = BigInt(
+      (bytes[4] << 24) | (bytes[5] << 16) | (bytes[6] << 8) | bytes[7],
+    ) & 0xffff_ffffn;
+    result = ((partial1 << 32n) | partial2) >> BigInt(64 - (partials * 8));
+  }
+
+  // Possibly surprising test here: Benchmarks indicate that V8 (and assumed to
+  // be similar in other JS VMs) has internal optimizations for left-shift on
+  // large positive numbers but _not_ large negative numbers. The cross-over
+  // point of this code was measured to be at 128 bytes for negative numbers.
+  if (!negative || (bytes.length <= 128)) {
+    // Note: Over ~1024 bytes, benchmarks indicate there is a win to be had by
+    // using a `DataView` to extract `uint64`s from `bytes`.
+    for (let i = partials; i < bytes.length; i += 8) {
+      const subResult1 = BigInt(
+        (bytes[i] << 24) | (bytes[i + 1] << 16) | (bytes[i + 2] << 8) |
+          bytes[i + 3],
+      ) & 0xffff_ffffn;
+      const subResult2 = BigInt(
+        (bytes[i + 4] << 24) | (bytes[i + 5] << 16) | (bytes[i + 6] << 8) |
+          bytes[i + 7],
+      ) & 0xffff_ffffn;
+      result = (result << 64n) | (subResult1 << 32n) | subResult2;
+    }
+
+    return result;
+  } else {
+    // Negative and large enough to feel the pain of an unoptimized `bigint`
+    // left shift. This uses uses a similar ones-complement trick as is done in
+    // the encoder function, above, so that we operate on positive `bigint`s
+    // within the loop.
+
+    result = ~result; // Because the `partials` calc made it negative.
+
+    for (let i = partials; i < bytes.length; i += 8) {
+      const subResult1 = BigInt(
+        ~((bytes[i] << 24) | (bytes[i + 1] << 16) | (bytes[i + 2] << 8) |
+          bytes[i + 3]),
+      ) & 0xffff_ffffn;
+      const subResult2 = BigInt(
+        ~((bytes[i + 4] << 24) | (bytes[i + 5] << 16) | (bytes[i + 6] << 8) |
+          bytes[i + 7]),
+      ) & 0xffff_ffffn;
+      result = (result << 64n) | (subResult1 << 32n) | subResult2;
+    }
+
+    return ~result;
+  }
+}

--- a/packages/utils/src/bigint-uint8-hex-string.ts
+++ b/packages/utils/src/bigint-uint8-hex-string.ts
@@ -2,13 +2,15 @@
  * Implementation of `bigint.ts` which uses the hex conversion methods of
  * `Uint8Array`. These only became part of the EcmaScript standard in 2025 and
  * so (as of this writing) cannot be relied on to exist in arbitrary JS
- * environments.
+ * environments. This implementation also ends up using the "direct" tactics /
+ * code for small lengths, where it has been measured to be a win.
  */
 
 import {
   encode5To8Bytes,
   hexStringFromPositiveValue,
 } from "./bigint-shared-impl.ts";
+import { bigintFromMtcDirect } from "./bigint-uint8-direct.ts";
 
 /**
  * Version of `bigintToMinimalTwosComplement()` which uses the `Uint8Array`
@@ -107,8 +109,8 @@ export function bigintToMtcHex(value: bigint): Uint8Array {
  * hex-string methods.
  */
 export function bigintFromMtcHex(bytes: Uint8Array): bigint {
-  if (bytes.length === 0) {
-    throw new Error("bigintFromMinimalTwosComplement: empty input");
+  if (bytes.length <= 32) {
+    return bigintFromMtcDirect(bytes);
   }
 
   const hexString = bytes.toHex();

--- a/packages/utils/src/bigint-uint8-hex-string.ts
+++ b/packages/utils/src/bigint-uint8-hex-string.ts
@@ -6,24 +6,9 @@
  */
 
 /**
- * Shared 8-byte scratch buffer.
- */
-const dv64Buf = new ArrayBuffer(8);
-
-/**
- * `DataView` of `dv64buf`.
- */
-const dv64View = new DataView(dv64Buf);
-
-/**
- * `Uint8Array` view of `dv64buf`.
- */
-const dv64Bytes = new Uint8Array(dv64Buf);
-
-/**
- * Helper for `bigintToMinimalTwosComplement()`, which converts a hex digit at a
- * particular index in a string to its 4-bit (nibble-sized) numeric value.
- * Handles '0'-'9' (0x30-0x39) and 'a'-'f' (0x61-0x66).
+ * Helper for `biToMtcHex()`, which converts a hex digit at a particular index
+ * in a string to its 4-bit (nibble-sized) numeric value. Handles '0'-'9'
+ * (0x30-0x39) and 'a'-'f' (0x61-0x66).
  */
 function nibbleValueAt(hex: string, at: number): number {
   const c = hex.charCodeAt(at);
@@ -33,19 +18,9 @@ function nibbleValueAt(hex: string, at: number): number {
 }
 
 /**
- * Helper for `bigintToMinimalTwosComplement()`, which converts a pair of hex
- * digits at a particular index in a string to its 8-bit (byte-sized) numeric
- * value. Handles '0'-'9' (0x30-0x39) and 'a'-'f' (0x61-0x66).
- */
-function byteValueAt(hex: string, at: number): number {
-  return (nibbleValueAt(hex, at) << 4) | nibbleValueAt(hex, at + 1);
-}
-
-/**
- * Helper for `bigintToMinimalTwosComplement()`, which converts a positive
- * `bigint` to a hex string with an even number of digits, _and_ a leading
- * `00` if it would otherwise be interpreted as a negative number in
- * twos-complement.
+ * Helper for `biToMtcHex()`, which converts a positive `bigint` to a hex string
+ * with an even number of digits, _and_ a leading `00` if it would otherwise be
+ * interpreted as a negative number in twos-complement.
  */
 function hexStringFromPositiveValue(value: bigint): string {
   const hex = value.toString(16);
@@ -63,137 +38,22 @@ function hexStringFromPositiveValue(value: bigint): string {
 }
 
 /**
- * Helper for `bigintToMinimalTwosComplement()`, which converts a value that
- * fits into 64 bits and requires `length >= 5`.
- */
-function encode5To8Bytes(value: bigint, negative: boolean): Uint8Array {
-  const skipByte = negative ? 0xff : 0x00;
-  const signBit = skipByte & 0x80;
-
-  dv64View.setBigInt64(0, value, false); // `false` means big-endian.
-
-  // Note: Loop necessarily ends before running off the end of the array
-  // because by virtue of the caller's up-front check, there's definitely a
-  // non-skipped byte).
-  for (let i = 0; true; i++) {
-    const byte = dv64Bytes[i];
-    if (byte !== skipByte) {
-      // Adjust starting index backwards if the non-skipped byte would flip
-      // the sign of the result.
-      return ((byte & 0x80) === signBit)
-        ? dv64Bytes.slice(i)
-        : dv64Bytes.slice(i - 1);
-    }
-  }
-}
-
-/**
  * Version of `bigintToMinimalTwosComplement()` which uses the `Uint8Array`
  * hex-string methods.
  */
 export function bigintToMtcHex(value: bigint): Uint8Array {
-  if (value >= 0n) {
-    if (value <= 0x7fff_ffffn) {
-      const num = Number(value);
-      if (num <= 0x7fff) {
-        if (num <= 0x7f) {
-          const result = new Uint8Array(1);
-          result[0] = num;
-          return result;
-        } else {
-          const result = new Uint8Array(2);
-          result[0] = num >> 8;
-          result[1] = num;
-          return result;
-        }
-      } else {
-        if (num <= 0x7f_ffff) {
-          const result = new Uint8Array(3);
-          result[0] = num >> 16;
-          result[1] = num >> 8;
-          result[2] = num;
-          return result;
-        } else {
-          const result = new Uint8Array(4);
-          result[0] = num >> 24;
-          result[1] = num >> 16;
-          result[2] = num >> 8;
-          result[3] = num;
-          return result;
-        }
-      }
-    } else if (value <= 0x7fff_ffff_ffff_ffffn) {
-      return encode5To8Bytes(value, false);
-    }
-
-    // Slow path for positive numbers: This stringifies and then parses back the
-    // `value`, to work around JS's very limited set of `bigint` functionality.
-    // If and when the TC39 BigInt Math proposal lands, this code could be
-    // reworked to be much more performant. See:
-    // <https://github.com/tc39/proposal-bigint-math>.
-
-    const hex = hexStringFromPositiveValue(value);
-
-    // Note: When it is widely-enough available, we will be able to say `return
-    // Uint8Array.fromHex(hex)` here and probably see a major performance
-    // improvement.
-
-    const bytes = new Uint8Array(hex.length >> 1);
-
-    for (let i = 0; i < bytes.length; i++) {
-      bytes[i] = byteValueAt(hex, i * 2);
-    }
-
-    return bytes;
+  if (value >= 0) {
+    const hexString = hexStringFromPositiveValue(value);
+    return Uint8Array.fromHex(hexString);
   } else {
-    if (value >= -0x8000_0000n) {
-      const num = Number(value);
-      if (num >= -0x8000) {
-        if (num >= -0x80) {
-          const result = new Uint8Array(1);
-          result[0] = num;
-          return result;
-        } else {
-          const result = new Uint8Array(2);
-          result[0] = num >> 8;
-          result[1] = num;
-          return result;
-        }
-      } else {
-        if (num >= -0x80_0000) {
-          const result = new Uint8Array(3);
-          result[0] = num >> 16;
-          result[1] = num >> 8;
-          result[2] = num;
-          return result;
-        } else {
-          const result = new Uint8Array(4);
-          result[0] = num >> 24;
-          result[1] = num >> 16;
-          result[2] = num >> 8;
-          result[3] = num;
-          return result;
-        }
-      }
-    } else if (value >= -0x8000_0000_0000_0000n) {
-      return encode5To8Bytes(value, true);
+    // Negative value. We ones-complement it before conversion to string, then
+    // undo the conversion in the array result.
+    const hexString = hexStringFromPositiveValue(~value);
+    const result = Uint8Array.fromHex(hexString);
+    for (let i = 0; i < result.length; i++) {
+      result[i] = ~result[i];
     }
-
-    // Slow path for negative numbers. See above for details. The extra twist
-    // here is that we need to end up with a string that correctly represents
-    // `value` as a twos-complement negative value. The trick we do here is
-    // convert the _ones_-complement of `value` to a string, and then undo it
-    // byte-by-byte when storing the result.
-
-    const hex = hexStringFromPositiveValue(~value);
-    const bytes = new Uint8Array(hex.length >> 1);
-
-    for (let i = 0; i < bytes.length; i++) {
-      // `0xff ^ value` to undo the ones-complement in `~value` above.
-      bytes[i] = 0xff ^ byteValueAt(hex, i * 2);
-    }
-
-    return bytes;
+    return result;
   }
 }
 

--- a/packages/utils/src/bigint-uint8-hex-string.ts
+++ b/packages/utils/src/bigint-uint8-hex-string.ts
@@ -1,0 +1,338 @@
+/**
+ * Implementation of `bigint.ts` which uses the hex conversion methods of
+ * `Uint8Array`. These only became part of the EcmaScript standard in 2025 and
+ * so (as of this writing) cannot be relied on to exist in arbitrary JS
+ * environments.
+ */
+
+/**
+ * Shared 8-byte scratch buffer.
+ */
+const dv64Buf = new ArrayBuffer(8);
+
+/**
+ * `DataView` of `dv64buf`.
+ */
+const dv64View = new DataView(dv64Buf);
+
+/**
+ * `Uint8Array` view of `dv64buf`.
+ */
+const dv64Bytes = new Uint8Array(dv64Buf);
+
+/**
+ * Helper for `bigintToMinimalTwosComplement()`, which converts a hex digit at a
+ * particular index in a string to its 4-bit (nibble-sized) numeric value.
+ * Handles '0'-'9' (0x30-0x39) and 'a'-'f' (0x61-0x66).
+ */
+function nibbleValueAt(hex: string, at: number): number {
+  const c = hex.charCodeAt(at);
+
+  // '0'-'9' = 0x30-0x39, 'a'-'f' = 0x61-0x66
+  return c < 0x3a ? c - 0x30 : c - 0x57;
+}
+
+/**
+ * Helper for `bigintToMinimalTwosComplement()`, which converts a pair of hex
+ * digits at a particular index in a string to its 8-bit (byte-sized) numeric
+ * value. Handles '0'-'9' (0x30-0x39) and 'a'-'f' (0x61-0x66).
+ */
+function byteValueAt(hex: string, at: number): number {
+  return (nibbleValueAt(hex, at) << 4) | nibbleValueAt(hex, at + 1);
+}
+
+/**
+ * Helper for `bigintToMinimalTwosComplement()`, which converts a positive
+ * `bigint` to a hex string with an even number of digits, _and_ a leading
+ * `00` if it would otherwise be interpreted as a negative number in
+ * twos-complement.
+ */
+function hexStringFromPositiveValue(value: bigint): string {
+  const hex = value.toString(16);
+  if ((hex.length & 1) === 1) {
+    // Round up to an even number of nibbles.
+    return "0" + hex;
+  } else if (nibbleValueAt(hex, 0) >= 8) {
+    // Add an extra `0x00` byte, because the high-order bit would otherwise
+    // be `1` and therefore the encoded result would be negative, which
+    // would be wrong.
+    return "00" + hex;
+  } else {
+    return hex;
+  }
+}
+
+/**
+ * Helper for `bigintToMinimalTwosComplement()`, which converts a value that
+ * fits into 64 bits and requires `length >= 5`.
+ */
+function encode5To8Bytes(value: bigint, negative: boolean): Uint8Array {
+  const skipByte = negative ? 0xff : 0x00;
+  const signBit = skipByte & 0x80;
+
+  dv64View.setBigInt64(0, value, false); // `false` means big-endian.
+
+  // Note: Loop necessarily ends before running off the end of the array
+  // because by virtue of the caller's up-front check, there's definitely a
+  // non-skipped byte).
+  for (let i = 0; true; i++) {
+    const byte = dv64Bytes[i];
+    if (byte !== skipByte) {
+      // Adjust starting index backwards if the non-skipped byte would flip
+      // the sign of the result.
+      return ((byte & 0x80) === signBit)
+        ? dv64Bytes.slice(i)
+        : dv64Bytes.slice(i - 1);
+    }
+  }
+}
+
+/**
+ * Version of `bigintToMinimalTwosComplement()` which uses the `Uint8Array`
+ * hex-string methods.
+ */
+export function bigintToMtcHex(value: bigint): Uint8Array {
+  if (value >= 0n) {
+    if (value <= 0x7fff_ffffn) {
+      const num = Number(value);
+      if (num <= 0x7fff) {
+        if (num <= 0x7f) {
+          const result = new Uint8Array(1);
+          result[0] = num;
+          return result;
+        } else {
+          const result = new Uint8Array(2);
+          result[0] = num >> 8;
+          result[1] = num;
+          return result;
+        }
+      } else {
+        if (num <= 0x7f_ffff) {
+          const result = new Uint8Array(3);
+          result[0] = num >> 16;
+          result[1] = num >> 8;
+          result[2] = num;
+          return result;
+        } else {
+          const result = new Uint8Array(4);
+          result[0] = num >> 24;
+          result[1] = num >> 16;
+          result[2] = num >> 8;
+          result[3] = num;
+          return result;
+        }
+      }
+    } else if (value <= 0x7fff_ffff_ffff_ffffn) {
+      return encode5To8Bytes(value, false);
+    }
+
+    // Slow path for positive numbers: This stringifies and then parses back the
+    // `value`, to work around JS's very limited set of `bigint` functionality.
+    // If and when the TC39 BigInt Math proposal lands, this code could be
+    // reworked to be much more performant. See:
+    // <https://github.com/tc39/proposal-bigint-math>.
+
+    const hex = hexStringFromPositiveValue(value);
+
+    // Note: When it is widely-enough available, we will be able to say `return
+    // Uint8Array.fromHex(hex)` here and probably see a major performance
+    // improvement.
+
+    const bytes = new Uint8Array(hex.length >> 1);
+
+    for (let i = 0; i < bytes.length; i++) {
+      bytes[i] = byteValueAt(hex, i * 2);
+    }
+
+    return bytes;
+  } else {
+    if (value >= -0x8000_0000n) {
+      const num = Number(value);
+      if (num >= -0x8000) {
+        if (num >= -0x80) {
+          const result = new Uint8Array(1);
+          result[0] = num;
+          return result;
+        } else {
+          const result = new Uint8Array(2);
+          result[0] = num >> 8;
+          result[1] = num;
+          return result;
+        }
+      } else {
+        if (num >= -0x80_0000) {
+          const result = new Uint8Array(3);
+          result[0] = num >> 16;
+          result[1] = num >> 8;
+          result[2] = num;
+          return result;
+        } else {
+          const result = new Uint8Array(4);
+          result[0] = num >> 24;
+          result[1] = num >> 16;
+          result[2] = num >> 8;
+          result[3] = num;
+          return result;
+        }
+      }
+    } else if (value >= -0x8000_0000_0000_0000n) {
+      return encode5To8Bytes(value, true);
+    }
+
+    // Slow path for negative numbers. See above for details. The extra twist
+    // here is that we need to end up with a string that correctly represents
+    // `value` as a twos-complement negative value. The trick we do here is
+    // convert the _ones_-complement of `value` to a string, and then undo it
+    // byte-by-byte when storing the result.
+
+    const hex = hexStringFromPositiveValue(~value);
+    const bytes = new Uint8Array(hex.length >> 1);
+
+    for (let i = 0; i < bytes.length; i++) {
+      // `0xff ^ value` to undo the ones-complement in `~value` above.
+      bytes[i] = 0xff ^ byteValueAt(hex, i * 2);
+    }
+
+    return bytes;
+  }
+}
+
+/**
+ * Version of `bigintFromMinimalTwosComplement()` which uses the `Uint8Array`
+ * hex-string methods.
+ */
+export function bigintFromMtcHex(bytes: Uint8Array): bigint {
+  switch (bytes.length) {
+    case 0: {
+      throw new Error("bigintFromMinimalTwosComplement: empty input");
+    }
+
+    case 1: {
+      // `(x << 24) >> 24` to sign extend. Similar below.
+      return BigInt((bytes[0] << 24) >> 24);
+    }
+
+    case 2: {
+      return BigInt(((bytes[0] << 24) | (bytes[1] << 16)) >> 16);
+    }
+
+    case 3: {
+      return BigInt(
+        ((bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8)) >> 8,
+      );
+    }
+
+    case 4: {
+      return BigInt(
+        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
+      );
+    }
+
+    case 5: {
+      const subResult1 = BigInt(
+        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
+      );
+      const subResult2 = BigInt(bytes[4]);
+      return (subResult1 << 8n) | subResult2;
+    }
+
+    case 6: {
+      const subResult1 = BigInt(
+        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
+      );
+      const subResult2 = BigInt((bytes[4] << 8) | bytes[5]);
+      return (subResult1 << 16n) | subResult2;
+    }
+
+    case 7: {
+      const subResult1 = BigInt(
+        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
+      );
+      const subResult2 = BigInt((bytes[4] << 16) | (bytes[5] << 8) | bytes[6]);
+      return (subResult1 << 24n) | subResult2;
+    }
+
+    case 8: {
+      const subResult1 = BigInt(
+        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
+      );
+      const subResult2 = BigInt(
+        (bytes[4] << 24) | (bytes[5] << 16) | (bytes[6] << 8) | bytes[7],
+      ) & 0xffff_ffffn;
+      return (subResult1 << 32n) | subResult2;
+    }
+  }
+
+  // Slow path.
+
+  // Determine sign from the high bit of the first byte.
+  const negative = (bytes[0]! & 0x80) !== 0;
+
+  // Count of partial-`int64` bytes.
+  const partials = bytes.length & 7;
+
+  let result;
+
+  // This calculates the high-order "partial" `int64`, if any. We waste a little
+  // bit of work in cases where the partial count isn't a multiple of `4`, but
+  // it's worth it for the simplicity (and is at worst negligible in time cost).
+  if (partials === 0) {
+    result = negative ? -1n : 0n;
+  } else if (partials <= 4) {
+    const partial = BigInt(
+      (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
+    );
+    result = partial >> BigInt(32 - (partials * 8));
+  } else {
+    const partial1 = BigInt(
+      (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
+    );
+    const partial2 = BigInt(
+      (bytes[4] << 24) | (bytes[5] << 16) | (bytes[6] << 8) | bytes[7],
+    ) & 0xffff_ffffn;
+    result = ((partial1 << 32n) | partial2) >> BigInt(64 - (partials * 8));
+  }
+
+  // Possibly surprising test here: Benchmarks indicate that V8 (and assumed to
+  // be similar in other JS VMs) has internal optimizations for left-shift on
+  // large positive numbers but _not_ large negative numbers. The cross-over
+  // point of this code was measured to be at 128 bytes for negative numbers.
+  if (!negative || (bytes.length <= 128)) {
+    // Note: Over ~1024 bytes, benchmarks indicate there is a win to be had by
+    // using a `DataView` to extract `uint64`s from `bytes`.
+    for (let i = partials; i < bytes.length; i += 8) {
+      const subResult1 = BigInt(
+        (bytes[i] << 24) | (bytes[i + 1] << 16) | (bytes[i + 2] << 8) |
+          bytes[i + 3],
+      ) & 0xffff_ffffn;
+      const subResult2 = BigInt(
+        (bytes[i + 4] << 24) | (bytes[i + 5] << 16) | (bytes[i + 6] << 8) |
+          bytes[i + 7],
+      ) & 0xffff_ffffn;
+      result = (result << 64n) | (subResult1 << 32n) | subResult2;
+    }
+
+    return result;
+  } else {
+    // Negative and large enough to feel the pain of an unoptimized `bigint`
+    // left shift. This uses uses a similar ones-complement trick as is done in
+    // the encoder function, above, so that we operate on positive `bigint`s
+    // within the loop.
+
+    result = ~result; // Because the `partials` calc made it negative.
+
+    for (let i = partials; i < bytes.length; i += 8) {
+      const subResult1 = BigInt(
+        ~((bytes[i] << 24) | (bytes[i + 1] << 16) | (bytes[i + 2] << 8) |
+          bytes[i + 3]),
+      ) & 0xffff_ffffn;
+      const subResult2 = BigInt(
+        ~((bytes[i + 4] << 24) | (bytes[i + 5] << 16) | (bytes[i + 6] << 8) |
+          bytes[i + 7]),
+      ) & 0xffff_ffffn;
+      result = (result << 64n) | (subResult1 << 32n) | subResult2;
+    }
+
+    return ~result;
+  }
+}

--- a/packages/utils/src/bigint-uint8-hex-string.ts
+++ b/packages/utils/src/bigint-uint8-hex-string.ts
@@ -5,24 +5,99 @@
  * environments.
  */
 
-import { hexStringFromPositiveValue } from "./bigint-shared-impl.ts";
+import {
+  encode5To8Bytes,
+  hexStringFromPositiveValue,
+} from "./bigint-shared-impl.ts";
 
 /**
  * Version of `bigintToMinimalTwosComplement()` which uses the `Uint8Array`
  * hex-string methods.
  */
 export function bigintToMtcHex(value: bigint): Uint8Array {
-  if (value >= 0) {
+  if (value >= 0n) {
+    if (value <= 0x7fff_ffffn) {
+      const num = Number(value);
+      if (num <= 0x7fff) {
+        if (num <= 0x7f) {
+          const result = new Uint8Array(1);
+          result[0] = num;
+          return result;
+        } else {
+          const result = new Uint8Array(2);
+          result[0] = num >> 8;
+          result[1] = num;
+          return result;
+        }
+      } else {
+        if (num <= 0x7f_ffff) {
+          const result = new Uint8Array(3);
+          result[0] = num >> 16;
+          result[1] = num >> 8;
+          result[2] = num;
+          return result;
+        } else {
+          const result = new Uint8Array(4);
+          result[0] = num >> 24;
+          result[1] = num >> 16;
+          result[2] = num >> 8;
+          result[3] = num;
+          return result;
+        }
+      }
+    } else if (value <= 0x7fff_ffff_ffff_ffffn) {
+      return encode5To8Bytes(value, false);
+    }
+
+    // Slow path for positive numbers, using string manipulation.
+
     const hexString = hexStringFromPositiveValue(value);
     return Uint8Array.fromHex(hexString);
   } else {
-    // Negative value. We ones-complement it before conversion to string, then
-    // undo the conversion in the array result.
+    if (value >= -0x8000_0000n) {
+      const num = Number(value);
+      if (num >= -0x8000) {
+        if (num >= -0x80) {
+          const result = new Uint8Array(1);
+          result[0] = num;
+          return result;
+        } else {
+          const result = new Uint8Array(2);
+          result[0] = num >> 8;
+          result[1] = num;
+          return result;
+        }
+      } else {
+        if (num >= -0x80_0000) {
+          const result = new Uint8Array(3);
+          result[0] = num >> 16;
+          result[1] = num >> 8;
+          result[2] = num;
+          return result;
+        } else {
+          const result = new Uint8Array(4);
+          result[0] = num >> 24;
+          result[1] = num >> 16;
+          result[2] = num >> 8;
+          result[3] = num;
+          return result;
+        }
+      }
+    } else if (value >= -0x8000_0000_0000_0000n) {
+      return encode5To8Bytes(value, true);
+    }
+
+    // Slow path for negative numbers, using string manipulation. We
+    // ones-complement it before conversion to string, then undo the conversion
+    // in the array result.
+
     const hexString = hexStringFromPositiveValue(~value);
     const result = Uint8Array.fromHex(hexString);
+
     for (let i = 0; i < result.length; i++) {
       result[i] = ~result[i];
     }
+
     return result;
   }
 }
@@ -42,8 +117,8 @@ export function bigintFromMtcHex(bytes: Uint8Array): bigint {
   if (bytes[0] <= 0x7f) {
     return positiveResult;
   } else {
-    // Negative number. We need to make the positive result of conversion
-    // negative.
+    // Negative number. We make the initial positive result of conversion
+    // negative by OR-ing on the sign bit.
     const signBit = -1n << (BigInt(bytes.length) * 8n);
     return positiveResult | signBit;
   }

--- a/packages/utils/src/bigint-uint8-hex-string.ts
+++ b/packages/utils/src/bigint-uint8-hex-string.ts
@@ -5,37 +5,7 @@
  * environments.
  */
 
-/**
- * Helper for `biToMtcHex()`, which converts a hex digit at a particular index
- * in a string to its 4-bit (nibble-sized) numeric value. Handles '0'-'9'
- * (0x30-0x39) and 'a'-'f' (0x61-0x66).
- */
-function nibbleValueAt(hex: string, at: number): number {
-  const c = hex.charCodeAt(at);
-
-  // '0'-'9' = 0x30-0x39, 'a'-'f' = 0x61-0x66
-  return c < 0x3a ? c - 0x30 : c - 0x57;
-}
-
-/**
- * Helper for `biToMtcHex()`, which converts a positive `bigint` to a hex string
- * with an even number of digits, _and_ a leading `00` if it would otherwise be
- * interpreted as a negative number in twos-complement.
- */
-function hexStringFromPositiveValue(value: bigint): string {
-  const hex = value.toString(16);
-  if ((hex.length & 1) === 1) {
-    // Round up to an even number of nibbles.
-    return "0" + hex;
-  } else if (nibbleValueAt(hex, 0) >= 8) {
-    // Add an extra `0x00` byte, because the high-order bit would otherwise
-    // be `1` and therefore the encoded result would be negative, which
-    // would be wrong.
-    return "00" + hex;
-  } else {
-    return hex;
-  }
-}
+import { hexStringFromPositiveValue } from "./bigint-shared-impl.ts";
 
 /**
  * Version of `bigintToMinimalTwosComplement()` which uses the `Uint8Array`

--- a/packages/utils/src/bigint-uint8-hex-string.ts
+++ b/packages/utils/src/bigint-uint8-hex-string.ts
@@ -202,137 +202,19 @@ export function bigintToMtcHex(value: bigint): Uint8Array {
  * hex-string methods.
  */
 export function bigintFromMtcHex(bytes: Uint8Array): bigint {
-  switch (bytes.length) {
-    case 0: {
-      throw new Error("bigintFromMinimalTwosComplement: empty input");
-    }
-
-    case 1: {
-      // `(x << 24) >> 24` to sign extend. Similar below.
-      return BigInt((bytes[0] << 24) >> 24);
-    }
-
-    case 2: {
-      return BigInt(((bytes[0] << 24) | (bytes[1] << 16)) >> 16);
-    }
-
-    case 3: {
-      return BigInt(
-        ((bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8)) >> 8,
-      );
-    }
-
-    case 4: {
-      return BigInt(
-        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
-      );
-    }
-
-    case 5: {
-      const subResult1 = BigInt(
-        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
-      );
-      const subResult2 = BigInt(bytes[4]);
-      return (subResult1 << 8n) | subResult2;
-    }
-
-    case 6: {
-      const subResult1 = BigInt(
-        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
-      );
-      const subResult2 = BigInt((bytes[4] << 8) | bytes[5]);
-      return (subResult1 << 16n) | subResult2;
-    }
-
-    case 7: {
-      const subResult1 = BigInt(
-        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
-      );
-      const subResult2 = BigInt((bytes[4] << 16) | (bytes[5] << 8) | bytes[6]);
-      return (subResult1 << 24n) | subResult2;
-    }
-
-    case 8: {
-      const subResult1 = BigInt(
-        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
-      );
-      const subResult2 = BigInt(
-        (bytes[4] << 24) | (bytes[5] << 16) | (bytes[6] << 8) | bytes[7],
-      ) & 0xffff_ffffn;
-      return (subResult1 << 32n) | subResult2;
-    }
+  if (bytes.length === 0) {
+    throw new Error("bigintFromMinimalTwosComplement: empty input");
   }
 
-  // Slow path.
+  const hexString = bytes.toHex();
+  const positiveResult = BigInt(`0x${hexString}`);
 
-  // Determine sign from the high bit of the first byte.
-  const negative = (bytes[0]! & 0x80) !== 0;
-
-  // Count of partial-`int64` bytes.
-  const partials = bytes.length & 7;
-
-  let result;
-
-  // This calculates the high-order "partial" `int64`, if any. We waste a little
-  // bit of work in cases where the partial count isn't a multiple of `4`, but
-  // it's worth it for the simplicity (and is at worst negligible in time cost).
-  if (partials === 0) {
-    result = negative ? -1n : 0n;
-  } else if (partials <= 4) {
-    const partial = BigInt(
-      (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
-    );
-    result = partial >> BigInt(32 - (partials * 8));
+  if (bytes[0] <= 0x7f) {
+    return positiveResult;
   } else {
-    const partial1 = BigInt(
-      (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
-    );
-    const partial2 = BigInt(
-      (bytes[4] << 24) | (bytes[5] << 16) | (bytes[6] << 8) | bytes[7],
-    ) & 0xffff_ffffn;
-    result = ((partial1 << 32n) | partial2) >> BigInt(64 - (partials * 8));
-  }
-
-  // Possibly surprising test here: Benchmarks indicate that V8 (and assumed to
-  // be similar in other JS VMs) has internal optimizations for left-shift on
-  // large positive numbers but _not_ large negative numbers. The cross-over
-  // point of this code was measured to be at 128 bytes for negative numbers.
-  if (!negative || (bytes.length <= 128)) {
-    // Note: Over ~1024 bytes, benchmarks indicate there is a win to be had by
-    // using a `DataView` to extract `uint64`s from `bytes`.
-    for (let i = partials; i < bytes.length; i += 8) {
-      const subResult1 = BigInt(
-        (bytes[i] << 24) | (bytes[i + 1] << 16) | (bytes[i + 2] << 8) |
-          bytes[i + 3],
-      ) & 0xffff_ffffn;
-      const subResult2 = BigInt(
-        (bytes[i + 4] << 24) | (bytes[i + 5] << 16) | (bytes[i + 6] << 8) |
-          bytes[i + 7],
-      ) & 0xffff_ffffn;
-      result = (result << 64n) | (subResult1 << 32n) | subResult2;
-    }
-
-    return result;
-  } else {
-    // Negative and large enough to feel the pain of an unoptimized `bigint`
-    // left shift. This uses uses a similar ones-complement trick as is done in
-    // the encoder function, above, so that we operate on positive `bigint`s
-    // within the loop.
-
-    result = ~result; // Because the `partials` calc made it negative.
-
-    for (let i = partials; i < bytes.length; i += 8) {
-      const subResult1 = BigInt(
-        ~((bytes[i] << 24) | (bytes[i + 1] << 16) | (bytes[i + 2] << 8) |
-          bytes[i + 3]),
-      ) & 0xffff_ffffn;
-      const subResult2 = BigInt(
-        ~((bytes[i + 4] << 24) | (bytes[i + 5] << 16) | (bytes[i + 6] << 8) |
-          bytes[i + 7]),
-      ) & 0xffff_ffffn;
-      result = (result << 64n) | (subResult1 << 32n) | subResult2;
-    }
-
-    return ~result;
+    // Negative number. We need to make the positive result of conversion
+    // negative.
+    const signBit = -1n << (BigInt(bytes.length) * 8n);
+    return positiveResult | signBit;
   }
 }

--- a/packages/utils/src/bigint.ts
+++ b/packages/utils/src/bigint.ts
@@ -17,7 +17,7 @@ import { bigintFromMtcHex, bigintToMtcHex } from "./bigint-uint8-hex-string.ts";
  * Whether to use the version that relies on `Uint8Array.{from,to}Hex()`,
  * methods which are new enough to JS to not be ubiquitously available.
  */
-const useUint8ArrayToFromHex: boolean = false;
+const useUint8ArrayToFromHex: boolean = !!Uint8Array.fromHex;
 
 /**
  * Converts a bigint to its minimal two's-complement big-endian byte

--- a/packages/utils/src/bigint.ts
+++ b/packages/utils/src/bigint.ts
@@ -7,91 +7,17 @@
  * except as needed for sign extension.
  */
 
-/**
- * Shared 8-byte scratch buffer.
- */
-const dv64Buf = new ArrayBuffer(8);
+import {
+  bigintFromMtcDirect,
+  bigintToMtcDirect,
+} from "./bigint-uint8-direct.ts";
+import { bigintFromMtcHex, bigintToMtcHex } from "./bigint-uint8-hex-string.ts";
 
 /**
- * `DataView` of `dv64buf`.
+ * Whether to use the version that relies on `Uint8Array.{from,to}Hex()`,
+ * methods which are new enough to JS to not be ubiquitously available.
  */
-const dv64View = new DataView(dv64Buf);
-
-/**
- * `Uint8Array` view of `dv64buf`.
- */
-const dv64Bytes = new Uint8Array(dv64Buf);
-
-// ---------------------------------------------------------------------------
-// `bigint` -> minimal two's-complement big-endian bytes
-// ---------------------------------------------------------------------------
-
-/**
- * Helper for `bigintToMinimalTwosComplement()`, which converts a hex digit at a
- * particular index in a string to its 4-bit (nibble-sized) numeric value.
- * Handles '0'-'9' (0x30-0x39) and 'a'-'f' (0x61-0x66).
- */
-function nibbleValueAt(hex: string, at: number): number {
-  const c = hex.charCodeAt(at);
-
-  // '0'-'9' = 0x30-0x39, 'a'-'f' = 0x61-0x66
-  return c < 0x3a ? c - 0x30 : c - 0x57;
-}
-
-/**
- * Helper for `bigintToMinimalTwosComplement()`, which converts a pair of hex
- * digits at a particular index in a string to its 8-bit (byte-sized) numeric
- * value. Handles '0'-'9' (0x30-0x39) and 'a'-'f' (0x61-0x66).
- */
-function byteValueAt(hex: string, at: number): number {
-  return (nibbleValueAt(hex, at) << 4) | nibbleValueAt(hex, at + 1);
-}
-
-/**
- * Helper for `bigintToMinimalTwosComplement()`, which converts a positive
- * `bigint` to a hex string with an even number of digits, _and_ a leading
- * `00` if it would otherwise be interpreted as a negative number in
- * twos-complement.
- */
-function hexStringFromPositiveValue(value: bigint): string {
-  const hex = value.toString(16);
-  if ((hex.length & 1) === 1) {
-    // Round up to an even number of nibbles.
-    return "0" + hex;
-  } else if (nibbleValueAt(hex, 0) >= 8) {
-    // Add an extra `0x00` byte, because the high-order bit would otherwise
-    // be `1` and therefore the encoded result would be negative, which
-    // would be wrong.
-    return "00" + hex;
-  } else {
-    return hex;
-  }
-}
-
-/**
- * Helper for `bigintToMinimalTwosComplement()`, which converts a value that
- * fits into 64 bits and requires `length >= 5`.
- */
-function encode5To8Bytes(value: bigint, negative: boolean): Uint8Array {
-  const skipByte = negative ? 0xff : 0x00;
-  const signBit = skipByte & 0x80;
-
-  dv64View.setBigInt64(0, value, false); // `false` means big-endian.
-
-  // Note: Loop necessarily ends before running off the end of the array
-  // because by virtue of the caller's up-front check, there's definitely a
-  // non-skipped byte).
-  for (let i = 0; true; i++) {
-    const byte = dv64Bytes[i];
-    if (byte !== skipByte) {
-      // Adjust starting index backwards if the non-skipped byte would flip
-      // the sign of the result.
-      return ((byte & 0x80) === signBit)
-        ? dv64Bytes.slice(i)
-        : dv64Bytes.slice(i - 1);
-    }
-  }
-}
+const useUint8ArrayToFromHex: boolean = false;
 
 /**
  * Converts a bigint to its minimal two's-complement big-endian byte
@@ -106,251 +32,17 @@ function encode5To8Bytes(value: bigint, negative: boolean): Uint8Array {
  *   when the high bit would otherwise be clear (sign extension for negative).
  */
 export function bigintToMinimalTwosComplement(value: bigint): Uint8Array {
-  if (value >= 0n) {
-    if (value <= 0x7fff_ffffn) {
-      const num = Number(value);
-      if (num <= 0x7fff) {
-        if (num <= 0x7f) {
-          const result = new Uint8Array(1);
-          result[0] = num;
-          return result;
-        } else {
-          const result = new Uint8Array(2);
-          result[0] = num >> 8;
-          result[1] = num;
-          return result;
-        }
-      } else {
-        if (num <= 0x7f_ffff) {
-          const result = new Uint8Array(3);
-          result[0] = num >> 16;
-          result[1] = num >> 8;
-          result[2] = num;
-          return result;
-        } else {
-          const result = new Uint8Array(4);
-          result[0] = num >> 24;
-          result[1] = num >> 16;
-          result[2] = num >> 8;
-          result[3] = num;
-          return result;
-        }
-      }
-    } else if (value <= 0x7fff_ffff_ffff_ffffn) {
-      return encode5To8Bytes(value, false);
-    }
-
-    // Slow path for positive numbers: This stringifies and then parses back the
-    // `value`, to work around JS's very limited set of `bigint` functionality.
-    // If and when the TC39 BigInt Math proposal lands, this code could be
-    // reworked to be much more performant. See:
-    // <https://github.com/tc39/proposal-bigint-math>.
-
-    const hex = hexStringFromPositiveValue(value);
-
-    // Note: When it is widely-enough available, we will be able to say `return
-    // Uint8Array.fromHex(hex)` here and probably see a major performance
-    // improvement.
-
-    const bytes = new Uint8Array(hex.length >> 1);
-
-    for (let i = 0; i < bytes.length; i++) {
-      bytes[i] = byteValueAt(hex, i * 2);
-    }
-
-    return bytes;
-  } else {
-    if (value >= -0x8000_0000n) {
-      const num = Number(value);
-      if (num >= -0x8000) {
-        if (num >= -0x80) {
-          const result = new Uint8Array(1);
-          result[0] = num;
-          return result;
-        } else {
-          const result = new Uint8Array(2);
-          result[0] = num >> 8;
-          result[1] = num;
-          return result;
-        }
-      } else {
-        if (num >= -0x80_0000) {
-          const result = new Uint8Array(3);
-          result[0] = num >> 16;
-          result[1] = num >> 8;
-          result[2] = num;
-          return result;
-        } else {
-          const result = new Uint8Array(4);
-          result[0] = num >> 24;
-          result[1] = num >> 16;
-          result[2] = num >> 8;
-          result[3] = num;
-          return result;
-        }
-      }
-    } else if (value >= -0x8000_0000_0000_0000n) {
-      return encode5To8Bytes(value, true);
-    }
-
-    // Slow path for negative numbers. See above for details. The extra twist
-    // here is that we need to end up with a string that correctly represents
-    // `value` as a twos-complement negative value. The trick we do here is
-    // convert the _ones_-complement of `value` to a string, and then undo it
-    // byte-by-byte when storing the result.
-
-    const hex = hexStringFromPositiveValue(~value);
-    const bytes = new Uint8Array(hex.length >> 1);
-
-    for (let i = 0; i < bytes.length; i++) {
-      // `0xff ^ value` to undo the ones-complement in `~value` above.
-      bytes[i] = 0xff ^ byteValueAt(hex, i * 2);
-    }
-
-    return bytes;
-  }
+  return useUint8ArrayToFromHex
+    ? bigintToMtcHex(value)
+    : bigintToMtcDirect(value);
 }
-
-// ---------------------------------------------------------------------------
-// Two's-complement big-endian bytes -> `bigint`
-// ---------------------------------------------------------------------------
 
 /**
  * Interprets a byte array as a two's-complement big-endian integer and returns
  * the corresponding bigint. Empty input throws.
  */
 export function bigintFromMinimalTwosComplement(bytes: Uint8Array): bigint {
-  switch (bytes.length) {
-    case 0: {
-      throw new Error("bigintFromMinimalTwosComplement: empty input");
-    }
-
-    case 1: {
-      // `(x << 24) >> 24` to sign extend. Similar below.
-      return BigInt((bytes[0] << 24) >> 24);
-    }
-
-    case 2: {
-      return BigInt(((bytes[0] << 24) | (bytes[1] << 16)) >> 16);
-    }
-
-    case 3: {
-      return BigInt(
-        ((bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8)) >> 8,
-      );
-    }
-
-    case 4: {
-      return BigInt(
-        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
-      );
-    }
-
-    case 5: {
-      const subResult1 = BigInt(
-        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
-      );
-      const subResult2 = BigInt(bytes[4]);
-      return (subResult1 << 8n) | subResult2;
-    }
-
-    case 6: {
-      const subResult1 = BigInt(
-        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
-      );
-      const subResult2 = BigInt((bytes[4] << 8) | bytes[5]);
-      return (subResult1 << 16n) | subResult2;
-    }
-
-    case 7: {
-      const subResult1 = BigInt(
-        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
-      );
-      const subResult2 = BigInt((bytes[4] << 16) | (bytes[5] << 8) | bytes[6]);
-      return (subResult1 << 24n) | subResult2;
-    }
-
-    case 8: {
-      const subResult1 = BigInt(
-        (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
-      );
-      const subResult2 = BigInt(
-        (bytes[4] << 24) | (bytes[5] << 16) | (bytes[6] << 8) | bytes[7],
-      ) & 0xffff_ffffn;
-      return (subResult1 << 32n) | subResult2;
-    }
-  }
-
-  // Slow path.
-
-  // Determine sign from the high bit of the first byte.
-  const negative = (bytes[0]! & 0x80) !== 0;
-
-  // Count of partial-`int64` bytes.
-  const partials = bytes.length & 7;
-
-  let result;
-
-  // This calculates the high-order "partial" `int64`, if any. We waste a little
-  // bit of work in cases where the partial count isn't a multiple of `4`, but
-  // it's worth it for the simplicity (and is at worst negligible in time cost).
-  if (partials === 0) {
-    result = negative ? -1n : 0n;
-  } else if (partials <= 4) {
-    const partial = BigInt(
-      (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
-    );
-    result = partial >> BigInt(32 - (partials * 8));
-  } else {
-    const partial1 = BigInt(
-      (bytes[0] << 24) | (bytes[1] << 16) | (bytes[2] << 8) | bytes[3],
-    );
-    const partial2 = BigInt(
-      (bytes[4] << 24) | (bytes[5] << 16) | (bytes[6] << 8) | bytes[7],
-    ) & 0xffff_ffffn;
-    result = ((partial1 << 32n) | partial2) >> BigInt(64 - (partials * 8));
-  }
-
-  // Possibly surprising test here: Benchmarks indicate that V8 (and assumed to
-  // be similar in other JS VMs) has internal optimizations for left-shift on
-  // large positive numbers but _not_ large negative numbers. The cross-over
-  // point of this code was measured to be at 128 bytes for negative numbers.
-  if (!negative || (bytes.length <= 128)) {
-    // Note: Over ~1024 bytes, benchmarks indicate there is a win to be had by
-    // using a `DataView` to extract `uint64`s from `bytes`.
-    for (let i = partials; i < bytes.length; i += 8) {
-      const subResult1 = BigInt(
-        (bytes[i] << 24) | (bytes[i + 1] << 16) | (bytes[i + 2] << 8) |
-          bytes[i + 3],
-      ) & 0xffff_ffffn;
-      const subResult2 = BigInt(
-        (bytes[i + 4] << 24) | (bytes[i + 5] << 16) | (bytes[i + 6] << 8) |
-          bytes[i + 7],
-      ) & 0xffff_ffffn;
-      result = (result << 64n) | (subResult1 << 32n) | subResult2;
-    }
-
-    return result;
-  } else {
-    // Negative and large enough to feel the pain of an unoptimized `bigint`
-    // left shift. This uses uses a similar ones-complement trick as is done in
-    // the encoder function, above, so that we operate on positive `bigint`s
-    // within the loop.
-
-    result = ~result; // Because the `partials` calc made it negative.
-
-    for (let i = partials; i < bytes.length; i += 8) {
-      const subResult1 = BigInt(
-        ~((bytes[i] << 24) | (bytes[i + 1] << 16) | (bytes[i + 2] << 8) |
-          bytes[i + 3]),
-      ) & 0xffff_ffffn;
-      const subResult2 = BigInt(
-        ~((bytes[i + 4] << 24) | (bytes[i + 5] << 16) | (bytes[i + 6] << 8) |
-          bytes[i + 7]),
-      ) & 0xffff_ffffn;
-      result = (result << 64n) | (subResult1 << 32n) | subResult2;
-    }
-
-    return ~result;
-  }
+  return useUint8ArrayToFromHex
+    ? bigintFromMtcHex(bytes)
+    : bigintFromMtcDirect(bytes);
 }

--- a/packages/utils/test/bigint.test.ts
+++ b/packages/utils/test/bigint.test.ts
@@ -5,6 +5,14 @@ import {
   bigintToMinimalTwosComplement,
 } from "@commonfabric/utils/bigint";
 import {
+  bigintFromMtcDirect,
+  bigintToMtcDirect,
+} from "../src/bigint-uint8-direct.ts";
+import {
+  bigintFromMtcHex,
+  bigintToMtcHex,
+} from "../src/bigint-uint8-hex-string.ts";
+import {
   fromBase64url,
   toUnpaddedBase64url,
 } from "@commonfabric/utils/base64url";
@@ -237,62 +245,76 @@ describe("`referenceEncode()` (test oracle)", () => {
 // Per-function fixture loops
 //
 
-const FIXTURE_SLICE_SIZE = 1000;
-for (let at = 0; at < fixtures.length; at += FIXTURE_SLICE_SIZE) {
-  const slice = fixtures.slice(at, at + FIXTURE_SLICE_SIZE);
-  const sliceLabel = `fixtures ${at}..${at + slice.length - 1}`;
+for (
+  const { biToMtc, biFromMtc, full } of [
+    {
+      biToMtc: bigintToMinimalTwosComplement,
+      biFromMtc: bigintFromMinimalTwosComplement,
+      full: false,
+    },
+    { biToMtc: bigintToMtcDirect, biFromMtc: bigintFromMtcDirect, full: true },
+    { biToMtc: bigintToMtcHex, biFromMtc: bigintFromMtcHex, full: true },
+  ]
+) {
+  const FIXTURE_SLICE_SIZE = 1000;
+  for (let at = 0; at < fixtures.length; at += FIXTURE_SLICE_SIZE) {
+    const slice = full
+      ? fixtures.slice(at, at + FIXTURE_SLICE_SIZE)
+      : fixtures.slice(at, at + 5);
+    const sliceLabel = `fixtures ${at}..${at + slice.length - 1}`;
 
-  describe("bigintToMinimalTwosComplement()", () => {
-    it(`correctly encodes ${sliceLabel}`, () => {
-      for (let i = 0; i < slice.length; i++) {
-        const { value, encoded, label } = slice[i];
-        try {
-          expect(bigintToMinimalTwosComplement(value)).toEqual(encoded);
-        } catch (e) {
-          throw new Error(`Failed on ${label}.`, { cause: e });
+    describe(`${biToMtc.name}()`, () => {
+      it(`correctly encodes ${sliceLabel}`, () => {
+        for (let i = 0; i < slice.length; i++) {
+          const { value, encoded, label } = slice[i];
+          try {
+            expect(biToMtc(value)).toEqual(encoded);
+          } catch (e) {
+            throw new Error(`Failed on ${label}.`, { cause: e });
+          }
         }
-      }
+      });
     });
-  });
 
-  describe("bigintFromMinimalTwosComplement()", () => {
-    it(`correctly decodes ${sliceLabel}`, () => {
-      for (let i = 0; i < slice.length; i++) {
-        const { value, encoded, label } = slice[i];
-        try {
-          expect(bigintFromMinimalTwosComplement(encoded)).toBe(value);
-        } catch (e) {
-          throw new Error(`Failed on ${label}.`, { cause: e });
+    describe(`${biFromMtc.name}()`, () => {
+      it(`correctly decodes ${sliceLabel}`, () => {
+        for (let i = 0; i < slice.length; i++) {
+          const { value, encoded, label } = slice[i];
+          try {
+            expect(biFromMtc(encoded)).toBe(value);
+          } catch (e) {
+            throw new Error(`Failed on ${label}.`, { cause: e });
+          }
         }
-      }
+      });
     });
-  });
 
-  describe("round trip through base64url", () => {
-    it(`correctly round-trips ${sliceLabel}`, () => {
-      for (let i = 0; i < slice.length; i++) {
-        const { value, label } = slice[i];
-        const bytes = bigintToMinimalTwosComplement(value);
-        const b64 = toUnpaddedBase64url(bytes);
-        const decodedBytes = fromBase64url(b64);
-        try {
-          expect(bigintFromMinimalTwosComplement(decodedBytes)).toBe(value);
-        } catch (e) {
-          throw new Error(`Failed on ${label}.`, { cause: e });
+    describe(`${biToMtc.name}()->${biFromMtc.name}() round trip through base64url`, () => {
+      it(`correctly round-trips ${sliceLabel}`, () => {
+        for (let i = 0; i < slice.length; i++) {
+          const { value, label } = slice[i];
+          const bytes = biToMtc(value);
+          const b64 = toUnpaddedBase64url(bytes);
+          const decodedBytes = fromBase64url(b64);
+          try {
+            expect(biFromMtc(decodedBytes)).toBe(value);
+          } catch (e) {
+            throw new Error(`Failed on ${label}.`, { cause: e });
+          }
         }
-      }
+      });
+    });
+  }
+
+  //
+  // Edge cases
+  //
+
+  describe(`${biFromMtc.name}()`, () => {
+    it("throws on empty input", () => {
+      expect(() => biFromMtc(new Uint8Array([]))).toThrow(
+        "empty input",
+      );
     });
   });
 }
-
-//
-// Edge cases
-//
-
-describe("bigintFromMinimalTwosComplement()", () => {
-  it("throws on empty input", () => {
-    expect(() => bigintFromMinimalTwosComplement(new Uint8Array([]))).toThrow(
-      "empty input",
-    );
-  });
-});


### PR DESCRIPTION
This PR introduces a second implementation of `bigintToMinimalTwosComplement()` / `bigintFromMinimalTwosComplement()` that uses the (relatively new) `Uint8Array.toHex()` / `Uint8Array.fromHex()` methods for the large-data path, with the original direct byte-pushing implementation retained as the small-length fast path inside both files (via shared helpers in `bigint-shared-impl.ts`).

`bigint.ts` is now a thin dispatcher. The choice is feature-detected at module load (`!!Uint8Array.fromHex`), so runtimes that support the hex methods get the new impl and older ones transparently fall back to the direct impl.

## Performance (M5 Pro, full sweep in `bench/bigint.bench.ts`)

Encode:
- 1–8B: essentially tied (both go through the direct fast path)
- 9–15B: hex ~3–9% faster
- 16B: hex ~1.3x faster
- 32B: hex ~1.5x faster
- 128B: hex ~2.0x faster
- 1024B: hex ~5x faster

Decode:
- 1–4B: direct ~1.6x faster (the small-length fast path inside the hex impl still pays a small dispatch cost)
- 5–8B: direct ~1.15x faster
- 9–11B: direct ~1.05x faster
- 12B+: essentially tied
- 128B+: hex ~1.8–4x faster

Net: on a runtime with `Uint8Array.fromHex`, the new impl is a clear win at sizes ≥16B and only modestly slower (by hundreds of ns) at very small decode sizes — an acceptable trade for the large-input speedup and the simpler hex-based code.

## Test plan
- [x] `deno task test` in `packages/utils` (all bigint cases, both impls covered)
- [x] Full repo `deno task test`
- [x] Benchmark sweep over byte sizes 1–127, 128, 256, 512, 1008–1039

## Performance Baseline

This PR speeds up a couple functions, and they aren't even used much yet. Therefore, the following accounts for spurious perf check failures:

NEW_PERF_BASELINE: job: Runner Tests (1/4) = 86s
NEW_PERF_BASELINE: subtest: pattern-unit-2/pattern-unit-tests > packages/patterns/cfc-trusted-surfaces/main.test.tsx = 24s
NEW_PERF_BASELINE: step: patterns integration = 141s
NEW_PERF_BASELINE: job: Pattern Integration Tests = 167s
NEW_PERF_BASELINE: job: Pattern Integration Tests (2/4) = 167s
NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/reading-list/reading-item-detail.test.tsx = 14s


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a hex-based bigint encoder/decoder that uses `Uint8Array.{toHex,fromHex}` when available and falls back to the existing direct path. Large inputs get faster, while small-input fast paths stay in place.

- New Features
  - `bigintToMinimalTwosComplement()` / `bigintFromMinimalTwosComplement()` now dispatch based on `!!Uint8Array.fromHex`.
  - Split implementations into `bigint-uint8-direct.ts` and `bigint-uint8-hex-string.ts` with shared helpers.
  - Benchmarks compare both implementations; tests cover both.

- Performance
  - Encode: ≥16B is ~1.3x–5x faster (up to ~5x at 1024B); ≤8B unchanged.
  - Decode: ≤8B up to ~1.6x slower; ≥128B ~1.8x–4x faster; mid-sizes ~tie.

<sup>Written for commit 295869f05cbe22a218bb93241ec8da3fb5df44c9. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3633?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

