### PR TITLE
[codex] Preserve local concise handler arrows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,13 @@ If you are developing runtime code, read the following documentation:
 - `docs/development/debugging/` - Runtime errors, type errors, and
   troubleshooting
 
+When investigating transformer behavior, inspect the emitted output directly
+before inferring from source code alone:
+
+```bash
+deno task cf check <pattern-or-fixture>.tsx --show-transformed --no-run
+```
+
 ### Adding New Packages
 
 When adding a new workspace package:

--- a/docs/specs/ts-transformer/ts_transformers_review_guide.md
+++ b/docs/specs/ts-transformer/ts_transformers_review_guide.md
@@ -90,6 +90,12 @@ does **not** make foreign callback containers themselves part of the language.
 
 ## Files To Review
 
+First diagnostic command when a transformer behavior is surprising:
+
+```bash
+deno task cf check <pattern-or-fixture>.tsx --show-transformed --no-run
+```
+
 - [expression-site-policy.ts](../../../packages/ts-transformers/src/transformers/expression-site-policy.ts)
   - shared expression-site handling decision
 - [call-kind.ts](../../../packages/ts-transformers/src/ast/call-kind.ts)

--- a/packages/ts-transformers/src/transformers/expression-site-lowering.ts
+++ b/packages/ts-transformers/src/transformers/expression-site-lowering.ts
@@ -521,6 +521,12 @@ export function rewritePatternOwnedExpressionSites<T extends ts.Node>(
 
   const visit: ts.Visitor = (node) => {
     if (ts.isVariableDeclaration(node)) {
+      if (
+        node.initializer && isFunctionLikeExpression(node.initializer)
+      ) {
+        return node;
+      }
+
       const visited = visitEachChildWithJsx(node, visit, context.tsContext);
       if (ts.isVariableDeclaration(visited)) {
         markSyntheticReactiveCollectionDeclarationIfNeeded(
@@ -829,6 +835,10 @@ export function rewriteArrayMethodCallbackExpressionSites(
   const rewriteSkippedArrayMethodCallbackInitializer = (
     expression: ts.Expression,
   ): ts.Expression | undefined => {
+    if (isFunctionLikeExpression(expression)) {
+      return undefined;
+    }
+
     if (isControlFlowRewriteExpression(expression)) {
       return undefined;
     }

--- a/packages/ts-transformers/test/pipeline-regressions.test.ts
+++ b/packages/ts-transformers/test/pipeline-regressions.test.ts
@@ -757,6 +757,80 @@ export default pattern<{ values: string[] }>(({ values }) => {
 );
 
 Deno.test(
+  "Pipeline regression: local concise ternary event handlers stay function-valued",
+  async () => {
+    const source =
+      `import { derive, handler, pattern, UI, Writable } from "commonfabric";
+
+interface Item {
+  id: string;
+}
+
+interface Vote {
+  itemId: string;
+  vote: "yes" | "no";
+}
+
+const castVote = handler<{ itemId: string; vote: "yes" }, { votes: Writable<Vote[]> }>(
+  (event, { votes }) => {
+    votes.push(event);
+  },
+);
+
+const clearVote = handler<{ itemId: string }, {}>(() => {});
+
+export default pattern<{ items: Writable<Item[]>; votes: Writable<Vote[]> }>(
+  ({ items, votes }) => {
+    const boundCastVote = castVote({ votes });
+    const boundClearVote = clearVote({});
+
+    return {
+      [UI]: (
+        <div>
+          {items.map((item) => {
+            const iid = item.id;
+            const myVote = derive(
+              { votes, itemId: iid },
+              ({ votes, itemId }) =>
+                votes.get().find((vote) => vote.itemId === itemId)?.vote,
+            );
+
+            const onVoteYes = () =>
+              myVote === "yes"
+                ? boundClearVote.send({ itemId: iid })
+                : boundCastVote.send({ itemId: iid, vote: "yes" });
+
+            return <cf-button onClick={onVoteYes}>yes</cf-button>;
+          })}
+        </div>
+      ),
+    };
+  },
+);
+`;
+
+    const output = await transformSource(source, {
+      types: COMMONFABRIC_TYPES,
+    });
+
+    assertStringIncludes(output, 'const onVoteYes = () => myVote === "yes"');
+    assertStringIncludes(output, "boundClearVote.send({ itemId: iid })");
+    assertStringIncludes(
+      output,
+      'boundCastVote.send({ itemId: iid, vote: "yes" })',
+    );
+    assert(
+      !output.includes("const onVoteYes = __cfHelpers.derive("),
+      "local event handler variable must not become a derive cell containing a function",
+    );
+    assert(
+      !output.includes("=> () => __cfHelpers.ifElse("),
+      "local event handler body must keep imperative ternary semantics",
+    );
+  },
+);
+
+Deno.test(
   "Pipeline regression: helper-owned IIFE local cell reads lower before use",
   async () => {
     const source = `import { pattern, UI, Writable } from "commonfabric";


### PR DESCRIPTION
## Summary

Fixes CT-1612 by preventing expression-site lowering from treating function-valued local variable initializers as reactive expression values.

When a mapped JSX handler is authored as a local concise-body arrow, for example:

```ts
const onVoteYes = () => myVote === "yes"
  ? boundClearVote.send({ itemId: iid })
  : boundCastVote.send({ itemId: iid, vote: "yes" });

return <cf-button onClick={onVoteYes}>yes</cf-button>;
```

the transformer previously rewrote the handler variable into `__cfHelpers.derive(...)`, producing a reactive cell whose value was a function. At runtime that surfaced as `Action returned a function` and the click did not fire.

## What Changed

- Preserve function-like variable initializers in pattern-owned expression-site lowering.
- Skip array-method callback local-initializer wrapping when the initializer itself is function-like.
- Add a pipeline regression covering a local concise-body ternary handler passed to `onClick`.
- Add agent-facing docs that call out `deno task cf check <file> --show-transformed --no-run` as the first diagnostic command for transformer investigations.

## Validation

- `/Users/gideonwald/.deno/bin/deno task cf check tmp/ct1612-onclick-ternary.tsx --show-transformed --no-run` confirmed the handler remains a plain arrow in emitted output.
- `/Users/gideonwald/.deno/bin/deno task test --filter "local concise ternary event handlers"`
- `/Users/gideonwald/.deno/bin/deno test --allow-read --allow-write --allow-env test/fixture-based.test.ts`
- `/Users/gideonwald/.deno/bin/deno task test` in `packages/ts-transformers` passed: 289 tests / 622 steps.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CT-1612 by preserving local concise arrow handlers so `onClick` works as expected. Avoids lowering these handlers into function-valued reactive cells.

- **Bug Fixes**
  - Preserve function-like variable initializers during pattern-owned expression-site lowering.
  - Skip wrapping array-method callback initializers when they are function-like.
  - Add a regression test for a local ternary handler passed to `onClick`, and a docs note on `deno task cf check <file> --show-transformed --no-run`.

<sup>Written for commit d29d54904a1f96d8dfb992f7ae69a7fe05c6c89f. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3648?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

