### PR TITLE
Support page loading through slug redirects

### DIFF
--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -16,6 +16,7 @@ import {
   pieceId,
   PieceManager,
   resolvePieceAddress as resolveStoredPieceAddress,
+  resolveSlugTargetCell,
   setSlugLink,
   SlugResolutionError,
 } from "@commonfabric/piece";
@@ -1072,13 +1073,24 @@ export async function inspectPiece(config: PieceConfig): Promise<{
   id: string;
   name?: string;
   patternName?: string;
-  source: Readonly<unknown>;
+  source?: Readonly<unknown>;
   result: Readonly<unknown>;
   readingFrom: Array<{ id: string; name?: string }>;
   readBy: Array<{ id: string; name?: string }>;
 }> {
   const manager = await loadManager(config);
-  const resolvedConfig = await resolvePieceConfigWithManager(config, manager);
+  let resolvedConfig: PieceConfig;
+  try {
+    resolvedConfig = await resolvePieceConfigWithManager(config, manager);
+  } catch (error) {
+    if (
+      error instanceof SlugResolutionError &&
+      error.code === "not-piece"
+    ) {
+      return await inspectSlugTargetCell(manager, config.piece);
+    }
+    throw error;
+  }
   const pieces = new PiecesController(manager);
   const piece = await pieces.get(
     resolvedConfig.piece,
@@ -1109,6 +1121,35 @@ export async function inspectPiece(config: PieceConfig): Promise<{
     result,
     readingFrom,
     readBy,
+  };
+}
+
+async function inspectSlugTargetCell(
+  manager: PieceManager,
+  slug: string,
+): Promise<{
+  id: string;
+  name?: string;
+  patternName?: string;
+  source?: Readonly<unknown>;
+  result: Readonly<unknown>;
+  readingFrom: Array<{ id: string; name?: string }>;
+  readBy: Array<{ id: string; name?: string }>;
+}> {
+  const target = await resolveSlugTargetCell(manager, slug);
+  await target.pull();
+  const result = target.get() as Readonly<unknown>;
+  const name = isRecord(result) && typeof result[NAME] === "string"
+    ? result[NAME]
+    : undefined;
+
+  return {
+    id: slug,
+    name,
+    patternName: "slug target cell",
+    result,
+    readingFrom: [],
+    readBy: [],
   };
 }
 

--- a/packages/piece/src/index.ts
+++ b/packages/piece/src/index.ts
@@ -2,6 +2,7 @@ export { getPatternIdFromPiece, pieceId, PieceManager } from "./manager.ts";
 export {
   assignSlug,
   resolvePieceAddress,
+  resolveSlugTargetCell,
   setSlugLink,
   SlugResolutionError,
 } from "./slugs.ts";

--- a/packages/piece/src/slugs.ts
+++ b/packages/piece/src/slugs.ts
@@ -90,6 +90,28 @@ export async function resolvePieceAddress(
     return token;
   }
 
+  const target = await resolveSlugTargetCell(manager, token);
+  if (!target.getSourceCell()) {
+    throw new SlugResolutionError(
+      `Slug "${token}" redirects to a document that is not a piece.`,
+      "not-piece",
+    );
+  }
+
+  const id = pieceId(target);
+  if (!id) {
+    throw new SlugResolutionError(
+      `Slug "${token}" redirects to a document without a piece id.`,
+      "missing-piece-id",
+    );
+  }
+  return id;
+}
+
+export async function resolveSlugTargetCell(
+  manager: PieceManager,
+  token: string,
+): Promise<Cell<unknown>> {
   const slug = validateSlug(token);
   const slugId = slugIdForSpace(manager.getSpace(), slug);
   const slugCell = manager.runtime.getCellFromEntityId(
@@ -117,19 +139,5 @@ export async function resolvePieceAddress(
     scope: targetLink.scope ?? "space",
   });
   await target.sync();
-  if (!target.getSourceCell()) {
-    throw new SlugResolutionError(
-      `Slug "${slug}" redirects to a document that is not a piece.`,
-      "not-piece",
-    );
-  }
-
-  const id = pieceId(target);
-  if (!id) {
-    throw new SlugResolutionError(
-      `Slug "${slug}" redirects to a document without a piece id.`,
-      "missing-piece-id",
-    );
-  }
-  return id;
+  return target;
 }

