### PR TITLE
[WIP/abandoned] cf --session: opt-in session pinning (research evidence)

### DIFF
--- a/docs/development/debugging/gotchas/scoped-cell-pitfalls.md
+++ b/docs/development/debugging/gotchas/scoped-cell-pitfalls.md
@@ -112,6 +112,37 @@ const newId = () =>
   }`;
 ```
 
+## 6. `perSession` cells do NOT persist across `cf` invocations by default
+
+**Symptom:** A `perSession` cell written by one `cf piece call` reads back as
+its default (empty) from the very next `cf piece get`, even within the same
+space and piece.
+
+**Why:** Each `cf` invocation is a fresh process that mounts a brand-new memory
+session, and the server mints a new session UUID per mount
+(`packages/memory/v2/session-registry.ts`). `perSession` state is keyed by that
+session id, so it is effectively per-invocation — it never carries from one
+command to the next.
+
+**Opt in to persistence:** Pass `--session <id>` (or set `CF_SESSION=<id>`) on
+each command. This pins a stable client-supplied session id so the server keeps
+the same `perSession` bucket across invocations. (The CLI persists the rotated
+session token in `~/.cache/common-fabric/cli-sessions.json` and replays it, so
+reuse within the 30s session TTL avoids the server's `revokedError`.)
+
+```bash
+# Same --session => shared perSession state
+cf piece call --session demo --piece <id> --space my-space setNote
+cf piece get  --session demo --piece <id> --space my-space note   # -> the set value
+
+# No --session => fresh session, default value
+cf piece get  --piece <id> --space my-space note                  # -> "" (empty)
+```
+
+**Alternatives if you don't want per-invocation behavior at all:** use a
+broader scope (`perSpace` / `perUser`), or pass the value explicitly as a
+handler payload instead of relying on session-scoped state.
+
 ## See Also
 
 - `docs/specs/scoped-cell-instances.md` — the underlying scope model

--- a/packages/cli/commands/piece.ts
+++ b/packages/cli/commands/piece.ts
@@ -150,7 +150,8 @@ TIPS:
   • Use 'setsrc' for iteration, not repeated 'new' (avoids clutter)
   • After 'set', run 'step' to trigger computed value updates
   • Path format: forward slashes only (items/0/name, not items[0].name)
-  • JSON values: strings need quotes: echo '"hello"' | cf piece set ...`);
+  • JSON values: strings need quotes: echo '"hello"' | cf piece set ...
+  • perSession cells reset every invocation (fresh session per command); pass --session <id> or set CF_SESSION to make them persist across commands`);
 
 export const piece = new Command()
   .name("piece")
@@ -170,6 +171,17 @@ export const piece = new Command()
   })
   .globalOption("-i,--identity <path:string>", "Path to an identity keyfile.")
   .globalOption("-s,--space <space:string>", "The space name or DID")
+  .globalEnv(
+    "CF_SESSION=<id:string>",
+    "Pin the memory session id (see --session).",
+    { prefix: "CF_" },
+  )
+  .globalOption(
+    "--session <id:string>",
+    cliText(
+      `Pin the memory session id so \`perSession\` cells persist across \`cf\` commands. By default each invocation gets a fresh session, so \`perSession\` state does NOT carry between commands.`,
+    ),
+  )
   /* piece ls */
   .command("ls", "List pieces in space.")
   .usage(spaceUsage)
@@ -930,6 +942,7 @@ interface PieceCLIOptions {
   identity?: string;
   space?: string;
   url?: string;
+  session?: string;
 }
 
 const CELL_SCOPE_VALUES = new Set(["space", "user", "session"]);
