### PR TITLE
Write slug metadata for resolved targets

### DIFF
--- a/packages/piece/src/slugs.ts
+++ b/packages/piece/src/slugs.ts
@@ -44,6 +44,11 @@ export async function setSlugLink(
     ? source.resolveAsCell()
     : source;
   await target.sync();
+  const metadataTarget = options?.writeTargetMetadata ||
+      options?.resolveBeforeLinking
+    ? target.resolveAsCell()
+    : undefined;
+  await metadataTarget?.sync();
 
   const slugCell = manager.runtime.getCellFromEntityId(
     manager.getSpace(),
@@ -53,17 +58,18 @@ export async function setSlugLink(
   await manager.runtime.editWithRetry((tx) => {
     const targetWithTx = target.withTx(tx);
     const slugWithTx = slugCell.withTx(tx);
-    const targetLink = targetWithTx.getAsNormalizedFullLink();
     const slugLink = slugWithTx.getAsNormalizedFullLink();
 
+    const metadataTargetLink = metadataTarget?.withTx(tx)
+      .getAsNormalizedFullLink();
     if (
-      options?.writeTargetMetadata &&
-      (!targetLink.path || targetLink.path.length === 0)
+      metadataTargetLink &&
+      (!metadataTargetLink.path || metadataTargetLink.path.length === 0)
     ) {
       tx.writeOrThrow({
-        space: targetLink.space,
-        id: targetLink.id,
-        scope: targetLink.scope,
+        space: metadataTargetLink.space,
+        id: metadataTargetLink.id,
+        scope: metadataTargetLink.scope,
         path: ["slug"],
       }, validSlug);
     }

--- a/packages/piece/test/slug.test.ts
+++ b/packages/piece/test/slug.test.ts
@@ -128,6 +128,44 @@ describe("piece slugs", () => {
     const link = parseLink(secondSlugCell.getRaw(), secondSlugCell);
     expect(link?.overwrite).toBe("redirect");
     expect(link?.id).toBe(piece.getAsNormalizedFullLink().id);
+    expect(readRootMeta(pieceId(piece)!, "slug")).toBe("second-link");
+  });
+
+  it("stores slug metadata on the fully resolved target", async () => {
+    const output = runtime.getCell(
+      manager.getSpace(),
+      { space: manager.getSpace(), random: "slug-final-target" },
+    );
+    const intermediate = runtime.getCell(
+      manager.getSpace(),
+      { space: manager.getSpace(), random: "slug-intermediate-target" },
+    );
+
+    await runtime.editWithRetry((tx) => {
+      output.withTx(tx).set({ value: 1 });
+      intermediate.withTx(tx).key("child").setRawUntyped(
+        output.withTx(tx).getAsWriteRedirectLink({
+          base: intermediate.withTx(tx).key("child"),
+        }),
+      );
+    });
+
+    await setSlugLink(manager, "resolved-target", intermediate.key("child"), {
+      writeTargetMetadata: true,
+    });
+
+    const slugCell = runtime.getCellFromEntityId(manager.getSpace(), {
+      "/": slugIdForSpace(manager.getSpace(), "resolved-target"),
+    });
+    await slugCell.sync();
+    const link = parseLink(slugCell.getRaw(), slugCell);
+    expect(link?.overwrite).toBe("redirect");
+    expect(link?.id).toBe(intermediate.getAsNormalizedFullLink().id);
+    expect(link?.path).toEqual(["child"]);
+    expect(readRootMeta(
+      String(output.getAsNormalizedFullLink().id).replace(/^of:/, ""),
+      "slug",
+    )).toBe("resolved-target");
   });
 
   it("preserves URI-shaped piece addresses", async () => {


### PR DESCRIPTION
## Summary
- write slug metadata onto resolved slug targets
- keep direct arbitrary cell links unchanged unless the caller explicitly resolves before linking
- cover the resolved redirect case in the slug tests

## Why
Loom mobile uses `cf piece set-slug --resolve-before-linking` for stable tab URLs like `projects`, `activity`, and `files`. The rendered direct slug URLs work, but tab-bar navigation emits the resolved target cell id. The shell then asks Labs for slug metadata for that cell id before replacing the URL with the human-readable slug.

Top-level piece slugs already wrote that metadata, but resolved slug targets did not. This meant navigating through the tab bar landed on a raw `fid1:` URL even when the target had a stable slug.

## Testing
- `deno fmt packages/piece/src/slugs.ts packages/piece/test/slug.test.ts`
- `deno test --allow-all packages/piece/test/slug.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Write slug metadata on the fully resolved target so navigation replaces raw IDs with stable slugs across redirects. Fixes Loom mobile tab-bar URLs that showed `fid1:` instead of human-readable slugs.

- **Bug Fixes**
  - In `setSlugLink`, when `writeTargetMetadata` or `resolveBeforeLinking` is set, resolve the final target and write slug metadata on that cell (root only), not on the intermediate path.
  - Keep direct cell links unchanged unless the caller resolves before linking.
  - Added tests that assert metadata is stored on redirect targets and on the fully resolved target of a redirect chain.

<sup>Written for commit d0e8926ee85a4ec76be47b691f759de0af8c5d4f. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3698?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

