### PR TITLE
Use cloneForIsolation in v2-transaction (drop isolateTransactionValue)

### DIFF
--- a/packages/data-model/fabric-value-modern.ts
+++ b/packages/data-model/fabric-value-modern.ts
@@ -67,7 +67,19 @@ export function shallowFabricFromNativeValueModern(
       return value as FabricValueLayer;
 
     case NATIVE_TAGS.Error: {
-      const wrapped = FabricError.fromNativeError(value as Error);
+      // An `Error`'s internal state (`cause`, custom properties) is part of
+      // the `FabricError`'s value, so it must itself be proper `FabricValue`
+      // -- there is no valid "shallow" `FabricError` whose `.cause` is a raw
+      // `Error`. The outer structural walk treats a `FabricInstance` as atomic
+      // and won't descend into it, so the internals are converted here, at
+      // construction. (`freeze` still freezes only the wrapper, matching the
+      // shallow contract for containers; the now-`FabricValue` internals are
+      // left in whatever frozen state the deep converter produced.)
+      const wrapped = rebuildFabricErrorDeep(
+        FabricError.fromNativeError(value as Error),
+        new Map(),
+        false,
+      );
       if (freeze) Object.freeze(wrapped);
       return wrapped;
     }

--- a/packages/data-model/fabric-value-modern.ts
+++ b/packages/data-model/fabric-value-modern.ts
@@ -67,19 +67,13 @@ export function shallowFabricFromNativeValueModern(
       return value as FabricValueLayer;
 
     case NATIVE_TAGS.Error: {
-      // An `Error`'s internal state (`cause`, custom properties) is part of
-      // the `FabricError`'s value, so it must itself be proper `FabricValue`
-      // -- there is no valid "shallow" `FabricError` whose `.cause` is a raw
-      // `Error`. The outer structural walk treats a `FabricInstance` as atomic
-      // and won't descend into it, so the internals are converted here, at
-      // construction. (`freeze` still freezes only the wrapper, matching the
-      // shallow contract for containers; the now-`FabricValue` internals are
-      // left in whatever frozen state the deep converter produced.)
-      const wrapped = rebuildFabricErrorDeep(
-        FabricError.fromNativeError(value as Error),
-        new Map(),
-        false,
-      );
+      // Shallow conversion: wrap the native `Error` without recursing into its
+      // internals (`cause`, custom properties). The result is therefore only a
+      // *shallow* `FabricError` -- its `.cause` may still be a raw `Error`.
+      // Callers that need a proper (fully-`FabricValue`) `FabricError` must use
+      // the deep `fabricFromNativeValue()` instead; the cell write paths do so
+      // at the points where they treat a `FabricError` as an atomic leaf.
+      const wrapped = FabricError.fromNativeError(value as Error);
       if (freeze) Object.freeze(wrapped);
       return wrapped;
     }

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -1,5 +1,6 @@
 import { isRecord } from "@commonfabric/utils/types";
 import {
+  fabricFromNativeValue,
   FabricInstance,
   type FabricObject,
   type FabricValue,
@@ -793,7 +794,18 @@ export function normalizeAndDiff(
       "diff",
       () => `[BRANCH_FABRIC_INSTANCE] Atomic FabricInstance at path=${pathStr}`,
     );
-    changes.push({ location: link, value: newValue as FabricValue });
+    // This layer treats a `FabricInstance` atomically and won't descend into
+    // it, so its internal state must already be a proper `FabricValue` before
+    // it is stored. A shallow conversion may have left non-`FabricValue`
+    // internals (e.g. a wrapper whose nested state is still a raw native), so
+    // run the deep `fabricFromNativeValue()` here. It is class-agnostic:
+    // already-proper / deep-frozen instances short-circuit by identity, and
+    // each subclass governs its own deep conversion -- this code does not (and
+    // must not) special-case any concrete `FabricInstance` subclass.
+    changes.push({
+      location: link,
+      value: fabricFromNativeValue(newValue) as FabricValue,
+    });
     return changes;
   }
 

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -794,14 +794,28 @@ export function normalizeAndDiff(
       "diff",
       () => `[BRANCH_FABRIC_INSTANCE] Atomic FabricInstance at path=${pathStr}`,
     );
-    // This layer treats a `FabricInstance` atomically and won't descend into
-    // it, so its internal state must already be a proper `FabricValue` before
-    // it is stored. A shallow conversion may have left non-`FabricValue`
-    // internals (e.g. a wrapper whose nested state is still a raw native), so
-    // run the deep `fabricFromNativeValue()` here. It is class-agnostic:
-    // already-proper / deep-frozen instances short-circuit by identity, and
-    // each subclass governs its own deep conversion -- this code does not (and
-    // must not) special-case any concrete `FabricInstance` subclass.
+    // BAND-AID: this *should* be a shallow conversion. This is a unified walk
+    // (one `seen` map for shared-ref/cycle handling, `[ID]` assignment, and
+    // diffing), and the right design is to shallow-wrap the `FabricInstance`
+    // here and let this walk descend into its `FabricValue` internals as part
+    // of the same coordinated pass. We don't support that descent yet, so the
+    // wrapper's internals could otherwise reach storage improperly converted.
+    //
+    // As a stopgap we run the deep `fabricFromNativeValue()`, which converts
+    // the internals via a *separate, uncoordinated* pass. The cost: any
+    // `FabricValue` reachable both inside the wrapper and elsewhere in the
+    // outer tree gets de-shared (the outer walk handles one copy; this deep
+    // call mints an independent, separately-frozen copy with no shared `seen`
+    // / ID bookkeeping). That is invisible for `FabricError` today only
+    // because an error's `cause` / custom props aren't, in practice, shared
+    // with the rest of the tree -- but `FabricSet` / `FabricMap` (collections
+    // of arbitrary, routinely-shared `FabricValue`s) WILL break here once they
+    // carry real traffic. Proper fix: coordinated descent into wrapper
+    // internals, after which a shallow conversion suffices.
+    //
+    // The call is class-agnostic (no concrete-subclass special-casing): each
+    // subclass governs its own deep conversion and already-proper / deep-frozen
+    // instances short-circuit by identity.
     changes.push({
       location: link,
       value: fabricFromNativeValue(newValue) as FabricValue,

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -794,6 +794,10 @@ export function normalizeAndDiff(
       "diff",
       () => `[BRANCH_FABRIC_INSTANCE] Atomic FabricInstance at path=${pathStr}`,
     );
+    // TODO(danfuzz): Replace this band-aid once the unified walk supports
+    // coordinated descent into `FabricInstance` internals (see below); at that
+    // point switch this to a shallow conversion.
+    //
     // BAND-AID: this *should* be a shallow conversion. This is a unified walk
     // (one `seen` map for shared-ref/cycle handling, `[ID]` assignment, and
     // diffing), and the right design is to shallow-wrap the `FabricInstance`

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -1,5 +1,6 @@
-import { deepFreeze, isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
+import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
 import {
+  cloneForIsolation,
   cloneForMutation,
   CloneForMutationError,
   cloneIfNecessary,
@@ -139,68 +140,6 @@ function withCommitTiming<T>(
   }
 }
 
-/**
- * Produces a value that is isolated from later mutations to the source. For
- * a deep-frozen input the source can't be mutated, so the input is returned
- * unchanged; otherwise plain objects and arrays are deep-cloned (with cycle
- * detection) and non-plain-prototype objects are passed through. Sub-trees
- * that are themselves deep-frozen short-circuit by identity during the
- * recursion, so partially-frozen trees only copy their unfrozen portions.
- *
- * The result is NOT guaranteed to be mutable, since deep-frozen inputs are
- * returned as-is. Callers that need a mutable spine into a value tree at
- * a specific path should use `cloneForMutation()` from
- * `@commonfabric/data-model` instead -- it shallow-thaws only the spine
- * containers, preserving identity of off-spine subtrees (and their place
- * in the deep-frozen cache).
- */
-const isolateTransactionValue = <T>(
-  value: T,
-  seen: Map<object, unknown> = new Map(),
-): T => {
-  if (value === null || typeof value !== "object") {
-    return value;
-  }
-
-  // A deep-frozen value is already isolated: nothing can mutate it, so the
-  // returned reference is safe to share with the caller. `isDeepFrozen()` is
-  // O(1) on values previously cached as deep-frozen (the common case for
-  // values that came back out of storage in modern data model).
-  if (isDeepFrozen(value)) {
-    return value;
-  }
-
-  if (seen.has(value)) {
-    return seen.get(value) as T;
-  }
-
-  if (Array.isArray(value)) {
-    const copy = new Array(value.length);
-    seen.set(value, copy);
-    for (let i = 0; i < value.length; i++) {
-      if (i in value) {
-        copy[i] = isolateTransactionValue(value[i], seen);
-      }
-    }
-    return copy as T;
-  }
-
-  const prototype = Object.getPrototypeOf(value);
-  if (prototype !== Object.prototype && prototype !== null) {
-    return value;
-  }
-
-  const copy = Object.create(prototype) as Record<PropertyKey, unknown>;
-  seen.set(value, copy);
-  for (const key of Reflect.ownKeys(value)) {
-    copy[key] = isolateTransactionValue(
-      (value as Record<PropertyKey, unknown>)[key],
-      seen,
-    );
-  }
-  return copy as T;
-};
-
 const currentDocument = (doc: DocumentEntry): RootAttestation =>
   doc.current ?? doc.initial;
 
@@ -232,11 +171,12 @@ const freezeReadValue = <T extends FabricValue | undefined>(value: T): T => {
   ) {
     return value;
   }
-  // `isolateTransactionValue()` short-circuits on already-deep-frozen input
-  // (returns the source by identity) and `deepFreeze()` is O(1) on values
-  // already in its cache, so the steady-state cost on repeated reads of the
-  // same stored value collapses to two cache lookups.
-  return deepFreeze(isolateTransactionValue(value)) as T;
+  // `cloneForIsolation()` isolates the result from later source mutation by
+  // deep-cloning only the not-already-deep-frozen portions, returning
+  // deep-frozen subtrees by identity; `deepFreeze()` is then O(1) on values
+  // already in its cache. On the hot read path the steady-state cost on
+  // repeated reads of the same stored value collapses to two cache lookups.
+  return deepFreeze(cloneForIsolation(value)) as T;
 };
 
 const collapseEmptyJsonDocumentEnvelope = (
@@ -1240,7 +1180,7 @@ export class V2StorageTransaction implements IStorageTransaction {
     }
     const isolatedValue = value === undefined
       ? undefined
-      : isolateTransactionValue(value) as FabricValue;
+      : cloneForIsolation(value) as FabricValue;
     const result = writeAttestation(current, address, isolatedValue);
     if (result.error) {
       return { error: result.error.from(space) };
@@ -1269,7 +1209,7 @@ export class V2StorageTransaction implements IStorageTransaction {
         allowArrayLength: true,
       }),
       previous.kind === "ok"
-        ? isolateTransactionValue(previous.value) as FabricValue | undefined
+        ? cloneForIsolation(previous.value) as FabricValue | undefined
         : undefined,
       doc,
     );
@@ -1342,7 +1282,7 @@ export class V2StorageTransaction implements IStorageTransaction {
         nextKeyAfterPath: remainingPath[remainingPath.length - 1]!,
       },
     );
-    const isolatedValue = isolateTransactionValue(value) as FabricValue;
+    const isolatedValue = cloneForIsolation(value) as FabricValue;
     const parentWrite = writeAttestation(
       {
         address: {
@@ -1378,10 +1318,10 @@ export class V2StorageTransaction implements IStorageTransaction {
       return { ok: collapsedNext };
     }
 
-    const previousActivityValue = isolateTransactionValue(
+    const previousActivityValue = cloneForIsolation(
       readValueAtPath(doc.current.value, lastExistingPath, {
         allowArrayLength: true,
-      }),
+      }) as FabricValue,
     ) as FabricValue | undefined;
 
     doc.current = collapsedNext;
@@ -1440,7 +1380,7 @@ export class V2StorageTransaction implements IStorageTransaction {
     for (const { address, value } of writes) {
       const isolatedValue = value === undefined
         ? undefined
-        : isolateTransactionValue(value) as FabricValue;
+        : cloneForIsolation(value) as FabricValue;
       const previousValue = readValueAtPath(nextRoot, address.path, {
         allowArrayLength: true,
       });
@@ -1452,17 +1392,17 @@ export class V2StorageTransaction implements IStorageTransaction {
         address.path,
         isolatedValue,
       ) ?? address.path;
-      const previousActivityValue = isolateTransactionValue(
+      const previousActivityValue = cloneForIsolation(
         readValueAtPath(nextRoot, activityPath, {
           allowArrayLength: true,
-        }),
+        }) as FabricValue,
       ) as FabricValue | undefined;
       if (
         !hasMutableRoot && address.path.length > 0 && nextRoot !== undefined
       ) {
-        // Use `cloneIfNecessary({ frozen: false })` (not
-        // `isolateTransactionValue()`): the next line passes `nextRoot` to
-        // `applyMutablePathWrite`, which mutates in place along the write
+        // Use `cloneIfNecessary({ frozen: false })` (not `cloneForIsolation()`,
+        // whose result is only mixed-mutable): the next line passes `nextRoot`
+        // to `applyMutablePathWrite`, which mutates in place along the write
         // path, so we need a guaranteed-mutable root even when the stored
         // value is deep-frozen.
         nextRoot = cloneIfNecessary(nextRoot, { frozen: false });
@@ -1492,7 +1432,7 @@ export class V2StorageTransaction implements IStorageTransaction {
         readValueAtPath(result.ok.root, address.path, {
           allowArrayLength: true,
         }),
-        isolateTransactionValue(previousValue) as FabricValue | undefined,
+        cloneForIsolation(previousValue) as FabricValue | undefined,
         doc,
       );
       this.recordWriteActivity(


### PR DESCRIPTION
## Summary

Swaps the v2-transaction layer's bespoke `isolateTransactionValue` helper for the new `cloneForIsolation()` primitive, and fixes a latent data-model invariant violation the swap surfaced.

**Stacked on #3664** (adds `cloneForIsolation`) — review/merge that first. This PR's own diff is the two commits below.

## Commits

**1. `fix(data-model): shallow Error conversion yields a proper FabricValue`**

`shallowFabricFromNativeValueModern`'s `Error` case wrapped a native `Error` without converting its internals, so a `FabricError` could be constructed with a **raw `Error` `.cause`** — violating its own `cause: FabricValue` contract. The outer write-path walk treats a `FabricInstance` as atomic and never descends, so nothing fixed it downstream and the improper value reached storage. Now the internals are converted at construction (reusing the deep path's `rebuildFabricErrorDeep`). *By the time a `FabricValue` is constructed it should be a proper `FabricValue`.*

**2. `refactor(storage): use cloneForIsolation, drop bespoke isolateTransactionValue`**

`isolateTransactionValue` duplicated data-model cloning with two flaws: it passed non-plain-prototype objects through **by identity** (a mutable `FabricInstance` shared the caller's reference — broken isolation), and it **silently tolerated** raw non-`FabricValue` instances.

- `freezeReadValue` = `deepFreeze(cloneForIsolation(value))`.
- Write-activity / snapshot sites use `cloneForIsolation` (non-freezing — freezing them perturbed CFC write-authorization diffing for array pushes).
- The one genuinely-mutable root keeps `cloneIfNecessary(_, { frozen: false })`.
- `isolateTransactionValue` deleted.

The strict throw is intentional: it **surfaces** improper values instead of masking them — exactly what caught the raw-`Error`-cause bug fixed in commit 1.

## Test plan

- [x] `deno task test` runner — 455 passed / 0 failed (was failing the modern Error-cause case before commit 1).
- [x] `deno task test` full workspace — all 23 packages green (~80s).
- [x] `deno check` + `deno lint` clean on changed files.
- [ ] CI green (after #3664 merges / once rebased on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Performance Baseline

This PR is some small code tweaks that should have nothing to do with the timing of building binaries. So, the following accounts for a spurious perf check failure:

NEW_PERF_BASELINE: job: Build Binaries = 69s


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced bespoke v2 transaction isolation with `cloneForIsolation` and moved deep conversion of atomic `FabricInstance` values to the storage write boundary via `fabricFromNativeValue`. This prevents shared mutable references, keeps shallow conversion truly shallow, and ensures stored instances (including `FabricError`) have proper `FabricValue` internals; the deep-convert at that leaf is documented as a temporary band-aid.

- **Bug Fixes**
  - At the write boundary, deep-convert atomic `FabricInstance` values with `fabricFromNativeValue` so wrapper internals (e.g., `Error.cause` and custom props) are proper `FabricValue` before storage.

- **Refactors**
  - Replaced `isolateTransactionValue` with `cloneForIsolation` from `@commonfabric/data-model`; strict on non-`FabricValue`. Reads use `deepFreeze(cloneForIsolation(value))`; writes/activity snapshots use `cloneForIsolation`; keep one mutable root with `cloneIfNecessary(_, { frozen: false })`.
  - Documented the deep-convert as a stopgap (TODO) until coordinated descent into `FabricInstance` internals lands; shallow Error conversion remains shallow, with properness enforced at the storage boundary.

<sup>Written for commit eb8d832aa3c8cf80cede786e402f88d78d57af47. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3665?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

