### PR TITLE
[codex] Add cf-harness SQLite chat session store

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -1885,6 +1885,11 @@
       "npm:zod@^3.24.1"
     ],
     "members": {
+      "packages/cf-harness": {
+        "dependencies": [
+          "jsr:@db/sqlite@0.12"
+        ]
+      },
       "packages/cli": {
         "dependencies": [
           "jsr:@cliffy/table@^1.0.0-rc.8"

--- a/packages/cf-harness/deno.json
+++ b/packages/cf-harness/deno.json
@@ -3,7 +3,7 @@
   "tasks": {
     "run": "deno run -A src/main.ts",
     "help": "deno run -A src/main.ts --help",
-    "test": "ENV=test deno test --allow-read --allow-write --allow-run test",
+    "test": "ENV=test deno test --allow-read --allow-write --allow-run --allow-ffi --allow-net --allow-env test",
     "test:integration": "CF_HARNESS_INTEGRATION=1 deno test -A integration"
   },
   "exports": {
@@ -13,6 +13,8 @@
     "./prompt-loop": "./src/prompt-loop.ts",
     "./interactive-chat-service": "./src/interactive-chat-service.ts",
     "./interactive-chat-stdio": "./src/interactive-chat-stdio.ts",
+    "./session-store": "./src/session-store.ts",
+    "./sqlite-session-store": "./src/sqlite-session-store.ts",
     "./subagent-return": "./src/subagent-return.ts",
     "./artifacts": "./src/artifacts.ts",
     "./cli": "./src/cli.ts",
@@ -36,5 +38,8 @@
     "./tools/read-skill-resource": "./src/tools/read-skill-resource.ts",
     "./tools/web-fetch": "./src/tools/web-fetch.ts",
     "./skills/registry": "./src/skills/registry.ts"
+  },
+  "imports": {
+    "@db/sqlite": "jsr:@db/sqlite@^0.12.0"
   }
 }

--- a/packages/cf-harness/src/contracts/interactive-chat.ts
+++ b/packages/cf-harness/src/contracts/interactive-chat.ts
@@ -27,7 +27,8 @@ export type HarnessChatRequestMethod =
   | "start_turn"
   | "cancel_turn"
   | "close_session"
-  | "status";
+  | "status"
+  | "list_events";
 
 export type HarnessChatSessionLifecycle =
   | "idle"
@@ -197,12 +198,19 @@ export interface HarnessChatStatusParams {
   sessionId?: string;
 }
 
+export interface HarnessChatListEventsParams {
+  sessionId?: string;
+  afterSequence?: number;
+  limit?: number;
+}
+
 export type HarnessChatRequestParamsByMethod = {
   start_session: HarnessChatStartSessionParams;
   start_turn: HarnessChatStartTurnParams;
   cancel_turn: HarnessChatCancelTurnParams;
   close_session: HarnessChatCloseSessionParams;
   status: HarnessChatStatusParams;
+  list_events: HarnessChatListEventsParams;
 };
 
 export type HarnessChatRequestEnvelope<
@@ -404,6 +412,11 @@ export interface HarnessChatEventEnvelope<
   sequence: number;
   emittedAt: string;
   event: Event;
+}
+
+export interface HarnessChatListEventsResult {
+  events: readonly HarnessChatEventEnvelope[];
+  latestSequence: number;
 }
 
 export interface CreateHarnessChatSessionStatusOptions {

--- a/packages/cf-harness/src/index.ts
+++ b/packages/cf-harness/src/index.ts
@@ -4,6 +4,7 @@ export * from "./engine.ts";
 export * from "./prompt-loop.ts";
 export * from "./interactive-chat-service.ts";
 export * from "./interactive-chat-stdio.ts";
+export * from "./session-store.ts";
 export * from "./structured-result.ts";
 export * from "./subagent-return.ts";
 export * from "./artifacts.ts";

--- a/packages/cf-harness/src/interactive-chat-service.ts
+++ b/packages/cf-harness/src/interactive-chat-service.ts
@@ -11,6 +11,8 @@ import {
   type HarnessChatBrowserAccessLease,
   type HarnessChatErrorResponse,
   type HarnessChatEventEnvelope,
+  type HarnessChatListEventsParams,
+  type HarnessChatListEventsResult,
   type HarnessChatPolicy,
   type HarnessChatRequestEnvelope,
   type HarnessChatResponse,
@@ -29,6 +31,7 @@ import type {
   HarnessToolTranscriptMessage,
   HarnessTranscriptMessage,
 } from "./contracts/transcript.ts";
+import type { HarnessChatSessionStore } from "./session-store.ts";
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value);
@@ -52,6 +55,7 @@ export interface CreateHarnessInteractiveChatServiceOptions {
   now?: () => string;
   randomUUID?: () => string;
   onEvent?: HarnessInteractiveChatEventListener;
+  sessionStore?: HarnessChatSessionStore;
 }
 
 interface HarnessInteractiveChatSessionRecord {
@@ -228,6 +232,7 @@ export class HarnessInteractiveChatService {
   readonly #now: () => string;
   readonly #randomUUID: () => string;
   readonly #onEvent?: HarnessInteractiveChatEventListener;
+  readonly #sessionStore?: HarnessChatSessionStore;
   readonly #sessions = new Map<string, HarnessInteractiveChatSessionRecord>();
   readonly #events: HarnessChatEventEnvelope[] = [];
   #sequence = 0;
@@ -239,12 +244,56 @@ export class HarnessInteractiveChatService {
     this.#now = options.now ?? (() => new Date().toISOString());
     this.#randomUUID = options.randomUUID ?? defaultRandomUUID;
     this.#onEvent = options.onEvent;
+    this.#sessionStore = options.sessionStore;
   }
 
-  events(sessionId?: string): readonly HarnessChatEventEnvelope[] {
-    return sessionId === undefined
-      ? [...this.#events]
-      : this.#events.filter((event) => event.sessionId === sessionId);
+  async initializeFromStore(): Promise<void> {
+    if (this.#sessionStore === undefined) {
+      return;
+    }
+    this.#sessions.clear();
+    for (const snapshot of await this.#sessionStore.listSessions()) {
+      this.#sessions.set(snapshot.session.sessionId, {
+        status: snapshot.session,
+        transcript: [...snapshot.transcript],
+        canceledTurnIds: new Set(),
+      });
+    }
+    this.#events.splice(
+      0,
+      this.#events.length,
+      ...await this.#sessionStore.listEvents(),
+    );
+    this.#sequence = Math.max(
+      await this.#sessionStore.latestSequence(),
+      ...this.#events.map((event) => event.sequence),
+    );
+  }
+
+  events(
+    sessionId?: string,
+    options: Omit<HarnessChatListEventsParams, "sessionId"> = {},
+  ): readonly HarnessChatEventEnvelope[] {
+    const afterSequence = options.afterSequence ?? 0;
+    const filtered = this.#events.filter((event) =>
+      (sessionId === undefined || event.sessionId === sessionId) &&
+      event.sequence > afterSequence
+    );
+    return options.limit === undefined
+      ? [...filtered]
+      : filtered.slice(0, options.limit);
+  }
+
+  listEvents(
+    params: HarnessChatListEventsParams = {},
+  ): HarnessChatListEventsResult {
+    return {
+      events: this.events(params.sessionId, {
+        afterSequence: params.afterSequence,
+        limit: params.limit,
+      }),
+      latestSequence: this.#sequence,
+    };
   }
 
   status(sessionId?: string): HarnessChatStatusResult {
@@ -312,6 +361,11 @@ export class HarnessInteractiveChatService {
           request.requestId,
           this.status(request.params.sessionId),
         );
+      case "list_events":
+        return createHarnessChatOkResponse(
+          request.requestId,
+          this.listEvents(request.params),
+        );
       default:
         return createHarnessChatErrorResponse(requestId, {
           code: "invalid_request",
@@ -326,6 +380,9 @@ export class HarnessInteractiveChatService {
   ): Promise<HarnessChatResponse<HarnessChatSessionStatus>> {
     const sessionId = params.sessionId ?? this.#randomUUID();
     if (this.#sessions.has(sessionId)) {
+      return sessionExistsError(requestId, sessionId);
+    }
+    if (await this.#sessionStore?.getSession(sessionId) !== undefined) {
       return sessionExistsError(requestId, sessionId);
     }
     const session = createHarnessChatSessionStatus({
@@ -538,6 +595,7 @@ export class HarnessInteractiveChatService {
             return;
           }
           observedTranscriptLength = event.transcript.length;
+          record.transcript = [...event.transcript];
           await this.#emitTranscriptEvent(session.sessionId, turnId, event);
         },
       });
@@ -676,7 +734,12 @@ export class HarnessInteractiveChatService {
     const record = this.#sessions.get(sessionId);
     if (record !== undefined) {
       record.status = reduceHarnessChatSessionStatus(record.status, envelope);
+      await this.#sessionStore?.saveSession({
+        session: record.status,
+        transcript: record.transcript,
+      });
     }
+    await this.#sessionStore?.appendEvent(envelope);
     await this.#onEvent?.(envelope);
   }
 }

--- a/packages/cf-harness/src/interactive-chat-service.ts
+++ b/packages/cf-harness/src/interactive-chat-service.ts
@@ -235,6 +235,7 @@ export class HarnessInteractiveChatService {
   readonly #sessionStore?: HarnessChatSessionStore;
   readonly #sessions = new Map<string, HarnessInteractiveChatSessionRecord>();
   readonly #events: HarnessChatEventEnvelope[] = [];
+  #emitQueue: Promise<void> = Promise.resolve();
   #sequence = 0;
 
   constructor(options: CreateHarnessInteractiveChatServiceOptions = {}) {
@@ -727,6 +728,18 @@ export class HarnessInteractiveChatService {
   }
 
   async #emit(
+    sessionId: string,
+    turnId: string | undefined,
+    event: HarnessChatStructuredEvent,
+  ): Promise<void> {
+    const emitTask = this.#emitQueue.then(() =>
+      this.#emitImmediately(sessionId, turnId, event)
+    );
+    this.#emitQueue = emitTask.catch(() => undefined);
+    return await emitTask;
+  }
+
+  async #emitImmediately(
     sessionId: string,
     turnId: string | undefined,
     event: HarnessChatStructuredEvent,

--- a/packages/cf-harness/src/interactive-chat-service.ts
+++ b/packages/cf-harness/src/interactive-chat-service.ts
@@ -385,6 +385,9 @@ export class HarnessInteractiveChatService {
     if (await this.#sessionStore?.getSession(sessionId) !== undefined) {
       return sessionExistsError(requestId, sessionId);
     }
+    if (this.#sessions.has(sessionId)) {
+      return sessionExistsError(requestId, sessionId);
+    }
     const session = createHarnessChatSessionStatus({
       sessionId,
       createdAt: this.#now(),
@@ -402,10 +405,15 @@ export class HarnessInteractiveChatService {
       transcript: [],
       canceledTurnIds: new Set(),
     });
-    await this.#emit(session.sessionId, undefined, {
-      kind: "session_started",
-      session,
-    });
+    try {
+      await this.#emit(session.sessionId, undefined, {
+        kind: "session_started",
+        session,
+      });
+    } catch (error) {
+      this.#sessions.delete(session.sessionId);
+      throw error;
+    }
     return createHarnessChatOkResponse(requestId, session);
   }
 
