### PR TITLE
[codex] Fix cell constructor follow-ups

### DIFF
--- a/docs/development/importers/bidirectional_sync.md
+++ b/docs/development/importers/bidirectional_sync.md
@@ -50,10 +50,10 @@ To prevent the window where synced state temporarily reverts a pending edit:
 - Optionally move applied edits to an `appliedEdits` array for audit/UI
   purposes.
 
-### 5. Stable Identity via `new Cell()`
+### 5. Stable Identity via `Cell.for()`
 
 When writing items that have an external canonical ID, use
-`new Cell(externalId).set(...)` to create the data. This ensures that links
+`Cell.for(externalId).set(...)` to create the data. This ensures that links
 created in the fabric point to stable cells derived from the canonical ID,
 rather than ephemeral cells that get replaced on each sync.
 
@@ -69,7 +69,7 @@ ensures any links created between the edit and the sync remain valid.
 
 ```typescript
 // After getting canonical ID for a newly created item:
-const canonicalCell = new Cell(canonicalId);
+const canonicalCell = Cell.for(canonicalId);
 const editCell = item.asResolvedCell();
 editCell.setRaw(canonicalCell.getAsWriteRedirectLink({ base: editCell }));
 ```
@@ -208,16 +208,16 @@ async function runSyncLoop(
         editWatermark = edits.length;
 
         // 2. Read full filesystem state, build cell structure
-        //    IMPORTANT: Use new Cell(canonicalId) for each item that has
+        //    IMPORTANT: Use Cell.for(canonicalId) for each item that has
         //    an external ID. This ensures stable links in the fabric.
         const fsState = readFilesystemState(watchPath);
         stateCell.set(
-          buildStateFromFs(fsState), // Must use new Cell() internally — see below
+          buildStateFromFs(fsState), // Must use Cell.for() internally — see below
         );
 
         // 3. Write redirect links for newly created items
         for (const [edit, canonicalId] of editIdMap) {
-          const canonicalCell = new Cell(canonicalId);
+          const canonicalCell = Cell.for(canonicalId);
           const editCell = edit.tempRef.asResolvedCell();
           editCell.setRaw(
             canonicalCell.getAsWriteRedirectLink({ base: editCell }),
@@ -248,22 +248,22 @@ async function runSyncLoop(
 
 ### Building State with Stable Identity
 
-> **TODO(seefeld):** `new Cell()` in handler frames creates cells scoped to that
+> **TODO(seefeld):** `Cell.for()` in handler frames creates cells scoped to that
 > handler invocation. For importers operating outside a pattern, we need a shared
-> frame so `new Cell()` produces consistent cells across the whole import. Current
+> frame so `Cell.for()` produces consistent cells across the whole import. Current
 > workaround: `pushFrameFromCause` with a stable cause string. This needs
 > platform-level support.
 
-The `buildStateFromFs` function (or equivalent) **must** use `new Cell()` for
+The `buildStateFromFs` function (or equivalent) **must** use `Cell.for()` for
 every sub-item that has an external canonical ID. For example:
 
 ```typescript
 function buildStateFromFs(fsState: FsState): State {
   return {
     items: fsState.items.map((item) =>
-      // new Cell() ensures this item has a stable cell derived from
+      // Cell.for() ensures this item has a stable cell derived from
       // its canonical ID. Links to this item survive across syncs.
-      new Cell(item.canonicalId).set({
+      Cell.for(item.canonicalId).set({
         name: item.name,
         path: item.path,
         // ...
@@ -275,7 +275,7 @@ function buildStateFromFs(fsState: FsState): State {
 
 This is not a post-processing step — it must happen as part of constructing the
 state structure. If you write the structure first and then try to set up
-`new Cell()` mappings afterward, the items in the array will have ephemeral cell
+`Cell.for()` mappings afterward, the items in the array will have ephemeral cell
 IDs that break on every sync.
 
 ### Don't Diff — Let the Runtime Do It
@@ -595,7 +595,7 @@ Not all edits are treated the same:
 - **Heavy actions** (create issue, close PR, merge branch): Do NOT optimistically
   apply to local state. Instead, render the edit itself as a pending action in the
   UI — a grayed-out card with a spinner. When the API responds or a webhook
-  confirms success, write the real entity with `new Cell(canonicalId)`. No write
+  confirms success, write the real entity with `Cell.for(canonicalId)`. No write
   redirects are needed because the edit was never materialized as a cell in the
   state structure.
 
@@ -614,7 +614,7 @@ When the user performs an action:
    `stage: "pending"`
 2. **Fire the API call** — immediately dispatch the request and advance to
    `stage: "in-flight"`
-3. **On success** — write the canonical entity via `new Cell(canonicalId)`,
+3. **On success** — write the canonical entity via `Cell.for(canonicalId)`,
    advance edit to `succeeded`, clean up
 4. **On failure** — mark edit as `failed` with error info
 
@@ -637,7 +637,7 @@ const createIssue = handler<{ edits: ApiEdit[] }>(
       try {
         const result = await github.createIssue({ title, body });
         // Write canonical entity
-        new Cell(`issue:${result.number}`).set({
+        Cell.for(`issue:${result.number}`).set({
           number: result.number,
           title: result.title,
           body: result.body,
@@ -671,11 +671,11 @@ async function handleWebhookEvent(event: WebhookEvent) {
   processedEvents.add(event.id);
 
   // Handle out-of-order delivery: ignore stale updates
-  const existing = new Cell(`issue:${event.issue.number}`).get();
+  const existing = Cell.for(`issue:${event.issue.number}`).get();
   if (existing && existing.updatedAt > event.issue.updatedAt) return;
 
   // Apply the update
-  new Cell(`issue:${event.issue.number}`).set({
+  Cell.for(`issue:${event.issue.number}`).set({
     number: event.issue.number,
     title: event.issue.title,
     body: event.issue.body,
@@ -721,7 +721,7 @@ async function fullRebuild() {
   try {
     stateCell.set({
       issues: allIssues.map((issue) =>
-        new Cell(`issue:${issue.number}`).set({
+        Cell.for(`issue:${issue.number}`).set({
           number: issue.number,
           title: issue.title,
           body: issue.body,
@@ -730,7 +730,7 @@ async function fullRebuild() {
         })
       ),
       pullRequests: allPRs.map((pr) =>
-        new Cell(`pr:${pr.number}`).set({
+        Cell.for(`pr:${pr.number}`).set({
           number: pr.number,
           title: pr.title,
           state: pr.state,
@@ -746,7 +746,7 @@ async function fullRebuild() {
 ```
 
 This is the same pattern as filesystem sync: read everything, write with
-`new Cell()`, single transaction. The only difference is the data source.
+`Cell.for()`, single transaction. The only difference is the data source.
 
 ### Pattern (UI) Integration for API Sync
 
@@ -824,7 +824,7 @@ need it.
 | Optimistic updates     | Apply edits to local state in same tx as enqueue       |
 | External canonical     | Overwrite local state from external source each sync   |
 | Anti-backsliding       | Single tx: apply edits + update state + clear queue    |
-| Stable identity        | `new Cell(externalId)` for canonical-ID-bearing items   |
+| Stable identity        | `Cell.for(externalId)` for canonical-ID-bearing items   |
 | In-flight link safety  | Write redirect links from temp cells to canonical ones |
 | Process safety         | Lockfile with PID, stale lock recovery                 |
 | System edit failures   | Keep in queue, crash daemon, operator restarts         |
@@ -832,4 +832,4 @@ need it.
 | UI pending state       | Render from edit queue; auto-clears on sync            |
 | Edit lifecycle         | Staged entities: pending → in-flight → succeeded/failed |
 | Heavy actions          | Render as pending edits, not optimistic state          |
-| Webhook sync           | Incremental updates via `new Cell()`; full rebuild as backstop |
+| Webhook sync           | Incremental updates via `Cell.for()`; full rebuild as backstop |

--- a/docs/specs/PATTERN_TESTING_SPEC.md
+++ b/docs/specs/PATTERN_TESTING_SPEC.md
@@ -87,11 +87,13 @@ This format keeps `action()` streams and `computed()` cells separate in the type
 import { action, computed, pattern, Writable } from "commonfabric";
 import ExpenseTracker from "./expense-tracker.tsx";
 
+type Expense = { description: string; amount: number; category: string };
+
 // Test pattern for expense tracker
 export default pattern(() => {
   // 1. Instantiate the pattern under test with initial state
   const subject = ExpenseTracker({
-    expenses: new Writable([]),
+    expenses: new Writable<Expense[]>([]),
   });
 
   // 2. Define test actions using action() - triggers events on the pattern

--- a/packages/fs-sync-example/README.md
+++ b/packages/fs-sync-example/README.md
@@ -29,7 +29,7 @@ daemon process.
 | -------------------------------- | -------------------------------------------------- |
 | `src/todo-list-pattern.tsx`      | UI pattern with handlers and optimistic updates    |
 | `src/todo-list-pattern.test.tsx` | Pattern tests (run with `deno task cf test`)       |
-| `src/daemon.ts`                  | Sync loop: CAS retries, edit watermark, new Cell() |
+| `src/daemon.ts`                  | Sync loop: CAS retries, edit watermark, Cell.for() |
 | `src/run-daemon.ts`              | CLI launcher for the daemon                        |
 | `src/types.ts`                   | Shared types (Todo, Edit, FailedEdit)              |
 | `src/markdown.ts`                | Markdown parser/serializer for the todo file       |
@@ -72,5 +72,5 @@ deno test packages/fs-sync-example/src/markdown.test.ts
 
 This example implements the patterns described in
 [docs/development/importers/bidirectional_sync.md](../../docs/development/importers/bidirectional_sync.md),
-covering CAS retry loops, edit watermarks, new Cell() for stable identity, and
+covering CAS retry loops, edit watermarks, Cell.for() for stable identity, and
 error classification.

--- a/packages/fs-sync-example/src/daemon.ts
+++ b/packages/fs-sync-example/src/daemon.ts
@@ -5,7 +5,7 @@
  * - CAS retry loop with editWatermark
  * - editIdMap surviving retries
  * - Single-transaction commit (apply edits + update state + clear queue)
- * - new Cell() for stable identity
+ * - Cell.for() for stable identity
  * - Write redirect links for in-flight creates
  * - Lockfile for process safety
  * - System vs conflict error handling
@@ -150,21 +150,21 @@ function applyEdit(
 }
 
 // ---------------------------------------------------------------------------
-// Build cell state from filesystem using new Cell() for stable identity
+// Build cell state from filesystem using Cell.for() for stable identity
 // ---------------------------------------------------------------------------
 
 function buildStateFromFs(
   filePath: string,
-  CellOf: (value: unknown) => Cell<any>,
+  CellFor: (cause: unknown) => Cell<any>,
 ): State {
   const text = Deno.readTextFileSync(filePath);
   const parsed = parseMarkdown(text);
 
   return {
-    // new Cell() ensures stable cell identity derived from the canonical ID.
+    // Cell.for() ensures stable cell identity derived from the canonical ID.
     // Links to this todo survive across syncs.
     todos: parsed.todos.map((todo) =>
-      CellOf(todo.id).set({
+      CellFor(todo.id).set({
         id: todo.id,
         description: todo.description,
         done: todo.done,
@@ -192,7 +192,7 @@ export function runSyncLoop(
   appliedEditsCell: Cell<Edit[]>,
   failedEditsCell: Cell<FailedEdit[]>,
   todoFilePath: string,
-  CellConstructor: { of: (value: unknown) => Cell<any> },
+  CellConstructor: { for: (cause: unknown) => Cell<any> },
   tempRefs?: TempRefMap,
 ) {
   const lockPath = todoFilePath + ".lock";
@@ -326,20 +326,20 @@ export function runSyncLoop(
         editWatermark = edits.length;
 
         // 2. Read full filesystem state, build cell structure.
-        //    new Cell() is used inside buildStateFromFs for each todo.
-        const fsState = buildStateFromFs(todoFilePath, CellConstructor.of);
+        //    Cell.for() is used inside buildStateFromFs for each todo.
+        const fsState = buildStateFromFs(todoFilePath, CellConstructor.for);
         txTodos.set(fsState.todos);
 
         // 3. Write redirect links for newly created items.
         //    tempRefs maps edit indices to the temp cells allocated by the
         //    pattern's optimistic create. Once we know the canonical ID,
-        //    we redirect the temp cell to the canonical new Cell() cell.
+        //    we redirect the temp cell to the canonical Cell.for() cell.
         if (tempRefs) {
           for (const [editIdx, tempCell] of tempRefs) {
             const edit = edits[editIdx];
             const canonicalId = edit && editIdMap.get(edit);
             if (canonicalId) {
-              const canonicalCell = CellConstructor.of(canonicalId);
+              const canonicalCell = CellConstructor.for(canonicalId);
               const resolved = tempCell.resolveAsCell();
               resolved.setRawUntyped(
                 canonicalCell.getAsWriteRedirectLink({ base: resolved }),

--- a/packages/fs-sync-example/src/run-daemon.ts
+++ b/packages/fs-sync-example/src/run-daemon.ts
@@ -21,10 +21,10 @@ import { PiecesController } from "@commonfabric/piece/ops";
 import { runSyncLoop } from "./daemon.ts";
 import type { Edit, FailedEdit, Todo } from "./types.ts";
 
-// Build a Cell constructor with .of() — must be called inside a reactive frame,
+// Build a Cell constructor with .for() — must be called inside a reactive frame,
 // which the daemon's doSync() provides via pushFrameFromCause.
 const CellConstructor = cellConstructorFactory("cell") as unknown as {
-  of: (value: unknown) => Cell<unknown>;
+  for: (cause: unknown) => Cell<unknown>;
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/ts-transformers/src/ast/call-kind.ts
+++ b/packages/ts-transformers/src/ast/call-kind.ts
@@ -233,6 +233,7 @@ export function detectNewExpressionKind(
   const factoryName = detectCellConstructorExpressionName(
     node.expression,
     checker,
+    new Set(),
   );
   if (!factoryName) return undefined;
   return { kind: "cell-factory", factoryName };
@@ -1770,6 +1771,7 @@ function detectCellMethodFromDeclaration(
 function detectCellConstructorExpressionName(
   expression: ts.Expression,
   checker: ts.TypeChecker,
+  seen: Set<ts.Symbol>,
 ): string | undefined {
   const target = stripWrappers(expression);
 
@@ -1777,7 +1779,11 @@ function detectCellConstructorExpressionName(
     ts.isPropertyAccessExpression(target) &&
     CELL_SCOPED_CONSTRUCTOR_NAMES.has(target.name.text)
   ) {
-    return detectCellConstructorExpressionName(target.expression, checker);
+    return detectCellConstructorExpressionName(
+      target.expression,
+      checker,
+      seen,
+    );
   }
 
   if (!ts.isIdentifier(target) && !ts.isPropertyAccessExpression(target)) {
@@ -1788,6 +1794,8 @@ function detectCellConstructorExpressionName(
     ts.isIdentifier(target) ? target : target.name,
   );
   if (!symbol) return undefined;
+  if (seen.has(symbol)) return undefined;
+  seen.add(symbol);
 
   const importedName = getImportedCommonFabricNamedExport(
     symbol,
@@ -1806,7 +1814,32 @@ function detectCellConstructorExpressionName(
     return name;
   }
 
+  for (const declaration of resolved.declarations ?? []) {
+    if (
+      ts.isVariableDeclaration(declaration) &&
+      isConstVariableDeclaration(declaration) &&
+      declaration.initializer &&
+      shouldFollowConstructorInitializer(declaration.initializer)
+    ) {
+      const nested = detectCellConstructorExpressionName(
+        declaration.initializer,
+        checker,
+        seen,
+      );
+      if (nested) return nested;
+    }
+  }
+
   return undefined;
+}
+
+function shouldFollowConstructorInitializer(
+  initializer: ts.Expression,
+): boolean {
+  const target = stripWrappers(initializer);
+  return ts.isIdentifier(target) ||
+    ts.isPropertyAccessExpression(target) ||
+    ts.isElementAccessExpression(target);
 }
 
 function isArrayMethodDeclaration(declaration: ts.Declaration): boolean {

--- a/packages/ts-transformers/test/ast/call-kind.test.ts
+++ b/packages/ts-transformers/test/ast/call-kind.test.ts
@@ -253,6 +253,25 @@ Deno.test("constructor classification ignores non-Common-Fabric ambient classes"
   assertEquals(detectNewExpressionKind(expression, checker), undefined);
 });
 
+Deno.test("constructor classification follows local Common-Fabric constructor aliases", () => {
+  const { sourceFile, checker } = createProgram(`
+    import { Writable } from "commonfabric";
+
+    const LocalWritable = Writable;
+    const value = new LocalWritable("aliased");
+  `);
+
+  const expression = findInitializer(sourceFile, "value");
+  if (!ts.isNewExpression(expression)) {
+    throw new Error("Expected new expression initializer");
+  }
+
+  assertEquals(detectNewExpressionKind(expression, checker), {
+    kind: "cell-factory",
+    factoryName: "Writable",
+  });
+});
+
 Deno.test("classifyArrayCallbackContainerCall recognizes plain value-returning non-map array callbacks", () => {
   const { sourceFile, checker } = createProgram(`
     interface Array<T> {

--- a/packages/ts-transformers/test/fixtures/schema-injection/cell-constructors.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/cell-constructors.expected.jsx
@@ -57,6 +57,10 @@ export default function TestCellConstructors() {
     const writeonly = new WriteonlyCell(400, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("writeonly", true);
+    const LocalWritable = WritableConstructor;
+    const aliased = new LocalWritable("aliased", {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema).for("aliased", true);
     return {
         explicitString,
         inferredNumber,
@@ -67,6 +71,7 @@ export default function TestCellConstructors() {
         comparable,
         readonly,
         writeonly,
+        aliased,
     };
 }
 __cfHardenFn(TestCellConstructors);

--- a/packages/ts-transformers/test/fixtures/schema-injection/cell-constructors.input.tsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/cell-constructors.input.tsx
@@ -29,6 +29,8 @@ export default function TestCellConstructors() {
   const comparable = new ComparableCell(200);
   const readonly = new ReadonlyCell(300);
   const writeonly = new WriteonlyCell(400);
+  const LocalWritable = WritableConstructor;
+  const aliased = new LocalWritable("aliased");
 
   return {
     explicitString,
@@ -40,5 +42,6 @@ export default function TestCellConstructors() {
     comparable,
     readonly,
     writeonly,
+    aliased,
   };
 }


### PR DESCRIPTION
## Summary

This follow-up addresses the three issues found while reviewing #3628 after it merged:

- Preserve transformer behavior for stable local aliases of Common Fabric cell constructors, e.g. `const LocalWritable = Writable; new LocalWritable("x")`.
- Correct stable-identity docs and the fs-sync example to use `Cell.for(canonicalId)` instead of treating `new Cell(canonicalId)` as an identity cause.
- Type the empty-array testing-spec snippet as `new Writable<Expense[]>([])` so it passes the transformer empty-array validation.

## Root Cause

Constructor lowering initially resolved imported/Common Fabric constructor symbols directly, but did not follow local `const` aliases. The older `.of(...)` path already handled that kind of alias, so `new Alias(...)` could skip schema injection and initializer `.for(...)`.

The docs migration also blurred two separate concepts: constructor arguments are defaults, while `.for(...)` sets the cell identity cause. Stable external IDs need to be passed through `.for(...)`.

Finally, `new Writable([])` runs into the existing empty-array validation because TypeScript infers `never[]`; explicit element typing is required.

## Validation

- `/Users/gideonwald/.deno/bin/deno fmt packages/ts-transformers/src/ast/call-kind.ts packages/ts-transformers/test/ast/call-kind.test.ts packages/ts-transformers/test/fixtures/schema-injection/cell-constructors.input.tsx packages/ts-transformers/test/fixtures/schema-injection/cell-constructors.expected.jsx packages/fs-sync-example/src/daemon.ts packages/fs-sync-example/src/run-daemon.ts`
- `/Users/gideonwald/.deno/bin/deno test -A packages/ts-transformers/test/ast/call-kind.test.ts`
- `cd packages/ts-transformers && env FIXTURE=cell-constructors /Users/gideonwald/.deno/bin/deno test -A test/fixture-based.test.ts`
- `/Users/gideonwald/.deno/bin/deno check packages/fs-sync-example/src/run-daemon.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cell-constructor lowering to follow local `const` aliases (including chained aliases) and updates docs/examples to use `Cell.for(canonicalId)` for stable identity. Also types the testing spec’s empty array so transformer validation passes.

- **Bug Fixes**
  - Transformer now recognizes `new` calls via local aliases of Common Fabric constructors in `commonfabric` (e.g., `const LocalWritable = Writable; new LocalWritable("x")`).
  - Typed the testing spec snippet as `new Writable<Expense[]>([])` to satisfy empty-array validation.

- **Migration**
  - Use `Cell.for(canonicalId)` for stable identity instead of `new Cell(canonicalId)`.
  - In the fs-sync daemon example, use the constructor factory’s `.for(cause)` and replace any `.of(...)` usage with `.for(...)`.

<sup>Written for commit a881f433601f701dac2852663782b7290cf902dd. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3634?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

