### PR TITLE
docs(fuse): specify CFC filesystem API semantics

### DIFF
--- a/docs/specs/fuse-filesystem/10-cfc-filesystem-api-semantics.md
+++ b/docs/specs/fuse-filesystem/10-cfc-filesystem-api-semantics.md
@@ -1,0 +1,154 @@
+# 10. CFC Filesystem API Semantics
+
+## Scope
+
+This chapter defines how the Common Fabric FUSE filesystem behaves when CFC
+annotations and writeback are enabled. It is normative for the filesystem API:
+ordinary programs must see normal POSIX-like success and error behavior. CFC
+adds labels, authorization checks, and fail-closed policy; it must not require
+ordinary programs to understand custom pending-success semantics.
+
+The default write contract is commit-confirmed: a mutating syscall reports
+success only after the corresponding Common Fabric mutation, runtime invocation,
+or explicitly specified acceptance boundary has succeeded. A mount may offer a
+separate local-ack compatibility mode, but that mode is non-default and must
+surface pending, failed, or unknown outcomes through diagnostics such as
+`.status` or operation logs.
+
+## Trust Model
+
+FUSE is the annotation producer and writeback reconciler. It is not, by itself,
+the sandbox observation-policy authority.
+
+- `trusted.cfc.*` is the logical protected namespace used for enforcement.
+  In production, these values are trusted only when carried through a
+  gVisor-mediated protected path.
+- `user.commonfabric.cfc.*` is a local compatibility/debug namespace. It may
+  mirror protected values for tools that cannot access `trusted.*`, but it must
+  not be used as enforcement input.
+- gVisor remains responsible for hiding or synthesizing sandbox-visible CFC
+  metadata, mediating metadata and path observations, tracking fd labels,
+  enforcing syscall-visible read/write policy, and passing trusted write-label
+  evidence back to FUSE.
+- Missing authoritative labels fail closed. FUSE must emit incomplete labels
+  rather than silently treating unknown data as public.
+
+## CFC Modes
+
+| Mode | Annotation output | Mutation behavior |
+|------|-------------------|-------------------|
+| `disabled` | CFC annotations are omitted unless explicitly requested for debugging. | CFC does not deny operations. Normal filesystem errors still apply. |
+| `observe` | CFC annotations are emitted. Missing runner metadata emits fail-closed labels. | Mutations proceed while missing, malformed, or stale prepare metadata is recorded as diagnostics. Valid prepare metadata may still be applied for testing and reconciliation. |
+| `enforce-explicit` | CFC annotations are emitted. | Annotated protected targets require valid trusted prepare metadata. Unannotated targets may proceed unless another policy denies them. |
+| `enforce-strict` | CFC annotations are emitted. | Projected mutations fail closed unless the relevant target or parent has coherent annotations and valid trusted prepare metadata. |
+
+## Common Operation Lifecycle
+
+Every mutating operation follows the same high-level lifecycle:
+
+1. Resolve the path to a logical Common Fabric ref: space, entity, cell,
+   JSON path, projection kind, and projection generation.
+2. Perform deterministic local validation: path type, JSON syntax, size/range,
+   supported operation, readonly projection, and CFC mode policy.
+3. For enforcing CFC modes, validate trusted prepare metadata against the current
+   ref, generation, operation, name, and parent/target annotations.
+4. Apply the Common Fabric mutation or runtime invocation.
+5. Rebuild or reconcile the projection and finalize any prepared CFC writeback.
+6. Reply success only if the operation reached its configured success boundary;
+   otherwise reply with the most specific standard errno.
+
+Read and traversal operations should remain cache-first and POSIX-like. Missing
+CFC labels on readable data do not make FUSE reads fail by themselves; instead,
+FUSE exposes fail-closed labels and the sandbox layer decides whether the caller
+may observe the bytes or metadata.
+
+## Errno Policy
+
+Use standard errno values. Do not invent a custom success state for pending CFC
+work.
+
+| Condition | Errno | Notes |
+|-----------|-------|-------|
+| CFC policy denial, missing required prepare, or unauthorized read/write/search | `EACCES` | Permission denied by policy. |
+| Operation forbidden independent of access bits, immutable/protected metadata mutation | `EPERM` | Use when the operation itself is not permitted. |
+| Read-only mount, disconnected read-only degradation, or immutable readonly projection | `EROFS` | Mutations cannot proceed in this state. |
+| Unsupported operation or unsupported xattr namespace | `ENOTSUP` / `EOPNOTSUPP` | Use for unsupported CFC operation classes, arbitrary symlink targets in enforcing modes, and unsupported xattr namespaces. |
+| Missing xattr | `ENODATA` on Linux, `ENOATTR` on macOS where exposed | Platform compatibility layer may normalize internally. |
+| Malformed CFC payload, invalid JSON, invalid flags, invalid symlink target | `EINVAL` | The caller supplied an invalid argument or file content. |
+| Stale ref, stale projection generation, or prepare metadata for an old generation | `ESTALE` | Prefer this over generic `EACCES` when the denial is retryable after re-reading metadata. |
+| Retryable race with current generation or in-flight rebuild | `EAGAIN` | Use only for explicitly retryable races, not for pending-success semantics. |
+| Backend timeout | `ETIMEDOUT` | The operation did not reach its success boundary before its deadline. |
+| Backend/storage/transport failure | `EIO` | Generic I/O failure when no more specific errno applies. |
+| Cross-space, cross-piece, or cross-cell rename | `EXDEV` | Rename cannot be atomic across those boundaries. |
+| Existing destination where replacement is not allowed | `EEXIST` | Especially create/mkdir and no-replace rename semantics. |
+| Directory type mismatch | `ENOTDIR` / `EISDIR` | Use the path-type-specific errno rather than collapsing to `ENOENT`. |
+| Non-empty directory removal or incompatible directory replacement | `ENOTEMPTY` | Applies when preserving normal directory semantics. |
+
+## Operation Matrix
+
+| Operation class | Operations | Normal program contract | CFC behavior | Primary CFC errors |
+|-----------------|------------|-------------------------|--------------|--------------------|
+| Traversal and attributes | `lookup`, `getattr`, `access`, `open`, `opendir`, `readdir`, `read`, `readlink`, `statfs` | Return cached or freshly resolved data, or a normal path/type/backend error. Reads should not require callers to understand CFC. | Emit annotation xattrs and fail-closed labels. gVisor mediates whether sandbox code may observe bytes, names, attrs, or xattrs. | `EACCES` for sandbox-mediated denial, `ENOENT`, `ENOTDIR`, `EISDIR`, `EINVAL`, `EIO`, `ETIMEDOUT`. |
+| Content writes | `write`, `flush`, `fsync`, `truncate`, `ftruncate` | Buffer partial writes as needed; validate complete file content at flush/fsync/close boundary; report success only after commit/acceptance boundary. | Existing annotated targets require trusted prepare in enforcing modes. Prepared content and metadata labels are applied before mutation and finalized after recomputation. | `EACCES`, `ESTALE`, `EINVAL`, `EROFS`, `EFBIG`, `ETIMEDOUT`, `EIO`. |
+| Handle cleanup | `release`, `releasedir` | Cleanup is best-effort; callers should receive writeback failures earlier via `write`, `flush`, or `fsync`. | Must not be the only place CFC or backend failures are reported. May record diagnostics for late failures. | Usually none; late failures become diagnostics, not hidden success contracts. |
+| Creation | `create`, `mkdir` | Create a file as an empty string or directory as an empty object only if parent and name are valid and backend mutation succeeds. | Parent namespace annotation controls the new entry. Enforcing modes require valid trusted prepare where required by mode. | `EACCES`, `ESTALE`, `EEXIST`, `EINVAL`, `ENOTDIR`, `EROFS`, `ETIMEDOUT`, `EIO`. |
+| Namespace deletion | `unlink`, `rmdir` | Remove the file or directory only if type checks and backend mutation succeed. Array deletion re-indexes as specified by the JSON mapping. | Parent namespace/entry labels govern the removal. In enforcing modes, prepare metadata must describe the removed name and generation. | `EACCES`, `ESTALE`, `ENOENT`, `ENOTDIR`, `EISDIR`, `ENOTEMPTY`, `EROFS`, `ETIMEDOUT`, `EIO`. |
+| Rename | `rename` | Same-cell rename is copy/delete at the JSON level but must appear as one filesystem operation. Cross-cell rename fails. Replacement semantics must be explicit. | Source and destination parent namespace labels govern the move. Prepare metadata must cover both sides when both are protected. | `EACCES`, `ESTALE`, `EXDEV`, `ENOENT`, `EEXIST`, `ENOTEMPTY`, `EINVAL`, `EROFS`, `ETIMEDOUT`, `EIO`. |
+| Symlink | `symlink`, `readlink` | Only Common Fabric sigil-link targets are supported by default. Invalid or escaping targets fail. | Parent namespace labels plus link-text/target-identity labels govern creation. Arbitrary symlink targets are unsupported in enforcing modes until modeled. | `EACCES`, `ESTALE`, `EINVAL`, `EEXIST`, `ENOTSUP`, `EROFS`, `ETIMEDOUT`, `EIO`. |
+| Metadata mutation | `setattr`, chmod/chown/timestamps | Apply only supported metadata changes. Synthetic metadata may acknowledge only when the specified semantics are modeled. | Prepare metadata must cover each requested metadata field. Unspecified labels fail closed. Unknown setattr flags fail rather than being silently trusted. | `EACCES`, `EPERM`, `ESTALE`, `EINVAL`, `ENOTSUP`, `EROFS`, `ETIMEDOUT`, `EIO`. |
+| Xattr reads | `getxattr`, `listxattr` | Expose supported JSON type and CFC annotation names/values; hide or omit unsupported/inaccessible attrs. | `trusted.cfc.*` is protected. `user.commonfabric.cfc.*` is compat/debug only. Missing labels are represented as fail-closed values, not public values. | `ENODATA`/`ENOATTR`, `ENOTSUP`, `ERANGE`, `EACCES`, `EIO`. |
+| Xattr writes | `setxattr`, `removexattr` | Only the documented CFC prepare/finalize names are writable, and only when the temporary writeback bridge is enabled. | Trusted prepare/finalize records seed and complete writeback reconciliation. Compat names may be accepted for local transports but are not trusted for sandbox enforcement. | `EACCES`, `EPERM`, `EINVAL`, `ESTALE`, `ENOTSUP`, `ENODATA`, `EROFS`, `EIO`. |
+| Callable projections | `.handler`, `.tool`, `cf exec` | `.tool` files are read-only. Handler file writes remain a compatibility path outside enforcing CFC writeback unless a CFC invocation contract is specified. `cf exec` is the preferred invocation surface. | Callable files are descriptors; invocation authority remains at the Common Fabric runtime boundary. Enforcing modes should reject callable-send writeback until label propagation and authorization are specified. | `EACCES`, `ENOTSUP`, `EINVAL`, `ETIMEDOUT`, `EIO`. |
+| Unsupported filesystem objects | `mknod`, hard links, device files, arbitrary host symlinks | Not supported by the Common Fabric JSON projection unless a future spec models them. | Fail closed in CFC modes. | `ENOTSUP` or `EPERM`. |
+
+## Prepare and Finalize Requirements
+
+Prepared writeback metadata must be operation-specific and generation-specific.
+The operation must fail closed in enforcing modes when any of the following is
+true:
+
+- trusted prepare metadata is required but absent;
+- prepare metadata is malformed;
+- the prepared operation name does not exactly match the filesystem operation;
+- the prepared target or parent ref does not match the current projection ref;
+- `expectedGeneration` differs from the current annotation generation;
+- required content, namespace, entry, symlink, target identity, or metadata-field
+  labels are missing;
+- strict mode requires an annotation but the target or parent annotation is
+  absent or incoherent.
+
+After the Common Fabric mutation succeeds, FUSE must reconcile the rebuilt
+projection against the prepared labels. Until exact recomputation/finalization,
+the affected annotation remains incomplete/fail-closed rather than public.
+
+## Compatibility Notes
+
+The current implementation contains local compatibility behavior that should not
+be mistaken for the normative contract:
+
+- Some write paths currently reply before backend commit and report later
+  failures through logs, `.status`, or writeback recovery records. This is a
+  compatibility behavior to be tightened for the default POSIX-like contract.
+- Some implementation errors currently collapse to `ENOENT` or `EACCES` where
+  the normative spec calls for `ENOTDIR`, `EISDIR`, `EINVAL`, `ESTALE`,
+  `ENOTSUP`, or `ENODATA`/`ENOATTR`.
+- The temporary writeback xattr bridge is useful for local testing and early
+  gVisor integration, but the production trusted prepare/finalize transport is
+  still a separate design decision.
+
+## Open Questions
+
+1. What is the production trusted transport for prepare/finalize: protected
+   xattr, ioctl-like operation, sidecar RPC, or gVisor-private metadata path?
+2. What exact event is the default write success boundary for each operation:
+   durable cell commit, runtime acceptance, or another named backend ack?
+3. How should handler/tool invocation carry CFC labels and writeback evidence?
+   Until specified, enforcing modes should reject callable-send writeback.
+4. Should stale CFC generation consistently return `ESTALE` in implementation,
+   or remain `EACCES` for compatibility until clients are updated?
+5. Which metadata mutations should be modeled as real durable Common Fabric
+   metadata rather than synthetic POSIX attributes?
+
+---
+
+**Previous:** [CFC Annotations](./9-cfc-annotations.md)

