### PR TITLE
Support reactive cf-theme values

### DIFF
--- a/packages/ui/src/v2/components/cf-theme/cf-theme.test.ts
+++ b/packages/ui/src/v2/components/cf-theme/cf-theme.test.ts
@@ -1,0 +1,64 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  createMockCellHandle,
+  pushUpdate,
+} from "../../test-utils/mock-cell-handle.ts";
+import {
+  subscribeToThemeCellValues,
+  unwrapThemeCellValues,
+} from "./cf-theme.ts";
+
+describe("cf-theme reactive theme values", () => {
+  it("unwraps top-level CellHandle values before theme merge", () => {
+    const accentColor = createMockCellHandle("#3b82f6");
+
+    expect(unwrapThemeCellValues({ accentColor })).toEqual({
+      accentColor: "#3b82f6",
+    });
+  });
+
+  it("unwraps nested CellHandle values in color tokens", () => {
+    const primary = createMockCellHandle("#121826");
+    const darkText = createMockCellHandle("#f8fafc");
+
+    expect(
+      unwrapThemeCellValues({
+        colors: {
+          primary,
+          text: {
+            light: "#111827",
+            dark: darkText,
+          },
+        },
+      }),
+    ).toEqual({
+      colors: {
+        primary: "#121826",
+        text: {
+          light: "#111827",
+          dark: "#f8fafc",
+        },
+      },
+    });
+  });
+
+  it("subscribes to nested CellHandle values without firing for initial values", () => {
+    const primary = createMockCellHandle("#121826");
+    const theme = { colors: { primary } };
+    let changeCount = 0;
+
+    const [off] = subscribeToThemeCellValues(theme, () => {
+      changeCount++;
+    });
+
+    expect(changeCount).toBe(0);
+
+    pushUpdate(primary, "#334155");
+    expect(changeCount).toBe(1);
+
+    off();
+    pushUpdate(primary, "#475569");
+    expect(changeCount).toBe(1);
+  });
+});

--- a/packages/ui/src/v2/components/cf-theme/cf-theme.ts
+++ b/packages/ui/src/v2/components/cf-theme/cf-theme.ts
@@ -11,15 +11,83 @@ import {
 } from "../theme-context.ts";
 import { type CellHandle, isCellHandle } from "@commonfabric/runtime-client";
 
+export function unwrapThemeCellValues(
+  value: unknown,
+  seen = new WeakSet<object>(),
+): unknown {
+  if (isCellHandle(value)) {
+    return value.get();
+  }
+
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+
+  if (seen.has(value)) {
+    return value;
+  }
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.map((item) => unwrapThemeCellValues(item, seen));
+  }
+
+  const out: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value)) {
+    out[key] = unwrapThemeCellValues(child, seen);
+  }
+  return out;
+}
+
+export function subscribeToThemeCellValues(
+  value: unknown,
+  onChange: () => void,
+  seen = new WeakSet<object>(),
+): Array<() => void> {
+  const unsubs: Array<() => void> = [];
+
+  const visit = (current: unknown) => {
+    if (isCellHandle(current)) {
+      const cellVal = current as CellHandle<unknown>;
+      let didReceiveInitialValue = false;
+      const off = cellVal.subscribe(() => {
+        if (!didReceiveInitialValue) {
+          didReceiveInitialValue = true;
+          return;
+        }
+        onChange();
+      });
+      unsubs.push(off);
+      return;
+    }
+
+    if (!current || typeof current !== "object") {
+      return;
+    }
+
+    if (seen.has(current)) {
+      return;
+    }
+    seen.add(current);
+
+    for (const child of Object.values(current)) {
+      visit(child);
+    }
+  };
+
+  visit(value);
+  return unsubs;
+}
+
 /**
  * cf-theme — Provides a theme to a subtree and applies CSS vars.
  *
  * Usage:
  * <cf-theme .theme=${partialTheme}><slot/></cf-theme>
  *
- * The component merges a partial theme (pattern-style) with defaults,
- * provides the result via context, and sets CSS custom properties on
- * the host so descendants pick up tokens.
+ * The component unwraps CellHandle values inside a partial theme, merges the
+ * result with defaults, provides it via context, and sets CSS custom properties
+ * on the host so descendants pick up tokens.
  *
  * @element cf-theme
  */
@@ -67,7 +135,9 @@ export class CFThemeProvider extends BaseElement {
   }
 
   private _recomputeAndApply() {
-    this._computedTheme = mergeWithDefaultTheme(this.theme);
+    this._computedTheme = mergeWithDefaultTheme(
+      unwrapThemeCellValues(this.theme),
+    );
     applyThemeToElement(this, this._computedTheme);
     this.#setupSubscriptions();
 
@@ -95,18 +165,10 @@ export class CFThemeProvider extends BaseElement {
     for (const off of this.#unsubs) off();
     this.#unsubs = [];
 
-    const t = this.theme as Record<string, unknown> | undefined;
-    if (!t) return;
-
-    // Subscribe to top-level cell properties to refresh CSS vars on change
-    for (const key of Object.keys(t)) {
-      const val = (t as any)[key];
-      if (isCellHandle(val)) {
-        const cellVal = val as CellHandle<any>;
-        const off = cellVal.subscribe(() => this._recomputeAndApply());
-        this.#unsubs.push(off);
-      }
-    }
+    this.#unsubs = subscribeToThemeCellValues(
+      this.theme,
+      () => this._recomputeAndApply(),
+    );
   }
 
   override disconnectedCallback(): void {


### PR DESCRIPTION
Summary: Adds focused cf-theme support for CellHandle values inside theme objects by unwrapping them before merge/apply and subscribing recursively to theme CellHandles. Suppresses the synchronous initial CellHandle subscribe callback so setup does not immediately recurse. Adds unit tests for top-level unwrapping, nested color token unwrapping, update notification, and unsubscribe behavior. Tests: deno test --allow-env --allow-ffi --allow-read --allow-write --allow-run packages/ui/src/v2/components/cf-theme/cf-theme.test.ts; deno check packages/ui/src/v2/components/cf-theme/cf-theme.ts packages/ui/src/v2/components/cf-theme/cf-theme.test.ts; deno test --allow-read --allow-write --allow-run --allow-env packages/ui/test/standard-decorators-phase5.test.ts; pre-commit deno fmt and deno lint.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `cf-theme` reactive to `CellHandle` values in theme objects. It unwraps cells before merge and subscribes to nested cells so CSS vars update on change, without firing on the initial subscribe.

- **New Features**
  - Added `unwrapThemeCellValues` to resolve cell values in themes (top-level and nested).
  - Added `subscribeToThemeCellValues` to recursively subscribe to cells and skip the initial value; `CFThemeProvider` now uses this to recompute and apply CSS vars on updates.
  - Added tests for unwrapping, nested color tokens, change notifications, and unsubscribe behavior.

<sup>Written for commit 0f14f5ef2a29a3ee36d7ce071ad9149dd9b03a0d. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3694?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

