### PR TITLE
feat(data-model): extend cloneForMutation with createMissing + structured error

### DIFF
--- a/packages/data-model/fabric-value.ts
+++ b/packages/data-model/fabric-value.ts
@@ -19,6 +19,8 @@ export {
 
 export {
   cloneForMutation,
+  CloneForMutationError,
+  type CloneForMutationErrorKind,
   type CloneForMutationOptions,
   type CloneForMutationResult,
   cloneIfNecessary,

--- a/packages/data-model/test/clone-for-mutation.test.ts
+++ b/packages/data-model/test/clone-for-mutation.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
   cloneForMutation,
+  CloneForMutationError,
   resetDataModelConfig,
   setDataModelConfig,
 } from "../fabric-value.ts";
@@ -369,7 +370,254 @@ describe("cloneForMutation", () => {
       });
 
       // ----------------------------------------------------------------------
-      // Error cases
+      // createMissing
+      // ----------------------------------------------------------------------
+
+      describe("createMissing", () => {
+        it("creates a missing intermediate object", () => {
+          const root = Object.freeze({ a: { existing: 1 } }) as FabricValue;
+          const { value, pathValue } = cloneForMutation(
+            root,
+            ["a", "new"],
+            { createMissing: true, nextKeyAfterPath: "key" },
+          );
+          const newA = (value as unknown as Record<string, unknown>)
+            .a as Record<
+              string,
+              unknown
+            >;
+          // The original `a.existing` is preserved by identity (off-spine).
+          expect(newA.existing).toBe(1);
+          // `a.new` is freshly created and is what `pathValue` points at.
+          expect(newA.new).toBe(pathValue);
+          // `nextKeyAfterPath: "key"` selects an object.
+          expect(pathValue).toEqual({});
+          expect(Array.isArray(pathValue)).toBe(false);
+        });
+
+        it("creates a missing intermediate array (numeric next key)", () => {
+          const root = Object.freeze({ a: {} }) as FabricValue;
+          const { value, pathValue } = cloneForMutation(
+            root,
+            ["a", "items"],
+            { createMissing: true, nextKeyAfterPath: "0" },
+          );
+          const newA = (value as unknown as Record<string, unknown>)
+            .a as Record<
+              string,
+              unknown
+            >;
+          expect(newA.items).toBe(pathValue);
+          expect(Array.isArray(pathValue)).toBe(true);
+          expect(pathValue).toEqual([]);
+        });
+
+        it("treats `-` as the JSON-Pointer array append marker", () => {
+          const root = Object.freeze({}) as FabricValue;
+          const { value: _v, pathValue } = cloneForMutation(
+            root,
+            ["items"],
+            { createMissing: true, nextKeyAfterPath: "-" },
+          );
+          expect(Array.isArray(pathValue)).toBe(true);
+        });
+
+        it("defaults to an object when nextKeyAfterPath is omitted", () => {
+          const root = Object.freeze({}) as FabricValue;
+          const { pathValue } = cloneForMutation(
+            root,
+            ["new"],
+            { createMissing: true },
+          );
+          expect(Array.isArray(pathValue)).toBe(false);
+          expect(pathValue).toEqual({});
+        });
+
+        it("chains multiple missing intermediates with correct shapes", () => {
+          // path: ["a", "0", "items", "0", "name"]
+          //   a -> object (next segment is "0" -- wait, this is the
+          //   array-index test below; for THIS test let's mix object
+          //   and array).
+          //
+          // Try: root.notes[0].title where notes doesn't exist.
+          // - path[0]="notes" -> needs container at root.notes. Next is
+          //   "0" -> array.
+          // - path[1]="0" -> needs container at root.notes[0]. Next is
+          //   "title" -> object.
+          // - path[2]="title" -> the leaf, nextKeyAfterPath="" -> object
+          //   if missing.
+          const root = Object.freeze({}) as FabricValue;
+          const { value, pathValue } = cloneForMutation(
+            root,
+            ["notes", "0", "title"],
+            { createMissing: true },
+          );
+          const newRoot = value as unknown as Record<string, unknown>;
+          expect(Array.isArray(newRoot.notes)).toBe(true);
+          const notes = newRoot.notes as unknown[];
+          expect(notes.length).toBe(1);
+          expect(typeof notes[0]).toBe("object");
+          expect(Array.isArray(notes[0])).toBe(false);
+          // The leaf was created with default `nextKeyAfterPath: ""` -> object.
+          expect(pathValue).toBe(
+            (notes[0] as Record<string, unknown>).title,
+          );
+          expect(pathValue).toEqual({});
+        });
+
+        it("preserves existing intermediates while creating missing ones", () => {
+          const existingNotes = Object.freeze([{ kept: 1 }]);
+          const root = Object.freeze({
+            notes: existingNotes,
+          }) as FabricValue;
+          const { value, pathValue } = cloneForMutation(
+            root,
+            ["notes", "0", "newKey"],
+            { createMissing: true, nextKeyAfterPath: "leaf" },
+          );
+          const newRoot = value as unknown as Record<string, unknown>;
+          const newNotes = newRoot.notes as unknown[];
+          // The existing element was thawed (spine touches it) but the
+          // sibling identity of `existingNotes[0].kept` is preserved.
+          const note0 = newNotes[0] as Record<string, unknown>;
+          expect(note0.kept).toBe(1);
+          // The newly-created leaf-parent slot.
+          expect(note0.newKey).toBe(pathValue);
+          expect(pathValue).toEqual({});
+        });
+
+        it("does not interfere with normal (non-missing) descent", () => {
+          // If everything exists, `createMissing: true` should behave the
+          // same as the default.
+          const root = Object.freeze({
+            a: Object.freeze({ b: Object.freeze({ c: 42 }) }),
+          }) as FabricValue;
+          const { pathValue } = cloneForMutation(
+            root,
+            ["a", "b"],
+            { createMissing: true },
+          );
+          expect(pathValue).toEqual({ c: 42 });
+        });
+
+        it("interacts correctly with force=false (identity on existing path)", () => {
+          // If `createMissing: true` but every step exists AND `force:
+          // false` AND input is already mutable, identity is preserved.
+          const inner = { existing: 1 };
+          const root = { a: inner } as FabricValue;
+          const { value, pathValue } = cloneForMutation(
+            root,
+            ["a"],
+            { createMissing: true, force: false },
+          );
+          expect(value).toBe(root);
+          expect(pathValue).toBe(inner);
+        });
+
+        it("respects force=true on the spine-thaw even when creating", () => {
+          // When force=true (default), already-mutable spine containers
+          // are still copied. `createMissing` doesn't change that.
+          const root = { existing: 1 } as FabricValue;
+          const { value, pathValue } = cloneForMutation(
+            root,
+            ["new"],
+            { createMissing: true },
+          );
+          expect(value).not.toBe(root); // root was force-copied
+          expect((value as unknown as Record<string, unknown>).existing).toBe(
+            1,
+          );
+          expect((value as unknown as Record<string, unknown>).new).toBe(
+            pathValue,
+          );
+        });
+      });
+
+      // ----------------------------------------------------------------------
+      // Structured error
+      // ----------------------------------------------------------------------
+
+      describe("CloneForMutationError", () => {
+        it("uses kind `missing-segment` for a missing intermediate", () => {
+          const root = Object.freeze({ a: { b: 1 } }) as FabricValue;
+          try {
+            cloneForMutation(root, ["a", "nonesuch", "more"]);
+            throw new Error("expected throw");
+          } catch (e) {
+            expect(e).toBeInstanceOf(CloneForMutationError);
+            const err = e as CloneForMutationError;
+            expect(err.kind).toBe("missing-segment");
+            expect(err.pathIndex).toBe(1);
+            expect(err.valueKind).toBe("undefined");
+          }
+        });
+
+        it("uses kind `non-container-descent` for primitive in path", () => {
+          const root = Object.freeze({ x: 42 }) as FabricValue;
+          try {
+            cloneForMutation(root, ["x", "anything"]);
+            throw new Error("expected throw");
+          } catch (e) {
+            expect(e).toBeInstanceOf(CloneForMutationError);
+            const err = e as CloneForMutationError;
+            expect(err.kind).toBe("non-container-descent");
+            expect(err.pathIndex).toBe(0);
+            expect(err.valueKind).toBe("number");
+          }
+        });
+
+        it("uses kind `non-mutable-leaf` for a primitive leaf", () => {
+          const root = Object.freeze({ x: 42 }) as FabricValue;
+          try {
+            cloneForMutation(root, ["x"]);
+            throw new Error("expected throw");
+          } catch (e) {
+            expect(e).toBeInstanceOf(CloneForMutationError);
+            const err = e as CloneForMutationError;
+            expect(err.kind).toBe("non-mutable-leaf");
+            expect(err.pathIndex).toBe(0);
+            expect(err.valueKind).toBe("number");
+          }
+        });
+
+        it("uses kind `non-mutable-root` for empty path with bad root", () => {
+          try {
+            cloneForMutation(42 as FabricValue, []);
+            throw new Error("expected throw");
+          } catch (e) {
+            expect(e).toBeInstanceOf(CloneForMutationError);
+            const err = e as CloneForMutationError;
+            expect(err.kind).toBe("non-mutable-root");
+            expect(err.pathIndex).toBe(-1);
+            expect(err.valueKind).toBe("number");
+          }
+        });
+
+        it("uses kind `non-container-root` for non-empty path with bad root", () => {
+          try {
+            cloneForMutation(42 as FabricValue, ["x"]);
+            throw new Error("expected throw");
+          } catch (e) {
+            expect(e).toBeInstanceOf(CloneForMutationError);
+            const err = e as CloneForMutationError;
+            expect(err.kind).toBe("non-container-root");
+            expect(err.pathIndex).toBe(-1);
+            expect(err.valueKind).toBe("number");
+          }
+        });
+
+        it("error.name is `CloneForMutationError`", () => {
+          try {
+            cloneForMutation(42 as FabricValue, []);
+            throw new Error("expected throw");
+          } catch (e) {
+            expect((e as Error).name).toBe("CloneForMutationError");
+          }
+        });
+      });
+
+      // ----------------------------------------------------------------------
+      // Error cases (message-level coverage; structured-error checks above)
       // ----------------------------------------------------------------------
 
       describe("errors", () => {

--- a/packages/data-model/value-clone.ts
+++ b/packages/data-model/value-clone.ts
@@ -305,6 +305,11 @@ export interface CloneForMutationOptions {
    * `createMissing: false` or when the final path step already exists.
    * Default: `""` (selects a plain object).
    *
+   * Same shape-selection rule as for intermediate steps: array-index-
+   * shaped values (per `isArrayIndexPropertyName`) and the JSON-Pointer
+   * append marker `"-"` select an array; everything else selects a
+   * plain object.
+   *
    * Mirrors `v2-path.ensureParentContainers`'s `lastKey` parameter.
    */
   nextKeyAfterPath?: string;

--- a/packages/data-model/value-clone.ts
+++ b/packages/data-model/value-clone.ts
@@ -3,6 +3,7 @@ import { NATIVE_TAGS, tagFromNativeValue } from "./native-type-tags.ts";
 import { isDeepFrozenFabricValue } from "./deep-freeze.ts";
 import { type Immutable, isPlainContainer } from "@commonfabric/utils/types";
 import { toDebugKindString } from "./value-debug.ts";
+import { isArrayIndexPropertyName } from "./array-utils.ts";
 
 /**
  * Options for `cloneIfNecessary()`.
@@ -207,6 +208,52 @@ export function cloneHelper(
 // =============================================================================
 
 /**
+ * Categorical kinds of error that `cloneForMutation()` can fail with.
+ *
+ * - `"non-mutable-root"` — empty `path` and the root value isn't a kind
+ *   for which a mutable handle exists (a primitive, a `FabricPrimitive`,
+ *   etc.).
+ * - `"non-container-root"` — non-empty `path` and the root isn't a plain
+ *   object or array, so there's nothing to descend into.
+ * - `"missing-segment"` — a `path` segment names a slot that doesn't
+ *   exist on its container, and `createMissing` is `false`.
+ * - `"non-container-descent"` — an intermediate segment lands on a value
+ *   that isn't a plain object or array, so descent can't continue.
+ * - `"non-mutable-leaf"` — the final segment lands on a value for which
+ *   no mutable handle exists (a primitive or `FabricPrimitive`).
+ */
+export type CloneForMutationErrorKind =
+  | "non-mutable-root"
+  | "non-container-root"
+  | "missing-segment"
+  | "non-container-descent"
+  | "non-mutable-leaf";
+
+/**
+ * Error thrown by `cloneForMutation()` when the input value or path is
+ * unsuitable for producing a mutable handle. Carries structured fields so
+ * the caller can preserve typed error info rather than parsing the
+ * message.
+ *
+ * - `kind` — categorical reason (see {@link CloneForMutationErrorKind}).
+ * - `pathIndex` — the path index at which the error occurred, or `-1`
+ *   for root-level errors.
+ * - `valueKind` — debug-string kind of the offending value (matches
+ *   `toDebugKindString()`).
+ */
+export class CloneForMutationError extends Error {
+  constructor(
+    readonly kind: CloneForMutationErrorKind,
+    readonly pathIndex: number,
+    readonly valueKind: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "CloneForMutationError";
+  }
+}
+
+/**
  * Options for `cloneForMutation()`.
  */
 export interface CloneForMutationOptions {
@@ -229,6 +276,38 @@ export interface CloneForMutationOptions {
    * deep: false, force })` calls that perform the actual shallow thaws.
    */
   force?: boolean;
+
+  /**
+   * Create missing intermediate containers along `path` as the helper
+   * descends. Default: `false` (throws `CloneForMutationError` with kind
+   * `"missing-segment"` on the first missing slot).
+   *
+   * When `createMissing: true`, at each path step where the container at
+   * that key is absent, the helper allocates a fresh container and
+   * splices it into its parent before descending. The new container's
+   * shape (array vs. plain object) is chosen from the NEXT segment that
+   * will be used as a key against it:
+   *
+   * - For intermediate path steps, the next segment is `path[i+1]`.
+   * - For the final path step, the next segment is `nextKeyAfterPath` if
+   *   supplied; otherwise the empty string (which selects a plain object).
+   *
+   * Array-index-shaped keys (`isArrayIndexPropertyName(key)`) and the
+   * JSON-Pointer append marker `"-"` select an array; everything else
+   * selects a plain object.
+   */
+  createMissing?: boolean;
+
+  /**
+   * Hint for the container shape to create at the final path step when
+   * it's missing and `createMissing: true`. Should be the next key the
+   * caller intends to access against the value-at-path. Ignored when
+   * `createMissing: false` or when the final path step already exists.
+   * Default: `""` (selects a plain object).
+   *
+   * Mirrors `v2-path.ensureParentContainers`'s `lastKey` parameter.
+   */
+  nextKeyAfterPath?: string;
 }
 
 /**
@@ -287,16 +366,20 @@ export interface CloneForMutationResult<T extends FabricValue> {
  * A `FabricInstance` is permitted as the final value at `path`, in which
  * case it's shallow-thawed via its own `shallowClone(false)` interface.
  *
+ * ### Missing path segments
+ *
+ * By default (`createMissing: false`), missing segments throw a
+ * `CloneForMutationError` with kind `"missing-segment"`. With
+ * `createMissing: true`, the helper allocates fresh containers as it
+ * descends through missing slots; see {@link CloneForMutationOptions} for
+ * the shape-selection rules (in particular the `nextKeyAfterPath` hint).
+ *
  * ### Errors
  *
- * Throws if:
- * - A path segment names a missing slot on a plain container.
- * - An intermediate segment lands on something other than a plain object
- *   or array (a primitive, a `FabricInstance`, a `FabricPrimitive`, ...).
- * - The final segment lands on a value that isn't mutable-handle-able
- *   (a primitive or a `FabricPrimitive`).
- * - The root itself isn't mutable-handle-able and `path` is empty.
- * - The root isn't a plain container and `path` is non-empty.
+ * Throws a `CloneForMutationError` (see {@link CloneForMutationErrorKind})
+ * for unsuitable inputs or paths. Other unexpected errors (e.g. cycles in
+ * the spine surfaced by the underlying `cloneIfNecessary` machinery)
+ * propagate as plain `Error`s.
  *
  * @param value - The input value tree.
  * @param path - Path to the container (or `FabricInstance`) to expose as
@@ -309,6 +392,8 @@ export function cloneForMutation<T extends FabricValue>(
   options?: CloneForMutationOptions,
 ): CloneForMutationResult<T> {
   const force = options?.force ?? true;
+  const createMissing = options?.createMissing ?? false;
+  const nextKeyAfterPath = options?.nextKeyAfterPath ?? "";
   // Used for every per-container shallow thaw along the spine, and for the
   // final value-at-`path` thaw if it's a plain container or `FabricInstance`.
   const cloneOpts = { frozen: false as const, deep: false as const, force };
@@ -316,7 +401,10 @@ export function cloneForMutation<T extends FabricValue>(
   // --- Empty-path fast path ---------------------------------------------
   if (path.length === 0) {
     if (!isMutableHandle(value)) {
-      throw new Error(
+      throw new CloneForMutationError(
+        "non-mutable-root",
+        -1,
+        toDebugKindString(value),
         `cloneForMutation: cannot mutate ${toDebugKindString(value)} at root ` +
           `(empty path)`,
       );
@@ -330,7 +418,10 @@ export function cloneForMutation<T extends FabricValue>(
   // root would have nowhere to go (path-style access into FabricInstance
   // internals isn't supported).
   if (!isPlainContainer(value)) {
-    throw new Error(
+    throw new CloneForMutationError(
+      "non-container-root",
+      -1,
+      toDebugKindString(value),
       `cloneForMutation: cannot descend into ${toDebugKindString(value)} at ` +
         `root (path has ${path.length} segment${path.length === 1 ? "" : "s"})`,
     );
@@ -348,18 +439,37 @@ export function cloneForMutation<T extends FabricValue>(
     const key = path[i]!;
     const isLast = i === path.length - 1;
 
-    if (!Object.hasOwn(current, key)) {
-      throw new Error(
+    let next: FabricValue;
+    if (Object.hasOwn(current, key)) {
+      next = (current as Record<string, FabricValue>)[key];
+    } else if (createMissing) {
+      // Allocate a fresh container at this slot. Its shape comes from the
+      // next key that will be used against it: `path[i+1]` for
+      // intermediate steps, `nextKeyAfterPath` for the final step.
+      const nextKey = isLast ? nextKeyAfterPath : path[i + 1]!;
+      next = createMissingContainer(nextKey);
+      (current as Record<string, FabricValue>)[key] = next;
+      // `next` is freshly allocated and already mutable; skip the
+      // shallow-thaw step below.
+      if (isLast) return { value: newRoot, pathValue: next };
+      current = next as Record<string, FabricValue> | FabricValue[];
+      continue;
+    } else {
+      throw new CloneForMutationError(
+        "missing-segment",
+        i,
+        "undefined",
         `cloneForMutation: missing path segment ${JSON.stringify(key)} at ` +
           `index ${i}`,
       );
     }
 
-    const next = (current as Record<string, FabricValue>)[key];
-
     if (isLast) {
       if (!isMutableHandle(next)) {
-        throw new Error(
+        throw new CloneForMutationError(
+          "non-mutable-leaf",
+          i,
+          toDebugKindString(next),
           `cloneForMutation: cannot mutate ${
             toDebugKindString(next)
           } at path ` +
@@ -368,7 +478,10 @@ export function cloneForMutation<T extends FabricValue>(
       }
     } else {
       if (!isPlainContainer(next)) {
-        throw new Error(
+        throw new CloneForMutationError(
+          "non-container-descent",
+          i,
+          toDebugKindString(next),
           `cloneForMutation: cannot descend into ${
             toDebugKindString(next)
           } at ` +
@@ -400,6 +513,18 @@ export function cloneForMutation<T extends FabricValue>(
   // `path.length > 0` (handled above for `path.length === 0`).
   /* c8 ignore next 3 */
   throw new Error("cloneForMutation: unreachable");
+}
+
+/**
+ * Allocates a fresh, mutable container of the right shape for `nextKey`.
+ * Array-index-shaped keys (per `isArrayIndexPropertyName`) and the
+ * JSON-Pointer append marker `"-"` produce an array; everything else
+ * produces a plain object.
+ */
+function createMissingContainer(
+  nextKey: string,
+): Record<string, FabricValue> | FabricValue[] {
+  return isArrayIndexPropertyName(nextKey) || nextKey === "-" ? [] : {};
 }
 
 /**


### PR DESCRIPTION
## Summary

Two follow-on capabilities for `cloneForMutation()` (introduced in #3652) so it can be used by write-path mutators that need to create missing intermediate containers as they descend — most immediately, the v2-transaction storage layer.

- **`createMissing: boolean`** (default `false`) on `CloneForMutationOptions`. When `true`, missing path segments are filled in with freshly-allocated mutable containers as the helper descends; the new container's shape (array vs. plain object) is chosen from the next key that will be used against it — `path[i+1]` for intermediates, `nextKeyAfterPath` for the final step.

- **`nextKeyAfterPath: string`** companion (default `""`, which selects a plain object). Array-index-shaped keys (per `isArrayIndexPropertyName`) and the JSON-Pointer append marker `"-"` select an array; everything else selects a plain object. Mirrors `v2-path.ensureParentContainers`'s `lastKey` argument, the runner helper this addition is intended to subsume in the follow-up.

- **`CloneForMutationError`** (new exported class) extends `Error` with structured fields (`kind`, `pathIndex`, `valueKind`). The function now throws this rather than a plain `Error`, so callers can preserve typed error info without parsing messages. Kinds: `non-mutable-root`, `non-container-root`, `missing-segment`, `non-container-descent`, `non-mutable-leaf`.

## Why now

Data-model-only prerequisite. The follow-up PR uses the helper at both write-path mutating sites in `packages/runner/src/storage/v2-transaction.ts`, replacing the current `cloneIfNecessary({ frozen: false }) + ensureParentContainers` deep-clone pattern.

Splitting per-layer per follow-up review: data-model surface area lands first, runner consumer lands second.

## Test coverage

`packages/data-model/test/clone-for-mutation.test.ts` gains 16 new steps across two describe blocks:

- `createMissing` (10 cases) — object/array intermediate creation, the `nextKeyAfterPath` hint, multi-step chains with mixed shapes, preservation of existing intermediates, interaction with `force=true`/`force=false`.
- `CloneForMutationError` (6 cases) — structured fields for every error kind, plus `error.name`.

All parameterized across both legacy and modern data-model flag states.

## Test plan

- [x] `deno task test` in `@commonfabric/data-model` — 46 tests / 1713 steps pass.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends `cloneForMutation()` to optionally create missing containers during descent and to throw structured errors for better handling. This enables a single helper for write-path mutators, including the v2-transaction storage layer.

- **New Features**
  - `createMissing` (default false): fills missing path segments with fresh containers; shape is chosen from the next key (`path[i+1]` or `nextKeyAfterPath`).
  - `nextKeyAfterPath`: hint for the final container’s shape; numeric keys and `"-"` create arrays, otherwise objects. Docs now state this rule inline for clarity.
  - `CloneForMutationError` and `CloneForMutationErrorKind`: structured error with `kind`, `pathIndex`, and `valueKind` (`non-mutable-root`, `non-container-root`, `missing-segment`, `non-container-descent`, `non-mutable-leaf`).

<sup>Written for commit 653f2a7d00804d76891028399c73d487703c65f6. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3657?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

