### PR TITLE
Preserve schema for nested page slug redirects

### DIFF
--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -151,6 +151,8 @@ describe("page slug redirects", () => {
 
   function mockCell(ref: CellRef, options: {
     raw?: unknown;
+    schemaCell?: unknown;
+    onPull?: () => void;
     sourceCell?: unknown;
     onSync?: () => void;
   } = {}) {
@@ -159,10 +161,15 @@ describe("page slug redirects", () => {
         options.onSync?.();
         return Promise.resolve();
       },
+      pull: () => {
+        options.onPull?.();
+        return Promise.resolve(options.raw);
+      },
       getRaw: () => options.raw,
       getSourceCell: () => options.sourceCell,
       getAsLink: () => cellRefToSigilLink(ref),
       getAsNormalizedFullLink: () => ref,
+      asSchemaFromLinks: () => options.schemaCell,
     };
   }
 
@@ -235,8 +242,26 @@ describe("page slug redirects", () => {
       scope: "space",
       path: [],
     };
+    const schemaRef: CellRef = {
+      ...targetRef,
+      schema: {
+        type: "object",
+        properties: {
+          "$NAME": { type: "string" },
+          "$UI": { type: "object" },
+        },
+        required: ["$NAME", "$UI"],
+      },
+    };
+    let schemaPulled = false;
+    const schemaCell = mockCell(schemaRef, {
+      onPull: () => {
+        schemaPulled = true;
+      },
+    });
     let targetSynced = false;
     const targetCell = mockCell(targetRef, {
+      schemaCell,
       sourceCell: {},
       onSync: () => {
         targetSynced = true;
@@ -267,7 +292,8 @@ describe("page slug redirects", () => {
       });
 
     expect(targetSynced).toBe(true);
-    expect(result.page.cell).toMatchObject(targetRef);
+    expect(schemaPulled).toBe(true);
+    expect(result.page.cell).toMatchObject(schemaRef);
   });
 
   it("loads slug redirects to piece cells through the piece manager", async () => {

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -692,9 +692,14 @@ export class RuntimeProcessor {
       });
       await target.sync();
       const targetLink = target.getAsNormalizedFullLink();
-      if (!target.getSourceCell() || targetLink.path.length > 0) {
+      const sourceCell = target.getSourceCell();
+      if (!sourceCell || targetLink.path.length > 0) {
+        const pageCell = sourceCell && targetLink.path.length > 0
+          ? target.asSchemaFromLinks()
+          : target;
+        await pageCell.pull();
         return {
-          page: createPageRef(target),
+          page: createPageRef(pageCell),
         };
       }
 


### PR DESCRIPTION
## Summary
- preserve recovered schema when a page slug redirects to a nested output cell
- pull the schema-bearing nested cell before returning it as a page
- keep nested output redirects out of the piece-manager load path
- cover the nested redirect case with a runtime-processor regression test

## Why
Loom mobile now assigns stable slugs directly to nested outputs like `home/activityTab`. The first slug fix lets those redirects resolve to the nested cell, but the route still needs to return a fully usable page cell. Using `asSchemaFromLinks()` keeps the nested cell's schema attached from the parent result link, and pulling that schema-bearing cell makes the computed subpage UI materialize before the response is returned.

## Testing
- `deno test --allow-all packages/runtime-client/backends/runtime-processor.test.ts`

## Loom verification
- synced Loom's `vendor/labs` checkout to `87f266b16`
- redeployed local Loom with `loom piece deploy loom --local --force`
- verified the local slug targets with `cf piece inspect`:
  - `projects` returns `$NAME: "Loom Projects"` and a `$UI`
  - `activity` returns `$NAME: "Loom Activity"` and a `$UI`
  - `files` returns `$NAME: "Loom Files"` and a `$UI`
  - `quick-capture` returns `$NAME: "Loom Capture"` and a `$UI`

After this merges, Loom should cut and pin a new `loom-stable-2026-05-27-*` Labs tag.
