### PR TITLE
[codex] Track CFC labels for write_file sinks

### DIFF
--- a/packages/cf-harness/src/tools/file-errors.ts
+++ b/packages/cf-harness/src/tools/file-errors.ts
@@ -103,13 +103,14 @@ export const createStructuredFileToolErrorOutput = (
   context: HarnessToolContext,
   toolId: "read_file" | "view_image" | "write_file" | "edit_file",
   options: {
+    outputId?: string;
     path: string;
     code: StructuredFileToolErrorCode;
     detail?: string;
     exitCode?: number;
   },
 ): StructuredFileToolErrorOutput => ({
-  outputId: context.nextOutputId(toolId),
+  outputId: options.outputId ?? context.nextOutputId(toolId),
   path: options.path,
   ok: false,
   error: {

--- a/packages/cf-harness/src/tools/write-file.ts
+++ b/packages/cf-harness/src/tools/write-file.ts
@@ -1,4 +1,5 @@
 import type { JSONSchema } from "@commonfabric/api";
+import type { CfcLabelView } from "@commonfabric/runner/cfc";
 import type { HarnessToolDescriptor } from "../contracts/tool-descriptor.ts";
 import type { HarnessToolDefinition } from "./types.ts";
 import {
@@ -22,6 +23,9 @@ export interface WriteFileToolInput {
   content: string;
   mode?: WriteFileMode;
   createParents?: boolean;
+  // Trusted harness/test plumbing for invocation input labels. This is omitted
+  // from the public tool schema so model-authored tool calls do not mint labels.
+  cfcInputLabels?: CfcLabelView;
 }
 
 export interface WriteFileToolSuccessOutput {
@@ -95,6 +99,7 @@ export const writeFileTool: HarnessToolDefinition<
       });
     }
     const mode = input.mode ?? "replace";
+    const outputId = context.nextOutputId("write_file");
     const command = [
       "set -eu",
       'path="$1"',
@@ -132,16 +137,23 @@ export const writeFileTool: HarnessToolDefinition<
       stdinText: input.content,
       cfcInvocationContext: await context.createCfcInvocationContext({
         toolId: "write_file",
+        toolOutputId: outputId,
         operation: "shell",
         cwd: context.currentDir,
         command,
         args,
         stdinText: input.content,
+        ...(input.cfcInputLabels !== undefined
+          ? { cfcInputLabels: input.cfcInputLabels }
+          : {}),
+        // write_file is a CFC sink: both the selected destination/mode args and
+        // the bytes written on stdin are model-authored invocation inputs.
         cfcInputLabelPaths: [["args"], ["stdin"]],
       }),
     });
     if (result.exitCode !== 0) {
       return createStructuredFileToolErrorOutput(context, "write_file", {
+        outputId,
         path: resolvedPath,
         code: classifyFileToolShellFailure(result),
         detail: detailFromShellFailure(result),
@@ -149,7 +161,7 @@ export const writeFileTool: HarnessToolDefinition<
       });
     }
     return {
-      outputId: context.nextOutputId("write_file"),
+      outputId,
       path: resolvedPath,
       mode,
     };

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -3673,6 +3673,110 @@ Deno.test("CfHarnessPromptLoop exposes mediated read_file content and tracks mod
   );
 });
 
