### PR TITLE
Track CFC labels for edit_file

### DIFF
--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -85,6 +85,7 @@ import {
   cwdMarkerForOutput,
   extractFinalWorkingDirectory,
 } from "./tools/shell-cwd.ts";
+import { isEditFileToolSuccessOutput } from "./tools/edit-file.ts";
 import { isReadFileToolSuccessOutput } from "./tools/read-file.ts";
 import { isStructuredFileToolErrorOutput } from "./tools/file-errors.ts";
 import { isViewImageToolSuccessOutput } from "./tools/view-image.ts";
@@ -922,6 +923,13 @@ const REDACTED_READ_FILE_ERROR_DETAIL =
   "Filesystem status details were redacted by CFC policy.";
 const READ_FILE_STATUS_OBSERVATION_DETAIL =
   "read_file failure may reveal filesystem path/status observations";
+const REDACTED_EDIT_FILE_ERROR_PATH = "[redacted]";
+const REDACTED_EDIT_FILE_ERROR_MESSAGE =
+  "edit_file failed: edit status not observable under CFC policy";
+const REDACTED_EDIT_FILE_ERROR_DETAIL =
+  "Edit failure details were redacted by CFC policy.";
+const EDIT_FILE_STATUS_OBSERVATION_DETAIL =
+  "edit_file failure may reveal file content, digest, path, or status observations";
 
 interface InvokedToolCallMessages {
   toolMessage: HarnessToolTranscriptMessage;
@@ -968,7 +976,8 @@ const toolOutputNeedsSandboxMediation = (
   output: unknown,
 ): boolean =>
   toolId === "bash" ||
-  (toolId === "read_file" && isReadFileToolSuccessOutput(output));
+  (toolId === "read_file" && isReadFileToolSuccessOutput(output)) ||
+  (toolId === "edit_file" && isEditFileToolSuccessOutput(output));
 
 const isReadFileStatusObservationError = (output: unknown): boolean =>
   isStructuredFileToolErrorOutput(output) &&
@@ -1000,6 +1009,30 @@ const redactReadFileStatusObservationError = (
       message: REDACTED_READ_FILE_ERROR_MESSAGE,
       path: REDACTED_READ_FILE_ERROR_PATH,
       detail: REDACTED_READ_FILE_ERROR_DETAIL,
+    },
+  };
+};
+
+const redactEditFileStatusObservationError = (
+  output: unknown,
+  resultRef: ToolResultRef,
+): unknown => {
+  if (!isStructuredFileToolErrorOutput(output)) {
+    return output;
+  }
+  const outputId = typeof output.outputId === "string"
+    ? output.outputId
+    : resultRef.outputId;
+  return {
+    outputId,
+    path: REDACTED_EDIT_FILE_ERROR_PATH,
+    ok: false,
+    error: {
+      type: "cf-harness.structured-file-tool-error",
+      code: "unknown",
+      message: REDACTED_EDIT_FILE_ERROR_MESSAGE,
+      path: REDACTED_EDIT_FILE_ERROR_PATH,
+      detail: REDACTED_EDIT_FILE_ERROR_DETAIL,
     },
   };
 };
@@ -1367,6 +1400,34 @@ const renderMediatedReadFileOutput = (
           contentOriginalLength: content.originalLength,
         }
         : {}),