--- a/docs/specs/fuse-filesystem/10-cfc-filesystem-api-semantics.md
+++ b/docs/specs/fuse-filesystem/10-cfc-filesystem-api-semantics.md
@@ -101,6 +101,113 @@ work.
 | Callable projections | `.handler`, `.tool`, `cf exec` | `.tool` files are read-only. Handler file writes remain a compatibility path outside enforcing CFC writeback unless a CFC invocation contract is specified. `cf exec` is the preferred invocation surface. | Callable files are descriptors; invocation authority remains at the Common Fabric runtime boundary. Enforcing modes should reject callable-send writeback until label propagation and authorization are specified. | `EACCES`, `ENOTSUP`, `EINVAL`, `ETIMEDOUT`, `EIO`. |
 | Unsupported filesystem objects | `mknod`, hard links, device files, arbitrary host symlinks | Not supported by the Common Fabric JSON projection unless a future spec models them. | Fail closed in CFC modes. | `ENOTSUP` or `EPERM`. |
 
+## Creation, Open, and Xattr Ordering
+
+Normal programs running inside the sandbox must not need to perform CFC-specific
+syscalls or special syscall ordering. `create`, `open`, `write`, and `setxattr`
+are still distinct filesystem operations at the FUSE boundary, but any trusted
+CFC write-intent evidence required for a mutation must be supplied transparently
+by the enforcement stack before FUSE commits the mutation. In the current gVisor
+prototype, the distinction is made at the syscall layer: ordinary sandbox
+`setxattr`/`removexattr` calls to `trusted.cfc.contentLabel` are blocked unless
+the task is privileged, while the kernel CFC hooks update internal
+device/inode-keyed label state and then call VFS/file `SetXattr` themselves.
+For a FUSE-backed file this reaches the userspace daemon as an ordinary
+`FUSE_SETXATTR` request carrying a trusted `trusted.cfc.*` name/value; there is
+no separate FUSE transport flag today that says "kernel policy metadata".
+
+Because FUSE sees a normal xattr request, it should trust only the protected CFC
+names and the deployment assumption that gVisor has hidden or blocked those
+names from unprivileged sandbox callers. A future transport may replace this
+with explicit per-operation metadata or a gVisor-private side channel, but that
+is not the current implementation.
+
+The temporary writable xattr bridge remains a local testing and integration
+mechanism. It is not the normal application contract and must not be the only way
+for ordinary programs to create or write files under CFC enforcement.
+
+Bridge to quarantine semantics: today, incomplete CFC writeback state is
+represented only by mediated prepare/finalize xattrs plus persisted
+`CfcWritebackStore` records. The current implementation does not create hidden
+quarantine dentries, does not publish incomplete entries into the confirmed
+`FsTree`, and does not make ordinary path lookup depend on quarantine state. The
+next quarantine implementation must keep that separation explicit: quarantine is
+a private transaction store layered beside the confirmed projection, not a hidden
+file in the normal namespace.
+
+For creation-like operations:
+
+1. Validate the parent namespace annotation, target name, current generation, and
+   operation-specific trusted write intent before mutating the parent cell. That
+   intent currently arrives as a protected CFC xattr request emitted by gVisor's
+   kernel-managed CFC hooks; a future implementation may use another trusted
+   transport. It must not depend on the sandboxed program issuing xattrs in a
+   special order.
+2. Derive the new entry's initial annotation from the parent namespace policy and
+   the prepared entry/content labels. Missing labels are incomplete/fail-closed,
+   never implicitly public.
+3. In `enforce-explicit` and `enforce-strict`, fail the app-visible
+   `create`/`mkdir` with `EACCES` or `ESTALE` when required trusted write intent
+   is absent, stale, malformed, or insufficient. Do not return success to a
+   normal program until the entry is fully labeled and committed.
+4. FUSE may still use a private quarantine record as an internal staging or
+   recovery artifact. That record is outside the normal POSIX namespace and is
+   not inserted into the confirmed `FsTree`, parent child maps, readdir indexes,
+   or kernel-visible inode/dentry state. If metadata cannot be completed, the
+   original operation fails and the quarantine record is aborted or
+   garbage-collected.
+5. In `observe`, or in an explicitly configured compatibility mode outside the
+   trusted gVisor path, creation may proceed without complete write-intent
+   metadata, but the resulting annotation remains incomplete/fail-closed and
+   diagnostics must note the missing or stale evidence.
+
+A quarantine record is a private FUSE/gVisor transaction record, not an
+unlabeled public object and not a POSIX-visible file state. When implemented,
+quarantine state must live in a private `QuarantineStore`. It must not live in
+the confirmed `FsTree`, parent child maps, readdir indexes, or kernel-visible
+inode/dentry state. Records must be keyed at least by `{ operationId, parentRef,
+name, expectedGeneration }`, with operation type, prepared label state, finalize
+state, timestamps, and diagnostics stored as record data.
+
+Normal namespace and handle paths must not consult `QuarantineStore`. This
+includes `lookup`, `readdir`, `readdirplus`, `getattr`, `access`, `open`, and
+`opendir`. Those operations resolve only the confirmed projection and must behave
+exactly as if no quarantine record exists. If a normal application file handle to
+a quarantine record would escape, treat that as an implementation error and fail
+or abort before reporting create success.
+
+Only the following trusted actors may read `QuarantineStore`: completion/finalize
+handling for protected prepare/finalize metadata, trusted abort handling, startup
+recovery, and TTL garbage collection. Completion must match by operation ID and
+validate the parent ref, target name, operation type, expected generation, and
+prepared/finalized label state before publishing anything into the normal
+projection. Once validation succeeds, FUSE may publish/invalidate the normal
+dentry as needed and report success or make the entry visible according to normal
+CFC policy. Invalid metadata leaves the record quarantined until trusted abort or
+garbage collection removes it.
+
+In the current gVisor/FUSE path, prepare/finalize metadata arrives as ordinary
+`FUSE_SETXATTR`; FUSE has no transport-level discriminator for kernel CFC
+metadata versus privileged/admin `setxattr`. FUSE therefore trusts protected
+`trusted.cfc.*` writeback names only under the deployment invariant that gVisor
+blocks or mediates user-origin writes before they reach FUSE. Ordinary
+applications must not be required to issue CFC prepare/finalize xattrs or follow
+special xattr ordering. Prepare/finalize xattrs are an enforcement-stack
+writeback bridge, not the POSIX application API.
+
+Quarantines must have bounded lifetime. FUSE should scan quarantine records on
+startup and periodically during runtime, aborting records older than the
+configured TTL; one hour is the default initial target unless active trusted
+completion is in progress. Cleanup events, expired quarantine counts, and any
+timed-out-unknown operations should be visible through `.status` diagnostics, not
+through normal directory entries.
+
+Post-create `setxattr` is a separate metadata mutation. It may write only the
+documented prepare/finalize records for local bridge testing, or another
+explicitly modeled metadata change. It must not retroactively authorize a create
+that should have failed, must not lower confidentiality or integrity policy, and
+must not expose an unlabeled file as public while reconciliation is pending.
+
 ## Prepare and Finalize Requirements
 
 Prepared writeback metadata must be operation-specific and generation-specific.
