### PR TITLE
feat(patterns): Add CFC-backed admin access demos

### DIFF
--- a/packages/patterns/admin.ts
+++ b/packages/patterns/admin.ts
@@ -1,0 +1,68 @@
+import {
+  type AddIntegrity,
+  type AnyCell,
+  type Default,
+  equals,
+} from "commonfabric";
+
+export type AdminSubject = AnyCell<any> | object;
+
+export interface AdminRoleAssignment<Subject extends AdminSubject> {
+  readonly subject: Subject;
+  readonly displayName: string;
+}
+
+export type ActiveAdminRole<
+  Subject extends AdminSubject,
+  Integrity extends string,
+> = AddIntegrity<AdminRoleAssignment<Subject>, readonly [Integrity]>;
+
+export type AdminManagerCredential<Integrity extends string> = AddIntegrity<
+  { readonly canManageAdmins: true },
+  readonly [Integrity]
+>;
+
+export interface AdminRegistryStoredValue<Role> {
+  readonly admins?: readonly Role[];
+}
+
+export type EmptyAdminRegistryValue = Record<PropertyKey, never>;
+export type AdminRegistryValue<Role> =
+  | AdminRegistryStoredValue<Role>
+  | Default<EmptyAdminRegistryValue>;
+
+export const adminManagerCredentialIsActive = (
+  credential:
+    | { readonly canManageAdmins?: boolean }
+    | null
+    | undefined,
+): boolean => credential?.canManageAdmins === true;
+
+export const adminRegistryEntries = <Role>(
+  registry: {
+    get(): AdminRegistryValue<Role> | undefined;
+  },
+): Role[] =>
+  Array.from(
+    (registry.get() as AdminRegistryStoredValue<Role> | undefined)
+      ?.admins ?? [],
+  );
+
+export const activeAdminRoleForSubject = <
+  Subject extends AdminSubject,
+  Role extends AdminRoleAssignment<Subject>,
+>(
+  roles: readonly Role[],
+  subject: Subject | undefined,
+): Role | undefined =>
+  subject === undefined
+    ? undefined
+    : roles.find((role) => equals(role.subject, subject));
+
+export const subjectHasAdminRole = <
+  Subject extends AdminSubject,
+  Role extends AdminRoleAssignment<Subject>,
+>(
+  roles: readonly Role[],
+  subject: Subject | undefined,
+): boolean => activeAdminRoleForSubject(roles, subject) !== undefined;

