### PR TITLE
refactor(runner): remove dead chronicle methods + adopt shallowMutableClone()

### DIFF
--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -9,6 +9,7 @@ import type { JSONSchemaObj, JSONValue } from "@commonfabric/api";
 import {
   cloneIfNecessary,
   type FabricValue,
+  shallowMutableClone,
 } from "@commonfabric/data-model/fabric-value";
 import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
@@ -828,10 +829,7 @@ function annotateWithBackToCellSymbols(
   if (!extensible || isCellResultForDereferencing(value)) {
     // We have to do a shallow clone of `value`. See function header comment
     // for details.
-    value = cloneIfNecessary(value as FabricValue, {
-      frozen: false,
-      deep: false,
-    });
+    value = shallowMutableClone(value as FabricValue);
   }
 
   // Non-enumerable, so that {...obj} won't copy these symbols

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -1,10 +1,10 @@
 import { Immutable, isRecord } from "@commonfabric/utils/types";
 import { getLogger } from "@commonfabric/utils/logger";
 import {
-  cloneIfNecessary,
   type FabricObject,
   type FabricValue,
   isArrayIndexPropertyName,
+  shallowMutableClone,
 } from "@commonfabric/data-model/fabric-value";
 import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
 import type {
@@ -439,13 +439,12 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
         }
         // When modernDataModel is ON, stored objects are deep-frozen by
         // fabricFromNativeValueModern(). Shallow-clone before mutation to avoid
-        // TypeError on frozen objects. force defaults to true (always clone)
-        // because the value may be the transaction's working copy, which
-        // must not be mutated in place.
-        valueObj = cloneIfNecessary(currentValue as FabricValue, {
-          deep: false,
-          frozen: false,
-        }) as FabricObject;
+        // TypeError on frozen objects. `shallowMutableClone` always copies,
+        // because the value may be the transaction's working copy, which must
+        // not be mutated in place.
+        valueObj = shallowMutableClone(
+          currentValue as FabricValue,
+        ) as FabricObject;
       }
       const remainingPath = address.path.slice(lastExistingPath.length);
       if (remainingPath.length === 0) {

--- a/packages/runner/src/storage/transaction/chronicle.ts
+++ b/packages/runner/src/storage/transaction/chronicle.ts
@@ -483,52 +483,6 @@ class Novelty {
     return this.select(address)?.get(address.path);
   }
 
-  /**
-   * Claims a new write invariant, merging it with existing parent invariants
-   * when possible instead of keeping both parent and child separately.
-   */
-  claim(
-    invariant: IAttestation,
-  ): Result<
-    IAttestation,
-    IStorageTransactionInconsistent | INotFoundError | ITypeMismatchError
-  > {
-    const candidates = this.edit(invariant.address);
-
-    for (const candidate of candidates) {
-      // If the candidate is a parent of the new invariant, merge the new invariant
-      // into the existing parent invariant.
-      if (Address.includes(candidate.address, invariant.address)) {
-        const { error, ok: merged } = applyWriteToAttestation(
-          candidate,
-          invariant.address,
-          invariant.value,
-        );
-
-        if (error) {
-          return { error };
-        } else {
-          candidates.put(merged);
-          return { ok: merged };
-        }
-      }
-    }
-
-    // If we did not find any parents we may have some children
-    // that will be replaced by this invariant
-    // Since we are altering the collection, we iterate over a copy.
-    for (const candidate of [...candidates]) {
-      if (Address.includes(invariant.address, candidate.address)) {
-        candidates.delete(candidate);
-      }
-    }
-
-    // Store this invariant
-    candidates.put(invariant);
-
-    return { ok: invariant };
-  }
-
   [Symbol.iterator]() {
     return this.#model.values();
   }
@@ -644,33 +598,6 @@ class Changes {
       this.#pathAttestations.set(pathKey, { address, value });
     }
     return result;
-  }
-
-  /** Legacy put() for compatibility - applies write to working copy */
-  put(invariant: IAttestation) {
-    if (!this.#workingCopy) {
-      // First write initializes the working copy
-      this.#workingCopy = invariant;
-    } else {
-      // Apply write to working copy
-      const result = applyWriteToAttestation(
-        this.#workingCopy,
-        invariant.address,
-        invariant.value,
-      );
-      if (result.ok) {
-        this.#workingCopy = result.ok;
-      }
-    }
-    // Store individual path attestation for novelty() iterator
-    const pathKey = JSON.stringify(invariant.address.path);
-    this.#pathAttestations.set(pathKey, invariant);
-  }
-
-  /** Legacy delete() - removes from path attestations */
-  delete(invariant: IAttestation) {
-    const pathKey = JSON.stringify(invariant.address.path);
-    this.#pathAttestations.delete(pathKey);
   }
 
   /**


### PR DESCRIPTION
## Summary

Two small, independent cleanups (one commit each):

**1. Remove dead code in `storage/transaction/chronicle.ts`.** `Novelty` and `Changes` are module-private classes, so reachability is fully local to the file. `Novelty.claim()` has no callers, and it was the sole caller of `Changes.put()` and `Changes.delete()` — all three are leftovers from the pre-CT-1123 `put() + rebase()` pattern that the working-copy `applyWrite()` replaced. Confirmed dead with @seefeldb. (The `Changes` iterator and `rebase()` are kept — still used by `Novelty.changes()` and `Chronicle` reads.)

**2. Adopt `shallowMutableClone()`.** Two sites used `cloneIfNecessary(v, { frozen: false, deep: false })` (force defaults to `true` under `frozen: false`), which is exactly the new `shallowMutableClone()` helper: `schema.ts` and `storage/extended-storage-transaction.ts`. Left as-is: `schema.ts`'s other `cloneIfNecessary` call uses `force: false` (thaw-if-frozen-else-identity), which is *not* `shallowMutableClone`.

## Test plan

- [x] `deno task test` (runner) — 470 / 0
- [x] `deno fmt --check` + `deno check` on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes dead chronicle code and adopts `shallowMutableClone()` in two places for clearer intent with no behavior changes.

- **Refactors**
  - Deleted unused `Novelty.claim()`, `Changes.put()`, and `Changes.delete()` from `packages/runner/src/storage/transaction/chronicle.ts`. Iterator and `rebase()` remain.
  - Replaced `cloneIfNecessary(v, { frozen: false, deep: false })` with `shallowMutableClone()` in `packages/runner/src/schema.ts` and `packages/runner/src/storage/extended-storage-transaction.ts`. The other `cloneIfNecessary` call in `schema.ts` (with `force: false`) is unchanged.

<sup>Written for commit 98d932e4cd08dc62f0d000bcf3e89f2fa4368515. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3719?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

