### PR TITLE
perf(runner/v2-transaction): short-circuit isolateTransactionValue on deep-frozen input

### DIFF
--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -1,5 +1,6 @@
-import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
+import { deepFreeze, isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
 import {
+  cloneIfNecessary,
   getDataModelConfig,
   isArrayIndexPropertyName,
 } from "@commonfabric/data-model/fabric-value";
@@ -140,11 +141,33 @@ function withCommitTiming<T>(
   }
 }
 
+/**
+ * Produces a value that is isolated from later mutations to the source. For
+ * a deep-frozen input the source can't be mutated, so the input is returned
+ * unchanged; otherwise plain objects and arrays are deep-cloned (with cycle
+ * detection) and non-plain-prototype objects are passed through. Sub-trees
+ * that are themselves deep-frozen short-circuit by identity during the
+ * recursion, so partially-frozen trees only copy their unfrozen portions.
+ *
+ * The result is NOT guaranteed to be mutable, since deep-frozen inputs are
+ * returned as-is. Callers that need a mutable copy (e.g. before in-place
+ * write helpers like `ensureParentContainers` or `applyMutablePathWrite`)
+ * must use `cloneIfNecessary(value, { frozen: false })` from
+ * `@commonfabric/data-model` instead.
+ */
 const isolateTransactionValue = <T>(
   value: T,
   seen: Map<object, unknown> = new Map(),
 ): T => {
   if (value === null || typeof value !== "object") {
+    return value;
+  }
+
+  // A deep-frozen value is already isolated: nothing can mutate it, so the
+  // returned reference is safe to share with the caller. `isDeepFrozen()` is
+  // O(1) on values previously cached as deep-frozen (the common case for
+  // values that came back out of storage in modern data model).
+  if (isDeepFrozen(value)) {
     return value;
   }
 
@@ -218,6 +241,10 @@ const freezeReadValue = <T extends FabricValue | undefined>(value: T): T => {
   ) {
     return value;
   }
+  // `isolateTransactionValue()` short-circuits on already-deep-frozen input
+  // (returns the source by identity) and `deepFreeze()` is O(1) on values
+  // already in its cache, so the steady-state cost on repeated reads of the
+  // same stored value collapses to two cache lookups.
   return deepFreeze(isolateTransactionValue(value)) as T;
 };
 
@@ -1309,7 +1336,11 @@ export class V2StorageTransaction implements IStorageTransaction {
       if (!isRecord(existingParent) && !Array.isArray(existingParent)) {
         return direct;
       }
-      parentValue = isolateTransactionValue(existingParent) as FabricValue;
+      // Use `cloneIfNecessary({ frozen: false })` (not
+      // `isolateTransactionValue()`): the parent is about to be mutated in
+      // place by `ensureParentContainers`, so we need a guaranteed-mutable
+      // copy even when the stored value is deep-frozen.
+      parentValue = cloneIfNecessary(existingParent, { frozen: false });
     }
 
     const seededParent = ensureParentContainers(
@@ -1435,7 +1466,12 @@ export class V2StorageTransaction implements IStorageTransaction {
       if (
         !hasMutableRoot && address.path.length > 0 && nextRoot !== undefined
       ) {
-        nextRoot = isolateTransactionValue(nextRoot) as FabricValue;
+        // Use `cloneIfNecessary({ frozen: false })` (not
+        // `isolateTransactionValue()`): the next line passes `nextRoot` to
+        // `applyMutablePathWrite`, which mutates in place along the write
+        // path, so we need a guaranteed-mutable root even when the stored
+        // value is deep-frozen.
+        nextRoot = cloneIfNecessary(nextRoot, { frozen: false });
         hasMutableRoot = true;
       }
       const result = applyMutablePathWrite(nextRoot, address, isolatedValue);


### PR DESCRIPTION
## Summary

- Pushes an `isDeepFrozen()` short-circuit into `isolateTransactionValue()` so every read AND every write-path snapshot/recording site short-circuits when the input is already deep-frozen — which is the steady-state case in modern data model, since storage hands back deeply-frozen values.
- Switches the two write-path sites that DO mutate in place (`ensureParentContainers` and `applyMutablePathWrite`) to `cloneIfNecessary(value, { frozen: false })` so they keep getting a guaranteed-mutable copy.
- Removes redundant top-level checks: `freezeReadValue()` now relies on its callees being cheap when nothing needs to change.

## Why

Modern data model's `freezeReadValue()` was unconditionally deep-cloning and re-freezing on every cell read. Under the failing `should render every rapidly created notebook note` test step on PR #3569 (which flips the modern flag on by default), that path was called ~10k times per 4 clicks and cost ~640ms of pure waste, and the 7-click case never converged inside the 60s `cell:get` IPC timeout — that's the consistent CI failure on #3569.

## Measured on the failing test step (3 runs each, same machine)

| Config | Mean step time |
|---|---|
| Pre-fix, modern **off** (main) | 18.0s |
| Post-fix, modern **off** | 18.7s (within noise) |
| Post-fix, modern **on** | 22.3s |
| Pre-fix, modern **on** | wedges (CI failure) |

Modern is now a steady ~20-25% surcharge over legacy instead of falling off a cliff under load.

## Test plan

- [x] `deno task test` in `@commonfabric/runner` (454 tests / 2504 steps, all passing)
- [x] `deno task test` in `@commonfabric/memory` (120 tests, all passing)
- [x] Integration: `should render every rapidly created notebook note` locally with modern on (passes ~22s, vs wedging pre-fix)
- [ ] CI green
- [ ] Spot-check perf-check delta (this is modern-off-by-default still, so should be roughly neutral on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Short-circuits value isolation for deep-frozen inputs and ensures mutating write paths get a guaranteed-mutable copy. This removes most clone+freeze work on read paths in modern storage and stabilizes the failing notebook render test.

- **Refactors**
  - Add deep-frozen short-circuit inside isolateTransactionValue (also skips frozen subtrees).
  - Use cloneIfNecessary(value, { frozen: false }) for ensureParentContainers and applyMutablePathWrite.
  - Simplify freezeReadValue to rely on cheap no-op paths in its callees.

- **Performance**
  - Notebook test: ~96% of reads short-circuit; clone+freeze cost ~45ms (was ~640ms); step now passes in ~22–26s.
  - Modern mode runs with ~20–25% overhead vs legacy; neutral when modern is off.

<sup>Written for commit 5029b41bc09a021a2750bc7bf41ee549e5227aaf. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3650?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

