### PR TITLE
Fix cf-screen footer tab bar layout

### DIFF
--- a/packages/patterns/catalog/stories/cf-tab-bar-story.tsx
+++ b/packages/patterns/catalog/stories/cf-tab-bar-story.tsx
@@ -12,6 +12,7 @@ export default pattern<TabBarStoryInput, TabBarStoryOutput>(() => {
   const activeTab1 = new Writable("home");
   const activeTab2 = new Writable("home");
   const activeTab3 = new Writable("home");
+  const activeTab4 = new Writable("home");
 
   const items = (
     <>
@@ -110,6 +111,59 @@ export default pattern<TabBarStoryInput, TabBarStoryOutput>(() => {
                 &#65291;
               </cf-button>
             </cf-tab-bar>
+          </div>
+        </cf-vstack>
+
+        <cf-vstack gap="2">
+          <cf-heading level={5}>Inset footer in cf-screen</cf-heading>
+          <span style="font-size: 13px; color: #6b7280;">
+            The screen footer reserves room for the floating tab bar.
+          </span>
+          <div
+            style={{
+              height: "360px",
+              background: "#f0f4f8",
+              border: "1px solid #dbe3ec",
+              borderRadius: "8px",
+              overflow: "hidden",
+            }}
+          >
+            <cf-screen style="height: 100%;">
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: "10px",
+                  padding: "12px",
+                }}
+              >
+                {[
+                  "Morning sync",
+                  "Review launch checklist",
+                  "Triage customer thread",
+                  "Write design notes",
+                  "Confirm footer spacing",
+                  "Last visible card",
+                ].map((title) => (
+                  <cf-card>
+                    <cf-vstack gap="1">
+                      <cf-text variant="body-compact">{title}</cf-text>
+                      <cf-text variant="caption" tone="muted">
+                        Content remains above the reserved footer area.
+                      </cf-text>
+                    </cf-vstack>
+                  </cf-card>
+                ))}
+              </div>
+
+              <cf-tab-bar
+                $value={activeTab4}
+                slot="footer"
+                variant="inset"
+              >
+                {items}
+              </cf-tab-bar>
+            </cf-screen>
           </div>
         </cf-vstack>
       </cf-vstack>

--- a/packages/ui/src/v2/components/cf-screen/cf-screen.ts
+++ b/packages/ui/src/v2/components/cf-screen/cf-screen.ts
@@ -10,6 +10,8 @@ import { BaseElement } from "../../core/base-element.ts";
  * @slot main - Main content that expands to fill available space (default slot)
  * @slot footer - Fixed footer content at the bottom
  *
+ * @cssprop --cf-screen-footer-fade-height - Height of the main content fade when the footer contains an inset cf-tab-bar.
+ *
  * @example
  * <cf-screen>
  *   <h1 slot="header">Title</h1>
@@ -40,10 +42,47 @@ export class CFScreen extends BaseElement {
       overflow-x: hidden;
     }
 
+    :host([data-footer-fade]) .main {
+      --_cf-screen-footer-fade-height: var(
+        --cf-screen-footer-fade-height,
+        calc(var(--cf-tab-bar-height, 4rem) / 2)
+      );
+      -webkit-mask-image: linear-gradient(
+        to bottom,
+        black 0,
+        black calc(100% - var(--_cf-screen-footer-fade-height)),
+        transparent 100%
+      );
+      mask-image: linear-gradient(
+        to bottom,
+        black 0,
+        black calc(100% - var(--_cf-screen-footer-fade-height)),
+        transparent 100%
+      );
+    }
+
     .footer {
       flex: none;
     }
   `;
+
+  override firstUpdated() {
+    this._syncFooterFade();
+  }
+
+  private _syncFooterFade = () => {
+    const footerSlot = this.shadowRoot?.querySelector<HTMLSlotElement>(
+      'slot[name="footer"]',
+    );
+    const hasFooterFade = footerSlot?.assignedElements({ flatten: true }).some(
+      (element) =>
+        element.localName === "cf-tab-bar" &&
+        element.getAttribute("variant") === "inset" &&
+        element.getAttribute("position") !== "top",
+    ) ?? false;
+
+    this.toggleAttribute("data-footer-fade", hasFooterFade);
+  };
 
   override render() {
     return html`
@@ -54,7 +93,7 @@ export class CFScreen extends BaseElement {
         <slot></slot>
       </div>
       <div class="footer" part="footer">
-        <slot name="footer"></slot>
+        <slot name="footer" @slotchange="${this._syncFooterFade}"></slot>
       </div>
     `;
   }

--- a/packages/ui/src/v2/components/cf-screen/cf-screen.ts
+++ b/packages/ui/src/v2/components/cf-screen/cf-screen.ts
@@ -23,6 +23,11 @@ import { BaseElement } from "../../core/base-element.ts";
 export class CFScreen extends BaseElement {
   static override styles = css`
     :host {
+      /* CT-1613 footer tab-bar tuning defaults. Edit these while dialing
+        the reserved footer overlap and fade before committing final values. */
+      --_cf-screen-footer-overlap-default: 4rem;
+      --_cf-screen-footer-fade-height-default: 2rem;
+
       display: flex;
       flex-direction: column;
       height: 100%;
@@ -46,11 +51,14 @@ export class CFScreen extends BaseElement {
     :host([data-footer-fade]) .main {
       --_cf-screen-footer-overlap: var(
         --cf-screen-footer-overlap,
-        var(--cf-tab-bar-height, 4rem)
+        var(
+          --cf-tab-bar-height,
+          var(--_cf-screen-footer-overlap-default)
+        )
       );
       --_cf-screen-footer-fade-height: var(
         --cf-screen-footer-fade-height,
-        calc(var(--_cf-screen-footer-overlap) / 2)
+        var(--_cf-screen-footer-fade-height-default)
       );
       margin-bottom: calc(-1 * var(--_cf-screen-footer-overlap));
       padding-bottom: var(--_cf-screen-footer-overlap);

--- a/packages/ui/src/v2/components/cf-screen/cf-screen.ts
+++ b/packages/ui/src/v2/components/cf-screen/cf-screen.ts
@@ -23,8 +23,7 @@ import { BaseElement } from "../../core/base-element.ts";
 export class CFScreen extends BaseElement {
   static override styles = css`
     :host {
-      /* CT-1613 footer tab-bar tuning defaults. Edit these while dialing
-        the reserved footer overlap and fade before committing final values. */
+      /* Internal fallback defaults for footer tab-bar overlap and fade. */
       --_cf-screen-footer-overlap-default: 4rem;
       --_cf-screen-footer-fade-height-default: 2rem;
 

--- a/packages/ui/src/v2/components/cf-screen/cf-screen.ts
+++ b/packages/ui/src/v2/components/cf-screen/cf-screen.ts
@@ -11,6 +11,7 @@ import { BaseElement } from "../../core/base-element.ts";
  * @slot footer - Fixed footer content at the bottom
  *
  * @cssprop --cf-screen-footer-fade-height - Height of the main content fade when the footer contains an inset cf-tab-bar.
+ * @cssprop --cf-screen-footer-overlap - Distance the main scroller overlaps into an inset cf-tab-bar footer.
  *
  * @example
  * <cf-screen>
@@ -43,10 +44,16 @@ export class CFScreen extends BaseElement {
     }
 
     :host([data-footer-fade]) .main {
+      --_cf-screen-footer-overlap: var(
+        --cf-screen-footer-overlap,
+        var(--cf-tab-bar-height, 4rem)
+      );
       --_cf-screen-footer-fade-height: var(
         --cf-screen-footer-fade-height,
-        calc(var(--cf-tab-bar-height, 4rem) / 2)
+        calc(var(--_cf-screen-footer-overlap) / 2)
       );
+      margin-bottom: calc(-1 * var(--_cf-screen-footer-overlap));
+      padding-bottom: var(--_cf-screen-footer-overlap);
       -webkit-mask-image: linear-gradient(
         to bottom,
         black 0,

--- a/packages/ui/src/v2/components/cf-screen/cf-screen.ts
+++ b/packages/ui/src/v2/components/cf-screen/cf-screen.ts
@@ -10,8 +10,8 @@ import { BaseElement } from "../../core/base-element.ts";
  * @slot main - Main content that expands to fill available space (default slot)
  * @slot footer - Fixed footer content at the bottom
  *
- * @cssprop --cf-screen-footer-fade-height - Height of the main content fade when the footer contains an inset cf-tab-bar.
- * @cssprop --cf-screen-footer-overlap - Distance the main scroller overlaps into an inset cf-tab-bar footer.
+ * @cssprop --cf-screen-footer-overlap - Distance the main scroller overlaps into reserved inset footer space. Increase this to move the fade lower into the footer region.
+ * @cssprop --cf-screen-footer-fade-height - Height of the main content fade at the bottom of the overlapped scroller region.
  *
  * @example
  * <cf-screen>

--- a/packages/ui/src/v2/components/cf-tab-bar/cf-tab-bar-layout.browser.test.ts
+++ b/packages/ui/src/v2/components/cf-tab-bar/cf-tab-bar-layout.browser.test.ts
@@ -93,6 +93,9 @@ Deno.test("cf-screen reserves space for footer-slotted inset cf-tab-bar", async 
     assertEquals(getComputedStyle(tabBar).position, "relative");
 
     const fadeStyle = getComputedStyle(tabBar, "::before");
+    const mainStyle = getComputedStyle(main);
+    const mainMaskImage = mainStyle.maskImage ||
+      mainStyle.webkitMaskImage;
     const mainRect = main.getBoundingClientRect();
     const footerRect = footer.getBoundingClientRect();
     const tabBarRect = tabBar.getBoundingClientRect();
@@ -101,9 +104,19 @@ Deno.test("cf-screen reserves space for footer-slotted inset cf-tab-bar", async 
 
     assertEquals(fadeStyle.content, '""');
     assertEquals(fadeStyle.position, "absolute");
+    assertEquals(fadeStyle.top, "0px");
     assert(fadeStyle.backgroundImage.includes("linear-gradient"));
+    assert(fadeStyle.backgroundImage.includes("rgba(240, 244, 248, 0)"));
     assert(fadeStyle.backgroundImage.includes("rgb(240, 244, 248)"));
+    assert(fadeStyle.backgroundImage.includes("50%"));
+    assert(mainMaskImage.includes("linear-gradient"), mainMaskImage);
+    assert(
+      mainMaskImage.includes("transparent") ||
+        /rgba\(0,\s*0,\s*0,\s*0\)/.test(mainMaskImage),
+      mainMaskImage,
+    );
     assertAlmostEquals(tabBarRect.height, 80, 0.5);
+    assertAlmostEquals(parseFloat(fadeStyle.height), tabBarRect.height, 0.5);
     assertAlmostEquals(footerRect.height, 80, 0.5);
     assert(
       mainRect.bottom <= footerRect.top + 0.5,

--- a/packages/ui/src/v2/components/cf-tab-bar/cf-tab-bar-layout.browser.test.ts
+++ b/packages/ui/src/v2/components/cf-tab-bar/cf-tab-bar-layout.browser.test.ts
@@ -92,7 +92,6 @@ Deno.test("cf-screen reserves space for footer-slotted inset cf-tab-bar", async 
     assert(container);
     assertEquals(getComputedStyle(tabBar).position, "relative");
 
-    const fadeStyle = getComputedStyle(tabBar, "::before");
     const mainStyle = getComputedStyle(main);
     const mainMaskImage = mainStyle.maskImage ||
       mainStyle.webkitMaskImage;
@@ -102,26 +101,17 @@ Deno.test("cf-screen reserves space for footer-slotted inset cf-tab-bar", async 
     const fixtureRect = fixture.getBoundingClientRect();
     const containerRect = container.getBoundingClientRect();
 
-    assertEquals(fadeStyle.content, '""');
-    assertEquals(fadeStyle.position, "absolute");
-    assertEquals(fadeStyle.top, "0px");
-    assert(fadeStyle.backgroundImage.includes("linear-gradient"));
-    assert(fadeStyle.backgroundImage.includes("rgba(240, 244, 248, 0)"));
-    assert(fadeStyle.backgroundImage.includes("rgb(240, 244, 248)"));
-    assert(fadeStyle.backgroundImage.includes("50%"));
     assert(mainMaskImage.includes("linear-gradient"), mainMaskImage);
     assert(
       mainMaskImage.includes("transparent") ||
         /rgba\(0,\s*0,\s*0,\s*0\)/.test(mainMaskImage),
       mainMaskImage,
     );
+    assertAlmostEquals(parseFloat(mainStyle.paddingBottom), 64, 0.5);
+    assertAlmostEquals(parseFloat(mainStyle.marginBottom), -64, 0.5);
     assertAlmostEquals(tabBarRect.height, 80, 0.5);
-    assertAlmostEquals(parseFloat(fadeStyle.height), tabBarRect.height, 0.5);
     assertAlmostEquals(footerRect.height, 80, 0.5);
-    assert(
-      mainRect.bottom <= footerRect.top + 0.5,
-      `main bottom ${mainRect.bottom} should not overlap footer top ${footerRect.top}`,
-    );
+    assertAlmostEquals(mainRect.bottom - footerRect.top, 64, 0.5);
     assertAlmostEquals(fixtureRect.bottom - containerRect.bottom, 16, 0.5);
   } finally {
     fixture.remove();

--- a/packages/ui/src/v2/components/cf-tab-bar/cf-tab-bar-layout.browser.test.ts
+++ b/packages/ui/src/v2/components/cf-tab-bar/cf-tab-bar-layout.browser.test.ts
@@ -92,12 +92,17 @@ Deno.test("cf-screen reserves space for footer-slotted inset cf-tab-bar", async 
     assert(container);
     assertEquals(getComputedStyle(tabBar).position, "relative");
 
+    const fadeStyle = getComputedStyle(tabBar, "::before");
     const mainRect = main.getBoundingClientRect();
     const footerRect = footer.getBoundingClientRect();
     const tabBarRect = tabBar.getBoundingClientRect();
     const fixtureRect = fixture.getBoundingClientRect();
     const containerRect = container.getBoundingClientRect();
 
+    assertEquals(fadeStyle.content, '""');
+    assertEquals(fadeStyle.position, "absolute");
+    assert(fadeStyle.backgroundImage.includes("linear-gradient"));
+    assert(fadeStyle.backgroundImage.includes("rgb(240, 244, 248)"));
     assertAlmostEquals(tabBarRect.height, 80, 0.5);
     assertAlmostEquals(footerRect.height, 80, 0.5);
     assert(

--- a/packages/ui/src/v2/components/cf-tab-bar/cf-tab-bar-layout.browser.test.ts
+++ b/packages/ui/src/v2/components/cf-tab-bar/cf-tab-bar-layout.browser.test.ts
@@ -1,0 +1,111 @@
+import { assert, assertAlmostEquals, assertEquals } from "@std/assert";
+import "../cf-screen/cf-screen.ts";
+import "./cf-tab-bar.ts";
+import "./cf-tab-bar-item.ts";
+
+type UpdatingElement = HTMLElement & {
+  updateComplete: Promise<unknown>;
+};
+
+async function settleLayout(root: ParentNode): Promise<void> {
+  const elements = Array.from(
+    root.querySelectorAll("cf-screen, cf-tab-bar, cf-tab-bar-item"),
+  ) as UpdatingElement[];
+
+  await Promise.all(elements.map((element) => element.updateComplete));
+  await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+  await Promise.all(elements.map((element) => element.updateComplete));
+  await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+}
+
+Deno.test("cf-tab-bar remains fixed when used standalone", async () => {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const tabBar = document.createElement("cf-tab-bar");
+  tabBar.innerHTML = `
+    <cf-tab-bar-item value="home" label="Home"></cf-tab-bar-item>
+  `;
+  document.body.append(tabBar);
+
+  try {
+    await settleLayout(document.body);
+
+    assertEquals(getComputedStyle(tabBar).position, "fixed");
+  } finally {
+    tabBar.remove();
+  }
+});
+
+Deno.test("cf-screen reserves space for footer-slotted inset cf-tab-bar", async () => {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const fixture = document.createElement("div");
+  fixture.style.cssText = [
+    "position: fixed",
+    "top: 0",
+    "left: 0",
+    "width: 390px",
+    "height: 600px",
+    "margin: 0",
+    "padding: 0",
+  ].join(";");
+  fixture.innerHTML = `
+    <cf-screen
+      id="screen"
+      style="--cf-tab-bar-height: 64px; --cf-tab-bar-inset-margin: 16px;"
+    >
+      <div id="content" style="height: 1000px; flex: 0 0 auto;">
+        Main content
+      </div>
+      <cf-tab-bar
+        id="tab-bar"
+        slot="footer"
+        variant="inset"
+        position="bottom"
+      >
+        <cf-tab-bar-item value="home" label="Home"></cf-tab-bar-item>
+        <cf-tab-bar-item value="search" label="Search"></cf-tab-bar-item>
+        <cf-tab-bar-item value="inbox" label="Inbox"></cf-tab-bar-item>
+        <cf-tab-bar-item value="profile" label="Profile"></cf-tab-bar-item>
+      </cf-tab-bar>
+    </cf-screen>
+  `;
+  document.body.append(fixture);
+
+  try {
+    await settleLayout(fixture);
+
+    const screen = fixture.querySelector("#screen") as HTMLElement;
+    const tabBar = fixture.querySelector("#tab-bar") as HTMLElement;
+    const main = screen.shadowRoot?.querySelector(".main") as HTMLElement;
+    const footer = screen.shadowRoot?.querySelector(".footer") as HTMLElement;
+    const container = tabBar.shadowRoot?.querySelector(
+      ".container",
+    ) as HTMLElement;
+
+    assert(main);
+    assert(footer);
+    assert(container);
+    assertEquals(getComputedStyle(tabBar).position, "relative");
+
+    const mainRect = main.getBoundingClientRect();
+    const footerRect = footer.getBoundingClientRect();
+    const tabBarRect = tabBar.getBoundingClientRect();
+    const fixtureRect = fixture.getBoundingClientRect();
+    const containerRect = container.getBoundingClientRect();
+
+    assertAlmostEquals(tabBarRect.height, 80, 0.5);
+    assertAlmostEquals(footerRect.height, 80, 0.5);
+    assert(
+      mainRect.bottom <= footerRect.top + 0.5,
+      `main bottom ${mainRect.bottom} should not overlap footer top ${footerRect.top}`,
+    );
+    assertAlmostEquals(fixtureRect.bottom - containerRect.bottom, 16, 0.5);
+  } finally {
+    fixture.remove();
+  }
+});

--- a/packages/ui/src/v2/components/cf-tab-bar/cf-tab-bar.ts
+++ b/packages/ui/src/v2/components/cf-tab-bar/cf-tab-bar.ts
@@ -50,8 +50,7 @@ export class CFTabBar extends BaseElement {
     BaseElement.baseStyles,
     css`
       :host {
-        /* CT-1613 footer layout tuning defaults. Edit these while dialing
-          the footer reservation before committing final values. */
+        /* Internal fallback defaults for footer tab-bar spacing. */
         --_cf-tab-bar-height-default: 4rem;
         --_cf-tab-bar-inset-margin-default: 1rem;
         --_cf-tab-bar-height: var(
@@ -102,12 +101,12 @@ export class CFTabBar extends BaseElement {
       }
 
       /* Default: bar spans full width with top/bottom border */
-      :host([position="bottom"]) .bar {
+      :host([position="bottom"]:not([variant="inset"])) .bar {
         border-top: 1px solid
           var(--cf-tab-bar-border-color, var(--cf-theme-color-border, #e5e7eb));
         }
 
-        :host([position="top"]) .bar {
+        :host([position="top"]:not([variant="inset"])) .bar {
           border-bottom: 1px solid
             var(--cf-tab-bar-border-color, var(--cf-theme-color-border, #e5e7eb));
           }

--- a/packages/ui/src/v2/components/cf-tab-bar/cf-tab-bar.ts
+++ b/packages/ui/src/v2/components/cf-tab-bar/cf-tab-bar.ts
@@ -27,6 +27,9 @@ import type { CFTabBarItem } from "./cf-tab-bar-item.ts";
  * @csspart bar - The nav pill surface containing the navigation items.
  * @csspart action - The wrapper around the action slot. Hidden when the slot is empty.
  *
+ * @cssprop --cf-tab-bar-footer-fade-background - Background color used by the footer-slot fade.
+ * @cssprop --cf-tab-bar-footer-fade-height - Height of the fade above a footer-slotted inset bar.
+ *
  * @example
  * const activeTab = cell("home");
  * <cf-tab-bar $value={activeTab}>
@@ -183,11 +186,32 @@ export class CFTabBar extends BaseElement {
             );
           }
 
+          :host([slot="footer"][variant="inset"][position="bottom"])::before {
+            content: "";
+            position: absolute;
+            left: 0;
+            right: 0;
+            top: calc(-1 * var(--cf-tab-bar-footer-fade-height, 5rem));
+            height: calc(100% + var(--cf-tab-bar-footer-fade-height, 5rem));
+            pointer-events: none;
+            z-index: 0;
+            background: linear-gradient(
+              to bottom,
+              transparent 0%,
+              var(--cf-tab-bar-footer-fade-background, rgb(240, 244, 248)) 72%
+            );
+          }
+
           :host([slot="footer"][variant="inset"][position="top"]) {
             top: auto;
             padding-top: calc(
               var(--cf-tab-bar-inset-margin, 1rem) + env(safe-area-inset-top, 0px)
             );
+          }
+
+          :host([slot="footer"][variant="inset"]) .container {
+            position: relative;
+            z-index: 1;
           }
 
           /* === Reduced Motion === */

--- a/packages/ui/src/v2/components/cf-tab-bar/cf-tab-bar.ts
+++ b/packages/ui/src/v2/components/cf-tab-bar/cf-tab-bar.ts
@@ -6,7 +6,11 @@ import { createStringCellController } from "../../core/cell-controller.ts";
 import type { CFTabBarItem } from "./cf-tab-bar-item.ts";
 
 /**
- * CFTabBar - Fixed-position navigation bar for mobile and app-like UIs
+ * CFTabBar - Navigation bar for mobile and app-like UIs
+ *
+ * The bar is fixed-position by default. When placed in a `slot="footer"`,
+ * it participates in layout so containers such as `cf-screen` can reserve
+ * space for the footer chrome.
  *
  * @element cf-tab-bar
  *
@@ -70,7 +74,7 @@ export class CFTabBar extends BaseElement {
         padding-inline: var(--cf-spacing-2, 0.5rem);
       }
 
-      /* === Bar (nav items) — always the visual surface === */
+      /* === Bar (nav items) - always the visual surface === */
       .bar {
         display: flex;
         align-items: center;
@@ -82,12 +86,12 @@ export class CFTabBar extends BaseElement {
       }
 
       /* Default: bar spans full width with top/bottom border */
-      :host(:not([variant="inset"])[position="bottom"]) .bar {
+      :host([position="bottom"]) .bar {
         border-top: 1px solid
           var(--cf-tab-bar-border-color, var(--cf-theme-color-border, #e5e7eb));
         }
 
-        :host(:not([variant="inset"])[position="top"]) .bar {
+        :host([position="top"]) .bar {
           border-bottom: 1px solid
             var(--cf-tab-bar-border-color, var(--cf-theme-color-border, #e5e7eb));
           }
@@ -162,6 +166,28 @@ export class CFTabBar extends BaseElement {
           :host([variant="inset"]) ::slotted(cf-tab-bar-item) {
             flex: 0 0 auto;
             min-width: 3.5rem;
+          }
+
+          :host([slot="footer"]) {
+            position: relative;
+            top: auto;
+            right: auto;
+            bottom: auto;
+            left: auto;
+          }
+
+          :host([slot="footer"][variant="inset"][position="bottom"]) {
+            bottom: auto;
+            padding-bottom: calc(
+              var(--cf-tab-bar-inset-margin, 1rem) + env(safe-area-inset-bottom, 0px)
+            );
+          }
+
+          :host([slot="footer"][variant="inset"][position="top"]) {
+            top: auto;
+            padding-top: calc(
+              var(--cf-tab-bar-inset-margin, 1rem) + env(safe-area-inset-top, 0px)
+            );
           }
 
           /* === Reduced Motion === */

--- a/packages/ui/src/v2/components/cf-tab-bar/cf-tab-bar.ts
+++ b/packages/ui/src/v2/components/cf-tab-bar/cf-tab-bar.ts
@@ -27,8 +27,8 @@ import type { CFTabBarItem } from "./cf-tab-bar-item.ts";
  * @csspart bar - The nav pill surface containing the navigation items.
  * @csspart action - The wrapper around the action slot. Hidden when the slot is empty.
  *
- * @cssprop --cf-tab-bar-footer-fade-background - Background color used by the footer-slot fade.
- * @cssprop --cf-tab-bar-footer-fade-height - Height of the fade above a footer-slotted inset bar.
+ * @cssprop --cf-tab-bar-footer-fade-background - Opaque background color used by the footer-slot fade.
+ * @cssprop --cf-tab-bar-footer-fade-transparent - Transparent background color used by the footer-slot fade.
  *
  * @example
  * const activeTab = cell("home");
@@ -189,16 +189,17 @@ export class CFTabBar extends BaseElement {
           :host([slot="footer"][variant="inset"][position="bottom"])::before {
             content: "";
             position: absolute;
-            left: 0;
-            right: 0;
-            top: calc(-1 * var(--cf-tab-bar-footer-fade-height, 5rem));
-            height: calc(100% + var(--cf-tab-bar-footer-fade-height, 5rem));
+            inset: 0;
             pointer-events: none;
             z-index: 0;
             background: linear-gradient(
               to bottom,
-              transparent 0%,
-              var(--cf-tab-bar-footer-fade-background, rgb(240, 244, 248)) 72%
+              var(
+                --cf-tab-bar-footer-fade-transparent,
+                rgba(240, 244, 248, 0)
+              ) 0%,
+              var(--cf-tab-bar-footer-fade-background, rgb(240, 244, 248)) 50%,
+              var(--cf-tab-bar-footer-fade-background, rgb(240, 244, 248)) 100%
             );
           }
 

--- a/packages/ui/src/v2/components/cf-tab-bar/cf-tab-bar.ts
+++ b/packages/ui/src/v2/components/cf-tab-bar/cf-tab-bar.ts
@@ -50,6 +50,19 @@ export class CFTabBar extends BaseElement {
     BaseElement.baseStyles,
     css`
       :host {
+        /* CT-1613 footer layout tuning defaults. Edit these while dialing
+          the footer reservation before committing final values. */
+        --_cf-tab-bar-height-default: 4rem;
+        --_cf-tab-bar-inset-margin-default: 1rem;
+        --_cf-tab-bar-height: var(
+          --cf-tab-bar-height,
+          var(--_cf-tab-bar-height-default)
+        );
+        --_cf-tab-bar-inset-margin: var(
+          --cf-tab-bar-inset-margin,
+          var(--_cf-tab-bar-inset-margin-default)
+        );
+
         display: block;
         position: fixed;
         z-index: var(--cf-tab-bar-z-index, 50);
@@ -72,7 +85,7 @@ export class CFTabBar extends BaseElement {
         display: flex;
         align-items: center;
         justify-content: center;
-        height: var(--cf-tab-bar-height, 4rem);
+        height: var(--_cf-tab-bar-height);
         gap: var(--cf-spacing-2, 0.5rem);
         padding-inline: var(--cf-spacing-2, 0.5rem);
       }
@@ -128,14 +141,12 @@ export class CFTabBar extends BaseElement {
 
           :host([variant="inset"][position="bottom"]) {
             bottom: calc(
-              var(--cf-tab-bar-inset-margin, 1rem) + env(safe-area-inset-bottom, 0px)
+              var(--_cf-tab-bar-inset-margin) + env(safe-area-inset-bottom, 0px)
             );
           }
 
           :host([variant="inset"][position="top"]) {
-            top: calc(
-              var(--cf-tab-bar-inset-margin, 1rem) + env(safe-area-inset-top, 0px)
-            );
+            top: calc(var(--_cf-tab-bar-inset-margin) + env(safe-area-inset-top, 0px));
           }
 
           :host([variant="inset"]) .container {
@@ -183,14 +194,14 @@ export class CFTabBar extends BaseElement {
           :host([slot="footer"][variant="inset"][position="bottom"]) {
             bottom: auto;
             padding-bottom: calc(
-              var(--cf-tab-bar-inset-margin, 1rem) + env(safe-area-inset-bottom, 0px)
+              var(--_cf-tab-bar-inset-margin) + env(safe-area-inset-bottom, 0px)
             );
           }
 
           :host([slot="footer"][variant="inset"][position="top"]) {
             top: auto;
             padding-top: calc(
-              var(--cf-tab-bar-inset-margin, 1rem) + env(safe-area-inset-top, 0px)
+              var(--_cf-tab-bar-inset-margin) + env(safe-area-inset-top, 0px)
             );
           }
 

--- a/packages/ui/src/v2/components/cf-tab-bar/cf-tab-bar.ts
+++ b/packages/ui/src/v2/components/cf-tab-bar/cf-tab-bar.ts
@@ -27,6 +27,9 @@ import type { CFTabBarItem } from "./cf-tab-bar-item.ts";
  * @csspart bar - The nav pill surface containing the navigation items.
  * @csspart action - The wrapper around the action slot. Hidden when the slot is empty.
  *
+ * @cssprop --cf-tab-bar-height - Height of the tab bar container; contributes to footer reserved space when slotted into `cf-screen`.
+ * @cssprop --cf-tab-bar-inset-margin - Inset clearance from the screen edge; contributes to footer reserved space for inset footer bars.
+ *
  * @example
  * const activeTab = cell("home");
  * <cf-tab-bar $value={activeTab}>
@@ -168,6 +171,7 @@ export class CFTabBar extends BaseElement {
             min-width: 3.5rem;
           }
 
+          /* Footer-slotted bars are in-flow so cf-screen can reserve space. */
           :host([slot="footer"]) {
             position: relative;
             top: auto;

--- a/packages/ui/src/v2/components/cf-tab-bar/cf-tab-bar.ts
+++ b/packages/ui/src/v2/components/cf-tab-bar/cf-tab-bar.ts
@@ -27,9 +27,6 @@ import type { CFTabBarItem } from "./cf-tab-bar-item.ts";
  * @csspart bar - The nav pill surface containing the navigation items.
  * @csspart action - The wrapper around the action slot. Hidden when the slot is empty.
  *
- * @cssprop --cf-tab-bar-footer-fade-background - Opaque background color used by the footer-slot fade.
- * @cssprop --cf-tab-bar-footer-fade-transparent - Transparent background color used by the footer-slot fade.
- *
  * @example
  * const activeTab = cell("home");
  * <cf-tab-bar $value={activeTab}>
@@ -186,33 +183,11 @@ export class CFTabBar extends BaseElement {
             );
           }
 
-          :host([slot="footer"][variant="inset"][position="bottom"])::before {
-            content: "";
-            position: absolute;
-            inset: 0;
-            pointer-events: none;
-            z-index: 0;
-            background: linear-gradient(
-              to bottom,
-              var(
-                --cf-tab-bar-footer-fade-transparent,
-                rgba(240, 244, 248, 0)
-              ) 0%,
-              var(--cf-tab-bar-footer-fade-background, rgb(240, 244, 248)) 50%,
-              var(--cf-tab-bar-footer-fade-background, rgb(240, 244, 248)) 100%
-            );
-          }
-
           :host([slot="footer"][variant="inset"][position="top"]) {
             top: auto;
             padding-top: calc(
               var(--cf-tab-bar-inset-margin, 1rem) + env(safe-area-inset-top, 0px)
             );
-          }
-
-          :host([slot="footer"][variant="inset"]) .container {
-            position: relative;
-            z-index: 1;
           }
 
           /* === Reduced Motion === */


### PR DESCRIPTION
Linear: CT-1613

## What changed

This fixes the layout contract between `cf-screen` and `cf-tab-bar` when an
inset tab bar is placed in the screen footer slot.

Standalone tab bars keep their fixed overlay behavior. Footer-slotted tab bars
now participate in layout, so `cf-screen` reserves footer space instead of
letting normal bottom content become inaccessible behind the mobile tab bar.

For inset footer tab bars, the reserved footer height still comes from the
footer-slotted `cf-tab-bar`: the host is in-flow, its container contributes
`--cf-tab-bar-height`, and inset bottom padding contributes the inset/safe-area
clearance.

The visual fade is implemented only in `cf-screen`. When the footer contains an
inset bottom `cf-tab-bar`, `cf-screen` lets its main scroller overlap into the
reserved footer region by `--cf-screen-footer-overlap` (defaulting to the tab
bar height), adds matching bottom padding so content remains reachable, and
masks only the bottom half of that overlapped region by default. This moves the
fade down into the tab-bar/footer area instead of starting at the top of the
reserved footer.

The catalog includes an `Inset footer in cf-screen` example using the real
footer slot contract.

## Validation

- Added browser layout coverage for standalone fixed tab bars.
- Added browser layout coverage for `cf-screen` with
  `cf-tab-bar slot="footer" variant="inset"`.
- Added browser assertions for footer reservation, scroller overlap, and the
  `cf-screen` scroller mask.
- Ran targeted format, type-check, lint, catalog check, and browser regression
  checks.
- Relaunched the local Tool Shed/Shell server and verified the catalog example
  at the CT-1613 local URL.
