### PR TITLE
feat(data-model): add cloneForMutation for spine-walk copy-on-write

### DIFF
--- a/packages/data-model/fabric-value.ts
+++ b/packages/data-model/fabric-value.ts
@@ -17,7 +17,13 @@ export {
   type SerializationContext,
 } from "./interface.ts";
 
-export { cloneIfNecessary, type CloneOptions } from "./value-clone.ts";
+export {
+  cloneForMutation,
+  type CloneForMutationOptions,
+  type CloneForMutationResult,
+  cloneIfNecessary,
+  type CloneOptions,
+} from "./value-clone.ts";
 
 import type {
   FabricNativeObject,

--- a/packages/data-model/test/clone-for-mutation.test.ts
+++ b/packages/data-model/test/clone-for-mutation.test.ts
@@ -1,0 +1,450 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  cloneForMutation,
+  resetDataModelConfig,
+  setDataModelConfig,
+} from "../fabric-value.ts";
+import type { FabricValue } from "../fabric-value.ts";
+import { deepFreeze, isDeepFrozen } from "../deep-freeze.ts";
+import { FabricEpochNsec } from "../fabric-epoch.ts";
+import { FabricError } from "../fabric-native-instances.ts";
+
+// ============================================================================
+// `cloneForMutation` tests
+// ============================================================================
+//
+// Both legacy and modern flag states use modern clone semantics. Test cases are
+// parameterized across both modes to ensure the contract is durable under
+// either flag setting.
+
+describe("cloneForMutation", () => {
+  afterEach(() => {
+    resetDataModelConfig();
+  });
+
+  for (const modernMode of [false, true]) {
+    const label = modernMode ? "modern" : "legacy";
+
+    describe(`(${label} path)`, () => {
+      beforeEach(() => setDataModelConfig(modernMode));
+
+      // ----------------------------------------------------------------------
+      // Empty path: root-only thaw
+      // ----------------------------------------------------------------------
+
+      describe("empty path", () => {
+        it("returns the root as mutable, plus identical `pathValue`", () => {
+          const root = Object.freeze({ a: 1, b: 2 }) as FabricValue;
+          const { value, pathValue } = cloneForMutation(root, []);
+
+          expect(value).not.toBe(root);
+          expect(Object.isFrozen(value)).toBe(false);
+          expect(pathValue).toBe(value);
+          expect(value).toEqual({ a: 1, b: 2 });
+        });
+
+        it("returns input identity when already mutable + force=false", () => {
+          const root = { a: 1 } as FabricValue;
+          const { value, pathValue } = cloneForMutation(root, [], {
+            force: false,
+          });
+          expect(value).toBe(root);
+          expect(pathValue).toBe(root);
+        });
+
+        it("does not touch the input on default options (force defaults to true)", () => {
+          // Default `force` is true, matching `cloneIfNecessary`'s default
+          // when `frozen: false`. Even with mutable input, the result is a
+          // fresh copy.
+          const root = { a: 1 } as FabricValue;
+          const { value, pathValue } = cloneForMutation(root, []);
+          expect(value).not.toBe(root);
+          expect(pathValue).toBe(value);
+          expect(value).toEqual({ a: 1 });
+          expect(Object.isFrozen(value)).toBe(false);
+        });
+
+        it("always shallow-clones the root when force=true", () => {
+          const root = { a: 1 } as FabricValue;
+          const { value, pathValue } = cloneForMutation(root, [], {
+            force: true,
+          });
+          expect(value).not.toBe(root);
+          expect(pathValue).toBe(value);
+          expect(value).toEqual({ a: 1 });
+          expect(Object.isFrozen(value)).toBe(false);
+        });
+
+        it("handles an empty-path FabricInstance via shallowClone(false)", () => {
+          const err = new FabricError(new Error("test"));
+          Object.freeze(err);
+          const { value, pathValue } = cloneForMutation(
+            err as unknown as FabricValue,
+            [],
+          );
+          expect(value).not.toBe(err);
+          expect(value).toBeInstanceOf(FabricError);
+          expect(Object.isFrozen(value)).toBe(false);
+          expect(pathValue).toBe(value);
+          // The wrapped Error reference is shared by `shallowUnfrozenClone`.
+          expect((value as unknown as FabricError).error).toBe(err.error);
+        });
+      });
+
+      // ----------------------------------------------------------------------
+      // Single-step paths
+      // ----------------------------------------------------------------------
+
+      describe("single-step path", () => {
+        it("clones only the spine and exposes the leaf container", () => {
+          const inner = Object.freeze({ x: 1 });
+          const sibling = Object.freeze({ y: 2 });
+          const root = Object.freeze({
+            a: inner,
+            b: sibling,
+          }) as FabricValue;
+
+          const { value, pathValue } = cloneForMutation(root, ["a"]);
+
+          expect(value).not.toBe(root);
+          expect(pathValue).toBe(
+            (value as unknown as Record<string, unknown>).a,
+          );
+          expect(pathValue).not.toBe(inner); // had to thaw it
+          expect(Object.isFrozen(value)).toBe(false);
+          expect(Object.isFrozen(pathValue)).toBe(false);
+
+          // Critical: the sibling subtree is preserved by identity.
+          expect((value as unknown as Record<string, unknown>).b).toBe(sibling);
+        });
+
+        it("descends into a single-element array", () => {
+          const noteA = Object.freeze({ title: "first" });
+          const noteB = Object.freeze({ title: "second" });
+          const root = Object.freeze({
+            notes: Object.freeze([noteA, noteB]),
+          }) as FabricValue;
+
+          const { value, pathValue } = cloneForMutation(root, ["notes"]);
+
+          expect(Array.isArray(pathValue)).toBe(true);
+          expect((pathValue as unknown as unknown[]).length).toBe(2);
+
+          // The note objects inside the freshly-thawed array are still the
+          // original frozen instances -- shallow-thaw shares references.
+          expect((pathValue as unknown as unknown[])[0]).toBe(noteA);
+          expect((pathValue as unknown as unknown[])[1]).toBe(noteB);
+
+          // The spliced-in array lives inside the new root.
+          expect((value as unknown as Record<string, unknown>).notes).toBe(
+            pathValue,
+          );
+        });
+
+        it("returns input root identity when already mutable + force=false", () => {
+          const inner = { x: 1 };
+          const root = { a: inner } as FabricValue;
+
+          const { value, pathValue } = cloneForMutation(root, ["a"], {
+            force: false,
+          });
+
+          // Already-mutable root reused by identity.
+          expect(value).toBe(root);
+          // Inner was already mutable too -- reused.
+          expect(pathValue).toBe(inner);
+        });
+
+        it("does not touch a mutable input on default options", () => {
+          // Default `force` is true: input is left alone even when mutable.
+          const inner = { x: 1 };
+          const root = { a: inner } as FabricValue;
+
+          const { value, pathValue } = cloneForMutation(root, ["a"]);
+
+          expect(value).not.toBe(root);
+          expect(pathValue).not.toBe(inner);
+          // Sibling identity still preserved (would be `b` if present).
+        });
+
+        it("always copies the root and leaf when force=true", () => {
+          const inner = { x: 1 };
+          const root = { a: inner } as FabricValue;
+
+          const { value, pathValue } = cloneForMutation(root, ["a"], {
+            force: true,
+          });
+
+          expect(value).not.toBe(root);
+          expect(pathValue).not.toBe(inner);
+          // ...but the leaf's children stay shared.
+          expect(pathValue).toEqual({ x: 1 });
+        });
+      });
+
+      // ----------------------------------------------------------------------
+      // Deep paths
+      // ----------------------------------------------------------------------
+
+      describe("deep paths", () => {
+        it("clones every spine container, preserves off-spine identity", () => {
+          // Tree shape:
+          //   root
+          //     ├ a (frozen, on spine)
+          //     │   ├ b (frozen, on spine)
+          //     │   │   └ c (frozen, on spine -- the target)
+          //     │   └ b2 (frozen, OFF spine)
+          //     └ a2 (frozen, OFF spine)
+          const c = Object.freeze({ leaf: true });
+          const b2 = Object.freeze({ off: "spine-b" });
+          const b = Object.freeze({ c, b2 });
+          const a2 = Object.freeze({ off: "spine-a" });
+          const a = Object.freeze({ b, a2 });
+          const root = Object.freeze({ a, a2 }) as FabricValue;
+
+          const { value, pathValue } = cloneForMutation(root, ["a", "b", "c"]);
+
+          // Every spine container is freshly cloned (or at minimum,
+          // distinct from the input's frozen original).
+          expect(value).not.toBe(root);
+          const newA = (value as unknown as Record<string, unknown>)
+            .a as Record<
+              string,
+              unknown
+            >;
+          expect(newA).not.toBe(a);
+          const newB = newA.b as Record<string, unknown>;
+          expect(newB).not.toBe(b);
+          const newC = newB.c;
+          expect(newC).toBe(pathValue);
+          expect(newC).not.toBe(c);
+
+          // Off-spine subtrees retained by identity:
+          //   - root.a2 (sibling of `a`)
+          //   - a.b is now newA.b (= newB); but a.a2 (= a2) -- wait, a2 is on
+          //     root, not on a. The off-spine peer at depth `a` is `root.a2`.
+          //   - The off-spine peer at depth `b` is `a.a2`... no, `a` only has
+          //     children `b` and `a2`. So `a2` is off-spine relative to the
+          //     descent into `b`.
+          expect((value as unknown as Record<string, unknown>).a2).toBe(a2);
+          expect(newA.a2).toBe(a2);
+          expect(newB.b2).toBe(b2);
+
+          // Spine is mutable, off-spine retains frozenness:
+          expect(Object.isFrozen(value)).toBe(false);
+          expect(Object.isFrozen(newA)).toBe(false);
+          expect(Object.isFrozen(newB)).toBe(false);
+          expect(Object.isFrozen(newC)).toBe(false);
+          expect(Object.isFrozen(a2)).toBe(true);
+          expect(Object.isFrozen(b2)).toBe(true);
+        });
+
+        it("descends through arrays as well as objects", () => {
+          const target = Object.freeze({ leaf: true });
+          const otherNote = Object.freeze({ leaf: false });
+          const notes = Object.freeze([otherNote, target]);
+          const root = Object.freeze({ notes }) as FabricValue;
+
+          const { value, pathValue } = cloneForMutation(
+            root,
+            ["notes", "1"],
+          );
+
+          const newNotes = (value as unknown as Record<string, unknown>).notes;
+          expect(Array.isArray(newNotes)).toBe(true);
+          expect(newNotes).not.toBe(notes);
+          // Other (off-spine) element preserved by identity.
+          expect((newNotes as unknown[])[0]).toBe(otherNote);
+          // Target is the freshly-thawed pathValue.
+          expect((newNotes as unknown[])[1]).toBe(pathValue);
+          expect(pathValue).not.toBe(target);
+        });
+      });
+
+      // ----------------------------------------------------------------------
+      // Deep-frozen cache preservation off-spine
+      // ----------------------------------------------------------------------
+
+      describe("deep-frozen cache preservation", () => {
+        it("preserves off-spine deep-frozen subtrees in the cache", () => {
+          // A deeply-nested off-spine subtree:
+          const sibling = deepFreeze({ deep: { nested: [1, 2, 3] } });
+          // (Sanity: deepFreeze has cached it.)
+          expect(isDeepFrozen(sibling)).toBe(true);
+
+          const target = Object.freeze({ leaf: true });
+          const root = deepFreeze({ a: target, b: sibling }) as FabricValue;
+
+          const { value } = cloneForMutation(root, ["a"]);
+
+          // The sibling subtree is preserved by identity AND retains its
+          // place in the deep-frozen cache (so future `isDeepFrozen` checks
+          // and `cloneIfNecessary` short-circuits stay O(1)).
+          expect((value as unknown as Record<string, unknown>).b).toBe(sibling);
+          expect(isDeepFrozen(sibling)).toBe(true);
+        });
+      });
+
+      // ----------------------------------------------------------------------
+      // FabricInstance as the leaf at `path`
+      // ----------------------------------------------------------------------
+
+      describe("FabricInstance at leaf", () => {
+        it("clones via shallowClone(false), not as a plain object", () => {
+          const err = new FabricError(new Error("boom"));
+          Object.freeze(err);
+          const root = Object.freeze({ payload: err }) as FabricValue;
+
+          const { value, pathValue } = cloneForMutation(root, ["payload"]);
+
+          expect(pathValue).toBeInstanceOf(FabricError);
+          expect(pathValue).not.toBe(err);
+          expect(Object.isFrozen(pathValue)).toBe(false);
+          // The wrapped native Error is preserved by identity (shallowClone).
+          expect((pathValue as unknown as FabricError).error).toBe(err.error);
+          // And spliced into the new spine.
+          expect((value as unknown as Record<string, unknown>).payload).toBe(
+            pathValue,
+          );
+        });
+      });
+
+      // ----------------------------------------------------------------------
+      // Caller mutates `pathValue`, observes effects on `value` only
+      // ----------------------------------------------------------------------
+
+      describe("mutation through pathValue", () => {
+        it("supports array push without touching the input", () => {
+          const notes = Object.freeze([{ id: 1 }, { id: 2 }]);
+          const root = Object.freeze({ notes }) as FabricValue;
+
+          const { value, pathValue } = cloneForMutation(root, ["notes"]);
+
+          (pathValue as unknown as Array<Record<string, unknown>>).push({
+            id: 3,
+          });
+
+          expect((value as unknown as Record<string, unknown>).notes).toBe(
+            pathValue,
+          );
+          expect((pathValue as unknown as unknown[]).length).toBe(3);
+          // Input is untouched.
+          expect(notes.length).toBe(2);
+        });
+
+        it("supports object property delete without touching the input", () => {
+          const root = Object.freeze({
+            keep: 1,
+            drop: 2,
+          }) as FabricValue;
+
+          const { value, pathValue } = cloneForMutation(root, []);
+
+          delete (pathValue as unknown as Record<string, unknown>).drop;
+
+          expect(value).toEqual({ keep: 1 });
+          expect((root as unknown as Record<string, unknown>).drop).toBe(2);
+        });
+
+        it("force=true does not touch the input even with mutable input", () => {
+          const inner = { x: 1, y: 2 };
+          const root = { inner };
+
+          const { value, pathValue } = cloneForMutation(
+            root as unknown as FabricValue,
+            ["inner"],
+            { force: true },
+          );
+
+          (pathValue as unknown as Record<string, unknown>).x = 999;
+
+          expect((value as unknown as Record<string, unknown>).inner).toBe(
+            pathValue,
+          );
+          // Input untouched.
+          expect(inner.x).toBe(1);
+          expect(root.inner).toBe(inner);
+        });
+      });
+
+      // ----------------------------------------------------------------------
+      // Error cases
+      // ----------------------------------------------------------------------
+
+      describe("errors", () => {
+        it("throws on a missing path segment", () => {
+          const root = Object.freeze({ a: { b: 1 } }) as FabricValue;
+          expect(() => cloneForMutation(root, ["a", "nonesuch"]))
+            .toThrow("missing path segment");
+        });
+
+        it("throws on a missing array index", () => {
+          const root = Object.freeze({
+            notes: Object.freeze([1, 2, 3]),
+          }) as FabricValue;
+          expect(() => cloneForMutation(root, ["notes", "10"]))
+            .toThrow("missing path segment");
+        });
+
+        it("throws when descending through a primitive", () => {
+          const root = Object.freeze({ x: 42 }) as FabricValue;
+          expect(() => cloneForMutation(root, ["x", "anything"]))
+            .toThrow("cannot descend into");
+        });
+
+        it("throws when descending through a FabricInstance", () => {
+          const err = new FabricError(new Error("inside"));
+          const root = Object.freeze({ err }) as FabricValue;
+          // `path = ["err", "something"]` tries to descend INTO the
+          // FabricInstance, which isn't supported.
+          expect(() => cloneForMutation(root, ["err", "message"])).toThrow(
+            "cannot descend into",
+          );
+        });
+
+        it("throws when descending through a FabricPrimitive", () => {
+          const epoch = new FabricEpochNsec(123n);
+          const root = Object.freeze({
+            epoch: epoch as unknown as FabricValue,
+          }) as FabricValue;
+          expect(() => cloneForMutation(root, ["epoch", "anything"]))
+            .toThrow("cannot descend into");
+        });
+
+        it("throws when the leaf is a primitive (not mutable)", () => {
+          const root = Object.freeze({ x: 42 }) as FabricValue;
+          expect(() => cloneForMutation(root, ["x"]))
+            .toThrow("cannot mutate");
+        });
+
+        it("throws when the leaf is a FabricPrimitive (not mutable)", () => {
+          const epoch = new FabricEpochNsec(123n);
+          const root = Object.freeze({
+            epoch: epoch as unknown as FabricValue,
+          }) as FabricValue;
+          expect(() => cloneForMutation(root, ["epoch"]))
+            .toThrow("cannot mutate");
+        });
+
+        it("throws on empty-path against a non-mutable root", () => {
+          expect(() => cloneForMutation(42 as FabricValue, []))
+            .toThrow("cannot mutate");
+        });
+
+        it("throws on non-empty path against a non-container root", () => {
+          expect(() => cloneForMutation(42 as FabricValue, ["x"]))
+            .toThrow("cannot descend into");
+        });
+
+        it("throws on non-empty path against a FabricInstance root", () => {
+          // A FabricInstance is OK at the leaf but not as the root of a
+          // non-empty path (we don't descend into FabricInstance internals).
+          const err = new FabricError(new Error("test"));
+          expect(() => cloneForMutation(err as unknown as FabricValue, ["x"]))
+            .toThrow("cannot descend into");
+        });
+      });
+    });
+  }
+});

