### PR TITLE
refactor(ts-transformers): mark schema-injected calls; drop redundant re-narrowing (CT-1621)

### DIFF
--- a/packages/ts-transformers/src/core/context.ts
+++ b/packages/ts-transformers/src/core/context.ts
@@ -197,6 +197,25 @@ export class TransformationContext {
   }
 
   /**
+   * Mark a builder call/new node that SchemaInjection has finalized, so a
+   * later re-traversal of the transformer's own output skips re-injection.
+   * Replaces the arg-count idempotency guards in schema-injection.ts. See
+   * `schemaInjectedRegistry` docs in core/mod.ts (CT-1621).
+   */
+  markSchemaInjected(node: ts.Node): void {
+    this.options.state?.markSchemaInjected(node);
+  }
+
+  /**
+   * Whether SchemaInjection has already finalized this node. Returns false
+   * when no state is present (so a missing registry never suppresses a real
+   * first-pass injection).
+   */
+  isSchemaInjected(node: ts.Node): boolean {
+    return this.options.state?.isSchemaInjected(node) ?? false;
+  }
+
+  /**
    * Record a schema-generation hint for a node (and its original node, so the
    * hint survives visitor node-replacement). Overwrites any existing hint for
    * the node, matching the prior direct-`.set` behavior. See `SchemaHints`

--- a/packages/ts-transformers/src/core/cross-stage-state.ts
+++ b/packages/ts-transformers/src/core/cross-stage-state.ts
@@ -42,6 +42,7 @@ export class CrossStageState {
   readonly schemaHints: SchemaHints = new WeakMap();
   readonly capabilitySummaryRegistry: CapabilitySummaryRegistry = new WeakMap();
   readonly narrowedWrapperTypeRegistry = new WeakMap<ts.TypeNode, ts.Type>();
+  readonly schemaInjectedRegistry = new WeakSet<ts.Node>();
 
   // --- mapCallbackRegistry ---
 
@@ -126,6 +127,26 @@ export class CrossStageState {
 
   lookupNarrowedWrapper(wrapperNode: ts.TypeNode): ts.Type | undefined {
     return this.narrowedWrapperTypeRegistry.get(wrapperNode);
+  }
+
+  // --- schemaInjectedRegistry ---
+  //
+  // Marks builder call/new nodes that SchemaInjection has already finalized,
+  // so a later re-traversal of the transformer's own output skips re-injection
+  // instead of re-deriving "already injected?" from argument count. Replaces
+  // the scattered arg-count idempotency guards (e.g. `args.length >= 5`).
+  //
+  // Unlike the other marker sets, this one uses a plain `.has` with NO
+  // `getOriginalNode` fallback: it tags SYNTHETIC nodes WE produced, whose
+  // original (if any) is the *pre-injection* user call. Falling back to the
+  // original would wrongly report a not-yet-injected user node as injected.
+
+  markSchemaInjected(node: ts.Node): void {
+    this.schemaInjectedRegistry.add(node);
+  }
+
+  isSchemaInjected(node: ts.Node): boolean {
+    return this.schemaInjectedRegistry.has(node);
   }
 
   // --- shared helper: membership check with getOriginalNode fallback ---

--- a/packages/ts-transformers/src/core/mod.ts
+++ b/packages/ts-transformers/src/core/mod.ts
@@ -1,13 +1,14 @@
 /**
  * Cross-transformer communication registries.
  *
- * The pipeline creates eight shared registries in CommonFabricTransformerPipeline
+ * The pipeline creates nine shared registries in CommonFabricTransformerPipeline
  * (cf-pipeline.ts). Each is keyed by AST node or symbol identity, which is
  * preserved when transformers are applied in sequence via ts.transform().
  *
- * (A ninth, syntheticLiftAppliedCallRegistry, was removed in the
+ * (A former member, syntheticLiftAppliedCallRegistry, was removed in the
  * registry-unification effort — it was verified functionally inert. See
- * docs/scratch/12-registry-unification-design.md.)
+ * docs/scratch/12-registry-unification-design.md. The current ninth member is
+ * schemaInjectedRegistry, added in CT-1621 — see its entry below.)
  *
  * TypeRegistry (WeakMap<ts.Node, ts.Type>)
  *   Preserves and recovers synthetic typing across the pipeline. Serves three
@@ -86,7 +87,49 @@
  *   Writers: context.markNarrowedWrapper() (called by
  *            transformers/type-shrinking.ts applyShrinkAndWrap)
  *   Readers: context.lookupNarrowedWrapper() (called by
- *            transformers/schema-injection.ts inner-lift revisit path)
+ *            transformers/schema-injection.ts lift `isToSchemaCall` branch)
+ *
+ *   CT-1621 INVARIANT (why this still exists, precisely):
+ *   The reader's load-bearing use is the FIRST-pass recovery of the pre-shrink
+ *   type for a synthetic wrapper whose lift input is a runtime VALUE that was
+ *   capability-shrunk (the checker resolves such a synthetic wrapper TypeNode
+ *   to `any`, so without this the inner `type:` is lost and only the `asCell`
+ *   capability wrapper survives). That value-as-input shape is produced ONLY by
+ *   the `derive`/`computed`→lift-applied lowering's value-input path — and in
+ *   practice ONLY by `derive`: `computed(fn)` lowers to the no-input
+ *   `lift(false, fn)()` form (no input wrapper at all), and a `computed`
+ *   capturing cells reifies those captures into an input OBJECT whose member
+ *   nodes carry checker-resolvable types via `typeRegistry` (verified: a
+ *   capturing-computed golden made with this registry matches with it neutered).
+ *   User-authored `lift` cannot express value-as-input (LiftFunction's leading
+ *   args are JSONSchema/fn, never a value), and the user `lift(toSchema<T>(),…)`
+ *   form has a real source TypeNode the checker resolves — so neither needs this.
+ *   The redundant SELF-RE-ENTRY consumer that CT-1621 originally targeted was
+ *   removed (schemaInjectedRegistry now skips re-processing our own output).
+ *   What remains is derive-bound. REMOVE THIS REGISTRY when `derive` is
+ *   deprecated/removed: drop the writer (applyShrinkAndWrap markNarrowedWrapper),
+ *   the reader (schema-injection isToSchemaCall lookup), this map + its methods,
+ *   the context shims, and this entry. Until then it is a principled,
+ *   single-purpose channel, not an ad-hoc workaround.
+ *
+ * schemaInjectedRegistry (WeakSet<ts.Node>)
+ *   Marks builder call/new nodes that SchemaInjection has already finalized.
+ *   The single top-of-visit guard in SchemaInjectionTransformer skips
+ *   re-processing a marked node (descending only into its children to reach
+ *   callback bodies). Replaces the scattered per-builder arg-count idempotency
+ *   guards (`args.length >= 5`, the implicit "drop the type args so
+ *   re-detection fails" trick, etc.) with one explicit signal, and plugs the
+ *   lift `isToSchemaCall` branch's missing idempotency guard — eliminating the
+ *   redundant self-re-entry re-narrowing that CT-1621 targeted. NOTE: this
+ *   marks SYNTHETIC nodes we produce; unlike the other marker sets it uses a
+ *   plain `.has` (no getOriginalNode fallback) because a marked node's original
+ *   is the *pre-injection* user call, which must NOT read as injected.
+ *   Some arg-count guards remain DELIBERATELY: the cell-factory/wish `>= 2`
+ *   checks also protect USER-supplied schemas (which this marker can't cover),
+ *   and the `!== 2`/`!== 3` checks are dispatch (input-shape) guards, not
+ *   idempotency.
+ *   Writers: context.markSchemaInjected() (SchemaInjection producer sites)
+ *   Readers: context.isSchemaInjected() (SchemaInjection top-of-visit guard)
  *
  * --- Cache invalidation contract ---
  *

--- a/packages/ts-transformers/src/transformers/schema-injection.ts
+++ b/packages/ts-transformers/src/transformers/schema-injection.ts
@@ -1368,8 +1368,13 @@ function visitInjectedDualSchemaBuilderCall(
     checker,
     typeRegistry,
   );
-  // Visit children to catch any pattern calls created by ClosureTransformer
-  // inside builder callbacks (e.g., from map transformations)
+  // Mark BEFORE re-descending: the re-descent below re-enters `updated` to
+  // reach the callback body (catching pattern calls ClosureTransformer
+  // created inside builder callbacks, e.g. from map transformations). Marking
+  // first means that re-entry self-skips the builder/schema logic — including
+  // the re-narrowing of the synthetic schema arg that previously required
+  // narrowedWrapperTypeRegistry (CT-1621) — and only the callback is visited.
+  context.markSchemaInjected(updated);
   return ts.visitEachChild(updated, visit, transformation);
 }
 
@@ -1420,6 +1425,7 @@ function visitPrependedWidenedSchemaCall(
     [...schemas, ...args],
   );
 
+  context.markSchemaInjected(updated);
   return ts.visitEachChild(updated, visit, transformation);
 }
 
@@ -2874,6 +2880,21 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
     const capabilityRegistry = context.options.state?.capabilitySummaryRegistry;
 
     const visit = (node: ts.Node): ts.Node => {
+      // Single idempotency guard: if SchemaInjection already finalized this
+      // builder call/new node, do NOT re-process it — only descend into its
+      // children (to reach callback bodies). This replaces the per-builder
+      // arg-count guards (`args.length >= 5`, etc.) and the implicit
+      // "drop the type args so re-detection fails" tricks, and it plugs the
+      // gap in the lift `isToSchemaCall` branch whose re-narrowing of the
+      // synthetic schema arg was the sole reason narrowedWrapperTypeRegistry
+      // existed (CT-1621). Producers call `context.markSchemaInjected(...)`.
+      if (
+        (ts.isCallExpression(node) || ts.isNewExpression(node)) &&
+        context.isSchemaInjected(node)
+      ) {
+        return ts.visitEachChild(node, visit, transformation);
+      }
+
       if (ts.isNewExpression(node)) {
         const callKind = detectNewExpressionKind(node, checker);
         if (callKind?.kind === "cell-factory") {
@@ -2882,7 +2903,11 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
           const args = node.arguments ?? [];
           const scope = cellConstructorCallScope(node, checker);
 
-          // If already has 2 arguments, assume schema is already present.
+          // If already has 2 arguments, the schema slot is filled — either we
+          // injected it (idempotency) or the user supplied one. Either way,
+          // leave it. (NOT replaced by the schema-injected marker: the marker
+          // only covers our own output; a user-supplied 2-arg cell must also
+          // be left alone, so this stays an argument-count check.)
           if (args.length >= 2) {
             return ts.visitEachChild(node, visit, transformation);
           }
@@ -2942,6 +2967,7 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
               node.typeArguments,
               newArgs,
             );
+            context.markSchemaInjected(updated);
             return ts.visitEachChild(updated, visit, transformation);
           }
         }
@@ -3059,6 +3085,7 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
             [toSchemaEvent, toSchemaState, ...node.arguments],
           );
 
+          context.markSchemaInjected(updated);
           return ts.visitEachChild(updated, visit, transformation);
         }
 
@@ -3160,6 +3187,7 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
               [toSchemaEvent, toSchemaState, handlerCandidate],
             );
 
+            context.markSchemaInjected(updated);
             return ts.visitEachChild(updated, visit, transformation);
           }
         }
@@ -3326,11 +3354,15 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
           );
           if (argumentType && liftCallback) {
             // Prefer the pre-shrink type from `narrowedWrapperTypeRegistry`
-            // when available — for our own injected lift-applied output, the
-            // outer call's first toSchema argument is a synthetic wrapper
-            // TypeNode that `checker.getTypeFromTypeNode` resolves to `any`.
-            // See type-shrinking.ts `applyShrinkAndWrap` for where this is
-            // populated and the rationale for the separate registry channel.
+            // when available — when the first toSchema argument is a synthetic
+            // wrapper TypeNode, `checker.getTypeFromTypeNode` resolves it to
+            // `any`, dropping the inner `type:`. The registry recovers the
+            // pre-shrink type. CT-1621: the only live consumer is `derive`'s
+            // value-as-input lowering (first pass); the redundant self-re-entry
+            // consumer was removed via the schemaInjectedRegistry marker, and
+            // `computed`/user-`lift` never produce this shape. Registry is
+            // derive-bound — see core/mod.ts and type-shrinking.ts
+            // `applyShrinkAndWrap`.
             const argumentTypeValue =
               context.lookupNarrowedWrapper(argumentType) ??
                 getTypeFromTypeNodeWithFallback(
@@ -3366,6 +3398,11 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
               node.typeArguments,
               [inputSchema, ...node.arguments.slice(1)],
             );
+            // Mark so the re-descent below does NOT re-enter this branch and
+            // re-narrow the synthetic `inputSchema` wrapper against `any`.
+            // That re-narrowing was the sole consumer of
+            // narrowedWrapperTypeRegistry (CT-1621).
+            context.markSchemaInjected(updated);
             return ts.visitEachChild(updated, visit, transformation);
           }
         }
@@ -3576,6 +3613,7 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
             node.typeArguments,
             newArgs,
           );
+          context.markSchemaInjected(updated);
           return ts.visitEachChild(updated, visit, transformation);
         }
       }
@@ -3664,6 +3702,7 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
             node.typeArguments,
             [...args, schemaCall],
           );
+          context.markSchemaInjected(updated);
           return ts.visitEachChild(updated, visit, transformation);
         }
       }
@@ -3740,6 +3779,7 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
             node.typeArguments,
             [newOptions, ...args.slice(1)],
           );
+          context.markSchemaInjected(updated);
           return ts.visitEachChild(updated, visit, transformation);
         }
       }
@@ -3748,12 +3788,11 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
       if (callKind?.kind === "when") {
         const args = node.arguments;
 
-        // Skip if already has schemas (5+ args means schemas present)
-        if (args.length >= 5) {
-          return ts.visitEachChild(node, visit, transformation);
-        }
-
-        // Must have exactly 2 arguments: condition, value
+        // Idempotency is owned by the top-of-visit schema-injected marker; no
+        // arg-count "already has schemas" guard needed. (The public
+        // WhenFunction type is exactly 2-arity, so the 5-arg withSchemas form
+        // can ONLY be our own injected output — never user source.)
+        // This stays a DISPATCH guard: only the 2-arg form is the injectable shape.
         if (args.length !== 2) {
           return ts.visitEachChild(node, visit, transformation);
         }
@@ -3795,12 +3834,9 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
       if (callKind?.kind === "unless") {
         const args = node.arguments;
 
-        // Skip if already has schemas (5+ args means schemas present)
-        if (args.length >= 5) {
-          return ts.visitEachChild(node, visit, transformation);
-        }
-
-        // Must have exactly 2 arguments: condition, fallback
+        // Idempotency owned by the schema-injected marker (see `when` above).
+        // UnlessFunction is exactly 2-arity, so the 5-arg form is only ever
+        // our injected output. DISPATCH guard: only the 2-arg form is injectable.
         if (args.length !== 2) {
           return ts.visitEachChild(node, visit, transformation);
         }
@@ -3842,12 +3878,9 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
       if (callKind?.kind === "ifElse") {
         const args = node.arguments;
 
-        // Skip if already has schemas (7+ args means schemas present)
-        if (args.length >= 7) {
-          return ts.visitEachChild(node, visit, transformation);
-        }
-
-        // Must have exactly 3 arguments: condition, ifTrue, ifFalse
+        // Idempotency owned by the schema-injected marker (see `when` above).
+        // IfElseFunction is exactly 3-arity, so the 7-arg form is only ever
+        // our injected output. DISPATCH guard: only the 3-arg form is injectable.
         if (args.length !== 3) {
           return ts.visitEachChild(node, visit, transformation);
         }

--- a/packages/ts-transformers/src/transformers/type-shrinking.ts
+++ b/packages/ts-transformers/src/transformers/type-shrinking.ts
@@ -3215,13 +3215,22 @@ export function applyShrinkAndWrap(
   );
   // Register the produced wrapper TypeNode against the pre-shrink semantic
   // baseType in `narrowedWrapperTypeRegistry`. This is consumed by
-  // SchemaInjection's inner-lift revisit path (see schema-injection.ts at the
-  // `kind === "builder" && builderName === "lift"` branch with
-  // `isToSchemaCall(firstArgument)`): after `ts.visitEachChild` re-enters our
-  // injected `__cfHelpers.lift(toSchema(...), toSchema(...), cb)` call,
-  // capability narrowing wants the original baseType to feed the next pass —
-  // without it the checker resolves the synthetic wrapper to `any` and the
-  // schema collapses to `unknown`.
+  // SchemaInjection (see schema-injection.ts at the `kind === "builder" &&
+  // builderName === "lift"` branch with `isToSchemaCall(firstArgument)`): when
+  // a synthetic wrapper TypeNode reaches that branch, the checker resolves it
+  // to `any`, so capability narrowing needs the original baseType fed back —
+  // without it the inner `type:` is lost and only the `asCell` wrapper
+  // survives.
+  //
+  // CT-1621: the redundant SELF-RE-ENTRY consumer (re-narrowing our own
+  // already-injected output on `ts.visitEachChild`) was eliminated — the
+  // schemaInjectedRegistry marker now makes that re-entry skip re-processing.
+  // The remaining live consumer is the FIRST-pass recovery for `derive`'s
+  // value-as-input lowering (the only shape that puts a runtime value through
+  // the shrink → synthetic wrapper); `computed` and user `lift` don't produce
+  // it. So this write — and the whole registry — is derive-bound and should be
+  // removed when `derive` is deprecated. See narrowedWrapperTypeRegistry's
+  // entry in core/mod.ts for the full invariant.
   //
   // We deliberately do NOT write to the main `typeRegistry` here. The schema
   // generator's wrapper-recovery path (`formatWrapperTypeFromNode`) reads from


### PR DESCRIPTION
Resolves the load-bearing half of [CT-1621](https://linear.app/common-tools/issue/CT-1621) and documents the precise invariant for the rest.

## What CT-1621 asked
Audit SchemaInjection's inner-lift "revisit" path: is the re-narrowing (and the `narrowedWrapperTypeRegistry` workaround it needs) semantically necessary? If not, eliminate it; if so, document the precise invariant.

## What we found
The re-narrowing had **two** sources, not one:

1. **A redundant self-re-entry.** The `isToSchemaCall` lift branch had no idempotency guard, so `ts.visitEachChild` re-entered our *own* injected `lift(toSchema(...), ...)` and re-ran the capability shrink on the synthetic wrapper TypeNode. The checker resolves a synthetic wrapper to `any`, so that second shrink dropped the inner `type:` — and `narrowedWrapperTypeRegistry` existed to un-clobber it. **This is genuinely redundant and is removed here.**

2. **A first-pass recovery for `derive`'s value-as-input lowering.** When a runtime *value* is the lift input and gets capability-shrunk, the synthetic wrapper's inner type can only be recovered from the registry. This is **not** redundant — but it is **derive-bound**.

Verified empirically (neuter `lookupNarrowedWrapper`, observe emitted output):
- Only 2 fixtures depend on the registry, both `derive` (`derive-no-captures`, `derive-unannotated-cell-input`), and both hit it on the *first* pass (not the re-entry).
- **`computed` is safe**: it lowers to `lift(false, fn)()` (no input wrapper), and a `computed` capturing cells reifies captures into an input object whose nodes carry checker-resolvable types via `typeRegistry` — confirmed by a golden generated with the registry that still matches with it neutered.
- **User `lift` can't express** the value-input shape (its public signature takes `JSONSchema`/fn as leading args, never a value).

## What this PR changes
- New **`schemaInjectedRegistry`** marker (`WeakSet<ts.Node>`) + `markSchemaInjected`/`isSchemaInjected` on `CrossStageState` and the context shim, in the existing blessed `mark`/`is` style.
- A **single top-of-visit idempotency guard** in `SchemaInjectionTransformer`: a marked builder call/new node skips re-processing (descending only into children to reach callback bodies). This replaces the scattered per-builder arg-count guards and the implicit "drop the type args so re-detection fails" trick with one explicit signal — and plugs the `isToSchemaCall` branch's missing guard, eliminating the redundant re-narrowing.
- Removed the **3 pure-idempotency** arg-count guards (`when`/`unless`/`ifElse` `>=5`/`>=7`), verified pure via the fixed-arity public API types. **Kept** the MIXED `cell`/`wish` `>=2` guards (they also protect user-supplied schemas) and all dispatch (input-shape) guards.

## What this PR deliberately does NOT change
`narrowedWrapperTypeRegistry` stays, with a precise documented invariant (in `mod.ts`, the writer in `type-shrinking.ts`, and the reader in `schema-injection.ts`): its only remaining consumer is `derive`'s value-as-input lowering, so **it should be removed when `derive` is deprecated** (drop the writer, reader, map+methods, shims, doc). Forcing its removal now would mean reworking a dying derive path.

## Verification
- Full `ts-transformers` suite green: **293 passed / 624 steps**.
- **No golden changes** — the refactor is behavior-preserving (byte-identical emitted output).

## Follow-up
- Link to the `derive` deprecation work: when derive is removed, delete `narrowedWrapperTypeRegistry` per the documented invariant.
- `schemaInjectedRegistry` is the first member of the future unified marker/NodeLinks abstraction (registry-unification / Phase-2 prep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a single marker to flag schema-injected calls so we don’t re-process our own output, removing the redundant re-narrowing in the `lift(toSchema(...), ...)` path. Addresses the core of CT-1621 and documents why `narrowedWrapperTypeRegistry` still exists (derive-only); no golden changes.

- **Refactors**
  - Introduced `schemaInjectedRegistry` with `markSchemaInjected`/`isSchemaInjected` and a top-of-visit guard to skip re-injection, fixing the missing guard in the `isToSchemaCall` lift branch.
  - Removed pure idempotency arg-count checks for `when`/`unless`/`ifElse`; kept `cell`/`wish` `>=2` guards (protect user-supplied schemas) and dispatch guards.
  - Documented the precise invariant for `narrowedWrapperTypeRegistry`: only needed for `derive`’s value-as-input lowering; remove when `derive` is deprecated.
  - Behavior unchanged: full suite green and no golden diffs.

<sup>Written for commit 1e0bcb0d4d555d13a90a86c234621eb14de20cb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3716?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

