### PR TITLE
Add cloneForIsolation to data-model

### DIFF
--- a/packages/data-model/fabric-value.ts
+++ b/packages/data-model/fabric-value.ts
@@ -18,6 +18,7 @@ export {
 } from "./interface.ts";
 
 export {
+  cloneForIsolation,
   cloneForMutation,
   CloneForMutationError,
   type CloneForMutationErrorKind,

--- a/packages/data-model/test/clone-for-isolation.test.ts
+++ b/packages/data-model/test/clone-for-isolation.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  cloneForIsolation,
+  fabricFromNativeValue,
+  resetDataModelConfig,
+  setDataModelConfig,
+} from "../fabric-value.ts";
+import type { FabricValue } from "../fabric-value.ts";
+import { deepFreeze, isDeepFrozen } from "../deep-freeze.ts";
+import { FabricBytes } from "../fabric-bytes.ts";
+import { FabricEpochNsec } from "../fabric-epoch.ts";
+import { FabricError } from "../fabric-native-instances.ts";
+
+// ============================================================================
+// cloneForIsolation
+// ============================================================================
+//
+// Contract: produce a deep clone isolated from later source mutation, while
+// preserving the identity of already-deep-frozen subtrees by reference. Throws
+// on any non-`FabricValue` (e.g. a raw `Date`/`Map`/`Error`). Parameterized
+// across both flag states (clone semantics are flag-independent).
+
+describe("cloneForIsolation", () => {
+  afterEach(() => {
+    resetDataModelConfig();
+  });
+
+  for (const modernMode of [false, true]) {
+    const label = modernMode ? "modern" : "legacy";
+
+    describe(`primitives & special primitives (${label})`, () => {
+      it("returns primitives as-is", () => {
+        setDataModelConfig(modernMode);
+        expect(cloneForIsolation(42 as FabricValue)).toBe(42);
+        expect(cloneForIsolation("hi" as FabricValue)).toBe("hi");
+        expect(cloneForIsolation(null as FabricValue)).toBe(null);
+        expect(cloneForIsolation(undefined as FabricValue)).toBe(undefined);
+        expect(cloneForIsolation(true as FabricValue)).toBe(true);
+      });
+
+      it("returns FabricPrimitive instances by identity (immutable)", () => {
+        setDataModelConfig(modernMode);
+        const bytes = new FabricBytes(new Uint8Array([1, 2, 3]));
+        const epoch = new FabricEpochNsec(123n);
+        expect(cloneForIsolation(bytes as FabricValue)).toBe(bytes);
+        expect(cloneForIsolation(epoch as FabricValue)).toBe(epoch);
+      });
+    });
+
+    describe(`deep-frozen identity preservation (${label})`, () => {
+      it("returns a fully deep-frozen input by identity", () => {
+        setDataModelConfig(modernMode);
+        const frozen = deepFreeze({ a: 1, b: { c: 2 } } as FabricValue);
+        expect(cloneForIsolation(frozen)).toBe(frozen);
+      });
+
+      it("preserves frozen subtrees by identity within a mutable parent", () => {
+        setDataModelConfig(modernMode);
+        const frozenChild = deepFreeze({ c: 2 } as FabricValue);
+        const parent = { a: 1, child: frozenChild } as FabricValue;
+        const result = cloneForIsolation(parent) as Record<string, unknown>;
+        expect(result).not.toBe(parent); // parent was mutable -> cloned
+        expect(result.child).toBe(frozenChild); // frozen subtree shared
+        expect(result).toEqual({ a: 1, child: { c: 2 } });
+      });
+    });
+
+    describe(`mutable input cloning (${label})`, () => {
+      it("deep-clones a mutable object (not same, but equal)", () => {
+        setDataModelConfig(modernMode);
+        const src = { a: 1, b: { c: 2 } } as FabricValue;
+        const result = cloneForIsolation(src) as Record<string, unknown>;
+        expect(result).not.toBe(src);
+        expect(result.b).not.toBe((src as Record<string, unknown>).b);
+        expect(result).toEqual({ a: 1, b: { c: 2 } });
+        // Mutating the source must not affect the isolated clone.
+        (src as Record<string, unknown>).a = 99;
+        expect(result.a).toBe(1);
+      });
+
+      it("result is mutable along non-frozen paths", () => {
+        setDataModelConfig(modernMode);
+        const result = cloneForIsolation(
+          { a: [1, 2] } as FabricValue,
+        ) as Record<string, unknown>;
+        expect(Object.isFrozen(result)).toBe(false);
+        expect(isDeepFrozen(result as FabricValue)).toBe(false);
+      });
+
+      it("deep-clones arrays and preserves sparse holes", () => {
+        setDataModelConfig(modernMode);
+        // deno-lint-ignore no-sparse-arrays
+        const src = [1, , 3] as unknown as FabricValue;
+        const result = cloneForIsolation(src) as unknown[];
+        expect(result).not.toBe(src);
+        expect(result.length).toBe(3);
+        expect(0 in result).toBe(true);
+        expect(1 in result).toBe(false);
+        expect(2 in result).toBe(true);
+      });
+
+      it("preserves null-prototype objects", () => {
+        setDataModelConfig(modernMode);
+        const src = Object.assign(Object.create(null), { x: 1 }) as FabricValue;
+        const result = cloneForIsolation(src);
+        expect(Object.getPrototypeOf(result)).toBe(null);
+        expect(result).toEqual(Object.assign(Object.create(null), { x: 1 }));
+      });
+
+      it("handles diamond references by preserving sharing", () => {
+        setDataModelConfig(modernMode);
+        const shared = { s: 1 };
+        const src = { a: shared, b: shared } as unknown as FabricValue;
+        const result = cloneForIsolation(src) as Record<string, unknown>;
+        expect(result.a).toBe(result.b); // sharing preserved
+        expect(result.a).not.toBe(shared); // but cloned
+      });
+
+      it("terminates on direct cycles", () => {
+        setDataModelConfig(modernMode);
+        const src: Record<string, unknown> = { a: 1 };
+        src.self = src;
+        const result = cloneForIsolation(src as FabricValue) as Record<
+          string,
+          unknown
+        >;
+        expect(result).not.toBe(src);
+        expect(result.self).toBe(result); // cycle re-pointed to the clone
+        expect(result.a).toBe(1);
+      });
+    });
+
+    describe(`FabricInstance handling (${label})`, () => {
+      it("returns a deep-frozen FabricError by identity", () => {
+        setDataModelConfig(modernMode);
+        const fe = FabricError.fromNativeError(new Error("boom"));
+        Object.freeze(fe);
+        expect(isDeepFrozen(fe)).toBe(true);
+        expect(cloneForIsolation(fe as unknown as FabricValue)).toBe(fe);
+      });
+
+      it("deep-clones a mutable FabricError", () => {
+        setDataModelConfig(modernMode);
+        const fe = FabricError.fromNativeError(
+          new Error("boom", { cause: { mutable: true } }),
+        );
+        Object.freeze(fe); // wrapper frozen, cause mutable -> not deep-frozen
+        expect(isDeepFrozen(fe)).toBe(false);
+        const result = cloneForIsolation(fe as unknown as FabricValue);
+        expect(result).toBeInstanceOf(FabricError);
+        expect(result).not.toBe(fe);
+        expect((result as unknown as FabricError).message).toBe("boom");
+      });
+
+      it("preserves a nested deep-frozen FabricError by identity", () => {
+        setDataModelConfig(modernMode);
+        const fe = FabricError.fromNativeError(new Error("nested"));
+        Object.freeze(fe);
+        const parent = { err: fe, x: 1 } as unknown as FabricValue;
+        const result = cloneForIsolation(parent) as Record<string, unknown>;
+        expect(result).not.toBe(parent);
+        expect(result.err).toBe(fe);
+      });
+    });
+
+    describe(`type-violation throws (${label})`, () => {
+      it("throws on a raw Date", () => {
+        setDataModelConfig(modernMode);
+        expect(() => cloneForIsolation(new Date() as unknown as FabricValue))
+          .toThrow(/Cannot clone for isolation/);
+      });
+
+      it("throws on a raw Map", () => {
+        setDataModelConfig(modernMode);
+        expect(() => cloneForIsolation(new Map() as unknown as FabricValue))
+          .toThrow(/Cannot clone for isolation/);
+      });
+
+      it("throws on a raw Error nested in a plain object", () => {
+        setDataModelConfig(modernMode);
+        const src = { err: new Error("raw") } as unknown as FabricValue;
+        expect(() => cloneForIsolation(src)).toThrow(
+          /Cannot clone for isolation/,
+        );
+      });
+    });
+
+    describe(`interaction with proper conversion (${label})`, () => {
+      it("isolates a converted Error tree without throwing", () => {
+        setDataModelConfig(modernMode);
+        // `fabricFromNativeValue` produces a proper value (in modern mode a
+        // FabricError whose cause is itself a FabricValue; in legacy mode an
+        // `@Error` plain object), so isolation must not choke on it.
+        const converted = fabricFromNativeValue(
+          new Error("outer", { cause: new Error("inner") }),
+          false,
+        );
+        const result = cloneForIsolation(converted);
+        if (modernMode) {
+          expect(result).toBeInstanceOf(FabricError);
+        } else {
+          // Legacy: `@Error` plain-object wrapper, deep-cloned for isolation.
+          expect(result).toHaveProperty("@Error");
+        }
+      });
+    });
+  }
+});

