### PR TITLE
[codex] Refactor agent-browser skill scripts

### DIFF
--- a/packages/cf-harness/docs/SKILLS_SUPPORT_SPEC.md
+++ b/packages/cf-harness/docs/SKILLS_SUPPORT_SPEC.md
@@ -276,6 +276,12 @@ the same reason: stdin execution deliberately avoids resolving supporting code
 from the mutable workspace cwd. Other executable shebang scripts are indexed for
 metadata, but are not executable by `run_skill_script` in v1.
 
+Bundled scripts that wrap host-adjacent tools should still be parameterized and
+policy-shaped. For example, the `agent-browser` scripts require an explicit
+local `--cdp` origin or `AGENT_BROWSER_CDP`, avoid saved browser state and
+filesystem capture commands, and emit snapshots/text to stdout so the harness
+can capture the run artifact.
+
 The tool executes via the sandbox direct argv API, not a model-authored shell
 string. The default cwd is the workspace root, even if the harness current
 directory is elsewhere. Optional `cwd` is resolved through normal sandbox path

--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -240,14 +240,25 @@ bundled scripts over constructing equivalent shell commands. Invoke them with
 the `agent-browser` CLI to be available on `PATH` in the script execution
 environment.
 
-| Script                                                               | Description                         |
-| -------------------------------------------------------------------- | ----------------------------------- |
-| [scripts/form-automation.sh](scripts/form-automation.sh)             | Form filling with validation        |
-| [scripts/authenticated-session.sh](scripts/authenticated-session.sh) | Login once, reuse state             |
-| [scripts/capture-workflow.sh](scripts/capture-workflow.sh)           | Content extraction with screenshots |
+For cf-harness runs, pass a local CDP origin with `--cdp` or set
+`AGENT_BROWSER_CDP`. The scripts intentionally avoid browser state, screenshots,
+PDFs, uploads, downloads, and local file output; they print snapshots and
+extracted content to stdout for harness capture.
+
+| Script                                                               | Description                                      |
+| -------------------------------------------------------------------- | ------------------------------------------------ |
+| [scripts/form-automation.sh](scripts/form-automation.sh)             | Discover form refs or run ordered form actions   |
+| [scripts/authenticated-session.sh](scripts/authenticated-session.sh) | Discover login refs or submit provided refs      |
+| [scripts/capture-workflow.sh](scripts/capture-workflow.sh)           | Capture page metadata, snapshot, and text output |
 
 ```bash
-./scripts/form-automation.sh https://example.com/form
-./scripts/authenticated-session.sh https://app.example.com/login
-./scripts/capture-workflow.sh https://example.com ./output
+./scripts/form-automation.sh --cdp http://host.docker.internal:9222 https://example.com/form
+./scripts/form-automation.sh --cdp http://host.docker.internal:9222 https://example.com/form \
+  --type @e1="Ada" --click @e3 --wait-url "**/success"
+
+APP_USERNAME="user@example.com" APP_PASSWORD="..." \
+  ./scripts/authenticated-session.sh --cdp http://host.docker.internal:9222 \
+  https://app.example.com/login --username-ref @e1 --password-ref @e2 --submit-ref @e3
+
+./scripts/capture-workflow.sh --cdp http://host.docker.internal:9222 https://example.com
 ```

--- a/skills/agent-browser/scripts/authenticated-session.sh
+++ b/skills/agent-browser/scripts/authenticated-session.sh
@@ -1,98 +1,215 @@
 #!/bin/bash
 # Script: Authenticated Session Workflow
-# Purpose: Login once, save state, reuse for subsequent runs
-# Usage: ./scripts/authenticated-session.sh <login-url> [state-file]
-#
-# Environment variables:
-#   APP_USERNAME - Login username/email
-#   APP_PASSWORD - Login password
-#
-# Two modes:
-#   1. Discovery mode (default): Shows form structure so you can identify refs
-#   2. Login mode: Performs actual login after you update the refs
-#
-# Setup steps:
-#   1. Run once to see form structure (discovery mode)
-#   2. Update refs in LOGIN FLOW section below
-#   3. Set APP_USERNAME and APP_PASSWORD
-#   4. Delete the DISCOVERY section
+# Purpose: Discover login refs or perform a single credentialed login.
 
 set -euo pipefail
 
 SCRIPT_NAME="${SKILL_SCRIPT:-scripts/authenticated-session.sh}"