--- a/packages/data-model/test/value-debug.test.ts
+++ b/packages/data-model/test/value-debug.test.ts
@@ -1,6 +1,17 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { toCompactDebugString, toIndentedDebugString } from "../value-debug.ts";
+import {
+  toCompactDebugString,
+  toDebugKindString,
+  toIndentedDebugString,
+} from "../value-debug.ts";
+import { FabricBytes } from "../fabric-bytes.ts";
+import { FabricEpochNsec } from "../fabric-epoch.ts";
+import {
+  FabricError,
+  FabricMap,
+  FabricRegExp,
+} from "../fabric-native-instances.ts";
 
 // ============================================================================
 // Tests
@@ -394,6 +405,72 @@ describe("value-debug", () => {
       a.self = a;
       expect(toIndentedDebugString(a))
         .toBe('{\n  "x": 1,\n  "self": <circle>\n}');
+    });
+  });
+
+  // --------------------------------------------------------------------------
+  // toDebugKindString
+  // --------------------------------------------------------------------------
+
+  describe("toDebugKindString", () => {
+    it("renders null and undefined literally", () => {
+      expect(toDebugKindString(null)).toBe("null");
+      expect(toDebugKindString(undefined)).toBe("undefined");
+    });
+
+    it("renders plain objects as 'object'", () => {
+      expect(toDebugKindString({})).toBe("object");
+      expect(toDebugKindString({ a: 1 })).toBe("object");
+      expect(toDebugKindString(Object.create(null))).toBe("object");
+    });
+
+    it("renders arrays as 'array'", () => {
+      expect(toDebugKindString([])).toBe("array");
+      expect(toDebugKindString([1, 2, 3])).toBe("array");
+    });
+
+    it("renders JS primitives as their typeof", () => {
+      expect(toDebugKindString(42)).toBe("number");
+      expect(toDebugKindString(42n)).toBe("bigint");
+      expect(toDebugKindString("hi")).toBe("string");
+      expect(toDebugKindString(true)).toBe("boolean");
+      expect(toDebugKindString(Symbol("s"))).toBe("symbol");
+      expect(toDebugKindString(() => {})).toBe("function");
+    });
+
+    it("renders FabricInstance subclasses with their constructor name", () => {
+      expect(toDebugKindString(new FabricError(new Error("x"))))
+        .toBe("FabricInstance (FabricError)");
+      expect(toDebugKindString(new FabricRegExp(/abc/g, "es2025")))
+        .toBe("FabricInstance (FabricRegExp)");
+      expect(toDebugKindString(new FabricMap(new Map())))
+        .toBe("FabricInstance (FabricMap)");
+    });
+
+    it("renders FabricPrimitive subclasses with their constructor name", () => {
+      expect(toDebugKindString(new FabricEpochNsec(123n)))
+        .toBe("FabricPrimitive (FabricEpochNsec)");
+      expect(toDebugKindString(new FabricBytes(new Uint8Array([1, 2, 3]))))
+        .toBe("FabricPrimitive (FabricBytes)");
+    });
+
+    it("renders non-fabric class instances with their constructor name", () => {
+      expect(toDebugKindString(new Date())).toBe("Date");
+      expect(toDebugKindString(new Map())).toBe("Map");
+      expect(toDebugKindString(new Set())).toBe("Set");
+      expect(toDebugKindString(new Error("oops"))).toBe("Error");
+      expect(toDebugKindString(/abc/)).toBe("RegExp");
+
+      class Foo {}
+      expect(toDebugKindString(new Foo())).toBe("Foo");
+    });
+
+    it("falls back to 'object' when constructor name is unavailable", () => {
+      // An object whose prototype was sliced out has no usable
+      // `constructor` chain; the predicate returns "object" as a final
+      // fallback.
+      const weird = Object.create({ constructor: undefined as unknown });
+      expect(toDebugKindString(weird)).toBe("object");
     });
   });
 });

