### PR TITLE
fix(ts-transformers): auto-wrap cell .get() computations at binding sites

### DIFF
--- a/packages/ts-transformers/src/transformers/pattern-context-validation.ts
+++ b/packages/ts-transformers/src/transformers/pattern-context-validation.ts
@@ -184,7 +184,15 @@ export class PatternContextValidationTransformer
               `Use ifElse() or wrap in computed() for conditional access.`,
             node,
           });
-        } else if (unsupportedCallRoot === "restricted-get-call") {
+        } else if (
+          unsupportedCallRoot === "restricted-get-call" &&
+          !findLowerableExpressionSite(node, context, analyze)
+        ) {
+          // A bare terminal `.get()` (no enclosing lowerable expression site)
+          // can't be auto-wrapped, so it stays an error. But a `.get()` that
+          // feeds a computation at a lowerable site (variable initializer, JSX,
+          // return, …) is auto-wrapped into a lift by the rewriter — so don't
+          // reject it here.
           context.reportDiagnostic({
             severity: "error",
             type: "pattern-context:get-call",

--- a/packages/ts-transformers/test/fixtures/schema-transform/cell-get-binding-autowrap.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/cell-get-binding-autowrap.expected.jsx
@@ -1,0 +1,60 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { pattern, Writable } from "commonfabric";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+// FIXTURE: cell-get-binding-autowrap
+// Verifies: a bare `cell.get()` that feeds a computation at a variable-initializer
+//   binding is auto-wrapped into a lift, the same way it is in a JSX expression.
+//   Previously the validator rejected top-level cell .get() with
+//   `pattern-context:get-call`; that restriction was legacy (the rewriter already
+//   lowers the computation). A bare *terminal* `cell.get()` (no enclosing
+//   computation) is still rejected elsewhere, since it has no lowerable site.
+// Context: enables `derive(cell, v => f(v))` migrations to drop the wrapper and
+//   write a plain expression even when the input is a Writable/Cell.
+export default pattern((__cf_pattern_input) => {
+    const layout = __cf_pattern_input.key("layout");
+    const len = __cfHelpers.lift<{
+        layout: __cfHelpers.Writable<string>;
+    }, number>({
+        type: "object",
+        properties: {
+            layout: {
+                type: "string",
+                asCell: ["readonly"]
+            }
+        },
+        required: ["layout"]
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "number"
+    } as const satisfies __cfHelpers.JSONSchema, ({ layout }) => layout.get().trim().length)({ layout: layout }).for("len", true);
+    return { len };
+}, {
+    type: "object",
+    properties: {
+        layout: {
+            type: "string",
+            asCell: ["cell"]
+        }
+    },
+    required: ["layout"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        len: {
+            type: "number"
+        }
+    },
+    required: ["len"]
+} as const satisfies __cfHelpers.JSONSchema);
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-transform/cell-get-binding-autowrap.input.tsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/cell-get-binding-autowrap.input.tsx
@@ -1,0 +1,17 @@
+import { pattern, Writable } from "commonfabric";
+
+// FIXTURE: cell-get-binding-autowrap
+// Verifies: a bare `cell.get()` that feeds a computation at a variable-initializer
+//   binding is auto-wrapped into a lift, the same way it is in a JSX expression.
+//   Previously the validator rejected top-level cell .get() with
+//   `pattern-context:get-call`; that restriction was legacy (the rewriter already
+//   lowers the computation). A bare *terminal* `cell.get()` (no enclosing
+//   computation) is still rejected elsewhere, since it has no lowerable site.
+// Context: enables `derive(cell, v => f(v))` migrations to drop the wrapper and
+//   write a plain expression even when the input is a Writable/Cell.
+export default pattern<{
+  layout: Writable<string>;
+}>(({ layout }) => {
+  const len = layout.get().trim().length;
+  return { len };
+});

--- a/packages/ts-transformers/test/validation.test.ts
+++ b/packages/ts-transformers/test/validation.test.ts
@@ -2218,6 +2218,28 @@ Deno.test("OpaqueRef .get() Validation", async (t) => {
   );
 
   await t.step(
+    "allows .get() on Writable feeding a computation at a binding (auto-wrapped)",
+    async () => {
+      const source = `      import { pattern, Writable } from "commonfabric";
+
+      export default pattern<{ layout: Writable<string> }>(({ layout }) => {
+        const len = layout.get().trim().length;
+        return { len };
+      });
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      assertEquals(
+        errors.length,
+        0,
+        "binding-site .get() feeding a computation is auto-wrapped, not an error",
+      );
+    },
+  );
+
+  await t.step(
     "allows .get() on Cell pattern input",
     async () => {
       const source =


### PR DESCRIPTION
## Summary
- A bare `cell.get()` feeding a computation at a variable-initializer binding (e.g. `const len = layout.get().trim().length`) was rejected by the pattern-context validator with `pattern-context:get-call`, even though the **identical** expression in a JSX position auto-wraps into a lift.
- The rewriter already lowers the binding-site form identically to JSX — the validator was the *sole* gate, a legacy restriction from before aggressive expression-site auto-wrapping existed.
- The fix adds the `!findLowerableExpressionSite(...)` escape hatch to the `.get()` branch, mirroring the existing optional-chaining branch.

## Behavior
- `const x = cell.get().trim()…` (a `.get()` feeding a computation) → now auto-wraps into a schema'd `lift`, no error.
- `const x = cell.get()` (bare *terminal* `.get()`, no enclosing computation) → **still errors** — it has no lowerable site and would otherwise become silently non-reactive. This guard is preserved.
- A plain TS ternary reading a cell at a binding auto-wraps to `ifElse` (lazy branches), as expected.

## Why
This removes a legacy two-dimensional (position × type) rule: previously a Cell read had to be wrapped in `computed()` at a binding but could be written bare in JSX. Flattening it lets authors write plain expressions over `Writable`/`Cell` inputs uniformly, and is a prerequisite for the upcoming `derive`-removal migration (so `derive(cell, v => f(v))` sites can drop the wrapper entirely).

## Tests
- New `validation.test.ts` step: binding-site `.get()` computation → 0 errors (contrast with the existing bare-terminal step that still errors).
- New fixture pair `schema-transform/cell-get-binding-autowrap` pinning the emitted `lift` (audited: correct input/output schema, `asCell` markings, `.for("len")` identity) — catches lowering regressions, not just validator regressions.
- Full ts-transformers suite: 293 passed, 626 steps, 0 failed.

## Test plan
- [ ] CI green on the ts-transformers suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `ts-transformers` to auto-wrap `cell.get()` computations at variable-initializer bindings into a `lift`, matching JSX behavior and removing the false `pattern-context:get-call` error. A bare terminal `.get()` still errors to prevent non-reactive code.

- **Bug Fixes**
  - Gate the `.get()` error on `!findLowerableExpressionSite(...)`, allowing auto-wrap at lowerable sites (bindings, JSX, return).
  - Preserve error for terminal `.get()` with no lowerable site.
  - Add `schema-transform/cell-get-binding-autowrap` fixture and a validation test to pin the behavior.

<sup>Written for commit e01fca15c6d4f8f02660a714e7b382508fd732cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3725?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

---BEGIN COPY-PASTE---
NEW_PERF_BASELINE: subtest: pattern-unit-1/pattern-unit-tests > packages/patterns/cfc-authorship-chat/main.test.tsx = 8s
NEW_PERF_BASELINE: step: background worker integration = 18s
---END COPY-PASTE---