+    },
+    ...(observation !== undefined
+      ? { cfcModelContextObservations: [observation] }
+      : {}),
+  };
+};
+
+const renderMediatedEditFileOutput = (
+  output: Record<string, unknown>,
+  cfcResult: CfcSandboxResult,
+  resultRef: ToolResultRef,
+  toolCallId: string,
+): ModelFacingToolOutputResult => {
+  const renderedDiff = renderStreamObservation(cfcResult.stdout, resultRef);
+  const observation = modelContextObservationForStream(
+    cfcResult.stdout,
+    resultRef,
+    toolCallId,
+  );
+  const publicOutput = stripInternalCfcFields(output) as Record<
+    string,
+    unknown
+  >;
+  return {
+    output: {
+      ...publicOutput,
+      diff: renderedDiff,
+      cfc: summarizeCfcSandboxResult(cfcResult),
     },
     ...(observation !== undefined
       ? { cfcModelContextObservations: [observation] }
@@ -2238,6 +2299,38 @@ export class CfHarnessPromptLoop {
         output: redactReadFileStatusObservationError(output, resultRef),
       };
     }
+    if (toolId === "edit_file" && isStructuredFileToolErrorOutput(output)) {
+      if (mode === "disabled") {
+        return { output: stripInternalCfcFields(output) };
+      }
+      if (mode === "observe") {
+        await writePolicyEvent({
+          severity: "warning",
+          mode,
+          toolId,
+          toolCallId,
+          detail:
+            `${EDIT_FILE_STATUS_OBSERVATION_DETAIL}; raw error was exposed because CFC is in observe mode`,
+        });
+        return { output: stripInternalCfcFields(output) };
+      }
+      const denial = makeObservationDenied("not-observable", {
+        detail: EDIT_FILE_STATUS_OBSERVATION_DETAIL,
+        handle: createOutputHandle(resultRef, "error"),
+      });
+      await writePolicyEvent({
+        severity: "denied",
+        mode,
+        toolId,
+        toolCallId,
+        detail:
+          `${EDIT_FILE_STATUS_OBSERVATION_DETAIL}; raw error details were redacted`,
+        observationDenied: denial,
+      });
+      return {
+        output: redactEditFileStatusObservationError(output, resultRef),
+      };
+    }
     if (!toolOutputNeedsSandboxMediation(toolId, output)) {
       return { output: stripInternalCfcFields(output) };
     }
@@ -2301,6 +2394,14 @@ export class CfHarnessPromptLoop {
     }
     if (toolId === "read_file" && isObjectRecord(output)) {
       return renderMediatedReadFileOutput(
+        output,
+        cfcResult,
+        resultRef,
+        toolCallId,
+      );
+    }
+    if (toolId === "edit_file" && isObjectRecord(output)) {
+      return renderMediatedEditFileOutput(
         output,
         cfcResult,
         resultRef,

--- a/packages/cf-harness/src/tools/edit-file.ts
+++ b/packages/cf-harness/src/tools/edit-file.ts
@@ -1,4 +1,12 @@
 import type { JSONSchema } from "@commonfabric/api";
+import type {
+  CfcLabelView,
+  CfcSandboxExitCodeObservation,
+  CfcSandboxResult,
+  CfcStreamObservation,
+  IFCLabel,
+} from "@commonfabric/runner/cfc";
+import { mergeCfcLabelViews } from "@commonfabric/runner/cfc";
 import type { HarnessToolDescriptor } from "../contracts/tool-descriptor.ts";
 import type { HarnessToolDefinition } from "./types.ts";
 import {
@@ -26,6 +34,9 @@ export interface EditFileToolInput {
   path: string;
   edits: EditFileTextEdit[];
   expectedDigest?: string;
+  // Trusted harness/test plumbing for invocation input labels. This is omitted
+  // from the public tool schema so model-authored tool calls do not mint labels.
+  cfcInputLabels?: CfcLabelView;
 }
 
 export interface EditFileToolSuccessOutput {
@@ -38,11 +49,24 @@ export interface EditFileToolSuccessOutput {
   oldSizeBytes: number;
   newSizeBytes: number;
   diff: string;
+  cfcResult?: CfcSandboxResult;
 }
 
 export type EditFileToolOutput =
   | EditFileToolSuccessOutput
   | StructuredFileToolErrorOutput;
+
+export const isEditFileToolSuccessOutput = (
+  output: unknown,
+): output is EditFileToolSuccessOutput =>
+  typeof output === "object" &&
+  output !== null &&
+  "outputId" in output &&
+  typeof output.outputId === "string" &&
+  "path" in output &&
+  typeof output.path === "string" &&
+  "diff" in output &&
+  typeof output.diff === "string";
 
 interface AppliedEditResult {
   content: string;
@@ -436,6 +460,154 @@ const createUnifiedDiff = (
   return `${truncateUnifiedDiffLines(lines).join("\n")}\n`;
 };
 
+const filterCfcInputLabels = (
+  labels: CfcLabelView | undefined,
+  roots: readonly string[],
+): CfcLabelView | undefined => {
+  if (labels === undefined) {
+    return undefined;
+  }
+  const rootSet = new Set(roots);
+  const entries = labels.entries.filter((entry) =>
+    entry.path.length > 0 && rootSet.has(entry.path[0]!)
+  );
+  return mergeCfcLabelViews([
+    entries.length > 0 ? { version: 1, entries } : undefined,
+  ]);
+};
+
+const cfcLabelViewForReadStdout = (
+  cfcResult: CfcSandboxResult | undefined,
+): CfcLabelView | undefined =>
+  cfcResult === undefined ? undefined : {
+    version: 1,
+    entries: [{ path: ["stdin"], label: cfcResult.stdout.label }],
+  };
+
+const mergeCfcLabels = (
+  labels: Array<IFCLabel | undefined>,
+): IFCLabel => {
+  const view = mergeCfcLabelViews(
+    labels.map((label) =>
+      label === undefined
+        ? undefined
+        : { version: 1, entries: [{ path: [], label }] }
+    ),
+  );
+  return view?.entries[0]?.label ?? {};
+};
+
+const observedStream = (
+  channel: "stdout" | "stderr",
+  label: IFCLabel,
+  text = "",
+): CfcStreamObservation => ({
+  channel,
+  policy: "observed",
+  label,
+  segments: [{ text, label }],
+});
+
+const observedStreamText = (
+  observation: CfcStreamObservation,
+): string | undefined =>
+  observation.policy === "observed"
+    ? observation.segments.map((segment) => segment.text).join("")
+    : undefined;
+
+const diffObservationForEditOutput = (
+  path: string,
+  read: CfcStreamObservation | undefined,
+  verify: CfcStreamObservation | undefined,
+): CfcStreamObservation | undefined => {
+  if (read === undefined || verify === undefined) {
+    return undefined;
+  }
+  const label = mergeCfcLabels([read.label, verify.label]);
+  if (read.policy === "denied" || verify.policy === "denied") {
+    return {
+      channel: "stdout",
+      policy: "denied",
+      label,
+      reason:
+        "edit_file diff includes content that was not released by CFC policy",
+    };
+  }
+  if (read.policy === "opaque" || verify.policy === "opaque") {
+    return {
+      channel: "stdout",
+      policy: "opaque",
+      label,
+      byteLength: (read.policy === "opaque" ? read.byteLength ?? 0 : 0) +
+        (verify.policy === "opaque" ? verify.byteLength ?? 0 : 0),
+      truncated: read.truncated === true || verify.truncated === true,
+    };
+  }
+  const oldText = observedStreamText(read);
+  const newText = observedStreamText(verify);
+  if (oldText === undefined || newText === undefined) {
+    return undefined;
+  }
+  return observedStream(
+    "stdout",
+    label,
+    createUnifiedDiff(path, oldText, newText),
+  );
+};
+
+const cfcResultForEditOutput = (
+  path: string,
+  readResult: CfcSandboxResult | undefined,
+  verifyResult: CfcSandboxResult | undefined,
+): CfcSandboxResult | undefined => {
+  if (readResult === undefined || verifyResult === undefined) {
+    return undefined;
+  }
+  const stdout = diffObservationForEditOutput(
+    path,
+    readResult.stdout,
+    verifyResult.stdout,
+  );
+  if (stdout === undefined) {
+    return undefined;
+  }
+  const stderrLabel = mergeCfcLabels([
+    readResult.stderr.label,
+    verifyResult.stderr.label,
+  ]);
+  const exitCodeLabel = mergeCfcLabels([
+    readResult.exitCode.label,
+    verifyResult.exitCode.label,
+  ]);
+  const exitCode: CfcSandboxExitCodeObservation =
+    readResult.exitCode.policy === "denied" ||
+      verifyResult.exitCode.policy === "denied"
+      ? {
+        policy: "denied",
+        label: exitCodeLabel,
+        reason: "edit_file exit status was not released by CFC policy",
+      }
+      : readResult.exitCode.policy === "opaque" ||
+          verifyResult.exitCode.policy === "opaque"
+      ? { policy: "opaque", label: exitCodeLabel }
+      : { policy: "observed", label: exitCodeLabel, value: 0 };
+  return {
+    version: 1,
+    stdout,
+    stderr: observedStream("stderr", stderrLabel),
+    exitCode,
+    ...(readResult.diagnostics !== undefined ||
+        verifyResult.diagnostics !== undefined
+      ? {
+        diagnostics: [
+          ...(readResult.diagnostics ?? []),
+          ...(verifyResult.diagnostics ?? []),
+        ],
+      }
+      : {}),
+  };
+};
+
 const READ_FILE_COMMAND = [
   "set -eu",
   'if [ ! -e "$1" ]; then',
@@ -506,6 +678,7 @@ export const editFileToolDescriptor: HarnessToolDescriptor = {
         oldSizeBytes: { type: "integer", minimum: 0 },
         newSizeBytes: { type: "integer", minimum: 0 },
         diff: { type: "string" },
+        cfcResult: { type: "object" },
       },
       required: [
         "outputId",
@@ -548,6 +721,10 @@ export const editFileTool: HarnessToolDefinition<
       });
     }
 
+    const outputId = context.nextOutputId("edit_file");
+    const pathInputLabels = filterCfcInputLabels(input.cfcInputLabels, [
+      "args",
+    ]);
     const readArgs = [resolvedPath];
     const readResult = await context.sandbox.runShell({
       command: READ_FILE_COMMAND,
@@ -555,15 +732,20 @@ export const editFileTool: HarnessToolDefinition<
       cwd: context.currentDir,
       cfcInvocationContext: await context.createCfcInvocationContext({
         toolId: "edit_file",
+        toolOutputId: outputId,
         operation: "shell",
         cwd: context.currentDir,
         command: READ_FILE_COMMAND,
         args: readArgs,
+        ...(pathInputLabels !== undefined
+          ? { cfcInputLabels: pathInputLabels }
+          : {}),
         cfcInputLabelPaths: [["args"]],
       }),
     });
     if (readResult.exitCode !== 0) {
       return createStructuredFileToolErrorOutput(context, "edit_file", {
+        outputId,
         path: resolvedPath,
         code: classifyFileToolShellFailure(readResult),
         detail: detailFromShellFailure(readResult),
@@ -577,6 +759,7 @@ export const editFileTool: HarnessToolDefinition<
       input.expectedDigest !== oldSummary.digest
     ) {
       return createStructuredFileToolErrorOutput(context, "edit_file", {
+        outputId,
         path: resolvedPath,
         code: "edit_conflict",
         detail:
@@ -589,6 +772,7 @@ export const editFileTool: HarnessToolDefinition<
       edited = applyEdits(readResult.stdout, input.edits);
     } catch (error) {
       return createStructuredFileToolErrorOutput(context, "edit_file", {
+        outputId,
         path: resolvedPath,
         code: "edit_conflict",
         detail: detailFromUnknownError(error),
@@ -597,6 +781,10 @@ export const editFileTool: HarnessToolDefinition<
 
     const newSummary = await summarizeText(edited.content);
     const writeArgs = [resolvedPath];
+    const writeInputLabels = mergeCfcLabelViews([
+      input.cfcInputLabels,
+      cfcLabelViewForReadStdout(readResult.cfcResult),
+    ]);
     const writeResult = await context.sandbox.runShell({
       command: WRITE_FILE_COMMAND,
       args: writeArgs,
@@ -604,16 +792,21 @@ export const editFileTool: HarnessToolDefinition<
       stdinText: edited.content,
       cfcInvocationContext: await context.createCfcInvocationContext({
         toolId: "edit_file",
+        toolOutputId: outputId,
         operation: "shell",
         cwd: context.currentDir,
         command: WRITE_FILE_COMMAND,
         args: writeArgs,
         stdinText: edited.content,
+        ...(writeInputLabels !== undefined
+          ? { cfcInputLabels: writeInputLabels }
+          : {}),
         cfcInputLabelPaths: [["args"], ["stdin"]],
       }),
     });
     if (writeResult.exitCode !== 0) {
       return createStructuredFileToolErrorOutput(context, "edit_file", {
+        outputId,
         path: resolvedPath,
         code: classifyFileToolShellFailure(writeResult),
         detail: detailFromShellFailure(writeResult),
@@ -627,15 +820,20 @@ export const editFileTool: HarnessToolDefinition<
       cwd: context.currentDir,
       cfcInvocationContext: await context.createCfcInvocationContext({
         toolId: "edit_file",
+        toolOutputId: outputId,
         operation: "shell",
         cwd: context.currentDir,
         command: READ_FILE_COMMAND,
         args: readArgs,
+        ...(pathInputLabels !== undefined
+          ? { cfcInputLabels: pathInputLabels }
+          : {}),
         cfcInputLabelPaths: [["args"]],
       }),
     });
     if (verifyResult.exitCode !== 0) {
       return createStructuredFileToolErrorOutput(context, "edit_file", {
+        outputId,
         path: resolvedPath,
         code: classifyFileToolShellFailure(verifyResult),
         detail: detailFromShellFailure(verifyResult),
@@ -645,6 +843,7 @@ export const editFileTool: HarnessToolDefinition<
     if (verifyResult.stdout !== edited.content) {
       const observedSummary = await summarizeText(verifyResult.stdout);
       return createStructuredFileToolErrorOutput(context, "edit_file", {
+        outputId,
         path: resolvedPath,
         code: "edit_conflict",
         detail:
@@ -653,7 +852,7 @@ export const editFileTool: HarnessToolDefinition<
     }
 
     return {
-      outputId: context.nextOutputId("edit_file"),
+      outputId,
       path: resolvedPath,
       editsApplied: input.edits.length,
       replacements: edited.replacements,
@@ -662,6 +861,14 @@ export const editFileTool: HarnessToolDefinition<
       oldSizeBytes: oldSummary.bytes,
       newSizeBytes: newSummary.bytes,
       diff: createUnifiedDiff(resolvedPath, readResult.stdout, edited.content),
+      ...(() => {
+        const cfcResult = cfcResultForEditOutput(
+          resolvedPath,
+          readResult.cfcResult,
+          verifyResult.cfcResult,
+        );
+        return cfcResult !== undefined ? { cfcResult } : {};
+      })(),
     };
   },
 };

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -1,4 +1,9 @@
-import { assert, assertEquals, assertRejects } from "@std/assert";
+import {
+  assert,
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+} from "@std/assert";
 import type { CfcSandboxResult } from "@commonfabric/runner/cfc";
 import { decodeBase64 } from "@std/encoding/base64";
 import { join } from "@std/path";
@@ -3774,6 +3779,390 @@ Deno.test("CfHarnessPromptLoop carries observed CFC labels into later write_file
   assertEquals(
     result.runState.cfcInvocationContexts?.[1]?.toolOutputId,
     createToolOutputId("run-write-file-cfc-model-context", "write_file", 2),
+  );
+});
+
+Deno.test("CfHarnessPromptLoop carries observed CFC labels into edit_file write inputs", async () => {
+  const fetchCalls: RequestInit[] = [];
+  const priorSecretLabel = "did:key:edit-prior-secret";
+  const editSourceLabel = "did:key:edit-source-secret";
+  const editVerifiedLabel = "did:key:edit-verified-secret";
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime([
+        {
+          stdout: "raw prior secret\n",
+          stderr: "",
+          exitCode: 0,
+          cfcResult: observedCfcResult("released prior secret\n", {
+            stdoutLabel: { confidentiality: [priorSecretLabel] },
+          }),
+        },
+        {
+          stdout: "alpha\nraw-beta\n",
+          stderr: "",
+          exitCode: 0,
+          cfcResult: observedCfcResult("alpha\nreleased-beta\n", {
+            stdoutLabel: { confidentiality: [editSourceLabel] },
+          }),
+        },
+        {
+          stdout: "",
+          stderr: "",
+          exitCode: 0,
+        },
+        {
+          stdout: "alpha\nraw-BETA\n",
+          stderr: "",
+          exitCode: 0,
+          cfcResult: observedCfcResult("alpha\nreleased-BETA\n", {
+            stdoutLabel: { confidentiality: [editVerifiedLabel] },
+          }),
+        },
+      ]),
+      runId: "run-edit-file-cfc-model-context",
+      model: "gpt-5.4",
+      cfcEnforcementMode: "enforce-explicit",
+    }),
+    fetchFn: (_input, init) => {
+      fetchCalls.push(init ?? {});
+      const payload = fetchCalls.length === 1
+        ? {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "",
+              tool_calls: [{
+                id: "call-read-secret-before-edit",
+                type: "function",
+                function: {
+                  name: "read_file",
+                  arguments: JSON.stringify({ path: "secret.txt" }),
+                },
+              }],
+            },
+          }],
+        }
+        : fetchCalls.length === 2
+        ? {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "",
+              tool_calls: [{
+                id: "call-edit-secret-derived-file",
+                type: "function",
+                function: {
+                  name: "edit_file",
+                  arguments: JSON.stringify({
+                    path: "notes/secret.txt",
+                    edits: [{
+                      oldText: "raw-beta\n",
+                      newText: "raw-BETA\n",
+                    }],
+                  }),
+                },
+              }],
+            },
+          }],
+        }
+        : {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "Done.",
+            },
+          }],
+        };
+      return Promise.resolve(
+        new Response(JSON.stringify(payload), { status: 200 }),
+      );
+    },
+  });
+
+  const result = await loop.runPrompt({
+    prompt: "Read a file, then edit another derived file.",
+    promptSlotBinding: directPromptSlotBinding,
+  });
+
+  assertEquals(
+    result.runState.cfcInvocationContexts?.map((context) => ({
+      toolId: context.toolId,
+      toolOutputId: context.toolOutputId,
+    })),
+    [
+      {
+        toolId: "read_file",
+        toolOutputId: undefined,
+      },
+      {
+        toolId: "edit_file",
+        toolOutputId: createToolOutputId(
+          "run-edit-file-cfc-model-context",
+          "edit_file",
+          2,
+        ),
+      },
+      {
+        toolId: "edit_file",
+        toolOutputId: createToolOutputId(
+          "run-edit-file-cfc-model-context",
+          "edit_file",
+          2,
+        ),
+      },
+      {
+        toolId: "edit_file",
+        toolOutputId: createToolOutputId(
+          "run-edit-file-cfc-model-context",
+          "edit_file",
+          2,
+        ),
+      },
+    ],
+  );
+  assertEquals(
+    invocationInputLabelContains(result.runState, 2, "args", priorSecretLabel),
+    true,
+  );
+  assertEquals(
+    invocationInputLabelContains(
+      result.runState,
+      2,
+      "stdin",
+      priorSecretLabel,
+    ),
+    true,
+  );
+  assertEquals(
+    invocationInputLabelContains(
+      result.runState,
+      2,
+      "stdin",
+      editSourceLabel,
+    ),
+    true,
+  );
+
+  const editToolMessage = result.transcript.find((message) =>
+    message.role === "tool" && message.toolName === "edit_file"
+  );
+  if (editToolMessage?.role !== "tool") {
+    throw new Error("expected edit_file tool message");
+  }
+  const modelFacingEditOutput = JSON.parse(editToolMessage.content) as Record<
+    string,
+    unknown
+  >;
+  assertEquals("cfcResult" in modelFacingEditOutput, false);
+  assertEquals(
+    (modelFacingEditOutput.cfc as { stdout?: { label?: unknown } }).stdout
+      ?.label,
+    { confidentiality: [editSourceLabel, editVerifiedLabel] },
+  );
+  assertStringIncludes(String(modelFacingEditOutput.diff), "-released-beta");
+  assertStringIncludes(String(modelFacingEditOutput.diff), "+released-BETA");
+  assertEquals(String(modelFacingEditOutput.diff).includes("raw-beta"), false);
+  assertEquals(String(modelFacingEditOutput.diff).includes("raw-BETA"), false);
+});
+
+Deno.test("CfHarnessPromptLoop denies edit_file success when an internal read lacks CFC metadata", async () => {
+  const fetchCalls: RequestInit[] = [];
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime([
+        {
+          stdout: "alpha\nraw-beta\n",
+          stderr: "",
+          exitCode: 0,
+        },
+        {
+          stdout: "",
+          stderr: "",
+          exitCode: 0,
+        },
+        {
+          stdout: "alpha\nraw-BETA\n",
+          stderr: "",
+          exitCode: 0,
+          cfcResult: observedCfcResult("alpha\nreleased-BETA\n"),
+        },
+      ]),
+      runId: "run-edit-file-missing-cfc-result",
+      model: "gpt-5.4",
+      cfcEnforcementMode: "enforce-explicit",
+    }),
+    fetchFn: (_input, init) => {
+      fetchCalls.push(init ?? {});
+      const payload = fetchCalls.length === 1
+        ? {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "",
+              tool_calls: [{
+                id: "call-edit-missing-cfc",
+                type: "function",
+                function: {
+                  name: "edit_file",
+                  arguments: JSON.stringify({
+                    path: "notes/secret.txt",
+                    edits: [{
+                      oldText: "raw-beta\n",
+                      newText: "raw-BETA\n",
+                    }],
+                  }),
+                },
+              }],
+            },
+          }],
+        }
+        : {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "Done.",
+            },
+          }],
+        };
+      return Promise.resolve(
+        new Response(JSON.stringify(payload), { status: 200 }),
+      );
+    },
+  });
+
+  const result = await loop.runPrompt({
+    prompt: "Edit a file.",
+    promptSlotBinding: directPromptSlotBinding,
+  });
+
+  const editToolMessage = result.transcript.find((message) =>
+    message.role === "tool" && message.toolName === "edit_file"
+  );
+  if (editToolMessage?.role !== "tool") {
+    throw new Error("expected edit_file tool message");
+  }
+  const modelFacingEditOutput = JSON.parse(editToolMessage.content) as {
+    type?: string;
+    handle?: { handleId?: string };
+  };
+  assertEquals(modelFacingEditOutput.type, "cf-harness.observation-denied");
+  assertStringIncludes(
+    String(modelFacingEditOutput.handle?.handleId),
+    "run-edit-file-missing-cfc-result:edit_file:1",
+  );
+  assertEquals(editToolMessage.content.includes("raw-beta"), false);
+  assertEquals(editToolMessage.content.includes("raw-BETA"), false);
+  assertEquals(
+    result.runState.policyEvents.some((event) =>
+      event.severity === "denied" && event.toolId === "edit_file"
+    ),
+    true,
+  );
+});
+
+Deno.test("CfHarnessPromptLoop redacts recoverable edit_file errors in enforce mode", async () => {
+  const fetchCalls: RequestInit[] = [];
+  const loop = new CfHarnessPromptLoop({
+    apiKey: "test-key",
+    engine: new CfHarnessEngine({
+      sandboxRuntime: new FakeSandboxRuntime([
+        {
+          stdout: "alpha\nsecret-token\n",
+          stderr: "",
+          exitCode: 0,
+          cfcResult: observedCfcResult("alpha\nreleased-secret\n"),
+        },
+      ]),
+      runId: "run-edit-file-error-redaction",
+      model: "gpt-5.4",
+      cfcEnforcementMode: "enforce-explicit",
+    }),
+    fetchFn: (_input, init) => {
+      fetchCalls.push(init ?? {});
+      const payload = fetchCalls.length === 1
+        ? {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "",
+              tool_calls: [{
+                id: "call-edit-conflict",
+                type: "function",
+                function: {
+                  name: "edit_file",
+                  arguments: JSON.stringify({
+                    path: "notes/secret.txt",
+                    edits: [{
+                      oldText: "missing-secret\n",
+                      newText: "replacement\n",
+                    }],
+                  }),
+                },
+              }],
+            },
+          }],
+        }
+        : {
+          choices: [{
+            index: 0,
+            message: {
+              role: "assistant",
+              content: "Done.",
+            },
+          }],
+        };
+      return Promise.resolve(
+        new Response(JSON.stringify(payload), { status: 200 }),
+      );
+    },
+  });
+
+  const result = await loop.runPrompt({
+    prompt: "Edit a file.",
+    promptSlotBinding: directPromptSlotBinding,
+  });
+
+  const editToolMessage = result.transcript.find((message) =>
+    message.role === "tool" && message.toolName === "edit_file"
+  );
+  if (editToolMessage?.role !== "tool") {
+    throw new Error("expected edit_file tool message");
+  }
+  const modelFacingEditOutput = JSON.parse(editToolMessage.content) as {
+    outputId?: string;
+    path?: string;
+    ok?: boolean;
+    error?: { code?: string; path?: string; message?: string };
+  };
+  assertEquals(
+    modelFacingEditOutput.outputId,
+    "run-edit-file-error-redaction:edit_file:1",
+  );
+  assertEquals(modelFacingEditOutput.path, "[redacted]");
+  assertEquals(modelFacingEditOutput.ok, false);
+  assertEquals(modelFacingEditOutput.error?.code, "unknown");
+  assertEquals(modelFacingEditOutput.error?.path, "[redacted]");
+  assertStringIncludes(
+    String(modelFacingEditOutput.error?.message),
+    "edit_file failed",
+  );
+  assertEquals(editToolMessage.content.includes("notes/secret.txt"), false);
+  assertEquals(editToolMessage.content.includes("missing-secret"), false);
+  assertEquals(editToolMessage.content.includes("secret-token"), false);
+  assertEquals(
+    result.runState.policyEvents.some((event) =>
+      event.severity === "denied" && event.toolId === "edit_file"
+    ),
+    true,
   );
 });
 

