### PR TITLE
Render slugged nested output pages directly

### DIFF
--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -222,6 +222,54 @@ describe("page slug redirects", () => {
     expect(result.page.cell).toMatchObject(targetRef);
   });
 
+  it("renders slug redirects to nested output cells directly", async () => {
+    const targetRef: CellRef = {
+      id: "of:fid1-parent-page" as CellRef["id"],
+      space,
+      scope: "space",
+      path: ["activityTab"],
+    };
+    const slugRef: CellRef = {
+      id: "of:fid1-slug-doc" as CellRef["id"],
+      space,
+      scope: "space",
+      path: [],
+    };
+    let targetSynced = false;
+    const targetCell = mockCell(targetRef, {
+      sourceCell: {},
+      onSync: () => {
+        targetSynced = true;
+      },
+    });
+    const slugCell = mockCell(slugRef, { raw: redirectRaw(targetRef) });
+    const manager = {
+      get: () => {
+        throw new Error(
+          "nested output-cell slug redirects should not load as pieces",
+        );
+      },
+    };
+    const processor = {
+      pieceManager: { getSpace: () => space },
+      runtime: {
+        getCellFromEntityId: () => slugCell,
+        getCellFromLink: () => targetCell,
+      },
+      cc: { manager: () => manager },
+    };
+
+    const result = await (RuntimeProcessor.prototype as any).handlePageGet
+      .call(processor, {
+        type: RequestType.PageGet,
+        pageId: "fid1-slug-doc",
+        runIt: true,
+      });
+
+    expect(targetSynced).toBe(true);
+    expect(result.page.cell).toMatchObject(targetRef);
+  });
+
   it("loads slug redirects to piece cells through the piece manager", async () => {
     const pieceRef: CellRef = {
       id: "of:fid1-piece" as CellRef["id"],

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -691,7 +691,8 @@ export class RuntimeProcessor {
         scope: redirect.scope ?? "space",
       });
       await target.sync();
-      if (!target.getSourceCell()) {
+      const targetLink = target.getAsNormalizedFullLink();
+      if (!target.getSourceCell() || targetLink.path.length > 0) {
         return {
           page: createPageRef(target),
         };


### PR DESCRIPTION
## Summary
- treat slug redirects to nested output paths as page cells instead of reloading the parent piece
- keep root piece redirects going through the piece manager
- add regression coverage for slug redirects to nested output cells that still report a source cell

## Why
Loom mobile stable URLs need slugs like `/activity` to point at `home/activityTab`. Those cells inherit the parent result source metadata, so the runtime previously interpreted them as the parent piece and never rendered the nested page body.

## Test
- deno test --allow-all packages/runtime-client/backends/runtime-processor.test.ts

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render slugged nested output pages directly so slugs like `/activity` correctly show the nested page (e.g., `home/activityTab`). Root piece slug redirects still route through the piece manager.

- **Bug Fixes**
  - Render slug redirects to output cells with a non-empty path as pages after sync.
  - Keep root piece slug redirects loading via the piece manager.
  - Add regression test to ensure nested output slugs render and sync the target cell.

<sup>Written for commit e514101f6cc95f45f9022f2c7ad5f755649bc2aa. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3696?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

