### PR TITLE
Replace isolateTransactionValue with cloneForIsolation

### DIFF
--- a/packages/data-model/fabric-value-modern.ts
+++ b/packages/data-model/fabric-value-modern.ts
@@ -67,7 +67,19 @@ export function shallowFabricFromNativeValueModern(
       return value as FabricValueLayer;
 
     case NATIVE_TAGS.Error: {
-      const wrapped = FabricError.fromNativeError(value as Error);
+      // An `Error`'s internal state (`cause`, custom properties) is part of
+      // the `FabricError`'s value, so it must itself be proper `FabricValue`
+      // -- there is no valid "shallow" `FabricError` whose `.cause` is a raw
+      // `Error`. The outer structural walk treats a `FabricInstance` as atomic
+      // and won't descend into it, so the internals are converted here, at
+      // construction. (`freeze` still freezes only the wrapper, matching the
+      // shallow contract for containers; the now-`FabricValue` internals are
+      // left in whatever frozen state the deep converter produced.)
+      const wrapped = rebuildFabricErrorDeep(
+        FabricError.fromNativeError(value as Error),
+        new Map(),
+        false,
+      );
       if (freeze) Object.freeze(wrapped);
       return wrapped;
     }

--- a/packages/data-model/fabric-value.ts
+++ b/packages/data-model/fabric-value.ts
@@ -18,6 +18,7 @@ export {
 } from "./interface.ts";
 
 export {
+  cloneForIsolation,
   cloneForMutation,
   CloneForMutationError,
   type CloneForMutationErrorKind,

--- a/packages/data-model/test/clone-for-isolation.test.ts
+++ b/packages/data-model/test/clone-for-isolation.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  cloneForIsolation,
+  fabricFromNativeValue,
+  resetDataModelConfig,
+  setDataModelConfig,
+} from "../fabric-value.ts";
+import type { FabricValue } from "../fabric-value.ts";
+import { deepFreeze, isDeepFrozen } from "../deep-freeze.ts";
+import { FabricBytes } from "../fabric-bytes.ts";
+import { FabricEpochNsec } from "../fabric-epoch.ts";
+import { FabricError } from "../fabric-native-instances.ts";
+
+// ============================================================================
+// cloneForIsolation
+// ============================================================================
+//
+// Contract: produce a deep clone isolated from later source mutation, while
+// preserving the identity of already-deep-frozen subtrees by reference. Throws
+// on any non-`FabricValue` (e.g. a raw `Date`/`Map`/`Error`). Parameterized
+// across both flag states (clone semantics are flag-independent).
+
+describe("cloneForIsolation", () => {
+  afterEach(() => {
+    resetDataModelConfig();
+  });
+
+  for (const modernMode of [false, true]) {
+    const label = modernMode ? "modern" : "legacy";
+
+    describe(`primitives & special primitives (${label})`, () => {
+      it("returns primitives as-is", () => {
+        setDataModelConfig(modernMode);
+        expect(cloneForIsolation(42 as FabricValue)).toBe(42);
+        expect(cloneForIsolation("hi" as FabricValue)).toBe("hi");
+        expect(cloneForIsolation(null as FabricValue)).toBe(null);
+        expect(cloneForIsolation(undefined as FabricValue)).toBe(undefined);
+        expect(cloneForIsolation(true as FabricValue)).toBe(true);
+      });
+
+      it("returns FabricPrimitive instances by identity (immutable)", () => {
+        setDataModelConfig(modernMode);
+        const bytes = new FabricBytes(new Uint8Array([1, 2, 3]));
+        const epoch = new FabricEpochNsec(123n);
+        expect(cloneForIsolation(bytes as FabricValue)).toBe(bytes);
+        expect(cloneForIsolation(epoch as FabricValue)).toBe(epoch);
+      });
+    });
+
+    describe(`deep-frozen identity preservation (${label})`, () => {
+      it("returns a fully deep-frozen input by identity", () => {
+        setDataModelConfig(modernMode);
+        const frozen = deepFreeze({ a: 1, b: { c: 2 } } as FabricValue);
+        expect(cloneForIsolation(frozen)).toBe(frozen);
+      });
+
+      it("preserves frozen subtrees by identity within a mutable parent", () => {
+        setDataModelConfig(modernMode);
+        const frozenChild = deepFreeze({ c: 2 } as FabricValue);
+        const parent = { a: 1, child: frozenChild } as FabricValue;
+        const result = cloneForIsolation(parent) as Record<string, unknown>;
+        expect(result).not.toBe(parent); // parent was mutable -> cloned
+        expect(result.child).toBe(frozenChild); // frozen subtree shared
+        expect(result).toEqual({ a: 1, child: { c: 2 } });
+      });
+    });
+
+    describe(`mutable input cloning (${label})`, () => {
+      it("deep-clones a mutable object (not same, but equal)", () => {
+        setDataModelConfig(modernMode);
+        const src = { a: 1, b: { c: 2 } } as FabricValue;
+        const result = cloneForIsolation(src) as Record<string, unknown>;
+        expect(result).not.toBe(src);
+        expect(result.b).not.toBe((src as Record<string, unknown>).b);
+        expect(result).toEqual({ a: 1, b: { c: 2 } });
+        // Mutating the source must not affect the isolated clone.
+        (src as Record<string, unknown>).a = 99;
+        expect(result.a).toBe(1);
+      });
+
+      it("result is mutable along non-frozen paths", () => {
+        setDataModelConfig(modernMode);
+        const result = cloneForIsolation(
+          { a: [1, 2] } as FabricValue,
+        ) as Record<string, unknown>;
+        expect(Object.isFrozen(result)).toBe(false);
+        expect(isDeepFrozen(result as FabricValue)).toBe(false);
+      });
+
+      it("deep-clones arrays and preserves sparse holes", () => {
+        setDataModelConfig(modernMode);
+        // deno-lint-ignore no-sparse-arrays
+        const src = [1, , 3] as unknown as FabricValue;
+        const result = cloneForIsolation(src) as unknown[];
+        expect(result).not.toBe(src);
+        expect(result.length).toBe(3);
+        expect(0 in result).toBe(true);
+        expect(1 in result).toBe(false);
+        expect(2 in result).toBe(true);
+      });
+
+      it("preserves null-prototype objects", () => {
+        setDataModelConfig(modernMode);
+        const src = Object.assign(Object.create(null), { x: 1 }) as FabricValue;
+        const result = cloneForIsolation(src);
+        expect(Object.getPrototypeOf(result)).toBe(null);
+        expect(result).toEqual(Object.assign(Object.create(null), { x: 1 }));
+      });
+
+      it("handles diamond references by preserving sharing", () => {
+        setDataModelConfig(modernMode);
+        const shared = { s: 1 };
+        const src = { a: shared, b: shared } as unknown as FabricValue;
+        const result = cloneForIsolation(src) as Record<string, unknown>;
+        expect(result.a).toBe(result.b); // sharing preserved
+        expect(result.a).not.toBe(shared); // but cloned
+      });
+
+      it("terminates on direct cycles", () => {
+        setDataModelConfig(modernMode);
+        const src: Record<string, unknown> = { a: 1 };
+        src.self = src;
+        const result = cloneForIsolation(src as FabricValue) as Record<
+          string,
+          unknown
+        >;
+        expect(result).not.toBe(src);
+        expect(result.self).toBe(result); // cycle re-pointed to the clone
+        expect(result.a).toBe(1);
+      });
+    });
+
+    describe(`FabricInstance handling (${label})`, () => {
+      it("returns a deep-frozen FabricError by identity", () => {
+        setDataModelConfig(modernMode);
+        const fe = FabricError.fromNativeError(new Error("boom"));
+        Object.freeze(fe);
+        expect(isDeepFrozen(fe)).toBe(true);
+        expect(cloneForIsolation(fe as unknown as FabricValue)).toBe(fe);
+      });
+
+      it("deep-clones a mutable FabricError", () => {
+        setDataModelConfig(modernMode);
+        const fe = FabricError.fromNativeError(
+          new Error("boom", { cause: { mutable: true } }),
+        );
+        Object.freeze(fe); // wrapper frozen, cause mutable -> not deep-frozen
+        expect(isDeepFrozen(fe)).toBe(false);
+        const result = cloneForIsolation(fe as unknown as FabricValue);
+        expect(result).toBeInstanceOf(FabricError);
+        expect(result).not.toBe(fe);
+        expect((result as unknown as FabricError).message).toBe("boom");
+      });
+
+      it("preserves a nested deep-frozen FabricError by identity", () => {
+        setDataModelConfig(modernMode);
+        const fe = FabricError.fromNativeError(new Error("nested"));
+        Object.freeze(fe);
+        const parent = { err: fe, x: 1 } as unknown as FabricValue;
+        const result = cloneForIsolation(parent) as Record<string, unknown>;
+        expect(result).not.toBe(parent);
+        expect(result.err).toBe(fe);
+      });
+    });
+
+    describe(`type-violation throws (${label})`, () => {
+      it("throws on a raw Date", () => {
+        setDataModelConfig(modernMode);
+        expect(() => cloneForIsolation(new Date() as unknown as FabricValue))
+          .toThrow(/Cannot clone for isolation/);
+      });
+
+      it("throws on a raw Map", () => {
+        setDataModelConfig(modernMode);
+        expect(() => cloneForIsolation(new Map() as unknown as FabricValue))
+          .toThrow(/Cannot clone for isolation/);
+      });
+
+      it("throws on a raw Error nested in a plain object", () => {
+        setDataModelConfig(modernMode);
+        const src = { err: new Error("raw") } as unknown as FabricValue;
+        expect(() => cloneForIsolation(src)).toThrow(
+          /Cannot clone for isolation/,
+        );
+      });
+    });
+
+    describe(`interaction with proper conversion (${label})`, () => {
+      it("isolates a converted Error tree without throwing", () => {
+        setDataModelConfig(modernMode);
+        // `fabricFromNativeValue` produces a proper value (in modern mode a
+        // FabricError whose cause is itself a FabricValue; in legacy mode an
+        // `@Error` plain object), so isolation must not choke on it.
+        const converted = fabricFromNativeValue(
+          new Error("outer", { cause: new Error("inner") }),
+          false,
+        );
+        const result = cloneForIsolation(converted);
+        if (modernMode) {
+          expect(result).toBeInstanceOf(FabricError);
+        } else {
+          // Legacy: `@Error` plain-object wrapper, deep-cloned for isolation.
+          expect(result).toHaveProperty("@Error");
+        }
+      });
+    });
+  }
+});

--- a/packages/data-model/value-clone.ts
+++ b/packages/data-model/value-clone.ts
@@ -204,6 +204,98 @@ export function cloneHelper(
 }
 
 // =============================================================================
+// `cloneForIsolation`
+// =============================================================================
+
+/**
+ * Produces a deep clone of `value` that is isolated from later mutations to
+ * the source, while preserving the identity of already-deep-frozen subtrees
+ * by reference.
+ *
+ * Dispatch:
+ * - Primitives and `FabricPrimitive` instances → returned as-is (immutable).
+ * - Already-deep-frozen values (per `isDeepFrozenFabricValue`) → returned by
+ *   identity at every level of the recursion. This is the perf optimization
+ *   the simpler `cloneIfNecessary(_, { frozen: false })` lacks: that one
+ *   `force`-clones, allocating new identities even for unchanged subtrees.
+ * - `FabricInstance` → deep-cloned via `.deepClone(false)` (its own semantics
+ *   govern any nested values).
+ * - Plain objects and arrays → deep-cloned recursively, with cycle detection
+ *   (back-references resolve to the in-progress copy, preserving shared
+ *   structure and terminating on cycles).
+ * - Any other class instance is a `FabricValue` type violation upstream; this
+ *   throws rather than silently passing it through.
+ *
+ * Result mutability is intentionally "mixed": the returned tree is mutable
+ * along any path that wasn't already deep-frozen in the input; deep-frozen
+ * subtrees inside the result remain frozen by reference. Callers that need a
+ * uniformly mutable result should use `cloneIfNecessary(value, { frozen:
+ * false })` instead.
+ */
+export function cloneForIsolation<T extends FabricValue>(value: T): T {
+  return cloneForIsolationHelper(value, null) as T;
+}
+
+function cloneForIsolationHelper(
+  value: FabricValue,
+  seen: Map<object, FabricValue> | null,
+): FabricValue {
+  switch (tagFromNativeValue(value)) {
+    // Inherently immutable: nothing to isolate from.
+    case NATIVE_TAGS.Primitive:
+    case NATIVE_TAGS.EpochNsec:
+    case NATIVE_TAGS.EpochDays:
+    case NATIVE_TAGS.ContentHash:
+    case NATIVE_TAGS.FabricBytes:
+      return value;
+
+    case NATIVE_TAGS.FabricInstance: {
+      // Already-deep-frozen instances can't be mutated, so share by identity.
+      if (isDeepFrozenFabricValue(value)) return value;
+      return (value as FabricInstance).deepClone(false);
+    }
+
+    case NATIVE_TAGS.Array: {
+      if (isDeepFrozenFabricValue(value)) return value;
+      const arr = value as FabricValue[];
+      const existing = seen?.get(arr);
+      if (existing !== undefined) return existing;
+      seen ??= new Map();
+      const copy: FabricValue[] = new Array(arr.length);
+      seen.set(arr, copy);
+      for (let i = 0; i < arr.length; i++) {
+        if (i in arr) copy[i] = cloneForIsolationHelper(arr[i], seen);
+      }
+      return copy;
+    }
+
+    case NATIVE_TAGS.Object: {
+      if (isDeepFrozenFabricValue(value)) return value;
+      const obj = value as object;
+      const existing = seen?.get(obj);
+      if (existing !== undefined) return existing;
+      seen ??= new Map();
+      // Preserve null prototypes (e.g. `Object.create(null)`).
+      const proto = Object.getPrototypeOf(obj);
+      const copy = Object.create(proto) as Record<string, FabricValue>;
+      seen.set(obj, copy);
+      for (const [key, val] of Object.entries(obj)) {
+        copy[key] = cloneForIsolationHelper(val as FabricValue, seen);
+      }
+      return copy;
+    }
+
+    default:
+      // Any other class instance is a `FabricValue` type violation upstream.
+      throw new Error(
+        `Cannot clone for isolation: ${
+          (value as object).constructor?.name ?? typeof value
+        }`,
+      );
+  }
+}
+
+// =============================================================================
 // `cloneForMutation`
 // =============================================================================
 

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -1,5 +1,6 @@
-import { deepFreeze, isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
+import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
 import {
+  cloneForIsolation,
   cloneForMutation,
   CloneForMutationError,
   cloneIfNecessary,
@@ -139,68 +140,6 @@ function withCommitTiming<T>(
   }
 }
 
-/**
- * Produces a value that is isolated from later mutations to the source. For
- * a deep-frozen input the source can't be mutated, so the input is returned
- * unchanged; otherwise plain objects and arrays are deep-cloned (with cycle
- * detection) and non-plain-prototype objects are passed through. Sub-trees
- * that are themselves deep-frozen short-circuit by identity during the
- * recursion, so partially-frozen trees only copy their unfrozen portions.
- *
- * The result is NOT guaranteed to be mutable, since deep-frozen inputs are
- * returned as-is. Callers that need a mutable spine into a value tree at
- * a specific path should use `cloneForMutation()` from
- * `@commonfabric/data-model` instead -- it shallow-thaws only the spine
- * containers, preserving identity of off-spine subtrees (and their place
- * in the deep-frozen cache).
- */
-const isolateTransactionValue = <T>(
-  value: T,
-  seen: Map<object, unknown> = new Map(),
-): T => {
-  if (value === null || typeof value !== "object") {
-    return value;
-  }
-
-  // A deep-frozen value is already isolated: nothing can mutate it, so the
-  // returned reference is safe to share with the caller. `isDeepFrozen()` is
-  // O(1) on values previously cached as deep-frozen (the common case for
-  // values that came back out of storage in modern data model).
-  if (isDeepFrozen(value)) {
-    return value;
-  }
-
-  if (seen.has(value)) {
-    return seen.get(value) as T;
-  }
-
-  if (Array.isArray(value)) {
-    const copy = new Array(value.length);
-    seen.set(value, copy);
-    for (let i = 0; i < value.length; i++) {
-      if (i in value) {
-        copy[i] = isolateTransactionValue(value[i], seen);
-      }
-    }
-    return copy as T;
-  }
-
-  const prototype = Object.getPrototypeOf(value);
-  if (prototype !== Object.prototype && prototype !== null) {
-    return value;
-  }
-
-  const copy = Object.create(prototype) as Record<PropertyKey, unknown>;
-  seen.set(value, copy);
-  for (const key of Reflect.ownKeys(value)) {
-    copy[key] = isolateTransactionValue(
-      (value as Record<PropertyKey, unknown>)[key],
-      seen,
-    );
-  }
-  return copy as T;
-};
-
 const currentDocument = (doc: DocumentEntry): RootAttestation =>
   doc.current ?? doc.initial;
 
@@ -232,11 +171,12 @@ const freezeReadValue = <T extends FabricValue | undefined>(value: T): T => {
   ) {
     return value;
   }
-  // `isolateTransactionValue()` short-circuits on already-deep-frozen input
-  // (returns the source by identity) and `deepFreeze()` is O(1) on values
-  // already in its cache, so the steady-state cost on repeated reads of the
-  // same stored value collapses to two cache lookups.
-  return deepFreeze(isolateTransactionValue(value)) as T;
+  // `cloneForIsolation()` isolates the result from later source mutation by
+  // deep-cloning only the not-already-deep-frozen portions, returning
+  // deep-frozen subtrees by identity; `deepFreeze()` is then O(1) on values
+  // already in its cache. On the hot read path the steady-state cost on
+  // repeated reads of the same stored value collapses to two cache lookups.
+  return deepFreeze(cloneForIsolation(value)) as T;
 };
 
 const collapseEmptyJsonDocumentEnvelope = (
@@ -1240,7 +1180,7 @@ export class V2StorageTransaction implements IStorageTransaction {
     }
     const isolatedValue = value === undefined
       ? undefined
-      : isolateTransactionValue(value) as FabricValue;
+      : cloneForIsolation(value) as FabricValue;
     const result = writeAttestation(current, address, isolatedValue);
     if (result.error) {
       return { error: result.error.from(space) };
@@ -1269,7 +1209,7 @@ export class V2StorageTransaction implements IStorageTransaction {
         allowArrayLength: true,
       }),
       previous.kind === "ok"
-        ? isolateTransactionValue(previous.value) as FabricValue | undefined
+        ? cloneForIsolation(previous.value) as FabricValue | undefined
         : undefined,
       doc,
     );
@@ -1342,7 +1282,7 @@ export class V2StorageTransaction implements IStorageTransaction {
         nextKeyAfterPath: remainingPath[remainingPath.length - 1]!,
       },
     );
