### PR TITLE
Add shell embed mode

### DIFF
--- a/docs/common/patterns/navigation.md
+++ b/docs/common/patterns/navigation.md
@@ -2,6 +2,12 @@
 
 Use `navigateTo()` for drilling into detail views from list patterns.
 
+`navigateTo()` changes the current shell view while preserving the current shell
+mode. If a pattern is running under the shell embed route
+`/.embed/<space-name-or-did>/<piece-id-or-slug>`, navigation to another piece
+stays under `/.embed/...`. Pattern authors do not need to handle embedded
+navigation specially.
+
 ## List Pattern
 
 ```typescript

--- a/packages/shell/CLAUDE.md
+++ b/packages/shell/CLAUDE.md
@@ -68,7 +68,11 @@ RootView (authentication wrapper)
    - Storage via StorageManager for persistent data
 
 4. **Routing**:
-   - URL pattern: `/{spaceName}/{pieceId}`
+   - URL patterns: `/{spaceNameOrDid}`, `/{spaceNameOrDid}/{pieceIdOrSlug}`, and
+     `/.embed/{spaceNameOrDid}/{pieceIdOrSlug}`
+   - Embed mode strips shell-owned chrome for iframe/web-view embedding
+   - Navigation preserves embed mode, including `navigateTo(...)` calls from
+     rendered patterns
    - History API integration with back/forward support
    - Default space: "common-knowledge"
 

--- a/packages/shell/README.md
+++ b/packages/shell/README.md
@@ -8,3 +8,20 @@
   `localhost:5173`. Access via `localhost:8000` when running with toolshed.
 - `deno task production`: Builds the frontend to `dist/` with production
   settings.
+
+## Routes
+
+The shell supports these browser URL forms:
+
+- `/<space-name-or-did>`: opens the space root pattern.
+- `/<space-name-or-did>/<piece-id-or-slug>`: opens a specific piece.
+- `/.embed/<space-name-or-did>/<piece-id-or-slug>`: opens the same piece in
+  embed mode.
+
+Embed mode is intended for rendering the shell inside another web view, such as
+an iframe. It removes shell-owned chrome around the pattern, including the
+header, debugger, quick jump, outer content padding, sidebar, and fab surfaces.
+
+Shell navigation preserves embed mode. For example, a pattern calling
+`navigateTo(...)` from a `/.embed/...` URL navigates to another `/.embed/...`
+URL rather than leaving the embedded surface.

--- a/packages/shell/shared/app/view.ts
+++ b/packages/shell/shared/app/view.ts
@@ -3,21 +3,37 @@ import { isSlugAddress } from "@commonfabric/runner/slugs";
 
 export type AppBuiltInView = "home";
 
+export type AppViewMode = "embed";
+
+const EMBED_PATH_PREFIX = ".embed";
+
 export type PieceViewRef = {
   pieceId?: string;
   pieceSlug?: string;
+};
+
+export type AppViewModeRef = {
+  mode?: AppViewMode;
 };
 
 export type AppView =
   | {
     builtin: AppBuiltInView;
   }
-  | ({
-    spaceName: string;
-  } & PieceViewRef)
-  | ({
-    spaceDid: DID;
-  } & PieceViewRef);
+  | (
+    & {
+      spaceName: string;
+    }
+    & PieceViewRef
+    & AppViewModeRef
+  )
+  | (
+    & {
+      spaceDid: DID;
+    }
+    & PieceViewRef
+    & AppViewModeRef
+  );
 
 export function isAppBuiltInView(view: unknown): view is AppBuiltInView {
   switch (view as AppBuiltInView) {
@@ -29,7 +45,10 @@ export function isAppBuiltInView(view: unknown): view is AppBuiltInView {
 
 export function isAppView(view: unknown): view is AppView {
   if (!view || typeof view !== "object") return false;
-  if ("builtin" in view) return isAppBuiltInView(view.builtin);
+  if ("builtin" in view) {
+    return isAppBuiltInView(view.builtin) && !("mode" in view);
+  }
+  if (!isAppViewModeRef(view)) return false;
   if ("spaceName" in view) {
     return typeof view.spaceName === "string" && !!view.spaceName &&
       !("pieceId" in view && "pieceSlug" in view);
@@ -40,9 +59,30 @@ export function isAppView(view: unknown): view is AppView {
   return false;
 }
 
+function isAppViewModeRef(view: object): view is AppViewModeRef {
+  return !("mode" in view) || view.mode === "embed";
+}
+
 export function isAppViewEqual(a: AppView, b: AppView): boolean {
   if (a === b) return true;
   return JSON.stringify(a) === JSON.stringify(b);
+}
+
+export function isEmbeddedView(view: AppView): boolean {
+  return "mode" in view && view.mode === "embed";
+}
+
+export function preserveAppViewMode(
+  currentView: AppView,
+  nextView: AppView,
+): AppView {
+  if (!isEmbeddedView(currentView) || "builtin" in nextView) {
+    return nextView;
+  }
+  if ("mode" in nextView) {
+    return nextView;
+  }
+  return { ...nextView, mode: "embed" };
 }
 
 export function isViewingDefaultPatternView(view: AppView): boolean {
@@ -53,23 +93,28 @@ export function isViewingDefaultPatternView(view: AppView): boolean {
 }
 
 export function appViewToUrlPath(view: AppView): `/${string}` {
+  const prefix = isEmbeddedView(view) ? `/${EMBED_PATH_PREFIX}` : "";
   if ("builtin" in view) {
     switch (view.builtin) {
       case "home":
         return `/`;
     }
   } else if ("spaceName" in view) {
-    return "pieceSlug" in view && view.pieceSlug
-      ? `/${view.spaceName}/${view.pieceSlug}`
-      : "pieceId" in view
-      ? `/${view.spaceName}/${view.pieceId}`
-      : `/${view.spaceName}`;
+    const pieceSlug = "pieceSlug" in view ? view.pieceSlug : undefined;
+    const pieceId = "pieceId" in view ? view.pieceId : undefined;
+    return pieceSlug
+      ? `${prefix}/${view.spaceName}/${pieceSlug}`
+      : pieceId
+      ? `${prefix}/${view.spaceName}/${pieceId}`
+      : `${prefix}/${view.spaceName}`;
   } else if ("spaceDid" in view) {
-    return "pieceSlug" in view && view.pieceSlug
-      ? `/${view.spaceDid}/${view.pieceSlug}`
-      : "pieceId" in view
-      ? `/${view.spaceDid}/${view.pieceId}`
-      : `/${view.spaceDid}`;
+    const pieceSlug = "pieceSlug" in view ? view.pieceSlug : undefined;
+    const pieceId = "pieceId" in view ? view.pieceId : undefined;
+    return pieceSlug
+      ? `${prefix}/${view.spaceDid}/${pieceSlug}`
+      : pieceId
+      ? `${prefix}/${view.spaceDid}/${pieceId}`
+      : `${prefix}/${view.spaceDid}`;
   }
   return `/`;
 }
@@ -77,20 +122,23 @@ export function appViewToUrlPath(view: AppView): `/${string}` {
 export function urlToAppView(url: URL): AppView {
   const segments = url.pathname.split("/");
   segments.shift(); // shift off the pathnames' prefix "/";
+  const mode = segments[0] === EMBED_PATH_PREFIX ? "embed" : undefined;
+  if (mode) segments.shift();
   const [first, pieceId] = [segments[0], segments[1]];
+  const modeRef: AppViewModeRef = mode ? { mode } : {};
 
   if (!first) {
     return { builtin: "home" };
   }
   if (isDID(first)) {
-    if (!pieceId) return { spaceDid: first };
+    if (!pieceId) return { spaceDid: first, ...modeRef };
     return isSlugAddress(pieceId)
-      ? { spaceDid: first, pieceSlug: pieceId }
-      : { spaceDid: first, pieceId };
+      ? { spaceDid: first, pieceSlug: pieceId, ...modeRef }
+      : { spaceDid: first, pieceId, ...modeRef };
   } else {
-    if (!pieceId) return { spaceName: first };
+    if (!pieceId) return { spaceName: first, ...modeRef };
     return isSlugAddress(pieceId)
-      ? { spaceName: first, pieceSlug: pieceId }
-      : { spaceName: first, pieceId };
+      ? { spaceName: first, pieceSlug: pieceId, ...modeRef }
+      : { spaceName: first, pieceId, ...modeRef };
   }
 }

--- a/packages/shell/shared/navigate.ts
+++ b/packages/shell/shared/navigate.ts
@@ -1,4 +1,10 @@
-import { App, AppView, appViewToUrlPath, urlToAppView } from "./app/mod.ts";
+import {
+  App,
+  AppView,
+  appViewToUrlPath,
+  preserveAppViewMode,
+  urlToAppView,
+} from "./app/mod.ts";
 import { getLogger } from "@commonfabric/utils/logger";
 
 const logger = getLogger("shell.navigation", {
@@ -154,11 +160,12 @@ function mapNavigationView(
     "spaceDid" in view && view.spaceDid && currentSpaceName &&
     view.spaceDid === currentSpaceDID
   ) {
-    return {
+    view = {
       ...("pieceId" in view ? { pieceId: view.pieceId } : undefined),
       ...("pieceSlug" in view ? { pieceSlug: view.pieceSlug } : undefined),
+      ...("mode" in view ? { mode: view.mode } : undefined),
       spaceName: currentSpaceName,
     };
   }
-  return view;
+  return preserveAppViewMode(currentView, view);
 }

--- a/packages/shell/src/components/PieceLink.ts
+++ b/packages/shell/src/components/PieceLink.ts
@@ -1,7 +1,13 @@
 import { css, html, LitElement } from "lit";
 import { property } from "lit/decorators.js";
 import { type DID } from "@commonfabric/identity";
-import { navigate } from "../../shared/mod.ts";
+import {
+  AppView,
+  appViewToUrlPath,
+  navigate,
+  preserveAppViewMode,
+  urlToAppView,
+} from "../../shared/mod.ts";
 
 export class PieceLinkElement extends LitElement {
   static override styles = css`