@@ -133,13 +240,16 @@ be mistaken for the normative contract:
   the normative spec calls for `ENOTDIR`, `EISDIR`, `EINVAL`, `ESTALE`,
   `ENOTSUP`, or `ENODATA`/`ENOATTR`.
 - The temporary writeback xattr bridge is useful for local testing and early
-  gVisor integration, but the production trusted prepare/finalize transport is
-  still a separate design decision.
+  gVisor integration. The inspected gVisor FUSE path currently transports
+  kernel-managed CFC labels as ordinary `FUSE_SETXATTR` requests after blocking
+  unprivileged sandbox writes to protected names at the syscall layer. A
+  non-xattr side channel would be a future design, not current behavior.
 
 ## Open Questions
 
-1. What is the production trusted transport for prepare/finalize: protected
-   xattr, ioctl-like operation, sidecar RPC, or gVisor-private metadata path?
+1. Should production keep using protected `trusted.cfc.*` FUSE xattrs for
+   prepare/finalize, or add an explicit gVisor/FUSE discriminator so the daemon
+   can distinguish kernel CFC metadata from privileged/admin xattr calls?
 2. What exact event is the default write success boundary for each operation:
    durable cell commit, runtime acceptance, or another named backend ack?
 3. How should handler/tool invocation carry CFC labels and writeback evidence?