-LOGIN_URL="${1:?Usage: $SCRIPT_NAME <login-url> [state-file]}"
-STATE_FILE="${2:-./auth-state.json}"
+CDP="${AGENT_BROWSER_CDP:-}"
+LOGIN_URL=""
+USERNAME_REF=""
+PASSWORD_REF=""
+SUBMIT_REF=""
+WAIT_LOAD="networkidle"
+WAIT_URL=""
+DISCOVERY_ONLY=0
+
+usage() {
+  cat <<USAGE
+Usage:
+  $SCRIPT_NAME --cdp <http://localhost:port> <login-url>
+  $SCRIPT_NAME --cdp <http://localhost:port> <login-url> \\
+    --username-ref @e1 --password-ref @e2 --submit-ref @e3 [--wait-url "**/dashboard"]
+
+Environment:
+  AGENT_BROWSER_CDP  Local CDP origin, used when --cdp is omitted.
+  APP_USERNAME       Username/email for credentialed mode.
+  APP_PASSWORD       Password for credentialed mode.
+
+Notes:
+  - The CDP endpoint must be a local http origin with an explicit port.
+  - Without all three refs, the script runs in discovery mode and prints the
+    login page snapshot so refs can be supplied on a later run.
+  - This script does not save or load browser state; reuse the connected
+    browser/session outside the script when persistence is needed.
+USAGE
+}
+
+fail() {
+  echo "$SCRIPT_NAME: $*" >&2
+  exit 2
+}
+
+require_value() {
+  local flag="$1"
+  local value="${2:-}"
+  [[ -n "$value" ]] || fail "$flag requires a value"
+}
+
+validate_cdp_endpoint() {
+  local endpoint="$1"
+  if [[ ! "$endpoint" =~ ^http://(localhost|127\.0\.0\.1|host\.docker\.internal):[0-9]+$ ]] &&
+    [[ ! "$endpoint" =~ ^http://\[::1\]:[0-9]+$ ]]; then
+    fail "--cdp must be an http:// local origin with an explicit port"
+  fi
+
+  local port="${endpoint##*:}"
+  [[ "$port" =~ ^[0-9]+$ ]] || fail "--cdp port must be numeric"
+  local port_number=$((10#$port))
+  ((port_number >= 1 && port_number <= 65535)) ||
+    fail "--cdp port must be between 1 and 65535"
+}
+
+validate_page_url() {
+  case "$1" in
+    http://* | https://*) ;;
+    *) fail "login-url must be http:// or https://" ;;
+  esac
+}
+
+browser() {
+  agent-browser --cdp "$CDP" "$@"
+}
+
+while (($# > 0)); do
+  case "$1" in
+    --cdp)
+      require_value "$1" "${2:-}"
+      CDP="$2"
+      shift 2
+      ;;
+    --cdp=*)
+      CDP="${1#*=}"
+      [[ -n "$CDP" ]] || fail "--cdp requires a value"
+      shift
+      ;;
+    --username-ref)
+      require_value "$1" "${2:-}"
+      USERNAME_REF="$2"
+      shift 2
+      ;;
+    --username-ref=*)
+      USERNAME_REF="${1#*=}"
+      [[ -n "$USERNAME_REF" ]] || fail "--username-ref requires a value"
+      shift
+      ;;
+    --password-ref)
+      require_value "$1" "${2:-}"
+      PASSWORD_REF="$2"
+      shift 2
+      ;;
+    --password-ref=*)
+      PASSWORD_REF="${1#*=}"
+      [[ -n "$PASSWORD_REF" ]] || fail "--password-ref requires a value"
+      shift
+      ;;
+    --submit-ref)
+      require_value "$1" "${2:-}"
+      SUBMIT_REF="$2"
+      shift 2
+      ;;
+    --submit-ref=*)
+      SUBMIT_REF="${1#*=}"
+      [[ -n "$SUBMIT_REF" ]] || fail "--submit-ref requires a value"
+      shift
+      ;;
+    --wait-load)
+      require_value "$1" "${2:-}"
+      WAIT_LOAD="$2"
+      shift 2
+      ;;
+    --wait-load=*)
+      WAIT_LOAD="${1#*=}"
+      [[ -n "$WAIT_LOAD" ]] || fail "--wait-load requires a value"
+      shift
+      ;;
+    --wait-url)
+      require_value "$1" "${2:-}"
+      WAIT_URL="$2"
+      shift 2
+      ;;
+    --wait-url=*)
+      WAIT_URL="${1#*=}"
+      [[ -n "$WAIT_URL" ]] || fail "--wait-url requires a value"
+      shift
+      ;;
+    --discovery)
+      DISCOVERY_ONLY=1
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      fail "unknown option: $1"
+      ;;
+    *)
+      [[ -z "$LOGIN_URL" ]] || fail "unexpected argument: $1"
+      LOGIN_URL="$1"
+      shift
+      ;;
+  esac
+done
+
+while (($# > 0)); do
+  [[ -z "$LOGIN_URL" ]] || fail "unexpected argument: $1"
+  LOGIN_URL="$1"
+  shift
+done
+
+[[ -n "$LOGIN_URL" ]] || {
+  usage >&2
+  exit 2
+}
+[[ -n "$CDP" ]] || fail "provide --cdp or set AGENT_BROWSER_CDP"
+CDP="${CDP%/}"
+validate_cdp_endpoint "$CDP"
+validate_page_url "$LOGIN_URL"
+command -v agent-browser >/dev/null 2>&1 || fail "agent-browser is not on PATH"
 
 echo "Authentication workflow: $LOGIN_URL"
+browser open "$LOGIN_URL"
+browser wait --load "$WAIT_LOAD"
 
-# ================================================================
-# SAVED STATE: Skip login if valid saved state exists
-# ================================================================
-if [[ -f "$STATE_FILE" ]]; then
-    echo "Loading saved state from $STATE_FILE..."
-    agent-browser state load "$STATE_FILE"
-    agent-browser open "$LOGIN_URL"
-    agent-browser wait --load networkidle
+echo
+echo "Login page snapshot:"
+echo "---"
+browser snapshot -i
+echo "---"
 
-    CURRENT_URL=$(agent-browser get url)
-    if [[ "$CURRENT_URL" != *"login"* ]] && [[ "$CURRENT_URL" != *"signin"* ]]; then
-        echo "Session restored successfully"
-        agent-browser snapshot -i
-        exit 0
-    fi
-    echo "Session expired, performing fresh login..."
-    rm -f "$STATE_FILE"
+if ((DISCOVERY_ONLY == 1)) ||
+  [[ -z "$USERNAME_REF" || -z "$PASSWORD_REF" || -z "$SUBMIT_REF" ]]; then
+  echo
+  echo "Discovery mode complete."
+  echo "Re-run with --username-ref, --password-ref, and --submit-ref to submit credentials."
+  exit 0
 fi
 
-# ================================================================
-# DISCOVERY MODE: Shows form structure (delete after setup)
-# ================================================================
-echo "Opening login page..."
-agent-browser open "$LOGIN_URL"
-agent-browser wait --load networkidle
+: "${APP_USERNAME:?Set APP_USERNAME in the script execution environment}"
+: "${APP_PASSWORD:?Set APP_PASSWORD in the script execution environment}"
 
-echo ""
-echo "Login form structure:"
-echo "---"
-agent-browser snapshot -i
-echo "---"
-echo ""
-echo "Next steps:"
-echo "  1. Note the refs: username=@e?, password=@e?, submit=@e?"
-echo "  2. Update the LOGIN FLOW section below with your refs"
-echo "  3. Set: export APP_USERNAME='...' APP_PASSWORD='...'"
-echo "  4. Delete this DISCOVERY MODE section"
-echo ""
-agent-browser close
-exit 0
+echo
+echo "Submitting credentials..."
+browser fill "$USERNAME_REF" "$APP_USERNAME"
+browser fill "$PASSWORD_REF" "$APP_PASSWORD"
+browser click "$SUBMIT_REF"
 
-# ================================================================
-# LOGIN FLOW: Uncomment and customize after discovery
-# ================================================================
-# : "${APP_USERNAME:?Set APP_USERNAME environment variable}"
-# : "${APP_PASSWORD:?Set APP_PASSWORD environment variable}"
-#
-# agent-browser open "$LOGIN_URL"
-# agent-browser wait --load networkidle
-# agent-browser snapshot -i
-#
-# # Fill credentials (update refs to match your form)
-# agent-browser fill @e1 "$APP_USERNAME"
-# agent-browser fill @e2 "$APP_PASSWORD"
-# agent-browser click @e3
-# agent-browser wait --load networkidle
-#
-# # Verify login succeeded
-# FINAL_URL=$(agent-browser get url)
-# if [[ "$FINAL_URL" == *"login"* ]] || [[ "$FINAL_URL" == *"signin"* ]]; then
-#     echo "Login failed - still on login page"
-#     agent-browser screenshot /tmp/login-failed.png
-#     agent-browser close
-#     exit 1
-# fi
-#
-# # Save state for future runs
-# echo "Saving state to $STATE_FILE"
-# agent-browser state save "$STATE_FILE"
-# echo "Login successful"
-# agent-browser snapshot -i
+if [[ -n "$WAIT_URL" ]]; then
+  browser wait --url "$WAIT_URL"
+else
+  browser wait --load "$WAIT_LOAD"
+fi
+
+echo
+echo "Post-login URL:"
+browser get url
+echo
+echo "Post-login snapshot:"
+echo "---"
+browser snapshot -i
+echo "---"

--- a/skills/agent-browser/scripts/capture-workflow.sh
+++ b/skills/agent-browser/scripts/capture-workflow.sh
@@ -1,70 +1,158 @@
 #!/bin/bash
 # Script: Content Capture Workflow
-# Purpose: Extract content from web pages (text, screenshots, PDF)
-# Usage: ./scripts/capture-workflow.sh <url> [output-dir]
-#
-# Outputs:
-#   - page-full.png: Full page screenshot
-#   - page-structure.txt: Page element structure with refs
-#   - page-text.txt: All text content
-#   - page.pdf: PDF version
-#
-# Optional: Load auth state for protected pages
+# Purpose: Capture page metadata, structure, and text to stdout.
 
 set -euo pipefail
 
 SCRIPT_NAME="${SKILL_SCRIPT:-scripts/capture-workflow.sh}"
-TARGET_URL="${1:?Usage: $SCRIPT_NAME <url> [output-dir]}"
-OUTPUT_DIR="${2:-.}"
+CDP="${AGENT_BROWSER_CDP:-}"
+TARGET_URL=""
+WAIT_LOAD="networkidle"
+TEXT_TARGET="body"
+SKIP_TEXT=0
+
+usage() {
+  cat <<USAGE
+Usage:
+  $SCRIPT_NAME --cdp <http://localhost:port> <url> [--text-target <selector-or-ref>]
+
+Environment:
+  AGENT_BROWSER_CDP  Local CDP origin, used when --cdp is omitted.
+
+Notes:
+  - The CDP endpoint must be a local http origin with an explicit port.
+  - Output is written to stdout so cf-harness can capture the run artifact.
+  - Screenshots, PDFs, browser state, and file downloads are intentionally
+    excluded from this first-class skill script.
+USAGE
+}
+
+fail() {
+  echo "$SCRIPT_NAME: $*" >&2
+  exit 2
+}
+
+require_value() {
+  local flag="$1"
+  local value="${2:-}"
+  [[ -n "$value" ]] || fail "$flag requires a value"
+}
+
+validate_cdp_endpoint() {
+  local endpoint="$1"
+  if [[ ! "$endpoint" =~ ^http://(localhost|127\.0\.0\.1|host\.docker\.internal):[0-9]+$ ]] &&
+    [[ ! "$endpoint" =~ ^http://\[::1\]:[0-9]+$ ]]; then
+    fail "--cdp must be an http:// local origin with an explicit port"
+  fi
+
+  local port="${endpoint##*:}"
+  [[ "$port" =~ ^[0-9]+$ ]] || fail "--cdp port must be numeric"
+  local port_number=$((10#$port))
+  ((port_number >= 1 && port_number <= 65535)) ||
+    fail "--cdp port must be between 1 and 65535"
+}
+
+validate_page_url() {
+  case "$1" in
+    http://* | https://*) ;;
+    *) fail "url must be http:// or https://" ;;
+  esac
+}
+
+browser() {
+  agent-browser --cdp "$CDP" "$@"
+}
+
+while (($# > 0)); do
+  case "$1" in
+    --cdp)
+      require_value "$1" "${2:-}"
+      CDP="$2"
+      shift 2
+      ;;
+    --cdp=*)
+      CDP="${1#*=}"
+      [[ -n "$CDP" ]] || fail "--cdp requires a value"
+      shift
+      ;;
+    --text-target)
+      require_value "$1" "${2:-}"
+      TEXT_TARGET="$2"
+      shift 2
+      ;;
+    --text-target=*)
+      TEXT_TARGET="${1#*=}"
+      [[ -n "$TEXT_TARGET" ]] || fail "--text-target requires a value"
+      shift
+      ;;
+    --wait-load)
+      require_value "$1" "${2:-}"
+      WAIT_LOAD="$2"
+      shift 2
+      ;;
+    --wait-load=*)
+      WAIT_LOAD="${1#*=}"
+      [[ -n "$WAIT_LOAD" ]] || fail "--wait-load requires a value"
+      shift
+      ;;
+    --skip-text)
+      SKIP_TEXT=1
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      fail "unknown option: $1"
+      ;;
+    *)
+      [[ -z "$TARGET_URL" ]] || fail "unexpected argument: $1"
+      TARGET_URL="$1"
+      shift
+      ;;
+  esac
+done
+
+while (($# > 0)); do
+  [[ -z "$TARGET_URL" ]] || fail "unexpected argument: $1"
+  TARGET_URL="$1"
+  shift
+done
+
+[[ -n "$TARGET_URL" ]] || {
+  usage >&2
+  exit 2
+}
+[[ -n "$CDP" ]] || fail "provide --cdp or set AGENT_BROWSER_CDP"
+CDP="${CDP%/}"
+validate_cdp_endpoint "$CDP"
+validate_page_url "$TARGET_URL"
+command -v agent-browser >/dev/null 2>&1 || fail "agent-browser is not on PATH"
 
 echo "Capturing: $TARGET_URL"
-mkdir -p "$OUTPUT_DIR"
+browser open "$TARGET_URL"
+browser wait --load "$WAIT_LOAD"
 
-# Optional: Load authentication state
-# if [[ -f "./auth-state.json" ]]; then
-#     echo "Loading authentication state..."
-#     agent-browser state load "./auth-state.json"
-# fi
+echo
+echo "Metadata:"
+echo "Title: $(browser get title)"
+echo "URL: $(browser get url)"
 
-# Navigate to target
-agent-browser open "$TARGET_URL"
-agent-browser wait --load networkidle
+echo
+echo "Interactive snapshot:"
+echo "---"
+browser snapshot -i
+echo "---"
 
-# Get metadata
-TITLE=$(agent-browser get title)
-URL=$(agent-browser get url)
-echo "Title: $TITLE"
-echo "URL: $URL"
-
-# Capture full page screenshot
-agent-browser screenshot --full "$OUTPUT_DIR/page-full.png"
-echo "Saved: $OUTPUT_DIR/page-full.png"
-
-# Get page structure with refs
-agent-browser snapshot -i > "$OUTPUT_DIR/page-structure.txt"
-echo "Saved: $OUTPUT_DIR/page-structure.txt"
-
-# Extract all text content
-agent-browser get text body > "$OUTPUT_DIR/page-text.txt"
-echo "Saved: $OUTPUT_DIR/page-text.txt"
-
-# Save as PDF
-agent-browser pdf "$OUTPUT_DIR/page.pdf"
-echo "Saved: $OUTPUT_DIR/page.pdf"
-
-# Optional: Extract specific elements using refs from structure
-# agent-browser get text @e5 > "$OUTPUT_DIR/main-content.txt"
-
-# Optional: Handle infinite scroll pages
-# for i in {1..5}; do
-#     agent-browser scroll down 1000
-#     agent-browser wait 1000
-# done
-# agent-browser screenshot --full "$OUTPUT_DIR/page-scrolled.png"
-
-# Cleanup
-agent-browser close
-
-echo ""
-echo "Capture complete:"
-ls -la "$OUTPUT_DIR"
+if ((SKIP_TEXT == 0)); then
+  echo
+  echo "Text content ($TEXT_TARGET):"
+  echo "---"
+  browser get text "$TEXT_TARGET"
+  echo "---"
+fi

--- a/skills/agent-browser/scripts/form-automation.sh
+++ b/skills/agent-browser/scripts/form-automation.sh
@@ -1,63 +1,284 @@
 #!/bin/bash
 # Script: Form Automation Workflow
-# Purpose: Fill and submit web forms with validation
-# Usage: ./scripts/form-automation.sh <form-url>
-#
-# This template demonstrates the snapshot-interact-verify pattern:
-# 1. Navigate to form
-# 2. Snapshot to get element refs
-# 3. Fill fields using refs
-# 4. Submit and verify result
-#
-# Customize: Update the refs (@e1, @e2, etc.) based on your form's snapshot output
+# Purpose: Discover form refs or run a parameterized form interaction sequence.
 
 set -euo pipefail
 
 SCRIPT_NAME="${SKILL_SCRIPT:-scripts/form-automation.sh}"
-FORM_URL="${1:?Usage: $SCRIPT_NAME <form-url>}"
+CDP="${AGENT_BROWSER_CDP:-}"
+FORM_URL=""
+WAIT_LOAD="networkidle"
+WAIT_URL=""
+NO_FINAL_WAIT=0
+ACTION_KINDS=()
+ACTION_VALUES=()
 
-echo "Form automation: $FORM_URL"
+usage() {
+  cat <<USAGE
+Usage:
+  $SCRIPT_NAME --cdp <http://localhost:port> <form-url>
+  $SCRIPT_NAME --cdp <http://localhost:port> <form-url> \\
+    --fill @e1="Jane Doe" --type @e2="jane@example.com" --click @e5
 
-# Step 1: Navigate to form
-agent-browser open "$FORM_URL"
-agent-browser wait --load networkidle
+Actions run in the order provided:
+  --fill REF=VALUE     Fill a native input or textarea.
+  --type REF=VALUE     Type into an element, useful for custom inputs.
+  --select REF=VALUE   Select an option.
+  --check REF          Check a checkbox.
+  --click REF          Click a control, link, button, or radio option.
+  --press KEY          Press a key, such as Enter.
 
-# Step 2: Snapshot to discover form elements
-echo ""
-echo "Form structure:"
-agent-browser snapshot -i
+Options:
+  --wait-url PATTERN   After actions, wait for a URL glob.
+  --wait-load STATE    Load state for initial and final waits (default: networkidle).
+  --no-final-wait      Do not wait after actions.
 
-# Step 3: Fill form fields (customize these refs based on snapshot output)
-#
-# Common field types:
-#   agent-browser fill @e1 "John Doe"           # Text input
-#   agent-browser fill @e2 "user@example.com"   # Email input
-#   agent-browser fill @e3 "SecureP@ss123"      # Password input
-#   agent-browser select @e4 "Option Value"     # Dropdown
-#   agent-browser check @e5                     # Checkbox
-#   agent-browser click @e6                     # Radio button
-#   agent-browser fill @e7 "Multi-line text"   # Textarea
-#   agent-browser upload @e8 /path/to/file.pdf # File upload
-#
-# Uncomment and modify:
-# agent-browser fill @e1 "Test User"
-# agent-browser fill @e2 "test@example.com"
-# agent-browser click @e3  # Submit button
+Environment:
+  AGENT_BROWSER_CDP  Local CDP origin, used when --cdp is omitted.
 
-# Step 4: Wait for submission
-# agent-browser wait --load networkidle
-# agent-browser wait --url "**/success"  # Or wait for redirect
+Notes:
+  - The CDP endpoint must be a local http origin with an explicit port.
+  - With no actions, the script prints an interactive snapshot for ref discovery.
+USAGE
+}
 
-# Step 5: Verify result
-echo ""
-echo "Result:"
-agent-browser get url
-agent-browser snapshot -i
+fail() {
+  echo "$SCRIPT_NAME: $*" >&2
+  exit 2
+}
 
-# Optional: Capture evidence
-agent-browser screenshot /tmp/form-result.png
-echo "Screenshot saved: /tmp/form-result.png"
+require_value() {
+  local flag="$1"
+  local value="${2:-}"
+  [[ -n "$value" ]] || fail "$flag requires a value"
+}
 
-# Cleanup
-agent-browser close
-echo "Done"
+validate_cdp_endpoint() {
+  local endpoint="$1"
+  if [[ ! "$endpoint" =~ ^http://(localhost|127\.0\.0\.1|host\.docker\.internal):[0-9]+$ ]] &&
+    [[ ! "$endpoint" =~ ^http://\[::1\]:[0-9]+$ ]]; then
+    fail "--cdp must be an http:// local origin with an explicit port"
+  fi
+
+  local port="${endpoint##*:}"
+  [[ "$port" =~ ^[0-9]+$ ]] || fail "--cdp port must be numeric"
+  local port_number=$((10#$port))
+  ((port_number >= 1 && port_number <= 65535)) ||
+    fail "--cdp port must be between 1 and 65535"
+}
+
+validate_page_url() {
+  case "$1" in
+    http://* | https://*) ;;
+    *) fail "form-url must be http:// or https://" ;;
+  esac
+}
+
+add_action() {
+  ACTION_KINDS+=("$1")
+  ACTION_VALUES+=("$2")
+}
+
+split_assignment() {
+  local flag="$1"
+  local assignment="$2"
+  [[ "$assignment" == *=* ]] || fail "$flag expects REF=VALUE"
+  REF="${assignment%%=*}"
+  VALUE="${assignment#*=}"
+  [[ -n "$REF" ]] || fail "$flag requires a non-empty ref"
+}
+
+browser() {
+  agent-browser --cdp "$CDP" "$@"
+}
+
+while (($# > 0)); do
+  case "$1" in
+    --cdp)
+      require_value "$1" "${2:-}"
+      CDP="$2"
+      shift 2
+      ;;
+    --cdp=*)
+      CDP="${1#*=}"
+      [[ -n "$CDP" ]] || fail "--cdp requires a value"
+      shift
+      ;;
+    --fill)
+      require_value "$1" "${2:-}"
+      add_action "fill" "$2"
+      shift 2
+      ;;
+    --fill=*)
+      add_action "fill" "${1#*=}"
+      shift
+      ;;
+    --type)
+      require_value "$1" "${2:-}"
+      add_action "type" "$2"
+      shift 2
+      ;;
+    --type=*)
+      add_action "type" "${1#*=}"
+      shift
+      ;;
+    --select)
+      require_value "$1" "${2:-}"
+      add_action "select" "$2"
+      shift 2
+      ;;
+    --select=*)
+      add_action "select" "${1#*=}"
+      shift
+      ;;
+    --check)
+      require_value "$1" "${2:-}"
+      add_action "check" "$2"
+      shift 2
+      ;;
+    --check=*)
+      add_action "check" "${1#*=}"
+      shift
+      ;;
+    --click)
+      require_value "$1" "${2:-}"
+      add_action "click" "$2"
+      shift 2
+      ;;
+    --click=*)
+      add_action "click" "${1#*=}"
+      shift
+      ;;
+    --press)
+      require_value "$1" "${2:-}"
+      add_action "press" "$2"
+      shift 2
+      ;;
+    --press=*)
+      add_action "press" "${1#*=}"
+      shift
+      ;;
+    --wait-load)
+      require_value "$1" "${2:-}"
+      WAIT_LOAD="$2"
+      shift 2
+      ;;
+    --wait-load=*)
+      WAIT_LOAD="${1#*=}"
+      [[ -n "$WAIT_LOAD" ]] || fail "--wait-load requires a value"
+      shift
+      ;;
+    --wait-url)
+      require_value "$1" "${2:-}"
+      WAIT_URL="$2"
+      shift 2
+      ;;
+    --wait-url=*)
+      WAIT_URL="${1#*=}"
+      [[ -n "$WAIT_URL" ]] || fail "--wait-url requires a value"
+      shift
+      ;;
+    --no-final-wait)
+      NO_FINAL_WAIT=1
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      fail "unknown option: $1"
+      ;;
+    *)
+      [[ -z "$FORM_URL" ]] || fail "unexpected argument: $1"
+      FORM_URL="$1"
+      shift
+      ;;
+  esac
+done
+
+while (($# > 0)); do
+  [[ -z "$FORM_URL" ]] || fail "unexpected argument: $1"
+  FORM_URL="$1"
+  shift
+done
+
+[[ -n "$FORM_URL" ]] || {
+  usage >&2
+  exit 2
+}
+[[ -n "$CDP" ]] || fail "provide --cdp or set AGENT_BROWSER_CDP"
+CDP="${CDP%/}"
+validate_cdp_endpoint "$CDP"
+validate_page_url "$FORM_URL"
+command -v agent-browser >/dev/null 2>&1 || fail "agent-browser is not on PATH"
+
+echo "Form workflow: $FORM_URL"
+browser open "$FORM_URL"
+browser wait --load "$WAIT_LOAD"
+
+echo
+echo "Initial form snapshot:"
+echo "---"
+browser snapshot -i
+echo "---"
+
+if ((${#ACTION_KINDS[@]} == 0)); then
+  echo
+  echo "Discovery mode complete. Re-run with --fill, --type, --select, --check, --click, or --press actions."
+  exit 0
+fi
+
+echo
+echo "Running ${#ACTION_KINDS[@]} action(s)..."
+for index in "${!ACTION_KINDS[@]}"; do
+  kind="${ACTION_KINDS[$index]}"
+  payload="${ACTION_VALUES[$index]}"
+  case "$kind" in
+    fill)
+      split_assignment "--fill" "$payload"
+      browser fill "$REF" "$VALUE"
+      ;;
+    type)
+      split_assignment "--type" "$payload"
+      browser type "$REF" "$VALUE"
+      ;;
+    select)
+      split_assignment "--select" "$payload"
+      browser select "$REF" "$VALUE"
+      ;;
+    check)
+      browser check "$payload"
+      ;;
+    click)
+      browser click "$payload"
+      ;;
+    press)
+      browser press "$payload"
+      ;;
+    *)
+      fail "internal error: unknown action kind $kind"
+      ;;
+  esac
+done
+
+if ((NO_FINAL_WAIT == 0)); then
+  if [[ -n "$WAIT_URL" ]]; then
+    browser wait --url "$WAIT_URL"
+  else
+    browser wait --load "$WAIT_LOAD"
+  fi
+fi
+
+echo
+echo "Result URL:"
+browser get url
+echo
+echo "Result snapshot:"
+echo "---"
+browser snapshot -i
+echo "---"


