### PR TITLE
Document cf-theme theming guidance

### DIFF
--- a/docs/common/patterns/style.md
+++ b/docs/common/patterns/style.md
@@ -51,6 +51,32 @@ Before writing JSX, decide these things explicitly:
 Do not settle into a generic default app shell. Commit to a direction and make
 the UI clearly about that direction.
 
+## Smallest Button Retheme
+
+If the task is just "make this button look different", wrap the button in a
+small `cf-theme` and set semantic tokens. Do not reach into the button's shadow
+DOM.
+
+```tsx
+const buttonTheme = {
+  borderRadius: "999px",
+  colors: {
+    primary: "#121826",
+    primaryForeground: "#ffffff",
+  },
+};
+
+<cf-theme theme={buttonTheme}>
+  <cf-button color="primary" variant="solid" size="lg">
+    Save changes
+  </cf-button>
+</cf-theme>;
+```
+
+This changes the filled primary button's background, text color, hover family,
+and radius for that subtree. Use the same pattern around a larger section when
+several controls should share the treatment.
+
 ## Theme-First Workflow
 
 When polishing a non-trivial UI, default to this workflow:
@@ -59,8 +85,10 @@ When polishing a non-trivial UI, default to this workflow:
 2. Wrap the main surface in `<cf-theme theme={theme}>`.
 3. Build the layout with `cf-screen`, `cf-vstack`, `cf-hstack`, `cf-vgroup`,
    `cf-hgroup`, `cf-card`, and other `cf-*` primitives.
-4. When `cf-screen` is part of the layout, put overflow content in an inner
-   `cf-vscroll` instead of relying on document scroll.
+4. Content in `cf-screen`'s default slot scrolls automatically when it
+   overflows. Use `cf-vscroll` only when you need snap-to-bottom behavior,
+   fade edges, or a styled/hidden scrollbar. Use `cf-hscroll` for wide
+   tabular content.
 5. Let the theme carry most of the typography, color, radius, density, and
    motion decisions.
 6. Use component-specific CSS custom properties only for local emphasis or
