### PR TITLE
fix: lower (reactive ?? []).map nested in map + unify closure-capture diagnostic (CT-1626)

### DIFF
--- a/packages/runner/src/builder/closure-capture-diagnostic.ts
+++ b/packages/runner/src/builder/closure-capture-diagnostic.ts
@@ -1,0 +1,75 @@
+import type { CellScope } from "./types.ts";
+
+/**
+ * Both pattern construction paths that detect a reactive cell being captured
+ * from an outer frame raise the SAME conceptual violation: a callback (a map /
+ * filter / flatMap / computed body) closed over a `Cell`/`OpaqueRef` that
+ * belongs to a different frame, instead of receiving it as an explicit
+ * reactive input.
+ *
+ * Historically the two sites threw two differently-worded errors, neither of
+ * which named the offending site, the cell, or the consuming module — so
+ * authors saw a bare SES stack and couldn't tell whether the two strings were
+ * the same problem. This module produces one diagnostic shared by both sites,
+ * enriched with whatever context is available at throw time.
+ *
+ * Note: the most common trigger — `(cell.get() ?? []).map(cb)` where `cb`
+ * captures a sibling cell — is now lowered to `mapWithPattern` by the
+ * transformer (CT-1626), so it no longer reaches here. This diagnostic is for
+ * the residual shapes that genuinely cannot be auto-rewritten and need author
+ * intervention.
+ */
+
+export interface CapturedCellInfo {
+  path?: readonly PropertyKey[];
+  scope?: CellScope;
+  name?: unknown;
+}
+
+function describeCapturedCell(info: CapturedCellInfo): string {
+  const parts: string[] = [];
+  if (typeof info.name === "string" && info.name.length > 0) {
+    parts.push(`'${info.name}'`);
+  }
+  if (info.path && info.path.length > 0) {
+    parts.push(`at path [${info.path.map((p) => String(p)).join(", ")}]`);
+  }
+  if (info.scope) {
+    parts.push(`${info.scope}-scoped`);
+  }
+  return parts.length > 0 ? ` (${parts.join(", ")})` : "";
+}
+
+/**
+ * Build the unified closure-capture diagnostic message.
+ *
+ * @param options.capturedCell identity of the offending cell, if available.
+ * @param options.sourceLocation source-mapped `file:line:col` of the
+ *   capturing callback, if it could be resolved at the call site.
+ */
+export function closureCaptureErrorMessage(
+  options: {
+    capturedCell?: CapturedCellInfo;
+    sourceLocation?: string | null;
+  } = {},
+): string {
+  const cellDesc = options.capturedCell
+    ? describeCapturedCell(options.capturedCell)
+    : "";
+  const locationLine = options.sourceLocation
+    ? `\n  at ${options.sourceLocation}`
+    : "";
+
+  return (
+    `Reactive cell${cellDesc} from an outer scope was captured by a closure ` +
+    `and cannot be connected across reactive frames.${locationLine}\n` +
+    "help: a callback (e.g. inside .map / .filter / .flatMap / computed) must " +
+    "receive reactive cells as explicit inputs, not close over them.\n" +
+    "  - Most array-method callbacks are handled automatically when the " +
+    "receiver is reactive — prefer `cell.map(...)`, or let the compiler lower " +
+    "`(cell.get() ?? []).map(...)` to `mapWithPattern`.\n" +
+    "  - For a hand-built callback, use `cell.mapWithPattern(pattern, params)` " +
+    "and thread captured cells through `params`, or `computed()` which " +
+    "extracts captures for you."
+  );
+}

--- a/packages/runner/src/builder/module.ts
+++ b/packages/runner/src/builder/module.ts
@@ -1,5 +1,6 @@
 import type {
   CellScope,
+  Frame,
   Handler,
   HandlerFactory,
   JSONSchema,
@@ -625,10 +626,10 @@ function prepareInspectableImplementation<
   return wrapped as T;
 }
 