### PR DESCRIPTION
## Summary

Refactors the bundled `agent-browser` skill scripts from editable templates into parameterized, v1-compatible cf-harness skill scripts.

- requires `--cdp` or `AGENT_BROWSER_CDP` with a local HTTP origin
- turns form automation into ordered CLI actions instead of source edits
- changes authenticated-session into ref discovery or credentialed submission without state persistence
- changes capture-workflow to emit metadata, snapshots, and text to stdout instead of screenshots/PDFs/files
- documents the policy-shaped script contract in the skill docs and cf-harness skills spec

## Validation

- `bash -n skills/agent-browser/scripts/authenticated-session.sh`
- `bash -n skills/agent-browser/scripts/capture-workflow.sh`
- `bash -n skills/agent-browser/scripts/form-automation.sh`
- stubbed `agent-browser` runs for capture, form actions, and authenticated submission
- registry discovery over `./skills` shows all three scripts as executable Bash/shebang resources with no diagnostics
- `ENV=test deno test --allow-read --allow-write --allow-run --filter run_skill_script packages/cf-harness/test/tools-execution.test.ts`
- `deno fmt --check packages/cf-harness/docs/SKILLS_SUPPORT_SPEC.md skills/agent-browser/SKILL.md`
- `git diff --check`
- `PATH=/Users/gideonwald/.deno/bin:$PATH deno task test` from `packages/cf-harness`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the bundled `agent-browser` scripts into parameterized, v1-compatible `cf-harness` skill scripts that run against a local CDP. Shifts from saved state and file outputs to discovery modes and stdout snapshots/metadata for harness capture.

- **Refactors**
  - Converted templates to CLI-driven scripts; updated docs/spec to reflect the policy-shaped contract.
  - Enforced local CDP via `--cdp` or `AGENT_BROWSER_CDP` with strict validation.
  - `form-automation.sh`: runs ordered actions (`--fill/--type/--select/--check/--click/--press`) with `--wait-url`/`--wait-load`.
  - `authenticated-session.sh`: discovery mode or single credentialed login using refs; no state save/load.
  - `capture-workflow.sh`: prints metadata, interactive snapshot, and optional text target to stdout; no screenshots/PDFs/files.

- **Migration**
  - Always provide `--cdp http://<local-host>:<port>` or set `AGENT_BROWSER_CDP`.
  - Replace any reliance on saved browser state and filesystem outputs; read snapshots/text from stdout.
  - Supply element refs (e.g., `@e1`) and credentials via flags/env (`APP_USERNAME`, `APP_PASSWORD`) when submitting forms/logins.

<sup>Written for commit a0add9954f1cd90d747e32ba901eeff1e9781d3c. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3682?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

---BEGIN COPY-PASTE---
NEW_PERF_BASELINE: step: background worker integration = 20s
---END COPY-PASTE---