### PR TITLE
Speed up large-negative `bigint` encoding via word-sized complement

### DIFF
--- a/packages/utils/src/bigint-uint8-hex-string.ts
+++ b/packages/utils/src/bigint-uint8-hex-string.ts
@@ -95,15 +95,27 @@ export function bigintToMtcHex(value: bigint): Uint8Array {
 
     const hexString = hexStringFromPositiveValue(~value);
     const result = Uint8Array.fromHex(hexString);
-    const byteRemainder = result.length & 0x03;
-    const resultUint32 = new Uint32Array(result.buffer, 0, result.length >> 2);
+    const resultLength = result.length;
 
-    for (let i = 0; i < resultUint32.length; i++) {
-      resultUint32[i] = ~resultUint32[i];
-    }
+    if (resultLength < 128) {
+      for (let i = 0; i < resultLength; i++) {
+        result[i] = ~result[i];
+      }
+    } else {
+      // At around 128 bytes (measured in benchmarks), it becomes faster to
+      // construct a temporary `Uint32Array` just to complement four bytes at a
+      // time. But we might have a little bit extra to do if the length isn't a
+      // multiple of four.
+      const byteRemainder = resultLength & 0x03;
+      const resultUint32 = new Uint32Array(result.buffer, 0, resultLength >> 2);
 
-    for (let i = result.length - byteRemainder; i < result.length; i++) {
-      result[i] = ~result[i];
+      for (let i = 0; i < resultUint32.length; i++) {
+        resultUint32[i] = ~resultUint32[i];
+      }
+
+      for (let i = resultLength - byteRemainder; i < resultLength; i++) {
+        result[i] = ~result[i];
+      }
     }
 
     return result;

--- a/packages/utils/src/bigint-uint8-hex-string.ts
+++ b/packages/utils/src/bigint-uint8-hex-string.ts
@@ -95,8 +95,14 @@ export function bigintToMtcHex(value: bigint): Uint8Array {
 
     const hexString = hexStringFromPositiveValue(~value);
     const result = Uint8Array.fromHex(hexString);
+    const byteRemainder = result.length & 0x03;
+    const resultUint32 = new Uint32Array(result.buffer, 0, result.length >> 2);
 
-    for (let i = 0; i < result.length; i++) {
+    for (let i = 0; i < resultUint32.length; i++) {
+      resultUint32[i] = ~resultUint32[i];
+    }
+
+    for (let i = result.length - byteRemainder; i < result.length; i++) {
       result[i] = ~result[i];
     }
 


### PR DESCRIPTION
## Summary

In `bigintToMtcHex`, the negative-value path complements every byte of the
intermediate buffer one at a time. For long encodes this loop is the dominant
cost. Switch to a `Uint32Array` view and complement four bytes at a time
(plus a remainder loop) when the result is at least 128 bytes; keep the
original per-byte loop below that, where the typed-array setup doesn't pay
for itself.

Bench results (`bench/bigint.bench.ts`, `encode negative <N>B hex`, vs `main`):

- 1-127 B: flat (within run-to-run noise).
- 128-256 B: roughly flat to mild win.
- 257-512 B: about -12%.
- 1008-1039 B band: about -15%.

The 128 B threshold sits at the measured crossover point. Below it, the cost
of constructing the `Uint32Array` view and running two loops outweighs the
savings from complementing four bytes at a time; above it, the per-iteration
savings dominate.

A `BigUint64Array` variant was tried and was substantially worse at every
size (up to roughly +78% on the longest inputs) — the bigint boxing per chunk
swamps the benefit of the doubled chunk width.

## Test plan

- [x] Existing `bigintToMtc` / `bigintFromMtc` unit tests pass locally.
- [x] Encode-negative benchmarks run on `main` and this branch; no
      regressions observed in any size band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up negative `bigint` encoding in `bigintToMtcHex` by complementing 32 bits at a time for large buffers. Keeps the per-byte loop for small outputs to avoid setup overhead.

- **Performance**
  - For outputs >= 128 B, use a `Uint32Array` view to complement 4 bytes at a time, with a small remainder loop.
  - Benchmarks: flat under 128 B; ~12–15% faster on 257–1039 B inputs.

<sup>Written for commit 79919fe0ebb8906c293862606712aedc99f37a59. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3644?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