--- a/packages/data-model/value-clone.ts
+++ b/packages/data-model/value-clone.ts
@@ -204,6 +204,98 @@ export function cloneHelper(
 }
 
 // =============================================================================
+// `cloneForIsolation`
+// =============================================================================
+
+/**
+ * Produces a deep clone of `value` that is isolated from later mutations to
+ * the source, while preserving the identity of already-deep-frozen subtrees
+ * by reference.
+ *
+ * Dispatch:
+ * - Primitives and `FabricPrimitive` instances → returned as-is (immutable).
+ * - Already-deep-frozen values (per `isDeepFrozenFabricValue`) → returned by
+ *   identity at every level of the recursion. This is the perf optimization
+ *   the simpler `cloneIfNecessary(_, { frozen: false })` lacks: that one
+ *   `force`-clones, allocating new identities even for unchanged subtrees.
+ * - `FabricInstance` → deep-cloned via `.deepClone(false)` (its own semantics
+ *   govern any nested values).
+ * - Plain objects and arrays → deep-cloned recursively, with cycle detection
+ *   (back-references resolve to the in-progress copy, preserving shared
+ *   structure and terminating on cycles).
+ * - Any other class instance is a `FabricValue` type violation upstream; this
+ *   throws rather than silently passing it through.
+ *
+ * Result mutability is intentionally "mixed": the returned tree is mutable
+ * along any path that wasn't already deep-frozen in the input; deep-frozen
+ * subtrees inside the result remain frozen by reference. Callers that need a
+ * uniformly mutable result should use `cloneIfNecessary(value, { frozen:
+ * false })` instead.
+ */
+export function cloneForIsolation<T extends FabricValue>(value: T): T {
+  return cloneForIsolationHelper(value, null) as T;
+}
+
+function cloneForIsolationHelper(
+  value: FabricValue,
+  seen: Map<object, FabricValue> | null,
+): FabricValue {
+  switch (tagFromNativeValue(value)) {
+    // Inherently immutable: nothing to isolate from.
+    case NATIVE_TAGS.Primitive:
+    case NATIVE_TAGS.EpochNsec:
+    case NATIVE_TAGS.EpochDays:
+    case NATIVE_TAGS.ContentHash:
+    case NATIVE_TAGS.FabricBytes:
+      return value;
+
+    case NATIVE_TAGS.FabricInstance: {
+      // Already-deep-frozen instances can't be mutated, so share by identity.
+      if (isDeepFrozenFabricValue(value)) return value;
+      return (value as FabricInstance).deepClone(false);
+    }
+
+    case NATIVE_TAGS.Array: {
+      if (isDeepFrozenFabricValue(value)) return value;
+      const arr = value as FabricValue[];
+      const existing = seen?.get(arr);
+      if (existing !== undefined) return existing;
+      seen ??= new Map();
+      const copy: FabricValue[] = new Array(arr.length);
+      seen.set(arr, copy);
+      for (let i = 0; i < arr.length; i++) {
+        if (i in arr) copy[i] = cloneForIsolationHelper(arr[i], seen);
+      }
+      return copy;
+    }
+
+    case NATIVE_TAGS.Object: {
+      if (isDeepFrozenFabricValue(value)) return value;
+      const obj = value as object;
+      const existing = seen?.get(obj);
+      if (existing !== undefined) return existing;
+      seen ??= new Map();
+      // Preserve null prototypes (e.g. `Object.create(null)`).
+      const proto = Object.getPrototypeOf(obj);
+      const copy = Object.create(proto) as Record<string, FabricValue>;
+      seen.set(obj, copy);
+      for (const [key, val] of Object.entries(obj)) {
+        copy[key] = cloneForIsolationHelper(val as FabricValue, seen);
+      }
+      return copy;
+    }
+
+    default:
+      // Any other class instance is a `FabricValue` type violation upstream.
+      throw new Error(
+        `Cannot clone for isolation: ${
+          (value as object).constructor?.name ?? typeof value
+        }`,
+      );
+  }
+}
+
+// =============================================================================
 // `cloneForMutation`
 // =============================================================================
 


