### PR TITLE
feat(cozy-poll-scoped): "we went here" history + open host takeover

### DIFF
--- a/packages/patterns/cozy-poll-scoped/DEPLOY-AND-SHARE.md
+++ b/packages/patterns/cozy-poll-scoped/DEPLOY-AND-SHARE.md
@@ -1,0 +1,132 @@
+# Deploying & sharing cozy-poll-scoped state
+
+This pattern's data lives in **`PerSpace` cells** (`users`, `options`, `votes`,
+`history`, `adminName`, `question`). That state belongs to **one deployed piece
+instance** in one space — addressed by `(space, causal-cell-id)` — not to "the
+pattern" in the abstract. So "share the state" means "everyone points at the
+same piece," and "copy the state" means "move those cell values into a new
+piece." This doc covers both, plus the identity caveat that bites first.
+
+## The canonical piece
+
+There is one shared instance everyone should iterate on:
+
+```
+space:  lunch-2026-05-26
+piece:  fid1:nye-cJnJnU5OQIPiVXzvAoq_YeU5pZARxyXp-9-JCZg
+url:    https://toolshed.saga-castor.ts.net/lunch-2026-05-26/fid1:nye-cJnJnU5OQIPiVXzvAoq_YeU5pZARxyXp-9-JCZg
+```
+
+(If this piece is ever lost — e.g. the space is reset — re-establish it with a
+single `cf piece new` and update the ID here. See "Re-establishing" below.)
+
+Set these once so you don't repeat flags:
+
+```bash
+export CF_API_URL=https://toolshed.saga-castor.ts.net/
+export CF_IDENTITY="$HOME/.config/commonfabric/identity.key"   # your key
+PIECE=fid1:nye-cJnJnU5OQIPiVXzvAoq_YeU5pZARxyXp-9-JCZg
+SPACE=lunch-2026-05-26
+```
+
+## Option A — deploy your version onto the shared state (recommended)
+
+To push code changes **and keep the accumulated state**, update the source of
+the existing piece in place. Do **not** run `cf piece new` — that mints a fresh,
+empty instance.
+
+```bash
+deno task cf piece setsrc --piece "$PIECE" -s "$SPACE" \
+  packages/patterns/cozy-poll-scoped/main.tsx
+```
+
+Why this preserves state: cell ids are derived from the causal generation chain,
+not from contents, and scope is excluded from that computation. Swapping the
+program with `setsrc` keeps the same result cell, so `users`/`votes`/`history`
+survive. **Adding a new `PerSpace` field is safe** — on an existing piece it
+just hydrates to its `Default<>` while the populated fields keep their data.
+
+Caveat: this holds as long as an input's identity in the recipe stays stable.
+Adding fields is safe; heavily reordering/renaming pattern inputs can in
+principle shift the causal chain and orphan old data. Don't treat the piece as a
+database you can refactor freely without thinking about it. If state must be
+durable even against re-`new`ing, store it in a separate dedicated data piece
+the poll links to (not yet implemented here).
+
+## Option B — copy the state into your own piece
+
+If you want your **own** instance seeded with the current data (e.g. to
+experiment without touching the shared poll):
+
+```bash
+# 1. Create your own empty piece (note the new ID it prints).
+MINE=$(deno task cf piece new packages/patterns/cozy-poll-scoped/main.tsx \
+  -s "$SPACE" | grep '^fid1:')
+
+# 2. Copy each PerSpace field from the canonical piece into yours.
+#    `--input` reads/writes the input cell where these live.
+for field in question users options votes history adminName; do
+  deno task cf piece get --piece "$PIECE" -s "$SPACE" "$field" --input -q \
+    | deno task cf piece set --piece "$MINE" -s "$SPACE" "$field" --input -q
+done
+
+# 3. Recompute so derived values (counts, ranking, nudges) refresh.
+deno task cf piece step --piece "$MINE" -s "$SPACE"
+deno task cf piece inspect --piece "$MINE" -s "$SPACE" --summary
+```
+
+This is a **one-time snapshot copy**, not a live link — the two pieces diverge
+after this. There is no automatic carry-over of `PerSpace` data between pieces.
+
+## Identity: why a fresh viewer "isn't recognized"
+
+`myName` is **`PerUser`** — keyed by the authenticated **DID**, not the space.
+`adminName` (first joiner) and the `users` directory are `PerSpace`. Two
+consequences trip everyone up:
+
+1. **CLI and browser are different identities unless you make them the same.**
+   If you join/seed from the `cf` CLI (one DID) and then open the piece in a
+   browser (a different passphrase/passkey DID), the browser's `myName` is empty
+   — it shows you the join card and won't treat you as host. To act as the same
+   person in both, import your CLI key into the browser (`Import CLI Key`); see
+   [`docs/development/SHARED_IDENTITY.md`](../../../docs/development/SHARED_IDENTITY.md).
+   Verify with `cf id did "$CF_IDENTITY"` and the browser's `shell.identity` log.
+
+2. **Names are unique (name-as-identity).** `joinAs` rejects a name already in
+   `users`. So if a test/seed already claimed your preferred name, you can't
+   re-join under it from another identity — pick a different name, or clear the
+   stale entry.
+
+3. **Host role is claimable.** The host seat (`adminName`) goes to the *first*
+   joiner, but any joined participant can take it over with the **Become host**
+   button (`claimHost` sets `adminName` to themselves). So a stuck/squatted host
+   seat no longer requires an operator reset — just join and click Become host.
+   (You can still reset `adminName` to `""` directly if no one is joined.)
+
+### Resetting / re-seeding state (host or operator)
+
+There is no "reset everything" handler (`resetVotes` only clears votes). To wipe
+or seed the shared cells directly, write the input cells. **This mutates shared
+state — coordinate before running against the canonical piece.**
+
+```bash
+echo '[]' | deno task cf piece set --piece "$PIECE" -s "$SPACE" users     --input -q
+echo '""' | deno task cf piece set --piece "$PIECE" -s "$SPACE" adminName --input -q
+echo '[]' | deno task cf piece set --piece "$PIECE" -s "$SPACE" options   --input -q
+echo '[]' | deno task cf piece set --piece "$PIECE" -s "$SPACE" votes     --input -q
+echo '[]' | deno task cf piece set --piece "$PIECE" -s "$SPACE" history   --input -q
+deno task cf piece step --piece "$PIECE" -s "$SPACE"
+```
+
+After this, the first person to join in the browser becomes host as their own
+browser identity.
+
+## Re-establishing the canonical piece (if it's lost)
+
+```bash
+deno task cf piece new packages/patterns/cozy-poll-scoped/main.tsx -s "$SPACE"
+# → prints a new fid1:… — update PIECE above and the "canonical piece" section.
+```
+
+You need `WRITE`/`OWNER` on the space (ACL-gated). A denied write is rejected by
+the kernel and changes nothing.

