### PR TITLE
docs(content-hash): add `@inheritDoc` to inherited method overrides

### DIFF
--- a/packages/content-hash/src/BaseCollectingHasher.ts
+++ b/packages/content-hash/src/BaseCollectingHasher.ts
@@ -36,6 +36,7 @@ export abstract class BaseCollectingHasher extends BaseIncrementalHasher {
     chunks: Uint8Array[],
   ): Uint8Array | string;
 
+  /** @inheritDoc */
   protected _rawUpdate(data: Uint8Array) {
     const length = data.length;
 
@@ -44,6 +45,7 @@ export abstract class BaseCollectingHasher extends BaseIncrementalHasher {
     this.#currentOffset += length;
   }
 
+  /** @inheritDoc */
   protected _rawDigest(encoding: string | undefined): Uint8Array | string {
     let lastChunk = this.#currentChunk;
     if (lastChunk) {

--- a/packages/content-hash/src/BaseIncrementalHasher.ts
+++ b/packages/content-hash/src/BaseIncrementalHasher.ts
@@ -12,6 +12,7 @@ import type { IncrementalHasher } from "./interface.ts";
 export abstract class BaseIncrementalHasher implements IncrementalHasher {
   #done: boolean = false;
 
+  /** @inheritDoc */
   digest(): Uint8Array;
   digest(encoding: "base64url"): string;
   digest(encoding: string | undefined): Uint8Array | string;
@@ -39,6 +40,7 @@ export abstract class BaseIncrementalHasher implements IncrementalHasher {
     }
   }
 
+  /** @inheritDoc */
   update(data: Uint8Array) {
     this.#throwIfDone();
     this._rawUpdate(data);

--- a/packages/content-hash/src/sha256-deno.ts
+++ b/packages/content-hash/src/sha256-deno.ts
@@ -34,10 +34,12 @@ function assertUsable() {
 class DenoHasher extends BaseIncrementalHasher {
   #hasher = crypto!.createHash("sha256");
 
+  /** @inheritDoc */
   _rawUpdate(data: Uint8Array) {
     this.#hasher.update(data);
   }
 
+  /** @inheritDoc */
   _rawDigest(encoding: string | undefined): Uint8Array | string {
     switch (encoding) {
       case "base64url": {

--- a/packages/content-hash/src/sha256-noble.ts
+++ b/packages/content-hash/src/sha256-noble.ts
@@ -15,10 +15,12 @@ import {
 class NobleHasher extends BaseSmallChunkUpdatingHasher {
   #hasher = sha256.create();
 
+  /** @inheritDoc */
   protected _rawUpdate(data: Uint8Array) {
     this.#hasher.update(data);
   }
 
+  /** @inheritDoc */
   protected _rawDigest(_encoding: string | undefined): Uint8Array {
     return this.#hasher.digest();
   }

--- a/packages/content-hash/src/sha256-wasm.ts
+++ b/packages/content-hash/src/sha256-wasm.ts
@@ -73,6 +73,7 @@ function assertUsable() {
  * one-shot digest at the end of processing.
  */
 class WasmCollectingHasher extends BaseCollectingHasher {
+  /** @inheritDoc */
   protected _digestChunks(
     _encoding: string | undefined,
     chunks: Uint8Array[],
@@ -94,10 +95,12 @@ class WasmCollectingHasher extends BaseCollectingHasher {
 class WasmUpdatingHasher extends BaseSmallChunkUpdatingHasher {
   #hasher: IHasher = hasherPool.acquire(this);
 
+  /** @inheritDoc */
   protected _rawUpdate(data: Uint8Array) {
     this.#hasher.update(data);
   }
 
+  /** @inheritDoc */
   protected _rawDigest(_encoding: string | undefined): Uint8Array {
     const hasher = this.#hasher;
     const result: Uint8Array = hasher.digest("binary");


### PR DESCRIPTION
## Summary

Pure doc-coverage pass over `packages/content-hash`, adding the
exact comment `/** @inheritDoc */` to 11 inherited method
overrides across 5 files. One commit, +11/-0. No behavioral
change.

## Conformance axis

**Documentation style — `@inheritDoc` coverage** per
`code-conventions.md` "Doc comments (JSDoc)": methods which are
overrides or implementations of an interface where no additional
detail is warranted use the exact doc comment
`/** @inheritDoc */`.

Sites by file:

- `BaseIncrementalHasher.ts` (2): public concrete `digest()` and
  `update()` — implementations of the `IncrementalHasher`
  interface. The `digest()` marker is on the first overload
  signature, matching the precedent in
  `BaseSmallChunkUpdatingHasher`.
- `BaseCollectingHasher.ts` (2): protected `_rawUpdate()` and
  `_rawDigest()` — overrides of `BaseIncrementalHasher`'s
  abstracts.
- `sha256-deno.ts` (2): `DenoHasher._rawUpdate()` and
  `_rawDigest()`.
- `sha256-noble.ts` (2): `NobleHasher._rawUpdate()` and
  `_rawDigest()`.
- `sha256-wasm.ts` (3): `WasmCollectingHasher._digestChunks()`
  (override of `BaseCollectingHasher`'s abstract);
  `WasmUpdatingHasher._rawUpdate()` and `_rawDigest()`.

`HasherPool._initInstance()` already carries the marker
pre-pass; unchanged here. Abstract method declarations
themselves are not annotated — they *are* the contract that
subclass `@inheritDoc` references.

## Out of scope

- Other conformance axes within `content-hash` (mechanical fixes
  and `initWasm` reorder landed separately in
  `33d75f127` / #3658).
- Other doc-comment additions that would warrant substantive
  prose (rather than `@inheritDoc`).
- Source files outside `packages/content-hash/`.

## Review

Internal review by `reviewer-flux`: **APPROVE no-NITs** (posted
as a COMMENT-class review on 2026-05-21; GitHub blocks formal
`--approve` on PRs co-authored against the PR author's own
account). Per-site verification clean on all 11 sites in the
faithful bucket, plus both negative-space claims confirmed
(abstract methods not annotated; `HasherPool._initInstance`
unchanged at the pre-existing `@inheritDoc`), conservation-of-
content (+11/+11 per-file delta match), missed-site sweep
clean, and exact-form discipline (11/11 sites use the precise
`/** @inheritDoc */` byte sequence). See the review thread for
the full trace.

## CI

All 29 functional checks SUCCESS (Check, Test, Runner/Pattern/
Package/CLI Integration Tests, Pattern Unit Tests, Build
Binaries, and `Performance Check` — landed green for this
pure-doc-coverage delta). 4 deploy/post-deploy jobs are SKIPPED
— expected behavior for branches without deploy targets.

## Methodology

Part of the session-078 `content-hash` conformance pass —
intentionally narrow + single-axis so the rule's contact-surface
with real code is visible cleanly. Rule-text feedback (where the
rules under-specify or surprise on contact) is a first-class
output of the broader pass.

This PR follows #3658 (mechanical fixes + `initWasm` reorder)
in the same conformance arc.
