### PR TITLE
feat(data-model): add cloneForIsolation for snapshot-style isolation cloning

### DIFF
--- a/packages/data-model/fabric-value.ts
+++ b/packages/data-model/fabric-value.ts
@@ -18,6 +18,7 @@ export {
 } from "./interface.ts";
 
 export {
+  cloneForIsolation,
   cloneForMutation,
   CloneForMutationError,
   type CloneForMutationErrorKind,

--- a/packages/data-model/test/clone-for-isolation.test.ts
+++ b/packages/data-model/test/clone-for-isolation.test.ts
@@ -1,0 +1,246 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  cloneForIsolation,
+  resetDataModelConfig,
+  setDataModelConfig,
+} from "../fabric-value.ts";
+import type { FabricValue } from "../fabric-value.ts";
+import { deepFreeze, isDeepFrozen } from "../deep-freeze.ts";
+import { FabricBytes } from "../fabric-bytes.ts";
+import { FabricEpochNsec } from "../fabric-epoch.ts";
+import { FabricError } from "../fabric-native-instances.ts";
+
+// ============================================================================
+// `cloneForIsolation` tests
+// ============================================================================
+//
+// Parameterized across both legacy and modern data-model flag states to keep
+// the contract durable under either flag setting.
+
+describe("cloneForIsolation", () => {
+  afterEach(() => {
+    resetDataModelConfig();
+  });
+
+  for (const modernMode of [false, true]) {
+    const label = modernMode ? "modern" : "legacy";
+
+    describe(`(${label} path)`, () => {
+      beforeEach(() => setDataModelConfig(modernMode));
+
+      // ----------------------------------------------------------------------
+      // Primitives and FabricPrimitive
+      // ----------------------------------------------------------------------
+
+      describe("primitives & FabricPrimitive", () => {
+        it("returns JS primitives unchanged", () => {
+          expect(cloneForIsolation(42 as FabricValue)).toBe(42);
+          expect(cloneForIsolation("hello" as FabricValue)).toBe("hello");
+          expect(cloneForIsolation(true as FabricValue)).toBe(true);
+          expect(cloneForIsolation(null)).toBe(null);
+          expect(cloneForIsolation(42n as FabricValue)).toBe(42n);
+        });
+
+        it("returns FabricPrimitive subclasses by identity", () => {
+          const epoch = new FabricEpochNsec(123n);
+          expect(cloneForIsolation(epoch as unknown as FabricValue))
+            .toBe(epoch);
+          const bytes = new FabricBytes(new Uint8Array([1, 2, 3]));
+          expect(cloneForIsolation(bytes as unknown as FabricValue))
+            .toBe(bytes);
+        });
+      });
+
+      // ----------------------------------------------------------------------
+      // Identity preservation for already-deep-frozen subtrees
+      // ----------------------------------------------------------------------
+
+      describe("deep-frozen identity preservation", () => {
+        it("returns a fully-deep-frozen input by identity", () => {
+          const value = deepFreeze({
+            a: { x: 1 },
+            b: [1, 2, 3],
+          }) as FabricValue;
+          expect(cloneForIsolation(value)).toBe(value);
+        });
+
+        it("preserves deep-frozen subtrees by identity within a mutable parent", () => {
+          const frozenChild = deepFreeze({ kept: true });
+          const frozenSibling = deepFreeze({ kept: "yes" });
+          // Mutable parent containing two deep-frozen children.
+          const value = {
+            a: frozenChild,
+            b: frozenSibling,
+          } as FabricValue;
+
+          const result = cloneForIsolation(value) as Record<string, unknown>;
+
+          // The outer object is freshly allocated (input was mutable).
+          expect(result).not.toBe(value);
+          // Both children retain their identity.
+          expect(result.a).toBe(frozenChild);
+          expect(result.b).toBe(frozenSibling);
+          // And `isDeepFrozen` still passes on them post-clone.
+          expect(isDeepFrozen(result.a)).toBe(true);
+          expect(isDeepFrozen(result.b)).toBe(true);
+        });
+
+        it("clones mutable subtrees while preserving frozen ones", () => {
+          const frozenSibling = deepFreeze({ kept: true });
+          const mutableSibling = { mutable: true };
+          const value = {
+            kept: frozenSibling,
+            churn: mutableSibling,
+          } as FabricValue;
+
+          const result = cloneForIsolation(value) as Record<string, unknown>;
+
+          expect(result).not.toBe(value);
+          expect(result.kept).toBe(frozenSibling); // identity preserved
+          expect(result.churn).not.toBe(mutableSibling); // fresh copy
+          expect(result.churn).toEqual({ mutable: true });
+        });
+      });
+
+      // ----------------------------------------------------------------------
+      // Mutable input is deep-cloned
+      // ----------------------------------------------------------------------
+
+      describe("mutable input cloning", () => {
+        it("deep-clones a mutable object", () => {
+          const inner = { x: 1 };
+          const value = { a: inner } as FabricValue;
+          const result = cloneForIsolation(value) as Record<string, unknown>;
+
+          expect(result).not.toBe(value);
+          expect(result.a).not.toBe(inner);
+          expect(result.a).toEqual({ x: 1 });
+        });
+
+        it("deep-clones a mutable array", () => {
+          const value = [1, 2, [3, 4]] as FabricValue;
+          const result = cloneForIsolation(value) as unknown[];
+
+          expect(result).not.toBe(value);
+          expect(result[2]).not.toBe((value as unknown[])[2]);
+          expect(result).toEqual([1, 2, [3, 4]]);
+        });
+
+        it("preserves null prototypes on objects", () => {
+          const value = Object.create(null) as Record<string, unknown>;
+          value.a = 1;
+          const result = cloneForIsolation(value as FabricValue) as Record<
+            string,
+            unknown
+          >;
+          expect(Object.getPrototypeOf(result)).toBe(null);
+          expect(result.a).toBe(1);
+        });
+
+        it("preserves sparse array holes", () => {
+          // deno-lint-ignore no-sparse-arrays
+          const value = [1, , 3] as FabricValue;
+          const result = cloneForIsolation(value) as unknown[];
+          expect(result.length).toBe(3);
+          expect(0 in result).toBe(true);
+          expect(1 in result).toBe(false); // sparse hole preserved
+          expect(2 in result).toBe(true);
+        });
+
+        it("handles shared (diamond) references in mutable input", () => {
+          const shared = { x: 1 };
+          const value = { a: shared, b: shared } as FabricValue;
+          const result = cloneForIsolation(value) as Record<string, unknown>;
+          // Diamond preserved: both branches point at the same clone.
+          expect(result.a).toBe(result.b);
+          expect(result.a).not.toBe(shared); // freshly cloned
+        });
+
+        it("throws on a direct cycle in mutable input", () => {
+          // `cloneForIsolation` doesn't try to recreate cycles (no Fabric
+          // value is allowed to contain one). The implementation's `seen`
+          // map prevents infinite recursion, but the result has a
+          // self-referential structure that mirrors the input -- which is
+          // arguably wrong (the result should be isolated), but matches
+          // `isolateTransactionValue`'s prior behavior. Document via test.
+          const obj = {} as Record<string, unknown>;
+          obj.self = obj;
+          const result = cloneForIsolation(obj as FabricValue) as Record<
+            string,
+            unknown
+          >;
+          expect(result).not.toBe(obj);
+          // The clone has its own self-reference (the `seen` map made it
+          // point back at the new copy, not the original).
+          expect(result.self).toBe(result);
+        });
+      });
+
+      // ----------------------------------------------------------------------
+      // FabricInstance handling
+      // ----------------------------------------------------------------------
+
+      describe("FabricInstance", () => {
+        it("returns a deep-frozen FabricInstance by identity", () => {
+          const err = new FabricError(new Error("test"));
+          Object.freeze(err.error);
+          deepFreeze(err);
+          expect(cloneForIsolation(err as unknown as FabricValue))
+            .toBe(err);
+        });
+
+        it("deep-clones a non-deep-frozen FabricInstance via .deepClone(false)", () => {
+          // A FabricError whose wrapped Error is mutable (so not
+          // deep-frozen). cloneForIsolation should rebuild rather than
+          // share the reference -- the "punt" bug in the prior
+          // `isolateTransactionValue` is the thing this PR's separation
+          // makes explicit.
+          const err = new FabricError(new Error("test"));
+          // Not frozen at all -> isDeepFrozen returns false.
+          const result = cloneForIsolation(err as unknown as FabricValue);
+          expect(result).toBeInstanceOf(FabricError);
+          expect(result).not.toBe(err);
+          // FabricError.deepClone is a stop-gap that preserves string-
+          // valued state (notably `.message`). Match the existing
+          // contract.
+          expect((result as unknown as FabricError).error.message).toBe(
+            "test",
+          );
+        });
+
+        it("deep-clones a FabricInstance inside an unfrozen parent", () => {
+          const err = new FabricError(new Error("nested"));
+          const value = { err } as FabricValue;
+          const result = cloneForIsolation(value) as Record<string, unknown>;
+          expect(result).not.toBe(value);
+          // FabricInstance was deep-cloned (not punted).
+          expect(result.err).not.toBe(err);
+          expect(result.err).toBeInstanceOf(FabricError);
+        });
+      });
+
+      // ----------------------------------------------------------------------
+      // Type violation
+      // ----------------------------------------------------------------------
+
+      describe("type-violation throw", () => {
+        it("throws on a non-FabricValue class instance", () => {
+          // `Date` isn't part of FabricValue (in modern it'd be wrapped
+          // in a FabricInstance subclass; in legacy too). A bare `Date`
+          // landing here is a type-violation upstream and the function
+          // surfaces it rather than silently sharing the reference.
+          const value = { when: new Date() } as unknown as FabricValue;
+          expect(() => cloneForIsolation(value))
+            .toThrow("unexpected non-FabricValue");
+        });
+
+        it("throws on a Map (similar non-FabricValue)", () => {
+          const value = { m: new Map() } as unknown as FabricValue;
+          expect(() => cloneForIsolation(value))
+            .toThrow("unexpected non-FabricValue");
+        });
+      });
+    });
+  }
+});

