### PR TITLE
Expose cf-harness capability probe

### DIFF
--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -28,6 +28,7 @@ import {
 } from "./contracts/run-manifest.ts";
 import {
   DEFAULT_SUBAGENT_PROFILE,
+  getHarnessSubagentProfileConfig,
   HARNESS_SUBAGENT_PROFILES,
   type HarnessSubagentProfile,
 } from "./contracts/subagent.ts";
@@ -62,11 +63,56 @@ import {
   parseStructuredResultSchema,
   validateStructuredResultValue,
 } from "./structured-result.ts";
+import { BUILTIN_TOOLS } from "./tools/registry.ts";
 
 const DEFAULT_MODEL = "gpt-5.5";
 const DEFAULT_MAX_MODEL_TURNS = 8;
 const DEFAULT_ARTIFACT_DIRNAME = ".cf-harness-artifacts";
 const CLI_OUTPUT_MODES = ["operator", "batch"] as const;
+const CLI_STRING_FLAGS = [
+  "workspace",
+  "cwd",
+  "focus-root",
+  "allow-tool",
+  "allow-skill-script",
+  "allow-subagent-profile",
+  "output-mode",
+  "prompt-slot-role",
+  "prompt",
+  "prompt-file",
+  "image",
+  "system-prompt",
+  "resume-run",
+  "model",
+  "skills-root",
+  "skill",
+  "gateway-base-url",
+  "gateway-auth-mode",
+  "artifact-root",
+  "result-json-path",
+  "structured-result-path",
+  "structured-result-schema",
+  "structured-result-schema-file",
+  "run-manifest",
+  "cfc-enforcement-mode",
+  "sandbox-image",
+  "max-model-turns",
+  "fabric-mount",
+] as const;
+const CLI_BOOLEAN_FLAGS = [
+  "help",
+  "describe-capabilities",
+  "print-transcript",
+  "stream-events",
+  "no-skill-catalog",
+] as const;
+const CLI_COLLECT_FLAGS = [
+  "allow-tool",
+  "allow-skill-script",
+  "allow-subagent-profile",
+  "skill",
+  "image",
+] as const;
 
 export type CfHarnessCliOutputMode = (typeof CLI_OUTPUT_MODES)[number];
 
