### PR TITLE
[codex] Add cf-harness durable turn records

### DIFF
--- a/packages/cf-harness/src/contracts/interactive-chat.ts
+++ b/packages/cf-harness/src/contracts/interactive-chat.ts
@@ -28,7 +28,8 @@ export type HarnessChatRequestMethod =
   | "cancel_turn"
   | "close_session"
   | "status"
-  | "list_events";
+  | "list_events"
+  | "list_turns";
 
 export type HarnessChatSessionLifecycle =
   | "idle"
@@ -204,6 +205,11 @@ export interface HarnessChatListEventsParams {
   limit?: number;
 }
 
+export interface HarnessChatListTurnsParams {
+  sessionId?: string;
+  status?: HarnessChatTurnLifecycle;
+}
+
 export type HarnessChatRequestParamsByMethod = {
   start_session: HarnessChatStartSessionParams;
   start_turn: HarnessChatStartTurnParams;
@@ -211,6 +217,7 @@ export type HarnessChatRequestParamsByMethod = {
   close_session: HarnessChatCloseSessionParams;
   status: HarnessChatStatusParams;
   list_events: HarnessChatListEventsParams;
+  list_turns: HarnessChatListTurnsParams;
 };
 
 export type HarnessChatRequestEnvelope<
@@ -230,6 +237,7 @@ export interface HarnessChatError {
     | "invalid_request"
     | "session_exists"
     | "session_not_found"
+    | "turn_exists"
     | "turn_not_found"
     | "turn_already_running"
     | "turn_canceled"
@@ -269,6 +277,7 @@ export interface HarnessChatTurnStatus {
   updatedAt: string;
   endedAt?: string;
   cancelReason?: string;
+  error?: HarnessChatError;
 }
 
 export interface HarnessChatSessionStatus {
@@ -294,6 +303,16 @@ export interface HarnessChatSessionStatus {
 
 export interface HarnessChatStatusResult {
   sessions: readonly HarnessChatSessionStatus[];
+}
+
+export interface HarnessChatTurnRecord {
+  sessionId: string;
+  turn: HarnessChatTurnStatus;
+  input: HarnessChatTurnInput;
+  context?: HarnessChatContext;
+  policy: HarnessChatPolicy;
+  browserAccess?: HarnessChatBrowserAccessLease;
+  metadata?: Record<string, unknown>;
 }
 
 export interface HarnessChatToolCallSummary {
@@ -389,6 +408,11 @@ export type HarnessChatStructuredEvent =
     usage?: HarnessChatGatewayUsage;
   }
   | {
+    kind: "turn_failed";
+    turnId: string;
+    error: HarnessChatError;
+  }
+  | {
     kind: "status_changed";
     session: HarnessChatSessionStatus;
   }
@@ -417,6 +441,10 @@ export interface HarnessChatEventEnvelope<
 export interface HarnessChatListEventsResult {
   events: readonly HarnessChatEventEnvelope[];
   latestSequence: number;
+}
+
+export interface HarnessChatListTurnsResult {
+  turns: readonly HarnessChatTurnRecord[];
 }
 
 export interface CreateHarnessChatSessionStatusOptions {
@@ -507,6 +535,14 @@ export const createHarnessChatErrorResponse = (
   error,
 });
 
+const clearSessionActiveTurn = (
+  status: HarnessChatSessionStatus,
+): Omit<HarnessChatSessionStatus, "activeTurn" | "activeTurnId"> => {
+  const { activeTurn: _activeTurn, activeTurnId: _activeTurnId, ...rest } =
+    status;
+  return rest;
+};
+
 export const reduceHarnessChatSessionStatus = (
   status: HarnessChatSessionStatus,
   envelope: HarnessChatEventEnvelope,
@@ -545,8 +581,30 @@ export const reduceHarnessChatSessionStatus = (
       };
     }
     case "turn_completed": {
-      const { activeTurn: _activeTurn, activeTurnId: _activeTurnId, ...rest } =
-        status;
+      const rest = clearSessionActiveTurn(status);
+      if (status.status === "closed" || status.status === "failed") {
+        return {
+          ...rest,
+          reusable: false,
+          updatedAt,
+        };
+      }
+      return {
+        ...rest,
+        status: "idle",
+        reusable: true,
+        updatedAt,
+      };
+    }
+    case "turn_failed": {
+      const rest = clearSessionActiveTurn(status);
+      if (status.status === "closed" || status.status === "failed") {
+        return {
+          ...rest,
+          reusable: false,
+          updatedAt,
+        };
+      }
       return {
         ...rest,
         status: "idle",
@@ -557,8 +615,7 @@ export const reduceHarnessChatSessionStatus = (
     case "status_changed":
       return envelope.event.session;
     case "session_closed": {
-      const { activeTurn: _activeTurn, activeTurnId: _activeTurnId, ...rest } =
-        status;
+      const rest = clearSessionActiveTurn(status);
       return {
         ...rest,
         status: "closed",
@@ -574,12 +631,15 @@ export const reduceHarnessChatSessionStatus = (
           updatedAt,
         };
       }
-      return {
-        ...status,
-        status: "failed",
-        reusable: false,
-        updatedAt,
-      };
+      {
+        const rest = clearSessionActiveTurn(status);
+        return {
+          ...rest,
+          status: "failed",
+          reusable: false,
+          updatedAt,
+        };
+      }
     default:
       return {
         ...status,

--- a/packages/cf-harness/src/interactive-chat-service.ts
+++ b/packages/cf-harness/src/interactive-chat-service.ts
@@ -9,10 +9,13 @@ import {
   createHarnessChatOkResponse,
   createHarnessChatSessionStatus,
   type HarnessChatBrowserAccessLease,
+  type HarnessChatError,
   type HarnessChatErrorResponse,
   type HarnessChatEventEnvelope,
   type HarnessChatListEventsParams,
   type HarnessChatListEventsResult,
+  type HarnessChatListTurnsParams,
+  type HarnessChatListTurnsResult,
   type HarnessChatPolicy,
   type HarnessChatRequestEnvelope,
   type HarnessChatResponse,
@@ -21,6 +24,7 @@ import {
   type HarnessChatStartTurnParams,
   type HarnessChatStatusResult,
   type HarnessChatStructuredEvent,
+  type HarnessChatTurnRecord,
   type HarnessChatTurnStatus,
   reduceHarnessChatSessionStatus,
   resolveHarnessChatPolicy,
@@ -61,10 +65,18 @@ export interface CreateHarnessInteractiveChatServiceOptions {
 interface HarnessInteractiveChatSessionRecord {
   status: HarnessChatSessionStatus;
   transcript: HarnessTranscriptMessage[];
+  startingTurnId?: string;
+  startingTurn?: HarnessChatTurnStatus;
   activeTurnToken?: object;
   activeTask?: Promise<void>;
   activeAbortController?: AbortController;
   canceledTurnIds: Set<string>;
+  turns: Map<string, HarnessChatTurnRecord>;
+}
+
+interface HarnessInteractiveChatEmitOptions {
+  turnRecord?: HarnessChatTurnRecord;
+  createTurn?: boolean;
 }
 
 const defaultPromptLoopFactory: HarnessInteractivePromptLoopFactory = (
@@ -73,15 +85,28 @@ const defaultPromptLoopFactory: HarnessInteractivePromptLoopFactory = (
 
 const defaultRandomUUID = (): string => crypto.randomUUID();
 
+class DurableTurnExistsError extends Error {
+  readonly sessionId: string;
+  readonly turnId: string;
+
+  constructor(sessionId: string, turnId: string) {
+    super(`chat turn already exists for session ${sessionId}: ${turnId}`);
+    this.name = "DurableTurnExistsError";
+    this.sessionId = sessionId;
+    this.turnId = turnId;
+  }
+}
+
 const activeTurnError = (
   requestId: string,
   session: HarnessChatSessionStatus,
+  activeTurnId = session.activeTurnId,
 ): HarnessChatErrorResponse =>
   createHarnessChatErrorResponse(requestId, {
     code: "turn_already_running",
-    message: session.activeTurnId === undefined
+    message: activeTurnId === undefined
       ? `session ${session.sessionId} already has an active turn task`
-      : `session ${session.sessionId} already has active turn ${session.activeTurnId}`,
+      : `session ${session.sessionId} already has active turn ${activeTurnId}`,
     retryable: true,
   });
 
@@ -92,6 +117,16 @@ const sessionExistsError = (
   createHarnessChatErrorResponse(requestId, {
     code: "session_exists",
     message: `chat session already exists: ${sessionId}`,
+  });
+
+const turnExistsError = (
+  requestId: string,
+  sessionId: string,
+  turnId: string,
+): HarnessChatErrorResponse =>
+  createHarnessChatErrorResponse(requestId, {
+    code: "turn_exists",
+    message: `chat turn already exists for session ${sessionId}: ${turnId}`,
   });
 
 const sessionNotFoundError = (
@@ -136,12 +171,37 @@ const createTurnAbortError = (turnId: string, reason: string): DOMException =>
     "AbortError",
   );
 
+const interruptedTurnError = (
+  turnId: string,
+  priorStatus: HarnessChatTurnStatus["status"],
+): HarnessChatError => ({
+  code: "internal_error",
+  message:
+    `cf-harness chat turn ${turnId} was interrupted before it reached a terminal state`,
+  details: {
+    terminalReason: "process_interrupted",
+    priorStatus,
+  },
+});
+
+const isTerminalTurnStatus = (
+  status: HarnessChatTurnStatus["status"],
+): boolean =>
+  status === "completed" || status === "failed" || status === "canceled";
+
 const clearActiveTurnStatus = (
   status: HarnessChatSessionStatus,
   updatedAt: string,
 ): HarnessChatSessionStatus => {
   const { activeTurn: _activeTurn, activeTurnId: _activeTurnId, ...rest } =
     status;
+  if (status.status === "closed" || status.status === "failed") {
+    return {
+      ...rest,
+      reusable: false,
+      updatedAt,
+    };
+  }
   return {
     ...rest,
     status: "idle",
@@ -253,11 +313,22 @@ export class HarnessInteractiveChatService {
       return;
     }
     this.#sessions.clear();
+    const turnsBySession = new Map<string, HarnessChatTurnRecord[]>();
+    for (const turn of await this.#sessionStore.listTurns()) {
+      const turns = turnsBySession.get(turn.sessionId) ?? [];
+      turns.push(turn);
+      turnsBySession.set(turn.sessionId, turns);
+    }
     for (const snapshot of await this.#sessionStore.listSessions()) {
       this.#sessions.set(snapshot.session.sessionId, {
         status: snapshot.session,
         transcript: [...snapshot.transcript],
         canceledTurnIds: new Set(),
+        turns: new Map(
+          (turnsBySession.get(snapshot.session.sessionId) ?? []).map((
+            turn,
+          ) => [turn.turn.turnId, turn]),
+        ),
       });
     }
     this.#events.splice(
@@ -269,6 +340,7 @@ export class HarnessInteractiveChatService {
       await this.#sessionStore.latestSequence(),
       ...this.#events.map((event) => event.sequence),
     );
+    await this.#terminalizeInterruptedTurnsFromStore();
   }
 
   events(
@@ -294,6 +366,30 @@ export class HarnessInteractiveChatService {
         limit: params.limit,
       }),
       latestSequence: this.#sequence,
+    };
+  }
+
+  turns(
+    sessionId?: string,
+    options: Omit<HarnessChatListTurnsParams, "sessionId"> = {},
+  ): readonly HarnessChatTurnRecord[] {
+    const turns = [...this.#sessions.values()].flatMap((
+      record,
+    ) => [...record.turns.values()]).filter((turn) =>
+      (sessionId === undefined || turn.sessionId === sessionId) &&
+      (options.status === undefined || turn.turn.status === options.status)
+    );
+    return turns.map((turn) => ({
+      ...turn,
+      turn: { ...turn.turn },
+    }));
+  }
+
+  listTurns(
+    params: HarnessChatListTurnsParams = {},
+  ): HarnessChatListTurnsResult {
+    return {
+      turns: this.turns(params.sessionId, { status: params.status }),
     };
   }
 
@@ -334,6 +430,73 @@ export class HarnessInteractiveChatService {
     }
   }
 
+  async #terminalizeInterruptedTurnsFromStore(): Promise<void> {
+    for (const record of [...this.#sessions.values()]) {
+      const activeTurnId = record.status.activeTurnId;
+      const activeTurn = activeTurnId === undefined
+        ? undefined
+        : record.turns.get(activeTurnId);
+      if (activeTurnId !== undefined && activeTurn === undefined) {
+        await this.#emit(record.status.sessionId, activeTurnId, {
+          kind: "turn_failed",
+          turnId: activeTurnId,
+          error: interruptedTurnError(
+            activeTurnId,
+            record.status.activeTurn?.status ?? "running",
+          ),
+        });
+      } else if (
+        activeTurn !== undefined &&
+        isTerminalTurnStatus(activeTurn.turn.status)
+      ) {
+        const updatedAt = this.#now();
+        const session = clearActiveTurnStatus(record.status, updatedAt);
+        const nextTurn = activeTurnId === undefined ? undefined : activeTurn;
+        await this.#emit(record.status.sessionId, undefined, {
+          kind: "status_changed",
+          session,
+        }, nextTurn === undefined ? {} : { turnRecord: nextTurn });
+      }
+
+      for (const turn of [...record.turns.values()]) {
+        if (isTerminalTurnStatus(turn.turn.status)) {
+          continue;
+        }
+        if (turn.turn.status === "canceling") {
+          const updatedAt = this.#now();
+          const nextTurn = this.#updatedTurnRecord(record, turn.turn.turnId, {
+            status: "canceled",
+            updatedAt,
+            endedAt: updatedAt,
+            cancelReason: turn.turn.cancelReason ?? "process_interrupted",
+          });
+          if (record.status.activeTurnId === turn.turn.turnId) {
+            const session = clearActiveTurnStatus(record.status, updatedAt);
+            await this.#emit(record.status.sessionId, undefined, {
+              kind: "status_changed",
+              session,
+            }, nextTurn === undefined ? {} : { turnRecord: nextTurn });
+          } else if (nextTurn !== undefined) {
+            const session = {
+              ...record.status,
+              updatedAt,
+            };
+            await this.#emit(record.status.sessionId, undefined, {
+              kind: "status_changed",
+              session,
+            }, { turnRecord: nextTurn });
+          }
+          continue;
+        }
+        await this.#emit(record.status.sessionId, turn.turn.turnId, {
+          kind: "turn_failed",
+          turnId: turn.turn.turnId,
+          error: interruptedTurnError(turn.turn.turnId, turn.turn.status),
+        });
+      }
+    }
+  }
+
   async handleRequest(
     request: HarnessChatRequestEnvelope,
   ): Promise<HarnessChatResponse> {
@@ -366,6 +529,11 @@ export class HarnessInteractiveChatService {
         return createHarnessChatOkResponse(
           request.requestId,
           this.listEvents(request.params),
+        );
+      case "list_turns":
+        return createHarnessChatOkResponse(
+          request.requestId,
+          this.listTurns(request.params),
         );
       default:
         return createHarnessChatErrorResponse(requestId, {
@@ -405,6 +573,7 @@ export class HarnessInteractiveChatService {
       status: session,
       transcript: [],
       canceledTurnIds: new Set(),
+      turns: new Map(),
     });
     try {
       await this.#emit(session.sessionId, undefined, {
@@ -435,6 +604,9 @@ export class HarnessInteractiveChatService {
     if (record.status.activeTurnId !== undefined) {
       return activeTurnError(requestId, record.status);
     }
+    if (record.startingTurnId !== undefined) {
+      return activeTurnError(requestId, record.status, record.startingTurnId);
+    }
     const context = params.context ?? record.status.context;
     const policy = resolveHarnessChatPolicy(
       params.policy ?? record.status.policy,
@@ -448,17 +620,51 @@ export class HarnessInteractiveChatService {
       return browserAccessRequiredError(requestId);
     }
 
+    const turnId = params.turnId ?? this.#randomUUID();
+    if (record.turns.has(turnId)) {
+      return turnExistsError(requestId, params.sessionId, turnId);
+    }
+
     const startedAt = this.#now();
     const turn: HarnessChatTurnStatus = {
-      turnId: params.turnId ?? this.#randomUUID(),
+      turnId,
       status: "running",
       startedAt,
       updatedAt: startedAt,
     };
-    await this.#emit(params.sessionId, turn.turnId, {
-      kind: "turn_started",
+    const turnRecord: HarnessChatTurnRecord = {
+      sessionId: params.sessionId,
       turn,
-    });
+      input: params.input,
+      policy,
+      ...(context !== undefined ? { context } : {}),
+      ...(browserAccess !== undefined ? { browserAccess } : {}),
+      ...(params.metadata !== undefined ? { metadata: params.metadata } : {}),
+    };
+    record.startingTurnId = turn.turnId;
+    record.startingTurn = turn;
+    try {
+      if (
+        await this.#sessionStore?.getTurn(params.sessionId, turnId) !==
+          undefined
+      ) {
+        return turnExistsError(requestId, params.sessionId, turnId);
+      }
+      await this.#emit(params.sessionId, turn.turnId, {
+        kind: "turn_started",
+        turn,
+      }, { turnRecord, createTurn: true });
+    } catch (error) {
+      if (error instanceof DurableTurnExistsError) {
+        return turnExistsError(requestId, params.sessionId, turnId);
+      }
+      throw error;
+    } finally {
+      if (record.startingTurnId === turn.turnId) {
+        record.startingTurnId = undefined;
+        record.startingTurn = undefined;
+      }
+    }
 
     const updatedRecord = this.#sessions.get(params.sessionId);
     if (updatedRecord === undefined) {
@@ -532,11 +738,18 @@ export class HarnessInteractiveChatService {
       latest.status.status === "canceling" &&
       latest.status.activeTurnId === turnId
     ) {
-      const session = clearActiveTurnStatus(latest.status, this.#now());
+      const updatedAt = this.#now();
+      const nextTurn = this.#updatedTurnRecord(latest, turnId, {
+        status: "canceled",
+        updatedAt,
+        endedAt: updatedAt,
+        cancelReason: latest.status.activeTurn?.cancelReason,
+      });
+      const session = clearActiveTurnStatus(latest.status, updatedAt);
       await this.#emit(sessionId, undefined, {
         kind: "status_changed",
         session,
-      });
+      }, nextTurn === undefined ? {} : { turnRecord: nextTurn });
     }
   }
 