--- a/packages/piece/test/slug.test.ts
+++ b/packages/piece/test/slug.test.ts
@@ -7,7 +7,12 @@ import { createBuilder } from "../../runner/src/builder/factory.ts";
 import { parseLink } from "../../runner/src/link-utils.ts";
 import { slugIdForSpace } from "../../runner/src/slugs.ts";
 import { pieceId, PieceManager } from "../src/manager.ts";
-import { assignSlug, resolvePieceAddress, setSlugLink } from "../src/slugs.ts";
+import {
+  assignSlug,
+  resolvePieceAddress,
+  resolveSlugTargetCell,
+  setSlugLink,
+} from "../src/slugs.ts";
 
 const signer = await Identity.fromPassphrase("piece slug tests");
 
@@ -79,6 +84,29 @@ describe("piece slugs", () => {
     expect(link?.id).toBe(piece.getAsNormalizedFullLink().id);
     expect(link?.path).toEqual(["value"]);
     expect(readRootMeta(slugId, "slug")).toBe("value-link");
+  });
+
+  it("resolves slug redirects to arbitrary cells without treating them as pieces", async () => {
+    const cell = runtime.getCell(
+      manager.getSpace(),
+      { space: manager.getSpace(), random: "slug-cell-target" },
+    );
+    await runtime.editWithRetry((tx) => {
+      cell.withTx(tx).set({ value: 1 });
+    });
+
+    await setSlugLink(manager, "value-link", cell);
+
+    const target = await resolveSlugTargetCell(manager, "value-link");
+    expect(target.getAsNormalizedFullLink().id).toBe(
+      cell.getAsNormalizedFullLink().id,
+    );
+    expect(target.getAsNormalizedFullLink().path).toEqual([]);
+    expect(target.get()).toEqual({ value: 1 });
+
+    await expect(resolvePieceAddress(manager, "value-link")).rejects.toThrow(
+      /not a piece/,
+    );
   });
 
   it("can resolve source links before setting a slug redirect", async () => {

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -144,6 +144,134 @@ describe("page slug metadata", () => {
   });
 });
 