### PR DESCRIPTION
## Summary

Adds `cloneForIsolation()` to `@commonfabric/data-model` as a sibling of `cloneIfNecessary` and `cloneForMutation`. Data-model-only; no existing behavior changes (pure addition).

```ts
export function cloneForIsolation<T extends FabricValue>(value: T): T
```

Produces a deep clone isolated from later mutations to the source, while **preserving the identity of already-deep-frozen subtrees** by reference.

Dispatch:
- Primitives and `FabricPrimitive` → returned as-is.
- Already-deep-frozen values (per `isDeepFrozenFabricValue`) → returned by identity at every level. This is the perf optimization the simpler `cloneIfNecessary(_, { frozen: false })` lacks (it `force`-clones, allocating new identities even for unchanged subtrees).
- `FabricInstance` → deep-cloned via `.deepClone(false)`.
- Plain objects and arrays → deep-cloned recursively, with cycle detection (back-references resolve to the in-progress copy).
- Any other class instance is a `FabricValue` type violation upstream; the function **throws** rather than silently passing it through.

Result mutability is "mixed": mutable along any path that wasn't already deep-frozen in the input; deep-frozen subtrees remain frozen by reference.

## Why

The intended consumer is the v2-transaction storage layer's `isolateTransactionValue` helper, which implements an isomorphic-but-buggy version: it punts on `FabricInstance` (sharing the source reference — broken isolation) and silently passes raw non-`FabricValue` class instances through. The runner-side swap lands as a **follow-up PR**; this is the data-model-only prerequisite.