@@ -105,25 +133,26 @@ const theme = {
 <cf-theme theme={theme}>
   <cf-screen>
     <cf-heading slot="header" level={2}>Budget tracker</cf-heading>
-    <cf-vscroll flex showScrollbar fadeEdges>
-      <cf-vstack gap="4" padding="4">
-        {/* themed UI */}
-      </cf-vstack>
-    </cf-vscroll>
+    <cf-vstack gap="4" padding="4">
+      {/* themed UI */}
+    </cf-vstack>
   </cf-screen>
 </cf-theme>;
 ```
 
 ## Full-Height Layout Rule
 
-`cf-screen` is a full-surface frame, not an automatically scrolling page.
+`cf-screen` is a full-surface frame with a pinned header, an auto-scrolling
+main area, and a pinned footer.
 
-- If the content can exceed one screen, wrap it in `cf-vscroll` inside
-  `cf-screen`.
+- Put ordinary vertical content directly in the default slot; it scrolls when
+  it overflows.
+- Use `cf-vscroll` inside `cf-screen` only when you need snap-to-bottom
+  behavior, fade edges, or a styled/hidden scrollbar.
 - If the layout is wider than one viewport, introduce a deliberate `cf-hscroll`
   region.
-- Do not place a long `cf-vstack` directly under `cf-screen` and assume the
-  shell or document will scroll for you.
+- Do not rely on document scrolling around `cf-screen`; the scroll boundary is
+  the component's main area.
 
 Verified top-level theme fields:
 
@@ -134,7 +163,21 @@ Verified top-level theme fields:
 - `density`
 - `colorScheme`
 - `animationSpeed`
+- `roundness`
+- `scale`
+- `motion`
 - `colors`
+
+Supported `colors` keys:
+
+- Core: `primary`, `primaryForeground`, `secondary`,
+  `secondaryForeground`, `background`, `surface`, `surfaceHover`, `text`,
+  `textMuted`, `border`, `borderMuted`, `success`, `successForeground`,
+  `error`, `errorForeground`, `warning`, `warningForeground`, `accent`,
+  `accentForeground`
+- Extended: `brand`, `brandForeground`, `textTertiary`, `textDisabled`,
+  `surfaceDisabled`, `surfacePressed`, `surfaceTertiary`, `surfaceInverse`,
+  `textOnColorSecondary`, `textOnInverse`, `textPressed`
 
 Supported pattern-style aliases:
 
@@ -156,7 +199,12 @@ See:
 - `--cf-theme-mono-font-family`
 - `--cf-theme-font-size`
 - `--cf-theme-border-radius`
+- `--cf-theme-border-radius-full`
 - `--cf-theme-animation-duration`
+
+Compatibility aliases are also emitted for older components:
+
+- `--cf-theme-font-mono`
 
 ### Colors
 
@@ -179,6 +227,30 @@ See:
 - `--cf-theme-color-warning-foreground`
 - `--cf-theme-color-accent`
 - `--cf-theme-color-accent-foreground`
+- `--cf-theme-color-brand`
+- `--cf-theme-color-brand-foreground`
+- `--cf-theme-color-text-tertiary`
+- `--cf-theme-color-text-disabled`
+- `--cf-theme-color-surface-disabled`
+- `--cf-theme-color-surface-pressed`
+- `--cf-theme-color-surface-tertiary`
+- `--cf-theme-color-surface-inverse`
+- `--cf-theme-color-text-on-color-secondary`
+- `--cf-theme-color-text-on-inverse`
+- `--cf-theme-color-text-pressed`
+
+Derived and compatibility color variables:
+
+- `--cf-theme-color-error-surface`
+- `--cf-theme-color-error-light`
+- `--cf-theme-color-primary-light`
+- `--cf-theme-color-success-light`
+- `--cf-theme-color-muted`
+- `--cf-theme-color-text-secondary`
+- `--cf-theme-{background,border,border-muted,error,primary,success,surface,surface-hover,text,text-muted}`
+- `--cf-theme-color-{primary,accent,danger}-{pressed,soft,subtle}`
+- `--cf-theme-color-status-{info,success,warning,error}`
+- `--cf-theme-color-status-{info,success,warning,error}-{pressed,soft,subtle,foreground}`
 
 ### Spacing
 
@@ -188,6 +260,9 @@ See:
 - `--cf-theme-spacing-padding-message`
 - `--cf-theme-spacing-padding-code`
 - `--cf-theme-spacing-padding-block`
+- `--cf-theme-spacing`
+- `--cf-theme-spacing-compact`
+- `--cf-theme-padding`
 
 These are the right starting point for most visual decisions.
 

--- a/packages/html/src/jsx.d.ts
+++ b/packages/html/src/jsx.d.ts
@@ -2794,7 +2794,7 @@ interface CFHTMLElement extends CFDOM.HTMLElement {}
 // Extend this to add attributes to only the CF elements.
 interface CFHTMLAttributes<T> extends CFDOM.HTMLAttributes<T> {}
 
-// Minimal theme typing for cf-theme
+// Theme typing for cf-theme
 type CFColorToken = string | {
   light: string;
   dark: string;
@@ -2820,20 +2820,49 @@ interface CFThemeColors {
   warningForeground: CFColorToken;
   accent: CFColorToken;
   accentForeground: CFColorToken;
+  brand: CFColorToken;
+  brandForeground: CFColorToken;
+  textTertiary: CFColorToken;
+  textDisabled: CFColorToken;
+  surfaceDisabled: CFColorToken;
+  surfacePressed: CFColorToken;
+  surfaceTertiary: CFColorToken;
+  surfaceInverse: CFColorToken;
+  textOnColorSecondary: CFColorToken;
+  textOnInverse: CFColorToken;
+  textPressed: CFColorToken;
 }
 
 interface CFThemeDef {
   fontFamily: string;
   monoFontFamily: string;
+  fontSize: string;
   borderRadius: string;
   density: "compact" | "comfortable" | "spacious";
   colorScheme: "light" | "dark" | "auto";
   animationSpeed: "none" | "slow" | "normal" | "fast";
+  roundness: number;
+  scale: number;
+  motion: number;
   colors: CFThemeColors;
 }
 
+interface CFThemeAliases {
+  accentColor: CFColorToken;
+  fontFace: string;
+}
+
 type CFThemeInput =
-  & Partial<Omit<CFThemeDef, "colors"> & { colors: Partial<CFThemeColors> }>
+  & Partial<
+    Omit<CFThemeDef, "colors"> & CFThemeAliases & {
+      colors:
+        & Partial<CFThemeColors>
+        & Record<
+          string,
+          CFColorToken | undefined
+        >;
+    }
+  >
   & Record<string, unknown>;
 
 type CFEvent<T> = {

--- a/skills/lit-component/SKILL.md
+++ b/skills/lit-component/SKILL.md
@@ -125,7 +125,10 @@ export type {}; /* exported types */
 
 ## Theme Integration
 
-For components that need to consume theme (input and complex components):
+Most components should use `var(--cf-theme-*)` CSS variables with fallbacks.
+Consume `cfThemeContext` only when JavaScript needs the theme object for runtime
+logic, derived values, or applying theme variables to dynamically created
+elements:
 
 ```typescript
 import { consume } from "@lit/context";

--- a/skills/lit-component/references/theme-system.md
+++ b/skills/lit-component/references/theme-system.md
@@ -13,7 +13,8 @@ ambient context that flows down the tree like CSS inheritance.
 1. **Default works:** Components should work without explicit theme
 2. **Composition over specification:** Nest theme providers for progressive
    refinement
-3. **Reactive:** Theme values can be Cells that update live
+3. **Reactive-friendly:** Pass a reactive/computed theme object when the whole
+   theme should update live
 4. **Pattern-friendly:** Support partial themes with pattern-style properties
    (`accentColor`, `fontFace`)
 5. **CSS-native:** Emit CSS variables for performance and browser devtools
@@ -28,23 +29,26 @@ The `<cf-theme>` component wraps children and provides theme context using
 
 - Uses `display: contents` to be invisible in layout
 - Merges partial themes with defaults (supports pattern-style)
-- Subscribes to Cell properties for reactive updates
+- Recomputes and reapplies CSS variables when the `theme` property changes
 - Applies CSS variables to itself for cascade to children
 
 ```typescript
 // Wrap any subtree to theme it
-<cf-theme .theme=${{ accentColor: cell("#3b82f6") }}>
+<cf-theme .theme=${{ accentColor: "#3b82f6" }}>
   <cf-button>Themed Button</cf-button>
 </cf-theme>
 
 // Nest providers for refinement
 <cf-theme .theme=${{ colorScheme: "dark" }}>
   <div>Dark section</div>
-  <cf-theme .theme=${{ accentColor: cell("#ff0000") }}>
+  <cf-theme .theme=${{ accentColor: "#ff0000" }}>
     <div>Dark section with red accent</div>
   </cf-theme>
 </cf-theme>
 ```
+
+In pattern JSX, prefer passing a reactive/computed theme object to `theme` when
+the theme should update. Keep individual theme fields as plain values.
 
 ## Theme Context
 
@@ -57,10 +61,14 @@ component tree.
 interface CFTheme {
   fontFamily: string;
   monoFontFamily: string;
+  fontSize: string;
   borderRadius: string;
   density: "compact" | "comfortable" | "spacious";
   colorScheme: "light" | "dark" | "auto";
   animationSpeed: "none" | "slow" | "normal" | "fast";
+  roundness: number;
+  scale: number;
+  motion: number;
   colors: {
     primary: ColorToken;
     primaryForeground: ColorToken;
@@ -81,6 +89,17 @@ interface CFTheme {
     warningForeground: ColorToken;
     accent: ColorToken;
     accentForeground: ColorToken;
+    brand: ColorToken;
+    brandForeground: ColorToken;
+    textTertiary: ColorToken;
+    textDisabled: ColorToken;
+    surfaceDisabled: ColorToken;
+    surfacePressed: ColorToken;
+    surfaceTertiary: ColorToken;
+    surfaceInverse: ColorToken;
+    textOnColorSecondary: ColorToken;
+    textOnInverse: ColorToken;
+    textPressed: ColorToken;
   };
 }
 
@@ -91,7 +110,12 @@ type ColorToken = string | { light: string; dark: string };
 
 ### Basic Theme Consumption
 
-Use `@consume` decorator to access theme context:
+Most components should read `var(--cf-theme-*)` in CSS with sane fallbacks.
+Consume `cfThemeContext` only when JavaScript needs the theme object for runtime
+logic, derived values, or applying theme variables to dynamically created
+elements.
+
+Use `@consume` decorator to access theme context when needed:
 
 ```typescript
 import { consume } from "@lit/context";
@@ -138,7 +162,12 @@ available:
 - `--cf-theme-mono-font-family`
 - `--cf-theme-font-size`
 - `--cf-theme-border-radius`
+- `--cf-theme-border-radius-full`
 - `--cf-theme-animation-duration`
+
+Compatibility aliases:
+
+- `--cf-theme-font-mono`
 
 **Colors:**
 
@@ -161,6 +190,30 @@ available:
 - `--cf-theme-color-warning-foreground`
 - `--cf-theme-color-accent`
 - `--cf-theme-color-accent-foreground`
+- `--cf-theme-color-brand`
+- `--cf-theme-color-brand-foreground`
+- `--cf-theme-color-text-tertiary`
+- `--cf-theme-color-text-disabled`
+- `--cf-theme-color-surface-disabled`
+- `--cf-theme-color-surface-pressed`
+- `--cf-theme-color-surface-tertiary`
+- `--cf-theme-color-surface-inverse`
+- `--cf-theme-color-text-on-color-secondary`
+- `--cf-theme-color-text-on-inverse`
+- `--cf-theme-color-text-pressed`
+
+**Derived and compatibility colors:**
+
+- `--cf-theme-color-error-surface`
+- `--cf-theme-color-error-light`
+- `--cf-theme-color-primary-light`
+- `--cf-theme-color-success-light`
+- `--cf-theme-color-muted`
+- `--cf-theme-color-text-secondary`
+- `--cf-theme-{background,border,border-muted,error,primary,success,surface,surface-hover,text,text-muted}`
+- `--cf-theme-color-{primary,accent,danger}-{pressed,soft,subtle}`
+- `--cf-theme-color-status-{info,success,warning,error}`
+- `--cf-theme-color-status-{info,success,warning,error}-{pressed,soft,subtle,foreground}`
 
 **Spacing:**
 
@@ -170,6 +223,9 @@ available:
 - `--cf-theme-spacing-padding-message`
 - `--cf-theme-spacing-padding-code`
 - `--cf-theme-spacing-padding-block`
+- `--cf-theme-spacing`
+- `--cf-theme-spacing-compact`
+- `--cf-theme-padding`
 
 ### CSS Variable Fallback Pattern
 


### PR DESCRIPTION
Summary: Updates the cf-theme guidance with a top-line button re-theme example, refreshes emitted token documentation, aligns cf-screen scrolling guidance, and updates JSX theme typing for currently implemented theme keys. Notes: Runtime subscription behavior was intentionally left unchanged in this PR; reactive guidance now recommends passing a reactive/computed whole theme object rather than nested cell-valued fields. Tests: deno fmt/checks via pre-commit, deno check packages/ui/src/v2/components/cf-theme/cf-theme.ts packages/html/src/jsx.d.ts, deno test --allow-read --allow-write --allow-run --allow-env packages/ui/test/standard-decorators-phase5.test.ts.