@@ -550,10 +763,16 @@ export class HarnessInteractiveChatService {
       return sessionNotFoundError(requestId, sessionId);
     }
     if (record.status.activeTurnId !== undefined) {
-      record.canceledTurnIds.add(record.status.activeTurnId);
+      const activeTurnId = record.status.activeTurnId;
+      record.canceledTurnIds.add(activeTurnId);
       record.activeAbortController?.abort(
-        createTurnAbortError(record.status.activeTurnId, reason),
+        createTurnAbortError(activeTurnId, reason),
       );
+      await this.#emit(sessionId, activeTurnId, {
+        kind: "turn_canceled",
+        turnId: activeTurnId,
+        reason,
+      });
     }
     await this.#emit(sessionId, undefined, {
       kind: "session_closed",
@@ -586,11 +805,11 @@ export class HarnessInteractiveChatService {
       },
     ];
     let observedTranscriptLength = transcript.length;
-    const loop = this.#createPromptLoop(
-      this.#buildPromptLoopOptions(session, policy, browserAccess),
-    );
 
     try {
+      const loop = this.#createPromptLoop(
+        this.#buildPromptLoopOptions(session, policy, browserAccess),
+      );
       const result = await loop.runTranscript({
         transcript,
         model: session.model,
@@ -622,8 +841,8 @@ export class HarnessInteractiveChatService {
         return;
       }
       await this.#emit(session.sessionId, turnId, {
-        kind: "error",
-        fatal: true,
+        kind: "turn_failed",
+        turnId,
         error: {
           code: "internal_error",
           message: error instanceof Error ? error.message : String(error),
@@ -727,13 +946,81 @@ export class HarnessInteractiveChatService {
     }
   }
 
+  #updatedTurnRecord(
+    record: HarnessInteractiveChatSessionRecord,
+    turnId: string,
+    update:
+      & Pick<HarnessChatTurnStatus, "status" | "updatedAt">
+      & Partial<
+        Pick<HarnessChatTurnStatus, "endedAt" | "cancelReason" | "error">
+      >,
+  ): HarnessChatTurnRecord | undefined {
+    const current = record.turns.get(turnId);
+    if (current === undefined) {
+      return undefined;
+    }
+    return {
+      ...current,
+      turn: {
+        ...current.turn,
+        ...update,
+      },
+    };
+  }
+
+  #turnRecordFromEvent(
+    record: HarnessInteractiveChatSessionRecord,
+    envelope: HarnessChatEventEnvelope,
+  ): HarnessChatTurnRecord | undefined {
+    switch (envelope.event.kind) {
+      case "turn_started":
+        return this.#updatedTurnRecord(record, envelope.event.turn.turnId, {
+          status: envelope.event.turn.status,
+          updatedAt: envelope.event.turn.updatedAt,
+        });
+      case "turn_canceled":
+        return this.#updatedTurnRecord(record, envelope.event.turnId, {
+          status: "canceling",
+          updatedAt: envelope.emittedAt,
+          cancelReason: envelope.event.reason,
+        });
+      case "turn_completed":
+        return this.#updatedTurnRecord(record, envelope.event.turnId, {
+          status: "completed",
+          updatedAt: envelope.emittedAt,
+          endedAt: envelope.emittedAt,
+        });
+      case "turn_failed":
+        return this.#updatedTurnRecord(record, envelope.event.turnId, {
+          status: "failed",
+          updatedAt: envelope.emittedAt,
+          endedAt: envelope.emittedAt,
+          error: envelope.event.error,
+        });
+      case "session_closed": {
+        const activeTurnId = record.status.activeTurnId;
+        return activeTurnId === undefined
+          ? undefined
+          : this.#updatedTurnRecord(record, activeTurnId, {
+            status: "canceled",
+            updatedAt: envelope.emittedAt,
+            endedAt: envelope.emittedAt,
+            cancelReason: envelope.event.reason,
+          });
+      }
+      default:
+        return undefined;
+    }
+  }
+
   async #emit(
     sessionId: string,
     turnId: string | undefined,
     event: HarnessChatStructuredEvent,
