### PR TITLE
fix(runner): demand pull parents from live child effects

### DIFF
--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -1402,6 +1402,7 @@ export class Scheduler {
       dependents: this.dependents,
       dependencies: this.dependencies,
       actionParent: this.actionParent,
+      actionChildren: this.actionChildren,
       isEffectAction: this.isEffectAction,
       pullDemandedFirstRunComputations: this.pullDemandedFirstRunComputations,
       pullDemandedContinuationComputations: this

--- a/packages/runner/src/scheduler/demand.ts
+++ b/packages/runner/src/scheduler/demand.ts
@@ -7,6 +7,7 @@ export interface PullDemandState {
   readonly dependents: WeakMap<Action, Set<Action>>;
   readonly dependencies: WeakMap<Action, ReactivityLog>;
   readonly actionParent: WeakMap<Action, Action>;
+  readonly actionChildren: WeakMap<Action, Set<Action>>;
   readonly isEffectAction: WeakMap<Action, boolean>;
   readonly pullDemandedFirstRunComputations: WeakSet<Action>;
   readonly pullDemandedContinuationComputations: WeakSet<Action>;
@@ -52,6 +53,7 @@ export function isDemandedPullComputation(
   visited.add(action);
 
   return hasTransitiveEffectDependent(state, action) ||
+    hasDemandedChildContext(state, action, visited) ||
     hasDemandedParentContext(state, action, visited);
 }
 
@@ -137,4 +139,20 @@ function hasDemandedParentContext(
   }
 
   return isDemandedPullComputation(state, parent, visited);
+}
+
+function hasDemandedChildContext(
+  state: PullDemandState,
+  action: Action,
+  visited = new Set<Action>(),
+): boolean {
+  const children = state.actionChildren.get(action);
+  if (!children) return false;
+
+  for (const child of children) {
+    if (isLiveEffect(state, child)) return true;
+    if (isDemandedPullComputation(state, child, visited)) return true;
+  }
+
+  return false;
 }

--- a/packages/runner/test/scheduler-pull.test.ts
+++ b/packages/runner/test/scheduler-pull.test.ts
@@ -601,6 +601,77 @@ describe("pull-based scheduling", () => {
     expect(effectRuns).toBeGreaterThan(initialEffectRuns);
   });
 
+  it("should run dirty parent computations with live child effect demand", async () => {
+    runtime.scheduler.enablePullMode();
+
+    const source = runtime.getCell<string>(
+      space,
+      "pull-live-child-demand-source",
+      undefined,
+      tx,
+    );
+    source.set("code-editor");
+    const parentOutput = runtime.getCell<string>(
+      space,
+      "pull-live-child-demand-output",
+      undefined,
+      tx,
+    );
+    parentOutput.set("");
+    await tx.commit();
+    tx = runtime.edit();
+
+    let parentRuns = 0;
+    let childEffectRuns = 0;
+    let cancelChildEffect: (() => void) | undefined;
+
+    const childEffect: Action = () => {
+      childEffectRuns++;
+    };
+
+    const parentComputation: Action = (actionTx) => {
+      parentRuns++;
+      parentOutput.withTx(actionTx).send(
+        source.withTx(actionTx).get() ?? "",
+      );
+
+      if (!cancelChildEffect) {
+        cancelChildEffect = runtime.scheduler.subscribe(
+          childEffect,
+          { reads: [], shallowReads: [], writes: [] },
+          { isEffect: true },
+        );
+      }
+    };
+
+    const cancelParent = runtime.scheduler.subscribe(
+      parentComputation,
+      {
+        reads: [toMemorySpaceAddress(source.getAsNormalizedFullLink())],
+        shallowReads: [],
+        writes: [toMemorySpaceAddress(parentOutput.getAsNormalizedFullLink())],
+      },
+      {},
+    );
+
+    expect(await parentOutput.pull()).toBe("code-editor");
+    await runtime.scheduler.idle();
+
+    expect(parentRuns).toBe(1);
+    expect(childEffectRuns).toBeGreaterThanOrEqual(1);
+
+    source.withTx(tx).send("button");
+    await tx.commit();
+    tx = runtime.edit();
+    await runtime.scheduler.idle();
+
+    expect(parentRuns).toBe(2);
+    expect(parentOutput.withTx(tx).get()).toBe("button");
+
+    cancelChildEffect?.();
+    cancelParent();
+  });
+
   it("should run dirty computations with live downstream effect demand", async () => {
     runtime.scheduler.enablePullMode();
 


### PR DESCRIPTION
## Summary

Fixes a pull scheduler demand gap where a dirty parent computation could stay dirty even though it had a live child effect created during its previous run.

This showed up in the deployed component catalog when switching stories from the sidebar: the click wrote `internal.selected`, but the main story area did not re-render until a full refresh.

## Reproduction

1. Open the deployed catalog:
   `http://localhost:8000/2026-05-27-ben/fid1:kxMpdZjZpbxmGsYff0_uFgXHaZShC4awRpjNcKAftKM`
2. Authenticate and load the catalog.
3. Click a different story in the sidebar, for example switch from `Code Editor` to `Button`.
4. Observe that the sidebar responds and the selected story cell changes, but the main content remains on the previous story.
5. Refresh the page and observe that the main content then reflects the selected story.

The console also showed:

```text
[ERROR][runner::21:44:09.137] pattern-load-error Failed to load pattern fid1:bqvNTSjSGcLbSkSUFC4B4FcgG5ww6O8KXuxJEJi_WmA Error: Pattern fid1:bqvNTSjSGcLbSkSUFC4B4FcgG5ww6O8KXuxJEJi_WmA has no stored source
```

That error appears unrelated to the stale render path: scheduler tracing showed the selected story write and dirty-marking were happening correctly.

## Diagnosis

Browser scheduler tracing showed:

- `selectedStory` changed to the new story id.
- The `catalog/ui/story-renderer.tsx` computation was marked dirty from the `internal.selected` write.
- `scheduleAffectedEffects(storyRenderer)` returned no scheduled effects.
- The graph showed `StoryRenderer` had live child effects from the previously rendered story, but no data-dependent downstream effect edge that would make the parent computation demanded.

In pull mode, a dirty computation runs when it is demanded by a live effect or a demanded parent context. The missing case was the inverse: a computation can be demanded by the live child effects it created on a previous run. That is the catalog shape, because switching stories requires rerunning the parent `StoryRenderer` computation so it can replace the mounted child pattern.

## Fix

Extend pull demand propagation to account for child actions:

- `PullDemandState` now includes `actionChildren`.
- `isDemandedPullComputation` treats a computation as demanded when any child action is a live effect or an otherwise demanded computation.
- The scheduler wires its existing `actionChildren` map into pull demand state.

This preserves pull laziness for computations without live UI demand, while allowing mounted child pattern effects to keep their parent story-selection computation live.

## Tests

Added a regression test:

- `should run dirty parent computations with live child effect demand`

Verification run locally:

```text
mise exec -- deno test --allow-ffi --allow-env --allow-read --allow-write=/tmp,/var/folders --allow-run=git packages/runner/test/scheduler-pull.test.ts
mise exec -- deno test --allow-ffi --allow-env --allow-read --allow-write=/tmp,/var/folders --allow-run=git packages/runner/test/scheduler-pull-array.test.ts
mise exec -- deno test --allow-ffi --allow-env --allow-read --allow-write=/tmp,/var/folders --allow-run=git packages/runner/test/scheduler-ordering.test.ts
mise exec -- deno test --allow-ffi --allow-env --allow-read --allow-write=/tmp,/var/folders --allow-run=git packages/runner/test/scheduler-core.test.ts
mise exec -- deno task cf check packages/patterns/catalog/catalog.tsx --no-run
mise exec -- deno fmt --check packages/runner/src/scheduler/demand.ts packages/runner/src/scheduler.ts packages/runner/test/scheduler-pull.test.ts
git diff --check
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix pull scheduler so dirty parent computations rerun when they have live child effects from a previous run. Story switches in the catalog now update the main content immediately without a refresh.

- **Bug Fixes**
  - Consider child demand: a parent is demanded if any child in `actionChildren` is a live effect or a demanded computation.
  - Pass `actionChildren` into `PullDemandState` and check it in `isDemandedPullComputation`.
  - Add a regression test covering the live-child-demand case.

<sup>Written for commit 80801f5f14d6b434d841e428a64925ecfefa1493. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3695?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

