### PR TITLE
feat(fuse): add supervisor readiness lifecycle

### DIFF
--- a/docs/specs/fuse-filesystem/10-cfc-filesystem-api-semantics.md
+++ b/docs/specs/fuse-filesystem/10-cfc-filesystem-api-semantics.md
@@ -128,12 +128,13 @@ for ordinary programs to create or write files under CFC enforcement.
 
 Bridge to quarantine semantics: today, incomplete CFC writeback state is
 represented only by mediated prepare/finalize xattrs plus persisted
-`CfcWritebackStore` records. The current implementation does not create hidden
-quarantine dentries, does not publish incomplete entries into the confirmed
-`FsTree`, and does not make ordinary path lookup depend on quarantine state. The
-next quarantine implementation must keep that separation explicit: quarantine is
-a private transaction store layered beside the confirmed projection, not a hidden
-file in the normal namespace.
+`CfcWritebackStore` records. The current compatibility implementation does not
+create hidden quarantine dentries or a separate quarantine namespace; prepared
+create/symlink scaffolding may still place fail-closed, incomplete annotations in
+the ordinary `FsTree` while local bridge behavior is exercised. The next
+quarantine implementation must remove that compatibility shortcut and keep the
+separation explicit: quarantine is a private transaction store layered beside the
+confirmed projection, not a hidden file in the normal namespace.
 
 For creation-like operations:
 

--- a/docs/specs/fuse-filesystem/5-architecture.md
+++ b/docs/specs/fuse-filesystem/5-architecture.md
@@ -11,7 +11,7 @@
                     /dev/fuse fd
                          |
               +---------------------------+
-              |      Deno Process          |   packages/fuse/
+              |  Deno FUSE Child Process   |   packages/fuse/
               |                            |
               |  libfuse (via Deno.dlopen) |
               |   - single-threaded mode   |
@@ -27,7 +27,7 @@
               |   - Cell read/write        |
               |   - Subscriptions          |
               +---------------------------+
-                         |
+                          |
                     HTTP / WebSocket
                          |
               +---------------------------+
@@ -35,21 +35,28 @@
               +---------------------------+
 ```
 
-## Single-Process FFI Approach
+## Deno FFI Approach
 
-The filesystem runs as a single Deno process that calls libfuse via
-`Deno.dlopen()`. All logic — FUSE operations, cell access, caching, inode
-management — lives in TypeScript.
+The FUSE child process calls libfuse via `Deno.dlopen()`. All filesystem logic —
+FUSE operations, cell access, caching, inode management — lives in TypeScript.
+`cf fuse mount` foreground mode starts one FFI-owning child process and waits for
+it without adding a supervisor; direct `deno run packages/fuse/mod.ts` is a
+single-process invocation of the same child entrypoint. Background mounts add a
+small Deno supervisor process outside libfuse; the supervisor starts the FUSE
+child, records the child PID in mount state, forwards termination, and waits for
+the child to publish explicit readiness before `cf fuse mount --background`
+reports success.
 
-### Why Single-Process?
+### Why keep FUSE logic in Deno?
 
 - **One language, one build system.** No Rust toolchain, no Cargo, no
   cross-language data duplication. Everything stays in the Deno monorepo.
-- **No IPC overhead.** The in-memory tree is directly accessible from FUSE
-  callbacks. No serialization, no Unix sockets, no JSON-RPC protocol to
-  design and debug.
-- **Simpler deployment.** `cf fuse mount` runs one process. No coordinating
-  startup/shutdown of two daemons.
+- **No data-plane IPC overhead.** The in-memory tree is directly accessible from
+  FUSE callbacks. No serialization, no Unix sockets, no JSON-RPC protocol is on
+  the request path.
+- **Contained lifecycle split.** `cf fuse mount --background` uses a supervisor
+  only for process lifecycle/readiness, while foreground CLI mounts remain a
+  direct parent/child wait without a supervisor.
 - **Easier debugging.** Single stack trace, single log stream, standard Deno
   debugging tools.
 
@@ -222,12 +229,16 @@ cf fuse unmount <mountpoint>
 cf fuse status
 ```
 
+`cf fuse status` reports `MOUNTPOINT`, `SUPERVISOR_PID`, `CHILD_PID`, `STATUS`,
+`STARTED`, and `LOG` for active background mounts. `STATUS` is read from the
+FUSE child's readiness/heartbeat sidecar when available.
+
 Options:
 - `--api-url <url>` — toolshed API URL
 - `--identity <keyfile>` — identity for authentication