--- a/docs/specs/fuse-filesystem/4-read-write.md
+++ b/docs/specs/fuse-filesystem/4-read-write.md
@@ -128,6 +128,11 @@ target path parsing rules and examples.
    not auto-retry a timed-out handler write unless a future idempotency-key
    contract exists.
 
+Runtime handoff alone is not a success boundary for mounted handler writes.
+Downstream reactive effects may continue after the write returns successfully,
+but known handler rejection, sync/idle timeout, and timed-out-unknown outcomes
+must be visible as errno plus `.status`/diagnostic state.
+
 Handlers remain writable so legacy flows like
 `echo '{"message":"hi"}' > result/addItem.handler` keep working.
 

--- a/docs/specs/fuse-filesystem/4-read-write.md
+++ b/docs/specs/fuse-filesystem/4-read-write.md
@@ -121,8 +121,12 @@ target path parsing rules and examples.
    handler writes elsewhere in FUSE.
 4. Deduplicate `flush`/`release` so one buffered write triggers one handler
    invocation.
-5. Return success after the write has been handed to the runtime, subject to
-   immediate local/CFC validation failures.
+5. Return success only after the runtime has accepted the invocation and the
+   configured sync/idle boundary has completed. Handler rejection, runtime
+   timeout, transport failure, or CFC denial is returned as a normal filesystem
+   error. Because handler invocations are non-idempotent, the filesystem must
+   not auto-retry a timed-out handler write unless a future idempotency-key
+   contract exists.
 
 Handlers remain writable so legacy flows like
 `echo '{"message":"hi"}' > result/addItem.handler` keep working.

--- a/docs/specs/fuse-filesystem/4-read-write.md
+++ b/docs/specs/fuse-filesystem/4-read-write.md
@@ -97,10 +97,12 @@ target path parsing rules and examples.
    key/index to the new value.
 4. Validate deterministic local policy first. Invalid sizes, invalid JSON, and
    CFC/writeback denials fail immediately.
-5. Return success from `flush` after the mutation has been accepted into the
-   local write pipeline. The backend cell write is optimistic and may complete
-   after the syscall returns; later conflicts or transport failures are exposed
-   through mount status, logs, and CFC writeback reconciliation.
+5. Return success from `flush` only after the Common Fabric mutation has reached
+   the operation's configured commit/acceptance boundary. For the default
+   POSIX-like contract, backend rejection, transport failure, timeout, or CFC
+   denial is returned to the caller as a normal filesystem error. Local-ack or
+   queued-offline behavior is a non-default compatibility mode and must be
+   surfaced through mount status and operation diagnostics.
 
 ### `write` to `.json` File
 
@@ -108,7 +110,7 @@ target path parsing rules and examples.
 2. On flush: parse the buffer as JSON.
 3. If the path is `result.json`, replace the entire result cell.
 4. If the path is `result/items/0.json`, replace just that subtree.
-5. Queue `cell.set()` at the appropriate path using the same optimistic
+5. Apply `cell.set()` at the appropriate path using the same commit-confirmed
    acknowledgement contract as scalar writes.
 
 ### `write` to `.handler` File
@@ -237,7 +239,9 @@ updates, write to the appropriate `.json` file instead.
 | Invalid offset/size | `EINVAL` |
 | Exceeds virtual file size limit | `EFBIG` |
 | Cross-cell rename | `EXDEV` |
-| Immediate network/timeout before local acceptance | `EIO` |
+| Backend/transport failure | `EIO` |
+| Backend timeout | `ETIMEDOUT` |
+| Stale projection or CFC generation | `ESTALE` |
 | Space not available | `ENOENT` |
 
 ---

--- a/docs/specs/fuse-filesystem/7-open-questions.md
+++ b/docs/specs/fuse-filesystem/7-open-questions.md
@@ -115,6 +115,11 @@ projection invalidation/reconciliation. A future implementation may tune that
 deadline downward, but the old <200ms network-round-trip target is no longer the
 default correctness contract for mutating operations.
 
+Open latency work should therefore track two budgets separately: low-latency
+cached metadata/read operations, and commit-confirmed mutation deadlines that
+include backend acceptance, CFC/writeback reconciliation, and explicit
+known-failure versus timed-out-unknown diagnostics.
+
 If the Deno IPC round-trip adds too much latency for `getattr`/`readdir`,
 the Rust layer must be fully self-sufficient for these operations (serving
 from its in-memory tree without IPC).

--- a/docs/specs/fuse-filesystem/7-open-questions.md
+++ b/docs/specs/fuse-filesystem/7-open-questions.md
@@ -106,7 +106,14 @@ A `getattr` call should complete in <1ms (from in-memory tree).
 A `readdir` call should complete in <5ms.
 A `read` of a cached value should complete in <1ms.
 A `read` requiring a cell fetch should complete in <100ms.
-A `write` + `flush` should complete in <200ms (network round-trip).
+
+Commit-confirmed mutations have a different budget than cached reads and
+metadata. The package-local reliability design currently proposes a 30s soft
+deadline for cell content `write`/`flush`, because success now means local
+validation, CFC authorization, backend mutation or runtime acceptance, and safe
+projection invalidation/reconciliation. A future implementation may tune that
+deadline downward, but the old <200ms network-round-trip target is no longer the
+default correctness contract for mutating operations.
 
 If the Deno IPC round-trip adds too much latency for `getattr`/`readdir`,
 the Rust layer must be fully self-sufficient for these operations (serving

--- a/docs/specs/fuse-filesystem/README.md
+++ b/docs/specs/fuse-filesystem/README.md
@@ -17,3 +17,4 @@ Directory listings reflect space contents and JSON structure traversal.
 - [7. Open Questions](./7-open-questions.md)
 - [8. Filesystem Projections (`[FS]`)](./8-fs-projections.md)
 - [9. CFC Annotations](./9-cfc-annotations.md)
+- [10. CFC Filesystem API Semantics](./10-cfc-filesystem-api-semantics.md)

--- a/packages/fuse/README.md
+++ b/packages/fuse/README.md
@@ -300,6 +300,11 @@ Writes are fire-and-forget: the FUSE reply is sent before the cell write
 completes, so subscription rebuilds don't block the callback chain (required to
 avoid FUSE-T crashes from `notify_inval_entry` during callbacks).
 