--- a/packages/cf-harness/test/tools-execution.test.ts
+++ b/packages/cf-harness/test/tools-execution.test.ts
@@ -216,13 +216,21 @@ const stripCfcInvocationContexts = (
     return { type: "runShell", request };
   });
 
-const observedCfcResult = (stdout: string): CfcSandboxResult => ({
+const observedCfcResult = (
+  stdout: string,
+  options: {
+    stdoutLabel?: CfcSandboxResult["stdout"]["label"];
+  } = {},
+): CfcSandboxResult => ({
   version: 1,
   stdout: {
     channel: "stdout",
     policy: "observed",
-    label: { confidentiality: ["public"] },
-    segments: [{ text: stdout, label: { confidentiality: ["public"] } }],
+    label: options.stdoutLabel ?? { confidentiality: ["public"] },
+    segments: [{
+      text: stdout,
+      label: options.stdoutLabel ?? { confidentiality: ["public"] },
+    }],
   },
   stderr: {
     channel: "stderr",
@@ -1134,9 +1142,122 @@ Deno.test("edit_file applies exact replacements and returns a unified diff", asy
     "edit_file",
   );
   assertEquals(
+    sandbox.calls.map((call) =>
+      call.type === "runShell"
+        ? call.request.cfcInvocationContext?.toolOutputId
+        : undefined
+    ),
+    [
+      createToolOutputId("run-1", "edit_file", 1),
+      createToolOutputId("run-1", "edit_file", 1),
+      createToolOutputId("run-1", "edit_file", 1),
+    ],
+  );
+  assertEquals(
     sandbox.calls[1]?.request.cfcInvocationContext?.inputs.stdin?.bytes,
     edited.length,
   );
+});
+
+Deno.test("edit_file labels write stdin with internal read CFC labels", async () => {
+  const original = "alpha\nbeta\n";
+  const edited = "alpha\nBETA\n";
+  const readLabel = { confidentiality: ["did:key:file-secret"] };
+  const trustedLabels: CfcLabelView = {
+    version: 1,
+    entries: [{
+      path: ["args"],
+      label: { confidentiality: ["did:key:trusted-path"] },
+    }],
+  };
+  const sandbox = new FakeSandboxRuntime([
+    {
+      stdout: original,
+      stderr: "",
+      exitCode: 0,
+      cfcResult: observedCfcResult(original, { stdoutLabel: readLabel }),
+    },
+    { stdout: "", stderr: "", exitCode: 0 },
+    {
+      stdout: edited,
+      stderr: "",
+      exitCode: 0,
+      cfcResult: observedCfcResult(edited, {
+        stdoutLabel: { confidentiality: ["did:key:verified-file"] },
+      }),
+    },
+  ]);
+
+  const output = await editFileTool.invoke(createContext(sandbox), {
+    path: "notes/secret.txt",
+    edits: [{ oldText: "beta\n", newText: "BETA\n" }],
+    cfcInputLabels: trustedLabels,
+  });
+
+  if ("ok" in output) {
+    throw new Error("expected successful edit_file output");
+  }
+  assertEquals(output.outputId, "run-1:edit_file:1");
+  assertEquals(output.cfcResult?.stdout.label, {
+    confidentiality: ["did:key:file-secret", "did:key:verified-file"],
+  });
+  assertEquals(output.cfcResult?.stdout.policy, "observed");
+  if (output.cfcResult?.stdout.policy !== "observed") {
+    throw new Error("expected observed CFC stdout");
+  }
+  assertEquals(
+    output.cfcResult.stdout.segments.map((segment) => segment.text).join(""),
+    [
+      "--- /workspace/notes/secret.txt",
+      "+++ /workspace/notes/secret.txt",
+      "@@ -1,2 +1,2 @@",
+      " alpha",
+      "-beta",
+      "+BETA",
+      "",
+    ].join("\n"),
+  );
+  assertEquals(
+    sandbox.calls[1]?.request.cfcInvocationContext?.cfcInputLabels,
+    {
+      version: 1,
+      entries: [
+        {
+          path: ["args"],
+          label: { confidentiality: ["did:key:trusted-path"] },
+        },
+        {
+          path: ["stdin"],
+          label: { confidentiality: ["did:key:file-secret"] },
+        },
+      ],
+    },
+  );
+});
+
+Deno.test("edit_file omits CFC result when either internal read is unmediated", async () => {
+  const original = "alpha\nbeta\n";
+  const edited = "alpha\nBETA\n";
+  const sandbox = new FakeSandboxRuntime([
+    { stdout: original, stderr: "", exitCode: 0 },
+    { stdout: "", stderr: "", exitCode: 0 },
+    {
+      stdout: edited,
+      stderr: "",
+      exitCode: 0,
+      cfcResult: observedCfcResult(edited),
+    },
+  ]);
+
+  const output = await editFileTool.invoke(createContext(sandbox), {
+    path: "notes/secret.txt",
+    edits: [{ oldText: "beta\n", newText: "BETA\n" }],
+  });
+
+  if ("ok" in output) {
+    throw new Error("expected successful edit_file output");
+  }
+  assertEquals("cfcResult" in output, false);
 });
 
 Deno.test("edit_file returns separate hunks for distant edits", async () => {

--- a/packages/patterns/cfc-group-chat-demo/logic.ts
+++ b/packages/patterns/cfc-group-chat-demo/logic.ts
@@ -93,7 +93,6 @@ const createImportedClaimedMessage = <ProfileRef>(
   origin: "imported",
   id: createId("imported"),
   authorName: author.name,
-  ...(author.profile !== undefined ? { authorProfile: author.profile } : {}),
   body,
   timestamp,
 });

--- a/packages/patterns/cfc-group-chat-demo/main.test.tsx
+++ b/packages/patterns/cfc-group-chat-demo/main.test.tsx
@@ -109,7 +109,9 @@ export default pattern(() => {
     return messageList.length === 4 &&
       importedMessages.length === 2 &&
       importedMessages.every((message) =>
-        message.authorName.length > 0 && message.body.length > 0
+        message.authorName.length > 0 &&
+        message.body.length > 0 &&
+        message.authorProfile === undefined
       );
   });
   const assert_thread_order_sortable = computed(() => {


### PR DESCRIPTION
## Summary
- correlate edit_file internal read/write/verify sandbox invocations with the final tool output id
- carry internal read CFC stdout labels onto edit_file write stdin labels, alongside prompt/model-context labels
- mediate successful edit_file diff output before exposing it to the model and keep raw cfcResult out of model-facing output

## Validation
- `/Users/gideonwald/.deno/bin/deno test --allow-read --allow-write --allow-run packages/cf-harness/test/tools-execution.test.ts packages/cf-harness/test/prompt-loop.test.ts packages/cf-harness/test/cfc-invocation-context.test.ts packages/cf-harness/test/engine.test.ts`
- `/Users/gideonwald/.deno/bin/deno check packages/cf-harness/src/main.ts`
- `git diff --check`
- `cd packages/cf-harness && /Users/gideonwald/.deno/bin/deno task test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds end-to-end CFC mediation for `edit_file` so labels flow from internal reads into writes and the model sees a safe, consistent diff. Also stabilizes imported claim messages in the CFC group chat demo.

- **New Features**
  - Carry labels: propagate internal read stdout labels to `edit_file` write stdin, merged with prompt/model labels; limited to `args`/`stdin`.
  - Correlate invocations: add `toolOutputId` to internal read/write/verify; return the same `outputId` on success and errors.
  - Mediate success: compute the diff from observed read+verify output, attach summarized `cfc`, and strip raw `cfcResult`; deny success if internal reads lack CFC metadata.
  - Redact errors: in enforce mode, redact `edit_file` error paths/messages and emit a policy event; expose raw errors in observe/disabled modes.

- **Bug Fixes**
  - Group chat demo: drop `authorProfile` from imported claim messages to keep the shape stable.

<sup>Written for commit ddabe9a73ccd9656824aab85433f7a5f1a103cc4. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3643?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

