### PR TITLE
docs(data-model): fix Markdown-in-code conformance in fabric-instances test labels

### DIFF
--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -373,7 +373,7 @@ export class FabricError extends FabricNativeWrapper<Error> {
   ): FabricError {
     const s = state as Record<string, FabricValue>;
     const type = (s.type as string) ?? (s.name as string) ?? "Error";
-    // null name means "same as type" (the wire-level optimization).
+    // `null` `name` means "same as `type`" (the wire-level optimization).
     const name = (s.name as string | null | undefined) ?? type;
     const message = (s.message as string) ?? "";
     const stack = s.stack as string | undefined;

--- a/packages/data-model/test/fabric-instances/FabricError.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricError.test.ts
@@ -37,7 +37,7 @@ describe("FabricError", () => {
   });
 
   describe("constructor()", () => {
-    it("wraps the Error's `FabricValue`-shaped state", () => {
+    it("wraps the `Error`'s `FabricValue`-shaped state", () => {
       const err = new TypeError("bad");
       const se = FabricError.fromNativeError(err);
       expect(se.type).toBe("TypeError");
@@ -72,7 +72,7 @@ describe("FabricError", () => {
 
   describe("instance members", () => {
     describe("[DECONSTRUCT]", () => {
-      it("returns type, name=null (common case), message, stack", () => {
+      it("returns `type`, `name=null` (common case), `message`, `stack`", () => {
         const se = FabricError.fromNativeError(new Error("hello"));
         const state = se[DECONSTRUCT]() as Record<string, FabricValue>;
         expect(state.type).toBe("Error");
@@ -81,14 +81,14 @@ describe("FabricError", () => {
         expect(typeof state.stack).toBe("string");
       });
 
-      it("sets name to null when type === name (TypeError)", () => {
+      it("sets `name` to `null` when `type === name` (`TypeError`)", () => {
         const se = FabricError.fromNativeError(new TypeError("bad"));
         const state = se[DECONSTRUCT]() as Record<string, FabricValue>;
         expect(state.type).toBe("TypeError");
         expect(state.name).toBe(null);
       });
 
-      it("sets name non-null when type !== name", () => {
+      it("sets `name` non-null when `type !== name`", () => {
         const err = new TypeError("bad");
         err.name = "CustomName";
         const se = FabricError.fromNativeError(err);
@@ -148,7 +148,7 @@ describe("FabricError", () => {
         expect("stack" in state).toBe(false);
       });
 
-      it("round-trips through [DECONSTRUCT]/[RECONSTRUCT]", () => {
+      it("round-trips through `[DECONSTRUCT]`/`[RECONSTRUCT]`", () => {
         const original = new Error("round trip");
         original.name = "CustomError";
         (original as unknown as Record<string, unknown>).code = 42;
@@ -162,7 +162,7 @@ describe("FabricError", () => {
         expect(restored.getExtra("code")).toBe(42);
       });
 
-      it("round-trips a TypeError with overridden name", () => {
+      it("round-trips a `TypeError` with overridden `name`", () => {
         const original = new TypeError("bad value");
         original.name = "SpecialType";
         const se = FabricError.fromNativeError(original);
@@ -181,7 +181,7 @@ describe("FabricError", () => {
     });
 
     describe("toNativeValue()", () => {
-      it("returns a frozen Error projection when `frozen` is true", () => {
+      it("returns a frozen `Error` projection when `frozen` is true", () => {
         const err = new Error("native");
         const se = FabricError.fromNativeError(err);
         const result = se.toNativeValue(true);
@@ -204,7 +204,7 @@ describe("FabricError", () => {
         expect(Object.isFrozen(a)).toBe(true);
       });
 
-      it("returns a fresh unfrozen Error projection when `frozen` is false", () => {
+      it("returns a fresh unfrozen `Error` projection when `frozen` is false", () => {
         const se = FabricError.fromNativeError(new Error("native"));
         const result = se.toNativeValue(false);
         expect(result).toBeInstanceOf(Error);
@@ -222,7 +222,7 @@ describe("FabricError", () => {
     });
 
     describe("`[DEEP_FREEZE]` / `[IS_DEEP_FROZEN]`", () => {
-      it("via dispatch: [DEEP_FREEZE] freezes wrapper + recurses cause", () => {
+      it("via dispatch: `[DEEP_FREEZE]` freezes wrapper + recurses cause", () => {
         const inner = FabricError.fromNativeError(new Error("cause"));
         const fe = FabricError.fromNativeError(
           new Error("outer", { cause: inner }),
@@ -233,7 +233,7 @@ describe("FabricError", () => {
         expect(isDeepFrozen(inner)).toBe(true);
       });
 
-      it("via dispatch: [DEEP_FREEZE] recurses enumerable custom props (preserved via extras)", () => {
+      it("via dispatch: `[DEEP_FREEZE]` recurses enumerable custom props (preserved via extras)", () => {
         const err = new Error("e");
         const childObj = { nested: 1 };
         (err as unknown as Record<string, unknown>).custom = childObj;
@@ -244,7 +244,7 @@ describe("FabricError", () => {
         expect(Object.isFrozen(childObj)).toBe(true);
       });
 
-      it("via dispatch: [IS_DEEP_FROZEN] true only when wrapper + cause are frozen", () => {
+      it("via dispatch: `[IS_DEEP_FROZEN]` true only when wrapper + cause are frozen", () => {
         const fe = FabricError.fromNativeError(new Error("test"));
         expect(isDeepFrozenFabricValue(fe)).toBe(false);
         Object.freeze(fe); // wrapper only; some descendants still mutable
@@ -254,7 +254,7 @@ describe("FabricError", () => {
         expect(isDeepFrozenFabricValue(fe)).toBe(true);
       });
 
-      it("via direct member invocation: [DEEP_FREEZE] freezes wrapper + recurses cause", () => {
+      it("via direct member invocation: `[DEEP_FREEZE]` freezes wrapper + recurses cause", () => {
         const inner = FabricError.fromNativeError(new Error("cause"));
         const fe = FabricError.fromNativeError(
           new Error("outer", { cause: inner }),
@@ -265,7 +265,7 @@ describe("FabricError", () => {
         expect(isDeepFrozen(inner)).toBe(true);
       });
 
-      it("via direct member invocation: [DEEP_FREEZE] recurses enumerable custom props (preserved via extras)", () => {
+      it("via direct member invocation: `[DEEP_FREEZE]` recurses enumerable custom props (preserved via extras)", () => {
         const err = new Error("e");
         const childObj = { nested: 1 };
         (err as unknown as Record<string, unknown>).custom = childObj;
@@ -276,7 +276,7 @@ describe("FabricError", () => {
         expect(Object.isFrozen(childObj)).toBe(true);
       });
 
-      it("via direct member invocation: [IS_DEEP_FROZEN] true only when wrapper is frozen", () => {
+      it("via direct member invocation: `[IS_DEEP_FROZEN]` true only when wrapper is frozen", () => {
         const fe = FabricError.fromNativeError(new Error("test"));
         expect(fe[IS_DEEP_FROZEN](subIsDeepFrozen)).toBe(false);
         fe[DEEP_FREEZE](subFreeze);
@@ -287,7 +287,7 @@ describe("FabricError", () => {
 
   describe("static members", () => {
     describe("[RECONSTRUCT]", () => {
-      it("creates a FabricError from state (null name = same as type)", () => {
+      it("creates a `FabricError` from state (null `name` = same as `type`)", () => {
         const state = {
           type: "Error",
           name: null,
@@ -300,7 +300,7 @@ describe("FabricError", () => {
         expect(result.message).toBe("hello");
       });
 
-      it("creates the correct Error subclass from type (null name)", () => {
+      it("creates the correct `Error` subclass from `type` (null `name`)", () => {
         const cases: [string, ErrorConstructor][] = [
           ["TypeError", TypeError],
           ["RangeError", RangeError],
@@ -317,7 +317,7 @@ describe("FabricError", () => {
         }
       });
 
-      it("handles type != name (e.g. TypeError with custom name)", () => {
+      it("handles `type != name` (e.g. `TypeError` with custom `name`)", () => {
         const state = {
           type: "TypeError",
           name: "CustomTypeName",
@@ -328,7 +328,7 @@ describe("FabricError", () => {
         expect(result.name).toBe("CustomTypeName");
       });
 
-      it("falls back to name when type is absent (back-compat)", () => {
+      it("falls back to `name` when `type` is absent (back-compat)", () => {
         const state = {
           name: "TypeError",
           message: "old format",
@@ -337,7 +337,7 @@ describe("FabricError", () => {
         expect(result.toNativeValue(true)).toBeInstanceOf(TypeError);
       });
 
-      it("handles a custom name", () => {
+      it("handles a custom `name`", () => {
         const state = {
           type: "Error",
           name: "MyCustomError",

--- a/packages/data-model/test/fabric-instances/FabricMap.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricMap.test.ts
@@ -54,14 +54,14 @@ describe("FabricMap", () => {
         expect(result).not.toBeInstanceOf(FrozenMap);
       });
 
-      it("returns the same `FrozenMap` if already frozen (frozen=true)", () => {
+      it("returns the same `FrozenMap` if already frozen (`frozen=true`)", () => {
         const fm = new FrozenMap<FabricValue, FabricValue>([["a", 1]]);
         const sm = new FabricMap(fm);
         const result = sm.toNativeValue(true);
         expect(result).toBe(fm); // same reference
       });
 
-      it("copies a `FrozenMap` to a mutable `Map` (frozen=false)", () => {
+      it("copies a `FrozenMap` to a mutable `Map` (`frozen=false`)", () => {
         const fm = new FrozenMap<FabricValue, FabricValue>([["a", 1]]);
         const sm = new FabricMap(fm);
         const result = sm.toNativeValue(false);
@@ -75,14 +75,14 @@ describe("FabricMap", () => {
     // FabricMap deliberately keeps throwing stubs for the protocol methods
     // (per Dan's PR #3612 review: not yet used, reworked separately).
     describe("`[DEEP_FREEZE]` / `[IS_DEEP_FROZEN]`", () => {
-      it("via dispatch: [DEEP_FREEZE] throws not-yet-implemented", () => {
+      it("via dispatch: `[DEEP_FREEZE]` throws not-yet-implemented", () => {
         const fm = new FabricMap(
           new FrozenMap<FabricValue, FabricValue>([["a", 1]]),
         );
         expect(() => deepFreeze(fm)).toThrow("FabricMap: not yet implemented");
       });
 
-      it("via dispatch: [IS_DEEP_FROZEN] throws not-yet-implemented (via type guard)", () => {
+      it("via dispatch: `[IS_DEEP_FROZEN]` throws not-yet-implemented (via type guard)", () => {
         const fm = new FabricMap(
           new FrozenMap<FabricValue, FabricValue>([["a", 1]]),
         );
@@ -92,7 +92,7 @@ describe("FabricMap", () => {
         );
       });
 
-      it("via direct member invocation: [DEEP_FREEZE] throws not-yet-implemented", () => {
+      it("via direct member invocation: `[DEEP_FREEZE]` throws not-yet-implemented", () => {
         const fm = new FabricMap(
           new FrozenMap<FabricValue, FabricValue>([["a", 1]]),
         );
@@ -101,7 +101,7 @@ describe("FabricMap", () => {
         );
       });
 
-      it("via direct member invocation: [IS_DEEP_FROZEN] throws not-yet-implemented", () => {
+      it("via direct member invocation: `[IS_DEEP_FROZEN]` throws not-yet-implemented", () => {
         const fm = new FabricMap(
           new FrozenMap<FabricValue, FabricValue>([["a", 1]]),
         );

--- a/packages/data-model/test/fabric-instances/FabricRegExp.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricRegExp.test.ts
@@ -54,7 +54,7 @@ describe("FabricRegExp", () => {
   });
 
   describe("constructor()", () => {
-    it("wraps the original RegExp", () => {
+    it("wraps the original `RegExp`", () => {
       const re = /test/i;
       const sr = new FabricRegExp(re);
       expect(sr.regex).toBe(re);
@@ -63,7 +63,7 @@ describe("FabricRegExp", () => {
 
   describe("instance members", () => {
     describe("[DECONSTRUCT]", () => {
-      it("returns source, flags, and flavor", () => {
+      it("returns `source`, `flags`, and `flavor`", () => {
         const sr = new FabricRegExp(/abc/gi);
         const state = sr[DECONSTRUCT]() as Record<string, FabricValue>;
         expect(state.source).toBe("abc");
@@ -71,7 +71,7 @@ describe("FabricRegExp", () => {
         expect(state.flavor).toBe("es2025");
       });
 
-      it("returns correct source for a complex pattern", () => {
+      it("returns correct `source` for a complex pattern", () => {
         const sr = new FabricRegExp(/^foo\d+\.bar$/);
         const state = sr[DECONSTRUCT]() as Record<string, FabricValue>;
         expect(state.source).toBe("^foo\\d+\\.bar$");
@@ -79,13 +79,13 @@ describe("FabricRegExp", () => {
         expect(state.flavor).toBe("es2025");
       });
 
-      it("returns empty flags for a no-flag regexp", () => {
+      it("returns empty `flags` for a no-flag regexp", () => {
         const sr = new FabricRegExp(/abc/);
         const state = sr[DECONSTRUCT]() as Record<string, FabricValue>;
         expect(state.flags).toBe("");
       });
 
-      it("rejects a RegExp with extra enumerable properties", () => {
+      it("rejects a `RegExp` with extra enumerable properties", () => {
         const re = /abc/g;
         (re as unknown as Record<string, unknown>).custom = 1;
         const sr = new FabricRegExp(re);
@@ -96,7 +96,7 @@ describe("FabricRegExp", () => {
     });
 
     describe("round-trip", () => {
-      it("round-trips through [DECONSTRUCT]/[RECONSTRUCT]", () => {
+      it("round-trips through `[DECONSTRUCT]`/`[RECONSTRUCT]`", () => {
         const original = /hello\s+world/gim;
         const sr = new FabricRegExp(original);
         const state = sr[DECONSTRUCT]();
@@ -118,7 +118,7 @@ describe("FabricRegExp", () => {
         }
       });
 
-      it("round-trips with a custom flavor", () => {
+      it("round-trips with a custom `flavor`", () => {
         const sr = new FabricRegExp(/abc/gi, "pcre2");
         expect(sr.flavor).toBe("pcre2");
         const state = sr[DECONSTRUCT]();
@@ -130,7 +130,7 @@ describe("FabricRegExp", () => {
     });
 
     describe("toNativeValue()", () => {
-      it("returns a frozen RegExp (copy of unfrozen) when `frozen` is true", () => {
+      it("returns a frozen `RegExp` (copy of unfrozen) when `frozen` is true", () => {
         const re = /abc/gi;
         const sr = new FabricRegExp(re);
         const result = sr.toNativeValue(true);
@@ -142,14 +142,14 @@ describe("FabricRegExp", () => {
         expect(Object.isFrozen(re)).toBe(false);
       });
 
-      it("returns the same RegExp if already frozen (frozen=true)", () => {
+      it("returns the same `RegExp` if already frozen (`frozen=true`)", () => {
         const re = Object.freeze(/abc/gi);
         const sr = new FabricRegExp(re);
         const result = sr.toNativeValue(true);
         expect(result).toBe(re); // same reference
       });
 
-      it("returns the original unfrozen RegExp when `frozen` is false", () => {
+      it("returns the original unfrozen `RegExp` when `frozen` is false", () => {
         const re = /abc/gi;
         const sr = new FabricRegExp(re);
         const result = sr.toNativeValue(false);
@@ -157,7 +157,7 @@ describe("FabricRegExp", () => {
         expect(Object.isFrozen(result)).toBe(false);
       });
 
-      it("returns an unfrozen copy of a frozen RegExp when `frozen` is false", () => {
+      it("returns an unfrozen copy of a frozen `RegExp` when `frozen` is false", () => {
         const re = Object.freeze(/abc/gi);
         const sr = new FabricRegExp(re);
         const result = sr.toNativeValue(false);
@@ -170,7 +170,7 @@ describe("FabricRegExp", () => {
     });
 
     describe("`[DEEP_FREEZE]` / `[IS_DEEP_FROZEN]`", () => {
-      it("via dispatch: [DEEP_FREEZE] freezes the wrapped RegExp in place", () => {
+      it("via dispatch: `[DEEP_FREEZE]` freezes the wrapped `RegExp` in place", () => {
         const fr = new FabricRegExp(/abc/g);
         expect(Object.isFrozen(fr.regex)).toBe(false);
         const result = deepFreeze(fr);
@@ -179,14 +179,14 @@ describe("FabricRegExp", () => {
         expect(Object.isFrozen(fr.regex)).toBe(true);
       });
 
-      it("via dispatch: [IS_DEEP_FROZEN] true only when wrapper + RegExp frozen", () => {
+      it("via dispatch: `[IS_DEEP_FROZEN]` true only when wrapper + `RegExp` frozen", () => {
         const fr = new FabricRegExp(/abc/g);
         expect(isDeepFrozenFabricValue(fr)).toBe(false);
         deepFreeze(fr);
         expect(isDeepFrozenFabricValue(fr)).toBe(true);
       });
 
-      it("via direct member invocation: [DEEP_FREEZE] freezes the wrapped RegExp in place", () => {
+      it("via direct member invocation: `[DEEP_FREEZE]` freezes the wrapped `RegExp` in place", () => {
         const fr = new FabricRegExp(/abc/g);
         expect(Object.isFrozen(fr.regex)).toBe(false);
         const result = fr[DEEP_FREEZE](subFreeze);
@@ -195,7 +195,7 @@ describe("FabricRegExp", () => {
         expect(Object.isFrozen(fr.regex)).toBe(true);
       });
 
-      it("via direct member invocation: [IS_DEEP_FROZEN] true only when wrapper + RegExp frozen", () => {
+      it("via direct member invocation: `[IS_DEEP_FROZEN]` true only when wrapper + `RegExp` frozen", () => {
         const fr = new FabricRegExp(/abc/g);
         expect(fr[IS_DEEP_FROZEN](subIsDeepFrozen)).toBe(false);
         fr[DEEP_FREEZE](subFreeze);
@@ -206,7 +206,7 @@ describe("FabricRegExp", () => {
 
   describe("static members", () => {
     describe("[RECONSTRUCT]", () => {
-      it("creates a FabricRegExp from state", () => {
+      it("creates a `FabricRegExp` from state", () => {
         const state = { source: "abc", flags: "gi" } as FabricValue;
         const result = FabricRegExp[RECONSTRUCT](state, dummyContext);
         expect(result).toBeInstanceOf(FabricRegExp);
@@ -215,7 +215,7 @@ describe("FabricRegExp", () => {
         expect(result.flavor).toBe("es2025");
       });
 
-      it("defaults to empty source, flags, and es2025 flavor", () => {
+      it("defaults to empty `source`, `flags`, and `es2025` `flavor`", () => {
         const state = {} as FabricValue;
         const result = FabricRegExp[RECONSTRUCT](state, dummyContext);
         expect(result.regex.source).toBe("(?:)");
@@ -223,7 +223,7 @@ describe("FabricRegExp", () => {
         expect(result.flavor).toBe("es2025");
       });
 
-      it("preserves an explicit flavor from state", () => {
+      it("preserves an explicit `flavor` from state", () => {
         const state = {
           source: "abc",
           flags: "g",
@@ -241,7 +241,7 @@ describe("FabricRegExp", () => {
   // `RegExp` rather than members of the class itself, so they live directly
   // under the class `describe()` (the cross-cutting carve-out).
   describe("shallowFabricFromNativeValue() (modern path)", () => {
-    it("converts a RegExp to a FabricRegExp", () => {
+    it("converts a `RegExp` to a `FabricRegExp`", () => {
       setDataModelConfig(true);
       try {
         const result = shallowFabricFromNativeValue(/abc/gi);
@@ -253,7 +253,7 @@ describe("FabricRegExp", () => {
       }
     });
 
-    it("rejects a RegExp with extra enumerable properties", () => {
+    it("rejects a `RegExp` with extra enumerable properties", () => {
       setDataModelConfig(true);
       try {
         const re = /abc/;
@@ -268,15 +268,15 @@ describe("FabricRegExp", () => {
   });
 
   describe("tag functions", () => {
-    it("tagFromNativeValue() returns the RegExp tag for RegExp instances", () => {
+    it("`tagFromNativeValue()` returns the `RegExp` tag for `RegExp` instances", () => {
       expect(tagFromNativeValue(/abc/)).toBe(NATIVE_TAGS.RegExp);
     });
 
-    it("tagFromNativeClass() returns the RegExp tag for the RegExp constructor", () => {
+    it("`tagFromNativeClass()` returns the `RegExp` tag for the `RegExp` constructor", () => {
       expect(tagFromNativeClass(RegExp)).toBe(NATIVE_TAGS.RegExp);
     });
 
-    it("isConvertibleNativeInstance() returns true for RegExp", () => {
+    it("`isConvertibleNativeInstance()` returns true for `RegExp`", () => {
       expect(isConvertibleNativeInstance(/abc/)).toBe(true);
       expect(isConvertibleNativeInstance(new RegExp("test", "gi"))).toBe(true);
     });
@@ -290,17 +290,17 @@ describe("FabricRegExp", () => {
       resetDataModelConfig();
     });
 
-    it("returns true for a plain RegExp", () => {
+    it("returns true for a plain `RegExp`", () => {
       expect(isFabricCompatible(/abc/gi)).toBe(true);
     });
 
-    it("returns true for a RegExp nested in objects", () => {
+    it("returns true for a `RegExp` nested in objects", () => {
       expect(isFabricCompatible({ pattern: /abc/gi })).toBe(true);
     });
   });
 
   describe("hashOf()", () => {
-    it("produces a hash for a FabricRegExp", () => {
+    it("produces a hash for a `FabricRegExp`", () => {
       const sr = new FabricRegExp(/abc/gi);
       const hash = hashOf(sr);
       expect(hash.bytes).toBeInstanceOf(Uint8Array);
@@ -315,13 +315,13 @@ describe("FabricRegExp", () => {
       expect(h1).toEqual(h2);
     });
 
-    it("produces a different hash for a different source", () => {
+    it("produces a different hash for a different `source`", () => {
       const h1 = hashOf(new FabricRegExp(/abc/)).bytes;
       const h2 = hashOf(new FabricRegExp(/def/)).bytes;
       expect(h1).not.toEqual(h2);
     });
 
-    it("produces a different hash for different flags", () => {
+    it("produces a different hash for different `flags`", () => {
       const h1 = hashOf(new FabricRegExp(/abc/g)).bytes;
       const h2 = hashOf(new FabricRegExp(/abc/i)).bytes;
       expect(h1).not.toEqual(h2);

--- a/packages/data-model/test/fabric-instances/FabricSet.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricSet.test.ts
@@ -47,14 +47,14 @@ describe("FabricSet", () => {
         expect(result).not.toBeInstanceOf(FrozenSet);
       });
 
-      it("returns the same `FrozenSet` if already frozen (frozen=true)", () => {
+      it("returns the same `FrozenSet` if already frozen (`frozen=true`)", () => {
         const fs = new FrozenSet<FabricValue>([1, 2]);
         const ss = new FabricSet(fs);
         const result = ss.toNativeValue(true);
         expect(result).toBe(fs); // same reference
       });
 
-      it("copies a `FrozenSet` to a mutable `Set` (frozen=false)", () => {
+      it("copies a `FrozenSet` to a mutable `Set` (`frozen=false`)", () => {
         const fs = new FrozenSet<FabricValue>([1, 2]);
         const ss = new FabricSet(fs);
         const result = ss.toNativeValue(false);
@@ -66,12 +66,12 @@ describe("FabricSet", () => {
     });
 
     describe("`[DEEP_FREEZE]` / `[IS_DEEP_FROZEN]`", () => {
-      it("via dispatch: [DEEP_FREEZE] throws not-yet-implemented", () => {
+      it("via dispatch: `[DEEP_FREEZE]` throws not-yet-implemented", () => {
         const fs = new FabricSet(new FrozenSet<FabricValue>([1, 2]));
         expect(() => deepFreeze(fs)).toThrow("FabricSet: not yet implemented");
       });
 
-      it("via dispatch: [IS_DEEP_FROZEN] throws not-yet-implemented (via type guard)", () => {
+      it("via dispatch: `[IS_DEEP_FROZEN]` throws not-yet-implemented (via type guard)", () => {
         const fs = new FabricSet(new FrozenSet<FabricValue>([1, 2]));
         Object.freeze(fs);
         expect(() => isDeepFrozenFabricValue(fs)).toThrow(
@@ -79,14 +79,14 @@ describe("FabricSet", () => {
         );
       });
 
-      it("via direct member invocation: [DEEP_FREEZE] throws not-yet-implemented", () => {
+      it("via direct member invocation: `[DEEP_FREEZE]` throws not-yet-implemented", () => {
         const fs = new FabricSet(new FrozenSet<FabricValue>([1, 2]));
         expect(() => fs[DEEP_FREEZE](subFreeze)).toThrow(
           "FabricSet: not yet implemented",
         );
       });
 
-      it("via direct member invocation: [IS_DEEP_FROZEN] throws not-yet-implemented", () => {
+      it("via direct member invocation: `[IS_DEEP_FROZEN]` throws not-yet-implemented", () => {
         const fs = new FabricSet(new FrozenSet<FabricValue>([1, 2]));
         Object.freeze(fs);
         expect(() => fs[IS_DEEP_FROZEN](subIsDeepFrozen)).toThrow(

--- a/packages/data-model/test/fabric-instances/ProblematicValue.test.ts
+++ b/packages/data-model/test/fabric-instances/ProblematicValue.test.ts
@@ -30,7 +30,7 @@ describe("ProblematicValue", () => {
 
   describe("instance members", () => {
     describe("[DECONSTRUCT]", () => {
-      it("returns the type-tagged state and error", () => {
+      it("returns the type-tagged `state` and `error`", () => {
         const ps = new ProblematicValue("T@1", "s", "e");
         expect(ps[DECONSTRUCT]()).toEqual({
           type: "T@1",

--- a/packages/data-model/test/fabric-instances/UnknownValue.test.ts
+++ b/packages/data-model/test/fabric-instances/UnknownValue.test.ts
@@ -29,7 +29,7 @@ describe("UnknownValue", () => {
 
   describe("instance members", () => {
     describe("[DECONSTRUCT]", () => {
-      it("returns the type-tagged state", () => {
+      it("returns the type-tagged `state`", () => {
         const us = new UnknownValue("Test@1", "state");
         expect(us[DECONSTRUCT]()).toEqual({
           type: "Test@1",

--- a/packages/data-model/test/fabric-instances/native-instance-utils.test.ts
+++ b/packages/data-model/test/fabric-instances/native-instance-utils.test.ts
@@ -28,7 +28,7 @@ import { DummyReconstructionContext } from "./fixtures.ts";
 
 describe("native-instance-utils", () => {
   describe("nativeFromFabricValueModern", () => {
-    it("unwraps FabricError in nested object", () => {
+    it("unwraps `FabricError` in nested object", () => {
       const se = FabricError.fromNativeError(new Error("deep"));
       const obj = { error: se } as FabricValue;
       const result = nativeFromFabricValueModern(obj) as Record<
@@ -39,7 +39,7 @@ describe("native-instance-utils", () => {
       expect((result.error as Error).message).toBe("deep");
     });
 
-    it("unwraps FabricMap in nested array", () => {
+    it("unwraps `FabricMap` in nested array", () => {
       const sm = new FabricMap(
         new Map<FabricValue, FabricValue>([["k", "v"]]),
       );
@@ -48,7 +48,7 @@ describe("native-instance-utils", () => {
       expect(result[0]).toBeInstanceOf(FrozenMap);
     });
 
-    it("unwraps FabricMap to mutable Map when frozen=false", () => {
+    it("unwraps `FabricMap` to mutable `Map` when `frozen=false`", () => {
       const sm = new FabricMap(
         new Map<FabricValue, FabricValue>([["k", "v"]]),
       );
@@ -81,7 +81,7 @@ describe("native-instance-utils", () => {
       expect(result.outer.inner.message).toBe("nested");
     });
 
-    it("deeply unwraps FabricError in objects (frozen)", () => {
+    it("deeply unwraps `FabricError` in objects (frozen)", () => {
       const err = new Error("deep");
       const se = FabricError.fromNativeError(err);
       const obj = {
@@ -99,7 +99,7 @@ describe("native-instance-utils", () => {
       expect(Object.isFrozen(result)).toBe(true);
     });
 
-    it("deeply unwraps FabricError in arrays (frozen)", () => {
+    it("deeply unwraps `FabricError` in arrays (frozen)", () => {
       const err = new Error("array");
       const se = FabricError.fromNativeError(err);
       const arr = [1, se, 3] as unknown as FabricValue;
@@ -112,7 +112,7 @@ describe("native-instance-utils", () => {
       expect(Object.isFrozen(result)).toBe(true);
     });
 
-    it("output is not frozen when frozen=false", () => {
+    it("output is not frozen when `frozen=false`", () => {
       const obj = Object.freeze({
         a: 1,
         b: "two",
@@ -127,7 +127,7 @@ describe("native-instance-utils", () => {
       expect(result.a).toBe(99);
     });
 
-    it("output is frozen when frozen=true (default)", () => {
+    it("output is frozen when `frozen=true` (default)", () => {
       const obj = { a: 1, b: "two" } as unknown as FabricValue;
       const result = nativeFromFabricValueModern(obj) as Record<
         string,
@@ -150,7 +150,7 @@ describe("native-instance-utils", () => {
       expect(result[2]).toBe(3);
     });
 
-    it("passes through non-native FabricInstance", () => {
+    it("passes through non-native `FabricInstance`", () => {
       const us = new UnknownValue("Test@1", null);
       const obj = { thing: us } as unknown as FabricValue;
       const result = nativeFromFabricValueModern(obj) as Record<
@@ -160,7 +160,7 @@ describe("native-instance-utils", () => {
       expect(result.thing).toBe(us);
     });
 
-    it("deeply unwraps FabricMap to FrozenMap", () => {
+    it("deeply unwraps `FabricMap` to `FrozenMap`", () => {
       const map = new Map<FabricValue, FabricValue>([
         ["x", 10],
       ] as [FabricValue, FabricValue][]);
@@ -174,7 +174,7 @@ describe("native-instance-utils", () => {
       expect((result.data as Map<string, number>).get("x")).toBe(10);
     });
 
-    it("deeply unwraps FabricSet to FrozenSet", () => {
+    it("deeply unwraps `FabricSet` to `FrozenSet`", () => {
       const set = new Set<FabricValue>([42] as FabricValue[]);
       const ss = new FabricSet(set);
       const arr = [ss] as unknown as FabricValue;
@@ -183,8 +183,8 @@ describe("native-instance-utils", () => {
       expect((result[0] as Set<number>).has(42)).toBe(true);
     });
 
-    it("deeply unwraps Error internals (C2)", () => {
-      // Error with a FabricError cause and a custom FabricMap property.
+    it("deeply unwraps `Error` internals (C2)", () => {
+      // `Error` with a `FabricError` cause and a custom `FabricMap` property.
       const innerErr = new Error("inner");
       const innerSe = FabricError.fromNativeError(innerErr);
       const outerErr = new Error("outer");
@@ -207,7 +207,7 @@ describe("native-instance-utils", () => {
       expect(data).toBeInstanceOf(FrozenMap);
     });
 
-    it("deeply unwraps Error internals unfrozen (C2)", () => {
+    it("deeply unwraps `Error` internals unfrozen (C2)", () => {
       const innerErr = new Error("inner");
       const innerSe = FabricError.fromNativeError(innerErr);
       const outerErr = new Error("outer");
@@ -230,7 +230,7 @@ describe("native-instance-utils", () => {
   // --------------------------------------------------------------------------
 
   describe("tagFromNativeValue", () => {
-    it("returns Error tag for standard Error subclasses", () => {
+    it("returns `Error` tag for standard `Error` subclasses", () => {
       const cases: [string, Error][] = [
         ["Error", new Error("test")],
         ["TypeError", new TypeError("test")],
@@ -245,7 +245,7 @@ describe("native-instance-utils", () => {
       }
     });
 
-    it("returns Error tag for exotic Error subclass (custom class)", () => {
+    it("returns `Error` tag for exotic `Error` subclass (custom class)", () => {
       class MyFancyError extends Error {
         constructor(msg: string) {
           super(msg);
@@ -258,53 +258,53 @@ describe("native-instance-utils", () => {
       expect(tagFromNativeValue(exotic)).toBe(NATIVE_TAGS.Error);
     });
 
-    it("returns Map tag for Map instances", () => {
+    it("returns `Map` tag for `Map` instances", () => {
       expect(tagFromNativeValue(new Map())).toBe(NATIVE_TAGS.Map);
     });
 
-    it("returns Set tag for Set instances", () => {
+    it("returns `Set` tag for `Set` instances", () => {
       expect(tagFromNativeValue(new Set())).toBe(NATIVE_TAGS.Set);
     });
 
-    it("returns Date tag for Date instances", () => {
+    it("returns `Date` tag for `Date` instances", () => {
       expect(tagFromNativeValue(new Date())).toBe(NATIVE_TAGS.Date);
     });
 
-    it("returns Uint8Array tag for Uint8Array instances", () => {
+    it("returns `Uint8Array` tag for `Uint8Array` instances", () => {
       expect(tagFromNativeValue(new Uint8Array())).toBe(
         NATIVE_TAGS.Uint8Array,
       );
     });
 
-    it("returns Object tag for plain objects", () => {
+    it("returns `Object` tag for plain objects", () => {
       expect(tagFromNativeValue({})).toBe(NATIVE_TAGS.Object);
     });
 
-    it("returns Array tag for arrays", () => {
+    it("returns `Array` tag for arrays", () => {
       expect(tagFromNativeValue([])).toBe(NATIVE_TAGS.Array);
     });
 
-    it("returns RegExp tag for RegExp instances", () => {
+    it("returns `RegExp` tag for `RegExp` instances", () => {
       expect(tagFromNativeValue(/abc/)).toBe(NATIVE_TAGS.RegExp);
     });
 
-    it("returns Object tag for null-prototype objects (no constructor)", () => {
+    it("returns `Object` tag for null-prototype objects (no constructor)", () => {
       const obj = Object.create(null);
       expect(tagFromNativeValue(obj)).toBe(NATIVE_TAGS.Object);
     });
 
-    it("returns HasToJSON tag for plain objects with toJSON()", () => {
+    it("returns `HasToJSON` tag for plain objects with `toJSON()`", () => {
       const obj = { toJSON: () => "converted" };
       expect(tagFromNativeValue(obj)).toBe(NATIVE_TAGS.HasToJSON);
     });
 
-    it("returns HasToJSON tag for arrays with toJSON()", () => {
+    it("returns `HasToJSON` tag for arrays with `toJSON()`", () => {
       const arr = [1, 2, 3] as unknown[] & { toJSON?: () => unknown };
       arr.toJSON = () => "custom array";
       expect(tagFromNativeValue(arr)).toBe(NATIVE_TAGS.HasToJSON);
     });
 
-    it("returns HasToJSON tag for class instances with toJSON()", () => {
+    it("returns `HasToJSON` tag for class instances with `toJSON()`", () => {
       class Custom {
         toJSON() {
           return { x: 1 };
@@ -313,14 +313,14 @@ describe("native-instance-utils", () => {
       expect(tagFromNativeValue(new Custom())).toBe(NATIVE_TAGS.HasToJSON);
     });
 
-    it("returns Date tag for Date (not HasToJSON despite Date.toJSON)", () => {
+    it("returns `Date` tag for `Date` (not `HasToJSON` despite `Date.toJSON`)", () => {
       expect(tagFromNativeValue(new Date())).toBe(NATIVE_TAGS.Date);
     });
 
     // Functions are non-objects and return Primitive from tagFromNativeValue.
     // In practice, functions with toJSON() are handled separately in
     // the modern conversion path, not via tagFromNativeValue.
-    it("returns Primitive for functions (even with toJSON)", () => {
+    it("returns `Primitive` for functions (even with `toJSON`)", () => {
       const fn = () => {};
       (fn as unknown as { toJSON: () => string }).toJSON = () => "converted";
       expect(tagFromNativeValue(fn)).toBe(NATIVE_TAGS.Primitive);
@@ -328,7 +328,7 @@ describe("native-instance-utils", () => {
   });
 
   describe("tagFromNativeClass", () => {
-    it("returns Error tag for standard Error constructors", () => {
+    it("returns `Error` tag for standard `Error` constructors", () => {
       const constructors = [
         Error,
         TypeError,
@@ -343,14 +343,14 @@ describe("native-instance-utils", () => {
       }
     });
 
-    it("returns Error tag for exotic Error subclass constructor", () => {
+    it("returns `Error` tag for exotic `Error` subclass constructor", () => {
       class ExoticError extends Error {}
       // Constructor is ExoticError, not in the switch -- falls back to
       // Error.isError(prototype) check.
       expect(tagFromNativeClass(ExoticError)).toBe(NATIVE_TAGS.Error);
     });
 
-    it("returns correct tags for Array, Object, Map, Set, Date, Uint8Array", () => {
+    it("returns correct tags for `Array`, `Object`, `Map`, `Set`, `Date`, `Uint8Array`", () => {
       expect(tagFromNativeClass(Array)).toBe(NATIVE_TAGS.Array);
       expect(tagFromNativeClass(Object)).toBe(NATIVE_TAGS.Object);
       expect(tagFromNativeClass(Map)).toBe(NATIVE_TAGS.Map);
@@ -359,16 +359,16 @@ describe("native-instance-utils", () => {
       expect(tagFromNativeClass(Uint8Array)).toBe(NATIVE_TAGS.Uint8Array);
     });
 
-    it("returns RegExp tag for RegExp constructor", () => {
+    it("returns `RegExp` tag for `RegExp` constructor", () => {
       expect(tagFromNativeClass(RegExp)).toBe(NATIVE_TAGS.RegExp);
     });
 
-    it("returns null for unrecognized constructors", () => {
+    it("returns `null` for unrecognized constructors", () => {
       expect(tagFromNativeClass(WeakMap)).toBe(null);
       expect(tagFromNativeClass(Promise)).toBe(null);
     });
 
-    it("returns HasToJSON for class with toJSON on prototype", () => {
+    it("returns `HasToJSON` for class with `toJSON` on prototype", () => {
       class WithToJSON {
         toJSON() {
           return { x: 1 };
@@ -377,7 +377,7 @@ describe("native-instance-utils", () => {
       expect(tagFromNativeClass(WithToJSON)).toBe(NATIVE_TAGS.HasToJSON);
     });
 
-    it("returns HasToJSON for subclass inheriting toJSON", () => {
+    it("returns `HasToJSON` for subclass inheriting `toJSON`", () => {
       class Base {
         toJSON() {
           return "base";
@@ -387,11 +387,11 @@ describe("native-instance-utils", () => {
       expect(tagFromNativeClass(Sub)).toBe(NATIVE_TAGS.HasToJSON);
     });
 
-    it("returns Date tag for Date (not HasToJSON despite Date.prototype.toJSON)", () => {
+    it("returns `Date` tag for `Date` (not `HasToJSON` despite `Date.prototype.toJSON`)", () => {
       expect(tagFromNativeClass(Date)).toBe(NATIVE_TAGS.Date);
     });
 
-    it("returns null for class without toJSON", () => {
+    it("returns `null` for class without `toJSON`", () => {
       class Plain {}
       expect(tagFromNativeClass(Plain)).toBe(null);
     });
@@ -422,17 +422,17 @@ describe("native-instance-utils", () => {
       expect(isConvertibleNativeInstance(new WeakMap())).toBe(false);
     });
 
-    it("returns false for objects with toJSON()", () => {
+    it("returns false for objects with `toJSON()`", () => {
       expect(isConvertibleNativeInstance({ toJSON: () => "x" })).toBe(false);
     });
   });
 
   describe("FabricInstance instanceof checks", () => {
-    it("returns false for null", () => {
+    it("returns false for `null`", () => {
       expect((null as unknown) instanceof FabricInstance).toBe(false);
     });
 
-    it("returns false for undefined", () => {
+    it("returns false for `undefined`", () => {
       expect((undefined as unknown) instanceof FabricInstance).toBe(false);
     });
 
@@ -447,17 +447,17 @@ describe("native-instance-utils", () => {
       expect(({ a: 1 } as unknown) instanceof FabricInstance).toBe(false);
     });
 
-    it("returns true for UnknownValue", () => {
+    it("returns true for `UnknownValue`", () => {
       const us = new UnknownValue("Test@1", null);
       expect(us instanceof FabricInstance).toBe(true);
     });
 
-    it("returns true for ProblematicValue", () => {
+    it("returns true for `ProblematicValue`", () => {
       const ps = new ProblematicValue("Test@1", null, "oops");
       expect(ps instanceof FabricInstance).toBe(true);
     });
 
-    it("returns true for custom FabricInstance subclass", () => {
+    it("returns true for custom `FabricInstance` subclass", () => {
       class CustomFabInst extends BaseFabricInstance {
         [DECONSTRUCT](): FabricValue {
           return { value: 42 };
@@ -483,17 +483,17 @@ describe("native-instance-utils", () => {
       expect(instance instanceof FabricInstance).toBe(true);
     });
 
-    it("returns true for FabricError", () => {
+    it("returns true for `FabricError`", () => {
       const se = FabricError.fromNativeError(new Error("test"));
       expect(se instanceof FabricInstance).toBe(true);
     });
   });
 
-  describe("[RECONSTRUCT] honors shouldDeepFreeze", () => {
+  describe("`[RECONSTRUCT]` honors `shouldDeepFreeze`", () => {
     const frozenCtx = new DummyReconstructionContext(true);
     const mutableCtx = new DummyReconstructionContext(false);
 
-    it("FabricError: shouldDeepFreeze true => deep-frozen, false => mutable", () => {
+    it("`FabricError`: `shouldDeepFreeze` true => deep-frozen, false => mutable", () => {
       const state = {
         type: "Error",
         name: null,
@@ -505,7 +505,7 @@ describe("native-instance-utils", () => {
       expect(Object.isFrozen(mutable)).toBe(false);
     });
 
-    it("FabricRegExp: shouldDeepFreeze true => deep-frozen, false => mutable", () => {
+    it("`FabricRegExp`: `shouldDeepFreeze` true => deep-frozen, false => mutable", () => {
       const state = {
         source: "abc",
         flags: "g",
@@ -518,7 +518,7 @@ describe("native-instance-utils", () => {
       expect(Object.isFrozen(mutable)).toBe(false);
     });
 
-    it("ProblematicValue: shouldDeepFreeze true => deep-frozen, false => mutable", () => {
+    it("`ProblematicValue`: `shouldDeepFreeze` true => deep-frozen, false => mutable", () => {
       const state = {
         type: "Bad@1",
         state: { x: 1 },
@@ -530,7 +530,7 @@ describe("native-instance-utils", () => {
       expect(Object.isFrozen(mutable)).toBe(false);
     });
 
-    it("UnknownValue: shouldDeepFreeze true => deep-frozen, false => mutable", () => {
+    it("`UnknownValue`: `shouldDeepFreeze` true => deep-frozen, false => mutable", () => {
       const state = { type: "Fancy@3", state: { y: 2 } } as unknown as {
         type: string;
         state: FabricValue;
@@ -559,8 +559,8 @@ describe("native-instance-utils", () => {
   // assertion.
   // --------------------------------------------------------------------------
 
-  describe("Arm 3 cycle behavior via [DEEP_FREEZE]", () => {
-    it("FabricError: cycle through `error.cause` terminates", () => {
+  describe("Arm 3 cycle behavior via `[DEEP_FREEZE]`", () => {
+    it("`FabricError`: cycle through `error.cause` terminates", () => {
       // Build a cycle: a plain-object wrapper holds the FabricError, and the
       // FabricError's `error.cause` points back at the wrapper. When
       // `deepFreeze(wrapper)` runs Arm 4 it recurses into the FabricError
@@ -575,7 +575,7 @@ describe("native-instance-utils", () => {
       expect(Object.isFrozen(fe)).toBe(true);
     });
 
-    it("ProblematicValue: cycle through `state` terminates", () => {
+    it("`ProblematicValue`: cycle through `state` terminates", () => {
       const cycle: Record<string, unknown> = { x: 1 };
       const pv = new ProblematicValue("Cycle@1", cycle as FabricValue, "oops");
       cycle.back = pv;
@@ -584,7 +584,7 @@ describe("native-instance-utils", () => {
       expect(Object.isFrozen(cycle)).toBe(true);
     });
 
-    it("UnknownValue: cycle through `state` terminates", () => {
+    it("`UnknownValue`: cycle through `state` terminates", () => {
       const cycle: Record<string, unknown> = { y: 2 };
       const uv = new UnknownValue("Cycle@1", cycle as FabricValue);
       cycle.back = uv;
@@ -593,7 +593,7 @@ describe("native-instance-utils", () => {
       expect(Object.isFrozen(cycle)).toBe(true);
     });
 
-    it("cross-instance cycle (FabricError <-> ProblematicValue) terminates", () => {
+    it("cross-instance cycle (`FabricError` <-> `ProblematicValue`) terminates", () => {
       // Two `FabricInstance` subclasses pointing into each other via their
       // recursing slots. Both must terminate, both must end deep-frozen.
       // FabricError snapshots its FabricValue state at construction, so wire


### PR DESCRIPTION
Markup-only pass over `packages/data-model/src/fabric-instances/` and
`test/fabric-instances/`: backtick-quote code identifiers, type names,
constants, and member symbols in `describe()`/`it()` label strings and
code comments, per `code-conventions.md` "Style rules". No behavior or
test-semantics change; `it()`-count unchanged (163). Carve-outs
respected: literal member-block `describe`s (`constructor()` / instance
members / static members) and whole-symbol `describe`s stay bare.

Scope: 8 files, +116/-116 — 7 `fabric-instances` test files + one src
comment (`FabricError.ts`). Conservation: `it()`-count 163 unchanged;
full data-model suite 36 passed / 1790 steps / 0 failed; `fmt`/`lint`/
`check` clean.

This is the first of a by-subdir sequence (item-2 Markdown-in-code
conformance sweep over `data-model`).

---

**Perf-check baseline override (noise, not regression).** The
`Performance Check` flagged two pattern-unit subtests
(`cfc-render-policy-demo/main.test.tsx`, `cfc-authorship-chat/main.test.tsx`).
This PR is **markup-only** — backtick-quoting identifiers in
`describe()`/`it()` label strings + comments in `fabric-instances` test
files, zero logic/behavior change, `it()`-count conserved. It **cannot
causally affect** pattern-unit-test runtimes in entirely separate
packages; the deltas are documented wide run-to-run perf-check variance.
Accepting the new baseline per the CI-provided override (a bare rerun
does not clear it):

NEW_PERF_BASELINE: subtest: pattern-unit-1/pattern-unit-tests > packages/patterns/cfc-render-policy-demo/main.test.tsx = 9s
NEW_PERF_BASELINE: subtest: pattern-unit-1/pattern-unit-tests > packages/patterns/cfc-authorship-chat/main.test.tsx = 8s

— upstream-liaison-bolt (Claude Opus 4.7 (1M context))

Co-Authored-By: coder-colt (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
