### PR TITLE
CFC: reconstruct written values via copy-on-write (no full base clone)

### DIFF
--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1,7 +1,8 @@
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { emptySchemaObject } from "@commonfabric/data-model/schema-utils";
 import {
-  cloneIfNecessary,
+  cloneForMutation,
+  type CloneForMutationResult,
   isArrayIndexPropertyName,
 } from "@commonfabric/data-model/fabric-value";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
@@ -1021,18 +1022,40 @@ export const writeDetailValueForTarget = (
     return baseValue;
   }
 
-  const baseIsContainer = isRecord(baseValue) || Array.isArray(baseValue);
-  const result: Record<PropertyKey, unknown> | unknown[] = baseIsContainer
-    ? cloneIfNecessary(baseValue as FabricValue, { frozen: false }) as
-      | Record<PropertyKey, unknown>
-      | unknown[]
-    : (descendants.every(({ rel }) => isArrayIndexPropertyName(rel[0]))
-      ? []
-      : {});
-  for (const { rel, value: descendantValue } of descendants) {
-    setValueAtPath(result, rel, descendantValue);
+  if (!(isRecord(baseValue) || Array.isArray(baseValue))) {
+    // Base isn't a container yet deeper writes exist (rare/incoherent): build a
+    // fresh container and overlay onto it (it's freshly mutable -- no COW).
+    const result: Record<PropertyKey, unknown> | unknown[] =
+      descendants.every(({ rel }) => isArrayIndexPropertyName(rel[0])) ? [] : {};
+    for (const { rel, value: descendantValue } of descendants) {
+      setValueAtPath(result, rel, descendantValue);
+    }
+    return result as FabricValue;
   }
-  return result as FabricValue;
+
+  // Overlay the deeper field-writes onto the base via copy-on-write
+  // spine-thawing: only the containers along each overlay path are shallow-
+  // copied; large off-spine subtrees are preserved by reference, never
+  // deep-copied. Process shallowest-first so an envelope write at a parent
+  // path lands before writes to its children. `cloneForMutation` defaults to
+  // `force: true`, so the shared (deep-frozen) base is never mutated.
+  const ordered = [...descendants].sort((a, b) => a.rel.length - b.rel.length);
+  let root: FabricValue = baseValue;
+  for (const { rel, value: descendantValue } of ordered) {
+    const leaf = rel[rel.length - 1]!;
+    const thawed: CloneForMutationResult<FabricValue> = cloneForMutation(
+      root,
+      rel.slice(0, -1),
+      { createMissing: true, nextKeyAfterPath: leaf },
+    );
+    setValueAtPath(
+      thawed.pathValue as Record<PropertyKey, unknown> | unknown[],
+      [leaf],
+      descendantValue,
+    );
+    root = thawed.value;
+  }
+  return root;
 };
 
 const writeValueForTarget = (

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1026,7 +1026,9 @@ export const writeDetailValueForTarget = (
     // Base isn't a container yet deeper writes exist (rare/incoherent): build a
     // fresh container and overlay onto it (it's freshly mutable -- no COW).
     const result: Record<PropertyKey, unknown> | unknown[] =
-      descendants.every(({ rel }) => isArrayIndexPropertyName(rel[0])) ? [] : {};
+      descendants.every(({ rel }) => isArrayIndexPropertyName(rel[0]))
+        ? []
+        : {};
     for (const { rel, value: descendantValue } of descendants) {
       setValueAtPath(result, rel, descendantValue);
     }

--- a/packages/runner/test/cfc-write-reconstruction.test.ts
+++ b/packages/runner/test/cfc-write-reconstruction.test.ts
@@ -1,12 +1,16 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStrictEquals } from "@std/assert";
 import { writeDetailValueForTarget } from "../src/cfc/prepare.ts";
 import { normalizeCellScope } from "../src/scope.ts";
+import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
+import type {
+  FabricValue,
+  MemorySpace,
+  URI,
+} from "@commonfabric/memory/interface";
 import type {
   IExtendedStorageTransaction,
-  MemorySpace,
   TransactionWriteDetail,
 } from "../src/storage/interface.ts";
-import type { URI } from "@commonfabric/memory/interface";
 
 // `writeDetailValueForTarget` reconstructs "the value this transaction wrote
 // at a path" from the recorded write-details. A value may be recorded either
@@ -154,4 +158,40 @@ Deno.test("writeDetailValueForTarget: no matching write returns undefined", () =
     ),
     undefined,
   );