--- a/packages/data-model/value-clone.ts
+++ b/packages/data-model/value-clone.ts
@@ -1,7 +1,7 @@
-import { FabricInstance, FabricValue } from "./interface.ts";
+import { FabricInstance, FabricPrimitive, FabricValue } from "./interface.ts";
 import { NATIVE_TAGS, tagFromNativeValue } from "./native-type-tags.ts";
 import { isDeepFrozenFabricValue } from "./deep-freeze.ts";
-import type { Immutable } from "@commonfabric/utils/types";
+import { type Immutable, isPlainObject } from "@commonfabric/utils/types";
 
 /**
  * Options for `cloneIfNecessary()`.
@@ -199,4 +199,242 @@ export function cloneHelper(
         `Cannot clone: ${(value as object).constructor?.name ?? typeof value}`,
       );
   }
+}
+
+// =============================================================================
+// `cloneForMutation`
+// =============================================================================
+
+/**
+ * Options for `cloneForMutation()`.
+ */
+export interface CloneForMutationOptions {
+  /**
+   * Force fresh shallow copies of every spine container, even when the
+   * input's containers are already mutable. Default: `true` -- matches
+   * `cloneIfNecessary`'s default when `frozen: false` (which is what each
+   * per-container thaw effectively requests).
+   *
+   * - `force: true` (default) — the caller's input is guaranteed to be left
+   *   untouched. Every container along the spine -- including the root and
+   *   the value at `path` -- is a fresh shallow copy.
+   * - `force: false` — spine containers that are already mutable are reused
+   *   by identity, and the helper may mutate the caller's input's spine
+   *   slots in place when it needs to splice a freshly-thawed child into a
+   *   mutable parent. Choose this when the caller owns the input outright.
+   *
+   * Mirrors `cloneIfNecessary`'s `force` semantics: this option is forwarded
+   * verbatim to the per-container `cloneIfNecessary(_, { frozen: false,
+   * deep: false, force })` calls that perform the actual shallow thaws.
+   */
+  force?: boolean;
+}
+
+/**
+ * The shape returned by `cloneForMutation()`. See the function's doc comment
+ * for the contract on each field.
+ */
+export interface CloneForMutationResult<T extends FabricValue> {
+  /**
+   * Replacement for the caller's input value, with the spine to `path` made
+   * mutable. Identical to the input by reference iff no clone was necessary
+   * (only possible when `force: false` and the input's spine was already
+   * mutable throughout).
+   */
+  value: T;
+
+  /**
+   * The value at `path` in the result tree, guaranteed mutable. The caller
+   * mutates this directly to perform their structured-mutation operation
+   * (property set/delete, array push/splice/set-element, ...). For a plain
+   * object or array at `path`, `pathValue` is a shallow-thawed copy whose
+   * own children remain identity-shared with the input. For a
+   * `FabricInstance` at `path`, `pathValue` is its `shallowClone(false)`.
+   */
+  pathValue: FabricValue;
+}
+
+/**
+ * Produces a view of `value` with the spine of containers along `path` made
+ * mutable, so the caller can apply a structured mutation at `path` without
+ * leaking changes back to the input. Subtrees off the spine retain their
+ * identity (and their place in the deep-frozen cache) -- so a subsequent
+ * `deepFreeze()` of the result tree short-circuits on every off-spine
+ * subtree.
+ *
+ * Conceptually a copy-on-write descent: starting from the root, at each
+ * step the next container along `path` is shallow-thawed (via
+ * `cloneIfNecessary(_, { frozen: false, deep: false, force })`) and the
+ * shallow clone is spliced into its (already-mutable) parent. The result
+ * `pathValue` is the mutable container at the end of `path`.
+ *
+ * ### Mutation patterns supported via the returned `pathValue`
+ *
+ * - Object property add / set / delete: `pathValue.k = v`, `delete pathValue.k`.
+ * - Array set-element / push / splice / length: `pathValue[i] = v`,
+ *   `pathValue.push(v)`, `pathValue.splice(i, n, ...add)`, `pathValue.length = n`.
+ * - "Replace the value at some slot": pass the parent's path as `path`,
+ *   then assign through `pathValue[lastKey] = newValue`.
+ *
+ * ### Path semantics
+ *
+ * `path` is an array of pre-parsed segments (JSON-Pointer-style, but already
+ * unescaped and split). Each segment is a property name for objects or an
+ * array-index string for arrays. The helper descends through plain JS
+ * objects and arrays; it does NOT descend into `FabricInstance` values
+ * (those don't expose path-style member access in the current data model).
+ * A `FabricInstance` is permitted as the final value at `path`, in which
+ * case it's shallow-thawed via its own `shallowClone(false)` interface.
+ *
+ * ### Errors
+ *
+ * Throws if:
+ * - A path segment names a missing slot on a plain container.
+ * - An intermediate segment lands on something other than a plain object
+ *   or array (a primitive, a `FabricInstance`, a `FabricPrimitive`, ...).
+ * - The final segment lands on a value that isn't mutable-handle-able
+ *   (a primitive or a `FabricPrimitive`).
+ * - The root itself isn't mutable-handle-able and `path` is empty.
+ * - The root isn't a plain container and `path` is non-empty.
+ *
+ * @param value - The input value tree.
+ * @param path - Path to the container (or `FabricInstance`) to expose as
+ *   mutable.
+ * @param options - See `CloneForMutationOptions`.
+ */
+export function cloneForMutation<T extends FabricValue>(
+  value: T,
+  path: readonly string[],
+  options?: CloneForMutationOptions,
+): CloneForMutationResult<T> {
+  const force = options?.force ?? true;
+  // Used for every per-container shallow thaw along the spine, and for the
+  // final value-at-`path` thaw if it's a plain container or `FabricInstance`.
+  const cloneOpts = { frozen: false as const, deep: false as const, force };
+
+  // --- Empty-path fast path ---------------------------------------------
+  if (path.length === 0) {
+    if (!isMutableHandle(value)) {
+      throw new Error(
+        `cloneForMutation: cannot mutate ${describeKind(value)} at root ` +
+          `(empty path)`,
+      );
+    }
+    const newRoot = cloneIfNecessary(value, cloneOpts) as T;
+    return { value: newRoot, pathValue: newRoot };
+  }
+
+  // --- Non-empty path ---------------------------------------------------
+  // The root must be a plain container; descent through a `FabricInstance`
+  // root would have nowhere to go (path-style access into FabricInstance
+  // internals isn't supported).
+  if (!isPlainContainer(value)) {
+    throw new Error(
+      `cloneForMutation: cannot descend into ${describeKind(value)} at ` +
+        `root (path has ${path.length} segment${path.length === 1 ? "" : "s"})`,
+    );
+  }
+
+  const newRoot = cloneIfNecessary(value, cloneOpts) as T;
+  // `current` is always a plain container at the top of each loop iteration:
+  // we enter with `newRoot` (a plain container by the root check above) and
+  // before descending we always type-check the next container.
+  let current: Record<string, FabricValue> | FabricValue[] = newRoot as
+    | Record<string, FabricValue>
+    | FabricValue[];
+
+  for (let i = 0; i < path.length; i++) {
+    const key = path[i]!;
+    const isLast = i === path.length - 1;
+
+    if (!Object.hasOwn(current, key)) {
+      throw new Error(
+        `cloneForMutation: missing path segment ${JSON.stringify(key)} at ` +
+          `index ${i}`,
+      );
+    }
+
+    const next = (current as Record<string, FabricValue>)[key];
+
+    if (isLast) {
+      if (!isMutableHandle(next)) {
+        throw new Error(
+          `cloneForMutation: cannot mutate ${describeKind(next)} at path ` +
+            `index ${i} (final segment)`,
+        );
+      }
+    } else {
+      if (!isPlainContainer(next)) {
+        throw new Error(
+          `cloneForMutation: cannot descend into ${describeKind(next)} at ` +
+            `path index ${i}`,
+        );
+      }
+    }
+
+    // Shallow-thaw the next spine container. For plain containers and
+    // `FabricInstance`s this is a `cloneIfNecessary(_, { frozen: false,
+    // deep: false, force })` call; under `force: false` and an
+    // already-mutable input it short-circuits to identity.
+    const thawed = cloneIfNecessary(next as FabricValue, cloneOpts);
+    if (thawed !== next) {
+      (current as Record<string, FabricValue>)[key] = thawed;
+    }
+
+    if (isLast) {
+      return { value: newRoot, pathValue: thawed };
+    }
+
+    // Type assertion safe: we type-checked `next` is a plain container,
+    // and shallow-thaw preserves prototype, so `thawed` is also a plain
+    // container.
+    current = thawed as Record<string, FabricValue> | FabricValue[];
+  }
+
+  // Unreachable: the loop always returns on its final iteration when
+  // `path.length > 0` (handled above for `path.length === 0`).
+  /* c8 ignore next 3 */
+  throw new Error("cloneForMutation: unreachable");
+}
+
+/**
+ * Returns `true` when `value` can serve as a descent target -- i.e. it's a
+ * plain object or array whose properties are accessed JSON-Pointer-style.
+ * `FabricInstance`s and `FabricPrimitive`s deliberately do not qualify;
+ * their internals aren't path-accessible.
+ */
+function isPlainContainer(
+  value: unknown,
+): value is Record<string, FabricValue> | FabricValue[] {
+  return Array.isArray(value) || isPlainObject(value);
+}
+
+/**
+ * Returns `true` when `cloneForMutation` can produce a mutable handle for
+ * the value at `path`. Plain containers and `FabricInstance`s qualify;
+ * primitives and `FabricPrimitive`s (which are immutable by construction)
+ * do not.
+ */
+function isMutableHandle(value: unknown): boolean {
+  return isPlainContainer(value) || value instanceof FabricInstance;
+}
+
+/**
+ * Short human-readable description of `value`'s kind, for error messages.
+ * Distinguishes plain containers, `FabricInstance`s, `FabricPrimitive`s,
+ * and primitives.
+ */
+function describeKind(value: unknown): string {
+  if (value === null) return "null";
+  if (value === undefined) return "undefined";
+  if (Array.isArray(value)) return "array";
+  if (typeof value !== "object") return typeof value;
+  if (value instanceof FabricInstance) {
+    return `FabricInstance (${value.constructor.name})`;
+  }
+  if (value instanceof FabricPrimitive) {
+    return `FabricPrimitive (${value.constructor.name})`;
+  }
+  if (isPlainObject(value)) return "object";
+  return value.constructor?.name ?? "object";
 }