--- a/packages/patterns/cozy-poll-scoped/DEPLOY-AND-SHARE.md
+++ b/packages/patterns/cozy-poll-scoped/DEPLOY-AND-SHARE.md
@@ -20,8 +20,8 @@ piece:  fid1:nye-cJnJnU5OQIPiVXzvAoq_YeU5pZARxyXp-9-JCZg
 url:    https://toolshed.saga-castor.ts.net/lunch-2026-05-26/fid1:nye-cJnJnU5OQIPiVXzvAoq_YeU5pZARxyXp-9-JCZg
 ```
 
-Set these once so you don't repeat flags (substitute your own identity key
-path and the current piece/space):
+Set these once so you don't repeat flags (substitute your own identity key path
+and the current piece/space):
 
 ```bash
 export CF_API_URL=https://toolshed.saga-castor.ts.net/
@@ -91,14 +91,15 @@ consequences trip everyone up:
    — it shows you the join card and won't treat you as host. To act as the same
    person in both, import your CLI key into the browser (`Import CLI Key`); see
    [`docs/development/SHARED_IDENTITY.md`](../../../docs/development/SHARED_IDENTITY.md).
-   Verify with `cf id did "$CF_IDENTITY"` and the browser's `shell.identity` log.
+   Verify with `cf id did "$CF_IDENTITY"` and the browser's `shell.identity`
+   log.
 
 2. **Names are unique (name-as-identity).** `joinAs` rejects a name already in
    `users`. So if a test/seed already claimed your preferred name, you can't
    re-join under it from another identity — pick a different name, or clear the
    stale entry.
 
-3. **Host role is claimable.** The host seat (`adminName`) goes to the *first*
+3. **Host role is claimable.** The host seat (`adminName`) goes to the _first_
    joiner, but any joined participant can take it over with the **Become host**
    button (`claimHost` sets `adminName` to themselves). So a stuck/squatted host
    seat no longer requires an operator reset — just join and click Become host.

--- a/packages/patterns/cozy-poll-scoped/DEPLOY-AND-SHARE.md
+++ b/packages/patterns/cozy-poll-scoped/DEPLOY-AND-SHARE.md
@@ -9,7 +9,10 @@ piece." This doc covers both, plus the identity caveat that bites first.
 
 ## The canonical piece
 
-There is one shared instance everyone should iterate on:
+There is one shared instance everyone should iterate on. **These values are a
+deployment pointer, not a stable identifier — current as of 2026-05-26.** A
+piece is tied to one space/server and can be reset; if it 404s or `inspect`
+fails, re-establish it (see "Re-establishing" below) and update this block.
 
 ```
 space:  lunch-2026-05-26
@@ -17,15 +20,13 @@ piece:  fid1:nye-cJnJnU5OQIPiVXzvAoq_YeU5pZARxyXp-9-JCZg
 url:    https://toolshed.saga-castor.ts.net/lunch-2026-05-26/fid1:nye-cJnJnU5OQIPiVXzvAoq_YeU5pZARxyXp-9-JCZg
 ```
 
-(If this piece is ever lost — e.g. the space is reset — re-establish it with a
-single `cf piece new` and update the ID here. See "Re-establishing" below.)
-
-Set these once so you don't repeat flags:
+Set these once so you don't repeat flags (substitute your own identity key
+path and the current piece/space):
 
 ```bash
 export CF_API_URL=https://toolshed.saga-castor.ts.net/
-export CF_IDENTITY="$HOME/.config/commonfabric/identity.key"   # your key
-PIECE=fid1:nye-cJnJnU5OQIPiVXzvAoq_YeU5pZARxyXp-9-JCZg
+export CF_IDENTITY=/path/to/your-identity.key   # e.g. ~/.config/commonfabric/identity.key
+PIECE=fid1:nye-cJnJnU5OQIPiVXzvAoq_YeU5pZARxyXp-9-JCZg   # current as of 2026-05-26
 SPACE=lunch-2026-05-26
 ```
 

--- a/packages/patterns/cozy-poll-scoped/LUNCH-COORDINATOR-TODO.md
+++ b/packages/patterns/cozy-poll-scoped/LUNCH-COORDINATOR-TODO.md
@@ -5,21 +5,42 @@
 into a full **Lunch Coordinator** — the poll stays at the core, but it grows the
 context a group actually needs to pick a place and go.
 
-This doc tracks the features we plan to add. Nothing here is built yet; it's the
-backlog.
+This doc tracks the features we plan to add. Feature #1 below is now built; the
+rest are still backlog.
 
 ## Planned features
 
-### 1. "Last days we went" history
+### 1. "Last days we went" history ✅ (shipped)
 
 Keep a per-space log of where the group actually ended up eating, with dates, so
 nobody suggests the same place three days running.
 
-- Append a history entry when a poll resolves (or via a manual "we went here"
-  action).
-- Surface recent history in the option list — e.g. dim or flag options visited
-  in the last N days.
-- Use it for a soft "you had this Tuesday" nudge rather than a hard block.
+- ✅ `history: PerSpace<HistoryEntry[]>` (`{ id, title, loggedByName, wentAt }`),
+  appended via a host-only `logVisit` handler. Each option has a "✓ we went
+  here" button that logs that place. `logVisit({})` with no target tallies the
+  winner from the votes — kept as an API path, no button (a Host-controls
+  "log winner" button was tried and removed as redundant with the per-option
+  buttons).
+- ✅ **Backdating:** a host "Log 'we went here' as of:" date field (blank =
+  today) backdates the entry; `logVisit` also accepts an explicit `wentAt`. The
+  date draft clears after each log so it defaults back to today.
+- ✅ **Editing:** `removeHistoryEntry({ id })` deletes a single mistaken entry
+  ("we didn't actually eat there") via a per-row ✕; `clearHistory` (two-step
+  confirm) wipes the whole log. Both host-only.
+- ✅ Shown as a **"Recently eaten" list below the options** (8 most recent,
+  most-recent-first), labelled with each visit's own date ("Tuesday, May 20").
+  No per-option nudge — history lives in this one section.
+- Implementation notes (hard-won; see also `scoped-cells-field-notes.md`):
+  - Visit labels derive **only from the stored `wentAt`**, never from the
+    current clock — calling `safeDateNow()` inside a `derive`/`computed` is
+    non-idempotent (it belongs in handlers, like the backdate parse). This is
+    also why there's no live "within the last N days" window; we show the
+    visit's own date and let the human judge.
+  - Interactive `onClick` handlers must live in **plain-ternary JSX**, not inside
+    a `computed(() => …)`-returned VNode, or they mis-lower as lifts
+    (`$event in inputs` → non-idempotent write).
+  - Don't name a `.map((h) => …)` callback `h` when the body contains JSX — `h`
+    is the JSX factory; shadowing it yields `TypeError: h is not a function`.
 
 ### 2. People's favorite foods
 