(Supersedes the earlier closed #3660, rewritten against current main with the strict throw-on-non-`FabricValue` behavior retained.)

## Test plan

- [x] `packages/data-model/test/clone-for-isolation.test.ts` — 46 steps across both flag states: primitives, `FabricPrimitive`, deep-frozen identity preservation (whole + per-subtree), mutable cloning (objects, arrays, null prototypes, sparse arrays, diamonds, cycles), `FabricInstance` handling, type-violation throws.
- [x] `deno task test` data-model — green.
- [x] `deno check` + `deno lint` clean.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Performance Baseline

This PR adds a new function which is not yet used, so the following accounts for a spurious perf check failure:

NEW_PERF_BASELINE: job: Runner Tests (1/4) = 68s


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `cloneForIsolation()` to `@commonfabric/data-model` to create mutation-isolated clones while reusing already deep-frozen subtrees by identity. No existing behavior changes; this is a new API used by upcoming transaction storage work.

- **New Features**
  - New `cloneForIsolation(value)` alongside `cloneIfNecessary` and `cloneForMutation`.
  - Primitives and `FabricPrimitive` are returned as-is; deep-frozen values are shared by identity.
  - `FabricInstance` is deep-cloned via `.deepClone(false)`.
  - Plain objects and arrays are cloned recursively with cycle detection; preserves sharing, sparse holes, and null prototypes.
  - Throws on non-`FabricValue` class instances (e.g., raw `Date`, `Map`, `Error`).
  - Result is mutable only where the source wasn’t already deep-frozen.

<sup>Written for commit e777e720d6e3659644b7f7c9d010bf5b8e314de1. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3664?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