@@ -39,14 +45,27 @@ export class PieceLinkElement extends LitElement {
     }
   };
 
-  asHref(): string {
+  asView(): AppView {
     if (this.spaceName) {
-      return `/${this.spaceName}${this.pieceId ? `/${this.pieceId}` : ""}`;
+      return this.pieceId
+        ? { spaceName: this.spaceName, pieceId: this.pieceId }
+        : { spaceName: this.spaceName };
     }
     if (this.spaceDid) {
-      return `/${this.spaceDid}${this.pieceId ? `/${this.pieceId}` : ""}`;
+      return this.pieceId
+        ? { spaceDid: this.spaceDid, pieceId: this.pieceId }
+        : { spaceDid: this.spaceDid };
     }
-    return "/";
+    return { builtin: "home" };
+  }
+
+  asHref(): string {
+    return appViewToUrlPath(
+      preserveAppViewMode(
+        urlToAppView(new URL(globalThis.location.href)),
+        this.asView(),
+      ),
+    );
   }
 
   override render() {

--- a/packages/shell/src/views/AppView.ts
+++ b/packages/shell/src/views/AppView.ts
@@ -1,4 +1,4 @@
-import { css, html } from "lit";
+import { css, html, nothing } from "lit";
 import { property, state } from "lit/decorators.js";
 import { BaseView, createDefaultAppState } from "./BaseView.ts";
 import { KeyStore } from "@commonfabric/identity";
@@ -9,6 +9,7 @@ import { Task, TaskStatus } from "@lit/task";
 import { CellEventTarget, CellUpdateEvent } from "../lib/cell-event-target.ts";
 import { type NameSchema, stringSchema } from "@commonfabric/runner/schemas";
 import {
+  isEmbeddedView,
   isViewingDefaultPatternView,
   replaceNavigation,
   updatePageTitle,
@@ -422,6 +423,7 @@ export class XAppView extends BaseView {
   override render() {
     const config = this.app.config ?? {};
     const { activePattern, spaceRootPattern } = this._patterns.value ?? {};
+    const embedded = isEmbeddedView(this.app.view);
     this.#setTitleSubscription(activePattern);
 
     const authenticated = html`
@@ -432,6 +434,7 @@ export class XAppView extends BaseView {
         .patternError="${this._patternError}"
         .showShellPieceListView="${config.showShellPieceListView ?? false}"
         .showSidebar="${config.showSidebar ?? false}"
+        .embedded="${embedded}"
       ></x-body-view>
     `;
     const unauthenticated = html`
@@ -449,22 +452,24 @@ export class XAppView extends BaseView {
     const content = this.app?.identity ? authenticated : unauthenticated;
     return html`
       <div class="shell-container">
-        <x-header-view
-          .isLoggedIn="${!!this.app.identity}"
-          .spaceName="${spaceName}"
-          .spaceDid="${spaceDid}"
-          .rt="${this.rt}"
-          .keyStore="${this.keyStore}"
-          .pieceTitle="${this.pieceTitle}"
-          .pieceId="${pieceId}"
-          .isViewingDefaultPattern="${isViewingDefaultPattern}"
-          .showDebuggerView="${config.showDebuggerView ?? false}"
-        ></x-header-view>
+        ${embedded ? nothing : html`
+          <x-header-view
+            .isLoggedIn="${!!this.app.identity}"
+            .spaceName="${spaceName}"
+            .spaceDid="${spaceDid}"
+            .rt="${this.rt}"
+            .keyStore="${this.keyStore}"
+            .pieceTitle="${this.pieceTitle}"
+            .pieceId="${pieceId}"
+            .isViewingDefaultPattern="${isViewingDefaultPattern}"
+            .showDebuggerView="${config.showDebuggerView ?? false}"
+          ></x-header-view>
+        `}
         <div class="content-area">
           ${content}
         </div>
       </div>
-      ${this.app.identity
+      ${this.app.identity && !embedded
         ? html`
           <x-debugger-view
             .visible="${this.debuggerController.isVisible()}"

--- a/packages/shell/src/views/BodyView.ts
+++ b/packages/shell/src/views/BodyView.ts
@@ -42,9 +42,17 @@ export class XBodyView extends BaseView {
       box-sizing: border-box;
     }
 
+    .content.embedded {
+      padding: 0;
+    }
+
     @media (max-width: 768px) {
       .content {
         padding: 1rem;
+      }
+
+      .content.embedded {
+        padding: 0;
       }
     }
 
@@ -102,6 +110,9 @@ export class XBodyView extends BaseView {
   @property({ attribute: false })
   accessor patternError: Error | undefined = undefined;
 
+  @property({ type: Boolean })
+  accessor embedded = false;
+
   override connectedCallback() {
     super.connectedCallback();
     this.addEventListener("cf-cell-pin", this._handleCellPin);
@@ -147,7 +158,13 @@ export class XBodyView extends BaseView {
   };
 
   private _subPages = new Task(this, {
-    task: async ([activePattern, spaceRootPattern]) => {
+    task: async ([activePattern, spaceRootPattern, embedded]) => {
+      if (embedded) {
+        return {
+          sidebarUI: undefined,
+          fabUI: undefined,
+        };
+      }
       const [sidebarUI, fabUI] = await Promise.all([
         getSubPageCell(
           activePattern?.cell() as CellHandle<SubPages> | undefined,
@@ -163,7 +180,7 @@ export class XBodyView extends BaseView {
         fabUI,
       };
     },
-    args: () => [this.activePattern, this.spaceRootPattern],
+    args: () => [this.activePattern, this.spaceRootPattern, this.embedded],
   });
 
   override render() {
@@ -183,12 +200,14 @@ export class XBodyView extends BaseView {
       `
       : null;
 
-    const sidebar = this._subPages?.value?.sidebarUI;
-    const fab = this._subPages?.value?.fabUI;
+    const sidebar = this.embedded
+      ? undefined
+      : this._subPages?.value?.sidebarUI;
+    const fab = this.embedded ? undefined : this._subPages?.value?.fabUI;
 
     return html`
-      <div class="content">
-        <x-omni-layout .sidebarOpen="${this.showSidebar}">
+      <div class="content ${this.embedded ? "embedded" : ""}">
+        <x-omni-layout .sidebarOpen="${!this.embedded && this.showSidebar}">
           ${mainContent} ${sidebar
             ? html`
               <cf-render slot="sidebar" .cell="${sidebar}"></cf-render>

--- a/packages/shell/src/views/RootView.ts
+++ b/packages/shell/src/views/RootView.ts
@@ -8,6 +8,7 @@ import {
   Command,
   isAppViewEqual,
   isCommand,
+  isEmbeddedView,
 } from "../../shared/mod.ts";
 import { BaseView, createDefaultAppState, SHELL_COMMAND } from "./BaseView.ts";
 import { KeyStore } from "@commonfabric/identity";
@@ -42,7 +43,7 @@ function getCommonfabricGlobal(): typeof globalThis & {
 
 const SPACE_BASE_SELECTOR = 'base[data-commonfabric-space-base="true"]';
 
-function setSpaceBaseHref(space?: DID): void {
+function setSpaceBaseHref(space?: DID, embedded = false): void {
   const existing = document.head.querySelector<HTMLBaseElement>(
     SPACE_BASE_SELECTOR,
   );
@@ -51,7 +52,7 @@ function setSpaceBaseHref(space?: DID): void {
     return;
   }
 
-  const href = `/${space}/`;
+  const href = embedded ? `/.embed/${space}/` : `/${space}/`;
   const base = existing ?? document.createElement("base");
   base.setAttribute("data-commonfabric-space-base", "true");
   base.href = href;
@@ -150,7 +151,7 @@ export class XRootView extends BaseView {
         // Update the provided runtime and space values
         this.runtime = rt.runtime();
         this.space = rt.space() as DID;
-        setSpaceBaseHref(this.space);
+        setSpaceBaseHref(this.space, isEmbeddedView(app.view));
 
         // Expose RuntimeClient for console debugging
         // (e.g. commonfabric.rt.setLoggerLevel("debug"))
@@ -234,6 +235,8 @@ export class XRootView extends BaseView {
 
     if (flipState || stateChanged) {
       this._rt.run([current]);
+    } else if (current.identity && this.space) {
+      setSpaceBaseHref(this.space, isEmbeddedView(current.view));
     }
   }
 

--- a/packages/shell/test/app-state.test.ts
+++ b/packages/shell/test/app-state.test.ts
@@ -5,7 +5,10 @@ import {
   AppStateSerialized,
   appViewToUrlPath,
   deserialize,
+  isAppView,
+  isEmbeddedView,
   isViewingDefaultPatternView,
+  preserveAppViewMode,
   serialize,
   urlToAppView,
 } from "@commonfabric/shell/shared";
@@ -117,6 +120,101 @@ describe("AppState", () => {
       appViewToUrlPath({ spaceName: "space", pieceSlug: "demo" }) ===
         "/space/demo",
     );
+  });
+
+  it("parses and serializes embedded routes", () => {
+    const spaceDid = "did:key:z6MkjosLwWEobyT9T6RqLTdaEhFrXAZUNkRZJuUae2ukgfEa";
+
+    assert(
+      JSON.stringify(
+        urlToAppView(new URL("http://common.test/.embed/space/demo")),
+      ) ===
+        JSON.stringify({
+          spaceName: "space",
+          pieceSlug: "demo",
+          mode: "embed",
+        }),
+    );
+    assert(
+      JSON.stringify(
+        urlToAppView(new URL("http://common.test/.embed/space/fid1:abc")),
+      ) ===
+        JSON.stringify({
+          spaceName: "space",
+          pieceId: "fid1:abc",
+          mode: "embed",
+        }),
+    );
+    assert(
+      JSON.stringify(
+        urlToAppView(new URL(`http://common.test/.embed/${spaceDid}/demo`)),
+      ) ===
+        JSON.stringify({
+          spaceDid,
+          pieceSlug: "demo",
+          mode: "embed",
+        }),
+    );
+    assert(
+      appViewToUrlPath({
+        spaceName: "space",
+        pieceSlug: "demo",
+        mode: "embed",
+      }) === "/.embed/space/demo",
+    );
+    assert(
+      appViewToUrlPath({
+        spaceDid,
+        pieceId: "fid1:abc",
+        mode: "embed",
+      }) === `/.embed/${spaceDid}/fid1:abc`,
+    );
+    assert(
+      appViewToUrlPath({
+        spaceName: "space",
+        pieceSlug: undefined,
+        mode: "embed",
+      }) === "/.embed/space",
+    );
+  });
+
+  it("validates and preserves embedded view mode", () => {
+    const current = {
+      spaceName: "space",
+      pieceSlug: "demo",
+      mode: "embed",
+    } as const;
+
+    assert(isAppView(current));
+    assert(isEmbeddedView(current));
+    assert(
+      JSON.stringify(
+        preserveAppViewMode(current, {
+          spaceName: "space",
+          pieceId: "fid1:abc",
+        }),
+      ) ===
+        JSON.stringify({
+          spaceName: "space",
+          pieceId: "fid1:abc",
+          mode: "embed",
+        }),
+    );
+    assert(
+      JSON.stringify(
+        preserveAppViewMode(current, {
+          spaceName: "space",
+          pieceId: "fid1:abc",
+          mode: undefined,
+        }),
+      ) ===
+        JSON.stringify({
+          spaceName: "space",
+          pieceId: "fid1:abc",
+        }),
+    );
+    assert(!isAppView({ builtin: "home", mode: "embed" }));
+    assert(!isAppView({ spaceName: "space", mode: "fullscreen" }));
   });
 
   it("treats slug piece routes as non-default pattern views", () => {

--- a/packages/ui/src/v2/components/cf-cell-link/cf-cell-link.ts
+++ b/packages/ui/src/v2/components/cf-cell-link/cf-cell-link.ts
@@ -13,7 +13,12 @@ import {
 } from "@commonfabric/runtime-client";
 import type { DID } from "@commonfabric/identity";
 import { runtimeContext, spaceContext } from "../../runtime-context.ts";
-import { appViewToUrlPath, navigate } from "@commonfabric/shell/shared";
+import {
+  appViewToUrlPath,
+  navigate,
+  preserveAppViewMode,
+  urlToAppView,
+} from "@commonfabric/shell/shared";
 import {
   createDragPreview,
   endDrag,
@@ -383,7 +388,12 @@ export class CFCellLink extends BaseElement {
 
       // Cmd (Mac) or Ctrl (Windows/Linux) opens in new tab
       if (e.metaKey || e.ctrlKey) {
-        const url = appViewToUrlPath(view);
+        const url = appViewToUrlPath(
+          preserveAppViewMode(
+            urlToAppView(new URL(globalThis.location.href)),
+            view,
+          ),
+        );
         globalThis.open(url, "_blank");
       } else {
         navigate(view);


### PR DESCRIPTION
## Summary
- add /.embed-prefixed shell routes and mode preservation across navigation
- hide shell chrome, padding, sidebar, and fab content in embed mode
- preserve embedded URLs for direct/cmd-open piece and cell links

## Tests
- deno task test (packages/shell)
- deno check packages/ui/src/v2/components/cf-cell-link/cf-cell-link.ts
- deno test --allow-read --allow-write --allow-run --allow-env packages/ui/src/v2/components/cf-cell-link/cf-cell-link.test.ts
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an embed mode for the shell with `/.embed` routes that hide shell chrome and preserve embed mode across navigation and deep links. Keeps URLs stable for cmd/ctrl-open and fixes relative links via a mode-aware base href.

- **New Features**
  - Routing: Added `AppViewMode: "embed"` and `/.embed` path prefix supported by `urlToAppView` and `appViewToUrlPath` in `@commonfabric/shell/shared`.
  - Mode preservation: New `preserveAppViewMode` used in `navigate`, `PieceLink`, and `cf-cell-link` (including cmd/ctrl-click).
  - UI: Hides header, debugger, sidebar, FAB, and outer padding in embed mode; `BodyView` accepts `embedded` to render content-only.
  - Base href: `RootView` sets `<base>` to `/.embed/<space>/` when embedded to keep relative URLs working.
  - Validation/Tests: Added `isEmbeddedView`, tightened `isAppView` (no mode on built-ins), and tests for `/.embed` parsing/serialization and mode carryover.

<sup>Written for commit ebad325b3c66a865017494ffbf96510a8bfe45c2. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3693?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