--- a/packages/patterns/cozy-poll-scoped/LUNCH-COORDINATOR-TODO.md
+++ b/packages/patterns/cozy-poll-scoped/LUNCH-COORDINATOR-TODO.md
@@ -15,10 +15,11 @@ rest are still backlog.
 Keep a per-space log of where the group actually ended up eating, with dates, so
 nobody suggests the same place three days running.
 
-- ✅ `history: PerSpace<HistoryEntry[]>` (`{ id, title, loggedByName, wentAt }`),
-  appended via a host-only `logVisit` handler. Each option has a "✓ we went
-  here" button that logs that place. The stored log is capped at the 50 most
-  recent visits so the PerSpace array can't grow without bound.
+- ✅ `history: PerSpace<HistoryEntry[]>`
+  (`{ id, title, loggedByName, wentAt }`), appended via a host-only `logVisit`
+  handler. Each option has a "✓ we went here" button that logs that place. The
+  stored log is capped at the 50 most recent visits so the PerSpace array can't
+  grow without bound.
 - ✅ **Backdating:** a host "Log 'we went here' as of:" date field (blank =
   today) backdates the entry; `logVisit` also accepts an explicit `wentAt`. The
   date draft clears after each log so it defaults back to today.
@@ -34,8 +35,8 @@ nobody suggests the same place three days running.
     non-idempotent (it belongs in handlers, like the backdate parse). This is
     also why there's no live "within the last N days" window; we show the
     visit's own date and let the human judge.
-  - Interactive `onClick` handlers must live in **plain-ternary JSX**, not inside
-    a `computed(() => …)`-returned VNode, or they mis-lower as lifts
+  - Interactive `onClick` handlers must live in **plain-ternary JSX**, not
+    inside a `computed(() => …)`-returned VNode, or they mis-lower as lifts
     (`$event in inputs` → non-idempotent write).
   - Don't name a `.map((h) => …)` callback `h` when the body contains JSX — `h`
     is the JSX factory; shadowing it yields `TypeError: h is not a function`.

--- a/packages/patterns/cozy-poll-scoped/LUNCH-COORDINATOR-TODO.md
+++ b/packages/patterns/cozy-poll-scoped/LUNCH-COORDINATOR-TODO.md
@@ -17,10 +17,8 @@ nobody suggests the same place three days running.
 
 - ✅ `history: PerSpace<HistoryEntry[]>` (`{ id, title, loggedByName, wentAt }`),
   appended via a host-only `logVisit` handler. Each option has a "✓ we went
-  here" button that logs that place. `logVisit({})` with no target tallies the
-  winner from the votes — kept as an API path, no button (a Host-controls
-  "log winner" button was tried and removed as redundant with the per-option
-  buttons).
+  here" button that logs that place. The stored log is capped at the 50 most
+  recent visits so the PerSpace array can't grow without bound.
 - ✅ **Backdating:** a host "Log 'we went here' as of:" date field (blank =
   today) backdates the entry; `logVisit` also accepts an explicit `wentAt`. The
   date draft clears after each log so it defaults back to today.

--- a/packages/patterns/cozy-poll-scoped/main.test.tsx
+++ b/packages/patterns/cozy-poll-scoped/main.test.tsx
@@ -79,9 +79,9 @@ export default pattern(() => {
     if (first) poll.removeOption.send({ optionId: first.id });
   });
 
