### PR TITLE
refactor(ts-transformers): registry unification (Phase A)

### DIFF
--- a/packages/ts-transformers/src/ast/type-building.ts
+++ b/packages/ts-transformers/src/ast/type-building.ts
@@ -386,7 +386,7 @@ export function expressionToTypeNode(
   if (declaredTypeNode) {
     const type = context.checker.getTypeFromTypeNode(declaredTypeNode);
     const clonedTypeNode = cloneTypeNode(declaredTypeNode);
-    context.options.typeRegistry?.set(clonedTypeNode, type);
+    context.options.state?.typeRegistry?.set(clonedTypeNode, type);
     return clonedTypeNode;
   }
 
@@ -395,12 +395,12 @@ export function expressionToTypeNode(
   const type = inferWidenedTypeFromExpression(
     expr,
     context.checker,
-    context.options.typeRegistry,
+    context.options.state?.typeRegistry,
   );
   return typeToTypeNodeWithRegistry(
     type,
     context,
-    context.options.typeRegistry,
+    context.options.state?.typeRegistry,
   );
 }
 
@@ -636,7 +636,7 @@ export function buildTypeElementsFromCaptureTree(
         {
           factory,
           checker,
-          typeRegistry: context.options.typeRegistry,
+          typeRegistry: context.options.state?.typeRegistry,
         },
       );
     } else {
@@ -698,7 +698,7 @@ export function createCaptureTypeLiteral(
     {
       factory: context.factory,
       checker: context.checker,
-      typeRegistry: context.options.typeRegistry,
+      typeRegistry: context.options.state?.typeRegistry,
     },
   );
 }
@@ -741,7 +741,7 @@ export function mergeCaptureTypesIntoTypeLiteral(
     {
       factory: context.factory,
       checker: context.checker,
-      typeRegistry: context.options.typeRegistry,
+      typeRegistry: context.options.state?.typeRegistry,
     },
   );
 }

