### PR TITLE
Reshape FabricError to FabricValue-shaped state

### DIFF
--- a/packages/data-model/fabric-native-instances.ts
+++ b/packages/data-model/fabric-native-instances.ts
@@ -174,34 +174,40 @@ export type FabricErrorState = {
  * `stack`, `cause`) plus a hidden extras bag accessed via map-like methods
  * (`getExtra`, `setExtra`, `hasExtra`, `deleteExtra`, `extraKeys`,
  * `extraEntries`). The native `Error` form is produced on demand by
- * `toNativeValue()`. Mutability of the extras bag tracks the instance's
- * frozen state: `setExtra` / `deleteExtra` throw when this instance is
- * frozen. The serialization layer handles `FabricError` via the generic
- * `FabricInstanceHandler` path. See Section 1.4.1 of the formal spec.
+ * `toNativeValue()`.
+ *
+ * Like all `FabricInstance`s, a `FabricError` is wholeheartedly mutable
+ * until frozen and immutable thereafter. The fixed-schema slots are plain
+ * writable own properties: assigning to one throws once the instance is
+ * `Object.freeze`'d (strict-mode non-writable-property semantics). The
+ * extras bag mirrors this by gating `setExtra` / `deleteExtra` on the
+ * frozen state. The serialization layer handles `FabricError` via the
+ * generic `FabricInstanceHandler` path. See Section 1.4.1 of the formal
+ * spec.
  */
 export class FabricError extends FabricNativeWrapper<Error> {
   /** @inheritDoc */
   readonly typeTag = TAGS.Error;
 
   /** Constructor name of the originating native `Error` (e.g. `"TypeError"`). */
-  readonly type: string;
+  type: string;
   /** The `.name` property (always a concrete string). */
-  readonly name: string;
+  name: string;
   /** The `.message` property. */
-  readonly message: string;
+  message: string;
   /** The `.stack` property, or `undefined`. */
-  readonly stack: string | undefined;
+  stack: string | undefined;
   /** The `.cause` value, in `FabricValue` form, or `undefined`. */
-  readonly cause: FabricValue | undefined;
+  cause: FabricValue | undefined;
 
   /** Hidden bag of custom enumerable properties, in `FabricValue` form. */
   readonly #extras: Map<string, FabricValue>;
 
   /**
-   * Cached lazy native projection. Built on first call to `wrappedValue` /
-   * `toNativeValue()` and reused thereafter. Always deep-frozen when
-   * populated (matching the typical use case); thawed copies are minted by
-   * `toNativeThawed()` on demand.
+   * Cached lazy native projection, populated only once this instance is
+   * frozen (so the projection can never go stale against mutable state).
+   * While unfrozen, `wrappedValue` rebuilds on each access; thawed copies
+   * are always minted fresh by `toNativeThawed()`.
    */
   #nativeFrozen: Error | undefined;
 
@@ -399,11 +405,16 @@ export class FabricError extends FabricNativeWrapper<Error> {
   }
 
   /**
-   * Returns the cached native projection, building it on first access. The
-   * cached projection is always deep-frozen; `toNativeValue(false)` uses
-   * `toNativeThawed()` to mint a thawed copy each time.
+   * Returns the frozen native projection. Once this instance is frozen the
+   * projection is cached (state can no longer change, so the cache is always
+   * valid); while mutable it is rebuilt on each access. `toNativeValue(false)`
+   * uses `toNativeThawed()` to mint a thawed copy each time.
    */
   protected get wrappedValue(): Error {
+    if (!Object.isFrozen(this)) {
+      // Mutable: state may still change, so never cache.
+      return this.#buildNativeError(true);
+    }
     if (this.#nativeFrozen === undefined) {
       this.#nativeFrozen = this.#buildNativeError(true);
     }

--- a/packages/data-model/fabric-native-instances.ts
+++ b/packages/data-model/fabric-native-instances.ts
@@ -52,43 +52,6 @@ export const UNSAFE_KEYS: FrozenSet<string> = new FrozenSet([
   "constructor",
 ]);
 
-/**
- * Helper for `copyError()` and `FabricError.[DECONSTRUCT]()`, which copies
- * own enumerable properties from `source` to `target`, skipping
- * prototype-sensitive keys (`__proto__`, `constructor`). When `noOverride`
- * is `true`, keys already present on `target` are also skipped.
- */
-function copyOwnSafeProperties(
-  source: object,
-  target: Record<string, unknown>,
-  noOverride = false,
-): void {
-  for (const key of Object.keys(source)) {
-    if (UNSAFE_KEYS.has(key)) continue;
-    if (noOverride && key in target) continue;
-    target[key] = (source as Record<string, unknown>)[key];
-  }
-}
-
-/**
- * Creates a shallow copy of an `Error`, preserving `constructor()`, `.name`,
- * `.message`, `.stack`, `.cause`, and custom enumerable properties. Used by
- * `toNativeValue()` when the freeze state of the wrapped `Error` doesn't match
- * the requested state.
- */
-function copyError(error: Error): Error {
-  const copy = new (error.constructor as ErrorConstructor)(error.message);
-  if (copy.name !== error.name) copy.name = error.name;
-  if (error.stack !== undefined) copy.stack = error.stack;
-  if (error.cause !== undefined) copy.cause = error.cause;
-  copyOwnSafeProperties(
-    error,
-    copy as unknown as Record<string, unknown>,
-    true,
-  );
-  return copy;
-}
-
 // ---------------------------------------------------------------------------
 // Utility: `Error` class lookup
 // ---------------------------------------------------------------------------
@@ -108,7 +71,7 @@ const ERROR_CLASS_BY_TYPE: ReadonlyMap<string, ErrorConstructor> = new Map([
  * constructor for the given type string (e.g. `"TypeError"`). Falls back
  * to the base `Error` constructor for unknown types.
  */
-function errorClassFromType(type: string): ErrorConstructor {
+export function errorClassFromType(type: string): ErrorConstructor {
   return ERROR_CLASS_BY_TYPE.get(type) ?? Error;
 }
 
@@ -157,180 +120,347 @@ export abstract class FabricNativeWrapper<T extends object>
 // ---------------------------------------------------------------------------
 
 /**
+ * Reserved key set for `FabricError`'s extras bag: these names belong to the
+ * fixed-schema slots (`type`, `name`, `message`, `stack`, `cause`) and cannot
+ * be used as extras keys.
+ */
+const FABRIC_ERROR_RESERVED_KEYS: FrozenSet<string> = new FrozenSet([
+  "type",
+  "name",
+  "message",
+  "stack",
+  "cause",
+]);
+
+/**
+ * Structured state for constructing a `FabricError`. Spec slots are
+ * `FabricValue`-typed; the optional `extras` carries any custom enumerable
+ * properties (also in `FabricValue` form). After construction, extras are
+ * accessed via map-like methods (`getExtra`, `setExtra`, etc.) on the
+ * instance; they are not exposed as an own property.
+ */
+export type FabricErrorState = {
+  /** Constructor name of the originating native `Error` (e.g. `"TypeError"`). */
+  readonly type: string;
+  /**
+   * The `.name` property. Pass `null` (or omit) to mean "same as `type`"; the
+   * resulting instance's `.name` is always a concrete string (`null` is a
+   * wire-level optimization at the `[DECONSTRUCT]` boundary, not part of the
+   * public API).
+   */
+  readonly name?: string | null | undefined;
+  /** The `.message` property. */
+  readonly message: string;
+  /** The `.stack` property, or `undefined`. */
+  readonly stack: string | undefined;
+  /** The `.cause` value, in `FabricValue` form, or `undefined`. */
+  readonly cause: FabricValue | undefined;
+  /**
+   * Optional iterable of custom enumerable own properties, in `FabricValue`
+   * form. Keys must not collide with the fixed-schema slot names or with
+   * prototype-sensitive keys.
+   */
+  readonly extras?:
+    | Iterable<readonly [string, FabricValue]>
+    | Readonly<Record<string, FabricValue>>
+    | undefined;
+};
+
+/**
  * Wrapper for `Error` instances in the fabric type system. Bridges native
  * `Error` (JS wild west) into the strongly-typed `FabricValue` layer by
- * implementing `FabricInstance`. The serialization layer handles
- * `FabricError` via the generic `FabricInstanceHandler` path.
- * See Section 1.4.1 of the formal spec.
+ * implementing `FabricInstance`. The publicly observable state is entirely
+ * `FabricValue`-typed: fixed-schema slots (`type`, `name`, `message`,
+ * `stack`, `cause`) plus a hidden extras bag accessed via map-like methods
+ * (`getExtra`, `setExtra`, `hasExtra`, `deleteExtra`, `extraKeys`,
+ * `extraEntries`). The native `Error` form is produced on demand by
+ * `toNativeValue()`. Mutability of the extras bag tracks the instance's
+ * frozen state: `setExtra` / `deleteExtra` throw when this instance is
+ * frozen. The serialization layer handles `FabricError` via the generic
+ * `FabricInstanceHandler` path. See Section 1.4.1 of the formal spec.
  */
 export class FabricError extends FabricNativeWrapper<Error> {
   /** @inheritDoc */
   readonly typeTag = TAGS.Error;
 
-  constructor(
-    /** The wrapped native `Error`. */
-    readonly error: Error,
-  ) {
+  /** Constructor name of the originating native `Error` (e.g. `"TypeError"`). */
+  readonly type: string;
+  /** The `.name` property (always a concrete string). */
+  readonly name: string;
+  /** The `.message` property. */
+  readonly message: string;
+  /** The `.stack` property, or `undefined`. */
+  readonly stack: string | undefined;
+  /** The `.cause` value, in `FabricValue` form, or `undefined`. */
+  readonly cause: FabricValue | undefined;
+
+  /** Hidden bag of custom enumerable properties, in `FabricValue` form. */
+  readonly #extras: Map<string, FabricValue>;
+
+  /**
+   * Cached lazy native projection. Built on first call to `wrappedValue` /
+   * `toNativeValue()` and reused thereafter. Always deep-frozen when
+   * populated (matching the typical use case); thawed copies are minted by
+   * `toNativeThawed()` on demand.
+   */
+  #nativeFrozen: Error | undefined;
+
+  /**
+   * Constructs from a `FabricErrorState` record. All state values must
+   * already be in `FabricValue` form -- the conversion layer
+   * (`fabric-value-modern.ts`) is responsible for ensuring this when
+   * constructing from a native `Error`. Use `FabricError.fromNativeError()`
+   * for shallow conversion from a native `Error`.
+   */
+  constructor(state: FabricErrorState) {
     super();
+    this.type = state.type;
+    this.name = state.name ?? state.type;
+    this.message = state.message;
+    this.stack = state.stack;
+    this.cause = state.cause;
+    this.#extras = new Map();
+    const extras = state.extras;
+    if (extras !== undefined) {
+      const entries: Iterable<readonly [string, FabricValue]> =
+        Symbol.iterator in extras
+          ? extras as Iterable<readonly [string, FabricValue]>
+          : Object.entries(extras as Record<string, FabricValue>);
+      for (const [key, value] of entries) {
+        if (UNSAFE_KEYS.has(key) || FABRIC_ERROR_RESERVED_KEYS.has(key)) {
+          continue;
+        }
+        this.#extras.set(key, value);
+      }
+    }
   }
 
   /**
-   * Deconstructs into essential state for serialization. Returns `.type`,
-   * `.name`, `.message`, `.stack`, `.cause`, and custom enumerable properties.
-   * Does NOT recurse into nested values -- the serialization system handles that.
+   * Shallow conversion from a native `Error`. Used by the shallow conversion
+   * layer (`shallowFabricFromNativeValueModern`). The error's `.cause` and
+   * custom properties are stored as-is (cast to `FabricValue`); the deep
+   * conversion path is responsible for converting them when needed.
+   */
+  static fromNativeError(error: Error): FabricError {
+    const type = error.constructor.name;
+    const name = error.name === type ? null : error.name;
+    const extras: Array<[string, FabricValue]> = [];
+    for (const key of Object.keys(error)) {
+      if (UNSAFE_KEYS.has(key) || FABRIC_ERROR_RESERVED_KEYS.has(key)) {
+        continue;
+      }
+      extras.push([
+        key,
+        (error as unknown as Record<string, FabricValue>)[key],
+      ]);
+    }
+    return new FabricError({
+      type,
+      name,
+      message: error.message,
+      stack: error.stack,
+      cause: error.cause as FabricValue | undefined,
+      extras,
+    });
+  }
+
+  /** Returns the value associated with `key`, or `undefined`. */
+  getExtra(key: string): FabricValue | undefined {
+    return this.#extras.get(key);
+  }
+
+  /** Returns `true` if `key` is present in the extras bag. */
+  hasExtra(key: string): boolean {
+    return this.#extras.has(key);
+  }
+
+  /**
+   * Sets `key` to `value` in the extras bag. Throws if this instance is
+   * frozen, if `key` is a fixed-schema slot name, or if `key` is a
+   * prototype-sensitive key (`__proto__`, `constructor`).
+   */
+  setExtra(key: string, value: FabricValue): void {
+    if (Object.isFrozen(this)) {
+      throw new Error("Cannot modify frozen FabricError");
+    }
+    if (UNSAFE_KEYS.has(key)) {
+      throw new Error(`Cannot use unsafe key in FabricError extras: ${key}`);
+    }
+    if (FABRIC_ERROR_RESERVED_KEYS.has(key)) {
+      throw new Error(
+        `Cannot use fixed-schema slot name in FabricError extras: ${key}`,
+      );
+    }
+    this.#extras.set(key, value);
+  }
+
+  /**
+   * Removes `key` from the extras bag, returning `true` if it was present.
+   * Throws if this instance is frozen.
+   */
+  deleteExtra(key: string): boolean {
+    if (Object.isFrozen(this)) {
+      throw new Error("Cannot modify frozen FabricError");
+    }
+    return this.#extras.delete(key);
+  }
+
+  /** Returns the number of entries in the extras bag. */
+  get extraSize(): number {
+    return this.#extras.size;
+  }
+
+  /** Returns the keys present in the extras bag. */
+  extraKeys(): IterableIterator<string> {
+    return this.#extras.keys();
+  }
+
+  /** Returns the `[key, value]` entries in the extras bag. */
+  extraEntries(): IterableIterator<[string, FabricValue]> {
+    return this.#extras.entries();
+  }
+
+  /**
+   * Deconstructs into essential state for serialization. Returns a flat
+   * record with `type`, `name`, `message`, `stack`, `cause`, and custom
+   * enumerable properties from the extras bag. Does NOT recurse into nested
+   * values -- the serialization system handles that.
    *
-   * `type` is the constructor name (e.g. "TypeError") used for reconstruction.
-   * `name` is the `.name` property -- emitted as `null` when it equals `type`
-   * (the common case) to avoid redundancy.
-   *
-   * **Invariant**: By the time this method runs, `this.error.cause` and any
-   * custom enumerable properties are already `FabricValue`. The conversion
-   * layer (`convertErrorInternals()` in `fabric-value-modern.ts`) ensures
-   * this by recursively converting `Error` internals before wrapping in
-   * `FabricError`. The `as FabricValue` casts below are therefore safe.
+   * `name` is emitted as `null` when it equals `type` (the common case) to
+   * avoid redundancy.
    */
   [DECONSTRUCT](): FabricValue {
-    const type = this.error.constructor.name;
-    const name = this.error.name;
     const state: Record<string, FabricValue> = {
-      type,
-      name: name === type ? null : name,
-      message: this.error.message,
+      type: this.type,
+      name: this.name === this.type ? null : this.name,
+      message: this.message,
     };
-    if (this.error.stack !== undefined) {
-      state.stack = this.error.stack;
+    if (this.stack !== undefined) {
+      state.stack = this.stack;
     }
-    if (this.error.cause !== undefined) {
-      state.cause = this.error.cause as FabricValue;
+    if (this.cause !== undefined) {
+      state.cause = this.cause;
     }
-    copyOwnSafeProperties(
-      this.error,
-      state as Record<string, unknown>,
-      true,
-    );
+    for (const [key, value] of this.#extras) {
+      state[key] = value;
+    }
     return state as FabricValue;
   }
 
   /**
-   * Deep-freezes in place. `Object.freeze` on the wrapped `Error` covers the
-   * standard non-enumerable slots (`message`, `name`, `stack`); the only
-   * deep-freeze gap is the (`FabricValue`-typed, per the `[DECONSTRUCT]`
-   * invariant) `cause` and any custom enumerable own properties, which are
-   * recursed via `subFreeze`. This freezes the existing instance -- it does
-   * NOT rebuild and does NOT narrow to string-valued state (that narrowing
-   * is a `deepClone()` stop-gap detail, not a `[DEEP_FREEZE]` requirement).
+   * Deep-freezes in place. Freezes this instance and recurses into the
+   * `FabricValue`-typed `cause` and extras-bag values via `subFreeze`. The
+   * extras bag's mutation methods are gated by this instance's frozen state,
+   * so freezing `this` is sufficient -- there is no separate `Object.freeze`
+   * on the bag itself (a `Map` ignores `Object.freeze` for `set`/`delete`).
+   * There is no native-`Error` slot to freeze -- the native projection is a
+   * derivation produced on demand, not stored as canonical state.
    */
   [DEEP_FREEZE](
     subFreeze: (value: FabricValue) => FabricValue,
   ): FabricValue {
-    if (this.error.cause !== undefined) {
-      subFreeze(this.error.cause as FabricValue);
+    if (this.cause !== undefined) {
+      subFreeze(this.cause);
     }
-    for (const key of Object.keys(this.error)) {
-      if (UNSAFE_KEYS.has(key) || key === "cause") continue;
-      subFreeze(
-        (this.error as unknown as Record<string, FabricValue>)[key],
-      );
+    for (const value of this.#extras.values()) {
+      subFreeze(value);
     }
-    Object.freeze(this.error);
     return Object.freeze(this) as unknown as FabricValue;
   }
 
   /**
    * Side-effect-free check mirroring `[DEEP_FREEZE]`'s canonical form: this
-   * wrapper and its wrapped `Error` are frozen, and the (`FabricValue`-typed)
-   * `cause` plus any custom enumerable own properties are recursively
-   * deep-frozen. Never throws.
+   * instance is frozen, and the `cause` plus each value in the extras bag
+   * are recursively deep-frozen. Never throws.
    */
   [IS_DEEP_FROZEN](
     subIsDeepFrozen: (value: FabricValue) => boolean,
   ): boolean {
-    if (!Object.isFrozen(this) || !Object.isFrozen(this.error)) {
+    if (!Object.isFrozen(this)) return false;
+    if (this.cause !== undefined && !subIsDeepFrozen(this.cause)) {
       return false;
     }
-    if (
-      this.error.cause !== undefined &&
-      !subIsDeepFrozen(this.error.cause as FabricValue)
-    ) {
-      return false;
-    }
-    for (const key of Object.keys(this.error)) {
-      if (UNSAFE_KEYS.has(key) || key === "cause") continue;
-      if (
-        !subIsDeepFrozen(
-          (this.error as unknown as Record<string, FabricValue>)[key],
-        )
-      ) {
-        return false;
-      }
+    for (const value of this.#extras.values()) {
+      if (!subIsDeepFrozen(value)) return false;
     }
     return true;
   }
 
   /** @inheritDoc */
   protected shallowUnfrozenClone(): FabricError {
-    return new FabricError(this.error);
+    return new FabricError({
+      type: this.type,
+      name: this.name,
+      message: this.message,
+      stack: this.stack,
+      cause: this.cause,
+      extras: this.#extras,
+    });
   }
 
-  /** @inheritDoc */
+  /**
+   * Returns the cached native projection, building it on first access. The
+   * cached projection is always deep-frozen; `toNativeValue(false)` uses
+   * `toNativeThawed()` to mint a thawed copy each time.
+   */
   protected get wrappedValue(): Error {
-    return this.error;
+    if (this.#nativeFrozen === undefined) {
+      this.#nativeFrozen = this.#buildNativeError(true);
+    }
+    return this.#nativeFrozen;
   }
 
   /** @inheritDoc */
   protected toNativeFrozen(): Error {
-    return Object.freeze(copyError(this.error));
+    return this.wrappedValue;
   }
 
   /** @inheritDoc */
   protected toNativeThawed(): Error {
-    return copyError(this.error);
+    return this.#buildNativeError(false);
+  }
+
+  /**
+   * Builds a fresh native `Error` from this `FabricError`'s state. `cause`
+   * and extras are copied through as-is (no recursive unwrap). Callers that
+   * need recursive unwrap should use `nativeFromFabricValue()`.
+   */
+  #buildNativeError(frozen: boolean): Error {
+    const ErrorClass = errorClassFromType(this.type);
+    const error = new ErrorClass(this.message);
+    if (error.name !== this.name) error.name = this.name;
+    if (this.stack !== undefined) error.stack = this.stack;
+    if (this.cause !== undefined) error.cause = this.cause;
+    for (const [key, value] of this.#extras) {
+      (error as unknown as Record<string, unknown>)[key] = value;
+    }
+    return frozen ? Object.freeze(error) : error;
   }
 
   /** @inheritDoc */
   override deepClone(frozen: boolean): FabricError {
-    // TODO(danfuzz): This is a partial implementation, meant to keep thins
-    // working well enough as the modern data model gets fleshed out.
-    // Ultimately, concrete classes should not have to implement this method at
-    // all.
+    if (frozen && isDeepFrozen(this)) return this;
 
-    if (frozen && isDeepFrozen(this)) {
-      return this;
-    }
-
-    // This makes a result that just has the  string properties of the original.
-
-    const state: Record<string, unknown> = this[DECONSTRUCT]() as Record<
-      string,
-      unknown
-    >;
-
-    for (const key in state) {
-      if (typeof state[key] !== "string") {
-        delete state[key];
-      }
-    }
-
-    // `[RECONSTRUCT]` now honors `context.shouldDeepFreeze`. This clone path
-    // owns its own frozenness decision (the `frozen ? deepFreeze : result`
-    // below), so it must NOT have `[RECONSTRUCT]` pre-freeze: pass a context
-    // whose `shouldDeepFreeze` matches this clone's `frozen` intent. The first
-    // ctor arg MUST be `frozen` (not defaulted) so the context's frozenness
-    // tracks this clone's intent rather than defaulting to `true`.
+    // `[RECONSTRUCT]` honors `context.shouldDeepFreeze`. This clone path owns
+    // its own frozenness decision via the wrapper `frozen ? deepFreeze :
+    // result` below, so pre-freezing inside `[RECONSTRUCT]` would be
+    // redundant when `frozen` is true and wrong when it is false. Match
+    // contexts to this clone's intent.
     const reconstructContext = new EmptyReconstructionContext(
       frozen,
       "no runtime context (FabricError deep-clone path).",
     );
-    const result = FabricError[RECONSTRUCT](state, reconstructContext);
-
+    const result = FabricError[RECONSTRUCT](
+      this[DECONSTRUCT](),
+      reconstructContext,
+    );
     return frozen ? deepFreeze(result) : result;
   }
 
   /**
-   * Reconstructs a `FabricError` from its essential state. Nested values
-   * in `state` have already been reconstructed by the serialization system.
-   * Returns a `FabricError` wrapping the reconstructed `Error`; callers
-   * who need the native `Error` use `nativeFromFabricValue()`.
+   * Reconstructs a `FabricError` from its essential state (flat record).
+   * Nested values in `state` have already been reconstructed by the
+   * serialization system.
    */
   static [RECONSTRUCT](
     state: FabricValue,
@@ -338,35 +468,28 @@ export class FabricError extends FabricNativeWrapper<Error> {
   ): FabricError {
     const s = state as Record<string, FabricValue>;
     const type = (s.type as string) ?? (s.name as string) ?? "Error";
-    // null name means "same as type" (the common case optimization).
-    const name = (s.name as string | null) ?? type;
+    // null name means "same as type" (the wire-level optimization).
+    const name = (s.name as string | null | undefined) ?? type;
     const message = (s.message as string) ?? "";
+    const stack = s.stack as string | undefined;
+    const cause = s.cause;
 
-    const ErrorClass = errorClassFromType(type);
-    const error = new ErrorClass(message);
-
-    // Set name explicitly (covers custom names like "MyError", and the case
-    // where type and name differ).
-    if (error.name !== name) {
-      error.name = name;
-    }
-
-    if (s.stack !== undefined) {
-      error.stack = s.stack as string;
-    }
-    if (s.cause !== undefined) {
-      error.cause = s.cause;
-    }
-
-    // Copy custom properties from state onto the error.
-    const skip = new Set(["type", "name", "message", "stack", "cause"]);
+    const extras: Array<[string, FabricValue]> = [];
     for (const key of Object.keys(s)) {
-      if (!skip.has(key) && !UNSAFE_KEYS.has(key)) {
-        (error as unknown as Record<string, unknown>)[key] = s[key];
+      if (FABRIC_ERROR_RESERVED_KEYS.has(key) || UNSAFE_KEYS.has(key)) {
+        continue;
       }
+      extras.push([key, s[key]]);
     }
 
-    const result = new FabricError(error);
+    const result = new FabricError({
+      type,
+      name,
+      message,
+      stack,
+      cause,
+      extras,
+    });
     // Honor `shouldDeepFreeze`: produce the type's correct deep-frozen form
     // via its `[DEEP_FREEZE]` member (recursing through `deepFreeze`).
     return context.shouldDeepFreeze ? deepFreeze(result) : result;

--- a/packages/data-model/fabric-value-modern.ts
+++ b/packages/data-model/fabric-value-modern.ts
@@ -7,6 +7,7 @@ import {
 } from "./interface.ts";
 import { FabricEpochNsec } from "./fabric-epoch.ts";
 import {
+  errorClassFromType,
   FabricError,
   FabricNativeWrapper,
   FabricRegExp,
@@ -66,7 +67,7 @@ export function shallowFabricFromNativeValueModern(
       return value as FabricValueLayer;
 
     case NATIVE_TAGS.Error: {
-      const wrapped = new FabricError(value as Error);
+      const wrapped = FabricError.fromNativeError(value as Error);
       if (freeze) Object.freeze(wrapped);
       return wrapped;
     }
@@ -296,23 +297,13 @@ function fabricFromNativeValueModernInternal(
     return value;
   }
 
-  // TODO(danfuzz): Look into avoiding this special case for `FabricError`.
-  // Ideally the recursive internals conversion would be handled generically
-  // rather than requiring a type-specific branch here.
-  //
-  // `FabricError` wraps a raw `Error` whose internals (`.cause`, custom
-  // properties) may contain raw native types that aren't `FabricValue`.
-  // We must recursively convert those internals NOW so that when
-  // `[DECONSTRUCT]` runs at serialization time, all nested values are
-  // already `FabricValue`. See spec: the conversion layer (not the
-  // serializer) is responsible for ensuring this.
+  // `FabricError` has `FabricValue`-typed state slots (`cause`, `extra`) by
+  // type contract, but the shallow conversion above copied them through from
+  // the native `Error` as-is (where they may be raw `Error`, `Map`, etc.).
+  // Rebuild via the deep recursion so the resulting `FabricError`'s slots
+  // really are `FabricValue`.
   if (value instanceof FabricError) {
-    const convertedError = convertErrorInternals(
-      value.error,
-      converted,
-      freeze,
-    );
-    const result = new FabricError(convertedError);
+    const result = rebuildFabricErrorDeep(value, converted, freeze);
     if (freeze) Object.freeze(result);
     if (isOriginalRecord) {
       converted.set(original, result);
@@ -383,47 +374,33 @@ function fabricFromNativeValueModernInternal(
  * We create a new `Error` rather than mutating the original because the
  * caller's `Error` should not be modified as a side effect of storing it.
  */
-function convertErrorInternals(
-  error: Error,
+function rebuildFabricErrorDeep(
+  shallow: FabricError,
   converted: Map<object, FabricValue>,
   freeze: boolean,
-): Error {
-  // Construct the same `Error` subclass.
-  const result = new (error.constructor as ErrorConstructor)(error.message);
-
-  // Preserve name (covers custom names like "MyError").
-  if (result.name !== error.name) {
-    result.name = error.name;
-  }
-
-  // Preserve stack as-is (string, no conversion needed).
-  if (error.stack !== undefined) {
-    result.stack = error.stack;
-  }
-
+): FabricError {
   // Recursively convert `.cause` -- it could be a raw `Error`, `Map`, etc.
-  if (error.cause !== undefined) {
-    result.cause = fabricFromNativeValueModernInternal(
-      error.cause,
-      converted,
-      freeze,
-    );
+  const cause = shallow.cause !== undefined
+    ? fabricFromNativeValueModernInternal(shallow.cause, converted, freeze)
+    : undefined;
+
+  // Recursively convert custom enumerable properties.
+  const extras: Array<[string, FabricValue]> = [];
+  for (const [key, value] of shallow.extraEntries()) {
+    extras.push([
+      key,
+      fabricFromNativeValueModernInternal(value, converted, freeze),
+    ]);
   }
 
-  // Recursively convert custom enumerable properties, skipping known `Error`
-  // keys (handled above) and prototype-pollution-sensitive keys.
-  const SKIP_KEYS = new Set(["name", "message", "stack", "cause"]);
-  for (const key of Object.keys(error)) {
-    if (SKIP_KEYS.has(key) || UNSAFE_KEYS.has(key)) continue;
-    (result as unknown as Record<string, unknown>)[key] =
-      fabricFromNativeValueModernInternal(
-        (error as unknown as Record<string, unknown>)[key],
-        converted,
-        freeze,
-      );
-  }
-
-  return result;
+  return new FabricError({
+    type: shallow.type,
+    name: shallow.name,
+    message: shallow.message,
+    stack: shallow.stack,
+    cause,
+    extras,
+  });
 }
 
 /**
@@ -625,7 +602,7 @@ export function nativeFromFabricValueModern(
   frozen = true,
 ): unknown {
   if (value instanceof FabricError) {
-    return deepUnwrapError(value.error, frozen);
+    return deepUnwrapFabricError(value, frozen);
   }
 
   if (value instanceof FabricNativeWrapper) {
@@ -666,26 +643,21 @@ export function nativeFromFabricValueModern(
   return result;
 }
 
-function deepUnwrapError(error: Error, frozen: boolean): Error {
-  const copy = new (error.constructor as ErrorConstructor)(error.message);
-  if (copy.name !== error.name) copy.name = error.name;
-  if (error.stack !== undefined) copy.stack = error.stack;
+function deepUnwrapFabricError(fe: FabricError, frozen: boolean): Error {
+  const type = fe.type;
+  const name = fe.name ?? type;
+  const ErrorClass = errorClassFromType(type);
+  const copy = new ErrorClass(fe.message);
+  if (copy.name !== name) copy.name = name;
+  if (fe.stack !== undefined) copy.stack = fe.stack;
 
-  if (error.cause !== undefined) {
-    copy.cause = nativeFromFabricValueModern(
-      error.cause as FabricValue,
-      frozen,
-    );
+  if (fe.cause !== undefined) {
+    copy.cause = nativeFromFabricValueModern(fe.cause, frozen);
   }
 
-  const SKIP = new Set(["name", "message", "stack", "cause"]);
-  for (const key of Object.keys(error)) {
-    if (SKIP.has(key) || UNSAFE_KEYS.has(key)) continue;
+  for (const [key, value] of fe.extraEntries()) {
     (copy as unknown as Record<string, unknown>)[key] =
-      nativeFromFabricValueModern(
-        (error as unknown as Record<string, unknown>)[key] as FabricValue,
-        frozen,
-      );
+      nativeFromFabricValueModern(value, frozen);
   }
 
   if (frozen) Object.freeze(copy);

--- a/packages/data-model/test/clone-for-mutation.test.ts
+++ b/packages/data-model/test/clone-for-mutation.test.ts
@@ -78,7 +78,7 @@ describe("cloneForMutation", () => {
         });
 
         it("handles an empty-path FabricInstance via shallowClone(false)", () => {
-          const err = new FabricError(new Error("test"));
+          const err = FabricError.fromNativeError(new Error("test"));
           Object.freeze(err);
           const { value, pathValue } = cloneForMutation(
             err as unknown as FabricValue,
@@ -88,8 +88,11 @@ describe("cloneForMutation", () => {
           expect(value).toBeInstanceOf(FabricError);
           expect(Object.isFrozen(value)).toBe(false);
           expect(pathValue).toBe(value);
-          // The wrapped Error reference is shared by `shallowUnfrozenClone`.
-          expect((value as unknown as FabricError).error).toBe(err.error);
+          // `shallowUnfrozenClone` preserves the FabricValue-shaped state.
+          const cloned = value as unknown as FabricError;
+          expect(cloned.type).toBe(err.type);
+          expect(cloned.name).toBe(err.name);
+          expect(cloned.message).toBe(err.message);
         });
       });
 
@@ -293,7 +296,7 @@ describe("cloneForMutation", () => {
 
       describe("FabricInstance at leaf", () => {
         it("clones via shallowClone(false), not as a plain object", () => {
-          const err = new FabricError(new Error("boom"));
+          const err = FabricError.fromNativeError(new Error("boom"));
           Object.freeze(err);
           const root = Object.freeze({ payload: err }) as FabricValue;
 
@@ -302,8 +305,10 @@ describe("cloneForMutation", () => {
           expect(pathValue).toBeInstanceOf(FabricError);
           expect(pathValue).not.toBe(err);
           expect(Object.isFrozen(pathValue)).toBe(false);
-          // The wrapped native Error is preserved by identity (shallowClone).
-          expect((pathValue as unknown as FabricError).error).toBe(err.error);
+          // The FabricValue-shaped state is preserved (shallowClone).
+          const cloned = pathValue as unknown as FabricError;
+          expect(cloned.type).toBe(err.type);
+          expect(cloned.message).toBe(err.message);
           // And spliced into the new spine.
           expect((value as unknown as Record<string, unknown>).payload).toBe(
             pathValue,
@@ -642,7 +647,7 @@ describe("cloneForMutation", () => {
         });
 
         it("throws when descending through a FabricInstance", () => {
-          const err = new FabricError(new Error("inside"));
+          const err = FabricError.fromNativeError(new Error("inside"));
           const root = Object.freeze({ err }) as FabricValue;
           // `path = ["err", "something"]` tries to descend INTO the
           // FabricInstance, which isn't supported.
@@ -688,7 +693,7 @@ describe("cloneForMutation", () => {
         it("throws on non-empty path against a FabricInstance root", () => {
           // A FabricInstance is OK at the leaf but not as the root of a
           // non-empty path (we don't descend into FabricInstance internals).
-          const err = new FabricError(new Error("test"));
+          const err = FabricError.fromNativeError(new Error("test"));
           expect(() => cloneForMutation(err as unknown as FabricValue, ["x"]))
             .toThrow("cannot descend into");
         });

--- a/packages/data-model/test/clone-if-necessary.test.ts
+++ b/packages/data-model/test/clone-if-necessary.test.ts
@@ -257,23 +257,34 @@ describe("cloneIfNecessary", () => {
     describe(`FabricInstance (${label} path)`, () => {
       beforeEach(() => setDataModelConfig(modernMode));
 
-      it("deep-clones a frozen `FabricError` (partial)", () => {
-        // Deep cloning of `FabricInstance` is now (partially) supported: the
-        // `FabricError` is rebuilt from its string-valued state, so the
-        // result is a fresh frozen `FabricError` preserving `message`.
-        const error = new FabricError(new Error("test"));
+      it("identity-returns an already-deep-frozen `FabricError`", () => {
+        // A `FabricError` with no `cause` or extras is deep-frozen as soon
+        // as the wrapper is `Object.freeze`'d (the wrapper itself is the
+        // canonical state). `cloneIfNecessary` therefore returns identity.
+        const error = FabricError.fromNativeError(new Error("test"));
+        Object.freeze(error);
+        const result = cloneIfNecessary(error);
+        expect(result).toBe(error);
+        expect((result as FabricError).message).toBe("test");
+      });
+
+      it("deep-clones a `FabricError` with a mutable cause", () => {
+        // Wrapper frozen but `cause` not -> not deep-frozen -> clone.
+        const error = FabricError.fromNativeError(
+          new Error("test", { cause: { mutable: true } }),
+        );
         Object.freeze(error);
         const result = cloneIfNecessary(error);
         expect(result).toBeInstanceOf(FabricError);
-        expect(result).not.toBe(error); // rebuilt (inner Error was not frozen)
+        expect(result).not.toBe(error);
         expect(Object.isFrozen(result)).toBe(true);
-        expect((result as FabricError).error.message).toBe("test");
+        expect((result as FabricError).message).toBe("test");
       });
 
       it("produces a mutable FabricError clone (deep, frozen=false)", () => {
         // Deep clone with `frozen: false` yields a fresh *mutable*
-        // `FabricError` (rebuilt from string state, not frozen).
-        const error = new FabricError(new Error("test"));
+        // `FabricError`.
+        const error = FabricError.fromNativeError(new Error("test"));
         Object.freeze(error);
         const result = cloneIfNecessary(
           error as unknown as FabricValue,
@@ -282,27 +293,28 @@ describe("cloneIfNecessary", () => {
         expect(result).toBeInstanceOf(FabricError);
         expect(result).not.toBe(error);
         expect(Object.isFrozen(result)).toBe(false);
-        expect((result as FabricError).error.message).toBe("test");
+        expect((result as FabricError).message).toBe("test");
       });
 
-      it("deep-clones a FabricError nested in an object (partial)", () => {
-        // Nested `FabricInstance`s are deep-cloned too, not shared: each is
-        // rebuilt from its string state.
-        const error = new FabricError(new Error("nested"));
+      it("preserves a nested already-deep-frozen FabricError by identity", () => {
+        // Container is rebuilt (mutable input -> frozen output) but the
+        // nested deep-frozen FabricError is returned by identity.
+        const error = FabricError.fromNativeError(new Error("nested"));
+        Object.freeze(error);
         const value = { err: error, x: 42 } as FabricValue;
         const result = cloneIfNecessary(value) as Record<string, unknown>;
         expect(result).not.toBe(value);
         expect(Object.isFrozen(result)).toBe(true);
         expect(result.err).toBeInstanceOf(FabricError);
-        expect(result.err).not.toBe(error); // deep-cloned, not shared
-        expect((result.err as FabricError).error.message).toBe("nested");
+        expect(result.err).toBe(error);
+        expect((result.err as FabricError).message).toBe("nested");
         expect(result.x).toBe(42);
       });
 
       it("shallow-clones an object containing a FabricError (deep=false)", () => {
         // Shallow clone of a container shares the nested instance by
         // reference -- it is never traversed or rebuilt.
-        const error = new FabricError(new Error("nested"));
+        const error = FabricError.fromNativeError(new Error("nested"));
         const value = { err: error, x: 42 } as FabricValue;
         const result = cloneIfNecessary(value, { deep: false }) as Record<
           string,
@@ -557,7 +569,7 @@ const subclassCases: readonly SubclassCase[] = [
   // ---------- `FabricInstance` with full protocol coverage ----------
   {
     name: "FabricError",
-    factory: () => new FabricError(new Error("test")),
+    factory: () => FabricError.fromNativeError(new Error("test")),
     deepCloneImplemented: true,
   },
   // ---------- `FabricInstance` with `deepClone` stub ----------

--- a/packages/data-model/test/deep-freeze.test.ts
+++ b/packages/data-model/test/deep-freeze.test.ts
@@ -215,35 +215,41 @@ describe("isDeepFrozen", () => {
     });
 
     it("FabricInstance pre-freeze returns false (wrapper unfrozen)", () => {
-      const fe = new FabricError(new Error("not-yet-frozen"));
+      const fe = FabricError.fromNativeError(new Error("not-yet-frozen"));
       expect(isDeepFrozen(fe)).toBe(false);
     });
 
     it("FabricInstance post-deepFreeze returns true (wrapper + wrapped recursively frozen)", () => {
       const inner = new Error("cause");
       const outer = new Error("outer", { cause: inner });
-      const fe = new FabricError(outer);
+      const fe = FabricError.fromNativeError(outer);
       deepFreeze(fe);
       expect(isDeepFrozen(fe)).toBe(true);
     });
 
-    it("partially-frozen FabricInstance returns false (wrapper frozen but inner Error not)", () => {
-      const fe = new FabricError(new Error("partial"));
+    it("partially-frozen FabricInstance returns false (wrapper frozen but cause not)", () => {
+      // FabricError no longer has a wrapped-native-Error slot; the only
+      // recursing slot is `cause` (and any extras). Construct one whose
+      // `cause` is a mutable plain object, freeze only the wrapper.
+      const err = new Error("partial", { cause: { mutable: true } });
+      const fe = FabricError.fromNativeError(err);
       Object.freeze(fe);
-      // Inner Error not frozen -> recursive walk discovers an unfrozen child.
+      // Cause is not frozen -> recursive walk discovers an unfrozen child.
       expect(isDeepFrozen(fe)).toBe(false);
     });
 
     it("FabricInstance participating in a circular reference terminates and returns true post-deepFreeze", () => {
       // Build a cycle: a plain-object wrapper holds the FabricError, and
-      // the FabricError's `error.cause` points back at the wrapper. After
+      // the FabricError's `cause` points back at the wrapper. After
       // `deepFreeze(wrapper)` (which threads `inProgress` cycle-state
       // through arm 3 and arm 4), every reachable value is frozen and the
-      // graph is cycle-safe for read-side traversal too.
-      const err = new Error("cycle-cause");
-      const fe = new FabricError(err);
-      const wrapper: Record<string, unknown> = { fe };
-      err.cause = wrapper;
+      // graph is cycle-safe for read-side traversal too. (FabricError
+      // snapshots its FabricValue state at construction, so the `cause`
+      // must be wired BEFORE `fromNativeError`.)
+      const wrapper: Record<string, unknown> = {};
+      const err = new Error("cycle-cause", { cause: wrapper });
+      const fe = FabricError.fromNativeError(err);
+      wrapper.fe = fe;
       deepFreeze(wrapper);
       // `isDeepFrozen` must terminate (its own `inProgress`-threading in
       // `isDeepFrozenInProgress` handles the cycle) and report true.
@@ -265,7 +271,7 @@ describe("deepFreeze [DEEP_FREEZE] protocol dispatch", () => {
   it("arm 3: delegates to [DEEP_FREEZE] and freezes in place", () => {
     const inner = new Error("cause");
     const outer = new Error("outer", { cause: inner });
-    const fe = new FabricError(outer);
+    const fe = FabricError.fromNativeError(outer);
     expect(Object.isFrozen(fe)).toBe(false);
 
     const result = deepFreeze(fe);
@@ -274,23 +280,25 @@ describe("deepFreeze [DEEP_FREEZE] protocol dispatch", () => {
     // Error + recursed cause).
     expect(result).toBe(fe);
     expect(Object.isFrozen(fe)).toBe(true);
-    expect(Object.isFrozen(fe.error)).toBe(true);
+    // (FabricError no longer has a wrapped Error slot to check directly;
+    // the native projection is lazy, and any built projection is frozen.)
     expect(Object.isFrozen(inner)).toBe(true);
   });
 
   it("arm 3: recurses [DEEP_FREEZE] into nested FabricValues", () => {
-    const fe = new FabricError(new Error("e"));
+    const fe = FabricError.fromNativeError(new Error("e"));
     const container = { wrapped: fe as unknown as FabricValue, n: 1 };
     deepFreeze(container);
     expect(Object.isFrozen(container)).toBe(true);
     expect(Object.isFrozen(fe)).toBe(true);
-    expect(Object.isFrozen(fe.error)).toBe(true);
+    // (FabricError no longer has a wrapped Error slot to check directly;
+    // the native projection is lazy, and any built projection is frozen.)
   });
 });
 
 describe("isDeepFrozenFabricValue with FabricInstance (R6)", () => {
   it("no longer throws on a FabricInstance; classifies via protocol", () => {
-    const fe = new FabricError(new Error("test"));
+    const fe = FabricError.fromNativeError(new Error("test"));
     // Pre-freeze: not deep-frozen, but must NOT throw (the #3604
     // `FabricInstance`-arm throw is retired).
     expect(() => isDeepFrozenFabricValue(fe)).not.toThrow();
@@ -298,20 +306,21 @@ describe("isDeepFrozenFabricValue with FabricInstance (R6)", () => {
   });
 
   it("returns true for a deep-frozen FabricInstance", () => {
-    const fe = new FabricError(new Error("test"));
+    const fe = FabricError.fromNativeError(new Error("test"));
     deepFreeze(fe);
     expect(isDeepFrozenFabricValue(fe)).toBe(true);
   });
 
   it("returns true for a deep-frozen FabricInstance nested in a tree", () => {
-    const fe = new FabricError(new Error("nested"));
+    const fe = FabricError.fromNativeError(new Error("nested"));
     const tree = deepFreeze({ a: 1, e: fe as unknown as FabricValue });
     expect(isDeepFrozenFabricValue(tree)).toBe(true);
   });
 
   it("returns false (no throw) for a non-canonical-form instance", () => {
-    // Wrapper frozen but inner Error left unfrozen -> not deep-frozen.
-    const fe = new FabricError(new Error("partial"));
+    // Wrapper frozen but `cause` left unfrozen -> not deep-frozen.
+    const err = new Error("partial", { cause: { mutable: true } });
+    const fe = FabricError.fromNativeError(err);
     Object.freeze(fe);
     expect(() => isDeepFrozenFabricValue(fe)).not.toThrow();
     expect(isDeepFrozenFabricValue(fe)).toBe(false);

--- a/packages/data-model/test/fabric-native-instances.test.ts
+++ b/packages/data-model/test/fabric-native-instances.test.ts
@@ -69,6 +69,30 @@ describe("fabric-native-instances", () => {
       expect(se.message).toBe("bad");
     });
 
+    it("fixed-schema slots are mutable while unfrozen", () => {
+      const se = FabricError.fromNativeError(new Error("orig"));
+      se.message = "changed";
+      se.name = "Renamed";
+      se.cause = { detail: 1 } as FabricValue;
+      expect(se.message).toBe("changed");
+      expect(se.name).toBe("Renamed");
+      expect(se.cause).toEqual({ detail: 1 });
+      // The native projection reflects the mutated state (no stale cache).
+      expect(se.toNativeValue(true).message).toBe("changed");
+    });
+
+    it("fixed-schema slots throw on assignment once frozen", () => {
+      const se = FabricError.fromNativeError(new Error("orig"));
+      Object.freeze(se);
+      expect(() => {
+        se.message = "nope";
+      }).toThrow();
+      expect(() => {
+        (se as { name: string }).name = "nope";
+      }).toThrow();
+      expect(se.message).toBe("orig");
+    });
+
     it("is instanceof FabricNativeWrapper", () => {
       const se = FabricError.fromNativeError(new Error("test"));
       expect(se instanceof FabricNativeWrapper).toBe(true);
@@ -265,8 +289,12 @@ describe("fabric-native-instances", () => {
       expect(Object.isFrozen(err)).toBe(false);
     });
 
-    it("toNativeValue(true) returns the same projection on repeat calls", () => {
+    it("toNativeValue(true) caches the projection once frozen", () => {
       const se = FabricError.fromNativeError(new Error("native"));
+      // While mutable, repeated calls rebuild (no stale cache risk).
+      expect(se.toNativeValue(true)).not.toBe(se.toNativeValue(true));
+      // Once frozen, the projection is cached and returned by identity.
+      Object.freeze(se);
       const a = se.toNativeValue(true);
       const b = se.toNativeValue(true);
       expect(a).toBe(b);

--- a/packages/data-model/test/fabric-native-instances.test.ts
+++ b/packages/data-model/test/fabric-native-instances.test.ts
@@ -52,28 +52,30 @@ describe("fabric-native-instances", () => {
 
   describe("FabricError", () => {
     it("implements FabricInstance (instanceof returns true)", () => {
-      const se = new FabricError(new Error("test"));
+      const se = FabricError.fromNativeError(new Error("test"));
       expect(se instanceof FabricInstance).toBe(true);
     });
 
     it("has typeTag 'Error@1'", () => {
-      const se = new FabricError(new Error("test"));
+      const se = FabricError.fromNativeError(new Error("test"));
       expect(se.typeTag).toBe("Error@1");
     });
 
-    it("wraps the original Error", () => {
+    it("wraps the Error's FabricValue-shaped state", () => {
       const err = new TypeError("bad");
-      const se = new FabricError(err);
-      expect(se.error).toBe(err);
+      const se = FabricError.fromNativeError(err);
+      expect(se.type).toBe("TypeError");
+      expect(se.name).toBe("TypeError");
+      expect(se.message).toBe("bad");
     });
 
     it("is instanceof FabricNativeWrapper", () => {
-      const se = new FabricError(new Error("test"));
+      const se = FabricError.fromNativeError(new Error("test"));
       expect(se instanceof FabricNativeWrapper).toBe(true);
     });
 
     it("[DECONSTRUCT] returns type, name=null (common case), message, stack", () => {
-      const se = new FabricError(new Error("hello"));
+      const se = FabricError.fromNativeError(new Error("hello"));
       const state = se[DECONSTRUCT]() as Record<string, FabricValue>;
       expect(state.type).toBe("Error");
       expect(state.name).toBe(null);
@@ -82,7 +84,7 @@ describe("fabric-native-instances", () => {
     });
 
     it("[DECONSTRUCT] name is null when type === name (TypeError)", () => {
-      const se = new FabricError(new TypeError("bad"));
+      const se = FabricError.fromNativeError(new TypeError("bad"));
       const state = se[DECONSTRUCT]() as Record<string, FabricValue>;
       expect(state.type).toBe("TypeError");
       expect(state.name).toBe(null);
@@ -91,15 +93,15 @@ describe("fabric-native-instances", () => {
     it("[DECONSTRUCT] name is non-null when type !== name", () => {
       const err = new TypeError("bad");
       err.name = "CustomName";
-      const se = new FabricError(err);
+      const se = FabricError.fromNativeError(err);
       const state = se[DECONSTRUCT]() as Record<string, FabricValue>;
       expect(state.type).toBe("TypeError");
       expect(state.name).toBe("CustomName");
     });
 
     it("[DECONSTRUCT] includes cause when present", () => {
-      const inner = new FabricError(new Error("inner"));
-      const outer = new FabricError(
+      const inner = FabricError.fromNativeError(new Error("inner"));
+      const outer = FabricError.fromNativeError(
         new Error("outer", { cause: inner }),
       );
       const state = outer[DECONSTRUCT]() as Record<string, FabricValue>;
@@ -110,7 +112,7 @@ describe("fabric-native-instances", () => {
       const err = new Error("oops");
       (err as unknown as Record<string, unknown>).code = 42;
       (err as unknown as Record<string, unknown>).detail = "more info";
-      const se = new FabricError(err);
+      const se = FabricError.fromNativeError(err);
       const state = se[DECONSTRUCT]() as Record<string, FabricValue>;
       expect(state.code).toBe(42);
       expect(state.detail).toBe("more info");
@@ -122,7 +124,7 @@ describe("fabric-native-instances", () => {
         value: "bad",
         enumerable: true,
       });
-      const se = new FabricError(err);
+      const se = FabricError.fromNativeError(err);
       const state = se[DECONSTRUCT]() as Record<string, FabricValue>;
       expect("__proto__" in state).toBe(false);
     });
@@ -135,7 +137,7 @@ describe("fabric-native-instances", () => {
         enumerable: true,
       });
       (err as unknown as Record<string, unknown>).name = "Error";
-      const se = new FabricError(err);
+      const se = FabricError.fromNativeError(err);
       const state = se[DECONSTRUCT]() as Record<string, FabricValue>;
       expect(state.message).toBe("original");
     });
@@ -143,7 +145,7 @@ describe("fabric-native-instances", () => {
     it("[DECONSTRUCT] omits stack when undefined", () => {
       const err = new Error("no stack");
       err.stack = undefined;
-      const se = new FabricError(err);
+      const se = FabricError.fromNativeError(err);
       const state = se[DECONSTRUCT]() as Record<string, FabricValue>;
       expect("stack" in state).toBe(false);
     });
@@ -156,9 +158,9 @@ describe("fabric-native-instances", () => {
       } as FabricValue;
       const result = FabricError[RECONSTRUCT](state, dummyContext);
       expect(result).toBeInstanceOf(FabricError);
-      expect(result.error).toBeInstanceOf(Error);
-      expect(result.error.name).toBe("Error");
-      expect(result.error.message).toBe("hello");
+      expect(result.toNativeValue(true)).toBeInstanceOf(Error);
+      expect(result.name).toBe("Error");
+      expect(result.message).toBe("hello");
     });
 
     it("[RECONSTRUCT] creates correct Error subclass from type (null name)", () => {
@@ -173,8 +175,8 @@ describe("fabric-native-instances", () => {
       for (const [type, cls] of cases) {
         const state = { type, name: null, message: "test" } as FabricValue;
         const result = FabricError[RECONSTRUCT](state, dummyContext);
-        expect(result.error).toBeInstanceOf(cls);
-        expect(result.error.name).toBe(type);
+        expect(result.toNativeValue(true)).toBeInstanceOf(cls);
+        expect(result.name).toBe(type);
       }
     });
 
@@ -185,8 +187,8 @@ describe("fabric-native-instances", () => {
         message: "mismatch",
       } as FabricValue;
       const result = FabricError[RECONSTRUCT](state, dummyContext);
-      expect(result.error).toBeInstanceOf(TypeError);
-      expect(result.error.name).toBe("CustomTypeName");
+      expect(result.toNativeValue(true)).toBeInstanceOf(TypeError);
+      expect(result.name).toBe("CustomTypeName");
     });
 
     it("[RECONSTRUCT] falls back to name when type is absent (back-compat)", () => {
@@ -195,7 +197,7 @@ describe("fabric-native-instances", () => {
         message: "old format",
       } as FabricValue;
       const result = FabricError[RECONSTRUCT](state, dummyContext);
-      expect(result.error).toBeInstanceOf(TypeError);
+      expect(result.toNativeValue(true)).toBeInstanceOf(TypeError);
     });
 
     it("[RECONSTRUCT] handles custom name", () => {
@@ -205,7 +207,7 @@ describe("fabric-native-instances", () => {
         message: "custom",
       } as FabricValue;
       const result = FabricError[RECONSTRUCT](state, dummyContext);
-      expect(result.error.name).toBe("MyCustomError");
+      expect(result.name).toBe("MyCustomError");
     });
 
     it("[RECONSTRUCT] restores cause and custom properties", () => {
@@ -217,32 +219,28 @@ describe("fabric-native-instances", () => {
         code: 404,
       } as FabricValue;
       const result = FabricError[RECONSTRUCT](state, dummyContext);
-      expect(result.error.cause).toBe("something went wrong");
-      expect(
-        (result.error as unknown as Record<string, unknown>).code,
-      ).toBe(404);
+      expect(result.cause).toBe("something went wrong");
+      expect(result.getExtra("code")).toBe(404);
     });
 
     it("round-trips through DECONSTRUCT/RECONSTRUCT", () => {
       const original = new Error("round trip");
       original.name = "CustomError";
       (original as unknown as Record<string, unknown>).code = 42;
-      const se = new FabricError(original);
+      const se = FabricError.fromNativeError(original);
 
       const state = se[DECONSTRUCT]();
       const restored = FabricError[RECONSTRUCT](state, dummyContext);
 
-      expect(restored.error.name).toBe("CustomError");
-      expect(restored.error.message).toBe("round trip");
-      expect(
-        (restored.error as unknown as Record<string, unknown>).code,
-      ).toBe(42);
+      expect(restored.name).toBe("CustomError");
+      expect(restored.message).toBe("round trip");
+      expect(restored.getExtra("code")).toBe(42);
     });
 
     it("round-trips TypeError with overridden name", () => {
       const original = new TypeError("bad value");
       original.name = "SpecialType";
-      const se = new FabricError(original);
+      const se = FabricError.fromNativeError(original);
 
       const state = se[DECONSTRUCT]() as Record<string, FabricValue>;
       expect(state.type).toBe("TypeError");
@@ -252,48 +250,43 @@ describe("fabric-native-instances", () => {
         state as FabricValue,
         dummyContext,
       );
-      expect(restored.error).toBeInstanceOf(TypeError);
-      expect(restored.error.name).toBe("SpecialType");
+      expect(restored.toNativeValue(true)).toBeInstanceOf(TypeError);
+      expect(restored.name).toBe("SpecialType");
     });
 
-    it("toNativeValue(true) returns frozen error (copy of unfrozen)", () => {
+    it("toNativeValue(true) returns a frozen Error projection", () => {
       const err = new Error("native");
-      const se = new FabricError(err);
+      const se = FabricError.fromNativeError(err);
       const result = se.toNativeValue(true);
-      // Creates a frozen copy since the input is unfrozen.
       expect(result).toBeInstanceOf(Error);
       expect(result.message).toBe("native");
       expect(Object.isFrozen(result)).toBe(true);
-      // Original should NOT be mutated.
+      // The originating native Error is not stored / not mutated.
       expect(Object.isFrozen(err)).toBe(false);
     });
 
-    it("toNativeValue(true) returns same error if already frozen", () => {
-      const err = new Error("native");
-      Object.freeze(err);
-      const se = new FabricError(err);
-      const result = se.toNativeValue(true);
-      expect(result).toBe(err); // same reference
-      expect(Object.isFrozen(result)).toBe(true);
+    it("toNativeValue(true) returns the same projection on repeat calls", () => {
+      const se = FabricError.fromNativeError(new Error("native"));
+      const a = se.toNativeValue(true);
+      const b = se.toNativeValue(true);
+      expect(a).toBe(b);
+      expect(Object.isFrozen(a)).toBe(true);
     });
 
-    it("toNativeValue(false) returns unfrozen error", () => {
-      const err = new Error("native");
-      const se = new FabricError(err);
+    it("toNativeValue(false) returns a fresh unfrozen Error projection", () => {
+      const se = FabricError.fromNativeError(new Error("native"));
       const result = se.toNativeValue(false);
-      expect(result).toBe(err); // same reference (already unfrozen)
-      expect(Object.isFrozen(result)).toBe(false);
-    });
-
-    it("toNativeValue(false) returns unfrozen copy of frozen error", () => {
-      const err = new Error("native");
-      Object.freeze(err);
-      const se = new FabricError(err);
-      const result = se.toNativeValue(false);
-      // Creates an unfrozen copy since the input is frozen.
       expect(result).toBeInstanceOf(Error);
       expect(result.message).toBe("native");
       expect(Object.isFrozen(result)).toBe(false);
+    });
+
+    it("toNativeValue(false) returns a fresh copy each call", () => {
+      const se = FabricError.fromNativeError(new Error("native"));
+      const a = se.toNativeValue(false);
+      const b = se.toNativeValue(false);
+      expect(a).not.toBe(b);
+      expect(a.message).toBe(b.message);
     });
   });
 
@@ -410,7 +403,7 @@ describe("fabric-native-instances", () => {
 
   describe("nativeFromFabricValueModern", () => {
     it("unwraps FabricError in nested object", () => {
-      const se = new FabricError(new Error("deep"));
+      const se = FabricError.fromNativeError(new Error("deep"));
       const obj = { error: se } as FabricValue;
       const result = nativeFromFabricValueModern(obj) as Record<
         string,
@@ -449,7 +442,7 @@ describe("fabric-native-instances", () => {
     });
 
     it("recursively unwraps nested structures", () => {
-      const se = new FabricError(new Error("nested"));
+      const se = FabricError.fromNativeError(new Error("nested"));
       const obj = {
         outer: {
           inner: se,
@@ -464,7 +457,7 @@ describe("fabric-native-instances", () => {
 
     it("deeply unwraps FabricError in objects (frozen)", () => {
       const err = new Error("deep");
-      const se = new FabricError(err);
+      const se = FabricError.fromNativeError(err);
       const obj = {
         error: se,
         code: 500,
@@ -482,7 +475,7 @@ describe("fabric-native-instances", () => {
 
     it("deeply unwraps FabricError in arrays (frozen)", () => {
       const err = new Error("array");
-      const se = new FabricError(err);
+      const se = FabricError.fromNativeError(err);
       const arr = [1, se, 3] as unknown as FabricValue;
       const result = nativeFromFabricValueModern(arr) as unknown[];
       expect(result[0]).toBe(1);
@@ -567,13 +560,13 @@ describe("fabric-native-instances", () => {
     it("deeply unwraps Error internals (C2)", () => {
       // Error with a FabricError cause and a custom FabricMap property.
       const innerErr = new Error("inner");
-      const innerSe = new FabricError(innerErr);
+      const innerSe = FabricError.fromNativeError(innerErr);
       const outerErr = new Error("outer");
       outerErr.cause = innerSe;
       (outerErr as unknown as Record<string, unknown>).data = new FabricMap(
         new Map([["k", 1]] as [FabricValue, FabricValue][]),
       );
-      const outerSe = new FabricError(outerErr);
+      const outerSe = FabricError.fromNativeError(outerErr);
 
       const result = nativeFromFabricValueModern(
         outerSe as FabricValue,
@@ -590,10 +583,10 @@ describe("fabric-native-instances", () => {
 
     it("deeply unwraps Error internals unfrozen (C2)", () => {
       const innerErr = new Error("inner");
-      const innerSe = new FabricError(innerErr);
+      const innerSe = FabricError.fromNativeError(innerErr);
       const outerErr = new Error("outer");
       outerErr.cause = innerSe;
-      const outerSe = new FabricError(outerErr);
+      const outerSe = FabricError.fromNativeError(outerErr);
 
       const result = nativeFromFabricValueModern(
         outerSe as FabricValue,
@@ -869,7 +862,7 @@ describe("fabric-native-instances", () => {
     });
 
     it("returns true for FabricError", () => {
-      const se = new FabricError(new Error("test"));
+      const se = FabricError.fromNativeError(new Error("test"));
       expect(se instanceof FabricInstance).toBe(true);
     });
   });
@@ -968,34 +961,34 @@ describe("fabric-native-instances", () => {
 
   describe("[DEEP_FREEZE] / [IS_DEEP_FROZEN] protocol — via dispatch", () => {
     describe("FabricError", () => {
-      it("[DEEP_FREEZE] freezes wrapper + Error + recurses cause", () => {
-        const inner = new Error("cause");
-        const fe = new FabricError(new Error("outer", { cause: inner }));
+      it("[DEEP_FREEZE] freezes wrapper + recurses cause", () => {
+        const inner = FabricError.fromNativeError(new Error("cause"));
+        const fe = FabricError.fromNativeError(
+          new Error("outer", { cause: inner }),
+        );
         const result = deepFreeze(fe);
         expect(result).toBe(fe); // freeze-in-place identity
         expect(Object.isFrozen(fe)).toBe(true);
-        expect(Object.isFrozen(fe.error)).toBe(true);
-        expect(Object.isFrozen(inner)).toBe(true);
+        expect(isDeepFrozen(inner)).toBe(true);
       });
 
-      it("[DEEP_FREEZE] recurses enumerable custom props, no string-narrow", () => {
+      it("[DEEP_FREEZE] recurses enumerable custom props (preserved via extras)", () => {
         const err = new Error("e");
         const childObj = { nested: 1 };
         (err as unknown as Record<string, unknown>).custom = childObj;
-        const fe = new FabricError(err);
+        const fe = FabricError.fromNativeError(err);
         deepFreeze(fe);
-        // Non-string custom state is preserved AND deep-frozen (it must not
-        // be dropped -- that narrowing is a deepClone stop-gap, not this).
-        expect((fe.error as unknown as Record<string, unknown>).custom)
-          .toBe(childObj);
+        // Non-string custom state is preserved AND deep-frozen.
+        expect(fe.getExtra("custom")).toBe(childObj);
         expect(Object.isFrozen(childObj)).toBe(true);
       });
 
-      it("[IS_DEEP_FROZEN] true only when wrapper + Error frozen", () => {
-        const fe = new FabricError(new Error("test"));
+      it("[IS_DEEP_FROZEN] true only when wrapper + cause are frozen", () => {
+        const fe = FabricError.fromNativeError(new Error("test"));
         expect(isDeepFrozenFabricValue(fe)).toBe(false);
-        Object.freeze(fe); // wrapper only; inner Error still mutable
-        expect(isDeepFrozenFabricValue(fe)).toBe(false);
+        Object.freeze(fe); // wrapper only; some descendants still mutable
+        // (May be true since this particular FabricError has no nested
+        // FabricValue descendants beyond primitive strings.)
         deepFreeze(fe);
         expect(isDeepFrozenFabricValue(fe)).toBe(true);
       });
@@ -1098,33 +1091,30 @@ describe("fabric-native-instances", () => {
       const subIsDeepFrozen = (v: FabricValue): boolean => isDeepFrozen(v);
 
       describe("FabricError", () => {
-        it("[DEEP_FREEZE] freezes wrapper + Error + recurses cause", () => {
-          const inner = new Error("cause");
-          const fe = new FabricError(new Error("outer", { cause: inner }));
+        it("[DEEP_FREEZE] freezes wrapper + recurses cause", () => {
+          const inner = FabricError.fromNativeError(new Error("cause"));
+          const fe = FabricError.fromNativeError(
+            new Error("outer", { cause: inner }),
+          );
           const result = fe[DEEP_FREEZE](subFreeze);
           expect(result).toBe(fe); // freeze-in-place identity
           expect(Object.isFrozen(fe)).toBe(true);
-          expect(Object.isFrozen(fe.error)).toBe(true);
-          expect(Object.isFrozen(inner)).toBe(true);
+          expect(isDeepFrozen(inner)).toBe(true);
         });
 
-        it("[DEEP_FREEZE] recurses enumerable custom props, no string-narrow", () => {
+        it("[DEEP_FREEZE] recurses enumerable custom props (preserved via extras)", () => {
           const err = new Error("e");
           const childObj = { nested: 1 };
           (err as unknown as Record<string, unknown>).custom = childObj;
-          const fe = new FabricError(err);
+          const fe = FabricError.fromNativeError(err);
           fe[DEEP_FREEZE](subFreeze);
-          // Non-string custom state is preserved AND deep-frozen (it must not
-          // be dropped -- that narrowing is a deepClone stop-gap, not this).
-          expect((fe.error as unknown as Record<string, unknown>).custom)
-            .toBe(childObj);
+          // Non-string custom state is preserved AND deep-frozen.
+          expect(fe.getExtra("custom")).toBe(childObj);
           expect(Object.isFrozen(childObj)).toBe(true);
         });
 
-        it("[IS_DEEP_FROZEN] true only when wrapper + Error frozen", () => {
-          const fe = new FabricError(new Error("test"));
-          expect(fe[IS_DEEP_FROZEN](subIsDeepFrozen)).toBe(false);
-          Object.freeze(fe); // wrapper only; inner Error still mutable
+        it("[IS_DEEP_FROZEN] true only when wrapper is frozen", () => {
+          const fe = FabricError.fromNativeError(new Error("test"));
           expect(fe[IS_DEEP_FROZEN](subIsDeepFrozen)).toBe(false);
           fe[DEEP_FREEZE](subFreeze);
           expect(fe[IS_DEEP_FROZEN](subIsDeepFrozen)).toBe(true);
@@ -1302,7 +1292,7 @@ describe("fabric-native-instances", () => {
       // (Arm 3), which subFreezes `error.cause` = wrapper, which re-enters
       // `deepFreeze()` -> the FabricError again -> ...
       const err = new Error("cycle-cause");
-      const fe = new FabricError(err);
+      const fe = FabricError.fromNativeError(err);
       const wrapper: Record<string, unknown> = { fe };
       err.cause = wrapper;
       expect(() => deepFreeze(wrapper)).not.toThrow();
@@ -1331,16 +1321,18 @@ describe("fabric-native-instances", () => {
     it("cross-instance cycle (FabricError <-> ProblematicValue) terminates", () => {
       // Two `FabricInstance` subclasses pointing into each other via their
       // recursing slots. Both must terminate, both must end deep-frozen.
+      // FabricError snapshots its FabricValue state at construction, so wire
+      // up the native Error's `cause` BEFORE `fromNativeError`.
       const peShared: Record<string, unknown> = { tag: "shared" };
       const pv = new ProblematicValue(
         "Cycle@1",
         peShared as FabricValue,
         "loop",
       );
-      const err = new Error("cross-cycle");
-      const fe = new FabricError(err);
-      peShared.fe = fe;
+      const err = new Error("cross-cycle") as Error & { cause: unknown };
       err.cause = pv;
+      const fe = FabricError.fromNativeError(err);
+      peShared.fe = fe;
       expect(() => deepFreeze(fe)).not.toThrow();
       expect(Object.isFrozen(fe)).toBe(true);
       expect(Object.isFrozen(pv)).toBe(true);

--- a/packages/data-model/test/fabric-value.test.ts
+++ b/packages/data-model/test/fabric-value.test.ts
@@ -1271,12 +1271,12 @@ describe("fabric-value", () => {
       // Top level should be a FabricError.
       expect(result).toBeInstanceOf(FabricError);
       const se = result as FabricError;
-      expect(se.error.message).toBe("outer");
+      expect(se.message).toBe("outer");
 
       // cause should also be a FabricError (not a raw Error).
-      expect(se.error.cause).toBeInstanceOf(FabricError);
-      const innerSe = se.error.cause as FabricError;
-      expect(innerSe.error.message).toBe("inner");
+      expect(se.cause).toBeInstanceOf(FabricError);
+      const innerSe = se.cause as FabricError;
+      expect(innerSe.message).toBe("inner");
     });
 
     it("converts deeply nested Error chain (3 levels)", () => {
@@ -1285,13 +1285,13 @@ describe("fabric-value", () => {
       const top = new Error("top", { cause: mid });
       const result = fabricFromNativeValue(top) as FabricError;
 
-      expect(result.error.message).toBe("top");
-      const midSe = result.error.cause as FabricError;
+      expect(result.message).toBe("top");
+      const midSe = result.cause as FabricError;
       expect(midSe).toBeInstanceOf(FabricError);
-      expect(midSe.error.message).toBe("mid");
-      const rootSe = midSe.error.cause as FabricError;
+      expect(midSe.message).toBe("mid");
+      const rootSe = midSe.cause as FabricError;
       expect(rootSe).toBeInstanceOf(FabricError);
-      expect(rootSe.error.message).toBe("root");
+      expect(rootSe.message).toBe("root");
     });
 
     it("converts custom enumerable properties on Error", () => {
@@ -1303,11 +1303,10 @@ describe("fabric-value", () => {
       error.details = { nested: "value" };
 
       const result = fabricFromNativeValue(error) as FabricError;
-      expect(result.error.message).toBe("with props");
+      expect(result.message).toBe("with props");
       // Custom properties should be preserved and converted.
-      const converted = result.error as unknown as Record<string, unknown>;
-      expect(converted.statusCode).toBe(404);
-      expect(converted.details).toEqual({ nested: "value" });
+      expect(result.getExtra("statusCode")).toBe(404);
+      expect(result.getExtra("details")).toEqual({ nested: "value" });
     });
 
     it("converts Error with non-Error cause (plain object)", () => {
@@ -1316,8 +1315,8 @@ describe("fabric-value", () => {
       const result = fabricFromNativeValue(error) as FabricError;
 
       // cause should be a plain object (already valid FabricValue).
-      expect(result.error.cause).toEqual({ code: "ENOENT", path: "/missing" });
-      expect(Object.isFrozen(result.error.cause)).toBe(true);
+      expect(result.cause).toEqual({ code: "ENOENT", path: "/missing" });
+      expect(Object.isFrozen(result.cause)).toBe(true);
     });
 
     it("preserves Error subclass through internals conversion", () => {
@@ -1325,11 +1324,11 @@ describe("fabric-value", () => {
       const outer = new TypeError("bad type", { cause: inner });
       const result = fabricFromNativeValue(outer) as FabricError;
 
-      expect(result.error).toBeInstanceOf(TypeError);
-      expect(result.error.name).toBe("TypeError");
-      const innerSe = result.error.cause as FabricError;
-      expect(innerSe.error).toBeInstanceOf(RangeError);
-      expect(innerSe.error.name).toBe("RangeError");
+      expect(result.toNativeValue(true)).toBeInstanceOf(TypeError);
+      expect(result.name).toBe("TypeError");
+      const innerSe = result.cause as FabricError;
+      expect(innerSe.toNativeValue(true)).toBeInstanceOf(RangeError);
+      expect(innerSe.name).toBe("RangeError");
     });
 
     it("does not mutate the original Error's cause", () => {
@@ -1345,7 +1344,7 @@ describe("fabric-value", () => {
     it("handles Error with undefined cause (no conversion needed)", () => {
       const error = new Error("simple");
       const result = fabricFromNativeValue(error) as FabricError;
-      expect(result.error.cause).toBeUndefined();
+      expect(result.cause).toBeUndefined();
     });
 
     it("freezes the FabricError wrapper when freeze=true", () => {
@@ -1361,7 +1360,7 @@ describe("fabric-value", () => {
       // But internals should still be converted.
       expect(result).toBeInstanceOf(FabricError);
       const se = result as FabricError;
-      expect(se.error.cause).toBeInstanceOf(FabricError);
+      expect(se.cause).toBeInstanceOf(FabricError);
     });
   });
 
@@ -1599,7 +1598,8 @@ describe("fabric-value", () => {
 
     // -- FabricInstance values --
     it("accepts FabricError wrappers", () => {
-      expect(isFabricCompatible(new FabricError(new Error("test")))).toBe(true);
+      expect(isFabricCompatible(FabricError.fromNativeError(new Error("test"))))
+        .toBe(true);
     });
 
     // -- Containers --

--- a/packages/data-model/test/json-encoding-context.test.ts
+++ b/packages/data-model/test/json-encoding-context.test.ts
@@ -119,7 +119,7 @@ describe("JsonEncodingContext", () => {
 
     it("round-trips FabricError through Uint8Array", () => {
       const { context, runtime } = makeTestContext();
-      const err = new FabricError(new TypeError("oops"));
+      const err = FabricError.fromNativeError(new TypeError("oops"));
       const bytes = context.encodeToBytes(err as FabricValue);
       const result = context.decodeFromBytes(
         bytes,
@@ -127,8 +127,8 @@ describe("JsonEncodingContext", () => {
       );
       expect(result).toBeInstanceOf(FabricError);
       const se = result as unknown as FabricError;
-      expect(se.error).toBeInstanceOf(TypeError);
-      expect(se.error.message).toBe("oops");
+      expect(se.toNativeValue(true)).toBeInstanceOf(TypeError);
+      expect(se.message).toBe("oops");
     });
 
     it("round-trips undefined through Uint8Array", () => {
@@ -142,7 +142,7 @@ describe("JsonEncodingContext", () => {
       const { context, runtime } = makeTestContext();
       const value = {
         users: [{ name: "Alice" }, { name: "Bob" }],
-        error: new FabricError(new Error("fail")),
+        error: FabricError.fromNativeError(new Error("fail")),
         nothing: undefined,
       } as unknown as FabricValue;
       const bytes = context.encodeToBytes(value);
@@ -782,7 +782,7 @@ describe("JsonEncodingContext", () => {
 
   describe("FabricError", () => {
     it("serializes basic FabricError to /Error@1", () => {
-      const se = new FabricError(new Error("test"));
+      const se = FabricError.fromNativeError(new Error("test"));
       const result = toWireFormat(
         se as FabricValue,
       ) as Record<string, unknown>;
@@ -794,51 +794,51 @@ describe("JsonEncodingContext", () => {
     });
 
     it("round-trips basic Error via FabricError", () => {
-      const se = new FabricError(new Error("hello"));
+      const se = FabricError.fromNativeError(new Error("hello"));
       const result = roundTrip(
         se as FabricValue,
       ) as unknown as FabricError;
       expect(result).toBeInstanceOf(FabricError);
-      expect(result.error).toBeInstanceOf(Error);
-      expect(result.error.name).toBe("Error");
-      expect(result.error.message).toBe("hello");
+      expect(result.toNativeValue(true)).toBeInstanceOf(Error);
+      expect(result.name).toBe("Error");
+      expect(result.message).toBe("hello");
     });
 
     it("round-trips TypeError", () => {
-      const se = new FabricError(new TypeError("bad type"));
+      const se = FabricError.fromNativeError(new TypeError("bad type"));
       const result = roundTrip(
         se as FabricValue,
       ) as unknown as FabricError;
       expect(result).toBeInstanceOf(FabricError);
-      expect(result.error).toBeInstanceOf(TypeError);
-      expect(result.error.name).toBe("TypeError");
-      expect(result.error.message).toBe("bad type");
+      expect(result.toNativeValue(true)).toBeInstanceOf(TypeError);
+      expect(result.name).toBe("TypeError");
+      expect(result.message).toBe("bad type");
     });
 
     it("round-trips RangeError", () => {
-      const se = new FabricError(new RangeError("out of range"));
+      const se = FabricError.fromNativeError(new RangeError("out of range"));
       const result = roundTrip(
         se as FabricValue,
       ) as unknown as FabricError;
       expect(result).toBeInstanceOf(FabricError);
-      expect(result.error).toBeInstanceOf(RangeError);
-      expect(result.error.name).toBe("RangeError");
+      expect(result.toNativeValue(true)).toBeInstanceOf(RangeError);
+      expect(result.name).toBe("RangeError");
     });
 
     it("round-trips Error with cause", () => {
-      const inner = new FabricError(new Error("inner"));
-      const outer = new FabricError(
+      const inner = FabricError.fromNativeError(new Error("inner"));
+      const outer = FabricError.fromNativeError(
         new Error("outer", { cause: inner }),
       );
       const result = roundTrip(
         outer as FabricValue,
       ) as unknown as FabricError;
-      expect(result.error.message).toBe("outer");
+      expect(result.message).toBe("outer");
       // The cause was serialized as a FabricError (the inner wrapper).
       // After round-trip, the cause is a FabricError.
-      expect(result.error.cause).toBeInstanceOf(FabricError);
+      expect(result.cause).toBeInstanceOf(FabricError);
       expect(
-        (result.error.cause as FabricError).error.message,
+        (result.cause as FabricError).message,
       ).toBe("inner");
     });
 
@@ -846,33 +846,34 @@ describe("JsonEncodingContext", () => {
       const err = new Error("oops");
       (err as unknown as Record<string, unknown>).code = 42;
       (err as unknown as Record<string, unknown>).detail = "more info";
-      const se = new FabricError(err);
+      const se = FabricError.fromNativeError(err);
       const result = roundTrip(
         se as FabricValue,
       ) as unknown as FabricError;
-      expect(result.error.message).toBe("oops");
+      expect(result.message).toBe("oops");
       expect(
-        (result.error as unknown as Record<string, unknown>).code,
+        (result.toNativeValue(true) as unknown as Record<string, unknown>).code,
       ).toBe(42);
       expect(
-        (result.error as unknown as Record<string, unknown>).detail,
+        (result.toNativeValue(true) as unknown as Record<string, unknown>)
+          .detail,
       ).toBe("more info");
     });
 
     it("round-trips Error with custom name", () => {
       const err = new Error("custom");
       err.name = "MyCustomError";
-      const se = new FabricError(err);
+      const se = FabricError.fromNativeError(err);
       const result = roundTrip(
         se as FabricValue,
       ) as unknown as FabricError;
-      expect(result.error.name).toBe("MyCustomError");
-      expect(result.error.message).toBe("custom");
+      expect(result.name).toBe("MyCustomError");
+      expect(result.message).toBe("custom");
     });
 
     it("wire format has name: null when name matches type (TypeError)", () => {
       // TypeError: name === constructor.name === "TypeError"
-      const se = new FabricError(new TypeError("type check"));
+      const se = FabricError.fromNativeError(new TypeError("type check"));
       const result = toWireFormat(
         se as FabricValue,
       ) as Record<string, unknown>;
@@ -885,7 +886,7 @@ describe("JsonEncodingContext", () => {
     it("wire format has explicit name when name differs from type", () => {
       const err = new Error("custom");
       err.name = "MyCustomError";
-      const se = new FabricError(err);
+      const se = FabricError.fromNativeError(err);
       const result = toWireFormat(
         se as FabricValue,
       ) as Record<string, unknown>;
@@ -898,30 +899,30 @@ describe("JsonEncodingContext", () => {
     it("round-trips TypeError preserving name === type identity", () => {
       // After round-trip, name and type should both be "TypeError",
       // and the Error should reconstruct as a TypeError instance.
-      const se = new FabricError(new TypeError("rt"));
+      const se = FabricError.fromNativeError(new TypeError("rt"));
       const result = roundTrip(
         se as FabricValue,
       ) as unknown as FabricError;
-      expect(result.error).toBeInstanceOf(TypeError);
-      expect(result.error.name).toBe("TypeError");
-      expect(result.error.constructor.name).toBe("TypeError");
+      expect(result.toNativeValue(true)).toBeInstanceOf(TypeError);
+      expect(result.name).toBe("TypeError");
+      expect(result.toNativeValue(true).constructor.name).toBe("TypeError");
     });
 
     it("round-trips Error with mismatched name and type", () => {
       // Error constructor is "Error" but name is overridden.
       const err = new Error("mismatch");
       err.name = "CustomName";
-      const se = new FabricError(err);
+      const se = FabricError.fromNativeError(err);
       const result = roundTrip(
         se as FabricValue,
       ) as unknown as FabricError;
-      expect(result.error).toBeInstanceOf(Error);
-      expect(result.error.name).toBe("CustomName");
-      expect(result.error.constructor.name).toBe("Error");
+      expect(result.toNativeValue(true)).toBeInstanceOf(Error);
+      expect(result.name).toBe("CustomName");
+      expect(result.toNativeValue(true).constructor.name).toBe("Error");
     });
 
     it("has typeTag property", () => {
-      const se = new FabricError(new Error("test"));
+      const se = FabricError.fromNativeError(new Error("test"));
       expect(se.typeTag).toBe("Error@1");
     });
 
@@ -930,18 +931,18 @@ describe("JsonEncodingContext", () => {
       // wrapping an Error whose cause is itself a FabricError (not a
       // raw Error). The serializer's recurse on [DECONSTRUCT] output
       // must find FabricValue, not raw Error.
-      const innerSe = new FabricError(new Error("inner"));
+      const innerSe = FabricError.fromNativeError(new Error("inner"));
       const outerErr = new Error("outer");
       outerErr.cause = innerSe;
-      const outerSe = new FabricError(outerErr);
+      const outerSe = FabricError.fromNativeError(outerErr);
 
       const result = roundTrip(
         outerSe as FabricValue,
       ) as unknown as FabricError;
-      expect(result.error.message).toBe("outer");
-      expect(result.error.cause).toBeInstanceOf(FabricError);
+      expect(result.message).toBe("outer");
+      expect(result.cause).toBeInstanceOf(FabricError);
       expect(
-        (result.error.cause as FabricError).error.message,
+        (result.cause as FabricError).message,
       ).toBe("inner");
     });
   });
@@ -1278,18 +1279,18 @@ describe("JsonEncodingContext", () => {
     });
 
     it("emits /object for /-keyed object with FabricError value", () => {
-      const err = new FabricError(new TypeError("eep!"));
+      const err = FabricError.fromNativeError(new TypeError("eep!"));
       const obj = { "/x": err } as unknown as FabricValue;
       const wire = toWireFormat(obj);
       expect(Object.keys(wire as object)).toEqual(["/object"]);
     });
 
     it("round-trips FabricError as value inside /-prefixed key object", () => {
-      const err = new FabricError(new TypeError("eep!"));
+      const err = FabricError.fromNativeError(new TypeError("eep!"));
       const obj = { "/x": err } as unknown as FabricValue;
       const result = roundTrip(obj) as Record<string, FabricValue>;
       expect(result["/x"]).toBeInstanceOf(FabricError);
-      expect((result["/x"] as unknown as FabricError).error.message).toBe(
+      expect((result["/x"] as unknown as FabricError).message).toBe(
         "eep!",
       );
     });
@@ -1305,7 +1306,7 @@ describe("JsonEncodingContext", () => {
     it("emits /object for mixed: literal and encoded values", () => {
       const obj = {
         "/a": "literal",
-        "/b": new FabricError(new Error("oops")),
+        "/b": FabricError.fromNativeError(new Error("oops")),
       } as unknown as FabricValue;
       const wire = toWireFormat(obj);
       expect(Object.keys(wire as object)).toEqual(["/object"]);
@@ -1314,7 +1315,7 @@ describe("JsonEncodingContext", () => {
     it("round-trips mixed literal+encoded /-keyed object", () => {
       const obj = {
         "/a": "literal",
-        "/b": new FabricError(new Error("oops")),
+        "/b": FabricError.fromNativeError(new Error("oops")),
       } as unknown as FabricValue;
       const result = roundTrip(obj) as Record<string, FabricValue>;
       expect(result["/a"]).toBe("literal");
@@ -1862,11 +1863,11 @@ describe("JsonEncodingContext", () => {
     it("encode/decode round-trip for tagged types", () => {
       const ctx = new JsonEncodingContext();
       const runtime = new TestReconstructionContext();
-      const se = new FabricError(new Error("test"));
+      const se = FabricError.fromNativeError(new Error("test"));
       const encoded = ctx.encode(se as FabricValue);
       const decoded = ctx.decode(encoded, runtime);
       expect(decoded).toBeInstanceOf(FabricError);
-      expect((decoded as unknown as FabricError).error.message).toBe("test");
+      expect((decoded as unknown as FabricError).message).toBe("test");
     });
 
     it("encodeToBytes/decodeFromBytes round-trip", () => {
@@ -1874,7 +1875,7 @@ describe("JsonEncodingContext", () => {
       const runtime = new TestReconstructionContext();
       const data = {
         name: "test",
-        error: new FabricError(new Error("fail")),
+        error: FabricError.fromNativeError(new Error("fail")),
       } as unknown as FabricValue;
       const bytes = ctx.encodeToBytes(data);
       expect(bytes).toBeInstanceOf(Uint8Array);
@@ -1928,33 +1929,33 @@ describe("JsonEncodingContext", () => {
     });
 
     it("round-trips FabricError in array", () => {
-      const se = new FabricError(new Error("oops"));
+      const se = FabricError.fromNativeError(new Error("oops"));
       const arr = [1, se, 3] as unknown as FabricValue;
       const result = roundTrip(arr) as FabricValue[];
       expect(result[0]).toBe(1);
       expect(result[1]).toBeInstanceOf(FabricError);
       expect(
-        (result[1] as unknown as FabricError).error.message,
+        (result[1] as unknown as FabricError).message,
       ).toBe("oops");
       expect(result[2]).toBe(3);
     });
 
     it("round-trips FabricError as object value", () => {
       const obj = {
-        error: new FabricError(new Error("fail")),
+        error: FabricError.fromNativeError(new Error("fail")),
         code: 500,
       } as unknown as FabricValue;
       const result = roundTrip(obj) as Record<string, FabricValue>;
       expect(result.error).toBeInstanceOf(FabricError);
       expect(
-        (result.error as unknown as FabricError).error.message,
+        (result.error as unknown as FabricError).message,
       ).toBe("fail");
       expect(result.code).toBe(500);
     });
 
     it("wire format is unchanged (backward compatible)", () => {
       // FabricError should produce the same wire format as the old ErrorHandler.
-      const se = new FabricError(new TypeError("compat test"));
+      const se = FabricError.fromNativeError(new TypeError("compat test"));
       const serialized = toWireFormat(
         se as FabricValue,
       ) as Record<string, unknown>;

--- a/packages/data-model/test/json-encoding.test.ts
+++ b/packages/data-model/test/json-encoding.test.ts
@@ -282,7 +282,7 @@ describe("json-encoding", () => {
     });
 
     it("throws on a class instance (FabricError)", () => {
-      const err = new FabricError(new Error("test"));
+      const err = FabricError.fromNativeError(new Error("test"));
       const json = jsonFromValue(err as FabricValue);
       expect(() => plainObjectFromJson(json)).toThrow(/instance/);
     });

--- a/packages/data-model/test/value-debug.test.ts
+++ b/packages/data-model/test/value-debug.test.ts
@@ -439,7 +439,7 @@ describe("value-debug", () => {
     });
 
     it("renders FabricInstance subclasses with their constructor name", () => {
-      expect(toDebugKindString(new FabricError(new Error("x"))))
+      expect(toDebugKindString(FabricError.fromNativeError(new Error("x"))))
         .toBe("FabricInstance (FabricError)");
       expect(toDebugKindString(new FabricRegExp(/abc/g, "es2025")))
         .toBe("FabricInstance (FabricRegExp)");

--- a/packages/data-model/test/value-hash.test.ts
+++ b/packages/data-model/test/value-hash.test.ts
@@ -485,7 +485,7 @@ describe("hashOf()", () => {
     // Build the expected byte stream programmatically because the
     // deconstructed state includes `stack` which is environment-dependent.
     // We construct the stream the same way `hashOf()` does, then SHA-256 it.
-    const error = new FabricError(new Error("test"));
+    const error = FabricError.fromNativeError(new Error("test"));
     const enc = new TextEncoder();
 
     // TAG_INSTANCE (0x12)
@@ -520,7 +520,7 @@ describe("hashOf()", () => {
 
     // Key "stack" + value (the actual stack string)
     pushShortString("stack");
-    pushLongString(error.error.stack!);
+    pushLongString(error.stack!);
 
     // Key "type" + value "Error"
     pushShortString("type");
@@ -534,14 +534,14 @@ describe("hashOf()", () => {
   });
 
   it("different errors produce different hashes", () => {
-    const e1 = new FabricError(new Error("hello"));
-    const e2 = new FabricError(new Error("world"));
+    const e1 = FabricError.fromNativeError(new Error("hello"));
+    const e2 = FabricError.fromNativeError(new Error("world"));
     expect(hex(hashBytesOf(e1))).not.toBe(hex(hashBytesOf(e2)));
   });
 
   it("TypeError vs Error produce different hashes", () => {
-    const e1 = new FabricError(new Error("msg"));
-    const e2 = new FabricError(new TypeError("msg"));
+    const e1 = FabricError.fromNativeError(new Error("msg"));
+    const e2 = FabricError.fromNativeError(new TypeError("msg"));
     expect(hex(hashBytesOf(e1))).not.toBe(hex(hashBytesOf(e2)));
   });
 
@@ -757,7 +757,7 @@ describe("hashOf()", () => {
       new FabricEpochNsec(0n),
       new FabricEpochDays(0n),
       new FabricBytes(new Uint8Array([1])),
-      new FabricError(new Error("x")),
+      FabricError.fromNativeError(new Error("x")),
     ];
     for (const v of values) {
       expect(hashBytesOf(v).length).toBe(32);

--- a/packages/memory/test/v2-patch-test.ts
+++ b/packages/memory/test/v2-patch-test.ts
@@ -22,12 +22,16 @@ Deno.test("memory v2 patch preserves `FabricInstance` values with full fidelity"
         {
           op: "replace",
           path: "/a",
-          value: new FabricError(new Error("boom")),
+          value: FabricError.fromNativeError(new Error("boom")),
         },
       ]) as { a: unknown },
     () =>
       applyPatch({}, [
-        { op: "add", path: "/a", value: new FabricError(new Error("boom")) },
+        {
+          op: "add",
+          path: "/a",
+          value: FabricError.fromNativeError(new Error("boom")),
+        },
       ]) as { a: unknown },
     () =>
       applyPatch({ a: ["keep"] }, [
@@ -36,7 +40,7 @@ Deno.test("memory v2 patch preserves `FabricInstance` values with full fidelity"
           path: "/a",
           index: 1,
           remove: 0,
-          add: [new FabricError(new Error("boom"))],
+          add: [FabricError.fromNativeError(new Error("boom"))],
         },
       ]) as { a: unknown[] },
   ];
@@ -49,14 +53,18 @@ Deno.test("memory v2 patch preserves `FabricInstance` values with full fidelity"
   placements.forEach((place, i) => {
     const out = reads[i]!(place()) as FabricError;
     assert(out instanceof FabricError, `placement ${i}: not a FabricError`);
-    assertEquals(out.error.message, "boom");
-    assertEquals(typeof out.error.stack, "string");
+    assertEquals(out.message, "boom");
+    assertEquals(typeof out.stack, "string");
   });
 });
 
 Deno.test("memory v2 patch keeps `FabricInstance` values as `FabricInstance`s (not demoted to plain objects)", () => {
   const patched = applyPatch({}, [
-    { op: "add", path: "/e", value: new FabricError(new Error("boom")) },
+    {
+      op: "add",
+      path: "/e",
+      value: FabricError.fromNativeError(new Error("boom")),
+    },
   ]) as { e: unknown };
   const out = patched.e;
 
@@ -69,7 +77,11 @@ Deno.test("memory v2 patch keeps `FabricInstance` values as `FabricInstance`s (n
 
 Deno.test("memory v2 patch round-trips `FabricInstance` values across replayed patch passes", () => {
   const first = applyPatch({ box: {} }, [
-    { op: "add", path: "/box/err", value: new FabricError(new Error("boom")) },
+    {
+      op: "add",
+      path: "/box/err",
+      value: FabricError.fromNativeError(new Error("boom")),
+    },
   ]);
   // `first` is deep-frozen by applyPatch; a second pass mimics the engine
   // replaying a stored patch sequence (here `move` -> `add`-clones the
@@ -80,8 +92,8 @@ Deno.test("memory v2 patch round-trips `FabricInstance` values across replayed p
   const out = second.moved as FabricError;
 
   assert(out instanceof FabricError);
-  assertEquals(out.error.message, "boom");
-  assertEquals(typeof out.error.stack, "string");
+  assertEquals(out.message, "boom");
+  assertEquals(typeof out.stack, "string");
 });
 
 Deno.test("memory v2 patch preserves `FabricPrimitive` values with full fidelity", () => {

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -2265,10 +2265,10 @@ export function recursivelyAddIDIfNeeded<T>(
 
   // `FabricInstance` values (`FabricError`, `FabricMap`, `FabricSet`,
   // `FabricRegExp`) are immutable wrappers with class-defined identity.
-  // Their own-enumerable properties are implementation details (e.g.,
-  // `FabricError.error` is the wrapped native `Error`), not user-visible
-  // structure; iterating them would re-wrap the embedded native value on
-  // each pass and recurse forever. Instead, walk the observable internal
+  // Their own-enumerable properties are implementation details, not
+  // user-visible structure; iterating them via the generic walker would
+  // descend into wrapper internals meaninglessly. Instead, walk the
+  // observable internal
   // structure via `[DECONSTRUCT]()` (the same mechanism the serialization
   // system uses) for side effects only — tracking shared references in
   // `seen` and populating `frame.generatedIdCounter` for any

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -781,9 +781,9 @@ export function normalizeAndDiff(
   // `FabricRegExp`) are atomic from this layer's perspective: their
   // own-enumerable properties are implementation details, not
   // user-visible structure, and iterating them via the generic
-  // `isRecord` branch below would re-wrap embedded native values (e.g.,
-  // `FabricError.error` is a native `Error`) on each pass, recursing
-  // forever. Emit a single change at this link with the wrapper as the
+  // `isRecord` branch below would walk wrapper-internal fields, which
+  // is meaningless at the change-emission level. Emit a single change at
+  // this link with the wrapper as the
   // value — the storage layer's JSON encoding handles serialization via
   // `[DECONSTRUCT]`/`[RECONSTRUCT]`. Placed after the write-redirect
   // resolution above so writes through a redirect land on the target,

--- a/packages/runner/test/cell-core.test.ts
+++ b/packages/runner/test/cell-core.test.ts
@@ -127,18 +127,19 @@ describe("Cell", () => {
 
     // Modern path: error is stored as a `FabricError`-shaped value rather
     // than the legacy `@Error` wrapper. `c.get()` returns a proxy view of
-    // the stored wrapper — its `error` slot exposes the wrapped Error's
-    // observable fields (`message`, `stack`), and its `typeTag` is
-    // `"Error"` (`FabricError`'s tag).
+    // the stored wrapper — its observable fields (`type`, `name`,
+    // `message`, `stack`, etc.) are exposed directly on the projection,
+    // and its `typeTag` is `"Error@1"` (`FabricError`'s tag).
     const result = c.get() as {
-      error: { message: string; stack: string };
+      message: string;
+      stack: string;
       typeTag: string;
       "@Error"?: unknown;
     };
     expect(result["@Error"]).toBeUndefined();
     expect(result.typeTag).toBe("Error@1");
-    expect(result.error.message).toBe("something went wrong");
-    expect(typeof result.error.stack).toBe("string");
+    expect(result.message).toBe("something went wrong");
+    expect(typeof result.stack).toBe("string");
     await localTx.commit();
     await rt.dispose();
     await sm.close();
@@ -196,17 +197,19 @@ describe("Cell", () => {
 
     // Modern path: outer error is a `FabricError`-shaped value; its cause
     // is also `FabricError`-shaped (recursively wrapped at conversion
-    // time), not a legacy `@Error` wrapper.
+    // time), not a legacy `@Error` wrapper. The proxy view exposes the
+    // wrapper's observable fields directly.
     const result = c.get() as {
-      error: { message: string; cause: { message: string; stack: string } };
+      message: string;
+      cause: { message: string; stack: string };
       typeTag: string;
       "@Error"?: unknown;
     };
     expect(result["@Error"]).toBeUndefined();
     expect(result.typeTag).toBe("Error@1");
-    expect(result.error.message).toBe("wrapper error");
-    expect(result.error.cause.message).toBe("root cause");
-    expect(typeof result.error.cause.stack).toBe("string");
+    expect(result.message).toBe("wrapper error");
+    expect(result.cause.message).toBe("root cause");
+    expect(typeof result.cause.stack).toBe("string");
     await localTx.commit();
     await rt.dispose();
     await sm.close();
@@ -252,11 +255,11 @@ describe("Cell", () => {
     parent.set({ slot: new TypeError("through nested redirect") });
 
     const targetResult = target.get() as {
-      error: { message: string };
+      message: string;
       typeTag: string;
     };
     expect(targetResult.typeTag).toBe("Error@1");
-    expect(targetResult.error.message).toBe("through nested redirect");
+    expect(targetResult.message).toBe("through nested redirect");
 
     await localTx.commit();
     await rt.dispose();

--- a/packages/runner/test/experimental-options.test.ts
+++ b/packages/runner/test/experimental-options.test.ts
@@ -128,7 +128,7 @@ describe("ExperimentalOptions", () => {
       const err = new Error("test error");
       const result = shallowFabricFromNativeValue(err);
       expect(result).toBeInstanceOf(FabricError);
-      expect((result as FabricError).error.message).toBe("test error");
+      expect((result as FabricError).message).toBe("test error");
     });
 
     it("preserves undefined in arrays when flag is ON", () => {
@@ -185,7 +185,7 @@ describe("ExperimentalOptions", () => {
         unknown
       >;
       expect(result.data).toBeInstanceOf(FabricError);
-      expect((result.data as FabricError).error.message).toBe("nested");
+      expect((result.data as FabricError).message).toBe("nested");
     });
 
     it("preserves undefined-valued object properties when flag is ON", () => {
@@ -200,7 +200,7 @@ describe("ExperimentalOptions", () => {
       const err = new Error("in array");
       const result = fabricFromNativeValue([1, err, 3]) as unknown[];
       expect(result[1]).toBeInstanceOf(FabricError);
-      expect((result[1] as FabricError).error.message).toBe("in array");
+      expect((result[1] as FabricError).message).toBe("in array");
     });
 
     it("preserves sparse array holes when flag is ON", () => {

--- a/packages/runner/test/fetch-data-mutex.test.ts
+++ b/packages/runner/test/fetch-data-mutex.test.ts
@@ -554,21 +554,23 @@ describe("fetch-data mutex mechanism", () => {
     };
 
     // Modern path: error is a `FabricError`-shaped value (`typeTag`
-    // "Error@1"), not the legacy `@Error` wrapper; its `.error` slot
-    // exposes the wrapped Error's observable fields. Regression guard for
-    // the `memory/v2/patch.ts` `structuredClone()` class-stripping bug,
-    // which made errors round-trip back as `{ error: {}, typeTag:
-    // "Error@1" }` with message/stack lost.
+    // "Error@1"), not the legacy `@Error` wrapper; its observable fields
+    // (`name`, `message`, `stack`) are exposed directly on the wrapper.
+    // Regression guard for the `memory/v2/patch.ts` `structuredClone()`
+    // class-stripping bug, which made errors round-trip back as `{ ... }`
+    // with message/stack lost.
     expect(data.error).toBeDefined();
     expect((data.error as { "@Error"?: unknown })["@Error"]).toBeUndefined();
     const fe = data.error as {
       typeTag: string;
-      error: { name: string; message: string; stack: string };
+      name: string;
+      message: string;
+      stack: string;
     };
     expect(fe.typeTag).toBe("Error@1");
-    expect(fe.error.name).toBe("Error");
-    expect(fe.error.message).toMatch(/HTTP 404/);
-    expect(typeof fe.error.stack).toBe("string");
+    expect(fe.name).toBe("Error");
+    expect(fe.message).toMatch(/HTTP 404/);
+    expect(typeof fe.stack).toBe("string");
     expect(data.pending).toBe(false);
 
     await localTx.commit();


### PR DESCRIPTION
## Summary

Reshapes `FabricError` so its publicly observable state is `FabricValue`-shaped end-to-end. Previously the wrapper exposed `readonly error: Error` — a raw native `Error` that is **not** a `FabricValue` — leaking a wild-west native object through the strongly-typed surface and forcing a string-only stop-gap in `deepClone()` that silently dropped non-string `cause` / custom properties.

This is the principled fix Dan flagged as "the crux of the problem": with `FabricError` truly FabricValue-shaped, the storage layer can eventually swap its `isolateTransactionValue` punt for `cloneIfNecessary` (follow-up work).

## What changed

**`FabricError` shape** (`packages/data-model/fabric-native-instances.ts`):

- Fixed-schema slots, all `FabricValue`-typed: `type`, `name`, `message`, `stack`, `cause`.
- Hidden **extras bag** for custom enumerable properties, accessed via map-like methods: `getExtra`, `setExtra`, `hasExtra`, `deleteExtra`, `extraKeys`, `extraEntries`, `extraSize`. It's not exposed as an own property.
- **Mutable until frozen** (the standard `FabricInstance` model). The fixed-schema slots are plain writable own properties: assignment succeeds while mutable and throws once `Object.freeze`'d (strict-mode non-writable-property semantics). The extras bag mirrors this by gating `setExtra` / `deleteExtra` on the frozen state (they also reject reserved/unsafe keys).
- The native `Error` form is a **lazy projection** via `toNativeValue()`. `toNativeValue(false)` mints a fresh thawed copy each call. The frozen projection is cached only once the instance is frozen — while mutable it is rebuilt on each access, so it can never go stale against state mutation. (The cache field is `#private`, so it stays writable even after `Object.freeze`, which is what lets it populate post-freeze.) No stored native `Error` reference.

**Construction:**
- `new FabricError(state)` — from FabricValue-shaped state.
- `FabricError.fromNativeError(error)` — shallow conversion from a native `Error` (used by `shallowFabricFromNativeValueModern`).

**Conversion layer** (`packages/data-model/fabric-value-modern.ts`):
- Deep conversion builds FabricValue state directly via `rebuildFabricErrorDeep` (replacing `convertErrorInternals`' native-Error rebuild).
- Deep unwrap via `deepUnwrapFabricError` (replacing `deepUnwrapError`).

## Consequences

- `deepClone()` drops its string-only stop-gap and does a principled `[DECONSTRUCT]`/`[RECONSTRUCT]` round-trip — `cause` and extras survive.
- A `FabricError` with no `cause` or extras is **deep-frozen as soon as the wrapper is `Object.freeze`'d** (the wrapper itself is the canonical state; there's no separate inner Error to freeze).
- Native-`Error` identity is no longer preserved across construction (it never was, across freeze-state mismatches).
- **Wire format is unchanged**: `[DECONSTRUCT]` still emits the flat record `{ type, name, message, stack?, cause?, ...custom }` with the `null`-name shorthand.

## Test plan

- [x] `deno task test` across the workspace — all 23 packages green (~84s).
- [x] `deno check` clean in data-model, runner, memory.
- [x] `deno lint` clean on changed source files.
- [x] New tests lock in mutable-until-frozen behavior (slots writable while unfrozen, throw once frozen) and frozen-only projection caching.
- [ ] CI green.

## Follow-ups (not in this PR)

- The `FabricError` section of the formal spec (`docs/specs/space-model-formal-spec/1-fabric-values.md` §1.4.2) still documents the old `readonly error: Error` shape — deferred to a spec-work session.
- The other native wrappers (`FabricMap`, `FabricSet`, `FabricRegExp`) are left as-is; they aren't used in the storage context. `FabricRegExp` still wraps a native `RegExp` directly, but has no leaky `cause`/extras concern.
- The `isolateTransactionValue` → `cloneIfNecessary` swap in `v2-transaction.ts`, now unblocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Performance Baseline

This PR only affects the use of `FabricError`, which is barely used in the system at all, and pretty much never intentionally. I wouldn't expect it to affect any pattern tests, so with pretty high confidence the following accounts for a spurious perf check failure.

NEW_PERF_BASELINE: subtest: pattern-unit-1/pattern-unit-tests > packages/patterns/battleship/multiplayer/lobby.test.tsx = 34s

