### PR TITLE
feat(shell): add slug piece routes

### DIFF
--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -239,6 +239,7 @@ export const piece = new Command()
     "--root <path:string>",
     "Root directory for resolving imports. Allows imports from parent directories within this root.",
   )
+  .option("--slug <slug:string>", "Slug URL/address for this piece.")
   .action(async (options, main) => {
     setQuietMode(!!options.quiet);
     const spaceConfig = parseSpaceOptions(options);
@@ -249,11 +250,12 @@ export const piece = new Command()
         mainExport: options.mainExport,
         rootPath: options.root ? absPath(options.root) : undefined,
       },
-      { start: options.start },
+      { start: options.start, slug: options.slug },
     );
     render(pieceId);
+    const browserPieceRef = options.slug ?? pieceId;
     hint(cliText(`NEXT STEPS:
-  → Open in browser: ${spaceConfig.apiUrl}/${spaceConfig.space}/${pieceId}
+  → Open in browser: ${spaceConfig.apiUrl}/${spaceConfig.space}/${browserPieceRef}
   → Update code:     cf piece setsrc --piece ${pieceId} ${main} ...
   → Test a callable: cf piece call --piece ${pieceId} <callableName> ...
   → Inspect state:   cf piece inspect --piece ${pieceId} ...`));

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -21,6 +21,7 @@ import {
   setCellValue,
   setHomePattern,
   setPiecePattern,
+  setPieceSlug,
   SpaceConfig,
   stepPiece,
 } from "../lib/piece.ts";