+    options: HarnessInteractiveChatEmitOptions = {},
   ): Promise<void> {
     const emitTask = this.#emitQueue.then(() =>
-      this.#emitImmediately(sessionId, turnId, event)
+      this.#emitImmediately(sessionId, turnId, event, options)
     );
     this.#emitQueue = emitTask.catch(() => undefined);
     return await emitTask;
@@ -743,6 +1030,7 @@ export class HarnessInteractiveChatService {
     sessionId: string,
     turnId: string | undefined,
     event: HarnessChatStructuredEvent,
+    options: HarnessInteractiveChatEmitOptions,
   ): Promise<void> {
     const sequence = this.#sequence + 1;
     const envelope = createHarnessChatEventEnvelope({
@@ -756,11 +1044,30 @@ export class HarnessInteractiveChatService {
     const nextStatus = record === undefined
       ? undefined
       : reduceHarnessChatSessionStatus(record.status, envelope);
+    const nextTurn = options.turnRecord ??
+      (record === undefined
+        ? undefined
+        : this.#turnRecordFromEvent(record, envelope));
     if (record !== undefined && nextStatus !== undefined) {
-      await this.#sessionStore?.saveSessionAndAppendEvent({
-        session: nextStatus,
-        transcript: record.transcript,
-      }, envelope);
+      if (nextTurn !== undefined) {
+        const saved = await this.#sessionStore?.saveSessionTurnAndAppendEvent({
+          session: {
+            session: nextStatus,
+            transcript: record.transcript,
+          },
+          turn: nextTurn,
+          event: envelope,
+          ...(options.createTurn ? { createTurn: true } : {}),
+        });
+        if (saved === false) {
+          throw new DurableTurnExistsError(sessionId, nextTurn.turn.turnId);
+        }
+      } else {
+        await this.#sessionStore?.saveSessionAndAppendEvent({
+          session: nextStatus,
+          transcript: record.transcript,
+        }, envelope);
+      }
     } else {
       await this.#sessionStore?.appendEvent(envelope);
     }
@@ -768,6 +1075,9 @@ export class HarnessInteractiveChatService {
     this.#events.push(envelope);
     if (record !== undefined && nextStatus !== undefined) {
       record.status = nextStatus;
+    }
+    if (record !== undefined && nextTurn !== undefined) {
+      record.turns.set(nextTurn.turn.turnId, nextTurn);
     }
     await this.#onEvent?.(envelope);
   }