@@ -1007,6 +1020,10 @@ export function parseSpaceOptions(
   const output: Partial<PieceConfig> = {
     identity: absPath(input.identity),
   };
+
+  // Pin the memory session id when provided (via --session / CF_SESSION).
+  // Applies regardless of whether the space comes from --url or --space.
+  if (input.session) output.sessionId = input.session;
 
   if (input.url) {
     const { apiUrl, space, piece, pieceScope } = parseUrl(input.url);

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -44,6 +44,7 @@ import {
   renderPieceCallHelp,
 } from "./exec-schema.ts";
 import { cliCommand } from "./cli-name.ts";
+import { getSessionToken, setSessionToken } from "./session-store.ts";
 
 export interface EntryConfig {
   mainPath: string;
@@ -55,6 +56,12 @@ export interface SpaceConfig {
   apiUrl: string;
   space: string;
   identity: string;
+  /**
+   * Opt-in: pin the memory session id so `perSession` cells persist across
+   * separate `cf` invocations. When unset, each invocation gets a fresh
+   * session and `perSession` state does not carry over.
+   */
+  sessionId?: string;
 }
 
 export interface PieceConfig extends SpaceConfig {
@@ -195,6 +202,17 @@ export async function loadManager(config: SpaceConfig): Promise<PieceManager> {
           as: session.as,
           address: new URL("/api/storage/memory", config.apiUrl),
           spaceIdentity: session.spaceIdentity,
+          ...(config.sessionId
+            ? {
+              session: {
+                id: config.sessionId,
+                getToken: () =>
+                  getSessionToken(config.space, config.sessionId!),
+                onToken: (token: string | undefined) =>
+                  setSessionToken(config.space, config.sessionId!, token),
+              },
+            }
+            : {}),
         }),
         errorHandlers: [
           (error) => {

--- a/packages/cli/lib/session-store.ts
+++ b/packages/cli/lib/session-store.ts
@@ -1,0 +1,82 @@
+/**
+ * Persistent store for pinned memory session tokens.
+ *
+ * When a user opts in to session pinning (via `--session <id>` / `CF_SESSION`),
+ * the server rotates the `sessionToken` on every mount and rejects reuse of a
+ * still-live `sessionId` that arrives without the matching token
+ * (`revokedError`). To make pinning work across separate `cf` invocations we
+ * persist the rotated token here, keyed by `${space}:${sessionId}`, and replay
+ * it on the next command.
+ *
+ * The store is best-effort: a missing or corrupt file is treated as empty, and
+ * write failures are swallowed (pinning degrades to "fresh session" rather than
+ * crashing the command).
+ */
+
+function sessionsFilePath(): string | undefined {
+  const home = Deno.env.get("HOME");
+  if (!home) return undefined;
+  return `${home}/.cache/common-fabric/cli-sessions.json`;
+}
+
+function keyFor(space: string, sessionId: string): string {
+  return `${space}:${sessionId}`;
+}
+
+function readStore(): Record<string, string> {
+  const path = sessionsFilePath();
+  if (!path) return {};
+  try {
+    const text = Deno.readTextFileSync(path);
+    const parsed = JSON.parse(text);
+    if (parsed && typeof parsed === "object") {
+      return parsed as Record<string, string>;
+    }
+    return {};
+  } catch {
+    // Missing or corrupt file -> treat as empty.
+    return {};
+  }
+}
+
+function writeStore(store: Record<string, string>): void {
+  const path = sessionsFilePath();
+  if (!path) return;
+  try {
+    const dir = path.slice(0, path.lastIndexOf("/"));
+    Deno.mkdirSync(dir, { recursive: true });
+    Deno.writeTextFileSync(path, JSON.stringify(store, null, 2));
+  } catch {
+    // Best-effort: ignore write failures.
+  }
+}
+
+/** Returns the persisted rotated session token, if any. */
+export function getSessionToken(
+  space: string,
+  sessionId: string,
+): string | undefined {
+  const store = readStore();
+  return store[keyFor(space, sessionId)];
+}
+
+/**
+ * Persists (or, with `undefined`, clears) the rotated session token for a
+ * pinned session.
+ */
+export function setSessionToken(
+  space: string,
+  sessionId: string,
+  token: string | undefined,
+): void {
+  const store = readStore();
+  const key = keyFor(space, sessionId);
+  if (token === undefined) {
+    if (!(key in store)) return;
+    delete store[key];
+  } else {
+    if (store[key] === token) return;
+    store[key] = token;
+  }
+  writeStore(store);
+}

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -539,6 +539,9 @@ export class Server {
         ? await this.syncSessionForConnection(
           message.space,
           opened.sessionId,
+          undefined,
+          undefined,
+          opened.presentedSeenSeq,
         )
         : null;
       return {
@@ -993,6 +996,7 @@ export class Server {
     sessionId: string,
     dirtyIds?: ReadonlySet<string>,
     dirtyOrigins?: ReadonlyMap<string, DirtyOrigin>,
+    resumeFromSeenSeq?: number,
   ): Promise<SessionEffectMessage | null> {
     const session = this.#sessions.get(space, sessionId);
     if (session === null || session.watches.length === 0) {
@@ -1095,10 +1099,21 @@ export class Server {
         sessionId,
       },
     );
+    // Per the protocol spec, resume catch-up is relative to the client's
+    // integrated `seenSeq`, not the server's `session.entities` cache (which
+    // mirrors the PRIOR owner's replica). A cold client — a fresh process
+    // resuming a persisted sessionId with an empty local replica — presents
+    // `seenSeq === 0` against an already-synced session; diffing against the
+    // populated cache would yield an empty sync and leave it unable to read
+    // its watched cells. Detect that and diff against an empty baseline so it
+    // gets a full sync. Warm reconnects present `seenSeq > 0` and keep the
+    // incremental diff against `session.entities` (preserving upserts AND
+    // removes), so the browser reconnect path is unchanged.
+    const coldReplica = resumeFromSeenSeq === 0 && session.lastSyncedSeq > 0;
     const sync = buildDiffSync(
-      session.entities,
+      coldReplica ? new Map<string, SessionCacheEntry>() : session.entities,
       entities,
-      session.lastSyncedSeq,
+      coldReplica ? 0 : session.lastSyncedSeq,
       serverSeq,
     );
     session.graphs = graphs;

--- a/packages/memory/v2/session-registry.ts
+++ b/packages/memory/v2/session-registry.ts
@@ -25,6 +25,15 @@ export type SessionState = {
 
 type OpenSessionState = SessionOpenResult & {
   revokedConnectionId?: string;
+  /**
+   * The `seenSeq` the client actually presented on this open (pre-`Math.max`
+   * clamp), i.e. the high-water mark of canonical seqs the client has
+   * integrated into its LOCAL replica. The resume catch-up baseline is
+   * computed from this (per spec), not from the server's `session.entities`
+   * cache — a cold client (fresh process, empty replica) presents `0` and
+   * must be full-synced even though the persisted session looks fully synced.
+   */
+  presentedSeenSeq: number;
 };
 
 const sessionKey = (space: string, sessionId: string): string =>
@@ -111,6 +120,7 @@ export class SessionRegistry {
       sessionId,
       sessionToken,
       serverSeq,
+      presentedSeenSeq: session.seenSeq ?? 0,
       ...(existing !== undefined ? { resumed: true } : {}),
       ...(revokedConnectionId ? { revokedConnectionId } : {}),
     };

--- a/packages/runner/src/storage/v2-remote-session.ts
+++ b/packages/runner/src/storage/v2-remote-session.ts
@@ -103,10 +103,26 @@ class WebSocketTransport implements MemoryClient.Transport {
   }
 }
 
+/**
+ * Opt-in session resume hook. When provided, the factory mounts with a
+ * client-supplied `sessionId` so server-side `perSession` state persists
+ * across separate client lifecycles (e.g. separate CLI invocations).
+ *
+ * The server rotates `sessionToken` on every mount and throws `revokedError`
+ * if a still-live `sessionId` is reused without the matching token, so the
+ * resumed token must be persisted via `onToken` and replayed via `getToken`.
+ */
+export interface SessionResume {
+  id: string;
+  getToken?: () => string | undefined;
+  onToken?: (token: string | undefined) => void;
+}
+
 export class RemoteSessionFactory implements SessionFactory {
   constructor(
     private readonly address: URL,
     private readonly defaultSigner: Signer,
+    private readonly resume?: SessionResume,
   ) {}
 
   async #createSessionOpenAuth(
@@ -141,9 +157,19 @@ export class RemoteSessionFactory implements SessionFactory {
         toSpaceWebSocketAddress(this.address, space),
       ),
     });
+    // Default behavior (no resume hook): mount with empty options so the
+    // server mints a fresh session id per client lifecycle.
+    let mountOptions: MemoryClient.MountOptions = {};
+    if (this.resume) {
+      const sessionToken = this.resume.getToken?.();
+      mountOptions = {
+        sessionId: this.resume.id,
+        ...(sessionToken !== undefined ? { sessionToken } : {}),
+      };
+    }
     const session = await client.mount(
       space,
-      {},
+      mountOptions,
       (targetSpace: string, descriptor: MemoryClient.MountOptions) =>
         this.#createSessionOpenAuth(
           signer,
@@ -151,6 +177,9 @@ export class RemoteSessionFactory implements SessionFactory {
           descriptor,
         ),
     );
+    // Persist the rotated token so the next mount with the same sessionId can
+    // replay it and avoid the server's revokedError.
+    this.resume?.onToken?.(session.sessionToken);
     return { client, session };
   }
 }

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -366,6 +366,17 @@ export interface Options {
   id?: string;
   settings?: IRemoteStorageProviderSettings;
   spaceIdentity?: Signer;
+  /**
+   * Opt-in: pin the memory session id so server-side `perSession` state
+   * persists across separate StorageManager lifecycles. The rotated session
+   * token must be persisted via `onToken` and replayed via `getToken` to
+   * avoid the server's revokedError on reuse within the session TTL.
+   */
+  session?: {
+    id: string;
+    getToken?: () => string | undefined;
+    onToken?: (token: string | undefined) => void;
+  };
 }
 
 export const defaultSettings: IRemoteStorageProviderSettings = {
@@ -523,7 +534,7 @@ export class StorageManager implements IStorageManager {
   static open(options: Options) {
     return new this(
       options,
-      new RemoteSessionFactory(options.address, options.as),
+      new RemoteSessionFactory(options.address, options.as, options.session),
     );
   }
 

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -50,6 +50,12 @@ or default. For identity-sensitive local work, use one key everywhere and import
 the CLI PKCS8/PEM key in the browser via `Import CLI Key`. See
 `docs/development/SHARED_IDENTITY.md`.
 
+**`perSession` is per-invocation by default:** each `cf` command mounts a fresh
+memory session, so `perSession` cells reset between commands. Pass
+`--session <id>` (or set `CF_SESSION`) on every command to pin a stable session
+and make `perSession` state persist across invocations. See
+`docs/development/debugging/gotchas/scoped-cell-pitfalls.md`.
+
 **Experimental flags** (must be set on both servers AND CLI commands):
 
 ```bash


### PR DESCRIPTION
> **Abandoned / do not land.** Pushed as research evidence for a Linear ticket on the underlying memory-v2 resume-sync behavior. Filed for framework-author review.

## Goal
Let `perSession` cells persist across separate `cf` CLI invocations via an opt-in `--session <id>` / `CF_SESSION`. By default each invocation mints a fresh memory session, so `perSession` state resets per command (now documented).

## What's implemented (complete, type-clean)
- **CLI**: `--session`/`CF_SESSION` global option+env, threaded `SpaceConfig → StorageManager.open → RemoteSessionFactory → client.mount`; a dotfile (`cli/lib/session-store.ts`) persists/replays the rotated `sessionToken` to survive the server's `revokedError` on resume. Help text + `scoped-cell-pitfalls.md`.
- **Server (memory/v2)**: align the resume catch-up with the protocol spec — honor the client's presented `seenSeq` as the catch-up baseline instead of the server's `session.entities` cache, so a cold client (presented `seenSeq 0`) gets a full sync. Stored `seenSeq` stays monotonic (ack watermark); warm reconnects keep the incremental diff. **No regression** — `packages/memory/test/v2-client-test.ts` 23/23 green incl. the warm-resume test.

## Why abandoned
End-to-end the CLI cold resume still fails with `No data at cell`. The data-delivery path for a fresh CLI process resuming a session is deeper than this single catch-up fix:
1. The client's `mount()` path does **not apply** the resume catch-up sync (only the warm `restore()`/reconnect path does).
2. The runner's root-cell `sync()` (`runner.ts:1129`) is involved and throws when the resumed cold replica is empty.

A correct fix spans memory-v2 **server** (catch-up baseline) **and client resume-application** semantics — framework-author territory. Full root-cause + design analysis (incl. the spec divergence and the warm-vs-cold debate) is in the linked Linear ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in session pinning to `cf` via `--session <id>`/`CF_SESSION` so `perSession` cells can persist across CLI invocations, and updates memory v2 resume catch-up to honor the client's `seenSeq` per spec. Supports the Linear investigation into resume-sync behavior and clarifies the default per-invocation session model.

- New Features
  - Global `--session` option and `CF_SESSION` env to pin a stable session id across commands.
  - Persist/replay rotated `sessionToken` in `~/.cache/common-fabric/cli-sessions.json` to avoid `revokedError`.
  - Runner wiring to pass pinned sessions (`StorageManager.open` → `RemoteSessionFactory` → `client.mount`), plus CLI help and docs explaining that `perSession` resets by default and how to pin it.

- Bug Fixes
  - Server (`memory/v2`) computes resume catch-up from the presented `seenSeq`; cold clients (`seenSeq = 0`) now get a full sync.
  - `session-registry` surfaces `presentedSeenSeq` for correct baseline selection.
  - Warm reconnect behavior is unchanged; existing unit tests remain green.

<sup>Written for commit 8335f008896cdf4b5f5125b05f91c01263687f9c. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3703?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