@@ -259,6 +260,45 @@ export const piece = new Command()
   → Update code:     cf piece setsrc --piece ${pieceId} ${main} ...
   → Test a callable: cf piece call --piece ${pieceId} <callableName> ...
   → Inspect state:   cf piece inspect --piece ${pieceId} ...`));
+  })
+  /* piece set-slug */
+  .command(
+    "set-slug",
+    "Set a slug redirect to a piece or cell link.",
+  )
+  .usage(spaceUsage)
+  .example(
+    cliText(`cf piece set-slug ${EX_ID} ${EX_COMP} project-notes bafypiece1`),
+    `Set slug "project-notes" to piece "bafypiece1".`,
+  )
+  .example(
+    cliText(
+      `cf piece set-slug ${EX_ID} ${EX_COMP} latest-note old-slug --resolve-before-linking`,
+    ),
+    `Set slug "latest-note" to the cell currently resolved by "old-slug".`,
+  )
+  .arguments("<slug:string> <source:string>")
+  .option(
+    "--resolve-before-linking",
+    "Resolve the source cell before writing it as the slug redirect target.",
+  )
+  .action(async (options, slug, sourceRef) => {
+    setQuietMode(!!options.quiet);
+    const spaceConfig = parseSpaceOptions(options);
+    const source = parseLink(sourceRef);
+    await setPieceSlug(
+      spaceConfig,
+      slug,
+      source.pieceId,
+      source.path || [],
+      {
+        sourceScope: source.scope,
+        resolveBeforeLinking: !!(options as any).resolveBeforeLinking,
+      },
+    );
+    render(`Set slug ${slug} to ${sourceRef}`);
+    hint(cliText(`NEXT STEPS:
+  → Open in browser: ${spaceConfig.apiUrl}/${spaceConfig.space}/${slug}`));
   })
   /* piece step */
   .command("step", "Run a single scheduling step: start → idle → synced → stop")

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -309,7 +309,7 @@ run_piece_links() {
   echo "Testing piece link with invented piece ID..."
 
   # Use an invented piece ID (not created via cf piece new) as a data source
-  INVENTED_ID="baedreizzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+  INVENTED_ID="fid1:zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
 
   # Write a value to the invented piece
   echo '42' | cf piece set $SPACE_ARGS --piece $INVENTED_ID value

--- a/packages/cli/integration/integration.sh
+++ b/packages/cli/integration/integration.sh
@@ -254,6 +254,14 @@ run_piece_links() {
 
   echo "Testing piece link..."
 
+  cf piece set-slug $SPACE_ARGS counter-alias $PIECE_ID
+
+  cf piece get $SPACE_ARGS --piece counter-alias value > /dev/null
+
+  cf piece set-slug $SPACE_ARGS resolved-counter counter-alias --resolve-before-linking
+
+  cf piece get $SPACE_ARGS --piece resolved-counter value > /dev/null
+
   # Create a second piece from the same pattern
   PIECE_ID2=$(cf piece new --main-export $CUSTOM_EXPORT $SPACE_ARGS $PATTERN_SRC)
   echo "Created second piece: $PIECE_ID2"
@@ -280,6 +288,12 @@ run_piece_links() {
 
   # Link piece1's output value to piece2's input value
   cf piece link $SPACE_ARGS $PIECE_ID/value $PIECE_ID2/value
+
+  # Linking to a missing destination slug should fail instead of treating it
+  # as an invented target piece ID.
+  if cf piece link $SPACE_ARGS $PIECE_ID/value missing-destination-slug/value 2>/dev/null; then
+    error "Linking to missing destination slug should have failed"
+  fi
 
   # Read back piece2's input value - should be piece1's output value (10)
   RESULT=$(cf piece get $SPACE_ARGS --piece $PIECE_ID2 value --input)

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -11,7 +11,12 @@ import {
 } from "@commonfabric/runner";
 import type { CellScope } from "@commonfabric/api";
 import { StorageManager } from "@commonfabric/runner/storage/cache";
-import { pieceId, PieceManager } from "@commonfabric/piece";
+import {
+  assignSlug,
+  pieceId,
+  PieceManager,
+  resolvePieceAddress as resolveStoredPieceAddress,
+} from "@commonfabric/piece";
 import { PiecesController } from "@commonfabric/piece/ops";
 import { dirname, join } from "@std/path";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
@@ -77,6 +82,14 @@ export interface ExecutedPieceCallable {
   outputText?: string;
   parsed: ParsedExecArgs;
   resolved: ResolvedPieceCallable;
+}
+
+export interface PieceResolutionDeps {
+  loadManager?: typeof loadManager;
+  resolvePieceAddress?: (
+    manager: PieceManager,
+    token: string,
+  ) => Promise<string>;
 }
 
 const CLI_TRACE_TIMINGS = Deno.env.get("CF_CLI_TRACE_TIMINGS") === "1";
@@ -242,11 +255,35 @@ export async function listPieces(
   );
 }
 
+async function resolvePieceConfigWithManager(
+  config: PieceConfig,
+  manager: PieceManager,
+  resolver: PieceResolutionDeps["resolvePieceAddress"] =
+    resolveStoredPieceAddress,
+): Promise<PieceConfig> {
+  return {
+    ...config,
+    piece: await resolver(manager, config.piece),
+  };
+}
+
+export async function resolvePieceConfig(
+  config: PieceConfig,
+  deps: PieceResolutionDeps = {},
+): Promise<PieceConfig> {
+  const manager = await (deps.loadManager ?? loadManager)(config);
+  return await resolvePieceConfigWithManager(
+    config,
+    manager,
+    deps.resolvePieceAddress,
+  );
+}
+
 // Creates a new piece from source code and optional input.
 export async function newPiece(
   config: SpaceConfig,
   entry: EntryConfig,
-  options?: { start?: boolean },
+  options?: { start?: boolean; slug?: string },
 ): Promise<string> {
   const manager = await timeCliPhase(
     "newPiece.loadManager",
@@ -278,7 +315,7 @@ export async function newPiece(
   );
   const PIECE_START_TIMEOUT_MS = 60_000;
   const piece = await timeCliPhase("newPiece.create", () => {
-    const createPromise = pieces.create(program, options);
+    const createPromise = pieces.create(program, { start: options?.start });
     let timer: ReturnType<typeof setTimeout> | undefined;
     const timeout = new Promise<never>((_, reject) => {
       timer = setTimeout(() => {
@@ -296,6 +333,13 @@ export async function newPiece(
     );
   });
 
+  if (options?.slug) {
+    await timeCliPhase(
+      "newPiece.assignSlug",
+      () => assignSlug(manager, piece.getCell(), options.slug!),
+    );
+  }
+
   // Explicitly add the piece to the space's allPieces list
   await timeCliPhase(
     "newPiece.addToDefaultPattern",
@@ -310,12 +354,13 @@ export async function setPiecePattern(
   entry: EntryConfig,
 ): Promise<void> {
   const manager = await loadManager(config);
+  const resolvedConfig = await resolvePieceConfigWithManager(config, manager);
   const pieces = new PiecesController(manager);
   const piece = await pieces.get(
-    config.piece,
+    resolvedConfig.piece,
     false,
     undefined,
-    config.pieceScope,
+    resolvedConfig.pieceScope,
   );
   await piece.setPattern(await getProgramFromFile(manager, entry));
 }
@@ -326,12 +371,13 @@ export async function savePiecePattern(
 ): Promise<void> {
   await ensureDir(outPath);
   const manager = await loadManager(config);
+  const resolvedConfig = await resolvePieceConfigWithManager(config, manager);
   const pieces = new PiecesController(manager);
   const piece = await pieces.get(
-    config.piece,
+    resolvedConfig.piece,
     false,
     undefined,
-    config.pieceScope,
+    resolvedConfig.pieceScope,
   );
   const meta = await piece.getPatternMeta();
 
@@ -349,19 +395,20 @@ export async function savePiecePattern(
     }
   } else {
     throw new Error(
-      `Piece "${config.piece}" does not contain a pattern source.`,
+      `Piece "${resolvedConfig.piece}" does not contain a pattern source.`,
     );
   }
 }
 
 export async function applyPieceInput(config: PieceConfig, input: object) {
   const manager = await loadManager(config);
+  const resolvedConfig = await resolvePieceConfigWithManager(config, manager);
   const pieces = new PiecesController(manager);
   const piece = await pieces.get(
-    config.piece,
+    resolvedConfig.piece,
     false,
     undefined,
-    config.pieceScope,
+    resolvedConfig.pieceScope,
   );
   await piece.setInput(input);
 }
@@ -485,6 +532,7 @@ async function resolvePieceCallable(
   deps: PieceCallableDependencies = {},
 ): Promise<ResolvedPieceCallable> {
   const manager = await (deps.loadManager ?? loadManager)(config);
+  const resolvedConfig = await resolvePieceConfigWithManager(config, manager);
   const pieces = new PiecesController(manager);
 
   if (!deps.loadPiece) {
@@ -499,10 +547,18 @@ async function resolvePieceCallable(
     }
   }
 
-  const piece =
-    await (deps.loadPiece
-      ? deps.loadPiece(manager, config.piece, config.pieceScope)
-      : pieces.get(config.piece, true, undefined, config.pieceScope));
+  const piece = await (deps.loadPiece
+    ? deps.loadPiece(
+      manager,
+      resolvedConfig.piece,
+      resolvedConfig.pieceScope,
+    )
+    : pieces.get(
+      resolvedConfig.piece,
+      true,
+      undefined,
+      resolvedConfig.pieceScope,
+    ));
   const space = manager.getSpace?.() ?? config.space;
 
   const resolved = (await tryResolvePieceCallableAt(
@@ -532,7 +588,7 @@ async function resolvePieceCallable(
       manager,
       space,
       callableName,
-      config.pieceScope,
+      resolvedConfig.pieceScope,
     );
     if (liveCallableCell) {
       return {
@@ -588,6 +644,14 @@ export async function linkPieces(
     () => loadManager(config),
   );
   const pieces = new PiecesController(manager);
+  const resolvedSourcePieceId = await timeCliPhase(
+    "linkPieces.resolveSource",
+    () => resolveStoredPieceAddress(manager, sourcePieceId),
+  );
+  const resolvedTargetPieceId = await timeCliPhase(
+    "linkPieces.resolveTarget",
+    () => resolveStoredPieceAddress(manager, targetPieceId),
+  );
 
   // Validate that source and target pieces/paths exist by reading them
   if (!options?.allowNonExisting) {
@@ -597,7 +661,13 @@ export async function linkPieces(
     // (i.e., was created via cf piece new, not just written to with cf piece set)
     const sourcePiece = await timeCliPhase(
       "linkPieces.getSourcePiece",
-      () => pieces.get(sourcePieceId, false, undefined, options?.sourceScope),
+      () =>
+        pieces.get(
+          resolvedSourcePieceId,
+          false,
+          undefined,
+          options?.sourceScope,
+        ),
     );
     const sourceHasProcess =
       sourcePiece.getCell().getSourceCell() !== undefined;
@@ -637,7 +707,13 @@ export async function linkPieces(
     // Check target piece exists by verifying it has a source/process cell
     const targetPiece = await timeCliPhase(
       "linkPieces.getTargetPiece",
-      () => pieces.get(targetPieceId, false, undefined, options?.targetScope),
+      () =>
+        pieces.get(
+          resolvedTargetPieceId,
+          false,
+          undefined,
+          options?.targetScope,
+        ),
     );
     const targetHasProcess =
       targetPiece.getCell().getSourceCell() !== undefined;
@@ -685,9 +761,9 @@ export async function linkPieces(
     "linkPieces.manager.link",
     () =>
       manager.link(
-        sourcePieceId,
+        resolvedSourcePieceId,
         sourcePath,
-        targetPieceId,
+        resolvedTargetPieceId,
         targetPath,
         options,
       ),
@@ -870,12 +946,13 @@ export async function inspectPiece(config: PieceConfig): Promise<{
   readBy: Array<{ id: string; name?: string }>;
 }> {
   const manager = await loadManager(config);
+  const resolvedConfig = await resolvePieceConfigWithManager(config, manager);
   const pieces = new PiecesController(manager);
   const piece = await pieces.get(
-    config.piece,
+    resolvedConfig.piece,
     false,
     undefined,
-    config.pieceScope,
+    resolvedConfig.pieceScope,
   );
 
   const id = piece.id;
@@ -935,12 +1012,13 @@ export async function getCellValue(
   options?: { input?: boolean },
 ): Promise<unknown> {
   const manager = await loadManager(config);
+  const resolvedConfig = await resolvePieceConfigWithManager(config, manager);
   const pieces = new PiecesController(manager);
   const piece = await pieces.get(
-    config.piece,
+    resolvedConfig.piece,
     false,
     undefined,
-    config.pieceScope,
+    resolvedConfig.pieceScope,
   );
   if (options?.input) {
     return await piece.input.get(path);
@@ -956,12 +1034,13 @@ export async function setCellValue(
   options?: { input?: boolean },
 ): Promise<void> {
   const manager = await loadManager(config);
+  const resolvedConfig = await resolvePieceConfigWithManager(config, manager);
   const pieces = new PiecesController(manager);
   const piece = await pieces.get(
-    config.piece,
+    resolvedConfig.piece,
     false,
     undefined,
-    config.pieceScope,
+    resolvedConfig.pieceScope,
   );
   if (options?.input) {
     await piece.input.set(value, path);
@@ -996,14 +1075,21 @@ export async function stepPiece(config: PieceConfig): Promise<void> {
     "stepPiece.loadManager",
     () => loadManager(config),
   );
+  const resolvedConfig = await resolvePieceConfigWithManager(config, manager);
   const pieces = new PiecesController(manager);
   const piece = await timeCliPhase(
     "stepPiece.getPiece",
-    () => pieces.get(config.piece, true, undefined, config.pieceScope),
+    () =>
+      pieces.get(
+        resolvedConfig.piece,
+        true,
+        undefined,
+        resolvedConfig.pieceScope,
+      ),
   );
   await timeCliPhase("stepPiece.pull", () => piece.getCell().pull());
   await timeCliPhase("stepPiece.manager.synced", () => manager.synced());
-  await timeCliPhase("stepPiece.stop", () => pieces.stop(config.piece));
+  await timeCliPhase("stepPiece.stop", () => pieces.stop(resolvedConfig.piece));
 }
 
 /**
@@ -1011,8 +1097,9 @@ export async function stepPiece(config: PieceConfig): Promise<void> {
  */
 export async function removePiece(config: PieceConfig): Promise<void> {
   const manager = await loadManager(config);
+  const resolvedConfig = await resolvePieceConfigWithManager(config, manager);
   const pieces = new PiecesController(manager);
-  const removed = await pieces.remove(config.piece);
+  const removed = await pieces.remove(resolvedConfig.piece);
 
   if (!removed) {
     throw new Error(`Piece "${config.piece}" not found`);

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -16,6 +16,7 @@ import {
   pieceId,
   PieceManager,
   resolvePieceAddress as resolveStoredPieceAddress,
+  SlugResolutionError,
 } from "@commonfabric/piece";
 import { PiecesController } from "@commonfabric/piece/ops";
 import { dirname, join } from "@std/path";
@@ -277,6 +278,22 @@ export async function resolvePieceConfig(
     manager,
     deps.resolvePieceAddress,
   );
+}
+
+export async function resolveLinkEndpointAddress(
+  manager: PieceManager,
+  token: string,
+  resolver: PieceResolutionDeps["resolvePieceAddress"] =
+    resolveStoredPieceAddress,
+): Promise<string> {
+  try {
+    return await resolver(manager, token);
+  } catch (error) {
+    if (error instanceof SlugResolutionError && error.code === "missing") {
+      return token;
+    }
+    throw error;
+  }
 }
 
 // Creates a new piece from source code and optional input.
@@ -646,11 +663,11 @@ export async function linkPieces(
   const pieces = new PiecesController(manager);
   const resolvedSourcePieceId = await timeCliPhase(
     "linkPieces.resolveSource",
-    () => resolveStoredPieceAddress(manager, sourcePieceId),
+    () => resolveLinkEndpointAddress(manager, sourcePieceId),
   );
   const resolvedTargetPieceId = await timeCliPhase(
     "linkPieces.resolveTarget",
-    () => resolveStoredPieceAddress(manager, targetPieceId),
+    () => resolveLinkEndpointAddress(manager, targetPieceId),
   );
 
   // Validate that source and target pieces/paths exist by reading them

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -16,6 +16,7 @@ import {
   pieceId,
   PieceManager,
   resolvePieceAddress as resolveStoredPieceAddress,
+  setSlugLink,
   SlugResolutionError,
 } from "@commonfabric/piece";
 import { PiecesController } from "@commonfabric/piece/ops";
@@ -285,11 +286,16 @@ export async function resolveLinkEndpointAddress(
   token: string,
   resolver: PieceResolutionDeps["resolvePieceAddress"] =
     resolveStoredPieceAddress,
+  options?: { allowMissingSlugFallback?: boolean },
 ): Promise<string> {
   try {
     return await resolver(manager, token);
   } catch (error) {
-    if (error instanceof SlugResolutionError && error.code === "missing") {
+    if (
+      options?.allowMissingSlugFallback &&
+      error instanceof SlugResolutionError &&
+      error.code === "missing"
+    ) {
       return token;
     }
     throw error;
@@ -364,6 +370,56 @@ export async function newPiece(
   );
 
   return piece.id;
+}
+
+export async function setPieceSlug(
+  config: SpaceConfig,
+  slug: string,
+  sourcePieceId: string,
+  sourcePath: (string | number)[],
+  options?: {
+    sourceScope?: PieceConfig["pieceScope"];
+    resolveBeforeLinking?: boolean;
+  },
+): Promise<void> {
+  const manager = await timeCliPhase(
+    "setPieceSlug.loadManager",
+    () => loadManager(config),
+  );
+  const resolvedSourcePieceId = await timeCliPhase(
+    "setPieceSlug.resolveSource",
+    () => resolveStoredPieceAddress(manager, sourcePieceId),
+  );
+  const source = sourcePath.length === 0
+    ? manager.runtime.getCellFromEntityId(
+      manager.getSpace(),
+      { "/": resolvedSourcePieceId },
+      [],
+      undefined,
+      undefined,
+      options?.sourceScope,
+    )
+    : (await timeCliPhase(
+      "setPieceSlug.getSourcePiece",
+      () => {
+        const pieces = new PiecesController(manager);
+        return pieces.get(
+          resolvedSourcePieceId,
+          false,
+          undefined,
+          options?.sourceScope,
+        );
+      },
+    )).getCell().key(...sourcePath);
+  await timeCliPhase("setPieceSlug.source.sync", () => source.sync());
+  await timeCliPhase(
+    "setPieceSlug.setSlugLink",
+    () =>
+      setSlugLink(manager, slug, source, {
+        resolveBeforeLinking: options?.resolveBeforeLinking,
+        writeTargetMetadata: sourcePath.length === 0,
+      }),
+  );
 }
 
 export async function setPiecePattern(
@@ -663,7 +719,10 @@ export async function linkPieces(
   const pieces = new PiecesController(manager);
   const resolvedSourcePieceId = await timeCliPhase(
     "linkPieces.resolveSource",
-    () => resolveLinkEndpointAddress(manager, sourcePieceId),
+    () =>
+      resolveLinkEndpointAddress(manager, sourcePieceId, undefined, {
+        allowMissingSlugFallback: true,
+      }),
   );
   const resolvedTargetPieceId = await timeCliPhase(
     "linkPieces.resolveTarget",

--- a/packages/cli/test/charm.test.ts
+++ b/packages/cli/test/charm.test.ts
@@ -309,6 +309,15 @@ describe("cli piece parsing", () => {
     expect(stripAnsi(stdout.join("\n"))).toContain("--slug");
   });
 
+  it("shows set-slug command options", async () => {
+    const { code, stdout, stderr } = await cf("piece set-slug --help");
+    checkStderr(stderr);
+    const output = stripAnsi(stdout.join("\n"));
+    expect(code).toBe(0);
+    expect(output).toContain("Set a slug redirect");
+    expect(output).toContain("--resolve-before-linking");
+  });
+
   it("resolves slug piece config through storage", async () => {
     const manager = {};
     const resolved = await resolvePieceConfig({
@@ -361,8 +370,22 @@ describe("cli piece parsing", () => {
         Promise.reject(
           new SlugResolutionError(`Slug "${token}" not found.`, "missing"),
         ),
+      { allowMissingSlugFallback: true },
     );
 
     expect(resolved).toBe(token);
+  });
+
+  it("rejects missing destination slug endpoints", async () => {
+    const manager = {};
+    const token = "demo";
+    await expect(resolveLinkEndpointAddress(
+      manager as any,
+      token,
+      () =>
+        Promise.reject(
+          new SlugResolutionError(`Slug "${token}" not found.`, "missing"),
+        ),
+    )).rejects.toThrow(/Slug "demo" not found/);
   });
 });

--- a/packages/cli/test/charm.test.ts
+++ b/packages/cli/test/charm.test.ts
@@ -1,7 +1,11 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { cf, checkStderr, stripAnsi } from "./utils.ts";
-import { recreateSpaceRootPattern, type SpaceConfig } from "../lib/piece.ts";
+import {
+  recreateSpaceRootPattern,
+  resolvePieceConfig,
+  type SpaceConfig,
+} from "../lib/piece.ts";
 import {
   parseLink,
   parsePieceOptions,
@@ -294,5 +298,34 @@ describe("cli piece parsing", () => {
       expect(result.pieceId).toBe("piece");
       expect(result.path).toEqual(["field", ""]);
     });
+  });
+
+  it("shows slug option for piece new", async () => {
+    const { code, stdout, stderr } = await cf("piece new --help");
+    checkStderr(stderr);
+    expect(code).toBe(0);
+    expect(stripAnsi(stdout.join("\n"))).toContain("--slug");
+  });
+
+  it("resolves slug piece config through storage", async () => {
+    const manager = {};
+    const resolved = await resolvePieceConfig({
+      apiUrl: API_URL,
+      space: SPACE,
+      identity: ID,
+      piece: "demo",
+    }, {
+      loadManager: (config: SpaceConfig) => {
+        expect(config.space).toBe(SPACE);
+        return Promise.resolve(manager as any);
+      },
+      resolvePieceAddress: (seenManager: unknown, token: string) => {
+        expect(seenManager).toBe(manager);
+        expect(token).toBe("demo");
+        return Promise.resolve(PIECE);
+      },
+    });
+
+    expect(resolved.piece).toBe(PIECE);
   });
 });

--- a/packages/cli/test/charm.test.ts
+++ b/packages/cli/test/charm.test.ts
@@ -331,6 +331,26 @@ describe("cli piece parsing", () => {
     expect(resolved.piece).toBe(PIECE);
   });
 
+  it("preserves URI piece config without slug lookup", async () => {
+    const resolved = await resolvePieceConfig({
+      apiUrl: API_URL,
+      space: SPACE,
+      identity: ID,
+      piece: "of:fid1:piece-123",
+    }, {
+      loadManager: () => Promise.resolve({} as any),
+    });
+
+    expect(resolved.piece).toBe("of:fid1:piece-123");
+  });
+
+  it("preserves URI link endpoints without slug lookup", async () => {
+    const token = "of:fid1:piece-123";
+    const resolved = await resolveLinkEndpointAddress({} as any, token);
+
+    expect(resolved).toBe(token);
+  });
+
   it("preserves non-fid link endpoints when no slug document exists", async () => {
     const manager = {};
     const token = "baedreiahv63wxwgaem4hzjkizl4qncfgvca7pj5cvdon7cukumfon3ioye";

--- a/packages/cli/test/charm.test.ts
+++ b/packages/cli/test/charm.test.ts
@@ -3,9 +3,11 @@ import { expect } from "@std/expect";
 import { cf, checkStderr, stripAnsi } from "./utils.ts";
 import {
   recreateSpaceRootPattern,
+  resolveLinkEndpointAddress,
   resolvePieceConfig,
   type SpaceConfig,
 } from "../lib/piece.ts";
+import { SlugResolutionError } from "@commonfabric/piece";
 import {
   parseLink,
   parsePieceOptions,
@@ -327,5 +329,20 @@ describe("cli piece parsing", () => {
     });
 
     expect(resolved.piece).toBe(PIECE);
+  });
+
+  it("preserves non-fid link endpoints when no slug document exists", async () => {
+    const manager = {};
+    const token = "baedreiahv63wxwgaem4hzjkizl4qncfgvca7pj5cvdon7cukumfon3ioye";
+    const resolved = await resolveLinkEndpointAddress(
+      manager as any,
+      token,
+      () =>
+        Promise.reject(
+          new SlugResolutionError(`Slug "${token}" not found.`, "missing"),
+        ),
+    );
+
+    expect(resolved).toBe(token);
   });
 });

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -22,7 +22,7 @@ describe("executePieceCallable", () => {
       {
         apiUrl: "http://localhost:8000",
         identity: "/tmp/test-identity.pem",
-        piece: "of:piece-123",
+        piece: "fid1:piece-123",
         space: "home",
       },
       "recordMessage",
@@ -93,7 +93,7 @@ describe("executePieceCallable", () => {
       {
         apiUrl: "http://localhost:8000",
         identity: "/tmp/test-identity.pem",
-        piece: "of:piece-123",
+        piece: "fid1:piece-123",
         space: "home",
       },
       "search",
@@ -136,7 +136,7 @@ describe("executePieceCallable", () => {
       {
         apiUrl: "http://localhost:8000",
         identity: "/tmp/test-identity.pem",
-        piece: "of:piece-123",
+        piece: "fid1:piece-123",
         pieceScope: "session",
         space: "home",
       },
@@ -183,7 +183,7 @@ describe("executePieceCallable", () => {
       {
         apiUrl: "http://localhost:8000",
         identity: "/tmp/test-identity.pem",
-        piece: "of:piece-123",
+        piece: "fid1:piece-123",
         space: "home",
       },
       "search",
@@ -209,7 +209,7 @@ describe("executePieceCallable", () => {
       {
         apiUrl: "http://localhost:8000",
         identity: "/tmp/test-identity.pem",
-        piece: "of:piece-123",
+        piece: "fid1:piece-123",
         space: "home",
       },
       "editContent",
@@ -252,7 +252,7 @@ describe("executePieceCallable", () => {
       {
         apiUrl: "http://localhost:8000",
         identity: "/tmp/test-identity.pem",
-        piece: "of:piece-123",
+        piece: "fid1:piece-123",
         space: "home",
       },
       "editContent",
@@ -300,7 +300,7 @@ describe("executePieceCallable", () => {
       {
         apiUrl: "http://localhost:8000",
         identity: "/tmp/test-identity.pem",
-        piece: "of:piece-123",
+        piece: "fid1:piece-123",
         space: "home",
       },
       "editContent",
@@ -332,7 +332,7 @@ describe("executePieceCallable", () => {
       {
         apiUrl: "http://localhost:8000",
         identity: "/tmp/test-identity.pem",
-        piece: "of:piece-123",
+        piece: "fid1:piece-123",
         space: "home",
       },
       "editContent",
@@ -376,7 +376,7 @@ describe("executePieceCallable", () => {
       {
         apiUrl: "http://localhost:8000",
         identity: "/tmp/test-identity.pem",
-        piece: "of:piece-123",
+        piece: "fid1:piece-123",
         space: "home",
       },
       "editContent",
@@ -423,7 +423,7 @@ describe("executePieceCallable", () => {
       {
         apiUrl: "http://localhost:8000",
         identity: "/tmp/test-identity.pem",
-        piece: "of:piece-123",
+        piece: "fid1:piece-123",
         space: "home",
       },
       "editContent",
@@ -467,7 +467,7 @@ describe("executePieceCallable", () => {
       {
         apiUrl: "http://localhost:8000",
         identity: "/tmp/test-identity.pem",
-        piece: "of:piece-123",
+        piece: "fid1:piece-123",
         space: "home",
       },
       "editContent",
@@ -513,7 +513,7 @@ describe("executePieceCallable", () => {
       {
         apiUrl: "http://localhost:8000",
         identity: "/tmp/test-identity.pem",
-        piece: "of:piece-123",
+        piece: "fid1:piece-123",
         space: "home",
       },
       "search",
@@ -562,7 +562,7 @@ describe("executePieceCallable", () => {
         {
           apiUrl: "http://localhost:8000",
           identity: "/tmp/test-identity.pem",
-          piece: "of:piece-123",
+          piece: "fid1:piece-123",
           space: "home",
         },
         "recordMessage",

--- a/packages/piece/src/index.ts
+++ b/packages/piece/src/index.ts
@@ -2,5 +2,6 @@ export { getPatternIdFromPiece, pieceId, PieceManager } from "./manager.ts";
 export {
   assignSlug,
   resolvePieceAddress,
+  setSlugLink,
   SlugResolutionError,
 } from "./slugs.ts";

--- a/packages/piece/src/index.ts
+++ b/packages/piece/src/index.ts
@@ -1,1 +1,6 @@
 export { getPatternIdFromPiece, pieceId, PieceManager } from "./manager.ts";
+export {
+  assignSlug,
+  resolvePieceAddress,
+  SlugResolutionError,
+} from "./slugs.ts";

--- a/packages/piece/src/slugs.ts
+++ b/packages/piece/src/slugs.ts
@@ -27,24 +27,46 @@ export async function assignSlug(
   piece: Cell<unknown>,
   slug: string,
 ): Promise<void> {
+  await setSlugLink(manager, slug, piece, { writeTargetMetadata: true });
+}
+
+export async function setSlugLink(
+  manager: PieceManager,
+  slug: string,
+  source: Cell<unknown>,
+  options?: {
+    resolveBeforeLinking?: boolean;
+    writeTargetMetadata?: boolean;
+  },
+): Promise<void> {
   const validSlug = validateSlug(slug);
+  const target = options?.resolveBeforeLinking
+    ? source.resolveAsCell()
+    : source;
+  await target.sync();
+
   const slugCell = manager.runtime.getCellFromEntityId(
     manager.getSpace(),
     { "/": slugIdForSpace(manager.getSpace(), validSlug) },
   );
 
   await manager.runtime.editWithRetry((tx) => {
-    const pieceWithTx = piece.withTx(tx);
+    const targetWithTx = target.withTx(tx);
     const slugWithTx = slugCell.withTx(tx);
-    const pieceLink = pieceWithTx.getAsNormalizedFullLink();
+    const targetLink = targetWithTx.getAsNormalizedFullLink();
     const slugLink = slugWithTx.getAsNormalizedFullLink();
 
-    tx.writeOrThrow({
-      space: pieceLink.space,
-      id: pieceLink.id,
-      scope: pieceLink.scope,
-      path: ["slug"],
-    }, validSlug);
+    if (
+      options?.writeTargetMetadata &&
+      (!targetLink.path || targetLink.path.length === 0)
+    ) {
+      tx.writeOrThrow({
+        space: targetLink.space,
+        id: targetLink.id,
+        scope: targetLink.scope,
+        path: ["slug"],
+      }, validSlug);
+    }
     tx.writeOrThrow({
       space: slugLink.space,
       id: slugLink.id,
@@ -52,7 +74,7 @@ export async function assignSlug(
       path: ["slug"],
     }, validSlug);
     slugWithTx.setRawUntyped(
-      pieceWithTx.getAsWriteRedirectLink({ base: slugWithTx }),
+      targetWithTx.getAsWriteRedirectLink({ base: slugWithTx }),
     );
   });
 

--- a/packages/piece/src/slugs.ts
+++ b/packages/piece/src/slugs.ts
@@ -1,0 +1,102 @@
+import type { Cell, URI } from "@commonfabric/runner";
+import {
+  isSlugAddress,
+  parseLink,
+  slugIdForSpace,
+  validateSlug,
+} from "@commonfabric/runner";
+import { pieceId, PieceManager } from "./manager.ts";
+
+export class SlugResolutionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SlugResolutionError";
+  }
+}
+
+export async function assignSlug(
+  manager: PieceManager,
+  piece: Cell<unknown>,
+  slug: string,
+): Promise<void> {
+  const validSlug = validateSlug(slug);
+  const slugCell = manager.runtime.getCellFromEntityId(
+    manager.getSpace(),
+    { "/": slugIdForSpace(manager.getSpace(), validSlug) },
+  );
+
+  await manager.runtime.editWithRetry((tx) => {
+    const pieceWithTx = piece.withTx(tx);
+    const slugWithTx = slugCell.withTx(tx);
+    const pieceLink = pieceWithTx.getAsNormalizedFullLink();
+    const slugLink = slugWithTx.getAsNormalizedFullLink();
+
+    tx.writeOrThrow({
+      space: pieceLink.space,
+      id: pieceLink.id,
+      scope: pieceLink.scope,
+      path: ["slug"],
+    }, validSlug);
+    tx.writeOrThrow({
+      space: slugLink.space,
+      id: slugLink.id,
+      scope: slugLink.scope,
+      path: ["slug"],
+    }, validSlug);
+    slugWithTx.setRawUntyped(
+      pieceWithTx.getAsWriteRedirectLink({ base: slugWithTx }),
+    );
+  });
+
+  await manager.runtime.idle();
+  await manager.synced();
+}
+
+export async function resolvePieceAddress(
+  manager: PieceManager,
+  token: string,
+): Promise<string> {
+  if (!isSlugAddress(token)) {
+    return token;
+  }
+
+  const slug = validateSlug(token);
+  const slugId = slugIdForSpace(manager.getSpace(), slug);
+  const slugCell = manager.runtime.getCellFromEntityId(
+    manager.getSpace(),
+    { "/": slugId },
+  );
+  await slugCell.sync();
+  const raw = slugCell.getRaw();
+  if (raw === undefined) {
+    throw new SlugResolutionError(`Slug "${slug}" not found.`);
+  }
+
+  const targetLink = parseLink(raw, slugCell);
+  if (!targetLink || targetLink.overwrite !== "redirect") {
+    throw new SlugResolutionError(
+      `Slug "${slug}" does not contain a valid redirect.`,
+    );
+  }
+
+  const target = manager.runtime.getCellFromLink({
+    ...targetLink,
+    id: targetLink.id as URI,
+    space: targetLink.space ?? manager.getSpace(),
+    scope: targetLink.scope ?? "space",
+  });
+  await target.sync();
+  if (!target.getSourceCell()) {
+    throw new SlugResolutionError(
+      `Slug "${slug}" redirects to a document that is not a piece.`,
+    );
+  }
+
+  const id = pieceId(target);
+  if (!id) {
+    throw new SlugResolutionError(
+      `Slug "${slug}" redirects to a document without a piece id.`,
+    );
+  }
+  return id;
+}

--- a/packages/piece/src/slugs.ts
+++ b/packages/piece/src/slugs.ts
@@ -8,7 +8,15 @@ import {
 import { pieceId, PieceManager } from "./manager.ts";
 
 export class SlugResolutionError extends Error {
-  constructor(message: string) {
+  constructor(
+    message: string,
+    readonly code?:
+      | "invalid"
+      | "missing"
+      | "malformed"
+      | "not-piece"
+      | "missing-piece-id",
+  ) {
     super(message);
     this.name = "SlugResolutionError";
   }
@@ -69,13 +77,14 @@ export async function resolvePieceAddress(
   await slugCell.sync();
   const raw = slugCell.getRaw();
   if (raw === undefined) {
-    throw new SlugResolutionError(`Slug "${slug}" not found.`);
+    throw new SlugResolutionError(`Slug "${slug}" not found.`, "missing");
   }
 
   const targetLink = parseLink(raw, slugCell);
   if (!targetLink || targetLink.overwrite !== "redirect") {
     throw new SlugResolutionError(
       `Slug "${slug}" does not contain a valid redirect.`,
+      "malformed",
     );
   }
 
@@ -89,6 +98,7 @@ export async function resolvePieceAddress(
   if (!target.getSourceCell()) {
     throw new SlugResolutionError(
       `Slug "${slug}" redirects to a document that is not a piece.`,
+      "not-piece",
     );
   }
 
@@ -96,6 +106,7 @@ export async function resolvePieceAddress(
   if (!id) {
     throw new SlugResolutionError(
       `Slug "${slug}" redirects to a document without a piece id.`,
+      "missing-piece-id",
     );
   }
   return id;

--- a/packages/piece/test/slug.test.ts
+++ b/packages/piece/test/slug.test.ts
@@ -76,7 +76,7 @@ describe("piece slugs", () => {
     await slugCell.sync();
     const link = parseLink(slugCell.getRaw(), slugCell);
     expect(link?.overwrite).toBe("redirect");
-    expect(link?.id).toBe(`of:${pieceId(piece)}`);
+    expect(link?.id).toBe(piece.getAsNormalizedFullLink().id);
     expect(link?.path).toEqual(["value"]);
     expect(readRootMeta(slugId, "slug")).toBe("value-link");
   });
@@ -99,7 +99,7 @@ describe("piece slugs", () => {
     await secondSlugCell.sync();
     const link = parseLink(secondSlugCell.getRaw(), secondSlugCell);
     expect(link?.overwrite).toBe("redirect");
-    expect(link?.id).toBe(`of:${pieceId(piece)}`);
+    expect(link?.id).toBe(piece.getAsNormalizedFullLink().id);
   });
 
   it("preserves URI-shaped piece addresses", async () => {

--- a/packages/piece/test/slug.test.ts
+++ b/packages/piece/test/slug.test.ts
@@ -63,6 +63,15 @@ describe("piece slugs", () => {
     expect(await resolvePieceAddress(manager, "demo")).toBe(id);
   });
 
+  it("preserves URI-shaped piece addresses", async () => {
+    expect(await resolvePieceAddress(manager, "fid1:piece-123")).toBe(
+      "fid1:piece-123",
+    );
+    expect(await resolvePieceAddress(manager, "of:fid1:piece-123")).toBe(
+      "of:fid1:piece-123",
+    );
+  });
+
   it("overwrites an existing slug redirect", async () => {
     const first = await createPiece("slug-first");
     const second = await createPiece("slug-second");

--- a/packages/piece/test/slug.test.ts
+++ b/packages/piece/test/slug.test.ts
@@ -4,9 +4,10 @@ import { createSession, Identity } from "@commonfabric/identity";
 import { Runtime, type URI } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { createBuilder } from "../../runner/src/builder/factory.ts";
+import { parseLink } from "../../runner/src/link-utils.ts";
 import { slugIdForSpace } from "../../runner/src/slugs.ts";
 import { pieceId, PieceManager } from "../src/manager.ts";
-import { assignSlug, resolvePieceAddress } from "../src/slugs.ts";
+import { assignSlug, resolvePieceAddress, setSlugLink } from "../src/slugs.ts";
 
 const signer = await Identity.fromPassphrase("piece slug tests");
 
@@ -61,6 +62,44 @@ describe("piece slugs", () => {
     expect(readRootMeta(id, "slug")).toBe("demo");
     expect(readRootMeta(slugId, "slug")).toBe("demo");
     expect(await resolvePieceAddress(manager, "demo")).toBe(id);
+  });
+
+  it("sets slug redirects to arbitrary cell links", async () => {
+    const piece = await createPiece("slug-link-target");
+    const slugId = slugIdForSpace(manager.getSpace(), "value-link");
+    const slugCell = runtime.getCellFromEntityId(manager.getSpace(), {
+      "/": slugId,
+    });
+
+    await setSlugLink(manager, "value-link", piece.key("value"));
+
+    await slugCell.sync();
+    const link = parseLink(slugCell.getRaw(), slugCell);
+    expect(link?.overwrite).toBe("redirect");
+    expect(link?.id).toBe(`of:${pieceId(piece)}`);
+    expect(link?.path).toEqual(["value"]);
+    expect(readRootMeta(slugId, "slug")).toBe("value-link");
+  });
+
+  it("can resolve source links before setting a slug redirect", async () => {
+    const piece = await createPiece("slug-resolved-link-target");
+    await setSlugLink(manager, "first-link", piece);
+
+    const firstSlugCell = runtime.getCellFromEntityId(manager.getSpace(), {
+      "/": slugIdForSpace(manager.getSpace(), "first-link"),
+    });
+    const secondSlugCell = runtime.getCellFromEntityId(manager.getSpace(), {
+      "/": slugIdForSpace(manager.getSpace(), "second-link"),
+    });
+
+    await setSlugLink(manager, "second-link", firstSlugCell, {
+      resolveBeforeLinking: true,
+    });
+
+    await secondSlugCell.sync();
+    const link = parseLink(secondSlugCell.getRaw(), secondSlugCell);
+    expect(link?.overwrite).toBe("redirect");
+    expect(link?.id).toBe(`of:${pieceId(piece)}`);
   });
 
   it("preserves URI-shaped piece addresses", async () => {

--- a/packages/piece/test/slug.test.ts
+++ b/packages/piece/test/slug.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { createSession, Identity } from "@commonfabric/identity";
+import { Runtime, type URI } from "@commonfabric/runner";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { createBuilder } from "../../runner/src/builder/factory.ts";
+import { slugIdForSpace } from "../../runner/src/slugs.ts";
+import { pieceId, PieceManager } from "../src/manager.ts";
+import { assignSlug, resolvePieceAddress } from "../src/slugs.ts";
+
+const signer = await Identity.fromPassphrase("piece slug tests");
+
+describe("piece slugs", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let manager: PieceManager;
+
+  beforeEach(async () => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    const session = await createSession({
+      identity: signer,
+      spaceName: "piece-slugs-" + crypto.randomUUID(),
+    });
+    manager = new PieceManager(session, runtime);
+    await manager.synced();
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  async function createPiece(cause: string) {
+    const { commonfabric } = createBuilder();
+    const piecePattern = commonfabric.pattern<{ value: number }>((
+      { value },
+    ) => ({ value }));
+    return await manager.runPersistent(piecePattern, { value: 1 }, cause);
+  }
+
+  function readRootMeta(id: string, key: string): unknown {
+    return runtime.readTx().readOrThrow({
+      space: manager.getSpace(),
+      id: `of:${id}` as URI,
+      scope: "space",
+      path: [key],
+    });
+  }
+
+  it("stores slug metadata and resolves through the slug document redirect", async () => {
+    const piece = await createPiece("slug-target");
+    const id = pieceId(piece)!;
+
+    await assignSlug(manager, piece, "demo");
+
+    const slugId = slugIdForSpace(manager.getSpace(), "demo");
+    expect(readRootMeta(id, "slug")).toBe("demo");
+    expect(readRootMeta(slugId, "slug")).toBe("demo");
+    expect(await resolvePieceAddress(manager, "demo")).toBe(id);
+  });
+
+  it("overwrites an existing slug redirect", async () => {
+    const first = await createPiece("slug-first");
+    const second = await createPiece("slug-second");
+
+    await assignSlug(manager, first, "demo");
+    await assignSlug(manager, second, "demo");
+
+    expect(await resolvePieceAddress(manager, "demo")).toBe(pieceId(second));
+  });
+
+  it("reports missing and malformed slug documents", async () => {
+    await expect(resolvePieceAddress(manager, "missing")).rejects.toThrow(
+      /Slug "missing" not found/,
+    );
+
+    const slugId = slugIdForSpace(manager.getSpace(), "malformed");
+    const slugCell = runtime.getCellFromEntityId(manager.getSpace(), {
+      "/": slugId,
+    });
+    await runtime.editWithRetry((tx) => {
+      slugCell.withTx(tx).setRawUntyped("not a redirect");
+    });
+
+    await expect(resolvePieceAddress(manager, "malformed")).rejects.toThrow(
+      /does not contain a valid redirect/,
+    );
+  });
+});

--- a/packages/runner/deno.json
+++ b/packages/runner/deno.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./shared": "./src/shared.ts",
+    "./slugs": "./src/slugs.ts",
     "./schemas": "./src/schemas.ts",
     "./storage/inspector": "./src/storage/inspector.ts",
     "./storage/telemetry": "./src/storage/telemetry.ts",

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -164,3 +164,9 @@ export {
   parseCellPath,
   resolveCellPath,
 } from "./piece-helpers.ts";
+export {
+  isSlugAddress,
+  slugCause,
+  slugIdForSpace,
+  validateSlug,
+} from "./slugs.ts";

--- a/packages/runner/src/slugs.ts
+++ b/packages/runner/src/slugs.ts
@@ -1,0 +1,36 @@
+import type { MemorySpace } from "@commonfabric/memory/interface";
+import { createRef } from "./create-ref.ts";
+
+export interface SlugCause {
+  space: MemorySpace;
+  slug: string;
+}
+
+export function isSlugAddress(value: string): boolean {
+  return !value.startsWith("fid1:");
+}
+
+export function validateSlug(slug: string): string {
+  if (slug.length === 0) {
+    throw new Error("Slug must not be empty.");
+  }
+  if (slug.includes("/")) {
+    throw new Error("Slug must not contain '/'.");
+  }
+  if (!isSlugAddress(slug)) {
+    throw new Error("Slug must not start with 'fid1:'.");
+  }
+  return slug;
+}
+
+export function slugCause(space: MemorySpace, slug: string): SlugCause {
+  return { space, slug: validateSlug(slug) };
+}
+
+export function slugIdForSpace(space: MemorySpace, slug: string): string {
+  const id = createRef({}, slugCause(space, slug)).toJSON?.()["/"];
+  if (typeof id !== "string") {
+    throw new Error("Could not derive slug id.");
+  }
+  return id;
+}

--- a/packages/runner/src/slugs.ts
+++ b/packages/runner/src/slugs.ts
@@ -1,5 +1,5 @@
 import type { MemorySpace } from "@commonfabric/memory/interface";
-import { createRef } from "./create-ref.ts";
+import { hashOf } from "@commonfabric/data-model/value-hash";
 
 export interface SlugCause {
   space: MemorySpace;
@@ -28,7 +28,7 @@ export function slugCause(space: MemorySpace, slug: string): SlugCause {
 }
 
 export function slugIdForSpace(space: MemorySpace, slug: string): string {
-  const id = createRef({}, slugCause(space, slug)).toJSON?.()["/"];
+  const id = hashOf({ causal: slugCause(space, slug) }).toJSON?.()["/"];
   if (typeof id !== "string") {
     throw new Error("Could not derive slug id.");
   }

--- a/packages/runner/src/slugs.ts
+++ b/packages/runner/src/slugs.ts
@@ -6,6 +6,9 @@ export interface SlugCause {
   slug: string;
 }
 
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const MAX_SLUG_LENGTH = 80;
+
 export function isSlugAddress(value: string): boolean {
   return !value.includes(":");
 }
@@ -19,6 +22,14 @@ export function validateSlug(slug: string): string {
   }
   if (slug.includes(":")) {
     throw new Error("Slug must not contain ':'.");
+  }
+  if (slug.length > MAX_SLUG_LENGTH) {
+    throw new Error(`Slug must be at most ${MAX_SLUG_LENGTH} characters.`);
+  }
+  if (!SLUG_PATTERN.test(slug)) {
+    throw new Error(
+      "Slug must use lowercase letters, numbers, and single hyphens between words.",
+    );
   }
   return slug;
 }

--- a/packages/runner/src/slugs.ts
+++ b/packages/runner/src/slugs.ts
@@ -7,7 +7,7 @@ export interface SlugCause {
 }
 
 export function isSlugAddress(value: string): boolean {
-  return !value.startsWith("fid1:");
+  return !value.includes(":");
 }
 
 export function validateSlug(slug: string): string {
@@ -17,8 +17,8 @@ export function validateSlug(slug: string): string {
   if (slug.includes("/")) {
     throw new Error("Slug must not contain '/'.");
   }
-  if (!isSlugAddress(slug)) {
-    throw new Error("Slug must not start with 'fid1:'.");
+  if (slug.includes(":")) {
+    throw new Error("Slug must not contain ':'.");
   }
   return slug;
 }

--- a/packages/runner/test/slug.test.ts
+++ b/packages/runner/test/slug.test.ts
@@ -10,9 +10,11 @@ import {
 const SPACE = "did:key:z6Mk-slug-space";
 
 describe("slug helpers", () => {
-  it("distinguishes slug addresses from fid1 ids", () => {
+  it("distinguishes slug addresses from URI ids", () => {
     expect(isSlugAddress("demo")).toBe(true);
     expect(isSlugAddress("fid1:abc")).toBe(false);
+    expect(isSlugAddress("of:fid1:abc")).toBe(false);
+    expect(isSlugAddress("of:abc")).toBe(false);
   });
 
   it("derives stable ids from space and slug", () => {
@@ -27,6 +29,7 @@ describe("slug helpers", () => {
     expect(validateSlug("demo")).toBe("demo");
     expect(() => validateSlug("")).toThrow(/Slug must not be empty/);
     expect(() => validateSlug("has/slash")).toThrow(/must not contain/);
-    expect(() => validateSlug("fid1:abc")).toThrow(/must not start/);
+    expect(() => validateSlug("fid1:abc")).toThrow(/must not contain ':'/);
+    expect(() => validateSlug("of:fid1:abc")).toThrow(/must not contain ':'/);
   });
 });

--- a/packages/runner/test/slug.test.ts
+++ b/packages/runner/test/slug.test.ts
@@ -1,0 +1,32 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  isSlugAddress,
+  slugCause,
+  slugIdForSpace,
+  validateSlug,
+} from "../src/index.ts";
+
+const SPACE = "did:key:z6Mk-slug-space";
+
+describe("slug helpers", () => {
+  it("distinguishes slug addresses from fid1 ids", () => {
+    expect(isSlugAddress("demo")).toBe(true);
+    expect(isSlugAddress("fid1:abc")).toBe(false);
+  });
+
+  it("derives stable ids from space and slug", () => {
+    expect(slugCause(SPACE, "demo")).toEqual({ space: SPACE, slug: "demo" });
+    expect(slugIdForSpace(SPACE, "demo")).toBe(slugIdForSpace(SPACE, "demo"));
+    expect(slugIdForSpace(SPACE, "demo")).not.toBe(
+      slugIdForSpace(SPACE, "other"),
+    );
+  });
+
+  it("validates slug syntax", () => {
+    expect(validateSlug("demo")).toBe("demo");
+    expect(() => validateSlug("")).toThrow(/Slug must not be empty/);
+    expect(() => validateSlug("has/slash")).toThrow(/must not contain/);
+    expect(() => validateSlug("fid1:abc")).toThrow(/must not start/);
+  });
+});

--- a/packages/runner/test/slug.test.ts
+++ b/packages/runner/test/slug.test.ts
@@ -27,9 +27,16 @@ describe("slug helpers", () => {
 
   it("validates slug syntax", () => {
     expect(validateSlug("demo")).toBe("demo");
+    expect(validateSlug("project-notes-2026")).toBe("project-notes-2026");
     expect(() => validateSlug("")).toThrow(/Slug must not be empty/);
     expect(() => validateSlug("has/slash")).toThrow(/must not contain/);
     expect(() => validateSlug("fid1:abc")).toThrow(/must not contain ':'/);
     expect(() => validateSlug("of:fid1:abc")).toThrow(/must not contain ':'/);
+    expect(() => validateSlug("Project")).toThrow(/lowercase/);
+    expect(() => validateSlug("has_underscore")).toThrow(/lowercase/);
+    expect(() => validateSlug("-leading")).toThrow(/lowercase/);
+    expect(() => validateSlug("trailing-")).toThrow(/lowercase/);
+    expect(() => validateSlug("two--hyphens")).toThrow(/lowercase/);
+    expect(() => validateSlug("x".repeat(81))).toThrow(/at most 80/);
   });
 });

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -72,6 +72,78 @@ const createRuntime = () => {
   return { runtime, storageManager };
 };
 
+describe("page slug metadata", () => {
+  it("reads slug metadata from the page document root", async () => {
+    const reads: unknown[] = [];
+    const processor = {
+      runtime: {
+        getCellFromEntityId: () => ({
+          sync: () => Promise.resolve(),
+          getAsNormalizedFullLink: () => ({
+            space: "did:key:z6Mk-runtime-processor-slug",
+            id: "of:fid1-slugged-piece",
+            scope: "space",
+            path: [],
+          }),
+        }),
+        readTx: () => ({
+          readOrThrow: (address: unknown) => {
+            reads.push(address);
+            return "demo";
+          },
+        }),
+      },
+      pieceManager: {
+        getSpace: () => "did:key:z6Mk-runtime-processor-slug",
+      },
+    };
+
+    const result = await (RuntimeProcessor.prototype as any).handlePageGetSlug
+      .call(processor, {
+        type: RequestType.PageGetSlug,
+        pageId: "fid1-slugged-piece",
+      });
+
+    expect(result).toEqual({ slug: "demo" });
+    expect(reads).toEqual([{
+      space: "did:key:z6Mk-runtime-processor-slug",
+      id: "of:fid1-slugged-piece",
+      scope: "space",
+      path: ["slug"],
+    }]);
+  });
+
+  it("ignores non-string slug metadata", async () => {
+    const processor = {
+      runtime: {
+        getCellFromEntityId: () => ({
+          sync: () => Promise.resolve(),
+          getAsNormalizedFullLink: () => ({
+            space: "did:key:z6Mk-runtime-processor-slug",
+            id: "of:fid1-slugged-piece",
+            scope: "space",
+            path: [],
+          }),
+        }),
+        readTx: () => ({
+          readOrThrow: () => ({ not: "a slug" }),
+        }),
+      },
+      pieceManager: {
+        getSpace: () => "did:key:z6Mk-runtime-processor-slug",
+      },
+    };
+
+    const result = await (RuntimeProcessor.prototype as any).handlePageGetSlug
+      .call(processor, {
+        type: RequestType.PageGetSlug,
+        pageId: "fid1-slugged-piece",
+      });
+
+    expect(result).toEqual({ slug: undefined });
+  });
+});
+
 describe("sanitizeForPostMessage", () => {
   describe("primitives", () => {
     it("passes through null and undefined", () => {

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -72,6 +72,7 @@ import {
   NotificationType,
   type PageCreateRequest,
   type PageGetRequest,
+  type PageGetSlugRequest,
   PageGetSpaceDefault as PatternGetSpaceRoot,
   type PageRemoveRequest,
   PageResponse,
@@ -91,6 +92,7 @@ import {
   type SettleStatsResponse,
   type SetTriggerTraceEnabledRequest,
   type SetWriteStackTraceMatchersRequest,
+  type SlugResponse,
   type TriggerTraceResponse,
   type UploadBlobRequest,
   type UploadBlobResponse,
@@ -683,6 +685,24 @@ export class RuntimeProcessor {
     };
   }
 
+  async handlePageGetSlug(
+    request: PageGetSlugRequest,
+  ): Promise<SlugResponse> {
+    const cell = this.runtime.getCellFromEntityId(
+      this.pieceManager.getSpace(),
+      { "/": request.pageId },
+    );
+    await cell.sync();
+    const link = cell.getAsNormalizedFullLink();
+    const slug = this.runtime.readTx().readOrThrow({
+      space: link.space,
+      id: link.id,
+      scope: link.scope,
+      path: ["slug"],
+    });
+    return { slug: typeof slug === "string" ? slug : undefined };
+  }
+
   async handlePageRemove(
     request: PageRemoveRequest,
   ): Promise<BooleanResponse> {
@@ -989,6 +1009,8 @@ export class RuntimeProcessor {
         );
       case RequestType.PageGet:
         return await this.handlePageGet(request);
+      case RequestType.PageGetSlug:
+        return await this.handlePageGetSlug(request);
       case RequestType.PageRemove:
         return await this.handlePageRemove(request);
       case RequestType.PageStart:

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -74,6 +74,7 @@ export enum RequestType {
   RecreateSpaceRootPattern = "pattern:recreateSpaceRoot",
   PageCreate = "page:create",
   PageGet = "page:get",
+  PageGetSlug = "page:getSlug",
   PageRemove = "page:remove",
   PageStart = "page:start",
   PageStop = "page:stop",
@@ -440,6 +441,11 @@ export interface PageGetRequest extends BaseRequest {
   runIt?: boolean;
 }
 
+export interface PageGetSlugRequest extends BaseRequest {
+  type: RequestType.PageGetSlug;
+  pageId: string;
+}
+
 export interface PageRemoveRequest extends BaseRequest {
   type: RequestType.PageRemove;
   pageId: string;
@@ -583,6 +589,7 @@ export type IPCClientRequest =
   | PageGetSpaceDefault
   | RecreateSpaceRootPatternRequest
   | PageGetRequest
+  | PageGetSlugRequest
   | PageRemoveRequest
   | PageStartRequest
   | PageStopRequest
@@ -618,6 +625,10 @@ export interface CfcLabelViewResponse {
 
 export interface PageResponse {
   page: PageRef;
+}
+
+export interface SlugResponse {
+  slug: string | undefined;
 }
 
 export interface GraphSnapshotResponse {
@@ -721,6 +732,7 @@ export type RemoteResponse =
   | TriggerTraceResponse
   | WriteStackTraceResponse
   | PageResponse
+  | SlugResponse
   | VDomMountResponse
   | DetectNonIdempotentResponse
   | PatternSourcesResponse
@@ -864,6 +876,10 @@ export type Commands = {
   [RequestType.PageGet]: {
     request: PageGetRequest;
     response: PageResponse | NullResponse;
+  };
+  [RequestType.PageGetSlug]: {
+    request: PageGetSlugRequest;
+    response: SlugResponse;
   };
   [RequestType.PageRemove]: {
     request: PageRemoveRequest;

--- a/packages/runtime-client/runtime-client.ts
+++ b/packages/runtime-client/runtime-client.ts
@@ -211,6 +211,14 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
     return new PageHandle<T>(this, response.page);
   }
 
+  async getPageSlug(pageId: string): Promise<string | undefined> {
+    const response = await this.#conn.request<RequestType.PageGetSlug>({
+      type: RequestType.PageGetSlug,
+      pageId,
+    });
+    return response.slug;
+  }
+
   async removePage(pageId: string): Promise<boolean> {
     const res = await this.#conn.request<RequestType.PageRemove>({
       type: RequestType.PageRemove,

--- a/packages/shell/integration/fixtures/slug-piece-v1.tsx
+++ b/packages/shell/integration/fixtures/slug-piece-v1.tsx
@@ -1,0 +1,15 @@
+import { NAME, pattern, UI, type VNode } from "commonfabric";
+
+interface SlugPieceOutput {
+  [NAME]: string;
+  [UI]: VNode;
+}
+
+export default pattern<void, SlugPieceOutput>(() => ({
+  [NAME]: "Slug Piece V1",
+  [UI]: (
+    <cf-screen>
+      <div id="slug-piece-marker">slug piece v1</div>
+    </cf-screen>
+  ),
+}));

--- a/packages/shell/integration/fixtures/slug-piece-v2.tsx
+++ b/packages/shell/integration/fixtures/slug-piece-v2.tsx
@@ -1,0 +1,15 @@
+import { NAME, pattern, UI, type VNode } from "commonfabric";
+
+interface SlugPieceOutput {
+  [NAME]: string;
+  [UI]: VNode;
+}
+
+export default pattern<void, SlugPieceOutput>(() => ({
+  [NAME]: "Slug Piece V2",
+  [UI]: (
+    <cf-screen>
+      <div id="slug-piece-marker">slug piece v2</div>
+    </cf-screen>
+  ),
+}));

--- a/packages/shell/integration/piece.test.ts
+++ b/packages/shell/integration/piece.test.ts
@@ -1,14 +1,89 @@
 import { env, waitFor } from "@commonfabric/integration";
 import { ShellIntegration } from "@commonfabric/integration/shell-utils";
 import { describe, it } from "@std/testing/bdd";
-import { join } from "@std/path";
+import { dirname, join, resolve } from "@std/path";
 import "../src/globals.ts";
 import { Identity } from "@commonfabric/identity";
 import { PieceController, PiecesController } from "@commonfabric/piece/ops";
 import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
 import { clickPierce } from "./shadow-dom.ts";
+import { expect } from "@std/expect";
 
 const { API_URL, SPACE_NAME, FRONTEND_URL } = env;
+const REPO_ROOT = resolve(import.meta.dirname!, "../../..");
+const decoder = new TextDecoder();
+
+async function runCfPieceNewWithSlug(options: {
+  sourcePath: string;
+  identityPath: string;
+  slug: string;
+}): Promise<string> {
+  const command = new Deno.Command(Deno.execPath(), {
+    cwd: REPO_ROOT,
+    args: [
+      "run",
+      "-A",
+      join(REPO_ROOT, "packages", "cli", "mod.ts"),
+      "piece",
+      "new",
+      options.sourcePath,
+      "--identity",
+      options.identityPath,
+      "--api-url",
+      API_URL,
+      "--space",
+      SPACE_NAME,
+      "--slug",
+      options.slug,
+    ],
+    env: {
+      CF_LOG_LEVEL: "error",
+    },
+  });
+  const result = await command.output();
+  const stdout = decoder.decode(result.stdout);
+  const stderr = decoder.decode(result.stderr);
+  if (!result.success) {
+    throw new Error(
+      `cf piece new failed with ${result.code}\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+    );
+  }
+  const pieceId = stdout.match(/fid1:[^\s]+/)?.[0];
+  if (!pieceId) {
+    throw new Error(`cf piece new did not print a fid1 id:\n${stdout}`);
+  }
+  return pieceId;
+}
+
+async function writeIdentityKey(identity: Identity): Promise<string> {
+  const dir = await Deno.makeTempDir({ prefix: "shell-slug-piece-" });
+  const path = join(dir, "identity.key");
+  await Deno.writeFile(path, identity.toPkcs8());
+  return path;
+}
+
+async function waitForSlugPieceMarker(
+  shell: ShellIntegration,
+  expectedText: string,
+): Promise<void> {
+  await waitFor(async () => {
+    return await shell.page().evaluate((expected) => {
+      function findText(root: Document | ShadowRoot): string | undefined {
+        const marker = root.querySelector("#slug-piece-marker");
+        if (marker?.textContent?.trim()) {
+          return marker.textContent.trim();
+        }
+        for (const element of root.querySelectorAll("*")) {
+          if (element.shadowRoot) {
+            const found = findText(element.shadowRoot);
+            if (found) return found;
+          }
+        }
+      }
+      return findText(document) === expected;
+    }, { args: [expectedText] });
+  });
+}
 
 describe("shell piece tests", () => {
   const shell = new ShellIntegration();
@@ -188,6 +263,61 @@ describe("shell piece tests", () => {
     } finally {
       pieceSinkCancel?.();
       await cc.dispose();
+    }
+  });
+
+  it("loads a slug piece and reloads when cf piece new repoints the slug", async () => {
+    const slug = `slug-repoint-${crypto.randomUUID()}`;
+    const identity = await Identity.generate({ implementation: "noble" });
+    const identityPath = await writeIdentityKey(identity);
+    const identityDir = dirname(identityPath);
+    const firstSource = join(
+      import.meta.dirname!,
+      "fixtures",
+      "slug-piece-v1.tsx",
+    );
+    const secondSource = join(
+      import.meta.dirname!,
+      "fixtures",
+      "slug-piece-v2.tsx",
+    );
+
+    try {
+      const firstPieceId = await runCfPieceNewWithSlug({
+        sourcePath: firstSource,
+        identityPath,
+        slug,
+      });
+
+      await shell.goto({
+        frontendUrl: FRONTEND_URL,
+        view: {
+          spaceName: SPACE_NAME,
+          pieceSlug: slug,
+        },
+        identity,
+      });
+      await waitForSlugPieceMarker(shell, "slug piece v1");
+      await shell.waitForState({
+        view: {
+          spaceName: SPACE_NAME,
+          pieceSlug: slug,
+        },
+        identity,
+      });
+
+      const secondPieceId = await runCfPieceNewWithSlug({
+        sourcePath: secondSource,
+        identityPath,
+        slug,
+      });
+      expect(secondPieceId).not.toBe(firstPieceId);
+
+      await waitForSlugPieceMarker(shell, "slug piece v2");
+      const href = await shell.page().evaluate(() => globalThis.location.href);
+      expect(href).toContain(`/${SPACE_NAME}/${slug}`);
+    } finally {
+      await Deno.remove(identityDir, { recursive: true });
     }
   });
 });