+describe("page slug redirects", () => {
+  const space = "did:key:z6Mk-runtime-processor-page-redirect" as CellRef[
+    "space"
+  ];
+
+  function mockCell(ref: CellRef, options: {
+    raw?: unknown;
+    sourceCell?: unknown;
+    onSync?: () => void;
+  } = {}) {
+    return {
+      sync: () => {
+        options.onSync?.();
+        return Promise.resolve();
+      },
+      getRaw: () => options.raw,
+      getSourceCell: () => options.sourceCell,
+      getAsLink: () => cellRefToSigilLink(ref),
+      getAsNormalizedFullLink: () => ref,
+    };
+  }
+
+  function redirectRaw(ref: CellRef) {
+    return {
+      "/": {
+        "link@1": {
+          ...ref,
+          overwrite: "redirect",
+        },
+      },
+    };
+  }
+
+  it("renders slug redirects to output cells directly", async () => {
+    const targetRef: CellRef = {
+      id: "of:fid1-sub-page" as CellRef["id"],
+      space,
+      scope: "space",
+      path: ["capture"],
+    };
+    const slugRef: CellRef = {
+      id: "of:fid1-slug-doc" as CellRef["id"],
+      space,
+      scope: "space",
+      path: [],
+    };
+    let targetSynced = false;
+    const targetCell = mockCell(targetRef, {
+      onSync: () => {
+        targetSynced = true;
+      },
+    });
+    const slugCell = mockCell(slugRef, { raw: redirectRaw(targetRef) });
+    const manager = {
+      get: () => {
+        throw new Error("output-cell slug redirects should not load as pieces");
+      },
+    };
+    const processor = {
+      pieceManager: { getSpace: () => space },
+      runtime: {
+        getCellFromEntityId: () => slugCell,
+        getCellFromLink: () => targetCell,
+      },
+      cc: { manager: () => manager },
+    };
+
+    const result = await (RuntimeProcessor.prototype as any).handlePageGet
+      .call(processor, {
+        type: RequestType.PageGet,
+        pageId: "fid1-slug-doc",
+        runIt: true,
+      });
+
+    expect(targetSynced).toBe(true);
+    expect(result.page.cell).toMatchObject(targetRef);
+  });
+
+  it("loads slug redirects to piece cells through the piece manager", async () => {
+    const pieceRef: CellRef = {
+      id: "of:fid1-piece" as CellRef["id"],
+      space,
+      scope: "space",
+      path: [],
+    };
+    const resultRef: CellRef = {
+      id: "of:fid1-piece-result" as CellRef["id"],
+      space,
+      scope: "space",
+      path: [],
+    };
+    const slugRef: CellRef = {
+      id: "of:fid1-slug-doc" as CellRef["id"],
+      space,
+      scope: "space",
+      path: [],
+    };
+    const pieceCell = mockCell(pieceRef, { sourceCell: {} });
+    const resultCell = mockCell(resultRef);
+    const slugCell = mockCell(slugRef, { raw: redirectRaw(pieceRef) });
+    const calls: unknown[][] = [];
+    const manager = {
+      get: (...args: unknown[]) => {
+        calls.push(args);
+        return Promise.resolve(resultCell);
+      },
+    };
+    const processor = {
+      pieceManager: { getSpace: () => space },
+      runtime: {
+        getCellFromEntityId: () => slugCell,
+        getCellFromLink: () => pieceCell,
+      },
+      cc: { manager: () => manager },
+    };
+
+    const result = await (RuntimeProcessor.prototype as any).handlePageGet
+      .call(processor, {
+        type: RequestType.PageGet,
+        pageId: "fid1-slug-doc",
+        runIt: true,
+      });
+
+    expect(calls).toEqual([[pieceCell, true]]);
+    expect(result.page.cell).toMatchObject(resultRef);
+  });
+});
+
 describe("sanitizeForPostMessage", () => {
   describe("primitives", () => {
     it("passes through null and undefined", () => {

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -675,6 +675,37 @@ export class RuntimeProcessor {
   async handlePageGet(
     request: PageGetRequest,
   ): Promise<PageResponse> {
+    const requestedCell = this.runtime.getCellFromEntityId(
+      this.pieceManager.getSpace(),
+      { "/": request.pageId },
+    );
+    await requestedCell.sync();
+    const redirect = parseLink(
+      requestedCell.getRaw(),
+      requestedCell.getAsNormalizedFullLink(),
+    );
+    if (redirect?.overwrite === "redirect") {
+      const target = this.runtime.getCellFromLink({
+        ...redirect,
+        space: redirect.space ?? this.pieceManager.getSpace(),
+        scope: redirect.scope ?? "space",
+      });
+      await target.sync();
+      if (!target.getSourceCell()) {
+        return {
+          page: createPageRef(target),
+        };
+      }
+
+      const cell = await this.cc.manager().get(
+        target,
+        request.runIt ?? false,
+      );
+      return {
+        page: createPageRef(cell),
+      };
+    }
+
     const cell = await this.cc.manager().get(
       request.pageId,
       request.runIt ?? false,

--- a/packages/shell/src/lib/runtime.ts
+++ b/packages/shell/src/lib/runtime.ts
@@ -1,4 +1,5 @@
 import { createSession, DID, Identity, Session } from "@commonfabric/identity";
+import { slugIdForSpace } from "@commonfabric/runner/slugs";
 import { NameSchema } from "@commonfabric/runner/schemas";
 import {
   CellHandle,
@@ -192,6 +193,22 @@ export class RuntimeInternals extends EventTarget {
     })();
     this.#patternCache.set(id, promise);
     return promise;
+  }
+
+  invalidatePattern(id: string): void {
+    this.#patternCache.delete(id);
+  }
+
+  async refreshPattern(id: string): Promise<PageHandle<NameSchema>> {
+    this.invalidatePattern(id);
+    return await this.getPattern(id);
+  }
+
+  async getSlugCell(slug: string): Promise<CellHandle<unknown>> {
+    this.#check();
+    return await this.#client.getCell(this.#space, {
+      "/": slugIdForSpace(this.#space, slug),
+    });
   }
 
   async getSlug(id: string): Promise<string | undefined> {

--- a/packages/shell/src/views/AppView.ts
+++ b/packages/shell/src/views/AppView.ts
@@ -14,7 +14,7 @@ import {
   updatePageTitle,
 } from "../../shared/mod.ts";
 import { KeyboardController } from "../lib/keyboard-router.ts";
-import { NAME, PageHandle } from "@commonfabric/runtime-client";
+import { type Cancel, NAME, PageHandle } from "@commonfabric/runtime-client";
 
 export class XAppView extends BaseView {
   static override styles = css`
@@ -61,6 +61,15 @@ export class XAppView extends BaseView {
 
   @state()
   private accessor _patternError: Error | undefined = undefined;
+
+  @state()
+  private accessor _slugRevision = 0;
+
+  private slugCancel: Cancel | undefined = undefined;
+  private slugPollInterval: number | undefined = undefined;
+  private slugSubscriptionKey: string | undefined = undefined;
+  private slugSubscriptionToken = 0;
+  private slugTargetKey: string | undefined = undefined;
 
   private debuggerController = new DebuggerController(this);
   private _keyboard = new KeyboardController(this);
@@ -123,7 +132,7 @@ export class XAppView extends BaseView {
         }
       }
     },
-    args: () => [this.app, this.rt],
+    args: () => [this.app, this.rt, this._slugRevision],
   });
 
   // This derives a space root pattern as well as an "active" (main)
@@ -170,6 +179,110 @@ export class XAppView extends BaseView {
       this._selectedPattern.status,
     ],
   });
+
+  #syncSlugSubscription() {
+    const rt = this.rt;
+    const slug = "pieceSlug" in this.app.view
+      ? this.app.view.pieceSlug
+      : undefined;
+    const key = rt && slug ? `${rt.space()}:${slug}` : undefined;
+
+    if (key === this.slugSubscriptionKey) return;
+    this.#clearSlugSubscription();
+    if (!rt || !slug || !key) return;
+
+    this.slugSubscriptionKey = key;
+    const token = ++this.slugSubscriptionToken;
+    rt.getSlugCell(slug).then(async (cell) => {
+      if (
+        this.slugSubscriptionToken !== token ||
+        this.slugSubscriptionKey !== key
+      ) {
+        return;
+      }
+
+      await this.#refreshSlugTarget(rt, slug, token, key, false);
+      if (
+        this.slugSubscriptionToken !== token ||
+        this.slugSubscriptionKey !== key
+      ) {
+        return;
+      }
+
+      this.slugPollInterval = globalThis.setInterval(() => {
+        void this.#refreshSlugTarget(rt, slug, token, key, true);
+      }, 1000);
+
+      let sawInitialCallback = false;
+      this.slugCancel = cell.subscribe(() => {
+        if (!sawInitialCallback) {
+          sawInitialCallback = true;
+          return;
+        }
+        void this.#refreshSlugTarget(rt, slug, token, key, true);
+      });
+    }).catch((error) => {
+      if (this.slugSubscriptionToken === token) {
+        console.error("[AppView] Failed to watch slug cell:", error);
+      }
+    });
+  }
+
+  #clearSlugSubscription() {
+    this.slugSubscriptionToken++;
+    this.slugCancel?.();
+    if (this.slugPollInterval !== undefined) {
+      globalThis.clearInterval(this.slugPollInterval);
+    }
+    this.slugCancel = undefined;
+    this.slugPollInterval = undefined;
+    this.slugSubscriptionKey = undefined;
+    this.slugTargetKey = undefined;
+  }
+
+  async #refreshSlugTarget(
+    rt: RuntimeInternals,
+    slug: string,
+    token: number,
+    key: string,
+    notify: boolean,
+  ) {
+    if (
+      this.slugSubscriptionToken !== token ||
+      this.slugSubscriptionKey !== key
+    ) {
+      return;
+    }
+
+    let targetKey: string;
+    try {
+      const pattern = await rt.refreshPattern(slugIdForSpace(rt.space(), slug));
+      targetKey = pattern.id();
+    } catch (error) {
+      if (notify) {
+        console.error("[AppView] Failed to refresh slug target:", error);
+      }
+      return;
+    }
+    if (targetKey === this.slugTargetKey) return;
+    this.slugTargetKey = targetKey;
+    if (notify) {
+      this.#handleSlugCellUpdate(rt, slug);
+    }
+  }
+
+  #handleSlugCellUpdate(rt: RuntimeInternals, slug: string) {
+    if (
+      this.rt !== rt ||
+      !("pieceSlug" in this.app.view) ||
+      this.app.view.pieceSlug !== slug
+    ) {
+      return;
+    }
+
+    rt.invalidatePattern(slugIdForSpace(rt.space(), slug));
+    this._slugRevision++;
+  }
 
   #setTitleSubscription(activePiece?: PageHandle<NameSchema>) {
     if (!activePiece) {
@@ -251,6 +364,7 @@ export class XAppView extends BaseView {
       "recreate-space-root-pattern",
       this.#handleRecreateSpaceRootPattern,
     );
+    this.#clearSlugSubscription();
   }
 
   override updated(changedProperties: Map<string, unknown>) {
@@ -283,6 +397,10 @@ export class XAppView extends BaseView {
       this.debuggerController.setVisibility(
         this.app.config.showDebuggerView ?? false,
       );
+    }
+
+    if (changedProperties.has("app") || changedProperties.has("rt")) {
+      this.#syncSlugSubscription();
     }
   }
 


### PR DESCRIPTION
## Summary
- resolve `page:get` requests through stored slug redirect links before loading a page
- render slug redirects to output cells directly, while still loading real piece targets through the piece manager
- expose native slug target-cell resolution for read-side callers
- let `cf piece inspect --piece <slug>` inspect a slug that redirects to a renderable target cell instead of failing with `SlugResolutionError: not-piece`
- add runtime-client and piece slug tests for piece and output-cell slug redirects

## Alex comment / Loom mobile case
This addresses the asymmetry Alex called out in https://github.com/commontoolsinc/labs/pull/3653#issuecomment-4512471512.

`cf piece set-slug --resolve-before-linking quick-capture home/capture` can continue to write a native redirect to a sub-pattern/output cell. The read side now has a native target-cell path as well: page loading renders cell targets, and `cf piece inspect --piece quick-capture` no longer fails just because the slug target is not a process-root piece.

## Testing
- `deno test --allow-all packages/piece/test/slug.test.ts packages/runtime-client/backends/runtime-processor.test.ts`
- `deno fmt --check packages/cli/lib/piece.ts packages/piece/src/slugs.ts packages/piece/src/index.ts packages/piece/test/slug.test.ts packages/runtime-client/backends/runtime-processor.ts packages/runtime-client/backends/runtime-processor.test.ts`
- `deno check packages/cli/lib/piece.ts packages/piece/src/slugs.ts packages/piece/src/index.ts packages/piece/test/slug.test.ts packages/runtime-client/backends/runtime-processor.ts packages/runtime-client/backends/runtime-processor.test.ts`
- live local Loom check with this branch: `cf piece inspect --piece quick-capture --summary --json` returned `{ "id": "quick-capture", "name": "Loom Capture", "patternName": "slug target cell", ... }`