### PR TITLE
perf(runner): identity-pass already-frozen values through v2 set-op + path-write materialization

### DIFF
--- a/packages/runner/src/storage/v2-path.ts
+++ b/packages/runner/src/storage/v2-path.ts
@@ -132,9 +132,7 @@ export const cloneWithValueAtPath = (
   value: FabricValue | undefined,
 ): EntityDocument | undefined => {
   if (path.length === 0) {
-    return deepFreeze(
-      cloneIfNecessary(value as FabricValue, { frozen: false }),
-    ) as EntityDocument;
+    return cloneIfNecessary(value as FabricValue) as EntityDocument;
   }
 
   const baseRoot = (root ?? {}) as Record<string, unknown>;
@@ -159,7 +157,7 @@ export const cloneWithValueAtPath = (
   }
 
   const last = path[path.length - 1]!;
-  const nextValue = cloneIfNecessary(value as FabricValue, { frozen: false });
+  const nextValue = cloneIfNecessary(value as FabricValue);
   setPathSegmentValue(currentClone, last, nextValue);
   return deepFreeze(nextRoot) as EntityDocument;
 };

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -1,4 +1,3 @@
-import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
 import { cloneIfNecessary } from "@commonfabric/data-model/fabric-value";
 import {
   type ConflictError as IConflictError,
@@ -272,9 +271,7 @@ const applyPendingVersion = (
     case "delete":
       return undefined;
     case "set":
-      return deepFreeze(
-        cloneIfNecessary(pending.value as FabricValue, { frozen: false }),
-      ) as EntityDocument;
+      return cloneIfNecessary(pending.value as FabricValue) as EntityDocument;
     case "patch": {
       let next = base;
       for (


### PR DESCRIPTION
## Summary

- Eliminate three sites of the `deepFreeze(cloneIfNecessary(v, { frozen: false }))` shape on the v2 storage materialization hot path. Under the modern data model the input is typically already deep-frozen, so default `cloneIfNecessary(v)` (`{ frozen: true }`) identity-passes via `isDeepFrozenFabricValue` and saves the deep-thaw + refreeze.
- One site in `storage/v2.ts` (`applyPendingVersion("set")` arm) and two in `storage/v2-path.ts` (both branches of `cloneWithValueAtPath`).

This is the optimization Comment 2 of #3588 deferred pending F1 (`isDeepFrozenFabricValue` handling `FabricInstance` subclasses without throwing). F1 has since landed — `isDeepFrozenFabricValue` now delegates to the `[IS_DEEP_FROZEN]` protocol on `FabricInstance` — so the deferred optimization is unblocked.

## Measurements

Paired interleaved A/B on `runner/test/cell-set.bench.ts` (and the cell-set-array-shape / cell-set-nested-array-docs benches for the v2-path commit), 2 rounds per side, M5 Pro:

| Stage | Geomean HEAD/BASE | Top wins |
|---|---|---|
| Commit 1 (v2.ts) vs main | **0.9795** (~2.1% faster) | ~200 writes 10.5%, schemaless 14-field 9.0%, single-tx many sets 7.2%, schema w/ asCell 7.1%, Cell.update() partial 5.5% |
| Commit 2 (v2-path.ts) on top of commit 1 | **0.9734** (~2.7% faster) | single-tx many sets 14.2%, ~500 writes 12.8%, Cell.update() set() partial 10.4%, single field 8.8%, nested field 7.7% |
| **Compounded vs main** | **~0.9534 (~4.7% faster)** | path-write shapes win biggest |

- 0 benches >5% slower in either within-batch comparison except one outlier: "length path write (100↔50 items)" −6.2% in the commit-2 comparison, within ~2× the within-pair spread (BASE 3.8% median) — likely a single-slot wobble (it was +4.5% on the same bench in the commit-1 comparison).

Expect the CI perf-check job to also show some delta, though the modest within-noise pattern-unit cost was the obstacle parking #3569 — this PR moves in the correct direction for that gate.

## Test plan

- [x] `deno task test` in `packages/runner` — 469 passed / 2526 steps / 0 failed
- [x] `deno fmt --check` and `deno check` on touched files
- [x] Existing deep-frozen invariant tests (`memory-v2-path-helpers.test.ts` added by #3588, `frozen-proxy-target.test.ts`, `frozen-mutation.test.ts`) pass — the materialized document remains deep-frozen because `cloneIfNecessary(v)` with default `frozen: true` either identity-returns an already-deep-frozen input or clone-and-freezes a not-yet-frozen one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Identity-pass already deep-frozen values during v2 set-op and path-write materialization to remove unnecessary thaw/refreeze. Updates `applyPendingVersion("set")` and both branches of `cloneWithValueAtPath`, yielding ~4.7% geomean speedup in local benches while preserving deep-freeze invariants.

<sup>Written for commit 72733e862e59ea93febee3bd2a90a0b6037af9ea. Summary will update on new commits. <a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3710?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



## Perf-check job (CI)

The CI Performance Check passed cleanly ("All metrics within normal range." — no OVERs, only two near-CLOSE entries on noisy pattern-unit aggregates). The wins concentrate exactly where the change applies — runner / runtime-client / storage paths:

**Steps that got faster (% vs baseline):**
- runner tests step: **−17.3%**
- runtime-client integration step: **−15.4%**
- background worker integration step: **−7.1%**
- workspace tests step: **−5.3%**

**Jobs that got faster:**
- Generated Patterns Integration Tests (4/4): **−16.3%**
- Pattern Integration Tests (3/4): **−11.9%**
- Runner Tests overall: **−11.3%** (Runner Tests (1/4) **−11.3%**, (4/4) **−3.3%**)
- Generated Patterns Integration Tests (3/4): **−7.8%**
- Generated Patterns Integration Tests overall: **−5.1%**
- Package Integration Tests (shell): **−5.2%**
- Test job: **−6.4%**

A few jobs went the other way (Package Integration Tests background-charm-service +13.5%, runner +12.7%, Pattern Integration Tests (4/4) +11.0%, pattern-unit-3 CLOSE at +11.9%). All within OK/CLOSE — no OVERs. Per the project's noise-floor memory, pattern-unit / integration aggregates routinely swing tens of percent between adjacent runs of the same PR, so the regressions are plausibly noise on the same scale as the wins. The asymmetry — biggest wins are on the runner-touching steps, biggest regressions are mostly on patterns/integration breadth — is consistent with the change being a real win on the hot path and noise dominating elsewhere.