--- a/packages/data-model/value-clone.ts
+++ b/packages/data-model/value-clone.ts
@@ -1,7 +1,8 @@
-import { FabricInstance, FabricPrimitive, FabricValue } from "./interface.ts";
+import { FabricInstance, FabricValue } from "./interface.ts";
 import { NATIVE_TAGS, tagFromNativeValue } from "./native-type-tags.ts";
 import { isDeepFrozenFabricValue } from "./deep-freeze.ts";
-import { type Immutable, isPlainObject } from "@commonfabric/utils/types";
+import { type Immutable, isPlainContainer } from "@commonfabric/utils/types";
+import { toDebugKindString } from "./value-debug.ts";
 
 /**
  * Options for `cloneIfNecessary()`.
@@ -316,7 +317,7 @@ export function cloneForMutation<T extends FabricValue>(
   if (path.length === 0) {
     if (!isMutableHandle(value)) {
       throw new Error(
-        `cloneForMutation: cannot mutate ${describeKind(value)} at root ` +
+        `cloneForMutation: cannot mutate ${toDebugKindString(value)} at root ` +
           `(empty path)`,
       );
     }
@@ -330,7 +331,7 @@ export function cloneForMutation<T extends FabricValue>(
   // internals isn't supported).
   if (!isPlainContainer(value)) {
     throw new Error(
-      `cloneForMutation: cannot descend into ${describeKind(value)} at ` +
+      `cloneForMutation: cannot descend into ${toDebugKindString(value)} at ` +
         `root (path has ${path.length} segment${path.length === 1 ? "" : "s"})`,
     );
   }
@@ -359,14 +360,18 @@ export function cloneForMutation<T extends FabricValue>(
     if (isLast) {
       if (!isMutableHandle(next)) {
         throw new Error(
-          `cloneForMutation: cannot mutate ${describeKind(next)} at path ` +
+          `cloneForMutation: cannot mutate ${
+            toDebugKindString(next)
+          } at path ` +
             `index ${i} (final segment)`,
         );
       }
     } else {
       if (!isPlainContainer(next)) {
         throw new Error(
-          `cloneForMutation: cannot descend into ${describeKind(next)} at ` +
+          `cloneForMutation: cannot descend into ${
+            toDebugKindString(next)
+          } at ` +
             `path index ${i}`,
         );
       }
@@ -398,18 +403,6 @@ export function cloneForMutation<T extends FabricValue>(
 }
 
 /**
- * Returns `true` when `value` can serve as a descent target -- i.e. it's a
- * plain object or array whose properties are accessed JSON-Pointer-style.
- * `FabricInstance`s and `FabricPrimitive`s deliberately do not qualify;
- * their internals aren't path-accessible.
- */
-function isPlainContainer(
-  value: unknown,
-): value is Record<string, FabricValue> | FabricValue[] {
-  return Array.isArray(value) || isPlainObject(value);
-}
-
-/**
  * Returns `true` when `cloneForMutation` can produce a mutable handle for
  * the value at `path`. Plain containers and `FabricInstance`s qualify;
  * primitives and `FabricPrimitive`s (which are immutable by construction)
@@ -417,24 +410,4 @@ function isPlainContainer(
  */
 function isMutableHandle(value: unknown): boolean {
   return isPlainContainer(value) || value instanceof FabricInstance;
-}
-
-/**
- * Short human-readable description of `value`'s kind, for error messages.
- * Distinguishes plain containers, `FabricInstance`s, `FabricPrimitive`s,
- * and primitives.
- */
-function describeKind(value: unknown): string {
-  if (value === null) return "null";
-  if (value === undefined) return "undefined";
-  if (Array.isArray(value)) return "array";
-  if (typeof value !== "object") return typeof value;
-  if (value instanceof FabricInstance) {
-    return `FabricInstance (${value.constructor.name})`;
-  }
-  if (value instanceof FabricPrimitive) {
-    return `FabricPrimitive (${value.constructor.name})`;
-  }
-  if (isPlainObject(value)) return "object";
-  return value.constructor?.name ?? "object";
 }