@@ -723,23 +731,31 @@ export class HarnessInteractiveChatService {
     turnId: string | undefined,
     event: HarnessChatStructuredEvent,
   ): Promise<void> {
+    const sequence = this.#sequence + 1;
     const envelope = createHarnessChatEventEnvelope({
       sessionId,
       ...(turnId !== undefined ? { turnId } : {}),
-      sequence: ++this.#sequence,
+      sequence,
       emittedAt: this.#now(),
       event,
     });
-    this.#events.push(envelope);
     const record = this.#sessions.get(sessionId);
-    if (record !== undefined) {
-      record.status = reduceHarnessChatSessionStatus(record.status, envelope);
-      await this.#sessionStore?.saveSession({
-        session: record.status,
+    const nextStatus = record === undefined
+      ? undefined
+      : reduceHarnessChatSessionStatus(record.status, envelope);
+    if (record !== undefined && nextStatus !== undefined) {
+      await this.#sessionStore?.saveSessionAndAppendEvent({
+        session: nextStatus,
         transcript: record.transcript,
-      });
+      }, envelope);
+    } else {
+      await this.#sessionStore?.appendEvent(envelope);
     }
-    await this.#sessionStore?.appendEvent(envelope);
+    this.#sequence = sequence;
+    this.#events.push(envelope);
+    if (record !== undefined && nextStatus !== undefined) {
+      record.status = nextStatus;
+    }
     await this.#onEvent?.(envelope);
   }
 }