+Deno.test("CfHarnessPromptLoop carries observed CFC labels into later write_file inputs", async () => {
+  const fetchCalls: RequestInit[] = [];
+  const secretLabel = "did:key:write-file-secret";
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime([
+        {
+          stdout: "raw file secret\n",
+          stderr: "",
+          exitCode: 0,
+          cfcResult: observedCfcResult("released file secret\n", {
+            stdoutLabel: { confidentiality: [secretLabel] },
+          }),
+        },
+        {
+          stdout: "",
+          stderr: "",
+          exitCode: 0,
+        },
+      ]),
+      runId: "run-write-file-cfc-model-context",
+      model: "gpt-5.4",
+      cfcEnforcementMode: "enforce-explicit",
+    }),
+    fetchFn: (_input, init) => {
+      fetchCalls.push(init ?? {});
+      const payload = fetchCalls.length === 1
+        ? {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "",
+              tool_calls: [{
+                id: "call-read-write-secret",
+                type: "function",
+                function: {
+                  name: "read_file",
+                  arguments: JSON.stringify({ path: "secret.txt" }),
+                },
+              }],
+            },
+          }],
+        }
+        : fetchCalls.length === 2
+        ? {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "",
+              tool_calls: [{
+                id: "call-write-secret-derived-output",
+                type: "function",
+                function: {
+                  name: "write_file",
+                  arguments: JSON.stringify({
+                    path: "derived.txt",
+                    content: "derived from released file secret\n",
+                  }),
+                },
+              }],
+            },
+          }],
+        }
+        : {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "Done.",
+            },
+          }],
+        };
+      return Promise.resolve(
+        new Response(JSON.stringify(payload), { status: 200 }),
+      );
+    },
+  });
+
+  const result = await loop.runPrompt({
+    prompt: "Read a file, then write derived output.",
+    promptSlotBinding: directPromptSlotBinding,
+  });
+
+  assertEquals(
+    result.runState.cfcInvocationContexts?.map((context) => context.toolId),
+    ["read_file", "write_file"],
+  );
+  assertEquals(
+    invocationInputLabelContains(result.runState, 1, "args", secretLabel),
+    true,
+  );
+  assertEquals(
+    invocationInputLabelContains(result.runState, 1, "stdin", secretLabel),
+    true,
+  );
+  assertEquals(
+    result.runState.cfcInvocationContexts?.[1]?.toolOutputId,
+    createToolOutputId("run-write-file-cfc-model-context", "write_file", 2),
+  );
+});
+
 Deno.test("CfHarnessPromptLoop accumulates observed CFC labels for the next model turn", async () => {
   const fetchCalls: RequestInit[] = [];
   const secretLabel = "did:key:alice";

--- a/packages/cf-harness/test/tools-execution.test.ts
+++ b/packages/cf-harness/test/tools-execution.test.ts
@@ -2,7 +2,7 @@ import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
 import { decodeBase64 } from "@std/encoding/base64";
 import { join } from "@std/path";
 import { normalize } from "@std/path/posix";
-import type { CfcSandboxResult } from "@commonfabric/runner/cfc";
+import type { CfcLabelView, CfcSandboxResult } from "@commonfabric/runner/cfc";
 import { createHarnessCfcInvocationContext } from "../src/contracts/cfc-invocation-context.ts";
 import type {
   HarnessSkillRegistry,
@@ -1336,6 +1336,38 @@ Deno.test("write_file tool supports append mode and passes content over stdin", 
   assertEquals(
     sandbox.calls[0]?.request.cfcInvocationContext?.cwd,
     "/workspace",
+  );
+  assertEquals(
+    sandbox.calls[0]?.request.cfcInvocationContext?.toolOutputId,
+    output.outputId,
+  );
+});
+
+Deno.test("write_file tool merges explicit trusted CFC labels with write inputs", async () => {
+  const sandbox = new FakeSandboxRuntime();
+  const trustedLabels: CfcLabelView = {
+    version: 1,
+    entries: [{
+      path: ["stdin"],
+      label: {
+        confidentiality: [{
+          type: "test.cfc/TrustedInput",
+          source: "unit-test",
+        }],
+      },
+    }],
+  };
+
+  await writeFileTool.invoke(createContext(sandbox), {
+    path: "notes/secret.txt",
+    content: "secret\n",
+    cfcInputLabels: trustedLabels,
+  });
+
+  assertEquals(
+    sandbox.calls[0]?.request.cfcInvocationContext?.cfcInputLabels
+      ?.entries[0],
+    trustedLabels.entries[0],
   );
 });
 


### PR DESCRIPTION
## Summary
- correlate write_file CFC invocation contexts with the retained tool output id
- let trusted harness plumbing merge explicit CFC input labels into write_file invocations without exposing that field in the public tool schema
- add coverage that observed CFC model-context labels flow into later write_file destination args and stdin content

## Notes
This keeps the scope to cf-harness sink intent/diagnostics. It does not claim durable Fabric/FUSE writeback or prepare/finalize semantics.

## Validation
- PATH="$HOME/.deno/bin:$PATH" deno test --allow-read --allow-write --allow-run packages/cf-harness/test/tools-execution.test.ts packages/cf-harness/test/prompt-loop.test.ts packages/cf-harness/test/cfc-invocation-context.test.ts packages/cf-harness/test/engine.test.ts
- PATH="$HOME/.deno/bin:$PATH" deno check packages/cf-harness/src/main.ts
- git diff --check
- cd packages/cf-harness && PATH="$HOME/.deno/bin:$PATH" deno task test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CFC label tracking for `write_file` sink inputs and correlates each invocation with a stable `outputId`. Ensures labels from model context flow into `write_file` args and stdin, improving auditability and enforcement.

- New Features
  - Added trusted-only `cfcInputLabels` to `write_file` (typed as `CfcLabelView` from `@commonfabric/runner/cfc`) and merge them into the invocation.
  - Marked `args` and `stdin` as labeled sink inputs and included `toolOutputId` in `cfcInvocationContext`.
  - Reused a single `outputId` for both success and error paths via `createStructuredFileToolErrorOutput`.
  - Added tests to verify label propagation to `write_file` args/stdin and `toolOutputId` consistency.

<sup>Written for commit 6e6c6e3d9cf8f5ad472c5100f7f3f1d9441f96c9. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3636?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

