### PR TITLE
refactor(data-model): unify [RECONSTRUCT] deep-freeze calls to deepFreeze()

### DIFF
--- a/packages/data-model/fabric-native-instances.ts
+++ b/packages/data-model/fabric-native-instances.ts
@@ -369,9 +369,7 @@ export class FabricError extends FabricNativeWrapper<Error> {
     const result = new FabricError(error);
     // Honor `shouldDeepFreeze`: produce the type's correct deep-frozen form
     // via its `[DEEP_FREEZE]` member (recursing through `deepFreeze`).
-    return context.shouldDeepFreeze
-      ? result[DEEP_FREEZE]((v) => deepFreeze(v)) as unknown as FabricError
-      : result;
+    return context.shouldDeepFreeze ? deepFreeze(result) : result;
   }
 }
 
@@ -613,9 +611,7 @@ export class FabricRegExp extends FabricNativeWrapper<RegExp> {
     const result = new FabricRegExp(new RegExp(source, flags), flavor);
     // Honor `shouldDeepFreeze`: produce the type's correct deep-frozen form
     // via its `[DEEP_FREEZE]` member (recursing through `deepFreeze`).
-    return context.shouldDeepFreeze
-      ? result[DEEP_FREEZE]((v) => deepFreeze(v)) as unknown as FabricRegExp
-      : result;
+    return context.shouldDeepFreeze ? deepFreeze(result) : result;
   }
 }
 

--- a/packages/data-model/problematic-value.ts
+++ b/packages/data-model/problematic-value.ts
@@ -67,8 +67,6 @@ export class ProblematicValue extends ExplicitTagValue {
     const result = new ProblematicValue(state.type, state.state, state.error);
     // Honor `shouldDeepFreeze`: produce the type's correct deep-frozen form
     // via its `[DEEP_FREEZE]` member (recursing through `deepFreeze`).
-    return context.shouldDeepFreeze
-      ? result[DEEP_FREEZE]((v) => deepFreeze(v)) as unknown as ProblematicValue
-      : result;
+    return context.shouldDeepFreeze ? deepFreeze(result) : result;
   }
 }

--- a/packages/data-model/unknown-value.ts
+++ b/packages/data-model/unknown-value.ts
@@ -63,8 +63,6 @@ export class UnknownValue extends ExplicitTagValue {
     const result = new UnknownValue(state.type, state.state);
     // Honor `shouldDeepFreeze`: produce the type's correct deep-frozen form
     // via its `[DEEP_FREEZE]` member (recursing through `deepFreeze`).
-    return context.shouldDeepFreeze
-      ? result[DEEP_FREEZE]((v) => deepFreeze(v)) as unknown as UnknownValue
-      : result;
+    return context.shouldDeepFreeze ? deepFreeze(result) : result;
   }
 }


### PR DESCRIPTION
## Summary

Simplifies the four `[RECONSTRUCT]` implementations on `FabricInstance`
subclasses (`FabricError`, `FabricRegExp`, `ProblematicValue`,
`UnknownValue`) to use the unified `deepFreeze()` utility for honoring
`ReconstructionContext.shouldDeepFreeze`, replacing ad-hoc direct
invocations of the `[DEEP_FREEZE]` protocol member.

## What this delivers

Each affected `[RECONSTRUCT]` impl's final conditional changes from:

```ts
return context.shouldDeepFreeze
  ? result[DEEP_FREEZE]((v) => deepFreeze(v)) as unknown as XxxType
  : result;
```

to:

```ts
return context.shouldDeepFreeze ? deepFreeze(result) : result;
```

The unified form is a straightforward simplification with three side
benefits:

- **Cycle-safe by construction.** `deepFreeze()` threads a shared
  in-progress set through all recursive calls, including into the
  protocol callback. The ad-hoc `(v) => deepFreeze(v)` shape did not
  carry that shared state into the per-type `[DEEP_FREEZE]` invocation,
  so a cycle reaching one of these `[RECONSTRUCT]` paths was not
  cycle-safe at the call-site level even though the underlying protocol
  is. The unified form inherits cycle-safety from the standard dispatch.
- **Cache-coherent.** The `FabricInstance` arm of `deepFreeze()` adds the
  result to the deep-frozen cache, so a subsequent `isDeepFrozen()` check
  on the reconstructed instance short-circuits in O(1). The ad-hoc form
  bypassed that cache-write.
- **Type-clean.** `deepFreeze<T>(value: T): T` preserves the input type,
  so the `as unknown as XxxType` casts are no longer needed and are
  dropped.

No behavioral change for the `context.shouldDeepFreeze === false` branch
(returns the unfrozen `result` unchanged). No protocol-signature change;
the per-class `[DEEP_FREEZE]` member implementations are untouched.

## Test plan

- `deno fmt` / `deno lint` / `deno check` clean (data-model package).
- `packages/data-model` `deno task test` — 44 passed / 1338 steps / 0
  failed (no regressions; the existing `[RECONSTRUCT]`-honors-
  shouldDeepFreeze and cycle-safety tests pass under the unified form).
- Cross-package `deno check` clean on `packages/memory`, `packages/runner`,
  `packages/toolshed`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies `[RECONSTRUCT]` deep-freeze logic in `packages/data-model` by using `deepFreeze()` for `FabricError`, `FabricRegExp`, `ProblematicValue`, and `UnknownValue`. This simplifies the code, improves cycle safety and cache coherence, and keeps behavior unchanged when freezing is off.

- **Refactors**
  - Replace ad-hoc `[DEEP_FREEZE]((v) => deepFreeze(v))` with `deepFreeze(result)`.
  - Inherits cycle-safe recursion and updates the deep-freeze cache.
  - Preserves types (removes casts) and respects `shouldDeepFreeze`.

<sup>Written for commit 9b881af8203507322c1e4fedbad310d65878c9a6. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3637?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