+});
+
+Deno.test("writeDetailValueForTarget: composition preserves large off-spine subtrees by reference (no deep copy)", () => {
+  // Deliberately ginormous, synthetic-but-realistic base: a large array of
+  // records plus a small sibling field, deep-frozen (as stored values are).
+  // It's recorded as a coarse base write at the target PLUS a granular write
+  // to the *small* field. Reconstruction must overlay the small field WITHOUT
+  // deep-copying the large array -- under arbitrary user data the base is
+  // unbounded, so a full deep clone here would be an O(size) cost per check.
+  const bigList = Array.from({ length: 50_000 }, (_, i) => ({
+    id: i,
+    body: `message number ${i}`,
+    meta: { seen: false, tags: ["a", "b"] },
+  }));
+  const base = deepFreeze(
+    { items: bigList, status: "draft" } as unknown as FabricValue,
+  ) as unknown as Record<string, unknown>;
+
+  const tx = txWith([
+    detail(["value"], base),
+    detail(["value", "status"], "published"),
+  ]);
+
+  const result = writeDetailValueForTarget(tx, target([]), "value") as Record<
+    string,
+    unknown
+  >;
+
+  // Correctness: the small field is overlaid.
+  assertEquals(result.status, "published");
+  // The top-level container is a fresh thawed copy (its spine changed)...
+  assertStrictEquals(result === base, false);
+  // ...but the large off-spine subtree is preserved BY REFERENCE -- not
+  // deep-copied. Under the pre-COW full-clone reconstruction this assertion
+  // would fail (it allocated a distinct deep copy of the whole array).
+  assertStrictEquals(result.items, base.items);
 });

--- a/packages/runner/test/cfc-write-reconstruction.test.ts
+++ b/packages/runner/test/cfc-write-reconstruction.test.ts
@@ -48,6 +48,29 @@ const target = (path: readonly string[]) => ({
   path,
 });
 
