### PR TITLE
refactor(memory/v2): revert cloneValue to default cloneIfNecessary opts

### DIFF
--- a/packages/memory/v2/patch.ts
+++ b/packages/memory/v2/patch.ts
@@ -22,22 +22,13 @@ const MAX_ARRAY_INDEX = 2 ** 32 - 2;
  *
  * `cloneIfNecessary()` deep-clones via the fabric value machinery
  * (`FabricInstance.deepClone()` for wrappers), preserving the class.
- *
- * `{ frozen: false }` (which implies `force: true`) is required, NOT the
- * `{ frozen: true }` default: with the default, `cloneIfNecessary`'s
- * identity check calls `isDeepFrozenFabricValue()`, whose `checkValue()`
- * currently THROWS on a `FabricInstance` ("Cannot yet handle instance of
- * class ..."). That path is hit whenever the engine replays a stored
- * patch sequence over an already-deep-frozen tree (e.g. a `move`/`add`
- * that re-clones a frozen subtree holding a `FabricError`). `force`
- * short-circuits the identity check before that throw. The result is
- * still deep-frozen: `applyPatch` deep-freezes the assembled tree at its
- * boundary regardless. (TODO(@danfuzz): once `checkValue()`/`isDeepFrozenFabricValue`
- * handle `FabricInstance`, the default could be used and would also reuse
- * already-frozen inputs identity-preservingly.)
+ * Its default options (`{ frozen: true, deep: true }`) return an
+ * already-deep-frozen input by identity, so replayed engine passes over a
+ * previously-frozen subtree reuse it in place; otherwise the value is
+ * deep-cloned to a deep-frozen result. The assembled tree is deep-frozen
+ * at the `applyPatch` boundary regardless.
  */
-const cloneValue = (value: FabricValue): FabricValue =>
-  cloneIfNecessary(value, { frozen: false });
+const cloneValue = (value: FabricValue): FabricValue => cloneIfNecessary(value);
 
 /**
  * Applies a sequence of RFC 6902 JSON Patch operations (`replace`, `add`,


### PR DESCRIPTION
## Summary

Simplifies `cloneValue` in `packages/memory/v2/patch.ts` to use
`cloneIfNecessary`'s default options (`{ frozen: true, deep: true }`)
instead of the previously-required `{ frozen: false }` workaround,
and removes the now-stale `TODO` that anticipated this change.

## What this delivers

The `cloneValue` helper used by the patch-apply machinery now invokes
`cloneIfNecessary(value)` with no options, restoring the function's
default behavior:

- **Identity-preserving reuse of already-deep-frozen inputs.** When the
  engine replays a stored patch sequence over an already-deep-frozen
  subtree (e.g. a `move` or `add` that re-clones a subtree holding a
  `FabricInstance`), `cloneIfNecessary`'s identity-optimization path now
  returns the input by reference rather than producing a fresh copy.
- **Deep-clone for isolation when necessary.** Mutable or partially-
  frozen inputs are still deep-cloned to a deep-frozen result, preserving
  the previous isolation guarantee.

Behavior unchanged from caller perspective: each `cloneValue` call site
gets a deep-frozen result, and the assembled tree is deep-frozen at the
`applyPatch` boundary regardless. The function signature and contract
are unchanged.

## Why this is possible now

The original `{ frozen: false }` form was a workaround for a throw on
the `FabricInstance` arm of `isDeepFrozenFabricValue` — the identity
check `cloneIfNecessary` performs when `frozen: true` is requested. With
the `[IS_DEEP_FROZEN]` symbol protocol (#3612) and unified `deepFreeze`
dispatch (#3637) now on `main`, that arm dispatches via the protocol and
returns a boolean answer for `FabricInstance` inputs rather than throwing.
The workaround is no longer needed.

## Test plan

- `deno fmt` / `deno lint` / `deno check` clean on
  `packages/memory/v2/patch.ts`.
- `packages/memory` `deno task test` — 120 passed / 28 steps / 0 failed.
- `packages/data-model` `deno task test` — 44 passed / 1338 steps / 0
  failed.
- Cross-package `deno check` clean on `packages/runner` and
  `packages/toolshed`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies `cloneValue` in `packages/memory/v2/patch.ts` to use `cloneIfNecessary(value)` defaults (`{ frozen: true, deep: true }`) and removes the stale TODO from the old `{ frozen: false }` workaround. Behavior is unchanged: results are deep-frozen, and already deep-frozen inputs are reused by identity.

<sup>Written for commit fb8ba97c54d2d4b19e40d4f1c471bc80bf0e146f. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3640?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

