### PR TITLE
fix(content-hash): add missing `protected` keyword on `DenoHasher` overrides

### DIFF
--- a/packages/content-hash/src/sha256-deno.ts
+++ b/packages/content-hash/src/sha256-deno.ts
@@ -35,12 +35,12 @@ class DenoHasher extends BaseIncrementalHasher {
   #hasher = crypto!.createHash("sha256");
 
   /** @inheritDoc */
-  _rawUpdate(data: Uint8Array) {
+  protected _rawUpdate(data: Uint8Array) {
     this.#hasher.update(data);
   }
 
   /** @inheritDoc */
-  _rawDigest(encoding: string | undefined): Uint8Array | string {
+  protected _rawDigest(encoding: string | undefined): Uint8Array | string {
     switch (encoding) {
       case "base64url": {
         return this.#hasher.digest(encoding);


### PR DESCRIPTION
## Summary

TS-correctness conformance-tightening on `packages/content-hash`,
adding the missing `protected` keyword to `DenoHasher._rawUpdate()`
and `DenoHasher._rawDigest()` in
`packages/content-hash/src/sha256-deno.ts`. One commit, +2/-2 /
1 file.

This is a *declarative tightening*, not a behavioral fix: TS
doesn't error on the missing `protected` (structural subtyping
permits access-widening on subclass overrides), and the runtime
behavior is identical — these methods are only called by
`BaseIncrementalHasher`'s public `digest()` and `update()`.

## Conformance axis

**TS-correctness — matching the base abstract's `protected`
declaration on subclass overrides.**

`BaseIncrementalHasher` declares `_rawUpdate` and `_rawDigest`
as `protected abstract`. `NobleHasher` (in `sha256-noble.ts`),
`WasmCollectingHasher`, and `WasmUpdatingHasher` (both in
`sha256-wasm.ts`) all carry `protected` on their overrides;
`DenoHasher` was the lone outlier. This PR brings it into line.

Sites:

- `sha256-deno.ts`: `DenoHasher._rawUpdate()` and
  `DenoHasher._rawDigest()`.

## Out of scope

- Behavioral changes / API surface changes. No public API moves;
  the access tightening is subclass-internal.
- Other access-modifier audits across the package. The matching-
  base-abstract rationale targets this specific outlier; a wider
  sweep isn't on this arc's agenda.
- Source files outside `packages/content-hash/`.

## Review

Internal review by `reviewer-flux`: **APPROVE no-NITs** (posted
as a COMMENT-class review on 2026-05-21; GitHub blocks formal
`--approve` on PRs co-authored against the PR author's own
account). Per-site parent-abstract match on both sites,
matching-precedent claim verified at-source across the other
three already-conforming subclasses, and Cedar's no-external-
caller claim chain verified independently across three steps
(no external callers; in-package callers are dispatch-only;
`DenoHasher` is only exposed via the `IncrementalHasher`
interface type which carries only public members). Declarative-
only confirmed by zero test-step delta vs PR-1/PR-2 (705
steps across all three PRs). See the review thread for the
full trace.

Plus cubic-dev-ai: "No issues found across 1 file."

## CI

All 30 functional checks SUCCESS — including `cubic · AI code
reviewer` and `Performance Check` (both landed green for this
2-line access-modifier tightening). 4 deploy/post-deploy jobs
are SKIPPED — expected behavior for branches without deploy
targets.

## Methodology

Third and closing PR of the session-078 `content-hash` conformance
arc, following #3658 (mechanical fixes + `initWasm` reorder at
`33d75f127`) and #3659 (`@inheritDoc` doc-coverage at `a76c28b68`).
PR-3 is a TS-correctness adjacency that surfaced during PR-2 —
the `DenoHasher` outlier was noticed during PR-2's `@inheritDoc`
sweep but kept as a separate axis to preserve PR-2's single-axis
shape. Continued this session per amortize-the-overhead.

Rule-text feedback (where conventions under-specify or surprise
on contact) remains a first-class output of the broader pass.