-function resolveLocationFromFunctionSource(
+export function resolveLocationFromFunctionSource(
   fn: (...args: any[]) => unknown,
+  frame: Frame | undefined = getTopFrame(),
 ): string | null {
-  const frame = getTopFrame();
   const context = frame?.sourceLocationContext;
   const harness = frame?.runtime?.harness;
   if (!context || !harness) {

--- a/packages/runner/src/builder/node-utils.ts
+++ b/packages/runner/src/builder/node-utils.ts
@@ -7,14 +7,33 @@ import {
   isCellResultForDereferencing,
 } from "../query-result-proxy.ts";
 import { isCell } from "../cell.ts";
+import { closureCaptureErrorMessage } from "./closure-capture-diagnostic.ts";
+import { resolveLocationFromFunctionSource } from "./module.ts";
 
 export function connectInputAndOutputs(node: NodeRef) {
   function connect(value: any): any {
     if (isCellResultForDereferencing(value)) value = getCellOrThrow(value);
     if (isCell(value)) {
-      if (value.export().frame !== node.frame) {
+      const exported = value.export();
+      if (exported.frame !== node.frame) {
+        const implementation = isRecord(node.module)
+          ? node.module.implementation
+          : undefined;
+        const sourceLocation = typeof implementation === "function"
+          ? resolveLocationFromFunctionSource(
+            implementation as (...args: any[]) => unknown,
+            node.frame,
+          )
+          : null;
         throw new Error(
-          "Reactive reference from outer scope cannot be accessed via closure. Wrap the access in a derive that passes the variable through, or use computed() which handles this automatically.",
+          closureCaptureErrorMessage({
+            capturedCell: {
+              path: exported.path,
+              scope: exported.scope,
+              name: exported.name,
+            },
+            sourceLocation,
+          }),
         );
       }
       value.connect(node);

--- a/packages/runner/src/builder/pattern.ts
+++ b/packages/runner/src/builder/pattern.ts
@@ -38,6 +38,7 @@ import {
   isCellResultForDereferencing,
 } from "../query-result-proxy.ts";
 import { isCell } from "../cell.ts";
+import { closureCaptureErrorMessage } from "./closure-capture-diagnostic.ts";
 import { Runtime } from "../runtime.ts";
 import type { ImplementationIdentity } from "../cfc/types.ts";
 import {
@@ -203,11 +204,12 @@ function factoryFromPattern<T, R>(
     traverseValue(value, (value) => {
       if (isCellResultForDereferencing(value)) value = getCellOrThrow(value);
       if (isCell(value) && !allCells.has(value)) {
-        const { frame, nodes } = value.export();
+        const { frame, nodes, path, scope, name } = value.export();
         if (isOpaqueRef(value) && frame !== getTopFrame()) {
           throw new Error(
-            "Cannot access cell via closure - reactive dependencies must be explicit parameters\n" +
-              "help: use computed() for automatic extraction, or pass cells as parameters to lift()",
+            closureCaptureErrorMessage({
+              capturedCell: { path, scope, name },
+            }),
           );
         }
         allCells.add(value);

--- a/packages/runner/test/closure-capture-diagnostic.test.ts
+++ b/packages/runner/test/closure-capture-diagnostic.test.ts
@@ -1,0 +1,56 @@
+// Unit coverage for the unified closure-capture diagnostic message (CT-1626).
+// Both construction-time throw sites (builder/node-utils.ts and
+// builder/pattern.ts) route through `closureCaptureErrorMessage`, so this pins
+// the shared wording: it names the offending cell, surfaces a source location
+// when one is available, and recommends the actual escape hatches
+// (mapWithPattern / computed) rather than the old "wrap in a derive" guidance.
+
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { closureCaptureErrorMessage } from "../src/builder/closure-capture-diagnostic.ts";
+
+describe("closureCaptureErrorMessage (CT-1626)", () => {
+  it("describes the captured cell's name, path, and scope", () => {
+    const message = closureCaptureErrorMessage({
+      capturedCell: {
+        name: "setAssign",
+        path: ["params", "setAssign"],
+        scope: "space",
+      },
+    });
+    expect(message).toContain("'setAssign'");
+    expect(message).toContain("at path [params, setAssign]");
+    expect(message).toContain("space-scoped");
+    expect(message).toContain("captured by a closure");
+  });
+
+  it("includes a source location when one is resolved", () => {
+    const message = closureCaptureErrorMessage({
+      capturedCell: { name: "x" },
+      sourceLocation: "/main.tsx:23:7",
+    });
+    expect(message).toContain("at /main.tsx:23:7");
+  });
+
+  it("omits the location line when none is available", () => {
+    const message = closureCaptureErrorMessage({
+      capturedCell: { name: "x" },
+      sourceLocation: null,
+    });
+    expect(message).not.toContain("\n  at ");
+  });
+
+  it("recommends the real escape hatches (mapWithPattern / computed)", () => {
+    const message = closureCaptureErrorMessage();
+    expect(message).toContain("mapWithPattern");
+    expect(message).toContain("computed()");
+    // The misleading "wrap the access in a derive" recipe is gone.
+    expect(message).not.toContain("derive that passes the variable through");
+  });
+
+  it("degrades gracefully with no cell info", () => {
+    const message = closureCaptureErrorMessage();
+    expect(message).toContain("Reactive cell from an outer scope");
+  });
+});

--- a/packages/ts-transformers/src/closures/strategies/array-method-policy.ts
+++ b/packages/ts-transformers/src/closures/strategies/array-method-policy.ts
@@ -7,12 +7,69 @@ import {
   getTypeAtLocationWithFallback,
   hasReactiveCollectionProvenance,
   isConsumedByTerminalChainCall,
+  isReactiveValueExpression,
 } from "../../ast/mod.ts";
 import type { TransformationContext } from "../../core/mod.ts";
 import {
   classifyReactiveReceiverKind,
   shouldRewriteCollectionMethod,
 } from "../../policy/mod.ts";
+import { unwrapExpression } from "../../utils/expression.ts";
+import { isFallbackOperator } from "../../utils/reactive-keys.ts";
+import { classifyOpaquePathTerminalCall } from "../../transformers/opaque-roots.ts";
+
+/**
+ * Detects a fallback-guarded reactive receiver: `(<reactive> ?? fallback)` or
+ * `(<reactive> || fallback)`, where `<reactive>` is a reactive value (e.g. a
+ * `cell.get()` lowered to a lift-applied call, a `.key(...)` access, or any
+ * other OpaqueRef-producing expression).
+ *
+ * The `?? []` (or `|| []`) guard is the documented defense against a scoped
+ * cell reading `undefined` before sync. But it also collapses the receiver's
+ * static type to a plain array and hides the reactive provenance from the
+ * type-based receiver classifier, so `(cell.get() ?? []).map(...)` would
+ * otherwise be left as a raw `CellImpl.map` — which throws at construction when
+ * its callback closes over a sibling pattern cell (CT-1626). Recognizing the
+ * shape here lets the inner `.map` lower to `mapWithPattern` like the
+ * unguarded `cell.map(...)` form already does.
+ */
+function isReactiveFallbackReceiver(
+  mapTarget: ts.Expression,
+  checker: ts.TypeChecker,
+): boolean {
+  const receiver = unwrapExpression(mapTarget);
+  if (
+    !ts.isBinaryExpression(receiver) ||
+    !isFallbackOperator(receiver.operatorToken.kind)
+  ) {
+    return false;
+  }
+  return isReactiveFallbackLeft(unwrapExpression(receiver.left), checker);
+}
+
+function isReactiveFallbackLeft(
+  left: ts.Expression,
+  checker: ts.TypeChecker,
+): boolean {
+  if (isReactiveValueExpression(left, checker)) {
+    return true;
+  }
+  // A `cell.get()` / `cell.key(...)` read isn't reactive-producing on its own
+  // (it's a read), but when its receiver is reactive the whole `.get()` result
+  // is still an OpaqueRef at runtime once lowered — so the fallback receiver
+  // needs the WithPattern rewrite. Match `<reactive>.get()` / `.key(...)`.
+  if (
+    ts.isCallExpression(left) &&
+    classifyOpaquePathTerminalCall(left) !== undefined &&
+    ts.isPropertyAccessExpression(left.expression)
+  ) {
+    return isReactiveValueExpression(
+      unwrapExpression(left.expression.expression),
+      checker,
+    );
+  }
+  return false;
+}
 
 function hasSharedReactiveCollectionProvenance(
   expression: ts.Expression,
@@ -103,6 +160,14 @@ export function shouldTransformArrayMethod(
     ts.isCallExpression(mapTarget) &&
     detectCallKind(mapTarget, context.checker)?.kind === "lift-applied"
   ) {
+    return contextInfo.kind === "pattern";
+  }
+
+  // `(reactive ?? fallback).map(...)`: the fallback guard hides the reactive
+  // receiver from the type-based classifier above (it sees a plain array), but
+  // at runtime the receiver is still an OpaqueRef and needs the WithPattern
+  // rewrite. Mirror the lift-applied special-case (CT-1626).
+  if (isReactiveFallbackReceiver(mapTarget, context.checker)) {
     return contextInfo.kind === "pattern";
   }
 

--- a/packages/ts-transformers/test/fixtures/closures/nested-map-fallback-receiver.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/nested-map-fallback-receiver.expected.jsx
@@ -1,0 +1,364 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { action, Default, pattern, UI, Writable } from "commonfabric";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+interface Person {
+    name: string;
+}
+interface State {
+    rows: Default<Array<{
+        id: string;
+        label: string;
+    }>, [
+    ]>;
+}
+// FIXTURE: nested-map-fallback-receiver
+// Verifies: a fallback-receiver array method — (reactiveCall() ?? []).map(...) —
+//   nested INSIDE another .map() callback is lowered to mapWithPattern, so its
+//   inner closure (which captures a sibling pattern cell) is threaded through
+//   params instead of being illegally accessed across frames.
+//     rows.map((row) => (people.get() ?? []).map((p) => ... setAssign ...))
+//       → rows.mapWithPattern(pattern(... (lift(...)(...) ?? []).mapWithPattern(...) ...))
+// Context: This is CT-1626. Before the fix, the inner `(people.get() ?? [])`
+//   receiver — a `??` binary whose LHS is a reactive (lift-applied) call —
+//   was classified as a plain `T[]` receiver, so the inner `.map` stayed a raw
+//   CellImpl.map and threw at construction ("Reactive reference from outer
+//   scope cannot be accessed via closure"). The `?? []` guard (correct for the
+//   scoped-cell-undefined-before-sync race) is exactly what hid the reactive
+//   receiver from the transformer.
+export default pattern((__cf_pattern_input) => {
+    const rows = __cf_pattern_input.key("rows");
+    const people = Writable.perSpace.of<Person[]>([], {
+        type: "array",
+        items: {
+            $ref: "#/$defs/Person"
+        },
+        $defs: {
+            Person: {
+                type: "object",
+                properties: {
+                    name: {
+                        type: "string"
+                    }
+                },
+                required: ["name"]
+            }
+        },
+        scope: "space"
+    } as const satisfies __cfHelpers.JSONSchema).for("people", true);
+    const assignName = Writable.perSpace.of<string>("", {
+        type: "string",
+        scope: "space"
+    } as const satisfies __cfHelpers.JSONSchema).for("assignName", true);
+    const setAssign = __cfHelpers.handler({
+        type: "object",
+        properties: {
+            name: {
+                type: "string"
+            }
+        },
+        required: ["name"]
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "object",
+        properties: {
+            assignName: {
+                type: "string",
+                asCell: [{
+                        kind: "cell",
+                        scope: "space"
+                    }]
+            }
+        },
+        required: ["assignName"]
+    } as const satisfies __cfHelpers.JSONSchema, (p, { assignName }) => assignName.set(p.name))({
+        assignName: assignName
+    }).for({ stream: "setAssign" }, true);
+    return {
+        [UI]: (<div>
+        {rows.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
+                const row = __cf_pattern_input.key("element");
+                const people = __cf_pattern_input.key("params", "people");
+                const setAssign = __cf_pattern_input.key("params", "setAssign");
+                return (<div>
+            <span>{row.key("label")}</span>
+            {(__cfHelpers.lift<{
+                        people: __cfHelpers.PerSpace<__cfHelpers.Cell<Person[]>>;
+                    }, readonly Person[]>({
+                        type: "object",
+                        properties: {
+                            people: {
+                                type: "array",
+                                items: {
+                                    $ref: "#/$defs/Person"
+                                },
+                                asCell: [{
+                                        kind: "cell",
+                                        scope: "space"
+                                    }]
+                            }
+                        },
+                        required: ["people"],
+                        $defs: {
+                            Person: {
+                                type: "object",
+                                properties: {
+                                    name: {
+                                        type: "string"
+                                    }
+                                },
+                                required: ["name"]
+                            }
+                        }
+                    } as const satisfies __cfHelpers.JSONSchema, {
+                        type: "array",
+                        items: {
+                            $ref: "#/$defs/Person"
+                        },
+                        $defs: {
+                            Person: {
+                                type: "object",
+                                properties: {
+                                    name: {
+                                        type: "string"
+                                    }
+                                },
+                                required: ["name"]
+                            }
+                        }
+                    } as const satisfies __cfHelpers.JSONSchema, ({ people }) => people.get())({ people: people }) ?? []).mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
+                        const p = __cf_pattern_input.key("element");
+                        const setAssign = __cf_pattern_input.key("params", "setAssign");
+                        return (<button type="button" onClick={__cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+                            type: "object",
+                            properties: {
+                                setAssign: {
+                                    type: "object",
+                                    properties: {
+                                        name: {
+                                            type: "string"
+                                        }
+                                    },
+                                    required: ["name"],
+                                    asCell: ["stream"]
+                                },
+                                p: {
+                                    type: "object",
+                                    properties: {
+                                        name: {
+                                            type: "string"
+                                        }
+                                    },
+                                    required: ["name"]
+                                }
+                            },
+                            required: ["setAssign", "p"]
+                        } as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, { setAssign, p }) => setAssign.send({ name: p.name }))({
+                            setAssign: setAssign,
+                            p: {
+                                name: p.key("name")
+                            }
+                        })}>
+                {p.key("name")}
+              </button>);
+                    }, {
+                        type: "object",
+                        properties: {
+                            element: {
+                                $ref: "#/$defs/Person"
+                            },
+                            params: {
+                                type: "object",
+                                properties: {
+                                    setAssign: {
+                                        type: "object",
+                                        properties: {
+                                            name: {
+                                                type: "string"
+                                            }
+                                        },
+                                        required: ["name"],
+                                        asCell: ["stream"]
+                                    }
+                                },
+                                required: ["setAssign"]
+                            }
+                        },
+                        required: ["element", "params"],
+                        $defs: {
+                            Person: {
+                                type: "object",
+                                properties: {
+                                    name: {
+                                        type: "string"
+                                    }
+                                },
+                                required: ["name"]
+                            }
+                        }
+                    } as const satisfies __cfHelpers.JSONSchema, {
+                        anyOf: [{
+                                $ref: "https://commonfabric.org/schemas/vnode.json"
+                            }, {
+                                $ref: "#/$defs/UIRenderable"
+                            }, {
+                                type: "object",
+                                properties: {}
+                            }],
+                        $defs: {
+                            UIRenderable: {
+                                type: "object",
+                                properties: {
+                                    $UI: {
+                                        $ref: "https://commonfabric.org/schemas/vnode.json"
+                                    }
+                                },
+                                required: ["$UI"]
+                            }
+                        }
+                    } as const satisfies __cfHelpers.JSONSchema), {
+                        setAssign: setAssign
+                    })}
+          </div>);
+            }, {
+                type: "object",
+                properties: {
+                    element: {
+                        type: "object",
+                        properties: {
+                            id: {
+                                type: "string"
+                            },
+                            label: {
+                                type: "string"
+                            }
+                        },
+                        required: ["id", "label"]
+                    },
+                    params: {
+                        type: "object",
+                        properties: {
+                            people: {
+                                type: "array",
+                                items: {
+                                    $ref: "#/$defs/Person"
+                                },
+                                asCell: [{
+                                        kind: "cell",
+                                        scope: "space"
+                                    }]
+                            },
+                            setAssign: {
+                                type: "object",
+                                properties: {
+                                    name: {
+                                        type: "string"
+                                    }
+                                },
+                                required: ["name"],
+                                asCell: ["stream"]
+                            }
+                        },
+                        required: ["people", "setAssign"]
+                    }
+                },
+                required: ["element", "params"],
+                $defs: {
+                    Person: {
+                        type: "object",
+                        properties: {
+                            name: {
+                                type: "string"
+                            }
+                        },
+                        required: ["name"]
+                    }
+                }
+            } as const satisfies __cfHelpers.JSONSchema, {
+                anyOf: [{
+                        $ref: "https://commonfabric.org/schemas/vnode.json"
+                    }, {
+                        $ref: "#/$defs/UIRenderable"
+                    }, {
+                        type: "object",
+                        properties: {}
+                    }],
+                $defs: {
+                    UIRenderable: {
+                        type: "object",
+                        properties: {
+                            $UI: {
+                                $ref: "https://commonfabric.org/schemas/vnode.json"
+                            }
+                        },
+                        required: ["$UI"]
+                    }
+                }
+            } as const satisfies __cfHelpers.JSONSchema), {
+                people: people,
+                setAssign: setAssign
+            })}
+      </div>),
+    };
+}, {
+    type: "object",
+    properties: {
+        rows: {
+            type: "array",
+            items: {
+                type: "object",
+                properties: {
+                    id: {
+                        type: "string"
+                    },
+                    label: {
+                        type: "string"
+                    }
+                },
+                required: ["id", "label"]
+            },
+            "default": []
+        }
+    },
+    required: ["rows"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        $UI: {
+            $ref: "#/$defs/JSXElement"
+        }
+    },
+    required: ["$UI"],
+    $defs: {
+        JSXElement: {
+            anyOf: [{
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }, {
+                    $ref: "#/$defs/UIRenderable"
+                }, {
+                    type: "object",
+                    properties: {}
+                }]
+        },
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/nested-map-fallback-receiver.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/nested-map-fallback-receiver.input.tsx
@@ -1,0 +1,47 @@
+import { action, Default, pattern, UI, Writable } from "commonfabric";
+
+interface Person {
+  name: string;
+}
+interface State {
+  rows: Default<Array<{ id: string; label: string }>, []>;
+}
+
+// FIXTURE: nested-map-fallback-receiver
+// Verifies: a fallback-receiver array method — (reactiveCall() ?? []).map(...) —
+//   nested INSIDE another .map() callback is lowered to mapWithPattern, so its
+//   inner closure (which captures a sibling pattern cell) is threaded through
+//   params instead of being illegally accessed across frames.
+//     rows.map((row) => (people.get() ?? []).map((p) => ... setAssign ...))
+//       → rows.mapWithPattern(pattern(... (lift(...)(...) ?? []).mapWithPattern(...) ...))
+// Context: This is CT-1626. Before the fix, the inner `(people.get() ?? [])`
+//   receiver — a `??` binary whose LHS is a reactive (lift-applied) call —
+//   was classified as a plain `T[]` receiver, so the inner `.map` stayed a raw
+//   CellImpl.map and threw at construction ("Reactive reference from outer
+//   scope cannot be accessed via closure"). The `?? []` guard (correct for the
+//   scoped-cell-undefined-before-sync race) is exactly what hid the reactive
+//   receiver from the transformer.
+export default pattern<State>(({ rows }) => {
+  const people = Writable.perSpace.of<Person[]>([]);
+  const assignName = Writable.perSpace.of<string>("");
+  const setAssign = action((p: { name: string }) => assignName.set(p.name));
+  return {
+    [UI]: (
+      <div>
+        {rows.map((row) => (
+          <div>
+            <span>{row.label}</span>
+            {(people.get() ?? []).map((p) => (
+              <button
+                type="button"
+                onClick={() => setAssign.send({ name: p.name })}
+              >
+                {p.name}
+              </button>
+            ))}
+          </div>
+        ))}
+      </div>
+    ),
+  };
+});


### PR DESCRIPTION
## What

Fixes [CT-1626](https://linear.app/common-tools/issue/CT-1626): `(cellCall() ?? []).map(...)` nested inside another `.map(...)` threw at pattern construction when its callback captured a sibling cell.

Two commits:

1. **Transformer policy fix** — lower fallback-guarded reactive receivers.
2. **Runner diagnostic** — unify and enrich the closure-capture error.

## Root cause (verified on current main)

The outer `rows.map` correctly becomes `mapWithPattern`, but the inner receiver `(people.get() ?? [])` is a `??` binary whose static type collapses to a plain array. `shouldTransformArrayMethod` classifies it as a `"plain"` receiver, so the inner `.map` stays a raw `CellImpl.map`. At runtime that synthesized frame's callback closes over a sibling pattern cell (`setAssign`), and `node-utils.ts` throws on the frame mismatch.

Confirmed via `--show-transformed` (inner stayed `.map`, not `mapWithPattern`) and the discriminating axis: replacing `(people.get() ?? [])` with direct `people.map(...)` compiles clean.

## Fix 1 — transformer policy (`array-method-policy.ts`)

Recognize fallback-guarded reactive receivers — `(<reactive> ?? fallback)` / `(<reactive> || fallback)` where `<reactive>` is an OpaqueRef value or a `<reactive>.get()` / `.key()` read — and lower their `map`/`filter`/`flatMap` like the existing `lift-applied` special-case. Adds the `nested-map-fallback-receiver` golden fixture.

The check is deliberately narrow and does **not** touch `isReactiveValueExpression`'s contract: `.get()` is intentionally non-reactive-as-written (the `computed`/`lift` closure-lifting depends on that). I tried the broader alternative — teaching `hasReactiveCollectionProvenance` to recurse through `.get()` — but it regressed `<cell>.get().filter(...)` (which the standalone-function diagnostic explicitly recommends as the eager escape hatch), confirming `.get()`'s "exit reactivity" boundary is load-bearing.

Verified: `UPDATE_GOLDENS` changed no existing goldens; the negative case `(plainNonReactive ?? []).map(...)` is correctly not wrapped.

## Fix 2 — runner diagnostic (`closure-capture-diagnostic.ts`)

The two construction-time throws (`node-utils.ts`, `pattern.ts`) used two differently-worded messages, neither naming the cell, site, or module; the "wrap in a derive" guidance pointed at the wrong recipe. Both now route through a shared `closureCaptureErrorMessage` that:

- names the captured cell (name / path / scope),
- surfaces the capturing callback's source location when resolvable (reuses `module.ts`'s source-mapping via an exported, frame-parameterized `resolveLocationFromFunctionSource`),
- recommends the real escape hatches (`mapWithPattern` / `computed`).

The policy fix removes the common trigger; this makes the residual, genuinely-unrewritable cases self-explaining.

## Tests

- New golden fixture `closures/nested-map-fallback-receiver` (inner map now lowers to `mapWithPattern`).
- New unit test `closure-capture-diagnostic.test.ts` pinning the unified message.
- Full ts-transformers suite green (295 passed); affected runner suites green (security, traverse, patterns-core/misc/regressions/reduce/per-path-reads, module, pattern-manager).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CT-1626 by lowering `(reactive ?? []).map(...)` nested in another `.map(...)` to pattern-aware methods and by unifying the closure-capture error with clearer guidance. Prevents construction-time throws when a callback captures a sibling cell.

- **Bug Fixes**
  - Transformer (`packages/ts-transformers`): detect fallback-guarded reactive receivers `(<reactive> ?? x)` / `(<reactive> || x)` (including `<reactive>.get()` / `.key()`) and lower `.map`/`.filter`/`.flatMap` to `mapWithPattern`.
  - Preserves `.get()`’s non-reactive-as-written contract; only the receiver’s provenance is checked.
  - Runner (`packages/runner`): route closure-capture throws through a shared `closureCaptureErrorMessage` that names the captured cell (name/path/scope), adds an optional source location, and recommends `mapWithPattern` or `computed`.
  - Tests: added golden `closures/nested-map-fallback-receiver` and a unit test for the unified diagnostic.

<sup>Written for commit d16f8781e451d968497db2fec0f5b85f17a6a427. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3726?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