--- a/packages/cf-harness/src/interactive-chat-stdio.ts
+++ b/packages/cf-harness/src/interactive-chat-stdio.ts
@@ -48,8 +48,16 @@ const SUPPORTED_REQUEST_METHODS = new Set<HarnessChatRequestMethod>([
   "close_session",
   "status",
   "list_events",
+  "list_turns",
 ]);
 const SUPPORTED_POLICY_TOOL_MODES = new Set(["workspace-write", "read-only"]);
+const SUPPORTED_TURN_STATUSES = new Set([
+  "running",
+  "canceling",
+  "canceled",
+  "completed",
+  "failed",
+]);
 const SUPPORTED_POLICY_TOOL_IDS = new Set<BuiltinToolId>([
   "bash",
   "bash-no-sandbox",
@@ -188,6 +196,11 @@ const isValidRequestParams = (
       return hasOptionalString(params, "sessionId") &&
         hasOptionalNonNegativeInteger(params, "afterSequence") &&
         hasOptionalPositiveInteger(params, "limit");
+    case "list_turns":
+      return hasOptionalString(params, "sessionId") &&
+        (params.status === undefined ||
+          (typeof params.status === "string" &&
+            SUPPORTED_TURN_STATUSES.has(params.status)));
   }
 };
 

--- a/packages/cf-harness/src/session-store.ts
+++ b/packages/cf-harness/src/session-store.ts
@@ -1,6 +1,8 @@
 import type {
   HarnessChatEventEnvelope,
   HarnessChatSessionStatus,
+  HarnessChatTurnLifecycle,
+  HarnessChatTurnRecord,
 } from "./contracts/interactive-chat.ts";
 import type { HarnessTranscriptMessage } from "./contracts/transcript.ts";
 
@@ -15,7 +17,19 @@ export interface HarnessChatEventListOptions {
   limit?: number;
 }
 
+export interface HarnessChatTurnListOptions {
+  sessionId?: string;
+  status?: HarnessChatTurnLifecycle;
+}
+
 export type HarnessMaybePromise<Value> = Value | Promise<Value>;
+
+export interface HarnessChatSessionTurnEventMutation {
+  session: HarnessChatSessionSnapshot;
+  event: HarnessChatEventEnvelope;
+  turn: HarnessChatTurnRecord;
+  createTurn?: boolean;
+}
 
 export interface HarnessChatSessionStore {
   saveSession(snapshot: HarnessChatSessionSnapshot): HarnessMaybePromise<void>;
@@ -27,6 +41,17 @@ export interface HarnessChatSessionStore {
     snapshot: HarnessChatSessionSnapshot,
     event: HarnessChatEventEnvelope,
   ): HarnessMaybePromise<void>;
+  saveSessionTurnAndAppendEvent(
+    mutation: HarnessChatSessionTurnEventMutation,
+  ): HarnessMaybePromise<boolean>;
+  saveTurn(turn: HarnessChatTurnRecord): HarnessMaybePromise<void>;
+  getTurn(
+    sessionId: string,
+    turnId: string,
+  ): HarnessMaybePromise<HarnessChatTurnRecord | undefined>;
+  listTurns(
+    options?: HarnessChatTurnListOptions,
+  ): HarnessMaybePromise<readonly HarnessChatTurnRecord[]>;
   appendEvent(event: HarnessChatEventEnvelope): HarnessMaybePromise<void>;
   listEvents(
     options?: HarnessChatEventListOptions,

--- a/packages/cf-harness/src/sqlite-session-store.ts
+++ b/packages/cf-harness/src/sqlite-session-store.ts
@@ -1,13 +1,21 @@
 import { Database } from "@db/sqlite";
 import {
+  type HarnessChatBrowserAccessLease,
+  type HarnessChatContext,
   type HarnessChatEventEnvelope,
+  type HarnessChatPolicy,
   type HarnessChatSessionStatus,
+  type HarnessChatTurnInput,
+  type HarnessChatTurnRecord,
+  type HarnessChatTurnStatus,
 } from "./contracts/interactive-chat.ts";
 import type { HarnessTranscriptMessage } from "./contracts/transcript.ts";
 import type {
   HarnessChatEventListOptions,
   HarnessChatSessionSnapshot,
   HarnessChatSessionStore,
+  HarnessChatSessionTurnEventMutation,
+  HarnessChatTurnListOptions,
 } from "./session-store.ts";
 
 const PRAGMAS = `
@@ -30,6 +38,29 @@ CREATE TABLE IF NOT EXISTS chat_session (
 );
 CREATE INDEX IF NOT EXISTS idx_chat_session_updated_at
   ON chat_session (updated_at);
+
+CREATE TABLE IF NOT EXISTS chat_turn (
+  session_id      TEXT NOT NULL,
+  turn_id         TEXT NOT NULL,
+  status          TEXT NOT NULL,
+  turn            TEXT NOT NULL,
+  input           TEXT NOT NULL,
+  context         TEXT,
+  policy          TEXT NOT NULL,
+  browser_access  TEXT,
+  metadata        TEXT,
+  started_at      TEXT NOT NULL,
+  updated_at      TEXT NOT NULL,
+  ended_at        TEXT,
+  cancel_reason   TEXT,
+  error           TEXT,
+  PRIMARY KEY (session_id, turn_id),
+  FOREIGN KEY (session_id) REFERENCES chat_session(session_id)
+);
+CREATE INDEX IF NOT EXISTS idx_chat_turn_session_status_updated
+  ON chat_turn (session_id, status, updated_at);
+CREATE INDEX IF NOT EXISTS idx_chat_turn_updated_at
+  ON chat_turn (updated_at);
 
 CREATE TABLE IF NOT EXISTS chat_event (
   sequence    INTEGER NOT NULL PRIMARY KEY,
@@ -57,12 +88,28 @@ type EventRow = {
   event: string;
 };
 
+type TurnRow = {
+  session_id: string;
+  turn: string;
+  input: string;
+  context: string | null;
+  policy: string;
+  browser_access: string | null;
+  metadata: string | null;
+};
+
 export interface OpenSqliteHarnessChatSessionStoreOptions {
   url: URL;
 }
 
-const databaseAddress = (url: URL): URL | string =>
-  url.protocol === "file:" ? url : ":memory:";
+const databaseAddress = (url: URL): URL => {
+  if (url.protocol !== "file:") {
+    throw new Error(
+      `unsupported SQLite chat session store URL protocol: ${url.protocol}; expected file:`,
+    );
+  }
+  return url;
+};
 
 const parseJsonColumn = <Value>(
   value: string,
@@ -78,6 +125,31 @@ const parseJsonColumn = <Value>(
     );
   }
 };
+
+const parseNullableJsonColumn = <Value>(
+  value: string | null,
+  column: string,
+): Value | undefined =>
+  value === null ? undefined : parseJsonColumn<Value>(value, column);
+
+const turnRowParams = (turn: HarnessChatTurnRecord) => ({
+  session_id: turn.sessionId,
+  turn_id: turn.turn.turnId,
+  status: turn.turn.status,
+  turn: JSON.stringify(turn.turn),
+  input: JSON.stringify(turn.input),
+  context: turn.context === undefined ? null : JSON.stringify(turn.context),
+  policy: JSON.stringify(turn.policy),
+  browser_access: turn.browserAccess === undefined
+    ? null
+    : JSON.stringify(turn.browserAccess),
+  metadata: turn.metadata === undefined ? null : JSON.stringify(turn.metadata),
+  started_at: turn.turn.startedAt,
+  updated_at: turn.turn.updatedAt,
+  ended_at: turn.turn.endedAt ?? null,
+  cancel_reason: turn.turn.cancelReason ?? null,
+  error: turn.turn.error === undefined ? null : JSON.stringify(turn.turn.error),
+});
 
 export class SqliteHarnessChatSessionStore implements HarnessChatSessionStore {
   readonly database: Database;
@@ -155,6 +227,154 @@ export class SqliteHarnessChatSessionStore implements HarnessChatSessionStore {
       }
       throw error;
     }
+  }
+
+  saveSessionTurnAndAppendEvent(
+    mutation: HarnessChatSessionTurnEventMutation,
+  ): boolean {
+    this.database.exec("BEGIN IMMEDIATE TRANSACTION;");
+    try {
+      if (mutation.createTurn) {
+        const inserted = this.insertTurn(mutation.turn);
+        if (!inserted) {
+          this.database.exec("ROLLBACK;");
+          return false;
+        }
+      } else {
+        this.saveTurn(mutation.turn);
+      }
+      this.saveSession(mutation.session);
+      this.appendEvent(mutation.event);
+      this.database.exec("COMMIT;");
+      return true;
+    } catch (error) {
+      try {
+        this.database.exec("ROLLBACK;");
+      } catch {
+        // Preserve the original persistence error.
+      }
+      throw error;
+    }
+  }
+
+  insertTurn(turn: HarnessChatTurnRecord): boolean {
+    return this.database.prepare(`
+      INSERT OR IGNORE INTO chat_turn (
+        session_id,
+        turn_id,
+        status,
+        turn,
+        input,
+        context,
+        policy,
+        browser_access,
+        metadata,
+        started_at,
+        updated_at,
+        ended_at,
+        cancel_reason,
+        error
+      )
+      VALUES (
+        :session_id,
+        :turn_id,
+        :status,
+        :turn,
+        :input,
+        :context,
+        :policy,
+        :browser_access,
+        :metadata,
+        :started_at,
+        :updated_at,
+        :ended_at,
+        :cancel_reason,
+        :error
+      )
+    `).run(turnRowParams(turn)) > 0;
+  }
+
+  saveTurn(turn: HarnessChatTurnRecord): void {
+    this.database.prepare(`
+      INSERT INTO chat_turn (
+        session_id,
+        turn_id,
+        status,
+        turn,
+        input,
+        context,
+        policy,
+        browser_access,
+        metadata,
+        started_at,
+        updated_at,
+        ended_at,
+        cancel_reason,
+        error
+      )
+      VALUES (
+        :session_id,
+        :turn_id,
+        :status,
+        :turn,
+        :input,
+        :context,
+        :policy,
+        :browser_access,
+        :metadata,
+        :started_at,
+        :updated_at,
+        :ended_at,
+        :cancel_reason,
+        :error
+      )
+      ON CONFLICT(session_id, turn_id) DO UPDATE SET
+        status = :status,
+        turn = :turn,
+        input = :input,
+        context = :context,
+        policy = :policy,
+        browser_access = :browser_access,
+        metadata = :metadata,
+        updated_at = :updated_at,
+        ended_at = :ended_at,
+        cancel_reason = :cancel_reason,
+        error = :error
+    `).run(turnRowParams(turn));
+  }
+
+  getTurn(
+    sessionId: string,
+    turnId: string,
+  ): HarnessChatTurnRecord | undefined {
+    const row = this.database.prepare(`
+      SELECT session_id, turn, input, context, policy, browser_access, metadata
+      FROM chat_turn
+      WHERE session_id = :session_id AND turn_id = :turn_id
+    `).get({ session_id: sessionId, turn_id: turnId }) as TurnRow | undefined;
+    return row === undefined ? undefined : decodeTurnRow(row);
+  }
+
+  listTurns(
+    options: HarnessChatTurnListOptions = {},
+  ): readonly HarnessChatTurnRecord[] {
+    const clauses: string[] = [];
+    const params: Record<string, string> = {};
+    if (options.sessionId !== undefined) {
+      clauses.push("session_id = :session_id");
+      params.session_id = options.sessionId;
+    }
+    if (options.status !== undefined) {
+      clauses.push("status = :status");
+      params.status = options.status;
+    }
+    const where = clauses.length === 0 ? "" : `WHERE ${clauses.join(" AND ")}`;
+    return (this.database.prepare(`
+      SELECT session_id, turn, input, context, policy, browser_access, metadata
+      FROM chat_turn
+      ${where}
+      ORDER BY started_at ASC, turn_id ASC
+    `).all(params) as TurnRow[]).map(decodeTurnRow);
   }
 
   appendEvent(event: HarnessChatEventEnvelope): void {
@@ -237,6 +457,30 @@ const decodeSessionRow = (row: SessionRow): HarnessChatSessionSnapshot => ({
     "chat_session.transcript",
   ),
 });
+
+const decodeTurnRow = (row: TurnRow): HarnessChatTurnRecord => {
+  const context = parseNullableJsonColumn<HarnessChatContext>(
+    row.context,
+    "chat_turn.context",
+  );
+  const browserAccess = parseNullableJsonColumn<HarnessChatBrowserAccessLease>(
+    row.browser_access,
+    "chat_turn.browser_access",
+  );
+  const metadata = parseNullableJsonColumn<Record<string, unknown>>(
+    row.metadata,
+    "chat_turn.metadata",
+  );
+  return {
+    sessionId: row.session_id,
+    turn: parseJsonColumn<HarnessChatTurnStatus>(row.turn, "chat_turn.turn"),
+    input: parseJsonColumn<HarnessChatTurnInput>(row.input, "chat_turn.input"),
+    policy: parseJsonColumn<HarnessChatPolicy>(row.policy, "chat_turn.policy"),
+    ...(context !== undefined ? { context } : {}),
+    ...(browserAccess !== undefined ? { browserAccess } : {}),
+    ...(metadata !== undefined ? { metadata } : {}),
+  };
+};
 
 export const openSqliteHarnessChatSessionStore = async (
   options: OpenSqliteHarnessChatSessionStoreOptions,

--- a/packages/cf-harness/test/interactive-chat-service.test.ts
+++ b/packages/cf-harness/test/interactive-chat-service.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertRejects } from "@std/assert";
 import {
   HARNESS_CHAT_PROTOCOL_VERSION,
   HARNESS_CHAT_REQUEST_TYPE,
@@ -104,6 +104,12 @@ Deno.test("interactive service starts sessions and completes non-streaming turns
   );
   assertEquals(service.status("session-1").sessions[0].status, "idle");
   assertEquals(service.status("session-1").sessions[0].turnCount, 1);
+  assertEquals(
+    service.listTurns({ sessionId: "session-1" }).turns.map((turn) =>
+      turn.turn.status
+    ),
+    ["completed"],
+  );
   assertEquals(
     service.listEvents({ sessionId: "session-1", afterSequence: 2 }).events
       .map((event) => event.event.kind),
@@ -416,6 +422,10 @@ Deno.test("interactive service aborts canceled turns without closing the session
   assertEquals(firstSignal?.aborted, true);
   assertEquals(service.status("session-1").sessions[0].status, "canceling");
   assertEquals(service.status("session-1").sessions[0].reusable, false);
+  assertEquals(
+    service.listTurns({ sessionId: "session-1" }).turns[0].turn.status,
+    "canceling",
+  );
   const earlySecondTurn = await service.startTurn("req-early", {
     sessionId: "session-1",
     turnId: "turn-early",
@@ -431,6 +441,10 @@ Deno.test("interactive service aborts canceled turns without closing the session
   await service.waitForTurn("session-1", "turn-1");
   assertEquals(service.status("session-1").sessions[0].status, "idle");
   assertEquals(service.status("session-1").sessions[0].reusable, true);
+  assertEquals(
+    service.listTurns({ sessionId: "session-1" }).turns[0].turn.status,
+    "canceled",
+  );
   assertEquals(
     service.events("session-1").map((event) => event.event.kind),
     ["session_started", "turn_started", "turn_canceled", "status_changed"],
@@ -499,11 +513,21 @@ Deno.test("interactive service aborts active turns when closing a session", asyn
   assertEquals(activeSignal?.aborted, true);
   assertEquals(service.status("session-1").sessions[0].status, "closed");
   assertEquals(service.status("session-1").sessions[0].reusable, false);
+  assertEquals(
+    service.listTurns({ sessionId: "session-1" }).turns[0].turn.status,
+    "canceled",
+  );
 
   await service.waitForTurn("session-1", "turn-1");
   assertEquals(
     service.events("session-1").map((event) => event.event.kind),
-    ["session_started", "turn_started", "session_closed"],
+    [
+      "session_started",
+      "turn_started",
+      "turn_canceled",
+      "status_changed",
+      "session_closed",
+    ],
   );
 });
 
@@ -581,6 +605,10 @@ Deno.test("interactive service rejects concurrent duplicate session creation aft
     getSession: () => durableCheck,
     listSessions: () => [],
     saveSessionAndAppendEvent: () => {},
+    saveSessionTurnAndAppendEvent: () => true,
+    saveTurn: () => {},
+    getTurn: () => undefined,
+    listTurns: () => [],
     appendEvent: () => {},
     listEvents: () => [],
     latestSequence: () => 0,
@@ -630,12 +658,20 @@ Deno.test("interactive service serializes concurrent emitted event sequences", a
       await Promise.resolve();
       persistedSequences.push(event.sequence);
     },
+    saveSessionTurnAndAppendEvent: async (mutation) => {
+      await Promise.resolve();
+      persistedSequences.push(mutation.event.sequence);
+      return true;
+    },
     appendEvent: async (event) => {
       await Promise.resolve();
       persistedSequences.push(event.sequence);
     },
     listEvents: () => [],
     latestSequence: () => 0,
+    saveTurn: () => {},
+    getTurn: () => undefined,
+    listTurns: () => [],
   };
   const createPromptLoop: HarnessInteractivePromptLoopFactory = () => ({
     runTranscript: async (options) => {
@@ -697,6 +733,120 @@ Deno.test("interactive service serializes concurrent emitted event sequences", a
   );
 });
 
+Deno.test("interactive service rolls back in-memory turn state when start persistence fails", async () => {
+  let failTurnPersistence = true;
+  const store: HarnessChatSessionStore = {
+    saveSession: () => {},
+    getSession: () => undefined,
+    listSessions: () => [],
+    saveSessionAndAppendEvent: () => {},
+    saveSessionTurnAndAppendEvent: () => {
+      if (failTurnPersistence) {
+        throw new Error("turn persistence failed");
+      }
+      return true;
+    },
+    appendEvent: () => {},
+    listEvents: () => [],
+    latestSequence: () => 0,
+    saveTurn: () => {},
+    getTurn: () => undefined,
+    listTurns: () => [],
+  };
+  const service = new HarnessInteractiveChatService({
+    createPromptLoop: () => ({
+      runTranscript: (options) => Promise.resolve(makeResult(options, "Done.")),
+    }),
+    now: nextIsoNow(),
+    sessionStore: store,
+  });
+
+  await service.startSession("req-1", {
+    sessionId: "session-1",
+    workspace: { hostPath: "/workspace" },
+  });
+  await assertRejects(
+    () =>
+      service.startTurn("req-2", {
+        sessionId: "session-1",
+        turnId: "turn-1",
+        input: { text: "First attempt" },
+      }),
+    Error,
+    "turn persistence failed",
+  );
+
+  assertEquals(service.listTurns({ sessionId: "session-1" }).turns, []);
+  assertEquals(service.status("session-1").sessions[0].status, "idle");
+
+  failTurnPersistence = false;
+  const retry = await service.startTurn("req-3", {
+    sessionId: "session-1",
+    turnId: "turn-1",
+    input: { text: "Retry" },
+  });
+  assertEquals(retry.ok, true);
+  await service.waitForTurn("session-1", "turn-1");
+  assertEquals(
+    service.listTurns({ sessionId: "session-1" }).turns.map((turn) =>
+      turn.turn.status
+    ),
+    ["completed"],
+  );
+});
+
+Deno.test("interactive service reserves turn start before durable duplicate checks", async () => {
+  let releaseDurableTurnCheck: (() => void) | undefined;
+  const durableTurnCheck = new Promise<undefined>((resolve) => {
+    releaseDurableTurnCheck = () => resolve(undefined);
+  });
+  const store: HarnessChatSessionStore = {
+    saveSession: () => {},
+    getSession: () => undefined,
+    listSessions: () => [],
+    saveSessionAndAppendEvent: () => {},
+    saveSessionTurnAndAppendEvent: () => true,
+    appendEvent: () => {},
+    listEvents: () => [],
+    latestSequence: () => 0,
+    saveTurn: () => {},
+    getTurn: () => durableTurnCheck,
+    listTurns: () => [],
+  };
+  const service = new HarnessInteractiveChatService({
+    createPromptLoop: () => ({
+      runTranscript: (options) => Promise.resolve(makeResult(options, "Done.")),
+    }),
+    now: nextIsoNow(),
+    sessionStore: store,
+  });
+
+  await service.startSession("req-1", {
+    sessionId: "session-1",
+    workspace: { hostPath: "/workspace" },
+  });
+  const first = service.startTurn("req-2", {
+    sessionId: "session-1",
+    turnId: "turn-1",
+    input: { text: "First" },
+  });
+  const second = await service.startTurn("req-3", {
+    sessionId: "session-1",
+    turnId: "turn-2",
+    input: { text: "Second" },
+  });
+  assertEquals(second.ok, false);
+  assertEquals(
+    second.ok === false ? second.error.code : "",
+    "turn_already_running",
+  );
+
+  releaseDurableTurnCheck?.();
+  const firstResult = await first;
+  assertEquals(firstResult.ok, true);
+  await service.waitForTurn("session-1", "turn-1");
+});
+
 Deno.test("interactive service rejects missing sessions and concurrent turns", async () => {
   const service = new HarnessInteractiveChatService({
     createPromptLoop: () => ({
@@ -754,4 +904,101 @@ Deno.test("interactive service rejects missing sessions and concurrent turns", a
   );
   release?.();
   await busyService.waitForTurn("session-1", "turn-1");
+});
+
+Deno.test("interactive service terminalizes failed turns without closing the session", async () => {
+  const service = new HarnessInteractiveChatService({
+    createPromptLoop: () => ({
+      runTranscript: () => Promise.reject(new Error("gateway unavailable")),
+    }),
+    now: nextIsoNow(),
+  });
+
+  await service.startSession("req-1", {
+    sessionId: "session-1",
+    workspace: { hostPath: "/workspace" },
+  });
+  await service.startTurn("req-2", {
+    sessionId: "session-1",
+    turnId: "turn-1",
+    input: { text: "Start" },
+  });
+  await service.waitForTurn("session-1", "turn-1");
+
+  assertEquals(service.status("session-1").sessions[0].status, "idle");
+  assertEquals(service.status("session-1").sessions[0].reusable, true);
+  assertEquals(
+    service.events("session-1").map((event) => event.event.kind),
+    ["session_started", "turn_started", "turn_failed"],
+  );
+  assertEquals(
+    service.listTurns({ sessionId: "session-1" }).turns[0].turn,
+    {
+      turnId: "turn-1",
+      status: "failed",
+      startedAt: "2026-05-22T00:00:03.000Z",
+      updatedAt: "2026-05-22T00:00:05.000Z",
+      endedAt: "2026-05-22T00:00:05.000Z",
+      error: {
+        code: "internal_error",
+        message: "gateway unavailable",
+      },
+    },
+  );
+
+  const nextTurn = await service.startTurn("req-3", {
+    sessionId: "session-1",
+    turnId: "turn-2",
+    input: { text: "Retry" },
+  });
+  assertEquals(nextTurn.ok, true);
+  await service.waitForTurn("session-1", "turn-2");
+});
+
+Deno.test("interactive service terminalizes prompt-loop setup failures", async () => {
+  let createCount = 0;
+  const service = new HarnessInteractiveChatService({
+    createPromptLoop: () => {
+      createCount += 1;
+      if (createCount === 1) {
+        throw new Error("prompt loop setup failed");
+      }
+      return {
+        runTranscript: (options) => Promise.resolve(makeResult(options, "OK.")),
+      };
+    },
+    now: nextIsoNow(),
+  });
+
+  await service.startSession("req-1", {
+    sessionId: "session-1",
+    workspace: { hostPath: "/workspace" },
+  });
+  const first = await service.startTurn("req-2", {
+    sessionId: "session-1",
+    turnId: "turn-1",
+    input: { text: "Start" },
+  });
+  assertEquals(first.ok, true);
+  await service.waitForTurn("session-1", "turn-1");
+
+  assertEquals(service.status("session-1").sessions[0].status, "idle");
+  assertEquals(service.status("session-1").sessions[0].reusable, true);
+  assertEquals(
+    service.listTurns({ sessionId: "session-1" }).turns[0].turn.status,
+    "failed",
+  );
+  assertEquals(
+    service.events("session-1").map((event) => event.event.kind),
+    ["session_started", "turn_started", "turn_failed"],
+  );
+
+  const second = await service.startTurn("req-3", {
+    sessionId: "session-1",
+    turnId: "turn-2",
+    input: { text: "Retry" },
+  });
+  assertEquals(second.ok, true);
+  await service.waitForTurn("session-1", "turn-2");
+  assertEquals(service.status("session-1").sessions[0].status, "idle");
 });

--- a/packages/cf-harness/test/interactive-chat-stdio.test.ts
+++ b/packages/cf-harness/test/interactive-chat-stdio.test.ts
@@ -171,6 +171,53 @@ Deno.test("interactive NDJSON transport accepts list_events requests", async () 
   );
 });
 
+Deno.test("interactive NDJSON transport accepts list_turns requests", async () => {
+  const output: string[] = [];
+  await runHarnessInteractiveChatNdjsonTransport({
+    lines: [
+      JSON.stringify({
+        type: HARNESS_CHAT_REQUEST_TYPE,
+        protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+        requestId: "req-1",
+        method: "start_session",
+        params: {
+          sessionId: "session-1",
+          workspace: { hostPath: "/workspace" },
+        },
+      }),
+      JSON.stringify({
+        type: HARNESS_CHAT_REQUEST_TYPE,
+        protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+        requestId: "req-2",
+        method: "list_turns",
+        params: {
+          sessionId: "session-1",
+          status: "completed",
+        },
+      }),
+    ],
+    writeLine: (line) => {
+      output.push(line);
+    },
+  });
+
+  const response = decodeLines(output).find((envelope) =>
+    "ok" in envelope && envelope.requestId === "req-2"
+  );
+  assertEquals(
+    response !== undefined && "ok" in response ? response.ok : false,
+    true,
+  );
+  assertEquals(
+    response !== undefined && "ok" in response && response.ok
+      ? response.result
+      : undefined,
+    {
+      turns: [],
+    },
+  );
+});
+
 Deno.test("interactive NDJSON transport rejects unsupported methods", async () => {
   const output: string[] = [];
   await runHarnessInteractiveChatNdjsonTransport({

--- a/packages/cf-harness/test/sqlite-session-store.test.ts
+++ b/packages/cf-harness/test/sqlite-session-store.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertThrows } from "@std/assert";
+import { assertEquals, assertRejects, assertThrows } from "@std/assert";
 import { toFileUrl } from "@std/path";
 import {
   createHarnessChatEventEnvelope,
@@ -36,6 +36,17 @@ const makeResult = (
   runState: {} as HarnessPromptLoopResult["runState"],
 });
 
+Deno.test("sqlite session store rejects unsupported URL schemes", async () => {
+  await assertRejects(
+    () =>
+      openSqliteHarnessChatSessionStore({
+        url: new URL("https://example.com/chat.sqlite"),
+      }),
+    Error,
+    "unsupported SQLite chat session store URL protocol: https:; expected file:",
+  );
+});
+
 Deno.test("sqlite session store persists chat sessions and replayable events", async () => {
   const path = await Deno.makeTempFile({ suffix: ".sqlite" });
   const store = await openSqliteHarnessChatSessionStore({
@@ -69,9 +80,24 @@ Deno.test("sqlite session store persists chat sessions and replayable events", a
       sessionId: "session-1",
       turnId: "turn-1",
       input: { text: "Remember this" },
+      metadata: { origin: "first-turn" },
     });
     await service.waitForTurn("session-1", "turn-1");
 
+    assertEquals(
+      (await store.listTurns({ sessionId: "session-1" })).map((turn) => ({
+        turnId: turn.turn.turnId,
+        status: turn.turn.status,
+        input: turn.input,
+        metadata: turn.metadata,
+      })),
+      [{
+        turnId: "turn-1",
+        status: "completed",
+        input: { text: "Remember this" },
+        metadata: { origin: "first-turn" },
+      }],
+    );
     assertEquals(
       (await store.listEvents({ sessionId: "session-1", afterSequence: 2 }))
         .map((event) => event.event.kind),
@@ -87,6 +113,12 @@ Deno.test("sqlite session store persists chat sessions and replayable events", a
 
     assertEquals(restored.status("session-1").sessions[0].status, "idle");
     assertEquals(restored.status("session-1").sessions[0].turnCount, 1);
+    assertEquals(
+      restored.listTurns({ sessionId: "session-1" }).turns.map((turn) =>
+        turn.turn.status
+      ),
+      ["completed"],
+    );
     assertEquals(
       restored.status("session-1").sessions[0].metadata,
       { source: "sqlite-test" },
@@ -119,6 +151,13 @@ Deno.test("sqlite session store persists chat sessions and replayable events", a
         [8, "assistant_completed"],
         [9, "turn_completed"],
       ],
+    );
+    assertEquals(
+      restored.listTurns({ sessionId: "session-1" }).turns.map((turn) => [
+        turn.turn.turnId,
+        turn.turn.status,
+      ]),
+      [["turn-1", "completed"], ["turn-2", "completed"]],
     );
 
     const duplicate = await new HarnessInteractiveChatService({
@@ -198,6 +237,247 @@ Deno.test("sqlite session store persists session snapshots and events atomically
     );
     assertEquals(store.getSession("session-atomic")?.transcript, []);
     assertEquals(await store.latestSequence(), 1);
+  } finally {
+    store.close();
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("sqlite session store persists turn session event mutations atomically", async () => {
+  const path = await Deno.makeTempFile({ suffix: ".sqlite" });
+  const store = await openSqliteHarnessChatSessionStore({
+    url: toFileUrl(path),
+  });
+
+  try {
+    const initialSession = createHarnessChatSessionStatus({
+      sessionId: "session-turn-atomic",
+      createdAt: "2026-05-27T00:00:00.000Z",
+      workspace: { hostPath: "/workspace" },
+      metadata: { version: "before" },
+    });
+    store.saveSessionAndAppendEvent(
+      {
+        session: initialSession,
+        transcript: [],
+      },
+      createHarnessChatEventEnvelope({
+        sessionId: "session-turn-atomic",
+        sequence: 1,
+        emittedAt: "2026-05-27T00:00:01.000Z",
+        event: {
+          kind: "session_started",
+          session: initialSession,
+        },
+      }),
+    );
+
+    const turn = {
+      turnId: "turn-1",
+      status: "running" as const,
+      startedAt: "2026-05-27T00:00:02.000Z",
+      updatedAt: "2026-05-27T00:00:02.000Z",
+    };
+    const updatedSession = {
+      ...initialSession,
+      status: "turn_running" as const,
+      reusable: true,
+      activeTurnId: turn.turnId,
+      activeTurn: turn,
+      turnCount: 1,
+      updatedAt: "2026-05-27T00:00:02.000Z",
+      metadata: { version: "after" },
+    };
+
+    assertThrows(() =>
+      store.saveSessionTurnAndAppendEvent({
+        session: {
+          session: updatedSession,
+          transcript: [{ role: "user", content: "should rollback" }],
+        },
+        turn: {
+          sessionId: "session-turn-atomic",
+          turn,
+          input: { text: "should rollback" },
+          policy: initialSession.policy,
+        },
+        createTurn: true,
+        event: createHarnessChatEventEnvelope({
+          sessionId: "session-turn-atomic",
+          turnId: turn.turnId,
+          sequence: 1,
+          emittedAt: "2026-05-27T00:00:02.000Z",
+          event: {
+            kind: "turn_started",
+            turn,
+          },
+        }),
+      })
+    );
+
+    assertEquals(
+      store.getSession("session-turn-atomic")?.session.metadata,
+      { version: "before" },
+    );
+    assertEquals(store.getSession("session-turn-atomic")?.transcript, []);
+    assertEquals(store.getTurn("session-turn-atomic", "turn-1"), undefined);
+    assertEquals(await store.latestSequence(), 1);
+  } finally {
+    store.close();
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("sqlite session store restores and terminalizes interrupted turns", async () => {
+  const path = await Deno.makeTempFile({ suffix: ".sqlite" });
+  const store = await openSqliteHarnessChatSessionStore({
+    url: toFileUrl(path),
+  });
+
+  try {
+    const stalled = new HarnessInteractiveChatService({
+      createPromptLoop: () => ({
+        runTranscript: () =>
+          new Promise<HarnessPromptLoopResult>(() => {
+            // Simulates a process dying while a turn is still in flight.
+          }),
+      }),
+      now: nextIsoNow(),
+      sessionStore: store,
+    });
+
+    await stalled.startSession("req-1", {
+      sessionId: "session-1",
+      workspace: { hostPath: "/workspace" },
+    });
+    await stalled.startTurn("req-2", {
+      sessionId: "session-1",
+      turnId: "turn-1",
+      input: { text: "This will be interrupted" },
+    });
+
+    assertEquals(
+      (await store.listTurns({ sessionId: "session-1" })).map((turn) =>
+        turn.turn.status
+      ),
+      ["running"],
+    );
+
+    const restored = new HarnessInteractiveChatService({
+      createPromptLoop: () => ({
+        runTranscript: (options) =>
+          Promise.resolve(makeResult(options, "Recovered.")),
+      }),
+      now: () => "2026-05-27T00:01:00.000Z",
+      sessionStore: store,
+    });
+    await restored.initializeFromStore();
+
+    assertEquals(restored.status("session-1").sessions[0].status, "idle");
+    assertEquals(restored.status("session-1").sessions[0].reusable, true);
+    assertEquals(
+      restored.listTurns({ sessionId: "session-1" }).turns[0].turn.status,
+      "failed",
+    );
+    assertEquals(
+      restored.listTurns({ sessionId: "session-1" }).turns[0].turn.error
+        ?.details,
+      {
+        terminalReason: "process_interrupted",
+        priorStatus: "running",
+      },
+    );
+    assertEquals(
+      restored.listEvents({ sessionId: "session-1", afterSequence: 2 }).events
+        .map((event) => [event.sequence, event.event.kind]),
+      [[3, "turn_failed"]],
+    );
+
+    const followUp = await restored.startTurn("req-3", {
+      sessionId: "session-1",
+      turnId: "turn-2",
+      input: { text: "Continue" },
+    });
+    assertEquals(followUp.ok, true);
+    await restored.waitForTurn("session-1", "turn-2");
+    assertEquals(
+      restored.listTurns({ sessionId: "session-1" }).turns.map((turn) => [
+        turn.turn.turnId,
+        turn.turn.status,
+      ]),
+      [["turn-1", "failed"], ["turn-2", "completed"]],
+    );
+  } finally {
+    store.close();
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("sqlite session restore keeps closed sessions closed while terminalizing turns", async () => {
+  const path = await Deno.makeTempFile({ suffix: ".sqlite" });
+  const store = await openSqliteHarnessChatSessionStore({
+    url: toFileUrl(path),
+  });
+
+  try {
+    const turn = {
+      turnId: "turn-closed",
+      status: "running" as const,
+      startedAt: "2026-05-27T00:00:01.000Z",
+      updatedAt: "2026-05-27T00:00:01.000Z",
+    };
+    const session = {
+      ...createHarnessChatSessionStatus({
+        sessionId: "session-closed",
+        createdAt: "2026-05-27T00:00:00.000Z",
+        workspace: { hostPath: "/workspace" },
+      }),
+      status: "closed" as const,
+      reusable: false,
+      activeTurnId: turn.turnId,
+      activeTurn: turn,
+      closedAt: "2026-05-27T00:00:02.000Z",
+      updatedAt: "2026-05-27T00:00:02.000Z",
+    };
+    store.saveSession({
+      session,
+      transcript: [],
+    });
+    store.saveTurn({
+      sessionId: "session-closed",
+      turn,
+      input: { text: "interrupted under closed session" },
+      policy: session.policy,
+    });
+
+    const restored = new HarnessInteractiveChatService({
+      createPromptLoop: () => ({
+        runTranscript: (options) =>
+          Promise.resolve(makeResult(options, "Should not run.")),
+      }),
+      now: () => "2026-05-27T00:01:00.000Z",
+      sessionStore: store,
+    });
+    await restored.initializeFromStore();
+
+    assertEquals(
+      restored.status("session-closed").sessions[0].status,
+      "closed",
+    );
+    assertEquals(
+      restored.status("session-closed").sessions[0].reusable,
+      false,
+    );
+    assertEquals(
+      restored.listTurns({ sessionId: "session-closed" }).turns[0].turn.status,
+      "failed",
+    );
+    assertEquals(
+      restored.listEvents({ sessionId: "session-closed" }).events.map((
+        event,
+      ) => event.event.kind),
+      ["turn_failed"],
+    );
   } finally {
     store.close();
     await Deno.remove(path);


### PR DESCRIPTION
## Summary

Stacked on #3711 (`codex/cf-harness-sqlite-sessions`). This adds the next cf-harness persistence slice: durable chat turn records and restart recovery on top of the SQLite session/event store.

Changes:
- add `HarnessChatTurnRecord` plus `list_turns` request/result types to the interactive chat protocol
- add a SQLite `chat_turn` table with turn/input/context/policy/browser lease/metadata persistence
- persist turn lifecycle transitions for running, canceling, canceled, completed, and failed turns
- add `turn_failed` as a per-turn terminal event so prompt-loop failures do not poison the reusable session
- terminalize restored interrupted turns during `initializeFromStore()` (`running` -> `failed` with `process_interrupted`; `canceling` -> `canceled`)
- add NDJSON transport validation for `list_turns`

## Why

The prior PR made sessions and event replay durable. This fills in explicit turn-level state so Loom/headless clients can inspect turn status directly and so a cf-harness process restart does not leave a session permanently stuck on an in-flight turn.

## Validation

- `deno fmt packages/cf-harness/src/session-store.ts packages/cf-harness/src/sqlite-session-store.ts packages/cf-harness/src/contracts/interactive-chat.ts packages/cf-harness/src/interactive-chat-service.ts packages/cf-harness/src/interactive-chat-stdio.ts packages/cf-harness/test/interactive-chat-service.test.ts packages/cf-harness/test/interactive-chat-stdio.test.ts packages/cf-harness/test/sqlite-session-store.test.ts`
- `deno check packages/cf-harness/src/session-store.ts packages/cf-harness/src/sqlite-session-store.ts packages/cf-harness/src/contracts/interactive-chat.ts packages/cf-harness/src/interactive-chat-service.ts packages/cf-harness/src/interactive-chat-stdio.ts packages/cf-harness/test/interactive-chat-service.test.ts packages/cf-harness/test/interactive-chat-stdio.test.ts packages/cf-harness/test/sqlite-session-store.test.ts`
- `deno lint packages/cf-harness/src/session-store.ts packages/cf-harness/src/sqlite-session-store.ts packages/cf-harness/src/contracts/interactive-chat.ts packages/cf-harness/src/interactive-chat-service.ts packages/cf-harness/src/interactive-chat-stdio.ts packages/cf-harness/test/interactive-chat-service.test.ts packages/cf-harness/test/interactive-chat-stdio.test.ts packages/cf-harness/test/sqlite-session-store.test.ts`
- `deno test --allow-read --allow-write --allow-run --allow-ffi --allow-net --allow-env packages/cf-harness/test/interactive-chat-service.test.ts packages/cf-harness/test/interactive-chat-stdio.test.ts packages/cf-harness/test/sqlite-session-store.test.ts` (`24 passed`)
- `deno task test` in `packages/cf-harness` (`356 passed`)
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds durable per-turn records with a restart-safe lifecycle to the `cf-harness` chat service. Persists turns in SQLite, adds `list_turns`, de-dupes `start_turn` by `turnId`, and emits clear terminal events so clients can query history and recover after restarts.

- **New Features**
  - Protocol: `HarnessChatTurnRecord`, `list_turns` request/result (with status filter), `turn_failed` event, `turn_exists` error; `error` added to `HarnessChatTurnStatus`.
  - Persistence: SQLite `chat_turn` table (turn/input/context/policy/browser lease/metadata/status/timestamps/error); atomic `saveSessionTurnAndAppendEvent` to persist session+turn+event; durable create with insert-or-ignore; file: URLs only.
  - Service/Transport: per-session in-memory turn map; filterable turn listing; durable de-dupe of `start_turn` with a reserved starting turn to prevent races; emits `turn_failed` on prompt-loop setup/runtime errors; NDJSON validation for `list_turns`.

- **Bug Fixes**
  - Restart recovery: on init, terminalize interrupted turns (running -> failed with `process_interrupted`; canceling -> canceled), clear stale `activeTurn`, keep closed/failed sessions non-reusable, and clear session `activeTurn` if the stored turn is already terminal.
  - Safety: rolls back in-memory turn state if persistence fails; serializes event sequences; closing a session cancels, emits, and persists the active turn.

<sup>Written for commit ab87e62982c95ec8574eee7911233ac2bee2a302. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3714?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