-    const isolatedValue = isolateTransactionValue(value) as FabricValue;
+    const isolatedValue = cloneForIsolation(value) as FabricValue;
     const parentWrite = writeAttestation(
       {
         address: {
@@ -1378,10 +1318,10 @@ export class V2StorageTransaction implements IStorageTransaction {
       return { ok: collapsedNext };
     }
 
-    const previousActivityValue = isolateTransactionValue(
+    const previousActivityValue = cloneForIsolation(
       readValueAtPath(doc.current.value, lastExistingPath, {
         allowArrayLength: true,
-      }),
+      }) as FabricValue,
     ) as FabricValue | undefined;
 
     doc.current = collapsedNext;
@@ -1440,7 +1380,7 @@ export class V2StorageTransaction implements IStorageTransaction {
     for (const { address, value } of writes) {
       const isolatedValue = value === undefined
         ? undefined
-        : isolateTransactionValue(value) as FabricValue;
+        : cloneForIsolation(value) as FabricValue;
       const previousValue = readValueAtPath(nextRoot, address.path, {
         allowArrayLength: true,
       });
@@ -1452,17 +1392,17 @@ export class V2StorageTransaction implements IStorageTransaction {
         address.path,
         isolatedValue,
       ) ?? address.path;
-      const previousActivityValue = isolateTransactionValue(
+      const previousActivityValue = cloneForIsolation(
         readValueAtPath(nextRoot, activityPath, {
           allowArrayLength: true,
-        }),
+        }) as FabricValue,
       ) as FabricValue | undefined;
       if (
         !hasMutableRoot && address.path.length > 0 && nextRoot !== undefined
       ) {
-        // Use `cloneIfNecessary({ frozen: false })` (not
-        // `isolateTransactionValue()`): the next line passes `nextRoot` to
-        // `applyMutablePathWrite`, which mutates in place along the write
+        // Use `cloneIfNecessary({ frozen: false })` (not `cloneForIsolation()`,
+        // whose result is only mixed-mutable): the next line passes `nextRoot`
+        // to `applyMutablePathWrite`, which mutates in place along the write
         // path, so we need a guaranteed-mutable root even when the stored
         // value is deep-frozen.
         nextRoot = cloneIfNecessary(nextRoot, { frozen: false });
@@ -1492,7 +1432,7 @@ export class V2StorageTransaction implements IStorageTransaction {
         readValueAtPath(result.ok.root, address.path, {
           allowArrayLength: true,
         }),
-        isolateTransactionValue(previousValue) as FabricValue | undefined,
+        cloneForIsolation(previousValue) as FabricValue | undefined,
         doc,
       );
       this.recordWriteActivity(


### PR DESCRIPTION
## Summary

Replaces the v2-transaction layer's bespoke `isolateTransactionValue` helper with a new shared `cloneForIsolation()` primitive in `@commonfabric/data-model`, and fixes a latent data-model invariant violation that the swap surfaced.

This is the follow-up the [FabricError reshape (#3662)](https://github.com/commontoolsinc/labs/pull/3662) unblocked.

## Two commits

**1. `fix(data-model): shallow Error conversion yields a proper FabricValue`**

`shallowFabricFromNativeValueModern`'s `Error` case wrapped a native `Error` without converting its internals, so a `FabricError` could be constructed with a **raw `Error` `.cause`** — violating its own `cause: FabricValue` contract. The outer write-path walk treats a `FabricInstance` as atomic and never descends, so nothing fixed it downstream and the improper value reached storage. Now the internals are converted at construction (reusing the deep path's `rebuildFabricErrorDeep`). *By the time a `FabricValue` is constructed it should be a proper `FabricValue`.*

**2. `refactor(storage): replace isolateTransactionValue with cloneForIsolation`**

`isolateTransactionValue` duplicated data-model cloning logic with two flaws: it passed non-plain-prototype objects through **by identity** (so a mutable `FabricInstance` shared the caller's reference — broken isolation), and it **silently tolerated** raw non-`FabricValue` instances.

`cloneForIsolation()` is a sibling of `cloneIfNecessary`/`cloneForMutation`: a deep clone isolated from later source mutation, **preserving the identity of already-deep-frozen subtrees** by reference (the perf short-circuit `cloneIfNecessary(_, { frozen: false })` lacks — it force-clones everything). It dispatches `FabricInstance` through the clone protocol and **throws** on any non-`FabricValue`.

Wiring:
- `freezeReadValue` = `deepFreeze(cloneForIsolation(value))`.
- Write-activity / snapshot sites use `cloneForIsolation` (non-freezing — freezing them perturbed CFC write-authorization diffing for array pushes).
- The one genuinely-mutable root keeps `cloneIfNecessary(_, { frozen: false })`.
- `isolateTransactionValue` deleted.

The strict throw is intentional: it **surfaces** improper values instead of masking them — which is exactly what caught the raw-`Error`-cause bug fixed in commit 1.

## Test plan

- [x] `deno task test` data-model — 47 files green (incl. new `clone-for-isolation.test.ts`, 46 steps across both flag states).
- [x] `deno task test` runner — 455 passed / 0 failed (was failing the modern Error-cause case before commit 1).
- [x] `deno task test` full workspace — all 23 packages green (~80s).
- [x] `deno lint` clean on changed files.
- [ ] CI green.

## Note on `FabricError.fromNativeError`

It can still construct a *transient* improper `FabricError` (raw cause) that the conversion layer immediately rebuilds — never escaping to consumers. Fully removing that escape hatch (centralizing native→FabricError construction) is a larger, test-churny change left for later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the v2 transaction isolation helper with a shared `cloneForIsolation` in `@commonfabric/data-model` to properly isolate values while preserving frozen subtree identity. Also fixed an `Error` conversion bug that let raw causes into `FabricError`, restoring the data-model invariant.

- **Bug Fixes**
  - Shallow `Error` conversion now rebuilds internals so `FabricError.cause` is a proper `FabricValue`, preventing raw errors from reaching storage.

- **Refactors**
  - Added `cloneForIsolation` in `@commonfabric/data-model`: deep-clones only mutable parts, preserves deep-frozen subtrees by identity, clones `FabricInstance` via `.deepClone(false)`, and throws on non-`FabricValue`.
  - Replaced `isolateTransactionValue` in v2 transactions: `freezeReadValue` uses `deepFreeze(cloneForIsolation(value))`; write/snapshot paths use `cloneForIsolation` (non-freezing); kept `cloneIfNecessary(_, { frozen: false })` for the one mutable root; removed the old helper.

<sup>Written for commit 04186621a2ca122a73e25a7fbdc5cbaf1cd846e7. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3663?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