--- a/packages/ts-transformers/src/cf-pipeline.ts
+++ b/packages/ts-transformers/src/cf-pipeline.ts
@@ -19,6 +19,7 @@ import {
 import { ClosureTransformer } from "./closures/transformer.ts";
 import { LiftLoweringTransformer } from "./lift/transformer.ts";
 import {
+  CrossStageState,
   Pipeline,
   TransformationDiagnostic,
   TransformationOptions,
@@ -116,14 +117,7 @@ export class CommonFabricTransformerPipeline extends Pipeline {
 
   constructor(options: TransformationOptions = {}) {
     const ops: TransformationOptions = {
-      typeRegistry: new WeakMap(),
-      mapCallbackRegistry: new WeakSet(),
-      syntheticComputeCallbackRegistry: new WeakSet(),
-      syntheticComputeOwnedNodeRegistry: new WeakSet(),
-      syntheticReactiveCollectionRegistry: new WeakSet(),
-      schemaHints: new WeakMap(),
-      capabilitySummaryRegistry: new WeakMap(),
-      narrowedWrapperTypeRegistry: new WeakMap(),
+      state: new CrossStageState(),
       ...options,
     };
     // Create a shared diagnostics collector

--- a/packages/ts-transformers/src/cf-pipeline.ts
+++ b/packages/ts-transformers/src/cf-pipeline.ts
@@ -124,7 +124,6 @@ export class CommonFabricTransformerPipeline extends Pipeline {
       schemaHints: new WeakMap(),
       capabilitySummaryRegistry: new WeakMap(),
       narrowedWrapperTypeRegistry: new WeakMap(),
-      syntheticLiftAppliedCallRegistry: new WeakSet(),
       ...options,
     };
     // Create a shared diagnostics collector

--- a/packages/ts-transformers/src/closures/strategies/action-strategy.ts
+++ b/packages/ts-transformers/src/closures/strategies/action-strategy.ts
@@ -162,7 +162,7 @@ function transformActionCall(
   // Note: The action call has type `ModuleFactory<T, Stream<void>>`, but the finalCall
   // is `handler(...)({...})` which CALLS the factory. We need the return type of that call,
   // which is `OpaqueRef<Stream<void>>`.
-  const typeRegistry = context.options.typeRegistry;
+  const typeRegistry = context.options.state?.typeRegistry;
   if (typeRegistry) {
     // Get the type of the original action call (ModuleFactory<T, Stream<void>>)
     const actionType = checker.getTypeAtLocation(actionCall);

--- a/packages/ts-transformers/src/closures/strategies/array-method-policy.ts
+++ b/packages/ts-transformers/src/closures/strategies/array-method-policy.ts
@@ -28,10 +28,10 @@ function hasSharedReactiveCollectionProvenance(
     context.checker,
     {
       ...options,
-      typeRegistry: context.options.typeRegistry,
+      typeRegistry: context.options.state?.typeRegistry,
       logger: context.options.logger,
-      syntheticReactiveCollectionRegistry:
-        context.options.syntheticReactiveCollectionRegistry,
+      syntheticReactiveCollectionRegistry: context.options.state
+        ?.syntheticReactiveCollectionRegistry,
     },
   );
 }
@@ -70,7 +70,7 @@ export function shouldTransformArrayMethod(
   const targetType = getTypeAtLocationWithFallback(
     mapTarget,
     context.checker,
-    context.options.typeRegistry,
+    context.options.state?.typeRegistry,
     context.options.logger,
   );
   const receiverKind = classifyReactiveReceiverKind(

--- a/packages/ts-transformers/src/closures/strategies/array-method-transform.ts
+++ b/packages/ts-transformers/src/closures/strategies/array-method-transform.ts
@@ -200,7 +200,7 @@ function createPatternCallWithParams(
   );
 
   const { checker } = context;
-  const typeRegistry = context.options.typeRegistry;
+  const typeRegistry = context.options.state?.typeRegistry;
   let resultTypeNode: ts.TypeNode | undefined;
 
   if (callback.type) {

--- a/packages/ts-transformers/src/closures/strategies/array-method-utils.ts
+++ b/packages/ts-transformers/src/closures/strategies/array-method-utils.ts
@@ -275,10 +275,10 @@ function createAliasExpressionAsLiftApplied(
   // The type comes from info.symbol which was captured from the original
   // binding element. Without this registration, createLiftAppliedCall cannot
   // determine the correct result type for the synthetic lift-applied call.
-  if (context.options.typeRegistry && info.symbol) {
+  if (context.options.state?.typeRegistry && info.symbol) {
     const symbolType = checker.getTypeOfSymbol(info.symbol);
     if (symbolType) {
-      context.options.typeRegistry.set(elementAccess, symbolType);
+      context.options.state?.typeRegistry.set(elementAccess, symbolType);
     }
   }
 

--- a/packages/ts-transformers/src/closures/strategies/lift-applied-strategy.ts
+++ b/packages/ts-transformers/src/closures/strategies/lift-applied-strategy.ts
@@ -362,7 +362,7 @@ export function transformLiftAppliedCall(
     callback.body,
     captureExpressions,
     checker,
-    options.typeRegistry,
+    options.state?.typeRegistry,
   );
 
   // Recursively transform the callback body first
@@ -407,7 +407,7 @@ export function transformLiftAppliedCall(
     captureExpressions,
     factory,
     checker,
-    options.typeRegistry,
+    options.state?.typeRegistry,
   );
 
   // Initialize PatternBuilder
@@ -454,8 +454,8 @@ export function transformLiftAppliedCall(
       );
 
       // Register the result Type in typeRegistry
-      if (resultTypeNode && options.typeRegistry) {
-        options.typeRegistry.set(resultTypeNode, resultType);
+      if (resultTypeNode && options.state?.typeRegistry) {
+        options.state?.typeRegistry.set(resultTypeNode, resultType);
       }
     }
   }
@@ -508,7 +508,7 @@ export function transformLiftAppliedCall(
       getTypeFromTypeNodeWithFallback(
         inputTypeNode,
         checker,
-        options.typeRegistry,
+        options.state?.typeRegistry,
       ),
       false,
       checker,
@@ -541,13 +541,13 @@ export function transformLiftAppliedCall(
   );
 
   // Register the type of the call expression itself
-  if (options.typeRegistry) {
+  if (options.state?.typeRegistry) {
     registerLiftAppliedCallType(
       rebuiltCall,
       resultTypeNode,
       resultType,
       checker,
-      options.typeRegistry,
+      options.state?.typeRegistry,
     );
   }
 

--- a/packages/ts-transformers/src/closures/utils/schema-factory.ts
+++ b/packages/ts-transformers/src/closures/utils/schema-factory.ts
@@ -32,7 +32,7 @@ export class SchemaFactory {
     captureTree: Map<string, CaptureTreeNode>,
   ): ts.TypeNode {
     const { checker } = this.context;
-    const typeRegistry = this.context.options.typeRegistry;
+    const typeRegistry = this.context.options.state?.typeRegistry;
 
     // 1. Determine element type
     let elemTypeNode: ts.TypeNode;
@@ -130,7 +130,7 @@ export class SchemaFactory {
       const explicit = tryExplicitParameterType(
         stateParam,
         this.context.checker,
-        this.context.options.typeRegistry,
+        this.context.options.state?.typeRegistry,
       );
       if (explicit) return explicit.typeNode;
     }
@@ -145,7 +145,7 @@ export class SchemaFactory {
       {
         factory: this.factory,
         checker: this.context.checker,
-        typeRegistry: this.context.options.typeRegistry,
+        typeRegistry: this.context.options.state?.typeRegistry,
       },
     );
   }
@@ -205,7 +205,7 @@ export class SchemaFactory {
       {
         factory,
         checker: this.context.checker,
-        typeRegistry: this.context.options.typeRegistry,
+        typeRegistry: this.context.options.state?.typeRegistry,
       },
     );
   }
@@ -228,7 +228,7 @@ export class SchemaFactory {
     callback: ts.ArrowFunction | ts.FunctionExpression,
   ): ts.TypeNode {
     const { factory, checker } = this.context;
-    const typeRegistry = this.context.options.typeRegistry;
+    const typeRegistry = this.context.options.state?.typeRegistry;
     const eventParam = callback.parameters[0];
 
     // If no event parameter exists, use never type (will generate false schema)

--- a/packages/ts-transformers/src/core/context.ts
+++ b/packages/ts-transformers/src/core/context.ts
@@ -13,6 +13,8 @@ import {
 import { getRelevantDataFlows } from "../ast/normalize.ts";
 import {
   DiagnosticInput,
+  type FunctionCapabilitySummary,
+  type SchemaHint,
   TransformationDiagnostic,
   TransformationOptions,
 } from "./transformers.ts";
@@ -230,6 +232,56 @@ export class TransformationContext {
    */
   lookupNarrowedWrapper(wrapperNode: ts.TypeNode): ts.Type | undefined {
     return this.options.narrowedWrapperTypeRegistry?.get(wrapperNode);
+  }
+
+  /**
+   * Record a schema-generation hint for a node (and its original node, so the
+   * hint survives visitor node-replacement). Overwrites any existing hint for
+   * the node, matching the prior direct-`.set` behavior. See `SchemaHints`
+   * docs in core/mod.ts: producers are schema-injection + jsx-site-router,
+   * consumers are schema-injection + the schema generator.
+   */
+  recordSchemaHint(node: ts.Node, hint: SchemaHint): void {
+    const registry = this.options.schemaHints;
+    if (!registry) return;
+    registry.set(node, hint);
+    const original = ts.getOriginalNode(node);
+    if (original !== node) {
+      registry.set(original, hint);
+    }
+  }
+
+  /**
+   * Look up a schema-generation hint for a node, falling back to its original
+   * node (handles visitor-replaced nodes). Returns undefined when absent.
+   */
+  lookupSchemaHint(node: ts.Node): SchemaHint | undefined {
+    const registry = this.options.schemaHints;
+    if (!registry) return undefined;
+    return registry.get(node) ?? registry.get(ts.getOriginalNode(node));
+  }
+
+  /**
+   * Record a per-function capability summary computed by
+   * PatternCallbackLoweringTransformer (expensive interprocedural analysis;
+   * cached here for SchemaInjection to reuse). See `CapabilitySummaryRegistry`
+   * docs in core/mod.ts.
+   */
+  recordCapabilitySummary(
+    fn: ts.Node,
+    summary: FunctionCapabilitySummary,
+  ): void {
+    this.options.capabilitySummaryRegistry?.set(fn, summary);
+  }
+
+  /**
+   * Look up a previously-recorded capability summary. Returns undefined when
+   * absent; callers fall through to computing the summary on demand.
+   */
+  lookupCapabilitySummary(
+    fn: ts.Node,
+  ): FunctionCapabilitySummary | undefined {
+    return this.options.capabilitySummaryRegistry?.get(fn);
   }
 
   markSyntheticLiftAppliedCall(call: ts.CallExpression): void {

--- a/packages/ts-transformers/src/core/context.ts
+++ b/packages/ts-transformers/src/core/context.ts
@@ -18,6 +18,7 @@ import {
   TransformationDiagnostic,
   TransformationOptions,
 } from "./transformers.ts";
+import { CrossStageState } from "./cross-stage-state.ts";
 import { CFHelpers } from "./cf-helpers.ts";
 
 const DEFAULT_OPTIONS: TransformationOptions = {
@@ -62,6 +63,7 @@ export class TransformationContext {
     this.options = {
       ...DEFAULT_OPTIONS,
       ...config.options,
+      state: config.options?.state ?? new CrossStageState(),
     };
   }
 
@@ -133,9 +135,7 @@ export class TransformationContext {
    * array method callback scopes.
    */
   markAsArrayMethodCallback(node: ts.Node): void {
-    if (this.options.mapCallbackRegistry) {
-      this.options.mapCallbackRegistry.add(node);
-    }
+    this.options.state?.markArrayMethodCallback(node);
     this.invalidateReactiveAnalysisCaches();
   }
 
@@ -143,15 +143,7 @@ export class TransformationContext {
    * Check if a node is an array method callback created by ClosureTransformer.
    */
   isArrayMethodCallback(node: ts.Node): boolean {
-    if (this.options.mapCallbackRegistry?.has(node)) {
-      return true;
-    }
-    const original = ts.getOriginalNode(node);
-    return !!(
-      original &&
-      original !== node &&
-      this.options.mapCallbackRegistry?.has(original)
-    );
+    return this.options.state?.isArrayMethodCallback(node) ?? false;
   }
 
   /**
@@ -160,9 +152,7 @@ export class TransformationContext {
    * authored nodes with original parent chains in pattern context.
    */
   markAsSyntheticComputeCallback(node: ts.Node): void {
-    if (this.options.syntheticComputeCallbackRegistry) {
-      this.options.syntheticComputeCallbackRegistry.add(node);
-    }
+    this.options.state?.markSyntheticComputeCallback(node);
     this.invalidateReactiveAnalysisCaches();
   }
 
@@ -170,40 +160,16 @@ export class TransformationContext {
    * Check if a node is a synthetic compute wrapper callback.
    */
   isSyntheticComputeCallback(node: ts.Node): boolean {
-    if (this.options.syntheticComputeCallbackRegistry?.has(node)) {
-      return true;
-    }
-    const original = ts.getOriginalNode(node);
-    return !!(
-      original &&
-      original !== node &&
-      this.options.syntheticComputeCallbackRegistry?.has(original)
-    );
+    return this.options.state?.isSyntheticComputeCallback(node) ?? false;
   }
 
   markSyntheticComputeOwnedSubtree(node: ts.Node): void {
-    const registry = this.options.syntheticComputeOwnedNodeRegistry;
-    if (!registry) return;
-
-    const visit = (current: ts.Node): void => {
-      registry.add(current);
-      ts.forEachChild(current, visit);
-    };
-
-    visit(node);
+    this.options.state?.markSyntheticComputeOwnedSubtree(node);
     this.invalidateReactiveAnalysisCaches();
   }
 
   isSyntheticComputeOwnedNode(node: ts.Node): boolean {
-    if (this.options.syntheticComputeOwnedNodeRegistry?.has(node)) {
-      return true;
-    }
-    const original = ts.getOriginalNode(node);
-    return !!(
-      original &&
-      original !== node &&
-      this.options.syntheticComputeOwnedNodeRegistry?.has(original)
-    );
+    return this.options.state?.isSyntheticComputeOwnedNode(node) ?? false;
   }
 
   /**
@@ -218,11 +184,7 @@ export class TransformationContext {
    * documented and enforced in one place (Berni's review §3.4).
    */
   markNarrowedWrapper(wrapperNode: ts.TypeNode, preShrinkType: ts.Type): void {
-    const registry = this.options.narrowedWrapperTypeRegistry;
-    if (!registry) return;
-    if (!registry.has(wrapperNode)) {
-      registry.set(wrapperNode, preShrinkType);
-    }
+    this.options.state?.markNarrowedWrapper(wrapperNode, preShrinkType);
   }
 
   /**
@@ -231,7 +193,7 @@ export class TransformationContext {
    * callers should fall through to their existing recovery path.
    */
   lookupNarrowedWrapper(wrapperNode: ts.TypeNode): ts.Type | undefined {
-    return this.options.narrowedWrapperTypeRegistry?.get(wrapperNode);
+    return this.options.state?.lookupNarrowedWrapper(wrapperNode);
   }
 
   /**
@@ -242,13 +204,7 @@ export class TransformationContext {
    * consumers are schema-injection + the schema generator.
    */
   recordSchemaHint(node: ts.Node, hint: SchemaHint): void {
-    const registry = this.options.schemaHints;
-    if (!registry) return;
-    registry.set(node, hint);
-    const original = ts.getOriginalNode(node);
-    if (original !== node) {
-      registry.set(original, hint);
-    }
+    this.options.state?.recordSchemaHint(node, hint);
   }
 
   /**
@@ -256,9 +212,7 @@ export class TransformationContext {
    * node (handles visitor-replaced nodes). Returns undefined when absent.
    */
   lookupSchemaHint(node: ts.Node): SchemaHint | undefined {
-    const registry = this.options.schemaHints;
-    if (!registry) return undefined;
-    return registry.get(node) ?? registry.get(ts.getOriginalNode(node));
+    return this.options.state?.lookupSchemaHint(node);
   }
 
   /**
@@ -271,7 +225,7 @@ export class TransformationContext {
     fn: ts.Node,
     summary: FunctionCapabilitySummary,
   ): void {
-    this.options.capabilitySummaryRegistry?.set(fn, summary);
+    this.options.state?.recordCapabilitySummary(fn, summary);
   }
 
   /**
@@ -281,7 +235,7 @@ export class TransformationContext {
   lookupCapabilitySummary(
     fn: ts.Node,
   ): FunctionCapabilitySummary | undefined {
-    return this.options.capabilitySummaryRegistry?.get(fn);
+    return this.options.state?.lookupCapabilitySummary(fn);
   }
 
   markSyntheticReactiveCollectionDeclaration(node: ts.Node): void {
@@ -295,7 +249,7 @@ export class TransformationContext {
     if (!symbol) {
       return;
     }
-    this.options.syntheticReactiveCollectionRegistry?.add(symbol);
+    this.options.state?.markSyntheticReactiveCollection(symbol);
     this.invalidateReactiveAnalysisCaches();
   }
 

--- a/packages/ts-transformers/src/core/context.ts
+++ b/packages/ts-transformers/src/core/context.ts
@@ -284,25 +284,6 @@ export class TransformationContext {
     return this.options.capabilitySummaryRegistry?.get(fn);
   }
 
-  markSyntheticLiftAppliedCall(call: ts.CallExpression): void {
-    this.options.syntheticLiftAppliedCallRegistry?.add(call);
-  }
-
-  isSyntheticLiftAppliedCall(call: ts.CallExpression): boolean {
-    if (this.options.syntheticLiftAppliedCallRegistry?.has(call)) {
-      return true;
-    }
-    const original = ts.getOriginalNode(call);
-    return !!(
-      original &&
-      original !== call &&
-      ts.isCallExpression(original as ts.Node) &&
-      this.options.syntheticLiftAppliedCallRegistry?.has(
-        original as ts.CallExpression,
-      )
-    );
-  }
-
   markSyntheticReactiveCollectionDeclaration(node: ts.Node): void {
     const symbol = ts.isVariableDeclaration(node)
       ? (ts.isIdentifier(node.name)

--- a/packages/ts-transformers/src/core/cross-stage-state.ts
+++ b/packages/ts-transformers/src/core/cross-stage-state.ts
@@ -1,0 +1,138 @@
+import ts from "typescript";
+import type {
+  CapabilitySummaryRegistry,
+  FunctionCapabilitySummary,
+  SchemaHint,
+  SchemaHints,
+  SyntheticReactiveCollectionRegistry,
+  TypeRegistry,
+} from "./transformers.ts";
+
+/**
+ * CrossStageState — the single owner of the pipeline's cross-transformer
+ * communication registries.
+ *
+ * Replaces the formerly-separate registry fields on `TransformationOptions`.
+ * Each registry is keyed by AST node or symbol identity, preserved across
+ * `ts.transform()` stages. See `core/mod.ts` for the per-registry contract.
+ *
+ * Division of responsibility with `TransformationContext`:
+ *   - CrossStageState owns the DATA (the WeakMaps/WeakSets) and exposes pure
+ *     data operations (record/lookup/mark/is). It performs NO cache
+ *     invalidation — it has no knowledge of the context's analysis caches.
+ *   - TransformationContext keeps the public mark/record methods. For the
+ *     four marker-set mutators it delegates to CrossStageState AND then calls
+ *     its own `invalidateReactiveAnalysisCaches()`. Invalidation stays a
+ *     context concern; this object stays a pure data holder. (This is why the
+ *     `mark*` methods here do not invalidate — the context wrapper does.)
+ *
+ * The raw maps are also exposed as readonly properties because the heavily
+ * used `typeRegistry` and the cross-package `schemaHints` are read directly by
+ * many call sites (and by the separate schema-generator package, which is not
+ * a transformer stage and must not depend on this type — it receives the bare
+ * map). Those two are the documented package boundary.
+ */
+export class CrossStageState {
+  readonly typeRegistry: TypeRegistry = new WeakMap();
+  readonly mapCallbackRegistry = new WeakSet<ts.Node>();
+  readonly syntheticComputeCallbackRegistry = new WeakSet<ts.Node>();
+  readonly syntheticComputeOwnedNodeRegistry = new WeakSet<ts.Node>();
+  readonly syntheticReactiveCollectionRegistry:
+    SyntheticReactiveCollectionRegistry = new WeakSet();
+  readonly schemaHints: SchemaHints = new WeakMap();
+  readonly capabilitySummaryRegistry: CapabilitySummaryRegistry = new WeakMap();
+  readonly narrowedWrapperTypeRegistry = new WeakMap<ts.TypeNode, ts.Type>();
+
+  // --- mapCallbackRegistry ---
+
+  markArrayMethodCallback(node: ts.Node): void {
+    this.mapCallbackRegistry.add(node);
+  }
+
+  isArrayMethodCallback(node: ts.Node): boolean {
+    return this.#hasWithOriginal(this.mapCallbackRegistry, node);
+  }
+
+  // --- syntheticComputeCallbackRegistry ---
+
+  markSyntheticComputeCallback(node: ts.Node): void {
+    this.syntheticComputeCallbackRegistry.add(node);
+  }
+
+  isSyntheticComputeCallback(node: ts.Node): boolean {
+    return this.#hasWithOriginal(this.syntheticComputeCallbackRegistry, node);
+  }
+
+  // --- syntheticComputeOwnedNodeRegistry ---
+
+  markSyntheticComputeOwnedSubtree(node: ts.Node): void {
+    const registry = this.syntheticComputeOwnedNodeRegistry;
+    const visit = (current: ts.Node): void => {
+      registry.add(current);
+      ts.forEachChild(current, visit);
+    };
+    visit(node);
+  }
+
+  isSyntheticComputeOwnedNode(node: ts.Node): boolean {
+    return this.#hasWithOriginal(this.syntheticComputeOwnedNodeRegistry, node);
+  }
+
+  // --- syntheticReactiveCollectionRegistry (keyed by ts.Symbol) ---
+
+  markSyntheticReactiveCollection(symbol: ts.Symbol): void {
+    this.syntheticReactiveCollectionRegistry.add(symbol);
+  }
+
+  isSyntheticReactiveCollection(symbol: ts.Symbol): boolean {
+    return this.syntheticReactiveCollectionRegistry.has(symbol);
+  }
+
+  // --- schemaHints ---
+
+  recordSchemaHint(node: ts.Node, hint: SchemaHint): void {
+    this.schemaHints.set(node, hint);
+    const original = ts.getOriginalNode(node);
+    if (original !== node) {
+      this.schemaHints.set(original, hint);
+    }
+  }
+
+  lookupSchemaHint(node: ts.Node): SchemaHint | undefined {
+    return this.schemaHints.get(node) ??
+      this.schemaHints.get(ts.getOriginalNode(node));
+  }
+
+  // --- capabilitySummaryRegistry ---
+
+  recordCapabilitySummary(
+    fn: ts.Node,
+    summary: FunctionCapabilitySummary,
+  ): void {
+    this.capabilitySummaryRegistry.set(fn, summary);
+  }
+
+  lookupCapabilitySummary(fn: ts.Node): FunctionCapabilitySummary | undefined {
+    return this.capabilitySummaryRegistry.get(fn);
+  }
+
+  // --- narrowedWrapperTypeRegistry ---
+
+  markNarrowedWrapper(wrapperNode: ts.TypeNode, preShrinkType: ts.Type): void {
+    if (!this.narrowedWrapperTypeRegistry.has(wrapperNode)) {
+      this.narrowedWrapperTypeRegistry.set(wrapperNode, preShrinkType);
+    }
+  }
+
+  lookupNarrowedWrapper(wrapperNode: ts.TypeNode): ts.Type | undefined {
+    return this.narrowedWrapperTypeRegistry.get(wrapperNode);
+  }
+
+  // --- shared helper: membership check with getOriginalNode fallback ---
+
+  #hasWithOriginal(set: WeakSet<ts.Node>, node: ts.Node): boolean {
+    if (set.has(node)) return true;
+    const original = ts.getOriginalNode(node);
+    return original !== node && set.has(original);
+  }
+}

--- a/packages/ts-transformers/src/core/mod.ts
+++ b/packages/ts-transformers/src/core/mod.ts
@@ -12,16 +12,29 @@
  * It only becomes observable if CT-1621 lands.
  *
  * TypeRegistry (WeakMap<ts.Node, ts.Type>)
- *   Preserves and recovers synthetic typing across the pipeline. Currently
- *   overloaded with three distinct uses sharing one map:
- *   - replacement expression nodes keep their original authored types
- *   - synthetic TypeNodes keep faithful schema/codegen types
- *   - synthetic call expressions keep their result types
- *   The schema generator (packages/schema-generator) also consults this
- *   registry as authoritative for wrapper-inner property recovery — so any
- *   pre-shrink type registered here will cause carefully-narrowed inner
- *   schemas to be un-shrunk. See narrowedWrapperTypeRegistry for the
- *   separate channel that bypasses this consumer.
+ *   Preserves and recovers synthetic typing across the pipeline. Serves three
+ *   distinct uses sharing one map:
+ *   - (a) replacement expression nodes keep their original authored types
+ *   - (b) synthetic TypeNodes keep faithful schema/codegen types
+ *   - (c) synthetic call expressions keep their result types
+ *
+ *   WHY ONE MAP IS SAFE (and why we did NOT split it — registry-unification
+ *   investigation, 2026-05, docs/scratch/12-registry-unification-design.md):
+ *   the three uses are isolated by KEY NODE-KIND, not by separate maps. A
+ *   use-(a) key is always a replacement Expression/Identifier, a use-(b) key
+ *   is always a ts.TypeNode, a use-(c) key is always a ts.CallExpression.
+ *   These node-kinds never coincide for the same ts.Node, so a reader that
+ *   looks up one kind of key can never retrieve another use's value. In
+ *   particular the schema-generator package reads ONLY TypeNode keys (verified
+ *   exhaustively: every .get/.has there keys on member.type, elementType,
+ *   innerTypeNode, etc.), so it can only ever see use-(b) entries. Splitting
+ *   into three physical maps would make this isolation explicit but fixes no
+ *   reachable bug, while adding churn the reads can't even exploit (the shared
+ *   read helpers — getTypeAtLocationWithFallback, ensureTypeNodeRegistered —
+ *   are node-kind-agnostic and would have to consult all three anyway).
+ *   The one genuine cross-consumer hazard CT-1615 hit (schema generator pulling
+ *   a *pre-shrink* type meant for a different consumer) is already solved by
+ *   the separate narrowedWrapperTypeRegistry channel — see its entry below.
  *   Writers: closure strategies, builtins/lift-applied, expression rewrites,
  *            type-building/schema-factory/type-shrinking, schema-injection
  *   Readers: lift-lowering transformer, schema-generator, type-inference,
@@ -136,20 +149,20 @@
  * abstraction. The plan and rationale live in
  * `docs/scratch/12-registry-unification-design.md` (supersedes the earlier
  * audit in `07-registry-audit.md`). Sequence:
- *   1. (this commit) doc refresh: count fix + mark the inert registry.
- *   2. Split typeRegistry into its three named purposes
- *      (replacementTypeRegistry, syntheticTypeNodeRegistry,
- *      syntheticCallResultRegistry) behind record/lookup methods, plus a
- *      combined lookupType() for the node-kind-agnostic read helper. CT-1615
- *      hit the overload's consequences firsthand — separate channels would
- *      have prevented it.
+ *   1. (done) doc refresh: count fix + mark the inert registry.
+ *   2. (done — NO-OP, by investigation) Splitting typeRegistry into three
+ *      maps was on the plan, but the split fixes no reachable bug: the three
+ *      uses are already isolated by key node-kind (see the TypeRegistry note
+ *      above), and the one real CT-1615 cross-consumer hazard is already
+ *      handled by narrowedWrapperTypeRegistry. Documented the invariant
+ *      instead of splitting.
  *   3. Lift the remaining direct-.get/.set registries (schemaHints,
  *      capabilitySummaryRegistry) to record/lookup methods.
  *   4. Remove syntheticLiftAppliedCallRegistry (inert; see its entry above).
  *   5. Fold the transformer-internal channels into CrossStageState; keep
- *      syntheticTypeNodeRegistry + schemaHints as loose maps at the
- *      schema-generator package boundary (the only channels that package
- *      reads), so no CrossStageState type crosses into schema-generator.
+ *      typeRegistry + schemaHints as loose maps at the schema-generator
+ *      package boundary (the only channels that package reads), so no
+ *      CrossStageState type crosses into schema-generator.
  */
 export { TransformationContext } from "./context.ts";
 export type {

--- a/packages/ts-transformers/src/core/mod.ts
+++ b/packages/ts-transformers/src/core/mod.ts
@@ -1,9 +1,15 @@
 /**
  * Cross-transformer communication registries.
  *
- * The pipeline creates eight shared registries in CommonFabricTransformerPipeline
+ * The pipeline creates nine shared registries in CommonFabricTransformerPipeline
  * (cf-pipeline.ts). Each is keyed by AST node or symbol identity, which is
  * preserved when transformers are applied in sequence via ts.transform().
+ *
+ * NOTE (registry-unification effort, 2026-05): the ninth,
+ * syntheticLiftAppliedCallRegistry, is functionally inert in the current
+ * pipeline (a downstream array-shrink re-collapses the type it preserves) and
+ * is slated for removal — see docs/scratch/12-registry-unification-design.md.
+ * It only becomes observable if CT-1621 lands.
  *
  * TypeRegistry (WeakMap<ts.Node, ts.Type>)
  *   Preserves and recovers synthetic typing across the pipeline. Currently
@@ -71,13 +77,19 @@
  *   Readers: context.lookupNarrowedWrapper() (called by
  *            transformers/schema-injection.ts inner-lift revisit path)
  *
- * syntheticLiftAppliedCallRegistry (WeakSet<ts.CallExpression>)
+ * syntheticLiftAppliedCallRegistry (WeakSet<ts.CallExpression>)  [INERT — SLATED FOR REMOVAL]
  *   Marks CallExpressions emitted by createLiftAppliedCall (the synthetic
- *   JSX compute-wrap path used by expression-rewrite). Used to suppress
- *   the capability-summary shrink in schema-injection's lift-applied
- *   dispatch, because the input TypeNode is already built from accurate
- *   capture analysis and re-shrinking collapses array element types to
- *   `unknown` (regression surfaced by CT-1615 Berni review on PR #3676).
+ *   JSX compute-wrap path used by expression-rewrite). Suppresses the
+ *   capability-summary shrink in schema-injection's lift-applied dispatch,
+ *   to keep the input TypeNode (already built from accurate capture analysis)
+ *   from being collapsed to `unknown`.
+ *   HOWEVER this is functionally inert today: a downstream array-shrink in
+ *   type-shrinking re-collapses the array items to `unknown[]` regardless, so
+ *   the final emitted schema is identical whether or not the marker fires
+ *   (verified by neutering the writer — full fixture + schema-shrink suites
+ *   unchanged). Kept only as pre-positioning for CT-1621; slated for removal
+ *   in the registry-unification effort. See
+ *   docs/scratch/12-registry-unification-design.md.
  *   User-source derive<T,R>(...) lowered via LiftLoweringTransformer is
  *   NOT marked, so it retains the legacy shrink behavior.
  *   Writers: context.markSyntheticLiftAppliedCall() (called by
@@ -118,23 +130,26 @@
  * analyzer instance is dropped together, so any state captured in its
  * closure is GC'd.
  *
- * --- Open architectural improvements ---
+ * --- Registry unification (in progress, 2026-05) ---
  *
- * See `docs/scratch/07-registry-audit.md` for a more thorough audit and
- * follow-up opportunities. In brief:
- *   - Lift the three remaining direct-.get/.set registries (typeRegistry,
- *     schemaHints, capabilitySummaryRegistry) to context.recordX/lookupX
- *     methods (matching the marker-set trio's pattern and the
- *     narrowedWrapperTypeRegistry promotion in CT-1615). Centralizes
- *     mutation, gets getOriginalNode fallback for free where applicable,
- *     eases adding invariants later.
- *   - Split typeRegistry into its three named purposes
- *     (replacementTypeRegistry, syntheticTypeNodeRegistry,
- *     syntheticCallResultRegistry). CT-1615 hit the consequences of the
- *     overload firsthand — separate channels would have prevented it.
- *   - Reconsider whether single-stage-pair registries (schemaHints,
- *     capabilitySummaryRegistry) should be threaded explicitly between just
- *     those stages rather than living in global options.
+ * This registry layer is being consolidated into a single CrossStageState
+ * abstraction. The plan and rationale live in
+ * `docs/scratch/12-registry-unification-design.md` (supersedes the earlier
+ * audit in `07-registry-audit.md`). Sequence:
+ *   1. (this commit) doc refresh: count fix + mark the inert registry.
+ *   2. Split typeRegistry into its three named purposes
+ *      (replacementTypeRegistry, syntheticTypeNodeRegistry,
+ *      syntheticCallResultRegistry) behind record/lookup methods, plus a
+ *      combined lookupType() for the node-kind-agnostic read helper. CT-1615
+ *      hit the overload's consequences firsthand — separate channels would
+ *      have prevented it.
+ *   3. Lift the remaining direct-.get/.set registries (schemaHints,
+ *      capabilitySummaryRegistry) to record/lookup methods.
+ *   4. Remove syntheticLiftAppliedCallRegistry (inert; see its entry above).
+ *   5. Fold the transformer-internal channels into CrossStageState; keep
+ *      syntheticTypeNodeRegistry + schemaHints as loose maps at the
+ *      schema-generator package boundary (the only channels that package
+ *      reads), so no CrossStageState type crosses into schema-generator.
  */
 export { TransformationContext } from "./context.ts";
 export type {

--- a/packages/ts-transformers/src/core/mod.ts
+++ b/packages/ts-transformers/src/core/mod.ts
@@ -146,6 +146,7 @@
  *      CrossStageState type crosses into schema-generator.
  */
 export { TransformationContext } from "./context.ts";
+export { CrossStageState } from "./cross-stage-state.ts";
 export type {
   CapabilityParamDefault,
   CapabilityParamSummary,

--- a/packages/ts-transformers/src/core/mod.ts
+++ b/packages/ts-transformers/src/core/mod.ts
@@ -1,15 +1,13 @@
 /**
  * Cross-transformer communication registries.
  *
- * The pipeline creates nine shared registries in CommonFabricTransformerPipeline
+ * The pipeline creates eight shared registries in CommonFabricTransformerPipeline
  * (cf-pipeline.ts). Each is keyed by AST node or symbol identity, which is
  * preserved when transformers are applied in sequence via ts.transform().
  *
- * NOTE (registry-unification effort, 2026-05): the ninth,
- * syntheticLiftAppliedCallRegistry, is functionally inert in the current
- * pipeline (a downstream array-shrink re-collapses the type it preserves) and
- * is slated for removal — see docs/scratch/12-registry-unification-design.md.
- * It only becomes observable if CT-1621 lands.
+ * (A ninth, syntheticLiftAppliedCallRegistry, was removed in the
+ * registry-unification effort — it was verified functionally inert. See
+ * docs/scratch/12-registry-unification-design.md.)
  *
  * TypeRegistry (WeakMap<ts.Node, ts.Type>)
  *   Preserves and recovers synthetic typing across the pipeline. Serves three
@@ -90,26 +88,6 @@
  *   Readers: context.lookupNarrowedWrapper() (called by
  *            transformers/schema-injection.ts inner-lift revisit path)
  *
- * syntheticLiftAppliedCallRegistry (WeakSet<ts.CallExpression>)  [INERT — SLATED FOR REMOVAL]
- *   Marks CallExpressions emitted by createLiftAppliedCall (the synthetic
- *   JSX compute-wrap path used by expression-rewrite). Suppresses the
- *   capability-summary shrink in schema-injection's lift-applied dispatch,
- *   to keep the input TypeNode (already built from accurate capture analysis)
- *   from being collapsed to `unknown`.
- *   HOWEVER this is functionally inert today: a downstream array-shrink in
- *   type-shrinking re-collapses the array items to `unknown[]` regardless, so
- *   the final emitted schema is identical whether or not the marker fires
- *   (verified by neutering the writer — full fixture + schema-shrink suites
- *   unchanged). Kept only as pre-positioning for CT-1621; slated for removal
- *   in the registry-unification effort. See
- *   docs/scratch/12-registry-unification-design.md.
- *   User-source derive<T,R>(...) lowered via LiftLoweringTransformer is
- *   NOT marked, so it retains the legacy shrink behavior.
- *   Writers: context.markSyntheticLiftAppliedCall() (called by
- *            transformers/builtins/lift-applied.ts → createLiftAppliedCall)
- *   Readers: context.isSyntheticLiftAppliedCall() (called by
- *            transformers/schema-injection.ts lift-applied dispatch branch)
- *
  * --- Cache invalidation contract ---
  *
  * The four context.mark* methods on TransformationContext (for
@@ -129,12 +107,14 @@
  * routing through the methods centralises the contract — Berni's review
  * §3.4 on CT-1615).
  *
- * The remaining three registries (typeRegistry, schemaHints,
- * capabilitySummaryRegistry) are mutated via direct .set() at call sites
- * and have no cache-invalidation discipline. This is fine today because no
- * analysis cache depends on their contents, but if you add a cache that
- * does, mutate the registry through a context method that invalidates it
- * (or extend invalidateReactiveAnalysisCaches).
+ * schemaHints and capabilitySummaryRegistry are accessed through context
+ * record/lookup methods (recordSchemaHint/lookupSchemaHint,
+ * recordCapabilitySummary/lookupCapabilitySummary) but, like
+ * narrowedWrapperTypeRegistry, do not invalidate caches (no analysis cache
+ * depends on them). typeRegistry is still mutated via direct .set() at call
+ * sites; same caveat applies. If you add a cache that depends on any of these,
+ * route the mutation through a method that invalidates it (or extend
+ * invalidateReactiveAnalysisCaches).
  *
  * If you add a new context-level cache or registry, mutate it through a
  * mark* method that calls invalidateReactiveAnalysisCaches() (or extend the
@@ -156,11 +136,12 @@
  *      above), and the one real CT-1615 cross-consumer hazard is already
  *      handled by narrowedWrapperTypeRegistry. Documented the invariant
  *      instead of splitting.
- *   3. Lift the remaining direct-.get/.set registries (schemaHints,
- *      capabilitySummaryRegistry) to record/lookup methods.
- *   4. Remove syntheticLiftAppliedCallRegistry (inert; see its entry above).
- *   5. Fold the transformer-internal channels into CrossStageState; keep
- *      typeRegistry + schemaHints as loose maps at the schema-generator
+ *   3. (done) Lifted schemaHints + capabilitySummaryRegistry to context
+ *      record/lookup methods. typeRegistry stays on direct .set (its split
+ *      was dropped in step 2, so there's no per-use method to route through).
+ *   4. (done) Removed syntheticLiftAppliedCallRegistry (verified inert).
+ *   5. (pending) Fold the transformer-internal channels into CrossStageState;
+ *      keep typeRegistry + schemaHints as loose maps at the schema-generator
  *      package boundary (the only channels that package reads), so no
  *      CrossStageState type crosses into schema-generator.
  */

--- a/packages/ts-transformers/src/core/transformers.ts
+++ b/packages/ts-transformers/src/core/transformers.ts
@@ -93,18 +93,6 @@ export interface TransformationOptions {
    */
   readonly narrowedWrapperTypeRegistry?: WeakMap<ts.TypeNode, ts.Type>;
   /**
-   * Marks CallExpressions emitted by `createLiftAppliedCall` (the synthetic
-   * JSX compute-wrap path used by expression-rewrite). SchemaInjection
-   * consults this when deciding whether to re-apply the capability-summary
-   * shrink on the lift's explicit input typeArg: synthetic emissions
-   * already produce their input TypeNode from accurate capture analysis,
-   * so re-shrinking collapses array element types to `unknown`
-   * (regression surfaced by CT-1615 Berni review on PR #3676).
-   * User-source derive<T,R>(...) lowered via LiftLoweringTransformer is
-   * NOT marked, so it retains the legacy shrink behavior.
-   */
-  readonly syntheticLiftAppliedCallRegistry?: WeakSet<ts.CallExpression>;
-  /**
    * Shared diagnostics collector that accumulates diagnostics across all transformers.
    * If provided, diagnostics are pushed to this array in addition to the local context.
    */

--- a/packages/ts-transformers/src/core/transformers.ts
+++ b/packages/ts-transformers/src/core/transformers.ts
@@ -1,5 +1,6 @@
 import ts from "typescript";
 import { TransformationContext } from "./mod.ts";
+import { CrossStageState } from "./cross-stage-state.ts";
 
 export type TransformMode = "transform" | "error";
 
@@ -73,25 +74,12 @@ export interface TransformationOptions {
   readonly mode?: TransformMode;
   readonly debug?: boolean;
   readonly logger?: (message: string) => void;
-  readonly typeRegistry?: TypeRegistry;
-  readonly mapCallbackRegistry?: WeakSet<ts.Node>;
-  readonly syntheticComputeCallbackRegistry?: WeakSet<ts.Node>;
-  readonly syntheticComputeOwnedNodeRegistry?: WeakSet<ts.Node>;
-  readonly syntheticReactiveCollectionRegistry?:
-    SyntheticReactiveCollectionRegistry;
-  readonly schemaHints?: SchemaHints;
-  readonly capabilitySummaryRegistry?: CapabilitySummaryRegistry;
   /**
-   * Maps synthetic wrapper TypeNodes produced by `applyShrinkAndWrap` back to
-   * the *pre-shrink* semantic Type that drove the narrowing. Read by
-   * SchemaInjection's inner-lift revisit path so it can re-narrow with the
-   * original baseType instead of receiving `any` from the checker on a
-   * synthetic node. Deliberately kept separate from the main `typeRegistry`
-   * because the schema generator consults `typeRegistry` to recover wrapper
-   * properties — if the pre-shrink type lived there, the generator would
-   * un-shrink carefully-narrowed inner schemas.
+   * Single owner of the pipeline's cross-transformer communication registries
+   * (typeRegistry, schemaHints, the marker sets, etc.). Replaces the formerly
+   * separate registry fields. See `CrossStageState`.
    */
-  readonly narrowedWrapperTypeRegistry?: WeakMap<ts.TypeNode, ts.Type>;
+  readonly state?: CrossStageState;
   /**
    * Shared diagnostics collector that accumulates diagnostics across all transformers.
    * If provided, diagnostics are pushed to this array in addition to the local context.

--- a/packages/ts-transformers/src/lift/transformer.ts
+++ b/packages/ts-transformers/src/lift/transformer.ts
@@ -200,7 +200,7 @@ function lowerDeriveCall(
   // parameter: `derive(5, x => …)` should see `number`, not the literal `5`.
   // Without the widen, schema injection picks up the literal type and emits
   // an over-narrowed schema (CT-1615 Berni review on PR #3676).
-  const typeRegistry = context.options.typeRegistry;
+  const typeRegistry = context.options.state?.typeRegistry;
   if (typeRegistry) {
     const callbackFn = unwrapToFunctionLike(callbackArg);
     const callbackParam = callbackFn?.parameters[0];
@@ -262,15 +262,15 @@ function finalizeLoweredCall(
     originalNode,
   );
 
-  if (context.options.typeRegistry) {
-    const originalType = context.options.typeRegistry.get(originalNode);
+  if (context.options.state?.typeRegistry) {
+    const originalType = context.options.state?.typeRegistry.get(originalNode);
     if (originalType) {
       registerLiftAppliedCallType(
         preservedVisitedCall,
         undefined,
         originalType,
         checker,
-        context.options.typeRegistry,
+        context.options.state?.typeRegistry,
       );
     }
   }

--- a/packages/ts-transformers/src/mod.ts
+++ b/packages/ts-transformers/src/mod.ts
@@ -6,6 +6,7 @@ export type {
   TransformMode,
 } from "./core/mod.ts";
 export {
+  CrossStageState,
   injectCfDataHelper,
   injectCfHelpers,
   Pipeline,

--- a/packages/ts-transformers/src/transformers/builtins/lift-applied.ts
+++ b/packages/ts-transformers/src/transformers/builtins/lift-applied.ts
@@ -214,7 +214,7 @@ export function createLiftAppliedCall(
     factory,
     tsContext,
     context.checker,
-    context.options.typeRegistry,
+    context.options.state?.typeRegistry,
   );
 
   const arrowFunction = factory.createArrowFunction(
@@ -272,13 +272,13 @@ export function createLiftAppliedCall(
   // Register the type of the call expression itself in the typeRegistry
   // so that type inference works correctly for synthetic nodes. The
   // result type is the value the callback returns.
-  if (context.options.typeRegistry && context.checker) {
+  if (context.options.state?.typeRegistry && context.checker) {
     registerLiftAppliedCallType(
       liftAppliedCall,
       resultTypeNode,
       undefined, // resultType not available in this code path
       context.checker,
-      context.options.typeRegistry,
+      context.options.state?.typeRegistry,
     );
   }
 
@@ -322,7 +322,7 @@ function buildInputTypeNode(
     {
       factory,
       checker: context.checker,
-      typeRegistry: context.options.typeRegistry,
+      typeRegistry: context.options.state?.typeRegistry,
     },
   );
 }
@@ -339,7 +339,7 @@ function buildResultTypeNode(
   const resultType = getTypeAtLocationWithFallback(
     expression,
     checker,
-    context.options.typeRegistry,
+    context.options.state?.typeRegistry,
   );
 
   // If we couldn't get a type, fallback to unknown
@@ -357,8 +357,8 @@ function buildResultTypeNode(
 
   if (resultTypeNode) {
     // Register the type in typeRegistry for SchemaGeneratorTransformer
-    if (context.options.typeRegistry) {
-      context.options.typeRegistry.set(resultTypeNode, resultType);
+    if (context.options.state?.typeRegistry) {
+      context.options.state?.typeRegistry.set(resultTypeNode, resultType);
     }
     return resultTypeNode;
   }

--- a/packages/ts-transformers/src/transformers/builtins/lift-applied.ts
+++ b/packages/ts-transformers/src/transformers/builtins/lift-applied.ts
@@ -269,17 +269,6 @@ export function createLiftAppliedCall(
     [inputObject],
   );
 
-  // Mark this synthetic emission so SchemaInjection can skip the explicit-
-  // argument capability-summary shrink. The shrink collapses array element
-  // types in our already-narrowed input TypeNode (CT-1615 Berni review on
-  // PR #3676 — `items: { type: "unknown" }` regression). User-source
-  // derive<T,R>(...) lowered via LiftLoweringTransformer is NOT marked, so
-  // it retains the legacy behavior of shrinking explicit type args.
-  if (ts.isCallExpression(innerLiftCall)) {
-    context.markSyntheticLiftAppliedCall?.(innerLiftCall);
-  }
-  context.markSyntheticLiftAppliedCall?.(liftAppliedCall);
-
   // Register the type of the call expression itself in the typeRegistry
   // so that type inference works correctly for synthetic nodes. The
   // result type is the value the callback returns.

--- a/packages/ts-transformers/src/transformers/destructuring-lowering.ts
+++ b/packages/ts-transformers/src/transformers/destructuring-lowering.ts
@@ -144,7 +144,7 @@ export function getStaticDefaultTypeNode(
       {
         factory,
         checker: context.checker,
-        typeRegistry: context.options.typeRegistry,
+        typeRegistry: context.options.state?.typeRegistry,
       },
     );
   }

--- a/packages/ts-transformers/src/transformers/expression-rewrite/emitters/binary-expression.ts
+++ b/packages/ts-transformers/src/transformers/expression-rewrite/emitters/binary-expression.ts
@@ -152,12 +152,12 @@ export const emitBinaryExpression: Emitter = ({
         cfHelpers: context.cfHelpers,
       });
 
-      if (context.options.typeRegistry) {
+      if (context.options.state?.typeRegistry) {
         const resultType = context.checker.getTypeAtLocation(expression);
         registerSyntheticCallType(
           whenCall,
           resultType,
-          context.options.typeRegistry,
+          context.options.state?.typeRegistry,
         );
       }
 
@@ -202,12 +202,12 @@ export const emitBinaryExpression: Emitter = ({
         cfHelpers: context.cfHelpers,
       });
 
-      if (context.options.typeRegistry) {
+      if (context.options.state?.typeRegistry) {
         const resultType = context.checker.getTypeAtLocation(expression);
         registerSyntheticCallType(
           unlessCall,
           resultType,
-          context.options.typeRegistry,
+          context.options.state?.typeRegistry,
         );
       }
 

--- a/packages/ts-transformers/src/transformers/expression-rewrite/emitters/conditional-expression.ts
+++ b/packages/ts-transformers/src/transformers/expression-rewrite/emitters/conditional-expression.ts
@@ -184,12 +184,12 @@ export const emitConditionalExpression: Emitter = ({
     },
   });
 
-  if (context.options.typeRegistry) {
+  if (context.options.state?.typeRegistry) {
     const resultType = context.checker.getTypeAtLocation(expression);
     registerSyntheticCallType(
       ifElseCall,
       resultType,
-      context.options.typeRegistry,
+      context.options.state?.typeRegistry,
     );
   }
 

--- a/packages/ts-transformers/src/transformers/expression-rewrite/rewrite-helpers.ts
+++ b/packages/ts-transformers/src/transformers/expression-rewrite/rewrite-helpers.ts
@@ -177,9 +177,9 @@ export function createReactiveWrapperForExpression(
   );
 
   // Register types for both the TypeNode and the lift-applied CallExpression
-  if (resultTypeNode && resultType && context.options.typeRegistry) {
-    context.options.typeRegistry.set(resultTypeNode, resultType);
-    context.options.typeRegistry.set(liftAppliedCall, resultType);
+  if (resultTypeNode && resultType && context.options.state?.typeRegistry) {
+    context.options.state?.typeRegistry.set(resultTypeNode, resultType);
+    context.options.state?.typeRegistry.set(liftAppliedCall, resultType);
   }
 
   // CRITICAL: Set parent pointers and connect to parent chain

--- a/packages/ts-transformers/src/transformers/jsx-expression-site-router.ts
+++ b/packages/ts-transformers/src/transformers/jsx-expression-site-router.ts
@@ -21,8 +21,8 @@ function transform(context: TransformationContext): ts.SourceFile {
     if (ts.isJsxElement(node) || ts.isJsxSelfClosingElement(node)) {
       const rewritten = rewriteUiHelperElement(node, context, visit);
       if (rewritten) {
-        if (rewritten.hint && context.options.schemaHints) {
-          context.options.schemaHints.set(rewritten.node, rewritten.hint);
+        if (rewritten.hint) {
+          context.recordSchemaHint(rewritten.node, rewritten.hint);
         }
         return rewritten.node;
       }

--- a/packages/ts-transformers/src/transformers/pattern-body-reactive-root-lowering.ts
+++ b/packages/ts-transformers/src/transformers/pattern-body-reactive-root-lowering.ts
@@ -68,7 +68,7 @@ function registerReplacementType(
   original: ts.Node,
   context: TransformationContext,
 ): void {
-  const typeRegistry = context.options.typeRegistry;
+  const typeRegistry = context.options.state?.typeRegistry;
   if (!typeRegistry) return;
 
   const originalType = getTypeAtLocationWithFallback(

--- a/packages/ts-transformers/src/transformers/pattern-callback-transform.ts
+++ b/packages/ts-transformers/src/transformers/pattern-callback-transform.ts
@@ -89,7 +89,7 @@ export function registerCapabilitySummary(
   interprocedural: boolean,
   defaultsByParamName?: ReadonlyMap<string, readonly CapabilityParamDefault[]>,
 ): void {
-  const registry = context.options.capabilitySummaryRegistry;
+  const registry = context.options.state?.capabilitySummaryRegistry;
   if (!registry) return;
 
   const summary = analyzeFunctionCapabilities(callback, {

--- a/packages/ts-transformers/src/transformers/reactive-variable-for.ts
+++ b/packages/ts-transformers/src/transformers/reactive-variable-for.ts
@@ -648,7 +648,7 @@ function shouldAddReactiveFor(
   const type = getTypeAtLocationWithFallback(
     expression,
     context.checker,
-    context.options.typeRegistry,
+    context.options.state?.typeRegistry,
     context.options.logger,
   );
   return isCellLikeType(type, context.checker);
@@ -726,9 +726,9 @@ function isReactiveArrayMethodCall(
       allowImplicitReactiveParameters: false,
       allowReactiveArrayCallbackParameters: false,
       sameScope: getEnclosingFunctionLikeDeclaration(call),
-      typeRegistry: context.options.typeRegistry,
-      syntheticReactiveCollectionRegistry:
-        context.options.syntheticReactiveCollectionRegistry,
+      typeRegistry: context.options.state?.typeRegistry,
+      syntheticReactiveCollectionRegistry: context.options.state
+        ?.syntheticReactiveCollectionRegistry,
       logger: context.options.logger,
     },
   ) || isExplicitReactiveCall(target.expression, context);
@@ -761,7 +761,7 @@ function shouldRetargetReactiveReference(
   const type = getTypeAtLocationWithFallback(
     target,
     context.checker,
-    context.options.typeRegistry,
+    context.options.state?.typeRegistry,
     context.options.logger,
   );
   if (type) {
@@ -898,7 +898,7 @@ function shouldUseStreamCause(
   const type = getTypeAtLocationWithFallback(
     target,
     context.checker,
-    context.options.typeRegistry,
+    context.options.state?.typeRegistry,
     context.options.logger,
   );
   return isStreamLikeType(type, context.checker);

--- a/packages/ts-transformers/src/transformers/schema-generator.ts
+++ b/packages/ts-transformers/src/transformers/schema-generator.ts
@@ -15,7 +15,9 @@ export class SchemaGeneratorTransformer extends HelpersOnlyTransformer {
   transform(context: TransformationContext): ts.SourceFile {
     const schemaTransformer = createSchemaTransformerV2();
     const { sourceFile, tsContext: transformation, checker } = context;
-    const { logger, typeRegistry, schemaHints } = context.options;
+    const { logger, state } = context.options;
+    const typeRegistry = state?.typeRegistry;
+    const schemaHints = state?.schemaHints;
 
     const visit: ts.Visitor = (node) => {
       if (isToSchemaNode(node)) {

--- a/packages/ts-transformers/src/transformers/schema-generator.ts
+++ b/packages/ts-transformers/src/transformers/schema-generator.ts
@@ -37,7 +37,13 @@ export class SchemaGeneratorTransformer extends HelpersOnlyTransformer {
         }
 
         // First check if we have a registered Type for this node or the typeArg
-        // (from schema-injection when synthetic TypeNodes were created)
+        // (from schema-injection when synthetic TypeNodes were created).
+        //
+        // Note on typeRegistry's three overloaded uses (see core/mod.ts): this
+        // reads the toSchema CallExpression key (use-(c), synthetic call result)
+        // here, then TypeNode keys (use-(b)) via getTypeFromTypeNodeWithFallback
+        // below and inside the schema-generator package. The uses don't collide
+        // because they key on different node-kinds; no split needed.
         let type: ts.Type;
         if (typeRegistry && typeRegistry.has(node)) {
           type = typeRegistry.get(node)!;

--- a/packages/ts-transformers/src/transformers/schema-injection.ts
+++ b/packages/ts-transformers/src/transformers/schema-injection.ts
@@ -3150,18 +3150,14 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
             return ts.visitEachChild(node, visit, transformation);
           }
 
-          // Lift-applied calls emitted by createLiftAppliedCall (the
-          // synthetic JSX compute-wrap path used by expression-rewrite)
-          // carry an input TypeNode already built from accurate capture
-          // analysis. Re-applying the capability-summary shrink would
-          // collapse array element types to `unknown` (CT-1615 Berni
-          // review on PR #3676). User-source derive<T,R>(...) lowered
-          // into lift-applied is NOT marked, so it retains the legacy
-          // shrink behavior.
-          const isSynthetic = context.isSyntheticLiftAppliedCall(node) ||
-            (innerLiftCall !== undefined &&
-              context.isSyntheticLiftAppliedCall(innerLiftCall));
-
+          // Always apply the capability-summary shrink to the explicit
+          // argument TypeNode. (Previously this was suppressed for calls
+          // marked by syntheticLiftAppliedCallRegistry, to avoid collapsing
+          // array element types to `unknown`. That marker was verified inert
+          // — a downstream array-shrink in type-shrinking re-collapses the
+          // items to `unknown[]` regardless, so the emitted schema is
+          // identical either way — and was removed in the registry-unification
+          // effort. See docs/scratch/12-registry-unification-design.md.)
           const resolved = resolveDualSchemaBuilderTypes(
             liftAppliedArgs?.callback,
             checker,
@@ -3175,7 +3171,7 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
               explicitArgumentTypeValue: typeRegistry?.get(argumentType),
               explicitResultTypeNode: resultType,
               explicitResultTypeValue: typeRegistry?.get(resultType),
-              applyExplicitArgumentCapabilitySummary: !isSynthetic,
+              applyExplicitArgumentCapabilitySummary: true,
             },
           );
           if (!resolved) {

--- a/packages/ts-transformers/src/transformers/schema-injection.ts
+++ b/packages/ts-transformers/src/transformers/schema-injection.ts
@@ -540,7 +540,7 @@ function collectFunctionSchemaTypeNodes(
       preserveUiContractHint(
         previousResultNode,
         synthesizedResult,
-        context.options.schemaHints,
+        context,
       );
       resultNode = synthesizedResult;
       resultType = undefined;
@@ -566,7 +566,7 @@ function collectFunctionSchemaTypeNodes(
       preserveUiContractHint(
         resultNode,
         scopedResult,
-        context.options.schemaHints,
+        context,
       );
       resultNode = scopedResult;
       resultType = undefined;
@@ -601,7 +601,7 @@ function collectFunctionSchemaTypeNodes(
         preserveUiContractHint(
           resultNode,
           recoveredNode,
-          context.options.schemaHints,
+          context,
         );
         resultNode = recoveredNode;
         resultType = undefined;
@@ -618,11 +618,13 @@ function collectFunctionSchemaTypeNodes(
         typeRegistry,
       );
       if (projectedResult?.result) {
-        preserveUiContractHint(
-          resultNode,
-          projectedResult.result,
-          context?.options.schemaHints,
-        );
+        if (context) {
+          preserveUiContractHint(
+            resultNode,
+            projectedResult.result,
+            context,
+          );
+        }
         resultNode = projectedResult.result;
         resultType = projectedResult.resultType;
       }
@@ -992,7 +994,20 @@ function createSchemaCallWithRegistryTransfer(
     typeRegistry,
   );
   const schemaCall = createToSchemaCall(context, emittedTypeNode, options);
-  preserveUiContractHint(typeNode, schemaCall, schemaHints);
+  // This leaf utility takes a narrowed `context` (Pick) and the schemaHints map
+  // explicitly, so it can't use context.recordSchemaHint; preserve the
+  // cfcUiContract hint directly on the raw map (mirroring to the original node).
+  if (schemaHints) {
+    const hint = schemaHints.get(typeNode)?.cfcUiContract ??
+      schemaHints.get(ts.getOriginalNode(typeNode))?.cfcUiContract;
+    if (hint) {
+      schemaHints.set(schemaCall, { cfcUiContract: hint });
+      const originalSchemaCall = ts.getOriginalNode(schemaCall);
+      if (originalSchemaCall !== schemaCall) {
+        schemaHints.set(originalSchemaCall, { cfcUiContract: hint });
+      }
+    }
+  }
 
   // Transfer TypeRegistry entry from source typeNode to schema call
   // This preserves type information for closure-captured variables
@@ -1014,8 +1029,7 @@ function applyIdentityArrayItemSchemaHints(
   identityPaths: readonly (readonly string[])[],
   context: TransformationContext,
 ): void {
-  const schemaHints = context.options.schemaHints;
-  if (!schemaHints || identityPaths.length === 0) return;
+  if (!context.options.schemaHints || identityPaths.length === 0) return;
 
   const grouped = new Map<string, boolean>();
   for (const path of identityPaths) {
@@ -1037,7 +1051,7 @@ function applyIdentityArrayItemSchemaHints(
           ? member.name.text
           : undefined;
         if (name && grouped.has(name)) {
-          schemaHints.set(member.type, { items: false });
+          context.recordSchemaHint(member.type, { items: false });
         }
       }
     }
@@ -1758,20 +1772,11 @@ function buildObjectLiteralReturnTypeNode(
       return undefined;
     }
     typeRegistry?.set(valueTypeNode, valueType);
-    const valueHint = getUiContractHintFromNode(
-      valueExpr,
-      context?.options.schemaHints,
-    );
-    if (valueHint && context?.options.schemaHints) {
-      context.options.schemaHints.set(valueTypeNode, {
-        cfcUiContract: valueHint,
-      });
-      const originalValueTypeNode = ts.getOriginalNode(valueTypeNode);
-      if (originalValueTypeNode !== valueTypeNode) {
-        context.options.schemaHints.set(originalValueTypeNode, {
-          cfcUiContract: valueHint,
-        });
-      }
+    const valueHint = context
+      ? getUiContractHintFromNode(valueExpr, context)
+      : undefined;
+    if (valueHint && context) {
+      context.recordSchemaHint(valueTypeNode, { cfcUiContract: valueHint });
     }
 
     members.push(
@@ -1877,8 +1882,7 @@ function propagateUiContractHintsFromObjectLiteral(
 ):
   | UiContractHint
   | undefined {
-  const schemaHints = context.options.schemaHints;
-  if (!schemaHints || !resultNode) {
+  if (!context.options.schemaHints || !resultNode) {
     return undefined;
   }
 
@@ -1897,7 +1901,7 @@ function propagateUiContractHintsFromObjectLiteral(
     const valueExpr = ts.isPropertyAssignment(property)
       ? property.initializer
       : property.name;
-    const hint = getUiContractHintFromNode(valueExpr, schemaHints);
+    const hint = getUiContractHintFromNode(valueExpr, context);
     if (!hint) {
       continue;
     }
@@ -1915,21 +1919,13 @@ function propagateUiContractHintsFromObjectLiteral(
           getObjectLiteralPropertyName(entry.name) === memberName,
       );
       if (member?.type) {
-        schemaHints.set(member.type, { cfcUiContract: hint });
-        const originalMemberType = ts.getOriginalNode(member.type);
-        if (originalMemberType !== member.type) {
-          schemaHints.set(originalMemberType, { cfcUiContract: hint });
-        }
+        context.recordSchemaHint(member.type, { cfcUiContract: hint });
       }
     }
   }
 
   if (resultHint) {
-    schemaHints.set(target, { cfcUiContract: resultHint });
-    const originalTarget = ts.getOriginalNode(target);
-    if (originalTarget !== target) {
-      schemaHints.set(originalTarget, { cfcUiContract: resultHint });
-    }
+    context.recordSchemaHint(target, { cfcUiContract: resultHint });
     return resultHint;
   }
 
@@ -1938,14 +1934,10 @@ function propagateUiContractHintsFromObjectLiteral(
 
 function getUiContractHintFromObjectLiteral(
   expr: ts.ObjectLiteralExpression,
-  schemaHints: TransformationContext["options"]["schemaHints"],
+  context: TransformationContext,
 ):
   | UiContractHint
   | undefined {
-  if (!schemaHints) {
-    return undefined;
-  }
-
   for (const property of expr.properties) {
     if (
       !ts.isPropertyAssignment(property) &&
@@ -1956,7 +1948,7 @@ function getUiContractHintFromObjectLiteral(
     const valueExpr = ts.isPropertyAssignment(property)
       ? property.initializer
       : property.name;
-    const hint = getUiContractHintFromNode(valueExpr, schemaHints);
+    const hint = getUiContractHintFromNode(valueExpr, context);
     if (hint) {
       return hint;
     }
@@ -1968,44 +1960,35 @@ function getUiContractHintFromObjectLiteral(
 function setUiContractHint(
   target: ts.Node | undefined,
   hint: UiContractHint | undefined,
-  schemaHints: TransformationContext["options"]["schemaHints"],
+  context: TransformationContext,
 ): void {
-  if (!schemaHints || !target || !hint) {
+  if (!target || !hint) {
     return;
   }
 
-  schemaHints.set(target, { cfcUiContract: hint });
-  const originalTarget = ts.getOriginalNode(target);
-  if (originalTarget !== target) {
-    schemaHints.set(originalTarget, { cfcUiContract: hint });
-  }
+  context.recordSchemaHint(target, { cfcUiContract: hint });
 }
 
 function preserveUiContractHint(
   fromNode: ts.Node | undefined,
   toNode: ts.Node | undefined,
-  schemaHints: TransformationContext["options"]["schemaHints"],
+  context: TransformationContext,
 ): void {
-  if (!schemaHints || !fromNode || !toNode) {
+  if (!fromNode || !toNode) {
     return;
   }
 
-  const hint = schemaHints.get(fromNode)?.cfcUiContract ??
-    schemaHints.get(ts.getOriginalNode(fromNode))?.cfcUiContract;
+  const hint = context.lookupSchemaHint(fromNode)?.cfcUiContract;
   if (!hint) {
     return;
   }
 
-  schemaHints.set(toNode, { cfcUiContract: hint });
-  const originalTarget = ts.getOriginalNode(toNode);
-  if (originalTarget !== toNode) {
-    schemaHints.set(originalTarget, { cfcUiContract: hint });
-  }
+  context.recordSchemaHint(toNode, { cfcUiContract: hint });
 }
 
 function getUiContractHintFromNode(
   node: ts.Node | undefined,
-  schemaHints: TransformationContext["options"]["schemaHints"],
+  context: TransformationContext,
 ):
   | UiContractHint
   | undefined {
@@ -2013,8 +1996,7 @@ function getUiContractHintFromNode(
     return undefined;
   }
 
-  const storedHint = schemaHints?.get(node)?.cfcUiContract ??
-    schemaHints?.get(ts.getOriginalNode(node))?.cfcUiContract;
+  const storedHint = context.lookupSchemaHint(node)?.cfcUiContract;
   if (storedHint) {
     return storedHint;
   }
@@ -2619,9 +2601,9 @@ function handlePatternSchemaInjection(
         resultTypeNode,
         getUiContractHintFromObjectLiteral(
           unwrappedPatternReturnExpr,
-          context.options.schemaHints,
+          context,
         ),
-        context.options.schemaHints,
+        context,
       );
     }
   } else if (typeArgs && typeArgs.length === 1) {
@@ -2713,12 +2695,12 @@ function handlePatternSchemaInjection(
       preserveUiContractHint(
         resultTypeNode,
         toSchemaResult,
-        context.options.schemaHints,
+        context,
       );
       preserveUiContractHint(
         getCallbackReturnExpression(builderFunction),
         toSchemaResult,
-        context.options.schemaHints,
+        context,
       );
       if (resultType && typeRegistry) {
         typeRegistry.set(toSchemaResult, resultType);
@@ -2732,10 +2714,10 @@ function handlePatternSchemaInjection(
           ts.isObjectLiteralExpression(unwrappedPatternReturnExpr)
           ? getUiContractHintFromObjectLiteral(
             unwrappedPatternReturnExpr,
-            context.options.schemaHints,
+            context,
           )
           : undefined,
-        context.options.schemaHints,
+        context,
       );
       return visited;
     } else {
@@ -2823,9 +2805,9 @@ function handlePatternSchemaInjection(
       resultSchemaCall,
       getUiContractHintFromObjectLiteral(
         unwrappedPatternReturnExpr,
-        context.options.schemaHints,
+        context,
       ),
-      context.options.schemaHints,
+      context,
     );
   }
   if (resultType && typeRegistry) {
@@ -2840,10 +2822,10 @@ function handlePatternSchemaInjection(
       ts.isObjectLiteralExpression(unwrappedPatternReturnExpr)
       ? getUiContractHintFromObjectLiteral(
         unwrappedPatternReturnExpr,
-        context.options.schemaHints,
+        context,
       )
       : undefined,
-    context.options.schemaHints,
+    context,
   );
   return visited;
 }

--- a/packages/ts-transformers/src/transformers/schema-injection.ts
+++ b/packages/ts-transformers/src/transformers/schema-injection.ts
@@ -34,6 +34,7 @@ import {
   type CapabilitySummaryRegistry,
   HelpersOnlyTransformer,
   type SchemaHint,
+  type SchemaHints,
   TransformationContext,
   type TypeRegistry,
 } from "../core/mod.ts";
@@ -278,7 +279,7 @@ function applyCapabilitySummaryToArgument(
     baseType = getTypeFromTypeNodeWithFallback(
       baseTypeNode,
       checker,
-      context?.options.typeRegistry,
+      context?.options.state?.typeRegistry,
     );
   }
 
@@ -339,7 +340,7 @@ function applyCapabilitySummaryToParameter(
     baseType = getTypeFromTypeNodeWithFallback(
       baseTypeNode,
       checker,
-      context?.options.typeRegistry,
+      context?.options.state?.typeRegistry,
     );
   }
 
@@ -510,7 +511,7 @@ function collectFunctionSchemaTypeNodes(
   const unwrappedReturnExpr = returnExpr
     ? unwrapExpression(returnExpr)
     : undefined;
-  const uiContractHint = context?.options.schemaHints &&
+  const uiContractHint = context?.options.state?.schemaHints &&
       unwrappedReturnExpr &&
       ts.isObjectLiteralExpression(unwrappedReturnExpr)
     ? propagateUiContractHintsFromObjectLiteral(
@@ -985,7 +986,7 @@ function createSchemaCallWithRegistryTransfer(
   checker: ts.TypeChecker,
   typeRegistry?: TypeRegistry,
   options?: SchemaCallOptions,
-  schemaHints?: TransformationContext["options"]["schemaHints"],
+  schemaHints?: SchemaHints,
 ): ts.CallExpression {
   const emittedTypeNode = normalizeSchemaInjectionTypeNode(
     typeNode,
@@ -1029,7 +1030,7 @@ function applyIdentityArrayItemSchemaHints(
   identityPaths: readonly (readonly string[])[],
   context: TransformationContext,
 ): void {
-  if (!context.options.schemaHints || identityPaths.length === 0) return;
+  if (!context.options.state?.schemaHints || identityPaths.length === 0) return;
 
   const grouped = new Map<string, boolean>();
   for (const path of identityPaths) {
@@ -1882,7 +1883,7 @@ function propagateUiContractHintsFromObjectLiteral(
 ):
   | UiContractHint
   | undefined {
-  if (!context.options.schemaHints || !resultNode) {
+  if (!context.options.state?.schemaHints || !resultNode) {
     return undefined;
   }
 
@@ -2531,7 +2532,7 @@ function handlePatternSchemaInjection(
 ): ts.Node | undefined {
   const { factory, checker, sourceFile, tsContext: transformation } = context;
   const typeArgs = node.typeArguments;
-  const capabilityRegistry = context.options.capabilitySummaryRegistry;
+  const capabilityRegistry = context.options.state?.capabilitySummaryRegistry;
   const argsArray = Array.from(node.arguments);
 
   // Find the function argument
@@ -2833,8 +2834,8 @@ function handlePatternSchemaInjection(
 export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
   transform(context: TransformationContext): ts.SourceFile {
     const { sourceFile, tsContext: transformation, checker } = context;
-    const typeRegistry = context.options.typeRegistry;
-    const capabilityRegistry = context.options.capabilitySummaryRegistry;
+    const typeRegistry = context.options.state?.typeRegistry;
+    const capabilityRegistry = context.options.state?.capabilitySummaryRegistry;
 
     const visit = (node: ts.Node): ts.Node => {
       if (ts.isNewExpression(node)) {

--- a/packages/ts-transformers/src/transformers/type-shrinking.ts
+++ b/packages/ts-transformers/src/transformers/type-shrinking.ts
@@ -1728,7 +1728,7 @@ export function validateShrinkCoverage(
         shrunk,
         checker,
         context.sourceFile,
-        context.options.typeRegistry,
+        context.options.state?.typeRegistry,
       ) ?? ts.factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword);
 
       validateShrinkCoverage(
@@ -1757,13 +1757,13 @@ export function validateShrinkCoverage(
         baseTypeNode,
         checker,
         context.sourceFile,
-        context.options.typeRegistry,
+        context.options.state?.typeRegistry,
       ) ?? ts.factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword);
       const shrunkElementNode = getArrayElementTypeNode(
         shrunk,
         checker,
         context.sourceFile,
-        context.options.typeRegistry,
+        context.options.state?.typeRegistry,
       );
 
       validateShrinkCoverage(
@@ -3023,7 +3023,7 @@ export function applyShrinkAndWrap(
         factory,
         checker,
         baseType,
-        context?.options.typeRegistry,
+        context?.options.state?.typeRegistry,
       )
       : applyCapabilityDefaultsToTypeNode(
         baseTypeNode,
@@ -3061,7 +3061,7 @@ export function applyShrinkAndWrap(
       factory,
       checker,
       baseType,
-      context?.options.typeRegistry,
+      context?.options.state?.typeRegistry,
     )
     : identityPaths.length > 0
     ? applyIdentityOnlyPathsToTypeNode(
@@ -3072,7 +3072,7 @@ export function applyShrinkAndWrap(
       factory,
       checker,
       baseType,
-      context?.options.typeRegistry,
+      context?.options.state?.typeRegistry,
     )
     : baseTypeNode;
   let shrunk: ts.TypeNode | undefined;
@@ -3102,7 +3102,7 @@ export function applyShrinkAndWrap(
         checker,
         sourceFile,
         factory,
-        context?.options.typeRegistry,
+        context?.options.state?.typeRegistry,
         fullShapePaths,
       );
       const nodeDriven = buildShrunkTypeNodeFromTypeNode(
@@ -3110,7 +3110,7 @@ export function applyShrinkAndWrap(
         retainedPaths,
         factory,
         checker,
-        context?.options.typeRegistry,
+        context?.options.state?.typeRegistry,
         fullShapePaths,
       );
       shrunk = choosePreferredShrinkCandidate(
@@ -3131,7 +3131,7 @@ export function applyShrinkAndWrap(
         retainedPaths,
         factory,
         checker,
-        context?.options.typeRegistry,
+        context?.options.state?.typeRegistry,
         fullShapePaths,
       );
       const typeDriven = baseType && identityPaths.length === 0
@@ -3141,7 +3141,7 @@ export function applyShrinkAndWrap(
           checker,
           sourceFile,
           factory,
-          context?.options.typeRegistry,
+          context?.options.state?.typeRegistry,
           fullShapePaths,
         )
         : undefined;
@@ -3168,7 +3168,7 @@ export function applyShrinkAndWrap(
       factory,
       checker,
       baseType,
-      context?.options.typeRegistry,
+      context?.options.state?.typeRegistry,
     );
     shrunk = next;
   }
@@ -3201,7 +3201,7 @@ export function applyShrinkAndWrap(
     factory,
     checker,
     sourceFile,
-    context?.options.typeRegistry,
+    context?.options.state?.typeRegistry,
   );
 
   if (!shouldWrap) {

--- a/packages/ts-transformers/test/cfc-authoring.test.ts
+++ b/packages/ts-transformers/test/cfc-authoring.test.ts
@@ -4,7 +4,7 @@ import { transformCfDirective } from "../src/mod.ts";
 import { transformSource, validateSource } from "./utils.ts";
 import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
 import { CFC_CANONICAL_ALIAS_NAMES } from "../src/cfc-authoring.ts";
-import { SchemaInjectionTransformer } from "../src/mod.ts";
+import { CrossStageState, SchemaInjectionTransformer } from "../src/mod.ts";
 
 function normalizePrintedNode(
   node: ts.Node,
@@ -159,7 +159,7 @@ function transformWithSchemaInjection(source: string): string {
   const program = ts.createProgram(rootFiles, compilerOptions, host);
   const transformer = new SchemaInjectionTransformer({
     mode: "transform",
-    typeRegistry: new WeakMap(),
+    state: new CrossStageState(),
   });
   const sourceFile = program.getSourceFile(fileName);
   if (!sourceFile) {

--- a/packages/ts-transformers/test/cfc-ui-helper.test.ts
+++ b/packages/ts-transformers/test/cfc-ui-helper.test.ts
@@ -2,6 +2,7 @@ import { assert, assertEquals, assertStringIncludes } from "@std/assert";
 import ts from "typescript";
 import {
   CommonFabricTransformerPipeline,
+  CrossStageState,
   transformCfDirective,
 } from "../src/mod.ts";
 import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
@@ -133,10 +134,9 @@ Deno.test(
     `;
 
     const { program, sourceFile } = createProgram(source);
-    const schemaHints = new WeakMap<ts.Node, { cfcUiContract?: unknown }>();
-    const pipeline = new CommonFabricTransformerPipeline({
-      schemaHints: schemaHints as WeakMap<ts.Node, never>,
-    });
+    const state = new CrossStageState();
+    const schemaHints = state.schemaHints;
+    const pipeline = new CommonFabricTransformerPipeline({ state });
 
     const result = ts.transform(sourceFile, pipeline.toFactories(program));
     const transformedFile = result.transformed[0];

--- a/packages/ts-transformers/test/closures/pattern-builder.test.ts
+++ b/packages/ts-transformers/test/closures/pattern-builder.test.ts
@@ -1,7 +1,7 @@
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import ts from "typescript";
 
-import { TransformationContext } from "../../src/core/mod.ts";
+import { CrossStageState, TransformationContext } from "../../src/core/mod.ts";
 import type { CaptureTreeNode } from "../../src/utils/capture-tree.ts";
 import {
   buildCallbackWithTopLevelCaptures,
@@ -45,12 +45,7 @@ function createProgramAndContext(source: string): {
     sourceFile,
     tsContext: { factory: ts.factory } as ts.TransformationContext,
     options: {
-      typeRegistry: new WeakMap(),
-      mapCallbackRegistry: new WeakSet(),
-      syntheticComputeCallbackRegistry: new WeakSet(),
-      syntheticComputeOwnedNodeRegistry: new WeakSet(),
-      schemaHints: new WeakMap(),
-      capabilitySummaryRegistry: new WeakMap(),
+      state: new CrossStageState(),
     },
   });
 

--- a/packages/ts-transformers/test/lift-applied/create-lift-applied-call.test.ts
+++ b/packages/ts-transformers/test/lift-applied/create-lift-applied-call.test.ts
@@ -3,6 +3,7 @@ import ts from "typescript";
 
 import { createLiftAppliedCall } from "../../src/transformers/builtins/lift-applied.ts";
 import { CFHelpers } from "../../src/core/cf-helpers.ts";
+import { CrossStageState } from "../../src/core/mod.ts";
 
 Deno.test("createLiftAppliedCall keeps fallback refs synced when names collide", () => {
   const source = ts.createSourceFile(
@@ -56,7 +57,7 @@ Deno.test("createLiftAppliedCall keeps fallback refs synced when names collide",
       sourceFile: source,
       cfHelpers,
       options: {
-        typeRegistry: new WeakMap(),
+        state: new CrossStageState(),
       },
     } as any;
 

--- a/packages/ts-transformers/test/opaque-ref/compute-wrap-invariants.test.ts
+++ b/packages/ts-transformers/test/opaque-ref/compute-wrap-invariants.test.ts
@@ -2,7 +2,7 @@ import { assertStrictEquals } from "@std/assert";
 import ts from "typescript";
 
 import { createDataFlowAnalyzer } from "../../src/ast/mod.ts";
-import { TransformationContext } from "../../src/core/mod.ts";
+import { CrossStageState, TransformationContext } from "../../src/core/mod.ts";
 import { findPendingComputeWrapCandidate } from "../../src/transformers/expression-rewrite/emitters/compute-wrap-invariants.ts";
 
 function createProgramAndContext(source: string): {
@@ -44,12 +44,7 @@ function createProgramAndContext(source: string): {
     sourceFile,
     tsContext: { factory: ts.factory } as ts.TransformationContext,
     options: {
-      typeRegistry: new WeakMap(),
-      mapCallbackRegistry: new WeakSet(),
-      syntheticComputeCallbackRegistry: new WeakSet(),
-      syntheticComputeOwnedNodeRegistry: new WeakSet(),
-      schemaHints: new WeakMap(),
-      capabilitySummaryRegistry: new WeakMap(),
+      state: new CrossStageState(),
     },
   });
 

--- a/packages/ts-transformers/test/policy/callback-support.test.ts
+++ b/packages/ts-transformers/test/policy/callback-support.test.ts
@@ -1,7 +1,7 @@
 import { assertEquals } from "@std/assert";
 import ts from "typescript";
 
-import { TransformationContext } from "../../src/core/mod.ts";
+import { CrossStageState, TransformationContext } from "../../src/core/mod.ts";
 import { classifyReactiveContext } from "../../src/ast/mod.ts";
 import {
   classifyCallbackBoundary,
@@ -48,12 +48,7 @@ function createProgramAndContext(source: string): {
     sourceFile,
     tsContext: { factory: ts.factory } as ts.TransformationContext,
     options: {
-      typeRegistry: new WeakMap(),
-      mapCallbackRegistry: new WeakSet(),
-      syntheticComputeCallbackRegistry: new WeakSet(),
-      syntheticComputeOwnedNodeRegistry: new WeakSet(),
-      schemaHints: new WeakMap(),
-      capabilitySummaryRegistry: new WeakMap(),
+      state: new CrossStageState(),
     },
   });
 

--- a/packages/ts-transformers/test/policy/expression-site-lowering.test.ts
+++ b/packages/ts-transformers/test/policy/expression-site-lowering.test.ts
@@ -2,7 +2,7 @@ import { assert, assertEquals } from "@std/assert";
 import ts from "typescript";
 
 import { createDataFlowAnalyzer } from "../../src/ast/mod.ts";
-import { TransformationContext } from "../../src/core/mod.ts";
+import { CrossStageState, TransformationContext } from "../../src/core/mod.ts";
 import {
   classifyExpressionSiteHandling,
   classifyRestrictedReactiveComputation,
@@ -50,12 +50,7 @@ function createProgramAndContext(source: string): {
     sourceFile,
     tsContext: { factory: ts.factory } as ts.TransformationContext,
     options: {
-      typeRegistry: new WeakMap(),
-      mapCallbackRegistry: new WeakSet(),
-      syntheticComputeCallbackRegistry: new WeakSet(),
-      syntheticComputeOwnedNodeRegistry: new WeakSet(),
-      schemaHints: new WeakMap(),
-      capabilitySummaryRegistry: new WeakMap(),
+      state: new CrossStageState(),
     },
   });
 

--- a/packages/ts-transformers/test/type-shrinking.test.ts
+++ b/packages/ts-transformers/test/type-shrinking.test.ts
@@ -2,7 +2,7 @@ import { assertEquals, assertStringIncludes } from "@std/assert";
 import ts from "typescript";
 
 import type { CapabilityParamSummary } from "../src/core/mod.ts";
-import { TransformationContext } from "../src/core/mod.ts";
+import { CrossStageState, TransformationContext } from "../src/core/mod.ts";
 import {
   applyShrinkAndWrap,
   printTypeNode,
@@ -847,13 +847,7 @@ function createMinimalContext(
     sourceFile,
     tsContext: { factory: ts.factory } as ts.TransformationContext,
     options: {
-      typeRegistry: new WeakMap(),
-      mapCallbackRegistry: new WeakSet(),
-      syntheticComputeCallbackRegistry: new WeakSet(),
-      syntheticComputeOwnedNodeRegistry: new WeakSet(),
-      schemaHints: new WeakMap(),
-      capabilitySummaryRegistry: new WeakMap(),
-      narrowedWrapperTypeRegistry: new WeakMap(),
+      state: new CrossStageState(),
     },
   });
   return { sourceFile, checker: program.getTypeChecker(), context };


### PR DESCRIPTION
Consolidates the ts-transformers cross-stage registry layer. **Stacked on #3676** (CT-1615 Phase 1) — base is the Phase 1 branch, not `main`, so this diff is just the registry work. Rebase onto main once #3676 lands.

## Why
The pipeline had grown to 9 registries threaded through `TransformationOptions`, with inconsistent access (some `mark*`/`is*` methods, some raw `.get`/`.set`) and `typeRegistry` overloaded with three uses. This cleans that up. Full reasoning + decisions in `docs/scratch/12-registry-unification-design.md`.

## What changed (5 commits, each green + behavior-preserving)

1. **Doc refresh** — fix stale registry count, mark the inert registry.
2. **Document the typeRegistry key-kind invariant** — the planned 3-way split was investigated and **dropped**: the three uses are already isolated by key node-kind (replacement-Expr / TypeNode / CallExpression never coincide for one node), the schema-generator package reads only TypeNode keys, and the one real cross-consumer hazard is already handled by `narrowedWrapperTypeRegistry`. Splitting fixed no reachable bug, so we documented the invariant instead.
3. **Lift `schemaHints` + `capabilitySummaryRegistry` to context record/lookup methods** — collapses repeated set-with-original-mirror / get-with-fallback boilerplate.
4. **Remove `syntheticLiftAppliedCallRegistry`** — verified functionally inert (a downstream array-shrink re-collapses the type it preserved; confirmed by neutering the writer — emitted schemas identical). The gated `applyExplicitArgumentCapabilitySummary` becomes unconditionally `true`.
5. **Consolidate into `CrossStageState`** — one object owns the 8 registries + pure data ops; `TransformationContext` keeps the public methods (delegating, and invalidating caches where it did before). Replaces the 8 `TransformationOptions` fields with one `state`. The schema-generator package boundary stays bare-map (no `CrossStageState` type crosses it).

## Verification
- ts-transformers: **292 passed (624 steps)**, schema-generator: **24 passed (226 steps)** — green after each commit.
- `deno fmt` + `deno lint` clean.

## Known cosmetic follow-up
`state` is optional on `TransformationOptions`, so ~80 reads use `options.state?.X` though `state` is always present in-pipeline. Making it required (dropping the `?.`) is a deliberately-deferred follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies cross-stage registries in `ts-transformers` behind a single `CrossStageState` and standardizes zero-capture computeds to emit `lift(false, fn)()` with matching runtime overloads. Keeps behavior identical aside from the emitted no-input shape (CT-1615).

- **Refactors**
  - Added `CrossStageState` and `TransformationOptions.state`; `TransformationContext` delegates and still handles cache invalidation for marker writes.
  - Promoted `schemaHints`/`capabilitySummaryRegistry` to `context.record*/lookup*` methods with original-node mirroring; callers updated (incl. JSX site router, schema-injection).
  - Removed `syntheticLiftAppliedCallRegistry`; schema-injection now always applies the explicit-argument capability-summary shrink (downstream shrink keeps outputs identical).
  - Documented why splitting `typeRegistry` isn’t needed (uses are isolated by key node-kind); noted at read sites, including the `schema-generator` transformer.
  - Boundary to `schema-generator` stays raw maps; code now reads `state?.typeRegistry`/`state?.schemaHints` and passes those through.

- **Migration**
  - Replace individual registries in options with `state: new CrossStageState()`.
  - If you wrote to hints/summaries, use `context.recordSchemaHint/lookupSchemaHint` and `context.recordCapabilitySummary/lookupCapabilitySummary`.
  - No changes for `schema-generator` consumers; only emitted code for zero-capture computeds changes shape.

<sup>Written for commit 0cc903d38802cf9520e00b0891f19b41870c5079. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3707?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

