### PR TITLE
feat: emit no-input computeds as lift(false, fn)()

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -1935,6 +1935,17 @@ export interface LiftFunction {
     implementation: T,
   ): ModuleFactory<StripCell<Parameters<T>[0]>, StripCell<ReturnType<T>>>;
 
+  // Two-arg form: lift(argumentSchema, fn). Listed before the all-optional
+  // catch-all so `lift(false, fn)` resolves here (fn in slot 2) instead of
+  // matching the catch-all and rejecting fn as a resultSchema. The transformer
+  // emits no-input (computed-origin) lifts as `lift(false, fn)()`:
+  // argumentSchema:false keeps the no-input application valid (the runner's
+  // isValidArgument check passes on `argumentSchema === false`).
+  <T, R>(
+    argumentSchema: JSONSchema,
+    implementation: (input: T) => R,
+  ): ModuleFactory<StripCell<T>, StripCell<R>>;
+
   <T, R>(
     argumentSchema?: JSONSchema,
     resultSchema?: JSONSchema,

--- a/packages/runner/src/builder/module.ts
+++ b/packages/runner/src/builder/module.ts
@@ -286,6 +286,14 @@ export function resolveSourceLocationFromStack(
  *
  * @returns A module node factory that also serializes as module.
  */
+// Two-arg form: lift(argumentSchema, fn). Listed before the three-arg overload
+// so `lift(false, fn)` resolves here (the impl in slot 2) rather than matching
+// the three-arg signature and erroring on a missing resultSchema. Used by the
+// transformer to emit no-input lifts as `lift(false, fn)()`.
+export function lift<T extends JSONSchema = JSONSchema, R = any>(
+  argumentSchema: T,
+  implementation: (input: Schema<T>) => R,
+): ModuleFactory<SchemaWithoutCell<T>, R>;
 export function lift<
   T extends JSONSchema = JSONSchema,
   R extends JSONSchema = JSONSchema,
@@ -305,12 +313,22 @@ export function lift<T extends (...args: any[]) => any>(
 ): ModuleFactory<Parameters<T>[0], ReturnType<T>>;
 export function lift<T, R>(
   argumentSchema?: JSONSchema | ((input: any) => any),
-  resultSchema?: JSONSchema,
+  resultSchema?: JSONSchema | ((input: any) => any),
   implementation?: (input: T) => R,
 ): ModuleFactory<T, R> {
   if (typeof argumentSchema === "function") {
+    // lift(fn)
     implementation = argumentSchema;
     argumentSchema = resultSchema = undefined;
+  } else if (typeof resultSchema === "function") {
+    // lift(argumentSchema, fn) — two-arg form. The middle slot is the
+    // implementation, not a result schema. Used by the transformer to emit
+    // no-input lifts as `lift(false, fn)()`: argumentSchema:false makes the
+    // application valid with no input (see runner's isValidArgument check),
+    // which is how computed-origin (zero-capture) lifts lower without the
+    // legacy `lift(fn)({})` empty-object stopgap.
+    implementation = resultSchema;
+    resultSchema = undefined;
   }
 
   return createNodeFactory({

--- a/packages/ts-transformers/src/transformers/schema-injection.ts
+++ b/packages/ts-transformers/src/transformers/schema-injection.ts
@@ -2184,6 +2184,22 @@ function isIntentionallyUnusedSchemaParameter(
   return true;
 }
 
+/**
+ * True when the outer applied-call args are exactly a single empty object
+ * literal `{}` — the no-capture placeholder LiftLoweringTransformer emits for
+ * computed-origin lifts and which ClosureTransformer leaves untouched when the
+ * computation captures nothing. By schema-injection time this reliably means
+ * "zero input"; captured computeds carry a populated input object here.
+ */
+function isSingleEmptyObjectInput(
+  args: readonly ts.Expression[],
+): boolean {
+  if (args.length !== 1) return false;
+  const arg = args[0];
+  return !!arg && ts.isObjectLiteralExpression(arg) &&
+    arg.properties.length === 0;
+}
+
 function prependSchemaArguments(
   context: Pick<TransformationContext, "factory" | "cfHelpers" | "sourceFile">,
   node: ts.CallExpression,
@@ -2227,6 +2243,26 @@ function prependSchemaArguments(
   // [argSchema, resSchema, ...originalInnerArgs].
   const innerLiftCall = getLiftAppliedInnerCall(node);
   if (innerLiftCall) {
+    // No-input case: a single empty object literal `{}` as the outer input
+    // means a genuinely zero-capture computation (computed-origin). By this
+    // stage ClosureTransformer has already reified any captures into the
+    // input, so an empty input here is final. Emit the canonical no-input
+    // form `lift(false, cb)()`: `false` argument schema (matching computed's
+    // runtime semantics — keeps the no-arg application valid) and no outer
+    // input. We deliberately omit the result schema, again matching computed.
+    if (isSingleEmptyObjectInput(node.arguments)) {
+      const rebuiltInner = context.factory.createCallExpression(
+        innerLiftCall.expression,
+        innerLiftCall.typeArguments,
+        [context.factory.createFalse(), ...innerLiftCall.arguments],
+      );
+      return context.factory.createCallExpression(
+        rebuiltInner,
+        undefined,
+        [],
+      );
+    }
+
     const rebuiltInner = context.factory.createCallExpression(
       innerLiftCall.expression,
       innerLiftCall.typeArguments,

--- a/packages/ts-transformers/test/fixtures/ast-transform/computed-alias-const-rewrite.expected.js
+++ b/packages/ts-transformers/test/fixtures/ast-transform/computed-alias-const-rewrite.expected.js
@@ -14,12 +14,7 @@ const __cfAmdHooks = undefined;
 // FIXTURE: computed-alias-const-rewrite
 // Verifies: stable const aliases to `computed()` still lower to `derive()`.
 const alias = computed;
-export default __cfHelpers.lift({
-    type: "object",
-    properties: {}
-} as const satisfies __cfHelpers.JSONSchema, {
-    type: "number"
-} as const satisfies __cfHelpers.JSONSchema, () => 1)({});
+export default __cfHelpers.lift(false, () => 1)();
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/computed-in-computed-property-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-in-computed-property-access.expected.jsx
@@ -19,26 +19,10 @@ const __cfAmdHooks = undefined;
 //   inside a derive callback need .key() rewriting even though they are not
 //   captured from an outer scope.
 export default pattern(() => {
-    const outer = __cfHelpers.lift({
-        type: "object",
-        properties: {}
-    } as const satisfies __cfHelpers.JSONSchema, {
-        type: "number"
-    } as const satisfies __cfHelpers.JSONSchema, () => {
-        const foo = __cfHelpers.lift({
-            type: "object",
-            properties: {}
-        } as const satisfies __cfHelpers.JSONSchema, {
-            type: "object",
-            properties: {
-                bar: {
-                    type: "number"
-                }
-            },
-            required: ["bar"]
-        } as const satisfies __cfHelpers.JSONSchema, () => ({ bar: 1 }))({}).for("foo", true);
+    const outer = __cfHelpers.lift(false, () => {
+        const foo = __cfHelpers.lift(false, () => ({ bar: 1 }))().for("foo", true);
         return foo.key("bar");
-    })({}).for("outer", true);
+    })().for("outer", true);
     return outer;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"

--- a/packages/ts-transformers/test/fixtures/closures/computed-in-computed-scoped-no-false-rewrite.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-in-computed-scoped-no-false-rewrite.expected.jsx
@@ -20,30 +20,14 @@ const config = __cfHelpers.__cf_data({ bar: "module-level" });
 // Context: The pre-scan collects opaque roots by name; it must not leak
 //   across lexical scopes and incorrectly rewrite unrelated same-named accesses.
 export default pattern(() => {
-    const outer = __cfHelpers.lift({
-        type: "object",
-        properties: {}
-    } as const satisfies __cfHelpers.JSONSchema, {
-        type: ["number", "string"]
-    } as const satisfies __cfHelpers.JSONSchema, () => {
+    const outer = __cfHelpers.lift(false, () => {
         const condition = 1 > 0;
         if (condition) {
-            const config = __cfHelpers.lift({
-                type: "object",
-                properties: {}
-            } as const satisfies __cfHelpers.JSONSchema, {
-                type: "object",
-                properties: {
-                    bar: {
-                        type: "number"
-                    }
-                },
-                required: ["bar"]
-            } as const satisfies __cfHelpers.JSONSchema, () => ({ bar: 1 }))({}).for("config", true);
+            const config = __cfHelpers.lift(false, () => ({ bar: 1 }))().for("config", true);
             return config.key("bar");
         }
         return config.bar;
-    })({}).for("outer", true);
+    })().for("outer", true);
     return outer;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "string"]

--- a/packages/ts-transformers/test/fixtures/closures/computed-no-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-no-captures.expected.jsx
@@ -17,12 +17,7 @@ const __cfAmdHooks = undefined;
 // Context: The capture schema has no properties and the captures object is empty {}.
 //   The callback parameter list is also empty (no destructuring needed).
 export default pattern(() => {
-    const result = __cfHelpers.lift({
-        type: "object",
-        properties: {}
-    } as const satisfies __cfHelpers.JSONSchema, {
-        type: "number"
-    } as const satisfies __cfHelpers.JSONSchema, () => 42)({}).for("result", true);
+    const result = __cfHelpers.lift(false, () => 42)().for("result", true);
     return result;
 }, false as const satisfies __cfHelpers.JSONSchema, {
     type: "number"

--- a/packages/ts-transformers/test/fixtures/closures/computed-nullable-optional-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-nullable-optional-chain.expected.jsx
@@ -26,36 +26,10 @@ type Question = {
 //   with asOpaque: true for the topQuestion capture.
 export default pattern((_) => {
     // This computed can return null - simulates finding a question from a list
-    const topQuestion = __cfHelpers.lift({
-        type: "object",
-        properties: {}
-    } as const satisfies __cfHelpers.JSONSchema, {
-        anyOf: [{
-                $ref: "#/$defs/Question"
-            }, {
-                type: "null"
-            }],
-        $defs: {
-            Question: {
-                type: "object",
-                properties: {
-                    question: {
-                        type: "string"
-                    },
-                    category: {
-                        type: "string"
-                    },
-                    priority: {
-                        type: "number"
-                    }
-                },
-                required: ["question", "category", "priority"]
-            }
-        }
-    } as const satisfies __cfHelpers.JSONSchema, (): Question | null => {
+    const topQuestion = __cfHelpers.lift(false, (): Question | null => {
         // In real code this would filter and return first match, or null
         return null;
-    })({}).for("topQuestion", true);
+    })().for("topQuestion", true);
     return {
         [NAME]: "Computed Nullable Optional Chain",
         [UI]: (<div>

--- a/packages/ts-transformers/test/fixtures/closures/map-regains-reactive-aliases.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-regains-reactive-aliases.expected.jsx
@@ -177,15 +177,7 @@ export default pattern((state) => {
             type: "string"
         }
     } as const satisfies __cfHelpers.JSONSchema, __cfModuleCallback_1)({ inner: inner }).for("fromLift", true);
-    const fromWish = __cfHelpers.lift({
-        type: "object",
-        properties: {}
-    } as const satisfies __cfHelpers.JSONSchema, {
-        type: "array",
-        items: {
-            type: "string"
-        }
-    } as const satisfies __cfHelpers.JSONSchema, __cfModuleCallback_2)({}).for("fromWish", true);
+    const fromWish = __cfHelpers.lift(false, __cfModuleCallback_2)().for("fromWish", true);
     const fromFiltered = __cfHelpers.lift<{
         inner: string[];
     }, string[]>({


### PR DESCRIPTION
Replaces the `lift(fn)({})` empty-object stopgap for computed-origin (zero-capture) lifts with the canonical no-input form `lift(false, fn)()`, matching `computed`'s runtime semantics (`argumentSchema: false`, no input). Independent of #3707.

## Why
CT-1615 Phase 1 lowered `computed(() => expr)` to `lift(fn)({})` — the `{}` was a stopgap to keep the no-input application valid. This switches to the intended canonical form.

## Runtime (packages/runner, packages/api)
- Add a 2-arg `lift(argumentSchema, implementation)` overload (module.ts + the `LiftFunction` interface), so `lift(false, fn)` type-checks. Listed before the all-optional catch-all so it resolves correctly; body dispatches via `typeof resultSchema === "function"`.
- `lift(false, fn)()` is required over a bare `lift(fn)()`: the runner's `isValidArgument = argumentSchema === false || argument !== undefined` would **skip** a no-arg lift with no argumentSchema (verified empirically). The `false` makes the no-input application valid.
- **Not** a blanket default: an earlier attempt to default `argumentSchema: false` for all no-schema lifts broke skip-on-undefined error propagation through derive-origin lift chains (caught by `computed throws error`). Only the genuinely-zero-input form gets `false`.

## Transformer (packages/ts-transformers)
- Gate the rewrite in `prependSchemaArguments` (schema-injection) — the convergence point for both lift-applied schema-injection branches. When the outer applied-call input is a single empty object literal `{}`, emit `lift(false, cb)()`.
- **Crucially this runs after ClosureTransformer**, where the input is final: `{}` is a capture placeholder that ClosureTransformer populates for captured computeds, so empty-input here reliably means zero captures. Captured computeds (`lift(({count})=>...)({count})`) are untouched. (Gating earlier in `lowerComputedCall` wrongly clobbered captures — this placement avoids that.)

## Verification
- 6 fixtures change — all genuinely zero-capture computeds; captured computeds unchanged.
- ts-transformers 293/624 green; runner CI-scope suite no net-new failures.

## Not included (separate follow-up)
Removing the runtime `derive` export was the other half of the original bundle, but `derive` is **not** dead — the transformer still lowers user-source `derive()`, and runner tests call it directly. That removal needs its own usage analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit zero-capture computeds as `lift(false, fn)()` instead of `lift(fn)({})` to match runtime semantics and allow valid no-input calls. Aligns with CT-1615 by removing the empty-object placeholder.

- **Refactors**
  - Runtime (`packages/api`, `packages/runner`): add a two-arg `lift(argumentSchema, implementation)` overload; ordered before the catch-all so `lift(false, fn)` resolves; `false` keeps no-input calls valid; no global default defaulting to `false`.
  - Transformer (`packages/ts-transformers`): in schema-injection (after ClosureTransformer), rewrite a single empty-object input to `lift(false, cb)()`; captured computeds are unchanged.
  - Tests: update 6 fixtures for zero-capture cases.

<sup>Written for commit d638cec56fb579c6d80bcf6ae4943db2a3ac728e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3709?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



---BEGIN COPY-PASTE---
NEW_PERF_BASELINE: subtest: pattern-unit-3/pattern-unit-tests > packages/patterns/google/core/gmail-importer.test.tsx = 16s
---END COPY-PASTE---