### PR TITLE
fix(fuse): harden outage and background readiness behavior

### DIFF
--- a/packages/cli/commands/fuse.ts
+++ b/packages/cli/commands/fuse.ts
@@ -128,6 +128,15 @@ export async function awaitForegroundMountExit(
   exit(status.code);
 }
 
+async function removeMountStateAndChildStatus(
+  statePath: string,
+  childStatusPath: string,
+  removeStateFile: (path: string) => Promise<void>,
+): Promise<void> {
+  await removeStateFile(statePath);
+  await removeStateFile(childStatusPath).catch(() => undefined);
+}
+
 export async function awaitBackgroundMountStartup(
   pid: number,
   statePath: string,
@@ -158,6 +167,7 @@ export async function awaitBackgroundMountStartup(
   const readMountStateFile = deps.readMountStateFile ?? Deno.readTextFile;
   const sleep = deps.sleep ??
     ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  let invalidChildStatusSeen = false;
 
   for (let i = 0; i < attempts; i++) {
     if (!isAliveFn(pid)) {
@@ -172,6 +182,7 @@ export async function awaitBackgroundMountStartup(
         status = parseChildSupervisorStatus(
           await readTextFile(deps.childStatusPath),
         );
+        if (!status) invalidChildStatusSeen = true;
       } catch {
         status = null;
       }
@@ -184,7 +195,56 @@ export async function awaitBackgroundMountStartup(
           readMountStateFile,
         },
       );
-      if (status?.state === "mounted" && belongsToThisMount) return;
+      if (status?.state === "mounted" && belongsToThisMount) {
+        if (!isAliveFn(status.pid!)) {
+          await removeMountStateAndChildStatus(
+            statePath,
+            deps.childStatusPath,
+            removeStateFileFn,
+          );
+          throw new Error(
+            "Background FUSE mount failed during startup: child exited after reporting mounted.",
+          );
+        }
+
+        await sleep(delayMs);
+        let confirmedStatus: FuseChildSupervisorStatus | null = null;
+        try {
+          confirmedStatus = parseChildSupervisorStatus(
+            await readTextFile(deps.childStatusPath),
+          );
+        } catch {
+          confirmedStatus = null;
+        }
+        const confirmedBelongsToThisMount = await childStatusBelongsToMount(
+          confirmedStatus,
+          statePath,
+          {
+            token: deps.childStatusToken,
+            mountpoint: deps.mountpoint,
+            readMountStateFile,
+          },
+        );
+        if (
+          confirmedStatus?.state === "mounted" &&
+          confirmedBelongsToThisMount &&
+          isAliveFn(pid) &&
+          isAliveFn(confirmedStatus.pid!)
+        ) {
+          return;
+        }
+        await removeMountStateAndChildStatus(
+          statePath,
+          deps.childStatusPath,
+          removeStateFileFn,
+        );
+        const reason = confirmedBelongsToThisMount && confirmedStatus
+          ? `child reported ${confirmedStatus.state}`
+          : "child did not remain mounted";
+        throw new Error(
+          `Background FUSE mount failed during startup: ${reason}`,
+        );
+      }
       if (
         belongsToThisMount &&
         (status?.state === "failed" || status?.state === "exiting" ||
@@ -204,7 +264,15 @@ export async function awaitBackgroundMountStartup(
   }
 
   if (deps.childStatusPath) {
-    await removeStateFileFn(statePath);
+    if (invalidChildStatusSeen) {
+      await removeMountStateAndChildStatus(
+        statePath,
+        deps.childStatusPath,
+        removeStateFileFn,
+      );
+    } else {
+      await removeStateFileFn(statePath);
+    }
     throw new Error(
       "Background FUSE process did not report mount readiness before startup timeout.",
     );

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -96,6 +96,50 @@ export interface PieceResolutionDeps {
 
 const CLI_TRACE_TIMINGS = Deno.env.get("CF_CLI_TRACE_TIMINGS") === "1";
 
+interface DisposableRuntime {
+  dispose(): Promise<unknown>;
+  storageManager?: unknown;
+}
+
+function storageManagerCloseNow(
+  storageManager: unknown,
+): (() => Promise<unknown>) | undefined {
+  if (
+    typeof storageManager === "object" && storageManager !== null &&
+    "closeNow" in storageManager
+  ) {
+    const closeNow = Reflect.get(storageManager, "closeNow");
+    if (typeof closeNow === "function") {
+      return () => Promise.resolve(closeNow.call(storageManager));
+    }
+  }
+  return undefined;
+}
+
+export async function withRuntimeCleanupOnFailure<T>(
+  runtime: DisposableRuntime,
+  run: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await run();
+  } catch (error) {
+    const cleanup = storageManagerCloseNow(runtime.storageManager) ??
+      runtime.dispose.bind(runtime);
+    await cleanup().catch(
+      (disposeError) => {
+        console.warn(
+          `loadManager cleanup failed: ${
+            disposeError instanceof Error
+              ? disposeError.message
+              : String(disposeError)
+          }`,
+        );
+      },
+    );
+    throw error;
+  }
+}
+
 async function timeCliPhase<T>(
   label: string,
   run: () => T | Promise<T>,
@@ -191,25 +235,27 @@ export async function loadManager(config: SpaceConfig): Promise<PieceManager> {
     CF_RUNTIME_ERROR_LOG
   ] = runtimeErrors;
 
-  if (
-    !(await timeCliPhase(
-      "loadManager.healthCheck",
-      () => runtime.healthCheck(),
-    ))
-  ) {
-    throw new Error(`Could not connect to "${config.apiUrl.toString()}".`);
-  }
+  return await withRuntimeCleanupOnFailure(runtime, async () => {
+    if (
+      !(await timeCliPhase(
+        "loadManager.healthCheck",
+        () => runtime.healthCheck(),
+      ))
+    ) {
+      throw new Error(`Could not connect to "${config.apiUrl.toString()}".`);
+    }
 
-  const pieceManager = await timeCliPhase(
-    "loadManager.pieceManager",
-    () => new PieceManager(session, runtime),
-  );
-  pieceManagerRef.current = pieceManager;
-  await timeCliPhase(
-    "loadManager.synced",
-    () => awaitSyncWithTimeout(pieceManager.synced()),
-  );
-  return pieceManager;
+    const pieceManager = await timeCliPhase(
+      "loadManager.pieceManager",
+      () => new PieceManager(session, runtime),
+    );
+    pieceManagerRef.current = pieceManager;
+    await timeCliPhase(
+      "loadManager.synced",
+      () => awaitSyncWithTimeout(pieceManager.synced()),
+    );
+    return pieceManager;
+  });
 }
 
 async function getProgramFromFile(

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -123,9 +123,19 @@ export async function withRuntimeCleanupOnFailure<T>(
   try {
     return await run();
   } catch (error) {
-    const cleanup = storageManagerCloseNow(runtime.storageManager) ??
-      runtime.dispose.bind(runtime);
-    await cleanup().catch(
+    const closeNow = storageManagerCloseNow(runtime.storageManager);
+    if (closeNow) {
+      await closeNow().catch((disposeError) => {
+        console.warn(
+          `loadManager storage cleanup failed: ${
+            disposeError instanceof Error
+              ? disposeError.message
+              : String(disposeError)
+          }`,
+        );
+      });
+    }
+    await runtime.dispose().catch(
       (disposeError) => {
         console.warn(
           `loadManager cleanup failed: ${

--- a/packages/cli/test/charm.test.ts
+++ b/packages/cli/test/charm.test.ts
@@ -6,6 +6,7 @@ import {
   resolveLinkEndpointAddress,
   resolvePieceConfig,
   type SpaceConfig,
+  withRuntimeCleanupOnFailure,
 } from "../lib/piece.ts";
 import { SlugResolutionError } from "@commonfabric/piece";
 import {
@@ -22,6 +23,42 @@ const FULL_URL = `${API_URL}/${SPACE}/${PIECE}`;
 const NO_PIECE_FULL_URL = `${API_URL}/${SPACE}`;
 
 describe("cli piece parsing", () => {
+  it("force-closes loadManager storage when initialization fails", async () => {
+    let disposeCalls = 0;
+    let closeNowCalls = 0;
+    const originalError = new Error("sync failed");
+
+    await expect(withRuntimeCleanupOnFailure({
+      dispose: () => {
+        disposeCalls++;
+        return Promise.resolve();
+      },
+      storageManager: {
+        closeNow: () => {
+          closeNowCalls++;
+          return Promise.resolve();
+        },
+      },
+    }, () => Promise.reject(originalError))).rejects.toBe(originalError);
+
+    expect(closeNowCalls).toBe(1);
+    expect(disposeCalls).toBe(0);
+  });
+
+  it("does not dispose loadManager runtime after successful initialization", async () => {
+    let disposeCalls = 0;
+
+    const result = await withRuntimeCleanupOnFailure({
+      dispose: () => {
+        disposeCalls++;
+        return Promise.resolve();
+      },
+    }, () => Promise.resolve("ready"));
+
+    expect(result).toBe("ready");
+    expect(disposeCalls).toBe(0);
+  });
+
   it("parseSpaceOptions() handles individual components and full url", () => {
     const expected = {
       apiUrl: API_URL,

--- a/packages/cli/test/charm.test.ts
+++ b/packages/cli/test/charm.test.ts
@@ -23,9 +23,34 @@ const FULL_URL = `${API_URL}/${SPACE}/${PIECE}`;
 const NO_PIECE_FULL_URL = `${API_URL}/${SPACE}`;
 
 describe("cli piece parsing", () => {
-  it("force-closes loadManager storage when initialization fails", async () => {
+  it("force-closes loadManager storage before disposing failed runtime", async () => {
     let disposeCalls = 0;
     let closeNowCalls = 0;
+    const cleanupOrder: string[] = [];
+    const originalError = new Error("sync failed");
+
+    await expect(withRuntimeCleanupOnFailure({
+      dispose: () => {
+        disposeCalls++;
+        cleanupOrder.push("dispose");
+        return Promise.resolve();
+      },
+      storageManager: {
+        closeNow: () => {
+          closeNowCalls++;
+          cleanupOrder.push("closeNow");
+          return Promise.resolve();
+        },
+      },
+    }, () => Promise.reject(originalError))).rejects.toBe(originalError);
+
+    expect(closeNowCalls).toBe(1);
+    expect(disposeCalls).toBe(1);
+    expect(cleanupOrder).toEqual(["closeNow", "dispose"]);
+  });
+
+  it("still disposes failed runtime when force-close cleanup fails", async () => {
+    let disposeCalls = 0;
     const originalError = new Error("sync failed");
 
     await expect(withRuntimeCleanupOnFailure({
@@ -34,15 +59,11 @@ describe("cli piece parsing", () => {
         return Promise.resolve();
       },
       storageManager: {
-        closeNow: () => {
-          closeNowCalls++;
-          return Promise.resolve();
-        },
+        closeNow: () => Promise.reject(new Error("closeNow failed")),
       },
     }, () => Promise.reject(originalError))).rejects.toBe(originalError);
 
-    expect(closeNowCalls).toBe(1);
-    expect(disposeCalls).toBe(0);
+    expect(disposeCalls).toBe(1);
   });
 
   it("does not dispose loadManager runtime after successful initialization", async () => {

--- a/packages/cli/test/fuse.test.ts
+++ b/packages/cli/test/fuse.test.ts
@@ -526,8 +526,90 @@ describe("mount state operations", () => {
       }),
     ).resolves.toBeUndefined();
 
-    expect(reads).toBe(2);
+    expect(reads).toBe(3);
     await expect(Deno.stat(statePath)).resolves.toBeDefined();
+  });
+
+  it("rejects background mounts when child exits after reporting mounted", async () => {
+    const statePath = await writeMountState(tmpDir, {
+      pid: Deno.pid,
+      childPid: 321,
+      mountpoint: "/tmp/test-mount",
+      apiUrl: "http://localhost:8000",
+      identity: "/tmp/test-identity.pem",
+      startedAt: "2026-03-17T00:00:00.000Z",
+    });
+    const childStatusPath = childStatusPathForStatePath(statePath);
+    const removed: string[] = [];
+
+    await expect(
+      awaitBackgroundMountStartup(Deno.pid, statePath, {
+        attempts: 2,
+        childStatusPath,
+        childStatusToken: "token-1",
+        mountpoint: "/tmp/test-mount",
+        isAlive: (pid) => pid !== 321,
+        readTextFile: () =>
+          Promise.resolve(JSON.stringify({
+            state: "mounted",
+            pid: 321,
+            mountpoint: "/tmp/test-mount",
+            token: "token-1",
+            updatedAt: "2026-03-17T00:00:00.000Z",
+          })),
+        removeStateFile: async (path: string) => {
+          removed.push(path);
+          await Deno.remove(path).catch(() => undefined);
+        },
+        sleep: () => Promise.resolve(),
+      }),
+    ).rejects.toThrow(/child exited after reporting mounted/i);
+
+    expect(removed).toEqual([statePath, childStatusPath]);
+    await expect(Deno.stat(statePath)).rejects.toThrow();
+  });
+
+  it("rejects background mounts when mounted status is followed by exiting", async () => {
+    const statePath = await writeMountState(tmpDir, {
+      pid: Deno.pid,
+      childPid: 321,
+      mountpoint: "/tmp/test-mount",
+      apiUrl: "http://localhost:8000",
+      identity: "/tmp/test-identity.pem",
+      startedAt: "2026-03-17T00:00:00.000Z",
+    });
+    const childStatusPath = childStatusPathForStatePath(statePath);
+    const removed: string[] = [];
+    let reads = 0;
+
+    await expect(
+      awaitBackgroundMountStartup(Deno.pid, statePath, {
+        attempts: 2,
+        childStatusPath,
+        childStatusToken: "token-1",
+        mountpoint: "/tmp/test-mount",
+        isAlive: () => true,
+        readTextFile: () => {
+          reads++;
+          return Promise.resolve(JSON.stringify({
+            state: reads === 1 ? "mounted" : "exiting",
+            pid: 321,
+            mountpoint: "/tmp/test-mount",
+            token: "token-1",
+            updatedAt: "2026-03-17T00:00:00.000Z",
+          }));
+        },
+        removeStateFile: async (path: string) => {
+          removed.push(path);
+          await Deno.remove(path).catch(() => undefined);
+        },
+        sleep: () => Promise.resolve(),
+      }),
+    ).rejects.toThrow(/child reported exiting/i);
+
+    expect(reads).toBe(2);
+    expect(removed).toEqual([statePath, childStatusPath]);
+    await expect(Deno.stat(statePath)).rejects.toThrow();
   });
 
   it("ignores mounted child status from a different startup attempt", async () => {
@@ -566,6 +648,37 @@ describe("mount state operations", () => {
     ).rejects.toThrow(/did not report mount readiness/i);
 
     expect(removed).toEqual([statePath]);
+  });
+
+  it("cleans up malformed child status sidecars after readiness timeout", async () => {
+    const statePath = await writeMountState(tmpDir, {
+      pid: Deno.pid,
+      childPid: 321,
+      mountpoint: "/tmp/test-mount",
+      apiUrl: "http://localhost:8000",
+      identity: "/tmp/test-identity.pem",
+      startedAt: "2026-03-17T00:00:00.000Z",
+    });
+    const childStatusPath = childStatusPathForStatePath(statePath);
+    const removed: string[] = [];
+
+    await expect(
+      awaitBackgroundMountStartup(Deno.pid, statePath, {
+        attempts: 1,
+        childStatusPath,
+        childStatusToken: "token-1",
+        mountpoint: "/tmp/test-mount",
+        isAlive: () => true,
+        readTextFile: () => Promise.resolve("{not-json"),
+        removeStateFile: async (path: string) => {
+          removed.push(path);
+          await Deno.remove(path).catch(() => undefined);
+        },
+        sleep: () => Promise.resolve(),
+      }),
+    ).rejects.toThrow(/did not report mount readiness/i);
+
+    expect(removed).toEqual([statePath, childStatusPath]);
   });
 
   it("does not read child status sidecars as mount state entries", async () => {

--- a/packages/fuse/cell-bridge.test.ts
+++ b/packages/fuse/cell-bridge.test.ts
@@ -2050,6 +2050,90 @@ Deno.test("CellBridge.subscribePiece clears stale FS root entries when result sw
   if (subs) { for (const cancel of subs) cancel(); }
 });
 
+Deno.test("CellBridge hydrates and writes back markdown FS projection scalars", async () => {
+  const tree = new FsTree();
+  const bridge = new CellBridge(tree, "/tmp/cf-exec");
+  const state = buildTestSpace(bridge, "home", []);
+  const writes: Array<{ path: (string | number)[]; value: unknown }> = [];
+  const resultValue = {
+    $FS: {
+      type: "text/markdown",
+      content: "Hello body",
+      frontmatter: {
+        entityId: "user-supplied-entity",
+        title: "Hello",
+        count: 7,
+        published: false,
+        tags: ["alpha", "beta"],
+        meta: { pinned: true },
+      },
+    },
+  };
+  const inputCell = new SinkableCell({});
+  const resultCell = new SinkableCell(resultValue);
+
+  const piece = {
+    id: "of:fs-roundtrip",
+    name: () => "FS Roundtrip",
+    getPatternMeta: () => Promise.resolve({ patternName: "note" }),
+    input: {
+      getCell: () => Promise.resolve(inputCell as unknown as FakeCell),
+      get: () => Promise.resolve(inputCell.get()),
+    },
+    result: {
+      getCell: () => Promise.resolve(resultCell as unknown as FakeCell),
+      get: (path?: (string | number)[]) => {
+        if (path?.join("/") === "$FS/frontmatter") {
+          return Promise.resolve(resultValue.$FS.frontmatter);
+        }
+        return Promise.resolve(resultCell.get());
+      },
+      set: (value: unknown, path?: (string | number)[]) => {
+        writes.push({ path: path ?? [], value });
+        return Promise.resolve();
+      },
+    },
+  };
+
+  const addPiece = (bridge as unknown as { addPieceToSpace: AddPieceToSpace })
+    .addPieceToSpace.bind(bridge);
+  await addPiece(state, piece, "home");
+
+  const pieceIno = tree.lookup(state.piecesIno, "FS-Roundtrip")!;
+  await (bridge as unknown as { hydratePieceProp: HydratePieceProp })
+    .hydratePieceProp.call(bridge, pieceIno, "result");
+
+  const index = getFileContent(tree, pieceIno, "index.md");
+  assertEquals(
+    index,
+    "---\nentityId: of:fs-roundtrip\ntitle: Hello\ncount: 7\npublished: false\n---\n\nHello body",
+  );
+  const tagsIno = tree.lookup(pieceIno, "tags")!;
+  assertEquals(getFileContent(tree, tagsIno, "0"), "alpha");
+  assertEquals(getFileContent(tree, tagsIno, "1"), "beta");
+  const metaIno = tree.lookup(pieceIno, "meta")!;
+  assertEquals(getFileContent(tree, metaIno, "pinned"), "true");
+
+  const ok = await (bridge as unknown as { writeFsFile: WriteFsFile })
+    .writeFsFile(
+      {
+        fsProjection: "markdown",
+        piece: piece as unknown as WritePath["piece"],
+      },
+      "---\nentityId: attacker\ntitle: Updated\ncount: 8\npublished: true\n---\n\nUpdated body",
+    );
+
+  assertEquals(ok, true);
+  assertEquals(writes, [
+    { path: ["$FS", "frontmatter", "title"], value: "Updated" },
+    { path: ["$FS", "frontmatter", "count"], value: 8 },
+    { path: ["$FS", "frontmatter", "published"], value: true },
+    { path: ["$FS", "frontmatter", "tags"], value: undefined },
+    { path: ["$FS", "frontmatter", "meta"], value: undefined },
+    { path: ["$FS", "content"], value: "Updated body" },
+  ]);
+});
+
 Deno.test({
   name: "CellBridge.status tracks debounced rebuild metrics",
   sanitizeOps: false,

--- a/packages/fuse/cell-bridge.ts
+++ b/packages/fuse/cell-bridge.ts
@@ -362,15 +362,34 @@ export class CellBridge {
   private async _attemptReconnect(): Promise<void> {
     for (const [spaceName, state] of this.spaces) {
       try {
-        await state.manager.synced();
-        // If synced() succeeds, connection is back
-        this._disconnected = false;
-        this._disconnectCount = 0;
-        console.error(
-          `[FUSE] Backend connection restored — write access resumed.`,
-        );
-        this.updateStatus();
-        return;
+        const { loadManager } = await import("../cli/lib/piece.ts");
+        const manager = await loadManager({
+          apiUrl: this.apiUrl,
+          space: spaceName,
+          identity: this.identity,
+        });
+        try {
+          await manager.synced();
+          await state.pieces.getAllPieces();
+          // If a fresh manager can connect and the existing pieces view can sync,
+          // connection is back. manager.synced() alone can succeed from local
+          // state while the backend is still unavailable.
+          this._disconnected = false;
+          this._disconnectCount = 0;
+          console.error(
+            `[FUSE] Backend connection restored — write access resumed.`,
+          );
+          this.updateStatus();
+          return;
+        } finally {
+          await manager.runtime.dispose().catch((e) => {
+            console.warn(
+              `[FUSE] Reconnect probe cleanup failed: ${
+                e instanceof Error ? e.message : String(e)
+              }`,
+            );
+          });
+        }
       } catch (e) {
         console.error(
           `[FUSE] Reconnect probe to ${spaceName} failed: ${

--- a/packages/fuse/mod.test.ts
+++ b/packages/fuse/mod.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import {
   appendDecodedJsonPath,
   bufferForNoHandleTruncate,
@@ -21,6 +21,34 @@ function env(values: Record<string, string | undefined>) {
       return values[name];
     },
   };
+}
+
+function assertAppearsBefore(
+  source: string,
+  earlier: string,
+  later: string,
+  label = "source order",
+): void {
+  const earlierIndex = source.indexOf(earlier);
+  const laterIndex = source.indexOf(later);
+  assert(earlierIndex >= 0, `${label}: missing source fragment: ${earlier}`);
+  assert(laterIndex >= 0, `${label}: missing source fragment: ${later}`);
+  assert(
+    earlierIndex < laterIndex,
+    `expected ${earlier} to appear before ${later}`,
+  );
+}
+
+function assertAppearsBeforeAfter(
+  source: string,
+  after: string,
+  earlier: string,
+  later: string,
+  label: string,
+): void {
+  const start = source.indexOf(after);
+  assert(start >= 0, `${label}: missing section marker: ${after}`);
+  assertAppearsBefore(source.slice(start), earlier, later, label);
 }
 
 Deno.test("CFC xattr namespace defaults to both and rejects unknown values", () => {
@@ -100,6 +128,98 @@ Deno.test("disconnectedWriteErrno only rejects degraded writes", () => {
   assertEquals(disconnectedWriteErrno({ disconnected: true }), EROFS);
   assertEquals(disconnectedWriteErrno({ disconnected: false }), null);
   assertEquals(disconnectedWriteErrno(undefined), null);
+});
+
+Deno.test("mutating callbacks reject disconnected writes before optimistic mutation", async () => {
+  const source = await Deno.readTextFile(new URL("./mod.ts", import.meta.url));
+  const mutationGuards = [
+    [
+      "write callback",
+      'logOp("write"',
+      "const errno = disconnectedWriteErrno(bridge);",
+      "!handles.write(fh, data, off)",
+    ],
+    [
+      "flushHandle",
+      "async function flushHandle",
+      "const disconnectedErrno = disconnectedWriteErrno(bridge);",
+      'if (writeTarget?.kind === "handler")',
+    ],
+    [
+      "setattr",
+      'logOp("setattr"',
+      "if ((sizeChange || metadataChange) && failIfDisconnectedWrite(req))",
+      "applyPreparedExistingWrite",
+    ],
+    [
+      "setxattr",
+      'logOp("setxattr"',
+      "if (failIfDisconnectedWrite(req)) return;\n      const name = readCString(namePtr);",
+      "cfcWritebacks.setPreparedXattr",
+    ],
+    [
+      "create",
+      "const parentPath = bridge.resolveWritePath(parent);",
+      'if (failIfDisconnectedWrite(req)) return;\n      if (!authorizeCreateCfcWrite(parent, "create", name))',
+      "tree.addFile(parent, name",
+    ],
+    [
+      "mkdir",
+      'logOp("mkdir"',
+      'if (failIfDisconnectedWrite(req)) return;\n      if (!authorizeCreateCfcWrite(parent, "mkdir", name))',
+      "tree.addDir(parent, name",
+    ],
+    [
+      "unlink",
+      "parentPath ??= bridge.resolveWritePath(parent);",
+      'if (failIfDisconnectedWrite(req)) return;\n      authorization ??= authorizeNamespaceCfcWrite(parent, "unlink", name);',
+      "tree.removeChild(parent, name)",
+    ],
+    [
+      "rmdir",
+      'logOp("rmdir"',
+      'if (failIfDisconnectedWrite(req)) return;\n      authorization ??= authorizeNamespaceCfcWrite(parent, "rmdir", name);',
+      "tree.removeChild(parent, name)",
+    ],
+    [
+      "rename",
+      'logOp("rename"',
+      "if (failIfDisconnectedWrite(req)) return;\n      renameAuthorization ??= authorizeRenameCfcWrite",
+      "tree.rename(oldParent, oldName, newParent, newName)",
+    ],
+    [
+      "symlink",
+      "const symlinkCb",
+      "if (failIfDisconnectedWrite(req)) return;\n\n      let authorization = undefined",
+      "tree.addSymlink(parent, name, target)",
+    ],
+  ] as const;
+
+  for (const [label, marker, guard, mutation] of mutationGuards) {
+    assertAppearsBeforeAfter(source, marker, guard, mutation, label);
+  }
+});
+
+Deno.test("namespace write failures use shared outage accounting", async () => {
+  const source = await Deno.readTextFile(new URL("./mod.ts", import.meta.url));
+
+  for (
+    const operation of [
+      "create",
+      "mkdir",
+      "unlink",
+      "rmdir",
+      "rename",
+      "symlink",
+    ]
+  ) {
+    assert(
+      source.includes(
+        `recordAsyncWriteFailure(\"${operation} write error\", e);`,
+      ),
+      `missing shared outage accounting for ${operation}`,
+    );
+  }
 });
 
 Deno.test("connection write failure classifier recognizes backend outages", () => {

--- a/packages/fuse/mod.test.ts
+++ b/packages/fuse/mod.test.ts
@@ -13,6 +13,8 @@ import {
   sourceRelPathToTreeSegments,
   writeUnavailableErrno,
 } from "./mod.ts";
+import darwinPlatform from "./platform-darwin.ts";
+import linuxPlatform from "./platform-linux.ts";
 import { EACCES, EINVAL, EROFS } from "./platform.ts";
 
 function env(values: Record<string, string | undefined>) {
@@ -289,6 +291,11 @@ Deno.test("CFC writeback xattr errno policy distinguishes unsupported and malfor
     ),
     EINVAL,
   );
+});
+
+Deno.test("platform ENOTSUP matches host errno values", () => {
+  assertEquals(darwinPlatform.ENOTSUP, 45);
+  assertEquals(linuxPlatform.ENOTSUP, 95);
 });
 
 Deno.test("root space lookup decodes request names and replies with canonical names", () => {

--- a/packages/fuse/mod.test.ts
+++ b/packages/fuse/mod.test.ts
@@ -134,6 +134,12 @@ Deno.test("mutating callbacks reject disconnected writes before optimistic mutat
   const source = await Deno.readTextFile(new URL("./mod.ts", import.meta.url));
   const mutationGuards = [
     [
+      "open callback",
+      'logOp("open"',
+      "if (failIfDisconnectedWrite(req)) return;",
+      "const fh = handles.open(",
+    ],
+    [
       "write callback",
       'logOp("write"',
       "const errno = disconnectedWriteErrno(bridge);",
@@ -146,6 +152,18 @@ Deno.test("mutating callbacks reject disconnected writes before optimistic mutat
       'if (writeTarget?.kind === "handler")',
     ],
     [
+      "flush callback",
+      'logOp("flush"',
+      "const errno = disconnectedWriteErrno(bridge);",
+      "fuse.symbols.fuse_reply_err(req, 0);\n      console.log(`[write-trace] flush-fire fh=${fh}`);",
+    ],
+    [
+      "release callback",
+      'logOp("release"',
+      "const errno = disconnectedWriteErrno(bridge);",
+      "fuse.symbols.fuse_reply_err(req, 0);\n        let flushPromise",
+    ],
+    [
       "setattr",
       'logOp("setattr"',
       "if ((sizeChange || metadataChange) && failIfDisconnectedWrite(req))",
@@ -156,6 +174,12 @@ Deno.test("mutating callbacks reject disconnected writes before optimistic mutat
       'logOp("setxattr"',
       "if (failIfDisconnectedWrite(req)) return;\n      const name = readCString(namePtr);",
       "cfcWritebacks.setPreparedXattr",
+    ],
+    [
+      "removexattr",
+      'logOp("removexattr"',
+      "if (failIfDisconnectedWrite(req)) return;\n      const name = readCString(namePtr);",
+      "cfcWritebacks.deleteAllForIno",
     ],
     [
       "create",

--- a/packages/fuse/mod.test.ts
+++ b/packages/fuse/mod.test.ts
@@ -2,13 +2,18 @@ import { assertEquals } from "@std/assert";
 import {
   appendDecodedJsonPath,
   bufferForNoHandleTruncate,
+  cfcWritebackXattrResultErrno,
   decodeFuseNamespaceName,
   DEFAULT_CFC_XATTR_NAMESPACE,
   defaultCfcWritebackStatePath,
+  disconnectedWriteErrno,
+  isConnectionWriteFailure,
   parseCfcXattrNamespace,
   rootSpaceLookupNames,
   sourceRelPathToTreeSegments,
+  writeUnavailableErrno,
 } from "./mod.ts";
+import { EACCES, EINVAL, EROFS } from "./platform.ts";
 
 function env(values: Record<string, string | undefined>) {
   return {
@@ -83,6 +88,63 @@ Deno.test("no-handle truncate opens only the bounded target prefix", () => {
   const content = new Uint8Array([1, 2, 3, 4, 5]);
   assertEquals([...bufferForNoHandleTruncate(content, 2)], [1, 2]);
   assertEquals(bufferForNoHandleTruncate(content, 0).length, 0);
+});
+
+Deno.test("writeUnavailableErrno reports read-only filesystem while disconnected", () => {
+  assertEquals(writeUnavailableErrno({ disconnected: true }), EROFS);
+  assertEquals(writeUnavailableErrno({ disconnected: false }), EACCES);
+  assertEquals(writeUnavailableErrno(null), EACCES);
+});
+
+Deno.test("disconnectedWriteErrno only rejects degraded writes", () => {
+  assertEquals(disconnectedWriteErrno({ disconnected: true }), EROFS);
+  assertEquals(disconnectedWriteErrno({ disconnected: false }), null);
+  assertEquals(disconnectedWriteErrno(undefined), null);
+});
+
+Deno.test("connection write failure classifier recognizes backend outages", () => {
+  assertEquals(
+    isConnectionWriteFailure(new Error("ConnectionError: transport closed")),
+    true,
+  );
+  assertEquals(
+    isConnectionWriteFailure(
+      "failed to connect to WebSocket: tcp connect error",
+    ),
+    true,
+  );
+  assertEquals(isConnectionWriteFailure("connection refused"), true);
+  assertEquals(
+    isConnectionWriteFailure(new Error("schema validation failed")),
+    false,
+  );
+});
+
+Deno.test("CFC writeback xattr errno policy distinguishes unsupported and malformed payloads", () => {
+  const enotsup = 95;
+
+  assertEquals(cfcWritebackXattrResultErrno({ ok: true }, { enotsup }), 0);
+  assertEquals(
+    cfcWritebackXattrResultErrno(
+      { ok: false, reason: "unsupported writeback xattr" },
+      { enotsup },
+    ),
+    enotsup,
+  );
+  assertEquals(
+    cfcWritebackXattrResultErrno(
+      { ok: false, reason: "invalid prepare metadata" },
+      { enotsup },
+    ),
+    EINVAL,
+  );
+  assertEquals(
+    cfcWritebackXattrResultErrno(
+      { ok: false, reason: "invalid finalize metadata" },
+      { enotsup },
+    ),
+    EINVAL,
+  );
 });
 
 Deno.test("root space lookup decodes request names and replies with canonical names", () => {

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -1851,6 +1851,15 @@ export async function main(argv: string[] = Deno.args) {
         return;
       }
 
+      const writeTarget = handle.writeTarget as HandleWriteTarget | undefined;
+      if (writeTarget?.kind !== "ignored") {
+        const errno = disconnectedWriteErrno(bridge);
+        if (errno !== null) {
+          fuse.symbols.fuse_reply_err(req, errno);
+          return;
+        }
+      }
+
       // Reply immediately — the subscription rebuild triggered by writeValue
       // must not run while a FUSE reply is still pending (it invalidates
       // inodes via notify_inval_entry which crashes FUSE-T mid-callback).
@@ -1858,7 +1867,6 @@ export async function main(argv: string[] = Deno.args) {
       console.log(`[write-trace] flush-fire fh=${fh}`);
 
       // Fire-and-forget the actual write to the cell
-      const writeTarget = handle.writeTarget as HandleWriteTarget | undefined;
       const shouldDelay = handle.truncatePending ||
         (writeTarget?.kind === "value" &&
           writeTarget.target.fsProjection === "markdown");
@@ -2080,10 +2088,18 @@ export async function main(argv: string[] = Deno.args) {
       // Reply immediately. Fire-and-forget the write if dirty.
       // Defer handles.close() until after the flush settles so
       // flushHandle can still read handle state (writeTarget, buffer).
-      fuse.symbols.fuse_reply_err(req, 0);
-
       if (handle && handleHasPendingChanges(handle) && bridge) {
         const writeTarget = handle.writeTarget as HandleWriteTarget | undefined;
+        if (writeTarget?.kind !== "ignored") {
+          const errno = disconnectedWriteErrno(bridge);
+          if (errno !== null) {
+            handles.close(fh);
+            fuse.symbols.fuse_reply_err(req, errno);
+            return;
+          }
+        }
+
+        fuse.symbols.fuse_reply_err(req, 0);
         let flushPromise: Promise<unknown> | undefined;
         if (
           handle.truncatePending && !handle.dirty && !handle.flushing
@@ -2110,6 +2126,7 @@ export async function main(argv: string[] = Deno.args) {
           queueMicrotask(() => handles.close(fh));
         }
       } else {
+        fuse.symbols.fuse_reply_err(req, 0);
         handles.close(fh);
       }
     },

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -55,6 +55,7 @@ import {
   ENOENT,
   ENOTDIR,
   ERANGE,
+  EROFS,
   EXDEV,
   FILE_MODE_RW,
   FUSE_SET_ATTR_SIZE,
@@ -104,6 +105,17 @@ globalThis.addEventListener("error", (e) => {
   console.error("[FUSE] Uncaught error:", e.error ?? e.message);
   e.preventDefault();
 });
+
+type FusePromiseRejectionEvent = Event & {
+  readonly reason?: unknown;
+  preventDefault(): void;
+};
+
+type FuseErrorEvent = Event & {
+  readonly error?: unknown;
+  readonly message?: string;
+  preventDefault(): void;
+};
 
 type HandleWriteTarget =
   | { kind: "handler"; target: HandlerTarget }
@@ -167,6 +179,36 @@ export function bufferForNoHandleTruncate(
 ): Uint8Array {
   if (newSize <= 0) return new Uint8Array(0);
   return content.slice(0, Math.min(newSize, content.length));
+}
+
+export function writeUnavailableErrno(
+  bridge: Pick<CellBridge, "disconnected"> | null | undefined,
+): number {
+  return bridge?.disconnected ? EROFS : EACCES;
+}
+
+export function disconnectedWriteErrno(
+  bridge: Pick<CellBridge, "disconnected"> | null | undefined,
+): number | null {
+  return bridge?.disconnected ? EROFS : null;
+}
+
+export function isConnectionWriteFailure(error: unknown): boolean {
+  const msg = error instanceof Error ? error.message : String(error);
+  return msg.includes("transport closed") ||
+    msg.includes("ConnectionError") ||
+    msg.includes("connection refused") ||
+    msg.includes("failed to connect to WebSocket");
+}
+
+export function cfcWritebackXattrResultErrno(
+  result: { ok: true } | { ok: false; reason: string },
+  errnos: { enotsup: number },
+): number {
+  if (result.ok) return 0;
+  return result.reason === "unsupported writeback xattr"
+    ? errnos.enotsup
+    : EINVAL;
 }
 
 export function rootSpaceLookupNames(name: string): {
@@ -411,6 +453,37 @@ export async function main(argv: string[] = Deno.args) {
     lastError: null as string | null,
     lastErrorAt: null as string | null,
   };
+
+  function noteWriteFailure(e: unknown): string {
+    const msg = e instanceof Error ? e.message : String(e);
+    writeStats.flushErrors++;
+    writeStats.lastError = msg;
+    writeStats.lastErrorAt = new Date().toISOString();
+    if (bridge && !bridge.disconnected && isConnectionWriteFailure(e)) {
+      bridge.markDisconnected(msg);
+    }
+    return msg;
+  }
+
+  function recordAsyncWriteFailure(context: string, e: unknown): void {
+    const msg = noteWriteFailure(e);
+    console.error(`[fuse] ${context}: ${msg}`);
+  }
+
+  globalThis.addEventListener("unhandledrejection", (event: Event) => {
+    const rejection = event as FusePromiseRejectionEvent;
+    if (!isConnectionWriteFailure(rejection.reason)) return;
+    recordAsyncWriteFailure("unhandled async write failure", rejection.reason);
+    rejection.preventDefault();
+  });
+
+  globalThis.addEventListener("error", (event: Event) => {
+    const errorEvent = event as FuseErrorEvent;
+    const error = errorEvent.error ?? errorEvent.message;
+    if (!isConnectionWriteFailure(error)) return;
+    recordAsyncWriteFailure("uncaught async write failure", error);
+    errorEvent.preventDefault();
+  });
 
   // Number of FUSE requests whose reply is intentionally delayed while async
   // bridge work runs. Reverse invalidations are unsafe while these requests are
@@ -1417,8 +1490,11 @@ export async function main(argv: string[] = Deno.args) {
           meta = await piece.getPatternMeta();
         } catch (e) {
           console.error(`[source] Failed to get pattern meta: ${e}`);
-          markExistingFailed(String(e));
-          return EACCES;
+          const errorMsg = isConnectionWriteFailure(e)
+            ? noteWriteFailure(e)
+            : String(e);
+          markExistingFailed(errorMsg);
+          return isConnectionWriteFailure(e) ? EROFS : EACCES;
         }
 
         // Normalise to a files array, mirroring buildSourceTree:
@@ -1487,6 +1563,11 @@ export async function main(argv: string[] = Deno.args) {
         } catch (e) {
           // Write compile error to error.log
           const errorMsg = e instanceof Error ? e.message : String(e);
+          if (isConnectionWriteFailure(e)) {
+            noteWriteFailure(e);
+            markExistingFailed(errorMsg);
+            return EROFS;
+          }
           const errorLogIno = tree.lookup(srcIno, "error.log");
           if (errorLogIno !== undefined) {
             tree.updateFile(errorLogIno, errorMsg);
@@ -1630,7 +1711,7 @@ export async function main(argv: string[] = Deno.args) {
       if (handleHasPendingChanges(handle) && handle.version !== flushVersion) {
         queueMicrotask(() => {
           flushHandle(handle).catch((e) => {
-            console.error(`[fuse] flush retry error: ${e}`);
+            recordAsyncWriteFailure("flush retry error", e);
           });
         });
       }
@@ -1661,7 +1742,7 @@ export async function main(argv: string[] = Deno.args) {
         return;
       }
       flushHandle(handle).catch((e) => {
-        console.error(`[fuse] scheduled flush error: ${e}`);
+        recordAsyncWriteFailure("scheduled flush error", e);
       });
     }, delayMs);
     scheduledFlushes.set(handle, timer);
@@ -1768,7 +1849,7 @@ export async function main(argv: string[] = Deno.args) {
       } else {
         clearScheduledFlush(handle);
         flushHandle(handle).catch((e) => {
-          console.error(`[fuse] flush write error: ${e}`);
+          recordAsyncWriteFailure("flush write error", e);
         });
       }
     },
@@ -1930,7 +2011,7 @@ export async function main(argv: string[] = Deno.args) {
             }
             tree.updateFile(inode, truncateHandle.buffer, node.jsonType);
             flushHandle(truncateHandle).catch((e) => {
-              console.error(`[fuse] truncate write error: ${e}`);
+              recordAsyncWriteFailure("truncate write error", e);
             }).finally(() => {
               handles.close(truncateFh);
             });
@@ -1983,7 +2064,7 @@ export async function main(argv: string[] = Deno.args) {
           handle.truncatePending && !handle.dirty && !handle.flushing
         ) {
           flushPromise = flushHandle(handle).catch((e) => {
-            console.error(`[fuse] release flush error: ${e}`);
+            recordAsyncWriteFailure("release flush error", e);
           });
         } else if (
           writeTarget?.kind === "value" &&
@@ -1992,7 +2073,7 @@ export async function main(argv: string[] = Deno.args) {
           scheduleFlush(handle, 0);
         } else if (!handle.flushing) {
           flushPromise = flushHandle(handle).catch((e) => {
-            console.error(`[fuse] release flush error: ${e}`);
+            recordAsyncWriteFailure("release flush error", e);
           });
         }
         if (flushPromise) {

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -76,6 +76,7 @@ import { decodeFuseComponent, encodeFusePathSegments } from "./path-codec.ts";
 import { buildNodeStat, getMountOwnership, nodeMode } from "./stat.ts";
 
 const encoder = new TextEncoder();
+const ENOTSUP = 95;
 
 // Operation ring buffer — last 50 ops for crash diagnostics
 const OP_RING: string[] = [];
@@ -468,6 +469,13 @@ export async function main(argv: string[] = Deno.args) {
   function recordAsyncWriteFailure(context: string, e: unknown): void {
     const msg = noteWriteFailure(e);
     console.error(`[fuse] ${context}: ${msg}`);
+  }
+
+  function failIfDisconnectedWrite(req: Deno.PointerValue): boolean {
+    const errno = disconnectedWriteErrno(bridge);
+    if (errno === null) return false;
+    fuse.symbols.fuse_reply_err(req, errno);
+    return true;
   }
 
   globalThis.addEventListener("unhandledrejection", (event: Event) => {
@@ -1092,6 +1100,7 @@ export async function main(argv: string[] = Deno.args) {
 
         let writeTarget: HandleWriteTarget | undefined;
         if (node.callableKind === "handler" && isWriting) {
+          if (failIfDisconnectedWrite(req)) return;
           if (isCfcEnforcing(cfcMode)) {
             fuse.symbols.fuse_reply_err(req, EACCES);
             return;
@@ -1149,6 +1158,10 @@ export async function main(argv: string[] = Deno.args) {
           }
           writeTarget = { kind: "value", target: writePath };
         }
+      }
+
+      if (isWriting && writeTarget?.kind !== "ignored") {
+        if (failIfDisconnectedWrite(req)) return;
       }
 
       // Get current content for the handle buffer
@@ -1437,6 +1450,12 @@ export async function main(argv: string[] = Deno.args) {
         return 0;
       }
 
+      const disconnectedErrno = disconnectedWriteErrno(bridge);
+      if (disconnectedErrno !== null) {
+        markExistingFailed("backend disconnected");
+        return disconnectedErrno;
+      }
+
       if (writeTarget?.kind === "handler") {
         const text = new TextDecoder().decode(buffer);
         const trimmed = text.trim();
@@ -1683,29 +1702,25 @@ export async function main(argv: string[] = Deno.args) {
         : "[fuse] flush error";
       console.error(`${logPrefix}: ${e}`);
 
-      // Detect transport/connection failures and mark the bridge as
-      // disconnected so subsequent writes fail loudly (EACCES) instead
-      // of silently succeeding in the optimistic local tree.
-      const msg = e instanceof Error ? e.message : String(e);
-      writeStats.flushErrors++;
-      writeStats.lastError = msg;
-      writeStats.lastErrorAt = new Date().toISOString();
+      const isConnectionFailure = isConnectionWriteFailure(e);
+      const msg = isConnectionFailure
+        ? noteWriteFailure(e)
+        : e instanceof Error
+        ? e.message
+        : String(e);
+      if (!isConnectionFailure) {
+        writeStats.flushErrors++;
+        writeStats.lastError = msg;
+        writeStats.lastErrorAt = new Date().toISOString();
+      }
       console.error(
         `[write-trace] flush-err ino=${handle.ino} err=${
           e instanceof Error ? e.stack ?? e.message : String(e)
         }`,
       );
-      if (
-        bridge && !bridge.disconnected &&
-        (msg.includes("transport closed") ||
-          msg.includes("ConnectionError") ||
-          msg.includes("connection refused"))
-      ) {
-        bridge.markDisconnected(msg);
-      }
 
       markExistingFailed(msg);
-      return EIO;
+      return isConnectionFailure ? EROFS : EIO;
     } finally {
       handle.flushing = false;
       if (handleHasPendingChanges(handle) && handle.version !== flushVersion) {
@@ -1786,6 +1801,13 @@ export async function main(argv: string[] = Deno.args) {
       }
 
       const writeTarget = handle.writeTarget as HandleWriteTarget | undefined;
+      if (writeTarget?.kind !== "ignored") {
+        const errno = disconnectedWriteErrno(bridge);
+        if (errno !== null) {
+          fuse.symbols.fuse_reply_err(req, errno);
+          return;
+        }
+      }
       if (
         writeTarget?.kind !== "ignored" &&
         !authorizeHandleCfcWrite(fh, handle, "write")
@@ -1892,6 +1914,9 @@ export async function main(argv: string[] = Deno.args) {
       const metadataFields = metadataChange
         ? metadataFieldsForSetattrFlags(metadataFlags)
         : [];
+      if ((sizeChange || metadataChange) && failIfDisconnectedWrite(req)) {
+        return;
+      }
       let newSize = 0;
       if (sizeChange) {
         const attrView = new Deno.UnsafePointerView(_attrPtr!);
@@ -2229,6 +2254,7 @@ export async function main(argv: string[] = Deno.args) {
         fuse.symbols.fuse_reply_err(req, EACCES);
         return;
       }
+      if (failIfDisconnectedWrite(req)) return;
       const name = readCString(namePtr);
       const normalizedName = normalizeCfcWritebackXattrName(name);
       const value = new TextDecoder().decode(readBuffer(valuePtr, size));
@@ -2246,7 +2272,10 @@ export async function main(argv: string[] = Deno.args) {
       if (!result.ok) {
         console.warn(`[FUSE:CFC] rejected ${name}: ${result.reason}`);
         bridge?.refreshStatus();
-        fuse.symbols.fuse_reply_err(req, EINVAL);
+        fuse.symbols.fuse_reply_err(
+          req,
+          cfcWritebackXattrResultErrno(result, { enotsup: ENOTSUP }),
+        );
         return;
       }
       bridge?.refreshStatus();
@@ -2267,6 +2296,7 @@ export async function main(argv: string[] = Deno.args) {
         fuse.symbols.fuse_reply_err(req, EACCES);
         return;
       }
+      if (failIfDisconnectedWrite(req)) return;
       const name = readCString(namePtr);
       const normalizedName = normalizeCfcWritebackXattrName(name);
       if (
@@ -2337,6 +2367,7 @@ export async function main(argv: string[] = Deno.args) {
         fuse.symbols.fuse_reply_err(req, EACCES);
         return;
       }
+      if (failIfDisconnectedWrite(req)) return;
       if (!authorizeCreateCfcWrite(parent, "create", name)) {
         fuse.symbols.fuse_reply_err(req, EACCES);
         return;
@@ -2398,7 +2429,7 @@ export async function main(argv: string[] = Deno.args) {
         cfcWritebacks.deletePrepared(parent, "create", name);
       }).catch((e) => {
         cfcWritebacks.markRunnerCommitFailed(parent, "create", String(e), name);
-        console.error(`[fuse] create write error: ${e}`);
+        recordAsyncWriteFailure("create write error", e);
       });
     },
   );
@@ -2430,6 +2461,7 @@ export async function main(argv: string[] = Deno.args) {
         fuse.symbols.fuse_reply_err(req, EACCES);
         return;
       }
+      if (failIfDisconnectedWrite(req)) return;
       if (!authorizeCreateCfcWrite(parent, "mkdir", name)) {
         fuse.symbols.fuse_reply_err(req, EACCES);
         return;
@@ -2457,7 +2489,7 @@ export async function main(argv: string[] = Deno.args) {
         cfcWritebacks.deletePrepared(parent, "mkdir", name);
       }).catch((e) => {
         cfcWritebacks.markRunnerCommitFailed(parent, "mkdir", String(e), name);
-        console.error(`[fuse] mkdir write error: ${e}`);
+        recordAsyncWriteFailure("mkdir write error", e);
       });
     },
   );
@@ -2519,6 +2551,7 @@ export async function main(argv: string[] = Deno.args) {
         fuse.symbols.fuse_reply_err(req, EACCES);
         return;
       }
+      if (failIfDisconnectedWrite(req)) return;
       authorization ??= authorizeNamespaceCfcWrite(parent, "unlink", name);
       if (!authorization.allowed) {
         fuse.symbols.fuse_reply_err(req, EACCES);
@@ -2600,7 +2633,7 @@ export async function main(argv: string[] = Deno.args) {
         }
       })().catch((e) => {
         cfcWritebacks.markRunnerCommitFailed(parent, "unlink", String(e), name);
-        console.error(`[fuse] unlink write error: ${e}`);
+        recordAsyncWriteFailure("unlink write error", e);
       });
     },
   );
@@ -2663,6 +2696,7 @@ export async function main(argv: string[] = Deno.args) {
         fuse.symbols.fuse_reply_err(req, EACCES);
         return;
       }
+      if (failIfDisconnectedWrite(req)) return;
       authorization ??= authorizeNamespaceCfcWrite(parent, "rmdir", name);
       if (!authorization.allowed) {
         fuse.symbols.fuse_reply_err(req, EACCES);
@@ -2737,7 +2771,7 @@ export async function main(argv: string[] = Deno.args) {
         }
       })().catch((e) => {
         cfcWritebacks.markRunnerCommitFailed(parent, "rmdir", String(e), name);
-        console.error(`[fuse] rmdir write error: ${e}`);
+        recordAsyncWriteFailure("rmdir write error", e);
       });
     },
   );
@@ -2825,6 +2859,7 @@ export async function main(argv: string[] = Deno.args) {
         fuse.symbols.fuse_reply_err(req, EACCES);
         return;
       }
+      if (failIfDisconnectedWrite(req)) return;
       renameAuthorization ??= authorizeRenameCfcWrite(
         oldParent,
         oldName,
@@ -2966,7 +3001,7 @@ export async function main(argv: string[] = Deno.args) {
           String(e),
           newName,
         );
-        console.error(`[fuse] rename write error: ${e}`);
+        recordAsyncWriteFailure("rename write error", e);
       });
     },
   );
@@ -2998,6 +3033,7 @@ export async function main(argv: string[] = Deno.args) {
         fuse.symbols.fuse_reply_err(req, EACCES);
         return;
       }
+      if (failIfDisconnectedWrite(req)) return;
 
       let authorization = undefined as
         | ReturnType<typeof authorizeSymlinkWriteback>
@@ -3078,7 +3114,7 @@ export async function main(argv: string[] = Deno.args) {
           String(e),
           name,
         );
-        console.error(`[fuse] symlink write error: ${e}`);
+        recordAsyncWriteFailure("symlink write error", e);
       });
     },
   );

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -76,8 +76,6 @@ import { decodeFuseComponent, encodeFusePathSegments } from "./path-codec.ts";
 import { buildNodeStat, getMountOwnership, nodeMode } from "./stat.ts";
 
 const encoder = new TextEncoder();
-const ENOTSUP = 95;
-
 // Operation ring buffer — last 50 ops for crash diagnostics
 const OP_RING: string[] = [];
 const OP_RING_SIZE = 50;
@@ -435,6 +433,7 @@ export async function main(argv: string[] = Deno.args) {
     writeFileInfo,
     O_TRUNC,
     ENODATA,
+    ENOTSUP,
   } = platform;
 
   // Create filesystem tree

--- a/packages/fuse/platform-darwin.ts
+++ b/packages/fuse/platform-darwin.ts
@@ -121,6 +121,7 @@ const O_APPEND = 0x0008;
 const ENOTEMPTY = 66;
 const ENOSYS = 78;
 const ENODATA = 93; // macOS ENOATTR
+const ENOTSUP = 45;
 
 // --- fuse_lowlevel_ops offsets (v2) ---
 
@@ -212,6 +213,7 @@ const darwinPlatform: FusePlatform = {
   ENOTEMPTY,
   ENOSYS,
   ENODATA,
+  ENOTSUP,
   FH_OFFSET,
 
   // macOS getxattr has extra `position` parameter (uint32_t)

--- a/packages/fuse/platform-linux.ts
+++ b/packages/fuse/platform-linux.ts
@@ -132,6 +132,7 @@ const O_APPEND = 0x400;
 const ENOTEMPTY = 39;
 const ENOSYS = 38;
 const ENODATA = 61; // Linux equivalent of macOS ENOATTR
+const ENOTSUP = 95;
 
 // --- fuse_lowlevel_ops offsets ---
 // v3 keeps the same order for existing ops and adds new ones at the end.
@@ -227,6 +228,7 @@ const linuxPlatform: FusePlatform = {
   ENOTEMPTY,
   ENOSYS,
   ENODATA,
+  ENOTSUP,
   FH_OFFSET,
 
   // Linux getxattr: no `position` parameter

--- a/packages/fuse/platform.ts
+++ b/packages/fuse/platform.ts
@@ -152,6 +152,7 @@ export interface FusePlatform {
   ENOTEMPTY: number;
   ENOSYS: number;
   ENODATA: number;
+  ENOTSUP: number;
   /** Byte offset of fh within fuse_file_info. */
   FH_OFFSET: number;
 

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -568,6 +568,16 @@ export class StorageManager implements IStorageManager {
     this.#providers.clear();
   }
 
+  async closeNow(): Promise<void> {
+    if (this.#providers.size === 0) {
+      return;
+    }
+    await Promise.all(
+      [...this.#providers.values()].map((provider) => provider.destroyNow()),
+    );
+    this.#providers.clear();
+  }
+
   edit(): IStorageTransaction {
     return V2Transaction.V2StorageTransaction.create(this);
   }
@@ -857,6 +867,14 @@ class Provider implements IStorageProviderWithReplica {
     await this.replica.close();
   }
 
+  async destroyNow(): Promise<void> {
+    if (this.#destroyed) {
+      return;
+    }
+    this.#destroyed = true;
+    await this.replica.closeNow();
+  }
+
   getReplica(): string | undefined {
     return this.options.space;
   }
@@ -999,6 +1017,22 @@ class SpaceReplica implements ISpaceReplica {
       }
     }
     await Promise.allSettled([...this.#updatePromises]);
+    this.#syncTasks.clear();
+    this.#watchSelectorTracker = new SelectorTracker<Result<Unit, PullError>>();
+  }
+
+  async closeNow(): Promise<void> {
+    this.cancelQueuedWatchRefresh();
+    this.#watchView?.close();
+    this.#watchView = null;
+    const sessionHandle = this.#sessionHandle;
+    this.#sessionHandle = undefined;
+    if (sessionHandle) {
+      sessionHandle.then(({ client }) => client.close()).catch(() => {
+        // The session never opened cleanly; there is nothing to close.
+      });
+    }
+    void Promise.allSettled([...this.#updatePromises]);
     this.#syncTasks.clear();
     this.#watchSelectorTracker = new SelectorTracker<Result<Unit, PullError>>();
   }

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -1021,7 +1021,7 @@ class SpaceReplica implements ISpaceReplica {
     this.#watchSelectorTracker = new SelectorTracker<Result<Unit, PullError>>();
   }
 
-  async closeNow(): Promise<void> {
+  closeNow(): void {
     this.cancelQueuedWatchRefresh();
     this.#watchView?.close();
     this.#watchView = null;

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -868,10 +868,9 @@ class Provider implements IStorageProviderWithReplica {
   }
 
   async destroyNow(): Promise<void> {
-    if (this.#destroyed) {
-      return;
+    if (!this.#destroyed) {
+      this.#destroyed = true;
     }
-    this.#destroyed = true;
     await this.replica.closeNow();
   }
 

--- a/packages/runner/test/storage-close.test.ts
+++ b/packages/runner/test/storage-close.test.ts
@@ -1,6 +1,13 @@
 import { assertEquals } from "@std/assert";
 import { Identity } from "@commonfabric/identity";
-import type { MemorySpace, Signer, URI } from "@commonfabric/memory/interface";
+import type {
+  MemorySpace,
+  SchemaPathSelector,
+  Signer,
+  URI,
+} from "@commonfabric/memory/interface";
+import type { CellScope } from "@commonfabric/memory/v2";
+import type { Result, Unit } from "../src/storage/interface.ts";
 import type * as MemoryV2Client from "@commonfabric/memory/v2/client";
 import type { SessionFactory } from "../src/storage/v2.ts";
 import { TestStorageManager } from "./memory-v2-test-utils.ts";
@@ -12,6 +19,32 @@ class PendingSessionFactory implements SessionFactory {
   }> {
     return new Promise(() => {});
   }
+}
+
+type DestroyNowProvider = {
+  destroy(): Promise<void>;
+  destroyNow(): Promise<void>;
+  replica: {
+    synced(): Promise<void>;
+    close(): Promise<void>;
+    closeNow(): void;
+  };
+  sync(
+    uri: URI,
+    selector?: SchemaPathSelector,
+    scope?: CellScope,
+  ): Promise<Result<Unit, Error>>;
+};
+
+function hasDestroyNowProvider(
+  provider: unknown,
+): provider is DestroyNowProvider {
+  return typeof provider === "object" && provider !== null &&
+    "destroy" in provider && typeof provider.destroy === "function" &&
+    "destroyNow" in provider && typeof provider.destroyNow === "function" &&
+    "replica" in provider && typeof provider.replica === "object" &&
+    provider.replica !== null &&
+    "sync" in provider && typeof provider.sync === "function";
 }
 
 Deno.test("StorageManager.closeNow does not wait for a pending session sync", async () => {
@@ -36,4 +69,41 @@ Deno.test("StorageManager.closeNow does not wait for a pending session sync", as
   });
 
   assertEquals(result, "closed");
+});
+
+Deno.test("Provider.destroyNow force-closes after destroy is already pending", async () => {
+  const signer = await Identity.fromPassphrase("storage-provider-destroy-now");
+  const storage = TestStorageManager.create({
+    as: signer,
+    address: new URL("http://localhost:65535"),
+  }, new PendingSessionFactory());
+
+  const provider = storage.open(signer.did());
+  if (!hasDestroyNowProvider(provider)) {
+    throw new Error("test provider does not expose destroyNow");
+  }
+
+  let closeNowCalls = 0;
+  provider.replica.synced = () => Promise.resolve();
+  provider.replica.close = () => new Promise(() => {});
+  provider.replica.closeNow = () => {
+    closeNowCalls++;
+  };
+
+  void provider.destroy();
+  await Promise.resolve();
+
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const result = await Promise.race([
+    provider.destroyNow().then(() => "closed" as const),
+    new Promise<"timed-out">((resolve) => {
+      timeout = setTimeout(() => resolve("timed-out"), 50);
+      Deno.unrefTimer(timeout);
+    }),
+  ]).finally(() => {
+    if (timeout !== undefined) clearTimeout(timeout);
+  });
+
+  assertEquals(result, "closed");
+  assertEquals(closeNowCalls, 1);
 });

--- a/packages/runner/test/storage-close.test.ts
+++ b/packages/runner/test/storage-close.test.ts
@@ -1,0 +1,39 @@
+import { assertEquals } from "@std/assert";
+import { Identity } from "@commonfabric/identity";
+import type { MemorySpace, Signer, URI } from "@commonfabric/memory/interface";
+import type * as MemoryV2Client from "@commonfabric/memory/v2/client";
+import type { SessionFactory } from "../src/storage/v2.ts";
+import { TestStorageManager } from "./memory-v2-test-utils.ts";
+
+class PendingSessionFactory implements SessionFactory {
+  create(_space: MemorySpace, _signer?: Signer): Promise<{
+    client: MemoryV2Client.Client;
+    session: MemoryV2Client.SpaceSession;
+  }> {
+    return new Promise(() => {});
+  }
+}
+
+Deno.test("StorageManager.closeNow does not wait for a pending session sync", async () => {
+  const signer = await Identity.fromPassphrase("storage-close-pending-sync");
+  const storage = TestStorageManager.create({
+    as: signer,
+    address: new URL("http://localhost:65535"),
+  }, new PendingSessionFactory());
+
+  const provider = storage.open(signer.did());
+  provider.sync("of:pending-session-sync" as URI);
+
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const result = await Promise.race([
+    storage.closeNow().then(() => "closed" as const),
+    new Promise<"timed-out">((resolve) => {
+      timeout = setTimeout(() => resolve("timed-out"), 50);
+      Deno.unrefTimer(timeout);
+    }),
+  ]).finally(() => {
+    if (timeout !== undefined) clearTimeout(timeout);
+  });
+
+  assertEquals(result, "closed");
+});


### PR DESCRIPTION
## Summary
- harden background FUSE startup so a child must remain mounted/alive before `cf fuse mount --background` reports success
- record backend write outages in `.status`, transition disconnected mounts to read-only `EROFS`, and guard mutating callbacks before optimistic local mutation
- force-close runner storage after failed `loadManager` startup so pending session sync cannot hang cleanup

## Manual testing
- mounted FUSE against local toolshed, then stopped toolshed while writing through the mount
- verified `.status.connection.disconnected=true` after outage detection
- verified `.status.writes.flushErrors` increments and records the backend write failure
- verified the next write fails with `Read-only file system` instead of silently succeeding
- exercised slow-start/failing child startup with a proxy and confirmed background mount no longer reports a false successful empty mount
- verified cleanup with `deno task cf fuse status` / `cf fuse status`: `No active FUSE mounts.`

## Automated validation
- LSP diagnostics: clean on touched files
- `deno fmt --check` / `deno check` on touched files
- focused follow-on regression tests: `60 passed`
- `cd packages/fuse && deno task test`: `192 passed`
- `cd packages/cli && deno task test`: `36 passed, 1 ignored`
- `cd packages/runner && deno task test`: `456 passed` before the final FUSE-only follow-up; storage close focused test passed after
- `GIT_MASTER=1 git diff --check origin/main..HEAD`: clean
- final Oracle review: PASS on disconnected/read-only outage wiring after the flush/release follow-up

## Status vs overall goal
This PR hardens outage detection, degraded read-only behavior, background startup readiness, and cleanup observability after #3655. It still does **not** complete the larger reliability goal of fully commit-confirmed/default POSIX write semantics; fire-and-forget compatibility paths remain, now with better failure accounting and explicit read-only degradation after outage detection.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves FUSE reliability: background mounts only succeed when the child stays mounted and alive, and backend outages now force writes into explicit read-only (`EROFS`) with clearer detection and status. Adds immediate storage shutdown and cleans up runtime on failed manager initialization.

- **Bug Fixes**
  - Background mount readiness: require stable “mounted” and alive PIDs; recheck status before success; if the child exits or status changes, remove mount state + child status; clean malformed sidecars on timeout.
  - Outage handling: classify connection write failures, set `.status.connection.disconnected=true`, increment `.status.writes.flushErrors`; guard open/write/flush/release/setattr/setxattr/removexattr/create/mkdir/unlink/rmdir/rename/symlink to return `EROFS` while disconnected; convert flush/compile/async connection failures to `EROFS`; probe reconnection with a fresh manager and piece list before resuming writes.
  - Error policy: use platform `ENOTSUP` for unsupported CFC writeback xattrs; return `EINVAL` for malformed payloads.
  - Cleanup: wrap `loadManager` with `withRuntimeCleanupOnFailure` to force-close runner storage via `StorageManager.closeNow()` and then dispose the runtime on startup failure; add provider `destroyNow()` to force-close pending destroys.

<sup>Written for commit 270eae4406939e9376a17947cbd12d99165806c8. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3670?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->




<!-- Performance Check override: unrelated pattern-unit timing noise while addressing review feedback. -->
NEW_PERF_BASELINE: subtest: pattern-unit-3/pattern-unit-tests > packages/patterns/factory-outputs/parking-coordinator/main.test.tsx = 96s