@@ -108,6 +154,26 @@ export interface CfHarnessStructuredResultConfig {
   path: string;
   sandboxPath: string;
   schema: JSONSchema;
+}
+
+export interface CfHarnessCliCapabilities {
+  type: "cf-harness.capabilities";
+  version: 1;
+  cliFlags: readonly string[];
+  repeatableCliFlags: readonly string[];
+  parentToolIds: readonly BuiltinToolId[];
+  builtinToolIds: readonly BuiltinToolId[];
+  subagentProfiles: readonly HarnessSubagentProfile[];
+  nativeModelToolIds: readonly string[];
+  features: {
+    images: true;
+    structuredResults: true;
+    skills: true;
+    skillScripts: true;
+    runManifest: true;
+    fabricMount: true;
+    resumeRun: true;
+  };
 }
 
 export interface CfHarnessCliIO {
@@ -237,6 +303,7 @@ Options:
   --fabric-mount <path>         Host path for a Fabric FUSE mount (mounted at /fabric in the sandbox)
   --max-model-turns <n>         Maximum model turns before aborting
   --print-transcript            Print the final transcript JSON after the response
+  --describe-capabilities       Print machine-readable capability JSON and exit
   --help                        Show this help text
 
 Environment:
@@ -275,6 +342,37 @@ const CLI_PARENT_TOOL_IDS = [
   "write_file",
   "delegate_task",
 ] as const satisfies readonly BuiltinToolId[];
+
+const uniqueStrings = <T extends string>(
+  values: readonly T[],
+): readonly T[] => [...new Set(values)];
+
+export const createCfHarnessCliCapabilities = (): CfHarnessCliCapabilities => ({
+  type: "cf-harness.capabilities",
+  version: 1,
+  cliFlags: [
+    ...CLI_STRING_FLAGS.map((flag) => `--${flag}`),
+    ...CLI_BOOLEAN_FLAGS.map((flag) => `--${flag}`),
+  ],
+  repeatableCliFlags: CLI_COLLECT_FLAGS.map((flag) => `--${flag}`),
+  parentToolIds: [...CLI_PARENT_TOOL_IDS],
+  builtinToolIds: BUILTIN_TOOLS.map((tool) => tool.descriptor.toolId),
+  subagentProfiles: [...HARNESS_SUBAGENT_PROFILES],
+  nativeModelToolIds: uniqueStrings(
+    HARNESS_SUBAGENT_PROFILES.flatMap((profile) =>
+      getHarnessSubagentProfileConfig(profile).nativeModelToolIds ?? []
+    ),
+  ),
+  features: {
+    images: true,
+    structuredResults: true,
+    skills: true,
+    skillScripts: true,
+    runManifest: true,
+    fabricMount: true,
+    resumeRun: true,
+  },
+});
 
 const parsePromptSlotRole = (
   input: string | undefined,
@@ -557,49 +655,9 @@ export const parseCfHarnessCliArgs = async (
 ): Promise<CfHarnessCliConfig | { help: true }> => {
   const normalizedArgv = argv[0] === "--" ? argv.slice(1) : argv;
   const args = parseArgs([...normalizedArgv], {
-    string: [
-      "workspace",
-      "cwd",
-      "focus-root",
-      "allow-tool",
-      "allow-skill-script",
-      "allow-subagent-profile",
-      "output-mode",
-      "prompt-slot-role",
-      "prompt",
-      "prompt-file",
-      "image",
-      "system-prompt",
-      "resume-run",
-      "model",
-      "skills-root",
-      "skill",
-      "gateway-base-url",
-      "gateway-auth-mode",
-      "artifact-root",
-      "result-json-path",
-      "structured-result-path",
-      "structured-result-schema",
-      "structured-result-schema-file",
-      "run-manifest",
-      "cfc-enforcement-mode",
-      "sandbox-image",
-      "max-model-turns",
-      "fabric-mount",
-    ],
-    boolean: [
-      "help",
-      "print-transcript",
-      "stream-events",
-      "no-skill-catalog",
-    ],
-    collect: [
-      "allow-tool",
-      "allow-skill-script",
-      "allow-subagent-profile",
-      "skill",
-      "image",
-    ],
+    string: [...CLI_STRING_FLAGS],
+    boolean: [...CLI_BOOLEAN_FLAGS],
+    collect: [...CLI_COLLECT_FLAGS],
     alias: {
       h: "help",
     },
@@ -1283,6 +1341,18 @@ export const formatCfHarnessCliResult = (
   return `${lines.join("\n")}\n`;
 };
 
+const parseCfHarnessCliControlArgs = (
+  argv: readonly string[],
+): ReturnType<typeof parseArgs> => {
+  const normalizedArgv = argv[0] === "--" ? argv.slice(1) : argv;
+  return parseArgs([...normalizedArgv], {
+    boolean: ["help", "describe-capabilities"],
+    alias: {
+      h: "help",
+    },
+  });
+};
+
 export const runCfHarnessCli = async (
   argv: readonly string[],
   deps: RunCfHarnessCliDependencies = {},
@@ -1298,6 +1368,17 @@ export const runCfHarnessCli = async (
     );
   };
   try {
+    const controlArgs = parseCfHarnessCliControlArgs(argv);
+    if (controlArgs.help) {
+      io.stdout(formatCfHarnessCliUsage());
+      return 0;
+    }
+    if (controlArgs["describe-capabilities"]) {
+      io.stdout(
+        `${JSON.stringify(createCfHarnessCliCapabilities(), null, 2)}\n`,
+      );
+      return 0;
+    }
     const parsed = await parseCfHarnessCliArgs(argv, deps);
     if ("help" in parsed) {
       io.stdout(formatCfHarnessCliUsage());

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -8,6 +8,7 @@ import {
   type CfHarnessCliIO,
   type CfHarnessCliSignalHandler,
   createCfHarnessBatchResult,
+  createCfHarnessCliCapabilities,
   formatCfHarnessCliResult,
   formatCfHarnessCliUsage,
   formatCfHarnessTranscriptEvent,
@@ -1101,6 +1102,30 @@ Deno.test("runCfHarnessCli prints usage for help", async () => {
   assertEquals(exitCode, 0);
   assertEquals(stdout, [formatCfHarnessCliUsage()]);
   assertEquals(stderr, []);
+});
+
+Deno.test("runCfHarnessCli prints machine-readable capabilities", async () => {
+  const { io, stdout, stderr } = createIoBuffers();
+  const exitCode = await runCfHarnessCli(["--describe-capabilities"], { io });
+
+  assertEquals(exitCode, 0);
+  assertEquals(stderr, []);
+  assertEquals(stdout.length, 1);
+  const capabilities = JSON.parse(stdout[0]);
+  assertEquals(capabilities, createCfHarnessCliCapabilities());
+  assertEquals(capabilities.type, "cf-harness.capabilities");
+  assertEquals(capabilities.version, 1);
+  assertEquals(capabilities.parentToolIds.includes("web_fetch"), true);
+  assertEquals(capabilities.parentToolIds.includes("bash-no-sandbox"), false);
+  assertEquals(capabilities.builtinToolIds.includes("bash-no-sandbox"), true);
+  assertEquals(capabilities.subagentProfiles.includes("web_search"), true);
+  assertEquals(capabilities.nativeModelToolIds.includes("google_search"), true);
+  assertEquals(
+    capabilities.cliFlags.includes("--structured-result-path"),
+    true,
+  );
+  assertEquals(capabilities.cliFlags.includes("--describe-capabilities"), true);
+  assertEquals(capabilities.repeatableCliFlags.includes("--allow-tool"), true);
 });
 
 Deno.test("installCfHarnessSignalHandlers terminalizes the active run before exiting", async () => {


### PR DESCRIPTION
## Summary
- add a machine-readable `--describe-capabilities` CLI mode for cf-harness
- report supported CLI flags, parent tools, built-in tools, subagent profiles, native model tools, and feature booleans
- cover the new probe with CLI tests

## Verification
- `PATH="/Users/gideonwald/.deno/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Users/gideonwald/.codex/tmp/arg0/codex-arg0MdSind:/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/opt/homebrew/opt/python@3.13/libexec/bin" deno check packages/cf-harness/src/main.ts packages/cf-harness/test/cli.test.ts`
- `PATH="/Users/gideonwald/.deno/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Users/gideonwald/.codex/tmp/arg0/codex-arg0MdSind:/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/opt/homebrew/opt/python@3.13/libexec/bin" deno test -A packages/cf-harness/test/cli.test.ts`
- `PATH="/Users/gideonwald/.deno/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Users/gideonwald/.codex/tmp/arg0/codex-arg0MdSind:/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/opt/homebrew/opt/python@3.13/libexec/bin" deno task test` from `packages/cf-harness`
- `PATH="/Users/gideonwald/.deno/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/Users/gideonwald/.codex/tmp/arg0/codex-arg0MdSind:/Applications/Codex.app/Contents/Resources:/opt/homebrew/bin:/opt/homebrew/opt/python@3.13/libexec/bin" deno task run -- --describe-capabilities` from `packages/cf-harness`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a machine-readable capability probe to `cf-harness` via `--describe-capabilities`. It outputs JSON describing supported flags, tools, subagent profiles, native model tools, and feature switches, and exits early.

- **New Features**
  - New `--describe-capabilities` flag returning JSON with: type, version, cliFlags, repeatableCliFlags, parentToolIds, builtinToolIds, subagentProfiles, nativeModelToolIds, features.
  - Help text updated; help/capabilities handled via lightweight early parsing.
  - Added CLI tests covering the probe output and parsing.

<sup>Written for commit 26df0d94d2eadd664dfa07853175354944670867. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3690?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