--- a/packages/shell/shared/app/state.ts
+++ b/packages/shell/shared/app/state.ts
@@ -72,7 +72,10 @@ export function applyCommand(
     }
     case "set-view": {
       next.view = command.view;
-      if ("pieceId" in command.view && command.view.pieceId) {
+      if (
+        ("pieceId" in command.view && command.view.pieceId) ||
+        ("pieceSlug" in command.view && command.view.pieceSlug)
+      ) {
         next.config.showShellPieceListView = false;
       }
       break;

--- a/packages/shell/shared/app/view.ts
+++ b/packages/shell/shared/app/view.ts
@@ -1,16 +1,20 @@
 import { DID, isDID } from "@commonfabric/identity";
+import { isSlugAddress } from "@commonfabric/runner";
 
 export type AppBuiltInView = "home";
 
+export type PieceViewRef = {
+  pieceId?: string;
+  pieceSlug?: string;
+};
+
 export type AppView = {
   builtin: AppBuiltInView;
-} | {
+} | ({
   spaceName: string;
-  pieceId?: string;
-} | {
+} & PieceViewRef) | ({
   spaceDid: DID;
-  pieceId?: string;
-};
+} & PieceViewRef);
 
 export function isAppBuiltInView(view: unknown): view is AppBuiltInView {
   switch (view as AppBuiltInView) {
@@ -24,9 +28,12 @@ export function isAppView(view: unknown): view is AppView {
   if (!view || typeof view !== "object") return false;
   if ("builtin" in view) return isAppBuiltInView(view.builtin);
   if ("spaceName" in view) {
-    return typeof view.spaceName === "string" && !!view.spaceName;
+    return typeof view.spaceName === "string" && !!view.spaceName &&
+      !("pieceId" in view && "pieceSlug" in view);
   }
-  if ("spaceDid" in view) return isDID(view.spaceDid);
+  if ("spaceDid" in view) {
+    return isDID(view.spaceDid) && !("pieceId" in view && "pieceSlug" in view);
+  }
   return false;
 }
 
@@ -42,11 +49,15 @@ export function appViewToUrlPath(view: AppView): `/${string}` {
         return `/`;
     }
   } else if ("spaceName" in view) {
-    return "pieceId" in view
+    return "pieceSlug" in view && view.pieceSlug
+      ? `/${view.spaceName}/${view.pieceSlug}`
+      : "pieceId" in view
       ? `/${view.spaceName}/${view.pieceId}`
       : `/${view.spaceName}`;
   } else if ("spaceDid" in view) {
-    return "pieceId" in view
+    return "pieceSlug" in view && view.pieceSlug
+      ? `/${view.spaceDid}/${view.pieceSlug}`
+      : "pieceId" in view
       ? `/${view.spaceDid}/${view.pieceId}`
       : `/${view.spaceDid}`;
   }
@@ -62,8 +73,14 @@ export function urlToAppView(url: URL): AppView {
     return { builtin: "home" };
   }
   if (isDID(first)) {
-    return pieceId ? { spaceDid: first, pieceId } : { spaceDid: first };
+    if (!pieceId) return { spaceDid: first };
+    return isSlugAddress(pieceId)
+      ? { spaceDid: first, pieceSlug: pieceId }
+      : { spaceDid: first, pieceId };
   } else {
-    return pieceId ? { spaceName: first, pieceId } : { spaceName: first };
+    if (!pieceId) return { spaceName: first };
+    return isSlugAddress(pieceId)
+      ? { spaceName: first, pieceSlug: pieceId }
+      : { spaceName: first, pieceId };
   }
 }

--- a/packages/shell/shared/app/view.ts
+++ b/packages/shell/shared/app/view.ts
@@ -45,6 +45,13 @@ export function isAppViewEqual(a: AppView, b: AppView): boolean {
   return JSON.stringify(a) === JSON.stringify(b);
 }
 
+export function isViewingDefaultPatternView(view: AppView): boolean {
+  return !(
+    ("pieceId" in view && view.pieceId) ||
+    ("pieceSlug" in view && view.pieceSlug)
+  );
+}
+
 export function appViewToUrlPath(view: AppView): `/${string}` {
   if ("builtin" in view) {
     switch (view.builtin) {

--- a/packages/shell/shared/app/view.ts
+++ b/packages/shell/shared/app/view.ts
@@ -1,5 +1,5 @@
 import { DID, isDID } from "@commonfabric/identity";
-import { isSlugAddress } from "@commonfabric/runner";
+import { isSlugAddress } from "@commonfabric/runner/slugs";
 
 export type AppBuiltInView = "home";
 
@@ -8,13 +8,16 @@ export type PieceViewRef = {
   pieceSlug?: string;
 };
 
-export type AppView = {
-  builtin: AppBuiltInView;
-} | ({
-  spaceName: string;
-} & PieceViewRef) | ({
-  spaceDid: DID;
-} & PieceViewRef);
+export type AppView =
+  | {
+    builtin: AppBuiltInView;
+  }
+  | ({
+    spaceName: string;
+  } & PieceViewRef)
+  | ({
+    spaceDid: DID;
+  } & PieceViewRef);
 
 export function isAppBuiltInView(view: unknown): view is AppBuiltInView {
   switch (view as AppBuiltInView) {

--- a/packages/shell/shared/navigate.ts
+++ b/packages/shell/shared/navigate.ts
@@ -9,6 +9,7 @@ const logger = getLogger("shell.navigation", {
 export type NavigationCommand = AppView;
 
 const NavigationEventName = "cf-navigate";
+const ReplaceNavigationEventName = "cf-replace-navigation";
 
 class NavigationEvent extends CustomEvent<NavigationCommand> {
   command: NavigationCommand;
@@ -20,6 +21,18 @@ class NavigationEvent extends CustomEvent<NavigationCommand> {
 
 export function navigate(command: NavigationCommand) {
   globalThis.dispatchEvent(new NavigationEvent(command));
+}
+
+class ReplaceNavigationEvent extends CustomEvent<NavigationCommand> {
+  command: NavigationCommand;
+  constructor(command: NavigationCommand) {
+    super(ReplaceNavigationEventName, { detail: command });
+    this.command = command;
+  }
+}
+
+export function replaceNavigation(command: NavigationCommand) {
+  globalThis.dispatchEvent(new ReplaceNavigationEvent(command));
 }
 
 const UpdatePageTitleEventName = "cf-update-page-title";
@@ -49,6 +62,10 @@ export class Navigation {
     this.#app = app;
 
     globalThis.addEventListener(NavigationEventName, this.onNavigate);
+    globalThis.addEventListener(
+      ReplaceNavigationEventName,
+      this.onReplaceNavigate,
+    );
     globalThis.addEventListener(
       UpdatePageTitleEventName,
       this.onUpdatePageTitle,
@@ -86,6 +103,14 @@ export class Navigation {
     logger.log("Navigate", command);
     command = mapNavigationView(this.#app, command);
     this.push(command);
+    this.apply(command);
+  };
+
+  private onReplaceNavigate = (e: Event) => {
+    let command = (e as ReplaceNavigationEvent).command;
+    logger.log("ReplaceNavigate", command);
+    command = mapNavigationView(this.#app, command);
+    this.replace(command);
     this.apply(command);
   };
 
@@ -131,6 +156,7 @@ function mapNavigationView(
   ) {
     return {
       ...("pieceId" in view ? { pieceId: view.pieceId } : undefined),
+      ...("pieceSlug" in view ? { pieceSlug: view.pieceSlug } : undefined),
       spaceName: currentSpaceName,
     };
   }

--- a/packages/shell/src/lib/runtime.ts
+++ b/packages/shell/src/lib/runtime.ts
@@ -194,6 +194,11 @@ export class RuntimeInternals extends EventTarget {
     return promise;
   }
 
+  async getSlug(id: string): Promise<string | undefined> {
+    this.#check();
+    return await this.#client.getPageSlug(id);
+  }
+
   async removePage(id: string): Promise<boolean> {
     return await this.#client.removePage(id);
   }

--- a/packages/shell/src/views/AppView.ts
+++ b/packages/shell/src/views/AppView.ts
@@ -8,7 +8,11 @@ import { DebuggerController } from "../lib/debugger-controller.ts";
 import { Task, TaskStatus } from "@lit/task";
 import { CellEventTarget, CellUpdateEvent } from "../lib/cell-event-target.ts";
 import { type NameSchema, stringSchema } from "@commonfabric/runner/schemas";
-import { replaceNavigation, updatePageTitle } from "../../shared/mod.ts";
+import {
+  isViewingDefaultPatternView,
+  replaceNavigation,
+  updatePageTitle,
+} from "../../shared/mod.ts";
 import { KeyboardController } from "../lib/keyboard-router.ts";
 import { NAME, PageHandle } from "@commonfabric/runtime-client";
 
@@ -323,9 +327,7 @@ export class XAppView extends BaseView {
     const spaceDid = this.app && "spaceDid" in this.app.view
       ? this.app.view.spaceDid
       : undefined;
-    // We're viewing the default pattern if there's no pieceId in the current view
-    const isViewingDefaultPattern = !("pieceId" in this.app.view &&
-      this.app.view.pieceId);
+    const isViewingDefaultPattern = isViewingDefaultPatternView(this.app.view);
     const content = this.app?.identity ? authenticated : unauthenticated;
     return html`
       <div class="shell-container">

--- a/packages/shell/src/views/AppView.ts
+++ b/packages/shell/src/views/AppView.ts
@@ -2,12 +2,13 @@ import { css, html } from "lit";
 import { property, state } from "lit/decorators.js";
 import { BaseView, createDefaultAppState } from "./BaseView.ts";
 import { KeyStore } from "@commonfabric/identity";
+import { slugIdForSpace, validateSlug } from "@commonfabric/runner";
 import { RuntimeInternals } from "../lib/runtime.ts";
 import { DebuggerController } from "../lib/debugger-controller.ts";
 import { Task, TaskStatus } from "@lit/task";
 import { CellEventTarget, CellUpdateEvent } from "../lib/cell-event-target.ts";
 import { type NameSchema, stringSchema } from "@commonfabric/runner/schemas";
-import { updatePageTitle } from "../../shared/mod.ts";
+import { replaceNavigation, updatePageTitle } from "../../shared/mod.ts";
 import { KeyboardController } from "../lib/keyboard-router.ts";
 import { NAME, PageHandle } from "@commonfabric/runtime-client";
 
@@ -88,9 +89,26 @@ export class XAppView extends BaseView {
     > => {
       if (!rt) return;
       this._patternError = undefined;
+      if ("pieceSlug" in app.view && app.view.pieceSlug) {
+        try {
+          const pieceId = slugIdForSpace(rt.space(), app.view.pieceSlug);
+          const pattern = await rt.getPattern(pieceId);
+          // Track as recently visited (fire-and-forget)
+          rt.trackRecentPiece(pieceId);
+          return pattern;
+        } catch (e) {
+          if (!signal.aborted) {
+            this._patternError = e as any;
+          }
+        }
+      }
       if ("pieceId" in app.view && app.view.pieceId) {
         try {
           const pattern = await rt.getPattern(app.view.pieceId);
+          const slug = await rt.getSlug(app.view.pieceId);
+          if (!signal.aborted && slug) {
+            this.#replacePieceUrlWithSlug(app.view, slug);
+          }
           // Track as recently visited (fire-and-forget)
           rt.trackRecentPiece(app.view.pieceId);
           return pattern;
@@ -127,7 +145,9 @@ export class XAppView extends BaseView {
       // The "active" pattern is the main pattern to be rendered.
       // This may be the same as the space root pattern, unless we're
       // in a view that specifies a different pattern to use.
-      const useSpaceRootAsActive = !("pieceId" in app.view && app.view.pieceId);
+      const useSpaceRootAsActive =
+        !("pieceId" in app.view && app.view.pieceId) &&
+        !("pieceSlug" in app.view && app.view.pieceSlug);
       const activePattern = useSpaceRootAsActive
         ? spaceRootPattern
         : selectedPatternStatus === TaskStatus.COMPLETE
@@ -178,6 +198,19 @@ export class XAppView extends BaseView {
     const event = e as CellUpdateEvent<string | undefined>;
     this.pieceTitle = event.detail ?? "";
   };
+
+  #replacePieceUrlWithSlug(view: typeof this.app.view, slug: string) {
+    try {
+      validateSlug(slug);
+    } catch {
+      return;
+    }
+    if ("spaceName" in view) {
+      replaceNavigation({ spaceName: view.spaceName, pieceSlug: slug });
+    } else if ("spaceDid" in view) {
+      replaceNavigation({ spaceDid: view.spaceDid, pieceSlug: slug });
+    }
+  }
 
   #isRecreatingSpaceRootPattern = false;
 
@@ -256,6 +289,11 @@ export class XAppView extends BaseView {
     if (activePattern) return activePattern.id();
     if ("pieceId" in this.app.view && this.app.view.pieceId) {
       return this.app.view.pieceId;
+    }
+    if ("pieceSlug" in this.app.view && this.app.view.pieceSlug) {
+      return this.rt
+        ? slugIdForSpace(this.rt.space(), this.app.view.pieceSlug)
+        : this.app.view.pieceSlug;
     }
   }
 

--- a/packages/shell/src/views/AppView.ts
+++ b/packages/shell/src/views/AppView.ts
@@ -2,7 +2,7 @@ import { css, html } from "lit";
 import { property, state } from "lit/decorators.js";
 import { BaseView, createDefaultAppState } from "./BaseView.ts";
 import { KeyStore } from "@commonfabric/identity";
-import { slugIdForSpace, validateSlug } from "@commonfabric/runner";
+import { slugIdForSpace, validateSlug } from "@commonfabric/runner/slugs";
 import { RuntimeInternals } from "../lib/runtime.ts";
 import { DebuggerController } from "../lib/debugger-controller.ts";
 import { Task, TaskStatus } from "@lit/task";

--- a/packages/shell/test/app-state.test.ts
+++ b/packages/shell/test/app-state.test.ts
@@ -109,6 +109,11 @@ describe("AppState", () => {
       ) === JSON.stringify({ spaceName: "space", pieceId: "fid1:abc" }),
     );
     assert(
+      JSON.stringify(
+        urlToAppView(new URL("http://common.test/space/of:fid1:abc")),
+      ) === JSON.stringify({ spaceName: "space", pieceId: "of:fid1:abc" }),
+    );
+    assert(
       appViewToUrlPath({ spaceName: "space", pieceSlug: "demo" }) ===
         "/space/demo",
     );

--- a/packages/shell/test/app-state.test.ts
+++ b/packages/shell/test/app-state.test.ts
@@ -107,7 +107,9 @@ describe("AppState", () => {
         urlToAppView(new URL("http://common.test/space/fid1:abc")),
       ) === JSON.stringify({ spaceName: "space", pieceId: "fid1:abc" }),
     );
-    assert(appViewToUrlPath({ spaceName: "space", pieceSlug: "demo" }) ===
-      "/space/demo");
+    assert(
+      appViewToUrlPath({ spaceName: "space", pieceSlug: "demo" }) ===
+        "/space/demo",
+    );
   });
 });

--- a/packages/shell/test/app-state.test.ts
+++ b/packages/shell/test/app-state.test.ts
@@ -5,6 +5,7 @@ import {
   AppStateSerialized,
   appViewToUrlPath,
   deserialize,
+  isViewingDefaultPatternView,
   serialize,
   urlToAppView,
 } from "@commonfabric/shell/shared";
@@ -110,6 +111,21 @@ describe("AppState", () => {
     assert(
       appViewToUrlPath({ spaceName: "space", pieceSlug: "demo" }) ===
         "/space/demo",
+    );
+  });
+
+  it("treats slug piece routes as non-default pattern views", () => {
+    assert(isViewingDefaultPatternView({ spaceName: "space" }) === true);
+    assert(
+      isViewingDefaultPatternView({
+        spaceName: "space",
+        pieceId: "fid1:abc",
+      }) ===
+        false,
+    );
+    assert(
+      isViewingDefaultPatternView({ spaceName: "space", pieceSlug: "demo" }) ===
+        false,
     );
   });
 });

--- a/packages/shell/test/app-state.test.ts
+++ b/packages/shell/test/app-state.test.ts
@@ -3,8 +3,10 @@ import {
   applyCommand,
   AppState,
   AppStateSerialized,
+  appViewToUrlPath,
   deserialize,
   serialize,
+  urlToAppView,
 } from "@commonfabric/shell/shared";
 import { Identity, serializeKeyPairRaw } from "@commonfabric/identity";
 import { assert } from "@std/assert";
@@ -93,5 +95,19 @@ describe("AppState", () => {
     });
 
     assert(next.config.showShellPieceListView === false);
+  });
+
+  it("parses and serializes slug piece routes", () => {
+    assert(
+      JSON.stringify(urlToAppView(new URL("http://common.test/space/demo"))) ===
+        JSON.stringify({ spaceName: "space", pieceSlug: "demo" }),
+    );
+    assert(
+      JSON.stringify(
+        urlToAppView(new URL("http://common.test/space/fid1:abc")),
+      ) === JSON.stringify({ spaceName: "space", pieceId: "fid1:abc" }),
+    );
+    assert(appViewToUrlPath({ spaceName: "space", pieceSlug: "demo" }) ===
+      "/space/demo");
   });
 });

--- a/packages/shell/test/runtime-navigation.test.ts
+++ b/packages/shell/test/runtime-navigation.test.ts
@@ -3,6 +3,13 @@ import { expect } from "@std/expect";
 import type { DID } from "@commonfabric/identity";
 import { EventEmitter } from "../../runtime-client/client/emitter.ts";
 
+const env = globalThis as typeof globalThis & {
+  $API_URL?: string;
+  $ENVIRONMENT?: string;
+};
+env.$API_URL ??= "http://shell.test/";
+env.$ENVIRONMENT ??= "development";
+
 type MockRuntimeClientEvents = {
   console: [unknown];
   navigaterequest: [{ cell: { id(): string; space(): DID } }];
@@ -13,6 +20,7 @@ type MockRuntimeClientEvents = {
 class MockRuntimeClient extends EventEmitter<MockRuntimeClientEvents> {
   idleCalls = 0;
   syncedCalls = 0;
+  slugByPageId = new Map<string, string | undefined>();
 
   idle(): Promise<void> {
     this.idleCalls += 1;
@@ -22,6 +30,10 @@ class MockRuntimeClient extends EventEmitter<MockRuntimeClientEvents> {
   synced(): Promise<void> {
     this.syncedCalls += 1;
     return Promise.resolve();
+  }
+
+  getPageSlug(pageId: string): Promise<string | undefined> {
+    return Promise.resolve(this.slugByPageId.get(pageId));
   }
 
   dispose(): Promise<void> {
@@ -51,6 +63,26 @@ type NavigationDetail = {
 };
 
 describe("RuntimeInternals navigation", () => {
+  it("exposes page slug metadata", async () => {
+    const { RuntimeInternals } = await import("../src/lib/runtime.ts");
+    const spaceDid = "did:key:z6Mk-shell-runtime-did-nav" as DID;
+    const client = new MockRuntimeClient();
+    client.slugByPageId.set("piece-789", "demo");
+    const runtime = new (RuntimeInternals as any)(
+      client,
+      spaceDid,
+      undefined,
+      false,
+      spaceDid,
+    );
+
+    try {
+      await expect(runtime.getSlug("piece-789")).resolves.toBe("demo");
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
   it("waits for same-space registration and convergence before navigating", async () => {
     const env = globalThis as typeof globalThis & {
       $API_URL?: string;


### PR DESCRIPTION
## Shell Slugs

This PR adds pretty slug URLs for pieces and CLI support for creating and updating those slug redirects.

A piece can now be opened in the shell at:

```text
/<space>/<slug>
```

For example:

```text
https://cf.dev/personal/project-notes
```

When the shell opens a canonical `fid1:` piece URL for a piece that has slug metadata, it replaces the URL with the slug form. When a slug is repointed, the shell reloads through the existing page loading flow and shows the new target.

## Slug Format

Slugs are intended for pretty URLs, so they are intentionally strict:

- lowercase letters, numbers, and hyphens only
- single hyphens between words
- no leading or trailing hyphen
- no `/` and no `:`
- at most 80 characters

Good examples:

```text
project-notes
weekly-plan-2026
counter-demo
```

Invalid examples:

```text
ProjectNotes
project_notes
project--notes
fid1:abc
notes/today
```

Any token containing `:` is treated as a URI or id, not as a slug.

## Create A Piece With A Slug

Use `cf piece new --slug <slug>` when creating a new piece:

```sh
cf piece new \
  --identity ./my.key \
  --api-url http://localhost:8000 \
  --space personal \
  --slug project-notes \
  ./patterns/project-notes/main.tsx
```

The command still prints the canonical piece id. It also writes slug metadata and creates the slug redirect document, so the piece can be opened at:

```text
http://localhost:8000/personal/project-notes
```

If the slug already exists, `piece new --slug` repoints that slug to the newly-created piece.

## Use Slugs Instead Of Piece IDs

Commands that take `--piece` can use a slug in place of the canonical piece id:

```sh
cf piece get --identity ./my.key --api-url http://localhost:8000 --space personal --piece project-notes value
cf piece inspect --identity ./my.key --api-url http://localhost:8000 --space personal --piece project-notes
cf piece setsrc --identity ./my.key --api-url http://localhost:8000 --space personal --piece project-notes ./patterns/project-notes/main.tsx
```

If the slug does not exist, commands that require an existing piece fail with a slug-specific error instead of silently inventing a target.

## Set Or Repoint A Slug

Use `cf piece set-slug <slug> <source>` to point a slug at an existing piece or cell link:

```sh
cf piece set-slug \
  --identity ./my.key \
  --api-url http://localhost:8000 \
  --space personal \
  project-notes \
  of:fid1:abc123...
```

The source can also be another slug:

```sh
cf piece set-slug --identity ./my.key --api-url http://localhost:8000 --space personal latest-notes project-notes
```

And it can point at a cell path inside a piece:

```sh
cf piece set-slug --identity ./my.key --api-url http://localhost:8000 --space personal published-title project-notes/value/title
```

By default, the slug redirect stores a link to the source you passed. If the source is itself a redirect, that relationship is preserved.

## Resolve Before Linking

Use `--resolve-before-linking` when you want the new slug to point directly at the source's current resolved target instead of pointing at the source token itself:

```sh
cf piece set-slug \
  --identity ./my.key \
  --api-url http://localhost:8000 \
  --space personal \
  stable-notes \
  latest-notes \
  --resolve-before-linking
```

This is useful when `latest-notes` is already a slug and you want `stable-notes` to keep pointing at whatever `latest-notes` resolves to now, even if `latest-notes` is repointed later.

## Link Behavior With Slugs

`cf piece link` resolves source and target piece tokens before creating the link:

```sh
cf piece link --identity ./my.key --api-url http://localhost:8000 --space personal project-notes/value dashboard/notes
```

Source endpoints may fall back to the original token where the command already supports non-existing sources, such as invented ids used with `--allow-non-existing`.

Destination endpoints must resolve. If the destination piece token is a slug and that slug does not exist, the link command fails instead of creating a link to a made-up destination.

## Validation

- `deno test -A packages/cli/test/charm.test.ts`
- `deno test -A packages/piece/test/test.ts`
- `deno test -A packages/piece/test/slug.test.ts`
- `deno test -A packages/runtime-client/backends/runtime-processor.test.ts`
- `deno test -A packages/runner/test/slug.test.ts`
- `deno test -A packages/shell/test`
- `PORT_OFFSET=745 FRONTEND_URL=http://localhost:5918 HEADLESS=1 deno task integration shell piece`
- `CF_CLI_INTEGRATION_USE_LOCAL=1 CF_CLI_INTEGRATION_SECTION=piece-links deno task integration cli`
- `deno task check`

NEW_PERF_BASELINE: step: shell integration = 83s
NEW_PERF_BASELINE: job: Package Integration Tests (shell) = 110s