--- a/packages/patterns/cfc-group-chat-demo/logic.ts
+++ b/packages/patterns/cfc-group-chat-demo/logic.ts
@@ -15,7 +15,6 @@ export interface ParticipantClaim<ProfileRef = unknown> {
 
 export interface SentChatMessage<ProfileRef = unknown> {
   readonly origin: "sent";
-  readonly id: string;
   readonly authorName: string;
   readonly authorProfile: ProfileRef;
   readonly body: string;
@@ -24,7 +23,6 @@ export interface SentChatMessage<ProfileRef = unknown> {
 
 export interface ImportedClaimedChatMessage<ProfileRef = unknown> {
   readonly origin: "imported";
-  readonly id: string;
   readonly authorName: string;
   readonly authorProfile?: ProfileRef;
   readonly body: string;
@@ -36,7 +34,6 @@ export type PlainChatMessage<ProfileRef = unknown> =
   | ImportedClaimedChatMessage<ProfileRef>;
 
 export interface ChatRoom<Message = PlainChatMessage> {
-  readonly id: string;
   readonly name: string;
   readonly messages: Message[];
   readonly createdAt: number;
@@ -76,16 +73,12 @@ export const makeProfileSnapshot = (
   accentColor: previous?.accentColor ?? accentColorForName(name),
 });
 
-const createId = (prefix: string): string =>
-  `${prefix}-${safeDateNow()}-${nonPrivateRandom().toString(36).slice(2, 8)}`;
-
 export const createSentMessageSnapshot = <ProfileRef>(
   authorProfile: ProfileRef,
   author: ChatProfile,
   body: string,
 ): SentChatMessage<ProfileRef> => ({
   origin: "sent",
-  id: createId("msg"),
   authorName: author.name,
   authorProfile,
   body,
@@ -95,7 +88,6 @@ export const createSentMessageSnapshot = <ProfileRef>(
 export const createRoomSnapshot = <Message>(
   name: string,
 ): ChatRoom<Message> => ({
-  id: createId("room"),
   name,
   messages: [],
   createdAt: safeDateNow(),
@@ -107,7 +99,6 @@ const createImportedClaimedMessage = <ProfileRef>(
   timestamp: number,
 ): ImportedClaimedChatMessage<ProfileRef> => ({
   origin: "imported",
-  id: createId("imported"),
   authorName: author.name,
   ...(author.profile !== undefined ? { authorProfile: author.profile } : {}),
   body,
@@ -115,15 +106,32 @@ const createImportedClaimedMessage = <ProfileRef>(
 });
 
 const compareMessagesByThreadOrder = (
-  left: Pick<PlainChatMessage, "id" | "timestamp">,
-  right: Pick<PlainChatMessage, "id" | "timestamp">,
-): number =>
-  left.timestamp === right.timestamp
-    ? left.id.localeCompare(right.id)
-    : left.timestamp - right.timestamp;
+  left: Pick<PlainChatMessage, "authorName" | "body" | "origin" | "timestamp">,
+  right: Pick<PlainChatMessage, "authorName" | "body" | "origin" | "timestamp">,
+): number => {
+  const timestampOrder = left.timestamp - right.timestamp;
+  if (timestampOrder !== 0) {
+    return timestampOrder;
+  }
+
+  const authorOrder = left.authorName.localeCompare(right.authorName);
+  if (authorOrder !== 0) {
+    return authorOrder;
+  }
+
+  const bodyOrder = left.body.localeCompare(right.body);
+  if (bodyOrder !== 0) {
+    return bodyOrder;
+  }
+
+  return left.origin.localeCompare(right.origin);
+};
 
 export const sortDisplayMessages = <
-  Message extends Pick<PlainChatMessage, "id" | "timestamp">,
+  Message extends Pick<
+    PlainChatMessage,
+    "authorName" | "body" | "origin" | "timestamp"
+  >,
 >(
   messages: readonly Message[],
 ): Message[] => Array.from(messages).sort(compareMessagesByThreadOrder);

--- a/packages/patterns/cfc-group-chat-demo/logic.ts
+++ b/packages/patterns/cfc-group-chat-demo/logic.ts
@@ -35,6 +35,13 @@ export type PlainChatMessage<ProfileRef = unknown> =
   | SentChatMessage<ProfileRef>
   | ImportedClaimedChatMessage<ProfileRef>;
 
+export interface ChatRoom<Message = PlainChatMessage> {
+  readonly id: string;
+  readonly name: string;
+  readonly messages: Message[];
+  readonly createdAt: number;
+}
+
 const PROFILE_COLORS = [
   "#2563eb",
   "#059669",
@@ -83,6 +90,15 @@ export const createSentMessageSnapshot = <ProfileRef>(
   authorProfile,
   body,
   timestamp: safeDateNow(),
+});
+
+export const createRoomSnapshot = <Message>(
+  name: string,
+): ChatRoom<Message> => ({
+  id: createId("room"),
+  name,
+  messages: [],
+  createdAt: safeDateNow(),
 });
 
 const createImportedClaimedMessage = <ProfileRef>(

--- a/packages/patterns/cfc-group-chat-demo/logic.ts
+++ b/packages/patterns/cfc-group-chat-demo/logic.ts
@@ -109,6 +109,7 @@ const createImportedClaimedMessage = <ProfileRef>(
   origin: "imported",
   id: createId("imported"),
   authorName: author.name,
+  ...(author.profile !== undefined ? { authorProfile: author.profile } : {}),
   body,
   timestamp,
 });

--- a/packages/patterns/cfc-group-chat-demo/main.test.tsx
+++ b/packages/patterns/cfc-group-chat-demo/main.test.tsx
@@ -16,6 +16,7 @@ import {
   roomsValue,
   type SharedChatMessage,
   type SharedMessagesValue,
+  type SharedProfilesValue,
   type SharedRoomsValue,
   TRUSTED_GROUP_CHAT_SET_ADMIN_ACTION,
 } from "./trusted.tsx";
@@ -30,6 +31,9 @@ export default pattern(() => {
   const messages = Writable.of<SharedMessagesValue>(
     [] as SharedMessagesValue,
   );
+  const profiles = Writable.of<SharedProfilesValue>(
+    [] as SharedProfilesValue,
+  );
   const rooms = Writable.of<SharedRoomsValue>(
     {} as SharedRoomsValue,
   );
@@ -43,6 +47,7 @@ export default pattern(() => {
   const roomDraft = Writable.of("");
   const chat = GroupChatDemo({
     myProfile,
+    profiles,
     messages,
     rooms,
     adminRegistry,
@@ -52,12 +57,38 @@ export default pattern(() => {
     hostMessageDraft,
     roomDraft,
   } as GroupChatDemoInputArg);
+  const bobProfile = Writable.of<MyProfileCellValue>(
+    {} as Default<EmptyMyProfileValue>,
+  );
+  const bobProfileDraft = Writable.of("");
+  const bobAdminDraft = Writable.of(true);
+  const bobMessageDraft = Writable.of("");
+  const bobHostMessageDraft = Writable.of("");
+  const bobRoomDraft = Writable.of("");
+  const bobChat = GroupChatDemo({
+    myProfile: bobProfile,
+    profiles,
+    messages,
+    rooms,
+    adminRegistry,
+    profileDraft: bobProfileDraft,
+    adminDraft: bobAdminDraft,
+    messageDraft: bobMessageDraft,
+    hostMessageDraft: bobHostMessageDraft,
+    roomDraft: bobRoomDraft,
+  } as GroupChatDemoInputArg);
 
   const action_set_profile_alice = action(() => {
     chat.setProfileDraft.send("Alice");
   });
   const action_save_profile = action(() => {
     chat.saveProfile.send();
+  });
+  const action_set_profile_bob = action(() => {
+    bobChat.setProfileDraft.send("Bob");
+  });
+  const action_save_profile_bob = action(() => {
+    bobChat.saveProfile.send();
   });
   const action_set_room_ops = action(() => {
     chat.setRoomDraft.send("Ops");
@@ -135,6 +166,11 @@ export default pattern(() => {
   const assert_profile_can_manage_admins = computed(() =>
     chat.currentUserCanManageAdmins === true
   );
+  const assert_alice_sees_bob_without_bob_message = computed(() => {
+    const participants = participantClaimsValue(profiles, myProfile, messages);
+    return participants.some((participant) => participant.name === "Alice") &&
+      participants.some((participant) => participant.name === "Bob");
+  });
   const assert_admin_view_manager_enabled = computed(() => {
     const toggleButton = findNodeByProp(
       chat[UI],
@@ -207,7 +243,7 @@ export default pattern(() => {
       importedMessages.every((message) =>
         message.authorName.length > 0 &&
         message.body.length > 0 &&
-        message.authorProfile === undefined
+        message.authorProfile !== undefined
       );
   });
   const assert_thread_order_sortable = computed(() => {
@@ -217,8 +253,13 @@ export default pattern(() => {
         index === 0 || ordered[index - 1]!.timestamp <= message.timestamp
       );
   });
+  const assert_verified_imports_do_not_duplicate_participants = computed(() =>
+    participantClaimsValue(profiles, myProfile, messages).filter((
+      participant,
+    ) => participant.name === "Alice Renamed").length === 1
+  );
   const assert_same_name_unverified_imports_are_distinct = computed(() => {
-    const participants = participantClaimsValue(myProfile, messages);
+    const participants = participantClaimsValue(profiles, myProfile, messages);
     return participants.filter((participant) =>
       participant.name === "Sam" && participant.profile === undefined
     ).length === 2;
@@ -233,6 +274,9 @@ export default pattern(() => {
       { assertion: assert_profile_created },
       { assertion: assert_profile_starts_non_admin },
       { assertion: assert_profile_can_manage_admins },
+      { action: action_set_profile_bob },
+      { action: action_save_profile_bob },
+      { assertion: assert_alice_sees_bob_without_bob_message },
       { assertion: assert_admin_view_manager_enabled },
       { action: action_set_room_ops },
       { action: action_try_add_room_without_admin },
@@ -258,6 +302,7 @@ export default pattern(() => {
       { action: action_add_random_imported },
       { assertion: assert_imported_messages_injected },
       { assertion: assert_thread_order_sortable },
+      { assertion: assert_verified_imports_do_not_duplicate_participants },
       { action: action_add_same_name_unverified_imports },
       { assertion: assert_same_name_unverified_imports_are_distinct },
     ],

--- a/packages/patterns/cfc-group-chat-demo/main.test.tsx
+++ b/packages/patterns/cfc-group-chat-demo/main.test.tsx
@@ -5,8 +5,10 @@ import {
   type MyProfileCellValue,
   type MyProfileValue,
   participantClaimsValue,
+  roomsValue,
   type SharedChatMessage,
   type SharedMessagesValue,
+  type SharedRoomsValue,
 } from "./trusted.tsx";
 import { GroupChatDemo } from "./main.tsx";
 
@@ -19,15 +21,23 @@ export default pattern(() => {
   const messages = Writable.of<SharedMessagesValue>(
     [] as SharedMessagesValue,
   );
+  const rooms = Writable.of<SharedRoomsValue>(
+    {} as SharedRoomsValue,
+  );
   const profileDraft = Writable.of("");
+  const adminDraft = Writable.of(false);
   const messageDraft = Writable.of("");
   const hostMessageDraft = Writable.of("");
+  const roomDraft = Writable.of("");
   const chat = GroupChatDemo({
     myProfile,
     messages,
+    rooms,
     profileDraft,
+    adminDraft,
     messageDraft,
     hostMessageDraft,
+    roomDraft,
   } as GroupChatDemoInputArg);
 
   const action_set_profile_alice = action(() => {
@@ -35,6 +45,18 @@ export default pattern(() => {
   });
   const action_save_profile = action(() => {
     chat.saveProfile.send();
+  });
+  const action_set_room_ops = action(() => {
+    chat.setRoomDraft.send("Ops");
+  });
+  const action_try_add_room_without_admin = action(() => {
+    chat.addTrustedRoom.send();
+  });
+  const action_enable_admin_draft = action(() => {
+    chat.setAdminDraft.send(true);
+  });
+  const action_add_room = action(() => {
+    chat.addTrustedRoom.send();
   });
   const action_set_message_alice = action(() => {
     chat.setMessageDraft.send("Hello from Alice");
@@ -81,6 +103,19 @@ export default pattern(() => {
   const assert_profile_created = computed(() =>
     chat.currentProfileName === "Alice"
   );
+  const assert_profile_starts_non_admin = computed(() =>
+    chat.currentUserIsAdmin !== true
+  );
+  const assert_non_admin_cannot_add_room = computed(() =>
+    roomsValue(rooms).length === 0
+  );
+  const assert_admin_enabled = computed(() => chat.currentUserIsAdmin === true);
+  const assert_admin_can_add_room = computed(() => {
+    const roomList = roomsValue(rooms);
+    return roomList.length === 1 &&
+      roomList[0]?.name === "Ops" &&
+      roomDraft.get() === "";
+  });
   const assert_message_sent_and_draft_cleared = computed(() =>
     messages.get().length === 1 &&
     messages.get()[0]?.origin === "sent" &&
@@ -134,6 +169,15 @@ export default pattern(() => {
       { action: action_set_profile_alice },
       { action: action_save_profile },
       { assertion: assert_profile_created },
+      { assertion: assert_profile_starts_non_admin },
+      { action: action_set_room_ops },
+      { action: action_try_add_room_without_admin },
+      { assertion: assert_non_admin_cannot_add_room },
+      { action: action_enable_admin_draft },
+      { action: action_save_profile },
+      { assertion: assert_admin_enabled },
+      { action: action_add_room },
+      { assertion: assert_admin_can_add_room },
       { action: action_set_message_alice },
       { action: action_send_message },
       { assertion: assert_message_sent_and_draft_cleared },

--- a/packages/patterns/cfc-group-chat-demo/main.test.tsx
+++ b/packages/patterns/cfc-group-chat-demo/main.test.tsx
@@ -1,6 +1,8 @@
 import { action, computed, Default, pattern, Writable } from "commonfabric";
 import { sortDisplayMessages } from "./logic.ts";
 import {
+  type ChatAdminRegistryValue,
+  chatAdminRolesValue,
   type EmptyMyProfileValue,
   type MyProfileCellValue,
   type MyProfileValue,
@@ -24,8 +26,11 @@ export default pattern(() => {
   const rooms = Writable.of<SharedRoomsValue>(
     {} as SharedRoomsValue,
   );
+  const adminRegistry = Writable.of<ChatAdminRegistryValue>(
+    {} as ChatAdminRegistryValue,
+  );
   const profileDraft = Writable.of("");
-  const adminDraft = Writable.of(false);
+  const adminDraft = Writable.of(true);
   const messageDraft = Writable.of("");
   const hostMessageDraft = Writable.of("");
   const roomDraft = Writable.of("");
@@ -33,6 +38,7 @@ export default pattern(() => {
     myProfile,
     messages,
     rooms,
+    adminRegistry,
     profileDraft,
     adminDraft,
     messageDraft,
@@ -54,6 +60,9 @@ export default pattern(() => {
   });
   const action_enable_admin_draft = action(() => {
     chat.setAdminDraft.send(true);
+  });
+  const action_toggle_alice_admin = action(() => {
+    chat.toggleCurrentUserAdmin.send();
   });
   const action_add_room = action(() => {
     chat.addTrustedRoom.send();
@@ -106,10 +115,16 @@ export default pattern(() => {
   const assert_profile_starts_non_admin = computed(() =>
     chat.currentUserIsAdmin !== true
   );
+  const assert_profile_can_manage_admins = computed(() =>
+    chat.currentUserCanManageAdmins === true
+  );
   const assert_non_admin_cannot_add_room = computed(() =>
     roomsValue(rooms).length === 0
   );
-  const assert_admin_enabled = computed(() => chat.currentUserIsAdmin === true);
+  const assert_admin_enabled = computed(() =>
+    chat.currentUserIsAdmin === true &&
+    chatAdminRolesValue(adminRegistry).length === 1
+  );
   const assert_admin_can_add_room = computed(() => {
     const roomList = roomsValue(rooms);
     return roomList.length === 1 &&
@@ -170,11 +185,14 @@ export default pattern(() => {
       { action: action_save_profile },
       { assertion: assert_profile_created },
       { assertion: assert_profile_starts_non_admin },
+      { assertion: assert_profile_can_manage_admins },
       { action: action_set_room_ops },
       { action: action_try_add_room_without_admin },
       { assertion: assert_non_admin_cannot_add_room },
       { action: action_enable_admin_draft },
       { action: action_save_profile },
+      { assertion: assert_profile_can_manage_admins },
+      { action: action_toggle_alice_admin },
       { assertion: assert_admin_enabled },
       { action: action_add_room },
       { assertion: assert_admin_can_add_room },

--- a/packages/patterns/cfc-group-chat-demo/main.test.tsx
+++ b/packages/patterns/cfc-group-chat-demo/main.test.tsx
@@ -128,14 +128,12 @@ export default pattern(() => {
       ...(messages.get() as SharedChatMessage[]),
       {
         origin: "imported",
-        id: "same-name-imported-1",
         authorName: "Sam",
         body: "first Sam",
         timestamp: 10_000,
       },
       {
         origin: "imported",
-        id: "same-name-imported-2",
         authorName: "Sam",
         body: "second Sam",
         timestamp: 10_001,
@@ -264,6 +262,12 @@ export default pattern(() => {
       participant.name === "Sam" && participant.profile === undefined
     ).length === 2;
   });
+  const assert_messages_and_rooms_do_not_store_ids = computed(() =>
+    (messages.get() as SharedChatMessage[]).every((message) =>
+      !("id" in message)
+    ) &&
+    roomsValue(rooms).every((room) => !("id" in room))
+  );
 
   return {
     tests: [
@@ -305,6 +309,7 @@ export default pattern(() => {
       { assertion: assert_verified_imports_do_not_duplicate_participants },
       { action: action_add_same_name_unverified_imports },
       { assertion: assert_same_name_unverified_imports_are_distinct },
+      { assertion: assert_messages_and_rooms_do_not_store_ids },
     ],
   };
 });

--- a/packages/patterns/cfc-group-chat-demo/main.test.tsx
+++ b/packages/patterns/cfc-group-chat-demo/main.test.tsx
@@ -1,4 +1,10 @@
-import { action, computed, Default, pattern, Writable } from "commonfabric";
+import { action, computed, Default, pattern, UI, Writable } from "commonfabric";
+import {
+  findNodeById,
+  findNodeByProp,
+  nodeIncludesText,
+  propValue,
+} from "../test-ui-helpers.ts";
 import { sortDisplayMessages } from "./logic.ts";
 import {
   type ChatAdminRegistryValue,
@@ -11,6 +17,7 @@ import {
   type SharedChatMessage,
   type SharedMessagesValue,
   type SharedRoomsValue,
+  TRUSTED_GROUP_CHAT_SET_ADMIN_ACTION,
 } from "./trusted.tsx";
 import { GroupChatDemo } from "./main.tsx";
 
@@ -109,6 +116,16 @@ export default pattern(() => {
     (myProfile.get() as MyProfileValue | undefined)?.profile === undefined &&
     (messages.get()?.length ?? 0) === 0
   );
+  const assert_admin_view_initially_locked = computed(() => {
+    const managerChip = findNodeById(chat[UI], "group-chat-manager-chip");
+    const panelStatus = findNodeById(
+      chat[UI],
+      "trusted-admin-manager-panel-status",
+    );
+    return propValue(managerChip, "label") === "Manager off" &&
+      propValue(panelStatus, "label") ===
+        "Save profile with admin-manager enabled to edit";
+  });
   const assert_profile_created = computed(() =>
     chat.currentProfileName === "Alice"
   );
@@ -118,6 +135,22 @@ export default pattern(() => {
   const assert_profile_can_manage_admins = computed(() =>
     chat.currentUserCanManageAdmins === true
   );
+  const assert_admin_view_manager_enabled = computed(() => {
+    const toggleButton = findNodeByProp(
+      chat[UI],
+      "data-ui-action",
+      TRUSTED_GROUP_CHAT_SET_ADMIN_ACTION,
+    );
+    const managerChip = findNodeById(chat[UI], "group-chat-manager-chip");
+    const panelStatus = findNodeById(
+      chat[UI],
+      "trusted-admin-manager-panel-status",
+    );
+    return propValue(managerChip, "label") === "Can manage admins" &&
+      propValue(panelStatus, "label") === "Admin registry editing enabled" &&
+      propValue(toggleButton, "disabled") === false &&
+      nodeIncludesText(toggleButton, "Make admin");
+  });
   const assert_non_admin_cannot_add_room = computed(() =>
     roomsValue(rooms).length === 0
   );
@@ -125,6 +158,19 @@ export default pattern(() => {
     chat.currentUserIsAdmin === true &&
     chatAdminRolesValue(adminRegistry).length === 1
   );
+  const assert_admin_view_current_user_admin = computed(() => {
+    const toggleButton = findNodeByProp(
+      chat[UI],
+      "data-ui-action",
+      TRUSTED_GROUP_CHAT_SET_ADMIN_ACTION,
+    );
+    return propValue(toggleButton, "disabled") === false &&
+      nodeIncludesText(toggleButton, "Remove admin") &&
+      nodeIncludesText(
+        findNodeById(chat[UI], "trusted-admin-user-list"),
+        "Admin",
+      );
+  });
   const assert_admin_can_add_room = computed(() => {
     const roomList = roomsValue(rooms);
     return roomList.length === 1 &&
@@ -181,11 +227,13 @@ export default pattern(() => {
   return {
     tests: [
       { assertion: assert_initially_empty },
+      { assertion: assert_admin_view_initially_locked },
       { action: action_set_profile_alice },
       { action: action_save_profile },
       { assertion: assert_profile_created },
       { assertion: assert_profile_starts_non_admin },
       { assertion: assert_profile_can_manage_admins },
+      { assertion: assert_admin_view_manager_enabled },
       { action: action_set_room_ops },
       { action: action_try_add_room_without_admin },
       { assertion: assert_non_admin_cannot_add_room },
@@ -194,6 +242,7 @@ export default pattern(() => {
       { assertion: assert_profile_can_manage_admins },
       { action: action_toggle_alice_admin },
       { assertion: assert_admin_enabled },
+      { assertion: assert_admin_view_current_user_admin },
       { action: action_add_room },
       { assertion: assert_admin_can_add_room },
       { action: action_set_message_alice },

--- a/packages/patterns/cfc-group-chat-demo/main.tsx
+++ b/packages/patterns/cfc-group-chat-demo/main.tsx
@@ -114,7 +114,6 @@ const SharedTranscript = pattern<
               {messageCell.authorName}
             </span>
             <cf-cfc-authorship
-              data-authorship-surface={messageCell.id}
               $value={messageCell.body}
               $author={messageCell.authorProfile}
               authorName={messageCell.authorName}

--- a/packages/patterns/cfc-group-chat-demo/main.tsx
+++ b/packages/patterns/cfc-group-chat-demo/main.tsx
@@ -18,11 +18,14 @@ import {
   sortDisplayMessages,
 } from "./logic.ts";
 import {
-  type AdminCredential,
-  type AdminCredentialCell,
-  type AdminDraftCell,
+  type AdminManagerCredentialCell,
+  type AdminManagerDraftCell,
+  type ChatAdminManagerCredential,
+  type ChatAdminRegistryCell,
+  type ChatAdminRegistryValue,
   commitTrustedMessageSend,
   currentProfileCell,
+  currentUserIsAdmin,
   messagesValue,
   type MyProfileCell,
   participantClaimsValue,
@@ -33,6 +36,7 @@ import {
   type SharedMessagesValue,
   type SharedRoomsCell,
   type SharedRoomsValue,
+  TrustedAdminPanel,
   TrustedChatSendSurface,
   TrustedProfileSaveSurface,
   TrustedRoomAddSurface,
@@ -55,7 +59,7 @@ const writeDraftText = handler<string, { value: DraftCell }>(
   },
 );
 
-const writeBooleanDraft = handler<boolean, { value: AdminDraftCell }>(
+const writeBooleanDraft = handler<boolean, { value: AdminManagerDraftCell }>(
   (nextValue, { value }) => {
     value.set(nextValue);
   },
@@ -195,6 +199,7 @@ type RoomsListInputArg = Parameters<typeof RoomsList>[0];
 type TrustedChatSendSurfaceInputArg = Parameters<
   typeof TrustedChatSendSurface
 >[0];
+type TrustedAdminPanelInputArg = Parameters<typeof TrustedAdminPanel>[0];
 type TrustedRoomAddSurfaceInputArg = Parameters<
   typeof TrustedRoomAddSurface
 >[0];
@@ -206,8 +211,9 @@ export interface GroupChatDemoInput {
   myProfile?: PerUser<MyProfileCell>;
   messages?: PerSpace<SharedMessagesCell>;
   rooms?: PerSpace<SharedRoomsCell>;
+  adminRegistry?: PerSpace<ChatAdminRegistryCell>;
   profileDraft?: PerUser<DraftCell>;
-  adminDraft?: PerUser<AdminDraftCell>;
+  adminDraft?: PerUser<AdminManagerDraftCell>;
   messageDraft?: PerUser<DraftCell>;
   hostMessageDraft?: PerSession<DraftCell>;
   roomDraft?: PerSession<RoomDraftCell>;
@@ -219,8 +225,9 @@ export interface GroupChatDemoOutput {
   myProfile: PerUser<MyProfileCell>;
   messages: PerSpace<SharedMessagesCell>;
   rooms: PerSpace<SharedRoomsCell>;
+  adminRegistry: PerSpace<ChatAdminRegistryCell>;
   profileDraft: PerUser<DraftCell>;
-  adminDraft: PerUser<AdminDraftCell>;
+  adminDraft: PerUser<AdminManagerDraftCell>;
   messageDraft: PerUser<DraftCell>;
   hostMessageDraft: PerSession<DraftCell>;
   roomDraft: PerSession<RoomDraftCell>;
@@ -231,7 +238,9 @@ export interface GroupChatDemoOutput {
   setRoomDraft: Stream<string>;
   currentProfileName: string;
   currentUserIsAdmin: boolean;
+  currentUserCanManageAdmins: boolean;
   saveProfile: Stream<void>;
+  toggleCurrentUserAdmin: Stream<void>;
   sendTrustedMessage: Stream<void>;
   addTrustedRoom: Stream<void>;
   hostLookalikeSend: Stream<void>;
@@ -243,6 +252,7 @@ export const GroupChatDemo = pattern<GroupChatDemoInput, GroupChatDemoOutput>((
     myProfile,
     messages,
     rooms,
+    adminRegistry,
     profileDraft,
     adminDraft,
     messageDraft,
@@ -251,29 +261,37 @@ export const GroupChatDemo = pattern<GroupChatDemoInput, GroupChatDemoOutput>((
   }: GroupChatDemoInput,
 ): GroupChatDemoOutput => {
   const myProfileCell = myProfile as MyProfileCell;
-  const adminCredentialCell = new Writable.perUser<AdminCredential | null>(
-    null,
-  ) as AdminCredentialCell;
+  const adminManagerCredentialCell = new Writable.perUser<
+    ChatAdminManagerCredential | null
+  >(null) as AdminManagerCredentialCell;
   const messagesCell = messages as SharedMessagesCell;
   const roomsCell = rooms as SharedRoomsCell;
+  const adminRegistryCell = adminRegistry as ChatAdminRegistryCell;
   const profileDraftCell = profileDraft as DraftCell;
-  const adminDraftCell = adminDraft as AdminDraftCell;
+  const adminManagerDraftCell = adminDraft as AdminManagerDraftCell;
   const messageDraftCell = messageDraft as DraftCell;
   const hostMessageDraftCell = hostMessageDraft as DraftCell;
   const roomDraftCell = roomDraft as RoomDraftCell;
   const trustedProfileSave = TrustedProfileSaveSurface({
     myProfile: myProfileCell,
-    adminCredential: adminCredentialCell,
+    adminManagerCredential: adminManagerCredentialCell,
     nameDraft: profileDraftCell,
-    adminDraft: adminDraftCell,
+    adminManagerDraft: adminManagerDraftCell,
   });
+  const trustedAdminPanel = TrustedAdminPanel({
+    myProfile: myProfileCell,
+    messages: messagesCell,
+    adminRegistry: adminRegistryCell,
+    adminManagerCredential: adminManagerCredentialCell,
+  } as TrustedAdminPanelInputArg);
   const trustedSend = TrustedChatSendSurface({
     myProfile: myProfileCell,
     messageDraft: messageDraftCell,
     messages: messagesCell,
   } as TrustedChatSendSurfaceInputArg);
   const trustedRoomAdd = TrustedRoomAddSurface({
-    adminCredential: adminCredentialCell,
+    myProfile: myProfileCell,
+    adminRegistry: adminRegistryCell,
     roomDraft: roomDraftCell,
     rooms: roomsCell,
   } as TrustedRoomAddSurfaceInputArg);
@@ -283,7 +301,7 @@ export const GroupChatDemo = pattern<GroupChatDemoInput, GroupChatDemoOutput>((
     messages: messagesCell,
   } as TrustedMessageSendInputArg);
   const setProfileDraft = writeDraftText({ value: profileDraftCell });
-  const setAdminDraft = writeBooleanDraft({ value: adminDraftCell });
+  const setAdminDraft = writeBooleanDraft({ value: adminManagerDraftCell });
   const setMessageDraft = writeDraftText({ value: messageDraftCell });
   const setHostMessageDraft = writeDraftText({ value: hostMessageDraftCell });
   const setRoomDraft = writeDraftText({ value: roomDraftCell });
@@ -347,9 +365,16 @@ export const GroupChatDemo = pattern<GroupChatDemoInput, GroupChatDemoOutput>((
                   />
                   <cf-chip
                     label={computed(() =>
-                      trustedProfileSave.currentUserIsAdmin
+                      currentUserIsAdmin(myProfileCell, adminRegistryCell)
                         ? "Admin enabled"
                         : "Admin off"
+                    )}
+                  />
+                  <cf-chip
+                    label={computed(() =>
+                      trustedProfileSave.currentUserCanManageAdmins
+                        ? "Can manage admins"
+                        : "Manager off"
                     )}
                   />
                 </cf-hstack>
@@ -358,6 +383,7 @@ export const GroupChatDemo = pattern<GroupChatDemoInput, GroupChatDemoOutput>((
           </cf-card>
 
           {trustedProfileSave}
+          {trustedAdminPanel}
 
           <cf-card id="rooms-panel">
             <cf-vstack slot="content" gap="3">
@@ -424,8 +450,9 @@ export const GroupChatDemo = pattern<GroupChatDemoInput, GroupChatDemoOutput>((
     myProfile: myProfileCell as PerUser<MyProfileCell>,
     messages: messagesCell as PerSpace<SharedMessagesCell>,
     rooms: roomsCell as PerSpace<SharedRoomsCell>,
+    adminRegistry: adminRegistryCell as PerSpace<ChatAdminRegistryCell>,
     profileDraft: profileDraftCell as PerUser<DraftCell>,
-    adminDraft: adminDraftCell as PerUser<AdminDraftCell>,
+    adminDraft: adminManagerDraftCell as PerUser<AdminManagerDraftCell>,
     messageDraft: messageDraftCell as PerUser<DraftCell>,
     hostMessageDraft: hostMessageDraftCell as PerSession<DraftCell>,
     roomDraft: roomDraftCell as PerSession<RoomDraftCell>,
@@ -435,8 +462,12 @@ export const GroupChatDemo = pattern<GroupChatDemoInput, GroupChatDemoOutput>((
     setHostMessageDraft,
     setRoomDraft,
     currentProfileName: trustedProfileSave.currentProfileName,
-    currentUserIsAdmin: trustedProfileSave.currentUserIsAdmin,
+    currentUserIsAdmin: computed(() =>
+      currentUserIsAdmin(myProfileCell, adminRegistryCell)
+    ),
+    currentUserCanManageAdmins: trustedProfileSave.currentUserCanManageAdmins,
     saveProfile: trustedProfileSave.saveProfile,
+    toggleCurrentUserAdmin: trustedAdminPanel.toggleCurrentUserAdmin,
     sendTrustedMessage: trustedSend.sendMessage,
     addTrustedRoom: trustedRoomAdd.addRoom,
     hostLookalikeSend,
@@ -446,4 +477,4 @@ export const GroupChatDemo = pattern<GroupChatDemoInput, GroupChatDemoOutput>((
 
 export default GroupChatDemo;
 
-export type { SharedMessagesValue, SharedRoomsValue };
+export type { ChatAdminRegistryValue, SharedMessagesValue, SharedRoomsValue };

--- a/packages/patterns/cfc-group-chat-demo/main.tsx
+++ b/packages/patterns/cfc-group-chat-demo/main.tsx
@@ -18,16 +18,24 @@ import {
   sortDisplayMessages,
 } from "./logic.ts";
 import {
+  type AdminCredential,
+  type AdminCredentialCell,
+  type AdminDraftCell,
   commitTrustedMessageSend,
   currentProfileCell,
   messagesValue,
   type MyProfileCell,
   participantClaimsValue,
+  type RoomDraftCell,
+  roomsValue,
   type SharedChatMessage,
   type SharedMessagesCell,
   type SharedMessagesValue,
+  type SharedRoomsCell,
+  type SharedRoomsValue,
   TrustedChatSendSurface,
   TrustedProfileSaveSurface,
+  TrustedRoomAddSurface,
 } from "./trusted.tsx";
 
 type DraftCell = Writable<string | Default<"">>;
@@ -35,10 +43,19 @@ type DraftCell = Writable<string | Default<"">>;
 const messageCountText = (count: number): string =>
   count === 0 ? "No messages yet" : `${count} message${count === 1 ? "" : "s"}`;
 
+const roomCountText = (count: number): string =>
+  count === 0 ? "No rooms yet" : `${count} room${count === 1 ? "" : "s"}`;
+
 const draftText = (draft: DraftCell): string =>
   (draft.get() as string | undefined) ?? "";
 
 const writeDraftText = handler<string, { value: DraftCell }>(
+  (nextValue, { value }) => {
+    value.set(nextValue);
+  },
+);
+
+const writeBooleanDraft = handler<boolean, { value: AdminDraftCell }>(
   (nextValue, { value }) => {
     value.set(nextValue);
   },
@@ -147,8 +164,39 @@ const SharedTranscript = pattern<
   };
 });
 type SharedTranscriptInputArg = Parameters<typeof SharedTranscript>[0];
+
+interface RoomsListInput {
+  rooms: SharedRoomsCell;
+  id: string;
+}
+
+const RoomsList = pattern<RoomsListInput, { [NAME]: string; [UI]: any }>((
+  { rooms, id }: RoomsListInput,
+): { [NAME]: string; [UI]: any } => {
+  const roomListText = computed(() => {
+    const names = roomsValue(rooms).map((room) => room.name);
+    return names.length === 0 ? "No rooms yet" : names.join(" · ");
+  });
+
+  return {
+    [NAME]: computed(() => `${id} rooms`),
+    [UI]: (
+      <cf-hstack id={id} gap="2" wrap>
+        <cf-chip
+          label={roomListText}
+          variant="accent"
+        />
+      </cf-hstack>
+    ),
+  };
+});
+type RoomsListInputArg = Parameters<typeof RoomsList>[0];
+
 type TrustedChatSendSurfaceInputArg = Parameters<
   typeof TrustedChatSendSurface
+>[0];
+type TrustedRoomAddSurfaceInputArg = Parameters<
+  typeof TrustedRoomAddSurface
 >[0];
 type TrustedMessageSendInputArg = Parameters<typeof commitTrustedMessageSend>[
   0
@@ -157,9 +205,12 @@ type TrustedMessageSendInputArg = Parameters<typeof commitTrustedMessageSend>[
 export interface GroupChatDemoInput {
   myProfile?: PerUser<MyProfileCell>;
   messages?: PerSpace<SharedMessagesCell>;
+  rooms?: PerSpace<SharedRoomsCell>;
   profileDraft?: PerUser<DraftCell>;
+  adminDraft?: PerUser<AdminDraftCell>;
   messageDraft?: PerUser<DraftCell>;
   hostMessageDraft?: PerSession<DraftCell>;
+  roomDraft?: PerSession<RoomDraftCell>;
 }
 
 export interface GroupChatDemoOutput {
@@ -167,15 +218,22 @@ export interface GroupChatDemoOutput {
   [UI]: any;
   myProfile: PerUser<MyProfileCell>;
   messages: PerSpace<SharedMessagesCell>;
+  rooms: PerSpace<SharedRoomsCell>;
   profileDraft: PerUser<DraftCell>;
+  adminDraft: PerUser<AdminDraftCell>;
   messageDraft: PerUser<DraftCell>;
   hostMessageDraft: PerSession<DraftCell>;
+  roomDraft: PerSession<RoomDraftCell>;
   setProfileDraft: Stream<string>;
+  setAdminDraft: Stream<boolean>;
   setMessageDraft: Stream<string>;
   setHostMessageDraft: Stream<string>;
+  setRoomDraft: Stream<string>;
   currentProfileName: string;
+  currentUserIsAdmin: boolean;
   saveProfile: Stream<void>;
   sendTrustedMessage: Stream<void>;
+  addTrustedRoom: Stream<void>;
   hostLookalikeSend: Stream<void>;
   addRandomMessages: Stream<void>;
 }
@@ -184,37 +242,58 @@ export const GroupChatDemo = pattern<GroupChatDemoInput, GroupChatDemoOutput>((
   {
     myProfile,
     messages,
+    rooms,
     profileDraft,
+    adminDraft,
     messageDraft,
     hostMessageDraft,
+    roomDraft,
   }: GroupChatDemoInput,
 ): GroupChatDemoOutput => {
   const myProfileCell = myProfile as MyProfileCell;
+  const adminCredentialCell = new Writable.perUser<AdminCredential | null>(
+    null,
+  ) as AdminCredentialCell;
   const messagesCell = messages as SharedMessagesCell;
+  const roomsCell = rooms as SharedRoomsCell;
   const profileDraftCell = profileDraft as DraftCell;
+  const adminDraftCell = adminDraft as AdminDraftCell;
   const messageDraftCell = messageDraft as DraftCell;
   const hostMessageDraftCell = hostMessageDraft as DraftCell;
+  const roomDraftCell = roomDraft as RoomDraftCell;
   const trustedProfileSave = TrustedProfileSaveSurface({
     myProfile: myProfileCell,
+    adminCredential: adminCredentialCell,
     nameDraft: profileDraftCell,
+    adminDraft: adminDraftCell,
   });
   const trustedSend = TrustedChatSendSurface({
     myProfile: myProfileCell,
     messageDraft: messageDraftCell,
     messages: messagesCell,
   } as TrustedChatSendSurfaceInputArg);
+  const trustedRoomAdd = TrustedRoomAddSurface({
+    adminCredential: adminCredentialCell,
+    roomDraft: roomDraftCell,
+    rooms: roomsCell,
+  } as TrustedRoomAddSurfaceInputArg);
   const hostLookalikeSend = commitTrustedMessageSend({
     myProfile: myProfileCell,
     messageDraft: hostMessageDraftCell,
     messages: messagesCell,
   } as TrustedMessageSendInputArg);
   const setProfileDraft = writeDraftText({ value: profileDraftCell });
+  const setAdminDraft = writeBooleanDraft({ value: adminDraftCell });
   const setMessageDraft = writeDraftText({ value: messageDraftCell });
   const setHostMessageDraft = writeDraftText({ value: hostMessageDraftCell });
+  const setRoomDraft = writeDraftText({ value: roomDraftCell });
   const participantCountLabel = computed(() => {
     const count = participantClaimsValue(myProfileCell, messagesCell).length;
     return `${count} participant${count === 1 ? "" : "s"}`;
   });
+  const roomCountLabel = computed(() =>
+    roomCountText(roomsValue(roomsCell).length)
+  );
   const hostSendDisabled = computed(() =>
     draftText(hostMessageDraftCell).trim().length === 0
   );
@@ -263,12 +342,38 @@ export const GroupChatDemo = pattern<GroupChatDemoInput, GroupChatDemoOutput>((
                       messageCountText(messagesValue(messagesCell).length)
                     )}
                   />
+                  <cf-chip
+                    label={roomCountLabel}
+                  />
+                  <cf-chip
+                    label={computed(() =>
+                      trustedProfileSave.currentUserIsAdmin
+                        ? "Admin enabled"
+                        : "Admin off"
+                    )}
+                  />
                 </cf-hstack>
               </cf-hstack>
             </cf-vstack>
           </cf-card>
 
           {trustedProfileSave}
+
+          <cf-card id="rooms-panel">
+            <cf-vstack slot="content" gap="3">
+              <cf-hstack justify="between" align="center" wrap gap="2">
+                <cf-vstack gap="1">
+                  <cf-heading level={3}>Rooms</cf-heading>
+                  <cf-label>{roomCountLabel}</cf-label>
+                </cf-vstack>
+              </cf-hstack>
+              {RoomsList({
+                rooms: roomsCell,
+                id: "trusted-room-list",
+              } as RoomsListInputArg)}
+              {trustedRoomAdd}
+            </cf-vstack>
+          </cf-card>
 
           <cf-card id="chat-panel">
             <cf-vstack slot="content" gap="3" style={{ minHeight: 0 }}>
@@ -318,15 +423,22 @@ export const GroupChatDemo = pattern<GroupChatDemoInput, GroupChatDemoOutput>((
     ),
     myProfile: myProfileCell as PerUser<MyProfileCell>,
     messages: messagesCell as PerSpace<SharedMessagesCell>,
+    rooms: roomsCell as PerSpace<SharedRoomsCell>,
     profileDraft: profileDraftCell as PerUser<DraftCell>,
+    adminDraft: adminDraftCell as PerUser<AdminDraftCell>,
     messageDraft: messageDraftCell as PerUser<DraftCell>,
     hostMessageDraft: hostMessageDraftCell as PerSession<DraftCell>,
+    roomDraft: roomDraftCell as PerSession<RoomDraftCell>,
     setProfileDraft,
+    setAdminDraft,
     setMessageDraft,
     setHostMessageDraft,
+    setRoomDraft,
     currentProfileName: trustedProfileSave.currentProfileName,
+    currentUserIsAdmin: trustedProfileSave.currentUserIsAdmin,
     saveProfile: trustedProfileSave.saveProfile,
     sendTrustedMessage: trustedSend.sendMessage,
+    addTrustedRoom: trustedRoomAdd.addRoom,
     hostLookalikeSend,
     addRandomMessages,
   };
@@ -334,4 +446,4 @@ export const GroupChatDemo = pattern<GroupChatDemoInput, GroupChatDemoOutput>((
 
 export default GroupChatDemo;
 
-export type { SharedMessagesValue };
+export type { SharedMessagesValue, SharedRoomsValue };

--- a/packages/patterns/cfc-group-chat-demo/main.tsx
+++ b/packages/patterns/cfc-group-chat-demo/main.tsx
@@ -34,6 +34,8 @@ import {
   type SharedChatMessage,
   type SharedMessagesCell,
   type SharedMessagesValue,
+  type SharedProfilesCell,
+  type SharedProfilesValue,
   type SharedRoomsCell,
   type SharedRoomsValue,
   TrustedAdminPanel,
@@ -199,6 +201,9 @@ type RoomsListInputArg = Parameters<typeof RoomsList>[0];
 type TrustedChatSendSurfaceInputArg = Parameters<
   typeof TrustedChatSendSurface
 >[0];
+type TrustedProfileSaveSurfaceInputArg = Parameters<
+  typeof TrustedProfileSaveSurface
+>[0];
 type TrustedAdminPanelInputArg = Parameters<typeof TrustedAdminPanel>[0];
 type TrustedRoomAddSurfaceInputArg = Parameters<
   typeof TrustedRoomAddSurface
@@ -209,6 +214,7 @@ type TrustedMessageSendInputArg = Parameters<typeof commitTrustedMessageSend>[
 
 export interface GroupChatDemoInput {
   myProfile?: PerUser<MyProfileCell>;
+  profiles?: PerSpace<SharedProfilesCell>;
   messages?: PerSpace<SharedMessagesCell>;
   rooms?: PerSpace<SharedRoomsCell>;
   adminRegistry?: PerSpace<ChatAdminRegistryCell>;
@@ -223,6 +229,7 @@ export interface GroupChatDemoOutput {
   [NAME]: string;
   [UI]: any;
   myProfile: PerUser<MyProfileCell>;
+  profiles: PerSpace<SharedProfilesCell>;
   messages: PerSpace<SharedMessagesCell>;
   rooms: PerSpace<SharedRoomsCell>;
   adminRegistry: PerSpace<ChatAdminRegistryCell>;
@@ -250,6 +257,7 @@ export interface GroupChatDemoOutput {
 export const GroupChatDemo = pattern<GroupChatDemoInput, GroupChatDemoOutput>((
   {
     myProfile,
+    profiles,
     messages,
     rooms,
     adminRegistry,
@@ -264,6 +272,7 @@ export const GroupChatDemo = pattern<GroupChatDemoInput, GroupChatDemoOutput>((
   const adminManagerCredentialCell = new Writable.perUser<
     ChatAdminManagerCredential | null
   >(null) as AdminManagerCredentialCell;
+  const profilesCell = profiles as SharedProfilesCell;
   const messagesCell = messages as SharedMessagesCell;
   const roomsCell = rooms as SharedRoomsCell;
   const adminRegistryCell = adminRegistry as ChatAdminRegistryCell;
@@ -274,19 +283,22 @@ export const GroupChatDemo = pattern<GroupChatDemoInput, GroupChatDemoOutput>((
   const roomDraftCell = roomDraft as RoomDraftCell;
   const trustedProfileSave = TrustedProfileSaveSurface({
     myProfile: myProfileCell,
+    profiles: profilesCell,
     adminManagerCredential: adminManagerCredentialCell,
     nameDraft: profileDraftCell,
     adminManagerDraft: adminManagerDraftCell,
-  });
+  } as TrustedProfileSaveSurfaceInputArg);
   const currentUserCanManageAdminsStatus =
     trustedProfileSave.currentUserCanManageAdmins;
   const trustedAdminPanel = TrustedAdminPanel({
+    profiles: profilesCell,
     myProfile: myProfileCell,
     messages: messagesCell,
     adminRegistry: adminRegistryCell,
     adminManagerCredential: adminManagerCredentialCell,
   } as TrustedAdminPanelInputArg);
   const trustedSend = TrustedChatSendSurface({
+    profiles: profilesCell,
     myProfile: myProfileCell,
     messageDraft: messageDraftCell,
     messages: messagesCell,
@@ -308,7 +320,8 @@ export const GroupChatDemo = pattern<GroupChatDemoInput, GroupChatDemoOutput>((
   const setHostMessageDraft = writeDraftText({ value: hostMessageDraftCell });
   const setRoomDraft = writeDraftText({ value: roomDraftCell });
   const participantCountLabel = computed(() => {
-    const count = participantClaimsValue(myProfileCell, messagesCell).length;
+    const count =
+      participantClaimsValue(profilesCell, myProfileCell, messagesCell).length;
     return `${count} participant${count === 1 ? "" : "s"}`;
   });
   const roomCountLabel = computed(() =>
@@ -318,13 +331,14 @@ export const GroupChatDemo = pattern<GroupChatDemoInput, GroupChatDemoOutput>((
     draftText(hostMessageDraftCell).trim().length === 0
   );
   const addRandomMessagesDisabled = computed(() =>
-    participantClaimsValue(myProfileCell, messagesCell).length === 0 ||
+    participantClaimsValue(profilesCell, myProfileCell, messagesCell).length ===
+      0 ||
     messagesValue(messagesCell).length === 0
   );
   const addRandomMessages = action(() => {
     const nextMessages = createRandomImportedClaimedMessages(
       sortDisplayMessages(messagesValue(messagesCell)),
-      participantClaimsValue(myProfileCell, messagesCell),
+      participantClaimsValue(profilesCell, myProfileCell, messagesCell),
     );
     nextMessages.forEach((message) =>
       messagesCell.push(message as SharedChatMessage)
@@ -449,6 +463,7 @@ export const GroupChatDemo = pattern<GroupChatDemoInput, GroupChatDemoOutput>((
       </cf-screen>
     ),
     myProfile: myProfileCell as PerUser<MyProfileCell>,
+    profiles: profilesCell as PerSpace<SharedProfilesCell>,
     messages: messagesCell as PerSpace<SharedMessagesCell>,
     rooms: roomsCell as PerSpace<SharedRoomsCell>,
     adminRegistry: adminRegistryCell as PerSpace<ChatAdminRegistryCell>,
@@ -478,4 +493,9 @@ export const GroupChatDemo = pattern<GroupChatDemoInput, GroupChatDemoOutput>((
 
 export default GroupChatDemo;
 
-export type { ChatAdminRegistryValue, SharedMessagesValue, SharedRoomsValue };
+export type {
+  ChatAdminRegistryValue,
+  SharedMessagesValue,
+  SharedProfilesValue,
+  SharedRoomsValue,
+};

--- a/packages/patterns/cfc-group-chat-demo/main.tsx
+++ b/packages/patterns/cfc-group-chat-demo/main.tsx
@@ -25,7 +25,7 @@ import {
   type ChatAdminRegistryValue,
   commitTrustedMessageSend,
   currentProfileCell,
-  currentUserIsAdmin,
+  currentUserIsAdmin as currentProfileIsAdmin,
   messagesValue,
   type MyProfileCell,
   participantClaimsValue,
@@ -278,6 +278,8 @@ export const GroupChatDemo = pattern<GroupChatDemoInput, GroupChatDemoOutput>((
     nameDraft: profileDraftCell,
     adminManagerDraft: adminManagerDraftCell,
   });
+  const currentUserCanManageAdminsStatus =
+    trustedProfileSave.currentUserCanManageAdmins;
   const trustedAdminPanel = TrustedAdminPanel({
     myProfile: myProfileCell,
     messages: messagesCell,
@@ -365,17 +367,16 @@ export const GroupChatDemo = pattern<GroupChatDemoInput, GroupChatDemoOutput>((
                   />
                   <cf-chip
                     label={computed(() =>
-                      currentUserIsAdmin(myProfileCell, adminRegistryCell)
+                      currentProfileIsAdmin(myProfileCell, adminRegistryCell)
                         ? "Admin enabled"
                         : "Admin off"
                     )}
                   />
                   <cf-chip
-                    label={computed(() =>
-                      trustedProfileSave.currentUserCanManageAdmins
-                        ? "Can manage admins"
-                        : "Manager off"
-                    )}
+                    id="group-chat-manager-chip"
+                    label={currentUserCanManageAdminsStatus
+                      ? "Can manage admins"
+                      : "Manager off"}
                   />
                 </cf-hstack>
               </cf-hstack>
@@ -463,9 +464,9 @@ export const GroupChatDemo = pattern<GroupChatDemoInput, GroupChatDemoOutput>((
     setRoomDraft,
     currentProfileName: trustedProfileSave.currentProfileName,
     currentUserIsAdmin: computed(() =>
-      currentUserIsAdmin(myProfileCell, adminRegistryCell)
+      currentProfileIsAdmin(myProfileCell, adminRegistryCell)
     ),
-    currentUserCanManageAdmins: trustedProfileSave.currentUserCanManageAdmins,
+    currentUserCanManageAdmins: currentUserCanManageAdminsStatus,
     saveProfile: trustedProfileSave.saveProfile,
     toggleCurrentUserAdmin: trustedAdminPanel.toggleCurrentUserAdmin,
     sendTrustedMessage: trustedSend.sendMessage,

--- a/packages/patterns/cfc-group-chat-demo/trusted.tsx
+++ b/packages/patterns/cfc-group-chat-demo/trusted.tsx
@@ -1,5 +1,5 @@
 import {
-  AddIntegrity,
+  type AddIntegrity,
   AuthoredByCurrentUser,
   Cfc,
   computed,
@@ -15,6 +15,14 @@ import {
   Writable,
   WriteAuthorizedBy,
 } from "commonfabric";
+import {
+  activeAdminRoleForSubject,
+  type AdminManagerCredential,
+  adminManagerCredentialIsActive,
+  adminRegistryEntries,
+  type EmptyAdminRegistryValue,
+  subjectHasAdminRole,
+} from "../admin.ts";
 import {
   type ChatProfile,
   type ChatRoom,
@@ -48,11 +56,15 @@ export const TRUSTED_GROUP_CHAT_PROFILE_SURFACE =
   "TrustedGroupChatProfileSurface";
 export const TRUSTED_GROUP_CHAT_SEND_SURFACE = "TrustedGroupChatSendSurface";
 export const TRUSTED_GROUP_CHAT_ROOM_SURFACE = "TrustedGroupChatRoomSurface";
+export const TRUSTED_GROUP_CHAT_ADMIN_SURFACE = "TrustedGroupChatAdminSurface";
 export const TRUSTED_GROUP_CHAT_SAVE_PROFILE_ACTION =
   "TrustedGroupChatSaveProfile";
 export const TRUSTED_GROUP_CHAT_SEND_ACTION = "TrustedGroupChatSendMessage";
 export const TRUSTED_GROUP_CHAT_ADD_ROOM_ACTION = "TrustedGroupChatAddRoom";
+export const TRUSTED_GROUP_CHAT_SET_ADMIN_ACTION = "TrustedGroupChatSetAdmin";
 export const GROUP_CHAT_ADMIN_INTEGRITY = "group-chat-admin" as const;
+export const GROUP_CHAT_ADMIN_MANAGER_INTEGRITY =
+  "group-chat-admin-manager" as const;
 
 export type TrustedProfile = RepresentsCurrentUser<
   TrustedActionWrite<
@@ -63,15 +75,23 @@ export type TrustedProfile = RepresentsCurrentUser<
   >
 >;
 
-export type AdminCredential = AddIntegrity<
-  { readonly isAdmin: true },
-  readonly [typeof GROUP_CHAT_ADMIN_INTEGRITY]
->;
-
 export type ProfileCell = Writable<ChatProfile | undefined>;
 export type TrustedProfileCell = Writable<TrustedProfile>;
-export type AdminCredentialCell = Writable<AdminCredential | null>;
-export type AdminDraftCell = Writable<boolean | Default<false>>;
+export interface ChatAdminRoleAssignment {
+  readonly subject: ProfileCell;
+  readonly displayName: string;
+}
+export type ChatAdminRole = AddIntegrity<
+  ChatAdminRoleAssignment,
+  readonly [typeof GROUP_CHAT_ADMIN_INTEGRITY]
+>;
+export type ChatAdminManagerCredential = AdminManagerCredential<
+  typeof GROUP_CHAT_ADMIN_MANAGER_INTEGRITY
+>;
+export type AdminManagerCredentialCell = Writable<
+  ChatAdminManagerCredential | null
+>;
+export type AdminManagerDraftCell = Writable<boolean | Default<true>>;
 
 export interface MyProfileValue {
   readonly profile?: ProfileCell;
@@ -109,6 +129,25 @@ export type SharedMessagesValue = SharedChatMessage[] | Default<[]>;
 export type SharedMessagesCell = Writable<SharedMessagesValue>;
 
 export type TrustedChatRoom = ChatRoom<SharedChatMessage>;
+
+export type ChatAdminList = RequiresIntegrity<
+  TrustedActionWrite<
+    ChatAdminRole[],
+    typeof commitTrustedAdminToggle,
+    typeof TRUSTED_GROUP_CHAT_SET_ADMIN_ACTION,
+    typeof TRUSTED_GROUP_CHAT_ADMIN_SURFACE
+  >,
+  readonly [typeof GROUP_CHAT_ADMIN_MANAGER_INTEGRITY]
+>;
+
+export interface ChatAdminRegistryStoredValue {
+  readonly admins?: ChatAdminList;
+}
+
+export type ChatAdminRegistryValue =
+  | ChatAdminRegistryStoredValue
+  | Default<EmptyAdminRegistryValue>;
+export type ChatAdminRegistryCell = Writable<ChatAdminRegistryValue>;
 
 export type SharedRoomList = RequiresIntegrity<
   TrustedActionWrite<
@@ -159,13 +198,27 @@ export const currentProfileSnapshot = (
   myProfile: MyProfileCell,
 ): ChatProfile | undefined => currentProfileCell(myProfile)?.get();
 
-export const currentUserIsAdmin = (
-  adminCredential: AdminCredentialCell,
-): boolean => adminCredentialValueIsAdmin(adminCredential.get());
+export const chatAdminRolesValue = (
+  adminRegistry: ChatAdminRegistryCell,
+): ChatAdminRole[] => adminRegistryEntries<ChatAdminRole>(adminRegistry);
 
-const adminCredentialValueIsAdmin = (
-  adminCredential: AdminCredential | null | undefined,
-): boolean => adminCredential?.isAdmin === true;
+export const currentUserAdminRole = (
+  myProfile: MyProfileCell,
+  adminRegistry: ChatAdminRegistryCell,
+): ChatAdminRole | undefined =>
+  activeAdminRoleForSubject(
+    chatAdminRolesValue(adminRegistry),
+    currentProfileCell(myProfile),
+  );
+
+export const currentUserIsAdmin = (
+  myProfile: MyProfileCell,
+  adminRegistry: ChatAdminRegistryCell,
+): boolean => currentUserAdminRole(myProfile, adminRegistry) !== undefined;
+
+export const currentUserCanManageAdmins = (
+  adminManagerCredential: AdminManagerCredentialCell,
+): boolean => adminManagerCredentialIsActive(adminManagerCredential.get());
 
 export const participantClaimsValue = (
   myProfile: MyProfileCell,
@@ -223,15 +276,49 @@ export const participantSummary = (
     : participants.map((participant) => participant.name).join(" · ");
 };
 
+export interface AdminParticipantRow {
+  readonly name: string;
+  readonly accentColor: string;
+  readonly profile?: AuthorProfileCell;
+  readonly isAdmin: boolean;
+  readonly canManageAdmins: boolean;
+}
+
+export const adminParticipantRowsValue = (
+  myProfile: MyProfileCell,
+  messages: SharedMessagesCell,
+  adminRegistry: ChatAdminRegistryCell,
+  adminManagerCredential: AdminManagerCredentialCell,
+): AdminParticipantRow[] => {
+  const adminRoles = chatAdminRolesValue(adminRegistry);
+  const canManageAdmins = currentUserCanManageAdmins(adminManagerCredential);
+  return participantClaimsValue(myProfile, messages).map((participant) => ({
+    name: participant.name,
+    accentColor: participant.accentColor,
+    ...(participant.profile !== undefined
+      ? { profile: participant.profile }
+      : {}),
+    isAdmin: subjectHasAdminRole(adminRoles, participant.profile),
+    canManageAdmins: canManageAdmins && participant.profile !== undefined,
+  }));
+};
+
 export const applyTrustedProfileSave = (
   myProfile: MyProfileCell,
-  adminCredential: AdminCredentialCell,
+  adminManagerCredential: AdminManagerCredentialCell,
   rawName: string,
-  wantsAdmin: boolean,
-): { trimmedName: string | null; profile?: ProfileCell; isAdmin: boolean } => {
+  canManageAdmins: boolean,
+): {
+  trimmedName: string | null;
+  profile?: ProfileCell;
+  canManageAdmins: boolean;
+} => {
   const trimmedName = rawName.trim();
   if (!trimmedName) {
-    return { trimmedName: null, isAdmin: currentUserIsAdmin(adminCredential) };
+    return {
+      trimmedName: null,
+      canManageAdmins: currentUserCanManageAdmins(adminManagerCredential),
+    };
   }
 
   const existingProfile = currentProfileSnapshot(myProfile);
@@ -241,12 +328,14 @@ export const applyTrustedProfileSave = (
     makeProfileSnapshot(trimmedName, existingProfile) as TrustedProfile,
   );
   myProfile.set({ profile });
-  if (wantsAdmin) {
-    adminCredential.set({ isAdmin: true } as AdminCredential);
-    return { trimmedName, profile, isAdmin: true };
+  if (canManageAdmins) {
+    adminManagerCredential.set({
+      canManageAdmins: true,
+    } as ChatAdminManagerCredential);
+    return { trimmedName, profile, canManageAdmins: true };
   }
-  adminCredential.set(null);
-  return { trimmedName, profile, isAdmin: false };
+  adminManagerCredential.set(null);
+  return { trimmedName, profile, canManageAdmins: false };
 };
 
 export const prepareTrustedMessageSend = (
@@ -312,7 +401,7 @@ export const applyTrustedMessageSend = (
 };
 
 export const prepareTrustedRoomAdd = (
-  adminCredential: AdminCredential | null | undefined,
+  currentAdminRole: ChatAdminRole | undefined,
   rawName: string,
 ): {
   trimmedName: string | null;
@@ -320,7 +409,7 @@ export const prepareTrustedRoomAdd = (
 } => {
   const trimmedName = rawName.trim();
   // This read supplies the admin integrity required by the shared rooms write.
-  if (!adminCredentialValueIsAdmin(adminCredential) || !trimmedName) {
+  if (currentAdminRole === undefined || !trimmedName) {
     return {
       trimmedName: null,
       room: null,
@@ -339,16 +428,16 @@ export const commitTrustedProfileSave = handler<
   void,
   {
     myProfile: MyProfileCell;
-    adminCredential: AdminCredentialCell;
+    adminManagerCredential: AdminManagerCredentialCell;
     nameDraft: Writable<string | Default<"">>;
-    adminDraft: AdminDraftCell;
+    adminManagerDraft: AdminManagerDraftCell;
   }
->((_, { myProfile, adminCredential, nameDraft, adminDraft }) => {
+>((_, { myProfile, adminManagerCredential, nameDraft, adminManagerDraft }) => {
   const { trimmedName } = applyTrustedProfileSave(
     myProfile,
-    adminCredential,
+    adminManagerCredential,
     draftText(nameDraft),
-    adminDraft.get() === true,
+    adminManagerDraft.get() !== false,
   );
   if (trimmedName) {
     nameDraft.set(trimmedName);
@@ -376,16 +465,77 @@ export const commitTrustedMessageSend = handler<
 });
 type TrustedMessageSendInput = Parameters<typeof commitTrustedMessageSend>[0];
 
+export const prepareTrustedAdminToggle = (
+  adminManagerCredential: ChatAdminManagerCredential | null | undefined,
+  adminRegistry: ChatAdminRegistryCell,
+  participant: AdminParticipantRow | undefined,
+  myProfile?: MyProfileCell,
+): ChatAdminRole[] | null => {
+  const targetProfile = participant?.profile ?? (
+    myProfile === undefined ? undefined : currentProfileCell(myProfile)
+  );
+  const targetName = participant?.name ??
+    (myProfile === undefined ? undefined : currentProfileSnapshot(myProfile)
+      ?.name);
+  if (
+    !adminManagerCredentialIsActive(adminManagerCredential) ||
+    targetProfile === undefined ||
+    !targetName
+  ) {
+    return null;
+  }
+
+  const adminRoles = chatAdminRolesValue(adminRegistry);
+  const withoutParticipant = adminRoles.filter((role) =>
+    !equals(role.subject, targetProfile)
+  );
+  if (withoutParticipant.length !== adminRoles.length) {
+    return withoutParticipant;
+  }
+
+  return [
+    ...withoutParticipant,
+    {
+      subject: targetProfile,
+      displayName: targetName,
+    } as ChatAdminRole,
+  ];
+};
+
+export const commitTrustedAdminToggle = handler<
+  void,
+  {
+    adminManagerCredential: AdminManagerCredentialCell;
+    adminRegistry: ChatAdminRegistryCell;
+    participant: AdminParticipantRow | undefined;
+    myProfile?: MyProfileCell;
+  }
+>((_, { adminManagerCredential, adminRegistry, participant, myProfile }) => {
+  const nextAdmins = prepareTrustedAdminToggle(
+    adminManagerCredential.get(),
+    adminRegistry,
+    participant,
+    myProfile,
+  );
+  if (nextAdmins === null) {
+    return;
+  }
+
+  adminRegistry.set({ admins: nextAdmins as ChatAdminList });
+});
+type TrustedAdminToggleInput = Parameters<typeof commitTrustedAdminToggle>[0];
+
 export const commitTrustedRoomAdd = handler<
   void,
   {
-    adminCredential: AdminCredential | null;
+    myProfile: MyProfileCell;
+    adminRegistry: ChatAdminRegistryCell;
     roomDraft: RoomDraftCell;
     rooms: SharedRoomsCell;
   }
->((_, { adminCredential, roomDraft, rooms }) => {
+>((_, { myProfile, adminRegistry, roomDraft, rooms }) => {
   const { trimmedName, room } = prepareTrustedRoomAdd(
-    adminCredential,
+    currentUserAdminRole(myProfile, adminRegistry),
     draftText(roomDraft),
   );
   if (!trimmedName || !room) {
@@ -426,18 +576,18 @@ type TrustedParticipantsPanelInputArg = Parameters<
 
 export interface TrustedProfileSaveSurfaceInput {
   myProfile: MyProfileCell;
-  adminCredential: AdminCredentialCell;
+  adminManagerCredential: AdminManagerCredentialCell;
   nameDraft: Writable<string | Default<"">>;
-  adminDraft: AdminDraftCell;
+  adminManagerDraft: AdminManagerDraftCell;
 }
 
 export interface TrustedProfileSaveSurfaceOutput {
   [NAME]: string;
   [UI]: any;
   myProfile: MyProfileCell;
-  adminCredential: AdminCredentialCell;
+  adminManagerCredential: AdminManagerCredentialCell;
   currentProfileName: string;
-  currentUserIsAdmin: boolean;
+  currentUserCanManageAdmins: boolean;
   saveProfile: Stream<void>;
 }
 
@@ -447,22 +597,24 @@ export const TrustedProfileSaveSurface = pattern<
 >((
   {
     myProfile,
-    adminCredential,
+    adminManagerCredential,
     nameDraft,
-    adminDraft,
+    adminManagerDraft,
   }: TrustedProfileSaveSurfaceInput,
 ): TrustedProfileSaveSurfaceOutput => {
   const saveProfile = commitTrustedProfileSave({
     myProfile,
-    adminCredential,
+    adminManagerCredential,
     nameDraft,
-    adminDraft,
+    adminManagerDraft,
   });
   const currentSavedName = computed(() =>
     currentProfileSnapshot(myProfile)?.name ?? "Name not set"
   );
-  const adminStatus = computed(() =>
-    currentUserIsAdmin(adminCredential) ? "Admin" : "Not admin"
+  const managerStatus = computed(() =>
+    currentUserCanManageAdmins(adminManagerCredential)
+      ? "Can manage admins"
+      : "Cannot manage admins"
   );
   const saveDisabled = computed(() => draftText(nameDraft).trim().length === 0);
 
@@ -483,8 +635,11 @@ export const TrustedProfileSaveSurface = pattern<
               placeholder="Set your name"
             />
           </cf-vgroup>
-          <cf-checkbox id="trusted-admin-checkbox" $checked={adminDraft}>
-            Trusted admin
+          <cf-checkbox
+            id="trusted-admin-manager-checkbox"
+            $checked={adminManagerDraft}
+          >
+            Can manage admins (demo)
           </cf-checkbox>
           <cf-button
             id="trusted-profile-save"
@@ -498,15 +653,138 @@ export const TrustedProfileSaveSurface = pattern<
           <cf-label id="trusted-profile-status">
             {currentSavedName}
           </cf-label>
-          <cf-chip id="trusted-admin-status" label={adminStatus} />
+          <cf-chip id="trusted-admin-manager-status" label={managerStatus} />
         </cf-hstack>
       </cf-card>
     ),
     myProfile,
-    adminCredential,
+    adminManagerCredential,
     currentProfileName: currentSavedName,
-    currentUserIsAdmin: computed(() => currentUserIsAdmin(adminCredential)),
+    currentUserCanManageAdmins: computed(() =>
+      currentUserCanManageAdmins(adminManagerCredential)
+    ),
     saveProfile,
+  };
+});
+
+export interface TrustedAdminPanelInput {
+  myProfile: MyProfileCell;
+  messages: SharedMessagesCell;
+  adminRegistry: ChatAdminRegistryCell;
+  adminManagerCredential: AdminManagerCredentialCell;
+}
+
+export interface TrustedAdminPanelOutput {
+  [NAME]: string;
+  [UI]: any;
+  adminRegistry: ChatAdminRegistryCell;
+  toggleCurrentUserAdmin: Stream<void>;
+}
+
+export const TrustedAdminPanel = pattern<
+  TrustedAdminPanelInput,
+  TrustedAdminPanelOutput
+>((
+  {
+    myProfile,
+    messages,
+    adminRegistry,
+    adminManagerCredential,
+  }: TrustedAdminPanelInput,
+): TrustedAdminPanelOutput => {
+  const adminRows = computed(() =>
+    adminParticipantRowsValue(
+      myProfile,
+      messages,
+      adminRegistry,
+      adminManagerCredential,
+    )
+  );
+  const toggleCurrentUserAdmin = commitTrustedAdminToggle({
+    adminManagerCredential,
+    adminRegistry,
+    participant: undefined,
+    myProfile,
+  } as TrustedAdminToggleInput);
+  const managerStatus = computed(() =>
+    currentUserCanManageAdmins(adminManagerCredential)
+      ? "Admin registry editing enabled"
+      : "Save profile with admin-manager enabled to edit"
+  );
+
+  return {
+    [NAME]: "admin registry",
+    [UI]: (
+      <cf-card
+        id="trusted-admin-panel"
+        data-ui-pattern={TRUSTED_GROUP_CHAT_ADMIN_SURFACE}
+        data-ui-event-integrity={TRUSTED_GROUP_CHAT_ADMIN_SURFACE}
+      >
+        <cf-vstack slot="content" gap="3">
+          <cf-hstack justify="between" align="center" wrap gap="2">
+            <cf-vstack gap="1">
+              <cf-heading level={3}>Users</cf-heading>
+              <cf-label>
+                Admin registry. Managers can change who may add rooms.
+              </cf-label>
+            </cf-vstack>
+            <cf-chip
+              id="trusted-admin-manager-panel-status"
+              label={managerStatus}
+            />
+          </cf-hstack>
+
+          <cf-vstack id="trusted-admin-user-list" gap="2">
+            {adminRows.map((participant) => {
+              const toggleAdmin = commitTrustedAdminToggle({
+                adminManagerCredential,
+                adminRegistry,
+                participant,
+              } as TrustedAdminToggleInput);
+              return (
+                <cf-hstack
+                  align="center"
+                  justify="between"
+                  gap="2"
+                  wrap
+                  style={{
+                    padding: "0.5rem 0.75rem",
+                    border: "1px solid var(--cf-color-border, #e5e7eb)",
+                    borderRadius: "0.75rem",
+                  }}
+                >
+                  <cf-hstack align="center" gap="2">
+                    <span
+                      style={{
+                        width: "0.75rem",
+                        height: "0.75rem",
+                        borderRadius: "9999px",
+                        background: participant.accentColor,
+                      }}
+                    />
+                    <cf-label>{participant.name}</cf-label>
+                    <cf-chip
+                      label={participant.isAdmin ? "Admin" : "Member"}
+                      variant={participant.isAdmin ? "accent" : "default"}
+                    />
+                  </cf-hstack>
+                  <cf-button
+                    data-ui-action={TRUSTED_GROUP_CHAT_SET_ADMIN_ACTION}
+                    size="sm"
+                    disabled={!participant.canManageAdmins}
+                    onClick={toggleAdmin}
+                  >
+                    {participant.isAdmin ? "Remove admin" : "Make admin"}
+                  </cf-button>
+                </cf-hstack>
+              );
+            })}
+          </cf-vstack>
+        </cf-vstack>
+      </cf-card>
+    ),
+    adminRegistry,
+    toggleCurrentUserAdmin,
   };
 });
 
@@ -584,7 +862,8 @@ export const TrustedChatSendSurface = pattern<
 });
 
 export interface TrustedRoomAddSurfaceInput {
-  adminCredential: AdminCredentialCell;
+  myProfile: MyProfileCell;
+  adminRegistry: ChatAdminRegistryCell;
   roomDraft: RoomDraftCell;
   rooms: SharedRoomsCell;
 }
@@ -601,18 +880,20 @@ export const TrustedRoomAddSurface = pattern<
   TrustedRoomAddSurfaceOutput
 >((
   {
-    adminCredential,
+    myProfile,
+    adminRegistry,
     roomDraft,
     rooms,
   }: TrustedRoomAddSurfaceInput,
 ): TrustedRoomAddSurfaceOutput => {
   const addRoom = commitTrustedRoomAdd({
-    adminCredential,
+    myProfile,
+    adminRegistry,
     roomDraft,
     rooms,
   } as TrustedRoomAddInput);
   const addDisabled = computed(() =>
-    !currentUserIsAdmin(adminCredential) ||
+    !currentUserIsAdmin(myProfile, adminRegistry) ||
     draftText(roomDraft).trim().length === 0
   );
 
@@ -644,9 +925,9 @@ export const TrustedRoomAddSurface = pattern<
           </cf-button>
           <cf-label id="trusted-room-admin-hint">
             {computed(() =>
-              currentUserIsAdmin(adminCredential)
+              currentUserIsAdmin(myProfile, adminRegistry)
                 ? "Admins can add rooms"
-                : "Save as trusted admin to add rooms"
+                : "Ask an admin manager to make you an admin"
             )}
           </cf-label>
         </cf-hstack>

--- a/packages/patterns/cfc-group-chat-demo/trusted.tsx
+++ b/packages/patterns/cfc-group-chat-demo/trusted.tsx
@@ -128,6 +128,13 @@ export type SharedChatMessage =
 export type SharedMessagesValue = SharedChatMessage[] | Default<[]>;
 export type SharedMessagesCell = Writable<SharedMessagesValue>;
 
+export interface SharedProfileEntry {
+  readonly profile: ProfileCell;
+}
+
+export type SharedProfilesValue = SharedProfileEntry[] | Default<[]>;
+export type SharedProfilesCell = Writable<SharedProfilesValue>;
+
 export type TrustedChatRoom = ChatRoom<SharedChatMessage>;
 
 export type ChatAdminList = RequiresIntegrity<
@@ -178,6 +185,19 @@ export const messagesValue = (
 ): SharedChatMessage[] =>
   Array.from((messages.get() as SharedChatMessage[] | undefined) ?? []);
 
+export const profilesValue = (
+  profiles: SharedProfilesCell,
+): ProfileCell[] =>
+  Array.from((profiles.get() as SharedProfileEntry[] | undefined) ?? [])
+    .map((entry) => entry.profile)
+    .reduce<ProfileCell[]>(
+      (uniqueProfiles, profile) =>
+        uniqueProfiles.some((knownProfile) => equals(knownProfile, profile))
+          ? uniqueProfiles
+          : [...uniqueProfiles, profile],
+      [],
+    );
+
 export const roomsValue = (
   rooms: SharedRoomsCell,
 ): TrustedChatRoom[] =>
@@ -221,6 +241,7 @@ export const currentUserCanManageAdmins = (
 ): boolean => adminManagerCredentialIsActive(adminManagerCredential.get());
 
 export const participantClaimsValue = (
+  profiles: SharedProfilesCell,
   myProfile: MyProfileCell,
   messages: SharedMessagesCell,
 ): ParticipantClaim<AuthorProfileCell>[] => {
@@ -246,6 +267,11 @@ export const participantClaimsValue = (
     });
   };
 
+  profilesValue(profiles).forEach((profile) => {
+    const profileValue = profile.get();
+    addParticipant(profileValue?.name, profileValue?.accentColor, profile);
+  });
+
   const mineValue = currentProfileSnapshot(myProfile);
   addParticipant(
     mineValue?.name,
@@ -267,10 +293,11 @@ export const participantClaimsValue = (
 };
 
 export const participantSummary = (
+  profiles: SharedProfilesCell,
   myProfile: MyProfileCell,
   messages: SharedMessagesCell,
 ): string => {
-  const participants = participantClaimsValue(myProfile, messages);
+  const participants = participantClaimsValue(profiles, myProfile, messages);
   return participants.length === 0
     ? "No participants yet"
     : participants.map((participant) => participant.name).join(" · ");
@@ -285,6 +312,7 @@ export interface AdminParticipantRow {
 }
 
 export const adminParticipantRowsValue = (
+  profiles: SharedProfilesCell,
   myProfile: MyProfileCell,
   messages: SharedMessagesCell,
   adminRegistry: ChatAdminRegistryCell,
@@ -292,19 +320,34 @@ export const adminParticipantRowsValue = (
 ): AdminParticipantRow[] => {
   const adminRoles = chatAdminRolesValue(adminRegistry);
   const canManageAdmins = currentUserCanManageAdmins(adminManagerCredential);
-  return participantClaimsValue(myProfile, messages).map((participant) => ({
-    name: participant.name,
-    accentColor: participant.accentColor,
-    ...(participant.profile !== undefined
-      ? { profile: participant.profile }
-      : {}),
-    isAdmin: subjectHasAdminRole(adminRoles, participant.profile),
-    canManageAdmins: canManageAdmins && participant.profile !== undefined,
-  }));
+  return participantClaimsValue(profiles, myProfile, messages)
+    .filter((participant) => participant.profile !== undefined)
+    .map((participant) => ({
+      name: participant.name,
+      accentColor: participant.accentColor,
+      profile: participant.profile,
+      isAdmin: subjectHasAdminRole(adminRoles, participant.profile),
+      canManageAdmins,
+    }));
+};
+
+export const registerProfile = (
+  profiles: SharedProfilesCell,
+  profile: ProfileCell,
+): void => {
+  const currentProfiles = profilesValue(profiles);
+  const nextProfiles =
+    currentProfiles.some((knownProfile) => equals(knownProfile, profile))
+      ? currentProfiles
+      : [...currentProfiles, profile];
+  profiles.set(
+    nextProfiles.map((profile) => ({ profile })) as SharedProfilesValue,
+  );
 };
 
 export const applyTrustedProfileSave = (
   myProfile: MyProfileCell,
+  profiles: SharedProfilesCell,
   adminManagerCredential: AdminManagerCredentialCell,
   rawName: string,
   canManageAdmins: boolean,
@@ -328,6 +371,7 @@ export const applyTrustedProfileSave = (
     makeProfileSnapshot(trimmedName, existingProfile) as TrustedProfile,
   );
   myProfile.set({ profile });
+  registerProfile(profiles, profile);
   if (canManageAdmins) {
     adminManagerCredential.set({
       canManageAdmins: true,
@@ -428,13 +472,18 @@ export const commitTrustedProfileSave = handler<
   void,
   {
     myProfile: MyProfileCell;
+    profiles: SharedProfilesCell;
     adminManagerCredential: AdminManagerCredentialCell;
     nameDraft: Writable<string | Default<"">>;
     adminManagerDraft: AdminManagerDraftCell;
   }
->((_, { myProfile, adminManagerCredential, nameDraft, adminManagerDraft }) => {
+>((
+  _,
+  { myProfile, profiles, adminManagerCredential, nameDraft, adminManagerDraft },
+) => {
   const { trimmedName } = applyTrustedProfileSave(
     myProfile,
+    profiles,
     adminManagerCredential,
     draftText(nameDraft),
     adminManagerDraft.get() !== false,
@@ -443,6 +492,7 @@ export const commitTrustedProfileSave = handler<
     nameDraft.set(trimmedName);
   }
 });
+type TrustedProfileSaveInput = Parameters<typeof commitTrustedProfileSave>[0];
 
 export const commitTrustedMessageSend = handler<
   void,
@@ -549,6 +599,7 @@ export const commitTrustedRoomAdd = handler<
 type TrustedRoomAddInput = Parameters<typeof commitTrustedRoomAdd>[0];
 
 interface TrustedParticipantsPanelInput {
+  profiles: SharedProfilesCell;
   myProfile: MyProfileCell;
   messages: SharedMessagesCell;
   id: string;
@@ -558,13 +609,15 @@ const TrustedParticipantsPanel = pattern<
   TrustedParticipantsPanelInput,
   { [NAME]: string; [UI]: any }
 >((
-  { myProfile, messages, id }: TrustedParticipantsPanelInput,
+  { profiles, myProfile, messages, id }: TrustedParticipantsPanelInput,
 ): { [NAME]: string; [UI]: any } => ({
   [NAME]: computed(() => `${id} participants panel`),
   [UI]: (
     <cf-hstack id={id} gap="2" wrap>
       <cf-chip
-        label={computed(() => participantSummary(myProfile, messages))}
+        label={computed(() =>
+          participantSummary(profiles, myProfile, messages)
+        )}
         variant="accent"
       />
     </cf-hstack>
@@ -576,6 +629,7 @@ type TrustedParticipantsPanelInputArg = Parameters<
 
 export interface TrustedProfileSaveSurfaceInput {
   myProfile: MyProfileCell;
+  profiles: SharedProfilesCell;
   adminManagerCredential: AdminManagerCredentialCell;
   nameDraft: Writable<string | Default<"">>;
   adminManagerDraft: AdminManagerDraftCell;
@@ -597,6 +651,7 @@ export const TrustedProfileSaveSurface = pattern<
 >((
   {
     myProfile,
+    profiles,
     adminManagerCredential,
     nameDraft,
     adminManagerDraft,
@@ -604,10 +659,11 @@ export const TrustedProfileSaveSurface = pattern<
 ): TrustedProfileSaveSurfaceOutput => {
   const saveProfile = commitTrustedProfileSave({
     myProfile,
+    profiles,
     adminManagerCredential,
     nameDraft,
     adminManagerDraft,
-  });
+  } as TrustedProfileSaveInput);
   const currentSavedName = computed(() =>
     currentProfileSnapshot(myProfile)?.name ?? "Name not set"
   );
@@ -668,6 +724,7 @@ export const TrustedProfileSaveSurface = pattern<
 });
 
 export interface TrustedAdminPanelInput {
+  profiles: SharedProfilesCell;
   myProfile: MyProfileCell;
   messages: SharedMessagesCell;
   adminRegistry: ChatAdminRegistryCell;
@@ -686,6 +743,7 @@ export const TrustedAdminPanel = pattern<
   TrustedAdminPanelOutput
 >((
   {
+    profiles,
     myProfile,
     messages,
     adminRegistry,
@@ -694,6 +752,7 @@ export const TrustedAdminPanel = pattern<
 ): TrustedAdminPanelOutput => {
   const adminRows = computed(() =>
     adminParticipantRowsValue(
+      profiles,
       myProfile,
       messages,
       adminRegistry,
@@ -789,6 +848,7 @@ export const TrustedAdminPanel = pattern<
 });
 
 export interface TrustedChatSendSurfaceInput {
+  profiles: SharedProfilesCell;
   myProfile: MyProfileCell;
   messageDraft: Writable<string | Default<"">>;
   messages: SharedMessagesCell;
@@ -805,7 +865,7 @@ export const TrustedChatSendSurface = pattern<
   TrustedChatSendSurfaceInput,
   TrustedChatSendSurfaceOutput
 >((
-  { myProfile, messageDraft, messages }: TrustedChatSendSurfaceInput,
+  { profiles, myProfile, messageDraft, messages }: TrustedChatSendSurfaceInput,
 ): TrustedChatSendSurfaceOutput => {
   const sendDisabled = computed(() =>
     currentProfileSnapshot(myProfile) === undefined ||
@@ -827,6 +887,7 @@ export const TrustedChatSendSurface = pattern<
       >
         <cf-vstack slot="content" gap="2">
           {TrustedParticipantsPanel({
+            profiles,
             myProfile,
             messages,
             id: "trusted-participants-panel",

--- a/packages/patterns/cfc-group-chat-demo/trusted.tsx
+++ b/packages/patterns/cfc-group-chat-demo/trusted.tsx
@@ -1,4 +1,5 @@
 import {
+  AddIntegrity,
   AuthoredByCurrentUser,
   Cfc,
   computed,
@@ -8,6 +9,7 @@ import {
   NAME,
   pattern,
   RepresentsCurrentUser,
+  RequiresIntegrity,
   Stream,
   UI,
   Writable,
@@ -15,6 +17,8 @@ import {
 } from "commonfabric";
 import {
   type ChatProfile,
+  type ChatRoom,
+  createRoomSnapshot,
   createSentMessageSnapshot,
   type ImportedClaimedChatMessage as PlainImportedClaimedChatMessage,
   makeProfileSnapshot,
@@ -43,9 +47,12 @@ export type TrustedActionWrite<
 export const TRUSTED_GROUP_CHAT_PROFILE_SURFACE =
   "TrustedGroupChatProfileSurface";
 export const TRUSTED_GROUP_CHAT_SEND_SURFACE = "TrustedGroupChatSendSurface";
+export const TRUSTED_GROUP_CHAT_ROOM_SURFACE = "TrustedGroupChatRoomSurface";
 export const TRUSTED_GROUP_CHAT_SAVE_PROFILE_ACTION =
   "TrustedGroupChatSaveProfile";
 export const TRUSTED_GROUP_CHAT_SEND_ACTION = "TrustedGroupChatSendMessage";
+export const TRUSTED_GROUP_CHAT_ADD_ROOM_ACTION = "TrustedGroupChatAddRoom";
+export const GROUP_CHAT_ADMIN_INTEGRITY = "group-chat-admin" as const;
 
 export type TrustedProfile = RepresentsCurrentUser<
   TrustedActionWrite<
@@ -56,8 +63,15 @@ export type TrustedProfile = RepresentsCurrentUser<
   >
 >;
 
+export type AdminCredential = AddIntegrity<
+  { readonly isAdmin: true },
+  readonly [typeof GROUP_CHAT_ADMIN_INTEGRITY]
+>;
+
 export type ProfileCell = Writable<ChatProfile | undefined>;
 export type TrustedProfileCell = Writable<TrustedProfile>;
+export type AdminCredentialCell = Writable<AdminCredential | null>;
+export type AdminDraftCell = Writable<boolean | Default<false>>;
 
 export interface MyProfileValue {
   readonly profile?: ProfileCell;
@@ -94,6 +108,29 @@ export type SharedChatMessage =
 export type SharedMessagesValue = SharedChatMessage[] | Default<[]>;
 export type SharedMessagesCell = Writable<SharedMessagesValue>;
 
+export type TrustedChatRoom = ChatRoom<SharedChatMessage>;
+
+export type SharedRoomList = RequiresIntegrity<
+  TrustedActionWrite<
+    TrustedChatRoom[],
+    typeof commitTrustedRoomAdd,
+    typeof TRUSTED_GROUP_CHAT_ADD_ROOM_ACTION,
+    typeof TRUSTED_GROUP_CHAT_ROOM_SURFACE
+  >,
+  readonly [typeof GROUP_CHAT_ADMIN_INTEGRITY]
+>;
+
+export interface SharedRoomsStoredValue {
+  readonly list?: SharedRoomList;
+}
+
+export type EmptySharedRoomsValue = Record<PropertyKey, never>;
+export type SharedRoomsValue =
+  | SharedRoomsStoredValue
+  | Default<EmptySharedRoomsValue>;
+export type SharedRoomsCell = Writable<SharedRoomsValue>;
+export type RoomDraftCell = Writable<string | Default<"">>;
+
 const draftText = (draft: Writable<string | Default<"">>): string =>
   (draft.get() as string | undefined) ?? "";
 
@@ -101,6 +138,11 @@ export const messagesValue = (
   messages: SharedMessagesCell,
 ): SharedChatMessage[] =>
   Array.from((messages.get() as SharedChatMessage[] | undefined) ?? []);
+
+export const roomsValue = (
+  rooms: SharedRoomsCell,
+): TrustedChatRoom[] =>
+  Array.from((rooms.get() as SharedRoomsStoredValue | undefined)?.list ?? []);
 
 export const myProfileValue = (
   myProfile: MyProfileCell,
@@ -116,6 +158,14 @@ export const currentProfileCell = (
 export const currentProfileSnapshot = (
   myProfile: MyProfileCell,
 ): ChatProfile | undefined => currentProfileCell(myProfile)?.get();
+
+export const currentUserIsAdmin = (
+  adminCredential: AdminCredentialCell,
+): boolean => adminCredentialValueIsAdmin(adminCredential.get());
+
+const adminCredentialValueIsAdmin = (
+  adminCredential: AdminCredential | null | undefined,
+): boolean => adminCredential?.isAdmin === true;
 
 export const participantClaimsValue = (
   myProfile: MyProfileCell,
@@ -175,25 +225,28 @@ export const participantSummary = (
 
 export const applyTrustedProfileSave = (
   myProfile: MyProfileCell,
+  adminCredential: AdminCredentialCell,
   rawName: string,
-): { trimmedName: string | null; profile?: ProfileCell } => {
+  wantsAdmin: boolean,
+): { trimmedName: string | null; profile?: ProfileCell; isAdmin: boolean } => {
   const trimmedName = rawName.trim();
   if (!trimmedName) {
-    return { trimmedName: null };
+    return { trimmedName: null, isAdmin: currentUserIsAdmin(adminCredential) };
   }
 
   const existingProfile = currentProfileSnapshot(myProfile);
-  if (existingProfile) {
-    currentProfileCell(myProfile)?.set(
-      makeProfileSnapshot(trimmedName, existingProfile) as TrustedProfile,
-    );
-    return { trimmedName, profile: currentProfileCell(myProfile) };
-  }
-
-  const profile = Writable.for<TrustedProfile>("profile");
-  profile.set(makeProfileSnapshot(trimmedName) as TrustedProfile);
+  const profile = currentProfileCell(myProfile) ??
+    Writable.for<TrustedProfile>("profile");
+  profile.set(
+    makeProfileSnapshot(trimmedName, existingProfile) as TrustedProfile,
+  );
   myProfile.set({ profile });
-  return { trimmedName, profile };
+  if (wantsAdmin) {
+    adminCredential.set({ isAdmin: true } as AdminCredential);
+    return { trimmedName, profile, isAdmin: true };
+  }
+  adminCredential.set(null);
+  return { trimmedName, profile, isAdmin: false };
 };
 
 export const prepareTrustedMessageSend = (
@@ -258,16 +311,44 @@ export const applyTrustedMessageSend = (
   };
 };
 
+export const prepareTrustedRoomAdd = (
+  adminCredential: AdminCredential | null | undefined,
+  rawName: string,
+): {
+  trimmedName: string | null;
+  room: TrustedChatRoom | null;
+} => {
+  const trimmedName = rawName.trim();
+  // This read supplies the admin integrity required by the shared rooms write.
+  if (!adminCredentialValueIsAdmin(adminCredential) || !trimmedName) {
+    return {
+      trimmedName: null,
+      room: null,
+    };
+  }
+
+  return {
+    trimmedName,
+    room: createRoomSnapshot<SharedChatMessage>(
+      trimmedName,
+    ) as TrustedChatRoom,
+  };
+};
+
 export const commitTrustedProfileSave = handler<
   void,
   {
     myProfile: MyProfileCell;
+    adminCredential: AdminCredentialCell;
     nameDraft: Writable<string | Default<"">>;
+    adminDraft: AdminDraftCell;
   }
->((_, { myProfile, nameDraft }) => {
+>((_, { myProfile, adminCredential, nameDraft, adminDraft }) => {
   const { trimmedName } = applyTrustedProfileSave(
     myProfile,
+    adminCredential,
     draftText(nameDraft),
+    adminDraft.get() === true,
   );
   if (trimmedName) {
     nameDraft.set(trimmedName);
@@ -294,6 +375,28 @@ export const commitTrustedMessageSend = handler<
   messageDraft.set("");
 });
 type TrustedMessageSendInput = Parameters<typeof commitTrustedMessageSend>[0];
+
+export const commitTrustedRoomAdd = handler<
+  void,
+  {
+    adminCredential: AdminCredential | null;
+    roomDraft: RoomDraftCell;
+    rooms: SharedRoomsCell;
+  }
+>((_, { adminCredential, roomDraft, rooms }) => {
+  const { trimmedName, room } = prepareTrustedRoomAdd(
+    adminCredential,
+    draftText(roomDraft),
+  );
+  if (!trimmedName || !room) {
+    return;
+  }
+
+  const nextRooms = [...roomsValue(rooms), room];
+  rooms.set({ list: nextRooms as SharedRoomList });
+  roomDraft.set("");
+});
+type TrustedRoomAddInput = Parameters<typeof commitTrustedRoomAdd>[0];
 
 interface TrustedParticipantsPanelInput {
   myProfile: MyProfileCell;
@@ -323,14 +426,18 @@ type TrustedParticipantsPanelInputArg = Parameters<
 
 export interface TrustedProfileSaveSurfaceInput {
   myProfile: MyProfileCell;
+  adminCredential: AdminCredentialCell;
   nameDraft: Writable<string | Default<"">>;
+  adminDraft: AdminDraftCell;
 }
 
 export interface TrustedProfileSaveSurfaceOutput {
   [NAME]: string;
   [UI]: any;
   myProfile: MyProfileCell;
+  adminCredential: AdminCredentialCell;
   currentProfileName: string;
+  currentUserIsAdmin: boolean;
   saveProfile: Stream<void>;
 }
 
@@ -338,14 +445,24 @@ export const TrustedProfileSaveSurface = pattern<
   TrustedProfileSaveSurfaceInput,
   TrustedProfileSaveSurfaceOutput
 >((
-  { myProfile, nameDraft }: TrustedProfileSaveSurfaceInput,
+  {
+    myProfile,
+    adminCredential,
+    nameDraft,
+    adminDraft,
+  }: TrustedProfileSaveSurfaceInput,
 ): TrustedProfileSaveSurfaceOutput => {
   const saveProfile = commitTrustedProfileSave({
     myProfile,
+    adminCredential,
     nameDraft,
+    adminDraft,
   });
   const currentSavedName = computed(() =>
     currentProfileSnapshot(myProfile)?.name ?? "Name not set"
+  );
+  const adminStatus = computed(() =>
+    currentUserIsAdmin(adminCredential) ? "Admin" : "Not admin"
   );
   const saveDisabled = computed(() => draftText(nameDraft).trim().length === 0);
 
@@ -366,6 +483,9 @@ export const TrustedProfileSaveSurface = pattern<
               placeholder="Set your name"
             />
           </cf-vgroup>
+          <cf-checkbox id="trusted-admin-checkbox" $checked={adminDraft}>
+            Trusted admin
+          </cf-checkbox>
           <cf-button
             id="trusted-profile-save"
             data-ui-action={TRUSTED_GROUP_CHAT_SAVE_PROFILE_ACTION}
@@ -378,11 +498,14 @@ export const TrustedProfileSaveSurface = pattern<
           <cf-label id="trusted-profile-status">
             {currentSavedName}
           </cf-label>
+          <cf-chip id="trusted-admin-status" label={adminStatus} />
         </cf-hstack>
       </cf-card>
     ),
     myProfile,
+    adminCredential,
     currentProfileName: currentSavedName,
+    currentUserIsAdmin: computed(() => currentUserIsAdmin(adminCredential)),
     saveProfile,
   };
 });
@@ -457,6 +580,80 @@ export const TrustedChatSendSurface = pattern<
     ),
     messages,
     sendMessage,
+  };
+});
+
+export interface TrustedRoomAddSurfaceInput {
+  adminCredential: AdminCredentialCell;
+  roomDraft: RoomDraftCell;
+  rooms: SharedRoomsCell;
+}
+
+export interface TrustedRoomAddSurfaceOutput {
+  [NAME]: string;
+  [UI]: any;
+  rooms: SharedRoomsCell;
+  addRoom: Stream<void>;
+}
+
+export const TrustedRoomAddSurface = pattern<
+  TrustedRoomAddSurfaceInput,
+  TrustedRoomAddSurfaceOutput
+>((
+  {
+    adminCredential,
+    roomDraft,
+    rooms,
+  }: TrustedRoomAddSurfaceInput,
+): TrustedRoomAddSurfaceOutput => {
+  const addRoom = commitTrustedRoomAdd({
+    adminCredential,
+    roomDraft,
+    rooms,
+  } as TrustedRoomAddInput);
+  const addDisabled = computed(() =>
+    !currentUserIsAdmin(adminCredential) ||
+    draftText(roomDraft).trim().length === 0
+  );
+
+  return {
+    [NAME]: "room add surface",
+    [UI]: (
+      <cf-card
+        id="trusted-room-surface"
+        data-ui-pattern={TRUSTED_GROUP_CHAT_ROOM_SURFACE}
+        data-ui-event-integrity={TRUSTED_GROUP_CHAT_ROOM_SURFACE}
+      >
+        <cf-hstack slot="content" gap="2" align="center" wrap>
+          <cf-vgroup gap="sm" style={{ minWidth: "12rem", flex: "1 1 12rem" }}>
+            <cf-input
+              id="trusted-room-name"
+              size="sm"
+              $value={roomDraft}
+              placeholder="Add a room"
+            />
+          </cf-vgroup>
+          <cf-button
+            id="trusted-room-add-button"
+            data-ui-action={TRUSTED_GROUP_CHAT_ADD_ROOM_ACTION}
+            size="sm"
+            disabled={addDisabled}
+            onClick={addRoom}
+          >
+            Add room
+          </cf-button>
+          <cf-label id="trusted-room-admin-hint">
+            {computed(() =>
+              currentUserIsAdmin(adminCredential)
+                ? "Admins can add rooms"
+                : "Save as trusted admin to add rooms"
+            )}
+          </cf-label>
+        </cf-hstack>
+      </cf-card>
+    ),
+    rooms,
+    addRoom,
   };
 });
 

--- a/packages/patterns/factory-outputs/parking-coordinator/main.test.tsx
+++ b/packages/patterns/factory-outputs/parking-coordinator/main.test.tsx
@@ -14,7 +14,13 @@
  *
  * NOTE: Uses .filter(() => true).length for array lengths per reactivity tracking note.
  */
-import { action, computed, pattern, safeDateNow } from "commonfabric";
+import { action, computed, pattern, safeDateNow, UI } from "commonfabric";
+import {
+  findNodeById,
+  findNodeByProp,
+  nodeIncludesText,
+  propValue,
+} from "../../test-ui-helpers.ts";
 import ParkingCoordinator, { DEFAULT_SPOTS } from "./main.tsx";
 import type { ParkingSpot, Person, SpotRequest } from "./main.tsx";
 
@@ -527,13 +533,79 @@ export default pattern(() => {
   );
 
   const assert_s8_admin_off = computed(() => s8.adminMode === false);
+  const assert_s8_admin_view_locked = computed(() => {
+    const adminAccess = findNodeById(s8[UI], "parking-admin-access");
+    const enableManager = findNodeById(
+      s8[UI],
+      "parking-enable-admin-manager",
+    );
+    const adminToggle = findNodeById(s8[UI], "parking-admin-mode-toggle");
+    const aliceAdminToggle = findNodeByProp(
+      s8[UI],
+      "data-parking-admin-toggle",
+      "Alice",
+    );
+    return nodeIncludesText(adminAccess, "Cannot manage admins") &&
+      nodeIncludesText(aliceAdminToggle, "Make admin") &&
+      propValue(enableManager, "disabled") === false &&
+      propValue(aliceAdminToggle, "disabled") === true &&
+      propValue(adminToggle, "disabled") === true &&
+      findNodeById(s8[UI], "parking-admin-people-section") === undefined;
+  });
   const assert_s8_can_manage_admins = computed(() =>
     s8.currentUserCanManageAdmins === true
   );
+  const assert_s8_admin_view_manager_enabled = computed(() => {
+    const adminAccess = findNodeById(s8[UI], "parking-admin-access");
+    const enableManager = findNodeById(
+      s8[UI],
+      "parking-enable-admin-manager",
+    );
+    const aliceAdminToggle = findNodeByProp(
+      s8[UI],
+      "data-parking-admin-toggle",
+      "Alice",
+    );
+    return nodeIncludesText(adminAccess, "Can manage admins") &&
+      nodeIncludesText(aliceAdminToggle, "Make admin") &&
+      propValue(enableManager, "disabled") === true &&
+      propValue(aliceAdminToggle, "disabled") === false;
+  });
   const assert_s8_alice_is_admin = computed(() =>
     s8.currentPersonIsAdmin === true
   );
+  const assert_s8_admin_view_alice_admin = computed(() => {
+    const adminToggle = findNodeById(s8[UI], "parking-admin-mode-toggle");
+    const aliceRow = findNodeByProp(
+      s8[UI],
+      "data-parking-admin-row",
+      "Alice",
+    );
+    const aliceAdminToggle = findNodeByProp(
+      s8[UI],
+      "data-parking-admin-toggle",
+      "Alice",
+    );
+    return nodeIncludesText(aliceRow, "Admin") &&
+      nodeIncludesText(aliceAdminToggle, "Remove admin") &&
+      propValue(adminToggle, "disabled") === false &&
+      nodeIncludesText(adminToggle, "Admin: OFF");
+  });
   const assert_s8_admin_on = computed(() => s8.adminMode === true);
+  const assert_s8_admin_view_admin_mode_visible = computed(() =>
+    nodeIncludesText(
+      findNodeById(s8[UI], "parking-admin-mode-toggle"),
+      "Admin: ON",
+    ) &&
+    nodeIncludesText(
+      findNodeById(s8[UI], "parking-admin-people-section"),
+      "People",
+    ) &&
+    nodeIncludesText(
+      findNodeById(s8[UI], "parking-admin-add-person-open"),
+      "+ Add Person",
+    )
+  );
 
   // ============================================================
   // Test sequence
@@ -626,14 +698,18 @@ export default pattern(() => {
 
       // Admin mode toggle
       { assertion: assert_s8_admin_off },
+      { assertion: assert_s8_admin_view_locked },
       { action: action_toggle_admin },
       { assertion: assert_s8_admin_off },
       { action: action_enable_s8_admin_manager },
       { assertion: assert_s8_can_manage_admins },
+      { assertion: assert_s8_admin_view_manager_enabled },
       { action: action_make_alice_mode_admin },
       { assertion: assert_s8_alice_is_admin },
+      { assertion: assert_s8_admin_view_alice_admin },
       { action: action_toggle_admin },
       { assertion: assert_s8_admin_on },
+      { assertion: assert_s8_admin_view_admin_mode_visible },
       { action: action_toggle_admin },
       { assertion: assert_s8_admin_off },
     ],

--- a/packages/patterns/factory-outputs/parking-coordinator/main.test.tsx
+++ b/packages/patterns/factory-outputs/parking-coordinator/main.test.tsx
@@ -51,6 +51,18 @@ export default pattern(() => {
     requests: [],
   });
 
+  const action_enable_s1_admin_manager = action(() =>
+    s1.enableAdminManager.send()
+  );
+
+  const assert_s1_manager_can_start_people_flow = computed(() =>
+    s1.currentUserCanManageAdmins === true &&
+    nodeIncludesText(
+      findNodeById(s1[UI], "parking-admin-add-person-open"),
+      "+ Add Person",
+    )
+  );
+
   const action_add_alice = action(() => {
     s1.addPerson.send({
       name: "Alice",
@@ -616,6 +628,8 @@ export default pattern(() => {
       // People management
       { assertion: assert_s1_no_people },
       { assertion: assert_s1_three_spots },
+      { action: action_enable_s1_admin_manager },
+      { assertion: assert_s1_manager_can_start_people_flow },
       { action: action_add_alice },
       { assertion: assert_s1_alice_exists },
       { assertion: assert_s1_alice_default_spot },

--- a/packages/patterns/factory-outputs/parking-coordinator/main.test.tsx
+++ b/packages/patterns/factory-outputs/parking-coordinator/main.test.tsx
@@ -191,12 +191,29 @@ export default pattern(() => {
   // ============================================================
   // Subject 3: Spot Management
   // ============================================================
+  const adminAlice3: Person = {
+    name: "Alice",
+    email: "alice@co.com",
+    commuteMode: "drive",
+    spotPreferences: [],
+    defaultSpot: "",
+    priorityRank: 1,
+  };
   const s3 = ParkingCoordinator({
     spots: DEFAULT_SPOTS,
-    people: [],
+    people: [adminAlice3],
     requests: [],
   });
 
+  const action_add_spot7_without_admin = action(() =>
+    s3.addSpot.send({ spotNumber: "7", label: "Level 2", notes: "Covered" })
+  );
+  const action_enable_s3_admin_manager = action(() =>
+    s3.enableAdminManager.send()
+  );
+  const action_make_alice_spot_admin = action(() =>
+    s3.togglePersonAdmin.send({ name: "Alice" })
+  );
   const action_add_spot7 = action(() =>
     s3.addSpot.send({ spotNumber: "7", label: "Level 2", notes: "Covered" })
   );
@@ -211,6 +228,13 @@ export default pattern(() => {
   });
 
   const assert_s3_three_spots = computed(() => len(s3.spots) === 3);
+  const assert_s3_non_admin_spot_blocked = computed(() => len(s3.spots) === 3);
+  const assert_s3_can_manage_admins = computed(() =>
+    s3.currentUserCanManageAdmins === true
+  );
+  const assert_s3_alice_is_admin = computed(() =>
+    s3.currentPersonIsAdmin === true
+  );
   const assert_s3_four_spots = computed(() => len(s3.spots) === 4);
   const assert_s3_spot7_label = computed(() => {
     const s = s3.spots.find((sp: ParkingSpot) => sp.spotNumber === "7");
@@ -429,10 +453,28 @@ export default pattern(() => {
     requests: [],
   });
 
+  const action_try_admin_override_without_admin = action(() => {
+    s7.adminOverride.send({ spotNumber: "5", date: today, personName: "Bob" });
+  });
+  const action_enable_s7_admin_manager = action(() =>
+    s7.enableAdminManager.send()
+  );
+  const action_make_alice_override_admin = action(() =>
+    s7.togglePersonAdmin.send({ name: "Alice" })
+  );
   const action_admin_override_bob_spot5 = action(() => {
     s7.adminOverride.send({ spotNumber: "5", date: today, personName: "Bob" });
   });
 
+  const assert_s7_non_admin_override_blocked = computed(() =>
+    len(s7.requests) === 0
+  );
+  const assert_s7_can_manage_admins = computed(() =>
+    s7.currentUserCanManageAdmins === true
+  );
+  const assert_s7_alice_is_admin = computed(() =>
+    s7.currentPersonIsAdmin === true
+  );
   const assert_s7_bob_override = computed(() => {
     return s7.requests.some(
       (r: SpotRequest) =>
@@ -472,13 +514,25 @@ export default pattern(() => {
   // ============================================================
   const s8 = ParkingCoordinator({
     spots: DEFAULT_SPOTS,
-    people: [],
+    people: [alice4],
     requests: [],
   });
 
   const action_toggle_admin = action(() => s8.toggleAdminMode.send());
+  const action_enable_s8_admin_manager = action(() =>
+    s8.enableAdminManager.send()
+  );
+  const action_make_alice_mode_admin = action(() =>
+    s8.togglePersonAdmin.send({ name: "Alice" })
+  );
 
   const assert_s8_admin_off = computed(() => s8.adminMode === false);
+  const assert_s8_can_manage_admins = computed(() =>
+    s8.currentUserCanManageAdmins === true
+  );
+  const assert_s8_alice_is_admin = computed(() =>
+    s8.currentPersonIsAdmin === true
+  );
   const assert_s8_admin_on = computed(() => s8.adminMode === true);
 
   // ============================================================
@@ -517,6 +571,12 @@ export default pattern(() => {
 
       // Spot management
       { assertion: assert_s3_three_spots },
+      { action: action_add_spot7_without_admin },
+      { assertion: assert_s3_non_admin_spot_blocked },
+      { action: action_enable_s3_admin_manager },
+      { assertion: assert_s3_can_manage_admins },
+      { action: action_make_alice_spot_admin },
+      { assertion: assert_s3_alice_is_admin },
       { action: action_add_spot7 },
       { assertion: assert_s3_four_spots },
       { assertion: assert_s3_spot7_label },
@@ -552,6 +612,12 @@ export default pattern(() => {
       { assertion: assert_s6_cancelled },
 
       // Admin override
+      { action: action_try_admin_override_without_admin },
+      { assertion: assert_s7_non_admin_override_blocked },
+      { action: action_enable_s7_admin_manager },
+      { assertion: assert_s7_can_manage_admins },
+      { action: action_make_alice_override_admin },
+      { assertion: assert_s7_alice_is_admin },
       { action: action_admin_override_bob_spot5 },
       { assertion: assert_s7_bob_override },
       { action: action_admin_override_alice_spot5 },
@@ -560,6 +626,12 @@ export default pattern(() => {
 
       // Admin mode toggle
       { assertion: assert_s8_admin_off },
+      { action: action_toggle_admin },
+      { assertion: assert_s8_admin_off },
+      { action: action_enable_s8_admin_manager },
+      { assertion: assert_s8_can_manage_admins },
+      { action: action_make_alice_mode_admin },
+      { assertion: assert_s8_alice_is_admin },
       { action: action_toggle_admin },
       { assertion: assert_s8_admin_on },
       { action: action_toggle_admin },

--- a/packages/patterns/factory-outputs/parking-coordinator/main.tsx
+++ b/packages/patterns/factory-outputs/parking-coordinator/main.tsx
@@ -1,11 +1,13 @@
 import {
   action,
+  type AddIntegrity,
   computed,
   Default,
   NAME,
   nonPrivateRandom,
   pattern,
   type PerSpace,
+  type RequiresIntegrity,
   safeDateNow,
   Stream,
   UI,
@@ -13,6 +15,12 @@ import {
   wish,
   Writable,
 } from "commonfabric";
+import {
+  type AdminManagerCredential,
+  adminManagerCredentialIsActive,
+  adminRegistryEntries,
+  type EmptyAdminRegistryValue,
+} from "../../admin.ts";
 
 // ============================================================
 // Domain Types
@@ -47,8 +55,51 @@ export interface SpotRequest {
   autoAllocated: boolean;
 }
 
+export const PARKING_ADMIN_INTEGRITY = "parking-admin" as const;
+export const PARKING_ADMIN_MANAGER_INTEGRITY = "parking-admin-manager" as const;
+
+export interface ParkingAdminSubject {
+  personName: string;
+}
+
+export interface ParkingAdminRoleAssignment {
+  subject: ParkingAdminSubject;
+  displayName: string;
+}
+
+export type ParkingAdminRole = AddIntegrity<
+  ParkingAdminRoleAssignment,
+  readonly [typeof PARKING_ADMIN_INTEGRITY]
+>;
+
+export type ParkingAdminManagerCredential = AdminManagerCredential<
+  typeof PARKING_ADMIN_MANAGER_INTEGRITY
+>;
+
+export type ParkingAdminList = RequiresIntegrity<
+  ParkingAdminRole[],
+  readonly [typeof PARKING_ADMIN_MANAGER_INTEGRITY]
+>;
+
+export interface ParkingAdminRegistryStoredValue {
+  admins?: ParkingAdminList;
+}
+
+export type ParkingAdminRegistryValue =
+  | ParkingAdminRegistryStoredValue
+  | Default<EmptyAdminRegistryValue>;
+export type ParkingAdminRegistryCell = Writable<ParkingAdminRegistryValue>;
+export type ParkingAdminManagerCredentialCell = Writable<
+  ParkingAdminManagerCredential | null
+>;
+
+export type ParkingSpotList = RequiresIntegrity<
+  ParkingSpot[],
+  readonly [typeof PARKING_ADMIN_INTEGRITY]
+>;
+
 type SpotsCell = Writable<
-  | ParkingSpot[]
+  | ParkingSpotList
   | Default<[
     { spotNumber: "1"; label: "Near entrance"; notes: ""; active: true },
     { spotNumber: "5"; label: ""; notes: ""; active: true },
@@ -71,6 +122,7 @@ export interface ParkingCoordinatorInput {
   spots?: PerSpace<SpotsCell>;
   people?: PerSpace<PeopleCell>;
   requests?: PerSpace<RequestsCell>;
+  adminRegistry?: PerSpace<ParkingAdminRegistryCell>;
 }
 
 export interface ParkingCoordinatorOutput {
@@ -83,6 +135,11 @@ export interface ParkingCoordinatorOutput {
   selectedPersonName: string;
   requestDate: string;
   requestResult: string;
+  adminRegistry: PerSpace<ParkingAdminRegistryCell>;
+  currentPersonIsAdmin: boolean;
+  currentUserCanManageAdmins: boolean;
+  enableAdminManager: Stream<void>;
+  togglePersonAdmin: Stream<{ name: string }>;
   toggleAdminMode: Stream<void>;
   submitRequest: Stream<{ personName: string; date: string }>;
   cancelRequest: Stream<{ requestId: string }>;
@@ -181,6 +238,77 @@ const genId = (): string =>
 const parsePreferences = (s: string | null | undefined): string[] =>
   (s ?? "").split(",").map((x) => x.trim()).filter(Boolean);
 
+const parkingAdminSubject = (personName: string): ParkingAdminSubject => ({
+  personName,
+});
+
+const parkingAdminRolesValue = (
+  registry: ParkingAdminRegistryCell,
+): ParkingAdminRole[] => adminRegistryEntries<ParkingAdminRole>(registry);
+
+const parkingAdminRoleForPerson = (
+  registry: ParkingAdminRegistryCell,
+  personName: string | undefined,
+): ParkingAdminRole | undefined => {
+  const trimmedName = (personName ?? "").trim();
+  return trimmedName === ""
+    ? undefined
+    : parkingAdminRolesValue(registry).find((role) =>
+      role.subject.personName === trimmedName
+    );
+};
+
+const personIsParkingAdmin = (
+  registry: ParkingAdminRegistryCell,
+  personName: string | undefined,
+): boolean => parkingAdminRoleForPerson(registry, personName) !== undefined;
+
+const currentActorName = (
+  selectedPersonName: Writable<string>,
+  people: PeopleCell,
+): string => selectedPersonName.get() || people.get()[0]?.name || "";
+
+const currentParkingAdminRole = (
+  registry: ParkingAdminRegistryCell,
+  selectedPersonName: Writable<string>,
+  people: PeopleCell,
+): ParkingAdminRole | undefined =>
+  parkingAdminRoleForPerson(
+    registry,
+    currentActorName(selectedPersonName, people),
+  );
+
+const currentUserCanManageParkingAdmins = (
+  credential: ParkingAdminManagerCredentialCell,
+): boolean => adminManagerCredentialIsActive(credential.get());
+
+const prepareParkingAdminToggle = (
+  credential: ParkingAdminManagerCredential | null | undefined,
+  registry: ParkingAdminRegistryCell,
+  rawName: string,
+): ParkingAdminRole[] | null => {
+  const personName = rawName.trim();
+  if (!adminManagerCredentialIsActive(credential) || personName === "") {
+    return null;
+  }
+
+  const adminRoles = parkingAdminRolesValue(registry);
+  const nextRoles = adminRoles.filter((role) =>
+    role.subject.personName !== personName
+  );
+  if (nextRoles.length !== adminRoles.length) {
+    return nextRoles;
+  }
+
+  return [
+    ...nextRoles,
+    {
+      subject: parkingAdminSubject(personName),
+      displayName: personName,
+    } as ParkingAdminRole,
+  ];
+};
+
 const commuteIcon = (mode: CommuteMode): string => {
   const icons: Record<CommuteMode, string> = {
     drive: "🚗",
@@ -252,10 +380,27 @@ export const DEFAULT_SPOTS: ParkingSpot[] = [
 // ============================================================
 
 export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
-  ({ spots: inputSpots, people: inputPeople, requests: inputRequests }) => {
+  (
+    {
+      spots: inputSpots,
+      people: inputPeople,
+      requests: inputRequests,
+      adminRegistry: inputAdminRegistry,
+    },
+  ) => {
     const spots = inputSpots ?? Writable.perSpace.of(DEFAULT_SPOTS);
     const people = inputPeople ?? Writable.perSpace.of<Person[]>([]);
     const requests = inputRequests ?? Writable.perSpace.of<SpotRequest[]>([]);
+    const defaultAdminRegistry = new Writable.perSpace<
+      ParkingAdminRegistryValue
+    >(
+      {} as ParkingAdminRegistryValue,
+    );
+    const adminRegistry =
+      (inputAdminRegistry ?? defaultAdminRegistry) as ParkingAdminRegistryCell;
+    const adminManagerCredential = new Writable.perUser<
+      ParkingAdminManagerCredential | null
+    >(null);
 
     const nowTimestamp = wish<number>({ query: "#now" });
     const todayStr = computed(() =>
@@ -320,7 +465,31 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
     // Actions
     // --------------------------------------------------------
 
+    const enableAdminManager = action(() => {
+      adminManagerCredential.set({
+        canManageAdmins: true,
+      } as ParkingAdminManagerCredential);
+    });
+
+    const togglePersonAdmin = action<{ name: string }>(({ name }) => {
+      const nextAdmins = prepareParkingAdminToggle(
+        adminManagerCredential.get(),
+        adminRegistry,
+        name,
+      );
+      if (nextAdmins === null) {
+        return;
+      }
+      adminRegistry.set({ admins: nextAdmins as ParkingAdminList });
+    });
+
     const toggleAdminMode = action(() => {
+      if (
+        !currentParkingAdminRole(adminRegistry, selectedPersonName, people)
+      ) {
+        adminMode.set(false);
+        return;
+      }
       adminMode.set(!adminMode.get());
     });
 
@@ -514,6 +683,18 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
             r.personName === originalName ? { ...r, personName: trimName } : r
           ),
         );
+        if (adminManagerCredentialIsActive(adminManagerCredential.get())) {
+          adminRegistry.set({
+            admins: parkingAdminRolesValue(adminRegistry).map((role) =>
+              role.subject.personName === originalName
+                ? {
+                  subject: parkingAdminSubject(trimName),
+                  displayName: trimName,
+                } as ParkingAdminRole
+                : role
+            ) as ParkingAdminList,
+          });
+        }
       }
 
       editingPersonName.set(null);
@@ -521,6 +702,13 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
 
     const removePerson = action<{ name: string }>(({ name }) => {
       people.set(people.get().filter((p) => p.name !== name));
+      if (adminManagerCredentialIsActive(adminManagerCredential.get())) {
+        adminRegistry.set({
+          admins: parkingAdminRolesValue(adminRegistry).filter((role) =>
+            role.subject.personName !== name
+          ) as ParkingAdminList,
+        });
+      }
       if (selectedPersonName.get() === name) {
         const remaining = people.get();
         selectedPersonName.set(remaining[0]?.name ?? "");
@@ -569,6 +757,11 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
     const addSpot = action<
       { spotNumber: string; label: string; notes: string }
     >((event) => {
+      if (
+        !currentParkingAdminRole(adminRegistry, selectedPersonName, people)
+      ) {
+        return;
+      }
       const {
         spotNumber: spotNumArg = newSpotNumber.get() ?? "",
         label = newSpotLabel.get() ?? "",
@@ -582,12 +775,15 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
         return;
       }
       addSpotError.set("");
-      spots.set([...current, {
-        spotNumber: trimNum,
-        label: label.trim(),
-        notes: notes.trim(),
-        active: true,
-      }]);
+      spots.set([
+        ...current,
+        {
+          spotNumber: trimNum,
+          label: label.trim(),
+          notes: notes.trim(),
+          active: true,
+        },
+      ] as ParkingSpotList);
       newSpotNumber.set("");
       newSpotLabel.set("");
       newSpotNotes.set("");
@@ -603,6 +799,11 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
         active: boolean;
       }
     >((event) => {
+      if (
+        !currentParkingAdminRole(adminRegistry, selectedPersonName, people)
+      ) {
+        return;
+      }
       const {
         originalNumber = editingSpotNumber.get() ?? "",
         spotNumber: spotNumArg2 = editSpotNum.get() ?? "",
@@ -629,7 +830,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
               active: editSpotActiveArg,
             }
             : s
-        ),
+        ) as ParkingSpotList,
       );
 
       if (trimNum !== originalNumber) {
@@ -646,7 +847,16 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
 
     const removeSpot = action<{ spotNumber: string }>(
       ({ spotNumber: spotNumArg3 }) => {
-        spots.set(spots.get().filter((s) => s.spotNumber !== spotNumArg3));
+        if (
+          !currentParkingAdminRole(adminRegistry, selectedPersonName, people)
+        ) {
+          return;
+        }
+        spots.set(
+          spots.get().filter((s) =>
+            s.spotNumber !== spotNumArg3
+          ) as ParkingSpotList,
+        );
         removeSpotConfirmTarget.set(null);
       },
     );
@@ -654,6 +864,11 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
     const adminOverride = action<
       { spotNumber: string; date: string; personName: string }
     >(({ spotNumber, date, personName }) => {
+      if (
+        !currentParkingAdminRole(adminRegistry, selectedPersonName, people)
+      ) {
+        return;
+      }
       if (!personName || !spotNumber || !date) return;
 
       const existingReqs = requests.get();
@@ -849,6 +1064,28 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
       activeRequestDate < todayStr || people.get().length === 0
     );
 
+    const currentPersonIsAdmin = computed(() =>
+      currentParkingAdminRole(adminRegistry, selectedPersonName, people) !==
+        undefined
+    );
+
+    const adminModeEnabled = computed(() =>
+      Boolean(adminMode.get() && currentPersonIsAdmin)
+    );
+
+    const currentUserCanManageAdmins = computed(() =>
+      currentUserCanManageParkingAdmins(adminManagerCredential)
+    );
+
+    const adminAccessRows = computed(() =>
+      people.get().map((person) => ({
+        name: person.name,
+        email: person.email,
+        isAdmin: personIsParkingAdmin(adminRegistry, person.name),
+        canManageAdmins: currentUserCanManageAdmins,
+      }))
+    );
+
     const commuteModeOptions = [
       { label: "🚗 Drive", value: "drive" },
       { label: "🚌 Transit", value: "transit" },
@@ -880,7 +1117,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
       const overrideSpot = gridOverrideSpot.get();
       const overrideDate = gridOverrideDate.get();
       const overridePerson = overridePersonName.get();
-      const weekGridShowAdmin = adminMode.get();
+      const weekGridShowAdmin = adminModeEnabled;
 
       return allSpots.map((spot) => {
         const spotNum = spot.spotNumber;
@@ -926,7 +1163,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
       const allSpots = spots.get().filter((s) => s != null && s.active);
       const allRequests = requests.get();
       const currentPerson = selectedPersonName.get();
-      const todayStripShowAdmin = adminMode.get();
+      const todayStripShowAdmin = adminModeEnabled;
 
       return allSpots.map((spot) => {
         const req = allRequests.find(
@@ -992,13 +1229,19 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
               </span>
               <cf-button
                 variant={computed(() =>
-                  adminMode.get() ? "primary" : "secondary"
+                  adminModeEnabled ? "primary" : "secondary"
                 )}
                 size="sm"
+                disabled={computed(() => !currentPersonIsAdmin)}
                 onClick={() => toggleAdminMode.send()}
               >
-                {computed(() => `Admin: ${adminMode.get() ? "ON" : "OFF"}`)}
+                {computed(() => `Admin: ${adminModeEnabled ? "ON" : "OFF"}`)}
               </cf-button>
+              <cf-chip
+                label={computed(() =>
+                  currentPersonIsAdmin ? "Current person is admin" : "Member"
+                )}
+              />
             </div>
           </div>
 
@@ -1169,6 +1412,84 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                       >
                         {result}
                       </span>
+                    );
+                  })}
+                </cf-vstack>
+              </cf-card>
+
+              {/* === Section C: Admin Access === */}
+              <cf-card id="parking-admin-access">
+                <cf-vstack gap="2">
+                  <cf-hstack justify="between" align="center" wrap gap="2">
+                    <cf-vstack gap="1">
+                      <cf-heading level={6}>Admin Access</cf-heading>
+                      <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+                        Demo manager access lets any user change who can manage
+                        parking spots.
+                      </span>
+                    </cf-vstack>
+                    <cf-chip
+                      label={computed(() =>
+                        currentUserCanManageAdmins
+                          ? "Can manage admins"
+                          : "Cannot manage admins"
+                      )}
+                    />
+                    <cf-button
+                      size="sm"
+                      disabled={computed(() =>
+                        Boolean(currentUserCanManageAdmins)
+                      )}
+                      onClick={() => enableAdminManager.send()}
+                    >
+                      Enable manager demo
+                    </cf-button>
+                  </cf-hstack>
+
+                  {noPeople
+                    ? (
+                      <span style="font-size: 0.875rem; color: var(--cf-color-gray-500);">
+                        Add people before assigning admins.
+                      </span>
+                    )
+                    : null}
+
+                  {adminAccessRows.map((row) => {
+                    const rowName = row.name;
+                    const rowEmail = row.email;
+                    const rowIsAdmin = row.isAdmin;
+                    const rowCanManageAdmins = row.canManageAdmins;
+                    return (
+                      <cf-hstack
+                        justify="between"
+                        align="center"
+                        gap="2"
+                        wrap
+                        style="padding: 0.5rem 0.75rem; border: 1px solid var(--cf-color-gray-200); border-radius: 0.75rem;"
+                      >
+                        <cf-vstack gap="0">
+                          <cf-hstack gap="2" align="center" wrap>
+                            <span style="font-weight: 600;">{rowName}</span>
+                            <cf-chip
+                              label={rowIsAdmin ? "Admin" : "Member"}
+                              variant={rowIsAdmin ? "accent" : "default"}
+                            />
+                          </cf-hstack>
+                          <span style="font-size: 0.75rem; color: var(--cf-color-gray-500);">
+                            {rowEmail}
+                          </span>
+                        </cf-vstack>
+                        <cf-button
+                          size="sm"
+                          disabled={!rowCanManageAdmins}
+                          onClick={() =>
+                            togglePersonAdmin.send({
+                              name: rowName,
+                            })}
+                        >
+                          {rowIsAdmin ? "Remove admin" : "Make admin"}
+                        </cf-button>
+                      </cf-hstack>
                     );
                   })}
                 </cf-vstack>
@@ -1386,7 +1707,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
               </cf-vstack>
 
               {/* === Section D: Admin (admin mode only) === */}
-              {adminMode.get()
+              {adminModeEnabled
                 ? (
                   <>
                     {/* People */}
@@ -2088,12 +2409,17 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
       spots,
       people,
       requests,
-      adminMode: computed(() => Boolean(adminMode.get())),
+      adminRegistry: adminRegistry as PerSpace<ParkingAdminRegistryCell>,
+      adminMode: computed(() => Boolean(adminModeEnabled)),
+      currentPersonIsAdmin,
+      currentUserCanManageAdmins,
       selectedPersonName: computed(() => selectedPersonName.get() ?? ""),
       requestDate: activeRequestDate,
       requestResult: computed(() => requestResult.get() ?? ""),
 
       // Exposed actions
+      enableAdminManager,
+      togglePersonAdmin,
       toggleAdminMode,
       submitRequest,
       cancelRequest,

--- a/packages/patterns/factory-outputs/parking-coordinator/main.tsx
+++ b/packages/patterns/factory-outputs/parking-coordinator/main.tsx
@@ -263,6 +263,8 @@ const personIsParkingAdmin = (
   personName: string | undefined,
 ): boolean => parkingAdminRoleForPerson(registry, personName) !== undefined;
 
+// Demo-only identity model: the selected person name stands in for the actor.
+// Do not copy this for production authorization; use a stable user/profile cell.
 const currentActorName = (
   selectedPersonName: Writable<string>,
   people: PeopleCell,
@@ -1070,7 +1072,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
     );
 
     const adminModeEnabled = computed(() =>
-      Boolean(adminMode.get() && currentPersonIsAdmin)
+      adminMode.get() ? currentPersonIsAdmin : false
     );
 
     const currentUserCanManageAdmins = computed(() =>
@@ -1082,7 +1084,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
         name: person.name,
         email: person.email,
         isAdmin: personIsParkingAdmin(adminRegistry, person.name),
-        canManageAdmins: currentUserCanManageAdmins,
+        canManageAdmins: currentUserCanManageAdmins === true,
       }))
     );
 
@@ -1117,7 +1119,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
       const overrideSpot = gridOverrideSpot.get();
       const overrideDate = gridOverrideDate.get();
       const overridePerson = overridePersonName.get();
-      const weekGridShowAdmin = adminModeEnabled;
+      const weekGridShowAdmin = adminModeEnabled === true;
 
       return allSpots.map((spot) => {
         const spotNum = spot.spotNumber;
@@ -1163,7 +1165,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
       const allSpots = spots.get().filter((s) => s != null && s.active);
       const allRequests = requests.get();
       const currentPerson = selectedPersonName.get();
-      const todayStripShowAdmin = adminModeEnabled;
+      const todayStripShowAdmin = adminModeEnabled === true;
 
       return allSpots.map((spot) => {
         const req = allRequests.find(
@@ -1228,19 +1230,17 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                 {todayFormatted}
               </span>
               <cf-button
-                variant={computed(() =>
-                  adminModeEnabled ? "primary" : "secondary"
-                )}
+                variant={adminModeEnabled ? "primary" : "secondary"}
                 size="sm"
-                disabled={computed(() => !currentPersonIsAdmin)}
+                disabled={!currentPersonIsAdmin}
                 onClick={() => toggleAdminMode.send()}
               >
-                {computed(() => `Admin: ${adminModeEnabled ? "ON" : "OFF"}`)}
+                {adminModeEnabled ? "Admin: ON" : "Admin: OFF"}
               </cf-button>
               <cf-chip
-                label={computed(() =>
-                  currentPersonIsAdmin ? "Current person is admin" : "Member"
-                )}
+                label={currentPersonIsAdmin
+                  ? "Current person is admin"
+                  : "Member"}
               />
             </div>
           </div>
@@ -1429,17 +1429,13 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                       </span>
                     </cf-vstack>
                     <cf-chip
-                      label={computed(() =>
-                        currentUserCanManageAdmins
-                          ? "Can manage admins"
-                          : "Cannot manage admins"
-                      )}
+                      label={currentUserCanManageAdmins
+                        ? "Can manage admins"
+                        : "Cannot manage admins"}
                     />
                     <cf-button
                       size="sm"
-                      disabled={computed(() =>
-                        Boolean(currentUserCanManageAdmins)
-                      )}
+                      disabled={currentUserCanManageAdmins}
                       onClick={() => enableAdminManager.send()}
                     >
                       Enable manager demo
@@ -1495,7 +1491,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                 </cf-vstack>
               </cf-card>
 
-              {/* === Section C: Week-Ahead Grid === */}
+              {/* === Section D: Week-Ahead Grid === */}
               <cf-vstack gap="1">
                 <cf-heading level={6}>This Week</cf-heading>
 
@@ -1706,7 +1702,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                 </div>
               </cf-vstack>
 
-              {/* === Section D: Admin (admin mode only) === */}
+              {/* === Section E: Admin (admin mode only) === */}
               {adminModeEnabled
                 ? (
                   <>
@@ -2410,7 +2406,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
       people,
       requests,
       adminRegistry: adminRegistry as PerSpace<ParkingAdminRegistryCell>,
-      adminMode: computed(() => Boolean(adminModeEnabled)),
+      adminMode: adminModeEnabled,
       currentPersonIsAdmin,
       currentUserCanManageAdmins,
       selectedPersonName: computed(() => selectedPersonName.get() ?? ""),

--- a/packages/patterns/factory-outputs/parking-coordinator/main.tsx
+++ b/packages/patterns/factory-outputs/parking-coordinator/main.tsx
@@ -1078,6 +1078,13 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
     const currentUserCanManageAdmins = computed(() =>
       currentUserCanManageParkingAdmins(adminManagerCredential)
     );
+    const canBootstrapPeople = computed(() =>
+      people.get().length === 0 &&
+      currentUserCanManageParkingAdmins(adminManagerCredential)
+    );
+    const showAdminPeopleSection = computed(() =>
+      adminModeEnabled === true || canBootstrapPeople === true
+    );
 
     const adminAccessRows = computed(() =>
       people.get().map((person) => ({
@@ -1706,8 +1713,8 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                 </div>
               </cf-vstack>
 
-              {/* === Section E: Admin (admin mode only) === */}
-              {adminModeEnabled
+              {/* === Section E: Admin / bootstrap people management === */}
+              {showAdminPeopleSection
                 ? (
                   <>
                     {/* People */}
@@ -2126,42 +2133,231 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                     </cf-vstack>
 
                     {/* Parking Spots */}
-                    <cf-vstack gap="2">
-                      <cf-hstack justify="between" align="center">
-                        <cf-heading level={6}>Parking Spots</cf-heading>
-                        <cf-button
-                          variant="primary"
-                          size="sm"
-                          onClick={() => toggleAddSpotForm.send()}
-                        >
-                          + Add Spot
-                        </cf-button>
-                      </cf-hstack>
+                    {adminModeEnabled
+                      ? (
+                        <cf-vstack gap="2">
+                          <cf-hstack justify="between" align="center">
+                            <cf-heading level={6}>Parking Spots</cf-heading>
+                            <cf-button
+                              variant="primary"
+                              size="sm"
+                              onClick={() => toggleAddSpotForm.send()}
+                            >
+                              + Add Spot
+                            </cf-button>
+                          </cf-hstack>
 
-                      {adminSpotsData.map((spot) => {
-                        const spotNum2 = spot.spotNumber;
-                        const spotLabel2 = spot.label;
-                        const spotNotes2 = spot.notes;
-                        const spotActive2 = spot.active;
-                        const isEditingSpot = computed(() =>
-                          editingSpotNumber.get() === spotNum2
-                        );
-                        const isRemoveSpotConfirm = computed(() =>
-                          removeSpotConfirmTarget.get() === spotNum2
-                        );
+                          {adminSpotsData.map((spot) => {
+                            const spotNum2 = spot.spotNumber;
+                            const spotLabel2 = spot.label;
+                            const spotNotes2 = spot.notes;
+                            const spotActive2 = spot.active;
+                            const isEditingSpot = computed(() =>
+                              editingSpotNumber.get() === spotNum2
+                            );
+                            const isRemoveSpotConfirm = computed(() =>
+                              removeSpotConfirmTarget.get() === spotNum2
+                            );
 
-                        return (
-                          <cf-card style={spotActive2 ? "" : "opacity: 0.65;"}>
-                            {isEditingSpot
-                              ? (
+                            return (
+                              <cf-card
+                                style={spotActive2 ? "" : "opacity: 0.65;"}
+                              >
+                                {isEditingSpot
+                                  ? (
+                                    <cf-vstack gap="2">
+                                      <cf-hstack gap="2" wrap>
+                                        <cf-vstack
+                                          gap="1"
+                                          style="min-width: 60px;"
+                                        >
+                                          <span style="font-size: 0.75rem; font-weight: 500;">
+                                            Number *
+                                          </span>
+                                          <cf-input
+                                            $value={editSpotNum}
+                                            placeholder="e.g. 12"
+                                            style="width: 4rem;"
+                                          />
+                                        </cf-vstack>
+                                        <cf-vstack gap="1" style="flex: 1;">
+                                          <span style="font-size: 0.75rem; font-weight: 500;">
+                                            Label
+                                          </span>
+                                          <cf-input
+                                            $value={editSpotLabel}
+                                            placeholder="e.g. Near entrance"
+                                            style="width: 100%;"
+                                          />
+                                        </cf-vstack>
+                                      </cf-hstack>
+                                      <cf-vstack gap="1">
+                                        <span style="font-size: 0.75rem; font-weight: 500;">
+                                          Notes
+                                        </span>
+                                        <cf-input
+                                          $value={editSpotNotes}
+                                          placeholder="e.g. Tight, no large vehicles"
+                                          style="width: 100%;"
+                                        />
+                                      </cf-vstack>
+                                      <cf-hstack gap="2" align="center">
+                                        <cf-checkbox $checked={editSpotActive}>
+                                          Active
+                                        </cf-checkbox>
+                                        {spotDeactivateWarning
+                                          ? (
+                                            <span style="font-size: 0.75rem; color: var(--cf-color-amber-600);">
+                                              Has upcoming allocations — they
+                                              will remain.
+                                            </span>
+                                          )
+                                          : null}
+                                      </cf-hstack>
+                                      <cf-hstack gap="2">
+                                        <cf-button
+                                          variant="primary"
+                                          size="sm"
+                                          onClick={() =>
+                                            saveEditSpot.send({
+                                              originalNumber: spotNum2,
+                                            })}
+                                        >
+                                          Save
+                                        </cf-button>
+                                        <cf-button
+                                          variant="secondary"
+                                          size="sm"
+                                          onClick={() => cancelEditSpot.send()}
+                                        >
+                                          Cancel
+                                        </cf-button>
+                                      </cf-hstack>
+                                    </cf-vstack>
+                                  )
+                                  : (
+                                    <>
+                                      <cf-hstack
+                                        justify="between"
+                                        align="center"
+                                        gap="2"
+                                        wrap
+                                      >
+                                        <cf-hstack gap="2" align="center" wrap>
+                                          <span
+                                            style={`font-weight: 700; font-size: 1rem; color: ${
+                                              spotActive2
+                                                ? "var(--cf-color-gray-800)"
+                                                : "var(--cf-color-gray-400)"
+                                            };`}
+                                          >
+                                            #{spotNum2}
+                                          </span>
+                                          <cf-vstack gap="0">
+                                            <span
+                                              style={`font-size: 0.875rem; color: ${
+                                                spotActive2
+                                                  ? "var(--cf-color-gray-700)"
+                                                  : "var(--cf-color-gray-400)"
+                                              }; text-decoration: ${
+                                                spotActive2
+                                                  ? "none"
+                                                  : "line-through"
+                                              };`}
+                                            >
+                                              {spotLabel2 || "(no label)"}
+                                            </span>
+                                            {spotNotes2
+                                              ? (
+                                                <span style="font-size: 0.75rem; color: var(--cf-color-gray-400);">
+                                                  {spotNotes2}
+                                                </span>
+                                              )
+                                              : null}
+                                          </cf-vstack>
+                                          {!spotActive2
+                                            ? (
+                                              <span style="font-size: 0.6875rem; background-color: #f3f4f6; color: #6b7280; padding: 1px 6px; border-radius: 9999px;">
+                                                Inactive
+                                              </span>
+                                            )
+                                            : null}
+                                        </cf-hstack>
+                                        <cf-hstack gap="1">
+                                          <cf-button
+                                            variant="ghost"
+                                            size="sm"
+                                            onClick={() =>
+                                              startEditSpot.send({
+                                                spotNumber: spotNum2,
+                                              })}
+                                          >
+                                            Edit
+                                          </cf-button>
+                                          <cf-button
+                                            variant="ghost"
+                                            size="sm"
+                                            onClick={() =>
+                                              initiateRemoveSpot.send({
+                                                spotNumber: spotNum2,
+                                              })}
+                                          >
+                                            Remove
+                                          </cf-button>
+                                        </cf-hstack>
+                                      </cf-hstack>
+                                      {isRemoveSpotConfirm
+                                        ? (
+                                          <cf-card style="background: #fef2f2; border: 1px solid #fecaca; margin-top: 0.5rem;">
+                                            <cf-vstack gap="1">
+                                              <span style="font-size: 0.75rem; color: var(--cf-color-red-700);">
+                                                Spot #{spotNum2}{" "}
+                                                has upcoming allocations. They
+                                                will be preserved. Remove
+                                                anyway?
+                                              </span>
+                                              <cf-hstack gap="2">
+                                                <cf-button
+                                                  variant="primary"
+                                                  size="sm"
+                                                  onClick={() =>
+                                                    removeSpot.send({
+                                                      spotNumber: spotNum2,
+                                                    })}
+                                                >
+                                                  Remove
+                                                </cf-button>
+                                                <cf-button
+                                                  variant="ghost"
+                                                  size="sm"
+                                                  onClick={() =>
+                                                    cancelRemoveSpot.send()}
+                                                >
+                                                  Cancel
+                                                </cf-button>
+                                              </cf-hstack>
+                                            </cf-vstack>
+                                          </cf-card>
+                                        )
+                                        : null}
+                                    </>
+                                  )}
+                              </cf-card>
+                            );
+                          })}
+
+                          {addSpotFormOpen.get()
+                            ? (
+                              <cf-card style="border: 2px dashed var(--cf-color-gray-200);">
                                 <cf-vstack gap="2">
+                                  <cf-heading level={6}>Add Spot</cf-heading>
                                   <cf-hstack gap="2" wrap>
                                     <cf-vstack gap="1" style="min-width: 60px;">
                                       <span style="font-size: 0.75rem; font-weight: 500;">
                                         Number *
                                       </span>
                                       <cf-input
-                                        $value={editSpotNum}
+                                        $value={newSpotNumber}
                                         placeholder="e.g. 12"
                                         style="width: 4rem;"
                                       />
@@ -2171,7 +2367,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                                         Label
                                       </span>
                                       <cf-input
-                                        $value={editSpotLabel}
+                                        $value={newSpotLabel}
                                         placeholder="e.g. Near entrance"
                                         style="width: 100%;"
                                       />
@@ -2182,222 +2378,43 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                                       Notes
                                     </span>
                                     <cf-input
-                                      $value={editSpotNotes}
-                                      placeholder="e.g. Tight, no large vehicles"
+                                      $value={newSpotNotes}
+                                      placeholder="e.g. Compact only"
                                       style="width: 100%;"
                                     />
                                   </cf-vstack>
-                                  <cf-hstack gap="2" align="center">
-                                    <cf-checkbox $checked={editSpotActive}>
-                                      Active
-                                    </cf-checkbox>
-                                    {spotDeactivateWarning
-                                      ? (
-                                        <span style="font-size: 0.75rem; color: var(--cf-color-amber-600);">
-                                          Has upcoming allocations — they will
-                                          remain.
-                                        </span>
-                                      )
-                                      : null}
-                                  </cf-hstack>
+                                  {computed(() => {
+                                    const err = addSpotError.get();
+                                    if (!err) return null;
+                                    return (
+                                      <span style="font-size: 0.75rem; color: var(--cf-color-red-600);">
+                                        {err}
+                                      </span>
+                                    );
+                                  })}
                                   <cf-hstack gap="2">
                                     <cf-button
                                       variant="primary"
                                       size="sm"
-                                      onClick={() =>
-                                        saveEditSpot.send({
-                                          originalNumber: spotNum2,
-                                        })}
+                                      onClick={() => submitAddSpot.send()}
                                     >
-                                      Save
+                                      Add Spot
                                     </cf-button>
                                     <cf-button
-                                      variant="secondary"
+                                      variant="ghost"
                                       size="sm"
-                                      onClick={() => cancelEditSpot.send()}
+                                      onClick={() => toggleAddSpotForm.send()}
                                     >
                                       Cancel
                                     </cf-button>
                                   </cf-hstack>
                                 </cf-vstack>
-                              )
-                              : (
-                                <>
-                                  <cf-hstack
-                                    justify="between"
-                                    align="center"
-                                    gap="2"
-                                    wrap
-                                  >
-                                    <cf-hstack gap="2" align="center" wrap>
-                                      <span
-                                        style={`font-weight: 700; font-size: 1rem; color: ${
-                                          spotActive2
-                                            ? "var(--cf-color-gray-800)"
-                                            : "var(--cf-color-gray-400)"
-                                        };`}
-                                      >
-                                        #{spotNum2}
-                                      </span>
-                                      <cf-vstack gap="0">
-                                        <span
-                                          style={`font-size: 0.875rem; color: ${
-                                            spotActive2
-                                              ? "var(--cf-color-gray-700)"
-                                              : "var(--cf-color-gray-400)"
-                                          }; text-decoration: ${
-                                            spotActive2
-                                              ? "none"
-                                              : "line-through"
-                                          };`}
-                                        >
-                                          {spotLabel2 || "(no label)"}
-                                        </span>
-                                        {spotNotes2
-                                          ? (
-                                            <span style="font-size: 0.75rem; color: var(--cf-color-gray-400);">
-                                              {spotNotes2}
-                                            </span>
-                                          )
-                                          : null}
-                                      </cf-vstack>
-                                      {!spotActive2
-                                        ? (
-                                          <span style="font-size: 0.6875rem; background-color: #f3f4f6; color: #6b7280; padding: 1px 6px; border-radius: 9999px;">
-                                            Inactive
-                                          </span>
-                                        )
-                                        : null}
-                                    </cf-hstack>
-                                    <cf-hstack gap="1">
-                                      <cf-button
-                                        variant="ghost"
-                                        size="sm"
-                                        onClick={() =>
-                                          startEditSpot.send({
-                                            spotNumber: spotNum2,
-                                          })}
-                                      >
-                                        Edit
-                                      </cf-button>
-                                      <cf-button
-                                        variant="ghost"
-                                        size="sm"
-                                        onClick={() =>
-                                          initiateRemoveSpot.send({
-                                            spotNumber: spotNum2,
-                                          })}
-                                      >
-                                        Remove
-                                      </cf-button>
-                                    </cf-hstack>
-                                  </cf-hstack>
-                                  {isRemoveSpotConfirm
-                                    ? (
-                                      <cf-card style="background: #fef2f2; border: 1px solid #fecaca; margin-top: 0.5rem;">
-                                        <cf-vstack gap="1">
-                                          <span style="font-size: 0.75rem; color: var(--cf-color-red-700);">
-                                            Spot #{spotNum2}{" "}
-                                            has upcoming allocations. They will
-                                            be preserved. Remove anyway?
-                                          </span>
-                                          <cf-hstack gap="2">
-                                            <cf-button
-                                              variant="primary"
-                                              size="sm"
-                                              onClick={() =>
-                                                removeSpot.send({
-                                                  spotNumber: spotNum2,
-                                                })}
-                                            >
-                                              Remove
-                                            </cf-button>
-                                            <cf-button
-                                              variant="ghost"
-                                              size="sm"
-                                              onClick={() =>
-                                                cancelRemoveSpot.send()}
-                                            >
-                                              Cancel
-                                            </cf-button>
-                                          </cf-hstack>
-                                        </cf-vstack>
-                                      </cf-card>
-                                    )
-                                    : null}
-                                </>
-                              )}
-                          </cf-card>
-                        );
-                      })}
-
-                      {addSpotFormOpen.get()
-                        ? (
-                          <cf-card style="border: 2px dashed var(--cf-color-gray-200);">
-                            <cf-vstack gap="2">
-                              <cf-heading level={6}>Add Spot</cf-heading>
-                              <cf-hstack gap="2" wrap>
-                                <cf-vstack gap="1" style="min-width: 60px;">
-                                  <span style="font-size: 0.75rem; font-weight: 500;">
-                                    Number *
-                                  </span>
-                                  <cf-input
-                                    $value={newSpotNumber}
-                                    placeholder="e.g. 12"
-                                    style="width: 4rem;"
-                                  />
-                                </cf-vstack>
-                                <cf-vstack gap="1" style="flex: 1;">
-                                  <span style="font-size: 0.75rem; font-weight: 500;">
-                                    Label
-                                  </span>
-                                  <cf-input
-                                    $value={newSpotLabel}
-                                    placeholder="e.g. Near entrance"
-                                    style="width: 100%;"
-                                  />
-                                </cf-vstack>
-                              </cf-hstack>
-                              <cf-vstack gap="1">
-                                <span style="font-size: 0.75rem; font-weight: 500;">
-                                  Notes
-                                </span>
-                                <cf-input
-                                  $value={newSpotNotes}
-                                  placeholder="e.g. Compact only"
-                                  style="width: 100%;"
-                                />
-                              </cf-vstack>
-                              {computed(() => {
-                                const err = addSpotError.get();
-                                if (!err) return null;
-                                return (
-                                  <span style="font-size: 0.75rem; color: var(--cf-color-red-600);">
-                                    {err}
-                                  </span>
-                                );
-                              })}
-                              <cf-hstack gap="2">
-                                <cf-button
-                                  variant="primary"
-                                  size="sm"
-                                  onClick={() => submitAddSpot.send()}
-                                >
-                                  Add Spot
-                                </cf-button>
-                                <cf-button
-                                  variant="ghost"
-                                  size="sm"
-                                  onClick={() => toggleAddSpotForm.send()}
-                                >
-                                  Cancel
-                                </cf-button>
-                              </cf-hstack>
-                            </cf-vstack>
-                          </cf-card>
-                        )
-                        : null}
-                    </cf-vstack>
+                              </cf-card>
+                            )
+                            : null}
+                        </cf-vstack>
+                      )
+                      : null}
                   </>
                 )
                 : null}

--- a/packages/patterns/factory-outputs/parking-coordinator/main.tsx
+++ b/packages/patterns/factory-outputs/parking-coordinator/main.tsx
@@ -1230,6 +1230,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                 {todayFormatted}
               </span>
               <cf-button
+                id="parking-admin-mode-toggle"
                 variant={adminModeEnabled ? "primary" : "secondary"}
                 size="sm"
                 disabled={!currentPersonIsAdmin}
@@ -1434,6 +1435,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                         : "Cannot manage admins"}
                     />
                     <cf-button
+                      id="parking-enable-admin-manager"
                       size="sm"
                       disabled={currentUserCanManageAdmins}
                       onClick={() => enableAdminManager.send()}
@@ -1457,6 +1459,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                     const rowCanManageAdmins = row.canManageAdmins;
                     return (
                       <cf-hstack
+                        data-parking-admin-row={rowName}
                         justify="between"
                         align="center"
                         gap="2"
@@ -1476,6 +1479,7 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                           </span>
                         </cf-vstack>
                         <cf-button
+                          data-parking-admin-toggle={rowName}
                           size="sm"
                           disabled={!rowCanManageAdmins}
                           onClick={() =>
@@ -1707,10 +1711,11 @@ export default pattern<ParkingCoordinatorInput, ParkingCoordinatorOutput>(
                 ? (
                   <>
                     {/* People */}
-                    <cf-vstack gap="2">
+                    <cf-vstack id="parking-admin-people-section" gap="2">
                       <cf-hstack justify="between" align="center">
                         <cf-heading level={6}>People</cf-heading>
                         <cf-button
+                          id="parking-admin-add-person-open"
                           variant="primary"
                           size="sm"
                           onClick={() => toggleAddPersonForm.send()}

--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -178,6 +178,10 @@ export async function fillCfInput(
               };
             }
 
+            input.scrollIntoView({ block: "center", inline: "center" });
+            await new Promise((resolve) =>
+              requestAnimationFrame(() => requestAnimationFrame(resolve))
+            );
             const rect = input.getBoundingClientRect();
             const style = globalThis.getComputedStyle(input);
             const visible = rect.width > 0 && rect.height > 0 &&
@@ -214,10 +218,6 @@ export async function fillCfInput(
               };
             }
 
-            input.scrollIntoView({ block: "center", inline: "center" });
-            await new Promise((resolve) =>
-              requestAnimationFrame(() => requestAnimationFrame(resolve))
-            );
             input.focus();
             const valueSetter = Object.getOwnPropertyDescriptor(
               HTMLInputElement.prototype,

--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -297,6 +297,128 @@ export async function waitForRuntimeIdle(
   }, { timeout, delay: 250 });
 }
 
+export async function waitForDisabled(
+  page: Page,
+  selector: string,
+  disabled: boolean,
+  { timeout = DEFAULT_CFC_BROWSER_TIMEOUT }: { timeout?: number } = {},
+) {
+  let probe: { disabled?: boolean; selector: string } | undefined;
+  try {
+    await waitFor(async () => {
+      try {
+        const node = await page.waitForSelector(selector, {
+          strategy: "pierce",
+          timeout: 1_000,
+        });
+        probe = await node.evaluate((element: Element) => {
+          const button = element instanceof HTMLButtonElement
+            ? element
+            : element.shadowRoot?.querySelector("button");
+          return {
+            selector: element.tagName.toLowerCase(),
+            disabled: button instanceof HTMLButtonElement
+              ? button.disabled
+              : undefined,
+          };
+        });
+        return probe.disabled === disabled;
+      } catch {
+        return false;
+      }
+    }, { timeout, delay: 250 });
+  } catch (cause) {
+    throw new Error(
+      `Timed out waiting for ${selector} disabled=${disabled}. Last probe: ${
+        toIndentedDebugString(probe)
+      }`,
+      { cause },
+    );
+  }
+}
+
+export async function clickCfButton(
+  page: Page,
+  selector: string,
+  { timeout = DEFAULT_CFC_BROWSER_TIMEOUT }: { timeout?: number } = {},
+) {
+  const token = `cf-button-${crypto.randomUUID()}`;
+  const mark = async () =>
+    await page.evaluate(async (targetSelector, targetToken, targetAttr) => {
+      function collect(
+        root: Document | ShadowRoot,
+        result: Element[],
+      ): void {
+        for (const element of root.querySelectorAll("*")) {
+          try {
+            if (element.matches(targetSelector)) {
+              result.push(element);
+            }
+          } catch {
+            // Invalid selectors are reported by returning false.
+          }
+          if (element.shadowRoot) {
+            collect(element.shadowRoot, result);
+          }
+        }
+      }
+
+      const matches: Element[] = [];
+      collect(document, matches);
+      const target = matches[0] as HTMLElement | undefined;
+      if (!target) {
+        return false;
+      }
+      target.scrollIntoView({ block: "center", inline: "center" });
+      await new Promise((resolve) =>
+        requestAnimationFrame(() => requestAnimationFrame(resolve))
+      );
+      const clickTarget =
+        (target.shadowRoot?.querySelector("[data-cf-button]") as
+          | HTMLElement
+          | null) ?? target;
+      clickTarget.setAttribute(targetAttr, targetToken);
+      return true;
+    }, { args: [selector, token, CLICK_TARGET_ATTR] });
+  try {
+    await waitFor(mark, { timeout, delay: 250 });
+  } catch (cause) {
+    throw new Error(`Unable to mark ${selector} for click`, { cause });
+  }
+  try {
+    const clickTarget = await page.waitForSelector(
+      `[${CLICK_TARGET_ATTR}="${token}"]`,
+      {
+        strategy: "pierce",
+        timeout: 2_000,
+      },
+    );
+    await clickTarget.click();
+  } finally {
+    await page.evaluate((targetToken, targetAttr) => {
+      function collect(
+        root: Document | ShadowRoot,
+        result: Element[],
+      ): void {
+        for (const element of root.querySelectorAll("*")) {
+          if (element.getAttribute(targetAttr) === targetToken) {
+            result.push(element);
+          }
+          if (element.shadowRoot) {
+            collect(element.shadowRoot, result);
+          }
+        }
+      }
+
+      const matches: Element[] = [];
+      collect(document, matches);
+      for (const element of matches) {
+        element.removeAttribute(targetAttr);
+      }
+    }, { args: [token, CLICK_TARGET_ATTR] }).catch(() => {});
+  }
+}
+
 async function textIsPresent(
   page: Page,
   selector: string,

--- a/packages/patterns/integration/cfc-group-chat-demo.test.ts
+++ b/packages/patterns/integration/cfc-group-chat-demo.test.ts
@@ -75,6 +75,7 @@ describe("cfc group chat demo integration test", () => {
     });
     await waitForRuntimeIdle(page);
 
+    await waitForText(page, "#group-chat-manager-chip", "Manager off");
     await waitForDisabled(page, "#trusted-send-button", true);
 
     await scrollIntoView(page, "#trusted-profile-name");
@@ -89,6 +90,11 @@ describe("cfc group chat demo integration test", () => {
     await waitForText(
       page,
       "#trusted-admin-manager-status",
+      "Can manage admins",
+    );
+    await waitForText(
+      page,
+      "#group-chat-manager-chip",
       "Can manage admins",
     );
     await waitForRuntimeIdle(page);

--- a/packages/patterns/integration/cfc-group-chat-demo.test.ts
+++ b/packages/patterns/integration/cfc-group-chat-demo.test.ts
@@ -6,7 +6,9 @@ import { ShellIntegration } from "@commonfabric/integration/shell-utils";
 import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
 import { join } from "@std/path";
 import {
+  clickCfButton,
   fillCfInput,
+  waitForDisabled,
   waitForRuntimeIdle,
   waitForText,
   waitForTextAbsent,
@@ -97,6 +99,11 @@ describe("cfc group chat demo integration test", () => {
       "#group-chat-manager-chip",
       "Can manage admins",
     );
+    await waitForText(
+      page,
+      "#trusted-admin-manager-panel-status",
+      "Admin registry editing enabled",
+    );
     await waitForRuntimeIdle(page);
 
     await scrollIntoView(page, "#trusted-room-name");
@@ -107,11 +114,26 @@ describe("cfc group chat demo integration test", () => {
     );
     await waitForDisabled(page, "#trusted-room-add-button", true);
     await scrollIntoView(page, "#trusted-admin-panel");
+    await waitForText(
+      page,
+      '[data-ui-action="TrustedGroupChatSetAdmin"]',
+      "Make admin",
+    );
+    await waitForDisabled(
+      page,
+      '[data-ui-action="TrustedGroupChatSetAdmin"]',
+      false,
+    );
     await clickCfButton(
       page,
       '[data-ui-action="TrustedGroupChatSetAdmin"]',
     );
     await waitForText(page, "#trusted-admin-user-list", "Admin");
+    await waitForText(
+      page,
+      '[data-ui-action="TrustedGroupChatSetAdmin"]',
+      "Remove admin",
+    );
     await waitForRuntimeIdle(page);
     await fillCfInput(
       page,
@@ -247,121 +269,6 @@ describe("cfc group chat demo integration test", () => {
     );
   });
 });
-
-async function waitForDisabled(
-  page: Page,
-  selector: string,
-  disabled: boolean,
-) {
-  let probe: { disabled?: boolean; selector: string } | undefined;
-  try {
-    await waitFor(async () => {
-      try {
-        const node = await page.waitForSelector(selector, {
-          strategy: "pierce",
-          timeout: 1_000,
-        });
-        probe = await node.evaluate((element: Element) => {
-          const button = element instanceof HTMLButtonElement
-            ? element
-            : element.shadowRoot?.querySelector("button");
-          return {
-            selector: element.tagName.toLowerCase(),
-            disabled: button instanceof HTMLButtonElement
-              ? button.disabled
-              : undefined,
-          };
-        });
-        return probe.disabled === disabled;
-      } catch {
-        return false;
-      }
-    }, { timeout: CFC_GROUP_CHAT_TIMEOUT, delay: 250 });
-  } catch (cause) {
-    throw new Error(
-      `Timed out waiting for ${selector} disabled=${disabled}. Last probe: ${
-        JSON.stringify(probe, null, 2)
-      }`,
-      { cause },
-    );
-  }
-}
-
-async function clickCfButton(page: Page, selector: string) {
-  const token = `cf-button-${crypto.randomUUID()}`;
-  const attr = "data-cfc-click-target";
-  const mark = async () =>
-    await page.evaluate(async (targetSelector, targetToken, targetAttr) => {
-      function collect(
-        root: Document | ShadowRoot,
-        result: Element[],
-      ): void {
-        for (const element of root.querySelectorAll("*")) {
-          try {
-            if (element.matches(targetSelector)) {
-              result.push(element);
-            }
-          } catch {
-            // Invalid selectors are reported by returning false.
-          }
-          if (element.shadowRoot) {
-            collect(element.shadowRoot, result);
-          }
-        }
-      }
-
-      const matches: Element[] = [];
-      collect(document, matches);
-      const target = matches[0] as HTMLElement | undefined;
-      if (!target) {
-        return false;
-      }
-      target.scrollIntoView({ block: "center", inline: "center" });
-      await new Promise((resolve) =>
-        requestAnimationFrame(() => requestAnimationFrame(resolve))
-      );
-      const clickTarget =
-        (target.shadowRoot?.querySelector("[data-cf-button]") as
-          | HTMLElement
-          | null) ?? target;
-      clickTarget.setAttribute(targetAttr, targetToken);
-      return true;
-    }, { args: [selector, token, attr] });
-  try {
-    await waitFor(mark, { timeout: CFC_GROUP_CHAT_TIMEOUT, delay: 250 });
-  } catch (cause) {
-    throw new Error(`Unable to mark ${selector} for click`, { cause });
-  }
-  try {
-    const clickTarget = await page.waitForSelector(`[${attr}="${token}"]`, {
-      strategy: "pierce",
-      timeout: 2_000,
-    });
-    await clickTarget.click();
-  } finally {
-    await page.evaluate((targetToken, targetAttr) => {
-      function collect(
-        root: Document | ShadowRoot,
-        result: Element[],
-      ): void {
-        for (const element of root.querySelectorAll("*")) {
-          if (element.getAttribute(targetAttr) === targetToken) {
-            result.push(element);
-          }
-          if (element.shadowRoot) {
-            collect(element.shadowRoot, result);
-          }
-        }
-      }
-
-      const matches: Element[] = [];
-      collect(document, matches);
-      for (const element of matches) {
-        element.removeAttribute(targetAttr);
-      }
-    }, { args: [token, attr] }).catch(() => {});
-  }
-}
 
 async function scrollIntoView(page: Page, selector: string) {
   const node = await page.waitForSelector(selector, {

--- a/packages/patterns/integration/cfc-group-chat-demo.test.ts
+++ b/packages/patterns/integration/cfc-group-chat-demo.test.ts
@@ -88,6 +88,29 @@ describe("cfc group chat demo integration test", () => {
     await waitForText(page, "#trusted-profile-status", "Alice");
     await waitForRuntimeIdle(page);
 
+    await scrollIntoView(page, "#trusted-room-name");
+    await fillCfInput(
+      page,
+      "#trusted-room-name",
+      "Ops",
+    );
+    await waitForDisabled(page, "#trusted-room-add-button", true);
+    await clickCfButton(page, "#trusted-admin-checkbox");
+    await clickCfButton(page, "#trusted-profile-save");
+    await waitForText(page, "#trusted-admin-status", "Admin");
+    await waitForRuntimeIdle(page);
+    await fillCfInput(
+      page,
+      "#trusted-room-name",
+      "Ops",
+    );
+    await waitForDisabled(page, "#trusted-room-add-button", false);
+    await waitForRuntimeIdle(page);
+    await clickCfButton(page, "#trusted-room-add-button");
+    await waitForRuntimeIdle(page);
+    await waitForText(page, "#rooms-panel", "1 room");
+    await waitForText(page, "#rooms-panel", "Ops");
+
     await scrollIntoView(page, "#host-message-draft");
     await fillCfInput(
       page,

--- a/packages/patterns/integration/cfc-group-chat-demo.test.ts
+++ b/packages/patterns/integration/cfc-group-chat-demo.test.ts
@@ -86,6 +86,11 @@ describe("cfc group chat demo integration test", () => {
     await waitForDisabled(page, "#trusted-profile-save", false);
     await clickCfButton(page, "#trusted-profile-save");
     await waitForText(page, "#trusted-profile-status", "Alice");
+    await waitForText(
+      page,
+      "#trusted-admin-manager-status",
+      "Can manage admins",
+    );
     await waitForRuntimeIdle(page);
 
     await scrollIntoView(page, "#trusted-room-name");
@@ -95,9 +100,12 @@ describe("cfc group chat demo integration test", () => {
       "Ops",
     );
     await waitForDisabled(page, "#trusted-room-add-button", true);
-    await clickCfButton(page, "#trusted-admin-checkbox");
-    await clickCfButton(page, "#trusted-profile-save");
-    await waitForText(page, "#trusted-admin-status", "Admin");
+    await scrollIntoView(page, "#trusted-admin-panel");
+    await clickCfButton(
+      page,
+      '[data-ui-action="TrustedGroupChatSetAdmin"]',
+    );
+    await waitForText(page, "#trusted-admin-user-list", "Admin");
     await waitForRuntimeIdle(page);
     await fillCfInput(
       page,

--- a/packages/patterns/integration/parking-coordinator-admin-view.test.ts
+++ b/packages/patterns/integration/parking-coordinator-admin-view.test.ts
@@ -1,0 +1,134 @@
+import { env } from "@commonfabric/integration";
+import { Identity } from "@commonfabric/identity";
+import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+import { PiecesController } from "@commonfabric/piece/ops";
+import { ShellIntegration } from "@commonfabric/integration/shell-utils";
+import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
+import { join } from "@std/path";
+import {
+  clickCfButton,
+  waitForDisabled,
+  waitForRuntimeIdle,
+  waitForText,
+  waitForTextAbsent,
+} from "./cfc-browser-helpers.ts";
+
+const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
+
+describe("parking coordinator admin view integration test", () => {
+  const shell = new ShellIntegration();
+  shell.bindLifecycle();
+
+  let identity: Identity;
+  let cc: PiecesController;
+  let pieceId: string;
+  let pieceSinkCancel: (() => void) | undefined;
+
+  beforeAll(async () => {
+    identity = await Identity.generate({ implementation: "noble" });
+    cc = await PiecesController.initialize({
+      spaceName: SPACE_NAME,
+      apiUrl: new URL(API_URL),
+      identity,
+    });
+
+    const sourcePath = join(
+      import.meta.dirname!,
+      "..",
+      "factory-outputs",
+      "parking-coordinator",
+      "main.tsx",
+    );
+    const rootPath = join(import.meta.dirname!, "..");
+    const program = await cc.manager().runtime.harness.resolve(
+      new FileSystemProgramResolver(sourcePath, rootPath),
+    );
+    const piece = await cc.create(program, {
+      start: true,
+      input: {
+        spots: [
+          {
+            spotNumber: "1",
+            label: "Near entrance",
+            notes: "",
+            active: true,
+          },
+          { spotNumber: "5", label: "", notes: "", active: true },
+          {
+            spotNumber: "12",
+            label: "Compact only",
+            notes: "Tight, no large vehicles",
+            active: true,
+          },
+        ],
+        people: [
+          {
+            name: "Alice",
+            email: "alice@example.test",
+            commuteMode: "drive",
+            spotPreferences: [],
+            defaultSpot: "",
+            priorityRank: 1,
+          },
+        ],
+        requests: [],
+      },
+    });
+    pieceId = piece.id;
+    const resultCell = cc.manager().getResult(piece.getCell());
+    pieceSinkCancel = resultCell.sink(() => {});
+  });
+
+  afterAll(async () => {
+    pieceSinkCancel?.();
+    await cc?.dispose();
+  });
+
+  it("renders manager and admin controls with the expected enabled states", async () => {
+    const page = shell.page();
+    await shell.goto({
+      frontendUrl: FRONTEND_URL,
+      view: {
+        spaceName: SPACE_NAME,
+        pieceId,
+      },
+      identity,
+    });
+    await waitForRuntimeIdle(page);
+
+    await waitForText(page, "#parking-admin-access", "Alice");
+    await waitForText(page, "#parking-admin-access", "Cannot manage admins");
+    await waitForText(
+      page,
+      '[data-parking-admin-toggle="Alice"]',
+      "Make admin",
+    );
+    await waitForDisabled(page, "#parking-enable-admin-manager", false);
+    await waitForDisabled(page, '[data-parking-admin-toggle="Alice"]', true);
+    await waitForDisabled(page, "#parking-admin-mode-toggle", true);
+    await waitForTextAbsent(page, "#parking-admin-people-section", "People");
+
+    await clickCfButton(page, "#parking-enable-admin-manager");
+    await waitForRuntimeIdle(page);
+    await waitForText(page, "#parking-admin-access", "Can manage admins");
+    await waitForDisabled(page, "#parking-enable-admin-manager", true);
+    await waitForDisabled(page, '[data-parking-admin-toggle="Alice"]', false);
+
+    await clickCfButton(page, '[data-parking-admin-toggle="Alice"]');
+    await waitForRuntimeIdle(page);
+    await waitForText(page, '[data-parking-admin-row="Alice"]', "Admin");
+    await waitForText(
+      page,
+      '[data-parking-admin-toggle="Alice"]',
+      "Remove admin",
+    );
+    await waitForDisabled(page, "#parking-admin-mode-toggle", false);
+    await waitForText(page, "#parking-admin-mode-toggle", "Admin: OFF");
+
+    await clickCfButton(page, "#parking-admin-mode-toggle");
+    await waitForRuntimeIdle(page);
+    await waitForText(page, "#parking-admin-mode-toggle", "Admin: ON");
+    await waitForText(page, "#parking-admin-people-section", "People");
+    await waitForText(page, "#parking-admin-add-person-open", "+ Add Person");
+  });
+});

--- a/packages/patterns/test-ui-helpers.ts
+++ b/packages/patterns/test-ui-helpers.ts
@@ -1,0 +1,96 @@
+import { UI } from "commonfabric";
+
+const isRecord = (value: unknown): value is Record<PropertyKey, unknown> =>
+  typeof value === "object" && value !== null;
+
+const readValue = (value: unknown): unknown => {
+  if (!isRecord(value) || typeof value.get !== "function") {
+    return value;
+  }
+  return (value.get as () => unknown)();
+};
+
+const propsOf = (node: unknown): Record<PropertyKey, unknown> | undefined => {
+  const value = readValue(node);
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const props = readValue(value.props);
+  return isRecord(props) ? props : undefined;
+};
+
+const childrenArray = (children: unknown): unknown[] => {
+  const value = readValue(children);
+  if (Array.isArray(value)) {
+    return value;
+  }
+  return value === undefined || value === null || typeof value === "boolean"
+    ? []
+    : [value];
+};
+
+const childNodes = (node: unknown): unknown[] => {
+  const value = readValue(node);
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (!isRecord(value)) {
+    return [];
+  }
+  const ui = value[UI];
+  return [
+    ...(ui === undefined || ui === value ? [] : [ui]),
+    ...childrenArray(value.children),
+  ];
+};
+
+export const findNodeByProp = (
+  root: unknown,
+  prop: string,
+  expected: unknown,
+): unknown | undefined => {
+  const value = readValue(root);
+  const props = propsOf(value);
+  if (props && readValue(props[prop]) === expected) {
+    return value;
+  }
+  return childNodes(value)
+    .map((child) => findNodeByProp(child, prop, expected))
+    .find((child) => child !== undefined);
+};
+
+export const findNodeById = (
+  root: unknown,
+  id: string,
+): unknown | undefined => findNodeByProp(root, "id", id);
+
+export const propValue = (node: unknown, prop: string): unknown => {
+  const props = propsOf(node);
+  return props ? readValue(props[prop]) : undefined;
+};
+
+const primitiveText = (value: unknown): string => {
+  const resolved = readValue(value);
+  return typeof resolved === "string" || typeof resolved === "number"
+    ? String(resolved)
+    : "";
+};
+
+export const textContent = (node: unknown): string => {
+  const value = readValue(node);
+  if (Array.isArray(value)) {
+    return value.map(textContent).join(" ");
+  }
+  if (!isRecord(value)) {
+    return primitiveText(value);
+  }
+  return [
+    primitiveText(propValue(value, "label")),
+    ...childNodes(value).map(textContent),
+  ].filter((text) => text.length > 0).join(" ");
+};
+
+export const nodeIncludesText = (
+  node: unknown,
+  expected: string,
+): boolean => textContent(node).includes(expected);

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1337,7 +1337,56 @@ const ifcEntryAppliesToAttemptedWrite = (
 ): boolean => {
   const wildcardIndex = path.indexOf("*");
   if (wildcardIndex === -1) {
-    return true;
+    const writes = [...(tx.getWriteDetails?.(target.space) ?? [])];
+    let touched = false;
+    for (const write of writes) {
+      if (write.address.id !== target.id) continue;
+      if (normalizeCellScope(write.address.scope) !== target.scope) continue;
+      if (write.address.path[0] !== "value") continue;
+      const writePath = write.address.path.slice(1).map((entry) =>
+        String(entry)
+      );
+      if (
+        concretePathHasPrefix(path, writePath) ||
+        concretePathHasPrefix(writePath, path)
+      ) {
+        touched = true;
+        break;
+      }
+    }
+    if (!touched) {
+      const reactiveWrites = [
+        ...(tx.getReactivityLog?.().writes ?? []),
+        ...(tx.getReactivityLog?.().attemptedWrites ?? []),
+      ];
+      touched = reactiveWrites.some((write) => {
+        if (write.space !== target.space) return false;
+        if (write.id !== target.id) return false;
+        if (normalizeCellScope(write.scope) !== target.scope) return false;
+        const writePath = canonicalizeLogicalPath(write.path);
+        return concretePathHasPrefix(path, writePath) ||
+          concretePathHasPrefix(writePath, path);
+      });
+    }
+    if (!touched) {
+      return false;
+    }
+    const value = writeValueForTarget(tx, { ...target, path }) ??
+      (() => {
+        try {
+          return tx.readValueOrThrow({ ...target, path }, {
+            meta: INTERNAL_VERIFIER_META,
+          });
+        } catch {
+          return undefined;
+        }
+      })();
+    if (path.length === 0) {
+      return value === undefined ||
+        wildcardPolicyMatchesValue(tx, target, schema, value);
+    }
+    return value !== undefined &&
+      wildcardPolicyMatchesValue(tx, target, schema, value);
   }
 
   const exactAttemptedPaths = [

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1371,19 +1371,23 @@ const ifcEntryAppliesToAttemptedWrite = (
     if (!touched) {
       return false;
     }
-    const value = writeValueForTarget(tx, { ...target, path }) ??
-      (() => {
-        try {
-          return tx.readValueOrThrow({ ...target, path }, {
-            meta: INTERNAL_VERIFIER_META,
-          });
-        } catch {
-          return undefined;
-        }
-      })();
+    const pathTarget = { ...target, path };
+    const written = writeValueForTarget(tx, pathTarget);
+    const value = written !== undefined ? written : (() => {
+      try {
+        return tx.readValueOrThrow(pathTarget, {
+          meta: INTERNAL_VERIFIER_META,
+        });
+      } catch {
+        return undefined;
+      }
+    })();
     if (path.length === 0) {
       return value === undefined ||
         wildcardPolicyMatchesValue(tx, target, schema, value);
+    }
+    if (value === undefined) {
+      return previousWriteValueForTarget(tx, pathTarget) !== undefined;
     }
     return value !== undefined &&
       wildcardPolicyMatchesValue(tx, target, schema, value);

--- a/packages/runner/test/cfc-boundary.test.ts
+++ b/packages/runner/test/cfc-boundary.test.ts
@@ -4021,6 +4021,37 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     }
   });
 
+  it("does not apply exact-path policies for omitted optional fields", async () => {
+    const { runtime, storageManager } = createRuntime();
+    try {
+      const tx = runtime.edit();
+      tx.setCfcEnforcementMode("enforce-explicit");
+      const output = runtime.getCell(
+        signer.did(),
+        "cfc-optional-exact-path-policy",
+        {
+          type: "object",
+          properties: {
+            public: { type: "string" },
+            guarded: {
+              type: "string",
+              ifc: { requiredIntegrity: ["trusted"] },
+            },
+          },
+        },
+        tx,
+      );
+      output.set({ public: "ok" });
+
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.ok).toBeDefined();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
   it("treats unrelated consumed reads as influencing every target path in phase 1", async () => {
     const { runtime, storageManager } = createRuntime();
     try {

--- a/packages/runner/test/cfc-boundary.test.ts
+++ b/packages/runner/test/cfc-boundary.test.ts
@@ -4052,6 +4052,197 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     }
   });
 
+  it("rejects removing an existing protected optional field without required integrity", async () => {
+    const { runtime, storageManager } = createRuntime();
+    try {
+      const schema = {
+        type: "object",
+        properties: {
+          public: { type: "string" },
+          guarded: {
+            type: "string",
+            ifc: { requiredIntegrity: ["trusted"] },
+          },
+        },
+      } as const satisfies JSONSchema;
+
+      const seed = runtime.edit();
+      const sourceId = parseLink(
+        runtime.getCell(
+          signer.did(),
+          "cfc-optional-removal-source",
+          {
+            type: "object",
+            properties: {
+              secret: { type: "string" },
+            },
+          },
+        ).getAsLink(),
+      ).id!;
+      seed.writeOrThrow({
+        space: signer.did(),
+        scope: "space",
+        id: sourceId,
+        path: [],
+      }, {
+        value: { secret: "untrusted" },
+        cfc: {
+          version: 1,
+          schemaHash: "optional-removal-source-schema",
+          labelMap: {
+            version: 1,
+            entries: [{
+              path: ["secret"],
+              label: { integrity: ["untrusted"] },
+            }],
+          },
+        },
+      });
+      const targetId = parseLink(
+        runtime.getCell(
+          signer.did(),
+          "cfc-optional-removal-target",
+          schema,
+        ).getAsLink(),
+      ).id!;
+      seed.writeOrThrow({
+        space: signer.did(),
+        scope: "space",
+        id: targetId,
+        path: [],
+      }, {
+        value: { public: "before", guarded: "old" },
+      });
+      expect((await seed.commit()).ok).toBeDefined();
+
+      const tx = runtime.edit();
+      tx.setCfcEnforcementMode("enforce-explicit");
+      const source = runtime.getCell(
+        signer.did(),
+        "cfc-optional-removal-source",
+        {
+          type: "object",
+          properties: {
+            secret: { type: "string" },
+          },
+        },
+        tx,
+      );
+      expect(source.get()).toEqual({ secret: "untrusted" });
+      tx.markCfcRelevant("stored-input-metadata");
+
+      const output = runtime.getCell(
+        signer.did(),
+        "cfc-optional-removal-target",
+        schema,
+        tx,
+      );
+      output.set({ public: "after" });
+
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error?.message).toContain("requiredIntegrity");
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("evaluates exact-path policies against explicit null writes", async () => {
+    const { runtime, storageManager } = createRuntime();
+    try {
+      const schema = {
+        type: "object",
+        properties: {
+          guarded: {
+            type: "null",
+            ifc: { requiredIntegrity: ["trusted"] },
+          },
+        },
+      } as const satisfies JSONSchema;
+
+      const seed = runtime.edit();
+      const sourceId = parseLink(
+        runtime.getCell(
+          signer.did(),
+          "cfc-null-write-source",
+          {
+            type: "object",
+            properties: {
+              secret: { type: "string" },
+            },
+          },
+        ).getAsLink(),
+      ).id!;
+      seed.writeOrThrow({
+        space: signer.did(),
+        scope: "space",
+        id: sourceId,
+        path: [],
+      }, {
+        value: { secret: "untrusted" },
+        cfc: {
+          version: 1,
+          schemaHash: "null-write-source-schema",
+          labelMap: {
+            version: 1,
+            entries: [{
+              path: ["secret"],
+              label: { integrity: ["untrusted"] },
+            }],
+          },
+        },
+      });
+      const targetId = parseLink(
+        runtime.getCell(
+          signer.did(),
+          "cfc-null-write-target",
+          schema,
+        ).getAsLink(),
+      ).id!;
+      seed.writeOrThrow({
+        space: signer.did(),
+        scope: "space",
+        id: targetId,
+        path: [],
+      }, {
+        value: { guarded: "stale" },
+      });
+      expect((await seed.commit()).ok).toBeDefined();
+
+      const tx = runtime.edit();
+      tx.setCfcEnforcementMode("enforce-explicit");
+      const source = runtime.getCell(
+        signer.did(),
+        "cfc-null-write-source",
+        {
+          type: "object",
+          properties: {
+            secret: { type: "string" },
+          },
+        },
+        tx,
+      );
+      expect(source.get()).toEqual({ secret: "untrusted" });
+      tx.markCfcRelevant("stored-input-metadata");
+
+      const output = runtime.getCell(
+        signer.did(),
+        "cfc-null-write-target",
+        schema,
+        tx,
+      );
+      output.set({ guarded: null });
+
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error?.message).toContain("requiredIntegrity");
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
   it("treats unrelated consumed reads as influencing every target path in phase 1", async () => {
     const { runtime, storageManager } = createRuntime();
     try {


### PR DESCRIPTION
## Summary

Adds CFC-backed admin flows to the group chat demo and extends the same shared admin model to the parking coordinator pattern.

- Adds reusable admin registry helpers for manager credentials, active admin roles, and subject matching.
- Gates group-chat room creation behind `group-chat-admin` integrity and models admin assignment through `group-chat-admin-manager`.
- Adds parking coordinator admin access UI, manager self-nomination for the demo, `parking-admin-manager`-protected admin registry updates, and `parking-admin`-protected spot management.
- Covers non-admin blocked paths and admin-grant flows in pattern tests.

## Validation

- `deno lint`
- `deno task cf check packages/patterns/cfc-group-chat-demo/main.tsx --no-run`
- `deno task cf check packages/patterns/factory-outputs/parking-coordinator/main.tsx --no-run`
- `deno task cf test packages/patterns/cfc-group-chat-demo/main.test.tsx --root packages/patterns`
- `deno task cf test packages/patterns/factory-outputs/parking-coordinator/main.test.tsx --root packages/patterns`
- `deno task test`

NEW_PERF_BASELINE: step: patterns integration = 206s
NEW_PERF_BASELINE: job: Pattern Integration Tests = 236s
NEW_PERF_BASELINE: job: Pattern Integration Tests (2/4) = 236s
NEW_PERF_BASELINE: subtest: pattern-unit-1/pattern-unit-tests > packages/patterns/cfc-group-chat-demo/main.test.tsx = 11s

<!-- This is an auto-generated description by cubic. -->---
## Summary by cubic
Adds CFC-backed admin access to the group chat and parking coordinator demos with shared helpers, admin/manager gating, and integrity-enforced writes. Also bootstraps parking people management so managers can start adding people right away.

- **New Features**
  - Shared admin helpers in `packages/patterns/admin.ts` for role entries, manager credential checks, and subject matching.
  - Group chat: admin registry and manager credential (`group-chat-admin`, `group-chat-admin-manager`); `TrustedAdminPanel`, `TrustedRoomAddSurface` gating room creation by admin integrity; rooms list UI; tests use `packages/patterns/test-ui-helpers.ts`.
  - Parking coordinator: admin registry and manager credential (`parking-admin`, `parking-admin-manager`); “Admin Access” panel with manager self-enable; spot add/edit/remove and admin override require `parking-admin`; admin mode toggle disabled unless current person is admin; registry syncs on person rename/remove; new browser test `packages/patterns/integration/parking-coordinator-admin-view.test.ts`.

- **Bug Fixes**
  - Tightened exact-path CFC enforcement: skip for omitted optional fields, enforce for deletions and explicit null writes, and detect touched subpaths; tests added.
  - Group chat: removed stored message IDs to avoid stale state; profiles stay in sync across views; clarified admin status bindings.
  - Parking coordinator: bootstrap people management so “+ Add Person” is available after manager enable.
  - `packages/patterns/integration/cfc-browser-helpers.ts`: improved stability by scrolling inputs into view; added `waitForDisabled` and `clickCfButton`; tests updated to use them.

<sup>Written for commit 78d8ce88e79711f12965ae1f0074adb15e083ea6. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3645?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->
