### PR TITLE
perf(runner/v2-transaction): spine-only thaw in the write path

### DIFF
--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -150,10 +150,10 @@ function withCommitTiming<T>(
  * recursion, so partially-frozen trees only copy their unfrozen portions.
  *
  * The result is NOT guaranteed to be mutable, since deep-frozen inputs are
- * returned as-is. Callers that need a mutable copy (e.g. before in-place
- * write helpers like `ensureParentContainers` or `applyMutablePathWrite`)
- * must use `cloneIfNecessary(value, { frozen: false })` from
- * `@commonfabric/data-model` instead.
+ * returned as-is. The remaining caller that wants a thaw-the-spine-only
+ * mutable handle (`writeWithinSpaceCreatingParents`) uses
+ * `cloneIfNecessary(value, { frozen: false, deep: false, force: false })`
+ * instead; `applyMutablePathWrite` handles its own spine thaws internally.
  */
 const isolateTransactionValue = <T>(
   value: T,
@@ -353,6 +353,27 @@ type MutableWriteResult = {
   changed: boolean;
 };
 
+/**
+ * Applies a write at `address.path` within `currentRoot`, returning the
+ * (possibly new) root, the previous value at the path, and whether
+ * anything changed.
+ *
+ * Does its own spine copy-on-write: each container along the write path is
+ * shallow-thawed (via
+ * `cloneIfNecessary(_, { frozen: false, deep: false, force: false })`) and
+ * the freshly-thawed clone is spliced into its (now-mutable) parent.
+ * Subtrees off the spine are preserved by identity -- they retain their
+ * `deepFrozenCache` registration, so re-freezing the result tree
+ * short-circuits everywhere except the spine.
+ *
+ * The caller's `currentRoot` is mutated in place ONLY where the input's
+ * spine is already mutable. Frozen inputs are thawed via shallow clones
+ * before any mutation, leaving the input tree untouched. Practically this
+ * means: when `currentRoot` is the storage-layer's deep-frozen current
+ * document value, the input is never mutated; when `currentRoot` is the
+ * batch loop's own freshly-thawed root, subsequent applies reuse and
+ * mutate it in place.
+ */
 const applyMutablePathWrite = (
   currentRoot: FabricValue | undefined,
   address: IMemoryAddress,
@@ -387,6 +408,16 @@ const applyMutablePathWrite = (
         "write",
       ),
     };
+  } else {
+    // Shallow-thaw the root so we can mutate its spine in place without
+    // leaking changes back to the caller's frozen input. `force: false`
+    // makes this a no-op if the caller already handed us a mutable root
+    // (the steady state inside `writeBatchRun`'s loop).
+    currentRoot = cloneIfNecessary(currentRoot as FabricValue, {
+      frozen: false,
+      deep: false,
+      force: false,
+    });
   }
 
   const root = currentRoot;
@@ -489,6 +520,19 @@ const applyMutablePathWrite = (
             "write",
           ),
         };
+      } else {
+        // Shallow-thaw the next spine container if frozen. Mutable
+        // children are returned by identity (no allocation, no
+        // re-splice).
+        const thawed = cloneIfNecessary(next, {
+          frozen: false,
+          deep: false,
+          force: false,
+        });
+        if (thawed !== next) {
+          current[slot] = thawed;
+          next = thawed;
+        }
       }
       current = next as Record<string, FabricValue> | FabricValue[];
       continue;
@@ -527,6 +571,18 @@ const applyMutablePathWrite = (
           "write",
         ),
       };
+    } else {
+      // Shallow-thaw the next spine container if frozen. Mutable children
+      // are returned by identity (no allocation, no re-splice).
+      const thawed = cloneIfNecessary(next, {
+        frozen: false,
+        deep: false,
+        force: false,
+      });
+      if (thawed !== next) {
+        current[key] = thawed;
+        next = thawed;
+      }
     }
     current = next as Record<string, FabricValue> | FabricValue[];
   }