+See [RELIABILITY_DESIGN.md](./RELIABILITY_DESIGN.md) for the package-local plan
+to move default mutating operations toward commit-confirmed replies, bounded
+deadlines, explicit backpressure, and watchdog/degraded-mode behavior while
+preserving normal filesystem semantics.
+
 ## Troubleshooting
 
 ### FUSE not found / `Could not open libfuse`

--- a/packages/fuse/RELIABILITY_DESIGN.md
+++ b/packages/fuse/RELIABILITY_DESIGN.md
@@ -1,0 +1,439 @@
+# FUSE Reliability Design
+
+## Purpose
+
+This document describes an implementation plan for making `@commonfabric/fuse`
+safe under backend stalls, transport failures, CFC writeback, and platform FUSE
+quirks while preserving normal filesystem behavior for ordinary programs.
+
+The normative API contract lives in `docs/specs/fuse-filesystem/`. This package
+document is implementation-specific: it names current code seams, proposed
+actors/FSMs, deadline and backpressure policy, rollout phases, and test targets.
+
+## Current Baseline
+
+The implementation already has several reliability foundations:
+
+- `mod.ts` tracks pending async FUSE replies with `trackPendingFuseReply()` and
+  defers kernel invalidation until pending replies drain.
+- `handles.ts` owns per-handle write buffers, truncate state, dirty flags,
+  versioning, range checks, and per-handle CFC authorization.
+- `mod.ts` schedules safety-net flushes for transports that do not reliably send
+  `flush`/`release`, and records write statistics in `.status`.
+- `cell-bridge.ts` exposes `.status`, marks the mount disconnected/read-only on
+  transport errors, and reconnects with capped exponential backoff.
+- `cell-bridge.ts` serializes and coalesces per-piece-property rebuilds, dedupes
+  in-flight hydrations, stages rebuilds under pending roots, and invalidates
+  cache entries after committed cell changes.
+- `cfc-writeback.ts` persists prepared CFC writeback records, tracks crash-point
+  states, and reconciles records after inode churn or subtree rebuild.
+
+The main gap is that several mutating paths still acknowledge FUSE success
+before the Common Fabric operation has reached a clear commit or acceptance
+boundary. That improves responsiveness but makes normal tools vulnerable to
+silent backend failure, transport loss, or CFC finalize failure.
+
+## Target Posture
+
+Treat the daemon as a bounded-latency POSIX adapter, not a best-effort RPC
+proxy. Every FUSE request should enter a tracked lifecycle: copy transient
+arguments, start a deadline, optionally register interrupt handling, enqueue
+under bounded concurrency, and reply exactly once.
+
+For the default mode, mutating operations are commit-confirmed: FUSE reports
+success only after local validation, CFC authorization, backend mutation or
+runtime acceptance, and safe projection invalidation/reconciliation reach the
+operation's success boundary. Local-ack or offline-queue behavior may exist only
+as an explicit compatibility mode and must be visible in `.status`.
+
+## Core Invariants
+
+1. **Exactly one reply per request.** Every received low-level request reaches
+   one terminal reply path. Timeout, cancellation, success, and error paths race
+   through one `replyOnce` guard.
+2. **Bounded wait.** No request waits indefinitely for backend I/O, reconnect,
+   rebuild, CFC reconciliation, or invalidation. Deadlines resolve to standard
+   errno values.
+3. **No default local-ack for mutations.** A mutating syscall reports success
+   only after the operation reaches its configured Common Fabric boundary.
+4. **Visible tree equals confirmed projection.** Shared `FsTree` state should
+   not expose optimistic creates, deletes, renames, symlinks, or cell writes.
+   Only handle-private buffers may be speculative.
+5. **Per-cell ordering.** Mutations serialize per logical
+   `(space, entity, cell)` unless the backend provides stronger
+   ordered/idempotent write primitives.
+6. **Handlers are non-idempotent.** One buffered handler write maps to at most
+   one runtime send. Never auto-retry handler invocations after timeout or
+   reconnect without a future idempotency-key contract.
+7. **CFC fails closed.** Missing, stale, or incomplete labels remain
+   incomplete/fail-closed. FUSE produces and reconciles annotations; gVisor owns
+   sandbox observation policy.
+8. **Backpressure is explicit.** Queue saturation, degraded state, or backend
+   unavailability become visible errno/status outcomes, not unbounded memory or
+   silent pending success.
+
+## Request Lifecycle
+
+Introduce a small `FuseRequestSlot` wrapper in `mod.ts` or a helper module:
+
+```text
+received
+  -> validating
+  -> queued
+  -> running
+  -> replying
+  -> replied
+
+received/validating/queued/running
+  -> timed-out
+  -> replying
+  -> replied
+```
+
+Each slot records:
+
+- operation name, inode, path/name copies, file handle, and logical ref when
+  known;
+- start time, deadline, and timeout reason;
+- whether an interrupt was observed;
+- reply state and errno/data summary;
+- associated mutation operation ID, if any.
+
+Callbacks must copy names, buffers, and file-info fields they need before
+returning to libfuse. The slot owns the reply pointer until `replyOnce()` fires.
+`forget`-style operations remain special: they use no normal reply but still
+must stay on the high-priority cleanup lane.
+
+### Suggested Deadlines
+
+Initial values should be constants surfaced through `.status`:
+
+| Operation class                       | Soft deadline   |
+| ------------------------------------- | --------------- |
+| cached metadata/read                  | 50 ms           |
+| cold lookup/hydration                 | 2 s             |
+| `readdir` page                        | 5 s             |
+| cell content write/flush              | 30 s            |
+| handler runtime acceptance            | 30 s            |
+| source pattern update                 | 60 s            |
+| `fsync` / explicit durability barrier | 60-120 s        |
+| reconnect probe                       | 5 s per attempt |
+
+Linux `request_timeout` and macFUSE `daemon_timeout` should be treated as hard
+provider safety nets above these internal deadlines. Provider hard timeouts may
+abort or eject the entire mount, so they are not normal control flow.
+
+## Actor Boundaries
+
+The implementation does not need a new framework. Treat existing modules as
+actors with explicit ownership and bounded mailboxes.
+
+| Actor                | Existing home                              | Responsibility                                                                                                                                                                                       |
+| -------------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| FUSE adapter         | `mod.ts`                                   | Low-level callback translation, local deterministic validation, request slots, errno replies, pending-reply tracking. It should not call backend mutation APIs directly once the coordinator exists. |
+| Handle actor         | `handles.ts`                               | Open-file state, write buffers, truncate state, dirty/version flags, max file size, flush/release dedupe.                                                                                            |
+| Mutation coordinator | new module, e.g. `mutation-coordinator.ts` | Per-cell queues, operation deadlines, commit ordering, timeout classification, result-to-errno mapping, `.status` operation metrics.                                                                 |
+| Projection actor     | `cell-bridge.ts`                           | Space connection, hydration, subscriptions, queued rebuilds, source tree rebuilds, cache invalidation scheduling.                                                                                    |
+| CFC writeback actor  | `cfc-writeback.ts`                         | Prepare/finalize records, stale-generation detection, recovery persistence, diagnostics, and reconciliation.                                                                                         |
+| Connection actor     | `cell-bridge.ts` initially                 | `online -> suspect -> readOnly/reconnecting -> online` transitions, reconnect backoff, synced/reconciled gating before writes resume.                                                                |
+
+## Supervisor, Worker, and Process Isolation
+
+Deno Workers are useful as an inner responsiveness boundary, but they are not a
+hard recovery boundary for native FFI or FUSE provider wedges. Workers run in
+the same OS process as their creator. `Worker.terminate()` can stop JavaScript
+execution and message processing, but it should be treated as best-effort for a
+worker blocked inside native libfuse/FFI code, a blocking FFI helper thread, or
+a provider/kernel call that never returns.
+
+The first process-boundary architecture should stay Deno-only:
+
+```text
+cf fuse mount --background
+  -> Deno supervisor process
+       -> Deno FUSE child process that loads libfuse and owns the mount
+            -> optional Deno Worker for libfuse session and hot FUSE state
+            -> child control plane for heartbeat, status, and graceful unmount
+```
+
+The supervisor process must not load libfuse or call Deno FFI. Its job is to
+spawn the FUSE child, track its PID/process group, monitor heartbeat/status,
+request graceful unmount, escalate to platform abort/force-unmount, and kill or
+restart the child when needed.
+
+The Deno FUSE child owns the libfuse session, callbacks, `FsTree`, `CellBridge`,
+CFC writeback store, request deadlines, and mutation coordinator. This is
+already enough to create a real kill/restart boundary: if the child wedges in
+native/libfuse/provider code, the supervisor remains schedulable because it is a
+separate OS process.
+
+An optional worker inside the child can keep the child process control plane
+responsive if the FUSE session's JavaScript event loop stalls. It should not be
+used as the only supervisor for production reliability. If the worker gets
+wedged in native code, the containing child process may still retain native
+threads, libfuse state, mount state, or corrupted address-space state. The hard
+reset boundary is the child process.
+
+Design rules:
+
+- If the libfuse session runs in a worker, keep the hot filesystem state in that
+  worker too: `FsTree`, callbacks, handle map, mutation coordinator, CFC
+  writeback integration, deadlines, and reply guards. Avoid serializing every
+  filesystem operation across worker messages.
+- Keep the child-process control plane small: heartbeat, status snapshots,
+  graceful `fuse_session_exit`/unmount request, and final process exit.
+- Keep the external supervisor outside any process that has loaded libfuse. It
+  owns wall-clock containment, forced unmount/abort, and process kill/restart.
+- Request deadlines still live inside the FUSE request lifecycle. A supervisor
+  can abort a mount, but it cannot provide clean per-operation errno replies
+  once the session worker is wedged.
+
+Initial implementation may remain single-process while the mutation coordinator
+and request deadlines are built. The first isolation step should then be the
+Deno supervisor + Deno FUSE child split above, not a worker-only refactor. A
+worker-only refactor is worthwhile only if JavaScript event-loop coupling is the
+dominant problem and native/provider wedges are not observed.
+
+A Rust component should be a sidecar executable, not a Deno extension, if it is
+introduced for reliability. A Rust extension loaded into Deno would share the
+same process-boundary problem as Deno FFI. A Rust sidecar can replace the Deno
+FUSE child later if hand-maintained FFI structs, signal handling, or libfuse
+threading inside the Deno child remains fragile, while preserving the same Deno
+supervisor contract.
+
+## Mutation Operation FSM
+
+All mutating operations should use one common FSM:
+
+```text
+queued
+  -> validating
+  -> cfc-prepared
+  -> applying
+  -> syncing
+  -> projecting
+  -> finalizing
+  -> succeeded
+
+validating/applying/syncing/projecting/finalizing
+  -> failed-known(errno)
+  -> timed-out-unknown
+  -> disconnected-readonly
+```
+
+`failed-known(errno)` means the operation definitely failed before committing or
+the backend returned a definite error. `timed-out-unknown` means the daemon can
+no longer tell whether the backend will eventually commit; return `ETIMEDOUT`,
+record the operation in `.status`, and never replay automatically unless the
+operation has an idempotency key.
+
+### Success Boundaries
+
+| Operation                                | Default success boundary                                                                                                                                         |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| scalar / `.json` cell write              | local validation and CFC authorization passed; `cell.set()` resolved; backend sync/acceptance completed; projection invalidation or rebuild is scheduled safely. |
+| `[FS]` projection write                  | parsed content applied to the corresponding cells; required deletes/updates completed; projection invalidation or rebuild is scheduled safely.                   |
+| source write                             | `piece.setPattern()` resolved; error log updated; source projection finalized or invalidated.                                                                    |
+| handler write                            | runtime accepted the invocation and sync/idle boundary completed. Downstream reactive effects may settle later.                                                  |
+| create/mkdir/unlink/rmdir/rename/symlink | parent/common cell mutation resolved and the shared `FsTree` is updated from confirmed state or safely invalidated for rebuild.                                  |
+| CFC writeback                            | trusted prepare was valid when required; mutation succeeded; finalize/reconcile was recorded, or incomplete/fail-closed state was persisted.                     |
+
+## Backpressure Policy
+
+Add bounded queues before backend work:
+
+- global active backend mutations: start with 32;
+- per-space active backend mutations: start with 16;
+- per-cell active mutation: 1, with bounded pending queue;
+- high-priority cleanup lane for `forget`, interrupts, `release`, and watchdog
+  cleanup;
+- bounded rebuild queue per piece prop, continuing to coalesce stale rebuilds;
+- max buffered handle bytes retains the current virtual file limit.
+
+Admission failure should be explicit. For normal blocking filesystem calls, wait
+within the request deadline; if no slot opens, return `ETIMEDOUT` or `EIO` based
+on state. Reserve `EAGAIN` for documented retryable races, not ordinary
+overload.
+
+## Connection and Degraded Modes
+
+Connection state should be explicit in `.status` and should control mutation
+admission:
+
+```text
+online
+  -> suspect
+  -> readOnly-reconnecting
+  -> reconciling
+  -> online
+```
+
+When transport failure is detected, remove write bits as the current
+`buildStat()` path already does, reject new mutations with `EROFS` or `EIO`,
+continue serving cached reads where safe, and probe reconnect with capped
+exponential backoff. Before writes resume, the connection actor should require
+backend sync plus any needed CFC/writeback reconciliation.
+
+## Invalidation and Platform Policy
+
+Keep invalidation out of active callback/reply paths. The existing pending-reply
+drain before `notify_inval_entry` / `notify_inval_inode` is a core safety rule,
+especially for FUSE-T.
+
+- On Linux, use deferred invalidation when supported, falling back to short TTLs
+  on `ENOSYS` or repeated failures.
+- On macOS/FUSE-T, assume provider-specific cache and call-order behavior.
+  Prefer short TTLs and deferred/no invalidation over synchronous reverse
+  invalidation while the kernel is waiting on the daemon.
+- Never store logs, state files, or watchdog artifacts inside the mounted tree;
+  that can deadlock the daemon by re-entering its own mount.
+
+## Watchdog and Abort Strategy
+
+The daemon can guarantee bounded replies only while its event loop and native
+FFI calls continue to make progress. A supervisor should provide outer
+containment:
+
+- heartbeat timestamp from the FUSE process;
+- last completed request ID and pending request count;
+- Linux fusectl `waiting` count when available;
+- last backend success/failure and reconnect state;
+- controlled unmount/abort/kill path when heartbeat stops and waiting requests
+  remain.
+
+On Linux, aborting the FUSE connection is the reliable last-resort escape for a
+wedged daemon. On macOS, forced unmount and provider-specific timeout/eject
+behavior are the last resort; this must be documented as weaker than a daemon
+deadline guarantee.
+
+### Hang Classes
+
+The reliability architecture prevents or contains several classes of hangs, but
+it cannot make every kernel/provider failure recoverable from inside the daemon.
+
+| Hang class                                                          | Prevented by this design?        | Containment                                                                                                                                                             |
+| ------------------------------------------------------------------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Backend promise never resolves                                      | Yes                              | Request deadlines, mutation timeouts, and connection degraded mode reply with errno instead of waiting forever.                                                         |
+| Deadlock caused by reverse invalidation during a pending FUSE reply | Yes                              | Keep invalidation deferred until pending replies drain; fall back to short TTLs when notify is unsafe or unsupported.                                                   |
+| Unbounded write/rebuild backlog                                     | Yes                              | Bounded mutation/rebuild queues and explicit timeout/error outcomes.                                                                                                    |
+| Transport disconnect after a started mutation                       | Partially                        | New writes fail fast while disconnected; started operations become known failure or timed-out unknown and are not auto-replayed.                                        |
+| Daemon event loop still alive but request progress stops            | Partially                        | Supervisor detects heartbeat/request-progress mismatch and aborts/unmounts externally.                                                                                  |
+| Deno process blocked inside a native libfuse/provider call          | Not from inside the process      | External supervisor must force unmount/abort/kill. Consider isolating riskier FFI/session work in an expendable child process if this recurs.                           |
+| Kernel/provider task wedges and does not return to userspace        | Not by daemon architecture alone | Linux fusectl abort may release waiters; macOS depends on provider forced unmount/eject behavior and may require process kill, force unmount, or reboot in worst cases. |
+
+Therefore the product guarantee should be phrased as two layers:
+
+1. **Daemon-level guarantee:** if the FUSE daemon remains schedulable and can
+   call reply functions, every request reaches data or errno by its deadline.
+2. **Containment guarantee:** if the daemon or provider stops making progress,
+   an external supervisor detects it and attempts platform-specific abort,
+   unmount, and process cleanup within a bounded wall-clock interval.
+
+If experiments still produce unkillable kernel waits, the next architecture step
+is stronger process isolation: run the libfuse session in a small supervised
+child whose only job is kernel/FUSE I/O, keep backend state and operation logs
+in the parent or a separate durable process, and treat child replacement/remount
+as the recovery path. That adds IPC complexity, so it should be triggered by
+real provider wedges rather than used as the first implementation step.
+
+## Observability
+
+Extend `.status` before changing behavior so experiments are visible:
+
+```json
+{
+  "requests": {
+    "inFlight": 0,
+    "completed": 0,
+    "timedOut": 0,
+    "lastTimeoutAt": null
+  },
+  "mutations": {
+    "queued": 0,
+    "inFlight": 0,
+    "succeeded": 0,
+    "failed": 0,
+    "unknown": 0,
+    "perCellQueueMax": 0
+  },
+  "connection": {
+    "state": "online",
+    "lastError": null,
+    "reconnectAttempts": 0
+  },
+  "deadlines": {
+    "cellWriteMs": 30000,
+    "handlerMs": 30000,
+    "sourceWriteMs": 60000
+  }
+}
+```
+
+The existing write stats and CFC writeback counts should remain, but operation
+IDs and unknown outcomes need first-class counters so agents and humans can tell
+the difference between success, known failure, and timed-out unknown state.
+
+## Rollout Plan
+
+1. **Document and instrument current behavior.** Add request/mutation counters,
+   deadline constants, and status fields without changing semantics.
+2. **Extract request slots.** Centralize exactly-once replies and timeout paths
+   in `mod.ts`; add tests for reply races using fake callbacks where possible.
+3. **Add mutation coordinator for handle writes.** Keep `write(2)` as
+   buffer-copy acknowledgement, but make `flush` and `fsync` wait for commit or
+   return errno.
+4. **Move namespace mutations behind the coordinator.** Stop optimistic shared
+   tree updates for create/mkdir/unlink/rmdir/rename/symlink; update or
+   invalidate the tree after backend success.
+5. **Integrate CFC writeback.** Use existing prepare/finalize persistence and
+   reconciliation inside the operation FSM, including timeout and
+   stale-generation status.
+6. **Add degraded-mode gates.** New writes fail fast while disconnected or
+   reconciling; cached reads continue where safe.
+7. **Split supervisor from FUSE child.** Teach `cf fuse mount --background` to
+   run a Deno supervisor process that does not load libfuse, then spawn a Deno
+   FUSE child that owns the mount, heartbeat, and status stream.
+8. **Add watchdog escalation.** The supervisor monitors heartbeat/status and
+   performs platform-appropriate graceful unmount, abort/force-unmount,
+   process-group kill, and restart.
+9. **Escalate to Rust sidecar only if needed.** If the Deno FFI child remains
+   fragile after the process split, replace the child with a Rust sidecar binary
+   while keeping the same supervisor/watchdog shape.
+
+## Test Plan
+
+- Unit-test request slot `replyOnce`, timeout, and interrupt races.
+- Unit-test mutation coordinator ordering, per-cell serialization, queue
+  saturation, and unknown timeout classification.
+- Extend `handles.test.ts` for flush/release dedupe and commit-confirmed errors.
+- Extend `cell-bridge.test.ts` for disconnected/read-only transitions and
+  reconnect gating before writes resume.
+- Extend `cfc-writeback.test.ts` for operation FSM integration with stale,
+  malformed, missing, committed, failed, and timed-out prepare/finalize paths.
+- Add fault-injection tests with never-resolving `cell.set()`, rejected backend
+  writes, late success after timeout, transport closed, and subscription storms.
+- Add platform smoke tests that wrap shell commands in `timeout` and verify they
+  terminate with data or errno rather than hanging.
+
+## Non-Goals
+
+- Replacing the Deno/libfuse implementation with Rust or a second daemon.
+- Making local-ack/offline queueing the default filesystem behavior.
+- Automatically retrying non-idempotent handler invocations.
+- Treating `user.commonfabric.cfc.*` as trusted enforcement input.
+- Guaranteeing recovery from kernel/provider hard lockups without an external
+  supervisor or forced unmount path.
+
+## Open Questions
+
+1. What backend primitive is the canonical commit/acceptance boundary for cell
+   writes: `cell.set()` resolution, `manager.synced()`, subscription
+   observation, or a new write receipt?
+2. Should namespace mutations update the nearest common parent value in one cell
+   write to avoid partial copy/delete behavior?
+3. What operation ID or idempotency mechanism is needed for safe retries of cell
+   writes, source updates, and future handler invocation contracts?
+4. Which deadline defaults should be user-configurable, and which should be hard
+   package constants?
+5. How should `.status` expose detailed operation records without leaking CFC or
+   transcript-sensitive metadata?