--- a/packages/cf-harness/src/interactive-chat-stdio.ts
+++ b/packages/cf-harness/src/interactive-chat-stdio.ts
@@ -47,6 +47,7 @@ const SUPPORTED_REQUEST_METHODS = new Set<HarnessChatRequestMethod>([
   "cancel_turn",
   "close_session",
   "status",
+  "list_events",
 ]);
 const SUPPORTED_POLICY_TOOL_MODES = new Set(["workspace-write", "read-only"]);
 const SUPPORTED_POLICY_TOOL_IDS = new Set<BuiltinToolId>([
@@ -77,6 +78,20 @@ const hasOptionalString = (
   value: Record<string, unknown>,
   key: string,
 ): boolean => value[key] === undefined || typeof value[key] === "string";
+
+const hasOptionalNonNegativeInteger = (
+  value: Record<string, unknown>,
+  key: string,
+): boolean =>
+  value[key] === undefined ||
+  (Number.isInteger(value[key]) && Number(value[key]) >= 0);
+
+const hasOptionalPositiveInteger = (
+  value: Record<string, unknown>,
+  key: string,
+): boolean =>
+  value[key] === undefined ||
+  (Number.isInteger(value[key]) && Number(value[key]) > 0);
 
 const isNonEmptyString = (value: unknown): value is string =>
   typeof value === "string" && value.trim() !== "";
@@ -169,6 +184,10 @@ const isValidRequestParams = (
         hasOptionalString(params, "reason");
     case "status":
       return hasOptionalString(params, "sessionId");
+    case "list_events":
+      return hasOptionalString(params, "sessionId") &&
+        hasOptionalNonNegativeInteger(params, "afterSequence") &&
+        hasOptionalPositiveInteger(params, "limit");
   }
 };
 

--- a/packages/cf-harness/src/session-store.ts
+++ b/packages/cf-harness/src/session-store.ts
@@ -1,0 +1,32 @@
+import type {
+  HarnessChatEventEnvelope,
+  HarnessChatSessionStatus,
+} from "./contracts/interactive-chat.ts";
+import type { HarnessTranscriptMessage } from "./contracts/transcript.ts";
+
+export interface HarnessChatSessionSnapshot {
+  session: HarnessChatSessionStatus;
+  transcript: readonly HarnessTranscriptMessage[];
+}
+
+export interface HarnessChatEventListOptions {
+  sessionId?: string;
+  afterSequence?: number;
+  limit?: number;
+}
+
+export type HarnessMaybePromise<Value> = Value | Promise<Value>;
+
+export interface HarnessChatSessionStore {
+  saveSession(snapshot: HarnessChatSessionSnapshot): HarnessMaybePromise<void>;
+  getSession(
+    sessionId: string,
+  ): HarnessMaybePromise<HarnessChatSessionSnapshot | undefined>;
+  listSessions(): HarnessMaybePromise<readonly HarnessChatSessionSnapshot[]>;
+  appendEvent(event: HarnessChatEventEnvelope): HarnessMaybePromise<void>;
+  listEvents(
+    options?: HarnessChatEventListOptions,
+  ): HarnessMaybePromise<readonly HarnessChatEventEnvelope[]>;
+  latestSequence(): HarnessMaybePromise<number>;
+  close?(): HarnessMaybePromise<void>;
+}

--- a/packages/cf-harness/src/session-store.ts
+++ b/packages/cf-harness/src/session-store.ts
@@ -23,6 +23,10 @@ export interface HarnessChatSessionStore {
     sessionId: string,
   ): HarnessMaybePromise<HarnessChatSessionSnapshot | undefined>;
   listSessions(): HarnessMaybePromise<readonly HarnessChatSessionSnapshot[]>;
+  saveSessionAndAppendEvent(
+    snapshot: HarnessChatSessionSnapshot,
+    event: HarnessChatEventEnvelope,
+  ): HarnessMaybePromise<void>;
   appendEvent(event: HarnessChatEventEnvelope): HarnessMaybePromise<void>;
   listEvents(
     options?: HarnessChatEventListOptions,

--- a/packages/cf-harness/src/sqlite-session-store.ts
+++ b/packages/cf-harness/src/sqlite-session-store.ts
@@ -1,0 +1,231 @@
+import { Database } from "@db/sqlite";
+import {
+  type HarnessChatEventEnvelope,
+  type HarnessChatSessionStatus,
+} from "./contracts/interactive-chat.ts";
+import type { HarnessTranscriptMessage } from "./contracts/transcript.ts";
+import type {
+  HarnessChatEventListOptions,
+  HarnessChatSessionSnapshot,
+  HarnessChatSessionStore,
+} from "./session-store.ts";
+
+const PRAGMAS = `
+  PRAGMA journal_mode = WAL;
+  PRAGMA synchronous = NORMAL;
+  PRAGMA busy_timeout = 5000;
+  PRAGMA foreign_keys = ON;
+`;
+
+const INIT = `
+BEGIN TRANSACTION;
+
+CREATE TABLE IF NOT EXISTS chat_session (
+  session_id  TEXT NOT NULL PRIMARY KEY,
+  status      TEXT NOT NULL,
+  transcript  TEXT NOT NULL,
+  created_at  TEXT NOT NULL,
+  updated_at  TEXT NOT NULL,
+  closed_at   TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_chat_session_updated_at
+  ON chat_session (updated_at);
+
+CREATE TABLE IF NOT EXISTS chat_event (
+  sequence    INTEGER NOT NULL PRIMARY KEY,
+  session_id  TEXT NOT NULL,
+  turn_id     TEXT,
+  kind        TEXT NOT NULL,
+  emitted_at  TEXT NOT NULL,
+  event       TEXT NOT NULL,
+  FOREIGN KEY (session_id) REFERENCES chat_session(session_id)
+);
+CREATE INDEX IF NOT EXISTS idx_chat_event_session_sequence
+  ON chat_event (session_id, sequence);
+CREATE INDEX IF NOT EXISTS idx_chat_event_emitted_at
+  ON chat_event (emitted_at);
+
+COMMIT;
+`;
+
+type SessionRow = {
+  status: string;
+  transcript: string;
+};
+
+type EventRow = {
+  event: string;
+};
+
+export interface OpenSqliteHarnessChatSessionStoreOptions {
+  url: URL;
+}
+
+const databaseAddress = (url: URL): URL | string =>
+  url.protocol === "file:" ? url : ":memory:";
+
+const parseJsonColumn = <Value>(
+  value: string,
+  column: string,
+): Value => {
+  try {
+    return JSON.parse(value) as Value;
+  } catch (error) {
+    throw new Error(
+      `failed to parse ${column}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+};
+
+export class SqliteHarnessChatSessionStore implements HarnessChatSessionStore {
+  readonly database: Database;
+
+  constructor(database: Database) {
+    this.database = database;
+  }
+
+  saveSession(snapshot: HarnessChatSessionSnapshot): void {
+    this.database.prepare(`
+      INSERT INTO chat_session (
+        session_id,
+        status,
+        transcript,
+        created_at,
+        updated_at,
+        closed_at
+      )
+      VALUES (
+        :session_id,
+        :status,
+        :transcript,
+        :created_at,
+        :updated_at,
+        :closed_at
+      )
+      ON CONFLICT(session_id) DO UPDATE SET
+        status = :status,
+        transcript = :transcript,
+        updated_at = :updated_at,
+        closed_at = :closed_at
+    `).run({
+      session_id: snapshot.session.sessionId,
+      status: JSON.stringify(snapshot.session),
+      transcript: JSON.stringify(snapshot.transcript),
+      created_at: snapshot.session.createdAt,
+      updated_at: snapshot.session.updatedAt,
+      closed_at: snapshot.session.closedAt ?? null,
+    });
+  }
+
+  getSession(
+    sessionId: string,
+  ): HarnessChatSessionSnapshot | undefined {
+    const row = this.database.prepare(`
+      SELECT status, transcript
+      FROM chat_session
+      WHERE session_id = :session_id
+    `).get({ session_id: sessionId }) as SessionRow | undefined;
+    return row === undefined ? undefined : decodeSessionRow(row);
+  }
+
+  listSessions(): readonly HarnessChatSessionSnapshot[] {
+    return (this.database.prepare(`
+      SELECT status, transcript
+      FROM chat_session
+      ORDER BY created_at ASC, session_id ASC
+    `).all() as SessionRow[]).map(decodeSessionRow);
+  }
+
+  appendEvent(event: HarnessChatEventEnvelope): void {
+    this.database.prepare(`
+      INSERT INTO chat_event (
+        sequence,
+        session_id,
+        turn_id,
+        kind,
+        emitted_at,
+        event
+      )
+      VALUES (
+        :sequence,
+        :session_id,
+        :turn_id,
+        :kind,
+        :emitted_at,
+        :event
+      )
+    `).run({
+      sequence: event.sequence,
+      session_id: event.sessionId,
+      turn_id: event.turnId ?? null,
+      kind: event.event.kind,
+      emitted_at: event.emittedAt,
+      event: JSON.stringify(event),
+    });
+  }
+
+  listEvents(
+    options: HarnessChatEventListOptions = {},
+  ): readonly HarnessChatEventEnvelope[] {
+    const clauses: string[] = [];
+    const params: Record<string, number | string> = {};
+    if (options.sessionId !== undefined) {
+      clauses.push("session_id = :session_id");
+      params.session_id = options.sessionId;
+    }
+    if (options.afterSequence !== undefined) {
+      clauses.push("sequence > :after_sequence");
+      params.after_sequence = options.afterSequence;
+    }
+    const where = clauses.length === 0 ? "" : `WHERE ${clauses.join(" AND ")}`;
+    const limit = options.limit === undefined ? "" : "LIMIT :limit";
+    if (options.limit !== undefined) {
+      params.limit = options.limit;
+    }
+    return (this.database.prepare(`
+      SELECT event
+      FROM chat_event
+      ${where}
+      ORDER BY sequence ASC
+      ${limit}
+    `).all(params) as EventRow[]).map((row) =>
+      parseJsonColumn<HarnessChatEventEnvelope>(row.event, "chat_event.event")
+    );
+  }
+
+  latestSequence(): number {
+    const row = this.database.prepare(`
+      SELECT COALESCE(MAX(sequence), 0) AS sequence
+      FROM chat_event
+    `).get() as { sequence: number };
+    return row.sequence;
+  }
+
+  close(): void {
+    this.database.close();
+  }
+}
+
+const decodeSessionRow = (row: SessionRow): HarnessChatSessionSnapshot => ({
+  session: parseJsonColumn<HarnessChatSessionStatus>(
+    row.status,
+    "chat_session.status",
+  ),
+  transcript: parseJsonColumn<HarnessTranscriptMessage[]>(
+    row.transcript,
+    "chat_session.transcript",
+  ),
+});
+
+export const openSqliteHarnessChatSessionStore = async (
+  options: OpenSqliteHarnessChatSessionStoreOptions,
+): Promise<SqliteHarnessChatSessionStore> => {
+  const database = await new Database(databaseAddress(options.url), {
+    create: true,
+  });
+  database.exec(PRAGMAS);
+  database.exec(INIT);
+  return new SqliteHarnessChatSessionStore(database);
+};

--- a/packages/cf-harness/src/sqlite-session-store.ts
+++ b/packages/cf-harness/src/sqlite-session-store.ts
@@ -138,6 +138,25 @@ export class SqliteHarnessChatSessionStore implements HarnessChatSessionStore {
     `).all() as SessionRow[]).map(decodeSessionRow);
   }
 
+  saveSessionAndAppendEvent(
+    snapshot: HarnessChatSessionSnapshot,
+    event: HarnessChatEventEnvelope,
+  ): void {
+    this.database.exec("BEGIN IMMEDIATE TRANSACTION;");
+    try {
+      this.saveSession(snapshot);
+      this.appendEvent(event);
+      this.database.exec("COMMIT;");
+    } catch (error) {
+      try {
+        this.database.exec("ROLLBACK;");
+      } catch {
+        // Preserve the original persistence error.
+      }
+      throw error;
+    }
+  }
+
   appendEvent(event: HarnessChatEventEnvelope): void {
     this.database.prepare(`
       INSERT INTO chat_event (

--- a/packages/cf-harness/test/interactive-chat-service.test.ts
+++ b/packages/cf-harness/test/interactive-chat-service.test.ts
@@ -103,6 +103,15 @@ Deno.test("interactive service starts sessions and completes non-streaming turns
   );
   assertEquals(service.status("session-1").sessions[0].status, "idle");
   assertEquals(service.status("session-1").sessions[0].turnCount, 1);
+  assertEquals(
+    service.listEvents({ sessionId: "session-1", afterSequence: 2 }).events
+      .map((event) => event.event.kind),
+    ["assistant_delta", "assistant_completed", "turn_completed"],
+  );
+  assertEquals(
+    service.listEvents({ sessionId: "session-1" }).latestSequence,
+    5,
+  );
   assertEquals(loopOptions[0], {
     workspaceHostPath: "/workspace",
     cwd: "/workspace/project",

--- a/packages/cf-harness/test/interactive-chat-service.test.ts
+++ b/packages/cf-harness/test/interactive-chat-service.test.ts
@@ -620,6 +620,83 @@ Deno.test("interactive service rejects concurrent duplicate session creation aft
   );
 });
 
+Deno.test("interactive service serializes concurrent emitted event sequences", async () => {
+  const persistedSequences: number[] = [];
+  const store: HarnessChatSessionStore = {
+    saveSession: () => {},
+    getSession: () => undefined,
+    listSessions: () => [],
+    saveSessionAndAppendEvent: async (_snapshot, event) => {
+      await Promise.resolve();
+      persistedSequences.push(event.sequence);
+    },
+    appendEvent: async (event) => {
+      await Promise.resolve();
+      persistedSequences.push(event.sequence);
+    },
+    listEvents: () => [],
+    latestSequence: () => 0,
+  };
+  const createPromptLoop: HarnessInteractivePromptLoopFactory = () => ({
+    runTranscript: async (options) => {
+      const first = { role: "assistant" as const, content: "First." };
+      const second = { role: "assistant" as const, content: "Second." };
+      const firstTranscript = [...options.transcript, first];
+      const secondTranscript = [...firstTranscript, second];
+      const firstEvent = options.onTranscriptEvent?.({
+        message: first,
+        transcript: firstTranscript,
+      }) ?? Promise.resolve();
+      const secondEvent = options.onTranscriptEvent?.({
+        message: second,
+        transcript: secondTranscript,
+      }) ?? Promise.resolve();
+      await Promise.all([firstEvent, secondEvent]);
+      return {
+        model: "gpt-test",
+        finalAssistantText: "Second.",
+        transcript: secondTranscript,
+        modelTurns: 1,
+        runState: {} as HarnessPromptLoopResult["runState"],
+      };
+    },
+  });
+  const service = new HarnessInteractiveChatService({
+    createPromptLoop,
+    now: nextIsoNow(),
+    sessionStore: store,
+  });
+
+  await service.startSession("req-1", {
+    sessionId: "session-1",
+    workspace: { hostPath: "/workspace" },
+  });
+  await service.startTurn("req-2", {
+    sessionId: "session-1",
+    turnId: "turn-1",
+    input: { text: "Hi" },
+  });
+  await service.waitForTurn("session-1", "turn-1");
+
+  assertEquals(
+    service.events("session-1").map((event) => event.sequence),
+    [1, 2, 3, 4, 5, 6, 7],
+  );
+  assertEquals(persistedSequences, [1, 2, 3, 4, 5, 6, 7]);
+  assertEquals(
+    service.events("session-1").map((event) => event.event.kind),
+    [
+      "session_started",
+      "turn_started",
+      "assistant_delta",
+      "assistant_delta",
+      "assistant_completed",
+      "assistant_completed",
+      "turn_completed",
+    ],
+  );
+});
+
 Deno.test("interactive service rejects missing sessions and concurrent turns", async () => {
   const service = new HarnessInteractiveChatService({
     createPromptLoop: () => ({

--- a/packages/cf-harness/test/interactive-chat-service.test.ts
+++ b/packages/cf-harness/test/interactive-chat-service.test.ts
@@ -13,6 +13,7 @@ import type {
   HarnessPromptLoopResult,
   RunHarnessTranscriptOptions,
 } from "../src/prompt-loop.ts";
+import type { HarnessChatSessionStore } from "../src/session-store.ts";
 
 const nextIsoNow = () => {
   let counter = 0;
@@ -561,6 +562,55 @@ Deno.test("interactive service rejects duplicate session ids", async () => {
   assertEquals(duplicate.ok, false);
   assertEquals(
     duplicate.ok === false ? duplicate.error.code : "",
+    "session_exists",
+  );
+  assertEquals(service.status().sessions.length, 1);
+  assertEquals(
+    service.status("session-1").sessions[0].workspace?.hostPath,
+    "/workspace",
+  );
+});
+
+Deno.test("interactive service rejects concurrent duplicate session creation after durable checks", async () => {
+  let releaseDurableCheck: (() => void) | undefined;
+  const durableCheck = new Promise<undefined>((resolve) => {
+    releaseDurableCheck = () => resolve(undefined);
+  });
+  const store: HarnessChatSessionStore = {
+    saveSession: () => {},
+    getSession: () => durableCheck,
+    listSessions: () => [],
+    saveSessionAndAppendEvent: () => {},
+    appendEvent: () => {},
+    listEvents: () => [],
+    latestSequence: () => 0,
+  };
+  const service = new HarnessInteractiveChatService({
+    createPromptLoop: () => ({
+      runTranscript: (options) => Promise.resolve(makeResult(options, "Done.")),
+    }),
+    now: nextIsoNow(),
+    sessionStore: store,
+  });
+
+  const first = service.startSession("req-1", {
+    sessionId: "session-1",
+    workspace: { hostPath: "/workspace" },
+  });
+  const duplicate = service.startSession("req-2", {
+    sessionId: "session-1",
+    workspace: { hostPath: "/other-workspace" },
+  });
+  releaseDurableCheck?.();
+  const [firstResult, duplicateResult] = await Promise.all([
+    first,
+    duplicate,
+  ]);
+
+  assertEquals(firstResult.ok, true);
+  assertEquals(duplicateResult.ok, false);
+  assertEquals(
+    duplicateResult.ok === false ? duplicateResult.error.code : "",
     "session_exists",
   );
   assertEquals(service.status().sessions.length, 1);

--- a/packages/cf-harness/test/interactive-chat-stdio.test.ts
+++ b/packages/cf-harness/test/interactive-chat-stdio.test.ts
@@ -122,6 +122,55 @@ Deno.test("interactive NDJSON transport returns structured parse errors", async 
   );
 });
 
+Deno.test("interactive NDJSON transport accepts list_events requests", async () => {
+  const output: string[] = [];
+  await runHarnessInteractiveChatNdjsonTransport({
+    lines: [
+      JSON.stringify({
+        type: HARNESS_CHAT_REQUEST_TYPE,
+        protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+        requestId: "req-1",
+        method: "start_session",
+        params: {
+          sessionId: "session-1",
+          workspace: { hostPath: "/workspace" },
+        },
+      }),
+      JSON.stringify({
+        type: HARNESS_CHAT_REQUEST_TYPE,
+        protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+        requestId: "req-2",
+        method: "list_events",
+        params: {
+          sessionId: "session-1",
+          afterSequence: 0,
+          limit: 10,
+        },
+      }),
+    ],
+    writeLine: (line) => {
+      output.push(line);
+    },
+  });
+
+  const response = decodeLines(output).find((envelope) =>
+    "ok" in envelope && envelope.requestId === "req-2"
+  );
+  assertEquals(
+    response !== undefined && "ok" in response ? response.ok : false,
+    true,
+  );
+  assertEquals(
+    response !== undefined && "ok" in response && response.ok
+      ? response.result
+      : undefined,
+    {
+      events: [decodeLines(output)[0]],
+      latestSequence: 1,
+    },
+  );
+});
+
 Deno.test("interactive NDJSON transport rejects unsupported methods", async () => {
   const output: string[] = [];
   await runHarnessInteractiveChatNdjsonTransport({

--- a/packages/cf-harness/test/sqlite-session-store.test.ts
+++ b/packages/cf-harness/test/sqlite-session-store.test.ts
@@ -1,5 +1,9 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertThrows } from "@std/assert";
 import { toFileUrl } from "@std/path";
+import {
+  createHarnessChatEventEnvelope,
+  createHarnessChatSessionStatus,
+} from "../src/contracts/interactive-chat.ts";
 import {
   HarnessInteractiveChatService,
   type HarnessInteractivePromptLoopFactory,
@@ -129,6 +133,71 @@ Deno.test("sqlite session store persists chat sessions and replayable events", a
       duplicate.ok === false ? duplicate.error.code : "",
       "session_exists",
     );
+  } finally {
+    store.close();
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("sqlite session store persists session snapshots and events atomically", async () => {
+  const path = await Deno.makeTempFile({ suffix: ".sqlite" });
+  const store = await openSqliteHarnessChatSessionStore({
+    url: toFileUrl(path),
+  });
+
+  try {
+    const initialSession = createHarnessChatSessionStatus({
+      sessionId: "session-atomic",
+      createdAt: "2026-05-27T00:00:00.000Z",
+      workspace: { hostPath: "/workspace" },
+      metadata: { version: "before" },
+    });
+    store.saveSessionAndAppendEvent(
+      {
+        session: initialSession,
+        transcript: [],
+      },
+      createHarnessChatEventEnvelope({
+        sessionId: "session-atomic",
+        sequence: 1,
+        emittedAt: "2026-05-27T00:00:01.000Z",
+        event: {
+          kind: "session_started",
+          session: initialSession,
+        },
+      }),
+    );
+
+    const updatedSession = createHarnessChatSessionStatus({
+      sessionId: "session-atomic",
+      createdAt: "2026-05-27T00:00:00.000Z",
+      workspace: { hostPath: "/workspace" },
+      metadata: { version: "after" },
+    });
+    assertThrows(() =>
+      store.saveSessionAndAppendEvent(
+        {
+          session: updatedSession,
+          transcript: [{ role: "assistant", content: "should rollback" }],
+        },
+        createHarnessChatEventEnvelope({
+          sessionId: "session-atomic",
+          sequence: 1,
+          emittedAt: "2026-05-27T00:00:02.000Z",
+          event: {
+            kind: "status_changed",
+            session: updatedSession,
+          },
+        }),
+      )
+    );
+
+    assertEquals(
+      store.getSession("session-atomic")?.session.metadata,
+      { version: "before" },
+    );
+    assertEquals(store.getSession("session-atomic")?.transcript, []);
+    assertEquals(await store.latestSequence(), 1);
   } finally {
     store.close();
     await Deno.remove(path);

--- a/packages/cf-harness/test/sqlite-session-store.test.ts
+++ b/packages/cf-harness/test/sqlite-session-store.test.ts
@@ -1,0 +1,136 @@
+import { assertEquals } from "@std/assert";
+import { toFileUrl } from "@std/path";
+import {
+  HarnessInteractiveChatService,
+  type HarnessInteractivePromptLoopFactory,
+} from "../src/interactive-chat-service.ts";
+import type {
+  HarnessPromptLoopResult,
+  RunHarnessTranscriptOptions,
+} from "../src/prompt-loop.ts";
+import { openSqliteHarnessChatSessionStore } from "../src/sqlite-session-store.ts";
+
+const nextIsoNow = () => {
+  let counter = 0;
+  return () => {
+    counter += 1;
+    return `2026-05-27T00:00:${String(counter).padStart(2, "0")}.000Z`;
+  };
+};
+
+const makeResult = (
+  options: RunHarnessTranscriptOptions,
+  finalAssistantText: string,
+): HarnessPromptLoopResult => ({
+  model: options.model ?? "gpt-test",
+  finalAssistantText,
+  transcript: [
+    ...options.transcript,
+    { role: "assistant", content: finalAssistantText },
+  ],
+  modelTurns: 1,
+  runState: {} as HarnessPromptLoopResult["runState"],
+});
+
+Deno.test("sqlite session store persists chat sessions and replayable events", async () => {
+  const path = await Deno.makeTempFile({ suffix: ".sqlite" });
+  const store = await openSqliteHarnessChatSessionStore({
+    url: toFileUrl(path),
+  });
+  const createPromptLoop: HarnessInteractivePromptLoopFactory = () => ({
+    runTranscript: async (options) => {
+      const result = makeResult(options, "Persisted.");
+      await options.onTranscriptEvent?.({
+        message: result.transcript[result.transcript.length - 1],
+        transcript: result.transcript,
+      });
+      return result;
+    },
+  });
+
+  try {
+    const service = new HarnessInteractiveChatService({
+      createPromptLoop,
+      now: nextIsoNow(),
+      sessionStore: store,
+    });
+
+    await service.startSession("req-1", {
+      sessionId: "session-1",
+      workspace: { hostPath: "/workspace" },
+      model: "gpt-test",
+      metadata: { source: "sqlite-test" },
+    });
+    await service.startTurn("req-2", {
+      sessionId: "session-1",
+      turnId: "turn-1",
+      input: { text: "Remember this" },
+    });
+    await service.waitForTurn("session-1", "turn-1");
+
+    assertEquals(
+      (await store.listEvents({ sessionId: "session-1", afterSequence: 2 }))
+        .map((event) => event.event.kind),
+      ["assistant_delta", "assistant_completed", "turn_completed"],
+    );
+    assertEquals(await store.latestSequence(), 5);
+
+    const restored = new HarnessInteractiveChatService({
+      createPromptLoop,
+      sessionStore: store,
+    });
+    await restored.initializeFromStore();
+
+    assertEquals(restored.status("session-1").sessions[0].status, "idle");
+    assertEquals(restored.status("session-1").sessions[0].turnCount, 1);
+    assertEquals(
+      restored.status("session-1").sessions[0].metadata,
+      { source: "sqlite-test" },
+    );
+    assertEquals(
+      restored.listEvents({ sessionId: "session-1", afterSequence: 1 }).events
+        .map((event) => event.event.kind),
+      [
+        "turn_started",
+        "assistant_delta",
+        "assistant_completed",
+        "turn_completed",
+      ],
+    );
+
+    await restored.startTurn("req-3", {
+      sessionId: "session-1",
+      turnId: "turn-2",
+      input: { text: "Continue after restart" },
+    });
+    await restored.waitForTurn("session-1", "turn-2");
+
+    assertEquals(await store.latestSequence(), 9);
+    assertEquals(
+      restored.listEvents({ sessionId: "session-1", afterSequence: 5 }).events
+        .map((event) => [event.sequence, event.event.kind]),
+      [
+        [6, "turn_started"],
+        [7, "assistant_delta"],
+        [8, "assistant_completed"],
+        [9, "turn_completed"],
+      ],
+    );
+
+    const duplicate = await new HarnessInteractiveChatService({
+      createPromptLoop,
+      sessionStore: store,
+    }).startSession("req-duplicate", {
+      sessionId: "session-1",
+      workspace: { hostPath: "/other" },
+    });
+    assertEquals(duplicate.ok, false);
+    assertEquals(
+      duplicate.ok === false ? duplicate.error.code : "",
+      "session_exists",
+    );
+  } finally {
+    store.close();
+    await Deno.remove(path);
+  }
+});


### PR DESCRIPTION
## Summary

This adds the first durable cf-harness chat/session persistence slice, using SQLite as the near-term backing store while keeping future Fabric-backed storage behind a storage boundary.

- Add a generic `HarnessChatSessionStore` interface for session snapshots, transcripts, ordered events, replay queries, and latest sequence reads.
- Add an explicit `./sqlite-session-store` implementation backed by `@db/sqlite`, with `chat_session` and `chat_event` tables.
- Add a `list_events` interactive-chat protocol method for replay since `afterSequence`, with optional session filtering and limits.
- Wire `HarnessInteractiveChatService` to persist session snapshots and event envelopes, restore state via `initializeFromStore()`, continue sequence numbers after restart, and reject duplicate durable session IDs.
- Keep the native SQLite implementation on an explicit subpath so root cf-harness imports do not automatically load SQLite.

## Notes

This intentionally does not migrate existing run artifacts yet. Run state, run reports, policy traces, tool outputs, and related JSON artifacts remain file-backed for this PR. The next slice should add explicit turn records / interrupted-turn terminalization and then move artifact persistence behind the same SQLite-backed storage direction.

## Validation

- `deno fmt` on touched files
- `deno lint packages/cf-harness/src/session-store.ts packages/cf-harness/src/sqlite-session-store.ts packages/cf-harness/src/contracts/interactive-chat.ts packages/cf-harness/src/interactive-chat-service.ts packages/cf-harness/src/interactive-chat-stdio.ts packages/cf-harness/src/index.ts packages/cf-harness/test/interactive-chat-service.test.ts packages/cf-harness/test/interactive-chat-stdio.test.ts packages/cf-harness/test/sqlite-session-store.test.ts`
- `deno check packages/cf-harness/src/session-store.ts packages/cf-harness/src/sqlite-session-store.ts packages/cf-harness/src/contracts/interactive-chat.ts packages/cf-harness/src/interactive-chat-service.ts packages/cf-harness/src/interactive-chat-stdio.ts packages/cf-harness/test/interactive-chat-service.test.ts packages/cf-harness/test/interactive-chat-stdio.test.ts packages/cf-harness/test/sqlite-session-store.test.ts`
- `deno test --allow-read --allow-write --allow-run --allow-ffi --allow-net --allow-env packages/cf-harness/test/interactive-chat-service.test.ts packages/cf-harness/test/interactive-chat-stdio.test.ts packages/cf-harness/test/sqlite-session-store.test.ts` (`21 passed`)
- `deno task test` in `packages/cf-harness` (`353 passed`)
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a durable chat/session store to `cf-harness` with a SQLite-backed implementation for persisting sessions and events. Adds `list_events` for replay and fixes race conditions by using atomic writes, duplicate session checks, and serialized event emission to preserve sequence order.

- **New Features**
  - Introduced `HarnessChatSessionStore` for session snapshots, event append/list, and latest sequence.
  - Added SQLite store `./sqlite-session-store` using `@db/sqlite` with `chat_session` and `chat_event` tables.
  - Added `list_events` protocol method with `sessionId`, `afterSequence`, `limit`, and `latestSequence` in responses; NDJSON transport validates these params.
  - Updated `HarnessInteractiveChatService` to persist snapshots/events, `initializeFromStore()`, continue sequences on restart, reject duplicate durable session IDs, commit in-memory state only after successful persistence, and serialize event emission to ensure strictly increasing, in-order sequences.
  - Kept SQLite on an explicit subpath; root `cf-harness` imports do not load SQLite.

- **Migration**
  - Opt in by importing `./sqlite-session-store` and passing `sessionStore` to `HarnessInteractiveChatService`.
  - When using SQLite, run with Deno permissions: `--allow-read --allow-write --allow-ffi` (plus `--allow-env/--allow-net` if needed).

<sup>Written for commit b28deff03d46a079c9713329fcf4bf228daf5bf9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3711?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



---BEGIN COPY-PASTE---
NEW_PERF_BASELINE: job: CLI Integration Tests (core-piece-links) = 136s
---END COPY-PASTE---