--- a/packages/data-model/value-clone.ts
+++ b/packages/data-model/value-clone.ts
@@ -1,7 +1,11 @@
-import { FabricInstance, FabricValue } from "./interface.ts";
+import { FabricInstance, FabricPrimitive, FabricValue } from "./interface.ts";
 import { NATIVE_TAGS, tagFromNativeValue } from "./native-type-tags.ts";
-import { isDeepFrozenFabricValue } from "./deep-freeze.ts";
-import { type Immutable, isPlainContainer } from "@commonfabric/utils/types";
+import { isDeepFrozen, isDeepFrozenFabricValue } from "./deep-freeze.ts";
+import {
+  type Immutable,
+  isPlainContainer,
+  isPlainObject,
+} from "@commonfabric/utils/types";
 import { toDebugKindString } from "./value-debug.ts";
 import { isArrayIndexPropertyName } from "./array-utils.ts";
 
@@ -540,4 +544,107 @@ function createMissingContainer(
  */
 function isMutableHandle(value: unknown): boolean {
   return isPlainContainer(value) || value instanceof FabricInstance;
+}
+
+// =============================================================================
+// `cloneForIsolation`
+// =============================================================================
+
+/**
+ * Produces a deep clone of `value` that is isolated from later mutations to
+ * the source, with one targeted optimization: already-deep-frozen subtrees
+ * are preserved by identity rather than re-cloned. This makes the dominant
+ * "everything is already deep-frozen" case (common in modern data model,
+ * where the storage layer hands back deep-frozen values) an O(1)
+ * cache-lookup-and-return; partially-frozen trees only copy their mutable
+ * portions.
+ *
+ * Dispatch:
+ *
+ * - Primitives are returned as-is.
+ * - Already-deep-frozen values (per `isDeepFrozen`, which uses the
+ *   `[IS_DEEP_FROZEN]` protocol for `FabricInstance`) are returned by
+ *   identity at any level of the recursion. This is the perf
+ *   optimization the simpler `cloneIfNecessary(_, { frozen: false })`
+ *   doesn't have (it `force: true`s a full deep clone).
+ * - `FabricPrimitive` instances are returned as-is (immutable by
+ *   construction; their frozenness is irrelevant).
+ * - `FabricInstance` instances are deep-cloned via `.deepClone(false)`
+ *   (whose own semantics govern any nested values inside the wrapper).
+ * - Plain objects and arrays are deep-cloned recursively, with cycle
+ *   detection.
+ * - Any other class instance is a `FabricValue` type violation upstream;
+ *   the function throws.
+ *
+ * Result mutability: the returned tree is mutable along any path that
+ * wasn't already deep-frozen in the input; deep-frozen subtrees inside
+ * the result remain frozen by reference. Callers that need a uniformly
+ * mutable result should use `cloneIfNecessary(value, { frozen: false })`.
+ *
+ * Intended use: snapshotting and write-isolation paths where the goal is
+ * "the result is independent of any subsequent mutation to the source"
+ * but the caller doesn't itself mutate the result. (The storage layer's
+ * read freezing and patch-intent recording are the canonical consumers.)
+ */
+export function cloneForIsolation<T extends FabricValue>(value: T): T {
+  return cloneForIsolationHelper(value, new Map()) as T;
+}
+
+function cloneForIsolationHelper(
+  value: FabricValue,
+  seen: Map<object, FabricValue>,
+): FabricValue {
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+
+  // Optimization: already-deep-frozen subtrees are immutable, so the
+  // source reference is safe to share with the caller.
+  if (isDeepFrozen(value)) {
+    return value;
+  }
+
+  const cached = seen.get(value);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  if (Array.isArray(value)) {
+    const copy: FabricValue[] = new Array(value.length);
+    seen.set(value, copy);
+    for (let i = 0; i < value.length; i++) {
+      if (i in value) {
+        copy[i] = cloneForIsolationHelper(value[i], seen);
+      }
+    }
+    return copy;
+  }
+
+  if (isPlainObject(value)) {
+    // Preserve null prototypes (e.g. `Object.create(null)`).
+    const proto = Object.getPrototypeOf(value);
+    const copy = Object.create(proto) as Record<PropertyKey, FabricValue>;
+    seen.set(value, copy);
+    const obj = value as Record<PropertyKey, FabricValue>;
+    for (const key of Reflect.ownKeys(obj)) {
+      copy[key] = cloneForIsolationHelper(obj[key], seen);
+    }
+    return copy;
+  }
+
+  // The only legal non-plain-prototype values inside a FabricValue are
+  // FabricPrimitive (immutable by construction; return as-is) and
+  // FabricInstance (delegate to its own clone protocol).
+  if (value instanceof FabricPrimitive) {
+    return value;
+  }
+  if (value instanceof FabricInstance) {
+    return (value as FabricInstance).deepClone(false) as FabricValue;
+  }
+
+  throw new Error(
+    `cloneForIsolation: unexpected non-FabricValue (${
+      toDebugKindString(value)
+    })`,
+  );
 }


### PR DESCRIPTION
## Summary

Adds `cloneForIsolation()` to `@commonfabric/data-model` as a sibling to `cloneIfNecessary` and `cloneForMutation`. Its job is snapshot-style isolation cloning: produce a copy that's independent of source mutation, while preserving the identity of already-deep-frozen subtrees by reference.

```ts
export function cloneForIsolation<T extends FabricValue>(value: T): T;
```

Dispatch:

- Primitives and `FabricPrimitive` instances → returned as-is.
- Already-deep-frozen values (per `isDeepFrozen`) → returned by identity at every level of the recursion. This is the perf optimization the simpler `cloneIfNecessary(_, { frozen: false })` doesn't have (it `force: true`s a full deep clone, allocating new identities even for unchanged subtrees).
- `FabricInstance` → deep-cloned via `.deepClone(false)` (whose own semantics govern any nested values inside the wrapper).
- Plain objects and arrays → deep-cloned recursively, with cycle detection.
- Any other class instance is a `FabricValue` type violation upstream; the function **throws**.

Result mutability is intentionally "mixed": the returned tree is mutable along any path that wasn't already deep-frozen in the input; deep-frozen subtrees inside the result remain frozen by reference. Callers that need a uniformly mutable result should use `cloneIfNecessary(value, { frozen: false })` instead.

## Why

The v2-transaction storage layer has a local helper `isolateTransactionValue` with isomorphic semantics, but with two issues this new helper fixes:

1. **`FabricInstance` punt (bug):** the existing helper returns any non-plain-prototype value as-is — including mutable `FabricInstance` instances. That breaks isolation: the caller and the function share the same reference. `cloneForIsolation` delegates to the `FabricInstance` clone protocol like `cloneIfNecessary` already does.

2. **Silent type-violation:** the existing helper also returns non-`FabricValue` class instances (e.g. a stray `Date`) as-is rather than surfacing the upstream type bug. `cloneForIsolation` throws.

The runner-side swap (replace `isolateTransactionValue` with `cloneForIsolation`) lands as a follow-up PR — this PR is the data-model-only prerequisite.

## Test coverage

`packages/data-model/test/clone-for-isolation.test.ts` contributes 44 steps across:

- Primitives + `FabricPrimitive` (immutable-by-construction identity).
- Deep-frozen identity preservation (whole-input + per-subtree, including mixed-frozenness trees).
- Mutable input cloning (plain objects, arrays, null-prototype objects, sparse arrays, diamond references, direct cycles).
- `FabricInstance` handling (deep-frozen-identity, mutable rebuild, nested-in-parent).
- Type-violation throws (`Date`, `Map` as stand-ins for any non-`FabricValue`).

Parameterized across both legacy and modern data-model flag states.

## Test plan

- [x] `deno task test` in `@commonfabric/data-model` — 47 tests / 1757 steps pass.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `cloneForIsolation()` to `@commonfabric/data-model` for snapshot-style isolation cloning that shares already deep-frozen subtrees and correctly clones `FabricInstance` values. This sets up replacing the runner’s `isolateTransactionValue` in a follow-up.

- **New Features**
  - New API: `cloneForIsolation<T extends FabricValue>(value: T): T`.
  - Primitives and `FabricPrimitive` are returned as-is; deep-frozen subtrees are returned by identity; plain objects/arrays are deep-cloned with cycle/shared-ref preservation.
  - `FabricInstance` values are cloned via `.deepClone(false)` to avoid reference sharing.
  - Throws on non-`FabricValue` class instances (e.g., `Date`, `Map`).

<sup>Written for commit ec431a80dc7278ea94e04b80c30437d7ed2468e5. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3660?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

