### PR TITLE
[codex] Wire cf-harness chat stdio to SQLite sessions

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -53,6 +53,8 @@ What works today:
   retention in tool-output artifacts; `web_fetch` is intentionally not part of
   the default parent tool surface
 - bounded OpenAI-compatible prompt/tool loop
+- interactive chat NDJSON stdio transport with opt-in SQLite session, turn, and
+  event persistence
 - single-child subagent delegation with fresh child prompt context, explicit
   default/browser/web_fetch/web_search child profiles, retained child run
   references, and a sanitized summary/state return channel
@@ -117,6 +119,10 @@ What is not done yet:
   - bounded prompt/tool loop
 - [src/cli.ts](src/cli.ts)
   - package-local operator CLI
+- [src/interactive-chat-stdio.ts](src/interactive-chat-stdio.ts)
+  - NDJSON stdio transport for the interactive chat protocol
+- [src/sqlite-session-store.ts](src/sqlite-session-store.ts)
+  - SQLite-backed interactive chat session, turn, and event persistence
 - [src/artifacts.ts](src/artifacts.ts)
   - persisted run state, run manifest, transcript, run report, capability
     snapshot, and tool output storage
@@ -161,6 +167,19 @@ deno task run -- \
   --prompt "Summarize the cf-harness package structure." \
   --print-transcript
 ```
+
+Interactive chat stdio transport:
+
+```bash
+cd packages/cf-harness
+deno run -A src/interactive-chat-stdio.ts \
+  --chat-session-db /tmp/cf-harness-chat.sqlite
+```
+
+The stdio transport reads one interactive chat request envelope per line from
+stdin and writes response/event envelopes as newline-delimited JSON. Pass
+`--chat-session-db` or set `CF_HARNESS_CHAT_SESSION_DB` to persist sessions,
+turn records, and replayable events across process restarts.
 
 Initial prompt image attachments:
 

--- a/packages/cf-harness/src/interactive-chat-stdio.ts
+++ b/packages/cf-harness/src/interactive-chat-stdio.ts
@@ -1,3 +1,4 @@
+import { resolve, toFileUrl } from "@std/path";
 import {
   createHarnessChatErrorResponse,
   HARNESS_CHAT_PROTOCOL_VERSION,
@@ -18,7 +19,9 @@ import type { BuiltinToolId } from "./contracts/tool-descriptor.ts";
 import {
   createHarnessInteractiveChatService,
   type HarnessInteractiveChatService,
+  type HarnessInteractivePromptLoopFactory,
 } from "./interactive-chat-service.ts";
+import type { HarnessChatSessionStore } from "./session-store.ts";
 
 export type HarnessInteractiveChatOutputEnvelope =
   | HarnessChatEventEnvelope
@@ -29,8 +32,28 @@ export interface RunHarnessInteractiveChatNdjsonTransportOptions {
   writeLine: (line: string) => void | Promise<void>;
   createService?: (
     onEvent: (event: HarnessChatEventEnvelope) => void | Promise<void>,
-  ) => HarnessInteractiveChatService;
+  ) => HarnessInteractiveChatService | Promise<HarnessInteractiveChatService>;
+  closeService?: (
+    service: HarnessInteractiveChatService,
+  ) => void | Promise<void>;
 }
+
+export interface RunHarnessInteractiveChatStdioOptions {
+  input?: ReadableStream<Uint8Array>;
+  output?: WritableStream<Uint8Array>;
+  sessionDbPath?: string;
+  createPromptLoop?: HarnessInteractivePromptLoopFactory;
+  createService?: (
+    onEvent: (event: HarnessChatEventEnvelope) => void | Promise<void>,
+  ) => HarnessInteractiveChatService | Promise<HarnessInteractiveChatService>;
+}
+
+export interface HarnessInteractiveChatStdioCliOptions {
+  sessionDbPath?: string;
+  help: boolean;
+}
+
+const CHAT_SESSION_DB_ENV = "CF_HARNESS_CHAT_SESSION_DB";
 
 const invalidRequestResponse = (
   message: string,
@@ -40,6 +63,71 @@ const invalidRequestResponse = (
     code: "invalid_request",
     message,
   });
+
+const usageText = `Usage: deno run -A src/interactive-chat-stdio.ts [options]
+
+Options:
+  --chat-session-db <path>  Persist chat sessions, turns, and events in SQLite
+  --help                   Print this help text to stderr
+
+Environment:
+  ${CHAT_SESSION_DB_ENV}    Default SQLite chat session DB path
+`;
+
+const nonEmptyOptionValue = (
+  name: string,
+  value: string | undefined,
+): string => {
+  if (value === undefined || value.trim() === "") {
+    throw new Error(`${name} requires a non-empty value`);
+  }
+  return value;
+};
+
+export const parseHarnessInteractiveChatStdioCliOptions = (
+  args: readonly string[],
+  env: Record<string, string | undefined> = Deno.env.toObject(),
+): HarnessInteractiveChatStdioCliOptions => {
+  let sessionDbPath = env[CHAT_SESSION_DB_ENV];
+  let help = false;
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--help" || arg === "-h") {
+      help = true;
+      continue;
+    }
+    if (arg === "--chat-session-db") {
+      index += 1;
+      sessionDbPath = nonEmptyOptionValue(arg, args[index]);
+      continue;
+    }
+    if (arg.startsWith("--chat-session-db=")) {
+      sessionDbPath = nonEmptyOptionValue(
+        "--chat-session-db",
+        arg.slice("--chat-session-db=".length),
+      );
+      continue;
+    }
+    throw new Error(`unsupported interactive chat stdio argument: ${arg}`);
+  }
+  return {
+    ...(sessionDbPath !== undefined && sessionDbPath.trim() !== ""
+      ? { sessionDbPath }
+      : {}),
+    help,
+  };
+};
+
+const openSessionStore = async (
+  sessionDbPath: string,
+): Promise<HarnessChatSessionStore> => {
+  const { openSqliteHarnessChatSessionStore } = await import(
+    "./sqlite-session-store.ts"
+  );
+  return await openSqliteHarnessChatSessionStore({
+    url: toFileUrl(resolve(sessionDbPath)),
+  });
+};
 
 const SUPPORTED_REQUEST_METHODS = new Set<HarnessChatRequestMethod>([
   "start_session",
@@ -268,25 +356,48 @@ export const runHarnessInteractiveChatNdjsonTransport = async (
     createHarnessInteractiveChatService({
       onEvent: writeEnvelope,
     });
+  const resolvedService = await service;
 
-  for await (const rawLine of options.lines) {
-    const line = rawLine.trim();
-    if (line.length === 0) {
-      continue;
+  let transportError: unknown;
+  let cleanupError: unknown;
+  try {
+    for await (const rawLine of options.lines) {
+      const line = rawLine.trim();
+      if (line.length === 0) {
+        continue;
+      }
+      let response: HarnessChatResponse;
+      try {
+        response = await resolvedService.handleRequest(parseRequestLine(line));
+      } catch (error) {
+        response = isTransportErrorResponse(error)
+          ? error
+          : invalidRequestResponse(
+            error instanceof Error ? error.message : String(error),
+          );
+      }
+      await writeEnvelope(response);
     }
-    let response: HarnessChatResponse;
+  } catch (error) {
+    transportError = error;
+  } finally {
     try {
-      response = await service.handleRequest(parseRequestLine(line));
+      await resolvedService.waitForIdle();
     } catch (error) {
-      response = isTransportErrorResponse(error)
-        ? error
-        : invalidRequestResponse(
-          error instanceof Error ? error.message : String(error),
-        );
+      cleanupError = error;
     }
-    await writeEnvelope(response);
+    try {
+      await options.closeService?.(resolvedService);
+    } catch (error) {
+      cleanupError ??= error;
+    }
   }
-  await service.waitForIdle();
+  if (transportError !== undefined) {
+    throw transportError;
+  }
+  if (cleanupError !== undefined) {
+    throw cleanupError;
+  }
 };
 
 const isTransportErrorResponse = (
@@ -333,21 +444,46 @@ const decodeUtf8Lines = async function* (
 };
 
 export const runHarnessInteractiveChatStdio = async (
-  options: {
-    input?: ReadableStream<Uint8Array>;
-    output?: WritableStream<Uint8Array>;
-    createService?: (
-      onEvent: (event: HarnessChatEventEnvelope) => void | Promise<void>,
-    ) => HarnessInteractiveChatService;
-  } = {},
+  options: RunHarnessInteractiveChatStdioOptions = {},
 ): Promise<void> => {
   const encoder = new TextEncoder();
   const output = options.output ?? Deno.stdout.writable;
   const writer = output.getWriter();
+  let sessionStore: HarnessChatSessionStore | undefined;
+  const createService = options.createService ??
+    (async (
+      onEvent: (event: HarnessChatEventEnvelope) => void | Promise<void>,
+    ) => {
+      let openedStore: HarnessChatSessionStore | undefined;
+      try {
+        if (options.sessionDbPath !== undefined) {
+          openedStore = await openSessionStore(options.sessionDbPath);
+          sessionStore = openedStore;
+        }
+        const service = createHarnessInteractiveChatService({
+          onEvent,
+          ...(options.createPromptLoop !== undefined
+            ? { createPromptLoop: options.createPromptLoop }
+            : {}),
+          ...(sessionStore !== undefined ? { sessionStore } : {}),
+        });
+        await service.initializeFromStore();
+        return service;
+      } catch (error) {
+        await openedStore?.close?.();
+        if (sessionStore === openedStore) {
+          sessionStore = undefined;
+        }
+        throw error;
+      }
+    });
   try {
     await runHarnessInteractiveChatNdjsonTransport({
       lines: decodeUtf8Lines(options.input ?? Deno.stdin.readable),
-      createService: options.createService,
+      createService,
+      closeService: async () => {
+        await sessionStore?.close?.();
+      },
       writeLine: async (line) => {
         await writer.write(encoder.encode(`${line}\n`));
       },
@@ -357,6 +493,22 @@ export const runHarnessInteractiveChatStdio = async (
   }
 };
 
+export const runHarnessInteractiveChatStdioCli = async (
+  args: readonly string[] = Deno.args,
+): Promise<void> => {
+  const options = parseHarnessInteractiveChatStdioCliOptions(args);
+  if (options.help) {
+    await Deno.stderr.write(new TextEncoder().encode(usageText));
+    return;
+  }
+  await runHarnessInteractiveChatStdio(options);
+};
+
 if (import.meta.main) {
-  await runHarnessInteractiveChatStdio();
+  try {
+    await runHarnessInteractiveChatStdioCli();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    Deno.exit(1);
+  }
 }

--- a/packages/cf-harness/test/interactive-chat-stdio.test.ts
+++ b/packages/cf-harness/test/interactive-chat-stdio.test.ts
@@ -1,14 +1,23 @@
-import { assertEquals, assertStringIncludes } from "@std/assert";
+import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import { fromFileUrl, join } from "@std/path";
 import {
   HARNESS_CHAT_PROTOCOL_VERSION,
   HARNESS_CHAT_REQUEST_TYPE,
+  type HarnessChatListEventsResult,
+  type HarnessChatListTurnsResult,
+  type HarnessChatStatusResult,
 } from "../src/contracts/interactive-chat.ts";
 import { HARNESS_BROWSER_ACCESS_LEASE_TYPE } from "../src/contracts/browser-access.ts";
 import { CFC_PROMPT_SLOT_BOUND_ATOM_TYPE } from "../src/contracts/prompt-slot.ts";
-import { HarnessInteractiveChatService } from "../src/interactive-chat-service.ts";
+import {
+  HarnessInteractiveChatService,
+  type HarnessInteractivePromptLoopFactory,
+} from "../src/interactive-chat-service.ts";
 import {
   type HarnessInteractiveChatOutputEnvelope,
+  parseHarnessInteractiveChatStdioCliOptions,
   runHarnessInteractiveChatNdjsonTransport,
+  runHarnessInteractiveChatStdio,
 } from "../src/interactive-chat-stdio.ts";
 import type { HarnessPromptLoopResult } from "../src/prompt-loop.ts";
 
@@ -16,6 +25,78 @@ const decodeLines = (
   lines: readonly string[],
 ): HarnessInteractiveChatOutputEnvelope[] =>
   lines.map((line) => JSON.parse(line) as HarnessInteractiveChatOutputEnvelope);
+
+const encodeInputLines = (
+  lines: readonly string[],
+): ReadableStream<Uint8Array> => {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const line of lines) {
+        controller.enqueue(encoder.encode(`${line}\n`));
+      }
+      controller.close();
+    },
+  });
+};
+
+const captureOutputLines = (): {
+  output: WritableStream<Uint8Array>;
+  lines: () => string[];
+} => {
+  const decoder = new TextDecoder();
+  let text = "";
+  return {
+    output: new WritableStream({
+      write(chunk) {
+        text += decoder.decode(chunk, { stream: true });
+      },
+      close() {
+        text += decoder.decode();
+      },
+    }),
+    lines: () => text.split("\n").filter((line) => line.trim().length > 0),
+  };
+};
+
+const runStdioCli = async (
+  lines: readonly string[],
+  args: readonly string[],
+): Promise<{
+  code: number;
+  stdout: string;
+  stderr: string;
+  envelopes: HarnessInteractiveChatOutputEnvelope[];
+}> => {
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+  const command = new Deno.Command(Deno.execPath(), {
+    args: [
+      "run",
+      "-A",
+      fromFileUrl(new URL("../src/interactive-chat-stdio.ts", import.meta.url)),
+      ...args,
+    ],
+    stdin: "piped",
+    stdout: "piped",
+    stderr: "piped",
+  });
+  const child = command.spawn();
+  const writer = child.stdin.getWriter();
+  await writer.write(encoder.encode(lines.map((line) => `${line}\n`).join("")));
+  await writer.close();
+  const output = await child.output();
+  const stdout = decoder.decode(output.stdout);
+  const stderr = decoder.decode(output.stderr);
+  return {
+    code: output.code,
+    stdout,
+    stderr,
+    envelopes: decodeLines(
+      stdout.split("\n").filter((line) => line.trim().length > 0),
+    ),
+  };
+};
 
 Deno.test("interactive NDJSON transport emits events and responses", async () => {
   const output: string[] = [];
@@ -96,6 +177,451 @@ Deno.test("interactive NDJSON transport emits events and responses", async () =>
       "ok" in envelope ? [envelope.requestId, envelope.ok] : undefined
     ),
     [["req-1", true], ["req-2", true]],
+  );
+});
+
+Deno.test("interactive NDJSON transport waits for active turns before close after write failure", async () => {
+  let loopFinished = false;
+  let resolveLoop: (() => void) | undefined;
+  let closeBeforeLoopFinished = false;
+  const service = new HarnessInteractiveChatService({
+    onEvent: async () => {},
+    createPromptLoop: () => ({
+      runTranscript: async (options) => {
+        await new Promise<void>((resolve) => {
+          resolveLoop = resolve;
+        });
+        loopFinished = true;
+        const finalMessage = {
+          role: "assistant" as const,
+          content: "done",
+        };
+        const transcript = [...options.transcript, finalMessage];
+        await options.onTranscriptEvent?.({
+          message: finalMessage,
+          transcript,
+        });
+        return {
+          model: "gpt-test",
+          finalAssistantText: "done",
+          transcript,
+          modelTurns: 1,
+          runState: {} as HarnessPromptLoopResult["runState"],
+        };
+      },
+    }),
+  });
+
+  await assertRejects(
+    () =>
+      runHarnessInteractiveChatNdjsonTransport({
+        lines: [
+          JSON.stringify({
+            type: HARNESS_CHAT_REQUEST_TYPE,
+            protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+            requestId: "req-start-session",
+            method: "start_session",
+            params: {
+              sessionId: "session-1",
+              workspace: { hostPath: "/workspace" },
+              model: "gpt-test",
+            },
+          }),
+          JSON.stringify({
+            type: HARNESS_CHAT_REQUEST_TYPE,
+            protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+            requestId: "req-start-turn",
+            method: "start_turn",
+            params: {
+              sessionId: "session-1",
+              turnId: "turn-1",
+              input: { text: "finish later" },
+            },
+          }),
+        ],
+        createService: () => service,
+        closeService: () => {
+          closeBeforeLoopFinished = !loopFinished;
+        },
+        writeLine: (line) => {
+          const envelope = JSON.parse(line) as Record<string, unknown>;
+          if (envelope.requestId === "req-start-turn") {
+            resolveLoop?.();
+            throw new Error("simulated stdout failure");
+          }
+        },
+      }),
+    Error,
+    "simulated stdout failure",
+  );
+
+  assertEquals(loopFinished, true);
+  assertEquals(closeBeforeLoopFinished, false);
+});
+
+Deno.test("interactive NDJSON transport calls close hook after normal completion", async () => {
+  const output: string[] = [];
+  let closeCalls = 0;
+  const service = new HarnessInteractiveChatService({
+    onEvent: async () => {},
+  });
+
+  await runHarnessInteractiveChatNdjsonTransport({
+    lines: [
+      JSON.stringify({
+        type: HARNESS_CHAT_REQUEST_TYPE,
+        protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+        requestId: "req-start-session",
+        method: "start_session",
+        params: {
+          sessionId: "session-1",
+          workspace: { hostPath: "/workspace" },
+          model: "gpt-test",
+        },
+      }),
+    ],
+    createService: () => service,
+    closeService: (closedService) => {
+      assertEquals(closedService, service);
+      closeCalls += 1;
+    },
+    writeLine: (line) => {
+      output.push(line);
+    },
+  });
+
+  assertEquals(closeCalls, 1);
+  assertEquals(
+    decodeLines(output).filter((envelope) => "ok" in envelope).map((
+      envelope,
+    ) => "ok" in envelope ? [envelope.requestId, envelope.ok] : undefined),
+    [["req-start-session", true]],
+  );
+});
+
+Deno.test({
+  name: "interactive stdio persists and restores SQLite chat runtime state",
+  // Dynamic SQLite imports load a native library that @db/sqlite does not unload.
+  sanitizeResources: false,
+  fn: async () => {
+    const tempDir = await Deno.makeTempDir({
+      prefix: "cf-harness-chat-stdio-",
+    });
+    const dbPath = join(tempDir, "chat.sqlite");
+    const createPromptLoop: HarnessInteractivePromptLoopFactory = () => ({
+      runTranscript: async (options) => {
+        const finalMessage = {
+          role: "assistant" as const,
+          content: "Persisted over stdio.",
+        };
+        const transcript = [...options.transcript, finalMessage];
+        await options.onTranscriptEvent?.({
+          message: finalMessage,
+          transcript,
+        });
+        return {
+          model: "gpt-test",
+          finalAssistantText: "Persisted over stdio.",
+          transcript,
+          modelTurns: 1,
+          runState: {} as HarnessPromptLoopResult["runState"],
+        };
+      },
+    });
+    try {
+      const firstOutput = captureOutputLines();
+      await runHarnessInteractiveChatStdio({
+        sessionDbPath: dbPath,
+        createPromptLoop,
+        input: encodeInputLines([
+          JSON.stringify({
+            type: HARNESS_CHAT_REQUEST_TYPE,
+            protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+            requestId: "req-1",
+            method: "start_session",
+            params: {
+              sessionId: "session-1",
+              workspace: { hostPath: "/workspace" },
+              model: "gpt-test",
+            },
+          }),
+          JSON.stringify({
+            type: HARNESS_CHAT_REQUEST_TYPE,
+            protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+            requestId: "req-2",
+            method: "start_turn",
+            params: {
+              sessionId: "session-1",
+              turnId: "turn-1",
+              input: { text: "Remember this" },
+            },
+          }),
+        ]),
+        output: firstOutput.output,
+      });
+      assertEquals(
+        decodeLines(firstOutput.lines()).filter((envelope) =>
+          "event" in envelope
+        )
+          .map((envelope) => "event" in envelope ? envelope.event.kind : ""),
+        [
+          "session_started",
+          "turn_started",
+          "assistant_delta",
+          "assistant_completed",
+          "turn_completed",
+        ],
+      );
+
+      const restoredOutput = captureOutputLines();
+      await runHarnessInteractiveChatStdio({
+        sessionDbPath: dbPath,
+        createPromptLoop,
+        input: encodeInputLines([
+          JSON.stringify({
+            type: HARNESS_CHAT_REQUEST_TYPE,
+            protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+            requestId: "req-status",
+            method: "status",
+            params: {
+              sessionId: "session-1",
+            },
+          }),
+          JSON.stringify({
+            type: HARNESS_CHAT_REQUEST_TYPE,
+            protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+            requestId: "req-events",
+            method: "list_events",
+            params: {
+              sessionId: "session-1",
+              afterSequence: 0,
+            },
+          }),
+          JSON.stringify({
+            type: HARNESS_CHAT_REQUEST_TYPE,
+            protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+            requestId: "req-turns",
+            method: "list_turns",
+            params: {
+              sessionId: "session-1",
+              status: "completed",
+            },
+          }),
+        ]),
+        output: restoredOutput.output,
+      });
+
+      const restoredEnvelopes = decodeLines(restoredOutput.lines());
+      const statusResponse = restoredEnvelopes.find((envelope) =>
+        "ok" in envelope && envelope.requestId === "req-status"
+      );
+      const statusResult = statusResponse !== undefined &&
+          "ok" in statusResponse && statusResponse.ok
+        ? statusResponse.result as HarnessChatStatusResult
+        : undefined;
+      assertEquals(
+        statusResult?.sessions.map((session) => ({
+          sessionId: session.sessionId,
+          status: session.status,
+          turnCount: session.turnCount,
+        })),
+        [{
+          sessionId: "session-1",
+          status: "idle",
+          turnCount: 1,
+        }],
+      );
+
+      const eventsResponse = restoredEnvelopes.find((envelope) =>
+        "ok" in envelope && envelope.requestId === "req-events"
+      );
+      const eventsResult = eventsResponse !== undefined &&
+          "ok" in eventsResponse && eventsResponse.ok
+        ? eventsResponse.result as HarnessChatListEventsResult
+        : undefined;
+      assertEquals(
+        eventsResult?.events.map((event) => event.event.kind),
+        [
+          "session_started",
+          "turn_started",
+          "assistant_delta",
+          "assistant_completed",
+          "turn_completed",
+        ],
+      );
+
+      const turnsResponse = restoredEnvelopes.find((envelope) =>
+        "ok" in envelope && envelope.requestId === "req-turns"
+      );
+      const turnsResult =
+        turnsResponse !== undefined && "ok" in turnsResponse &&
+          turnsResponse.ok
+          ? turnsResponse.result as HarnessChatListTurnsResult
+          : undefined;
+      assertEquals(
+        turnsResult?.turns.map((turn) => ({
+          turnId: turn.turn.turnId,
+          status: turn.turn.status,
+          input: turn.input,
+        })),
+        [{
+          turnId: "turn-1",
+          status: "completed",
+          input: { text: "Remember this" },
+        }],
+      );
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  },
+});
+
+Deno.test("interactive stdio CLI persists sessions across process invocations", async () => {
+  const tempDir = await Deno.makeTempDir({
+    prefix: "cf-harness-chat-stdio-cli-",
+  });
+  const dbPath = join(tempDir, "chat.sqlite");
+  try {
+    const first = await runStdioCli([
+      JSON.stringify({
+        type: HARNESS_CHAT_REQUEST_TYPE,
+        protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+        requestId: "req-start",
+        method: "start_session",
+        params: {
+          sessionId: "cli-session-1",
+          workspace: { hostPath: "/workspace" },
+          model: "gpt-test",
+        },
+      }),
+    ], ["--chat-session-db", dbPath]);
+    assertEquals(first.code, 0, first.stderr);
+    assertEquals(
+      first.envelopes.filter((envelope) => "event" in envelope).map((
+        envelope,
+      ) => "event" in envelope ? envelope.event.kind : ""),
+      ["session_started"],
+    );
+    assertEquals(
+      first.envelopes.filter((envelope) => "ok" in envelope).map((
+        envelope,
+      ) => "ok" in envelope ? [envelope.requestId, envelope.ok] : undefined),
+      [["req-start", true]],
+    );
+
+    const restored = await runStdioCli([
+      JSON.stringify({
+        type: HARNESS_CHAT_REQUEST_TYPE,
+        protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+        requestId: "req-status",
+        method: "status",
+        params: {
+          sessionId: "cli-session-1",
+        },
+      }),
+      JSON.stringify({
+        type: HARNESS_CHAT_REQUEST_TYPE,
+        protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+        requestId: "req-events",
+        method: "list_events",
+        params: {
+          sessionId: "cli-session-1",
+          afterSequence: 0,
+        },
+      }),
+    ], [`--chat-session-db=${dbPath}`]);
+    assertEquals(restored.code, 0, restored.stderr);
+    const statusResponse = restored.envelopes.find((envelope) =>
+      "ok" in envelope && envelope.requestId === "req-status"
+    );
+    const statusResult = statusResponse !== undefined &&
+        "ok" in statusResponse && statusResponse.ok
+      ? statusResponse.result as HarnessChatStatusResult
+      : undefined;
+    assertEquals(
+      statusResult?.sessions.map((session) => ({
+        sessionId: session.sessionId,
+        status: session.status,
+        turnCount: session.turnCount,
+      })),
+      [{
+        sessionId: "cli-session-1",
+        status: "idle",
+        turnCount: 0,
+      }],
+    );
+
+    const eventsResponse = restored.envelopes.find((envelope) =>
+      "ok" in envelope && envelope.requestId === "req-events"
+    );
+    const eventsResult = eventsResponse !== undefined &&
+        "ok" in eventsResponse && eventsResponse.ok
+      ? eventsResponse.result as HarnessChatListEventsResult
+      : undefined;
+    assertEquals(
+      eventsResult?.events.map((event) => event.event.kind),
+      ["session_started"],
+    );
+  } finally {
+    await Deno.remove(tempDir, { recursive: true });
+  }
+});
+
+Deno.test({
+  name:
+    "interactive stdio CLI reports invalid SQLite session DB startup failures",
+  // Dynamic SQLite imports load a native library that @db/sqlite does not unload.
+  sanitizeResources: false,
+  fn: async () => {
+    const tempDir = await Deno.makeTempDir({
+      prefix: "cf-harness-chat-stdio-bad-db-",
+    });
+    try {
+      const result = await runStdioCli([], [
+        "--chat-session-db",
+        join(tempDir, "missing", "chat.sqlite"),
+      ]);
+      assertEquals(result.code, 1);
+      assertEquals(result.stdout, "");
+      assertEquals(result.envelopes, []);
+      assertEquals(result.stderr.trim().length > 0, true);
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  },
+});
+
+Deno.test("interactive stdio CLI parses SQLite session DB options", () => {
+  assertEquals(
+    parseHarnessInteractiveChatStdioCliOptions([], {
+      CF_HARNESS_CHAT_SESSION_DB: "/tmp/chat.sqlite",
+    }),
+    {
+      sessionDbPath: "/tmp/chat.sqlite",
+      help: false,
+    },
+  );
+  assertEquals(
+    parseHarnessInteractiveChatStdioCliOptions([
+      "--chat-session-db",
+      "/tmp/explicit.sqlite",
+    ], {
+      CF_HARNESS_CHAT_SESSION_DB: "/tmp/env.sqlite",
+    }),
+    {
+      sessionDbPath: "/tmp/explicit.sqlite",
+      help: false,
+    },
+  );
+  assertEquals(
+    parseHarnessInteractiveChatStdioCliOptions([
+      "--chat-session-db=/tmp/inline.sqlite",
+      "--help",
+    ], {}),
+    {
+      sessionDbPath: "/tmp/inline.sqlite",
+      help: true,
+    },
   );
 });
 


### PR DESCRIPTION
## Summary
- add opt-in SQLite persistence to the cf-harness interactive chat stdio transport via --chat-session-db / CF_HARNESS_CHAT_SESSION_DB
- restore persisted chat sessions, turns, and replayable events when the stdio process starts
- close the SQLite store on shutdown/init failure and document the durable stdio entrypoint
- add in-process and child-process CLI coverage for persistence across process invocations

## Validation
- deno fmt packages/cf-harness/README.md packages/cf-harness/src/interactive-chat-stdio.ts packages/cf-harness/test/interactive-chat-stdio.test.ts
- deno check packages/cf-harness/src/interactive-chat-stdio.ts packages/cf-harness/test/interactive-chat-stdio.test.ts
- deno lint packages/cf-harness/src/interactive-chat-stdio.ts packages/cf-harness/test/interactive-chat-stdio.test.ts
- deno test --allow-read --allow-write --allow-run --allow-ffi --allow-net --allow-env packages/cf-harness/test/interactive-chat-stdio.test.ts: 14 passed
- deno test --allow-read --allow-write --allow-run --allow-ffi --allow-net --allow-env packages/cf-harness/test/interactive-chat-service.test.ts packages/cf-harness/test/interactive-chat-stdio.test.ts packages/cf-harness/test/sqlite-session-store.test.ts: 36 passed
- deno task test in packages/cf-harness: 368 passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in SQLite persistence to the interactive chat NDJSON stdio transport so sessions, turns, and replayable events survive restarts. Introduces a CLI for DB path selection with safe startup/teardown and stronger transport lifecycle handling.

- **New Features**
  - Persist via `--chat-session-db <path>` or `CF_HARNESS_CHAT_SESSION_DB`; open from path and safely close the SQLite store.
  - Restore sessions and events on process start; `runHarnessInteractiveChatStdioCli` supports `--help`, prints usage to stderr, validates args, and exits 1 on startup errors.
  - NDJSON transport accepts async `createService`, waits for idle, and calls optional `closeService` on normal exit and after write failures.
  - `runHarnessInteractiveChatStdio` supports `sessionDbPath` and injectable `createPromptLoop`, initializes from store, and closes it on shutdown/init failure.
  - README documents stdio usage; tests cover in-process and child-process persistence, write-failure cleanup, CLI parsing, and error reporting.

<sup>Written for commit 3e35a7dc8c6026977d161bb48b0b37619529444f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3730?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

