### PR TITLE
fix(runner): validate cached pattern compilation

### DIFF
--- a/docs/specs/compilation-cache.md
+++ b/docs/specs/compilation-cache.md
@@ -90,6 +90,7 @@ PatternManager.compileOrGetPattern(program)
             │
             └─ cache miss → Engine.compile(program) → CompileResult
                               │
+                              ├─ SES bundle validation passes
                               ├─ CachedCompiler.set(programHash, CompileResult)
                               └─ evaluateToPattern() → Pattern
 ```
@@ -165,6 +166,13 @@ takes priority because when set, the operator is declaring the code identity.
 (e.g., type definition loading race), and the cost of a redundant failed
 compilation is bounded. Caching a failure risks masking an error that would
 succeed on retry.
+
+**Only SES-validated bundles are cached.** `Engine.compile()` marks a
+`CompileResult` only after the compiled JavaScript bundle passes the SES
+compiled-bundle validator. `CachedCompiler` refuses to write unvalidated results
+and treats legacy entries without that marker as misses. A validated cache hit
+can skip the evaluate-time bundle validation parse because the cached entry
+already records that the exact emitted JavaScript passed the validator.
 
 **No TTL.** The fingerprint is the source of truth for freshness. If the
 fingerprint matches, the entry is valid regardless of age.

--- a/packages/html/src/worker/reconciler.ts
+++ b/packages/html/src/worker/reconciler.ts
@@ -1781,8 +1781,13 @@ export class WorkerReconciler {
             existingState.cancel();
           }
 
-          // Skip if value hasn't changed
-          if (existingState && existingState.currentValue === value) continue;
+          // Skip only when a previous primitive value is unchanged. Object/cell
+          // prop states do not track currentValue, so they must still emit a
+          // set-prop when transitioning to a primitive such as undefined.
+          if (
+            existingState && !existingState.cell &&
+            existingState.currentValue === value
+          ) continue;
 
           const propValue = this.transformPropValueForState(
             state,

--- a/packages/html/test/worker-reconciler-cell-props.test.ts
+++ b/packages/html/test/worker-reconciler-cell-props.test.ts
@@ -373,6 +373,46 @@ Deno.test("worker reconciler - Cell<Props> handling", async (t) => {
       }
     });
 
+    await t.step(
+      "Cell<Props> object prop transitioning to undefined is emitted",
+      async () => {
+        const collector = createOpsCollector();
+        const reconciler = new WorkerReconciler({
+          onOps: collector.onOps,
+        });
+
+        const propsCell = new MockPropsCell({
+          style: { color: "blue" },
+        });
+        const rootCell = new MockCell({
+          type: "vnode",
+          name: "div",
+          props: propsCell,
+          children: [],
+        });
+
+        const cancel = mountReconciler(reconciler, rootCell);
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          collector.clear();
+
+          propsCell.set({ style: undefined });
+          await new Promise((resolve) => setTimeout(resolve, 10));
+
+          const setPropOps = collector.getOpsOfType("set-prop");
+          assertEquals(
+            setPropOps.some((op: any) =>
+              op.key === "style" && op.value === undefined
+            ),
+            true,
+            "Should emit set-prop when an object-backed prop becomes undefined",
+          );
+        } finally {
+          cancel();
+        }
+      },
+    );
+
     await t.step("Cell<Props> array prop", async () => {
       const collector = createOpsCollector();
       const reconciler = new WorkerReconciler({

--- a/packages/runner/src/compilation-cache/mod.ts
+++ b/packages/runner/src/compilation-cache/mod.ts
@@ -19,9 +19,14 @@ const DEFAULT_EVICTION_INTERVAL = 50;
 export interface CachedCompilerStats {
   hits: number;
   misses: number;
-  missReasons: { notFound: number; fingerprintMismatch: number };
+  missReasons: {
+    notFound: number;
+    fingerprintMismatch: number;
+    unvalidated: number;
+  };
   writes: number;
   writeErrors: number;
+  skippedUnvalidatedWrites: number;
   countEvictions: number;
 }
 
@@ -33,9 +38,10 @@ export class CachedCompiler {
   private stats: CachedCompilerStats = {
     hits: 0,
     misses: 0,
-    missReasons: { notFound: 0, fingerprintMismatch: 0 },
+    missReasons: { notFound: 0, fingerprintMismatch: 0, unvalidated: 0 },
     writes: 0,
     writeErrors: 0,
+    skippedUnvalidatedWrites: 0,
     countEvictions: 0,
   };
 
@@ -70,15 +76,30 @@ export class CachedCompiler {
       this.stats.missReasons.fingerprintMismatch++;
       return undefined;
     }
+    if (entry.sesValidated !== true) {
+      this.stats.misses++;
+      this.stats.missReasons.unvalidated++;
+      return undefined;
+    }
     this.stats.hits++;
-    return { id: entry.id, jsScript: entry.jsScript };
+    return { id: entry.id, jsScript: entry.jsScript, sesValidated: true };
   }
 
   async set(programHash: string, result: CompileResult): Promise<void> {
+    if (result.sesValidated !== true) {
+      this.stats.skippedUnvalidatedWrites++;
+      logger.warn(
+        "compilation-cache",
+        "Refusing to cache unvalidated compiled bundle",
+        programHash,
+      );
+      return;
+    }
     try {
       await this.cache.set(programHash, {
         id: result.id,
         jsScript: result.jsScript,
+        sesValidated: true,
         fingerprint: this.fingerprint,
         cachedAt: Date.now(),
       });

--- a/packages/runner/src/compilation-cache/storage.ts
+++ b/packages/runner/src/compilation-cache/storage.ts
@@ -7,6 +7,8 @@ export interface CompilationCacheEntry {
   id: string;
   /** Full JsScript including source maps. */
   jsScript: JsScript;
+  /** True only for bundles that passed the SES compiled-bundle validator. */
+  sesValidated?: true;
   fingerprint: string;
   /** Timestamp for diagnostics / count-based eviction. */
   cachedAt: number;

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -1,6 +1,7 @@
 import { Console } from "./console.ts";
 import {
   type CompileResult,
+  type EvaluateOptions,
   type Exports,
   type Harness,
   type HarnessedFunction,
@@ -10,11 +11,11 @@ import {
 import {
   getTypeScriptEnvironmentTypes,
   InMemoryProgram,
-  JsScript,
+  type JsScript,
   type MappedPosition,
-  Program,
-  ProgramResolver,
-  Source,
+  type Program,
+  type ProgramResolver,
+  type Source,
   TypeScriptCompiler,
 } from "@commonfabric/js-compiler";
 import {
@@ -99,8 +100,7 @@ export class EngineProgramResolver extends InMemoryProgram {
   }
 }
 
-interface Internals {
-  compiler: TypeScriptCompiler;
+interface RuntimeInternals {
   runtime: SESRuntime;
   runtimeExports: Record<string, any> | undefined;
   // Callback will be called with a map of exported values to `RuntimeProgram`
@@ -109,12 +109,17 @@ interface Internals {
   exportsCallback: (exports: Map<any, RuntimeProgram>) => void;
 }
 
+interface CompilerInternals {
+  compiler: TypeScriptCompiler;
+}
+
 export interface EngineOptions {
   hideInternalStackFrames?: boolean;
 }
 
 export class Engine extends EventTarget implements Harness {
-  private internals: Internals | undefined;
+  private runtimeInternals: RuntimeInternals | undefined;
+  private compilerInternals: CompilerInternals | undefined;
   private ctRuntime: Runtime;
   private sesRuntime: SESRuntime | undefined;
   private loadIds = new WeakMap<JsScript, string>();
@@ -131,19 +136,31 @@ export class Engine extends EventTarget implements Harness {
     this.ctRuntime = ctRuntime;
   }
 
-  async initialize() {
+  async initializeRuntime(): Promise<RuntimeInternals> {
+    const runtime = this.getSESRuntime();
+    const { runtimeExports, exportsCallback } = await getRuntimeModuleExports();
+    return { runtime, runtimeExports, exportsCallback };
+  }
+
+  async initializeCompiler(): Promise<CompilerInternals> {
     const environmentTypes = await Engine.getEnvironmentTypes(
       this.ctRuntime.staticCache,
     );
     const compiler = new TypeScriptCompiler(environmentTypes);
-    const runtime = this.getSESRuntime();
-    const { runtimeExports, exportsCallback } = await getRuntimeModuleExports();
-    return { compiler, runtime, runtimeExports, exportsCallback };
+    return { compiler };
+  }
+
+  async initialize(): Promise<RuntimeInternals & CompilerInternals> {
+    const [runtimeInternals, compilerInternals] = await Promise.all([
+      this.getRuntimeInternals(),
+      this.getCompilerInternals(),
+    ]);
+    return { ...runtimeInternals, ...compilerInternals };
   }
 
   // Resolve a `ProgramResolver` into a `Program`.
   async resolve(program: ProgramResolver): Promise<RuntimeProgram> {
-    const { compiler } = await this.getInternals();
+    const { compiler } = await this.getCompilerInternals();
     logger.timeStart("resolve");
     try {
       return await compiler.resolveProgram(program, {
@@ -169,7 +186,7 @@ export class Engine extends EventTarget implements Harness {
         this.ctRuntime.staticCache,
       );
 
-      const { compiler } = await this.getInternals();
+      const { compiler } = await this.getCompilerInternals();
       const resolvedProgram = await this.resolve(resolver);
 
       const diagnosticMessageTransformer = new OpaqueRefErrorTransformer({
@@ -203,7 +220,7 @@ export class Engine extends EventTarget implements Harness {
 
       this.bundleValidator.verify(jsScript, filename);
 
-      return { id, jsScript };
+      return { id, jsScript, sesValidated: true };
     } finally {
       logger.timeEnd("compile");
     }
@@ -216,14 +233,17 @@ export class Engine extends EventTarget implements Harness {
     id: string,
     jsScript: JsScript,
     files: Source[],
+    options: EvaluateOptions = {},
   ): Promise<
     { main?: Exports; exportMap?: Record<string, Exports>; loadId?: string }
   > {
     logger.timeStart("evaluate");
     try {
-      this.bundleValidator.verify(jsScript, `${id}.js`);
+      if (!options.skipBundleValidation) {
+        this.bundleValidator.verify(jsScript, `${id}.js`);
+      }
       const { runtime, runtimeExports, exportsCallback } = await this
-        .getInternals();
+        .getRuntimeInternals();
       const loadId = this.getLoadId(id, jsScript);
       this.executableRegistry.beginVerifiedLoad(loadId);
       this.executableRegistry.setVerifiedLoadBundleId(
@@ -300,8 +320,8 @@ export class Engine extends EventTarget implements Harness {
     // and if we have functions from this source, this should already
     // be set up.
     // Some tests invoke values outside of this isolate, so just
-    // execute and return if internals have not been initialized.
-    if (!this.internals && !this.sesRuntime) {
+    // execute and return if runtime internals have not been initialized.
+    if (!this.runtimeInternals && !this.sesRuntime) {
       return fn();
     }
     return this.getSESRuntime().getIsolate("__engine-invoke__").value(fn)
@@ -398,17 +418,17 @@ export class Engine extends EventTarget implements Harness {
     line: number,
     column: number,
   ): MappedPosition | null {
-    if (!this.internals) return null;
-    return this.internals.runtime.mapPosition(filename, line, column);
+    if (!this.runtimeInternals) return null;
+    return this.runtimeInternals.runtime.mapPosition(filename, line, column);
   }
 
   // Parse an error stack trace, mapping all positions back to original sources.
-  // Returns the original stack if internals haven't been initialized.
+  // Returns the original stack if runtime internals haven't been initialized.
   parseStack(stack: string): string {
-    if (!this.internals) {
+    if (!this.runtimeInternals) {
       return stack;
     }
-    return this.internals.runtime.parseStack(stack);
+    return this.runtimeInternals.runtime.parseStack(stack);
   }
 
   // Returns a map of runtime module types.
@@ -424,11 +444,18 @@ export class Engine extends EventTarget implements Harness {
     return [...RuntimeModuleIdentifiers];
   }
 
-  private async getInternals(): Promise<Internals> {
-    if (!this.internals) {
-      this.internals = await this.initialize();
+  private async getRuntimeInternals(): Promise<RuntimeInternals> {
+    if (!this.runtimeInternals) {
+      this.runtimeInternals = await this.initializeRuntime();
     }
-    return this.internals;
+    return this.runtimeInternals;
+  }
+
+  private async getCompilerInternals(): Promise<CompilerInternals> {
+    if (!this.compilerInternals) {
+      this.compilerInternals = await this.initializeCompiler();
+    }
+    return this.compilerInternals;
   }
 
   /**
@@ -440,7 +467,8 @@ export class Engine extends EventTarget implements Harness {
       this.sesRuntime.clear();
     }
     this.sesRuntime = undefined;
-    this.internals = undefined;
+    this.runtimeInternals = undefined;
+    this.compilerInternals = undefined;
     this.loadIds = new WeakMap();
     this.nextLoadId = 0;
     this.executableRegistry.clear();

--- a/packages/runner/src/harness/types.ts
+++ b/packages/runner/src/harness/types.ts
@@ -38,12 +38,22 @@ export interface CompileResult {
    *  from export map keys. */
   id: string;
   jsScript: JsScript;
+  /** True only after the compiled JavaScript bundle has passed SES validation. */
+  sesValidated?: true;
 }
 
 export interface EvaluateResult {
   main?: Exports;
   exportMap?: Record<string, Exports>;
   loadId?: string;
+}
+
+export interface EvaluateOptions {
+  /**
+   * Skip SES bundle validation for compiled JavaScript loaded from a trusted
+   * cache entry. Direct callers should leave this unset.
+   */
+  skipBundleValidation?: boolean;
 }
 
 // A `Harness` wraps a flow of compiling, bundling, and executing typescript.
@@ -61,6 +71,7 @@ export interface Harness extends EventTarget {
     id: string,
     jsScript: JsScript,
     files: Source[],
+    options?: EvaluateOptions,
   ): Promise<EvaluateResult>;
 
   // Resolves a `ProgramResolver` into a `Program` using the engine's

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -433,12 +433,16 @@ export class PatternManager {
         "pattern source",
       ).toString();
       let compileResult = await cachedCompiler.get(programHash);
+      let loadedFromCache = true;
       if (!compileResult) {
+        loadedFromCache = false;
         compileResult = await this.runtime.harness.compile(program);
         // Fire-and-forget cache write
         cachedCompiler.set(programHash, compileResult).catch(() => {});
       }
-      return this.evaluateToPattern(compileResult, program);
+      return this.evaluateToPattern(compileResult, program, {
+        skipBundleValidation: loadedFromCache,
+      });
     }
 
     // No persistent cache — compile and evaluate directly
@@ -449,11 +453,13 @@ export class PatternManager {
   private async evaluateToPattern(
     { id, jsScript }: CompileResult,
     program: RuntimeProgram,
+    options?: { skipBundleValidation?: boolean },
   ): Promise<Pattern> {
     const { main, loadId } = await this.runtime.harness.evaluate(
       id,
       jsScript,
       program.files,
+      options,
     );
     if (!main) {
       throw new Error("Pattern compilation produced no exports.");

--- a/packages/runner/test/compilation-cache.test.ts
+++ b/packages/runner/test/compilation-cache.test.ts
@@ -27,11 +27,13 @@ const testJsScript2: JsScript = {
 const testResult: CompileResult = {
   id: "test-id-1",
   jsScript: testJsScript,
+  sesValidated: true,
 };
 
 const testResult2: CompileResult = {
   id: "test-id-2",
   jsScript: testJsScript2,
+  sesValidated: true,
 };
 
 // Run the same storage test suite against each backend
@@ -322,6 +324,29 @@ describe("CachedCompiler", () => {
     expect(result).toBeDefined();
     expect(result!.id).toBe("test-id-1");
     expect(result!.jsScript.js).toBe("var x = 42;");
+    expect(result!.sesValidated).toBe(true);
+  });
+
+  it("does not store unvalidated CompileResult values", async () => {
+    await compiler.set("hash1", {
+      id: "test-id-1",
+      jsScript: testJsScript,
+    });
+
+    expect(await storage.get("hash1")).toBeUndefined();
+    expect(compiler.getStats().skippedUnvalidatedWrites).toBe(1);
+  });
+
+  it("treats legacy entries without SES validation as misses", async () => {
+    await storage.set("hash1", {
+      id: "test-id-1",
+      jsScript: testJsScript,
+      fingerprint: "fingerprint-v1",
+      cachedAt: 1000,
+    });
+
+    expect(await compiler.get("hash1")).toBeUndefined();
+    expect(compiler.getStats().missReasons.unvalidated).toBe(1);
   });
 
   it("returns undefined when fingerprint doesn't match", async () => {

--- a/packages/runner/test/engine.test.ts
+++ b/packages/runner/test/engine.test.ts
@@ -324,6 +324,37 @@ describe("Engine.evaluate()", () => {
     expect(result.exportMap).toBeDefined();
   });
 
+  it("does not initialize the TypeScript compiler when evaluating precompiled JS", async () => {
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/main.tsx",
+          contents: "export default 42;",
+        },
+      ],
+    };
+
+    const { jsScript, id } = await engine.compile(program);
+    const evaluateOnlyEngine = new class extends Engine {
+      override initializeCompiler(): never {
+        throw new Error("compiler initialized during evaluate");
+      }
+    }(runtime);
+
+    try {
+      const result = await evaluateOnlyEngine.evaluate(
+        id,
+        jsScript,
+        program.files,
+        { skipBundleValidation: true },
+      );
+      expect(result.main!["default"]).toBe(42);
+    } finally {
+      evaluateOnlyEngine.dispose();
+    }
+  });
+
   it("rejects invalid bundles passed directly to evaluate()", async () => {
     const jsScript = {
       filename: "invalid-bundle.js",

--- a/packages/runner/test/pattern-manager.test.ts
+++ b/packages/runner/test/pattern-manager.test.ts
@@ -401,6 +401,24 @@ describe("PatternManager compilation cache integration", () => {
     expect(cachedCompiler.getStats().writes).toBe(1);
   });
 
+  it("skips evaluate-time bundle validation for SES-validated cache hits", async () => {
+    const first = await runtime.patternManager.compilePattern(simpleProgram);
+    expect(first).toBeDefined();
+
+    const originalEvaluate = runtime.harness.evaluate.bind(runtime.harness);
+    let evaluateOptions:
+      | Parameters<typeof runtime.harness.evaluate>[3]
+      | undefined;
+    runtime.harness.evaluate = ((id, jsScript, files, options) => {
+      evaluateOptions = options;
+      return originalEvaluate(id, jsScript, files, options);
+    }) as typeof runtime.harness.evaluate;
+
+    const second = await runtime.patternManager.compilePattern(simpleProgram);
+    expect(second).toBeDefined();
+    expect(evaluateOptions?.skipBundleValidation).toBe(true);
+  });
+
   it("cache miss with wrong fingerprint triggers recompile", async () => {
     // Seed the cache with a known key and fingerprint, then use a
     // CachedCompiler with a different fingerprint to observe the mismatch.

--- a/packages/shell/integration/piece.test.ts
+++ b/packages/shell/integration/piece.test.ts
@@ -5,7 +5,6 @@ import { dirname, join, resolve } from "@std/path";
 import "../src/globals.ts";
 import { Identity } from "@commonfabric/identity";
 import { PieceController, PiecesController } from "@commonfabric/piece/ops";
-import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
 import { clickPierce } from "./shadow-dom.ts";
 import { expect } from "@std/expect";
 
@@ -85,6 +84,41 @@ async function waitForSlugPieceMarker(
   });
 }
 
+async function getClientEngineCompileCount(
+  page: ReturnType<ShellIntegration["page"]>,
+): Promise<number> {
+  return await page.evaluate(async () => {
+    const rt = globalThis.commonfabric?.rt;
+    if (!rt) {
+      throw new Error("Runtime client was not exposed");
+    }
+    const { timing } = await rt.getLoggerCounts();
+    return timing.engine?.compile?.count ?? 0;
+  });
+}
+
+async function waitForSpaceRootPattern(
+  page: ReturnType<ShellIntegration["page"]>,
+): Promise<void> {
+  await waitFor(async () => {
+    return await page.evaluate(() => {
+      const rootView = document.querySelector("x-root-view");
+      const appView = rootView?.shadowRoot?.querySelector("x-app-view") as
+        | {
+          _patterns?: {
+            value?: {
+              spaceRootPattern?: {
+                id(): string;
+              };
+            };
+          };
+        }
+        | null;
+      return !!appView?._patterns?.value?.spaceRootPattern?.id?.();
+    });
+  });
+}
+
 describe("shell piece tests", () => {
   const shell = new ShellIntegration();
   shell.bindLifecycle();
@@ -99,10 +133,13 @@ describe("shell piece tests", () => {
     });
     let piece: PieceController | undefined;
     let pieceSinkCancel: (() => void) | undefined;
+    let identityPath: string | undefined;
     const logDebugSnapshot = async (label: string) => {
       console.log(label, {
         shellState: await shell.state(),
         pieceValue: piece ? await piece.result.get(["value"]) : undefined,
+        clientEngineCompileCount: await getClientEngineCompileCount(page)
+          .catch((error) => error instanceof Error ? error.message : error),
         page: await page.evaluate(() => {
           const rootView = document.querySelector("x-root-view");
           const typedRootView = rootView as
@@ -177,16 +214,14 @@ describe("shell piece tests", () => {
         "counter",
         "counter.tsx",
       );
-      const program = await cc.manager().runtime.harness
-        .resolve(
-          new FileSystemProgramResolver(sourcePath),
-        );
-      const currentPiece = await cc.create(
-        program,
-        { start: true },
-      );
+      identityPath = await writeIdentityKey(identity);
+      const pieceId = await runCfPieceNewWithSlug({
+        sourcePath,
+        identityPath,
+        slug: `compile-cache-${crypto.randomUUID()}`,
+      });
+      const currentPiece = await cc.get(pieceId, false);
       piece = currentPiece;
-      const pieceId = currentPiece.id;
 
       const resultCell = cc.manager().getResult(currentPiece.getCell());
       pieceSinkCancel = resultCell.sink(() => {});
@@ -209,6 +244,10 @@ describe("shell piece tests", () => {
       await waitFor(async () => {
         return await page.evaluate(() => !!globalThis.commonfabric?.rt);
       });
+      await waitForSpaceRootPattern(page);
+      const clientCompileCountBeforePieceLoad =
+        await getClientEngineCompileCount(page);
+
       await page.evaluate(async (spaceName, pieceId) => {
         await globalThis.app.setView({ spaceName, pieceId });
       }, { args: [SPACE_NAME, pieceId] });
@@ -242,6 +281,19 @@ describe("shell piece tests", () => {
       };
 
       await waitForActivePattern();
+      const clientCompileCountAfterPieceLoad =
+        await getClientEngineCompileCount(
+          page,
+        );
+      if (
+        clientCompileCountAfterPieceLoad !== clientCompileCountBeforePieceLoad
+      ) {
+        throw new Error(
+          `Expected 0 in-client compilations while loading cf-created piece ${pieceId}; ` +
+            `engine compile count changed from ${clientCompileCountBeforePieceLoad} to ${clientCompileCountAfterPieceLoad}`,
+        );
+      }
+
       await waitFor(async () =>
         (await currentPiece.result.get(["value"])) === 0
       );
@@ -263,6 +315,11 @@ describe("shell piece tests", () => {
     } finally {
       pieceSinkCancel?.();
       await cc.dispose();
+      if (identityPath) {
+        await Deno.remove(dirname(identityPath), { recursive: true }).catch(
+          () => {},
+        );
+      }
     }
   });
 


### PR DESCRIPTION
## Summary

- mark compile results as SES validated only after compiled-bundle verification passes
- persist and accept only SES-validated compilation cache entries, treating legacy unvalidated entries as misses
- skip evaluate-time bundle validation for trusted cache hits and lazily initialize the TypeScript compiler only on compile/resolve paths
- cover the shell cf-created piece flow with an assertion that client-side piece loading performs zero in-client compilations

## Validation

- deno fmt --check docs/specs/compilation-cache.md packages/runner/src/compilation-cache/mod.ts packages/runner/src/compilation-cache/storage.ts packages/runner/src/harness/engine.ts packages/runner/src/harness/types.ts packages/runner/src/pattern-manager.ts packages/runner/test/compilation-cache.test.ts packages/runner/test/engine.test.ts packages/runner/test/pattern-manager.test.ts packages/shell/integration/piece.test.ts
- deno test -A packages/runner/test/compilation-cache.test.ts
- deno test -A packages/runner/test/pattern-manager.test.ts
- deno test -A packages/runner/test/engine.test.ts --filter "Engine.evaluate"
- deno test --no-run -A packages/shell/integration/piece.test.ts
- deno task integration shell piece

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache only SES-validated compiled bundles and treat legacy entries as misses to speed up trusted pattern loads. Also fix prop updates so object-backed cell props emit updates when transitioning to primitives like undefined.

- **Bug Fixes**
  - Mark `CompileResult` as validated only after SES bundle verification; refuse caching unvalidated results.
  - Treat cache entries without SES validation as misses and track `unvalidated` miss stats; include `skippedUnvalidatedWrites`.
  - Skip evaluate-time bundle validation for SES-validated cache hits.
  - Ensure the worker reconciler emits a set-prop when an object-backed prop becomes a primitive (e.g., undefined).
  - Add shell test asserting zero in-client compilations when loading a `cf`-created piece.

- **Refactors**
  - Split engine init into runtime vs compiler; lazy-init the TypeScript compiler only on compile/resolve paths.
  - Thread `skipBundleValidation` from `PatternManager` to `Engine.evaluate()` on cache hits.
  - Update docs and tests for cache validation, lazy init, and reconciler behavior.

<sup>Written for commit 48961a1e32a269b47b7a159ebec3259fd6f01f72. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3685?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



NEW_PERF_BASELINE: job: Package Integration Tests (background-charm-service) = 60s