--- a/packages/fuse/RELIABILITY_DESIGN.md
+++ b/packages/fuse/RELIABILITY_DESIGN.md
@@ -227,6 +227,12 @@ no longer tell whether the backend will eventually commit; return `ETIMEDOUT`,
 record the operation in `.status`, and never replay automatically unless the
 operation has an idempotency key.
 
+Human and agent diagnostics must preserve that distinction. `.status` should
+show whether the last mutation was a known failure, a timed-out unknown, or an
+accepted operation whose downstream reactive effects may still be settling, so
+normal errno-style failures remain debuggable from both shell clients and
+cf-harness runs.
+
 ### Success Boundaries
 
 | Operation                                | Default success boundary                                                                                                                                         |
@@ -270,10 +276,11 @@ recovery, and TTL garbage collection may read `QuarantineStore`. Completion must
 match by operation ID and validate parent ref, target name, operation type,
 generation, and prepared/finalized labels before publishing anything into the
 normal projection. FUSE should scan quarantine records on startup and
-periodically at runtime, aborting records older than the configured TTL; one hour
-is the initial target unless active trusted completion is in progress.
+periodically at runtime, aborting records older than the configured TTL; one
+hour is the initial target unless active trusted completion is in progress.
 Post-create xattrs are separate modeled metadata operations; they may not
