### PR TITLE
feat(patterns): Add bootstrap admin list mode to group chat

### DIFF
--- a/packages/patterns/cfc-group-chat-demo/main.test.tsx
+++ b/packages/patterns/cfc-group-chat-demo/main.test.tsx
@@ -98,7 +98,10 @@ export default pattern(() => {
     bobChat.addTrustedRoom.send();
   });
   const action_disable_everyone_admin = action(() => {
-    chat.toggleEveryoneAdmin.send({ everyoneIsAdmin: false });
+    chat.toggleEveryoneAdmin.send({
+      type: "click",
+      target: { name: "", value: "on" },
+    });
   });
   const action_toggle_bob_admin = action(() => {
     chat.toggleParticipantAdmin.send({ name: "Bob" });
@@ -226,6 +229,11 @@ export default pattern(() => {
         "Admin",
       );
   });
+  const assert_admin_view_lists_bob_after_lockdown = computed(() => {
+    const userList = findNodeById(chat[UI], "trusted-admin-user-list");
+    return nodeIncludesText(userList, "Bob") &&
+      nodeIncludesText(userList, "Make admin");
+  });
   const assert_last_admin_removal_blocked = computed(() =>
     chat.currentUserIsAdmin === true &&
     bobChat.currentUserIsAdmin !== true &&
@@ -239,7 +247,9 @@ export default pattern(() => {
   const assert_bob_admin_enabled = computed(() =>
     bobChat.currentUserIsAdmin === true &&
     bobChat.currentUserCanManageAdmins === true &&
-    chatAdminRolesValue(adminRegistry).length === 2
+    chatAdminRolesValue(adminRegistry).length === 2 &&
+    (adminRegistry.get() as { everyoneIsAdmin?: boolean }).everyoneIsAdmin ===
+      false
   );
   const assert_bob_can_add_room = computed(() => {
     const roomList = roomsValue(rooms);
@@ -329,6 +339,7 @@ export default pattern(() => {
       { action: action_disable_everyone_admin },
       { assertion: assert_everyone_disabled_seeds_alice },
       { assertion: assert_admin_view_explicit_alice },
+      { assertion: assert_admin_view_lists_bob_after_lockdown },
       { action: action_try_remove_last_admin },
       { assertion: assert_last_admin_removal_blocked },
       { action: action_set_room_bob },

--- a/packages/patterns/cfc-group-chat-demo/main.test.tsx
+++ b/packages/patterns/cfc-group-chat-demo/main.test.tsx
@@ -103,6 +103,9 @@ export default pattern(() => {
   const action_toggle_bob_admin = action(() => {
     chat.toggleParticipantAdmin.send({ name: "Bob" });
   });
+  const action_try_remove_last_admin = action(() => {
+    chat.toggleCurrentUserAdmin.send({});
+  });
   const action_bob_add_room = action(() => {
     bobChat.addTrustedRoom.send();
   });
@@ -223,6 +226,13 @@ export default pattern(() => {
         "Admin",
       );
   });
+  const assert_last_admin_removal_blocked = computed(() =>
+    chat.currentUserIsAdmin === true &&
+    bobChat.currentUserIsAdmin !== true &&
+    chatAdminRolesValue(adminRegistry).length === 1 &&
+    (adminRegistry.get() as { everyoneIsAdmin?: boolean }).everyoneIsAdmin ===
+      false
+  );
   const assert_bob_cannot_add_room_after_lockdown = computed(() =>
     roomsValue(rooms).length === 1
   );
@@ -319,6 +329,8 @@ export default pattern(() => {
       { action: action_disable_everyone_admin },
       { assertion: assert_everyone_disabled_seeds_alice },
       { assertion: assert_admin_view_explicit_alice },
+      { action: action_try_remove_last_admin },
+      { assertion: assert_last_admin_removal_blocked },
       { action: action_set_room_bob },
       { action: action_bob_try_add_room },
       { assertion: assert_bob_cannot_add_room_after_lockdown },

--- a/packages/patterns/cfc-group-chat-demo/main.test.tsx
+++ b/packages/patterns/cfc-group-chat-demo/main.test.tsx
@@ -18,7 +18,6 @@ import {
   type SharedMessagesValue,
   type SharedProfilesValue,
   type SharedRoomsValue,
-  TRUSTED_GROUP_CHAT_SET_ADMIN_ACTION,
 } from "./trusted.tsx";
 import { GroupChatDemo } from "./main.tsx";
 
@@ -41,7 +40,6 @@ export default pattern(() => {
     {} as ChatAdminRegistryValue,
   );
   const profileDraft = Writable.of("");
-  const adminDraft = Writable.of(true);
   const messageDraft = Writable.of("");
   const hostMessageDraft = Writable.of("");
   const roomDraft = Writable.of("");
@@ -52,7 +50,6 @@ export default pattern(() => {
     rooms,
     adminRegistry,
     profileDraft,
-    adminDraft,
     messageDraft,
     hostMessageDraft,
     roomDraft,
@@ -61,7 +58,6 @@ export default pattern(() => {
     {} as Default<EmptyMyProfileValue>,
   );
   const bobProfileDraft = Writable.of("");
-  const bobAdminDraft = Writable.of(true);
   const bobMessageDraft = Writable.of("");
   const bobHostMessageDraft = Writable.of("");
   const bobRoomDraft = Writable.of("");
@@ -72,7 +68,6 @@ export default pattern(() => {
     rooms,
     adminRegistry,
     profileDraft: bobProfileDraft,
-    adminDraft: bobAdminDraft,
     messageDraft: bobMessageDraft,
     hostMessageDraft: bobHostMessageDraft,
     roomDraft: bobRoomDraft,
@@ -93,16 +88,28 @@ export default pattern(() => {
   const action_set_room_ops = action(() => {
     chat.setRoomDraft.send("Ops");
   });
-  const action_try_add_room_without_admin = action(() => {
-    chat.addTrustedRoom.send();
-  });
-  const action_enable_admin_draft = action(() => {
-    chat.setAdminDraft.send(true);
-  });
-  const action_toggle_alice_admin = action(() => {
-    chat.toggleCurrentUserAdmin.send();
+  const action_set_room_bob = action(() => {
+    bobChat.setRoomDraft.send("Bob room");
   });
   const action_add_room = action(() => {
+    chat.addTrustedRoom.send();
+  });
+  const action_bob_try_add_room = action(() => {
+    bobChat.addTrustedRoom.send();
+  });
+  const action_disable_everyone_admin = action(() => {
+    chat.toggleEveryoneAdmin.send({ everyoneIsAdmin: false });
+  });
+  const action_toggle_bob_admin = action(() => {
+    chat.toggleParticipantAdmin.send({ name: "Bob" });
+  });
+  const action_bob_add_room = action(() => {
+    bobChat.addTrustedRoom.send();
+  });
+  const action_set_room_ops_again = action(() => {
+    chat.setRoomDraft.send("Ops 2");
+  });
+  const action_alice_add_second_room = action(() => {
     chat.addTrustedRoom.send();
   });
   const action_set_message_alice = action(() => {
@@ -145,58 +152,69 @@ export default pattern(() => {
     (myProfile.get() as MyProfileValue | undefined)?.profile === undefined &&
     (messages.get()?.length ?? 0) === 0
   );
-  const assert_admin_view_initially_locked = computed(() => {
+  const assert_admin_view_waits_for_profile = computed(() => {
     const managerChip = findNodeById(chat[UI], "group-chat-manager-chip");
     const panelStatus = findNodeById(
       chat[UI],
       "trusted-admin-manager-panel-status",
     );
-    return propValue(managerChip, "label") === "Manager off" &&
+    return propValue(managerChip, "label") === "No profile" &&
       propValue(panelStatus, "label") ===
-        "Save profile with admin-manager enabled to edit";
+        "Save a profile to manage admins";
   });
   const assert_profile_created = computed(() =>
     chat.currentProfileName === "Alice"
   );
-  const assert_profile_starts_non_admin = computed(() =>
-    chat.currentUserIsAdmin !== true
-  );
-  const assert_profile_can_manage_admins = computed(() =>
-    chat.currentUserCanManageAdmins === true
+  const assert_profile_bootstraps_admin = computed(() =>
+    chat.currentUserIsAdmin === true &&
+    chat.currentUserCanManageAdmins === true &&
+    chatAdminRolesValue(adminRegistry).length === 0
   );
   const assert_alice_sees_bob_without_bob_message = computed(() => {
     const participants = participantClaimsValue(profiles, myProfile, messages);
     return participants.some((participant) => participant.name === "Alice") &&
       participants.some((participant) => participant.name === "Bob");
   });
-  const assert_admin_view_manager_enabled = computed(() => {
+  const assert_admin_view_everyone_enabled = computed(() => {
     const toggleButton = findNodeByProp(
       chat[UI],
-      "data-ui-action",
-      TRUSTED_GROUP_CHAT_SET_ADMIN_ACTION,
+      "data-ui-control",
+      "admin-user-toggle",
+    );
+    const everyoneCheckbox = findNodeById(
+      chat[UI],
+      "trusted-everyone-admin-checkbox",
     );
     const managerChip = findNodeById(chat[UI], "group-chat-manager-chip");
     const panelStatus = findNodeById(
       chat[UI],
       "trusted-admin-manager-panel-status",
     );
-    return propValue(managerChip, "label") === "Can manage admins" &&
-      propValue(panelStatus, "label") === "Admin registry editing enabled" &&
-      propValue(toggleButton, "disabled") === false &&
-      nodeIncludesText(toggleButton, "Make admin");
+    return propValue(managerChip, "label") === "Everyone is admin" &&
+      propValue(panelStatus, "label") === "Everyone can add rooms" &&
+      propValue(everyoneCheckbox, "checked") === true &&
+      propValue(everyoneCheckbox, "disabled") === false &&
+      propValue(toggleButton, "disabled") === true &&
+      nodeIncludesText(toggleButton, "Admin via everyone");
   });
-  const assert_non_admin_cannot_add_room = computed(() =>
-    roomsValue(rooms).length === 0
-  );
-  const assert_admin_enabled = computed(() =>
+  const assert_bootstrap_admin_can_add_room = computed(() => {
+    const roomList = roomsValue(rooms);
+    return roomList.length === 1 &&
+      roomList[0]?.name === "Ops" &&
+      roomDraft.get() === "";
+  });
+  const assert_everyone_disabled_seeds_alice = computed(() =>
     chat.currentUserIsAdmin === true &&
-    chatAdminRolesValue(adminRegistry).length === 1
+    bobChat.currentUserIsAdmin !== true &&
+    chatAdminRolesValue(adminRegistry).length === 1 &&
+    (adminRegistry.get() as { everyoneIsAdmin?: boolean }).everyoneIsAdmin ===
+      false
   );
-  const assert_admin_view_current_user_admin = computed(() => {
+  const assert_admin_view_explicit_alice = computed(() => {
     const toggleButton = findNodeByProp(
       chat[UI],
-      "data-ui-action",
-      TRUSTED_GROUP_CHAT_SET_ADMIN_ACTION,
+      "data-ui-control",
+      "admin-user-toggle",
     );
     return propValue(toggleButton, "disabled") === false &&
       nodeIncludesText(toggleButton, "Remove admin") &&
@@ -205,10 +223,24 @@ export default pattern(() => {
         "Admin",
       );
   });
-  const assert_admin_can_add_room = computed(() => {
+  const assert_bob_cannot_add_room_after_lockdown = computed(() =>
+    roomsValue(rooms).length === 1
+  );
+  const assert_bob_admin_enabled = computed(() =>
+    bobChat.currentUserIsAdmin === true &&
+    bobChat.currentUserCanManageAdmins === true &&
+    chatAdminRolesValue(adminRegistry).length === 2
+  );
+  const assert_bob_can_add_room = computed(() => {
     const roomList = roomsValue(rooms);
-    return roomList.length === 1 &&
-      roomList[0]?.name === "Ops" &&
+    return roomList.length === 2 &&
+      roomList[1]?.name === "Bob room" &&
+      bobRoomDraft.get() === "";
+  });
+  const assert_alice_can_still_add_room = computed(() => {
+    const roomList = roomsValue(rooms);
+    return roomList.length === 3 &&
+      roomList[2]?.name === "Ops 2" &&
       roomDraft.get() === "";
   });
   const assert_message_sent_and_draft_cleared = computed(() =>
@@ -272,27 +304,31 @@ export default pattern(() => {
   return {
     tests: [
       { assertion: assert_initially_empty },
-      { assertion: assert_admin_view_initially_locked },
+      { assertion: assert_admin_view_waits_for_profile },
       { action: action_set_profile_alice },
       { action: action_save_profile },
       { assertion: assert_profile_created },
-      { assertion: assert_profile_starts_non_admin },
-      { assertion: assert_profile_can_manage_admins },
+      { assertion: assert_profile_bootstraps_admin },
       { action: action_set_profile_bob },
       { action: action_save_profile_bob },
       { assertion: assert_alice_sees_bob_without_bob_message },
-      { assertion: assert_admin_view_manager_enabled },
+      { assertion: assert_admin_view_everyone_enabled },
       { action: action_set_room_ops },
-      { action: action_try_add_room_without_admin },
-      { assertion: assert_non_admin_cannot_add_room },
-      { action: action_enable_admin_draft },
-      { action: action_save_profile },
-      { assertion: assert_profile_can_manage_admins },
-      { action: action_toggle_alice_admin },
-      { assertion: assert_admin_enabled },
-      { assertion: assert_admin_view_current_user_admin },
       { action: action_add_room },
-      { assertion: assert_admin_can_add_room },
+      { assertion: assert_bootstrap_admin_can_add_room },
+      { action: action_disable_everyone_admin },
+      { assertion: assert_everyone_disabled_seeds_alice },
+      { assertion: assert_admin_view_explicit_alice },
+      { action: action_set_room_bob },
+      { action: action_bob_try_add_room },
+      { assertion: assert_bob_cannot_add_room_after_lockdown },
+      { action: action_toggle_bob_admin },
+      { assertion: assert_bob_admin_enabled },
+      { action: action_bob_add_room },
+      { assertion: assert_bob_can_add_room },
+      { action: action_set_room_ops_again },
+      { action: action_alice_add_second_room },
+      { assertion: assert_alice_can_still_add_room },
       { action: action_set_message_alice },
       { action: action_send_message },
       { assertion: assert_message_sent_and_draft_cleared },

--- a/packages/patterns/cfc-group-chat-demo/main.tsx
+++ b/packages/patterns/cfc-group-chat-demo/main.tsx
@@ -18,13 +18,12 @@ import {
   sortDisplayMessages,
 } from "./logic.ts";
 import {
-  type AdminManagerCredentialCell,
-  type AdminManagerDraftCell,
-  type ChatAdminManagerCredential,
+  chatAdminEveryoneIsAdmin,
   type ChatAdminRegistryCell,
   type ChatAdminRegistryValue,
   commitTrustedMessageSend,
   currentProfileCell,
+  currentUserCanManageAdmins,
   currentUserIsAdmin as currentProfileIsAdmin,
   messagesValue,
   type MyProfileCell,
@@ -56,12 +55,6 @@ const draftText = (draft: DraftCell): string =>
   (draft.get() as string | undefined) ?? "";
 
 const writeDraftText = handler<string, { value: DraftCell }>(
-  (nextValue, { value }) => {
-    value.set(nextValue);
-  },
-);
-
-const writeBooleanDraft = handler<boolean, { value: AdminManagerDraftCell }>(
   (nextValue, { value }) => {
     value.set(nextValue);
   },
@@ -218,7 +211,6 @@ export interface GroupChatDemoInput {
   rooms?: PerSpace<SharedRoomsCell>;
   adminRegistry?: PerSpace<ChatAdminRegistryCell>;
   profileDraft?: PerUser<DraftCell>;
-  adminDraft?: PerUser<AdminManagerDraftCell>;
   messageDraft?: PerUser<DraftCell>;
   hostMessageDraft?: PerSession<DraftCell>;
   roomDraft?: PerSession<RoomDraftCell>;
@@ -233,12 +225,10 @@ export interface GroupChatDemoOutput {
   rooms: PerSpace<SharedRoomsCell>;
   adminRegistry: PerSpace<ChatAdminRegistryCell>;
   profileDraft: PerUser<DraftCell>;
-  adminDraft: PerUser<AdminManagerDraftCell>;
   messageDraft: PerUser<DraftCell>;
   hostMessageDraft: PerSession<DraftCell>;
   roomDraft: PerSession<RoomDraftCell>;
   setProfileDraft: Stream<string>;
-  setAdminDraft: Stream<boolean>;
   setMessageDraft: Stream<string>;
   setHostMessageDraft: Stream<string>;
   setRoomDraft: Stream<string>;
@@ -246,7 +236,9 @@ export interface GroupChatDemoOutput {
   currentUserIsAdmin: boolean;
   currentUserCanManageAdmins: boolean;
   saveProfile: Stream<void>;
-  toggleCurrentUserAdmin: Stream<void>;
+  toggleCurrentUserAdmin: Stream<{ name?: string; everyoneIsAdmin?: boolean }>;
+  toggleParticipantAdmin: Stream<{ name?: string; everyoneIsAdmin?: boolean }>;
+  toggleEveryoneAdmin: Stream<{ name?: string; everyoneIsAdmin?: boolean }>;
   sendTrustedMessage: Stream<void>;
   addTrustedRoom: Stream<void>;
   hostLookalikeSend: Stream<void>;
@@ -261,40 +253,30 @@ export const GroupChatDemo = pattern<GroupChatDemoInput, GroupChatDemoOutput>((
     rooms,
     adminRegistry,
     profileDraft,
-    adminDraft,
     messageDraft,
     hostMessageDraft,
     roomDraft,
   }: GroupChatDemoInput,
 ): GroupChatDemoOutput => {
   const myProfileCell = myProfile as MyProfileCell;
-  const adminManagerCredentialCell = new Writable.perUser<
-    ChatAdminManagerCredential | null
-  >(null) as AdminManagerCredentialCell;
   const profilesCell = profiles as SharedProfilesCell;
   const messagesCell = messages as SharedMessagesCell;
   const roomsCell = rooms as SharedRoomsCell;
   const adminRegistryCell = adminRegistry as ChatAdminRegistryCell;
   const profileDraftCell = profileDraft as DraftCell;
-  const adminManagerDraftCell = adminDraft as AdminManagerDraftCell;
   const messageDraftCell = messageDraft as DraftCell;
   const hostMessageDraftCell = hostMessageDraft as DraftCell;
   const roomDraftCell = roomDraft as RoomDraftCell;
   const trustedProfileSave = TrustedProfileSaveSurface({
     myProfile: myProfileCell,
     profiles: profilesCell,
-    adminManagerCredential: adminManagerCredentialCell,
     nameDraft: profileDraftCell,
-    adminManagerDraft: adminManagerDraftCell,
   } as TrustedProfileSaveSurfaceInputArg);
-  const currentUserCanManageAdminsStatus =
-    trustedProfileSave.currentUserCanManageAdmins;
   const trustedAdminPanel = TrustedAdminPanel({
     profiles: profilesCell,
     myProfile: myProfileCell,
     messages: messagesCell,
     adminRegistry: adminRegistryCell,
-    adminManagerCredential: adminManagerCredentialCell,
   } as TrustedAdminPanelInputArg);
   const trustedSend = TrustedChatSendSurface({
     profiles: profilesCell,
@@ -314,7 +296,6 @@ export const GroupChatDemo = pattern<GroupChatDemoInput, GroupChatDemoOutput>((
     messages: messagesCell,
   } as TrustedMessageSendInputArg);
   const setProfileDraft = writeDraftText({ value: profileDraftCell });
-  const setAdminDraft = writeBooleanDraft({ value: adminManagerDraftCell });
   const setMessageDraft = writeDraftText({ value: messageDraftCell });
   const setHostMessageDraft = writeDraftText({ value: hostMessageDraftCell });
   const setRoomDraft = writeDraftText({ value: roomDraftCell });
@@ -387,9 +368,18 @@ export const GroupChatDemo = pattern<GroupChatDemoInput, GroupChatDemoOutput>((
                   />
                   <cf-chip
                     id="group-chat-manager-chip"
-                    label={currentUserCanManageAdminsStatus
-                      ? "Can manage admins"
-                      : "Manager off"}
+                    label={computed(() =>
+                      currentProfileCell(myProfileCell) === undefined
+                        ? "No profile"
+                        : chatAdminEveryoneIsAdmin(adminRegistryCell)
+                        ? "Everyone is admin"
+                        : currentUserCanManageAdmins(
+                            myProfileCell,
+                            adminRegistryCell,
+                          )
+                        ? "Can manage admins"
+                        : "Manager off"
+                    )}
                   />
                 </cf-hstack>
               </cf-hstack>
@@ -467,12 +457,10 @@ export const GroupChatDemo = pattern<GroupChatDemoInput, GroupChatDemoOutput>((
     rooms: roomsCell as PerSpace<SharedRoomsCell>,
     adminRegistry: adminRegistryCell as PerSpace<ChatAdminRegistryCell>,
     profileDraft: profileDraftCell as PerUser<DraftCell>,
-    adminDraft: adminManagerDraftCell as PerUser<AdminManagerDraftCell>,
     messageDraft: messageDraftCell as PerUser<DraftCell>,
     hostMessageDraft: hostMessageDraftCell as PerSession<DraftCell>,
     roomDraft: roomDraftCell as PerSession<RoomDraftCell>,
     setProfileDraft,
-    setAdminDraft,
     setMessageDraft,
     setHostMessageDraft,
     setRoomDraft,
@@ -480,9 +468,13 @@ export const GroupChatDemo = pattern<GroupChatDemoInput, GroupChatDemoOutput>((
     currentUserIsAdmin: computed(() =>
       currentProfileIsAdmin(myProfileCell, adminRegistryCell)
     ),
-    currentUserCanManageAdmins: currentUserCanManageAdminsStatus,
+    currentUserCanManageAdmins: computed(() =>
+      currentUserCanManageAdmins(myProfileCell, adminRegistryCell)
+    ),
     saveProfile: trustedProfileSave.saveProfile,
     toggleCurrentUserAdmin: trustedAdminPanel.toggleCurrentUserAdmin,
+    toggleParticipantAdmin: trustedAdminPanel.toggleParticipantAdmin,
+    toggleEveryoneAdmin: trustedAdminPanel.toggleEveryoneAdmin,
     sendTrustedMessage: trustedSend.sendMessage,
     addTrustedRoom: trustedRoomAdd.addRoom,
     hostLookalikeSend,

--- a/packages/patterns/cfc-group-chat-demo/main.tsx
+++ b/packages/patterns/cfc-group-chat-demo/main.tsx
@@ -38,6 +38,7 @@ import {
   type SharedRoomsCell,
   type SharedRoomsValue,
   TrustedAdminPanel,
+  type TrustedAdminPolicyEvent,
   TrustedChatSendSurface,
   TrustedProfileSaveSurface,
   TrustedRoomAddSurface,
@@ -236,9 +237,9 @@ export interface GroupChatDemoOutput {
   currentUserIsAdmin: boolean;
   currentUserCanManageAdmins: boolean;
   saveProfile: Stream<void>;
-  toggleCurrentUserAdmin: Stream<{ name?: string; everyoneIsAdmin?: boolean }>;
-  toggleParticipantAdmin: Stream<{ name?: string; everyoneIsAdmin?: boolean }>;
-  toggleEveryoneAdmin: Stream<{ name?: string; everyoneIsAdmin?: boolean }>;
+  toggleCurrentUserAdmin: Stream<TrustedAdminPolicyEvent>;
+  toggleParticipantAdmin: Stream<TrustedAdminPolicyEvent>;
+  toggleEveryoneAdmin: Stream<TrustedAdminPolicyEvent>;
   sendTrustedMessage: Stream<void>;
   addTrustedRoom: Stream<void>;
   hostLookalikeSend: Stream<void>;

--- a/packages/patterns/cfc-group-chat-demo/trusted.tsx
+++ b/packages/patterns/cfc-group-chat-demo/trusted.tsx
@@ -119,21 +119,34 @@ export type ChatAdminList = RequiresIntegrity<
   readonly [typeof GROUP_CHAT_ADMIN_INTEGRITY]
 >;
 
-export type ChatEveryoneAdminFlag = RequiresIntegrity<
-  AddIntegrity<
-    TrustedActionWrite<
-      boolean,
-      typeof commitTrustedAdminToggle,
-      typeof TRUSTED_GROUP_CHAT_SET_ADMIN_ACTION,
-      typeof TRUSTED_GROUP_CHAT_ADMIN_SURFACE
-    >,
-    readonly [typeof GROUP_CHAT_ADMIN_INTEGRITY]
-  >,
+export type ChatAdminBootstrapRole = AddIntegrity<
+  ChatAdminRoleAssignment,
   readonly [typeof GROUP_CHAT_ADMIN_INTEGRITY]
 >;
 
+export type ChatEveryoneAdminFlag =
+  | RequiresIntegrity<
+    AddIntegrity<
+      TrustedActionWrite<
+        true,
+        typeof commitTrustedAdminToggle,
+        typeof TRUSTED_GROUP_CHAT_SET_ADMIN_ACTION,
+        typeof TRUSTED_GROUP_CHAT_ADMIN_SURFACE
+      >,
+      readonly [typeof GROUP_CHAT_ADMIN_INTEGRITY]
+    >,
+    readonly [typeof GROUP_CHAT_ADMIN_INTEGRITY]
+  >
+  | TrustedActionWrite<
+    false,
+    typeof commitTrustedAdminToggle,
+    typeof TRUSTED_GROUP_CHAT_SET_ADMIN_ACTION,
+    typeof TRUSTED_GROUP_CHAT_ADMIN_SURFACE
+  >;
+
 export interface ChatAdminRegistryStoredValue {
   readonly admins?: ChatAdminList;
+  readonly bootstrapAdmin?: ChatAdminBootstrapRole;
   readonly everyoneIsAdmin?: ChatEveryoneAdminFlag;
 }
 
@@ -165,6 +178,11 @@ export type RoomDraftCell = Writable<string | Default<"">>;
 
 const draftText = (draft: Writable<string | Default<"">>): string =>
   (draft.get() as string | undefined) ?? "";
+
+const nonEmptyEventName = (value: string | undefined): string | undefined => {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+};
 
 export const messagesValue = (
   messages: SharedMessagesCell,
@@ -206,7 +224,23 @@ export const currentProfileSnapshot = (
 
 export const chatAdminRolesValue = (
   adminRegistry: ChatAdminRegistryCell,
-): ChatAdminRole[] => adminRegistryEntries<ChatAdminRole>(adminRegistry);
+): ChatAdminRole[] => {
+  const explicitAdmins = adminRegistryEntries<ChatAdminRole>(adminRegistry);
+  if (explicitAdmins.length > 0) {
+    return explicitAdmins;
+  }
+  const bootstrapAdmin = (
+    adminRegistry.get() as ChatAdminRegistryStoredValue | undefined
+  )?.bootstrapAdmin;
+  if (bootstrapAdmin === undefined) {
+    return [];
+  }
+  return [{
+    ...bootstrapAdmin,
+    subject: adminRegistry.key("bootstrapAdmin").key("subject")
+      .resolveAsCell() as ProfileCell,
+  } as ChatAdminRole];
+};
 
 export const chatAdminEveryoneIsAdmin = (
   adminRegistry: ChatAdminRegistryCell,
@@ -513,7 +547,15 @@ export const commitTrustedMessageSend = handler<
 type TrustedMessageSendInput = Parameters<typeof commitTrustedMessageSend>[0];
 
 export interface TrustedAdminPolicyEvent {
+  readonly type?: string;
   readonly name?: string;
+  readonly target?: {
+    readonly name?: string;
+    readonly value?: string;
+    readonly dataset?: {
+      readonly adminName?: string;
+    };
+  };
   readonly everyoneIsAdmin?: boolean;
   readonly detail?: {
     readonly checked?: boolean;
@@ -521,7 +563,8 @@ export interface TrustedAdminPolicyEvent {
 }
 
 interface TrustedAdminPolicyChange {
-  readonly admins: ChatAdminRole[];
+  readonly admins?: ChatAdminRole[];
+  readonly bootstrapAdmin?: ChatAdminRole;
   readonly everyoneIsAdmin?: boolean;
 }
 
@@ -540,7 +583,6 @@ export const prepareTrustedAdminToggle = (
   if (nextEveryoneIsAdmin !== undefined) {
     if (nextEveryoneIsAdmin) {
       return {
-        admins: adminRoles,
         everyoneIsAdmin: true,
       };
     }
@@ -551,18 +593,20 @@ export const prepareTrustedAdminToggle = (
     const currentName = myProfile === undefined
       ? undefined
       : currentProfileSnapshot(myProfile)?.name;
-    const seededAdmins =
+    const bootstrapAdmin =
       adminRoles.length === 0 && currentProfile !== undefined &&
         currentName
-        ? [
-          {
-            subject: currentProfile,
-            displayName: currentName,
-          } as ChatAdminRole,
-        ]
-        : adminRoles;
-    return seededAdmins.length === 0 ? null : {
-      admins: seededAdmins,
+        ? {
+          subject: currentProfile,
+          displayName: currentName,
+        } as ChatAdminRole
+        : undefined;
+    if (adminRoles.length === 0 && bootstrapAdmin === undefined) {
+      return null;
+    }
+    return {
+      ...(adminRoles.length > 0 ? { admins: adminRoles } : {}),
+      ...(bootstrapAdmin !== undefined ? { bootstrapAdmin } : {}),
       everyoneIsAdmin: false,
     };
   }
@@ -593,7 +637,6 @@ export const prepareTrustedAdminToggle = (
     }
     return {
       admins: withoutParticipant,
-      everyoneIsAdmin: false,
     };
   }
 
@@ -605,7 +648,6 @@ export const prepareTrustedAdminToggle = (
         displayName: targetName,
       } as ChatAdminRole,
     ],
-    everyoneIsAdmin: false,
   };
 };
 
@@ -622,16 +664,24 @@ export const commitTrustedAdminToggle = handler<
   event,
   { profiles, myProfile, messages, adminRegistry, participant },
 ) => {
-  const eventParticipant = event?.name === undefined
+  const eventName = nonEmptyEventName(event?.name) ??
+    nonEmptyEventName(event?.target?.dataset?.adminName) ??
+    nonEmptyEventName(event?.target?.name);
+  const eventParticipant = eventName === undefined
     ? undefined
     : adminParticipantRowsValue(
       profiles,
       myProfile,
       messages,
       adminRegistry,
-    ).find((row) => row.name === event.name);
+    ).find((row) => row.name === eventName);
   const nextEveryoneIsAdmin = event?.everyoneIsAdmin ??
-    event?.detail?.checked;
+    event?.detail?.checked ??
+    (participant === undefined &&
+        eventName === undefined &&
+        (event as { type?: string } | undefined)?.type === "click"
+      ? !chatAdminEveryoneIsAdmin(adminRegistry)
+      : undefined);
   const nextPolicy = prepareTrustedAdminToggle(
     currentUserAdminRole(myProfile, adminRegistry),
     adminRegistry,
@@ -643,14 +693,43 @@ export const commitTrustedAdminToggle = handler<
     return;
   }
 
-  adminRegistry.set({
-    admins: nextPolicy.admins as ChatAdminList,
-    ...(nextPolicy.everyoneIsAdmin !== undefined
-      ? {
-        everyoneIsAdmin: nextPolicy.everyoneIsAdmin as ChatEveryoneAdminFlag,
-      }
-      : {}),
-  });
+  if (
+    nextPolicy.bootstrapAdmin !== undefined ||
+    nextPolicy.everyoneIsAdmin !== undefined
+  ) {
+    const currentRegistry = adminRegistry.get() as
+      | ChatAdminRegistryStoredValue
+      | undefined;
+    adminRegistry.set({
+      ...(currentRegistry?.admins !== undefined
+        ? { admins: currentRegistry.admins }
+        : {}),
+      ...(currentRegistry?.bootstrapAdmin !== undefined
+        ? { bootstrapAdmin: currentRegistry.bootstrapAdmin }
+        : {}),
+      ...(currentRegistry?.everyoneIsAdmin !== undefined
+        ? { everyoneIsAdmin: currentRegistry.everyoneIsAdmin }
+        : {}),
+      ...(nextPolicy.admins !== undefined
+        ? { admins: nextPolicy.admins as ChatAdminList }
+        : {}),
+      ...(nextPolicy.bootstrapAdmin !== undefined
+        ? {
+          bootstrapAdmin: nextPolicy.bootstrapAdmin as ChatAdminBootstrapRole,
+        }
+        : {}),
+      ...(nextPolicy.everyoneIsAdmin !== undefined
+        ? {
+          everyoneIsAdmin: nextPolicy.everyoneIsAdmin as ChatEveryoneAdminFlag,
+        }
+        : {}),
+    });
+    return;
+  }
+
+  if (nextPolicy.admins !== undefined) {
+    adminRegistry.key("admins").set(nextPolicy.admins as ChatAdminList);
+  }
 });
 type TrustedAdminToggleInput = Parameters<typeof commitTrustedAdminToggle>[0];
 
@@ -805,14 +884,6 @@ export const TrustedAdminPanel = pattern<
     adminRegistry,
   }: TrustedAdminPanelInput,
 ): TrustedAdminPanelOutput => {
-  const adminRows = computed(() =>
-    adminParticipantRowsValue(
-      profiles,
-      myProfile,
-      messages,
-      adminRegistry,
-    )
-  );
   const toggleAdminPolicy = commitTrustedAdminToggle({
     profiles,
     myProfile,
@@ -860,20 +931,38 @@ export const TrustedAdminPanel = pattern<
             disabled={computed(() =>
               !currentUserCanManageAdmins(myProfile, adminRegistry)
             )}
-            oncf-change={toggleAdminPolicy}
+            onClick={toggleAdminPolicy}
           >
             Everyone is admin
           </cf-checkbox>
 
           <cf-vstack id="trusted-admin-user-list" gap="2">
-            {adminRows.map((participant) => {
-              const toggleAdmin = commitTrustedAdminToggle({
-                profiles,
-                myProfile,
-                messages,
-                adminRegistry,
-                participant,
-              } as TrustedAdminToggleInput);
+            {profiles.map((entry) => {
+              const profile = entry.profile;
+              const name = computed(() =>
+                profile.get()?.name ?? "Unnamed user"
+              );
+              const accentColor = computed(() =>
+                profile.get()?.accentColor ?? "#64748b"
+              );
+              const everyoneForProfile = computed(() =>
+                chatAdminEveryoneIsAdmin(adminRegistry)
+              );
+              const isAdmin = computed(() =>
+                everyoneForProfile ||
+                subjectHasAdminRole(chatAdminRolesValue(adminRegistry), profile)
+              );
+              const canManageAdmins = computed(() =>
+                currentUserCanManageAdmins(myProfile, adminRegistry)
+              );
+              const participant = {
+                name,
+                accentColor,
+                profile,
+                isAdmin,
+                everyoneIsAdmin: everyoneForProfile,
+                canManageAdmins,
+              } as AdminParticipantRow;
               const toggleDisabled = computed(() =>
                 !participant.canManageAdmins || participant.everyoneIsAdmin
               );
@@ -914,9 +1003,10 @@ export const TrustedAdminPanel = pattern<
                   <cf-button
                     data-ui-control="admin-user-toggle"
                     data-ui-action={TRUSTED_GROUP_CHAT_SET_ADMIN_ACTION}
+                    data-admin-name={participant.name}
                     size="sm"
                     disabled={toggleDisabled}
-                    onClick={toggleAdmin}
+                    onClick={toggleAdminPolicy}
                   >
                     {toggleLabel}
                   </cf-button>

--- a/packages/patterns/cfc-group-chat-demo/trusted.tsx
+++ b/packages/patterns/cfc-group-chat-demo/trusted.tsx
@@ -16,9 +16,8 @@ import {
 } from "commonfabric";
 import {
   activeAdminRoleForSubject,
-  type AdminManagerCredential,
-  adminManagerCredentialIsActive,
   adminRegistryEntries,
+  adminRegistryEveryoneIsAdmin,
   type EmptyAdminRegistryValue,
   subjectHasAdminRole,
 } from "../cfc/admin/mod.ts";
@@ -45,8 +44,6 @@ export const TRUSTED_GROUP_CHAT_SEND_ACTION = "TrustedGroupChatSendMessage";
 export const TRUSTED_GROUP_CHAT_ADD_ROOM_ACTION = "TrustedGroupChatAddRoom";
 export const TRUSTED_GROUP_CHAT_SET_ADMIN_ACTION = "TrustedGroupChatSetAdmin";
 export const GROUP_CHAT_ADMIN_INTEGRITY = "group-chat-admin" as const;
-export const GROUP_CHAT_ADMIN_MANAGER_INTEGRITY =
-  "group-chat-admin-manager" as const;
 
 export type TrustedProfile = RepresentsCurrentUser<
   TrustedActionWrite<
@@ -67,13 +64,6 @@ export type ChatAdminRole = AddIntegrity<
   ChatAdminRoleAssignment,
   readonly [typeof GROUP_CHAT_ADMIN_INTEGRITY]
 >;
-export type ChatAdminManagerCredential = AdminManagerCredential<
-  typeof GROUP_CHAT_ADMIN_MANAGER_INTEGRITY
->;
-export type AdminManagerCredentialCell = Writable<
-  ChatAdminManagerCredential | null
->;
-export type AdminManagerDraftCell = Writable<boolean | Default<true>>;
 
 export interface MyProfileValue {
   readonly profile?: ProfileCell;
@@ -126,11 +116,25 @@ export type ChatAdminList = RequiresIntegrity<
     typeof TRUSTED_GROUP_CHAT_SET_ADMIN_ACTION,
     typeof TRUSTED_GROUP_CHAT_ADMIN_SURFACE
   >,
-  readonly [typeof GROUP_CHAT_ADMIN_MANAGER_INTEGRITY]
+  readonly [typeof GROUP_CHAT_ADMIN_INTEGRITY]
+>;
+
+export type ChatEveryoneAdminFlag = RequiresIntegrity<
+  AddIntegrity<
+    TrustedActionWrite<
+      boolean,
+      typeof commitTrustedAdminToggle,
+      typeof TRUSTED_GROUP_CHAT_SET_ADMIN_ACTION,
+      typeof TRUSTED_GROUP_CHAT_ADMIN_SURFACE
+    >,
+    readonly [typeof GROUP_CHAT_ADMIN_INTEGRITY]
+  >,
+  readonly [typeof GROUP_CHAT_ADMIN_INTEGRITY]
 >;
 
 export interface ChatAdminRegistryStoredValue {
   readonly admins?: ChatAdminList;
+  readonly everyoneIsAdmin?: ChatEveryoneAdminFlag;
 }
 
 export type ChatAdminRegistryValue =
@@ -204,14 +208,38 @@ export const chatAdminRolesValue = (
   adminRegistry: ChatAdminRegistryCell,
 ): ChatAdminRole[] => adminRegistryEntries<ChatAdminRole>(adminRegistry);
 
+export const chatAdminEveryoneIsAdmin = (
+  adminRegistry: ChatAdminRegistryCell,
+): boolean => adminRegistryEveryoneIsAdmin<ChatAdminRole>(adminRegistry);
+
 export const currentUserAdminRole = (
   myProfile: MyProfileCell,
   adminRegistry: ChatAdminRegistryCell,
-): ChatAdminRole | undefined =>
-  activeAdminRoleForSubject(
+): ChatAdminRole | undefined => {
+  if (myProfileValue(myProfile).profile === undefined) {
+    return undefined;
+  }
+  const profile = myProfile.key("profile").resolveAsCell();
+  const explicitRole = activeAdminRoleForSubject(
     chatAdminRolesValue(adminRegistry),
-    currentProfileCell(myProfile),
+    profile,
   );
+  if (explicitRole !== undefined) {
+    return explicitRole;
+  }
+  const profileValue = currentProfileSnapshot(myProfile);
+  if (
+    !profileValue?.name ||
+    !chatAdminEveryoneIsAdmin(adminRegistry)
+  ) {
+    return undefined;
+  }
+
+  return {
+    subject: profile,
+    displayName: profileValue.name,
+  } as ChatAdminRole;
+};
 
 export const currentUserIsAdmin = (
   myProfile: MyProfileCell,
@@ -219,8 +247,9 @@ export const currentUserIsAdmin = (
 ): boolean => currentUserAdminRole(myProfile, adminRegistry) !== undefined;
 
 export const currentUserCanManageAdmins = (
-  adminManagerCredential: AdminManagerCredentialCell,
-): boolean => adminManagerCredentialIsActive(adminManagerCredential.get());
+  myProfile: MyProfileCell,
+  adminRegistry: ChatAdminRegistryCell,
+): boolean => currentUserIsAdmin(myProfile, adminRegistry);
 
 export const participantClaimsValue = (
   profiles: SharedProfilesCell,
@@ -290,6 +319,7 @@ export interface AdminParticipantRow {
   readonly accentColor: string;
   readonly profile?: AuthorProfileCell;
   readonly isAdmin: boolean;
+  readonly everyoneIsAdmin: boolean;
   readonly canManageAdmins: boolean;
 }
 
@@ -298,17 +328,19 @@ export const adminParticipantRowsValue = (
   myProfile: MyProfileCell,
   messages: SharedMessagesCell,
   adminRegistry: ChatAdminRegistryCell,
-  adminManagerCredential: AdminManagerCredentialCell,
 ): AdminParticipantRow[] => {
   const adminRoles = chatAdminRolesValue(adminRegistry);
-  const canManageAdmins = currentUserCanManageAdmins(adminManagerCredential);
+  const everyoneIsAdmin = chatAdminEveryoneIsAdmin(adminRegistry);
+  const canManageAdmins = currentUserCanManageAdmins(myProfile, adminRegistry);
   return participantClaimsValue(profiles, myProfile, messages)
     .filter((participant) => participant.profile !== undefined)
     .map((participant) => ({
       name: participant.name,
       accentColor: participant.accentColor,
       profile: participant.profile,
-      isAdmin: subjectHasAdminRole(adminRoles, participant.profile),
+      isAdmin: everyoneIsAdmin ||
+        subjectHasAdminRole(adminRoles, participant.profile),
+      everyoneIsAdmin,
       canManageAdmins,
     }));
 };
@@ -330,20 +362,14 @@ export const registerProfile = (
 export const applyTrustedProfileSave = (
   myProfile: MyProfileCell,
   profiles: SharedProfilesCell,
-  adminManagerCredential: AdminManagerCredentialCell,
   rawName: string,
-  canManageAdmins: boolean,
 ): {
   trimmedName: string | null;
   profile?: ProfileCell;
-  canManageAdmins: boolean;
 } => {
   const trimmedName = rawName.trim();
   if (!trimmedName) {
-    return {
-      trimmedName: null,
-      canManageAdmins: currentUserCanManageAdmins(adminManagerCredential),
-    };
+    return { trimmedName: null };
   }
 
   const existingProfile = currentProfileSnapshot(myProfile);
@@ -354,14 +380,7 @@ export const applyTrustedProfileSave = (
   );
   myProfile.set({ profile });
   registerProfile(profiles, profile);
-  if (canManageAdmins) {
-    adminManagerCredential.set({
-      canManageAdmins: true,
-    } as ChatAdminManagerCredential);
-    return { trimmedName, profile, canManageAdmins: true };
-  }
-  adminManagerCredential.set(null);
-  return { trimmedName, profile, canManageAdmins: false };
+  return { trimmedName, profile };
 };
 
 export const prepareTrustedMessageSend = (
@@ -455,20 +474,16 @@ export const commitTrustedProfileSave = handler<
   {
     myProfile: MyProfileCell;
     profiles: SharedProfilesCell;
-    adminManagerCredential: AdminManagerCredentialCell;
     nameDraft: Writable<string | Default<"">>;
-    adminManagerDraft: AdminManagerDraftCell;
   }
 >((
   _,
-  { myProfile, profiles, adminManagerCredential, nameDraft, adminManagerDraft },
+  { myProfile, profiles, nameDraft },
 ) => {
   const { trimmedName } = applyTrustedProfileSave(
     myProfile,
     profiles,
-    adminManagerCredential,
     draftText(nameDraft),
-    adminManagerDraft.get() !== false,
   );
   if (trimmedName) {
     nameDraft.set(trimmedName);
@@ -497,12 +512,65 @@ export const commitTrustedMessageSend = handler<
 });
 type TrustedMessageSendInput = Parameters<typeof commitTrustedMessageSend>[0];
 
+export interface TrustedAdminPolicyEvent {
+  readonly name?: string;
+  readonly everyoneIsAdmin?: boolean;
+  readonly detail?: {
+    readonly checked?: boolean;
+  };
+}
+
+interface TrustedAdminPolicyChange {
+  readonly admins: ChatAdminRole[];
+  readonly everyoneIsAdmin?: boolean;
+}
+
 export const prepareTrustedAdminToggle = (
-  adminManagerCredential: ChatAdminManagerCredential | null | undefined,
+  currentAdminRole: ChatAdminRole | undefined,
   adminRegistry: ChatAdminRegistryCell,
   participant: AdminParticipantRow | undefined,
   myProfile?: MyProfileCell,
-): ChatAdminRole[] | null => {
+  nextEveryoneIsAdmin?: boolean,
+): TrustedAdminPolicyChange | null => {
+  if (currentAdminRole === undefined) {
+    return null;
+  }
+
+  const adminRoles = chatAdminRolesValue(adminRegistry);
+  if (nextEveryoneIsAdmin !== undefined) {
+    if (nextEveryoneIsAdmin) {
+      return {
+        admins: adminRoles,
+        everyoneIsAdmin: true,
+      };
+    }
+
+    const currentProfile = myProfile === undefined
+      ? undefined
+      : currentProfileCell(myProfile);
+    const currentName = myProfile === undefined
+      ? undefined
+      : currentProfileSnapshot(myProfile)?.name;
+    const seededAdmins =
+      adminRoles.length === 0 && currentProfile !== undefined &&
+        currentName
+        ? [
+          {
+            subject: currentProfile,
+            displayName: currentName,
+          } as ChatAdminRole,
+        ]
+        : adminRoles;
+    return seededAdmins.length === 0 ? null : {
+      admins: seededAdmins,
+      everyoneIsAdmin: false,
+    };
+  }
+
+  if (chatAdminEveryoneIsAdmin(adminRegistry)) {
+    return null;
+  }
+
   const targetProfile = participant?.profile ?? (
     myProfile === undefined ? undefined : currentProfileCell(myProfile)
   );
@@ -510,50 +578,76 @@ export const prepareTrustedAdminToggle = (
     (myProfile === undefined ? undefined : currentProfileSnapshot(myProfile)
       ?.name);
   if (
-    !adminManagerCredentialIsActive(adminManagerCredential) ||
     targetProfile === undefined ||
     !targetName
   ) {
     return null;
   }
 
-  const adminRoles = chatAdminRolesValue(adminRegistry);
   const withoutParticipant = adminRoles.filter((role) =>
     !equals(role.subject, targetProfile)
   );
   if (withoutParticipant.length !== adminRoles.length) {
-    return withoutParticipant;
+    return {
+      admins: withoutParticipant,
+      everyoneIsAdmin: false,
+    };
   }
 
-  return [
-    ...withoutParticipant,
-    {
-      subject: targetProfile,
-      displayName: targetName,
-    } as ChatAdminRole,
-  ];
+  return {
+    admins: [
+      ...withoutParticipant,
+      {
+        subject: targetProfile,
+        displayName: targetName,
+      } as ChatAdminRole,
+    ],
+    everyoneIsAdmin: false,
+  };
 };
 
 export const commitTrustedAdminToggle = handler<
-  void,
+  TrustedAdminPolicyEvent,
   {
-    adminManagerCredential: AdminManagerCredentialCell;
+    profiles: SharedProfilesCell;
+    myProfile: MyProfileCell;
+    messages: SharedMessagesCell;
     adminRegistry: ChatAdminRegistryCell;
-    participant: AdminParticipantRow | undefined;
-    myProfile?: MyProfileCell;
+    participant?: AdminParticipantRow;
   }
->((_, { adminManagerCredential, adminRegistry, participant, myProfile }) => {
-  const nextAdmins = prepareTrustedAdminToggle(
-    adminManagerCredential.get(),
+>((
+  event,
+  { profiles, myProfile, messages, adminRegistry, participant },
+) => {
+  const eventParticipant = event?.name === undefined
+    ? undefined
+    : adminParticipantRowsValue(
+      profiles,
+      myProfile,
+      messages,
+      adminRegistry,
+    ).find((row) => row.name === event.name);
+  const nextEveryoneIsAdmin = event?.everyoneIsAdmin ??
+    event?.detail?.checked;
+  const nextPolicy = prepareTrustedAdminToggle(
+    currentUserAdminRole(myProfile, adminRegistry),
     adminRegistry,
-    participant,
+    participant ?? eventParticipant,
     myProfile,
+    nextEveryoneIsAdmin,
   );
-  if (nextAdmins === null) {
+  if (nextPolicy === null) {
     return;
   }
 
-  adminRegistry.set({ admins: nextAdmins as ChatAdminList });
+  adminRegistry.set({
+    admins: nextPolicy.admins as ChatAdminList,
+    ...(nextPolicy.everyoneIsAdmin !== undefined
+      ? {
+        everyoneIsAdmin: nextPolicy.everyoneIsAdmin as ChatEveryoneAdminFlag,
+      }
+      : {}),
+  });
 });
 type TrustedAdminToggleInput = Parameters<typeof commitTrustedAdminToggle>[0];
 
@@ -612,18 +706,14 @@ type TrustedParticipantsPanelInputArg = Parameters<
 export interface TrustedProfileSaveSurfaceInput {
   myProfile: MyProfileCell;
   profiles: SharedProfilesCell;
-  adminManagerCredential: AdminManagerCredentialCell;
   nameDraft: Writable<string | Default<"">>;
-  adminManagerDraft: AdminManagerDraftCell;
 }
 
 export interface TrustedProfileSaveSurfaceOutput {
   [NAME]: string;
   [UI]: any;
   myProfile: MyProfileCell;
-  adminManagerCredential: AdminManagerCredentialCell;
   currentProfileName: string;
-  currentUserCanManageAdmins: boolean;
   saveProfile: Stream<void>;
 }
 
@@ -634,25 +724,16 @@ export const TrustedProfileSaveSurface = pattern<
   {
     myProfile,
     profiles,
-    adminManagerCredential,
     nameDraft,
-    adminManagerDraft,
   }: TrustedProfileSaveSurfaceInput,
 ): TrustedProfileSaveSurfaceOutput => {
   const saveProfile = commitTrustedProfileSave({
     myProfile,
     profiles,
-    adminManagerCredential,
     nameDraft,
-    adminManagerDraft,
   } as TrustedProfileSaveInput);
   const currentSavedName = computed(() =>
     currentProfileSnapshot(myProfile)?.name ?? "Name not set"
-  );
-  const managerStatus = computed(() =>
-    currentUserCanManageAdmins(adminManagerCredential)
-      ? "Can manage admins"
-      : "Cannot manage admins"
   );
   const saveDisabled = computed(() => draftText(nameDraft).trim().length === 0);
 
@@ -673,12 +754,6 @@ export const TrustedProfileSaveSurface = pattern<
               placeholder="Set your name"
             />
           </cf-vgroup>
-          <cf-checkbox
-            id="trusted-admin-manager-checkbox"
-            $checked={adminManagerDraft}
-          >
-            Can manage admins (demo)
-          </cf-checkbox>
           <cf-button
             id="trusted-profile-save"
             data-ui-action={TRUSTED_GROUP_CHAT_SAVE_PROFILE_ACTION}
@@ -691,16 +766,11 @@ export const TrustedProfileSaveSurface = pattern<
           <cf-label id="trusted-profile-status">
             {currentSavedName}
           </cf-label>
-          <cf-chip id="trusted-admin-manager-status" label={managerStatus} />
         </cf-hstack>
       </cf-card>
     ),
     myProfile,
-    adminManagerCredential,
     currentProfileName: currentSavedName,
-    currentUserCanManageAdmins: computed(() =>
-      currentUserCanManageAdmins(adminManagerCredential)
-    ),
     saveProfile,
   };
 });
@@ -710,14 +780,15 @@ export interface TrustedAdminPanelInput {
   myProfile: MyProfileCell;
   messages: SharedMessagesCell;
   adminRegistry: ChatAdminRegistryCell;
-  adminManagerCredential: AdminManagerCredentialCell;
 }
 
 export interface TrustedAdminPanelOutput {
   [NAME]: string;
   [UI]: any;
   adminRegistry: ChatAdminRegistryCell;
-  toggleCurrentUserAdmin: Stream<void>;
+  toggleCurrentUserAdmin: Stream<TrustedAdminPolicyEvent>;
+  toggleParticipantAdmin: Stream<TrustedAdminPolicyEvent>;
+  toggleEveryoneAdmin: Stream<TrustedAdminPolicyEvent>;
 }
 
 export const TrustedAdminPanel = pattern<
@@ -729,7 +800,6 @@ export const TrustedAdminPanel = pattern<
     myProfile,
     messages,
     adminRegistry,
-    adminManagerCredential,
   }: TrustedAdminPanelInput,
 ): TrustedAdminPanelOutput => {
   const adminRows = computed(() =>
@@ -738,19 +808,25 @@ export const TrustedAdminPanel = pattern<
       myProfile,
       messages,
       adminRegistry,
-      adminManagerCredential,
     )
   );
-  const toggleCurrentUserAdmin = commitTrustedAdminToggle({
-    adminManagerCredential,
-    adminRegistry,
-    participant: undefined,
+  const toggleAdminPolicy = commitTrustedAdminToggle({
+    profiles,
     myProfile,
+    messages,
+    adminRegistry,
   } as TrustedAdminToggleInput);
   const managerStatus = computed(() =>
-    currentUserCanManageAdmins(adminManagerCredential)
+    currentProfileSnapshot(myProfile) === undefined
+      ? "Save a profile to manage admins"
+      : chatAdminEveryoneIsAdmin(adminRegistry)
+      ? "Everyone can add rooms"
+      : currentUserCanManageAdmins(myProfile, adminRegistry)
       ? "Admin registry editing enabled"
-      : "Save profile with admin-manager enabled to edit"
+      : "Only admins can edit"
+  );
+  const everyoneIsAdmin = computed(() =>
+    chatAdminEveryoneIsAdmin(adminRegistry)
   );
 
   return {
@@ -766,7 +842,7 @@ export const TrustedAdminPanel = pattern<
             <cf-vstack gap="1">
               <cf-heading level={3}>Users</cf-heading>
               <cf-label>
-                Admin registry. Managers can change who may add rooms.
+                Admin registry. Current admins can change who may add rooms.
               </cf-label>
             </cf-vstack>
             <cf-chip
@@ -774,14 +850,37 @@ export const TrustedAdminPanel = pattern<
               label={managerStatus}
             />
           </cf-hstack>
+          <cf-checkbox
+            id="trusted-everyone-admin-checkbox"
+            data-ui-action={TRUSTED_GROUP_CHAT_SET_ADMIN_ACTION}
+            checked={everyoneIsAdmin}
+            disabled={computed(() =>
+              !currentUserCanManageAdmins(myProfile, adminRegistry)
+            )}
+            oncf-change={toggleAdminPolicy}
+          >
+            Everyone is admin
+          </cf-checkbox>
 
           <cf-vstack id="trusted-admin-user-list" gap="2">
             {adminRows.map((participant) => {
               const toggleAdmin = commitTrustedAdminToggle({
-                adminManagerCredential,
+                profiles,
+                myProfile,
+                messages,
                 adminRegistry,
                 participant,
               } as TrustedAdminToggleInput);
+              const toggleDisabled = computed(() =>
+                !participant.canManageAdmins || participant.everyoneIsAdmin
+              );
+              const toggleLabel = computed(() =>
+                participant.everyoneIsAdmin
+                  ? "Admin via everyone"
+                  : participant.isAdmin
+                  ? "Remove admin"
+                  : "Make admin"
+              );
               return (
                 <cf-hstack
                   align="center"
@@ -810,12 +909,13 @@ export const TrustedAdminPanel = pattern<
                     />
                   </cf-hstack>
                   <cf-button
+                    data-ui-control="admin-user-toggle"
                     data-ui-action={TRUSTED_GROUP_CHAT_SET_ADMIN_ACTION}
                     size="sm"
-                    disabled={!participant.canManageAdmins}
+                    disabled={toggleDisabled}
                     onClick={toggleAdmin}
                   >
-                    {participant.isAdmin ? "Remove admin" : "Make admin"}
+                    {toggleLabel}
                   </cf-button>
                 </cf-hstack>
               );
@@ -825,7 +925,9 @@ export const TrustedAdminPanel = pattern<
       </cf-card>
     ),
     adminRegistry,
-    toggleCurrentUserAdmin,
+    toggleCurrentUserAdmin: toggleAdminPolicy,
+    toggleParticipantAdmin: toggleAdminPolicy,
+    toggleEveryoneAdmin: toggleAdminPolicy,
   };
 });
 

--- a/packages/patterns/cfc-group-chat-demo/trusted.tsx
+++ b/packages/patterns/cfc-group-chat-demo/trusted.tsx
@@ -588,6 +588,9 @@ export const prepareTrustedAdminToggle = (
     !equals(role.subject, targetProfile)
   );
   if (withoutParticipant.length !== adminRoles.length) {
+    if (withoutParticipant.length === 0) {
+      return null;
+    }
     return {
       admins: withoutParticipant,
       everyoneIsAdmin: false,

--- a/packages/patterns/cfc/INDEX.md
+++ b/packages/patterns/cfc/INDEX.md
@@ -16,6 +16,7 @@ From `admin/mod.ts`:
 - `AdminRegistryValue`
 - `adminManagerCredentialIsActive`
 - `adminRegistryEntries`
+- `adminRegistryEveryoneIsAdmin`
 - `activeAdminRoleForSubject`
 - `subjectHasAdminRole`
 

--- a/packages/patterns/cfc/README.md
+++ b/packages/patterns/cfc/README.md
@@ -51,6 +51,7 @@ import {
   type AdminManagerCredential,
   adminManagerCredentialIsActive,
   adminRegistryEntries,
+  adminRegistryEveryoneIsAdmin,
 } from "../cfc/admin/mod.ts";
 import {
   type AddIntegrity,
@@ -81,11 +82,14 @@ type ProjectAdminManagerCredential = AdminManagerCredential<
 >;
 
 const admins = adminRegistryEntries<ProjectAdminRole>(adminRegistry);
+const everyoneIsAdmin = adminRegistryEveryoneIsAdmin(adminRegistry);
 const canEditAdmins = adminManagerCredentialIsActive(managerCredential.get());
 ```
 
 Keep subject lookup and local role toggling in the pattern when the domain model
 is local, such as people, profiles, rooms, or projects.
+`adminRegistryEveryoneIsAdmin` treats an empty admin list as bootstrap mode:
+everyone is an admin until the pattern writes at least one explicit admin role.
 
 ## Use Prompt-Injection Helpers
 

--- a/packages/patterns/cfc/README.md
+++ b/packages/patterns/cfc/README.md
@@ -89,7 +89,8 @@ const canEditAdmins = adminManagerCredentialIsActive(managerCredential.get());
 Keep subject lookup and local role toggling in the pattern when the domain model
 is local, such as people, profiles, rooms, or projects.
 `adminRegistryEveryoneIsAdmin` treats an empty admin list as bootstrap mode:
-everyone is an admin until the pattern writes at least one explicit admin role.
+everyone is an admin until the pattern writes at least one explicit admin role
+or explicitly stores `everyoneIsAdmin: false`.
 
 ## Use Prompt-Injection Helpers
 

--- a/packages/patterns/cfc/admin/mod.ts
+++ b/packages/patterns/cfc/admin/mod.ts
@@ -54,12 +54,15 @@ export const adminRegistryEveryoneIsAdmin = <Role>(
     get(): AdminRegistryValue<Role> | undefined;
   },
 ): boolean => {
+  const stored = registry.get() as AdminRegistryStoredValue<Role> | undefined;
+  if (stored?.everyoneIsAdmin === false) {
+    return false;
+  }
   const roles = adminRegistryEntries<Role>(registry);
   if (roles.length === 0) {
     return true;
   }
-  return (registry.get() as AdminRegistryStoredValue<Role> | undefined)
-    ?.everyoneIsAdmin === true;
+  return stored?.everyoneIsAdmin === true;
 };
 
 export const activeAdminRoleForSubject = <

--- a/packages/patterns/cfc/admin/mod.ts
+++ b/packages/patterns/cfc/admin/mod.ts
@@ -24,6 +24,7 @@ export type AdminManagerCredential<Integrity extends string> = AddIntegrity<
 
 export interface AdminRegistryStoredValue<Role> {
   readonly admins?: readonly Role[];
+  readonly everyoneIsAdmin?: boolean;
 }
 
 export type EmptyAdminRegistryValue = Record<PropertyKey, never>;
@@ -47,6 +48,19 @@ export const adminRegistryEntries = <Role>(
     (registry.get() as AdminRegistryStoredValue<Role> | undefined)
       ?.admins ?? [],
   );
+
+export const adminRegistryEveryoneIsAdmin = <Role>(
+  registry: {
+    get(): AdminRegistryValue<Role> | undefined;
+  },
+): boolean => {
+  const roles = adminRegistryEntries<Role>(registry);
+  if (roles.length === 0) {
+    return true;
+  }
+  return (registry.get() as AdminRegistryStoredValue<Role> | undefined)
+    ?.everyoneIsAdmin === true;
+};
 
 export const activeAdminRoleForSubject = <
   Subject extends AdminSubject,

--- a/packages/patterns/integration/cfc-group-chat-demo.test.ts
+++ b/packages/patterns/integration/cfc-group-chat-demo.test.ts
@@ -77,7 +77,7 @@ describe("cfc group chat demo integration test", () => {
     });
     await waitForRuntimeIdle(page);
 
-    await waitForText(page, "#group-chat-manager-chip", "Manager off");
+    await waitForText(page, "#group-chat-manager-chip", "No profile");
     await waitForDisabled(page, "#trusted-send-button", true);
 
     await scrollIntoView(page, "#trusted-profile-name");
@@ -91,18 +91,13 @@ describe("cfc group chat demo integration test", () => {
     await waitForText(page, "#trusted-profile-status", "Alice");
     await waitForText(
       page,
-      "#trusted-admin-manager-status",
-      "Can manage admins",
-    );
-    await waitForText(
-      page,
       "#group-chat-manager-chip",
-      "Can manage admins",
+      "Everyone is admin",
     );
     await waitForText(
       page,
       "#trusted-admin-manager-panel-status",
-      "Admin registry editing enabled",
+      "Everyone can add rooms",
     );
     await waitForRuntimeIdle(page);
 
@@ -112,35 +107,18 @@ describe("cfc group chat demo integration test", () => {
       "#trusted-room-name",
       "Ops",
     );
-    await waitForDisabled(page, "#trusted-room-add-button", true);
+    await waitForDisabled(page, "#trusted-room-add-button", false);
     await scrollIntoView(page, "#trusted-admin-panel");
     await waitForText(
       page,
-      '[data-ui-action="TrustedGroupChatSetAdmin"]',
-      "Make admin",
+      '[data-ui-control="admin-user-toggle"]',
+      "Admin via everyone",
     );
     await waitForDisabled(
       page,
-      '[data-ui-action="TrustedGroupChatSetAdmin"]',
-      false,
+      '[data-ui-control="admin-user-toggle"]',
+      true,
     );
-    await clickCfButton(
-      page,
-      '[data-ui-action="TrustedGroupChatSetAdmin"]',
-    );
-    await waitForText(page, "#trusted-admin-user-list", "Admin");
-    await waitForText(
-      page,
-      '[data-ui-action="TrustedGroupChatSetAdmin"]',
-      "Remove admin",
-    );
-    await waitForRuntimeIdle(page);
-    await fillCfInput(
-      page,
-      "#trusted-room-name",
-      "Ops",
-    );
-    await waitForDisabled(page, "#trusted-room-add-button", false);
     await waitForRuntimeIdle(page);
     await clickCfButton(page, "#trusted-room-add-button");
     await waitForRuntimeIdle(page);

--- a/packages/runner/test/cfc-boundary.test.ts
+++ b/packages/runner/test/cfc-boundary.test.ts
@@ -2623,6 +2623,52 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     }
   });
 
+  it("applies wildcard policy entries with refs resolved from parent defs", async () => {
+    const { runtime, storageManager } = createRuntime();
+    try {
+      const tx = runtime.edit();
+      tx.setCfcEnforcementMode("enforce-explicit");
+      const cell = runtime.getCell(
+        signer.did(),
+        "cfc-resolved-ref-policy-match",
+        {
+          type: "object",
+          properties: {
+            items: {
+              type: "array",
+              items: {
+                $ref: "#/$defs/GuardedItem",
+              },
+            },
+          },
+          $defs: {
+            GuardedItem: {
+              $ref: "#/$defs/GuardedItemShape",
+              ifc: { writeAuthorizedBy: ["trusted-handler"] },
+            },
+            GuardedItemShape: {
+              type: "object",
+              properties: {
+                title: { type: "string" },
+              },
+            },
+          },
+        },
+        tx,
+      );
+      cell.set({ items: [{ title: "resolved" }] });
+
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error?.message).toContain(
+        "writeAuthorizedBy requires a trusted builtin identity at /items/*",
+      );
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
   it("does not apply wildcard policy entries when item value shape mismatches", async () => {
     const { runtime, storageManager } = createRuntime();
     try {


### PR DESCRIPTION
## Summary

Adds bootstrap-friendly admin registry behavior to the CFC group chat demo.

- Adds `everyoneIsAdmin` support to the shared admin registry helper, where an empty admin list means everyone is treated as admin for bootstrap.
- Replaces the group chat demo's per-user self-nominated admin-manager credential with an admin-list-backed policy surface.
- Adds a trusted "Everyone is admin" checkbox that current admins can toggle; disabling it seeds the current user into the explicit admin list.
- Updates group chat pattern and browser integration tests for the new bootstrap/admin-list flow.
- Fixes browser-driven admin toggles so checkbox clicks and row clicks preserve the CFC-backed `everyoneIsAdmin` policy while updating only the intended admin registry fields.
- Documents the new shared admin helper in the CFC helper README and index.

## Validation

- `deno lint packages/patterns/cfc/admin/mod.ts packages/patterns/cfc-group-chat-demo/main.tsx packages/patterns/cfc-group-chat-demo/trusted.tsx packages/patterns/cfc-group-chat-demo/main.test.tsx packages/patterns/integration/cfc-group-chat-demo.test.ts`
- `deno task cf test packages/patterns/cfc-group-chat-demo/main.test.tsx --root packages/patterns`
- `deno task cf test packages/patterns/factory-outputs/parking-coordinator/main.test.tsx --root packages/patterns`
- `deno task integration patterns cfc-group-chat-demo`
- Headless two-user browser play-test on a fresh local deployment: Alice disables everyone-admin mode, Bob is blocked from adding rooms, Alice makes Bob admin, then Bob adds a room with zero error-level console logs.
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds bootstrap admin mode to the CFC group chat with an “Everyone is admin” policy and safe transitions. Also blocks removing the last explicit admin and fixes admin toggle behavior in the UI.

- **New Features**
  - Added `everyoneIsAdmin` to the admin registry with `adminRegistryEveryoneIsAdmin`; exposed as `chatAdminEveryoneIsAdmin` in the demo.
  - New “Everyone is admin” checkbox; turning it off seeds the current user into the explicit admin list.
  - Block removal of the last explicit admin when `everyoneIsAdmin` is `false`.
  - Updated admin UI: chip shows “No profile”/“Everyone is admin,” panel shows “Everyone can add rooms,” and user toggles show “Admin via everyone” and are disabled while `everyoneIsAdmin` is on.
  - Integration, pattern, and CFC boundary tests updated for the bootstrap flow and admin toggle behavior.

- **Migration**
  - Remove `adminDraft` and `adminManagerCredential` from the demo; use `currentUserCanManageAdmins(myProfile, adminRegistry)` and `chatAdminEveryoneIsAdmin(adminRegistry)`.
  - `toggleCurrentUserAdmin` now accepts a policy event (`{ name?: string; everyoneIsAdmin?: boolean }`); use `toggleParticipantAdmin` and `toggleEveryoneAdmin` when relevant.
  - UI automation: target `data-ui-control="admin-user-toggle"` and `#trusted-everyone-admin-checkbox`; expect chip “Everyone is admin” and panel “Everyone can add rooms.”

<sup>Written for commit 51f3de9376e47770face13eef9c5b187389670fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3715?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->


