### PR TITLE
refactor(data-model): encapsulate FabricEpoch* value behind a getter

### DIFF
--- a/packages/data-model/src/fabric-primitives/FabricEpochDays.ts
+++ b/packages/data-model/src/fabric-primitives/FabricEpochDays.ts
@@ -1,3 +1,7 @@
+import type {
+  FabricEpochDays as ApiFabricEpochDays,
+  FabricEpochDaysConstructor as ApiFabricEpochDaysConstructor,
+} from "@commonfabric/api";
 import { FabricPrimitive } from "../interface.ts";
 
 /**
@@ -6,12 +10,24 @@ import { FabricPrimitive } from "../interface.ts";
  * `FabricValue` (not a `FabricInstance`).
  * See Section 1.4.7 of the formal spec.
  */
-export class FabricEpochDays extends FabricPrimitive {
-  constructor(
-    /** Days from POSIX Epoch. Negative values represent pre-epoch dates. */
-    readonly value: bigint,
-  ) {
+export class FabricEpochDays extends FabricPrimitive
+  implements ApiFabricEpochDays {
+  /** Days from POSIX Epoch. Negative values represent pre-epoch dates. */
+  readonly #value: bigint;
+
+  constructor(value: bigint) {
     super();
+    this.#value = value;
     Object.freeze(this);
   }
+
+  /** Days from POSIX Epoch. Negative values represent pre-epoch dates. */
+  get value(): bigint {
+    return this.#value;
+  }
 }
+
+// Compile-time check that the exported `FabricEpochDays` constructor matches the
+// `FabricEpochDaysConstructor` declared in `@commonfabric/api`. This catches
+// drift between the public type contract and this implementation.
+FabricEpochDays satisfies ApiFabricEpochDaysConstructor;

--- a/packages/data-model/src/fabric-primitives/FabricEpochNsec.ts
+++ b/packages/data-model/src/fabric-primitives/FabricEpochNsec.ts
@@ -1,3 +1,7 @@
+import type {
+  FabricEpochNsec as ApiFabricEpochNsec,
+  FabricEpochNsecConstructor as ApiFabricEpochNsecConstructor,
+} from "@commonfabric/api";
 import { FabricPrimitive } from "../interface.ts";
 
 /**
@@ -6,12 +10,24 @@ import { FabricPrimitive } from "../interface.ts";
  * `FabricValue` (not a `FabricInstance`).
  * See Section 1.4.6 of the formal spec.
  */
-export class FabricEpochNsec extends FabricPrimitive {
-  constructor(
-    /** Nanoseconds from POSIX Epoch. Negative values represent pre-epoch timestamps. */
-    readonly value: bigint,
-  ) {
+export class FabricEpochNsec extends FabricPrimitive
+  implements ApiFabricEpochNsec {
+  /** Nanoseconds from POSIX Epoch. Negative values represent pre-epoch timestamps. */
+  readonly #value: bigint;
+
+  constructor(value: bigint) {
     super();
+    this.#value = value;
     Object.freeze(this);
   }
+
+  /** Nanoseconds from POSIX Epoch. Negative values represent pre-epoch timestamps. */
+  get value(): bigint {
+    return this.#value;
+  }
 }
+
+// Compile-time check that the exported `FabricEpochNsec` constructor matches the
+// `FabricEpochNsecConstructor` declared in `@commonfabric/api`. This catches
+// drift between the public type contract and this implementation.
+FabricEpochNsec satisfies ApiFabricEpochNsecConstructor;


### PR DESCRIPTION
Rework `FabricEpochNsec` and `FabricEpochDays` to mirror the
`FabricBytes` / `FabricHash` encapsulation pattern: move the
`value: bigint` from a public TS `readonly value`
constructor-parameter-property to a true hard-private `#value` member
exposed only via `get value(): bigint`, keeping the existing `super()`
+ `Object.freeze(this)`.

This is a structural / encapsulation refactor, not a behavior change.
The getter structurally satisfies the `readonly value: bigint` declared
in `@commonfabric/api`, and all consumers read `.value` via plain
property access, so no consumer or `api/index.ts` change is needed.

Also adds the `FabricHash`-style compile-time contract checks — an
`implements ApiFabricEpoch*` clause (instance side) and a
`satisfies ApiFabricEpoch*Constructor` check (construct side) — so
future API-contract drift is caught at compile time.

Scope: two source files (`FabricEpochNsec.ts` + `FabricEpochDays.ts`)
in `packages/data-model/src/fabric-primitives/`, +42/-10. No
`api/index.ts`, consumer, or `deno.json` changes.

Co-Authored-By: coder-cedar (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Encapsulates FabricEpochNsec and FabricEpochDays values behind a getter to match other primitives and tighten the API contract. No behavior change; consumers still read .value.

- **Refactors**
  - Replace public readonly constructor property with hard-private #value and a get value() accessor.
  - Add compile-time contract checks: implements ApiFabricEpoch* and satisfies *Constructor from `@commonfabric/api`.

<sup>Written for commit 93d261d2e2a55b25a2cf9cbe945d6a146d74e1a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3718?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