-- `--foreground` — run in foreground (don't daemonize)
+- `--background` — run under a non-FFI supervisor and return after child
+  readiness
 - `--debug` — enable FUSE debug logging
-- `--read-only` — mount as read-only
 
 All accessible spaces are exposed under the single mountpoint. The home space
 is always listed; other spaces are accessible by name or DID on demand (see
@@ -235,11 +246,15 @@ is always listed; other spaces are accessible by name or DID on demand (see
 
 The `mount` command:
 1. Connects to toolshed, loads identity
-2. Loads libfuse via `Deno.dlopen()`
-3. Registers FUSE callbacks
-4. Mounts the filesystem
-5. Enters the FUSE event loop (integrated with Deno's event loop)
-6. Daemonizes (unless `--foreground`)
+2. For foreground mounts, starts the FUSE child directly
+3. For background mounts, starts a non-FFI supervisor process
+4. The supervisor starts the FFI-owning FUSE child, records `childPid`, and
+   forwards cleanup signals
+5. The child loads libfuse via `Deno.dlopen()`, registers FUSE callbacks, mounts
+   the filesystem, and writes `starting`/`mounted`/`failed`/`exiting`/`exited`
+   readiness states plus a heartbeat
+6. The CLI reports background startup success only after the matching child
+   readiness sidecar reaches `mounted`
 
 Sessions for individual spaces are created lazily on first access.
 

--- a/packages/cli/commands/fuse.ts
+++ b/packages/cli/commands/fuse.ts
@@ -2,17 +2,69 @@ import { Command } from "@cliffy/command";
 import { basename, resolve } from "@std/path";
 import ports from "@commonfabric/ports" with { type: "json" };
 import {
+  buildBackgroundSupervisorDenoArgs,
   buildDenoArgs,
   defaultStateDir,
   ensureExecShim,
   fuseMod,
+  fuseSupervisorMod,
   isAlive,
+  isMountStateAlive,
+  mountpointHash,
   readAllMountStates,
   readMountState,
   removeMountStateFile,
   writeMountState,
 } from "../lib/fuse.ts";
 import { cliText } from "../lib/cli-name.ts";
+
+export function isFuseProcessCommand(command: string): boolean {
+  return command.includes("packages/fuse/mod.ts") ||
+    command.includes("packages/cli/lib/fuse-supervisor.ts") ||
+    command.includes("fuse-supervisor") ||
+    command.includes("fuse-daemon");
+}
+
+type FuseChildSupervisorState =
+  | "starting"
+  | "mounted"
+  | "failed"
+  | "exiting"
+  | "exited";
+
+interface FuseChildSupervisorStatus {
+  state: FuseChildSupervisorState;
+  pid?: number;
+  mountpoint?: string;
+  updatedAt?: string;
+  token?: string;
+  error?: string;
+  exitCode?: number;
+}
+
+export function childStatusPathForStatePath(statePath: string): string {
+  return `${statePath}.child-status`;
+}
+
+function parseChildSupervisorStatus(
+  text: string,
+): FuseChildSupervisorStatus | null {
+  try {
+    const parsed = JSON.parse(text) as Partial<FuseChildSupervisorStatus>;
+    switch (parsed.state) {
+      case "starting":
+      case "mounted":
+      case "failed":
+      case "exiting":
+      case "exited":
+        return parsed as FuseChildSupervisorStatus;
+      default:
+        return null;
+    }
+  } catch {
+    return null;
+  }
+}
 
 const fuseDescription = cliText(
   `Mount Common Fabric spaces as a FUSE filesystem.
@@ -75,13 +127,20 @@ export async function awaitBackgroundMountStartup(
     delayMs?: number;
     isAlive?: (pid: number) => boolean;
     removeStateFile?: (path: string) => Promise<void>;
+    readTextFile?: (path: string) => Promise<string>;
+    readMountStateFile?: (path: string) => Promise<string>;
+    childStatusPath?: string;
+    childStatusToken?: string;
+    mountpoint?: string;
     sleep?: (ms: number) => Promise<void>;
   } = {},
 ): Promise<void> {
-  const attempts = deps.attempts ?? 20;
-  const delayMs = deps.delayMs ?? 50;
+  const attempts = deps.attempts ?? (deps.childStatusPath ? 50 : 20);
+  const delayMs = deps.delayMs ?? (deps.childStatusPath ? 100 : 50);
   const isAliveFn = deps.isAlive ?? isAlive;
   const removeStateFileFn = deps.removeStateFile ?? removeMountStateFile;
+  const readTextFile = deps.readTextFile ?? Deno.readTextFile;
+  const readMountStateFile = deps.readMountStateFile ?? Deno.readTextFile;
   const sleep = deps.sleep ??
     ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
 
@@ -92,9 +151,72 @@ export async function awaitBackgroundMountStartup(
         "Background FUSE process exited during startup. Re-run without --background to inspect startup errors.",
       );
     }
+    if (deps.childStatusPath) {
+      let status: FuseChildSupervisorStatus | null = null;
+      try {
+        status = parseChildSupervisorStatus(
+          await readTextFile(deps.childStatusPath),
+        );
+      } catch {
+        status = null;
+      }
+      const belongsToThisMount = await childStatusBelongsToMount(
+        status,
+        statePath,
+        {
+          token: deps.childStatusToken,
+          mountpoint: deps.mountpoint,
+          readMountStateFile,
+        },
+      );
+      if (status?.state === "mounted" && belongsToThisMount) return;
+      if (
+        belongsToThisMount &&
+        (status?.state === "failed" || status?.state === "exiting" ||
+          status?.state === "exited")
+      ) {
+        await removeStateFileFn(statePath);
+        throw new Error(
+          `Background FUSE mount failed during startup: ${
+            status.error ?? `child reported ${status.state}`
+          }`,
+        );
+      }
+    }
     if (i < attempts - 1) {
       await sleep(delayMs);
     }
+  }
+
+  if (deps.childStatusPath) {
+    await removeStateFileFn(statePath);
+    throw new Error(
+      "Background FUSE process did not report mount readiness before startup timeout.",
+    );
+  }
+}
+
+async function childStatusBelongsToMount(
+  status: FuseChildSupervisorStatus | null,
+  statePath: string,
+  deps: {
+    token?: string;
+    mountpoint?: string;
+    readMountStateFile: (path: string) => Promise<string>;
+  },
+): Promise<boolean> {
+  if (!status) return false;
+  if (deps.token && status.token !== deps.token) return false;
+  if (deps.mountpoint && status.mountpoint !== deps.mountpoint) return false;
+  if (typeof status.pid !== "number") return false;
+
+  try {
+    const state = JSON.parse(await deps.readMountStateFile(statePath)) as {
+      childPid?: unknown;
+    };
+    return state.childPid === status.pid;
+  } catch {
+    return false;
   }
 }
 
@@ -241,9 +363,62 @@ export const fuse = new Command()
       // Derive log file path: /tmp/cf-fuse-<mountname>.log
       const logFile = `/tmp/cf-fuse-${basename(absMountpoint)}.log`;
 
-      // Pass --log-file so the daemon redirects its own output (including
-      // the ring-buffer crash dump) to disk rather than /dev/null.
-      spawnArgs.push("--log-file", logFile);
+      const statePath = resolve(
+        stateDir,
+        `${await mountpointHash(absMountpoint)}.json`,
+      );
+      const childStatusPath = childStatusPathForStatePath(statePath);
+      const childStatusToken = crypto.randomUUID();
+      try {
+        await Deno.remove(childStatusPath);
+      } catch (error) {
+        if (!(error instanceof Deno.errors.NotFound)) throw error;
+      }
+
+      if (isCompiledBinary) {
+        spawnCmd = execPath;
+        spawnArgs = ["fuse-supervisor", absMountpoint];
+        if (apiUrl) spawnArgs.push("--api-url", apiUrl);
+        if (identity) spawnArgs.push("--identity", identity);
+        if (options.allowOther) spawnArgs.push("--allow-other");
+        if (options.cfcMode) spawnArgs.push("--cfc-mode", options.cfcMode);
+        if (options.cfcAnnotations) spawnArgs.push("--cfc-annotations");
+        if (options.cfcXattrNamespace) {
+          spawnArgs.push("--cfc-xattr-namespace", options.cfcXattrNamespace);
+        }
+        if (options.cfcWritebackXattrs) {
+          spawnArgs.push("--cfc-writeback-xattrs");
+        }
+        if (options.cfcWritebackState) {
+          spawnArgs.push("--cfc-writeback-state", options.cfcWritebackState);
+        }
+        if (execCli) spawnArgs.push("--exec-cli", execCli);
+        spawnArgs.push("--log-file", logFile);
+        spawnArgs.push("--state-path", statePath);
+        spawnArgs.push("--supervisor-status", childStatusPath);
+        spawnArgs.push("--supervisor-token", childStatusToken);
+        for (const s of options.space ?? []) spawnArgs.push("--space", s);
+      } else {
+        spawnCmd = execPath;
+        spawnArgs = buildBackgroundSupervisorDenoArgs({
+          cliModPath: fuseSupervisorMod(import.meta.url),
+          mountpoint: absMountpoint,
+          apiUrl,
+          identity,
+          execCli,
+          logFile,
+          spaces: options.space ?? [],
+          allowOther: options.allowOther,
+          cfcMode: options.cfcMode,
+          cfcAnnotations: options.cfcAnnotations,
+          cfcXattrNamespace: options.cfcXattrNamespace,
+          cfcWritebackXattrs: options.cfcWritebackXattrs,
+          cfcWritebackState: options.cfcWritebackState,
+          statePath,
+          supervisorStatusPath: childStatusPath,
+          supervisorToken: childStatusToken,
+        });
+      }
 
       // Detached background process
       const cmd = new Deno.Command(spawnCmd, {
@@ -256,17 +431,21 @@ export const fuse = new Command()
       child.unref();
 
       const pid = child.pid;
-      let statePath: string;
       try {
-        statePath = await writeMountState(stateDir, {
+        await writeMountState(stateDir, {
           pid,
           mountpoint: absMountpoint,
           apiUrl,
           identity,
           startedAt: new Date().toISOString(),
           logFile,
+          childStatusPath,
         });
-        await awaitBackgroundMountStartup(pid, statePath);
+        await awaitBackgroundMountStartup(pid, statePath, {
+          childStatusPath,
+          childStatusToken,
+          mountpoint: absMountpoint,
+        });
       } catch (error) {
         try {
           Deno.kill(pid, "SIGTERM");
@@ -330,39 +509,45 @@ export const fuse = new Command()
     const stateDir = defaultStateDir();
     const pidFile = await readMountState(stateDir, absMountpoint);
 
-    if (pidFile && isAlive(pidFile.entry.pid)) {
+    const targetPid = pidFile && isAlive(pidFile.entry.pid)
+      ? pidFile.entry.pid
+      : pidFile?.entry.childPid;
+
+    if (pidFile && targetPid !== undefined && isAlive(targetPid)) {
       // Verify the PID belongs to a deno/fuse process before killing
       let verified = false;
       try {
         const ps = new Deno.Command("ps", {
-          args: ["-p", String(pidFile.entry.pid), "-o", "command="],
+          args: ["-p", String(targetPid), "-o", "command="],
           stdout: "piped",
         });
         const out = await ps.output();
         const cmd = new TextDecoder().decode(out.stdout).trim();
-        verified = cmd.includes("deno") && cmd.includes("fuse");
+        verified = isFuseProcessCommand(cmd);
       } catch {
         // ps failed — proceed cautiously (skip kill)
       }
 
       if (verified) {
-        console.log(`Sending SIGTERM to PID ${pidFile.entry.pid}...`);
+        console.log(`Sending SIGTERM to PID ${targetPid}...`);
         try {
-          Deno.kill(pidFile.entry.pid, "SIGTERM");
-          // Wait briefly for graceful shutdown
-          await new Promise((r) => setTimeout(r, 1000));
+          Deno.kill(targetPid, "SIGTERM");
+          // Wait briefly for the supervisor to terminate after child cleanup.
+          for (let i = 0; i < 20 && isAlive(targetPid); i++) {
+            await new Promise((r) => setTimeout(r, 100));
+          }
         } catch {
           // Process may have already exited
         }
-      } else if (isAlive(pidFile.entry.pid)) {
+      } else if (isAlive(targetPid)) {
         console.log(
-          `PID ${pidFile.entry.pid} does not appear to be a FUSE process; skipping kill.`,
+          `PID ${targetPid} does not appear to be a FUSE process; skipping kill.`,
         );
       }
     }
 
     // Fallback: try system unmount
-    if (pidFile && isAlive(pidFile.entry.pid)) {
+    if (pidFile && isMountStateAlive(pidFile.entry)) {
       console.log("Process still alive, trying system unmount...");
       const unmountCmd = Deno.build.os === "darwin"
         ? new Deno.Command("umount", { args: [absMountpoint] })
@@ -376,7 +561,7 @@ export const fuse = new Command()
     }
 
     // Clean up PID file
-    if (pidFile) {
+    if (pidFile && !isMountStateAlive(pidFile.entry)) {
       await removeMountStateFile(pidFile.path);
     }
 
@@ -397,7 +582,7 @@ export const fuse = new Command()
     const rows: string[][] = [];
 
     for (const { entry, path } of entries) {
-      const alive = isAlive(entry.pid);
+      const alive = isMountStateAlive(entry);
       if (!alive) {
         // Clean stale entry
         await removeMountStateFile(path);
@@ -406,7 +591,8 @@ export const fuse = new Command()
       rows.push([
         entry.mountpoint,
         String(entry.pid),
-        "running",
+        entry.childPid === undefined ? "-" : String(entry.childPid),
+        entry.childStatusPath ? await readChildMountStatus(entry) : "running",
         entry.startedAt,
         entry.logFile ?? "-",
       ]);
@@ -417,8 +603,20 @@ export const fuse = new Command()
       return;
     }
 
-    console.log("MOUNTPOINT\tPID\tSTATUS\tSTARTED\tLOG");
+    console.log("MOUNTPOINT\tSUPERVISOR_PID\tCHILD_PID\tSTATUS\tSTARTED\tLOG");
     for (const row of rows) {
       console.log(row.join("\t"));
     }
   });
+
+async function readChildMountStatus(entry: { childStatusPath?: string }) {
+  if (!entry.childStatusPath) return "running";
+  try {
+    const status = parseChildSupervisorStatus(
+      await Deno.readTextFile(entry.childStatusPath),
+    );
+    return status?.state ?? "unknown";
+  } catch {
+    return "unknown";
+  }
+}

--- a/packages/cli/commands/fuse.ts
+++ b/packages/cli/commands/fuse.ts
@@ -43,6 +43,11 @@ interface FuseChildSupervisorStatus {
   exitCode?: number;
 }
 
+const BACKGROUND_STARTUP_ATTEMPTS = 20;
+const CHILD_STATUS_STARTUP_ATTEMPTS = 200;
+const BACKGROUND_STARTUP_DELAY_MS = 50;
+const CHILD_STATUS_STARTUP_DELAY_MS = 100;
+
 export function childStatusPathForStatePath(statePath: string): string {
   return `${statePath}.child-status`;
 }
@@ -139,8 +144,14 @@ export async function awaitBackgroundMountStartup(
     sleep?: (ms: number) => Promise<void>;
   } = {},
 ): Promise<void> {
-  const attempts = deps.attempts ?? (deps.childStatusPath ? 50 : 20);
-  const delayMs = deps.delayMs ?? (deps.childStatusPath ? 100 : 50);
+  const attempts = deps.attempts ??
+    (deps.childStatusPath
+      ? CHILD_STATUS_STARTUP_ATTEMPTS
+      : BACKGROUND_STARTUP_ATTEMPTS);
+  const delayMs = deps.delayMs ??
+    (deps.childStatusPath
+      ? CHILD_STATUS_STARTUP_DELAY_MS
+      : BACKGROUND_STARTUP_DELAY_MS);
   const isAliveFn = deps.isAlive ?? isAlive;
   const removeStateFileFn = deps.removeStateFile ?? removeMountStateFile;
   const readTextFile = deps.readTextFile ?? Deno.readTextFile;

--- a/packages/cli/commands/fuse.ts
+++ b/packages/cli/commands/fuse.ts
@@ -11,6 +11,7 @@ import {
   isAlive,
   isMountStateAlive,
   mountpointHash,
+  type MountStateEntry,
   readAllMountStates,
   readMountState,
   removeMountStateFile,
@@ -45,6 +46,9 @@ interface FuseChildSupervisorStatus {
 export function childStatusPathForStatePath(statePath: string): string {
   return `${statePath}.child-status`;
 }
+
+export const mountStatusHeader =
+  "MOUNTPOINT\tSUPERVISOR_PID\tCHILD_PID\tSTATUS\tSTARTED\tLOG";
 
 function parseChildSupervisorStatus(
   text: string,
@@ -574,40 +578,46 @@ export const fuse = new Command()
     const stateDir = defaultStateDir();
     const entries = await readAllMountStates(stateDir);
 
-    if (entries.length === 0) {
-      console.log("No active FUSE mounts.");
-      return;
-    }
-
-    const rows: string[][] = [];
-
-    for (const { entry, path } of entries) {
-      const alive = isMountStateAlive(entry);
-      if (!alive) {
-        // Clean stale entry
-        await removeMountStateFile(path);
-        continue;
-      }
-      rows.push([
-        entry.mountpoint,
-        String(entry.pid),
-        entry.childPid === undefined ? "-" : String(entry.childPid),
-        entry.childStatusPath ? await readChildMountStatus(entry) : "running",
-        entry.startedAt,
-        entry.logFile ?? "-",
-      ]);
-    }
-
-    if (rows.length === 0) {
-      console.log("No active FUSE mounts.");
-      return;
-    }
-
-    console.log("MOUNTPOINT\tSUPERVISOR_PID\tCHILD_PID\tSTATUS\tSTARTED\tLOG");
-    for (const row of rows) {
-      console.log(row.join("\t"));
-    }
+    console.log(formatMountStatusTable(await buildMountStatusRows(entries)));
   });
+
+export async function buildMountStatusRows(
+  entries: Array<{ entry: MountStateEntry; path: string }>,
+  deps: {
+    isMountStateAlive?: (entry: MountStateEntry) => boolean;
+    removeMountStateFile?: (path: string) => Promise<void>;
+    readChildMountStatus?: (entry: MountStateEntry) => Promise<string>;
+  } = {},
+): Promise<string[][]> {
+  const isMountStateAliveFn = deps.isMountStateAlive ?? isMountStateAlive;
+  const removeMountStateFileFn = deps.removeMountStateFile ??
+    removeMountStateFile;
+  const readChildMountStatusFn = deps.readChildMountStatus ??
+    readChildMountStatus;
+  const rows: string[][] = [];
+
+  for (const { entry, path } of entries) {
+    if (!isMountStateAliveFn(entry)) {
+      await removeMountStateFileFn(path);
+      continue;
+    }
+    rows.push([
+      entry.mountpoint,
+      String(entry.pid),
+      entry.childPid === undefined ? "-" : String(entry.childPid),
+      entry.childStatusPath ? await readChildMountStatusFn(entry) : "running",
+      entry.startedAt,
+      entry.logFile ?? "-",
+    ]);
+  }
+
+  return rows;
+}
+
+export function formatMountStatusTable(rows: string[][]): string {
+  if (rows.length === 0) return "No active FUSE mounts.";
+  return [mountStatusHeader, ...rows.map((row) => row.join("\t"))].join("\n");
+}
 
 async function readChildMountStatus(entry: { childStatusPath?: string }) {
   if (!entry.childStatusPath) return "running";

--- a/packages/cli/commands/main.ts
+++ b/packages/cli/commands/main.ts
@@ -87,6 +87,63 @@ export const main = new Command()
         await main(daemonArgs);
       }),
   )
+  .command(
+    "fuse-supervisor",
+    new Command()
+      .description(
+        "Internal: supervise a background FUSE child process.",
+      )
+      .hidden()
+      .arguments("<mountpoint:string>")
+      .option("--api-url <url:string>", "URL of the fabric instance.")
+      .option("--identity <path:string>", "Path to an identity keyfile.")
+      .option("--exec-cli <path:string>", "Path to the cf exec shim.")
+      .option("--log-file <path:string>", "Path to the FUSE child log file.")
+      .option("--allow-other", "Pass allow_other through to the FUSE child.")
+      .option("--cfc-mode <mode:string>", "FUSE-side CFC mode.")
+      .option("--cfc-annotations", "Publish CFC annotation xattrs.")
+      .option(
+        "--cfc-xattr-namespace <namespace:string>",
+        "CFC xattr namespace.",
+      )
+      .option("--cfc-writeback-xattrs", "Enable CFC writeback xattrs.")
+      .option(
+        "--cfc-writeback-state <path:string>",
+        "CFC writeback state path.",
+      )
+      .option("--state-path <path:string>", "Mount state file to update.")
+      .option(
+        "--supervisor-status <path:string>",
+        "Child readiness and heartbeat status file.",
+      )
+      .option(
+        "--supervisor-token <token:string>",
+        "Child readiness status correlation token.",
+      )
+      .option("-s, --space <name:string>", "Space(s) to connect.", {
+        collect: true,
+      })
+      .action(async (options, mountpoint) => {
+        const { runFuseSupervisor } = await import("../lib/fuse-supervisor.ts");
+        await runFuseSupervisor({
+          mountpoint,
+          apiUrl: options.apiUrl ?? "",
+          identity: options.identity ?? "",
+          execCli: options.execCli ?? "",
+          logFile: options.logFile ?? "",
+          spaces: options.space ?? [],
+          allowOther: options.allowOther,
+          cfcMode: options.cfcMode,
+          cfcAnnotations: options.cfcAnnotations,
+          cfcXattrNamespace: options.cfcXattrNamespace,
+          cfcWritebackXattrs: options.cfcWritebackXattrs,
+          cfcWritebackState: options.cfcWritebackState,
+          statePath: options.statePath,
+          supervisorStatusPath: options.supervisorStatus,
+          supervisorToken: options.supervisorToken,
+        });
+      }),
+  )
   .command("id", identity)
   .command("init", init)
   .command("test", test)

--- a/packages/cli/lib/fuse-supervisor.ts
+++ b/packages/cli/lib/fuse-supervisor.ts
@@ -1,0 +1,406 @@
+import { basename } from "@std/path";
+import { buildFuseChildDenoArgs, fuseMod } from "./fuse.ts";
+
+export interface FuseSupervisorOptions {
+  mountpoint: string;
+  apiUrl: string;
+  identity: string;
+  execCli: string;
+  logFile: string;
+  spaces: string[];
+  allowOther?: boolean;
+  cfcMode?: string;
+  cfcAnnotations?: boolean;
+  cfcXattrNamespace?: string;
+  cfcWritebackXattrs?: boolean;
+  cfcWritebackState?: string;
+  statePath?: string;
+  supervisorStatusPath?: string;
+  supervisorToken?: string;
+  importMetaUrl?: string;
+  command?: FuseCommandConstructor;
+  execPath?: string;
+  childShutdownTimeoutMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+  exit?: (code: number) => never | void;
+  addSignalListener?: (signal: Deno.Signal, handler: () => void) => void;
+  removeSignalListener?: (signal: Deno.Signal, handler: () => void) => void;
+  supervisorPid?: number;
+}
+
+export interface FuseCommandConstructor {
+  new (command: string | URL, options: Deno.CommandOptions): {
+    spawn(): {
+      pid: number;
+      status: Promise<Deno.CommandStatus>;
+      kill(signal: Deno.Signal): void;
+    };
+  };
+}
+
+export interface SupervisedFuseChild {
+  killed?: boolean;
+  kill: (signal: Deno.Signal) => void;
+  status?: Promise<Deno.CommandStatus>;
+}
+
+const DEFAULT_CHILD_SHUTDOWN_TIMEOUT_MS = 5_000;
+
+export function buildFuseChildCommand(
+  options: FuseSupervisorOptions,
+): { command: string; args: string[] } {
+  const execPath = options.execPath ?? Deno.execPath();
+  const execBase = basename(execPath);
+  const isCompiledBinary = execBase !== "deno" && execBase !== "deno.exe";
+
+  if (isCompiledBinary) {
+    const args = ["fuse-daemon", options.mountpoint];
+    if (options.apiUrl) args.push("--api-url", options.apiUrl);
+    if (options.identity) args.push("--identity", options.identity);
+    if (options.execCli) args.push("--exec-cli", options.execCli);
+    if (options.logFile) args.push("--log-file", options.logFile);
+    if (options.allowOther) args.push("--allow-other");
+    if (options.cfcMode) args.push("--cfc-mode", options.cfcMode);
+    if (options.cfcAnnotations) args.push("--cfc-annotations");
+    if (options.cfcXattrNamespace) {
+      args.push("--cfc-xattr-namespace", options.cfcXattrNamespace);
+    }
+    if (options.cfcWritebackXattrs) args.push("--cfc-writeback-xattrs");
+    if (options.cfcWritebackState) {
+      args.push("--cfc-writeback-state", options.cfcWritebackState);
+    }
+    if (options.supervisorStatusPath) {
+      args.push("--supervisor-status", options.supervisorStatusPath);
+    }
+    if (options.supervisorToken) {
+      args.push("--supervisor-token", options.supervisorToken);
+    }
+    for (const space of options.spaces) args.push("--space", space);
+    return { command: execPath, args };
+  }
+
+  return {
+    command: execPath,
+    args: buildFuseChildDenoArgs({
+      modPath: fuseMod(options.importMetaUrl ?? import.meta.url),
+      mountpoint: options.mountpoint,
+      apiUrl: options.apiUrl,
+      identity: options.identity,
+      execCli: options.execCli,
+      logFile: options.logFile,
+      spaces: options.spaces,
+      allowOther: options.allowOther,
+      cfcMode: options.cfcMode,
+      cfcAnnotations: options.cfcAnnotations,
+      cfcXattrNamespace: options.cfcXattrNamespace,
+      cfcWritebackXattrs: options.cfcWritebackXattrs,
+      cfcWritebackState: options.cfcWritebackState,
+      supervisorStatusPath: options.supervisorStatusPath,
+      supervisorToken: options.supervisorToken,
+    }),
+  };
+}
+
+export async function runFuseSupervisor(
+  options: FuseSupervisorOptions,
+): Promise<void> {
+  const childCommand = buildFuseChildCommand(options);
+  const CommandCtor = options.command ?? Deno.Command;
+  const exit = options.exit ?? Deno.exit;
+  const child = new CommandCtor(childCommand.command, {
+    args: childCommand.args,
+    stdin: "null",
+    stdout: "null",
+    stderr: "null",
+  }).spawn();
+
+  let childExited = false;
+  const supervisedChild: SupervisedFuseChild = {
+    get killed(): boolean {
+      return childExited;
+    },
+    kill: (signal: Deno.Signal) => child.kill(signal),
+    status: child.status,
+  };
+
+  let terminating = false;
+  const forwardTermination = (signal: Deno.Signal): void => {
+    if (terminating) return;
+    terminating = true;
+    cleanupFuseChild(supervisedChild, {
+      signal,
+      timeoutMs: options.childShutdownTimeoutMs,
+    }).then(() => {
+      exit(signal === "SIGINT" ? 130 : 143);
+    }).catch(() => {
+      exit(1);
+    });
+  };
+  const onSigterm = () => forwardTermination("SIGTERM");
+  const onSigint = () => forwardTermination("SIGINT");
+
+  addSupervisorSignalListener("SIGTERM", onSigterm, options.addSignalListener);
+  addSupervisorSignalListener("SIGINT", onSigint, options.addSignalListener);
+
+  try {
+    if (options.statePath) {
+      const recorded = await recordFuseChildPid({
+        statePath: options.statePath,
+        childPid: child.pid,
+        supervisorPid: options.supervisorPid ?? Deno.pid,
+        sleep: options.sleep,
+      });
+      if (!recorded) {
+        throw new Error("Unable to record FUSE child PID in mount state.");
+      }
+    }
+    const status = await child.status;
+    childExited = true;
+    exit(status.code);
+  } finally {
+    removeSupervisorSignalListener(
+      "SIGTERM",
+      onSigterm,
+      options.removeSignalListener,
+    );
+    removeSupervisorSignalListener(
+      "SIGINT",
+      onSigint,
+      options.removeSignalListener,
+    );
+    await cleanupFuseChild(supervisedChild, {
+      timeoutMs: options.childShutdownTimeoutMs,
+    });
+  }
+}
+
+export async function cleanupFuseChild(
+  child: SupervisedFuseChild,
+  options: {
+    signal?: Deno.Signal;
+    timeoutMs?: number;
+  } = {},
+): Promise<void> {
+  if (child.killed) return;
+
+  const signal = options.signal ?? "SIGTERM";
+  const timeoutMs = options.timeoutMs ?? DEFAULT_CHILD_SHUTDOWN_TIMEOUT_MS;
+
+  try {
+    child.kill(signal);
+  } catch {
+    // The child may have exited between the status check and kill attempt.
+    return;
+  }
+
+  if (!child.status) return;
+
+  const timedOut = Symbol("timedOut");
+  let timeoutId: number | undefined;
+  const result = await Promise.race<Deno.CommandStatus | typeof timedOut>([
+    child.status,
+    new Promise<typeof timedOut>((resolve) => {
+      timeoutId = setTimeout(() => resolve(timedOut), timeoutMs);
+    }),
+  ]).finally(() => {
+    if (timeoutId !== undefined) clearTimeout(timeoutId);
+  });
+
+  if (result !== timedOut) return;
+
+  try {
+    child.kill("SIGKILL");
+  } catch {
+    // The child may have exited during the timeout window.
+  }
+
+  await child.status.catch(() => undefined);
+}
+
+interface ParsedSupervisorArgs {
+  options: FuseSupervisorOptions;
+  help: boolean;
+}
+
+function parseSupervisorArgs(rawArgs: string[]): ParsedSupervisorArgs {
+  const options: FuseSupervisorOptions = {
+    mountpoint: "",
+    apiUrl: "",
+    identity: "",
+    execCli: "",
+    logFile: "",
+    spaces: [],
+  };
+  let help = false;
+
+  for (let i = 0; i < rawArgs.length; i++) {
+    const arg = rawArgs[i];
+    switch (arg) {
+      case "--help":
+      case "-h":
+        help = true;
+        break;
+      case "--api-url":
+        options.apiUrl = requireValue(rawArgs, ++i, arg);
+        break;
+      case "--identity":
+        options.identity = requireValue(rawArgs, ++i, arg);
+        break;
+      case "--exec-cli":
+        options.execCli = requireValue(rawArgs, ++i, arg);
+        break;
+      case "--log-file":
+        options.logFile = requireValue(rawArgs, ++i, arg);
+        break;
+      case "--allow-other":
+        options.allowOther = true;
+        break;
+      case "--cfc-mode":
+        options.cfcMode = requireValue(rawArgs, ++i, arg);
+        break;
+      case "--cfc-annotations":
+        options.cfcAnnotations = true;
+        break;
+      case "--cfc-xattr-namespace":
+        options.cfcXattrNamespace = requireValue(rawArgs, ++i, arg);
+        break;
+      case "--cfc-writeback-xattrs":
+        options.cfcWritebackXattrs = true;
+        break;
+      case "--cfc-writeback-state":
+        options.cfcWritebackState = requireValue(rawArgs, ++i, arg);
+        break;
+      case "--state-path":
+        options.statePath = requireValue(rawArgs, ++i, arg);
+        break;
+      case "--supervisor-status":
+        options.supervisorStatusPath = requireValue(rawArgs, ++i, arg);
+        break;
+      case "--supervisor-token":
+        options.supervisorToken = requireValue(rawArgs, ++i, arg);
+        break;
+      case "--space":
+      case "-s":
+        options.spaces.push(requireValue(rawArgs, ++i, arg));
+        break;
+      default:
+        if (arg.startsWith("-")) {
+          throw new Error(`Unknown fuse supervisor option: ${arg}`);
+        }
+        if (options.mountpoint) {
+          throw new Error(`Unexpected fuse supervisor argument: ${arg}`);
+        }
+        options.mountpoint = arg;
+    }
+  }
+
+  return { options, help };
+}
+
+function requireValue(args: string[], index: number, flag: string): string {
+  const value = args[index];
+  if (value === undefined) {
+    throw new Error(`Missing value for ${flag}`);
+  }
+  return value;
+}
+
+function supervisorHelp(): string {
+  return `Usage: fuse-supervisor <mountpoint> [options]
+
+Internal: supervise a background FUSE child process.
+
+Options:
+  --api-url <url>                 URL of the fabric instance
+  --identity <path>               Path to an identity keyfile
+  --exec-cli <path>               Path to the cf exec shim
+  --log-file <path>               Path to the FUSE child log file
+  --allow-other                   Pass allow_other through to the FUSE child
+  --cfc-mode <mode>               FUSE-side CFC mode
+  --cfc-annotations               Publish CFC annotation xattrs
+  --cfc-xattr-namespace <ns>      CFC xattr namespace
+  --cfc-writeback-xattrs          Enable CFC writeback xattrs
+  --cfc-writeback-state <path>    CFC writeback state path
+  --state-path <path>             Mount state file to update with child PID
+  --supervisor-status <path>      Child readiness and heartbeat status file
+  --supervisor-token <token>      Child readiness status correlation token
+  -s, --space <name>              Space(s) to connect
+  -h, --help                      Show this help
+`;
+}
+
+export async function recordFuseChildPid(
+  options: {
+    statePath: string;
+    childPid: number;
+    supervisorPid: number;
+    sleep?: (ms: number) => Promise<void>;
+  },
+): Promise<boolean> {
+  const sleep = options.sleep ??
+    ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  for (let attempt = 0; attempt < 20; attempt++) {
+    try {
+      const state = JSON.parse(
+        await Deno.readTextFile(options.statePath),
+      ) as Record<string, unknown>;
+      if (state.pid !== options.supervisorPid) {
+        await sleep(50);
+        continue;
+      }
+      state.childPid = options.childPid;
+      await Deno.writeTextFile(
+        options.statePath,
+        JSON.stringify(state, null, 2),
+      );
+      return true;
+    } catch {
+      await sleep(50);
+    }
+  }
+  return false;
+}
+
+if (import.meta.main) {
+  try {
+    const { options, help } = parseSupervisorArgs(Deno.args);
+    if (help) {
+      console.log(supervisorHelp());
+      Deno.exit(0);
+    }
+    if (!options.mountpoint) {
+      throw new Error("Missing mountpoint for fuse supervisor.");
+    }
+    await runFuseSupervisor(options);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    Deno.exit(1);
+  }
+}
+
+function addSupervisorSignalListener(
+  signal: Deno.Signal,
+  handler: () => void,
+  addSignalListener: (signal: Deno.Signal, handler: () => void) => void = Deno
+    .addSignalListener,
+): void {
+  try {
+    addSignalListener(signal, handler);
+  } catch {
+    // Some platforms do not support all signal listeners.
+  }
+}
+
+function removeSupervisorSignalListener(
+  signal: Deno.Signal,
+  handler: () => void,
+  removeSignalListener: (signal: Deno.Signal, handler: () => void) => void =
+    Deno
+      .removeSignalListener,
+): void {
+  try {
+    removeSignalListener(signal, handler);
+  } catch {
+    // Ignore unsupported or already-removed listeners.
+  }
+}

--- a/packages/cli/lib/fuse.ts
+++ b/packages/cli/lib/fuse.ts
@@ -12,11 +12,37 @@ import { cliName } from "./cli-name.ts";
 
 export interface MountStateEntry {
   pid: number;
+  childPid?: number;
+  childStatusPath?: string;
   mountpoint: string;
   apiUrl: string;
   identity: string;
   startedAt: string;
   logFile?: string;
+}
+
+export interface FuseChildDenoArgsOptions {
+  modPath: string;
+  mountpoint: string;
+  apiUrl: string;
+  identity: string;
+  execCli: string;
+  logFile?: string;
+  spaces?: string[];
+  allowOther?: boolean;
+  cfcMode?: string;
+  cfcAnnotations?: boolean;
+  cfcXattrNamespace?: string;
+  cfcWritebackXattrs?: boolean;
+  cfcWritebackState?: string;
+  supervisorStatusPath?: string;
+  supervisorToken?: string;
+}
+
+export interface BackgroundSupervisorDenoArgsOptions
+  extends Omit<FuseChildDenoArgsOptions, "modPath"> {
+  cliModPath: string;
+  statePath?: string;
 }
 
 export async function canonicalizeMountLookupPath(
@@ -49,6 +75,20 @@ function normalizeMountStateEntry(entry: MountStateEntry): MountStateEntry {
       ? (isAbsolute(entry.identity) ? entry.identity : resolve(entry.identity))
       : "",
   };
+}
+
+function isMountStateEntry(value: unknown): value is MountStateEntry {
+  if (typeof value !== "object" || value === null) return false;
+  const entry = value as Record<string, unknown>;
+  return typeof entry.pid === "number" &&
+    typeof entry.mountpoint === "string" &&
+    typeof entry.apiUrl === "string" &&
+    typeof entry.identity === "string" &&
+    typeof entry.startedAt === "string" &&
+    (entry.childPid === undefined || typeof entry.childPid === "number") &&
+    (entry.childStatusPath === undefined ||
+      typeof entry.childStatusPath === "string") &&
+    (entry.logFile === undefined || typeof entry.logFile === "string");
 }
 
 function isWithinMountpoint(path: string, mountpoint: string): boolean {
@@ -130,8 +170,10 @@ export async function readMountState(
   for (const path of candidatePaths) {
     try {
       const text = await Deno.readTextFile(path);
+      const parsed = JSON.parse(text) as unknown;
+      if (!isMountStateEntry(parsed)) continue;
       matches.push({
-        entry: normalizeMountStateEntry(JSON.parse(text) as MountStateEntry),
+        entry: normalizeMountStateEntry(parsed),
         path,
       });
     } catch {
@@ -139,7 +181,8 @@ export async function readMountState(
     }
   }
 
-  return matches.find(({ entry }) => isAlive(entry.pid)) ?? matches[0] ?? null;
+  return matches.find(({ entry }) => isMountStateAlive(entry)) ?? matches[0] ??
+    null;
 }
 
 export async function readAllMountStates(
@@ -148,12 +191,17 @@ export async function readAllMountStates(
   const results: { entry: MountStateEntry; path: string }[] = [];
   try {
     for await (const file of Deno.readDir(stateDir)) {
-      if (!file.isFile || !file.name.endsWith(".json")) continue;
+      if (
+        !file.isFile || !file.name.endsWith(".json") ||
+        file.name.endsWith(".child-status.json")
+      ) continue;
       const path = resolve(stateDir, file.name);
       try {
         const text = await Deno.readTextFile(path);
+        const parsed = JSON.parse(text) as unknown;
+        if (!isMountStateEntry(parsed)) continue;
         results.push({
-          entry: normalizeMountStateEntry(JSON.parse(text) as MountStateEntry),
+          entry: normalizeMountStateEntry(parsed),
           path,
         });
       } catch {
@@ -176,7 +224,7 @@ export async function findMountForPath(
   let bestMatch: { entry: MountStateEntry; path: string } | null = null;
   let bestMatchMountpoint: string | null = null;
   for (const candidate of entries) {
-    if (!isAlive(candidate.entry.pid)) {
+    if (!isMountStateAlive(candidate.entry)) {
       try {
         await Deno.remove(candidate.path);
       } catch {
@@ -219,6 +267,11 @@ export function isAlive(pid: number): boolean {
   }
 }
 
+export function isMountStateAlive(entry: MountStateEntry): boolean {
+  return isAlive(entry.pid) ||
+    (entry.childPid !== undefined && isAlive(entry.childPid));
+}
+
 /** Default state directory for FUSE mount state. */
 export function defaultStateDir(): string {
   return resolve(Deno.env.get("HOME") ?? "/tmp", ".cf", "fuse");
@@ -228,6 +281,12 @@ export function defaultStateDir(): string {
 export function fuseMod(importMetaUrl: string): string {
   const cliCommandsDir = dirname(fromFileUrl(importMetaUrl));
   return resolve(cliCommandsDir, "../../fuse/mod.ts");
+}
+
+/** Resolve path to the minimal FUSE supervisor entrypoint. */
+export function fuseSupervisorMod(importMetaUrl: string): string {
+  const cliCommandsDir = dirname(fromFileUrl(importMetaUrl));
+  return resolve(cliCommandsDir, "../lib/fuse-supervisor.ts");
 }
 
 export async function ensureExecShim(
@@ -282,20 +341,9 @@ exec "${Deno.execPath()}" run --allow-net --allow-ffi --allow-read --allow-write
 }
 
 /** Build the deno subprocess args for running the FUSE module. */
-export function buildDenoArgs(opts: {
-  modPath: string;
-  mountpoint: string;
-  apiUrl: string;
-  identity: string;
-  execCli: string;
-  logFile?: string;
-  allowOther?: boolean;
-  cfcMode?: string;
-  cfcAnnotations?: boolean;
-  cfcXattrNamespace?: string;
-  cfcWritebackXattrs?: boolean;
-  cfcWritebackState?: string;
-}): string[] {
+export function buildFuseChildDenoArgs(
+  opts: FuseChildDenoArgsOptions,
+): string[] {
   const args = [
     "run",
     "--unstable-ffi",
@@ -322,6 +370,59 @@ export function buildDenoArgs(opts: {
   if (opts.cfcWritebackState) {
     args.push("--cfc-writeback-state", opts.cfcWritebackState);
   }
+  if (opts.supervisorStatusPath) {
+    args.push("--supervisor-status", opts.supervisorStatusPath);
+  }
+  if (opts.supervisorToken) {
+    args.push("--supervisor-token", opts.supervisorToken);
+  }
+  for (const space of opts.spaces ?? []) args.push("--space", space);
 
   return args;
+}
+
+/** Build the deno subprocess args for running the non-FFI FUSE supervisor. */
+export function buildBackgroundSupervisorDenoArgs(
+  opts: BackgroundSupervisorDenoArgsOptions,
+): string[] {
+  const args = [
+    "run",
+    "--allow-run",
+    opts.cliModPath,
+    opts.mountpoint,
+  ];
+
+  if (opts.statePath) {
+    args.splice(2, 0, `--allow-read=${opts.statePath}`);
+    args.splice(3, 0, `--allow-write=${opts.statePath}`);
+    args.push("--state-path", opts.statePath);
+  }
+
+  if (opts.apiUrl) args.push("--api-url", opts.apiUrl);
+  if (opts.identity) args.push("--identity", opts.identity);
+  if (opts.execCli) args.push("--exec-cli", opts.execCli);
+  if (opts.logFile) args.push("--log-file", opts.logFile);
+  if (opts.allowOther) args.push("--allow-other");
+  if (opts.cfcMode) args.push("--cfc-mode", opts.cfcMode);
+  if (opts.cfcAnnotations) args.push("--cfc-annotations");
+  if (opts.cfcXattrNamespace) {
+    args.push("--cfc-xattr-namespace", opts.cfcXattrNamespace);
+  }
+  if (opts.cfcWritebackXattrs) args.push("--cfc-writeback-xattrs");
+  if (opts.cfcWritebackState) {
+    args.push("--cfc-writeback-state", opts.cfcWritebackState);
+  }
+  if (opts.supervisorStatusPath) {
+    args.push("--supervisor-status", opts.supervisorStatusPath);
+  }
+  if (opts.supervisorToken) {
+    args.push("--supervisor-token", opts.supervisorToken);
+  }
+  for (const space of opts.spaces ?? []) args.push("--space", space);
+
+  return args;
+}
+
+export function buildDenoArgs(opts: FuseChildDenoArgsOptions): string[] {
+  return buildFuseChildDenoArgs(opts);
 }

--- a/packages/cli/test/fuse.test.ts
+++ b/packages/cli/test/fuse.test.ts
@@ -4,9 +4,12 @@ import { basename, join, resolve, toFileUrl } from "@std/path";
 import {
   awaitBackgroundMountStartup,
   awaitForegroundMountExit,
+  buildMountStatusRows,
   childStatusPathForStatePath,
+  formatMountStatusTable,
   fuse,
   isFuseProcessCommand,
+  mountStatusHeader,
 } from "../commands/fuse.ts";
 import {
   buildBackgroundSupervisorDenoArgs,
@@ -597,6 +600,70 @@ describe("mount state operations", () => {
     const states = await readAllMountStates(tmpDir);
 
     expect(states.map(({ path }) => path)).toEqual([statePath]);
+  });
+
+  it("formats active supervisor and child status rows", async () => {
+    const statePath = await writeMountState(tmpDir, {
+      pid: 123,
+      childPid: 456,
+      mountpoint: "/tmp/test-mount",
+      apiUrl: "",
+      identity: "",
+      startedAt: "2026-03-17T00:00:00.000Z",
+      logFile: "/tmp/cf-fuse-test-mount.log",
+      childStatusPath: join(tmpDir, "child-status"),
+    });
+    await Deno.writeTextFile(
+      join(tmpDir, "child-status"),
+      JSON.stringify({
+        state: "mounted",
+        pid: 456,
+        mountpoint: "/tmp/test-mount",
+        updatedAt: "2026-03-17T00:00:01.000Z",
+      }),
+    );
+
+    const rows = await buildMountStatusRows(await readAllMountStates(tmpDir), {
+      isMountStateAlive: () => true,
+    });
+
+    expect(formatMountStatusTable(rows)).toBe([
+      mountStatusHeader,
+      [
+        "/tmp/test-mount",
+        "123",
+        "456",
+        "mounted",
+        "2026-03-17T00:00:00.000Z",
+        "/tmp/cf-fuse-test-mount.log",
+      ].join("\t"),
+    ].join("\n"));
+    expect(rows).toHaveLength(1);
+    expect((await Deno.stat(statePath)).isFile).toBe(true);
+  });
+
+  it("formats empty status after removing stale mount entries", async () => {
+    const statePath = await writeMountState(tmpDir, {
+      pid: 123,
+      mountpoint: "/tmp/test-mount",
+      apiUrl: "",
+      identity: "",
+      startedAt: "2026-03-17T00:00:00.000Z",
+    });
+    const removed: string[] = [];
+
+    const rows = await buildMountStatusRows(await readAllMountStates(tmpDir), {
+      isMountStateAlive: () => false,
+      removeMountStateFile: async (path) => {
+        removed.push(path);
+        await Deno.remove(path);
+      },
+    });
+
+    expect(rows).toEqual([]);
+    expect(formatMountStatusTable(rows)).toBe("No active FUSE mounts.");
+    expect(removed).toEqual([statePath]);
+    await expect(Deno.stat(statePath)).rejects.toThrow();
   });
 
   it("rejects background mounts when child reports startup failure", async () => {

--- a/packages/cli/test/fuse.test.ts
+++ b/packages/cli/test/fuse.test.ts
@@ -4,18 +4,30 @@ import { basename, join, resolve, toFileUrl } from "@std/path";
 import {
   awaitBackgroundMountStartup,
   awaitForegroundMountExit,
+  childStatusPathForStatePath,
   fuse,
+  isFuseProcessCommand,
 } from "../commands/fuse.ts";
 import {
+  buildBackgroundSupervisorDenoArgs,
   buildDenoArgs,
+  buildFuseChildDenoArgs,
   ensureExecShim,
   findMountForPath,
   isAlive,
+  isMountStateAlive,
   mountpointHash,
   readAllMountStates,
   readMountState,
   writeMountState,
 } from "../lib/fuse.ts";
+import {
+  buildFuseChildCommand,
+  cleanupFuseChild,
+  recordFuseChildPid,
+  runFuseSupervisor,
+} from "../lib/fuse-supervisor.ts";
+import { writeFailedSupervisorStartupStatus } from "../../fuse/mod.ts";
 import { withEnv } from "./utils.ts";
 
 describe("mountpointHash", () => {
@@ -392,6 +404,7 @@ describe("mount state operations", () => {
   it("always removes foreground mount state files before exiting", async () => {
     const statePath = await writeMountState(tmpDir, {
       pid: Deno.pid,
+      childPid: 321,
       mountpoint: "/tmp/test-mount",
       apiUrl: "http://localhost:8000",
       identity: "/tmp/test-identity.pem",
@@ -450,6 +463,7 @@ describe("mount state operations", () => {
   it("allows background mounts that stay alive through the startup window", async () => {
     const statePath = await writeMountState(tmpDir, {
       pid: Deno.pid,
+      childPid: 321,
       mountpoint: "/tmp/test-mount",
       apiUrl: "http://localhost:8000",
       identity: "/tmp/test-identity.pem",
@@ -474,6 +488,233 @@ describe("mount state operations", () => {
 
     expect(checks).toBe(3);
     await expect(Deno.stat(statePath)).resolves.toBeDefined();
+  });
+
+  it("waits for explicit child mounted status when available", async () => {
+    const statePath = await writeMountState(tmpDir, {
+      pid: Deno.pid,
+      childPid: 321,
+      mountpoint: "/tmp/test-mount",
+      apiUrl: "http://localhost:8000",
+      identity: "/tmp/test-identity.pem",
+      startedAt: "2026-03-17T00:00:00.000Z",
+    });
+    const childStatusPath = childStatusPathForStatePath(statePath);
+    let reads = 0;
+
+    await expect(
+      awaitBackgroundMountStartup(Deno.pid, statePath, {
+        attempts: 3,
+        childStatusPath,
+        childStatusToken: "token-1",
+        mountpoint: "/tmp/test-mount",
+        isAlive: () => true,
+        readTextFile: () => {
+          reads++;
+          return Promise.resolve(JSON.stringify({
+            state: reads === 1 ? "starting" : "mounted",
+            pid: 321,
+            mountpoint: "/tmp/test-mount",
+            token: "token-1",
+            updatedAt: "2026-03-17T00:00:00.000Z",
+          }));
+        },
+        sleep: () => Promise.resolve(),
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(reads).toBe(2);
+    await expect(Deno.stat(statePath)).resolves.toBeDefined();
+  });
+
+  it("ignores mounted child status from a different startup attempt", async () => {
+    const statePath = await writeMountState(tmpDir, {
+      pid: Deno.pid,
+      childPid: 321,
+      mountpoint: "/tmp/test-mount",
+      apiUrl: "http://localhost:8000",
+      identity: "/tmp/test-identity.pem",
+      startedAt: "2026-03-17T00:00:00.000Z",
+    });
+    const childStatusPath = childStatusPathForStatePath(statePath);
+    const removed: string[] = [];
+
+    await expect(
+      awaitBackgroundMountStartup(Deno.pid, statePath, {
+        attempts: 1,
+        childStatusPath,
+        childStatusToken: "token-1",
+        mountpoint: "/tmp/test-mount",
+        isAlive: () => true,
+        readTextFile: () =>
+          Promise.resolve(JSON.stringify({
+            state: "mounted",
+            pid: 321,
+            mountpoint: "/tmp/test-mount",
+            token: "stale-token",
+            updatedAt: "2026-03-17T00:00:00.000Z",
+          })),
+        removeStateFile: async (path: string) => {
+          removed.push(path);
+          await Deno.remove(path);
+        },
+        sleep: () => Promise.resolve(),
+      }),
+    ).rejects.toThrow(/did not report mount readiness/i);
+
+    expect(removed).toEqual([statePath]);
+  });
+
+  it("does not read child status sidecars as mount state entries", async () => {
+    const statePath = await writeMountState(tmpDir, {
+      pid: Deno.pid,
+      childPid: 321,
+      mountpoint: "/tmp/test-mount",
+      apiUrl: "http://localhost:8000",
+      identity: "/tmp/test-identity.pem",
+      startedAt: "2026-03-17T00:00:00.000Z",
+      childStatusPath: "",
+    });
+    await Deno.writeTextFile(
+      childStatusPathForStatePath(statePath),
+      JSON.stringify({
+        state: "mounted",
+        pid: 321,
+        mountpoint: "/tmp/test-mount",
+        updatedAt: "2026-03-17T00:00:00.000Z",
+      }),
+    );
+    await Deno.writeTextFile(
+      `${statePath}.child-status.json`,
+      JSON.stringify({
+        state: "mounted",
+        pid: 321,
+        mountpoint: "/tmp/test-mount",
+        updatedAt: "2026-03-17T00:00:00.000Z",
+      }),
+    );
+
+    const states = await readAllMountStates(tmpDir);
+
+    expect(states.map(({ path }) => path)).toEqual([statePath]);
+  });
+
+  it("rejects background mounts when child reports startup failure", async () => {
+    const statePath = await writeMountState(tmpDir, {
+      pid: Deno.pid,
+      childPid: 321,
+      mountpoint: "/tmp/test-mount",
+      apiUrl: "http://localhost:8000",
+      identity: "/tmp/test-identity.pem",
+      startedAt: "2026-03-17T00:00:00.000Z",
+    });
+    const childStatusPath = childStatusPathForStatePath(statePath);
+    const removed: string[] = [];
+
+    await expect(
+      awaitBackgroundMountStartup(Deno.pid, statePath, {
+        attempts: 1,
+        childStatusPath,
+        childStatusToken: "token-1",
+        mountpoint: "/tmp/test-mount",
+        isAlive: () => true,
+        readTextFile: () =>
+          Promise.resolve(JSON.stringify({
+            state: "failed",
+            pid: 321,
+            mountpoint: "/tmp/test-mount",
+            token: "token-1",
+            updatedAt: "2026-03-17T00:00:00.000Z",
+            error: "fuse_session_mount failed",
+          })),
+        removeStateFile: async (path: string) => {
+          removed.push(path);
+          await Deno.remove(path);
+        },
+        sleep: () => Promise.resolve(),
+      }),
+    ).rejects.toThrow(/fuse_session_mount failed/);
+
+    expect(removed).toEqual([statePath]);
+    await expect(Deno.stat(statePath)).rejects.toThrow();
+  });
+
+  it("rejects background mounts when child exits during startup", async () => {
+    const statePath = await writeMountState(tmpDir, {
+      pid: Deno.pid,
+      childPid: 321,
+      mountpoint: "/tmp/test-mount",
+      apiUrl: "http://localhost:8000",
+      identity: "/tmp/test-identity.pem",
+      startedAt: "2026-03-17T00:00:00.000Z",
+    });
+    const childStatusPath = childStatusPathForStatePath(statePath);
+    const removed: string[] = [];
+
+    await expect(
+      awaitBackgroundMountStartup(Deno.pid, statePath, {
+        attempts: 1,
+        childStatusPath,
+        childStatusToken: "token-1",
+        mountpoint: "/tmp/test-mount",
+        isAlive: () => true,
+        readTextFile: () =>
+          Promise.resolve(JSON.stringify({
+            state: "exiting",
+            pid: 321,
+            mountpoint: "/tmp/test-mount",
+            token: "token-1",
+            updatedAt: "2026-03-17T00:00:00.000Z",
+          })),
+        removeStateFile: async (path: string) => {
+          removed.push(path);
+          await Deno.remove(path);
+        },
+        sleep: () => Promise.resolve(),
+      }),
+    ).rejects.toThrow(/child reported exiting/);
+
+    expect(removed).toEqual([statePath]);
+    await expect(Deno.stat(statePath)).rejects.toThrow();
+  });
+
+  it("rejects background mounts when child readiness times out", async () => {
+    const statePath = await writeMountState(tmpDir, {
+      pid: Deno.pid,
+      childPid: 321,
+      mountpoint: "/tmp/test-mount",
+      apiUrl: "http://localhost:8000",
+      identity: "/tmp/test-identity.pem",
+      startedAt: "2026-03-17T00:00:00.000Z",
+    });
+    const childStatusPath = childStatusPathForStatePath(statePath);
+    const removed: string[] = [];
+
+    await expect(
+      awaitBackgroundMountStartup(Deno.pid, statePath, {
+        attempts: 1,
+        childStatusPath,
+        childStatusToken: "token-1",
+        mountpoint: "/tmp/test-mount",
+        isAlive: () => true,
+        readTextFile: () =>
+          Promise.resolve(JSON.stringify({
+            state: "starting",
+            pid: 321,
+            mountpoint: "/tmp/test-mount",
+            token: "token-1",
+            updatedAt: "2026-03-17T00:00:00.000Z",
+          })),
+        removeStateFile: async (path: string) => {
+          removed.push(path);
+          await Deno.remove(path);
+        },
+        sleep: () => Promise.resolve(),
+      }),
+    ).rejects.toThrow(/did not report mount readiness/i);
+
+    expect(removed).toEqual([statePath]);
+    await expect(Deno.stat(statePath)).rejects.toThrow();
   });
 });
 
@@ -571,5 +812,420 @@ describe("buildDenoArgs", () => {
     expect(args).toContain("--cfc-writeback-xattrs");
     expect(args).toContain("--cfc-writeback-state");
     expect(args).toContain("/tmp/cf-writeback.json");
+  });
+});
+
+describe("FUSE supervisor command construction", () => {
+  it("writes failed supervisor status for daemon startup failures", async () => {
+    const writes: Array<{ state: string; extra?: Record<string, unknown> }> =
+      [];
+
+    await writeFailedSupervisorStartupStatus(
+      new Error("connectSpace failed"),
+      (state, extra) => {
+        writes.push({ state, extra });
+        return Promise.resolve();
+      },
+    );
+
+    expect(writes).toEqual([{
+      state: "failed",
+      extra: { error: "Error: connectSpace failed" },
+    }]);
+  });
+
+  it("builds a background supervisor invocation that does not load libfuse", () => {
+    const args = buildBackgroundSupervisorDenoArgs({
+      cliModPath: "/repo/packages/cli/lib/fuse-supervisor.ts",
+      mountpoint: "/mnt",
+      apiUrl: "http://localhost:8000",
+      identity: "/tmp/id.key",
+      execCli: "/tmp/cf-exec",
+      logFile: "/tmp/cf-fuse-mnt.log",
+      spaces: ["home", "work"],
+      statePath: "/tmp/cf-state.json",
+      supervisorStatusPath: "/tmp/cf-state.json.child-status",
+      supervisorToken: "token-1",
+      allowOther: true,
+      cfcMode: "observe",
+      cfcAnnotations: true,
+      cfcXattrNamespace: "both",
+      cfcWritebackXattrs: true,
+      cfcWritebackState: "/tmp/cfc.json",
+    });
+
+    expect(args.slice(0, 2)).toEqual(["run", "--allow-run"]);
+    expect(args).not.toContain("--allow-read");
+    expect(args).not.toContain("--allow-write");
+    expect(args).toContain("--allow-read=/tmp/cf-state.json");
+    expect(args).toContain("--allow-write=/tmp/cf-state.json");
+    expect(args).not.toContain("--allow-env");
+    expect(args).not.toContain("--allow-net");
+    expect(args).not.toContain("--unstable-ffi");
+    expect(args).not.toContain("--allow-ffi");
+    expect(args).toContain("/repo/packages/cli/lib/fuse-supervisor.ts");
+    expect(args).not.toContain("fuse-supervisor");
+    expect(args).not.toContain("/repo/packages/fuse/mod.ts");
+    expect(args).not.toContain("fuse-daemon");
+    expect(args).toContain("--log-file");
+    expect(args).toContain("/tmp/cf-fuse-mnt.log");
+    expect(args).toContain("--state-path");
+    expect(args).toContain("/tmp/cf-state.json");
+    expect(args).toContain("--supervisor-status");
+    expect(args).toContain("/tmp/cf-state.json.child-status");
+    expect(args).toContain("--supervisor-token");
+    expect(args).toContain("token-1");
+    expect(args.filter((arg) => arg === "--space").length).toBe(2);
+  });
+
+  it("builds a distinct FUSE child invocation that owns libfuse", () => {
+    const supervisorArgs = buildBackgroundSupervisorDenoArgs({
+      cliModPath: "/repo/packages/cli/lib/fuse-supervisor.ts",
+      mountpoint: "/mnt",
+      apiUrl: "",
+      identity: "",
+      execCli: "",
+      logFile: "/tmp/cf-fuse-mnt.log",
+      spaces: [],
+      supervisorStatusPath: "/tmp/cf-status.json",
+      supervisorToken: "token-1",
+    });
+    const childArgs = buildFuseChildDenoArgs({
+      modPath: "/repo/packages/fuse/mod.ts",
+      mountpoint: "/mnt",
+      apiUrl: "",
+      identity: "",
+      execCli: "",
+      logFile: "/tmp/cf-fuse-mnt.log",
+      spaces: [],
+      supervisorStatusPath: "/tmp/cf-status.json",
+      supervisorToken: "token-1",
+    });
+
+    expect(childArgs).not.toEqual(supervisorArgs);
+    expect(childArgs).toContain("--unstable-ffi");
+    expect(childArgs).toContain("--allow-ffi");
+    expect(childArgs).toContain("/repo/packages/fuse/mod.ts");
+    expect(childArgs).toContain("--supervisor-status");
+    expect(childArgs).toContain("/tmp/cf-status.json");
+    expect(childArgs).toContain("--supervisor-token");
+    expect(childArgs).toContain("token-1");
+    expect(childArgs).not.toContain(
+      "/repo/packages/cli/lib/fuse-supervisor.ts",
+    );
+    expect(childArgs).not.toContain("fuse-supervisor");
+  });
+
+  it("represents the supervisor-spawned FUSE child as a distinct command", () => {
+    const child = buildFuseChildCommand({
+      mountpoint: "/mnt",
+      apiUrl: "http://localhost:8000",
+      identity: "/tmp/id.key",
+      execCli: "/tmp/cf-exec",
+      logFile: "/tmp/cf-fuse-mnt.log",
+      spaces: ["home"],
+      importMetaUrl: toFileUrl("/repo/packages/cli/lib/fuse-supervisor.ts")
+        .href,
+      execPath: "/usr/bin/deno",
+    });
+
+    expect(child.command).toBe("/usr/bin/deno");
+    expect(child.args).toContain("--allow-ffi");
+    expect(child.args).toContain("/repo/packages/fuse/mod.ts");
+    expect(child.args).not.toContain("fuse-supervisor");
+    expect(child.args).not.toContain("/repo/packages/cli/mod.ts");
+  });
+
+  it("represents the compiled supervisor-spawned FUSE child as a hidden subcommand", () => {
+    const child = buildFuseChildCommand({
+      mountpoint: "/mnt",
+      apiUrl: "http://localhost:8000",
+      identity: "/tmp/id.key",
+      execCli: "/tmp/cf-exec",
+      logFile: "/tmp/cf-fuse-mnt.log",
+      spaces: ["home"],
+      execPath: "/usr/local/bin/cf",
+      supervisorStatusPath: "/tmp/cf-status",
+      supervisorToken: "token-1",
+    });
+
+    expect(child.command).toBe("/usr/local/bin/cf");
+    expect(child.args).toContain("fuse-daemon");
+    expect(child.args).toContain("--supervisor-status");
+    expect(child.args).toContain("/tmp/cf-status");
+    expect(child.args).toContain("--supervisor-token");
+    expect(child.args).toContain("token-1");
+  });
+
+  it("terminates the spawned FUSE child during supervisor cleanup", async () => {
+    const signals: Deno.Signal[] = [];
+
+    await cleanupFuseChild({
+      killed: false,
+      kill: (signal: Deno.Signal) => {
+        signals.push(signal);
+      },
+    });
+
+    expect(signals).toEqual(["SIGTERM"]);
+  });
+
+  it("does not terminate the spawned FUSE child after it has already exited", async () => {
+    const signals: Deno.Signal[] = [];
+
+    await cleanupFuseChild({
+      killed: true,
+      kill: (signal: Deno.Signal) => {
+        signals.push(signal);
+      },
+    });
+
+    expect(signals).toEqual([]);
+  });
+
+  it("waits for the spawned FUSE child during supervisor cleanup", async () => {
+    const signals: Deno.Signal[] = [];
+    let resolveStatus: (status: Deno.CommandStatus) => void = () => undefined;
+    const status = new Promise<Deno.CommandStatus>((resolve) => {
+      resolveStatus = resolve;
+    });
+
+    await cleanupFuseChild({
+      killed: false,
+      status,
+      kill: (signal: Deno.Signal) => {
+        signals.push(signal);
+        resolveStatus({ success: true, code: 0, signal: null });
+      },
+    });
+
+    expect(signals).toEqual(["SIGTERM"]);
+  });
+
+  it("escalates if the spawned FUSE child ignores graceful cleanup", async () => {
+    const signals: Deno.Signal[] = [];
+    let resolveStatus: (status: Deno.CommandStatus) => void = () => undefined;
+    const status = new Promise<Deno.CommandStatus>((resolve) => {
+      resolveStatus = resolve;
+    });
+
+    await cleanupFuseChild({
+      killed: false,
+      status,
+      kill: (signal: Deno.Signal) => {
+        signals.push(signal);
+        if (signal === "SIGKILL") {
+          resolveStatus({ success: false, code: 137, signal: "SIGKILL" });
+        }
+      },
+    }, {
+      timeoutMs: 0,
+    });
+
+    expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+  });
+
+  it("recognizes Deno and compiled FUSE supervisor process commands", () => {
+    expect(
+      isFuseProcessCommand("deno run packages/cli/lib/fuse-supervisor.ts /mnt"),
+    )
+      .toBe(true);
+    expect(isFuseProcessCommand("/usr/local/bin/cf fuse-supervisor /mnt"))
+      .toBe(true);
+    expect(isFuseProcessCommand("/usr/local/bin/cf fuse-daemon /mnt"))
+      .toBe(true);
+    expect(isFuseProcessCommand("deno run packages/fuse/mod.ts /mnt"))
+      .toBe(true);
+    expect(isFuseProcessCommand("deno run unrelated.ts fuse"))
+      .toBe(false);
+  });
+
+  it("treats a live FUSE child PID as active mount state", () => {
+    expect(isMountStateAlive({
+      pid: 1073741824,
+      childPid: Deno.pid,
+      mountpoint: "/tmp/test-mount",
+      apiUrl: "",
+      identity: "",
+      startedAt: "2026-03-17T00:00:00.000Z",
+    })).toBe(true);
+  });
+
+  it("records childPid only into state owned by the supervisor PID", async () => {
+    const statePath = await Deno.makeTempFile({ prefix: "cf-fuse-state-" });
+    try {
+      await Deno.writeTextFile(
+        statePath,
+        JSON.stringify({
+          pid: 100,
+          mountpoint: "/tmp/test-mount",
+          apiUrl: "",
+          identity: "",
+          startedAt: "2026-03-17T00:00:00.000Z",
+        }),
+      );
+
+      const staleResult = await recordFuseChildPid({
+        statePath,
+        childPid: 300,
+        supervisorPid: 200,
+        sleep: () => Promise.resolve(),
+      });
+      const staleState = JSON.parse(await Deno.readTextFile(statePath)) as {
+        childPid?: number;
+      };
+
+      expect(staleResult).toBe(false);
+      expect(staleState.childPid).toBeUndefined();
+
+      await Deno.writeTextFile(
+        statePath,
+        JSON.stringify({
+          pid: 200,
+          mountpoint: "/tmp/test-mount",
+          apiUrl: "",
+          identity: "",
+          startedAt: "2026-03-17T00:00:00.000Z",
+        }),
+      );
+
+      const matchingResult = await recordFuseChildPid({
+        statePath,
+        childPid: 300,
+        supervisorPid: 200,
+        sleep: () => Promise.resolve(),
+      });
+      const matchingState = JSON.parse(await Deno.readTextFile(statePath)) as {
+        childPid?: number;
+      };
+
+      expect(matchingResult).toBe(true);
+      expect(matchingState.childPid).toBe(300);
+    } finally {
+      await Deno.remove(statePath).catch(() => undefined);
+    }
+  });
+
+  it("fails supervisor startup when childPid cannot be recorded", async () => {
+    const statePath = await Deno.makeTempFile({ prefix: "cf-fuse-state-" });
+    const signals: Deno.Signal[] = [];
+    let resolveStatus: (status: Deno.CommandStatus) => void = () => undefined;
+
+    class FakeCommand {
+      constructor(_command: string | URL, _options: Deno.CommandOptions) {}
+
+      spawn() {
+        return {
+          pid: 300,
+          status: new Promise<Deno.CommandStatus>((resolve) => {
+            resolveStatus = resolve;
+          }),
+          kill: (signal: Deno.Signal) => {
+            signals.push(signal);
+            resolveStatus({ success: true, code: 143, signal });
+          },
+        };
+      }
+    }
+
+    try {
+      await Deno.writeTextFile(
+        statePath,
+        JSON.stringify({
+          pid: 100,
+          mountpoint: "/tmp/test-mount",
+          apiUrl: "",
+          identity: "",
+          startedAt: "2026-03-17T00:00:00.000Z",
+        }),
+      );
+
+      await expect(runFuseSupervisor({
+        mountpoint: "/tmp/test-mount",
+        apiUrl: "",
+        identity: "",
+        execCli: "",
+        logFile: "",
+        spaces: [],
+        statePath,
+        supervisorPid: 200,
+        command: FakeCommand,
+        sleep: () => Promise.resolve(),
+        addSignalListener: () => undefined,
+        removeSignalListener: () => undefined,
+      })).rejects.toThrow(/Unable to record FUSE child PID/);
+
+      expect(signals).toEqual(["SIGTERM"]);
+    } finally {
+      await Deno.remove(statePath).catch(() => undefined);
+    }
+  });
+
+  it("installs supervisor signal handlers before recording childPid", async () => {
+    const statePath = await Deno.makeTempFile({ prefix: "cf-fuse-state-" });
+    const addedSignals: Deno.Signal[] = [];
+    let handlersInstalledBeforeRecord = false;
+
+    class FakeCommand {
+      constructor(_command: string | URL, _options: Deno.CommandOptions) {}
+
+      spawn() {
+        return {
+          pid: 300,
+          status: Promise.resolve({ success: true, code: 0, signal: null }),
+          kill: () => undefined,
+        };
+      }
+    }
+
+    try {
+      await Deno.writeTextFile(
+        statePath,
+        JSON.stringify({
+          pid: 100,
+          mountpoint: "/tmp/test-mount",
+          apiUrl: "",
+          identity: "",
+          startedAt: "2026-03-17T00:00:00.000Z",
+        }),
+      );
+
+      await expect(runFuseSupervisor({
+        mountpoint: "/tmp/test-mount",
+        apiUrl: "",
+        identity: "",
+        execCli: "",
+        logFile: "",
+        spaces: [],
+        statePath,
+        supervisorPid: 200,
+        command: FakeCommand,
+        sleep: async () => {
+          handlersInstalledBeforeRecord = addedSignals.includes("SIGTERM") &&
+            addedSignals.includes("SIGINT");
+          await Deno.writeTextFile(
+            statePath,
+            JSON.stringify({
+              pid: 200,
+              mountpoint: "/tmp/test-mount",
+              apiUrl: "",
+              identity: "",
+              startedAt: "2026-03-17T00:00:00.000Z",
+            }),
+          );
+        },
+        addSignalListener: (signal) => {
+          addedSignals.push(signal);
+        },
+        removeSignalListener: () => undefined,
+        exit: (code: number) => {
+          throw new Error(`exit:${code}`);
+        },
+      })).rejects.toThrow(/exit:0/);
+
+      expect(handlersInstalledBeforeRecord).toBe(true);
+    } finally {
+      await Deno.remove(statePath).catch(() => undefined);
+    }
   });
 });

--- a/packages/fuse/README.md
+++ b/packages/fuse/README.md
@@ -231,6 +231,22 @@ cf exec /tmp/cf/home/pieces/todo-app/result/search.tool --help
 
 Environment variables `CF_API_URL` and `CF_IDENTITY` are also supported.
 
+`cf fuse status` reports background mounts with separate supervisor and FUSE
+child process IDs:
+
+```text
+MOUNTPOINT  SUPERVISOR_PID  CHILD_PID  STATUS   STARTED  LOG
+/tmp/cf     12345           12346      mounted  ...      /tmp/cf-fuse-cf.log
+```
+
+For background mounts, `cf fuse mount --background` starts a small supervisor
+process that does not load libfuse. The supervisor starts the FFI-owning FUSE
+child, records the child PID in mount state, and waits for the child to publish
+a readiness sidecar before the mount command reports success. The child writes
+`starting`, `mounted`, `failed`, `exiting`, and `exited` states plus a mounted
+heartbeat; startup succeeds only when the status matches the current mount
+attempt and recorded child PID.
+
 ### Linux: Docker / other-user access
 
 If you need Docker or another user to traverse a Linux FUSE mount, mount with:
@@ -288,7 +304,12 @@ sandbox-visible enforcement.
 
 ## Architecture
 
-Single Deno process using FFI to libfuse. FUSE callbacks are registered via
+Foreground `cf fuse mount` starts one FFI-owning FUSE child process and waits
+for it without adding a supervisor; direct `deno run packages/fuse/mod.ts` is a
+single-process invocation of the same child entrypoint. Background mounts split
+lifecycle management into a non-FFI supervisor process and an FFI-owning FUSE
+child process so supervisor cleanup and startup readiness can be observed
+independently from libfuse. FUSE callbacks are registered via
 `Deno.UnsafeCallback` with `nonblocking: true` on the session loop, so WebSocket
 subscriptions and FUSE requests run concurrently on Deno's event loop.
 

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -3201,6 +3201,7 @@ export async function main(argv: string[] = Deno.args) {
   });
   const supervisorHeartbeat = supervisorStatusPath
     ? setInterval(() => {
+      if (unmounting) return;
       writeSupervisorStatus("mounted").catch(() => undefined);
     }, 1_000)
     : undefined;

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -188,6 +188,26 @@ function readBuffer(ptr: Deno.PointerValue, size: bigint): Uint8Array {
   return data;
 }
 
+type SupervisorStatusState =
+  | "starting"
+  | "mounted"
+  | "failed"
+  | "exiting"
+  | "exited";
+
+export async function writeFailedSupervisorStartupStatus(
+  error: unknown,
+  writeSupervisorStatus: (
+    state: "failed",
+    extra?: Record<string, unknown>,
+  ) => Promise<void>,
+): Promise<void> {
+  console.error(String(error));
+  await writeSupervisorStatus("failed", { error: String(error) }).catch(() => {
+    // Best effort; startup failure is already being reported by process exit.
+  });
+}
+
 export async function main(argv: string[] = Deno.args) {
   const args = parseArgs(argv, {
     string: [
@@ -196,6 +216,8 @@ export async function main(argv: string[] = Deno.args) {
       "identity",
       "exec-cli",
       "log-file",
+      "supervisor-status",
+      "supervisor-token",
       "cfc-xattr-namespace",
       "cfc-mode",
       "cfc-writeback-state",
@@ -213,6 +235,8 @@ export async function main(argv: string[] = Deno.args) {
       identity: Deno.env.get("CF_IDENTITY") ?? "",
       "exec-cli": "",
       "log-file": "",
+      "supervisor-status": "",
+      "supervisor-token": "",
       "cfc-xattr-namespace": DEFAULT_CFC_XATTR_NAMESPACE,
       "cfc-mode": "",
       "cfc-writeback-state": "",
@@ -296,6 +320,37 @@ export async function main(argv: string[] = Deno.args) {
     );
     Deno.exit(1);
   }
+  const supervisorStatusPath = String(args["supervisor-status"] ?? "");
+  const supervisorToken = String(args["supervisor-token"] ?? "");
+  const supervisorStatusStartedAt = new Date().toISOString();
+  async function writeSupervisorStatus(
+    state: SupervisorStatusState,
+    extra: Record<string, unknown> = {},
+  ): Promise<void> {
+    if (!supervisorStatusPath) return;
+    await Deno.writeTextFile(
+      supervisorStatusPath,
+      JSON.stringify(
+        {
+          state,
+          pid: Deno.pid,
+          mountpoint,
+          token: supervisorToken || undefined,
+          startedAt: supervisorStatusStartedAt,
+          updatedAt: new Date().toISOString(),
+          ...extra,
+        },
+        null,
+        2,
+      ),
+    );
+  }
+  try {
+    await writeSupervisorStatus("starting");
+  } catch (error) {
+    console.error(`[FUSE] Unable to write supervisor status: ${error}`);
+    Deno.exit(1);
+  }
   const requestedCfcWritebackState = String(args["cfc-writeback-state"] ?? "");
   const cfcWritebackStatePath = requestedCfcWritebackState ||
     (cfcWritebackXattrs || cfcMode !== "disabled"
@@ -308,16 +363,23 @@ export async function main(argv: string[] = Deno.args) {
   });
   const cfcDiagnostics: string[] = [];
 
-  // Ensure mountpoint exists
+  let platform: Awaited<ReturnType<typeof getPlatform>>;
+  let fuse: ReturnType<Awaited<ReturnType<typeof getPlatform>>["openFuse"]>;
   try {
-    Deno.statSync(mountpoint);
-  } catch {
-    Deno.mkdirSync(mountpoint, { recursive: true });
-  }
+    // Ensure mountpoint exists
+    try {
+      Deno.statSync(mountpoint);
+    } catch {
+      Deno.mkdirSync(mountpoint, { recursive: true });
+    }
 
-  // Open libfuse via platform abstraction
-  const platform = await getPlatform();
-  const fuse = platform.openFuse();
+    // Open libfuse via platform abstraction
+    platform = await getPlatform();
+    fuse = platform.openFuse();
+  } catch (e) {
+    await writeFailedSupervisorStartupStatus(e, writeSupervisorStatus);
+    Deno.exit(1);
+  }
   const {
     STAT_SIZE,
     ENTRY_PARAM_SIZE,
@@ -370,42 +432,47 @@ export async function main(argv: string[] = Deno.args) {
   }
 
   // Populate tree
-  const apiUrl = args["api-url"];
-  if (apiUrl) {
-    bridge = new CellBridge(tree, args["exec-cli"] || "", {
-      cfcAnnotations: cfcAnnotationsEnabled,
-      statusProvider: () => ({
-        writes: { ...writeStats },
-        logFile: logFilePath || null,
-        cfc: {
-          mode: cfcMode,
-          annotations: cfcAnnotationsEnabled,
-          writebackXattrs: cfcWritebackXattrs,
-          writeback: cfcWritebacks.status(),
-          diagnostics: cfcDiagnostics.slice(-50),
-        },
-      }),
-      onCfcProjectionRebuilt: reconcileCfcWritebacks,
-    });
-    bridge.init({
-      apiUrl,
-      identity: args.identity || "",
-    });
-    bridge.setDebug(debug);
-    bridge.initStatus();
+  try {
+    const apiUrl = args["api-url"];
+    if (apiUrl) {
+      bridge = new CellBridge(tree, args["exec-cli"] || "", {
+        cfcAnnotations: cfcAnnotationsEnabled,
+        statusProvider: () => ({
+          writes: { ...writeStats },
+          logFile: logFilePath || null,
+          cfc: {
+            mode: cfcMode,
+            annotations: cfcAnnotationsEnabled,
+            writebackXattrs: cfcWritebackXattrs,
+            writeback: cfcWritebacks.status(),
+            diagnostics: cfcDiagnostics.slice(-50),
+          },
+        }),
+        onCfcProjectionRebuilt: reconcileCfcWritebacks,
+      });
+      bridge.init({
+        apiUrl,
+        identity: args.identity || "",
+      });
+      bridge.setDebug(debug);
+      bridge.initStatus();
 
-    // Connect initial spaces (default: "home")
-    const spaces = (args.space as string[]).length > 0
-      ? (args.space as string[])
-      : ["home"];
-    for (const spaceName of spaces) {
-      await bridge.connectSpace(spaceName);
-      reconcileCfcWritebacks();
-      console.log(`Connected space: ${spaceName}`);
+      // Connect initial spaces (default: "home")
+      const spaces = (args.space as string[]).length > 0
+        ? (args.space as string[])
+        : ["home"];
+      for (const spaceName of spaces) {
+        await bridge.connectSpace(spaceName);
+        reconcileCfcWritebacks();
+        console.log(`Connected space: ${spaceName}`);
+      }
+    } else {
+      tree.addFile(tree.rootIno, "hello.txt", "Hello from FUSE!\n", "string");
+      console.log("Static mode: hello.txt");
     }
-  } else {
-    tree.addFile(tree.rootIno, "hello.txt", "Hello from FUSE!\n", "string");
-    console.log("Static mode: hello.txt");
+  } catch (e) {
+    await writeFailedSupervisorStartupStatus(e, writeSupervisorStatus);
+    Deno.exit(1);
   }
 
   // --- Callbacks ---
@@ -3002,6 +3069,9 @@ export async function main(argv: string[] = Deno.args) {
     );
   } catch (e) {
     console.error(String(e));
+    await writeSupervisorStatus("failed", { error: String(e) }).catch(() => {
+      // Best effort; mount failure is already being reported by process exit.
+    });
     Deno.exit(1);
   }
   // handle is guaranteed assigned — Deno.exit(1) never returns
@@ -3126,6 +3196,15 @@ export async function main(argv: string[] = Deno.args) {
     };
   }
 
+  await writeSupervisorStatus("mounted").catch((error) => {
+    console.warn(`[FUSE] Unable to write mounted supervisor status: ${error}`);
+  });
+  const supervisorHeartbeat = supervisorStatusPath
+    ? setInterval(() => {
+      writeSupervisorStatus("mounted").catch(() => undefined);
+    }, 1_000)
+    : undefined;
+
   console.log(`Mounted at ${mountpoint}`);
   console.log("Press Ctrl+C to unmount");
 
@@ -3134,6 +3213,7 @@ export async function main(argv: string[] = Deno.args) {
     if (unmounting) return;
     unmounting = true;
     console.log("\nUnmounting...");
+    writeSupervisorStatus("exiting").catch(() => undefined);
     platform.unmount(fuse, handle, mountpointBuf);
   }
 
@@ -3147,6 +3227,10 @@ export async function main(argv: string[] = Deno.args) {
   // Run FUSE event loop (nonblocking: true → returns Promise)
   const result = await fuse.symbols.fuse_session_loop(handle.session);
   console.log(`FUSE loop exited (code ${result})`);
+  if (supervisorHeartbeat !== undefined) clearInterval(supervisorHeartbeat);
+  await writeSupervisorStatus("exited", { exitCode: result }).catch(() => {
+    // Best effort during shutdown.
+  });
 
   // Final cleanup
   platform.cleanup(fuse, handle, mountpointBuf, unmounting);


### PR DESCRIPTION
## Summary
- split `cf fuse mount --background` into a Deno supervisor process and a FUSE-owning Deno child process
- add child readiness/status sidecar reporting, heartbeat/lifecycle states, readiness token validation, child PID tracking, and startup failure handling
- update `cf fuse status` to show supervisor PID, child PID, child lifecycle status, started time, and log path
- add hermetic tests for supervisor readiness success/failure/timeout, cleanup escalation, stale sidecar handling, and status table formatting
- align FUSE docs/specs with the implemented supervisor/child readiness boundary

## Verification
- LSP diagnostics clean for touched TypeScript files
- `deno fmt --check docs/specs/fuse-filesystem/10-cfc-filesystem-api-semantics.md docs/specs/fuse-filesystem/5-architecture.md packages/cli/commands/fuse.ts packages/cli/commands/main.ts packages/cli/lib/fuse-supervisor.ts packages/cli/lib/fuse.ts packages/cli/test/fuse.test.ts packages/fuse/README.md packages/fuse/mod.ts`
- `deno check packages/cli/commands/fuse.ts packages/cli/commands/main.ts packages/cli/lib/fuse-supervisor.ts packages/cli/lib/fuse.ts packages/cli/test/fuse.test.ts packages/fuse/mod.ts`
- `deno test --allow-all packages/cli/test/fuse.test.ts` — 6 suites / 51 steps passed
- `GIT_MASTER=1 git diff --check`

## Manual smoke
- Verified `/dev/fuse` and `fusermount3` availability locally
- Mounted static-mode FUSE with `env -u CF_API_URL -u CF_IDENTITY deno task cf fuse mount <tmp> --background`
- Confirmed `cf fuse status` reported supervisor PID, child PID, and `mounted`
- Read mounted `hello.txt` successfully and unmounted with `cf fuse unmount <tmp>`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a small Deno supervisor for background FUSE mounts with a token-validated readiness sidecar and heartbeat so startup is reliable and observable. Status and unmount now track both supervisor and child PIDs; background startup waits until the child reports mounted with an extended timeout.

- **New Features**
  - Added hidden `fuse-supervisor` that starts the FFI-owning child (`fuse-daemon` or `packages/fuse/mod.ts`), records `childPid` in state, forwards signals, and cleans up.
  - Child publishes a JSON sidecar with states: starting, mounted, failed, exiting, exited (plus heartbeat), including token, PID, and mountpoint; `cf fuse mount --background` returns only after a matching `mounted`.
  - `cf fuse status` now shows MOUNTPOINT, SUPERVISOR_PID, CHILD_PID, STATUS, STARTED, LOG; reads STATUS from the child sidecar and ignores sidecar files as mount entries.
  - `cf fuse unmount` targets the supervisor/child safely, verifies the process via `isFuseProcessCommand`, waits for cleanup, and falls back to system unmount; stale state is removed only when neither PID is alive.

- **Bug Fixes**
  - Extended background readiness timeout when waiting on the child status sidecar to reduce startup flakiness on slower systems.
  - Stopped the child heartbeat once unmount begins to prevent stale status writes during shutdown.

<sup>Written for commit 83859277200ab7fb1ac3bd0fe68ddee45d107dc7. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3655?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



NEW_PERF_BASELINE: subtest: pattern-unit-2/pattern-unit-tests > packages/patterns/contacts/contact-book.test.tsx = 10s
