### PR TITLE
[codex] Update cf-harness default model

### DIFF
--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -63,7 +63,7 @@ import {
   validateStructuredResultValue,
 } from "./structured-result.ts";
 
-const DEFAULT_MODEL = "gpt-5.4";
+const DEFAULT_MODEL = "gpt-5.5";
 const DEFAULT_MAX_MODEL_TURNS = 8;
 const DEFAULT_ARTIFACT_DIRNAME = ".cf-harness-artifacts";
 const CLI_OUTPUT_MODES = ["operator", "batch"] as const;

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -59,7 +59,7 @@ Deno.test("parseCfHarnessCliArgs resolves defaults from cwd and positional promp
   }
   assertEquals(parsed.workspace, "/tmp/project");
   assertEquals(parsed.prompt, "Summarize this workspace");
-  assertEquals(parsed.model, "gpt-5.4");
+  assertEquals(parsed.model, "gpt-5.5");
   assertEquals(parsed.gatewayAuthMode, "bearer");
   assertEquals(parsed.outputMode, "operator");
   assertEquals(parsed.streamEvents, false);


### PR DESCRIPTION
## Summary

Updates the default `cf-harness` model from `gpt-5.4` to `gpt-5.5`.

This keeps the change intentionally narrow:

- changes the centralized `DEFAULT_MODEL` in `packages/cf-harness/src/cli.ts`
- updates the direct CLI default parsing assertion
- leaves explicit `gpt-5.4` test fixtures untouched where they are not default behavior

## Validation

- `ENV=test deno test --allow-read --allow-write --allow-run packages/cf-harness/test/cli.test.ts`
- `deno fmt --check packages/cf-harness/src/cli.ts packages/cf-harness/test/cli.test.ts`
- `git diff --check`
- `PATH=/Users/gideonwald/.deno/bin:$PATH deno task test` from `packages/cf-harness`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the `cf-harness` CLI default model to `gpt-5.5` (was `gpt-5.4`). Updated the CLI default parsing test to match.

<sup>Written for commit 0c72129eb9315094c07327988c9327899ac51bfe. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3683?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

