### PR TITLE
refactor(data-model,memory,runner): dedupe spine shallow-thaw onto shallowMutableClone()

### DIFF
--- a/packages/data-model/src/fabric-value.ts
+++ b/packages/data-model/src/fabric-value.ts
@@ -25,6 +25,7 @@ export {
   type CloneForMutationResult,
   cloneIfNecessary,
   type CloneOptions,
+  shallowMutableClone,
 } from "./value-clone.ts";
 
 import type {

--- a/packages/data-model/src/value-clone.ts
+++ b/packages/data-model/src/value-clone.ts
@@ -103,13 +103,6 @@ export function cloneIfNecessary<T extends FabricValue>(
  * identity-shared with the input. Equivalent to
  * `cloneIfNecessary(value, { frozen: false, deep: false, force: true })`.
  *
- * This is the canonical helper for the copy-on-write "spine" pattern:
- * shallow-clone each container along a mutated path, mutate the copies in
- * place, then `deepFreeze()` the assembled tree at the boundary. Routing
- * through `cloneIfNecessary` preserves the class of any `FabricInstance` /
- * `FabricPrimitive` it copies (via their own `shallowClone()` /
- * immutable-passthrough), unlike a bare `Object.assign`-based shallow copy.
- *
  * @param value - An already-valid `FabricValue`.
  */
 export function shallowMutableClone<T extends FabricValue>(value: T): T {

--- a/packages/data-model/src/value-clone.ts
+++ b/packages/data-model/src/value-clone.ts
@@ -98,6 +98,25 @@ export function cloneIfNecessary<T extends FabricValue>(
 }
 
 /**
+ * Shallow-thaws a `FabricValue` to a fresh mutable top-level copy: the
+ * top-level container is always copied, while its children stay
+ * identity-shared with the input. Equivalent to
+ * `cloneIfNecessary(value, { frozen: false, deep: false, force: true })`.
+ *
+ * This is the canonical helper for the copy-on-write "spine" pattern:
+ * shallow-clone each container along a mutated path, mutate the copies in
+ * place, then `deepFreeze()` the assembled tree at the boundary. Routing
+ * through `cloneIfNecessary` preserves the class of any `FabricInstance` /
+ * `FabricPrimitive` it copies (via their own `shallowClone()` /
+ * immutable-passthrough), unlike a bare `Object.assign`-based shallow copy.
+ *
+ * @param value - An already-valid `FabricValue`.
+ */
+export function shallowMutableClone<T extends FabricValue>(value: T): T {
+  return cloneIfNecessary(value, { frozen: false, deep: false, force: true });
+}
+
+/**
  * Performs the unified clone for both shallow and deep modes.
  *
  * When `deep` is true, recursively clones containers and detects circular

--- a/packages/data-model/test/shallowMutableClone.test.ts
+++ b/packages/data-model/test/shallowMutableClone.test.ts
@@ -1,0 +1,94 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { cloneIfNecessary, shallowMutableClone } from "../src/fabric-value.ts";
+import { deepFreeze } from "../src/deep-freeze.ts";
+import { FabricBytes } from "../src/fabric-primitives/FabricBytes.ts";
+import { FabricHash } from "../src/fabric-primitives/FabricHash.ts";
+import { FabricError } from "../src/fabric-instances/FabricError.ts";
+
+// `shallowMutableClone(v)` is a thin wrapper for
+// `cloneIfNecessary(v, { frozen: false, deep: false, force: true })`, so the
+// coverage here is intentionally light: it pins the wrapper's headline
+// guarantees (fresh mutable top-level copy, identity-shared children,
+// class-preserving) rather than re-testing `cloneIfNecessary` exhaustively.
+describe("shallowMutableClone", () => {
+  it("returns a fresh, mutable, top-level object copy", () => {
+    const input = deepFreeze({ a: 1, b: 2 });
+    const out = shallowMutableClone(input);
+
+    expect(out).not.toBe(input);
+    expect(out).toEqual({ a: 1, b: 2 });
+    expect(Object.isFrozen(out)).toBe(false);
+    // Mutable: can be written in place (the spine-write use case).
+    (out as Record<string, number>).a = 99;
+    expect((out as Record<string, number>).a).toBe(99);
+    // Input is untouched.
+    expect((input as Record<string, number>).a).toBe(1);
+  });
+
+  it("returns a fresh, mutable, top-level array copy", () => {
+    const input = deepFreeze([1, 2, 3]);
+    const out = shallowMutableClone(input);
+
+    expect(out).not.toBe(input);
+    expect(out).toEqual([1, 2, 3]);
+    expect(Object.isFrozen(out)).toBe(false);
+  });
+
+  it("shares children by identity (shallow, not deep)", () => {
+    const child = deepFreeze({ nested: true });
+    const input = deepFreeze({ child });
+    const out = shallowMutableClone(input) as Record<string, unknown>;
+
+    expect(out.child).toBe(child);
+  });
+
+  it("always copies, even an already-mutable input (force)", () => {
+    const input = { a: 1 };
+    const out = shallowMutableClone(input as Record<string, number>);
+
+    expect(out).not.toBe(input);
+  });
+
+  it("preserves a FabricInstance class and content (not a husk)", () => {
+    const native = new Error("boom");
+    (native as unknown as Record<string, unknown>).code = "E42";
+    const input = deepFreeze(FabricError.fromNativeError(native));
+
+    const out = shallowMutableClone(input);
+
+    expect(out).toBeInstanceOf(FabricError);
+    expect(out.getExtra("code")).toBe("E42");
+    expect(out.message).toBe("boom");
+  });
+
+  it("preserves getter-backed FabricPrimitives by identity-passthrough", () => {
+    const hash = FabricHash.fromString("sha256:abcd");
+    const bytes = new FabricBytes(new Uint8Array([1, 2, 3]));
+
+    // Inherently immutable -- returned as-is, with state intact.
+    const outHash = shallowMutableClone(hash);
+    expect(outHash).toBe(hash);
+    expect(outHash.tag).toBe("sha256");
+
+    const outBytes = shallowMutableClone(bytes);
+    expect(outBytes).toBe(bytes);
+    expect(outBytes.length).toBe(3);
+  });
+
+  it("matches the equivalent cloneIfNecessary options", () => {
+    const input = deepFreeze({ a: { b: 1 } });
+    const viaWrapper = shallowMutableClone(input) as Record<string, unknown>;
+    const viaOptions = cloneIfNecessary(input, {
+      frozen: false,
+      deep: false,
+      force: true,
+    }) as Record<string, unknown>;
+
+    // Same shallow semantics: top-level copied, child shared by identity.
+    expect(viaWrapper).not.toBe(input);
+    expect(viaOptions).not.toBe(input);
+    expect(viaWrapper.a).toBe((input as Record<string, unknown>).a);
+    expect(viaOptions.a).toBe((input as Record<string, unknown>).a);
+  });
+});

--- a/packages/memory/v2/patch.ts
+++ b/packages/memory/v2/patch.ts
@@ -1,6 +1,9 @@
 import type { FabricValue } from "../interface.ts";
 import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
-import { cloneIfNecessary } from "@commonfabric/data-model/fabric-value";
+import {
+  cloneIfNecessary,
+  shallowMutableClone,
+} from "@commonfabric/data-model/fabric-value";
 import { isInstance, isObject } from "@commonfabric/utils/types";
 import type { PatchOp } from "../v2.ts";
 import { encodePointer, parsePointer } from "./path.ts";
@@ -30,16 +33,6 @@ const MAX_ARRAY_INDEX = 2 ** 32 - 2;
  */
 const cloneValue = (value: FabricValue): FabricValue => cloneIfNecessary(value);
 
-// Shallow-thaw a spine container to a mutable copy: clone only the top-level
-// container (children stay identity-shared), always allocate (`force`), and
-// leave the result mutable for the in-place spine write that follows. The
-// boundary `deepFreeze()` re-freezes the assembled tree on the way out.
-const SHALLOW_THAW_OPTS = {
-  frozen: false,
-  deep: false,
-  force: true,
-} as const;
-
 /**
  * Applies a sequence of RFC 6902 JSON Patch operations (`replace`, `add`,
  * `remove`, `move`, `splice`) to a document tree, returning a new document
@@ -52,11 +45,10 @@ const SHALLOW_THAW_OPTS = {
  * The function is therefore on the hot path for any read that reconstructs
  * a document from its stored patch list.
  *
- * Mutation discipline: each `applyOp` call uses `cloneIfNecessary(_, {
- * frozen: false, deep: false, force: true })` to produce a new top-level
- * copy of the container being modified, then recurses into the path;
- * containers off the modified path remain frozen-by-reference. The
- * returned tree is then fully deep-frozen at the
+ * Mutation discipline: each `applyOp` call uses `shallowMutableClone()` to
+ * produce a new top-level copy of the container being modified, then
+ * recurses into the path; containers off the modified path remain
+ * frozen-by-reference. The returned tree is then fully deep-frozen at the
  * function boundary, completing the shallow-clone / mutate / deep-freeze
  * pattern: shallow clones at the immediate containers on the modified
  * path, deep-freeze of the assembled result before it leaves the function.
@@ -106,7 +98,7 @@ const replaceAtPath = (
 
   if (Array.isArray(root)) {
     const index = requireExistingArrayIndex(root, path[0]!, fullPath);
-    const next = cloneIfNecessary(root, SHALLOW_THAW_OPTS) as FabricValue[];
+    const next = shallowMutableClone(root) as FabricValue[];
     if (path.length === 1) {
       next[index] = cloneValue(value);
       return next;
@@ -124,7 +116,7 @@ const replaceAtPath = (
     throw new Error(`path is not traversable at ${encodePointer(fullPath)}`);
   }
 
-  const next = cloneIfNecessary(root, SHALLOW_THAW_OPTS) as PatchObject;
+  const next = shallowMutableClone(root) as PatchObject;
   const key = path[0]!;
   if (path.length === 1) {
     next[key] = cloneValue(value);
@@ -154,7 +146,7 @@ const addAtPath = (
   }
 
   if (Array.isArray(root)) {
-    const next = cloneIfNecessary(root, SHALLOW_THAW_OPTS) as FabricValue[];
+    const next = shallowMutableClone(root) as FabricValue[];
     const segment = path[0]!;
     if (path.length === 1) {
       if (segment === "-") {
@@ -179,7 +171,7 @@ const addAtPath = (
     throw new Error(`path is not traversable at ${encodePointer(fullPath)}`);
   }
 
-  const next = cloneIfNecessary(root, SHALLOW_THAW_OPTS) as PatchObject;
+  const next = shallowMutableClone(root) as PatchObject;
   const key = path[0]!;
   if (path.length === 1) {
     next[key] = cloneValue(value);
@@ -208,7 +200,7 @@ const removeAtPath = (
 
   if (Array.isArray(root)) {
     const index = requireExistingArrayIndex(root, path[0]!, fullPath);
-    const next = cloneIfNecessary(root, SHALLOW_THAW_OPTS) as FabricValue[];
+    const next = shallowMutableClone(root) as FabricValue[];
     if (path.length === 1) {
       next.splice(index, 1);
       return next;
@@ -226,7 +218,7 @@ const removeAtPath = (
     throw new Error(`path is not traversable at ${encodePointer(fullPath)}`);
   }
 
-  const next = cloneIfNecessary(root, SHALLOW_THAW_OPTS) as PatchObject;
+  const next = shallowMutableClone(root) as PatchObject;
   const key = path[0]!;
   if (path.length === 1) {
     if (!Object.hasOwn(root, key)) {
@@ -281,13 +273,13 @@ const spliceAtPath = (
     if (index < 0 || remove < 0 || index > root.length) {
       throw new Error(`invalid splice at ${encodePointer(fullPath)}`);
     }
-    const next = cloneIfNecessary(root, SHALLOW_THAW_OPTS) as FabricValue[];
+    const next = shallowMutableClone(root) as FabricValue[];
     next.splice(index, remove, ...add.map((value) => cloneValue(value)));
     return next;
   }
 
   if (Array.isArray(root)) {
-    const next = cloneIfNecessary(root, SHALLOW_THAW_OPTS) as FabricValue[];
+    const next = shallowMutableClone(root) as FabricValue[];
     const pathIndex = requireExistingArrayIndex(root, path[0]!, fullPath);
     const child = root[pathIndex];
     if (!isContainer(child)) {
@@ -318,7 +310,7 @@ const spliceAtPath = (
     throw new Error(`path is not traversable at ${encodePointer(fullPath)}`);
   }
 
-  const next = cloneIfNecessary(root, SHALLOW_THAW_OPTS) as PatchObject;
+  const next = shallowMutableClone(root) as PatchObject;
   next[key] = spliceAtPath(child, path.slice(1), index, remove, add, fullPath);
   return next;
 };

--- a/packages/memory/v2/patch.ts
+++ b/packages/memory/v2/patch.ts
@@ -30,6 +30,16 @@ const MAX_ARRAY_INDEX = 2 ** 32 - 2;
  */
 const cloneValue = (value: FabricValue): FabricValue => cloneIfNecessary(value);
 
+// Shallow-thaw a spine container to a mutable copy: clone only the top-level
+// container (children stay identity-shared), always allocate (`force`), and
+// leave the result mutable for the in-place spine write that follows. The
+// boundary `deepFreeze()` re-freezes the assembled tree on the way out.
+const SHALLOW_THAW_OPTS = {
+  frozen: false,
+  deep: false,
+  force: true,
+} as const;
+
 /**
  * Applies a sequence of RFC 6902 JSON Patch operations (`replace`, `add`,
  * `remove`, `move`, `splice`) to a document tree, returning a new document
@@ -42,10 +52,11 @@ const cloneValue = (value: FabricValue): FabricValue => cloneIfNecessary(value);
  * The function is therefore on the hot path for any read that reconstructs
  * a document from its stored patch list.
  *
- * Mutation discipline: each `applyOp` call uses `shallowCloneContainer` to
- * produce a new top-level copy of the container being modified, then
- * recurses into the path; containers off the modified path remain
- * frozen-by-reference. The returned tree is then fully deep-frozen at the
+ * Mutation discipline: each `applyOp` call uses `cloneIfNecessary(_, {
+ * frozen: false, deep: false, force: true })` to produce a new top-level
+ * copy of the container being modified, then recurses into the path;
+ * containers off the modified path remain frozen-by-reference. The
+ * returned tree is then fully deep-frozen at the
  * function boundary, completing the shallow-clone / mutate / deep-freeze
  * pattern: shallow clones at the immediate containers on the modified
  * path, deep-freeze of the assembled result before it leaves the function.
@@ -95,7 +106,7 @@ const replaceAtPath = (
 
   if (Array.isArray(root)) {
     const index = requireExistingArrayIndex(root, path[0]!, fullPath);
-    const next = shallowCloneContainer(root) as FabricValue[];
+    const next = cloneIfNecessary(root, SHALLOW_THAW_OPTS) as FabricValue[];
     if (path.length === 1) {
       next[index] = cloneValue(value);
       return next;
@@ -113,7 +124,7 @@ const replaceAtPath = (
     throw new Error(`path is not traversable at ${encodePointer(fullPath)}`);
   }
 
-  const next = shallowCloneContainer(root) as PatchObject;
+  const next = cloneIfNecessary(root, SHALLOW_THAW_OPTS) as PatchObject;
   const key = path[0]!;
   if (path.length === 1) {
     next[key] = cloneValue(value);
@@ -143,7 +154,7 @@ const addAtPath = (
   }
 
   if (Array.isArray(root)) {
-    const next = shallowCloneContainer(root) as FabricValue[];
+    const next = cloneIfNecessary(root, SHALLOW_THAW_OPTS) as FabricValue[];
     const segment = path[0]!;
     if (path.length === 1) {
       if (segment === "-") {
@@ -168,7 +179,7 @@ const addAtPath = (
     throw new Error(`path is not traversable at ${encodePointer(fullPath)}`);
   }
 
-  const next = shallowCloneContainer(root) as PatchObject;
+  const next = cloneIfNecessary(root, SHALLOW_THAW_OPTS) as PatchObject;
   const key = path[0]!;
   if (path.length === 1) {
     next[key] = cloneValue(value);
@@ -197,7 +208,7 @@ const removeAtPath = (
 
   if (Array.isArray(root)) {
     const index = requireExistingArrayIndex(root, path[0]!, fullPath);
-    const next = shallowCloneContainer(root) as FabricValue[];
+    const next = cloneIfNecessary(root, SHALLOW_THAW_OPTS) as FabricValue[];
     if (path.length === 1) {
       next.splice(index, 1);
       return next;
@@ -215,7 +226,7 @@ const removeAtPath = (
     throw new Error(`path is not traversable at ${encodePointer(fullPath)}`);
   }
 
-  const next = shallowCloneContainer(root) as PatchObject;
+  const next = cloneIfNecessary(root, SHALLOW_THAW_OPTS) as PatchObject;
   const key = path[0]!;
   if (path.length === 1) {
     if (!Object.hasOwn(root, key)) {
@@ -270,13 +281,13 @@ const spliceAtPath = (
     if (index < 0 || remove < 0 || index > root.length) {
       throw new Error(`invalid splice at ${encodePointer(fullPath)}`);
     }
-    const next = shallowCloneContainer(root) as FabricValue[];
+    const next = cloneIfNecessary(root, SHALLOW_THAW_OPTS) as FabricValue[];
     next.splice(index, remove, ...add.map((value) => cloneValue(value)));
     return next;
   }
 
   if (Array.isArray(root)) {
-    const next = shallowCloneContainer(root) as FabricValue[];
+    const next = cloneIfNecessary(root, SHALLOW_THAW_OPTS) as FabricValue[];
     const pathIndex = requireExistingArrayIndex(root, path[0]!, fullPath);
     const child = root[pathIndex];
     if (!isContainer(child)) {
@@ -307,7 +318,7 @@ const spliceAtPath = (
     throw new Error(`path is not traversable at ${encodePointer(fullPath)}`);
   }
 
-  const next = shallowCloneContainer(root) as PatchObject;
+  const next = cloneIfNecessary(root, SHALLOW_THAW_OPTS) as PatchObject;
   next[key] = spliceAtPath(child, path.slice(1), index, remove, add, fullPath);
   return next;
 };
@@ -328,18 +339,6 @@ const getAtPath = (root: FabricValue, path: string[]): FabricValue => {
 
 const createContainer = (nextSegment: string): PatchContainer => {
   return isArraySegment(nextSegment) || nextSegment === "-" ? [] : {};
-};
-
-const shallowCloneContainer = (value: PatchContainer): PatchContainer => {
-  if (Array.isArray(value)) {
-    const copy = new Array(value.length);
-    Object.assign(copy, value);
-    return copy as FabricValue[];
-  }
-
-  const copy = Object.create(Object.getPrototypeOf(value)) as PatchObject;
-  Object.assign(copy, value);
-  return copy;
 };
 
 const parseArrayIndex = (segment: string): number => {

--- a/packages/runner/src/storage/v2-path.ts
+++ b/packages/runner/src/storage/v2-path.ts
@@ -90,24 +90,15 @@ export const readValueAtPath = (
   return current as FabricValue | undefined;
 };
 
-const shallowCloneContainer = <
-  Container extends Record<string, unknown> | unknown[],
->(
-  value: Container,
-): Container => {
-  if (Array.isArray(value)) {
-    const copy = new Array(value.length);
-    Object.assign(copy, value);
-    return copy as Container;
-  }
-
-  const copy = Object.create(Object.getPrototypeOf(value)) as Record<
-    string,
-    unknown
-  >;
-  Object.assign(copy, value);
-  return copy as Container;
-};
+// Shallow-thaw a spine container to a mutable copy: clone only the top-level
+// container (children stay identity-shared), always allocate (`force`), and
+// leave the result mutable for the in-place spine write that follows. The
+// boundary `deepFreeze()` re-freezes the assembled tree on the way out.
+const SHALLOW_THAW_OPTS = {
+  frozen: false,
+  deep: false,
+  force: true,
+} as const;
 
 const getPathSegmentValue = (
   value: Record<string, unknown> | unknown[],
@@ -136,7 +127,10 @@ export const cloneWithValueAtPath = (
   }
 
   const baseRoot = (root ?? {}) as Record<string, unknown>;
-  const nextRoot = shallowCloneContainer(baseRoot);
+  const nextRoot = cloneIfNecessary(
+    baseRoot as FabricValue,
+    SHALLOW_THAW_OPTS,
+  ) as Record<string, unknown>;
   let currentClone: Record<string, unknown> | unknown[] = nextRoot;
   let currentBase: unknown = baseRoot;
   for (let index = 0; index < path.length - 1; index += 1) {
@@ -149,7 +143,7 @@ export const cloneWithValueAtPath = (
       )
       : undefined;
     const nextChild = isRecord(existing) || Array.isArray(existing)
-      ? shallowCloneContainer(existing)
+      ? cloneIfNecessary(existing as FabricValue, SHALLOW_THAW_OPTS)
       : createPathContainer(nextSegment);
     setPathSegmentValue(currentClone, segment, nextChild);
     currentClone = nextChild as Record<string, unknown> | unknown[];
@@ -190,7 +184,10 @@ export const cloneWithoutPath = (
     return root;
   }
 
-  const nextRoot = shallowCloneContainer(root);
+  const nextRoot = cloneIfNecessary(
+    root as FabricValue,
+    SHALLOW_THAW_OPTS,
+  ) as Record<string, unknown>;
   let currentClone: Record<string, unknown> | unknown[] = nextRoot;
   let currentBase: Record<string, unknown> | unknown[] = root;
   for (let index = 0; index < path.length - 1; index += 1) {
@@ -198,7 +195,10 @@ export const cloneWithoutPath = (
     const next = getPathSegmentValue(currentBase, segment) as
       | Record<string, unknown>
       | unknown[];
-    const nextClone = shallowCloneContainer(next);
+    const nextClone = cloneIfNecessary(
+      next as FabricValue,
+      SHALLOW_THAW_OPTS,
+    ) as Record<string, unknown> | unknown[];
     setPathSegmentValue(currentClone, segment, nextClone);
     currentClone = nextClone;
     currentBase = next;

--- a/packages/runner/src/storage/v2-path.ts
+++ b/packages/runner/src/storage/v2-path.ts
@@ -2,6 +2,7 @@ import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
 import {
   cloneIfNecessary,
   isArrayIndexPropertyName,
+  shallowMutableClone,
 } from "@commonfabric/data-model/fabric-value";
 import type { EntityDocument } from "@commonfabric/memory/v2";
 import type { FabricValue } from "@commonfabric/memory/interface";
@@ -90,16 +91,6 @@ export const readValueAtPath = (
   return current as FabricValue | undefined;
 };
 
-// Shallow-thaw a spine container to a mutable copy: clone only the top-level
-// container (children stay identity-shared), always allocate (`force`), and
-// leave the result mutable for the in-place spine write that follows. The
-// boundary `deepFreeze()` re-freezes the assembled tree on the way out.
-const SHALLOW_THAW_OPTS = {
-  frozen: false,
-  deep: false,
-  force: true,
-} as const;
-
 const getPathSegmentValue = (
   value: Record<string, unknown> | unknown[],
   segment: string,
@@ -127,10 +118,10 @@ export const cloneWithValueAtPath = (
   }
 
   const baseRoot = (root ?? {}) as Record<string, unknown>;
-  const nextRoot = cloneIfNecessary(
-    baseRoot as FabricValue,
-    SHALLOW_THAW_OPTS,
-  ) as Record<string, unknown>;
+  const nextRoot = shallowMutableClone(baseRoot as FabricValue) as Record<
+    string,
+    unknown
+  >;
   let currentClone: Record<string, unknown> | unknown[] = nextRoot;
   let currentBase: unknown = baseRoot;
   for (let index = 0; index < path.length - 1; index += 1) {
@@ -143,7 +134,7 @@ export const cloneWithValueAtPath = (
       )
       : undefined;
     const nextChild = isRecord(existing) || Array.isArray(existing)
-      ? cloneIfNecessary(existing as FabricValue, SHALLOW_THAW_OPTS)
+      ? shallowMutableClone(existing as FabricValue)
       : createPathContainer(nextSegment);
     setPathSegmentValue(currentClone, segment, nextChild);
     currentClone = nextChild as Record<string, unknown> | unknown[];
@@ -184,10 +175,10 @@ export const cloneWithoutPath = (
     return root;
   }
 
-  const nextRoot = cloneIfNecessary(
-    root as FabricValue,
-    SHALLOW_THAW_OPTS,
-  ) as Record<string, unknown>;
+  const nextRoot = shallowMutableClone(root as FabricValue) as Record<
+    string,
+    unknown
+  >;
   let currentClone: Record<string, unknown> | unknown[] = nextRoot;
   let currentBase: Record<string, unknown> | unknown[] = root;
   for (let index = 0; index < path.length - 1; index += 1) {
@@ -195,10 +186,9 @@ export const cloneWithoutPath = (
     const next = getPathSegmentValue(currentBase, segment) as
       | Record<string, unknown>
       | unknown[];
-    const nextClone = cloneIfNecessary(
-      next as FabricValue,
-      SHALLOW_THAW_OPTS,
-    ) as Record<string, unknown> | unknown[];
+    const nextClone = shallowMutableClone(next as FabricValue) as
+      | Record<string, unknown>
+      | unknown[];
     setPathSegmentValue(currentClone, segment, nextClone);
     currentClone = nextClone;
     currentBase = next;

--- a/packages/runner/test/memory-v2-path-helpers.test.ts
+++ b/packages/runner/test/memory-v2-path-helpers.test.ts
@@ -1,6 +1,8 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
+import { deepFreeze, isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
+import { FabricError } from "@commonfabric/data-model/fabric-instances";
+import { FabricHash } from "@commonfabric/data-model/fabric-primitives";
 import type { FabricValue } from "@commonfabric/memory/interface";
 import type { EntityDocument } from "@commonfabric/memory/v2";
 import {
@@ -170,5 +172,71 @@ describe("memory v2 path helpers — deep-freeze contract", () => {
     const result = cloneWithoutPath(root, ["value", "right", "remove"])!;
 
     expect(isDeepFrozen(result)).toBe(true);
+  });
+});
+
+// These helpers shallow-clone each container along the mutated spine. The
+// clone must preserve the *class* of whatever it copies: a Fabric wrapper
+// (`FabricInstance` / `FabricPrimitive`) traversed on the spine must come out
+// intact, not demoted to a prototype-shaped husk. The pre-dedup
+// implementation used `Object.create(getPrototypeOf(v)) + Object.assign(v)`,
+// which copies only enumerable own data properties -- so a wrapper whose
+// state lives in private fields (and whose accessors are prototype getters)
+// became a hollow husk: its getters threw `Cannot read private member`, and
+// for `FabricError` even `deepFreeze()` threw. Delegating to
+// `cloneIfNecessary` routes wrappers through their own `shallowClone()` /
+// immutable-passthrough, preserving identity and content.
+describe("memory v2 path helpers — Fabric wrapper preservation on spine", () => {
+  it("cloneWithValueAtPath preserves a FabricError traversed on the spine", () => {
+    const native = new Error("boom");
+    (native as unknown as Record<string, unknown>).code = "E42";
+    const wrapper = deepFreeze(FabricError.fromNativeError(native));
+    const root = deepFreeze({
+      value: { wrapper },
+    }) as unknown as EntityDocument;
+
+    // Descends through `wrapper`, so it is shallow-cloned on the spine.
+    const result = cloneWithValueAtPath(
+      root,
+      ["value", "wrapper", "added"],
+      1,
+    )!;
+
+    const out = (result.value as Record<string, unknown>)
+      .wrapper as FabricError;
+    expect(out).toBeInstanceOf(FabricError);
+    // Content survives: pre-dedup this threw inside `deepFreeze()` because the
+    // husk's private `#extras` was absent.
+    expect(out.getExtra("code")).toBe("E42");
+    expect(out.message).toBe("boom");
+  });
+
+  // Prophylactic (does not fail pre-dedup): a `FabricPrimitive` is opaque, so
+  // it can only ever be an off-spine *sibling* within a shallow-cloned spine
+  // container, never a traversed-through spine node itself (it has no
+  // traversable members). This pins that a getter-backed primitive
+  // (`FabricHash` exposes all state via prototype getters over private fields
+  // -- exactly the shape `Object.assign` would hollow out) survives a spine
+  // shallow-clone by identity, guarding against a future clone change that
+  // deep-copies or class-demotes nested wrappers.
+  it("cloneWithValueAtPath preserves a FabricHash sibling of the mutated spine", () => {
+    const hash = FabricHash.fromString("sha256:abcd");
+    const root = deepFreeze({
+      value: { keep: hash, target: { count: 1 } },
+    }) as unknown as EntityDocument;
+
+    // `value` is shallow-cloned (it's on the spine to `target.count`); its
+    // `keep` sibling must ride along by identity, not be reconstructed.
+    const result = cloneWithValueAtPath(
+      root,
+      ["value", "target", "count"],
+      2,
+    )!;
+
+    const out = (result.value as Record<string, unknown>).keep as FabricHash;
+    expect(out).toBe(hash);
+    expect(out).toBeInstanceOf(FabricHash);
+    expect(out.tag).toBe("sha256");
+    expect(out.taggedHashString).toBe("sha256:abcd");
   });
 });


### PR DESCRIPTION
## Summary

- Adds a named helper `shallowMutableClone(value)` to `data-model/src/value-clone.ts` (re-exported via `fabric-value.ts`) for the copy-on-write "spine" shallow-thaw: clone each container along a mutated path to a fresh mutable top-level copy (children stay identity-shared), mutate in place, then `deepFreeze()` the assembled tree at the boundary. It's a thin wrapper for `cloneIfNecessary(value, { frozen: false, deep: false, force: true })`.
- Removes a byte-identical private `shallowCloneContainer` helper that was duplicated across `memory/v2/patch.ts` and `runner/src/storage/v2-path.ts`, routing both onto `shallowMutableClone()`.

## Why

The duplicated helper used `Object.create(getPrototypeOf(v)) + Object.assign` (objects) and `new Array(len) + Object.assign` (arrays). For plain objects/arrays that matches `shallowMutableClone`, but it silently mangled any **Fabric wrapper** it cloned: `Object.assign` copies only enumerable own data properties, so a class instance became a prototype-shaped *husk* with absent private fields. For getter-backed wrappers (`FabricHash`, `FabricBytes`) the accessors then threw `Cannot read private member`; for `FabricError`, even `deepFreeze()` threw on the husk's missing `#extras`. `shallowMutableClone` routes wrappers through their own `shallowClone()` (instances) or identity-passthrough (immutable primitives).

Reachability split:
- **`v2-path.ts` was vulnerable** — its spine gate is `isRecord` (`typeof === "object" && !== null`), which admits class instances. A patch path descending through a `FabricError` would throw during materialization.
- **`patch.ts` was already guarded** — `isPatchObject = isObject && !isInstance` excludes class instances, and `isContainer` throws on descent. Consolidation only there.

It also fixes sparse-array handling as a side benefit: `new Array(len) + Object.assign` → `cloneIfNecessary`'s `for (i…) if (i in arr)` copy.

## Tests

- `shallowMutableClone.test.ts` (data-model) — light coverage of the wrapper: fresh/mutable/top-level copy, identity-shared children, force-copy, FabricInstance content preservation, FabricPrimitive identity-passthrough, equivalence to the explicit `cloneIfNecessary` options.
- `memory-v2-path-helpers.test.ts` (runner):
  - `cloneWithValueAtPath` preserves a `FabricError` traversed on the spine — a regression guard; verified to throw inside `deepFreeze()` on the pre-change helper, passes now.
  - `cloneWithValueAtPath` preserves a `FabricHash` sibling of the mutated spine — a forward-looking prophylactic guarding against a future clone change that deep-copies or class-demotes nested wrappers. (`FabricPrimitive`s are opaque, so they can only appear as off-spine siblings, never as traversed spine nodes.)

## Test plan

- [x] `deno task test` — data-model 36 / 0, memory 120 / 0, runner 470 / 0
- [x] `deno fmt --check` + `deno check` on touched files
- [x] Pre-change failure of the FabricError regression test verified by reverting only `v2-path.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