--- a/packages/data-model/value-debug.ts
+++ b/packages/data-model/value-debug.ts
@@ -2,6 +2,9 @@
  * Debugging-ish helpers for `FabricValue`s.
  */
 
+import { isPlainObject } from "@commonfabric/utils/types";
+import { FabricInstance, FabricPrimitive } from "./interface.ts";
+
 /**
  * Sentinel marker used to wrap content that should appear unquoted in the
  * final output. The replacer brackets a bare-token payload (e.g. `42n` or
@@ -228,4 +231,34 @@ export function toCompactDebugString(
  */
 export function toIndentedDebugString(value: unknown): string {
   return renderDebugString(value, 2);
+}
+
+/**
+ * Produces a short human-readable kind-string for a value, suitable for
+ * error messages and other diagnostic contexts where the caller wants to
+ * say something like _"can't operate on a `${toDebugKindString(value)}`"_.
+ *
+ * Distinguishes:
+ *
+ * - `null` / `undefined` -- rendered literally.
+ * - Plain objects and arrays -- `"object"` / `"array"`.
+ * - `FabricInstance` and `FabricPrimitive` -- rendered with their concrete
+ *   subclass constructor name (e.g. `"FabricInstance (FabricError)"`).
+ * - Other class instances -- rendered with their constructor name.
+ * - JS primitives -- rendered as their `typeof` (`"number"`, `"string"`,
+ *   `"bigint"`, `"boolean"`, `"symbol"`, `"function"`).
+ */
+export function toDebugKindString(value: unknown): string {
+  if (value === null) return "null";
+  if (value === undefined) return "undefined";
+  if (Array.isArray(value)) return "array";
+  if (typeof value !== "object") return typeof value;
+  if (value instanceof FabricInstance) {
+    return `FabricInstance (${value.constructor.name})`;
+  }
+  if (value instanceof FabricPrimitive) {
+    return `FabricPrimitive (${value.constructor.name})`;
+  }
+  if (isPlainObject(value)) return "object";
+  return value.constructor?.name ?? "object";
 }

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -85,6 +85,23 @@ export function isPlainObject(value: unknown): boolean {
 }
 
 /**
+ * Check whether a value is a plain container -- a plain object (per
+ * `isPlainObject`) or an `Array`. Useful when the relevant question is
+ * "can I do property-name / array-index member access on this?", since
+ * plain objects and arrays are the two value shapes that support that
+ * uniformly. Non-plain class instances (`Date`, `Map`, `Set`, `Error`,
+ * user-defined classes, ...) deliberately do not qualify.
+ *
+ * @param value - The value to check
+ * @returns True if the value is a plain object or an array
+ */
+export function isPlainContainer(
+  value: unknown,
+): value is Record<string, unknown> | unknown[] {
+  return Array.isArray(value) || isPlainObject(value);
+}
+
+/**
  * Predicate for narrowing a `string` type.
  * @param value - The value to check
  * @returns True if the value is a string

--- a/packages/utils/test/types.test.ts
+++ b/packages/utils/test/types.test.ts
@@ -7,6 +7,7 @@ import {
   isInstance,
   isNumber,
   isObject,
+  isPlainContainer,
   isPlainObject,
   isRecord,
   isString,
@@ -229,6 +230,60 @@ describe("types", () => {
       expect(isPlainObject(true)).toBe(false);
       expect(isPlainObject(Symbol("test"))).toBe(false);
       expect(isPlainObject(() => {})).toBe(false);
+    });
+  });
+
+  describe("isPlainContainer", () => {
+    it("returns true for plain objects", () => {
+      expect(isPlainContainer({})).toBe(true);
+      expect(isPlainContainer({ a: 1 })).toBe(true);
+      expect(isPlainContainer(new Object())).toBe(true);
+    });
+
+    it("returns true for null-prototype objects", () => {
+      expect(isPlainContainer(Object.create(null))).toBe(true);
+    });
+
+    it("returns true for arrays", () => {
+      expect(isPlainContainer([])).toBe(true);
+      expect(isPlainContainer([1, 2, 3])).toBe(true);
+      // Sparse arrays.
+      // deno-lint-ignore no-sparse-arrays
+      expect(isPlainContainer([1, , 3])).toBe(true);
+      // Frozen arrays.
+      expect(isPlainContainer(Object.freeze([]))).toBe(true);
+    });
+
+    it("returns true for frozen plain objects", () => {
+      expect(isPlainContainer(Object.freeze({}))).toBe(true);
+      expect(isPlainContainer(Object.freeze({ a: 1 }))).toBe(true);
+    });
+
+    it("returns false for class instances", () => {
+      class MyClass {}
+      expect(isPlainContainer(new MyClass())).toBe(false);
+      expect(isPlainContainer(new Date())).toBe(false);
+      expect(isPlainContainer(new Map())).toBe(false);
+      expect(isPlainContainer(new Set())).toBe(false);
+      expect(isPlainContainer(new Error("x"))).toBe(false);
+      expect(isPlainContainer(/regex/)).toBe(false);
+    });
+
+    it("returns false for objects with a non-Object/non-null prototype", () => {
+      // `Object.create({})` produces an object whose prototype is another
+      // plain object, which puts it outside the "plain" definition.
+      expect(isPlainContainer(Object.create({}))).toBe(false);
+    });
+
+    it("returns false for null, primitives, and functions", () => {
+      expect(isPlainContainer(null)).toBe(false);
+      expect(isPlainContainer(undefined)).toBe(false);
+      expect(isPlainContainer(42)).toBe(false);
+      expect(isPlainContainer(42n)).toBe(false);
+      expect(isPlainContainer("string")).toBe(false);
+      expect(isPlainContainer(true)).toBe(false);
+      expect(isPlainContainer(Symbol("test"))).toBe(false);
+      expect(isPlainContainer(() => {})).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary

Adds `cloneForMutation(value, path, options) -> { value, pathValue }` to `@commonfabric/data-model`, alongside `cloneIfNecessary` in `value-clone.ts`.

Spine-walk copy-on-write: shallow-clones only the containers along `path` from the root to the leaf, splicing each fresh clone into its (now mutable) parent. Subtrees off the spine are preserved by identity — they keep their `deepFrozenCache` registration, so re-freezing the result tree short-circuits everywhere except the freshly allocated spine.

## Signature

```ts
export interface CloneForMutationOptions {
  /** Default: `true`. Matches `cloneIfNecessary`'s default when
   * `frozen: false`. With `force: true` the caller's input is guaranteed
   * untouched; with `force: false` already-mutable spine containers are
   * reused by identity. */
  force?: boolean;
}