@@ -1336,11 +1392,17 @@ export class V2StorageTransaction implements IStorageTransaction {
       if (!isRecord(existingParent) && !Array.isArray(existingParent)) {
         return direct;
       }
-      // Use `cloneIfNecessary({ frozen: false })` (not
-      // `isolateTransactionValue()`): the parent is about to be mutated in
-      // place by `ensureParentContainers`, so we need a guaranteed-mutable
-      // copy even when the stored value is deep-frozen.
-      parentValue = cloneIfNecessary(existingParent, { frozen: false });
+      // Shallow-thaw is sufficient: `ensureParentContainers` only mutates
+      // the parent's top-level slot to attach the first freshly-created
+      // intermediate container (the missing-path segments are all absent
+      // by construction here, so the helper never descends through
+      // existing children). Subtrees off that single slot stay shared by
+      // identity and keep their place in the deep-frozen cache.
+      parentValue = cloneIfNecessary(existingParent, {
+        frozen: false,
+        deep: false,
+        force: false,
+      });
     }
 
     const seededParent = ensureParentContainers(
@@ -1440,7 +1502,6 @@ export class V2StorageTransaction implements IStorageTransaction {
     const doc = ensureWritableDocument(readDoc);
     const originalRoot = doc.current.value;
     let nextRoot = originalRoot;
-    let hasMutableRoot = false;
     let changed = false;
 
     for (const { address, value } of writes) {
@@ -1463,17 +1524,11 @@ export class V2StorageTransaction implements IStorageTransaction {
           allowArrayLength: true,
         }),
       ) as FabricValue | undefined;
-      if (
-        !hasMutableRoot && address.path.length > 0 && nextRoot !== undefined
-      ) {
-        // Use `cloneIfNecessary({ frozen: false })` (not
-        // `isolateTransactionValue()`): the next line passes `nextRoot` to
-        // `applyMutablePathWrite`, which mutates in place along the write
-        // path, so we need a guaranteed-mutable root even when the stored
-        // value is deep-frozen.
-        nextRoot = cloneIfNecessary(nextRoot, { frozen: false });
-        hasMutableRoot = true;
-      }
+      // `applyMutablePathWrite` shallow-thaws the spine internally; no
+      // pre-thaw needed here. The first write of a batch starts from the
+      // frozen `doc.current.value` and the function produces a fresh
+      // mutable root; subsequent writes reuse that mutable root by
+      // identity.
       const result = applyMutablePathWrite(nextRoot, address, isolatedValue);
       if (result.error) {
         if (changed) {
@@ -1510,9 +1565,6 @@ export class V2StorageTransaction implements IStorageTransaction {
         previousActivityValue,
         doc,
       );
-      if (address.path.length === 0 || !hasMutableRoot) {
-        hasMutableRoot = true;
-      }
     }
 
     if (!changed) {


### PR DESCRIPTION
## Summary

Replaces the deep-clone-then-mutate pattern at v2-transaction's two write-path mutating sites with a spine-only thaw, eliminating the O(N) per-write allocation of the entire document tree.

- `applyMutablePathWrite` now performs its own copy-on-write spine thaw as it descends. Each spine container is shallow-thawed via `cloneIfNecessary(_, { frozen: false, deep: false, force: false })` and spliced into its (now mutable) parent. Off-spine subtrees keep their identity. The caller's pre-thaw of `nextRoot` and the `hasMutableRoot` flag in `writeBatchRun` are gone.
- `writeWithinSpaceCreatingParents` switches from a deep clone of the existing parent to a shallow clone — the helper only mutates the parent's top-level slot to attach a freshly-created intermediate container; subtrees off that slot keep their identity.

Asymptotically: allocations per write drop from O(N) (entire document) to O(D) (spine depth). Within a multi-write batch, only the first write's spine pays an allocation cost; subsequent writes reuse the already-mutable spine by identity (the `force: false` arm of `cloneIfNecessary`).

## Why now

This is the third in a sequence:

1. PR #3650 — short-circuited the read path's `freezeReadValue` on already-deep-frozen input. Fixed the cliff that was failing the modern-flag flip PR. **Reads.**
2. PR #3651 — exhaustive cloneIfNecessary subclass-coverage matrix. **Tests.**
3. PR #3652 — `cloneForMutation` helper in `@commonfabric/data-model`. **Building block.**
4. This PR — applies the spine-only thaw to v2-transaction's write path. **Writes.**

The previous PR's read-path fix relied on the deep-frozen cache staying warm across writes. This PR delivers that property: off-spine subtrees never lose their cached deep-frozen registration through a write, so subsequent reads on those subtrees stay on the cheap path.

## Wall-clock perf

On the same `should render every rapidly created notebook note` canary used for PR #3650:

| Config | Mean step time (3 runs) | Notes |
|---|---|---|
| Post-fix legacy | ~17.3s | Within noise of PR #3650's 18.7s. |
| Post-fix modern | ~22s | Identical to PR #3650's 22.3s. |

That test's settle time is dominated by the reactive-compute cascade (sinks, computeds re-firing on every push), which this PR doesn't touch. The win this PR delivers is at the allocator and the deep-frozen-cache layer — it compounds over write-heavier workloads (large batches, deep documents) than the notebook integration test exercises.

## Behavior preservation

No behavior change. The full `@commonfabric/runner` test suite — including the rich `memory-v2-*` invariant tests that pin the storage layer's externally-observable contracts — passes unchanged.

## Test plan

- [x] `deno task test` in `@commonfabric/runner` — 454 tests / 2504 steps pass.
- [x] `deno task test` in `@commonfabric/memory` — 120 tests pass.
- [x] Canary integration test (`should render every rapidly created notebook note`) under both legacy and modern flags, locally.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Thaws only the write-path spine in v2 transactions instead of deep-cloning the whole document. This cuts per-write allocations from O(N) to O(D) while preserving off-spine identities and deep-frozen-cache entries.

- **Refactors**
  - `applyMutablePathWrite` now does copy-on-write spine thaw via `cloneIfNecessary(..., { frozen: false, deep: false, force: false })`; splices thawed containers into parents; removes `nextRoot` pre-thaw and the `hasMutableRoot` flag in `writeBatchRun`.
  - `writeWithinSpaceCreatingParents` switches to a shallow clone of the existing parent before attaching intermediate containers; only the top-level slot is mutated and off-spine subtrees stay shared.

<sup>Written for commit 50de55cc6c5855ac253ec82767df4aee6d583141. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3654?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