-retroactively authorize a usable entry or lower confidentiality/integrity labels.
+retroactively authorize a usable entry or lower confidentiality/integrity
+labels.
 
 ## Backpressure Policy
 

--- a/packages/fuse/RELIABILITY_DESIGN.md
+++ b/packages/fuse/RELIABILITY_DESIGN.md
@@ -238,6 +238,43 @@ operation has an idempotency key.
 | create/mkdir/unlink/rmdir/rename/symlink | parent/common cell mutation resolved and the shared `FsTree` is updated from confirmed state or safely invalidated for rebuild.                                  |
 | CFC writeback                            | trusted prepare was valid when required; mutation succeeded; finalize/reconcile was recorded, or incomplete/fail-closed state was persisted.                     |
 
+`create`/`mkdir` must not depend on the sandboxed program calling `setxattr`
+afterward. Normal programs should run unchanged against `/fabric`; any required
+CFC write intent must be supplied by gVisor's kernel-space policy path before
+FUSE commits the mutation. In the current gVisor FUSE prototype, gVisor blocks
+unprivileged sandbox writes to protected CFC xattr names at the syscall layer,
+then its kernel CFC hooks update internal label state and emit ordinary
+`FUSE_SETXATTR` requests for `trusted.cfc.*` names. FUSE should therefore treat
+protected CFC xattrs as trusted only under that gVisor mediation assumption; a
+non-xattr side channel or explicit discriminator would be a future transport
+change, not current behavior. The local `user.commonfabric.cfc.*` compatibility
+bridge remains only for testing/integration and is not a sandbox trust boundary.
+In observe or explicit compatibility mode, a create without complete trusted
+intent may proceed only with incomplete/fail-closed annotations and diagnostics.
+Enforcing-mode create is app-visible only after the entry is fully labeled and
+committed, or it fails with a normal errno.
+
+Implementation bridge: the current code has mediated prepare/finalize xattrs and
+persisted `CfcWritebackStore` records; it does not yet have hidden quarantine
+dentries or a separate quarantine namespace. The quarantine step must add a
+private `QuarantineStore` beside the confirmed `FsTree`. Quarantine records must
+not be inserted into parent child maps, readdir indexes, or kernel-visible
+inode/dentry state, and normal `lookup`, `readdir`, `readdirplus`, `getattr`,
+`access`, `open`, and `opendir` must never consult the store. Records should be
+keyed at least by `{ operationId, parentRef, name, expectedGeneration }`, with
+operation type, prepared/finalized label state, timestamps, and diagnostics as
+record data.
+
+Only trusted completion/finalize handling, trusted abort handling, startup
+recovery, and TTL garbage collection may read `QuarantineStore`. Completion must
+match by operation ID and validate parent ref, target name, operation type,
+generation, and prepared/finalized labels before publishing anything into the
+normal projection. FUSE should scan quarantine records on startup and
+periodically at runtime, aborting records older than the configured TTL; one hour
+is the initial target unless active trusted completion is in progress.
+Post-create xattrs are separate modeled metadata operations; they may not
+retroactively authorize a usable entry or lower confidentiality/integrity labels.
+
 ## Backpressure Policy
 
 Add bounded queues before backend work:


### PR DESCRIPTION
## Summary
- add a CFC filesystem API semantics chapter to the FUSE spec
- define default commit-confirmed write behavior and standard errno mapping
- add the package-local FUSE reliability implementation plan and link it from `packages/fuse/README.md`
- address review feedback by clarifying handler write success boundaries, separating cached-read latency from commit-confirmed mutation deadlines, and documenting `.status` diagnostics for known failure vs timed-out unknown vs accepted-but-still-settling operations

## Verification
- `deno fmt --check`
- `deno task check`
- `GIT_MASTER=1 git diff --check`

## Performance Check
The performance check flagged an unrelated pattern-unit subtest wall-time outlier on this docs-only PR. No runtime/test code changed.

NEW_PERF_BASELINE: subtest: pattern-unit-1/pattern-unit-tests > packages/patterns/battleship/multiplayer/lobby.test.tsx = 34s