export interface CloneForMutationResult<T extends FabricValue> {
  /** Replacement for the input value, with the spine made mutable. */
  value: T;
  /** The value at `path`, guaranteed mutable. */
  pathValue: FabricValue;
}

export function cloneForMutation<T extends FabricValue>(
  value: T,
  path: readonly string[],
  options?: CloneForMutationOptions,
): CloneForMutationResult<T>;
```

## Semantics

- `path` is an array of pre-parsed segments (JSON-Pointer-style, already unescaped and split).
- Descent goes through plain objects and arrays only — not through `FabricInstance` / `FabricPrimitive`. A `FabricInstance` is permitted as the **final** value at `path`, in which case it's shallow-thawed via its own `shallowClone(false)`. (Descending **into** a `FabricInstance` is intentionally out of scope here, marked as a possible future extension.)
- Each per-container thaw delegates to `cloneIfNecessary(_, { frozen: false, deep: false, force })`, so the existing `cloneIfNecessary` semantics for plain objects / arrays / `FabricInstance` are reused verbatim.

## Errors

- Missing path segment.
- Descent through a non-plain-container (primitive, `FabricInstance`, `FabricPrimitive`).
- Non-mutable leaf (primitive or `FabricPrimitive`).
- Empty path with a non-mutable root, or non-empty path with a non-container (incl. `FabricInstance`) root.

## Helper hoisting (second commit)

Two helpers that were initially private file-locals in `value-clone.ts` got promoted to their natural homes, with dedicated unit-test coverage:

- `isPlainContainer(v)` → `@commonfabric/utils/types`, next to `isPlainObject`. Now a proper type guard (`value is Record<string, unknown> | unknown[]`).
- `describeKind(v)` → `packages/data-model/value-debug.ts`, renamed `toDebugKindString` to match that file's `to…DebugString` naming pattern.

Each got its own describe block in the package's existing types/value-debug tests covering plain objects / arrays / frozen variants / null-prototype / class instances / FabricInstance & FabricPrimitive subclasses / primitives / fallback paths.

## Why

Prep for the upcoming structural-sharing PR in `packages/runner/src/storage/v2-transaction.ts`. Today its two write-path mutating sites use `cloneIfNecessary(_, { frozen: false })` which deep-clones the entire value tree just to expose a mutable spine; they'll switch to `cloneForMutation` and stop allocating O(N) clones for an O(D) mutation.

## Test plan

- [x] `deno task test` in `@commonfabric/data-model` — 46 tests / 1679 steps pass. New `clone-for-mutation` tests contribute 70 steps covering: empty / single-step / deep paths; both `force` values; both frozen and mutable inputs; default-options behavior (`force` defaults to `true`); off-spine identity preservation; deep-frozen-cache preservation; `FabricInstance` at leaf via `shallowClone(false)`; every error path. New `toDebugKindString` tests contribute 9 steps. All parameterized across both legacy and modern data-model flag states where the flag is relevant.
- [x] `deno task test` in `@commonfabric/utils` — 83 tests pass. New `isPlainContainer` tests contribute 7 steps.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Performance Baseline

This PR adds utility functions which are not yet used, so the following accounts for a spurious perf check failure:

NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/reading-list/reading-list.test.tsx = 24s
NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/notes/notebook.test.tsx = 62s