-  // logVisit with no target logs the current winner (top choice by tally).
-  const action_log_winner = action(() => {
-    poll.logVisit.send({});
+  // Log a specific place by title (defaults wentAt to today).
+  const action_log_thai = action(() => {
+    poll.logVisit.send({ title: "Thai Kitchen" });
   });
 
   // Backdated visits — fixed past timestamp so assertions are deterministic.
@@ -171,7 +171,7 @@ export default pattern(() => {
   // has the sole vote, so it's the top choice. Attributed to the host. If the
   // pre-join attempt ("Sneaky") had not been gated, history[0] would be
   // "Sneaky" — so this implicitly verifies the host gate too.
-  const assert_winner_logged = computed(() =>
+  const assert_thai_logged = computed(() =>
     poll.history.length === 1 &&
     poll.history[0]?.title === "Thai Kitchen" &&
     poll.history[0]?.loggedByName === "Alex"
@@ -252,10 +252,9 @@ export default pattern(() => {
 
       // "We went here" history. The pre-join attempt above ("Sneaky") must
       // have left no trace.
-      // Vote for the surviving option, then log the winner via logVisit({}).
-      { action: action_vote_green_first },
-      { action: action_log_winner },
-      { assertion: assert_winner_logged },
+      // Log the surviving option by title → one entry, attributed to host.
+      { action: action_log_thai },
+      { assertion: assert_thai_logged },
       // A second, backdated, explicit log → two entries (proves backdating).
       { action: action_log_visit_chipotle_backdated },
       { assertion: assert_two_history },

--- a/packages/patterns/cozy-poll-scoped/main.test.tsx
+++ b/packages/patterns/cozy-poll-scoped/main.test.tsx
@@ -30,6 +30,10 @@ export default pattern(() => {
     poll.resetVotes.send({});
   });
 
+  const action_try_log_before_join = action(() => {
+    poll.logVisit.send({ title: "Sneaky" });
+  });
+
   const action_join_as_alex = action(() => {
     poll.joinAs.send({ name: "Alex" });
   });
@@ -73,6 +77,33 @@ export default pattern(() => {
   const action_remove_first_option = action(() => {
     const first = poll.options[0];
     if (first) poll.removeOption.send({ optionId: first.id });
+  });
+
+  // logVisit with no target logs the current winner (top choice by tally).
+  const action_log_winner = action(() => {
+    poll.logVisit.send({});
+  });
+
+  // Backdated visits — fixed past timestamp so assertions are deterministic.
+  const PAST_VISIT = 1700000000000; // 2023-11-14
+  const action_log_visit_chipotle_backdated = action(() => {
+    poll.logVisit.send({ title: "Chipotle", wentAt: PAST_VISIT + 1000 });
+  });
+
+  const action_remove_first_history = action(() => {
+    const first = poll.history[0];
+    if (first) poll.removeHistoryEntry.send({ id: first.id });
+  });
+
+  const action_clear_history = action(() => {
+    poll.clearHistory.send({});
+  });
+
+  // Single-identity caveat (CT-1598): we can't simulate a *second* user, so
+  // host *takeover* can't be exercised. This just confirms claimHost is wired
+  // and is a harmless no-op when the caller already holds the role.
+  const action_claim_host = action(() => {
+    poll.claimHost.send({});
   });
 
   // === Assertions ===
@@ -132,6 +163,36 @@ export default pattern(() => {
     poll.votes.length === 0
   );
 
+  const assert_still_alex_host = computed(() =>
+    poll.adminName === "Alex" && poll.isAdmin === true
+  );
+
+  // Winner logged via logVisit({}) — the only remaining option (Thai Kitchen)
+  // has the sole vote, so it's the top choice. Attributed to the host. If the
+  // pre-join attempt ("Sneaky") had not been gated, history[0] would be
+  // "Sneaky" — so this implicitly verifies the host gate too.
+  const assert_winner_logged = computed(() =>
+    poll.history.length === 1 &&
+    poll.history[0]?.title === "Thai Kitchen" &&
+    poll.history[0]?.loggedByName === "Alex"
+  );
+
+  // Second entry is the backdated Chipotle log, with the exact wentAt we
+  // passed (proves backdating).
+  const assert_two_history = computed(() =>
+    poll.history.length === 2 &&
+    poll.history[1]?.title === "Chipotle" &&
+    poll.history[1]?.wentAt === PAST_VISIT + 1000
+  );
+
+  // After deleting history[0] (Thai), only the Chipotle entry remains.
+  const assert_one_history_after_remove = computed(() =>
+    poll.history.length === 1 &&
+    poll.history[0]?.title === "Chipotle"
+  );
+
+  const assert_history_cleared = computed(() => poll.history.length === 0);
+
   return {
     tests: [
       // Admin-gated handlers are no-ops before anyone joins (myName empty).
@@ -143,6 +204,7 @@ export default pattern(() => {
       { action: action_try_add_before_join },
       { action: action_try_remove_before_join },
       { action: action_try_reset_before_join },
+      { action: action_try_log_before_join },
 
       // First join → claims admin
       { action: action_join_as_alex },
@@ -151,6 +213,10 @@ export default pattern(() => {
       // Second join attempt → no-op (name immutable after join)
       { action: action_try_rejoin_as_alex_two },
       { assertion: assert_immutable_after_join },
+
+      // claimHost is a harmless no-op when the caller is already host.
+      { action: action_claim_host },
+      { assertion: assert_still_alex_host },
 
       // Admin adds options
       { action: action_add_chipotle },
@@ -183,6 +249,22 @@ export default pattern(() => {
       { action: action_vote_green_first },
       { action: action_remove_first_option },
       { assertion: assert_option_removed_with_its_votes },
+
+      // "We went here" history. The pre-join attempt above ("Sneaky") must
+      // have left no trace.
+      // Vote for the surviving option, then log the winner via logVisit({}).
+      { action: action_vote_green_first },
+      { action: action_log_winner },
+      { assertion: assert_winner_logged },
+      // A second, backdated, explicit log → two entries (proves backdating).
+      { action: action_log_visit_chipotle_backdated },
+      { assertion: assert_two_history },
+      // Delete a single entry (host) → the other remains.
+      { action: action_remove_first_history },
+      { assertion: assert_one_history_after_remove },
+      // Clear all → empty.
+      { action: action_clear_history },
+      { assertion: assert_history_cleared },
     ],
     poll,
   };

--- a/packages/patterns/cozy-poll-scoped/main.tsx
+++ b/packages/patterns/cozy-poll-scoped/main.tsx
@@ -19,11 +19,11 @@
  * "We went here" history (Lunch Coordinator roadmap #1): the host logs where
  * the group actually ate via each option's "we went here" button. A host date
  * field backdates the next log (blank = today; `logVisit` also takes an
- * explicit `wentAt`, and `logVisit({})` with no target tallies the current
- * winner — an API path with no button). Each entry is a per-space `HistoryEntry`
- * (place + date). The log shows as a "Recently eaten" list below the options
- * (8 most recent); the host can delete a single mistaken entry
- * (`removeHistoryEntry`) or clear the whole log. See `LUNCH-COORDINATOR-TODO.md`.
+ * explicit `wentAt`). Each entry is a per-space `HistoryEntry` (place + date);
+ * the stored log is capped at the MAX_HISTORY most recent. The log shows as a
+ * "Recently eaten" list below the options (8 most recent); the host can delete
+ * a single mistaken entry (`removeHistoryEntry`) or clear the whole log.
+ * See `LUNCH-COORDINATOR-TODO.md`.
  */
 
 import {
@@ -188,6 +188,10 @@ const DAY_NAMES = [
   "Saturday",
 ];
 
+// Cap on the stored visit log so a long-lived poll's PerSpace array can't grow
+// without bound. The "Recently eaten" card shows fewer (the 8 most recent).
+const MAX_HISTORY = 50;
+
 const newHistoryId = () =>
   `h_${safeDateNow().toString(36)}_${
     Math.floor(nonPrivateRandom() * 1e6).toString(36)
@@ -345,12 +349,11 @@ const logVisit = handler<LogVisitEvent, {
   options: OptionsCell;
   myName: NameCell;
   adminName: NameCell;
-  votes: VotesCell;
   visitDate: NameCell;
 }>(
   (
     { optionId, title, wentAt },
-    { history, options, myName, adminName, votes, visitDate },
+    { history, options, myName, adminName, visitDate },
   ) => {
     const me = trimmedName(myName.get());
     const admin = trimmedName(adminName.get());
@@ -360,24 +363,23 @@ const logVisit = handler<LogVisitEvent, {
       const opt = options.get().find((o) => o.id === optionId);
       place = opt ? trimmedName(opt.title) : "";
     }
-    // No explicit target → log the current winner (top choice by tally).
-    if (!place && !optionId) {
-      const currentVotes = votes.get();
-      if (currentVotes.length > 0) {
-        const winner = tallyOptions(options.get(), currentVotes, [])[0];
-        place = winner ? trimmedName(winner.option.title) : "";
-      }
-    }
     if (!place) return;
     const when = typeof wentAt === "number"
       ? wentAt
       : parseVisitDate(visitDate.get());
-    history.push({
+    const entry: HistoryEntry = {
       id: newHistoryId(),
       title: place,
       loggedByName: me,
       wentAt: when,
-    });
+    };
+    // Cap the stored log at the MAX_HISTORY most recent visits (by date).
+    const next = [...history.get(), entry];
+    history.set(
+      next.length > MAX_HISTORY
+        ? [...next].sort((a, b) => b.wentAt - a.wentAt).slice(0, MAX_HISTORY)
+        : next,
+    );
     // Reset the date draft so the next log defaults back to today.
     visitDate.set("");
   },
@@ -542,7 +544,6 @@ export default pattern<CozyPollInput, CozyPollOutput>(
       options,
       myName,
       adminName,
-      votes,
       visitDate,
     });
     const boundRemoveHistoryEntry = removeHistoryEntry({
@@ -1508,6 +1509,7 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                           type="date"
                           $value={visitDate}
                           aria-label="Visit date (blank = today)"
+                          timing-strategy="immediate"
                         />
                         <span style={{ color: "#64748b" }}>(blank = today)</span>
                       </div>

--- a/packages/patterns/cozy-poll-scoped/main.tsx
+++ b/packages/patterns/cozy-poll-scoped/main.tsx
@@ -781,10 +781,12 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                   </div>
                 )}
 
-                {/* Open host takeover — kept out of the way: a non-host sees a
+                {
+                  /* Open host takeover — kept out of the way: a non-host sees a
                   subtle "Hosted by …" label and clicks it to reveal the
                   "Become host" button. Plain JSX with a per-session toggle so
-                  the onClicks lower as handlers (not lifts). */}
+                  the onClicks lower as handlers (not lifts). */
+                }
                 {canClaimHost
                   ? (isClaimHostRevealed
                     ? (
@@ -1141,9 +1143,11 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                               </button>
                             )
                             : null}
-                          {/* Host logs that the group actually ate here —
+                          {
+                            /* Host logs that the group actually ate here —
                             a visible pill so it reads as an action. Uses the
-                            host's date field (blank = today). */}
+                            host's date field (blank = today). */
+                          }
                           {isAdmin
                             ? (
                               <button
@@ -1275,12 +1279,14 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                   );
                 })}
 
-                {/* Recently eaten — the visit log, shown below the options.
+                {
+                  /* Recently eaten — the visit log, shown below the options.
                   Everyone sees it; the host can delete a single mistaken entry
                   (✕) or clear the whole log. Plain JSX with derived-boolean
                   ternaries (the host-controls idiom), NOT a computed-returned
                   VNode, so the interactive onClick handlers lower as handlers
-                  rather than lifts ("$event in inputs" / non-idempotent trap). */}
+                  rather than lifts ("$event in inputs" / non-idempotent trap). */
+                }
                 {hasHistory
                   ? (
                     <div
@@ -1491,8 +1497,10 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                             </cf-button>
                           )}
                       </div>
-                      {/* Backdates the next "✓ we went here" you click on an
-                        option above. Blank = today; cleared after each log. */}
+                      {
+                        /* Backdates the next "✓ we went here" you click on an
+                        option above. Blank = today; cleared after each log. */
+                      }
                       <div
                         style={{
                           marginTop: "8px",
@@ -1511,7 +1519,9 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                           aria-label="Visit date (blank = today)"
                           timing-strategy="immediate"
                         />
-                        <span style={{ color: "#64748b" }}>(blank = today)</span>
+                        <span style={{ color: "#64748b" }}>
+                          (blank = today)
+                        </span>
                       </div>
                     </div>
                   )

--- a/packages/patterns/cozy-poll-scoped/main.tsx
+++ b/packages/patterns/cozy-poll-scoped/main.tsx
@@ -12,6 +12,18 @@
  *   immutable thereafter.
  * - The first joiner's name is captured into `adminName` (per-space). They can
  *   add/remove options and reset votes. `isAdmin` is derived, not stored.
+ * - Open host takeover: any joined participant can `claimHost`, transferring
+ *   the role (and the host controls) to themselves. Deliberately ungated
+ *   beyond "must be joined"; see `ADMIN-FUTURE.md`.
+ *
+ * "We went here" history (Lunch Coordinator roadmap #1): the host logs where
+ * the group actually ate via each option's "we went here" button. A host date
+ * field backdates the next log (blank = today; `logVisit` also takes an
+ * explicit `wentAt`, and `logVisit({})` with no target tallies the current
+ * winner — an API path with no button). Each entry is a per-space `HistoryEntry`
+ * (place + date). The log shows as a "Recently eaten" list below the options
+ * (8 most recent); the host can delete a single mistaken entry
+ * (`removeHistoryEntry`) or clear the whole log. See `LUNCH-COORDINATOR-TODO.md`.
  */
 
 import {
@@ -55,6 +67,8 @@ export interface JoinEvent {
   name?: string;
 }
 
+export type ClaimHostEvent = Record<PropertyKey, never>;
+
 export interface AddOptionEvent {
   title?: string;
 }
@@ -70,10 +84,36 @@ export interface CastVoteEvent {
 
 export type ResetVotesEvent = Record<PropertyKey, never>;
 
+/** A place the group actually ate, logged by the host. */
+export interface HistoryEntry {
+  id: string;
+  title: string;
+  loggedByName: string;
+  wentAt: number;
+}
+
+/**
+ * Log a visit — by existing option id, or a free-typed place title.
+ * `wentAt` backdates the entry (ms epoch); omitted → the host's date draft,
+ * which itself defaults to today.
+ */
+export interface LogVisitEvent {
+  optionId?: string;
+  title?: string;
+  wentAt?: number;
+}
+
+export interface RemoveHistoryEntryEvent {
+  id: string;
+}
+
+export type ClearHistoryEvent = Record<PropertyKey, never>;
+
 type QuestionCell = Writable<string | Default<"Where should we eat?">>;
 type OptionsCell = Writable<Option[] | Default<[]>>;
 type VotesCell = Writable<Vote[] | Default<[]>>;
 type UsersCell = Writable<User[] | Default<[]>>;
+type HistoryCell = Writable<HistoryEntry[] | Default<[]>>;
 type NameCell = Writable<string | Default<"">>;
 
 const PLAYER_COLORS = [
@@ -138,6 +178,42 @@ const getInitials = (name: string): string => {
   );
 };
 
+const DAY_NAMES = [
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+];
+
+const newHistoryId = () =>
+  `h_${safeDateNow().toString(36)}_${
+    Math.floor(nonPrivateRandom() * 1e6).toString(36)
+  }`;
+
+// Parse a "YYYY-MM-DD" draft (from the host's date input) into a timestamp,
+// anchored to local midnight. Blank or unparseable → now. Only ever called
+// from a handler, so reading the clock here is fine.
+const parseVisitDate = (draft: string | undefined): number => {
+  const s = (draft ?? "").trim();
+  if (!s) return safeDateNow();
+  const t = new Date(`${s}T00:00:00`).getTime();
+  return Number.isNaN(t) ? safeDateNow() : t;
+};
+
+// Label for a visit derived purely from its own timestamp — never from the
+// current clock, so it stays idempotent inside reactive derives (timestamps
+// read against "now" belong in handlers, not computeds). Reads like
+// "Tuesday, May 20".
+const visitLabel = (wentAt: number): string => {
+  const d = new Date(wentAt);
+  return `${DAY_NAMES[d.getDay()]}, ${
+    d.toLocaleDateString([], { month: "short", day: "numeric" })
+  }`;
+};
+
 const joinAs = handler<JoinEvent, {
   users: UsersCell;
   myName: NameCell;
@@ -161,6 +237,20 @@ const joinAs = handler<JoinEvent, {
   if (trimmedName(adminName.get()) === "") {
     adminName.set(trimmed);
   }
+});
+
+// Open host takeover: any joined participant can claim the host role, which
+// transfers it away from the current host (isAdmin is derived from this). This
+// is deliberately ungated beyond "must be joined" — see ADMIN-FUTURE.md for the
+// kernel-level authority model this pattern-level check is a placeholder for.
+const claimHost = handler<ClaimHostEvent, {
+  myName: NameCell;
+  adminName: NameCell;
+}>((_, { myName, adminName }) => {
+  const me = trimmedName(myName.get());
+  if (!me) return;
+  if (trimmedName(adminName.get()) === me) return;
+  adminName.set(me);
 });
 
 const addOption = handler<AddOptionEvent, {
@@ -248,6 +338,73 @@ const clearMyVote = handler<ClearVoteEvent, {
   );
 });
 
+// Host-only, same gate as the other mutating admin actions. Logs where the
+// group actually ate — by option id (resolved to its title) or a free title.
+const logVisit = handler<LogVisitEvent, {
+  history: HistoryCell;
+  options: OptionsCell;
+  myName: NameCell;
+  adminName: NameCell;
+  votes: VotesCell;
+  visitDate: NameCell;
+}>(
+  (
+    { optionId, title, wentAt },
+    { history, options, myName, adminName, votes, visitDate },
+  ) => {
+    const me = trimmedName(myName.get());
+    const admin = trimmedName(adminName.get());
+    if (!me || me !== admin) return;
+    let place = trimmedName(title);
+    if (!place && optionId) {
+      const opt = options.get().find((o) => o.id === optionId);
+      place = opt ? trimmedName(opt.title) : "";
+    }
+    // No explicit target → log the current winner (top choice by tally).
+    if (!place && !optionId) {
+      const currentVotes = votes.get();
+      if (currentVotes.length > 0) {
+        const winner = tallyOptions(options.get(), currentVotes, [])[0];
+        place = winner ? trimmedName(winner.option.title) : "";
+      }
+    }
+    if (!place) return;
+    const when = typeof wentAt === "number"
+      ? wentAt
+      : parseVisitDate(visitDate.get());
+    history.push({
+      id: newHistoryId(),
+      title: place,
+      loggedByName: me,
+      wentAt: when,
+    });
+    // Reset the date draft so the next log defaults back to today.
+    visitDate.set("");
+  },
+);
+
+const removeHistoryEntry = handler<RemoveHistoryEntryEvent, {
+  history: HistoryCell;
+  myName: NameCell;
+  adminName: NameCell;
+}>(({ id }, { history, myName, adminName }) => {
+  const me = trimmedName(myName.get());
+  const admin = trimmedName(adminName.get());
+  if (!me || me !== admin) return;
+  history.set(history.get().filter((h) => h.id !== id));
+});
+
+const clearHistory = handler<ClearHistoryEvent, {
+  history: HistoryCell;
+  myName: NameCell;
+  adminName: NameCell;
+}>((_, { history, myName, adminName }) => {
+  const me = trimmedName(myName.get());
+  const admin = trimmedName(adminName.get());
+  if (!me || me !== admin) return;
+  history.set([]);
+});
+
 interface OptionTally {
   option: Option;
   green: number;
@@ -298,6 +455,7 @@ export interface CozyPollInput {
   options?: PerSpace<Option[] | Default<[]>>;
   votes?: PerSpace<Vote[] | Default<[]>>;
   users?: PerSpace<User[] | Default<[]>>;
+  history?: PerSpace<HistoryEntry[] | Default<[]>>;
   adminName?: PerSpace<string | Default<"">>;
   myName?: PerUser<string | Default<"">>;
   // joinName + optionDraft are internal form drafts, declared as local
@@ -311,19 +469,25 @@ export interface CozyPollOutput {
   options: readonly Option[];
   votes: readonly Vote[];
   users: readonly User[];
+  history: readonly HistoryEntry[];
   adminName: string;
   myName: string;
   userCount: number;
   optionCount: number;
   voteCount: number;
+  historyCount: number;
   isJoined: boolean;
   isAdmin: boolean;
   joinAs: Stream<JoinEvent>;
+  claimHost: Stream<ClaimHostEvent>;
   addOption: Stream<AddOptionEvent>;
   removeOption: Stream<RemoveOptionEvent>;
   castVote: Stream<CastVoteEvent>;
   clearMyVote: Stream<ClearVoteEvent>;
   resetVotes: Stream<ResetVotesEvent>;
+  logVisit: Stream<LogVisitEvent>;
+  removeHistoryEntry: Stream<RemoveHistoryEntryEvent>;
+  clearHistory: Stream<ClearHistoryEvent>;
 }
 
 export default pattern<CozyPollInput, CozyPollOutput>(
@@ -333,6 +497,7 @@ export default pattern<CozyPollInput, CozyPollOutput>(
       options,
       votes,
       users,
+      history,
       adminName,
       myName,
     },
@@ -342,13 +507,21 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     // introduced by parking-coordinator (PR #3610).
     const joinName = Writable.perSession.of<string>("");
     const optionDraft = Writable.perSession.of<string>("");
+    // Host's backdate field for "we went here" — a "YYYY-MM-DD" draft, blank
+    // means today. Per-session like the other form drafts.
+    const visitDate = Writable.perSession.of<string>("");
     // Two-step confirmation for destructive actions. Stores the optionId
     // pending remove-confirm (null = nothing pending). Same idiom as
     // parking-coordinator's `removePersonConfirmTarget`.
     const removeConfirmTarget = Writable.perSession.of<string | null>(null);
     const resetConfirmPending = Writable.perSession.of<boolean>(false);
+    const clearHistoryConfirmPending = Writable.perSession.of<boolean>(false);
+    // Click-to-reveal for the host-takeover control, so it stays out of the
+    // way until a non-host clicks the "Hosted by …" label.
+    const claimHostRevealed = Writable.perSession.of<boolean>(false);
 
     const boundJoin = joinAs({ users, myName, adminName, joinName });
+    const boundClaimHost = claimHost({ myName, adminName });
     const boundAddOption = addOption({
       options,
       myName,
@@ -364,10 +537,31 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     const boundCastVote = castVote({ votes, myName });
     const boundClearMyVote = clearMyVote({ votes, myName });
     const boundResetVotes = resetVotes({ votes, myName, adminName });
+    const boundLogVisit = logVisit({
+      history,
+      options,
+      myName,
+      adminName,
+      votes,
+      visitDate,
+    });
+    const boundRemoveHistoryEntry = removeHistoryEntry({
+      history,
+      myName,
+      adminName,
+    });
+    const boundClearHistory = clearHistory({ history, myName, adminName });
 
     const userCount = derive(users, (u) => u.length);
     const optionCount = derive(options, (o) => o.length);
     const voteCount = derive(votes, (v) => v.length);
+    const historyCount = derive(history, (h) => h.length);
+    const hasHistory = derive(history, (h) => h.length > 0);
+    // Most-recent-first, capped — the "Recently eaten" card stays compact.
+    const recentHistory = derive(
+      history,
+      (h) => [...h].sort((a, b) => b.wentAt - a.wentAt).slice(0, 8),
+    );
     const isJoined = derive(myName, (n) => trimmedName(n) !== "");
     const isAdmin = derive(
       { myName, adminName },
@@ -386,6 +580,10 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     // narrow `resetConfirmPending` itself and lose the `.set` method in
     // the false branch.
     const isResetConfirm = computed(() => resetConfirmPending.get());
+    const isClearHistoryConfirm = computed(() =>
+      clearHistoryConfirmPending.get()
+    );
+    const isClaimHostRevealed = computed(() => claimHostRevealed.get());
     const ranked = derive(
       { options, votes, users },
       ({ options, votes, users }) => tallyOptions(options, votes, users),
@@ -395,6 +593,13 @@ export default pattern<CozyPollInput, CozyPollOutput>(
       { ranked, voteCount },
       ({ ranked, voteCount }) =>
         voteCount > 0 && ranked.length > 0 ? ranked[0] : null,
+    );
+    // A joined viewer who is not the current host can take the host role.
+    const canClaimHost = derive(
+      { myName, adminName },
+      ({ myName, adminName }) =>
+        trimmedName(myName) !== "" &&
+        trimmedName(myName) !== trimmedName(adminName),
     );
 
     return {
@@ -574,6 +779,72 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                     </div>
                   </div>
                 )}
+
+                {/* Open host takeover — kept out of the way: a non-host sees a
+                  subtle "Hosted by …" label and clicks it to reveal the
+                  "Become host" button. Plain JSX with a per-session toggle so
+                  the onClicks lower as handlers (not lifts). */}
+                {canClaimHost
+                  ? (isClaimHostRevealed
+                    ? (
+                      <div
+                        style={{
+                          display: "flex",
+                          alignItems: "center",
+                          gap: "8px",
+                          flexWrap: "wrap",
+                          padding: "8px 12px",
+                          marginBottom: "16px",
+                          backgroundColor: "#eef2ff",
+                          border: "1px solid #c7d2fe",
+                          borderRadius: "8px",
+                          fontSize: "13px",
+                          color: "#3730a3",
+                        }}
+                      >
+                        <span>{joinHint}</span>
+                        <cf-button
+                          size="sm"
+                          variant="secondary"
+                          onClick={() => {
+                            boundClaimHost.send({});
+                            claimHostRevealed.set(false);
+                          }}
+                        >
+                          Become host
+                        </cf-button>
+                        <cf-button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() => claimHostRevealed.set(false)}
+                        >
+                          Cancel
+                        </cf-button>
+                      </div>
+                    )
+                    : (
+                      <div style={{ marginBottom: "16px" }}>
+                        <button
+                          type="button"
+                          aria-label="Hosting info — click to take over as host"
+                          title="Click to take over as host"
+                          style={{
+                            background: "none",
+                            border: "none",
+                            padding: 0,
+                            fontSize: "13px",
+                            color: "#6b7280",
+                            cursor: "pointer",
+                            textDecoration: "underline dotted",
+                            textUnderlineOffset: "3px",
+                          }}
+                          onClick={() => claimHostRevealed.set(true)}
+                        >
+                          {joinHint}
+                        </button>
+                      </div>
+                    ))
+                  : null}
 
                 {/* Top choice — only when there are votes */}
                 {computed(() => {
@@ -869,6 +1140,31 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                               </button>
                             )
                             : null}
+                          {/* Host logs that the group actually ate here —
+                            a visible pill so it reads as an action. Uses the
+                            host's date field (blank = today). */}
+                          {isAdmin
+                            ? (
+                              <button
+                                type="button"
+                                aria-label="Log that we went here (host)"
+                                style={{
+                                  background: "#eaf6ef",
+                                  border: "1px solid #b7e0c8",
+                                  borderRadius: "9999px",
+                                  padding: "2px 10px",
+                                  color: "#2f6f4e",
+                                  fontSize: "11px",
+                                  fontWeight: 600,
+                                  cursor: "pointer",
+                                }}
+                                onClick={() =>
+                                  boundLogVisit.send({ optionId: oid })}
+                              >
+                                ✓ we went here
+                              </button>
+                            )
+                            : null}
                         </div>
                         {isRemoveConfirm
                           ? (
@@ -978,6 +1274,155 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                   );
                 })}
 
+                {/* Recently eaten — the visit log, shown below the options.
+                  Everyone sees it; the host can delete a single mistaken entry
+                  (✕) or clear the whole log. Plain JSX with derived-boolean
+                  ternaries (the host-controls idiom), NOT a computed-returned
+                  VNode, so the interactive onClick handlers lower as handlers
+                  rather than lifts ("$event in inputs" / non-idempotent trap). */}
+                {hasHistory
+                  ? (
+                    <div
+                      style={{
+                        marginBottom: "16px",
+                        padding: "12px 16px",
+                        backgroundColor: "#fdf6ec",
+                        border: "1px solid #f0e0c8",
+                        borderRadius: "8px",
+                      }}
+                    >
+                      <div
+                        style={{
+                          display: "flex",
+                          alignItems: "center",
+                          justifyContent: "space-between",
+                          gap: "8px",
+                          marginBottom: "10px",
+                        }}
+                      >
+                        <div
+                          style={{
+                            fontSize: "11px",
+                            fontWeight: 700,
+                            letterSpacing: "0.05em",
+                            textTransform: "uppercase",
+                            color: "#92702a",
+                          }}
+                        >
+                          🗓 Recently eaten
+                        </div>
+                        {isAdmin
+                          ? (isClearHistoryConfirm
+                            ? (
+                              <span
+                                style={{
+                                  display: "inline-flex",
+                                  gap: "6px",
+                                  alignItems: "center",
+                                }}
+                              >
+                                <cf-button
+                                  size="sm"
+                                  variant="primary"
+                                  onClick={() => {
+                                    boundClearHistory.send({});
+                                    clearHistoryConfirmPending.set(false);
+                                  }}
+                                >
+                                  Clear all
+                                </cf-button>
+                                <cf-button
+                                  size="sm"
+                                  variant="ghost"
+                                  onClick={() =>
+                                    clearHistoryConfirmPending.set(false)}
+                                >
+                                  Cancel
+                                </cf-button>
+                              </span>
+                            )
+                            : (
+                              <button
+                                type="button"
+                                aria-label="Clear all history (host)"
+                                style={{
+                                  background: "none",
+                                  border: "none",
+                                  padding: 0,
+                                  color: "#b08642",
+                                  fontSize: "11px",
+                                  textDecoration: "underline",
+                                  cursor: "pointer",
+                                }}
+                                onClick={() =>
+                                  clearHistoryConfirmPending.set(true)}
+                              >
+                                clear all
+                              </button>
+                            ))
+                          : null}
+                      </div>
+                      {recentHistory.map((entry) => {
+                        const entryId = entry.id;
+                        return (
+                          <div
+                            style={{
+                              display: "flex",
+                              alignItems: "baseline",
+                              justifyContent: "space-between",
+                              gap: "8px",
+                              padding: "4px 0",
+                              fontSize: "13px",
+                              color: "#5b4a2c",
+                            }}
+                          >
+                            <span style={{ fontWeight: 500 }}>
+                              {entry.title}
+                            </span>
+                            <span
+                              style={{
+                                display: "inline-flex",
+                                alignItems: "baseline",
+                                gap: "8px",
+                              }}
+                            >
+                              <span
+                                style={{ fontSize: "12px", color: "#a08552" }}
+                              >
+                                {visitLabel(entry.wentAt)}
+                              </span>
+                              {isAdmin
+                                ? (
+                                  <button
+                                    type="button"
+                                    aria-label="Delete this visit (host)"
+                                    title="We didn't actually eat there"
+                                    style={{
+                                      background: "none",
+                                      border: "none",
+                                      padding: 0,
+                                      color: "#b08642",
+                                      fontSize: "13px",
+                                      lineHeight: 1,
+                                      cursor: "pointer",
+                                    }}
+                                    onClick={() =>
+                                      boundRemoveHistoryEntry.send({
+                                        id: entryId,
+                                      })}
+                                  >
+                                    ✕
+                                  </button>
+                                )
+                                : null}
+                            </span>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  )
+                  : null}
+
                 {/* Host controls — only the admin sees this card. */}
                 {isAdmin
                   ? (
@@ -1045,6 +1490,27 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                             </cf-button>
                           )}
                       </div>
+                      {/* Backdates the next "✓ we went here" you click on an
+                        option above. Blank = today; cleared after each log. */}
+                      <div
+                        style={{
+                          marginTop: "8px",
+                          display: "flex",
+                          gap: "8px",
+                          alignItems: "center",
+                          flexWrap: "wrap",
+                          fontSize: "12px",
+                          color: "#1e40af",
+                        }}
+                      >
+                        <span>Date for "✓ we went here":</span>
+                        <cf-input
+                          type="date"
+                          $value={visitDate}
+                          aria-label="Visit date (blank = today)"
+                        />
+                        <span style={{ color: "#64748b" }}>(blank = today)</span>
+                      </div>
                     </div>
                   )
                   : null}
@@ -1057,19 +1523,25 @@ export default pattern<CozyPollInput, CozyPollOutput>(
       options: derive(options, (o) => o),
       votes: derive(votes, (v) => v),
       users: derive(users, (u) => u),
+      history: derive(history, (h) => h),
       adminName: derive(adminName, (a) => a),
       myName: derive(myName, (n) => n),
       userCount,
       optionCount,
       voteCount,
+      historyCount,
       isJoined,
       isAdmin,
       joinAs: boundJoin,
+      claimHost: boundClaimHost,
       addOption: boundAddOption,
       removeOption: boundRemoveOption,
       castVote: boundCastVote,
       clearMyVote: boundClearMyVote,
       resetVotes: boundResetVotes,
+      logVisit: boundLogVisit,
+      removeHistoryEntry: boundRemoveHistoryEntry,
+      clearHistory: boundClearHistory,
     };
   },
 );


### PR DESCRIPTION
## Why

`cozy-poll-scoped` is the seed of the **Lunch Coordinator** (see roadmap added in #3699). Two pain points block it from being usable day-to-day by a real group:

1. **No memory of where we actually ate.** The poll picks a place but forgets it, so the group cheerfully suggests the same spot three days running. Roadmap #1 ("last days we went") is the local-only, no-new-capabilities first step — so it's what this PR ships.
2. **The host seat was stuck.** `adminName` went to the *first* joiner and was immutable, so a shared poll seeded/tested by one identity left everyone else unable to access host controls (made worse by `myName` being per-DID — a CLI seed and a browser viewer are different users). Real groups need anyone to be able to pick up hosting.

This PR addresses both, staying entirely within the existing scoped-cells identity model (no new runtime capabilities).

## What Changed

**History (`history: PerSpace<HistoryEntry[]>`, `{ id, title, loggedByName, wentAt }`):**
- Host-only `logVisit` / `removeHistoryEntry` / `clearHistory`.
- Each option has a "✓ we went here" button; a host date field backdates the next log (blank = today). `logVisit({})` tallies the current winner (API path, no button).
- A "Recently eaten" list below the options (8 most recent), with per-row delete (✕) and clear-all (two-step confirm). Visit labels derive **only from the stored `wentAt`** — never the current clock — so the reactive derives stay idempotent.

**Open host takeover:**
- `claimHost` lets any joined participant take the role (ungated beyond "must be joined"; `ADMIN-FUTURE.md` remains the kernel-authority direction). Surfaced as a click-to-reveal "Hosted by …" label, so it stays out of the way.

**Docs:** marks roadmap #1 shipped in `LUNCH-COORDINATOR-TODO.md` (with the hard-won gotchas), and adds `DEPLOY-AND-SHARE.md` documenting how the next person deploys onto the shared piece (`setsrc`) vs. copies state into their own, plus the identity caveats.

### Gotchas captured (for the next pattern author)
- `safeDateNow()` in a `derive`/`computed` is non-idempotent — timestamps belong in handlers.
- Interactive `onClick`s must live in plain-ternary JSX, not inside a `computed(() => …)`-returned VNode, or they mis-lower as lifts (`$event in inputs`).
- Don't shadow the JSX factory `h` with a `.map((h) => …)` param when the body contains JSX.

## Test plan
- `deno task cf test packages/patterns/cozy-poll-scoped/main.test.tsx` → **16/16 pass**. New coverage: winner-log via `logVisit({})`, backdating with exact `wentAt`, single-entry delete, clear-all, host-gating of all history handlers, and a `claimHost` smoke (single-identity framework can't simulate a second user for true takeover — noted inline).
- `deno task cf check … --no-run` clean; transformed output verified to have no `.send`-wrapped-in-`derive` (all new onClicks lower as handlers).
- Deployed to the shared piece via `setsrc` and exercised end-to-end in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-space visit history and open host takeover to `cozy-poll-scoped`, so groups remember where they ate and anyone joined can take hosting. Completes Lunch Coordinator roadmap #1 with capped history and reliable backdating.

- New Features
  - Per-space history (`history: PerSpace<HistoryEntry[]>`) with host-only `logVisit`, `removeHistoryEntry`, and `clearHistory`.
  - UI: per-option “✓ we went here”; host date field to backdate (blank = today).
  - “Recently eaten” list (last 8, newest first) with labels from stored `wentAt`; host can delete a row or clear all (two-step confirm).
  - Open host takeover: `claimHost` lets any joined participant become host, revealed via a click-to-reveal “Hosted by …” label.
  - Docs/tests: added `DEPLOY-AND-SHARE.md`; roadmap #1 marked shipped; tests cover history, backdating, single-entry delete, clear-all, host gating, and a `claimHost` smoke.

- Bug Fixes
  - Capped stored history at 50 most recent entries.
  - Date input uses immediate timing to avoid stale backdates when logging.
  - Removed the unused “log current winner” path from `logVisit`; tests now log by title.

<sup>Written for commit 0e15c8eb45c87702afbe58c92984908057ea00c6. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3701?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