+// Counts the object/array nodes present in both trees but NOT shared by
+// reference (i.e. that were copied). Used to make a "lost the shared
+// structure" failure loud and quantified.
+const countUnsharedNodes = (orig: unknown, copy: unknown): number => {
+  if (orig === copy) return 0; // shared subtree -- stop descending
+  if (
+    orig === null || typeof orig !== "object" ||
+    copy === null || typeof copy !== "object"
+  ) {
+    return 0; // primitives aren't "copies"
+  }
+  let n = 1; // this container differs by reference
+  if (Array.isArray(orig) && Array.isArray(copy)) {
+    const len = Math.min(orig.length, copy.length);
+    for (let i = 0; i < len; i++) n += countUnsharedNodes(orig[i], copy[i]);
+  } else {
+    const o = orig as Record<string, unknown>;
+    const c = copy as Record<string, unknown>;
+    for (const k of Object.keys(o)) n += countUnsharedNodes(o[k], c[k]);
+  }
+  return n;
+};
+
 Deno.test("writeDetailValueForTarget: coarse whole-object write reconstructs as-is", () => {
   const tx = txWith([
     detail(["value"], { origin: "imported", body: "allowed" }),
@@ -190,8 +213,17 @@ Deno.test("writeDetailValueForTarget: composition preserves large off-spine subt
   assertEquals(result.status, "published");
   // The top-level container is a fresh thawed copy (its spine changed)...
   assertStrictEquals(result === base, false);
-  // ...but the large off-spine subtree is preserved BY REFERENCE -- not
-  // deep-copied. Under the pre-COW full-clone reconstruction this assertion
-  // would fail (it allocated a distinct deep copy of the whole array).
-  assertStrictEquals(result.items, base.items);
+  // ...but the large off-spine subtree MUST be preserved by reference -- not
+  // deep-copied. If it isn't (e.g. a regression back to a full-clone
+  // reconstruction), fail loudly with the damage quantified.
+  if (result.items !== base.items) {
+    const copies = countUnsharedNodes(base.items, result.items);
+    const mb = (JSON.stringify(result.items).length / (1024 * 1024)).toFixed(1);
+    throw new Error(
+      `Failed to maintain large shared structure: reconstruction created ` +
+        `${copies.toLocaleString()} separate copies using ~${mb} unnecessary ` +
+        `megabytes. Off-spine subtrees must be preserved by reference (use ` +
+        `copy-on-write spine-thawing, not a full deep clone).`,
+    );
+  }
 });


### PR DESCRIPTION
## Summary

Makes CFC's write-detail reconstruction **non-copying**: it no longer deep-clones the base value to overlay deeper field-writes. This resolves the known follow-up flagged in #3666.

## Why

#3666 made `writeDetailValueForTarget` reconstruct a value from granular write-details by deep-cloning the base (`cloneIfNecessary(baseValue, { frozen: false })`) and overlaying the descendant field-writes. That's an **O(base-size)** allocation+copy per reconstruction. It's invisible in tests (tiny fixtures), but under **arbitrary user data/patterns** a value at a policy-relevant path is effectively unbounded, so this is real GC/throughput pressure on the authorization path (fired potentially many times per commit).

## Change

Replace the full clone with `cloneForMutation`'s copy-on-write spine-thaw. For a container base, overlay each descendant by thawing only the containers along its path; large off-spine subtrees are preserved **by reference**, never deep-copied. Descendants are processed shallowest-first so an envelope write at a parent path lands before writes to its children, and `cloneForMutation`'s default `force: true` guarantees the shared (deep-frozen) base is never mutated. The rare non-container-base case keeps the fresh-synthesize path.

- `packages/runner/src/cfc/prepare.ts`: composition loop now uses `cloneForMutation` (+ `CloneForMutationResult`) instead of `cloneIfNecessary` (no longer used here).

## Test plan

- [x] `cfc-write-reconstruction.test.ts`: 8 existing reconstruction tests still pass; **new ginormous-fixture test** (a 50k-record array as an off-spine subtree) asserts the large subtree is preserved by reference — i.e. not deep-copied.
- [x] Verified the new test has teeth: swapping the COW loop for a deep copy makes it **fail** (and run ~17× slower: 448ms vs 26ms).
- [x] Full `runner` suite green; `deno check` + `deno lint` clean. CFC behavior unchanged (`cfc-ui-contract` passes).

CFC-scoped for @seefeldb.

### Example failure message

If a future change regresses to a deep clone, the ginormous-fixture test fails loudly with the damage quantified:

```
Failed to maintain large shared structure: reconstruction created 150,001
separate copies using ~3.9 unnecessary megabytes. Off-spine subtrees must be
preserved by reference (use copy-on-write spine-thawing, not a full deep clone).
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reconstructs written values using copy-on-write instead of deep-cloning the base to remove O(n) copies and cut GC on the authorization path (follow-up to #3666). Behavior is unchanged; large off-spine subtrees remain shared by reference.

- **Refactors**
  - Replace deep clone with `cloneForMutation` from `@commonfabric/data-model/fabric-value`; only the path spine is thawed.
  - Apply overlays shallowest-first; the shared deep-frozen base is never mutated. Non-container bases still synthesize a fresh container.
  - Strengthen the large-fixture test (50k items) to assert off-spine arrays remain by reference and fail with quantified copy counts and MB if sharing breaks.

<sup>Written for commit 1770622029845051df1c27d0f7b06892f93fa785. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3671?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

