### PR TITLE
refactor(patterns): remove derive; bare expressions / computed / ternaries (CT-1621)

### DIFF
--- a/packages/patterns/cozy-poll-scoped/main.tsx
+++ b/packages/patterns/cozy-poll-scoped/main.tsx
@@ -1033,9 +1033,7 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                     );
                     return idx >= 0 ? idx + 1 : 0;
                   });
-                  const isRemoveConfirm = computed(() =>
-                    removeConfirmTarget.get() === oid
-                  );
+                  const isRemoveConfirm = removeConfirmTarget.get() === oid;
                   // The castVote handler toggles per-color: clicking your
                   // active color clears, a different color updates, none
                   // pushes. JSX dispatches one event per click; the handler

--- a/packages/patterns/cozy-poll-scoped/main.tsx
+++ b/packages/patterns/cozy-poll-scoped/main.tsx
@@ -29,7 +29,6 @@
 import {
   computed,
   Default,
-  derive,
   handler,
   NAME,
   nonPrivateRandom,
@@ -208,7 +207,7 @@ const parseVisitDate = (draft: string | undefined): number => {
 };
 
 // Label for a visit derived purely from its own timestamp — never from the
-// current clock, so it stays idempotent inside reactive derives (timestamps
+// current clock, so it stays idempotent inside reactive computations (timestamps
 // read against "now" belong in handlers, not computeds). Reads like
 // "Tuesday, May 20".
 const visitLabel = (wentAt: number): string => {
@@ -553,30 +552,23 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     });
     const boundClearHistory = clearHistory({ history, myName, adminName });
 
-    const userCount = derive(users, (u) => u.length);
-    const optionCount = derive(options, (o) => o.length);
-    const voteCount = derive(votes, (v) => v.length);
-    const historyCount = derive(history, (h) => h.length);
-    const hasHistory = derive(history, (h) => h.length > 0);
+    const userCount = users.length;
+    const optionCount = options.length;
+    const voteCount = votes.length;
+    const historyCount = history.length;
+    const hasHistory = history.length > 0;
     // Most-recent-first, capped — the "Recently eaten" card stays compact.
-    const recentHistory = derive(
-      history,
-      (h) => [...h].sort((a, b) => b.wentAt - a.wentAt).slice(0, 8),
+    // Whole-array transform over a reactive array → computed (a single lift
+    // over the array), not bare; see 04-finding-map-on-reactive-array.md.
+    const recentHistory = computed(() =>
+      [...history].sort((a, b) => b.wentAt - a.wentAt).slice(0, 8)
     );
-    const isJoined = derive(myName, (n) => trimmedName(n) !== "");
-    const isAdmin = derive(
-      { myName, adminName },
-      ({ myName, adminName }) =>
-        trimmedName(myName) !== "" &&
-        trimmedName(myName) === trimmedName(adminName),
-    );
-    const joinHint = derive(
-      adminName,
-      (a) =>
-        trimmedName(a) === ""
-          ? "First to join becomes the host."
-          : `Hosted by ${trimmedName(a)}.`,
-    );
+    const isJoined = trimmedName(myName) !== "";
+    const isAdmin = trimmedName(myName) !== "" &&
+      trimmedName(myName) === trimmedName(adminName);
+    const joinHint = trimmedName(adminName) === ""
+      ? "First to join becomes the host."
+      : `Hosted by ${trimmedName(adminName)}.`;
     // Hoist a boolean cell for the reset-confirm JSX ternary so TS doesn't
     // narrow `resetConfirmPending` itself and lose the `.set` method in
     // the false branch.
@@ -585,23 +577,12 @@ export default pattern<CozyPollInput, CozyPollOutput>(
       clearHistoryConfirmPending.get()
     );
     const isClaimHostRevealed = computed(() => claimHostRevealed.get());
-    const ranked = derive(
-      { options, votes, users },
-      ({ options, votes, users }) => tallyOptions(options, votes, users),
-    );
+    const ranked = tallyOptions(options, votes, users);
 
-    const topChoice = derive(
-      { ranked, voteCount },
-      ({ ranked, voteCount }) =>
-        voteCount > 0 && ranked.length > 0 ? ranked[0] : null,
-    );
+    const topChoice = voteCount > 0 && ranked.length > 0 ? ranked[0] : null;
     // A joined viewer who is not the current host can take the host role.
-    const canClaimHost = derive(
-      { myName, adminName },
-      ({ myName, adminName }) =>
-        trimmedName(myName) !== "" &&
-        trimmedName(myName) !== trimmedName(adminName),
-    );
+    const canClaimHost = trimmedName(myName) !== "" &&
+      trimmedName(myName) !== trimmedName(adminName);
 
     return {
       [NAME]: "Cozy lunch poll",
@@ -1045,20 +1026,13 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                 {options.map((option) => {
                   const oid = option.id;
                   const optionTitle = option.title;
-                  const myVote = derive(
-                    { votes, myName, optionId: oid },
-                    ({ votes, myName, optionId }) =>
-                      myVoteFor(votes, trimmedName(myName), optionId),
-                  );
-                  const rank = derive(
-                    { ranked, optionId: oid },
-                    ({ ranked, optionId }) => {
-                      const idx = ranked.findIndex(
-                        (t) => t.option.id === optionId,
-                      );
-                      return idx >= 0 ? idx + 1 : 0;
-                    },
-                  );
+                  const myVote = myVoteFor(votes, trimmedName(myName), oid);
+                  const rank = computed(() => {
+                    const idx = ranked.findIndex(
+                      (t) => t.option.id === oid,
+                    );
+                    return idx >= 0 ? idx + 1 : 0;
+                  });
                   const isRemoveConfirm = computed(() =>
                     removeConfirmTarget.get() === oid
                   );
@@ -1531,13 +1505,13 @@ export default pattern<CozyPollInput, CozyPollOutput>(
           </cf-screen>
         </cf-theme>
       ),
-      question: derive(question, (q) => q),
-      options: derive(options, (o) => o),
-      votes: derive(votes, (v) => v),
-      users: derive(users, (u) => u),
-      history: derive(history, (h) => h),
-      adminName: derive(adminName, (a) => a),
-      myName: derive(myName, (n) => n),
+      question,
+      options,
+      votes,
+      users,
+      history,
+      adminName,
+      myName,
       userCount,
       optionCount,
       voteCount,

--- a/packages/patterns/examples/llm.tsx
+++ b/packages/patterns/examples/llm.tsx
@@ -1,7 +1,6 @@
 import {
   BuiltInLLMContent,
   Default,
-  derive,
   generateText,
   handler,
   NAME,
@@ -54,40 +53,35 @@ export default pattern<LLMTestInput>(({ title }) => {
         </div>
 
         <cf-cell-context $cell={question}>
-          {derive(question, (q) =>
-            q
-              ? (
-                <div>
-                  <h3>Your Question:</h3>
-                  <blockquote>
-                    {q}
-                  </blockquote>
-                </div>
-              )
-              : null)}
+          {question.get()
+            ? (
+              <div>
+                <h3>Your Question:</h3>
+                <blockquote>
+                  {question.get()}
+                </blockquote>
+              </div>
+            )
+            : null}
         </cf-cell-context>
 
         <cf-cell-context $cell={llmResponse}>
-          {derive(
-            [llmResponse.pending, llmResponse.result],
-            ([pending, r]) =>
-              pending
-                ? (
-                  <div>
-                    <cf-loader show-elapsed /> Thinking...
-                  </div>
-                )
-                : r
-                ? (
-                  <div>
-                    <h3>LLM Response:</h3>
-                    <pre>
-                      {r}
-                    </pre>
-                  </div>
-                )
-                : null,
-          )}
+          {llmResponse.pending
+            ? (
+              <div>
+                <cf-loader show-elapsed /> Thinking...
+              </div>
+            )
+            : llmResponse.result
+            ? (
+              <div>
+                <h3>LLM Response:</h3>
+                <pre>
+                  {llmResponse.result}
+                </pre>
+              </div>
+            )
+            : null}
         </cf-cell-context>
       </div>
     ),

--- a/packages/patterns/examples/profile-aware-writer.tsx
+++ b/packages/patterns/examples/profile-aware-writer.tsx
@@ -2,7 +2,6 @@ import {
   Cell,
   computed,
   Default,
-  derive,
   generateText,
   handler,
   NAME,
@@ -69,41 +68,35 @@ Write content personalized to the user when appropriate.`;
         </div>
 
         <cf-cell-context $cell={topic}>
-          {derive(topic, (t) =>
-            t
-              ? (
-                <div style="margin-top: 16px;">
-                  <h3>Topic:</h3>
-                  <blockquote>
-                    {t}
-                  </blockquote>
-                </div>
-              )
-              : null)}
+          {topic.get()
+            ? (
+              <div style="margin-top: 16px;">
+                <h3>Topic:</h3>
+                <blockquote>
+                  {topic.get()}
+                </blockquote>
+              </div>
+            )
+            : null}
         </cf-cell-context>
 
         <cf-cell-context $cell={result}>
-          {derive(
-            [result.pending, result.result],
-            ([pending, r]) =>
-              pending
-                ? (
-                  <div style="margin-top: 16px;">
-                    <cf-loader show-elapsed />{" "}
-                    Generating personalized content...
-                  </div>
-                )
-                : r
-                ? (
-                  <div style="margin-top: 16px;">
-                    <h3>Generated Text:</h3>
-                    <div style="white-space: pre-wrap; padding: 12px; background: #f9f9f9; border-radius: 4px; line-height: 1.6;">
-                      {r}
-                    </div>
-                  </div>
-                )
-                : null,
-          )}
+          {result.pending
+            ? (
+              <div style="margin-top: 16px;">
+                <cf-loader show-elapsed /> Generating personalized content...
+              </div>
+            )
+            : result.result
+            ? (
+              <div style="margin-top: 16px;">
+                <h3>Generated Text:</h3>
+                <div style="white-space: pre-wrap; padding: 12px; background: #f9f9f9; border-radius: 4px; line-height: 1.6;">
+                  {result.result}
+                </div>
+              </div>
+            )
+            : null}
         </cf-cell-context>
       </div>
     ),

--- a/packages/patterns/experimental/chat-note.tsx
+++ b/packages/patterns/experimental/chat-note.tsx
@@ -1,7 +1,6 @@
 import {
   computed,
   type Default,
-  derive,
   generateText,
   handler,
   NAME,
@@ -375,35 +374,34 @@ const ChatNote = pattern<Input, Output>(
     const beforeAIInsert = new Writable<string>("");
 
     // Watch for LLM streaming partial updates
-    // Use explicit dependency array for proper reactive tracking
-    derive(
-      [isGenerating, llmResponse.partial, beforeAIInsert],
-      () => {
-        const generating = isGenerating.get();
-        const partial = llmResponse.partial;
-        const prefix = beforeAIInsert.get();
-        if (generating && partial && prefix) {
-          content.set(prefix + partial);
-        }
-      },
-    );
+    // Side-effect-only reactive computation: tracks its reactive reads
+    // (isGenerating, llmResponse.partial, beforeAIInsert) automatically.
+    computed(() => {
+      const generating = isGenerating.get();
+      const partial = llmResponse.partial;
+      const prefix = beforeAIInsert.get();
+      if (generating && partial && prefix) {
+        content.set(prefix + partial);
+      }
+    });
 
     // Watch for LLM completion
-    derive(
-      [isGenerating, llmResponse.pending, llmResponse.result],
-      ([generating, pending, result]) => {
-        // When complete, finalize with result and closing separator
-        if (!pending && result && generating) {
-          const prefix = beforeAIInsert.get();
-          if (prefix) {
-            content.set(prefix + result + "\n---\n");
-          }
-          isGenerating.set(false);
-          llmMessages.set([]);
-          beforeAIInsert.set("");
+    // Side-effect-only reactive computation; reactive reads tracked automatically.
+    computed(() => {
+      const generating = isGenerating.get();
+      const pending = llmResponse.pending;
+      const result = llmResponse.result;
+      // When complete, finalize with result and closing separator
+      if (!pending && result && generating) {
+        const prefix = beforeAIInsert.get();
+        if (prefix) {
+          content.set(prefix + result + "\n---\n");
         }
-      },
-    );
+        isGenerating.set(false);
+        llmMessages.set([]);
+        beforeAIInsert.set("");
+      }
+    });
 
     // Compute parent notebook
     const parentNotebook = computed(() => {
@@ -420,10 +418,8 @@ const ChatNote = pattern<Input, Output>(
       return custom || JSON.stringify(ChatNote);
     });
 
-    // Computed for generation state display
-    const showGenerating = computed(
-      () => isGenerating.get() && llmResponse.pending,
-    );
+    // Generation state display (reactive expression auto-wraps at use sites)
+    const showGenerating = isGenerating.get() && llmResponse.pending;
 
     // Can generate when there's content and not already generating
     // Optimized to avoid splitting entire content on every keystroke
@@ -458,7 +454,7 @@ const ChatNote = pattern<Input, Output>(
     const modelChangeHandler = handleModelChange({ model });
 
     return {
-      [NAME]: computed(() => `💬 ${title.get()}`),
+      [NAME]: `💬 ${title.get()}`,
       [UI]: (
         <cf-screen>
           <cf-vstack
@@ -474,10 +470,7 @@ const ChatNote = pattern<Input, Output>(
               gap="2"
               align="center"
               style={{
-                display: computed(() => {
-                  const p = (self as any).parentNotebook;
-                  return p ? "flex" : "none";
-                }),
+                display: (self as any).parentNotebook ? "flex" : "none",
                 marginBottom: "4px",
               }}
             >
@@ -490,10 +483,8 @@ const ChatNote = pattern<Input, Output>(
                 In:
               </span>
               <cf-chip
-                label={computed(() => {
-                  const p = (self as any).parentNotebook;
-                  return p?.[NAME] ?? p?.title ?? "Notebook";
-                })}
+                label={(self as any).parentNotebook?.[NAME] ??
+                  (self as any).parentNotebook?.title ?? "Notebook"}
                 interactive
                 oncf-click={goToParent({ self })}
               />
@@ -503,9 +494,7 @@ const ChatNote = pattern<Input, Output>(
               {/* Editable Title - click to edit */}
               <div
                 style={{
-                  display: computed(() =>
-                    isEditingTitle.get() ? "none" : "flex"
-                  ),
+                  display: isEditingTitle.get() ? "none" : "flex",
                   alignItems: "center",
                   gap: "8px",
                   cursor: "pointer",
@@ -521,9 +510,7 @@ const ChatNote = pattern<Input, Output>(
               </div>
               <div
                 style={{
-                  display: computed(() =>
-                    isEditingTitle.get() ? "flex" : "none"
-                  ),
+                  display: isEditingTitle.get() ? "flex" : "none",
                   flex: 1,
                   marginRight: "12px",
                 }}
@@ -542,7 +529,7 @@ const ChatNote = pattern<Input, Output>(
                 value={model}
                 onChange={modelChangeHandler}
                 style={{
-                  display: computed(() => (showGenerating ? "none" : "block")),
+                  display: showGenerating ? "none" : "block",
                   padding: "4px 8px",
                   fontSize: "13px",
                   borderRadius: "6px",
@@ -566,9 +553,9 @@ const ChatNote = pattern<Input, Output>(
                   mentionable,
                   beforeAIInsert,
                 })}
-                disabled={computed(() => !canGenerate)}
+                disabled={!canGenerate}
                 style={{
-                  display: computed(() => (showGenerating ? "none" : "flex")),
+                  display: showGenerating ? "none" : "flex",
                 }}
                 title="Generate (Cmd+Enter)"
               >
@@ -580,7 +567,7 @@ const ChatNote = pattern<Input, Output>(
                 gap="2"
                 align="center"
                 style={{
-                  display: computed(() => (showGenerating ? "flex" : "none")),
+                  display: showGenerating ? "flex" : "none",
                   flexShrink: 0,
                 }}
               >

--- a/packages/patterns/experimental/email-task-engine.tsx
+++ b/packages/patterns/experimental/email-task-engine.tsx
@@ -23,7 +23,6 @@ import {
   derive,
   generateObject,
   handler,
-  ifElse,
   NAME,
   type Opaque,
   pattern,
@@ -471,8 +470,8 @@ export default pattern<PatternInput, PatternOutput>(({ overrideAuth }) => {
   });
 
   // Resolve auth: use overrideAuth if provided, otherwise use created auth
-  const hasOverrideAuth = computed(() => !!(overrideAuth as any)?.token);
-  const resolvedAuth = ifElse(hasOverrideAuth, overrideAuth, auth);
+  const hasOverrideAuth = !!(overrideAuth as any)?.token;
+  const resolvedAuth = hasOverrideAuth ? overrideAuth : auth;
 
   // Create a Stream from the fetchLabels handler for auto-triggering
   const labelFetcherStream = fetchLabels({
@@ -525,7 +524,7 @@ export default pattern<PatternInput, PatternOutput>(({ overrideAuth }) => {
       });
   });
 
-  const taskCount = computed(() => taskEmails?.length || 0);
+  const taskCount = taskEmails?.length || 0;
 
   // Get available notes for the LLM context
   const availableNotes = computed(() => {
@@ -592,8 +591,8 @@ Respond with the most appropriate action.`;
       model: "anthropic:claude-sonnet-4-5",
     });
 
-    // Return the cells directly without wrapping in computed
-    // This allows derive() to properly unwrap them
+    // Return the cells directly without wrapping in computed;
+    // reactive reads unwrap them at the consuming sites.
     return {
       email,
       pending: llmAnalysis.pending,
@@ -642,10 +641,7 @@ Respond with the most appropriate action.`;
       <div style={{ flex: 1 }}>
         <div style={{ fontWeight: "600", fontSize: "14px" }}>Email Tasks</div>
         <div style={{ fontSize: "12px", color: "#6b7280" }}>
-          {computed(() => {
-            const count = taskCount;
-            return count === 1 ? "1 task" : `${count} tasks`;
-          })}
+          {taskCount === 1 ? "1 task" : `${taskCount} tasks`}
         </div>
         <ProcessingStatus
           totalCount={taskCount}
@@ -681,153 +677,151 @@ Respond with the most appropriate action.`;
             {authUI}
 
             {/* Connection status and refresh */}
-            {ifElse(
-              isReady,
-              <div
-                style={{
-                  padding: "12px 16px",
-                  backgroundColor: "#d1fae5",
-                  borderRadius: "8px",
-                  border: "1px solid #10b981",
-                  display: "flex",
-                  alignItems: "center",
-                  gap: "8px",
-                }}
-              >
-                <span
+            {isReady
+              ? (
+                <div
                   style={{
-                    width: "10px",
-                    height: "10px",
-                    borderRadius: "50%",
-                    backgroundColor: "#10b981",
-                  }}
-                />
-                <span>Connected</span>
-                <span style={{ marginLeft: "auto", color: "#059669" }}>
-                  {computed(() => `${taskCount} tasks found`)}
-                </span>
-                <button
-                  type="button"
-                  onClick={extractor.refresh}
-                  style={{
-                    marginLeft: "8px",
-                    padding: "6px 12px",
-                    backgroundColor: "#10b981",
-                    color: "white",
-                    border: "none",
-                    borderRadius: "6px",
-                    cursor: "pointer",
-                    fontSize: "13px",
-                    fontWeight: "500",
+                    padding: "12px 16px",
+                    backgroundColor: "#d1fae5",
+                    borderRadius: "8px",
+                    border: "1px solid #10b981",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "8px",
                   }}
                 >
-                  Refresh
-                </button>
-              </div>,
-              null,
-            )}
+                  <span
+                    style={{
+                      width: "10px",
+                      height: "10px",
+                      borderRadius: "50%",
+                      backgroundColor: "#10b981",
+                    }}
+                  />
+                  <span>Connected</span>
+                  <span style={{ marginLeft: "auto", color: "#059669" }}>
+                    {`${taskCount} tasks found`}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={extractor.refresh}
+                    style={{
+                      marginLeft: "8px",
+                      padding: "6px 12px",
+                      backgroundColor: "#10b981",
+                      color: "white",
+                      border: "none",
+                      borderRadius: "6px",
+                      cursor: "pointer",
+                      fontSize: "13px",
+                      fontWeight: "500",
+                    }}
+                  >
+                    Refresh
+                  </button>
+                </div>
+              )
+              : null}
 
             {/* Analysis progress */}
-            {ifElse(
-              derive(
-                { isReady, pendingCount },
-                ({ isReady, pendingCount }) => isReady && pendingCount > 0,
-              ),
-              <div
-                style={{
-                  padding: "12px 16px",
-                  backgroundColor: "#eff6ff",
-                  borderRadius: "8px",
-                  border: "1px solid #3b82f6",
-                  display: "flex",
-                  alignItems: "center",
-                  gap: "8px",
-                }}
-              >
-                <cf-loader size="sm" />
-                <span style={{ color: "#2563eb" }}>
-                  Analyzing {pendingCount} tasks...
-                </span>
-              </div>,
-              null,
-            )}
-
-            {/* Label status warning */}
-            {ifElse(
-              derive(
-                { isReady, taskCurrentLabelId, loadingLabels },
-                ({ isReady, taskCurrentLabelId, loadingLabels }) =>
-                  isReady && (!taskCurrentLabelId || loadingLabels),
-              ),
-              <div
-                style={{
-                  padding: "8px 12px",
-                  backgroundColor: "#fef3c7",
-                  borderRadius: "6px",
-                  fontSize: "13px",
-                  color: "#b45309",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "space-between",
-                }}
-              >
-                {ifElse(
-                  loadingLabels,
-                  <span>Loading labels...</span>,
-                  <span>task-current label not found - click Load Labels</span>,
-                )}
-                <button
-                  type="button"
-                  onClick={labelFetcherStream}
-                  disabled={loadingLabels}
+            {isReady && pendingCount > 0
+              ? (
+                <div
                   style={{
-                    marginLeft: "8px",
-                    padding: "4px 10px",
-                    backgroundColor: loadingLabels ? "#9ca3af" : "#6366f1",
-                    color: "white",
-                    border: "none",
-                    borderRadius: "4px",
-                    fontSize: "12px",
-                    cursor: loadingLabels ? "not-allowed" : "pointer",
-                    fontWeight: "500",
+                    padding: "12px 16px",
+                    backgroundColor: "#eff6ff",
+                    borderRadius: "8px",
+                    border: "1px solid #3b82f6",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "8px",
                   }}
                 >
-                  {ifElse(loadingLabels, "Loading...", "Load Labels")}
-                </button>
-              </div>,
-              null,
-            )}
+                  <cf-loader size="sm" />
+                  <span style={{ color: "#2563eb" }}>
+                    Analyzing {pendingCount} tasks...
+                  </span>
+                </div>
+              )
+              : null}
+
+            {/* Label status warning */}
+            {isReady && (!taskCurrentLabelId.get() || loadingLabels.get())
+              ? (
+                <div
+                  style={{
+                    padding: "8px 12px",
+                    backgroundColor: "#fef3c7",
+                    borderRadius: "6px",
+                    fontSize: "13px",
+                    color: "#b45309",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                  }}
+                >
+                  {loadingLabels.get() ? <span>Loading labels...</span> : (
+                    <span>
+                      task-current label not found - click Load Labels
+                    </span>
+                  )}
+                  <button
+                    type="button"
+                    onClick={labelFetcherStream}
+                    disabled={loadingLabels.get()}
+                    style={{
+                      marginLeft: "8px",
+                      padding: "4px 10px",
+                      backgroundColor: loadingLabels.get()
+                        ? "#9ca3af"
+                        : "#6366f1",
+                      color: "white",
+                      border: "none",
+                      borderRadius: "4px",
+                      fontSize: "12px",
+                      cursor: loadingLabels.get() ? "not-allowed" : "pointer",
+                      fontWeight: "500",
+                    }}
+                  >
+                    {loadingLabels.get() ? "Loading..." : "Load Labels"}
+                  </button>
+                </div>
+              )
+              : null}
 
             {/* Task cards */}
-            {ifElse(
-              derive(taskCount, (count) => count === 0),
-              <div
-                style={{
-                  padding: "24px",
-                  textAlign: "center",
-                  color: "#6b7280",
-                  backgroundColor: "#f9fafb",
-                  borderRadius: "8px",
-                }}
-              >
-                <div style={{ fontSize: "16px", marginBottom: "8px" }}>
-                  No tasks found
+            {taskCount === 0
+              ? (
+                <div
+                  style={{
+                    padding: "24px",
+                    textAlign: "center",
+                    color: "#6b7280",
+                    backgroundColor: "#f9fafb",
+                    borderRadius: "8px",
+                  }}
+                >
+                  <div style={{ fontSize: "16px", marginBottom: "8px" }}>
+                    No tasks found
+                  </div>
+                  <div style={{ fontSize: "13px" }}>
+                    Send yourself an email with a subject and add the
+                    "task-current" label to see it here.
+                  </div>
                 </div>
-                <div style={{ fontSize: "13px" }}>
-                  Send yourself an email with a subject and add the
-                  "task-current" label to see it here.
-                </div>
-              </div>,
-              <cf-vstack gap="3">
-                {analyses.map((analysis) => {
-                  const isProcessing = computed(() =>
-                    processingTasks.get().includes(analysis.email.id)
-                  );
+              )
+              : (
+                <cf-vstack gap="3">
+                  {analyses.map((analysis) => {
+                    const isProcessing = processingTasks.get().includes(
+                      analysis.email.id,
+                    );
 
-                  // Determine card border color based on suggestion type
-                  const borderColor = derive(
-                    { pending: analysis.pending, result: analysis.result },
-                    ({ pending, result }) => {
+                    // Determine card border color based on suggestion type.
+                    // Statement body (early returns) → keep as a computed.
+                    const borderColor = computed(() => {
+                      const pending = analysis.pending;
+                      const result = analysis.result;
                       if (pending) return "#e5e7eb";
                       if (!result || result.actionType === "no-action") {
                         return "#e5e7eb";
@@ -835,13 +829,12 @@ Respond with the most appropriate action.`;
                       if (result.confidence >= 0.8) return "#10b981"; // High confidence - green
                       if (result.confidence >= 0.5) return "#f59e0b"; // Medium - amber
                       return "#e5e7eb"; // Low - neutral
-                    },
-                  );
+                    });
 
-                  // Pre-compute the handler based on action type BEFORE the button
-                  const executeHandler = derive(
-                    analysis.result,
-                    (result) => {
+                    // Pre-compute the handler based on action type BEFORE the
+                    // button. Statement body (branching) → keep as a computed.
+                    const executeHandler = computed(() => {
+                      const result = analysis.result;
                       if (result?.actionType === "edit-note") {
                         return executeEditNote({
                           removeLabels: extractor.removeLabels,
@@ -866,202 +859,178 @@ Respond with the most appropriate action.`;
                         });
                       }
                       return null;
-                    },
-                  );
+                    });
 
-                  return (
-                    <div
-                      style={{
-                        padding: "16px",
-                        backgroundColor: "#ffffff",
-                        borderRadius: "8px",
-                        border: derive(borderColor, (c) => `2px solid ${c}`),
-                        boxShadow: "0 1px 2px rgba(0, 0, 0, 0.05)",
-                      }}
-                    >
-                      {/* Email header */}
+                    return (
                       <div
                         style={{
-                          display: "flex",
-                          alignItems: "flex-start",
-                          justifyContent: "space-between",
-                          marginBottom: "12px",
+                          padding: "16px",
+                          backgroundColor: "#ffffff",
+                          borderRadius: "8px",
+                          border: `2px solid ${borderColor}`,
+                          boxShadow: "0 1px 2px rgba(0, 0, 0, 0.05)",
                         }}
                       >
-                        <div style={{ flex: 1 }}>
-                          <div
-                            style={{
-                              fontWeight: "600",
-                              fontSize: "14px",
-                              marginBottom: "4px",
-                            }}
-                          >
-                            {derive(analysis, (a) => a.email.subject)}
-                          </div>
-                          <div
-                            style={{
-                              fontSize: "12px",
-                              color: "#6b7280",
-                              marginBottom: "4px",
-                            }}
-                          >
-                            {derive(analysis, (a) => a.email.from)} •{" "}
-                            {derive(analysis, (a) => formatDate(a.email.date))}
-                          </div>
-                          <div
-                            style={{
-                              fontSize: "13px",
-                              color: "#4b5563",
-                            }}
-                          >
-                            {derive(
-                              analysis,
-                              (a) => truncateText(a.email.snippet, 150),
-                            )}
-                          </div>
-                        </div>
-
-                        {/* Confidence badge */}
-                        {ifElse(
-                          derive(
-                            {
-                              pending: analysis.pending,
-                              result: analysis.result,
-                            },
-                            ({ pending, result }) => !pending && result,
-                          ),
-                          <div
-                            style={{
-                              padding: "2px 8px",
-                              borderRadius: "12px",
-                              fontSize: "11px",
-                              fontWeight: "500",
-                              backgroundColor: derive(
-                                analysis.result,
-                                (result) => {
-                                  if (!result) return "#f3f4f6";
-                                  if (result.confidence >= 0.8) {
-                                    return "#d1fae5";
-                                  }
-                                  if (result.confidence >= 0.5) {
-                                    return "#fef3c7";
-                                  }
-                                  return "#f3f4f6";
-                                },
-                              ),
-                              color: derive(
-                                analysis.result,
-                                (result) => {
-                                  if (!result) return "#6b7280";
-                                  if (result.confidence >= 0.8) {
-                                    return "#059669";
-                                  }
-                                  if (result.confidence >= 0.5) {
-                                    return "#b45309";
-                                  }
-                                  return "#6b7280";
-                                },
-                              ),
-                            }}
-                          >
-                            {derive(
-                              analysis.result,
-                              (result) =>
-                                result
-                                  ? `${Math.round(result.confidence * 100)}%`
-                                  : "",
-                            )}
-                          </div>,
-                          null,
-                        )}
-                      </div>
-
-                      {/* Suggestion section */}
-                      {ifElse(
-                        analysis.pending,
+                        {/* Email header */}
                         <div
                           style={{
                             display: "flex",
-                            alignItems: "center",
-                            gap: "8px",
-                            padding: "12px",
-                            backgroundColor: "#f9fafb",
-                            borderRadius: "6px",
+                            alignItems: "flex-start",
+                            justifyContent: "space-between",
+                            marginBottom: "12px",
                           }}
                         >
-                          <cf-loader size="sm" />
-                          <span style={{ fontSize: "13px", color: "#6b7280" }}>
-                            Analyzing...
-                          </span>
-                        </div>,
-                        // Show suggestion when analysis is complete
-                        ifElse(
-                          derive(
-                            analysis.result,
-                            (result) => result?.actionType === "edit-note",
-                          ),
-                          // Edit note suggestion
-                          <div
-                            style={{
-                              padding: "12px",
-                              backgroundColor: "#eff6ff",
-                              borderRadius: "6px",
-                              marginBottom: "12px",
-                            }}
-                          >
+                          <div style={{ flex: 1 }}>
                             <div
                               style={{
                                 fontWeight: "600",
-                                fontSize: "13px",
-                                color: "#1d4ed8",
+                                fontSize: "14px",
                                 marginBottom: "4px",
                               }}
                             >
-                              Suggest: Edit note "
-                              {derive(analysis.result, (result) =>
-                                result?.actionType === "edit-note"
-                                  ? result.noteTitle || ""
-                                  : "")}
-                              "
+                              {analysis.email.subject}
+                            </div>
+                            <div
+                              style={{
+                                fontSize: "12px",
+                                color: "#6b7280",
+                                marginBottom: "4px",
+                              }}
+                            >
+                              {analysis.email.from} •{" "}
+                              {formatDate(analysis.email.date)}
                             </div>
                             <div
                               style={{
                                 fontSize: "13px",
                                 color: "#4b5563",
-                                marginBottom: "8px",
-                                fontStyle: "italic",
                               }}
                             >
-                              {derive(
-                                analysis.result,
-                                (result) => result?.reasoning || "",
-                              )}
+                              {truncateText(analysis.email.snippet, 150)}
                             </div>
+                          </div>
+
+                          {/* Confidence badge */}
+                          {!analysis.pending && analysis.result
+                            ? (
+                              <div
+                                style={{
+                                  padding: "2px 8px",
+                                  borderRadius: "12px",
+                                  fontSize: "11px",
+                                  fontWeight: "500",
+                                  backgroundColor: computed(() => {
+                                    const result = analysis.result;
+                                    if (!result) return "#f3f4f6";
+                                    if (result.confidence >= 0.8) {
+                                      return "#d1fae5";
+                                    }
+                                    if (result.confidence >= 0.5) {
+                                      return "#fef3c7";
+                                    }
+                                    return "#f3f4f6";
+                                  }),
+                                  color: computed(() => {
+                                    const result = analysis.result;
+                                    if (!result) return "#6b7280";
+                                    if (result.confidence >= 0.8) {
+                                      return "#059669";
+                                    }
+                                    if (result.confidence >= 0.5) {
+                                      return "#b45309";
+                                    }
+                                    return "#6b7280";
+                                  }),
+                                }}
+                              >
+                                {analysis.result
+                                  ? `${
+                                    Math.round(analysis.result.confidence * 100)
+                                  }%`
+                                  : ""}
+                              </div>
+                            )
+                            : null}
+                        </div>
+
+                        {/* Suggestion section */}
+                        {analysis.pending
+                          ? (
                             <div
                               style={{
-                                fontSize: "13px",
-                                color: "#374151",
-                                padding: "8px",
-                                backgroundColor: "#ffffff",
-                                borderRadius: "4px",
-                                border: "1px solid #e5e7eb",
+                                display: "flex",
+                                alignItems: "center",
+                                gap: "8px",
+                                padding: "12px",
+                                backgroundColor: "#f9fafb",
+                                borderRadius: "6px",
                               }}
                             >
-                              {derive(
-                                analysis.result,
-                                (result) =>
-                                  result?.actionType === "edit-note"
-                                    ? truncateText(result.addition || "", 200)
-                                    : "",
-                              )}
+                              <cf-loader size="sm" />
+                              <span
+                                style={{ fontSize: "13px", color: "#6b7280" }}
+                              >
+                                Analyzing...
+                              </span>
                             </div>
-                          </div>,
-                          ifElse(
-                            derive(
-                              analysis.result,
-                              (result) =>
-                                result?.actionType === "create-note",
-                            ),
+                          )
+                          // Show suggestion when analysis is complete
+                          : analysis.result?.actionType === "edit-note"
+                          ? (
+                            // Edit note suggestion
+                            <div
+                              style={{
+                                padding: "12px",
+                                backgroundColor: "#eff6ff",
+                                borderRadius: "6px",
+                                marginBottom: "12px",
+                              }}
+                            >
+                              <div
+                                style={{
+                                  fontWeight: "600",
+                                  fontSize: "13px",
+                                  color: "#1d4ed8",
+                                  marginBottom: "4px",
+                                }}
+                              >
+                                Suggest: Edit note "
+                                {analysis.result?.actionType === "edit-note"
+                                  ? analysis.result.noteTitle || ""
+                                  : ""}
+                                "
+                              </div>
+                              <div
+                                style={{
+                                  fontSize: "13px",
+                                  color: "#4b5563",
+                                  marginBottom: "8px",
+                                  fontStyle: "italic",
+                                }}
+                              >
+                                {analysis.result?.reasoning || ""}
+                              </div>
+                              <div
+                                style={{
+                                  fontSize: "13px",
+                                  color: "#374151",
+                                  padding: "8px",
+                                  backgroundColor: "#ffffff",
+                                  borderRadius: "4px",
+                                  border: "1px solid #e5e7eb",
+                                }}
+                              >
+                                {analysis.result?.actionType === "edit-note"
+                                  ? truncateText(
+                                    analysis.result.addition || "",
+                                    200,
+                                  )
+                                  : ""}
+                              </div>
+                            </div>
+                          )
+                          : analysis.result?.actionType === "create-note"
+                          ? (
                             // Create note suggestion
                             <div
                               style={{
@@ -1080,13 +1049,9 @@ Respond with the most appropriate action.`;
                                 }}
                               >
                                 Suggest: Create note "
-                                {derive(
-                                  analysis.result,
-                                  (result) =>
-                                    result?.actionType === "create-note"
-                                      ? result.title || ""
-                                      : "",
-                                )}
+                                {analysis.result?.actionType === "create-note"
+                                  ? analysis.result.title || ""
+                                  : ""}
                                 "
                               </div>
                               <div
@@ -1097,10 +1062,7 @@ Respond with the most appropriate action.`;
                                   fontStyle: "italic",
                                 }}
                               >
-                                {derive(
-                                  analysis.result,
-                                  (result) => result?.reasoning || "",
-                                )}
+                                {analysis.result?.reasoning || ""}
                               </div>
                               <div
                                 style={{
@@ -1112,16 +1074,17 @@ Respond with the most appropriate action.`;
                                   border: "1px solid #e5e7eb",
                                 }}
                               >
-                                {derive(
-                                  analysis.result,
-                                  (result) =>
-                                    result?.actionType === "create-note"
-                                      ? truncateText(result.content || "", 200)
-                                      : "",
-                                )}
+                                {analysis.result?.actionType === "create-note"
+                                  ? truncateText(
+                                    analysis.result.content || "",
+                                    200,
+                                  )
+                                  : ""}
                               </div>
-                            </div>,
-                            // No action or low confidence
+                            </div>
+                          )
+                          // No action or low confidence
+                          : (
                             <div
                               style={{
                                 padding: "12px",
@@ -1136,109 +1099,93 @@ Respond with the most appropriate action.`;
                                   color: "#6b7280",
                                 }}
                               >
-                                {derive(
-                                  analysis.result,
-                                  (result) =>
-                                    result?.actionType === "no-action"
-                                      ? `No auto-suggestion: ${
-                                        result.reason || ""
-                                      }`
-                                      : "No auto-suggestion available",
-                                )}
+                                {analysis.result?.actionType === "no-action"
+                                  ? `No auto-suggestion: ${
+                                    analysis.result.reason || ""
+                                  }`
+                                  : "No auto-suggestion available"}
                               </div>
-                            </div>,
-                          ),
-                        ),
-                      )}
-
-                      {/* Action buttons */}
-                      {ifElse(
-                        derive(analysis.pending, (pending) => !pending),
-                        <div
-                          style={{
-                            display: "flex",
-                            gap: "8px",
-                            justifyContent: "flex-end",
-                          }}
-                        >
-                          {/* Execute button - only show for actionable suggestions */}
-                          {ifElse(
-                            derive(
-                              analysis.result,
-                              (result) => {
-                                return (
-                                  result &&
-                                  (result.actionType === "edit-note" ||
-                                    result.actionType === "create-note")
-                                );
-                              },
-                            ),
-                            <button
-                              type="button"
-                              onClick={executeHandler}
-                              disabled={derive(
-                                { isProcessing, taskCurrentLabelId },
-                                ({ isProcessing, taskCurrentLabelId }) =>
-                                  isProcessing || !taskCurrentLabelId,
-                              )}
-                              style={{
-                                padding: "6px 16px",
-                                backgroundColor: isProcessing
-                                  ? "#e5e7eb"
-                                  : "#10b981",
-                                color: isProcessing ? "#9ca3af" : "white",
-                                border: "none",
-                                borderRadius: "6px",
-                                fontSize: "13px",
-                                cursor: isProcessing
-                                  ? "not-allowed"
-                                  : "pointer",
-                                fontWeight: "500",
-                              }}
-                            >
-                              {ifElse(isProcessing, "Processing...", "Execute")}
-                            </button>,
-                            null,
+                            </div>
                           )}
 
-                          {/* Dismiss button */}
-                          <button
-                            type="button"
-                            onClick={dismissTask({
-                              removeLabels: extractor.removeLabels,
-                              emailId: analysis.email.id,
-                              taskCurrentLabelId,
-                              hiddenTasks,
-                              processingTasks,
-                            })}
-                            disabled={derive(
-                              { isProcessing, taskCurrentLabelId },
-                              ({ isProcessing, taskCurrentLabelId }) =>
-                                isProcessing || !taskCurrentLabelId,
-                            )}
-                            style={{
-                              padding: "6px 16px",
-                              backgroundColor: isProcessing
-                                ? "#e5e7eb"
-                                : "#f3f4f6",
-                              color: isProcessing ? "#9ca3af" : "#4b5563",
-                              border: "1px solid #e5e7eb",
-                              borderRadius: "6px",
-                              fontSize: "13px",
-                              cursor: isProcessing ? "not-allowed" : "pointer",
-                              fontWeight: "500",
-                            }}
-                          >
-                            Dismiss
-                          </button>
-                        </div>,
-                        null,
-                      )}
-                    </div>
-                  );
-                })}
-              </cf-vstack>,
-            )}
+                        {/* Action buttons */}
+                        {!analysis.pending
+                          ? (
+                            <div
+                              style={{
+                                display: "flex",
+                                gap: "8px",
+                                justifyContent: "flex-end",
+                              }}
+                            >
+                              {/* Execute button - only show for actionable suggestions */}
+                              {analysis.result &&
+                                  (analysis.result.actionType === "edit-note" ||
+                                    analysis.result.actionType ===
+                                      "create-note")
+                                ? (
+                                  <button
+                                    type="button"
+                                    onClick={executeHandler}
+                                    disabled={isProcessing ||
+                                      !taskCurrentLabelId.get()}
+                                    style={{
+                                      padding: "6px 16px",
+                                      backgroundColor: isProcessing
+                                        ? "#e5e7eb"
+                                        : "#10b981",
+                                      color: isProcessing ? "#9ca3af" : "white",
+                                      border: "none",
+                                      borderRadius: "6px",
+                                      fontSize: "13px",
+                                      cursor: isProcessing
+                                        ? "not-allowed"
+                                        : "pointer",
+                                      fontWeight: "500",
+                                    }}
+                                  >
+                                    {isProcessing ? "Processing..." : "Execute"}
+                                  </button>
+                                )
+                                : null}
+
+                              {/* Dismiss button */}
+                              <button
+                                type="button"
+                                onClick={dismissTask({
+                                  removeLabels: extractor.removeLabels,
+                                  emailId: analysis.email.id,
+                                  taskCurrentLabelId,
+                                  hiddenTasks,
+                                  processingTasks,
+                                })}
+                                disabled={isProcessing ||
+                                  !taskCurrentLabelId.get()}
+                                style={{
+                                  padding: "6px 16px",
+                                  backgroundColor: isProcessing
+                                    ? "#e5e7eb"
+                                    : "#f3f4f6",
+                                  color: isProcessing ? "#9ca3af" : "#4b5563",
+                                  border: "1px solid #e5e7eb",
+                                  borderRadius: "6px",
+                                  fontSize: "13px",
+                                  cursor: isProcessing
+                                    ? "not-allowed"
+                                    : "pointer",
+                                  fontWeight: "500",
+                                }}
+                              >
+                                Dismiss
+                              </button>
+                            </div>
+                          )
+                          : null}
+                      </div>
+                    );
+                  })}
+                </cf-vstack>
+              )}
           </cf-vstack>
         </cf-vscroll>
       </cf-screen>

--- a/packages/patterns/experimental/email-task-engine.tsx
+++ b/packages/patterns/experimental/email-task-engine.tsx
@@ -20,7 +20,6 @@
 import {
   computed,
   Default,
-  derive,
   generateObject,
   handler,
   NAME,

--- a/packages/patterns/experimental/folksonomy-demo.tsx
+++ b/packages/patterns/experimental/folksonomy-demo.tsx
@@ -18,15 +18,7 @@
  * - Community suggestions show dimmed with usage counts
  * - Events are posted to the aggregator in real-time
  */
-import {
-  type Default,
-  derive,
-  NAME,
-  pattern,
-  UI,
-  wish,
-  Writable,
-} from "commonfabric";
+import { type Default, NAME, pattern, UI, wish, Writable } from "commonfabric";
 
 // Import the FolksonomyTags sub-pattern
 import { FolksonomyTags } from "./folksonomy-tags.tsx";
@@ -59,17 +51,12 @@ export default pattern<Input, Output>(
       query: "#folksonomy-aggregator",
       scope: ["~", "."],
     });
-    const hasAggregator = derive(
-      aggregatorWish.result,
-      (agg: unknown) => agg != null,
-    );
+    const hasAggregator = aggregatorWish.result != null;
 
     // Shared scope for A and B
-    const sharedScope = derive(
-      customScope,
-      (cs: string) =>
-        `https://github.com/commontools/folksonomy-demo/${cs || "demo-shared"}`,
-    );
+    const sharedScope = `https://github.com/commontools/folksonomy-demo/${
+      customScope || "demo-shared"
+    }`;
 
     // Isolated scope for C
     const isolatedScope = new Writable(

--- a/packages/patterns/experimental/folksonomy-tags.tsx
+++ b/packages/patterns/experimental/folksonomy-tags.tsx
@@ -28,8 +28,8 @@
  * cf-render boundaries, we use $value binding instead of oncf-select handlers.
  */
 import {
+  computed,
   type Default,
-  derive,
   handler,
   lift,
   NAME,
@@ -140,7 +140,7 @@ const _postTelemetryEvent = handler<
     timestamp: safeDateNow(),
   };
 
-  // Stream from derive() is a Cell containing the stream - call .send() directly
+  // Stream projected from the aggregator is a Cell containing the stream - call .send() directly
   try {
     aggregatorStream.send(tagEvent);
   } catch (e) {
@@ -290,54 +290,37 @@ export const FolksonomyTags = pattern<
     });
 
     // Use injected aggregator if available, otherwise use wish result
-    const aggregator = derive(
-      [injectedAggregator, aggregatorWish.result],
-      (
-        [injected, wished]: [
-          AggregatorCharm | undefined,
-          AggregatorCharm | null,
-        ],
-      ) => injected ?? wished ?? null,
-    );
+    const aggregator = injectedAggregator ?? aggregatorWish.result ?? null;
 
     // Get the aggregator's postEvent stream for telemetry
-    const aggregatorStream = derive(
-      aggregator,
-      (agg: AggregatorCharm | null) =>
-        (agg?.postEvent as Stream<TagEvent>) ?? null,
-    );
+    const aggregatorStream = (aggregator?.postEvent as Stream<TagEvent>) ??
+      null;
 
     // Track previous tags for change detection
     const previousTags = new Writable<string[]>([]).for("previousTags");
 
     // Get community suggestions for this scope
-    const communitySuggestions = derive(
-      [aggregator, scope],
-      ([agg, scopeValue]: [AggregatorCharm | null, string]) => {
-        if (!agg || !scopeValue) return [];
-        const suggs = agg.suggestions || {};
-        return suggs[scopeValue] || [];
-      },
-    );
+    const communitySuggestions = computed(() => {
+      const scopeValue = scope.get();
+      if (!aggregator || !scopeValue) return [];
+      const suggs = aggregator.suggestions || {};
+      return suggs[scopeValue] || [];
+    });
 
-    // For now, local tags are just the current tags (same scope within same charm)
-    const localTags = derive(tags, (t: string[]) => t || []);
-
-    // Build autocomplete items combining local and community
+    // Build autocomplete items combining local and community.
+    // Local tags are just the current tags (same scope within same charm).
     const autocompleteItems = buildAutocompleteItems({
-      localTags,
+      localTags: tags,
       communitySuggestions,
       currentTags: tags,
     });
 
     // Check if aggregator is connected
-    const hasAggregator = derive(
-      aggregator,
-      (agg: AggregatorCharm | null) => agg != null,
-    );
+    const hasAggregator = aggregator != null;
 
     // Computed name for display
-    const displayName = derive(tags, (tagList: string[]) => {
+    const displayName = computed(() => {
+      const tagList = tags.get();
       if (!tagList || tagList.length === 0) return "🏷️ Tags";
       return `🏷️ Tags (${tagList.length})`;
     });

--- a/packages/patterns/github-activity/main.tsx
+++ b/packages/patterns/github-activity/main.tsx
@@ -1,7 +1,6 @@
 import {
   computed,
   Default,
-  derive,
   fetchData,
   generateText,
   NAME,
@@ -93,30 +92,27 @@ export default pattern<{
         </div>
 
         <cf-cell-context $cell={summary.pending}>
-          {derive(
-            [summary.pending, summary.result],
-            ([pending, result]) =>
-              pending
-                ? (
-                  <div style="margin-bottom: 16px;">
-                    <cf-loader show-elapsed /> Generating summary...
-                  </div>
-                )
-                : result
-                ? (
-                  <div style="margin-bottom: 16px; padding: 12px; background: #f5f5f5; border-radius: 4px;">
-                    <h3 style="margin: 0 0 8px 0; font-size: 14px; font-weight: 600;">
-                      Activity Summary
-                    </h3>
-                    <p style="margin: 0; line-height: 1.5;">{result}</p>
-                  </div>
-                )
-                : null,
-          )}
+          {summary.pending
+            ? (
+              <div style="margin-bottom: 16px;">
+                <cf-loader show-elapsed /> Generating summary...
+              </div>
+            )
+            : summary.result
+            ? (
+              <div style="margin-bottom: 16px; padding: 12px; background: #f5f5f5; border-radius: 4px;">
+                <h3 style="margin: 0 0 8px 0; font-size: 14px; font-weight: 600;">
+                  Activity Summary
+                </h3>
+                <p style="margin: 0; line-height: 1.5;">{summary.result}</p>
+              </div>
+            )
+            : null}
         </cf-cell-context>
 
         <cf-cell-context $cell={commits}>
-          {derive(commits, (commitList) => {
+          {computed(() => {
+            const commitList = commits;
             if (!commitList || commitList.length === 0) {
               return (
                 <div style="padding: 16px; text-align: center; color: #666;">

--- a/packages/patterns/google/core/experimental/calendar-event-manager.tsx
+++ b/packages/patterns/google/core/experimental/calendar-event-manager.tsx
@@ -22,10 +22,9 @@
  */
 
 import {
+  computed,
   Default,
-  derive,
   handler,
-  ifElse,
   NAME,
   pattern,
   UI,
@@ -438,16 +437,12 @@ export default pattern<Input, Output>(({ draft, existingEvent }) => {
   const result = new Writable<OperationResult>(null);
 
   // Computed helpers
-  const hasExistingEvent = derive(existingEvent, (e) => !!e?.id);
-  const canCreate = derive(
-    { hasAuth, draft, processing },
-    ({ hasAuth, draft, processing }) =>
-      hasAuth &&
-      draft.summary.trim() !== "" &&
-      draft.start.trim() !== "" &&
-      draft.end.trim() !== "" &&
-      !processing,
-  );
+  const hasExistingEvent = !!existingEvent?.id;
+  const canCreate = hasAuth &&
+    draft.summary.trim() !== "" &&
+    draft.start.trim() !== "" &&
+    draft.end.trim() !== "" &&
+    !processing.get();
 
   return {
     [NAME]: "Calendar Manager",
@@ -469,121 +464,120 @@ export default pattern<Input, Output>(({ draft, existingEvent }) => {
         {fullUI}
 
         {/* Result display */}
-        {ifElse(
-          derive(result, (r: OperationResult) => r?.success === true),
-          <div
-            style={{
-              padding: "16px",
-              background: "#d1fae5",
-              borderRadius: "8px",
-              border: "1px solid #10b981",
-            }}
-          >
+        {result.get()?.success === true
+          ? (
             <div
               style={{
-                display: "flex",
-                justifyContent: "space-between",
-                alignItems: "flex-start",
+                padding: "16px",
+                background: "#d1fae5",
+                borderRadius: "8px",
+                border: "1px solid #10b981",
               }}
             >
-              <div>
-                <div
+              <div
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "flex-start",
+                }}
+              >
+                <div>
+                  <div
+                    style={{
+                      fontWeight: "bold",
+                      marginBottom: "4px",
+                      color: "#065f46",
+                    }}
+                  >
+                    {computed(() => {
+                      switch (result.get()?.operation) {
+                        case "create":
+                          return "Event Created!";
+                        case "update":
+                          return "Event Updated!";
+                        case "delete":
+                          return "Event Deleted!";
+                        case "rsvp":
+                          return "RSVP Sent!";
+                        default:
+                          return "Success!";
+                      }
+                    })}
+                  </div>
+                  {!!result.get()?.eventId
+                    ? (
+                      <div style={{ fontSize: "12px", color: "#047857" }}>
+                        Event ID: {result.get()?.eventId}
+                      </div>
+                    )
+                    : null}
+                </div>
+                <button
+                  type="button"
+                  onClick={dismissResult({ result })}
                   style={{
-                    fontWeight: "bold",
-                    marginBottom: "4px",
+                    background: "none",
+                    border: "none",
+                    cursor: "pointer",
+                    fontSize: "18px",
                     color: "#065f46",
                   }}
                 >
-                  {derive(result, (r: OperationResult) => {
-                    switch (r?.operation) {
-                      case "create":
-                        return "Event Created!";
-                      case "update":
-                        return "Event Updated!";
-                      case "delete":
-                        return "Event Deleted!";
-                      case "rsvp":
-                        return "RSVP Sent!";
-                      default:
-                        return "Success!";
-                    }
-                  })}
-                </div>
-                {ifElse(
-                  derive(result, (r: OperationResult) => !!r?.eventId),
-                  <div style={{ fontSize: "12px", color: "#047857" }}>
-                    Event ID:{" "}
-                    {derive(result, (r: OperationResult) => r?.eventId)}
-                  </div>,
-                  null,
-                )}
+                  ×
+                </button>
               </div>
-              <button
-                type="button"
-                onClick={dismissResult({ result })}
-                style={{
-                  background: "none",
-                  border: "none",
-                  cursor: "pointer",
-                  fontSize: "18px",
-                  color: "#065f46",
-                }}
-              >
-                ×
-              </button>
             </div>
-          </div>,
-          null,
-        )}
+          )
+          : null}
 
-        {ifElse(
-          derive(result, (r: OperationResult) => r?.success === false),
-          <div
-            style={{
-              padding: "16px",
-              background: "#fee2e2",
-              borderRadius: "8px",
-              border: "1px solid #ef4444",
-            }}
-          >
+        {result.get()?.success === false
+          ? (
             <div
               style={{
-                display: "flex",
-                justifyContent: "space-between",
-                alignItems: "flex-start",
+                padding: "16px",
+                background: "#fee2e2",
+                borderRadius: "8px",
+                border: "1px solid #ef4444",
               }}
             >
-              <div>
-                <div
+              <div
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "flex-start",
+                }}
+              >
+                <div>
+                  <div
+                    style={{
+                      fontWeight: "bold",
+                      marginBottom: "4px",
+                      color: "#991b1b",
+                    }}
+                  >
+                    Operation Failed
+                  </div>
+                  <div style={{ fontSize: "14px", color: "#b91c1c" }}>
+                    {result.get()?.error}
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={dismissResult({ result })}
                   style={{
-                    fontWeight: "bold",
-                    marginBottom: "4px",
+                    background: "none",
+                    border: "none",
+                    cursor: "pointer",
+                    fontSize: "18px",
                     color: "#991b1b",
                   }}
                 >
-                  Operation Failed
-                </div>
-                <div style={{ fontSize: "14px", color: "#b91c1c" }}>
-                  {derive(result, (r: OperationResult) => r?.error)}
-                </div>
+                  ×
+                </button>
               </div>
-              <button
-                type="button"
-                onClick={dismissResult({ result })}
-                style={{
-                  background: "none",
-                  border: "none",
-                  cursor: "pointer",
-                  fontSize: "18px",
-                  color: "#991b1b",
-                }}
-              >
-                ×
-              </button>
             </div>
-          </div>,
-          null,
-        )}
+          )
+          : null}
 
         {/* Event form */}
         <div
@@ -598,27 +592,24 @@ export default pattern<Input, Output>(({ draft, existingEvent }) => {
           }}
         >
           {/* Existing event indicator */}
-          {ifElse(
-            hasExistingEvent,
-            <div
-              style={{
-                padding: "8px 12px",
-                background: "#dbeafe",
-                borderRadius: "6px",
-                fontSize: "13px",
-                color: "#1e40af",
-              }}
-            >
-              Editing event:{" "}
-              <strong>
-                {derive(
-                  existingEvent,
-                  (e: ExistingEvent) => e?.summary || e?.id,
-                )}
-              </strong>
-            </div>,
-            null,
-          )}
+          {hasExistingEvent
+            ? (
+              <div
+                style={{
+                  padding: "8px 12px",
+                  background: "#dbeafe",
+                  borderRadius: "6px",
+                  fontSize: "13px",
+                  color: "#1e40af",
+                }}
+              >
+                Editing event:{" "}
+                <strong>
+                  {existingEvent?.summary || existingEvent?.id}
+                </strong>
+              </div>
+            )
+            : null}
 
           <div>
             <label
@@ -737,13 +728,11 @@ export default pattern<Input, Output>(({ draft, existingEvent }) => {
             style={{ display: "flex", gap: "12px", flexWrap: "wrap" }}
           >
             {/* Create button (shown when no existing event) */}
-            {ifElse(
-              hasExistingEvent,
-              null,
+            {hasExistingEvent ? null : (
               <button
                 type="button"
                 onClick={prepareCreate({ draft, pendingOp })}
-                disabled={derive(canCreate, (can) => !can)}
+                disabled={!canCreate}
                 style={{
                   padding: "12px 24px",
                   background: "#2563eb",
@@ -753,279 +742,245 @@ export default pattern<Input, Output>(({ draft, existingEvent }) => {
                   fontSize: "14px",
                   fontWeight: "500",
                   cursor: "pointer",
-                  opacity: derive(canCreate, (can) => (can ? 1 : 0.5)),
+                  opacity: canCreate ? 1 : 0.5,
                 }}
               >
                 Create Event
-              </button>,
+              </button>
             )}
 
             {/* Update/Delete/RSVP buttons (shown when existing event) */}
-            {ifElse(
-              hasExistingEvent,
-              <div style={{ display: "flex", gap: "8px", flexWrap: "wrap" }}>
-                <button
-                  type="button"
-                  onClick={prepareUpdate({ draft, existingEvent, pendingOp })}
-                  disabled={derive(canCreate, (can) => !can)}
-                  style={{
-                    padding: "10px 20px",
-                    background: "#2563eb",
-                    color: "white",
-                    border: "none",
-                    borderRadius: "6px",
-                    fontSize: "14px",
-                    fontWeight: "500",
-                    cursor: "pointer",
-                    opacity: derive(canCreate, (can) => (can ? 1 : 0.5)),
-                  }}
-                >
-                  Update Event
-                </button>
-                <button
-                  type="button"
-                  onClick={prepareDelete({ draft, existingEvent, pendingOp })}
-                  disabled={processing}
-                  style={{
-                    padding: "10px 20px",
-                    background: "#dc2626",
-                    color: "white",
-                    border: "none",
-                    borderRadius: "6px",
-                    fontSize: "14px",
-                    fontWeight: "500",
-                    cursor: "pointer",
-                  }}
-                >
-                  Delete Event
-                </button>
-                <div
-                  style={{
-                    display: "flex",
-                    gap: "4px",
-                    marginLeft: "8px",
-                    alignItems: "center",
-                  }}
-                >
-                  <span
-                    style={{
-                      fontSize: "13px",
-                      color: "#6b7280",
-                      marginRight: "4px",
-                    }}
-                  >
-                    RSVP:
-                  </span>
+            {hasExistingEvent
+              ? (
+                <div style={{ display: "flex", gap: "8px", flexWrap: "wrap" }}>
                   <button
                     type="button"
-                    onClick={prepareRsvp({
-                      status: "accepted",
-                      draft,
-                      existingEvent,
-                      pendingOp,
-                    })}
-                    disabled={processing}
+                    onClick={prepareUpdate({ draft, existingEvent, pendingOp })}
+                    disabled={!canCreate}
                     style={{
-                      padding: "8px 12px",
-                      background: "#10b981",
+                      padding: "10px 20px",
+                      background: "#2563eb",
                       color: "white",
                       border: "none",
                       borderRadius: "6px",
-                      fontSize: "13px",
+                      fontSize: "14px",
+                      fontWeight: "500",
                       cursor: "pointer",
+                      opacity: canCreate ? 1 : 0.5,
                     }}
                   >
-                    Accept
+                    Update Event
                   </button>
                   <button
                     type="button"
-                    onClick={prepareRsvp({
-                      status: "tentative",
-                      draft,
-                      existingEvent,
-                      pendingOp,
-                    })}
+                    onClick={prepareDelete({ draft, existingEvent, pendingOp })}
                     disabled={processing}
                     style={{
-                      padding: "8px 12px",
-                      background: "#f59e0b",
+                      padding: "10px 20px",
+                      background: "#dc2626",
                       color: "white",
                       border: "none",
                       borderRadius: "6px",
-                      fontSize: "13px",
+                      fontSize: "14px",
+                      fontWeight: "500",
                       cursor: "pointer",
                     }}
                   >
-                    Maybe
+                    Delete Event
                   </button>
-                  <button
-                    type="button"
-                    onClick={prepareRsvp({
-                      status: "declined",
-                      draft,
-                      existingEvent,
-                      pendingOp,
-                    })}
-                    disabled={processing}
+                  <div
                     style={{
-                      padding: "8px 12px",
-                      background: "#ef4444",
-                      color: "white",
-                      border: "none",
-                      borderRadius: "6px",
-                      fontSize: "13px",
-                      cursor: "pointer",
+                      display: "flex",
+                      gap: "4px",
+                      marginLeft: "8px",
+                      alignItems: "center",
                     }}
                   >
-                    Decline
-                  </button>
+                    <span
+                      style={{
+                        fontSize: "13px",
+                        color: "#6b7280",
+                        marginRight: "4px",
+                      }}
+                    >
+                      RSVP:
+                    </span>
+                    <button
+                      type="button"
+                      onClick={prepareRsvp({
+                        status: "accepted",
+                        draft,
+                        existingEvent,
+                        pendingOp,
+                      })}
+                      disabled={processing}
+                      style={{
+                        padding: "8px 12px",
+                        background: "#10b981",
+                        color: "white",
+                        border: "none",
+                        borderRadius: "6px",
+                        fontSize: "13px",
+                        cursor: "pointer",
+                      }}
+                    >
+                      Accept
+                    </button>
+                    <button
+                      type="button"
+                      onClick={prepareRsvp({
+                        status: "tentative",
+                        draft,
+                        existingEvent,
+                        pendingOp,
+                      })}
+                      disabled={processing}
+                      style={{
+                        padding: "8px 12px",
+                        background: "#f59e0b",
+                        color: "white",
+                        border: "none",
+                        borderRadius: "6px",
+                        fontSize: "13px",
+                        cursor: "pointer",
+                      }}
+                    >
+                      Maybe
+                    </button>
+                    <button
+                      type="button"
+                      onClick={prepareRsvp({
+                        status: "declined",
+                        draft,
+                        existingEvent,
+                        pendingOp,
+                      })}
+                      disabled={processing}
+                      style={{
+                        padding: "8px 12px",
+                        background: "#ef4444",
+                        color: "white",
+                        border: "none",
+                        borderRadius: "6px",
+                        fontSize: "13px",
+                        cursor: "pointer",
+                      }}
+                    >
+                      Decline
+                    </button>
+                  </div>
                 </div>
-              </div>,
-              null,
-            )}
+              )
+              : null}
           </div>
         </div>
 
         {/* CONFIRMATION DIALOG */}
-        {ifElse(
-          derive(pendingOp, (op: PendingOperation) => op !== null),
-          <div
-            style={{
-              position: "fixed",
-              top: 0,
-              left: 0,
-              right: 0,
-              bottom: 0,
-              background: "rgba(0, 0, 0, 0.5)",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              zIndex: 1000,
-            }}
-          >
+        {pendingOp.get() !== null
+          ? (
             <div
               style={{
-                background: "white",
-                borderRadius: "12px",
-                maxWidth: "600px",
-                width: "90%",
-                maxHeight: "90vh",
-                overflow: "auto",
-                boxShadow: "0 25px 50px -12px rgba(0, 0, 0, 0.25)",
+                position: "fixed",
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                background: "rgba(0, 0, 0, 0.5)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                zIndex: 1000,
               }}
             >
-              {/* Header */}
               <div
                 style={{
-                  padding: "20px",
-                  borderBottom: derive(
-                    pendingOp,
-                    (op: PendingOperation) =>
-                      `2px solid ${
-                        op?.operation === "delete" ? "#dc2626" : "#2563eb"
-                      }`,
-                  ),
-                  display: "flex",
-                  alignItems: "center",
-                  gap: "12px",
+                  background: "white",
+                  borderRadius: "12px",
+                  maxWidth: "600px",
+                  width: "90%",
+                  maxHeight: "90vh",
+                  overflow: "auto",
+                  boxShadow: "0 25px 50px -12px rgba(0, 0, 0, 0.25)",
                 }}
               >
-                <span style={{ fontSize: "24px" }}>
-                  {derive(pendingOp, (op: PendingOperation) => {
-                    switch (op?.operation) {
-                      case "create":
-                        return "📅";
-                      case "update":
-                        return "✏️";
-                      case "delete":
-                        return "🗑️";
-                      case "rsvp":
-                        return "📬";
-                      default:
-                        return "📅";
-                    }
-                  })}
-                </span>
-                <h3
-                  style={{
-                    margin: 0,
-                    fontSize: "20px",
-                    color: derive(
-                      pendingOp,
-                      (op: PendingOperation) =>
-                        op?.operation === "delete" ? "#dc2626" : "#2563eb",
-                    ),
-                  }}
-                >
-                  {derive(pendingOp, (op: PendingOperation) => {
-                    switch (op?.operation) {
-                      case "create":
-                        return "Create Event";
-                      case "update":
-                        return "Update Event";
-                      case "delete":
-                        return "Delete Event";
-                      case "rsvp":
-                        return "RSVP to Event";
-                      default:
-                        return "Confirm";
-                    }
-                  })}
-                </h3>
-              </div>
-
-              {/* Content */}
-              <div style={{ padding: "20px" }}>
+                {/* Header */}
                 <div
                   style={{
-                    background: "#f9fafb",
-                    borderRadius: "8px",
-                    padding: "16px",
-                    marginBottom: "16px",
+                    padding: "20px",
+                    borderBottom: `2px solid ${
+                      pendingOp.get()?.operation === "delete"
+                        ? "#dc2626"
+                        : "#2563eb"
+                    }`,
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "12px",
                   }}
                 >
-                  {/* Event summary */}
-                  <div
+                  <span style={{ fontSize: "24px" }}>
+                    {computed(() => {
+                      switch (pendingOp.get()?.operation) {
+                        case "create":
+                          return "📅";
+                        case "update":
+                          return "✏️";
+                        case "delete":
+                          return "🗑️";
+                        case "rsvp":
+                          return "📬";
+                        default:
+                          return "📅";
+                      }
+                    })}
+                  </span>
+                  <h3
                     style={{
-                      fontSize: "18px",
-                      fontWeight: "600",
-                      marginBottom: "12px",
+                      margin: 0,
+                      fontSize: "20px",
+                      color: pendingOp.get()?.operation === "delete"
+                        ? "#dc2626"
+                        : "#2563eb",
                     }}
                   >
-                    {derive(
-                      pendingOp,
-                      (op: PendingOperation) => op?.event.summary || "Untitled",
-                    )}
-                  </div>
+                    {computed(() => {
+                      switch (pendingOp.get()?.operation) {
+                        case "create":
+                          return "Create Event";
+                        case "update":
+                          return "Update Event";
+                        case "delete":
+                          return "Delete Event";
+                        case "rsvp":
+                          return "RSVP to Event";
+                        default:
+                          return "Confirm";
+                      }
+                    })}
+                  </h3>
+                </div>
 
-                  {/* Time */}
+                {/* Content */}
+                <div style={{ padding: "20px" }}>
                   <div
                     style={{
-                      display: "flex",
-                      alignItems: "center",
-                      gap: "8px",
-                      marginBottom: "8px",
-                      color: "#4b5563",
+                      background: "#f9fafb",
+                      borderRadius: "8px",
+                      padding: "16px",
+                      marginBottom: "16px",
                     }}
                   >
-                    <span>🕐</span>
-                    <span>
-                      {derive(pendingOp, (op: PendingOperation) =>
-                        op?.event.start
-                          ? `${formatDateTime(op.event.start)} - ${
-                            formatDateTime(op.event.end)
-                          }`
-                          : "")}
-                    </span>
-                  </div>
+                    {/* Event summary */}
+                    <div
+                      style={{
+                        fontSize: "18px",
+                        fontWeight: "600",
+                        marginBottom: "12px",
+                      }}
+                    >
+                      {pendingOp.get()?.event.summary || "Untitled"}
+                    </div>
 
-                  {/* Location */}
-                  {ifElse(
-                    derive(
-                      pendingOp,
-                      (op: PendingOperation) =>
-                        !!op?.event.location,
-                    ),
+                    {/* Time */}
                     <div
                       style={{
                         display: "flex",
@@ -1035,232 +990,216 @@ export default pattern<Input, Output>(({ draft, existingEvent }) => {
                         color: "#4b5563",
                       }}
                     >
-                      <span>📍</span>
+                      <span>🕐</span>
                       <span>
-                        {derive(pendingOp, (op: PendingOperation) =>
-                          op?.event.location)}
+                        {pendingOp.get()?.event.start
+                          ? `${
+                            formatDateTime(pendingOp.get()!.event.start)
+                          } - ${formatDateTime(pendingOp.get()!.event.end)}`
+                          : ""}
                       </span>
-                    </div>,
-                    null,
-                  )}
+                    </div>
 
-                  {/* Attendees */}
-                  {ifElse(
-                    derive(
-                      pendingOp,
-                      (op: PendingOperation) =>
-                        op?.event.attendees && op.event.attendees.length > 0,
-                    ),
-                    <div
-                      style={{
-                        marginTop: "12px",
-                        paddingTop: "12px",
-                        borderTop: "1px solid #e5e7eb",
-                      }}
-                    >
-                      <div
-                        style={{
-                          display: "flex",
-                          alignItems: "center",
-                          gap: "8px",
-                          fontWeight: "500",
-                          marginBottom: "8px",
-                        }}
-                      >
-                        <span>👥</span>
-                        <span>
-                          Attendees (
-                          {derive(
-                            pendingOp,
-                            (op: PendingOperation) =>
-                              op?.event.attendees?.length || 0,
-                          )}
-                          )
-                        </span>
-                      </div>
-                      <div
-                        style={{
-                          display: "flex",
-                          flexWrap: "wrap",
-                          gap: "6px",
-                        }}
-                      >
-                        {derive(pendingOp, (op: PendingOperation) =>
-                          (op?.event.attendees || []).map((email) => (
-                            <span
-                              style={{
-                                background: "white",
-                                border: "1px solid #e5e7eb",
-                                borderRadius: "16px",
-                                padding: "4px 10px",
-                                fontSize: "13px",
-                              }}
-                            >
-                              {email}
+                    {/* Location */}
+                    {!!pendingOp.get()?.event.location
+                      ? (
+                        <div
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: "8px",
+                            marginBottom: "8px",
+                            color: "#4b5563",
+                          }}
+                        >
+                          <span>📍</span>
+                          <span>
+                            {pendingOp.get()?.event.location}
+                          </span>
+                        </div>
+                      )
+                      : null}
+
+                    {/* Attendees */}
+                    {pendingOp.get()?.event.attendees &&
+                        pendingOp.get()!.event.attendees!.length > 0
+                      ? (
+                        <div
+                          style={{
+                            marginTop: "12px",
+                            paddingTop: "12px",
+                            borderTop: "1px solid #e5e7eb",
+                          }}
+                        >
+                          <div
+                            style={{
+                              display: "flex",
+                              alignItems: "center",
+                              gap: "8px",
+                              fontWeight: "500",
+                              marginBottom: "8px",
+                            }}
+                          >
+                            <span>👥</span>
+                            <span>
+                              Attendees (
+                              {pendingOp.get()?.event.attendees?.length || 0}
+                              )
                             </span>
-                          )))}
-                      </div>
-                    </div>,
-                    null,
-                  )}
+                          </div>
+                          <div
+                            style={{
+                              display: "flex",
+                              flexWrap: "wrap",
+                              gap: "6px",
+                            }}
+                          >
+                            {computed(() =>
+                              (pendingOp.get()?.event.attendees || []).map((
+                                email,
+                              ) => (
+                                <span
+                                  style={{
+                                    background: "white",
+                                    border: "1px solid #e5e7eb",
+                                    borderRadius: "16px",
+                                    padding: "4px 10px",
+                                    fontSize: "13px",
+                                  }}
+                                >
+                                  {email}
+                                </span>
+                              ))
+                            )}
+                          </div>
+                        </div>
+                      )
+                      : null}
 
-                  {/* RSVP status indicator */}
-                  {ifElse(
-                    derive(
-                      pendingOp,
-                      (op: PendingOperation) =>
-                        op?.operation === "rsvp" && !!op?.rsvpStatus,
-                    ),
+                    {/* RSVP status indicator */}
+                    {pendingOp.get()?.operation === "rsvp" &&
+                        !!pendingOp.get()?.rsvpStatus
+                      ? (
+                        <div
+                          style={{
+                            marginTop: "12px",
+                            padding: "8px 12px",
+                            borderRadius: "6px",
+                            textAlign: "center",
+                            background: computed(() => {
+                              switch (pendingOp.get()?.rsvpStatus) {
+                                case "accepted":
+                                  return "#d1fae5";
+                                case "declined":
+                                  return "#fee2e2";
+                                case "tentative":
+                                  return "#fef3c7";
+                                default:
+                                  return "#f3f4f6";
+                              }
+                            }),
+                          }}
+                        >
+                          Your response:{" "}
+                          <strong>
+                            {pendingOp.get()?.rsvpStatus}
+                          </strong>
+                        </div>
+                      )
+                      : null}
+                  </div>
+
+                  {/* Warning */}
+                  <div
+                    style={{
+                      padding: "12px 16px",
+                      borderRadius: "8px",
+                      border: pendingOp.get()?.operation === "delete"
+                        ? "1px solid #ef4444"
+                        : "1px solid #f59e0b",
+                      background: pendingOp.get()?.operation === "delete"
+                        ? "#fee2e2"
+                        : "#fef3c7",
+                    }}
+                  >
                     <div
                       style={{
-                        marginTop: "12px",
-                        padding: "8px 12px",
-                        borderRadius: "6px",
-                        textAlign: "center",
-                        background: derive(
-                          pendingOp,
-                          (op: PendingOperation) => {
-                            switch (op?.rsvpStatus) {
-                              case "accepted":
-                                return "#d1fae5";
-                              case "declined":
-                                return "#fee2e2";
-                              case "tentative":
-                                return "#fef3c7";
-                              default:
-                                return "#f3f4f6";
-                            }
-                          },
-                        ),
+                        fontWeight: "600",
+                        marginBottom: "4px",
+                        color: pendingOp.get()?.operation === "delete"
+                          ? "#991b1b"
+                          : "#92400e",
                       }}
                     >
-                      Your response:{" "}
-                      <strong>
-                        {derive(
-                          pendingOp,
-                          (op: PendingOperation) =>
-                            op?.rsvpStatus,
-                        )}
-                      </strong>
-                    </div>,
-                    null,
-                  )}
+                      {getOperationWarning(pendingOp.get()).title}
+                    </div>
+                    <div
+                      style={{
+                        fontSize: "14px",
+                        color: pendingOp.get()?.operation === "delete"
+                          ? "#b91c1c"
+                          : "#78350f",
+                      }}
+                    >
+                      {getOperationWarning(pendingOp.get()).desc}
+                    </div>
+                  </div>
                 </div>
 
-                {/* Warning */}
+                {/* Footer */}
                 <div
                   style={{
-                    padding: "12px 16px",
-                    borderRadius: "8px",
-                    border: derive(
-                      pendingOp,
-                      (op: PendingOperation) =>
-                        op?.operation === "delete"
-                          ? "1px solid #ef4444"
-                          : "1px solid #f59e0b",
-                    ),
-                    background: derive(
-                      pendingOp,
-                      (op: PendingOperation) =>
-                        op?.operation === "delete" ? "#fee2e2" : "#fef3c7",
-                    ),
+                    padding: "16px 20px",
+                    borderTop: "1px solid #e5e7eb",
+                    display: "flex",
+                    gap: "12px",
+                    justifyContent: "flex-end",
                   }}
                 >
-                  <div
+                  <button
+                    type="button"
+                    onClick={cancelOperation({ pendingOp })}
+                    disabled={processing}
                     style={{
-                      fontWeight: "600",
-                      marginBottom: "4px",
-                      color: derive(
-                        pendingOp,
-                        (op: PendingOperation) =>
-                          op?.operation === "delete" ? "#991b1b" : "#92400e",
-                      ),
-                    }}
-                  >
-                    {derive(
-                      pendingOp,
-                      (op: PendingOperation) =>
-                        getOperationWarning(op).title,
-                    )}
-                  </div>
-                  <div
-                    style={{
+                      padding: "10px 20px",
+                      background: "white",
+                      color: "#374151",
+                      border: "1px solid #d1d5db",
+                      borderRadius: "6px",
                       fontSize: "14px",
-                      color: derive(
-                        pendingOp,
-                        (op: PendingOperation) =>
-                          op?.operation === "delete" ? "#b91c1c" : "#78350f",
-                      ),
+                      fontWeight: "500",
+                      cursor: "pointer",
                     }}
                   >
-                    {derive(
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={confirmOperation({
                       pendingOp,
-                      (op: PendingOperation) =>
-                        getOperationWarning(op).desc,
-                    )}
-                  </div>
-                </div>
-              </div>
-
-              {/* Footer */}
-              <div
-                style={{
-                  padding: "16px 20px",
-                  borderTop: "1px solid #e5e7eb",
-                  display: "flex",
-                  gap: "12px",
-                  justifyContent: "flex-end",
-                }}
-              >
-                <button
-                  type="button"
-                  onClick={cancelOperation({ pendingOp })}
-                  disabled={processing}
-                  style={{
-                    padding: "10px 20px",
-                    background: "white",
-                    color: "#374151",
-                    border: "1px solid #d1d5db",
-                    borderRadius: "6px",
-                    fontSize: "14px",
-                    fontWeight: "500",
-                    cursor: "pointer",
-                  }}
-                >
-                  Cancel
-                </button>
-                <button
-                  type="button"
-                  onClick={confirmOperation({
-                    pendingOp,
-                    auth,
-                    processing,
-                    result,
-                    draft,
-                    existingEvent,
-                  })}
-                  disabled={processing}
-                  style={{
-                    padding: "10px 20px",
-                    background: derive(
-                      pendingOp,
-                      (op: PendingOperation) =>
-                        op?.operation === "delete" ? "#dc2626" : "#2563eb",
-                    ),
-                    color: "white",
-                    border: "none",
-                    borderRadius: "6px",
-                    fontSize: "14px",
-                    fontWeight: "500",
-                    cursor: "pointer",
-                    opacity: derive(processing, (p) => (p ? 0.7 : 1)),
-                  }}
-                >
-                  {ifElse(
-                    processing,
-                    "Processing...",
-                    derive(pendingOp, (op: PendingOperation) => {
-                      switch (op?.operation) {
+                      auth,
+                      processing,
+                      result,
+                      draft,
+                      existingEvent,
+                    })}
+                    disabled={processing}
+                    style={{
+                      padding: "10px 20px",
+                      background: pendingOp.get()?.operation === "delete"
+                        ? "#dc2626"
+                        : "#2563eb",
+                      color: "white",
+                      border: "none",
+                      borderRadius: "6px",
+                      fontSize: "14px",
+                      fontWeight: "500",
+                      cursor: "pointer",
+                      opacity: processing.get() ? 0.7 : 1,
+                    }}
+                  >
+                    {processing.get() ? "Processing..." : computed(() => {
+                      switch (pendingOp.get()?.operation) {
                         case "create":
                           return "Create Event";
                         case "update":
@@ -1272,14 +1211,13 @@ export default pattern<Input, Output>(({ draft, existingEvent }) => {
                         default:
                           return "Confirm";
                       }
-                    }),
-                  )}
-                </button>
+                    })}
+                  </button>
+                </div>
               </div>
             </div>
-          </div>,
-          null,
-        )}
+          )
+          : null}
       </div>
     ),
     draft,

--- a/packages/patterns/google/core/experimental/calendar-event-manager.tsx
+++ b/packages/patterns/google/core/experimental/calendar-event-manager.tsx
@@ -504,7 +504,7 @@ export default pattern<Input, Output>(({ draft, existingEvent }) => {
                       }
                     })}
                   </div>
-                  {!!result.get()?.eventId
+                  {result.get()?.eventId
                     ? (
                       <div style={{ fontSize: "12px", color: "#047857" }}>
                         Event ID: {result.get()?.eventId}
@@ -1001,7 +1001,7 @@ export default pattern<Input, Output>(({ draft, existingEvent }) => {
                     </div>
 
                     {/* Location */}
-                    {!!pendingOp.get()?.event.location
+                    {pendingOp.get()?.event.location
                       ? (
                         <div
                           style={{

--- a/packages/patterns/google/core/experimental/calendar-viewer.tsx
+++ b/packages/patterns/google/core/experimental/calendar-viewer.tsx
@@ -8,10 +8,9 @@
  *   ./tools/apple-sync.ts calendar
  */
 import {
+  computed,
   Default,
-  derive,
   handler,
-  ifElse,
   NAME,
   pattern,
   UI,
@@ -111,56 +110,39 @@ export default pattern<{
 }>(({ events }) => {
   const hiddenCalendars = new Writable<string[]>([]);
 
-  const eventCount = derive(
-    events,
-    (evts: CalendarEvent[]) => evts?.length ?? 0,
-  );
+  const eventCount = events?.length ?? 0;
 
   // Extract unique calendar names for the filter bar
   // Refactored to use filter/map after CT-1102 fix
-  const uniqueCalendars = derive(
-    events,
-    (evts: CalendarEvent[]) =>
-      [
-        ...new Set(
-          (evts || []).filter((evt) => evt?.calendarName).map((evt) =>
-            evt.calendarName
-          ),
+  const uniqueCalendars = computed(() =>
+    [
+      ...new Set(
+        (events || []).filter((evt) => evt?.calendarName).map((evt) =>
+          evt.calendarName
         ),
-      ].sort(),
+      ),
+    ].sort()
   );
 
   // Upcoming events (sorted by start date, filtered by hidden calendars)
-  const upcomingEvents = derive(
-    { events, hiddenCalendars },
-    ({
-      events: evts,
-      hiddenCalendars: hidden,
-    }: {
-      events: CalendarEvent[];
-      hiddenCalendars: string[];
-    }) => {
-      const now = new Date();
-      const hiddenSet = new Set(hidden || []);
-      return [...(evts || [])]
-        .filter((e: CalendarEvent) =>
-          e?.startDate &&
-          new Date(e.startDate) >= now &&
-          !hiddenSet.has(e.calendarName)
-        )
-        .sort((a: CalendarEvent, b: CalendarEvent) =>
-          new Date(a.startDate).getTime() - new Date(b.startDate).getTime()
-        );
-    },
-  );
+  const upcomingEvents = computed(() => {
+    const now = new Date();
+    const hiddenSet = new Set(hiddenCalendars.get() || []);
+    return [...(events || [])]
+      .filter((e: CalendarEvent) =>
+        e?.startDate &&
+        new Date(e.startDate) >= now &&
+        !hiddenSet.has(e.calendarName)
+      )
+      .sort((a: CalendarEvent, b: CalendarEvent) =>
+        new Date(a.startDate).getTime() - new Date(b.startDate).getTime()
+      );
+  });
 
-  const totalUpcoming = derive(
-    upcomingEvents,
-    (evts: CalendarEvent[]) => evts.length,
-  );
+  const totalUpcoming = upcomingEvents.length;
 
   return {
-    [NAME]: derive(eventCount, (count: number) => `Calendar (${count} events)`),
+    [NAME]: `Calendar (${eventCount} events)`,
     [UI]: (
       <cf-screen
         style={{
@@ -184,34 +166,26 @@ export default pattern<{
         </div>
 
         {/* Calendar Filter Bar */}
-        {ifElse(
-          derive(eventCount, (c: number) => c > 0),
-          <div
-            style={{
-              padding: "8px 16px",
-              backgroundColor: "#fff",
-              borderBottom: "1px solid #e0e0e0",
-              display: "flex",
-              gap: "8px",
-              flexWrap: "wrap",
-            }}
-          >
-            {derive(
-              { uniqueCalendars, hiddenCalendars },
-              ({
-                uniqueCalendars: calendars,
-                hiddenCalendars: hiddenList,
-              }: {
-                uniqueCalendars: string[];
-                hiddenCalendars: string[];
-              }) =>
-                (calendars || []).map((name: string) => {
-                  const isHidden = (hiddenList || []).includes(name);
+        {eventCount > 0
+          ? (
+            <div
+              style={{
+                padding: "8px 16px",
+                backgroundColor: "#fff",
+                borderBottom: "1px solid #e0e0e0",
+                display: "flex",
+                gap: "8px",
+                flexWrap: "wrap",
+              }}
+            >
+              {computed(() =>
+                (uniqueCalendars || []).map((name: string) => {
+                  const isHidden = (hiddenCalendars.get() || []).includes(name);
                   const color = getCalendarColor(name);
                   return (
                     <button
                       type="button"
-                      // Pass the Cell from outer scope, not the destructured value
+                      // Pass the Cell from outer scope so the handler binds the live cell
                       onClick={toggleCalendar({
                         calendarName: name,
                         hiddenCalendars,
@@ -240,56 +214,57 @@ export default pattern<{
                       {name}
                     </button>
                   );
-                }),
-            )}
-          </div>,
-          <></>,
-        )}
+                })
+              )}
+            </div>
+          )
+          : <></>}
 
         {/* Content */}
         <div style={{ flex: 1, overflow: "auto" }}>
-          {ifElse(
-            derive(eventCount, (c: number) => c === 0),
+          {eventCount === 0
             // Empty state
-            <div
-              style={{
-                display: "flex",
-                flexDirection: "column",
-                alignItems: "center",
-                justifyContent: "center",
-                height: "100%",
-                color: "#666",
-                padding: "20px",
-                textAlign: "center",
-              }}
-            >
-              <div style={{ fontSize: "48px", marginBottom: "16px" }}>
-                Calendar
-              </div>
+            ? (
               <div
                 style={{
-                  fontSize: "18px",
-                  fontWeight: "bold",
-                  marginBottom: "8px",
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  height: "100%",
+                  color: "#666",
+                  padding: "20px",
+                  textAlign: "center",
                 }}
               >
-                No Events Yet
-              </div>
-              <div style={{ fontSize: "14px", maxWidth: "300px" }}>
-                Run the apple-sync CLI to import your calendar events:
-                <pre
+                <div style={{ fontSize: "48px", marginBottom: "16px" }}>
+                  Calendar
+                </div>
+                <div
                   style={{
-                    backgroundColor: "#e0e0e0",
-                    padding: "8px 12px",
-                    borderRadius: "4px",
-                    marginTop: "12px",
-                    fontSize: "12px",
+                    fontSize: "18px",
+                    fontWeight: "bold",
+                    marginBottom: "8px",
                   }}
                 >
+                  No Events Yet
+                </div>
+                <div style={{ fontSize: "14px", maxWidth: "300px" }}>
+                  Run the apple-sync CLI to import your calendar events:
+                  <pre
+                    style={{
+                      backgroundColor: "#e0e0e0",
+                      padding: "8px 12px",
+                      borderRadius: "4px",
+                      marginTop: "12px",
+                      fontSize: "12px",
+                    }}
+                  >
                   ./tools/apple-sync.ts calendar
-                </pre>
+                  </pre>
+                </div>
               </div>
-            </div>,
+            )
             /*
              * Paginated event preview - showing 10 events at a time.
              *
@@ -304,70 +279,75 @@ export default pattern<{
              * The full event data is still available via the `events` output for
              * other patterns to access via linking.
              */
-            <div style={{ padding: "20px" }}>
-              <div
-                style={{
-                  fontSize: "18px",
-                  fontWeight: "bold",
-                  marginBottom: "8px",
-                }}
-              >
-                Upcoming Events ({totalUpcoming} total)
-              </div>
+            : (
+              <div style={{ padding: "20px" }}>
+                <div
+                  style={{
+                    fontSize: "18px",
+                    fontWeight: "bold",
+                    marginBottom: "8px",
+                  }}
+                >
+                  Upcoming Events ({totalUpcoming} total)
+                </div>
 
-              {derive(upcomingEvents, (evts: CalendarEvent[]) => {
-                if (!evts || evts.length === 0) {
+                {computed(() => {
+                  if (!upcomingEvents || upcomingEvents.length === 0) {
+                    return (
+                      <div style={{ color: "#999" }}>No upcoming events</div>
+                    );
+                  }
+
+                  // Show first 10 events (simplified - no pagination)
+                  const displayEvents = upcomingEvents.slice(0, 10);
+
                   return (
-                    <div style={{ color: "#999" }}>No upcoming events</div>
-                  );
-                }
-
-                // Show first 10 events (simplified - no pagination)
-                const displayEvents = evts.slice(0, 10);
-
-                return (
-                  <div>
-                    {displayEvents.map((evt: CalendarEvent, idx: number) => (
-                      <div
-                        key={idx}
-                        style={{
-                          padding: "12px 16px",
-                          backgroundColor: "#fff",
-                          borderBottom: "1px solid #f0f0f0",
-                          display: "flex",
-                          gap: "12px",
-                        }}
-                      >
+                    <div>
+                      {displayEvents.map((evt: CalendarEvent, idx: number) => (
                         <div
+                          key={idx}
                           style={{
-                            width: "4px",
-                            backgroundColor: getCalendarColor(evt.calendarName),
-                            borderRadius: "2px",
-                            flexShrink: 0,
+                            padding: "12px 16px",
+                            backgroundColor: "#fff",
+                            borderBottom: "1px solid #f0f0f0",
+                            display: "flex",
+                            gap: "12px",
                           }}
-                        />
-                        <div style={{ flex: 1 }}>
-                          <div style={{ fontWeight: "600" }}>{evt.title}</div>
-                          <div style={{ fontSize: "14px", color: "#666" }}>
-                            {getRelativeLabel(evt.startDate)} {evt.isAllDay
-                              ? "(All day)"
-                              : formatTime(evt.startDate)}
+                        >
+                          <div
+                            style={{
+                              width: "4px",
+                              backgroundColor: getCalendarColor(
+                                evt.calendarName,
+                              ),
+                              borderRadius: "2px",
+                              flexShrink: 0,
+                            }}
+                          />
+                          <div style={{ flex: 1 }}>
+                            <div style={{ fontWeight: "600" }}>{evt.title}</div>
+                            <div style={{ fontSize: "14px", color: "#666" }}>
+                              {getRelativeLabel(evt.startDate)} {evt.isAllDay
+                                ? "(All day)"
+                                : formatTime(evt.startDate)}
+                            </div>
+                            {evt.location
+                              ? (
+                                <div
+                                  style={{ fontSize: "13px", color: "#999" }}
+                                >
+                                  {evt.location}
+                                </div>
+                              )
+                              : <></>}
                           </div>
-                          {evt.location
-                            ? (
-                              <div style={{ fontSize: "13px", color: "#999" }}>
-                                {evt.location}
-                              </div>
-                            )
-                            : <></>}
                         </div>
-                      </div>
-                    ))}
-                  </div>
-                );
-              })}
-            </div>,
-          )}
+                      ))}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
         </div>
       </cf-screen>
     ),

--- a/packages/patterns/google/core/experimental/gmail-agentic-search.tsx
+++ b/packages/patterns/google/core/experimental/gmail-agentic-search.tsx
@@ -1042,11 +1042,9 @@ const GmailAgenticSearch = pattern<
     const itemFoundSignal = itemFoundSignalInput;
     // Track last signal value in a Cell (closure vars don't persist in derive)
     const lastSignalValueCell = new Writable<number>(0);
-    // Track last executed query ID in a Cell (so derive can access it)
+    // Track last executed query ID in a Cell
     const lastExecutedQueryIdCell = new Writable<string | null>(null);
     // Track foundItems counts separately from localQueries
-    // Local cells work correctly in derives (no closure issues with input cells)
-    // See: community-docs/superstitions/2025-12-08-locally-created-cells-not-unwrapped-in-derive.md
     const foundItemsTracker = new Writable<Record<string, number>>({});
 
     // Watch the signal and update foundItemsTracker when it increases.
@@ -1131,12 +1129,12 @@ const GmailAgenticSearch = pattern<
     // other pieces to trigger token refresh in google-auth's transaction context.
     //
     // KEY INSIGHT (from Berni, verified 2024-12-10):
-    // - Streams from wished pieces appear as opaque objects with `$stream` marker at derive time
+    // - Streams from wished pieces appear as opaque objects with `$stream` marker at build time
     // - To call .send(), you must pass the stream to a handler with `Stream<T>` in its type signature
     // - The framework "unwraps" the opaque stream into a callable one inside the handler
     //
     // PATTERN:
-    // 1. Extract stream via derive (will be opaque)
+    // 1. Extract stream via a plain projection (will be opaque)
     // 2. Pass to handler with Stream<T> declared in signature
     // 3. Call .send() inside handler
     //
@@ -1519,7 +1517,7 @@ When you're done searching, STOP calling tools and produce your final structured
         {/* Account Type Selector (only shown if not using direct auth) */}
         {hasDirectAuth ? null : accountTypeSelector}
 
-        {/* Auth Status - use nested ifElse to avoid Cell-in-Cell problem */}
+        {/* Auth Status - nested ternaries to avoid the Cell-in-Cell problem */}
         {
           /* Only show custom error UIs for specific warning states;
             authFullUI handles everything else (not-auth, selecting, ready) */

--- a/packages/patterns/google/core/experimental/gmail-agentic-search.tsx
+++ b/packages/patterns/google/core/experimental/gmail-agentic-search.tsx
@@ -24,11 +24,10 @@
  */
 import {
   action,
+  computed,
   Default,
-  derive,
   generateObject,
   handler,
-  ifElse,
   NAME,
   navigateTo,
   nonPrivateRandom,
@@ -1013,7 +1012,7 @@ const GmailAgenticSearch = pattern<
     // ========================================================================
 
     // Check if we have direct auth input (CT-1085 workaround)
-    const hasDirectAuth = derive(inputAuth, (a: Auth) => !!(a?.token));
+    const hasDirectAuth = !!(inputAuth?.token);
 
     // Local writable cell for account type selection
     // Input `accountType` may be read-only (Default cells are read-only when using default value)
@@ -1050,65 +1049,56 @@ const GmailAgenticSearch = pattern<
     // See: community-docs/superstitions/2025-12-08-locally-created-cells-not-unwrapped-in-derive.md
     const foundItemsTracker = new Writable<Record<string, number>>({});
 
-    // Watch the signal and update foundItemsTracker when it increases
-    derive(
-      [itemFoundSignal, lastSignalValueCell, lastExecutedQueryIdCell],
-      (
-        [signalValue, lastSignalValue, queryId]: [
-          number,
-          number,
-          string | null,
-        ],
-      ) => {
-        // Use the unwrapped values from derive directly
-        const signalVal = signalValue || 0;
-        const lastSignalVal = lastSignalValue || 0;
+    // Watch the signal and update foundItemsTracker when it increases.
+    // Side-effect-only reactive computation (return unused); statement body → computed.
+    computed(() => {
+      const signalVal = itemFoundSignal || 0;
+      const lastSignalVal = lastSignalValueCell.get() || 0;
+      const queryId = lastExecutedQueryIdCell.get();
 
-        if (DEBUG_AGENT) {
-          console.log(
-            `[GmailAgenticSearch] itemFoundSignal derive triggered: signalValue=${signalVal}, lastSignalValue=${lastSignalVal}, queryId=${queryId}`,
-          );
-        }
+      if (DEBUG_AGENT) {
+        console.log(
+          `[GmailAgenticSearch] itemFoundSignal watcher triggered: signalValue=${signalVal}, lastSignalValue=${lastSignalVal}, queryId=${queryId}`,
+        );
+      }
 
-        if (signalVal > lastSignalVal) {
-          if (queryId) {
-            const tracker = foundItemsTracker.get() || {};
-            const currentCount = tracker[queryId] || 0;
-            const newCount = currentCount + 1;
+      if (signalVal > lastSignalVal) {
+        if (queryId) {
+          const tracker = foundItemsTracker.get() || {};
+          const currentCount = tracker[queryId] || 0;
+          const newCount = currentCount + 1;
 
-            foundItemsTracker.set({
-              ...tracker,
-              [queryId]: newCount,
-            });
+          foundItemsTracker.set({
+            ...tracker,
+            [queryId]: newCount,
+          });
 
-            if (DEBUG_AGENT) {
-              console.log(
-                `[GmailAgenticSearch] Marked query ${queryId} as found item (now ${newCount})`,
-              );
-            }
-          } else {
-            if (DEBUG_AGENT) {
-              console.warn(
-                "[GmailAgenticSearch] itemFoundSignal increased but no recent query to mark",
-              );
-            }
+          if (DEBUG_AGENT) {
+            console.log(
+              `[GmailAgenticSearch] Marked query ${queryId} as found item (now ${newCount})`,
+            );
           }
-          lastSignalValueCell.set(signalVal);
+        } else {
+          if (DEBUG_AGENT) {
+            console.warn(
+              "[GmailAgenticSearch] itemFoundSignal increased but no recent query to mark",
+            );
+          }
         }
-      },
-    );
+        lastSignalValueCell.set(signalVal);
+      }
+    });
 
     // Merge localQueries with foundItems from the tracker for display
-    const localQueriesWithFoundItems = derive(
-      [localQueries, foundItemsTracker],
-      ([queries, tracker]: [LocalQuery[], Record<string, number>]) => {
-        return (queries || []).map((q) => {
-          if (!q || !q.id) return q;
-          const trackedCount = tracker[q.id] || 0;
-          return { ...q, foundItems: trackedCount };
-        });
-      },
-    );
+    const localQueriesWithFoundItems = computed(() => {
+      const queries = localQueries;
+      const tracker = foundItemsTracker.get();
+      return (queries || []).map((q: LocalQuery) => {
+        if (!q || !q.id) return q;
+        const trackedCount = tracker[q.id] || 0;
+        return { ...q, foundItems: trackedCount };
+      });
+    });
 
     // Use createGoogleAuth utility for wish-based auth (when not using direct auth)
     // Passes reactive selectedAccountType for dynamic account switching
@@ -1123,11 +1113,8 @@ const GmailAgenticSearch = pattern<
       accountType: selectedAccountType,
     });
 
-    // For compatibility with existing code - derive piece from authInfo
-    const wishedAuthPiece = derive(
-      authInfo,
-      (info: any) => info?.piece || null,
-    );
+    // For compatibility with existing code - project piece from authInfo
+    const wishedAuthPiece = (authInfo as any)?.piece || null;
     const hasWishedAuth = wishedAuthReady;
 
     // Access auth via property path to maintain writability
@@ -1135,11 +1122,7 @@ const GmailAgenticSearch = pattern<
     // When hasDirectAuth is false, we use wishedAuth from the utility
     // NOTE: This means inputAuth must be passed as a live cell reference, not derived.
     // See: community-docs/superstitions/2025-12-03-derive-creates-readonly-cells-use-property-access.md
-    const auth = ifElse(
-      hasDirectAuth,
-      inputAuth,
-      wishedAuth,
-    );
+    const auth = hasDirectAuth ? inputAuth : wishedAuth;
 
     // ========================================================================
     // CROSS-CHARM TOKEN REFRESH
@@ -1161,25 +1144,21 @@ const GmailAgenticSearch = pattern<
     // See: patterns/jkomoros/issues/ISSUE-Token-Refresh-Blocked-By-Storage-Transaction.md
     //
     // Extract refresh stream from wished piece (will be opaque at derive time)
-    const authRefreshStream = derive(
-      wishedAuthPiece,
-      (piece: any) => piece?.refreshToken || null,
-    );
+    const authRefreshStream = wishedAuthPiece?.refreshToken || null;
 
     // Track where auth came from
-    const authSource = derive(
-      [hasDirectAuth, hasWishedAuth],
-      ([direct, wished]: [boolean, boolean]): "direct" | "wish" | "none" =>
-        direct ? "direct" : wished ? "wish" : "none",
-    );
+    const authSource: "direct" | "wish" | "none" = hasDirectAuth
+      ? "direct"
+      : hasWishedAuth
+      ? "wish"
+      : "none";
 
-    const isAuthenticated = derive(
-      auth,
-      (a: Auth) => !!(a && a.token && a.user && a.user.email),
-    );
+    const isAuthenticated = !!(auth && auth.token && auth.user &&
+      auth.user.email);
 
     // Check if token may be expired based on expiresAt timestamp
-    const tokenMayBeExpired = derive(auth, (a: Auth) => {
+    const tokenMayBeExpired = computed(() => {
+      const a = auth as Auth;
       if (!a?.expiresAt) return false;
       // Add 5 minute buffer - if within 5 min of expiry, consider it potentially expired
       const bufferMs = 5 * 60 * 1000;
@@ -1189,10 +1168,9 @@ const GmailAgenticSearch = pattern<
     // Gmail scope URL for checking
     const GMAIL_SCOPE = "https://www.googleapis.com/auth/gmail.readonly";
 
-    const hasGmailScope = derive(auth, (a: Auth) => {
-      const scopes = (a?.scope || []) as string[];
-      return scopes.includes(GMAIL_SCOPE);
-    });
+    const hasGmailScope = (((auth as Auth)?.scope || []) as string[]).includes(
+      GMAIL_SCOPE,
+    );
 
     // Note: Scope warnings are handled by authFullUI via createGoogleAuth utility
 
@@ -1248,132 +1226,121 @@ const GmailAgenticSearch = pattern<
     // ========================================================================
 
     // Wish for the community registry (tagged #gmailSearchRegistry)
-    // NOTE: wish() must be called outside derive() to avoid infinite loops
-    // See: community-docs/superstitions/2025-12-06-wish-inside-derive-causes-infinite-loop.md
     const registryWish = wish<GmailSearchRegistryOutput>({
       query: "#gmailSearchRegistry",
     });
 
     // Extract community queries for this agent type (with IDs for upvoting)
     // Conditional enablement is handled here, not in the wish call
-    const communityQueryRefs = derive(
-      [registryWish, agentTypeUrl, enableCommunityQueries],
-      (
-        [wishResult, typeUrl, enabled]: [any, string, boolean],
-      ): CommunityQueryRef[] => {
-        // Guard: skip if community queries disabled or no agent type URL
-        if (!enabled || !typeUrl) return [];
-        if (!wishResult?.result) return [];
-        // wishResult.result is a Cell reference, use .key() for dynamic access
-        const registryCell = wishResult.result;
-        const registriesCell = registryCell?.key?.("registries");
-        if (!registriesCell) return [];
-        const agentRegistry = registriesCell.key(typeUrl)?.get?.();
-        if (!agentRegistry) return [];
-        // Return top queries sorted by score, keeping IDs for upvoting
-        return [...(agentRegistry.queries || [])]
-          .sort((a: SharedQuery, b: SharedQuery) =>
-            (b.upvotes - b.downvotes) - (a.upvotes - a.downvotes)
-          )
-          .slice(0, 10)
-          .map((q: SharedQuery) => ({ id: q.id, query: q.query }));
-      },
-    );
+    const communityQueryRefs = computed((): CommunityQueryRef[] => {
+      const wishResult = registryWish as any;
+      const typeUrl = agentTypeUrl;
+      const enabled = enableCommunityQueries;
+      // Guard: skip if community queries disabled or no agent type URL
+      if (!enabled || !typeUrl) return [];
+      if (!wishResult?.result) return [];
+      // wishResult.result is a Cell reference, use .key() for dynamic access
+      const registryCell = wishResult.result;
+      const registriesCell = registryCell?.key?.("registries");
+      if (!registriesCell) return [];
+      const agentRegistry = registriesCell.key(typeUrl)?.get?.();
+      if (!agentRegistry) return [];
+      // Return top queries sorted by score, keeping IDs for upvoting
+      return [...(agentRegistry.queries || [])]
+        .sort((a: SharedQuery, b: SharedQuery) =>
+          (b.upvotes - b.downvotes) - (a.upvotes - a.downvotes)
+        )
+        .slice(0, 10)
+        .map((q: SharedQuery) => ({ id: q.id, query: q.query }));
+    });
 
     // Just the query strings for combining with other suggestions
-    const communityQueries = derive(
-      communityQueryRefs,
-      (refs: CommunityQueryRef[]) => refs.map((r) => r.query),
+    const communityQueries = computed(() =>
+      communityQueryRefs.map((r: CommunityQueryRef) => r.query)
     );
 
     // Combine all suggested queries: local effective + community + pattern-defined
-    const allSuggestedQueries = derive(
-      [suggestedQueries, localQueries, communityQueries],
-      ([suggested, local, community]: [string[], LocalQuery[], string[]]) => {
-        const effectiveLocal = (local || [])
-          .filter((q) => q && q.effectiveness >= 3)
-          .map((q) => q.query);
-        // Deduplicate and combine: pattern-defined first, then community, then local
-        const all = new Set<string>();
-        (suggested || []).forEach((q) => all.add(q));
-        (community || []).forEach((q) => all.add(q));
-        effectiveLocal.forEach((q) => all.add(q));
-        return Array.from(all);
-      },
-    );
+    const allSuggestedQueries = computed(() => {
+      const suggested = suggestedQueries;
+      const local = localQueries;
+      const community = communityQueries;
+      const effectiveLocal = (local || [])
+        .filter((q: LocalQuery) => q && q.effectiveness >= 3)
+        .map((q: LocalQuery) => q.query);
+      // Deduplicate and combine: pattern-defined first, then community, then local
+      const all = new Set<string>();
+      (suggested || []).forEach((q: string) => all.add(q));
+      (community || []).forEach((q: string) => all.add(q));
+      effectiveLocal.forEach((q: string) => all.add(q));
+      return Array.from(all);
+    });
 
     // ========================================================================
     // AGENT SETUP
     // ========================================================================
 
     // Build the full prompt with suggested queries
-    const fullPrompt = derive(
-      [agentGoal, suggestedQueries, maxSearches],
-      ([goal, queries, max]: [string, string[], number]) => {
-        if (!goal) return ""; // Don't run agent without a goal
+    const fullPrompt = computed(() => {
+      const goal = agentGoal;
+      const queries = suggestedQueries;
+      const max = maxSearches;
+      if (!goal) return ""; // Don't run agent without a goal
 
-        let prompt = goal;
+      let prompt = goal;
 
-        if (queries && queries.length > 0) {
-          prompt += `\n\nSuggested queries to try:\n`;
-          prompt += queries.map((q, i) => `${i + 1}. ${q}`).join("\n");
-        }
+      if (queries && queries.length > 0) {
+        prompt += `\n\nSuggested queries to try:\n`;
+        prompt += queries.map((q: string, i: number) => `${i + 1}. ${q}`).join(
+          "\n",
+        );
+      }
 
-        if (max > 0) {
-          prompt +=
-            `\n\n⚠️ LIMITED TO ${max} SEARCHES. Focus on high-value queries!`;
-        }
+      if (max > 0) {
+        prompt +=
+          `\n\n⚠️ LIMITED TO ${max} SEARCHES. Focus on high-value queries!`;
+      }
 
-        return prompt;
-      },
-    );
+      return prompt;
+    });
 
     // Build agent prompt (only active when scanning)
-    const agentPrompt = derive(
-      [isScanning, fullPrompt],
-      ([scanning, prompt]: [boolean, string]) => {
-        if (!scanning) return ""; // Don't run unless scanning
-        return prompt;
-      },
-    );
+    const agentPrompt = isScanning ? fullPrompt : "";
 
     // Merge searchGmail with additional tools
-    const allTools = derive(
-      additionalTools,
-      (additional: Record<string, ToolDefinition>) => {
-        const baseTools = {
-          searchGmail: {
-            description:
-              "Search Gmail with a query and return matching emails. Returns email id, subject, from, date, snippet, and body text.",
-            handler: searchGmailHandler({
-              auth,
-              authRefreshStream,
-              progress: searchProgress,
-              maxSearches,
-              debugLog,
-              localQueries,
-              communityQueryRefs,
-              registryWish,
-              agentTypeUrl,
-              lastExecutedQueryIdCell,
-            }),
-          },
-        };
+    const allTools = computed(() => {
+      const additional = additionalTools;
+      const baseTools = {
+        searchGmail: {
+          description:
+            "Search Gmail with a query and return matching emails. Returns email id, subject, from, date, snippet, and body text.",
+          handler: searchGmailHandler({
+            auth,
+            authRefreshStream,
+            progress: searchProgress,
+            maxSearches,
+            debugLog,
+            localQueries,
+            communityQueryRefs,
+            registryWish,
+            agentTypeUrl,
+            lastExecutedQueryIdCell,
+          }),
+        },
+      };
 
-        // Merge additional tools if provided
-        if (additional && typeof additional === "object") {
-          return { ...baseTools, ...additional };
-        }
-        return baseTools;
-      },
-    );
+      // Merge additional tools if provided
+      if (additional && typeof additional === "object") {
+        return { ...baseTools, ...additional };
+      }
+      return baseTools;
+    });
 
     // Default system prompt - includes suggested queries from all sources
-    const fullSystemPrompt = derive(
-      [systemPrompt, allSuggestedQueries],
-      ([custom, suggested]: [string, string[]]) => {
-        const base =
-          `You are a Gmail search agent. Your job is to search through emails to find relevant information.
+    const fullSystemPrompt = computed(() => {
+      const custom = systemPrompt;
+      const suggested = allSuggestedQueries;
+      const base =
+        `You are a Gmail search agent. Your job is to search through emails to find relevant information.
 
 You have the searchGmail tool available. Use it to search Gmail with queries like:
 - from:domain.com
@@ -1390,21 +1357,20 @@ IMPORTANT - WHEN TO STOP SEARCHING:
 
 When you're done searching, STOP calling tools and produce your final structured output.`;
 
-        // Add suggested queries if available
-        let prompt = base;
-        if (suggested && suggested.length > 0) {
-          prompt +=
-            `\n\nSuggested queries to try (from pattern config and community):\n${
-              suggested.map((q) => `- ${q}`).join("\n")
-            }`;
-        }
+      // Add suggested queries if available
+      let prompt = base;
+      if (suggested && suggested.length > 0) {
+        prompt +=
+          `\n\nSuggested queries to try (from pattern config and community):\n${
+            suggested.map((q) => `- ${q}`).join("\n")
+          }`;
+      }
 
-        if (custom) {
-          prompt += `\n\n${custom}`;
-        }
-        return prompt;
-      },
-    );
+      if (custom) {
+        prompt += `\n\n${custom}`;
+      }
+      return prompt;
+    });
 
     // Create the agent
     const agent = generateObject({
@@ -1412,7 +1378,8 @@ When you're done searching, STOP calling tools and produce your final structured
       prompt: agentPrompt,
       tools: allTools,
       model: "anthropic:claude-sonnet-4-5",
-      schema: derive(resultSchema, (schema: object) => {
+      schema: computed(() => {
+        const schema = resultSchema;
         if (schema && Object.keys(schema).length > 0) {
           return schema;
         }
@@ -1434,46 +1401,40 @@ When you're done searching, STOP calling tools and produce your final structured
     const { result: agentResult, pending: agentPending } = agent;
 
     // Detect when agent completes
-    const scanCompleted = derive(
-      [isScanning, agentPending, agentResult],
-      ([scanning, pending, result]: [boolean, boolean, any]) =>
-        scanning && !pending && !!result,
-    );
+    const scanCompleted = isScanning && !agentPending && !!agentResult;
 
     // Detect auth errors from agent result or token validation
-    const hasAuthError = derive(
-      [agentResult, searchProgress],
-      ([r, progress]: [any, SearchProgress]) => {
-        // Check progress status first (from token validation)
-        if (progress?.status === "auth_error") {
-          return true;
-        }
-        // Check agent result
-        const summary = r?.summary || "";
-        return (
-          summary.includes("401") ||
-          summary.toLowerCase().includes("authentication error")
-        );
-      },
-    );
+    const hasAuthError = computed(() => {
+      const r = agentResult as any;
+      const progress = searchProgress as SearchProgress;
+      // Check progress status first (from token validation)
+      if (progress?.status === "auth_error") {
+        return true;
+      }
+      // Check agent result
+      const summary = r?.summary || "";
+      return (
+        summary.includes("401") ||
+        summary.toLowerCase().includes("authentication error")
+      );
+    });
 
     // Get the specific auth error message
-    const authErrorMessage = derive(
-      [searchProgress, agentResult],
-      ([progress, result]: [SearchProgress, any]) => {
-        if (progress?.authError) {
-          return progress.authError;
-        }
-        const summary = result?.summary || "";
-        if (summary.includes("401")) {
-          return "Token expired. Please re-authenticate.";
-        }
-        if (summary.toLowerCase().includes("authentication error")) {
-          return "Authentication error. Please re-authenticate.";
-        }
-        return "";
-      },
-    );
+    const authErrorMessage = computed(() => {
+      const progress = searchProgress as SearchProgress;
+      const result = agentResult as any;
+      if (progress?.authError) {
+        return progress.authError;
+      }
+      const summary = result?.summary || "";
+      if (summary.includes("401")) {
+        return "Token expired. Please re-authenticate.";
+      }
+      if (summary.toLowerCase().includes("authentication error")) {
+        return "Authentication error. Please re-authenticate.";
+      }
+      return "";
+    });
 
     // Pre-bind handlers (important: must be done outside of derive callbacks)
     // Use module-scope handlers (startScanHandler, stopScanHandler, completeScanHandler)
@@ -1495,8 +1456,7 @@ When you're done searching, STOP calling tools and produce your final structured
     // UI PIECES (extracted for flexible composition)
     // ========================================================================
 
-    // Account type selector - built OUTSIDE derive so handler works
-    // Handlers don't work inside derive() callbacks
+    // Account type selector
     const accountTypeSelector = (
       <div
         style={{
@@ -1524,39 +1484,32 @@ When you're done searching, STOP calling tools and produce your final structured
         >
           <option
             value="default"
-            selected={derive(
-              selectedAccountType,
-              (t: string) => t === "default",
-            )}
+            selected={selectedAccountType.get() === "default"}
           >
             Any Google Account
           </option>
           <option
             value="personal"
-            selected={derive(
-              selectedAccountType,
-              (t: string) => t === "personal",
-            )}
+            selected={selectedAccountType.get() === "personal"}
           >
             Personal Account
           </option>
           <option
             value="work"
-            selected={derive(selectedAccountType, (t: string) => t === "work")}
+            selected={selectedAccountType.get() === "work"}
           >
             Work Account
           </option>
         </select>
-        {derive(selectedAccountType, (type: string) =>
-          type !== "default"
-            ? (
-              <span style={{ color: "#94a3b8", fontSize: "11px" }}>
-                (using #{type === "personal"
-                  ? "googleAuthPersonal"
-                  : "googleAuthWork"})
-              </span>
-            )
-            : null)}
+        {selectedAccountType.get() !== "default"
+          ? (
+            <span style={{ color: "#94a3b8", fontSize: "11px" }}>
+              (using #{selectedAccountType.get() === "personal"
+                ? "googleAuthPersonal"
+                : "googleAuthWork"})
+            </span>
+          )
+          : null}
       </div>
     );
 
@@ -1564,44 +1517,39 @@ When you're done searching, STOP calling tools and produce your final structured
     const authUI = (
       <div>
         {/* Account Type Selector (only shown if not using direct auth) */}
-        {ifElse(hasDirectAuth, null, accountTypeSelector)}
+        {hasDirectAuth ? null : accountTypeSelector}
 
         {/* Auth Status - use nested ifElse to avoid Cell-in-Cell problem */}
         {
           /* Only show custom error UIs for specific warning states;
             authFullUI handles everything else (not-auth, selecting, ready) */
         }
-        {ifElse(
-          // Show custom error UI only when authenticated AND has API error
-          derive(
-            [isAuthenticated, hasAuthError],
-            ([auth, err]: [boolean, boolean]) => auth && err,
-          ),
+        {isAuthenticated && hasAuthError
           // Auth error state - custom warning UI
-          <div
-            style={{
-              padding: "12px",
-              background: "#fef3c7",
-              border: "1px solid #fde68a",
-              borderRadius: "8px",
-            }}
-          >
+          ? (
             <div
               style={{
-                fontSize: "14px",
-                color: "#92400e",
-                textAlign: "center",
-                marginBottom: "8px",
+                padding: "12px",
+                background: "#fef3c7",
+                border: "1px solid #fde68a",
+                borderRadius: "8px",
               }}
             >
-              ⚠️ {authErrorMessage}
-            </div>
-            <div style={{ textAlign: "center" }}>
-              {derive(wishedAuthPiece, (piece: any) =>
-                piece
+              <div
+                style={{
+                  fontSize: "14px",
+                  color: "#92400e",
+                  textAlign: "center",
+                  marginBottom: "8px",
+                }}
+              >
+                ⚠️ {authErrorMessage}
+              </div>
+              <div style={{ textAlign: "center" }}>
+                {wishedAuthPiece
                   ? (
                     <cf-button
-                      onClick={() => navigateTo(piece)}
+                      onClick={() => navigateTo(wishedAuthPiece)}
                       size="sm"
                       variant="secondary"
                     >
@@ -1616,17 +1564,14 @@ When you're done searching, STOP calling tools and produce your final structured
                     >
                       Connect Gmail
                     </cf-button>
-                  ))}
+                  )}
+              </div>
             </div>
-          </div>,
+          )
           // No auth error - check for token expiry warning
-          ifElse(
-            // Show expiry warning only when authenticated AND token may be expired
-            derive(
-              [isAuthenticated, tokenMayBeExpired],
-              ([auth, exp]: [boolean, boolean]) => auth && exp,
-            ),
-            // Token expiry warning - custom warning UI
+          : isAuthenticated && tokenMayBeExpired
+          // Token expiry warning - custom warning UI
+          ? (
             <div
               style={{
                 padding: "12px",
@@ -1646,136 +1591,120 @@ When you're done searching, STOP calling tools and produce your final structured
                 ⚠️ Gmail token may have expired - will verify on scan
               </div>
               <div style={{ textAlign: "center" }}>
-                {derive(wishedAuthPiece, (piece: any) =>
-                  piece
-                    ? (
-                      <cf-button
-                        onClick={() => navigateTo(piece)}
-                        size="sm"
-                        variant="secondary"
-                      >
-                        Re-authenticate Gmail
-                      </cf-button>
-                    )
-                    : null)}
+                {wishedAuthPiece
+                  ? (
+                    <cf-button
+                      onClick={() => navigateTo(wishedAuthPiece)}
+                      size="sm"
+                      variant="secondary"
+                    >
+                      Re-authenticate Gmail
+                    </cf-button>
+                  )
+                  : null}
               </div>
-            </div>,
-            // All other cases: use authFullUI directly
-            // - Not authenticated → shows onboarding/picker UI
-            // - Authenticated success → shows user chip with avatar, email, Switch/Add buttons
-            authFullUI,
-          ),
-        )}
+            </div>
+          )
+          // All other cases: use authFullUI directly
+          // - Not authenticated → shows onboarding/picker UI
+          // - Authenticated success → shows user chip with avatar, email, Switch/Add buttons
+          : authFullUI}
       </div>
     );
 
     // Check if agentGoal is empty (pattern not configured for a specific task)
-    const hasAgentGoal = derive(
-      agentGoal,
-      (goal: string) => !!(goal && goal.trim()),
-    );
+    const hasAgentGoal = !!(agentGoal && agentGoal.trim());
 
     // Controls UI - scan and stop buttons
     const controlsUI = (
       <div>
         {/* Warning when no agent goal is set */}
-        {derive(
-          [isAuthenticated, hasAgentGoal],
-          ([authenticated, hasGoal]: [boolean, boolean]) =>
-            authenticated && !hasGoal
-              ? (
-                <div
-                  style={{
-                    padding: "16px",
-                    background: "#fef3c7",
-                    border: "1px solid #fde68a",
-                    borderRadius: "8px",
-                    marginBottom: "12px",
-                  }}
-                >
-                  <div
-                    style={{
-                      fontWeight: "600",
-                      color: "#92400e",
-                      marginBottom: "8px",
-                      fontSize: "14px",
-                    }}
-                  >
-                    ⚠️ No Search Goal Configured
-                  </div>
-                  <div style={{ fontSize: "13px", color: "#78350f" }}>
-                    This is the base Gmail Agentic Search pattern. To use it,
-                    you need to either:
-                  </div>
-                  <ul
-                    style={{
-                      margin: "8px 0 0 0",
-                      paddingLeft: "20px",
-                      fontSize: "12px",
-                      color: "#78350f",
-                    }}
-                  >
-                    <li>
-                      Use a specialized pattern (like Hotel Membership
-                      Extractor) that has a built-in goal
-                    </li>
-                    <li>
-                      Pass an <code>agentGoal</code>{" "}
-                      input when embedding this pattern
-                    </li>
-                  </ul>
-                  <div
-                    style={{
-                      marginTop: "12px",
-                      fontSize: "11px",
-                      color: "#92400e",
-                    }}
-                  >
-                    The agent won't run without a search goal.
-                  </div>
-                </div>
-              )
-              : null,
-        )}
+        {isAuthenticated && !hasAgentGoal
+          ? (
+            <div
+              style={{
+                padding: "16px",
+                background: "#fef3c7",
+                border: "1px solid #fde68a",
+                borderRadius: "8px",
+                marginBottom: "12px",
+              }}
+            >
+              <div
+                style={{
+                  fontWeight: "600",
+                  color: "#92400e",
+                  marginBottom: "8px",
+                  fontSize: "14px",
+                }}
+              >
+                ⚠️ No Search Goal Configured
+              </div>
+              <div style={{ fontSize: "13px", color: "#78350f" }}>
+                This is the base Gmail Agentic Search pattern. To use it, you
+                need to either:
+              </div>
+              <ul
+                style={{
+                  margin: "8px 0 0 0",
+                  paddingLeft: "20px",
+                  fontSize: "12px",
+                  color: "#78350f",
+                }}
+              >
+                <li>
+                  Use a specialized pattern (like Hotel Membership Extractor)
+                  that has a built-in goal
+                </li>
+                <li>
+                  Pass an <code>agentGoal</code>{" "}
+                  input when embedding this pattern
+                </li>
+              </ul>
+              <div
+                style={{
+                  marginTop: "12px",
+                  fontSize: "11px",
+                  color: "#92400e",
+                }}
+              >
+                The agent won't run without a search goal.
+              </div>
+            </div>
+          )
+          : null}
 
         {/* Scan Button */}
-        {ifElse(
-          isAuthenticated,
-          <cf-button
-            onClick={boundStartScan}
-            size="lg"
-            style="width: 100%;"
-            disabled={derive(
-              [isScanning, hasAgentGoal],
-              ([scanning, hasGoal]: [boolean, boolean]) => scanning || !hasGoal,
-            )}
-          >
-            {derive(
-              [isScanning, hasAgentGoal],
-              ([scanning, hasGoal]: [boolean, boolean]) =>
-                scanning
-                  ? "⏳ Scanning..."
-                  : hasGoal
-                  ? scanButtonLabel
-                  : "⚠️ No Goal Set",
-            )}
-          </cf-button>,
-          null,
-        )}
+        {isAuthenticated
+          ? (
+            <cf-button
+              onClick={boundStartScan}
+              size="lg"
+              style="width: 100%;"
+              disabled={isScanning || !hasAgentGoal}
+            >
+              {isScanning
+                ? "⏳ Scanning..."
+                : hasAgentGoal
+                ? scanButtonLabel
+                : "⚠️ No Goal Set"}
+            </cf-button>
+          )
+          : null}
 
         {/* Stop Button */}
-        {ifElse(
-          isScanning,
-          <cf-button
-            onClick={boundStopScan}
-            variant="secondary"
-            size="lg"
-            style="width: 100%; margin-top: 8px;"
-          >
-            ⏹ Stop Scan
-          </cf-button>,
-          null,
-        )}
+        {isScanning
+          ? (
+            <cf-button
+              onClick={boundStopScan}
+              variant="secondary"
+              size="lg"
+              style="width: 100%; margin-top: 8px;"
+            >
+              ⏹ Stop Scan
+            </cf-button>
+          )
+          : null}
       </div>
     );
 
@@ -1785,333 +1714,320 @@ When you're done searching, STOP calling tools and produce your final structured
     const progressUI = (
       <div>
         {/* Progress during scanning - hide when scan is complete */}
-        {ifElse(
-          scanCompleted,
-          null,
-          derive(
-            [isScanning, searchProgress],
-            ([scanning, progress]: [boolean, SearchProgress]) =>
-              scanning && progress.status !== "idle" &&
-                progress.status !== "auth_error"
+        {scanCompleted
+          ? null
+          : isScanning && searchProgress.status !== "idle" &&
+              searchProgress.status !== "auth_error"
+          ? (
+            <div
+              style={{
+                padding: "16px",
+                background: "#f8fafc",
+                border: "1px solid #e2e8f0",
+                borderRadius: "8px",
+              }}
+            >
+              <div
+                style={{
+                  fontWeight: "600",
+                  marginBottom: "12px",
+                  textAlign: "center",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  gap: "12px",
+                  color: "#475569",
+                }}
+              >
+                <cf-loader show-elapsed></cf-loader>
+                Scanning emails...
+              </div>
+
+              {/* Current Activity */}
+              {searchProgress.currentQuery
                 ? (
                   <div
                     style={{
-                      padding: "16px",
-                      background: "#f8fafc",
-                      border: "1px solid #e2e8f0",
-                      borderRadius: "8px",
+                      padding: "8px",
+                      background: "#f1f5f9",
+                      borderRadius: "4px",
+                      marginBottom: "12px",
                     }}
                   >
                     <div
                       style={{
-                        fontWeight: "600",
-                        marginBottom: "12px",
-                        textAlign: "center",
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "center",
-                        gap: "12px",
+                        fontSize: "12px",
                         color: "#475569",
+                        fontWeight: "600",
                       }}
                     >
-                      <cf-loader show-elapsed></cf-loader>
-                      Scanning emails...
+                      🔍 Currently searching:
                     </div>
-
-                    {/* Current Activity */}
-                    {derive(searchProgress, (progress: SearchProgress) =>
-                      progress.currentQuery
-                        ? (
-                          <div
-                            style={{
-                              padding: "8px",
-                              background: "#f1f5f9",
-                              borderRadius: "4px",
-                              marginBottom: "12px",
-                            }}
-                          >
-                            <div
-                              style={{
-                                fontSize: "12px",
-                                color: "#475569",
-                                fontWeight: "600",
-                              }}
-                            >
-                              🔍 Currently searching:
-                            </div>
-                            <div
-                              style={{
-                                fontSize: "13px",
-                                color: "#334155",
-                                fontFamily: "monospace",
-                                wordBreak: "break-all",
-                              }}
-                            >
-                              {progress.currentQuery}
-                            </div>
-                          </div>
-                        )
-                        : (
-                          <div
-                            style={{
-                              padding: "8px",
-                              background: "#f1f5f9",
-                              borderRadius: "4px",
-                              marginBottom: "12px",
-                            }}
-                          >
-                            <div
-                              style={{
-                                fontSize: "12px",
-                                color: "#475569",
-                                display: "flex",
-                                alignItems: "center",
-                                gap: "8px",
-                              }}
-                            >
-                              <cf-loader size="sm"></cf-loader>
-                              Analyzing emails...
-                            </div>
-                          </div>
-                        ))}
-
-                    {/* Completed Searches */}
-                    {derive(searchProgress, (progress: SearchProgress) =>
-                      progress.completedQueries.length > 0
-                        ? (
-                          <div style={{ marginTop: "8px" }}>
-                            <div
-                              style={{
-                                fontSize: "12px",
-                                color: "#475569",
-                                fontWeight: "600",
-                                marginBottom: "4px",
-                              }}
-                            >
-                              ✅ Completed searches ({progress.completedQueries
-                                .length}
-                              ):
-                            </div>
-                            <div
-                              style={{
-                                maxHeight: "120px",
-                                overflowY: "auto",
-                                fontSize: "11px",
-                                color: "#3b82f6",
-                              }}
-                            >
-                              {[...progress.completedQueries]
-                                .reverse()
-                                .slice(0, 5)
-                                .map(
-                                  (
-                                    q: { query: string; emailCount: number },
-                                    i: number,
-                                  ) => (
-                                    <div
-                                      key={i}
-                                      style={{
-                                        padding: "2px 0",
-                                        borderBottom: "1px solid #dbeafe",
-                                      }}
-                                    >
-                                      <span style={{ fontFamily: "monospace" }}>
-                                        {q?.query
-                                          ? q.query.length > 50
-                                            ? q.query.substring(0, 50) + "..."
-                                            : q.query
-                                          : "unknown"}
-                                      </span>
-                                      <span
-                                        style={{
-                                          marginLeft: "8px",
-                                          color: "#059669",
-                                        }}
-                                      >
-                                        ({q?.emailCount ?? 0} emails)
-                                      </span>
-                                    </div>
-                                  ),
-                                )}
-                            </div>
-                          </div>
-                        )
-                        : null)}
+                    <div
+                      style={{
+                        fontSize: "13px",
+                        color: "#334155",
+                        fontFamily: "monospace",
+                        wordBreak: "break-all",
+                      }}
+                    >
+                      {searchProgress.currentQuery}
+                    </div>
                   </div>
                 )
-                : null,
-          ),
-        )}
+                : (
+                  <div
+                    style={{
+                      padding: "8px",
+                      background: "#f1f5f9",
+                      borderRadius: "4px",
+                      marginBottom: "12px",
+                    }}
+                  >
+                    <div
+                      style={{
+                        fontSize: "12px",
+                        color: "#475569",
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "8px",
+                      }}
+                    >
+                      <cf-loader size="sm"></cf-loader>
+                      Analyzing emails...
+                    </div>
+                  </div>
+                )}
+
+              {/* Completed Searches */}
+              {searchProgress.completedQueries.length > 0
+                ? (
+                  <div style={{ marginTop: "8px" }}>
+                    <div
+                      style={{
+                        fontSize: "12px",
+                        color: "#475569",
+                        fontWeight: "600",
+                        marginBottom: "4px",
+                      }}
+                    >
+                      ✅ Completed searches ({searchProgress
+                        .completedQueries
+                        .length}
+                      ):
+                    </div>
+                    <div
+                      style={{
+                        maxHeight: "120px",
+                        overflowY: "auto",
+                        fontSize: "11px",
+                        color: "#3b82f6",
+                      }}
+                    >
+                      {[...searchProgress.completedQueries]
+                        .reverse()
+                        .slice(0, 5)
+                        .map(
+                          (
+                            q: { query: string; emailCount: number },
+                            i: number,
+                          ) => (
+                            <div
+                              key={i}
+                              style={{
+                                padding: "2px 0",
+                                borderBottom: "1px solid #dbeafe",
+                              }}
+                            >
+                              <span style={{ fontFamily: "monospace" }}>
+                                {q?.query
+                                  ? q.query.length > 50
+                                    ? q.query.substring(0, 50) + "..."
+                                    : q.query
+                                  : "unknown"}
+                              </span>
+                              <span
+                                style={{
+                                  marginLeft: "8px",
+                                  color: "#059669",
+                                }}
+                              >
+                                ({q?.emailCount ?? 0} emails)
+                              </span>
+                            </div>
+                          ),
+                        )}
+                    </div>
+                  </div>
+                )
+                : null}
+            </div>
+          )
+          : null}
 
         {/* Scan Complete */}
-        {derive(scanCompleted, (completed: boolean) =>
-          completed
-            ? (
+        {scanCompleted
+          ? (
+            <div
+              style={{
+                padding: "16px",
+                background: "#f0fdf4",
+                border: "1px solid #bbf7d0",
+                borderRadius: "8px",
+              }}
+            >
               <div
                 style={{
-                  padding: "16px",
-                  background: "#f0fdf4",
-                  border: "1px solid #bbf7d0",
-                  borderRadius: "8px",
+                  fontSize: "16px",
+                  fontWeight: "600",
+                  color: "#166534",
+                  marginBottom: "12px",
+                  textAlign: "center",
                 }}
               >
-                <div
-                  style={{
-                    fontSize: "16px",
-                    fontWeight: "600",
-                    color: "#166534",
-                    marginBottom: "12px",
-                    textAlign: "center",
-                  }}
-                >
-                  ✓ Scan Complete
-                </div>
-                <div
-                  style={{
-                    fontSize: "12px",
-                    color: "#059669",
-                    textAlign: "center",
-                  }}
-                >
-                  <cf-markdown>
-                    {derive(agentResult, (r: any) => r?.summary || "")}
-                  </cf-markdown>
-                </div>
-                <cf-button
-                  onClick={boundCompleteScan}
-                  size="lg"
-                  style="width: 100%; margin-top: 12px;"
-                >
-                  ✓ Done
-                </cf-button>
+                ✓ Scan Complete
               </div>
-            )
-            : null)}
+              <div
+                style={{
+                  fontSize: "12px",
+                  color: "#059669",
+                  textAlign: "center",
+                }}
+              >
+                <cf-markdown>
+                  {(agentResult as any)?.summary || ""}
+                </cf-markdown>
+              </div>
+              <cf-button
+                onClick={boundCompleteScan}
+                size="lg"
+                style="width: 100%; margin-top: 12px;"
+              >
+                ✓ Done
+              </cf-button>
+            </div>
+          )
+          : null}
       </div>
     );
 
     // Stats UI - last scan timestamp
     const statsUI = (
       <div style={{ fontSize: "13px", color: "#666" }}>
-        {derive(lastScanAt, (ts: number) =>
-          ts > 0
-            ? <div>Last Scan: {new Date(ts).toLocaleString()}</div>
-            : null)}
+        {lastScanAt > 0
+          ? <div>Last Scan: {new Date(lastScanAt).toLocaleString()}</div>
+          : null}
       </div>
     );
 
     // Debug Log UI - collapsible log of agent activity
     const debugLogUI = (
       <div style={{ marginTop: "8px" }}>
-        {derive(debugLog, (log: DebugLogEntry[]) =>
-          log && log.length > 0
-            ? (
+        {debugLog && debugLog.length > 0
+          ? (
+            <div
+              style={{
+                border: "1px solid #e2e8f0",
+                borderRadius: "8px",
+                overflow: "hidden",
+              }}
+            >
+              {/* Header - clickable to toggle */}
               <div
+                onClick={toggleDebugHandler({ expanded: debugExpanded })}
                 style={{
-                  border: "1px solid #e2e8f0",
-                  borderRadius: "8px",
-                  overflow: "hidden",
+                  padding: "8px 12px",
+                  background: "#f8fafc",
+                  borderBottom: "1px solid #e2e8f0",
+                  cursor: "pointer",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  fontSize: "13px",
+                  fontWeight: "500",
+                  color: "#475569",
                 }}
               >
-                {/* Header - clickable to toggle */}
-                <div
-                  onClick={toggleDebugHandler({ expanded: debugExpanded })}
-                  style={{
-                    padding: "8px 12px",
-                    background: "#f8fafc",
-                    borderBottom: "1px solid #e2e8f0",
-                    cursor: "pointer",
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "space-between",
-                    fontSize: "13px",
-                    fontWeight: "500",
-                    color: "#475569",
-                  }}
-                >
-                  <span>
-                    {derive(debugExpanded, (e: boolean) => e ? "▼" : "▶")}{" "}
-                    Debug Log ({log.length} entries)
-                  </span>
-                  <span style={{ fontSize: "11px", color: "#94a3b8" }}>
-                    click to {derive(
-                      debugExpanded,
-                      (e: boolean) => e ? "collapse" : "expand",
-                    )}
-                  </span>
-                </div>
+                <span>
+                  {debugExpanded.get() ? "▼" : "▶"} Debug Log ({debugLog.length}
+                  {" "}
+                  entries)
+                </span>
+                <span style={{ fontSize: "11px", color: "#94a3b8" }}>
+                  click to {debugExpanded.get() ? "collapse" : "expand"}
+                </span>
+              </div>
 
-                {/* Content - shown when expanded */}
-                {derive(debugExpanded, (expanded: boolean) =>
-                  expanded
-                    ? (
+              {/* Content - shown when expanded */}
+              {debugExpanded.get()
+                ? (
+                  <div
+                    style={{
+                      maxHeight: "300px",
+                      overflowY: "auto",
+                      background: "#1e293b",
+                      padding: "12px",
+                      fontFamily: "monospace",
+                      fontSize: "11px",
+                    }}
+                  >
+                    {debugLog.filter((e): e is DebugLogEntry => e != null).map((
+                      entry: DebugLogEntry,
+                      i: number,
+                    ) => (
                       <div
+                        key={i}
                         style={{
-                          maxHeight: "300px",
-                          overflowY: "auto",
-                          background: "#1e293b",
-                          padding: "12px",
-                          fontFamily: "monospace",
-                          fontSize: "11px",
+                          padding: "4px 0",
+                          borderBottom: "1px solid #334155",
+                          color: entry.type === "error"
+                            ? "#f87171"
+                            : entry.type === "search_start"
+                            ? "#60a5fa"
+                            : entry.type === "search_result"
+                            ? "#4ade80"
+                            : "#e2e8f0",
                         }}
                       >
-                        {log.filter((e): e is DebugLogEntry => e != null).map((
-                          entry: DebugLogEntry,
-                          i: number,
-                        ) => (
+                        <span style={{ color: "#64748b" }}>
+                          {new Date(entry.timestamp).toLocaleTimeString()}
+                        </span>{" "}
+                        <span
+                          style={{
+                            padding: "1px 4px",
+                            borderRadius: "3px",
+                            fontSize: "10px",
+                            background: entry.type === "error"
+                              ? "#7f1d1d"
+                              : entry.type === "search_start"
+                              ? "#1e3a5f"
+                              : entry.type === "search_result"
+                              ? "#14532d"
+                              : "#334155",
+                          }}
+                        >
+                          {entry.type}
+                        </span>{" "}
+                        {entry.message}
+                        {entry.details && (
                           <div
-                            key={i}
                             style={{
-                              padding: "4px 0",
-                              borderBottom: "1px solid #334155",
-                              color: entry.type === "error"
-                                ? "#f87171"
-                                : entry.type === "search_start"
-                                ? "#60a5fa"
-                                : entry.type === "search_result"
-                                ? "#4ade80"
-                                : "#e2e8f0",
+                              marginLeft: "16px",
+                              color: "#94a3b8",
+                              fontSize: "10px",
                             }}
                           >
-                            <span style={{ color: "#64748b" }}>
-                              {new Date(entry.timestamp).toLocaleTimeString()}
-                            </span>{" "}
-                            <span
-                              style={{
-                                padding: "1px 4px",
-                                borderRadius: "3px",
-                                fontSize: "10px",
-                                background: entry.type === "error"
-                                  ? "#7f1d1d"
-                                  : entry.type === "search_start"
-                                  ? "#1e3a5f"
-                                  : entry.type === "search_result"
-                                  ? "#14532d"
-                                  : "#334155",
-                              }}
-                            >
-                              {entry.type}
-                            </span>{" "}
-                            {entry.message}
-                            {entry.details && (
-                              <div
-                                style={{
-                                  marginLeft: "16px",
-                                  color: "#94a3b8",
-                                  fontSize: "10px",
-                                }}
-                              >
-                                {toIndentedDebugString(entry.details)}
-                              </div>
-                            )}
+                            {toIndentedDebugString(entry.details)}
                           </div>
-                        ))}
+                        )}
                       </div>
-                    )
-                    : null)}
-              </div>
-            )
-            : null)}
+                    ))}
+                  </div>
+                )
+                : null}
+            </div>
+          )
+          : null}
       </div>
     );
 
@@ -2123,168 +2039,162 @@ When you're done searching, STOP calling tools and produce your final structured
     // and called directly with all parameters in onClick handlers (no pre-binding needed)
     // Note: localQueriesExpanded/toggleLocalQueries removed - using native <details>/<summary> instead
 
-    // Local Queries UI - collapsible list of saved queries
-    // Uses native <details>/<summary> to avoid nested derive closure issues
-    // (see superstition: 2025-12-06-use-native-details-summary-for-expand-collapse.md)
-    //
-    // Key fix: Instead of nested derive(localQueriesExpanded, ...) inside derive(localQueries, ...),
-    // we use native <details open> which handles expand/collapse via browser without reactive state.
-    // The derive(localQueries) renders the entire details block including content - no closure issues.
+    // Local Queries UI - collapsible list of saved queries.
+    // Uses native <details>/<summary> so expand/collapse is handled by the
+    // browser without reactive state.
     const localQueriesUI = (
       <div style={{ marginTop: "8px" }}>
-        {derive(
-          [localQueriesWithFoundItems, onlySaveQueriesWithItems],
-          ([queries, onlyWithItems]: [LocalQuery[], boolean]) => {
-            // Filter queries: when onlyWithItems is true, only show queries that found target items
-            const filteredQueries = (queries || []).filter(
+        {computed(() => {
+          // Filter queries: when onlySaveQueriesWithItems is true, only show queries that found target items
+          const filteredQueries =
+            (localQueriesWithFoundItems as LocalQuery[] || []).filter(
               (q): q is LocalQuery => {
                 if (!q) return false;
-                if (onlyWithItems) {
+                if (onlySaveQueriesWithItems) {
                   return (q.foundItems || 0) > 0;
                 }
                 return true;
               },
             );
 
-            if (filteredQueries.length === 0) return null;
+          if (filteredQueries.length === 0) return null;
 
-            return (
-              <details
-                open
+          return (
+            <details
+              open
+              style={{
+                border: "1px solid #e2e8f0",
+                borderRadius: "8px",
+                overflow: "hidden",
+              }}
+            >
+              {/* Summary - clickable header */}
+              <summary
                 style={{
-                  border: "1px solid #e2e8f0",
-                  borderRadius: "8px",
-                  overflow: "hidden",
+                  padding: "8px 12px",
+                  background: "#fefce8",
+                  borderBottom: "1px solid #fef08a",
+                  cursor: "pointer",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  fontSize: "13px",
+                  fontWeight: "500",
+                  color: "#854d0e",
+                  listStyle: "none",
                 }}
               >
-                {/* Summary - clickable header */}
-                <summary
-                  style={{
-                    padding: "8px 12px",
-                    background: "#fefce8",
-                    borderBottom: "1px solid #fef08a",
-                    cursor: "pointer",
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "space-between",
-                    fontSize: "13px",
-                    fontWeight: "500",
-                    color: "#854d0e",
-                    listStyle: "none",
-                  }}
-                >
-                  <span>My Saved Queries ({filteredQueries.length})</span>
-                  <span style={{ fontSize: "11px", color: "#a16207" }}>
-                    click to toggle
-                  </span>
-                </summary>
+                <span>My Saved Queries ({filteredQueries.length})</span>
+                <span style={{ fontSize: "11px", color: "#a16207" }}>
+                  click to toggle
+                </span>
+              </summary>
 
-                {/* Content - shown when expanded (handled by browser) */}
-                <div
-                  style={{
-                    maxHeight: "300px",
-                    overflowY: "auto",
-                    background: "#fffbeb",
-                    padding: "8px",
-                  }}
-                >
-                  {[...filteredQueries]
-                    .sort((a, b) =>
-                      (b.effectiveness || 0) - (a.effectiveness || 0)
-                    )
-                    .map((query: LocalQuery) => (
+              {/* Content - shown when expanded (handled by browser) */}
+              <div
+                style={{
+                  maxHeight: "300px",
+                  overflowY: "auto",
+                  background: "#fffbeb",
+                  padding: "8px",
+                }}
+              >
+                {[...filteredQueries]
+                  .sort((a, b) =>
+                    (b.effectiveness || 0) - (a.effectiveness || 0)
+                  )
+                  .map((query: LocalQuery) => (
+                    <div
+                      style={{
+                        padding: "8px",
+                        marginBottom: "8px",
+                        background: "white",
+                        borderRadius: "6px",
+                        border: "1px solid #fef08a",
+                      }}
+                    >
                       <div
                         style={{
-                          padding: "8px",
-                          marginBottom: "8px",
-                          background: "white",
-                          borderRadius: "6px",
-                          border: "1px solid #fef08a",
+                          display: "flex",
+                          justifyContent: "space-between",
+                          alignItems: "flex-start",
                         }}
                       >
-                        <div
-                          style={{
-                            display: "flex",
-                            justifyContent: "space-between",
-                            alignItems: "flex-start",
-                          }}
-                        >
-                          <div style={{ flex: 1 }}>
-                            <div
-                              style={{
-                                fontFamily: "monospace",
-                                fontSize: "12px",
-                                color: "#1e293b",
-                                wordBreak: "break-all",
-                                marginBottom: "4px",
-                              }}
-                            >
-                              {query.query}
-                            </div>
-                            <div style={{ fontSize: "10px", color: "#64748b" }}>
-                              Used {query.useCount}x
-                              {query.lastUsed &&
-                                ` · Last: ${
-                                  new Date(query.lastUsed).toLocaleDateString()
-                                }`}
-                              {query.shareStatus === "pending_review" && (
-                                <span
-                                  style={{
-                                    color: "#3b82f6",
-                                    marginLeft: "8px",
-                                  }}
-                                >
-                                  (pending review)
-                                </span>
-                              )}
-                              {query.shareStatus === "submitted" && (
-                                <span
-                                  style={{
-                                    color: "#22c55e",
-                                    marginLeft: "8px",
-                                  }}
-                                >
-                                  (shared)
-                                </span>
-                              )}
-                            </div>
+                        <div style={{ flex: 1 }}>
+                          <div
+                            style={{
+                              fontFamily: "monospace",
+                              fontSize: "12px",
+                              color: "#1e293b",
+                              wordBreak: "break-all",
+                              marginBottom: "4px",
+                            }}
+                          >
+                            {query.query}
                           </div>
-                          <div style={{ display: "flex", gap: "4px" }}>
-                            {query.shareStatus === "private" && (
-                              <cf-button
-                                onClick={flagForShareHandler({
-                                  queryId: query.id,
-                                  localQueries,
-                                  pendingSubmissions,
-                                })}
-                                variant="ghost"
-                                size="sm"
-                                style="color: #3b82f6; font-size: 11px;"
+                          <div style={{ fontSize: "10px", color: "#64748b" }}>
+                            Used {query.useCount}x
+                            {query.lastUsed &&
+                              ` · Last: ${
+                                new Date(query.lastUsed).toLocaleDateString()
+                              }`}
+                            {query.shareStatus === "pending_review" && (
+                              <span
+                                style={{
+                                  color: "#3b82f6",
+                                  marginLeft: "8px",
+                                }}
                               >
-                                Share
-                              </cf-button>
+                                (pending review)
+                              </span>
                             )}
+                            {query.shareStatus === "submitted" && (
+                              <span
+                                style={{
+                                  color: "#22c55e",
+                                  marginLeft: "8px",
+                                }}
+                              >
+                                (shared)
+                              </span>
+                            )}
+                          </div>
+                        </div>
+                        <div style={{ display: "flex", gap: "4px" }}>
+                          {query.shareStatus === "private" && (
                             <cf-button
-                              onClick={deleteLocalQueryHandler({
+                              onClick={flagForShareHandler({
                                 queryId: query.id,
                                 localQueries,
                                 pendingSubmissions,
                               })}
                               variant="ghost"
                               size="sm"
-                              style="color: #dc2626; font-size: 12px;"
+                              style="color: #3b82f6; font-size: 11px;"
                             >
-                              ×
+                              Share
                             </cf-button>
-                          </div>
+                          )}
+                          <cf-button
+                            onClick={deleteLocalQueryHandler({
+                              queryId: query.id,
+                              localQueries,
+                              pendingSubmissions,
+                            })}
+                            variant="ghost"
+                            size="sm"
+                            style="color: #dc2626; font-size: 12px;"
+                          >
+                            ×
+                          </cf-button>
                         </div>
                       </div>
-                    ))}
-                </div>
-              </details>
-            );
-          },
-        )}
+                    </div>
+                  ))}
+              </div>
+            </details>
+          );
+        })}
       </div>
     );
 
@@ -2345,23 +2255,22 @@ When you're done searching, STOP calling tools and produce your final structured
 
     // Run PII screening on pending submissions
     // Uses derive to reactively screen new submissions
-    const piiScreeningPrompt = derive(
-      pendingSubmissions,
-      (submissions: PendingSubmission[]) => {
-        // Filter out any undefined/null items first, then find unscreened submissions
-        const validSubmissions = (submissions || []).filter((
+    const piiScreeningPrompt = computed(() => {
+      // Filter out any undefined/null items first, then find unscreened submissions
+      const validSubmissions =
+        ((pendingSubmissions as PendingSubmission[]) || []).filter((
           s,
         ): s is PendingSubmission => s != null);
-        const unscreened = validSubmissions.filter(
-          (s) =>
-            s.sanitizedQuery === s.originalQuery &&
-            s.piiWarnings.length === 0 && !s.userApproved,
-        );
-        if (unscreened.length === 0) return "";
+      const unscreened = validSubmissions.filter(
+        (s) =>
+          s.sanitizedQuery === s.originalQuery &&
+          s.piiWarnings.length === 0 && !s.userApproved,
+      );
+      if (unscreened.length === 0) return "";
 
-        // Build prompt for the first unscreened submission
-        const submission = unscreened[0];
-        return `Analyze this Gmail search query for privacy issues and generalizability.
+      // Build prompt for the first unscreened submission
+      const submission = unscreened[0];
+      return `Analyze this Gmail search query for privacy issues and generalizability.
 
 Query: "${submission.originalQuery}"
 
@@ -2395,14 +2304,13 @@ Return a sanitized version that:
 1. Removes/generalizes PII
 2. Makes the query more general if it's too specific
 3. Returns empty string "" if the query can't be made useful for others`;
-      },
-    );
+    });
 
     // Only run PII screening when there's a prompt
-    const piiScreeningResult = derive(piiScreeningPrompt, (prompt: string) => {
-      if (!prompt) return null;
+    const piiScreeningResult = computed(() => {
+      if (!piiScreeningPrompt) return null;
       return generateObject({
-        prompt,
+        prompt: piiScreeningPrompt,
         schema: piiScreeningSchema,
         system:
           `You are a privacy analyst and query curator for a community knowledge base.
@@ -2421,7 +2329,8 @@ Be conservative: when in doubt, recommend "do_not_share".`,
 
     // Update pending submissions with screening results
     // This is a side effect that runs when screening completes
-    derive(piiScreeningResult, (result: any) => {
+    computed(() => {
+      const result = piiScreeningResult as any;
       if (!result || !result.result) return;
 
       const screeningData = result.result as {
@@ -2479,440 +2388,426 @@ Be conservative: when in doubt, recommend "do_not_share".`,
     // Pending Submissions UI
     const pendingSubmissionsUI = (
       <div style={{ marginTop: "8px" }}>
-        {derive(pendingSubmissions, (submissions: PendingSubmission[]) =>
-          submissions && submissions.length > 0
-            ? (
+        {(pendingSubmissions as PendingSubmission[]) &&
+            (pendingSubmissions as PendingSubmission[]).length > 0
+          ? (
+            <div
+              style={{
+                border: "1px solid #dbeafe",
+                borderRadius: "8px",
+                overflow: "hidden",
+              }}
+            >
+              {/* Header */}
               <div
+                onClick={togglePendingSubmissionsHandler({
+                  expanded: pendingSubmissionsExpanded,
+                })}
                 style={{
-                  border: "1px solid #dbeafe",
-                  borderRadius: "8px",
-                  overflow: "hidden",
+                  padding: "8px 12px",
+                  background: "#eff6ff",
+                  borderBottom: "1px solid #dbeafe",
+                  cursor: "pointer",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  fontSize: "13px",
+                  fontWeight: "500",
+                  color: "#1e40af",
                 }}
               >
-                {/* Header */}
-                <div
-                  onClick={togglePendingSubmissionsHandler({
-                    expanded: pendingSubmissionsExpanded,
-                  })}
-                  style={{
-                    padding: "8px 12px",
-                    background: "#eff6ff",
-                    borderBottom: "1px solid #dbeafe",
-                    cursor: "pointer",
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "space-between",
-                    fontSize: "13px",
-                    fontWeight: "500",
-                    color: "#1e40af",
-                  }}
-                >
-                  <span>
-                    {derive(pendingSubmissionsExpanded, (e: boolean) =>
-                      e ? "▼" : "▶")}{" "}
-                    Share Your Discoveries ({submissions.length} pending)
-                  </span>
-                  <span style={{ fontSize: "11px", color: "#3b82f6" }}>
-                    click to{" "}
-                    {derive(pendingSubmissionsExpanded, (e: boolean) =>
-                      e ? "collapse" : "expand")}
-                  </span>
-                </div>
+                <span>
+                  {pendingSubmissionsExpanded.get() ? "▼" : "▶"}{" "}
+                  Share Your Discoveries
+                  ({(pendingSubmissions as PendingSubmission[]).length} pending)
+                </span>
+                <span style={{ fontSize: "11px", color: "#3b82f6" }}>
+                  click to{" "}
+                  {pendingSubmissionsExpanded.get() ? "collapse" : "expand"}
+                </span>
+              </div>
 
-                {/* Content */}
-                {derive(pendingSubmissionsExpanded, (expanded: boolean) =>
-                  expanded
-                    ? (
+              {/* Content */}
+              {pendingSubmissionsExpanded.get()
+                ? (
+                  <div
+                    style={{
+                      maxHeight: "400px",
+                      overflowY: "auto",
+                      background: "#f8fafc",
+                      padding: "8px",
+                    }}
+                  >
+                    {(pendingSubmissions as PendingSubmission[]).filter((
+                      s,
+                    ): s is PendingSubmission => s != null).map((
+                      submission: PendingSubmission,
+                    ) => (
                       <div
                         style={{
-                          maxHeight: "400px",
-                          overflowY: "auto",
-                          background: "#f8fafc",
-                          padding: "8px",
+                          padding: "12px",
+                          marginBottom: "8px",
+                          background: "white",
+                          borderRadius: "6px",
+                          border: "1px solid #e2e8f0",
                         }}
                       >
-                        {submissions.filter((s): s is PendingSubmission =>
-                          s != null
-                        ).map((submission: PendingSubmission) => (
+                        {/* Original query */}
+                        <div style={{ marginBottom: "8px" }}>
                           <div
                             style={{
-                              padding: "12px",
-                              marginBottom: "8px",
-                              background: "white",
-                              borderRadius: "6px",
-                              border: "1px solid #e2e8f0",
+                              fontSize: "11px",
+                              color: "#64748b",
+                              marginBottom: "2px",
                             }}
                           >
-                            {/* Original query */}
-                            <div style={{ marginBottom: "8px" }}>
-                              <div
-                                style={{
-                                  fontSize: "11px",
-                                  color: "#64748b",
-                                  marginBottom: "2px",
-                                }}
-                              >
-                                Original Query:
-                              </div>
-                              <div
-                                style={{
-                                  fontFamily: "monospace",
-                                  fontSize: "12px",
-                                  color: "#1e293b",
-                                  background: "#f1f5f9",
-                                  padding: "6px 8px",
-                                  borderRadius: "4px",
-                                }}
-                              >
-                                {submission.originalQuery}
-                              </div>
-                            </div>
+                            Original Query:
+                          </div>
+                          <div
+                            style={{
+                              fontFamily: "monospace",
+                              fontSize: "12px",
+                              color: "#1e293b",
+                              background: "#f1f5f9",
+                              padding: "6px 8px",
+                              borderRadius: "4px",
+                            }}
+                          >
+                            {submission.originalQuery}
+                          </div>
+                        </div>
 
-                            {/* Recommendation badge */}
-                            {submission.recommendation !== "pending" && (
-                              <div style={{ marginBottom: "8px" }}>
-                                <span
-                                  style={{
-                                    display: "inline-block",
-                                    padding: "2px 8px",
-                                    borderRadius: "4px",
-                                    fontSize: "11px",
-                                    fontWeight: "500",
-                                    background:
-                                      submission.recommendation === "share"
-                                        ? "#dcfce7"
-                                        : submission.recommendation ===
-                                            "share_with_edits"
-                                        ? "#fef9c3"
-                                        : "#fee2e2",
-                                    color: submission.recommendation === "share"
-                                      ? "#166534"
-                                      : submission.recommendation ===
-                                          "share_with_edits"
-                                      ? "#854d0e"
-                                      : "#b91c1c",
-                                  }}
-                                >
-                                  {submission.recommendation === "share"
-                                    ? "✓ Good to share"
+                        {/* Recommendation badge */}
+                        {submission.recommendation !== "pending" && (
+                          <div style={{ marginBottom: "8px" }}>
+                            <span
+                              style={{
+                                display: "inline-block",
+                                padding: "2px 8px",
+                                borderRadius: "4px",
+                                fontSize: "11px",
+                                fontWeight: "500",
+                                background:
+                                  submission.recommendation === "share"
+                                    ? "#dcfce7"
                                     : submission.recommendation ===
                                         "share_with_edits"
-                                    ? "⚠ Needs editing"
-                                    : "✗ Not recommended"}
-                                </span>
-                              </div>
-                            )}
-
-                            {/* PII Warnings */}
-                            {submission.piiWarnings.length > 0 && (
-                              <div style={{ marginBottom: "8px" }}>
-                                <div
-                                  style={{
-                                    fontSize: "11px",
-                                    color: "#dc2626",
-                                    marginBottom: "2px",
-                                  }}
-                                >
-                                  ⚠️ Privacy Issues:
-                                </div>
-                                <div
-                                  style={{ fontSize: "12px", color: "#b91c1c" }}
-                                >
-                                  {submission.piiWarnings.join(", ")}
-                                </div>
-                              </div>
-                            )}
-
-                            {/* Generalizability Issues */}
-                            {submission.generalizabilityIssues.length > 0 && (
-                              <div style={{ marginBottom: "8px" }}>
-                                <div
-                                  style={{
-                                    fontSize: "11px",
-                                    color: "#b45309",
-                                    marginBottom: "2px",
-                                  }}
-                                >
-                                  ⚠️ Generalizability Issues:
-                                </div>
-                                <div
-                                  style={{ fontSize: "12px", color: "#92400e" }}
-                                >
-                                  {submission.generalizabilityIssues.join(", ")}
-                                </div>
-                              </div>
-                            )}
-
-                            {/* Sanitized query (editable) */}
-                            <div style={{ marginBottom: "8px" }}>
-                              <div
-                                style={{
-                                  fontSize: "11px",
-                                  color: "#64748b",
-                                  marginBottom: "2px",
-                                }}
-                              >
-                                {submission.piiWarnings.length > 0
-                                  ? "Sanitized Query (editable):"
-                                  : "Query to Share:"}
-                              </div>
-                              <input
-                                type="text"
-                                value={submission.sanitizedQuery}
-                                onChange={(e: any) => {
-                                  const newValue = e.target.value;
-                                  const pendingWritable =
-                                    pendingSubmissions as Writable<
-                                      PendingSubmission[]
-                                    >;
-                                  const subs = pendingWritable.get() || [];
-                                  const idx = subs.findIndex((
-                                    s: PendingSubmission,
-                                  ) =>
-                                    s.localQueryId === submission.localQueryId
-                                  );
-                                  if (idx >= 0) {
-                                    (pendingWritable.key(idx).key(
-                                      "sanitizedQuery",
-                                    ) as Writable<string>).set(newValue);
-                                  }
-                                }}
-                                style={{
-                                  width: "100%",
-                                  fontFamily: "monospace",
-                                  fontSize: "12px",
-                                  padding: "6px 8px",
-                                  border: "1px solid #d1d5db",
-                                  borderRadius: "4px",
-                                }}
-                              />
-                            </div>
-
-                            {/* Action buttons */}
-                            <div
-                              style={{
-                                display: "flex",
-                                gap: "8px",
-                                justifyContent: "flex-end",
+                                    ? "#fef9c3"
+                                    : "#fee2e2",
+                                color: submission.recommendation === "share"
+                                  ? "#166534"
+                                  : submission.recommendation ===
+                                      "share_with_edits"
+                                  ? "#854d0e"
+                                  : "#b91c1c",
                               }}
                             >
-                              <cf-button
-                                onClick={() => {
-                                  // Reject
-                                  const pendingWritable =
-                                    pendingSubmissions as Writable<
-                                      PendingSubmission[]
-                                    >;
-                                  const localWritable =
-                                    localQueries as Writable<LocalQuery[]>;
-                                  const subs = pendingWritable.get() || [];
-                                  pendingWritable.set(
-                                    subs.filter((s: PendingSubmission) =>
-                                      s.localQueryId !== submission.localQueryId
-                                    ),
-                                  );
-                                  // Reset local query status
-                                  const queries = localWritable.get() || [];
-                                  const idx = queries.findIndex((
-                                    q: LocalQuery,
-                                  ) =>
-                                    q.id === submission.localQueryId
-                                  );
-                                  if (idx >= 0) {
-                                    (localWritable.key(idx).key(
-                                      "shareStatus",
-                                    ) as Writable<
-                                      "private" | "pending_review" | "submitted"
-                                    >).set("private");
-                                  }
-                                }}
-                                variant="ghost"
-                                size="sm"
-                                style="color: #64748b;"
-                              >
-                                Keep Private
-                              </cf-button>
-                              <cf-button
-                                onClick={() => {
-                                  // Approve
-                                  const pendingWritable =
-                                    pendingSubmissions as Writable<
-                                      PendingSubmission[]
-                                    >;
-                                  const subs = pendingWritable.get() || [];
-                                  const idx = subs.findIndex((
-                                    s: PendingSubmission,
-                                  ) =>
-                                    s.localQueryId === submission.localQueryId
-                                  );
-                                  if (idx >= 0) {
-                                    (pendingWritable.key(idx).key(
-                                      "userApproved",
-                                    ) as Writable<boolean>).set(true);
-                                  }
-                                }}
-                                variant={submission.userApproved
-                                  ? "secondary"
-                                  : "default"}
-                                size="sm"
-                                disabled={submission.userApproved}
-                              >
-                                {submission.userApproved
-                                  ? "✓ Approved"
-                                  : "Approve for Sharing"}
-                              </cf-button>
+                              {submission.recommendation === "share"
+                                ? "✓ Good to share"
+                                : submission.recommendation ===
+                                    "share_with_edits"
+                                ? "⚠ Needs editing"
+                                : "✗ Not recommended"}
+                            </span>
+                          </div>
+                        )}
+
+                        {/* PII Warnings */}
+                        {submission.piiWarnings.length > 0 && (
+                          <div style={{ marginBottom: "8px" }}>
+                            <div
+                              style={{
+                                fontSize: "11px",
+                                color: "#dc2626",
+                                marginBottom: "2px",
+                              }}
+                            >
+                              ⚠️ Privacy Issues:
+                            </div>
+                            <div
+                              style={{ fontSize: "12px", color: "#b91c1c" }}
+                            >
+                              {submission.piiWarnings.join(", ")}
                             </div>
                           </div>
-                        ))}
+                        )}
 
-                        {/* Submit all approved button */}
-                        {derive(
-                          [pendingSubmissions, registryWish, agentTypeUrl],
-                          (
-                            [subs, registry, typeUrl]: [
-                              PendingSubmission[],
-                              any,
-                              string,
-                            ],
-                          ) => {
-                            const approvedCount = (subs || []).filter((s) =>
-                              s.userApproved && !s.submittedAt
-                            ).length;
-                            const hasRegistry = !!registry?.result?.submitQuery;
+                        {/* Generalizability Issues */}
+                        {submission.generalizabilityIssues.length > 0 && (
+                          <div style={{ marginBottom: "8px" }}>
+                            <div
+                              style={{
+                                fontSize: "11px",
+                                color: "#b45309",
+                                marginBottom: "2px",
+                              }}
+                            >
+                              ⚠️ Generalizability Issues:
+                            </div>
+                            <div
+                              style={{ fontSize: "12px", color: "#92400e" }}
+                            >
+                              {submission.generalizabilityIssues.join(", ")}
+                            </div>
+                          </div>
+                        )}
 
-                            return approvedCount > 0
-                              ? (
+                        {/* Sanitized query (editable) */}
+                        <div style={{ marginBottom: "8px" }}>
+                          <div
+                            style={{
+                              fontSize: "11px",
+                              color: "#64748b",
+                              marginBottom: "2px",
+                            }}
+                          >
+                            {submission.piiWarnings.length > 0
+                              ? "Sanitized Query (editable):"
+                              : "Query to Share:"}
+                          </div>
+                          <input
+                            type="text"
+                            value={submission.sanitizedQuery}
+                            onChange={(e: any) => {
+                              const newValue = e.target.value;
+                              const pendingWritable =
+                                pendingSubmissions as Writable<
+                                  PendingSubmission[]
+                                >;
+                              const subs = pendingWritable.get() || [];
+                              const idx = subs.findIndex((
+                                s: PendingSubmission,
+                              ) => s.localQueryId === submission.localQueryId);
+                              if (idx >= 0) {
+                                (pendingWritable.key(idx).key(
+                                  "sanitizedQuery",
+                                ) as Writable<string>).set(newValue);
+                              }
+                            }}
+                            style={{
+                              width: "100%",
+                              fontFamily: "monospace",
+                              fontSize: "12px",
+                              padding: "6px 8px",
+                              border: "1px solid #d1d5db",
+                              borderRadius: "4px",
+                            }}
+                          />
+                        </div>
+
+                        {/* Action buttons */}
+                        <div
+                          style={{
+                            display: "flex",
+                            gap: "8px",
+                            justifyContent: "flex-end",
+                          }}
+                        >
+                          <cf-button
+                            onClick={() => {
+                              // Reject
+                              const pendingWritable =
+                                pendingSubmissions as Writable<
+                                  PendingSubmission[]
+                                >;
+                              const localWritable = localQueries as Writable<
+                                LocalQuery[]
+                              >;
+                              const subs = pendingWritable.get() || [];
+                              pendingWritable.set(
+                                subs.filter((s: PendingSubmission) =>
+                                  s.localQueryId !== submission.localQueryId
+                                ),
+                              );
+                              // Reset local query status
+                              const queries = localWritable.get() || [];
+                              const idx = queries.findIndex((
+                                q: LocalQuery,
+                              ) => q.id === submission.localQueryId);
+                              if (idx >= 0) {
+                                (localWritable.key(idx).key(
+                                  "shareStatus",
+                                ) as Writable<
+                                  "private" | "pending_review" | "submitted"
+                                >).set("private");
+                              }
+                            }}
+                            variant="ghost"
+                            size="sm"
+                            style="color: #64748b;"
+                          >
+                            Keep Private
+                          </cf-button>
+                          <cf-button
+                            onClick={() => {
+                              // Approve
+                              const pendingWritable =
+                                pendingSubmissions as Writable<
+                                  PendingSubmission[]
+                                >;
+                              const subs = pendingWritable.get() || [];
+                              const idx = subs.findIndex((
+                                s: PendingSubmission,
+                              ) => s.localQueryId === submission.localQueryId);
+                              if (idx >= 0) {
+                                (pendingWritable.key(idx).key(
+                                  "userApproved",
+                                ) as Writable<boolean>).set(true);
+                              }
+                            }}
+                            variant={submission.userApproved
+                              ? "secondary"
+                              : "default"}
+                            size="sm"
+                            disabled={submission.userApproved}
+                          >
+                            {submission.userApproved
+                              ? "✓ Approved"
+                              : "Approve for Sharing"}
+                          </cf-button>
+                        </div>
+                      </div>
+                    ))}
+
+                    {/* Submit all approved button */}
+                    {computed(() => {
+                      const subs = pendingSubmissions as PendingSubmission[];
+                      const registry = registryWish as any;
+                      const typeUrl = agentTypeUrl as string;
+                      const approvedCount = (subs || []).filter((s) =>
+                        s.userApproved && !s.submittedAt
+                      ).length;
+                      const hasRegistry = !!registry?.result?.submitQuery;
+
+                      return approvedCount > 0
+                        ? (
+                          <div
+                            style={{
+                              marginTop: "12px",
+                              textAlign: "center",
+                            }}
+                          >
+                            <cf-button
+                              variant="default"
+                              disabled={!hasRegistry}
+                              onClick={() => {
+                                if (!hasRegistry || !typeUrl) {
+                                  return;
+                                }
+                                const approved = (subs || []).filter((
+                                  s: PendingSubmission,
+                                ) =>
+                                  s.userApproved && !s.submittedAt
+                                );
+                                const submitHandler = registry?.result
+                                  ?.submitQuery;
+                                const pendingWritable =
+                                  pendingSubmissions as Writable<
+                                    PendingSubmission[]
+                                  >;
+                                const localWritable = localQueries as Writable<
+                                  LocalQuery[]
+                                >;
+
+                                // Submit each approved query
+                                approved.forEach(
+                                  (submission: PendingSubmission) => {
+                                    if (submitHandler) {
+                                      submitHandler({
+                                        agentTypeUrl: typeUrl,
+                                        query: submission.sanitizedQuery,
+                                      });
+                                    }
+
+                                    // Mark as submitted in pendingSubmissions
+                                    const currentSubs = pendingWritable.get() ||
+                                      [];
+                                    const idx = currentSubs.findIndex((
+                                      s: PendingSubmission,
+                                    ) =>
+                                      s.localQueryId ===
+                                        submission.localQueryId
+                                    );
+                                    if (idx >= 0) {
+                                      (pendingWritable.key(idx).key(
+                                        "submittedAt",
+                                      ) as Writable<number | undefined>)
+                                        .set(safeDateNow());
+                                    }
+
+                                    // Update local query status to submitted
+                                    const queries = localWritable.get() ||
+                                      [];
+                                    const qIdx = queries.findIndex((
+                                      q: LocalQuery,
+                                    ) => q.id === submission.localQueryId);
+                                    if (qIdx >= 0) {
+                                      (localWritable.key(qIdx).key(
+                                        "shareStatus",
+                                      ) as Writable<
+                                        | "private"
+                                        | "pending_review"
+                                        | "submitted"
+                                      >).set("submitted");
+                                    }
+                                  },
+                                );
+                              }}
+                            >
+                              Submit {approvedCount} Approved{" "}
+                              {approvedCount === 1 ? "Query" : "Queries"}{" "}
+                              to Community
+                            </cf-button>
+                            {!hasRegistry && (
+                              <div
+                                style={{
+                                  marginTop: "12px",
+                                  padding: "12px",
+                                  background: "#fef3c7",
+                                  border: "1px solid #fde68a",
+                                  borderRadius: "8px",
+                                }}
+                              >
                                 <div
                                   style={{
-                                    marginTop: "12px",
-                                    textAlign: "center",
+                                    fontSize: "12px",
+                                    color: "#92400e",
+                                    marginBottom: "8px",
                                   }}
                                 >
-                                  <cf-button
-                                    variant="default"
-                                    disabled={!hasRegistry}
-                                    onClick={() => {
-                                      if (!hasRegistry || !typeUrl) {
-                                        return;
-                                      }
-                                      const approved = (subs || []).filter((
-                                        s: PendingSubmission,
-                                      ) =>
-                                        s.userApproved && !s.submittedAt
-                                      );
-                                      const submitHandler = registry?.result
-                                        ?.submitQuery;
-                                      const pendingWritable =
-                                        pendingSubmissions as Writable<
-                                          PendingSubmission[]
-                                        >;
-                                      const localWritable =
-                                        localQueries as Writable<LocalQuery[]>;
-
-                                      // Submit each approved query
-                                      approved.forEach(
-                                        (submission: PendingSubmission) => {
-                                          if (submitHandler) {
-                                            submitHandler({
-                                              agentTypeUrl: typeUrl,
-                                              query: submission.sanitizedQuery,
-                                            });
-                                          }
-
-                                          // Mark as submitted in pendingSubmissions
-                                          const currentSubs =
-                                            pendingWritable.get() || [];
-                                          const idx = currentSubs.findIndex((
-                                            s: PendingSubmission,
-                                          ) =>
-                                            s.localQueryId ===
-                                              submission.localQueryId
-                                          );
-                                          if (idx >= 0) {
-                                            (pendingWritable.key(idx).key(
-                                              "submittedAt",
-                                            ) as Writable<number | undefined>)
-                                              .set(safeDateNow());
-                                          }
-
-                                          // Update local query status to submitted
-                                          const queries = localWritable.get() ||
-                                            [];
-                                          const qIdx = queries.findIndex((
-                                            q: LocalQuery,
-                                          ) =>
-                                            q.id === submission.localQueryId
-                                          );
-                                          if (qIdx >= 0) {
-                                            (localWritable.key(qIdx).key(
-                                              "shareStatus",
-                                            ) as Writable<
-                                              | "private"
-                                              | "pending_review"
-                                              | "submitted"
-                                            >).set("submitted");
-                                          }
-                                        },
-                                      );
-                                    }}
-                                  >
-                                    Submit {approvedCount} Approved{" "}
-                                    {approvedCount === 1 ? "Query" : "Queries"}
-                                    {" "}
-                                    to Community
-                                  </cf-button>
-                                  {!hasRegistry && (
-                                    <div
-                                      style={{
-                                        marginTop: "12px",
-                                        padding: "12px",
-                                        background: "#fef3c7",
-                                        border: "1px solid #fde68a",
-                                        borderRadius: "8px",
-                                      }}
-                                    >
-                                      <div
-                                        style={{
-                                          fontSize: "12px",
-                                          color: "#92400e",
-                                          marginBottom: "8px",
-                                        }}
-                                      >
-                                        No community registry found. You can
-                                        create one to share queries with other
-                                        users.
-                                      </div>
-                                      <div
-                                        style={{
-                                          fontSize: "10px",
-                                          color: "#a16207",
-                                          marginBottom: "8px",
-                                        }}
-                                      >
-                                        Note: Registry will be created in your
-                                        current space. After creation, favorite
-                                        it with tag #gmailSearchRegistry.
-                                      </div>
-                                      <cf-button
-                                        onClick={createSearchRegistry}
-                                        variant="secondary"
-                                        size="sm"
-                                      >
-                                        Create Registry
-                                      </cf-button>
-                                    </div>
-                                  )}
+                                  No community registry found. You can create
+                                  one to share queries with other users.
                                 </div>
-                              )
-                              : null;
-                          },
-                        )}
-                      </div>
-                    )
-                    : null)}
-              </div>
-            )
-            : null)}
+                                <div
+                                  style={{
+                                    fontSize: "10px",
+                                    color: "#a16207",
+                                    marginBottom: "8px",
+                                  }}
+                                >
+                                  Note: Registry will be created in your current
+                                  space. After creation, favorite it with tag
+                                  #gmailSearchRegistry.
+                                </div>
+                                <cf-button
+                                  onClick={createSearchRegistry}
+                                  variant="secondary"
+                                  size="sm"
+                                >
+                                  Create Registry
+                                </cf-button>
+                              </div>
+                            )}
+                          </div>
+                        )
+                        : null;
+                    })}
+                  </div>
+                )
+                : null}
+            </div>
+          )
+          : null}
       </div>
     );
 

--- a/packages/patterns/google/core/experimental/gmail-label-manager.tsx
+++ b/packages/patterns/google/core/experimental/gmail-label-manager.tsx
@@ -24,10 +24,9 @@
  */
 
 import {
+  computed,
   Default,
-  derive,
   handler,
-  ifElse,
   NAME,
   pattern,
   UI,
@@ -269,19 +268,11 @@ export default pattern<Input, Output>(
     const processing = new Writable(false);
     const result = new Writable<OperationResult | null>(null);
 
-    // Computed
-    const messageCount = derive(messageIds, (ids) => ids.length);
-    const hasMessages = derive(messageIds, (ids) => ids.length > 0);
-    const hasChanges = derive(
-      { labelsToAdd, labelsToRemove },
-      ({ labelsToAdd, labelsToRemove }) =>
-        labelsToAdd.length > 0 || labelsToRemove.length > 0,
-    );
-    const canApply = derive(
-      { hasAuth, hasMessages, hasChanges, processing },
-      ({ hasAuth, hasMessages, hasChanges, processing }) =>
-        hasAuth && hasMessages && hasChanges && !processing,
-    );
+    // Computed (these values are derived from reactive inputs and local state)
+    const messageCount = messageIds.length;
+    const hasMessages = messageIds.length > 0;
+    const hasChanges = labelsToAdd.length > 0 || labelsToRemove.length > 0;
+    const canApply = hasAuth && hasMessages && hasChanges && !processing.get();
 
     // Common system labels that are useful (prefixed with _ as not currently used)
     const _systemLabelIds = [
@@ -313,135 +304,136 @@ export default pattern<Input, Output>(
           {fullUI}
 
           {/* Refresh labels button - protected until authenticated */}
-          {ifElse(
-            isReady,
-            <div
-              style={{
-                display: "flex",
-                justifyContent: "flex-end",
-              }}
-            >
-              <button
-                type="button"
-                onClick={fetchLabels({ auth, availableLabels, loadingLabels })}
-                disabled={loadingLabels}
-                style={{
-                  padding: "6px 12px",
-                  background: "#10b981",
-                  color: "white",
-                  border: "none",
-                  borderRadius: "4px",
-                  fontSize: "12px",
-                  cursor: "pointer",
-                }}
-              >
-                {loadingLabels ? "Loading..." : "Refresh Labels"}
-              </button>
-            </div>,
-            null,
-          )}
-
-          {/* Result display */}
-          {ifElse(
-            derive(result, (r: OperationResult | null) => r?.success === true),
-            <div
-              style={{
-                padding: "16px",
-                background: "#d1fae5",
-                borderRadius: "8px",
-                border: "1px solid #10b981",
-              }}
-            >
+          {isReady
+            ? (
               <div
                 style={{
                   display: "flex",
-                  justifyContent: "space-between",
-                  alignItems: "flex-start",
+                  justifyContent: "flex-end",
                 }}
               >
-                <div>
-                  <div
+                <button
+                  type="button"
+                  onClick={fetchLabels({
+                    auth,
+                    availableLabels,
+                    loadingLabels,
+                  })}
+                  disabled={loadingLabels}
+                  style={{
+                    padding: "6px 12px",
+                    background: "#10b981",
+                    color: "white",
+                    border: "none",
+                    borderRadius: "4px",
+                    fontSize: "12px",
+                    cursor: "pointer",
+                  }}
+                >
+                  {loadingLabels ? "Loading..." : "Refresh Labels"}
+                </button>
+              </div>
+            )
+            : null}
+
+          {/* Result display */}
+          {result.get()?.success === true
+            ? (
+              <div
+                style={{
+                  padding: "16px",
+                  background: "#d1fae5",
+                  borderRadius: "8px",
+                  border: "1px solid #10b981",
+                }}
+              >
+                <div
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "flex-start",
+                  }}
+                >
+                  <div>
+                    <div
+                      style={{
+                        fontWeight: "bold",
+                        marginBottom: "4px",
+                        color: "#065f46",
+                      }}
+                    >
+                      Labels Updated Successfully!
+                    </div>
+                    <div style={{ fontSize: "12px", color: "#047857" }}>
+                      Modified {result.get()?.messageCount} message(s)
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={dismissResult({ result })}
                     style={{
-                      fontWeight: "bold",
-                      marginBottom: "4px",
+                      background: "none",
+                      border: "none",
+                      cursor: "pointer",
+                      fontSize: "18px",
                       color: "#065f46",
                     }}
                   >
-                    Labels Updated Successfully!
-                  </div>
-                  <div style={{ fontSize: "12px", color: "#047857" }}>
-                    Modified {derive(result, (r: OperationResult | null) =>
-                      r?.messageCount)} message(s)
-                  </div>
+                    ×
+                  </button>
                 </div>
-                <button
-                  type="button"
-                  onClick={dismissResult({ result })}
-                  style={{
-                    background: "none",
-                    border: "none",
-                    cursor: "pointer",
-                    fontSize: "18px",
-                    color: "#065f46",
-                  }}
-                >
-                  ×
-                </button>
               </div>
-            </div>,
-            null,
-          )}
+            )
+            : null}
 
-          {ifElse(
-            derive(result, (r: OperationResult | null) =>
-              r?.success === false),
-            <div
-              style={{
-                padding: "16px",
-                background: "#fee2e2",
-                borderRadius: "8px",
-                border: "1px solid #ef4444",
-              }}
-            >
+          {result.get()?.success === false
+            ? (
               <div
                 style={{
-                  display: "flex",
-                  justifyContent: "space-between",
-                  alignItems: "flex-start",
+                  padding: "16px",
+                  background: "#fee2e2",
+                  borderRadius: "8px",
+                  border: "1px solid #ef4444",
                 }}
               >
-                <div>
-                  <div
+                <div
+                  style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "flex-start",
+                  }}
+                >
+                  <div>
+                    <div
+                      style={{
+                        fontWeight: "bold",
+                        marginBottom: "4px",
+                        color: "#991b1b",
+                      }}
+                    >
+                      Failed to Update Labels
+                    </div>
+                    <div style={{ fontSize: "14px", color: "#b91c1c" }}>
+                      {result.get()?.error}
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={dismissResult({ result })}
                     style={{
-                      fontWeight: "bold",
-                      marginBottom: "4px",
+                      background: "none",
+                      border: "none",
+                      cursor: "pointer",
+                      fontSize: "18px",
                       color: "#991b1b",
                     }}
                   >
-                    Failed to Update Labels
-                  </div>
-                  <div style={{ fontSize: "14px", color: "#b91c1c" }}>
-                    {derive(result, (r: OperationResult | null) =>
-                      r?.error)}
-                  </div>
+                    ×
+                  </button>
                 </div>
-                <button
-                  type="button"
-                  onClick={dismissResult({ result })}
-                  style={{
-                    background: "none",
-                    border: "none",
-                    cursor: "pointer",
-                    fontSize: "18px",
-                    color: "#991b1b",
-                  }}
-                >
-                  ×
-                </button>
               </div>
-            </div>,
-            null,
-          )}
+            )
+            : null}
 
           {/* Message count indicator */}
           <div
@@ -453,180 +445,160 @@ export default pattern<Input, Output>(
             }}
           >
             <strong>
-              {ifElse(
-                hasMessages,
-                <span>
-                  {messageCount} message(s) selected for label changes
-                </span>,
-                <span style={{ color: "#6b7280" }}>
-                  No messages selected. Link messageIds from a Gmail Importer.
-                </span>,
-              )}
+              {hasMessages
+                ? (
+                  <span>
+                    {messageCount} message(s) selected for label changes
+                  </span>
+                )
+                : (
+                  <span style={{ color: "#6b7280" }}>
+                    No messages selected. Link messageIds from a Gmail Importer.
+                  </span>
+                )}
             </strong>
           </div>
 
           {/* Label selection */}
-          {ifElse(
-            derive(availableLabels, (l: GmailLabel[]) => l.length > 0),
-            <div
-              style={{
-                display: "flex",
-                flexDirection: "column",
-                gap: "16px",
-              }}
-            >
-              {/* Add labels section */}
+          {availableLabels.get().length > 0
+            ? (
               <div
                 style={{
-                  padding: "16px",
-                  background: "#f0fdf4",
-                  borderRadius: "8px",
-                  border: "1px solid #86efac",
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: "16px",
                 }}
               >
+                {/* Add labels section */}
                 <div
                   style={{
-                    fontWeight: "600",
-                    marginBottom: "12px",
-                    color: "#166534",
+                    padding: "16px",
+                    background: "#f0fdf4",
+                    borderRadius: "8px",
+                    border: "1px solid #86efac",
                   }}
                 >
-                  + Add Labels
+                  <div
+                    style={{
+                      fontWeight: "600",
+                      marginBottom: "12px",
+                      color: "#166534",
+                    }}
+                  >
+                    + Add Labels
+                  </div>
+                  <div
+                    style={{ display: "flex", flexWrap: "wrap", gap: "8px" }}
+                  >
+                    {computed(() =>
+                      availableLabels.get().map((label) => {
+                        const isSelected = labelsToAdd.includes(label.id);
+                        const isInRemove = labelsToRemove.includes(label.id);
+                        return (
+                          <button
+                            type="button"
+                            onClick={toggleAddLabel({
+                              labelsToAdd,
+                              labelId: label.id,
+                            })}
+                            disabled={isInRemove}
+                            style={{
+                              padding: "6px 12px",
+                              borderRadius: "16px",
+                              fontSize: "13px",
+                              cursor: "pointer",
+                              border: "1px solid",
+                              borderColor: isSelected ? "#16a34a" : "#d1d5db",
+                              background: isSelected ? "#dcfce7" : "white",
+                              color: isSelected ? "#166534" : "#374151",
+                              opacity: isInRemove ? 0.5 : 1,
+                            }}
+                          >
+                            {label.type === "system"
+                              ? `[${label.name}]`
+                              : label.name}
+                          </button>
+                        );
+                      })
+                    )}
+                  </div>
                 </div>
-                <div
-                  style={{ display: "flex", flexWrap: "wrap", gap: "8px" }}
-                >
-                  {derive(availableLabels, (labels) =>
-                    labels.map((label) => {
-                      const isSelected = derive(labelsToAdd, (add) =>
-                        add.includes(label.id));
-                      const isInRemove = derive(labelsToRemove, (rem) =>
-                        rem.includes(label.id));
-                      return (
-                        <button
-                          type="button"
-                          onClick={toggleAddLabel({
-                            labelsToAdd,
-                            labelId: label.id,
-                          })}
-                          disabled={isInRemove}
-                          style={{
-                            padding: "6px 12px",
-                            borderRadius: "16px",
-                            fontSize: "13px",
-                            cursor: "pointer",
-                            border: "1px solid",
-                            borderColor: derive(
-                              isSelected,
-                              (s) => s ? "#16a34a" : "#d1d5db",
-                            ),
-                            background: derive(
-                              isSelected,
-                              (s) =>
-                                s ? "#dcfce7" : "white",
-                            ),
-                            color: derive(
-                              isSelected,
-                              (s) =>
-                                s ? "#166534" : "#374151",
-                            ),
-                            opacity: derive(isInRemove, (r) => (r ? 0.5 : 1)),
-                          }}
-                        >
-                          {label.type === "system"
-                            ? `[${label.name}]`
-                            : label.name}
-                        </button>
-                      );
-                    }))}
-                </div>
-              </div>
 
-              {/* Remove labels section */}
+                {/* Remove labels section */}
+                <div
+                  style={{
+                    padding: "16px",
+                    background: "#fef2f2",
+                    borderRadius: "8px",
+                    border: "1px solid #fca5a5",
+                  }}
+                >
+                  <div
+                    style={{
+                      fontWeight: "600",
+                      marginBottom: "12px",
+                      color: "#991b1b",
+                    }}
+                  >
+                    − Remove Labels
+                  </div>
+                  <div
+                    style={{ display: "flex", flexWrap: "wrap", gap: "8px" }}
+                  >
+                    {computed(() =>
+                      availableLabels.get().map((label) => {
+                        const isSelected = labelsToRemove.includes(label.id);
+                        const isInAdd = labelsToAdd.includes(label.id);
+                        return (
+                          <button
+                            type="button"
+                            onClick={toggleRemoveLabel({
+                              labelsToRemove,
+                              labelId: label.id,
+                            })}
+                            disabled={isInAdd}
+                            style={{
+                              padding: "6px 12px",
+                              borderRadius: "16px",
+                              fontSize: "13px",
+                              cursor: "pointer",
+                              border: "1px solid",
+                              borderColor: isSelected ? "#dc2626" : "#d1d5db",
+                              background: isSelected ? "#fee2e2" : "white",
+                              color: isSelected ? "#991b1b" : "#374151",
+                              opacity: isInAdd ? 0.5 : 1,
+                            }}
+                          >
+                            {label.type === "system"
+                              ? `[${label.name}]`
+                              : label.name}
+                          </button>
+                        );
+                      })
+                    )}
+                  </div>
+                </div>
+              </div>
+            )
+            : (
               <div
                 style={{
                   padding: "16px",
-                  background: "#fef2f2",
+                  background: "#f3f4f6",
                   borderRadius: "8px",
-                  border: "1px solid #fca5a5",
+                  textAlign: "center",
+                  color: "#6b7280",
                 }}
               >
-                <div
-                  style={{
-                    fontWeight: "600",
-                    marginBottom: "12px",
-                    color: "#991b1b",
-                  }}
-                >
-                  − Remove Labels
-                </div>
-                <div
-                  style={{ display: "flex", flexWrap: "wrap", gap: "8px" }}
-                >
-                  {derive(availableLabels, (labels) =>
-                    labels.map((label) => {
-                      const isSelected = derive(labelsToRemove, (rem) =>
-                        rem.includes(label.id));
-                      const isInAdd = derive(labelsToAdd, (add) =>
-                        add.includes(label.id));
-                      return (
-                        <button
-                          type="button"
-                          onClick={toggleRemoveLabel({
-                            labelsToRemove,
-                            labelId: label.id,
-                          })}
-                          disabled={isInAdd}
-                          style={{
-                            padding: "6px 12px",
-                            borderRadius: "16px",
-                            fontSize: "13px",
-                            cursor: "pointer",
-                            border: "1px solid",
-                            borderColor: derive(
-                              isSelected,
-                              (s) => s ? "#dc2626" : "#d1d5db",
-                            ),
-                            background: derive(
-                              isSelected,
-                              (s) =>
-                                s ? "#fee2e2" : "white",
-                            ),
-                            color: derive(
-                              isSelected,
-                              (s) =>
-                                s ? "#991b1b" : "#374151",
-                            ),
-                            opacity: derive(isInAdd, (a) => (a ? 0.5 : 1)),
-                          }}
-                        >
-                          {label.type === "system"
-                            ? `[${label.name}]`
-                            : label.name}
-                        </button>
-                      );
-                    }))}
-                </div>
+                {hasAuth
+                  ? (
+                    <span>
+                      Click "Refresh Labels" above to load your Gmail labels.
+                    </span>
+                  )
+                  : <span>Authenticate to load labels.</span>}
               </div>
-            </div>,
-            <div
-              style={{
-                padding: "16px",
-                background: "#f3f4f6",
-                borderRadius: "8px",
-                textAlign: "center",
-                color: "#6b7280",
-              }}
-            >
-              {ifElse(
-                hasAuth,
-                <span>
-                  Click "Refresh Labels" above to load your Gmail labels.
-                </span>,
-                <span>Authenticate to load labels.</span>,
-              )}
-            </div>,
-          )}
+            )}
 
           {/* Apply button */}
           <button
@@ -638,7 +610,7 @@ export default pattern<Input, Output>(
               availableLabels,
               pendingOp,
             })}
-            disabled={derive(canApply, (can) => !can)}
+            disabled={!canApply}
             style={{
               padding: "12px 24px",
               background: "#2563eb",
@@ -648,252 +620,251 @@ export default pattern<Input, Output>(
               fontSize: "16px",
               fontWeight: "500",
               cursor: "pointer",
-              opacity: derive(canApply, (can) => (can ? 1 : 0.5)),
+              opacity: canApply ? 1 : 0.5,
             }}
           >
             Review & Apply Changes
           </button>
 
           {/* CONFIRMATION DIALOG */}
-          {ifElse(
-            pendingOp,
-            <div
-              style={{
-                position: "fixed",
-                top: 0,
-                left: 0,
-                right: 0,
-                bottom: 0,
-                background: "rgba(0, 0, 0, 0.5)",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                zIndex: 1000,
-              }}
-            >
+          {pendingOp.get()
+            ? (
               <div
                 style={{
-                  background: "white",
-                  borderRadius: "12px",
-                  maxWidth: "500px",
-                  width: "90%",
-                  maxHeight: "90vh",
-                  overflow: "auto",
-                  boxShadow: "0 25px 50px -12px rgba(0, 0, 0, 0.25)",
+                  position: "fixed",
+                  top: 0,
+                  left: 0,
+                  right: 0,
+                  bottom: 0,
+                  background: "rgba(0, 0, 0, 0.5)",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  zIndex: 1000,
                 }}
               >
-                {/* Header */}
                 <div
                   style={{
-                    padding: "20px",
-                    borderBottom: "2px solid #2563eb",
-                    display: "flex",
-                    alignItems: "center",
-                    gap: "12px",
+                    background: "white",
+                    borderRadius: "12px",
+                    maxWidth: "500px",
+                    width: "90%",
+                    maxHeight: "90vh",
+                    overflow: "auto",
+                    boxShadow: "0 25px 50px -12px rgba(0, 0, 0, 0.25)",
                   }}
                 >
-                  <span style={{ fontSize: "24px" }}>🏷️</span>
-                  <h3 style={{ margin: 0, color: "#2563eb", fontSize: "20px" }}>
-                    Confirm Label Changes
-                  </h3>
-                </div>
-
-                {/* Content */}
-                <div style={{ padding: "20px" }}>
+                  {/* Header */}
                   <div
                     style={{
-                      background: "#f9fafb",
-                      borderRadius: "8px",
-                      padding: "16px",
-                      marginBottom: "16px",
+                      padding: "20px",
+                      borderBottom: "2px solid #2563eb",
+                      display: "flex",
+                      alignItems: "center",
+                      gap: "12px",
                     }}
                   >
+                    <span style={{ fontSize: "24px" }}>🏷️</span>
+                    <h3
+                      style={{ margin: 0, color: "#2563eb", fontSize: "20px" }}
+                    >
+                      Confirm Label Changes
+                    </h3>
+                  </div>
+
+                  {/* Content */}
+                  <div style={{ padding: "20px" }}>
                     <div
                       style={{
-                        fontSize: "16px",
+                        background: "#f9fafb",
+                        borderRadius: "8px",
+                        padding: "16px",
+                        marginBottom: "16px",
+                      }}
+                    >
+                      <div
+                        style={{
+                          fontSize: "16px",
+                          fontWeight: "500",
+                          marginBottom: "12px",
+                        }}
+                      >
+                        Modifying{" "}
+                        <strong>
+                          {pendingOp.get()?.messageIds.length || 0}
+                        </strong>{" "}
+                        message(s)
+                      </div>
+
+                      {/* Labels to add */}
+                      {(pendingOp.get()?.addLabelNames.length || 0) > 0
+                        ? (
+                          <div style={{ marginBottom: "12px" }}>
+                            <div
+                              style={{
+                                fontSize: "13px",
+                                color: "#166534",
+                                fontWeight: "500",
+                                marginBottom: "6px",
+                              }}
+                            >
+                              + Adding:
+                            </div>
+                            <div
+                              style={{
+                                display: "flex",
+                                flexWrap: "wrap",
+                                gap: "6px",
+                              }}
+                            >
+                              {computed(() =>
+                                (pendingOp.get()?.addLabelNames || []).map((
+                                  name: string,
+                                ) => (
+                                  <span
+                                    style={{
+                                      background: "#dcfce7",
+                                      color: "#166534",
+                                      padding: "4px 10px",
+                                      borderRadius: "12px",
+                                      fontSize: "13px",
+                                    }}
+                                  >
+                                    {name}
+                                  </span>
+                                ))
+                              )}
+                            </div>
+                          </div>
+                        )
+                        : null}
+
+                      {/* Labels to remove */}
+                      {(pendingOp.get()?.removeLabelNames.length || 0) > 0
+                        ? (
+                          <div>
+                            <div
+                              style={{
+                                fontSize: "13px",
+                                color: "#991b1b",
+                                fontWeight: "500",
+                                marginBottom: "6px",
+                              }}
+                            >
+                              − Removing:
+                            </div>
+                            <div
+                              style={{
+                                display: "flex",
+                                flexWrap: "wrap",
+                                gap: "6px",
+                              }}
+                            >
+                              {computed(() =>
+                                (pendingOp.get()?.removeLabelNames || []).map((
+                                  name: string,
+                                ) => (
+                                  <span
+                                    style={{
+                                      background: "#fee2e2",
+                                      color: "#991b1b",
+                                      padding: "4px 10px",
+                                      borderRadius: "12px",
+                                      fontSize: "13px",
+                                    }}
+                                  >
+                                    {name}
+                                  </span>
+                                ))
+                              )}
+                            </div>
+                          </div>
+                        )
+                        : null}
+                    </div>
+
+                    {/* Warning */}
+                    <div
+                      style={{
+                        padding: "12px 16px",
+                        background: "#fef3c7",
+                        borderRadius: "8px",
+                        border: "1px solid #f59e0b",
+                      }}
+                    >
+                      <div
+                        style={{
+                          fontWeight: "600",
+                          marginBottom: "4px",
+                          color: "#92400e",
+                        }}
+                      >
+                        This will modify your Gmail labels
+                      </div>
+                      <div style={{ fontSize: "14px", color: "#78350f" }}>
+                        The selected labels will be added or removed from the
+                        specified messages in your Gmail account.
+                      </div>
+                    </div>
+                  </div>
+
+                  {/* Footer */}
+                  <div
+                    style={{
+                      padding: "16px 20px",
+                      borderTop: "1px solid #e5e7eb",
+                      display: "flex",
+                      gap: "12px",
+                      justifyContent: "flex-end",
+                    }}
+                  >
+                    <button
+                      type="button"
+                      onClick={cancelOperation({ pendingOp })}
+                      disabled={processing}
+                      style={{
+                        padding: "10px 20px",
+                        background: "white",
+                        color: "#374151",
+                        border: "1px solid #d1d5db",
+                        borderRadius: "6px",
+                        fontSize: "14px",
                         fontWeight: "500",
-                        marginBottom: "12px",
+                        cursor: "pointer",
                       }}
                     >
-                      Modifying{" "}
-                      <strong>
-                        {derive(pendingOp, (op: LabelOperation | null) =>
-                          op?.messageIds.length || 0)}
-                      </strong>{" "}
-                      message(s)
-                    </div>
-
-                    {/* Labels to add */}
-                    {ifElse(
-                      derive(
+                      Cancel
+                    </button>
+                    <button
+                      type="button"
+                      onClick={confirmOperation({
                         pendingOp,
-                        (op: LabelOperation | null) =>
-                          (op?.addLabelNames.length || 0) > 0,
-                      ),
-                      <div style={{ marginBottom: "12px" }}>
-                        <div
-                          style={{
-                            fontSize: "13px",
-                            color: "#166534",
-                            fontWeight: "500",
-                            marginBottom: "6px",
-                          }}
-                        >
-                          + Adding:
-                        </div>
-                        <div
-                          style={{
-                            display: "flex",
-                            flexWrap: "wrap",
-                            gap: "6px",
-                          }}
-                        >
-                          {derive(pendingOp, (op: LabelOperation | null) =>
-                            (op?.addLabelNames || []).map((name: string) => (
-                              <span
-                                style={{
-                                  background: "#dcfce7",
-                                  color: "#166534",
-                                  padding: "4px 10px",
-                                  borderRadius: "12px",
-                                  fontSize: "13px",
-                                }}
-                              >
-                                {name}
-                              </span>
-                            )))}
-                        </div>
-                      </div>,
-                      null,
-                    )}
-
-                    {/* Labels to remove */}
-                    {ifElse(
-                      derive(
-                        pendingOp,
-                        (op: LabelOperation | null) =>
-                          (op?.removeLabelNames.length || 0) > 0,
-                      ),
-                      <div>
-                        <div
-                          style={{
-                            fontSize: "13px",
-                            color: "#991b1b",
-                            fontWeight: "500",
-                            marginBottom: "6px",
-                          }}
-                        >
-                          − Removing:
-                        </div>
-                        <div
-                          style={{
-                            display: "flex",
-                            flexWrap: "wrap",
-                            gap: "6px",
-                          }}
-                        >
-                          {derive(pendingOp, (op: LabelOperation | null) =>
-                            (op?.removeLabelNames || []).map((name: string) => (
-                              <span
-                                style={{
-                                  background: "#fee2e2",
-                                  color: "#991b1b",
-                                  padding: "4px 10px",
-                                  borderRadius: "12px",
-                                  fontSize: "13px",
-                                }}
-                              >
-                                {name}
-                              </span>
-                            )))}
-                        </div>
-                      </div>,
-                      null,
-                    )}
-                  </div>
-
-                  {/* Warning */}
-                  <div
-                    style={{
-                      padding: "12px 16px",
-                      background: "#fef3c7",
-                      borderRadius: "8px",
-                      border: "1px solid #f59e0b",
-                    }}
-                  >
-                    <div
+                        auth,
+                        processing,
+                        result,
+                        labelsToAdd,
+                        labelsToRemove,
+                      })}
+                      disabled={processing}
                       style={{
-                        fontWeight: "600",
-                        marginBottom: "4px",
-                        color: "#92400e",
+                        padding: "10px 20px",
+                        background: "#2563eb",
+                        color: "white",
+                        border: "none",
+                        borderRadius: "6px",
+                        fontSize: "14px",
+                        fontWeight: "500",
+                        cursor: "pointer",
+                        opacity: processing.get() ? 0.7 : 1,
                       }}
                     >
-                      This will modify your Gmail labels
-                    </div>
-                    <div style={{ fontSize: "14px", color: "#78350f" }}>
-                      The selected labels will be added or removed from the
-                      specified messages in your Gmail account.
-                    </div>
+                      {processing ? "Applying..." : "Apply Changes"}
+                    </button>
                   </div>
-                </div>
-
-                {/* Footer */}
-                <div
-                  style={{
-                    padding: "16px 20px",
-                    borderTop: "1px solid #e5e7eb",
-                    display: "flex",
-                    gap: "12px",
-                    justifyContent: "flex-end",
-                  }}
-                >
-                  <button
-                    type="button"
-                    onClick={cancelOperation({ pendingOp })}
-                    disabled={processing}
-                    style={{
-                      padding: "10px 20px",
-                      background: "white",
-                      color: "#374151",
-                      border: "1px solid #d1d5db",
-                      borderRadius: "6px",
-                      fontSize: "14px",
-                      fontWeight: "500",
-                      cursor: "pointer",
-                    }}
-                  >
-                    Cancel
-                  </button>
-                  <button
-                    type="button"
-                    onClick={confirmOperation({
-                      pendingOp,
-                      auth,
-                      processing,
-                      result,
-                      labelsToAdd,
-                      labelsToRemove,
-                    })}
-                    disabled={processing}
-                    style={{
-                      padding: "10px 20px",
-                      background: "#2563eb",
-                      color: "white",
-                      border: "none",
-                      borderRadius: "6px",
-                      fontSize: "14px",
-                      fontWeight: "500",
-                      cursor: "pointer",
-                      opacity: derive(processing, (p) => (p ? 0.7 : 1)),
-                    }}
-                  >
-                    {processing ? "Applying..." : "Apply Changes"}
-                  </button>
                 </div>
               </div>
-            </div>,
-            null,
-          )}
+            )
+            : null}
         </div>
       ),
       messageIds,

--- a/packages/patterns/google/core/experimental/google-docs-comment-orchestrator.tsx
+++ b/packages/patterns/google/core/experimental/google-docs-comment-orchestrator.tsx
@@ -1,11 +1,9 @@
 import {
   computed,
   Default,
-  derive,
   generateObject,
   getPatternEnvironment,
   handler,
-  ifElse,
   NAME,
   pattern,
   UI,
@@ -591,17 +589,10 @@ export default pattern<Input, Output>(
 
     // Fetch button disabled when not authenticated or fetching
     // Prefixed with _ as not currently used - preserved for potential future UI binding
-    const _fetchButtonDisabled = derive(
-      [isAuthenticated, isFetchingCell],
-      ([authenticated, fetching]: [boolean, boolean]) =>
-        !authenticated || fetching,
-    );
+    const _fetchButtonDisabled = !isAuthenticated || isFetchingCell.get();
 
     // Open comment count
-    const openCommentCount = computed(() => {
-      const c = commentsCell.get() ?? [];
-      return c.length;
-    });
+    const openCommentCount = (commentsCell.get() ?? []).length;
 
     // ==========================================================================
     // Per-Comment AI Generation
@@ -726,9 +717,9 @@ export default pattern<Input, Output>(
     // Single computed returning object - idiomatic pattern per CELLS_AND_REACTIVITY.md
     // ==========================================================================
 
-    // Boolean computed for ifElse condition
-    const hasAction = computed(() => pendingActionCell.get() !== null);
-    const hasLastError = computed(() => !!lastErrorCell.get());
+    // Boolean conditions for the confirmation UI
+    const hasAction = pendingActionCell.get() !== null;
+    const hasLastError = !!lastErrorCell.get();
 
     // Single computed for all action display values
     const actionDetails = computed(() => {
@@ -792,52 +783,52 @@ export default pattern<Input, Output>(
                     placeholder="https://docs.google.com/document/d/..."
                     style="flex: 1;"
                   />
-                  {ifElse(
-                    isAuthenticated,
-                    <cf-button
-                      variant="primary"
-                      type="button"
-                      disabled={isFetchingCell}
-                      onClick={fetchComments({
-                        docUrl: docUrlCell,
-                        auth,
-                        comments: commentsCell,
-                        docContent: docContentCell,
-                        isFetching: isFetchingCell,
-                        lastError: lastErrorCell,
-                      })}
-                    >
-                      {ifElse(
-                        computed(() => isFetchingCell.get() === true),
-                        <cf-hstack align="center" gap={1}>
-                          <cf-loader />
-                          <span>Fetching...</span>
-                        </cf-hstack>,
-                        "Fetch Comments",
-                      )}
-                    </cf-button>,
-                    null,
-                  )}
+                  {isAuthenticated
+                    ? (
+                      <cf-button
+                        variant="primary"
+                        type="button"
+                        disabled={isFetchingCell}
+                        onClick={fetchComments({
+                          docUrl: docUrlCell,
+                          auth,
+                          comments: commentsCell,
+                          docContent: docContentCell,
+                          isFetching: isFetchingCell,
+                          lastError: lastErrorCell,
+                        })}
+                      >
+                        {isFetchingCell.get() === true
+                          ? (
+                            <cf-hstack align="center" gap={1}>
+                              <cf-loader />
+                              <span>Fetching...</span>
+                            </cf-hstack>
+                          )
+                          : "Fetch Comments"}
+                      </cf-button>
+                    )
+                    : null}
                 </cf-hstack>
 
                 {/* Error display */}
-                {ifElse(
-                  computed(() => !!lastError),
-                  <div
-                    style={{
-                      marginTop: "8px",
-                      padding: "8px 12px",
-                      backgroundColor: "var(--cf-color-red-50, #fef2f2)",
-                      border: "1px solid var(--cf-color-red-200, #fecaca)",
-                      borderRadius: "6px",
-                      fontSize: "12px",
-                      color: "var(--cf-color-red-700, #b91c1c)",
-                    }}
-                  >
-                    {lastError}
-                  </div>,
-                  null,
-                )}
+                {!!lastError
+                  ? (
+                    <div
+                      style={{
+                        marginTop: "8px",
+                        padding: "8px 12px",
+                        backgroundColor: "var(--cf-color-red-50, #fef2f2)",
+                        border: "1px solid var(--cf-color-red-200, #fecaca)",
+                        borderRadius: "6px",
+                        fontSize: "12px",
+                        color: "var(--cf-color-red-700, #b91c1c)",
+                      }}
+                    >
+                      {lastError}
+                    </div>
+                  )
+                  : null}
               </cf-vstack>
             </cf-card>
 
@@ -864,31 +855,31 @@ export default pattern<Input, Output>(
                   </span>
                 </span>
                 <span style={{ color: "#888" }}>
-                  {ifElse(showGlobalPrompt, "\u25BC", "\u25B6")}
+                  {showGlobalPrompt ? "\u25BC" : "\u25B6"}
                 </span>
               </cf-hstack>
 
-              {ifElse(
-                showGlobalPrompt,
-                <div style={{ marginTop: "12px" }}>
-                  <cf-input
-                    $value={globalPrompt}
-                    placeholder="E.g., Be concise. Use formal language. Always acknowledge valid concerns before disagreeing."
-                    style="width: 100%;"
-                  />
-                  <div
-                    style={{
-                      fontSize: "11px",
-                      color: "#888",
-                      marginTop: "4px",
-                    }}
-                  >
-                    These guidelines will be included in all AI-generated
-                    responses.
+              {showGlobalPrompt
+                ? (
+                  <div style={{ marginTop: "12px" }}>
+                    <cf-input
+                      $value={globalPrompt}
+                      placeholder="E.g., Be concise. Use formal language. Always acknowledge valid concerns before disagreeing."
+                      style="width: 100%;"
+                    />
+                    <div
+                      style={{
+                        fontSize: "11px",
+                        color: "#888",
+                        marginTop: "4px",
+                      }}
+                    >
+                      These guidelines will be included in all AI-generated
+                      responses.
+                    </div>
                   </div>
-                </div>,
-                null,
-              )}
+                )
+                : null}
             </cf-card>
 
             {/* Comments List */}
@@ -995,405 +986,406 @@ export default pattern<Input, Output>(
                           {item.content}
                         </div>
 
-                        {/* Reply count badge - use ifElse to avoid $alias leakage */}
-                        {ifElse(
-                          item.replyCount > 0,
-                          <span
-                            style={{
-                              display: "inline-block",
-                              marginTop: "4px",
-                              fontSize: "11px",
-                              padding: "2px 6px",
-                              borderRadius: "10px",
-                              backgroundColor:
-                                "var(--cf-color-surface-secondary, #f0f0f0)",
-                              color: "#666",
-                            }}
-                          >
-                            {item.replyCount}{" "}
-                            {ifElse(item.replyCount === 1, "reply", "replies")}
-                          </span>,
-                          null,
-                        )}
-                      </div>
-                    </div>
-
-                    {/* Expanded content - use ifElse to avoid conditional && which can leak reactive values */}
-                    {ifElse(
-                      item.isExpanded,
-                      <div
-                        style={{
-                          borderTop:
-                            "1px solid var(--cf-color-border, #e0e0e0)",
-                          padding: "16px",
-                          backgroundColor:
-                            "var(--cf-color-surface-secondary, #fafafa)",
-                        }}
-                      >
-                        {/* Full quoted text - use ifElse for conditional content */}
-                        {ifElse(
-                          item.quotedFileContent !== null,
-                          <div
-                            style={{
-                              padding: "12px",
-                              marginBottom: "12px",
-                              borderLeft:
-                                "3px solid var(--cf-color-blue-500, #3b82f6)",
-                              backgroundColor: "white",
-                              borderRadius: "4px",
-                            }}
-                          >
-                            <div
+                        {/* Reply count badge - ternary to avoid $alias leakage */}
+                        {item.replyCount > 0
+                          ? (
+                            <span
                               style={{
+                                display: "inline-block",
+                                marginTop: "4px",
                                 fontSize: "11px",
-                                color: "#888",
-                                marginBottom: "4px",
-                              }}
-                            >
-                              Highlighted text:
-                            </div>
-                            <div
-                              style={{ fontSize: "13px", fontStyle: "italic" }}
-                            >
-                              "{item.quotedFileContent?.value ?? ""}"
-                            </div>
-                          </div>,
-                          null,
-                        )}
-
-                        {/* Existing replies - use ifElse for conditional content */}
-                        {ifElse(
-                          item.replies.length > 0,
-                          <div>
-                            <div
-                              style={{
-                                fontSize: "12px",
-                                fontWeight: 600,
-                                marginBottom: "8px",
+                                padding: "2px 6px",
+                                borderRadius: "10px",
+                                backgroundColor:
+                                  "var(--cf-color-surface-secondary, #f0f0f0)",
                                 color: "#666",
                               }}
                             >
-                              Previous replies:
-                            </div>
-                            {item.replies.map((reply) => (
+                              {item.replyCount}{" "}
+                              {item.replyCount === 1 ? "reply" : "replies"}
+                            </span>
+                          )
+                          : null}
+                      </div>
+                    </div>
+
+                    {/* Expanded content - ternary to avoid conditional && which can leak reactive values */}
+                    {item.isExpanded
+                      ? (
+                        <div
+                          style={{
+                            borderTop:
+                              "1px solid var(--cf-color-border, #e0e0e0)",
+                            padding: "16px",
+                            backgroundColor:
+                              "var(--cf-color-surface-secondary, #fafafa)",
+                          }}
+                        >
+                          {/* Full quoted text - ternary for conditional content */}
+                          {item.quotedFileContent !== null
+                            ? (
                               <div
                                 style={{
-                                  padding: "8px 12px",
-                                  marginBottom: "4px",
-                                  borderLeft: "2px solid #ddd",
+                                  padding: "12px",
+                                  marginBottom: "12px",
+                                  borderLeft:
+                                    "3px solid var(--cf-color-blue-500, #3b82f6)",
                                   backgroundColor: "white",
                                   borderRadius: "4px",
-                                  fontSize: "13px",
                                 }}
                               >
-                                <span style={{ fontWeight: 500 }}>
-                                  {reply.author.displayName}:
-                                </span>{" "}
-                                {reply.content}
+                                <div
+                                  style={{
+                                    fontSize: "11px",
+                                    color: "#888",
+                                    marginBottom: "4px",
+                                  }}
+                                >
+                                  Highlighted text:
+                                </div>
+                                <div
+                                  style={{
+                                    fontSize: "13px",
+                                    fontStyle: "italic",
+                                  }}
+                                >
+                                  "{item.quotedFileContent?.value ?? ""}"
+                                </div>
                               </div>
-                            ))}
-                          </div>,
-                          null,
-                        )}
-                      </div>,
-                      null,
-                    )}
+                            )
+                            : null}
+
+                          {/* Existing replies - ternary for conditional content */}
+                          {item.replies.length > 0
+                            ? (
+                              <div>
+                                <div
+                                  style={{
+                                    fontSize: "12px",
+                                    fontWeight: 600,
+                                    marginBottom: "8px",
+                                    color: "#666",
+                                  }}
+                                >
+                                  Previous replies:
+                                </div>
+                                {item.replies.map((reply) => (
+                                  <div
+                                    style={{
+                                      padding: "8px 12px",
+                                      marginBottom: "4px",
+                                      borderLeft: "2px solid #ddd",
+                                      backgroundColor: "white",
+                                      borderRadius: "4px",
+                                      fontSize: "13px",
+                                    }}
+                                  >
+                                    <span style={{ fontWeight: 500 }}>
+                                      {reply.author.displayName}:
+                                    </span>{" "}
+                                    {reply.content}
+                                  </div>
+                                ))}
+                              </div>
+                            )
+                            : null}
+                        </div>
+                      )
+                      : null}
                   </div>
                 ))}
               </cf-vscroll>
 
               {/* AI Response Panel - OUTSIDE map, at pattern body level */}
-              {ifElse(
-                computed(() => !!expandedCommentIdCell.get()),
-                <div
-                  style={{
-                    padding: "16px",
-                    backgroundColor: "var(--cf-color-green-50, #f0fdf4)",
-                    borderRadius: "8px",
-                    border: "1px solid var(--cf-color-green-200, #bbf7d0)",
-                    marginTop: "12px",
-                  }}
-                >
+              {!!expandedCommentIdCell.get()
+                ? (
                   <div
                     style={{
-                      display: "flex",
-                      justifyContent: "space-between",
-                      alignItems: "center",
-                      marginBottom: "12px",
+                      padding: "16px",
+                      backgroundColor: "var(--cf-color-green-50, #f0fdf4)",
+                      borderRadius: "8px",
+                      border: "1px solid var(--cf-color-green-200, #bbf7d0)",
+                      marginTop: "12px",
                     }}
                   >
-                    <span
+                    <div
                       style={{
-                        fontSize: "14px",
-                        fontWeight: 600,
-                        color: "var(--cf-color-green-700, #15803d)",
+                        display: "flex",
+                        justifyContent: "space-between",
+                        alignItems: "center",
+                        marginBottom: "12px",
                       }}
                     >
-                      AI Suggested Response
-                    </span>
-                    <cf-button
-                      variant="pill"
-                      type="button"
-                      title="Generate a new response"
-                      onClick={regenerateResponse({
-                        commentStates: commentStatesCell,
-                        commentId: computed(() =>
-                          expandedCommentIdCell.get() ?? ""
-                        ),
-                      })}
-                    >
-                      Regenerate
-                    </cf-button>
-                  </div>
+                      <span
+                        style={{
+                          fontSize: "14px",
+                          fontWeight: 600,
+                          color: "var(--cf-color-green-700, #15803d)",
+                        }}
+                      >
+                        AI Suggested Response
+                      </span>
+                      <cf-button
+                        variant="pill"
+                        type="button"
+                        title="Generate a new response"
+                        onClick={regenerateResponse({
+                          commentStates: commentStatesCell,
+                          commentId: computed(() =>
+                            expandedCommentIdCell.get() ?? ""
+                          ),
+                        })}
+                      >
+                        Regenerate
+                      </cf-button>
+                    </div>
 
-                  {/* Response content - reads aiResponse directly at pattern body level */}
+                    {/* Response content - reads aiResponse directly at pattern body level */}
+                    <div
+                      style={{
+                        fontSize: "14px",
+                        lineHeight: 1.6,
+                        marginBottom: "16px",
+                      }}
+                    >
+                      {aiResponse.pending
+                        ? (
+                          <span style={{ color: "#888" }}>
+                            Generating response...
+                          </span>
+                        )
+                        : aiResponse.result?.suggestedResponse
+                        ? <div>{aiResponse.result?.suggestedResponse}</div>
+                        : (
+                          <span style={{ color: "#888" }}>
+                            Expand a comment to generate an AI response
+                          </span>
+                        )}
+                    </div>
+
+                    {/* Action Buttons */}
+                    <div
+                      style={{ display: "flex", gap: "8px", flexWrap: "wrap" }}
+                    >
+                      <cf-button
+                        variant="primary"
+                        type="button"
+                        disabled={aiResponse.pending ||
+                          !aiResponse.result?.suggestedResponse}
+                        onClick={prepareReply({
+                          docUrl: docUrlCell,
+                          comments: commentsCell,
+                          commentId: computed(() =>
+                            expandedCommentIdCell.get() ?? ""
+                          ),
+                          responseText: computed(() =>
+                            aiResponse.result?.suggestedResponse ?? ""
+                          ),
+                          resolve: false,
+                          pendingAction: pendingActionCell,
+                        })}
+                      >
+                        Reply
+                      </cf-button>
+                      <cf-button
+                        variant="secondary"
+                        type="button"
+                        disabled={aiResponse.pending ||
+                          !aiResponse.result?.suggestedResponse}
+                        onClick={prepareReply({
+                          docUrl: docUrlCell,
+                          comments: commentsCell,
+                          commentId: computed(() =>
+                            expandedCommentIdCell.get() ?? ""
+                          ),
+                          responseText: computed(() =>
+                            aiResponse.result?.suggestedResponse ?? ""
+                          ),
+                          resolve: true,
+                          pendingAction: pendingActionCell,
+                        })}
+                      >
+                        Reply + Resolve
+                      </cf-button>
+                      <cf-button
+                        variant="ghost"
+                        type="button"
+                        onClick={skipComment({
+                          commentId: computed(() =>
+                            expandedCommentIdCell.get() ?? ""
+                          ),
+                          commentStates: commentStatesCell,
+                          expandedCommentId: expandedCommentIdCell,
+                        })}
+                      >
+                        Skip
+                      </cf-button>
+                    </div>
+                  </div>
+                )
+                : (
                   <div
                     style={{
+                      padding: "16px",
+                      textAlign: "center",
+                      color: "#888",
                       fontSize: "14px",
-                      lineHeight: 1.6,
-                      marginBottom: "16px",
+                      marginTop: "12px",
                     }}
                   >
-                    {ifElse(
-                      aiResponse.pending,
-                      <span style={{ color: "#888" }}>
-                        Generating response...
-                      </span>,
-                      ifElse(
-                        aiResponse.result?.suggestedResponse,
-                        <div>{aiResponse.result?.suggestedResponse}</div>,
-                        <span style={{ color: "#888" }}>
-                          Expand a comment to generate an AI response
-                        </span>,
-                      ),
-                    )}
+                    Select a comment to generate an AI response
                   </div>
-
-                  {/* Action Buttons */}
-                  <div
-                    style={{ display: "flex", gap: "8px", flexWrap: "wrap" }}
-                  >
-                    <cf-button
-                      variant="primary"
-                      type="button"
-                      disabled={computed(() => aiResponse.pending ||
-                        !aiResponse.result?.suggestedResponse
-                      )}
-                      onClick={prepareReply({
-                        docUrl: docUrlCell,
-                        comments: commentsCell,
-                        commentId: computed(() =>
-                          expandedCommentIdCell.get() ?? ""
-                        ),
-                        responseText: computed(() =>
-                          aiResponse.result?.suggestedResponse ?? ""
-                        ),
-                        resolve: false,
-                        pendingAction: pendingActionCell,
-                      })}
-                    >
-                      Reply
-                    </cf-button>
-                    <cf-button
-                      variant="secondary"
-                      type="button"
-                      disabled={computed(() =>
-                        aiResponse.pending ||
-                        !aiResponse.result?.suggestedResponse
-                      )}
-                      onClick={prepareReply({
-                        docUrl: docUrlCell,
-                        comments: commentsCell,
-                        commentId: computed(() =>
-                          expandedCommentIdCell.get() ?? ""
-                        ),
-                        responseText: computed(() =>
-                          aiResponse.result?.suggestedResponse ?? ""
-                        ),
-                        resolve: true,
-                        pendingAction: pendingActionCell,
-                      })}
-                    >
-                      Reply + Resolve
-                    </cf-button>
-                    <cf-button
-                      variant="ghost"
-                      type="button"
-                      onClick={skipComment({
-                        commentId: computed(() =>
-                          expandedCommentIdCell.get() ?? ""
-                        ),
-                        commentStates: commentStatesCell,
-                        expandedCommentId: expandedCommentIdCell,
-                      })}
-                    >
-                      Skip
-                    </cf-button>
-                  </div>
-                </div>,
-                <div
-                  style={{
-                    padding: "16px",
-                    textAlign: "center",
-                    color: "#888",
-                    fontSize: "14px",
-                    marginTop: "12px",
-                  }}
-                >
-                  Select a comment to generate an AI response
-                </div>,
-              )}
+                )}
             </cf-card>
 
             {/* Trusted Confirmation Component - renders inline when pendingAction is set */}
             {/* TRUST BOUNDARY: executeAction lives in google-docs-comment-confirm.tsx */}
-            {ifElse(
-              hasAction,
-              <cf-card
-                style={{
-                  padding: "20px",
-                  marginTop: "16px",
-                  border: "2px solid #f59e0b",
-                  backgroundColor: "#fffbeb",
-                  borderRadius: "8px",
-                }}
-              >
-                {/* Header */}
-                <cf-hstack
-                  align="center"
-                  gap={2}
-                  style={{ marginBottom: "16px" }}
-                >
-                  <span style={{ fontSize: "24px" }}>⚠️</span>
-                  <cf-heading level={4}>
-                    Confirm Action on Google Docs
-                  </cf-heading>
-                </cf-hstack>
-
-                {/* Action type badge */}
-                <div
+            {hasAction
+              ? (
+                <cf-card
                   style={{
-                    display: "inline-block",
-                    padding: "4px 12px",
-                    backgroundColor: "#fef3c7",
-                    border: "1px solid #f59e0b",
-                    borderRadius: "4px",
-                    fontSize: "14px",
-                    fontWeight: "600",
-                    marginBottom: "12px",
+                    padding: "20px",
+                    marginTop: "16px",
+                    border: "2px solid #f59e0b",
+                    backgroundColor: "#fffbeb",
+                    borderRadius: "8px",
                   }}
                 >
-                  {actionDetails?.typeLabel}
-                </div>
+                  {/* Header */}
+                  <cf-hstack
+                    align="center"
+                    gap={2}
+                    style={{ marginBottom: "16px" }}
+                  >
+                    <span style={{ fontSize: "24px" }}>⚠️</span>
+                    <cf-heading level={4}>
+                      Confirm Action on Google Docs
+                    </cf-heading>
+                  </cf-hstack>
 
-                {/* Context info */}
-                <cf-vstack gap={2} style={{ marginBottom: "16px" }}>
-                  <div style={{ fontSize: "14px", color: "#666" }}>
-                    <strong>Document:</strong> {actionDetails?.docUrlShort}
-                  </div>
-                  <div style={{ fontSize: "14px", color: "#666" }}>
-                    <strong>Comment by:</strong> {actionDetails?.commentAuthor}
-                  </div>
-                  {ifElse(
-                    computed(() => !!actionDetails?.hasQuotedText),
-                    <div
-                      style={{
-                        fontSize: "14px",
-                        color: "#666",
-                        padding: "8px",
-                        backgroundColor: "#fff",
-                        borderLeft: "3px solid #ddd",
-                        fontStyle: "italic",
-                      }}
-                    >
-                      "{actionDetails?.quotedText}"
-                    </div>,
-                    null,
-                  )}
-                  <div style={{ fontSize: "14px", color: "#333" }}>
-                    <strong>Original comment:</strong>{" "}
-                    {actionDetails?.commentContent}
-                  </div>
-                </cf-vstack>
-
-                {/* Your response */}
-                <div
-                  style={{
-                    padding: "12px",
-                    backgroundColor: "#fff",
-                    border: "1px solid #ddd",
-                    borderRadius: "4px",
-                    marginBottom: "16px",
-                  }}
-                >
+                  {/* Action type badge */}
                   <div
                     style={{
-                      fontSize: "12px",
-                      color: "#666",
-                      marginBottom: "4px",
+                      display: "inline-block",
+                      padding: "4px 12px",
+                      backgroundColor: "#fef3c7",
+                      border: "1px solid #f59e0b",
+                      borderRadius: "4px",
+                      fontSize: "14px",
                       fontWeight: "600",
+                      marginBottom: "12px",
                     }}
                   >
-                    Your response:
+                    {actionDetails?.typeLabel}
                   </div>
-                  <div style={{ fontSize: "14px" }}>
-                    {actionDetails?.responseText}
-                  </div>
-                </div>
 
-                {/* Error display */}
-                {ifElse(
-                  hasLastError,
+                  {/* Context info */}
+                  <cf-vstack gap={2} style={{ marginBottom: "16px" }}>
+                    <div style={{ fontSize: "14px", color: "#666" }}>
+                      <strong>Document:</strong> {actionDetails?.docUrlShort}
+                    </div>
+                    <div style={{ fontSize: "14px", color: "#666" }}>
+                      <strong>Comment by:</strong>{" "}
+                      {actionDetails?.commentAuthor}
+                    </div>
+                    {!!actionDetails?.hasQuotedText
+                      ? (
+                        <div
+                          style={{
+                            fontSize: "14px",
+                            color: "#666",
+                            padding: "8px",
+                            backgroundColor: "#fff",
+                            borderLeft: "3px solid #ddd",
+                            fontStyle: "italic",
+                          }}
+                        >
+                          "{actionDetails?.quotedText}"
+                        </div>
+                      )
+                      : null}
+                    <div style={{ fontSize: "14px", color: "#333" }}>
+                      <strong>Original comment:</strong>{" "}
+                      {actionDetails?.commentContent}
+                    </div>
+                  </cf-vstack>
+
+                  {/* Your response */}
                   <div
                     style={{
                       padding: "12px",
-                      backgroundColor: "#fef2f2",
-                      border: "1px solid #ef4444",
+                      backgroundColor: "#fff",
+                      border: "1px solid #ddd",
                       borderRadius: "4px",
                       marginBottom: "16px",
-                      color: "#dc2626",
-                      fontSize: "14px",
                     }}
                   >
-                    {lastErrorCell}
-                  </div>,
-                  null,
-                )}
+                    <div
+                      style={{
+                        fontSize: "12px",
+                        color: "#666",
+                        marginBottom: "4px",
+                        fontWeight: "600",
+                      }}
+                    >
+                      Your response:
+                    </div>
+                    <div style={{ fontSize: "14px" }}>
+                      {actionDetails?.responseText}
+                    </div>
+                  </div>
 
-                {/* Action buttons */}
-                <cf-hstack gap={2} justify="end">
-                  <cf-button
-                    variant="secondary"
-                    type="button"
-                    disabled={isExecutingCell}
-                    onClick={cancelAction({ action: pendingActionCell })}
-                  >
-                    Cancel
-                  </cf-button>
-                  <cf-button
-                    variant="primary"
-                    type="button"
-                    disabled={isExecutingCell}
-                    onClick={executeAction({
-                      action: pendingActionCell,
-                      auth,
-                      comments: commentsCell,
-                      commentStates: commentStatesCell,
-                      expandedCommentId: expandedCommentIdCell,
-                      lastError: lastErrorCell,
-                      isExecuting: isExecutingCell,
-                    })}
-                  >
-                    {ifElse(
-                      isExecutingCell,
-                      "Posting...",
-                      <span>✓ Post {actionDetails?.typeLabel}</span>,
-                    )}
-                  </cf-button>
-                </cf-hstack>
-              </cf-card>,
-              null,
-            )}
+                  {/* Error display */}
+                  {hasLastError
+                    ? (
+                      <div
+                        style={{
+                          padding: "12px",
+                          backgroundColor: "#fef2f2",
+                          border: "1px solid #ef4444",
+                          borderRadius: "4px",
+                          marginBottom: "16px",
+                          color: "#dc2626",
+                          fontSize: "14px",
+                        }}
+                      >
+                        {lastErrorCell}
+                      </div>
+                    )
+                    : null}
+
+                  {/* Action buttons */}
+                  <cf-hstack gap={2} justify="end">
+                    <cf-button
+                      variant="secondary"
+                      type="button"
+                      disabled={isExecutingCell}
+                      onClick={cancelAction({ action: pendingActionCell })}
+                    >
+                      Cancel
+                    </cf-button>
+                    <cf-button
+                      variant="primary"
+                      type="button"
+                      disabled={isExecutingCell}
+                      onClick={executeAction({
+                        action: pendingActionCell,
+                        auth,
+                        comments: commentsCell,
+                        commentStates: commentStatesCell,
+                        expandedCommentId: expandedCommentIdCell,
+                        lastError: lastErrorCell,
+                        isExecuting: isExecutingCell,
+                      })}
+                    >
+                      {isExecutingCell.get()
+                        ? "Posting..."
+                        : <span>✓ Post {actionDetails?.typeLabel}</span>}
+                    </cf-button>
+                  </cf-hstack>
+                </cf-card>
+              )
+              : null}
           </cf-vstack>
         </cf-screen>
       ),

--- a/packages/patterns/google/core/experimental/google-docs-comment-orchestrator.tsx
+++ b/packages/patterns/google/core/experimental/google-docs-comment-orchestrator.tsx
@@ -812,7 +812,7 @@ export default pattern<Input, Output>(
                 </cf-hstack>
 
                 {/* Error display */}
-                {!!lastError
+                {lastError
                   ? (
                     <div
                       style={{
@@ -1097,7 +1097,7 @@ export default pattern<Input, Output>(
               </cf-vscroll>
 
               {/* AI Response Panel - OUTSIDE map, at pattern body level */}
-              {!!expandedCommentIdCell.get()
+              {expandedCommentIdCell.get()
                 ? (
                   <div
                     style={{
@@ -1288,7 +1288,7 @@ export default pattern<Input, Output>(
                       <strong>Comment by:</strong>{" "}
                       {actionDetails?.commentAuthor}
                     </div>
-                    {!!actionDetails?.hasQuotedText
+                    {actionDetails?.hasQuotedText
                       ? (
                         <div
                           style={{

--- a/packages/patterns/google/core/gmail-importer.tsx
+++ b/packages/patterns/google/core/gmail-importer.tsx
@@ -1,9 +1,7 @@
 import {
   computed,
   Default,
-  derive,
   handler,
-  ifElse,
   NAME,
   pattern,
   patternTool,
@@ -36,11 +34,12 @@ type SyncableWritable<T> = Writable<T> & {
 /**
  * Auth data structure for Google OAuth tokens.
  *
- * ⚠️ CRITICAL: When consuming this auth, DO NOT use derive()!
- * derive() creates read-only projections - token refresh will silently fail.
- * Use property access (piece.auth) or ifElse() instead.
- *
- * See: community-docs/superstitions/2025-12-03-derive-creates-readonly-cells-use-property-access.md
+ * ⚠️ CRITICAL: When consuming this auth, keep it a live, writable cell
+ * reference - do NOT copy it into a read-only projection. Token refresh
+ * mutates the auth cell in place, so any consumer that reads a detached
+ * snapshot will see refresh silently fail.
+ * Use direct property access (piece.auth) or select it with a ternary
+ * (which lowers to ifElse and preserves the underlying cell reference).
  */
 export type Auth = {
   token: Secret<string> | Default<"">;
@@ -1040,7 +1039,7 @@ const EmailCard = pattern<
   { email: Email },
   { [NAME]: string; summary: string; [UI]: VNode }
 >(({ email }) => ({
-  [NAME]: computed(() => email.subject),
+  [NAME]: email.subject,
   summary: str`${email.subject} from ${email.from}: ${email.snippet}`,
   [UI]: (
     <div
@@ -1115,20 +1114,15 @@ export default pattern<
   });
 
   // Check if overrideAuth is provided (for manual linking when wish() is unavailable)
-  const hasOverrideAuth = computed(() => !!overrideAuth?.token);
-  const overrideAuthEmail = computed(() => overrideAuth?.user?.email || "");
+  const hasOverrideAuth = !!overrideAuth?.token;
+  const overrideAuthEmail = overrideAuth?.user?.email || "";
 
-  const auth = ifElse(
-    hasOverrideAuth,
-    overrideAuth,
-    wishedAuth,
-  );
-  const isReady = ifElse(hasOverrideAuth, hasOverrideAuth, wishedIsReady);
-  const currentEmail = ifElse(
-    hasOverrideAuth,
-    overrideAuthEmail,
-    wishedCurrentEmail,
-  );
+  // IMPORTANT: select auth via a bare ternary (lowers to ifElse), NOT a plain
+  // projection that would copy the value. This keeps `auth` a live, writable
+  // cell reference so cross-piece token refresh can mutate it in place.
+  const auth = hasOverrideAuth ? overrideAuth : wishedAuth;
+  const isReady = hasOverrideAuth ? hasOverrideAuth : wishedIsReady;
+  const currentEmail = hasOverrideAuth ? overrideAuthEmail : wishedCurrentEmail;
 
   const summary = computed(() => {
     const emailList = emails.get();
@@ -1202,7 +1196,7 @@ export default pattern<
             {authUI}
 
             <h3 style={{ fontSize: "18px", fontWeight: "bold" }}>
-              Imported email count: {computed(() => emails.get().length)}
+              Imported email count: {emails.get().length}
             </h3>
 
             <div style={{ fontSize: "14px", color: "#666" }}>
@@ -1297,30 +1291,30 @@ export default pattern<
                   Debug Mode (verbose console logging)
                 </label>
               </div>
-              {ifElse(
-                isReady,
-                <cf-button
-                  type="button"
-                  onClick={googleUpdaterStream}
-                  disabled={fetching}
-                >
-                  {ifElse(
-                    fetching,
-                    <span
-                      style={{
-                        display: "flex",
-                        alignItems: "center",
-                        gap: "8px",
-                      }}
-                    >
-                      <cf-loader size="sm" show-elapsed></cf-loader>
-                      Fetching...
-                    </span>,
-                    "Fetch Emails",
-                  )}
-                </cf-button>,
-                null,
-              )}
+              {isReady
+                ? (
+                  <cf-button
+                    type="button"
+                    onClick={googleUpdaterStream}
+                    disabled={fetching}
+                  >
+                    {fetching.get()
+                      ? (
+                        <span
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: "8px",
+                          }}
+                        >
+                          <cf-loader size="sm" show-elapsed></cf-loader>
+                          Fetching...
+                        </span>
+                      )
+                      : "Fetch Emails"}
+                  </cf-button>
+                )
+                : null}
             </cf-vstack>
 
             <div>
@@ -1350,7 +1344,7 @@ export default pattern<
                         style={{ border: "1px solid black", padding: "10px" }}
                       >
                         &nbsp;
-                        {derive(email, (email) => email?.labelIds?.join(", "))}
+                        {email?.labelIds?.join(", ")}
                         &nbsp;
                       </td>
                       <td
@@ -1381,14 +1375,14 @@ export default pattern<
     authUI,
     emails,
     mentionable: emails.map((e) => <EmailCard email={e} />),
-    emailCount: derive(emails, (list: Email[]) => list?.length || 0),
+    emailCount: emails.get()?.length || 0,
     summary,
     bgUpdater: googleUpdaterStream,
     isReady,
     // Pattern tools for omnibot
     searchEmails: patternTool(
       ({ query, emails }: { query: string; emails: Email[] }) => {
-        return derive({ query, emails }, ({ query, emails }) => {
+        return computed(() => {
           if (!query || !emails) return [];
           const lowerQuery = query.toLowerCase();
           return emails.filter(
@@ -1403,13 +1397,13 @@ export default pattern<
     ),
     getEmailCount: patternTool(
       ({ emails }: { emails: Email[] }) => {
-        return derive(emails, (list: Email[]) => list?.length || 0);
+        return emails?.length || 0;
       },
       { emails },
     ),
     getRecentEmails: patternTool(
       ({ count, emails }: { count: number; emails: Email[] }) => {
-        return derive({ count, emails }, ({ count, emails }) => {
+        return computed(() => {
           if (!emails || emails.length === 0) return "No emails";
           const recent = emails.slice(0, count || 5);
           return recent

--- a/packages/patterns/google/core/google-calendar-importer.tsx
+++ b/packages/patterns/google/core/google-calendar-importer.tsx
@@ -1,10 +1,8 @@
 import {
   computed,
   Default,
-  derive,
   getPatternEnvironment,
   handler,
-  ifElse,
   NAME,
   pattern,
   patternTool,
@@ -582,8 +580,8 @@ const GoogleCalendarImporter = pattern<GoogleCalendarImporterInput, Output>(
     });
 
     // Check if overrideAuth is provided (for manual linking when wish() is unavailable)
-    const hasLinkedAuth = computed(() => !!(overrideAuth?.token));
-    const overrideAuthEmail = computed(() => overrideAuth?.user?.email || "");
+    const hasLinkedAuth = !!(overrideAuth?.token);
+    const overrideAuthEmail = overrideAuth?.user?.email || "";
 
     // Use overrideAuth if provided, otherwise use wished auth
     // This allows manual linking via CLI when wish() is unavailable (e.g., favorites disabled)
@@ -596,18 +594,16 @@ const GoogleCalendarImporter = pattern<GoogleCalendarImporterInput, Output>(
     });
 
     // Choose auth source based on overrideAuth availability
-    const auth = ifElse(hasLinkedAuth, overrideAuthCell, wishedAuth) as any;
-    const isReady = ifElse(hasLinkedAuth, hasLinkedAuth, wishedIsReady);
-    const currentEmail = ifElse(
-      hasLinkedAuth,
-      overrideAuthEmail,
-      wishedCurrentEmail,
-    );
+    // Keep the bare ternary so the chosen branch stays a live cell reference
+    // (preserves token writability for refresh); avoid projecting auth.
+    const auth = (hasLinkedAuth ? overrideAuthCell : wishedAuth) as any;
+    const isReady = hasLinkedAuth ? hasLinkedAuth : wishedIsReady;
+    const currentEmail = hasLinkedAuth ? overrideAuthEmail : wishedCurrentEmail;
 
     // Computed values for pagination
-    const upcomingEvents = derive(events, (evts: CalendarEvent[]) => {
+    const upcomingEvents = computed(() => {
       const now = new Date();
-      return [...evts]
+      return [...events.get()]
         .filter((e) => new Date(e.startDateTime || e.start) >= now)
         .sort((a, b) =>
           new Date(a.startDateTime || a.start).getTime() -
@@ -615,22 +611,14 @@ const GoogleCalendarImporter = pattern<GoogleCalendarImporterInput, Output>(
         );
     });
 
-    const summary = derive(events, (eventList: CalendarEvent[]) => {
-      return eventList
-        .slice(0, 20)
-        .map((e) => `${e.summary || ""} ${e.start || ""}`.trim())
-        .filter((s) => s.length > 0)
-        .join(" | ");
-    });
+    const summary = events.get()
+      .slice(0, 20)
+      .map((e) => `${e.summary || ""} ${e.start || ""}`.trim())
+      .filter((s) => s.length > 0)
+      .join(" | ");
 
-    const totalUpcoming = derive(
-      upcomingEvents,
-      (evts: CalendarEvent[]) => evts.length,
-    );
-    const _maxPageNum = derive(
-      totalUpcoming,
-      (total: number) => Math.max(0, Math.ceil(total / PAGE_SIZE) - 1),
-    );
+    const totalUpcoming = upcomingEvents.length;
+    const _maxPageNum = Math.max(0, Math.ceil(totalUpcoming / PAGE_SIZE) - 1);
 
     // Paginated events for display - use computed with events Cell directly
     const _paginatedEvents = computed(() => {
@@ -666,11 +654,11 @@ const GoogleCalendarImporter = pattern<GoogleCalendarImporterInput, Output>(
               {fullUI}
 
               <h3 style={{ fontSize: "18px", fontWeight: "bold" }}>
-                Imported event count: {computed(() => events.get().length)}
+                Imported event count: {events.get().length}
               </h3>
 
               <div style={{ fontSize: "14px", color: "#666" }}>
-                Calendars found: {computed(() => calendars.get().length)}
+                Calendars found: {calendars.get().length}
               </div>
 
               <cf-vstack gap="4">
@@ -742,37 +730,37 @@ const GoogleCalendarImporter = pattern<GoogleCalendarImporterInput, Output>(
                     Debug Mode (verbose console logging)
                   </label>
                 </div>
-                {ifElse(
-                  isReady,
-                  <cf-button
-                    type="button"
-                    onClick={calendarUpdater({
-                      events,
-                      calendars,
-                      auth,
-                      settings,
-                      fetching,
-                      selectedCalendarIds,
-                    })}
-                    disabled={fetching}
-                  >
-                    {ifElse(
-                      fetching,
-                      <span
-                        style={{
-                          display: "flex",
-                          alignItems: "center",
-                          gap: "8px",
-                        }}
-                      >
-                        <cf-loader size="sm" show-elapsed></cf-loader>
-                        Fetching...
-                      </span>,
-                      "Fetch Calendar Events",
-                    )}
-                  </cf-button>,
-                  null,
-                )}
+                {isReady
+                  ? (
+                    <cf-button
+                      type="button"
+                      onClick={calendarUpdater({
+                        events,
+                        calendars,
+                        auth,
+                        settings,
+                        fetching,
+                        selectedCalendarIds,
+                      })}
+                      disabled={fetching}
+                    >
+                      {fetching
+                        ? (
+                          <span
+                            style={{
+                              display: "flex",
+                              alignItems: "center",
+                              gap: "8px",
+                            }}
+                          >
+                            <cf-loader size="sm" show-elapsed></cf-loader>
+                            Fetching...
+                          </span>
+                        )
+                        : "Fetch Calendar Events"}
+                    </cf-button>
+                  )
+                  : null}
               </cf-vstack>
 
               {/* Calendar list with selection */}
@@ -786,7 +774,7 @@ const GoogleCalendarImporter = pattern<GoogleCalendarImporterInput, Output>(
                   }}
                 >
                   <h4 style={{ fontSize: "16px", margin: 0 }}>
-                    Your Calendars ({computed(() => calendars.get().length)})
+                    Your Calendars ({calendars.get().length})
                   </h4>
                   <div style={{ display: "flex", gap: "8px" }}>
                     <button
@@ -866,11 +854,9 @@ const GoogleCalendarImporter = pattern<GoogleCalendarImporterInput, Output>(
                           fetching,
                         })}
                       >
-                        {ifElse(
-                          calendarSelectionMap[cal.id],
-                          <span>✓</span>,
-                          <span />,
-                        )}
+                        {calendarSelectionMap[cal.id]
+                          ? <span>✓</span>
+                          : <span />}
                         {cal.primary ? <span>★</span> : null}
                         {cal.summary}
                       </div>
@@ -904,88 +890,86 @@ const GoogleCalendarImporter = pattern<GoogleCalendarImporterInput, Output>(
                     {showEvents ? "▼" : "▶"}
                   </span>
                   <h4 style={{ fontSize: "16px", margin: 0 }}>
-                    {derive(
-                      events,
-                      (evts: CalendarEvent[]) =>
-                        `${evts.length} events imported`,
-                    )}
+                    {`${events.get().length} events imported`}
                   </h4>
                 </div>
-                {ifElse(
-                  showEvents,
-                  <div
-                    style={{
-                      marginTop: "12px",
-                      maxHeight: "400px",
-                      overflowY: "auto",
-                      border: "1px solid #e5e7eb",
-                      borderRadius: "8px",
-                    }}
-                  >
-                    {events.map((event) => {
-                      // Use pre-computed colors map - direct indexing works with Cell values
-                      return (
-                        <div
-                          style={{
-                            padding: "8px 12px",
-                            borderBottom: "1px solid #f3f4f6",
-                            fontSize: "13px",
-                          }}
-                        >
+                {showEvents
+                  ? (
+                    <div
+                      style={{
+                        marginTop: "12px",
+                        maxHeight: "400px",
+                        overflowY: "auto",
+                        border: "1px solid #e5e7eb",
+                        borderRadius: "8px",
+                      }}
+                    >
+                      {events.map((event) => {
+                        // Use pre-computed colors map - direct indexing works with Cell values
+                        return (
                           <div
                             style={{
-                              display: "flex",
-                              alignItems: "center",
-                              gap: "8px",
+                              padding: "8px 12px",
+                              borderBottom: "1px solid #f3f4f6",
+                              fontSize: "13px",
                             }}
                           >
-                            <span
+                            <div
                               style={{
-                                padding: "2px 8px",
-                                borderRadius: "12px",
-                                backgroundColor:
-                                  calendarColorsMap[event.calendarId]?.bg ??
-                                    "#4285f4",
-                                color:
-                                  calendarColorsMap[event.calendarId]?.fg ??
-                                    "#ffffff",
-                                fontSize: "11px",
-                                whiteSpace: "nowrap",
+                                display: "flex",
+                                alignItems: "center",
+                                gap: "8px",
                               }}
                             >
-                              {event.calendarName}
-                            </span>
-                            <span style={{ fontWeight: "500" }}>
-                              {event.summary}
-                            </span>
+                              <span
+                                style={{
+                                  padding: "2px 8px",
+                                  borderRadius: "12px",
+                                  backgroundColor:
+                                    calendarColorsMap[event.calendarId]?.bg ??
+                                      "#4285f4",
+                                  color:
+                                    calendarColorsMap[event.calendarId]?.fg ??
+                                      "#ffffff",
+                                  fontSize: "11px",
+                                  whiteSpace: "nowrap",
+                                }}
+                              >
+                                {event.calendarName}
+                              </span>
+                              <span style={{ fontWeight: "500" }}>
+                                {event.summary}
+                              </span>
+                            </div>
+                            <div
+                              style={{
+                                color: "#6b7280",
+                                fontSize: "12px",
+                                marginTop: "4px",
+                              }}
+                            >
+                              {formatEventDate(
+                                event.startDateTime,
+                                event.endDateTime,
+                                event.isAllDay,
+                              )}
+                            </div>
                           </div>
-                          <div
-                            style={{
-                              color: "#6b7280",
-                              fontSize: "12px",
-                              marginTop: "4px",
-                            }}
-                          >
-                            {formatEventDate(
-                              event.startDateTime,
-                              event.endDateTime,
-                              event.isAllDay,
-                            )}
-                          </div>
-                        </div>
-                      );
-                    })}
-                  </div>,
-                  <p
-                    style={{
-                      fontSize: "12px",
-                      color: "#666",
-                      marginTop: "8px",
-                    }}
-                  >
-                    Click to expand event list.
-                  </p>,
-                )}
+                        );
+                      })}
+                    </div>
+                  )
+                  : (
+                    <p
+                      style={{
+                        fontSize: "12px",
+                        color: "#666",
+                        marginTop: "8px",
+                      }}
+                    >
+                      Click to expand event list.
+                    </p>
+                  )}
               </div>
             </cf-vstack>
           </cf-vscroll>
@@ -993,7 +977,7 @@ const GoogleCalendarImporter = pattern<GoogleCalendarImporterInput, Output>(
       ),
       events,
       calendars,
-      eventCount: derive(events, (list: CalendarEvent[]) => list?.length || 0),
+      eventCount: events.get()?.length || 0,
       summary,
       bgUpdater: calendarUpdater({
         events,
@@ -1005,7 +989,7 @@ const GoogleCalendarImporter = pattern<GoogleCalendarImporterInput, Output>(
       // Pattern tools for omnibot
       searchEvents: patternTool(
         ({ query, events }: { query: string; events: CalendarEvent[] }) => {
-          return derive({ query, events }, ({ query, events }) => {
+          return computed(() => {
             if (!query || !events) return [];
             const lowerQuery = query.toLowerCase();
             return events.filter((event) =>
@@ -1019,13 +1003,13 @@ const GoogleCalendarImporter = pattern<GoogleCalendarImporterInput, Output>(
       ),
       getEventCount: patternTool(
         ({ events }: { events: CalendarEvent[] }) => {
-          return derive(events, (list) => list?.length || 0);
+          return computed(() => events?.length || 0);
         },
         { events },
       ),
       getUpcomingEvents: patternTool(
         ({ count, events }: { count: number; events: CalendarEvent[] }) => {
-          return derive({ count, events }, ({ count, events }) => {
+          return computed(() => {
             if (!events || events.length === 0) return "No events";
             const now = new Date();
             const upcoming = events
@@ -1048,7 +1032,7 @@ const GoogleCalendarImporter = pattern<GoogleCalendarImporterInput, Output>(
       ),
       getTodaysEvents: patternTool(
         ({ events }: { events: CalendarEvent[] }) => {
-          return derive(events, (events) => {
+          return computed(() => {
             if (!events || events.length === 0) return "No events";
             const today = new Date().toISOString().split("T")[0];
             const todayEvents = events.filter((e) =>

--- a/packages/patterns/google/core/imported-calendar.tsx
+++ b/packages/patterns/google/core/imported-calendar.tsx
@@ -15,9 +15,7 @@ import {
   Cell,
   computed,
   Default,
-  derive,
   handler,
-  ifElse,
   NAME,
   nonPrivateRandom,
   pattern,
@@ -386,13 +384,10 @@ const ImportedCalendar = pattern<Input, Output>(({ title, localEvents }) => {
   const lastDropTime = new Cell(0);
 
   // Computed Values
-  const importedEventCount = derive(
-    importedEvents,
-    (evts: CalendarEvent[]) => evts?.length || 0,
-  );
-  const localEventCount = computed(() => localEvents.get().length);
-  const eventCount = computed(() => importedEventCount + localEventCount);
-  const weekDates = computed(() => getWeekDates(startDate.get(), 7));
+  const importedEventCount = importedEvents?.length || 0;
+  const localEventCount = localEvents.get().length;
+  const eventCount = importedEventCount + localEventCount;
+  const weekDates = getWeekDates(startDate.get(), 7);
   const todayDate = getTodayDate();
 
   // Navigation Actions
@@ -475,7 +470,10 @@ const ImportedCalendar = pattern<Input, Output>(({ title, localEvents }) => {
     editingEventIndex.set(-1);
   });
 
-  // Computed Styles for View Toggle
+  // Computed Styles for View Toggle.
+  // Whole-object bindings at pattern-factory scope must stay wrapped in
+  // computed(): a bare object-literal initializer is a disallowed top-level
+  // value under SES verification.
   const dayButtonStyle = computed(() => ({
     ...STYLES.button.base,
     backgroundColor: visibleDays.get() === 1 ? "#3b82f6" : "#fff",
@@ -490,7 +488,7 @@ const ImportedCalendar = pattern<Input, Output>(({ title, localEvents }) => {
 
   // ===== Render =====
   return {
-    [NAME]: computed(() => `${title} (${eventCount})`),
+    [NAME]: `${title} (${eventCount})`,
     [UI]: (
       <cf-screen>
         {/* Header */}
@@ -627,11 +625,9 @@ const ImportedCalendar = pattern<Input, Output>(({ title, localEvents }) => {
                       style={{
                         ...STYLES.colorSwatch,
                         backgroundColor: c,
-                        border: computed(() =>
-                          newEventColor.get() === c
-                            ? "2px solid #111"
-                            : "2px solid transparent"
-                        ),
+                        border: newEventColor.get() === c
+                          ? "2px solid #111"
+                          : "2px solid transparent",
                       }}
                       onClick={colorActions[idx]}
                     />
@@ -760,11 +756,9 @@ const ImportedCalendar = pattern<Input, Output>(({ title, localEvents }) => {
                       style={{
                         ...STYLES.colorSwatch,
                         backgroundColor: c,
-                        border: computed(() =>
-                          editEventColor.get() === c
-                            ? "2px solid #111"
-                            : "2px solid transparent"
-                        ),
+                        border: editEventColor.get() === c
+                          ? "2px solid #111"
+                          : "2px solid transparent",
                       }}
                       onClick={editColorActions[idx]}
                     />
@@ -850,21 +844,22 @@ const ImportedCalendar = pattern<Input, Output>(({ title, localEvents }) => {
 
                 {/* Day Columns */}
                 {COLUMN_INDICES.map((colIdx) => {
-                  // Use computed() to properly extract values from the computed array
-                  const columnDate = computed(() => weekDates[colIdx] || "");
-                  const isToday = derive(weekDates, (dates) =>
-                    dates?.[colIdx] === todayDate);
-                  const dateHeader = derive(weekDates, (dates) => {
-                    const d = dates?.[colIdx];
+                  // Extract per-column values from the reactive weekDates array
+                  const columnDate = weekDates[colIdx] || "";
+                  const isToday = weekDates?.[colIdx] === todayDate;
+                  const dateHeader = computed(() => {
+                    const d = weekDates?.[colIdx];
                     return d ? formatDateHeader(d) : "";
                   });
-                  const displayStyle = computed(() =>
-                    colIdx < visibleDays.get() ? "flex" : "none"
-                  );
-                  const headerBg = derive(weekDates, (dates) =>
-                    dates?.[colIdx] === todayDate ? "#eff6ff" : "transparent");
-                  const headerColor = derive(weekDates, (dates) =>
-                    dates?.[colIdx] === todayDate ? "#2563eb" : "#374151");
+                  const displayStyle = colIdx < visibleDays.get()
+                    ? "flex"
+                    : "none";
+                  const headerBg = weekDates?.[colIdx] === todayDate
+                    ? "#eff6ff"
+                    : "transparent";
+                  const headerColor = weekDates?.[colIdx] === todayDate
+                    ? "#2563eb"
+                    : "#374151";
 
                   // Drop handler for moving/resizing local events
                   const handleDayDrop = action((e: {
@@ -993,13 +988,15 @@ const ImportedCalendar = pattern<Input, Output>(({ title, localEvents }) => {
                         >
                           {dateHeader}
                         </div>
-                        {ifElse(
-                          isToday,
-                          <div style={{ fontSize: "0.6rem", color: "#3b82f6" }}>
-                            Today
-                          </div>,
-                          null,
-                        )}
+                        {isToday
+                          ? (
+                            <div
+                              style={{ fontSize: "0.6rem", color: "#3b82f6" }}
+                            >
+                              Today
+                            </div>
+                          )
+                          : null}
                       </div>
 
                       {/* Time Grid with Drop Zone */}
@@ -1027,66 +1024,55 @@ const ImportedCalendar = pattern<Input, Output>(({ title, localEvents }) => {
                   );
                 })}
 
-                {/* Event Blocks - using derive() to compute everything at once */}
+                {/* Event Blocks - extract display properties per event */}
                 {importedEvents.map((evt: any) => {
-                  // Use derive() to extract display properties
-                  // All derives guard against undefined events
-                  const evtTitle = derive(
-                    evt,
-                    (e) =>
-                      e?.summary || "(No title)",
+                  // Project display properties from the event.
+                  // All projections guard against undefined events.
+                  const evtTitle = evt?.summary || "(No title)";
+                  const evtColor = getColorForCalendar(
+                    evt?.calendarId || "default",
                   );
-                  const evtColor = derive(
-                    evt,
-                    (e) =>
-                      getColorForCalendar(e?.calendarId || "default"),
-                  );
-                  const evtLocation = derive(evt, (e) =>
-                    e?.location || "");
-                  const evtTimeRange = derive(evt, (e) => {
-                    if (!e) {
+                  const evtLocation = evt?.location || "";
+                  const evtTimeRange = computed(() => {
+                    if (!evt) {
                       return "";
                     }
-                    const startTime = e.isAllDay
+                    const startTime = evt.isAllDay
                       ? "00:00"
-                      : extractTime(e.startDateTime);
-                    const endTime = e.isAllDay
+                      : extractTime(evt.startDateTime);
+                    const endTime = evt.isAllDay
                       ? "23:59"
-                      : extractTime(e.endDateTime);
+                      : extractTime(evt.endDateTime);
                     return `${startTime} - ${endTime}`;
                   });
-                  const hasLocation = derive(
-                    evt,
-                    (e) =>
-                      (e?.location || "").length > 0,
-                  );
+                  const hasLocation = (evt?.location || "").length > 0;
 
                   // Build direct event edit link: /r/eventedit/{base64(eventId + " " + calendarId)}
                   // This loads faster than the full calendar view
-                  const googleLink = derive(evt, (e) => {
-                    if (!e) {
+                  const googleLink = computed(() => {
+                    if (!evt) {
                       return "";
                     }
-                    if (!e.id || !e.calendarId) {
-                      return e.htmlLink || "";
+                    if (!evt.id || !evt.calendarId) {
+                      return evt.htmlLink || "";
                     }
                     try {
-                      const combined = `${e.id} ${e.calendarId}`;
+                      const combined = `${evt.id} ${evt.calendarId}`;
                       const encoded = btoa(combined);
                       return `https://calendar.google.com/calendar/u/0/r/eventedit/${encoded}`;
                     } catch {
                       // Fallback to htmlLink if encoding fails
-                      return e.htmlLink || "";
+                      return evt.htmlLink || "";
                     }
                   });
 
-                  // Compute position/visibility in single derive
-                  // Note: startDate and visibleDays are new Cell(), so access with .get()
-                  const styles = derive(evt, (e) => {
+                  // Compute position/visibility once.
+                  // Note: startDate and visibleDays are new Writable(), so access with .get()
+                  const styles = computed(() => {
                     const weekStart = startDate.get();
                     const visibleCount = visibleDays.get();
-                    const eventDate = e
-                      ? extractDate(e.start || e.startDateTime)
+                    const eventDate = evt
+                      ? extractDate(evt.start || evt.startDateTime)
                       : null;
 
                     const hidden = {
@@ -1114,12 +1100,12 @@ const ImportedCalendar = pattern<Input, Output>(({ title, localEvents }) => {
                       return hidden;
                     }
 
-                    const startTime = e.isAllDay
+                    const startTime = evt.isAllDay
                       ? "00:00"
-                      : extractTime(e.startDateTime);
-                    const endTime = e.isAllDay
+                      : extractTime(evt.startDateTime);
+                    const endTime = evt.isAllDay
                       ? "23:59"
-                      : extractTime(e.endDateTime);
+                      : extractTime(evt.endDateTime);
                     const startMin = timeToMinutes(startTime) - DAY_START * 60;
                     const endMin = timeToMinutes(endTime) - DAY_START * 60;
                     const top = (startMin / 60) * HOUR_HEIGHT;
@@ -1186,19 +1172,19 @@ const ImportedCalendar = pattern<Input, Output>(({ title, localEvents }) => {
                         }}
                       >
                         {evtTimeRange}
-                        {ifElse(
-                          hasLocation,
-                          <div
-                            style={{
-                              overflow: "hidden",
-                              textOverflow: "ellipsis",
-                              whiteSpace: "nowrap",
-                            }}
-                          >
-                            📍 {evtLocation}
-                          </div>,
-                          null,
-                        )}
+                        {hasLocation
+                          ? (
+                            <div
+                              style={{
+                                overflow: "hidden",
+                                textOverflow: "ellipsis",
+                                whiteSpace: "nowrap",
+                              }}
+                            >
+                              📍 {evtLocation}
+                            </div>
+                          )
+                          : null}
                       </div>
                     </a>
                   );
@@ -1377,23 +1363,22 @@ const ImportedCalendar = pattern<Input, Output>(({ title, localEvents }) => {
         </div>
 
         {/* Empty State */}
-        {ifElse(
-          computed(() =>
-            eventCount === 0
-          ),
-          <div
-            slot="footer"
-            style={{
-              textAlign: "center",
-              padding: "16px",
-              color: "#6b7280",
-              fontSize: "0.875rem",
-            }}
-          >
-            No events yet. Click "+ Add" or click on a time slot to create one.
-          </div>,
-          null,
-        )}
+        {eventCount === 0
+          ? (
+            <div
+              slot="footer"
+              style={{
+                textAlign: "center",
+                padding: "16px",
+                color: "#6b7280",
+                fontSize: "0.875rem",
+              }}
+            >
+              No events yet. Click "+ Add" or click on a time slot to create
+              one.
+            </div>
+          )
+          : null}
       </cf-screen>
     ),
     title,

--- a/packages/patterns/google/extractors/email-notes.tsx
+++ b/packages/patterns/google/extractors/email-notes.tsx
@@ -17,16 +17,7 @@
  * 2. Authenticate with Google (will auto-prompt)
  * 3. View notes, copy content, mark as done
  */
-import {
-  computed,
-  derive,
-  handler,
-  ifElse,
-  NAME,
-  pattern,
-  UI,
-  Writable,
-} from "commonfabric";
+import { computed, handler, NAME, pattern, UI, Writable } from "commonfabric";
 import GmailExtractor, { type Email } from "../core/gmail-extractor.tsx";
 import type { Auth } from "../core/util/google-auth-manager.tsx";
 import {
@@ -211,9 +202,9 @@ export default pattern<PatternInput, PatternOutput>(() => {
   const sortNewestFirst = new Writable(true).for("sortNewestFirst");
 
   // Use createGoogleAuth for scopes that include gmailModify
-  // Note: We use auth directly (not wrapped in ifElse) because GmailSendClient
-  // requires a Writable<Auth> with .get() method. Wrapping in ifElse() creates
-  // a derived value that loses writability.
+  // Note: We use auth directly (not wrapped in a reactive projection) because
+  // GmailSendClient requires a Writable<Auth> with .get() method. Wrapping it in
+  // a derived/conditional value would lose writability.
   const {
     auth,
     fullUI: authUI,
@@ -279,11 +270,11 @@ export default pattern<PatternInput, PatternOutput>(() => {
       });
   });
 
-  const noteCount = computed(() => notes?.length || 0);
+  const noteCount = notes?.length || 0;
 
   // No processing/analysis in this pattern, so pending is always 0
-  const pendingCount = computed(() => 0);
-  const completedCount = computed(() => noteCount);
+  const pendingCount = 0;
+  const completedCount = noteCount;
 
   // Preview UI for compact display
   const previewUI = (
@@ -315,8 +306,7 @@ export default pattern<PatternInput, PatternOutput>(() => {
       <div style={{ flex: 1 }}>
         <div style={{ fontWeight: "600", fontSize: "14px" }}>Email Notes</div>
         <div style={{ fontSize: "12px", color: "#6b7280" }}>
-          {derive(noteCount, (count) =>
-            count === 1 ? "1 note" : `${count} notes`)}
+          {noteCount === 1 ? "1 note" : `${noteCount} notes`}
         </div>
         {/* Loading/progress indicator */}
         <ProcessingStatus
@@ -352,222 +342,207 @@ export default pattern<PatternInput, PatternOutput>(() => {
             {authUI}
 
             {/* Connection status and refresh */}
-            {ifElse(
-              isReady,
-              <div
-                style={{
-                  padding: "12px 16px",
-                  backgroundColor: "#d1fae5",
-                  borderRadius: "8px",
-                  border: "1px solid #10b981",
-                  display: "flex",
-                  alignItems: "center",
-                  gap: "8px",
-                }}
-              >
-                <span
+            {isReady
+              ? (
+                <div
                   style={{
-                    width: "10px",
-                    height: "10px",
-                    borderRadius: "50%",
-                    backgroundColor: "#10b981",
-                  }}
-                />
-                <span>Connected</span>
-                <span style={{ marginLeft: "auto", color: "#059669" }}>
-                  {noteCount} notes found
-                </span>
-                <button
-                  type="button"
-                  onClick={extractor.refresh}
-                  style={{
-                    marginLeft: "8px",
-                    padding: "6px 12px",
-                    backgroundColor: "#10b981",
-                    color: "white",
-                    border: "none",
-                    borderRadius: "6px",
-                    cursor: "pointer",
-                    fontSize: "13px",
-                    fontWeight: "500",
+                    padding: "12px 16px",
+                    backgroundColor: "#d1fae5",
+                    borderRadius: "8px",
+                    border: "1px solid #10b981",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "8px",
                   }}
                 >
-                  Refresh
-                </button>
-              </div>,
-              null,
-            )}
+                  <span
+                    style={{
+                      width: "10px",
+                      height: "10px",
+                      borderRadius: "50%",
+                      backgroundColor: "#10b981",
+                    }}
+                  />
+                  <span>Connected</span>
+                  <span style={{ marginLeft: "auto", color: "#059669" }}>
+                    {noteCount} notes found
+                  </span>
+                  <button
+                    type="button"
+                    onClick={extractor.refresh}
+                    style={{
+                      marginLeft: "8px",
+                      padding: "6px 12px",
+                      backgroundColor: "#10b981",
+                      color: "white",
+                      border: "none",
+                      borderRadius: "6px",
+                      cursor: "pointer",
+                      fontSize: "13px",
+                      fontWeight: "500",
+                    }}
+                  >
+                    Refresh
+                  </button>
+                </div>
+              )
+              : null}
 
             {/* Label status - only show when there's a problem or loading */}
-            {ifElse(
-              derive(
-                { isReady, taskCurrentLabelId, loadingLabels },
-                ({ isReady, taskCurrentLabelId, loadingLabels }) =>
-                  isReady && (!taskCurrentLabelId || loadingLabels),
-              ),
-              <div
-                style={{
-                  padding: "8px 12px",
-                  backgroundColor: "#fef3c7",
-                  borderRadius: "6px",
-                  fontSize: "13px",
-                  color: "#b45309",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "space-between",
-                }}
-              >
-                {ifElse(
-                  loadingLabels,
-                  <span>Loading labels...</span>,
-                  <span>
-                    task-current label not found - click Load Labels
-                  </span>,
-                )}
-                <button
-                  type="button"
-                  onClick={labelFetcherStream}
-                  disabled={loadingLabels}
+            {isReady && (!taskCurrentLabelId.get() || loadingLabels.get())
+              ? (
+                <div
                   style={{
-                    marginLeft: "8px",
-                    padding: "4px 10px",
-                    backgroundColor: loadingLabels ? "#9ca3af" : "#6366f1",
-                    color: "white",
-                    border: "none",
-                    borderRadius: "4px",
-                    fontSize: "12px",
-                    cursor: loadingLabels ? "not-allowed" : "pointer",
-                    fontWeight: "500",
+                    padding: "8px 12px",
+                    backgroundColor: "#fef3c7",
+                    borderRadius: "6px",
+                    fontSize: "13px",
+                    color: "#b45309",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
                   }}
                 >
-                  {loadingLabels ? "Loading..." : "Load Labels"}
-                </button>
-              </div>,
-              null,
-            )}
+                  {loadingLabels.get() ? <span>Loading labels...</span> : (
+                    <span>
+                      task-current label not found - click Load Labels
+                    </span>
+                  )}
+                  <button
+                    type="button"
+                    onClick={labelFetcherStream}
+                    disabled={loadingLabels}
+                    style={{
+                      marginLeft: "8px",
+                      padding: "4px 10px",
+                      backgroundColor: loadingLabels ? "#9ca3af" : "#6366f1",
+                      color: "white",
+                      border: "none",
+                      borderRadius: "4px",
+                      fontSize: "12px",
+                      cursor: loadingLabels ? "not-allowed" : "pointer",
+                      fontWeight: "500",
+                    }}
+                  >
+                    {loadingLabels ? "Loading..." : "Load Labels"}
+                  </button>
+                </div>
+              )
+              : null}
 
             {/* Notes list */}
-            {ifElse(
-              derive(noteCount, (count) => count === 0),
-              <div
-                style={{
-                  padding: "24px",
-                  textAlign: "center",
-                  color: "#6b7280",
-                  backgroundColor: "#f9fafb",
-                  borderRadius: "8px",
-                }}
-              >
-                <div style={{ fontSize: "16px", marginBottom: "8px" }}>
-                  No notes found
+            {noteCount === 0
+              ? (
+                <div
+                  style={{
+                    padding: "24px",
+                    textAlign: "center",
+                    color: "#6b7280",
+                    backgroundColor: "#f9fafb",
+                    borderRadius: "8px",
+                  }}
+                >
+                  <div style={{ fontSize: "16px", marginBottom: "8px" }}>
+                    No notes found
+                  </div>
+                  <div style={{ fontSize: "13px" }}>
+                    Send yourself an email with no subject and the label
+                    "task-current" to see it here.
+                  </div>
                 </div>
-                <div style={{ fontSize: "13px" }}>
-                  Send yourself an email with no subject and the label
-                  "task-current" to see it here.
-                </div>
-              </div>,
-              <cf-vstack gap="3">
-                {notes.map((note) => {
-                  // Check if this note is being processed
-                  // Extract noteId before computed to avoid OpaqueRef issues
-                  const noteId = note.id;
-                  const isProcessing = computed(() =>
-                    (processingNotes.get() || []).includes(noteId)
-                  );
+              )
+              : (
+                <cf-vstack gap="3">
+                  {notes.map((note) => {
+                    // Check if this note is being processed
+                    // Extract noteId first to avoid OpaqueRef issues in the projection
+                    const noteId = note.id;
+                    const isProcessing = (processingNotes.get() || []).includes(
+                      noteId,
+                    );
 
-                  return (
-                    <div
-                      style={{
-                        padding: "16px",
-                        backgroundColor: "#ffffff",
-                        borderRadius: "8px",
-                        border: "1px solid #e5e7eb",
-                        boxShadow: "0 1px 2px rgba(0, 0, 0, 0.05)",
-                      }}
-                    >
-                      {/* Header with date and actions */}
+                    return (
                       <div
                         style={{
-                          display: "flex",
-                          alignItems: "center",
-                          justifyContent: "space-between",
-                          marginBottom: "12px",
+                          padding: "16px",
+                          backgroundColor: "#ffffff",
+                          borderRadius: "8px",
+                          border: "1px solid #e5e7eb",
+                          boxShadow: "0 1px 2px rgba(0, 0, 0, 0.05)",
                         }}
                       >
-                        <span
+                        {/* Header with date and actions */}
+                        <div
                           style={{
-                            fontSize: "12px",
-                            color: "#9ca3af",
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "space-between",
+                            marginBottom: "12px",
                           }}
                         >
-                          {derive(note, (n) => formatDate(n.date))}
-                        </span>
-                        <div style={{ display: "flex", gap: "8px" }}>
-                          {/* Copy button - copies both plain text and HTML for rich pasting */}
-                          <cf-copy-button
-                            text={derive(note, (n) => ({
-                              "text/plain": n.content,
-                              "text/html": n.htmlContent,
-                            }))}
-                            variant="outline"
-                            size="sm"
-                          />
-
-                          {/* Mark as Done button */}
-                          <button
-                            type="button"
-                            onClick={markAsDone({
-                              removeLabels: extractor.removeLabels,
-                              noteId: note.id,
-                              taskCurrentLabelId,
-                              hiddenNotes,
-                              processingNotes,
-                            })}
-                            disabled={derive(
-                              { isProcessing, taskCurrentLabelId },
-                              ({ isProcessing, taskCurrentLabelId }) =>
-                                isProcessing || !taskCurrentLabelId,
-                            )}
+                          <span
                             style={{
-                              padding: "4px 10px",
-                              backgroundColor: derive(
-                                isProcessing,
-                                (p) => p ? "#e5e7eb" : "#3b82f6",
-                              ),
-                              color: derive(
-                                isProcessing,
-                                (p) => p ? "#9ca3af" : "white",
-                              ),
-                              border: "none",
-                              borderRadius: "4px",
                               fontSize: "12px",
-                              cursor: derive(
-                                isProcessing,
-                                (p) => p ? "not-allowed" : "pointer",
-                              ),
-                              fontWeight: "500",
-                              opacity: derive(
-                                taskCurrentLabelId,
-                                (id) => id ? 1 : 0.5,
-                              ),
+                              color: "#9ca3af",
                             }}
                           >
-                            {isProcessing ? "Processing..." : "Done"}
-                          </button>
-                        </div>
-                      </div>
+                            {formatDate(note.date)}
+                          </span>
+                          <div style={{ display: "flex", gap: "8px" }}>
+                            {/* Copy button - copies both plain text and HTML for rich pasting */}
+                            <cf-copy-button
+                              text={{
+                                "text/plain": note.content,
+                                "text/html": note.htmlContent,
+                              }}
+                              variant="outline"
+                              size="sm"
+                            />
 
-                      {/* Note content - rendered as markdown */}
-                      <cf-markdown
-                        content={derive(note, (n) => n.content)}
-                        compact
-                        style="font-size: 14px; line-height: 1.5; color: #374151;"
-                      />
-                    </div>
-                  );
-                })}
-              </cf-vstack>,
-            )}
+                            {/* Mark as Done button */}
+                            <button
+                              type="button"
+                              onClick={markAsDone({
+                                removeLabels: extractor.removeLabels,
+                                noteId: note.id,
+                                taskCurrentLabelId,
+                                hiddenNotes,
+                                processingNotes,
+                              })}
+                              disabled={isProcessing ||
+                                !taskCurrentLabelId.get()}
+                              style={{
+                                padding: "4px 10px",
+                                backgroundColor: isProcessing
+                                  ? "#e5e7eb"
+                                  : "#3b82f6",
+                                color: isProcessing ? "#9ca3af" : "white",
+                                border: "none",
+                                borderRadius: "4px",
+                                fontSize: "12px",
+                                cursor: isProcessing
+                                  ? "not-allowed"
+                                  : "pointer",
+                                fontWeight: "500",
+                                opacity: taskCurrentLabelId.get() ? 1 : 0.5,
+                              }}
+                            >
+                              {isProcessing ? "Processing..." : "Done"}
+                            </button>
+                          </div>
+                        </div>
+
+                        {/* Note content - rendered as markdown */}
+                        <cf-markdown
+                          content={note.content}
+                          compact
+                          style="font-size: 14px; line-height: 1.5; color: #374151;"
+                        />
+                      </div>
+                    );
+                  })}
+                </cf-vstack>
+              )}
           </cf-vstack>
         </cf-vscroll>
       </cf-screen>

--- a/packages/patterns/google/extractors/email-pattern-launcher.tsx
+++ b/packages/patterns/google/extractors/email-pattern-launcher.tsx
@@ -20,7 +20,6 @@
 import {
   //compileAndRun,
   computed,
-  derive,
   fetchData,
   //fetchProgram,
   NAME,
@@ -242,7 +241,8 @@ export default pattern<PatternInput, PatternOutput>(({ overrideAuth }) => {
     */
 
     const compiled = {
-      result: derive(matchInfo.patternUri, (patternUri) => {
+      result: computed(() => {
+        const patternUri = matchInfo.patternUri;
         const pattern = PATTERNS[patternUri];
         if (!pattern) return null;
         return pattern({} as any).for(patternUri);
@@ -413,9 +413,7 @@ export default pattern<PatternInput, PatternOutput>(({ overrideAuth }) => {
             )}
 
             {/* No Matches Message */}
-            {computed(() =>
-              !registryLoading && emailCount > 0 && matchCount === 0
-            ) && (
+            {!registryLoading && emailCount > 0 && matchCount === 0 && (
               <div
                 style={{
                   display: "block",

--- a/packages/patterns/google/extractors/email-style-extractor.tsx
+++ b/packages/patterns/google/extractors/email-style-extractor.tsx
@@ -18,10 +18,8 @@
  */
 import {
   computed,
-  derive,
   generateObject,
   handler,
-  ifElse,
   JSONSchema,
   NAME,
   pattern,
@@ -257,20 +255,15 @@ Extract the writing style patterns from these emails.`;
       return null;
     });
 
-    const isAnalyzing = computed(() => !!styleResult.pending);
+    const isAnalyzing = !!styleResult.pending;
 
-    // Unwrap Writables once so derive calls in the UI get plain values.
-    // The explicit param type is needed because derive infers Cell<T> for Writable<T>.
-    const style = derive(
-      savedStyle,
-      (s: EmailStyle | null) => s,
-    );
-    const hasStyle = derive(style, (s) => !!s);
-    const analyzedCount = derive(emailsAnalyzedCount, (c: number) => c);
-    const analyzedAt = derive(lastAnalyzedAt, (ts: string) => ts);
+    // Whether a style has been extracted yet
+    const hasStyle = !!savedStyle.get();
 
-    // Pre-built prompt string any consumer can drop into an LLM call
-    const stylePrompt = derive(style, (s) => {
+    // Pre-built prompt string any consumer can drop into an LLM call.
+    // Statement body (intermediate locals + early return) stays a computed.
+    const stylePrompt = computed(() => {
+      const s = savedStyle.get();
       if (!s?.summary) return "";
       const greetings = (s.greetingPatterns || []).join(", ");
       const closings = (s.closingPatterns || []).join(", ");
@@ -293,7 +286,7 @@ Write as if the user wrote it themselves, matching their natural voice.`;
 
     return {
       [NAME]: "Email Style Extractor",
-      style,
+      style: savedStyle,
       stylePrompt,
       emailsAnalyzed: emailsAnalyzedCount,
       lastAnalyzedAt,
@@ -307,115 +300,122 @@ Write as if the user wrote it themselves, matching their natural voice.`;
           <cf-vscroll flex showScrollbar>
             <cf-vstack padding="6" gap="4">
               {authUI}
-              {ifElse(
-                isReady,
-                <div
-                  style={{
-                    padding: "8px",
-                    backgroundColor: "#d1fae5",
-                    borderRadius: "6px",
-                  }}
-                >
-                  Auth ready. Emails: {derive(extractor.emailCount, (c) =>
-                    c > 0 ? `${c} fetched` : "Fetching...")}
-                </div>,
-                <div
-                  style={{
-                    padding: "8px",
-                    backgroundColor: "#fecaca",
-                    borderRadius: "6px",
-                  }}
-                >
-                  Waiting for Google auth...
-                </div>,
-              )}
-              {ifElse(
-                isAnalyzing,
-                <div
-                  style={{
-                    padding: "8px",
-                    backgroundColor: "#e0e7ff",
-                    borderRadius: "6px",
-                  }}
-                >
-                  Analyzing style...
-                </div>,
-                <div />,
-              )}
-              {ifElse(
-                hasStyle,
-                <div
-                  style={{
-                    padding: "12px",
-                    backgroundColor: "#fff",
-                    border: "1px solid #e5e7eb",
-                    borderRadius: "8px",
-                  }}
-                >
-                  <div style={{ fontWeight: "600", marginBottom: "8px" }}>
-                    Your Writing Style
-                  </div>
-                  <div style={{ marginBottom: "6px" }}>
-                    {derive(style, (s) =>
-                      s?.summary || "")}
-                  </div>
-                  <div style={{ fontSize: "12px", color: "#6b7280" }}>
-                    Tone: {derive(style, (s) =>
-                      s?.overallTone || "")} | Formality: {derive(style, (s) =>
-                        s?.formalityLevel || "")}
-                  </div>
+              {isReady
+                ? (
                   <div
                     style={{
-                      fontSize: "11px",
-                      color: "#9ca3af",
-                      marginTop: "8px",
+                      padding: "8px",
+                      backgroundColor: "#d1fae5",
+                      borderRadius: "6px",
                     }}
                   >
-                    {derive(analyzedCount, (c) => `${c} emails analyzed`)}{" "}
-                    {derive(analyzedAt, (ts) =>
-                      ts ? `| Last: ${new Date(ts).toLocaleString()}` : "")}
+                    Auth ready. Emails: {extractor.emailCount > 0
+                      ? `${extractor.emailCount} fetched`
+                      : "Fetching..."}
                   </div>
-                </div>,
-                <div style={{ padding: "8px", color: "#6b7280" }}>
-                  No style extracted yet
-                </div>,
-              )}
-              {ifElse(
-                isReady,
-                <div style={{ display: "flex", gap: "8px" }}>
-                  <button
-                    type="button"
-                    onClick={extractor.refresh}
+                )
+                : (
+                  <div
                     style={{
-                      padding: "6px 12px",
-                      backgroundColor: "#10b981",
-                      color: "white",
-                      border: "none",
+                      padding: "8px",
+                      backgroundColor: "#fecaca",
                       borderRadius: "6px",
-                      cursor: "pointer",
-                      fontSize: "13px",
                     }}
                   >
-                    Refresh Emails
-                  </button>
-                  <button
-                    type="button"
-                    onClick={triggerReanalyze({ reanalyzeFlag })}
+                    Waiting for Google auth...
+                  </div>
+                )}
+              {isAnalyzing
+                ? (
+                  <div
                     style={{
-                      padding: "6px 12px",
-                      backgroundColor: "#6366f1",
-                      color: "white",
-                      border: "none",
+                      padding: "8px",
+                      backgroundColor: "#e0e7ff",
                       borderRadius: "6px",
-                      cursor: "pointer",
-                      fontSize: "13px",
                     }}
                   >
-                    Re-analyze
-                  </button>
-                </div>,
-                <div />,
-              )}
+                    Analyzing style...
+                  </div>
+                )
+                : <div />}
+              {hasStyle
+                ? (
+                  <div
+                    style={{
+                      padding: "12px",
+                      backgroundColor: "#fff",
+                      border: "1px solid #e5e7eb",
+                      borderRadius: "8px",
+                    }}
+                  >
+                    <div style={{ fontWeight: "600", marginBottom: "8px" }}>
+                      Your Writing Style
+                    </div>
+                    <div style={{ marginBottom: "6px" }}>
+                      {savedStyle.get()?.summary || ""}
+                    </div>
+                    <div style={{ fontSize: "12px", color: "#6b7280" }}>
+                      Tone: {savedStyle.get()?.overallTone || ""} | Formality:
+                      {" "}
+                      {savedStyle.get()?.formalityLevel || ""}
+                    </div>
+                    <div
+                      style={{
+                        fontSize: "11px",
+                        color: "#9ca3af",
+                        marginTop: "8px",
+                      }}
+                    >
+                      {`${emailsAnalyzedCount.get()} emails analyzed`}{" "}
+                      {lastAnalyzedAt.get()
+                        ? `| Last: ${
+                          new Date(lastAnalyzedAt.get()).toLocaleString()
+                        }`
+                        : ""}
+                    </div>
+                  </div>
+                )
+                : (
+                  <div style={{ padding: "8px", color: "#6b7280" }}>
+                    No style extracted yet
+                  </div>
+                )}
+              {isReady
+                ? (
+                  <div style={{ display: "flex", gap: "8px" }}>
+                    <button
+                      type="button"
+                      onClick={extractor.refresh}
+                      style={{
+                        padding: "6px 12px",
+                        backgroundColor: "#10b981",
+                        color: "white",
+                        border: "none",
+                        borderRadius: "6px",
+                        cursor: "pointer",
+                        fontSize: "13px",
+                      }}
+                    >
+                      Refresh Emails
+                    </button>
+                    <button
+                      type="button"
+                      onClick={triggerReanalyze({ reanalyzeFlag })}
+                      style={{
+                        padding: "6px 12px",
+                        backgroundColor: "#6366f1",
+                        color: "white",
+                        border: "none",
+                        borderRadius: "6px",
+                        cursor: "pointer",
+                        fontSize: "13px",
+                      }}
+                    >
+                      Re-analyze
+                    </button>
+                  </div>
+                )
+                : <div />}
             </cf-vstack>
           </cf-vscroll>
         </cf-screen>

--- a/packages/patterns/google/extractors/expect-response-followup.tsx
+++ b/packages/patterns/google/extractors/expect-response-followup.tsx
@@ -21,10 +21,8 @@
  */
 import {
   computed,
-  derive,
   generateText,
   handler,
-  ifElse,
   NAME,
   pattern,
   UI,
@@ -612,10 +610,7 @@ export default pattern<PatternInput, PatternOutput>(() => {
   }>({
     query: "#emailStyle",
   });
-  const emailStylePrompt = derive(
-    emailStyleWish.result,
-    (r) => r?.stylePrompt ?? "",
-  );
+  const emailStylePrompt = emailStyleWish.result?.stylePrompt ?? "";
 
   // ==========================================================================
   // GMAIL EXTRACTOR
@@ -742,13 +737,9 @@ export default pattern<PatternInput, PatternOutput>(() => {
   // Uses computed prompt that builds from the selected thread's data
   // NOTE: When prompt is falsy/undefined, generateText should skip the API call
   // Build style-aware system prompt
-  const draftSystemPrompt = derive(
-    emailStylePrompt,
-    (prompt) =>
-      prompt
-        ? `You are a helpful assistant that drafts follow-up emails matching the user's personal writing style.\n\n${prompt}`
-        : "You are a helpful assistant that drafts professional follow-up emails.",
-  );
+  const draftSystemPrompt = emailStylePrompt
+    ? `You are a helpful assistant that drafts follow-up emails matching the user's personal writing style.\n\n${emailStylePrompt}`
+    : "You are a helpful assistant that drafts professional follow-up emails.";
 
   const draftLlmResult = generateText({
     prompt: computed((): string | undefined => {
@@ -909,524 +900,481 @@ Write only the email body, no subject line or greeting line (the greeting will b
             {authUI}
 
             {/* Refresh button when authenticated */}
-            {ifElse(
-              isReady,
-              <div
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  gap: "8px",
-                  padding: "8px 12px",
-                  backgroundColor: "#f9fafb",
-                  borderRadius: "6px",
-                }}
-              >
-                <span style={{ color: "#6b7280", fontSize: "13px" }}>
-                  {threadCount} threads awaiting response
-                </span>
-                <button
-                  type="button"
-                  onClick={extractor.refresh}
+            {isReady
+              ? (
+                <div
                   style={{
-                    marginLeft: "auto",
-                    padding: "6px 12px",
-                    backgroundColor: "#10b981",
-                    color: "white",
-                    border: "none",
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "8px",
+                    padding: "8px 12px",
+                    backgroundColor: "#f9fafb",
                     borderRadius: "6px",
-                    cursor: "pointer",
-                    fontSize: "13px",
-                    fontWeight: "500",
                   }}
                 >
-                  Refresh
-                </button>
-              </div>,
-              null,
-            )}
+                  <span style={{ color: "#6b7280", fontSize: "13px" }}>
+                    {threadCount} threads awaiting response
+                  </span>
+                  <button
+                    type="button"
+                    onClick={extractor.refresh}
+                    style={{
+                      marginLeft: "auto",
+                      padding: "6px 12px",
+                      backgroundColor: "#10b981",
+                      color: "white",
+                      border: "none",
+                      borderRadius: "6px",
+                      cursor: "pointer",
+                      fontSize: "13px",
+                      fontWeight: "500",
+                    }}
+                  >
+                    Refresh
+                  </button>
+                </div>
+              )
+              : null}
 
             {/* Label status */}
-            {ifElse(
-              derive(
-                { isReady, expectResponseLabelId, loadingLabels },
-                ({ isReady, expectResponseLabelId, loadingLabels }) =>
-                  isReady && (!expectResponseLabelId || loadingLabels),
-              ),
-              <div
-                style={{
-                  padding: "8px 12px",
-                  backgroundColor: "#fef3c7",
-                  borderRadius: "6px",
-                  fontSize: "13px",
-                  color: "#b45309",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "space-between",
-                }}
-              >
-                {ifElse(
-                  loadingLabels,
-                  <span>Loading labels...</span>,
-                  <span>
-                    expect-response label not found - click Load Labels
-                  </span>,
-                )}
-                <button
-                  type="button"
-                  onClick={fetchLabels({
-                    auth,
-                    expectResponseLabelId,
-                    loadingLabels,
-                  })}
-                  disabled={loadingLabels}
+            {isReady && (!expectResponseLabelId.get() || loadingLabels.get())
+              ? (
+                <div
                   style={{
-                    marginLeft: "8px",
-                    padding: "4px 10px",
-                    backgroundColor: derive(
-                      loadingLabels,
-                      (l) => l ? "#9ca3af" : "#6366f1",
-                    ),
-                    color: "white",
-                    border: "none",
-                    borderRadius: "4px",
-                    fontSize: "12px",
-                    cursor: derive(
-                      loadingLabels,
-                      (l) => l ? "not-allowed" : "pointer",
-                    ),
-                    fontWeight: "500",
+                    padding: "8px 12px",
+                    backgroundColor: "#fef3c7",
+                    borderRadius: "6px",
+                    fontSize: "13px",
+                    color: "#b45309",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
                   }}
                 >
-                  {loadingLabels ? "Loading..." : "Load Labels"}
-                </button>
-              </div>,
-              null,
-            )}
+                  {loadingLabels.get() ? <span>Loading labels...</span> : (
+                    <span>
+                      expect-response label not found - click Load Labels
+                    </span>
+                  )}
+                  <button
+                    type="button"
+                    onClick={fetchLabels({
+                      auth,
+                      expectResponseLabelId,
+                      loadingLabels,
+                    })}
+                    disabled={loadingLabels}
+                    style={{
+                      marginLeft: "8px",
+                      padding: "4px 10px",
+                      backgroundColor: loadingLabels.get()
+                        ? "#9ca3af"
+                        : "#6366f1",
+                      color: "white",
+                      border: "none",
+                      borderRadius: "4px",
+                      fontSize: "12px",
+                      cursor: loadingLabels.get() ? "not-allowed" : "pointer",
+                      fontWeight: "500",
+                    }}
+                  >
+                    {loadingLabels ? "Loading..." : "Load Labels"}
+                  </button>
+                </div>
+              )
+              : null}
 
             {/* Threads list */}
-            {ifElse(
-              derive(threadCount, (count) => count === 0),
-              <div
-                style={{
-                  padding: "24px",
-                  textAlign: "center",
-                  color: "#6b7280",
-                  backgroundColor: "#f9fafb",
-                  borderRadius: "8px",
-                }}
-              >
-                <div style={{ fontSize: "16px", marginBottom: "8px" }}>
-                  No threads awaiting response
+            {threadCount === 0
+              ? (
+                <div
+                  style={{
+                    padding: "24px",
+                    textAlign: "center",
+                    color: "#6b7280",
+                    backgroundColor: "#f9fafb",
+                    borderRadius: "8px",
+                  }}
+                >
+                  <div style={{ fontSize: "16px", marginBottom: "8px" }}>
+                    No threads awaiting response
+                  </div>
+                  <div style={{ fontSize: "13px" }}>
+                    Add the "expect-response" label to emails you're waiting on.
+                  </div>
                 </div>
-                <div style={{ fontSize: "13px" }}>
-                  Add the "expect-response" label to emails you're waiting on.
-                </div>
-              </div>,
-              <cf-vstack gap="3">
-                {threads.map((thread) => {
-                  const uiThreadId = thread.threadId;
-                  const isExpanded = computed(() =>
-                    expandedThreads.get().includes(uiThreadId)
-                  );
-                  const isSendingThis = computed(() =>
-                    activeSendThread.get() === uiThreadId
-                  );
-                  const settingsOpen = computed(() =>
-                    settingsOpenFor.get() === uiThreadId
-                  );
+              )
+              : (
+                <cf-vstack gap="3">
+                  {threads.map((thread) => {
+                    const uiThreadId = thread.threadId;
+                    const isExpanded = computed(() =>
+                      expandedThreads.get().includes(uiThreadId)
+                    );
+                    const isSendingThis = computed(() =>
+                      activeSendThread.get() === uiThreadId
+                    );
+                    const settingsOpen = computed(() =>
+                      settingsOpenFor.get() === uiThreadId
+                    );
+                    const isGenerating = computed(() =>
+                      generatingDraftFor.get() === uiThreadId &&
+                      draftLlmResult.pending
+                    );
+                    const hasDraft = computed(() => {
+                      const d = drafts.get();
+                      if (d[uiThreadId]) return true;
+                      const genFor = generatingDraftFor.get();
+                      if (
+                        genFor === uiThreadId &&
+                        !draftLlmResult.pending &&
+                        draftLlmResult.result
+                      ) {
+                        return true;
+                      }
+                      return false;
+                    });
+                    const draftText = computed((): string => {
+                      const d = drafts.get();
+                      if (d[uiThreadId]) return String(d[uiThreadId]);
+                      const genFor = generatingDraftFor.get();
+                      if (genFor === uiThreadId) {
+                        const result = draftLlmResult.result;
+                        const error = draftLlmResult.error;
+                        return String(result || error || "");
+                      }
+                      return "";
+                    });
 
-                  return (
-                    <div
-                      style={{
-                        backgroundColor: "#ffffff",
-                        borderRadius: "8px",
-                        border: derive(
-                          thread,
-                          (t) =>
-                            t.shouldGiveUp
-                              ? "2px solid #f97316"
-                              : t.isDue
-                              ? "2px solid #3b82f6"
-                              : "1px solid #e5e7eb",
-                        ),
-                        overflow: "hidden",
-                      }}
-                    >
-                      {/* Thread header */}
+                    return (
                       <div
                         style={{
-                          padding: "12px 16px",
-                          backgroundColor: derive(
-                            thread,
-                            (t) =>
-                              t.shouldGiveUp
-                                ? "#fff7ed"
-                                : t.isDue
-                                ? "#eff6ff"
-                                : "#f9fafb",
-                          ),
-                          borderBottom: "1px solid #e5e7eb",
+                          backgroundColor: "#ffffff",
+                          borderRadius: "8px",
+                          border: thread.shouldGiveUp
+                            ? "2px solid #f97316"
+                            : thread.isDue
+                            ? "2px solid #3b82f6"
+                            : "1px solid #e5e7eb",
+                          overflow: "hidden",
                         }}
                       >
+                        {/* Thread header */}
                         <div
                           style={{
-                            display: "flex",
-                            alignItems: "center",
-                            gap: "12px",
-                            marginBottom: "8px",
+                            padding: "12px 16px",
+                            backgroundColor: thread.shouldGiveUp
+                              ? "#fff7ed"
+                              : thread.isDue
+                              ? "#eff6ff"
+                              : "#f9fafb",
+                            borderBottom: "1px solid #e5e7eb",
                           }}
                         >
-                          {/* Subject */}
                           <div
                             style={{
-                              flex: 1,
-                              fontWeight: "600",
-                              fontSize: "14px",
-                              color: "#111827",
+                              display: "flex",
+                              alignItems: "center",
+                              gap: "12px",
+                              marginBottom: "8px",
                             }}
                           >
-                            {derive(thread, (t) => t.subject)}
-                          </div>
+                            {/* Subject */}
+                            <div
+                              style={{
+                                flex: 1,
+                                fontWeight: "600",
+                                fontSize: "14px",
+                                color: "#111827",
+                              }}
+                            >
+                              {thread.subject}
+                            </div>
 
-                          {/* Ping count badge */}
-                          {ifElse(
-                            derive(thread, (t) => t.pingCount > 0),
-                            <span
+                            {/* Ping count badge */}
+                            {thread.pingCount > 0
+                              ? (
+                                <span
+                                  style={{
+                                    padding: "2px 8px",
+                                    backgroundColor: "#fef3c7",
+                                    color: "#b45309",
+                                    borderRadius: "12px",
+                                    fontSize: "11px",
+                                    fontWeight: "500",
+                                  }}
+                                >
+                                  {thread.pingCount} pings
+                                </span>
+                              )
+                              : null}
+
+                            {/* Context badge */}
+                            <button
+                              type="button"
+                              onClick={toggleSettings({
+                                settingsOpenFor,
+                                threadId: uiThreadId,
+                              })}
                               style={{
                                 padding: "2px 8px",
-                                backgroundColor: "#fef3c7",
-                                color: "#b45309",
+                                backgroundColor:
+                                  contextBadgeColors[thread.settings.context]
+                                    .bg,
+                                color:
+                                  contextBadgeColors[thread.settings.context]
+                                    .text,
                                 borderRadius: "12px",
                                 fontSize: "11px",
                                 fontWeight: "500",
+                                border: "none",
+                                cursor: "pointer",
                               }}
                             >
-                              {derive(thread, (t) => t.pingCount)} pings
-                            </span>,
-                            null,
-                          )}
+                              {thread.settings.context.charAt(0).toUpperCase() +
+                                thread.settings.context.slice(1)}
+                            </button>
+                          </div>
 
-                          {/* Context badge */}
-                          <button
-                            type="button"
-                            onClick={toggleSettings({
-                              settingsOpenFor,
-                              threadId: uiThreadId,
-                            })}
+                          {/* Metadata row */}
+                          <div
                             style={{
-                              padding: "2px 8px",
-                              backgroundColor: derive(
-                                thread,
-                                (t) =>
-                                  contextBadgeColors[t.settings.context].bg,
-                              ),
-                              color: derive(
-                                thread,
-                                (t) =>
-                                  contextBadgeColors[t.settings.context].text,
-                              ),
-                              borderRadius: "12px",
-                              fontSize: "11px",
-                              fontWeight: "500",
-                              border: "none",
-                              cursor: "pointer",
-                            }}
-                          >
-                            {derive(
-                              thread,
-                              (t) =>
-                                t.settings.context.charAt(0).toUpperCase() +
-                                t.settings.context.slice(1),
-                            )}
-                          </button>
-                        </div>
-
-                        {/* Metadata row */}
-                        <div
-                          style={{
-                            display: "flex",
-                            alignItems: "center",
-                            gap: "16px",
-                            fontSize: "12px",
-                            color: "#6b7280",
-                          }}
-                        >
-                          <span>
-                            From: {derive(thread, (t) => t.lastResponder)}
-                          </span>
-                          <span>
-                            Last: {derive(
-                              thread,
-                              (t) => formatDate(t.lastMessageDate),
-                            )}
-                          </span>
-                          <span
-                            style={{
-                              fontWeight: "600",
-                              color: derive(
-                                thread,
-                                (t) => (t.isDue ? "#dc2626" : "#059669"),
-                              ),
-                            }}
-                          >
-                            {derive(
-                              thread,
-                              (t) =>
-                                formatDaysDisplay(
-                                  t.daysSinceLastResponse,
-                                  t.settings.context,
-                                ),
-                            )} waiting
-                          </span>
-                          <button
-                            type="button"
-                            onClick={toggleExpanded({
-                              expandedThreads,
-                              threadId: uiThreadId,
-                            })}
-                            style={{
-                              marginLeft: "auto",
-                              background: "none",
-                              border: "none",
-                              color: "#3b82f6",
-                              cursor: "pointer",
+                              display: "flex",
+                              alignItems: "center",
+                              gap: "16px",
                               fontSize: "12px",
+                              color: "#6b7280",
                             }}
                           >
-                            {isExpanded ? "Hide thread" : "Show thread"}
-                          </button>
-                        </div>
-                      </div>
-
-                      {/* Settings panel (collapsible) */}
-                      {ifElse(
-                        settingsOpen,
-                        <div
-                          style={{
-                            padding: "12px 16px",
-                            backgroundColor: "#f3f4f6",
-                            borderBottom: "1px solid #e5e7eb",
-                            display: "flex",
-                            alignItems: "center",
-                            gap: "16px",
-                            fontSize: "13px",
-                          }}
-                        >
-                          <label
-                            style={{
-                              display: "flex",
-                              alignItems: "center",
-                              gap: "6px",
-                            }}
-                          >
-                            Context:
-                            <select
-                              value={derive(thread, (t) => t.settings.context)}
-                              onChange={updateContext({
-                                threadMetadata,
+                            <span>
+                              From: {thread.lastResponder}
+                            </span>
+                            <span>
+                              Last: {formatDate(thread.lastMessageDate)}
+                            </span>
+                            <span
+                              style={{
+                                fontWeight: "600",
+                                color: thread.isDue ? "#dc2626" : "#059669",
+                              }}
+                            >
+                              {formatDaysDisplay(
+                                thread.daysSinceLastResponse,
+                                thread.settings.context,
+                              )} waiting
+                            </span>
+                            <button
+                              type="button"
+                              onClick={toggleExpanded({
+                                expandedThreads,
                                 threadId: uiThreadId,
                               })}
                               style={{
-                                padding: "4px 8px",
-                                borderRadius: "4px",
-                                border: "1px solid #d1d5db",
+                                marginLeft: "auto",
+                                background: "none",
+                                border: "none",
+                                color: "#3b82f6",
+                                cursor: "pointer",
                                 fontSize: "12px",
                               }}
                             >
-                              <option value="personal">Personal</option>
-                              <option value="business">Business</option>
-                              <option value="urgent">Urgent</option>
-                            </select>
-                          </label>
-                          <label
-                            style={{
-                              display: "flex",
-                              alignItems: "center",
-                              gap: "6px",
-                            }}
-                          >
-                            Due after:
-                            <input
-                              type="number"
-                              value={derive(
-                                thread,
-                                (t) => t.settings.daysThreshold,
-                              )}
-                              onChange={updateDaysThreshold({
-                                threadMetadata,
-                                threadId: uiThreadId,
-                                context: derive(
-                                  thread,
-                                  (t) => t.settings.context,
-                                ),
-                              })}
-                              min="1"
-                              max="30"
-                              style={{
-                                width: "50px",
-                                padding: "4px 8px",
-                                borderRadius: "4px",
-                                border: "1px solid #d1d5db",
-                                fontSize: "12px",
-                              }}
-                            />
-                            days
-                          </label>
-                          <label
-                            style={{
-                              display: "flex",
-                              alignItems: "center",
-                              gap: "6px",
-                            }}
-                          >
-                            Max pings:
-                            <input
-                              type="number"
-                              value={derive(thread, (t) => t.settings.maxPings)}
-                              onChange={updateMaxPings({
-                                threadMetadata,
-                                threadId: uiThreadId,
-                                context: derive(
-                                  thread,
-                                  (t) => t.settings.context,
-                                ),
-                              })}
-                              min="1"
-                              max="10"
-                              style={{
-                                width: "50px",
-                                padding: "4px 8px",
-                                borderRadius: "4px",
-                                border: "1px solid #d1d5db",
-                                fontSize: "12px",
-                              }}
-                            />
-                          </label>
-                        </div>,
-                        null,
-                      )}
+                              {isExpanded ? "Hide thread" : "Show thread"}
+                            </button>
+                          </div>
+                        </div>
 
-                      {/* Thread history (expandable) */}
-                      {ifElse(
-                        isExpanded,
-                        <div
-                          style={{
-                            padding: "12px 16px",
-                            backgroundColor: "#f9fafb",
-                            borderBottom: "1px solid #e5e7eb",
-                            maxHeight: "200px",
-                            overflowY: "auto",
-                          }}
-                        >
-                          {derive(thread, (t) =>
-                            t.emails.map((email, i) => (
-                              <div
-                                key={i}
+                        {/* Settings panel (collapsible) */}
+                        {settingsOpen
+                          ? (
+                            <div
+                              style={{
+                                padding: "12px 16px",
+                                backgroundColor: "#f3f4f6",
+                                borderBottom: "1px solid #e5e7eb",
+                                display: "flex",
+                                alignItems: "center",
+                                gap: "16px",
+                                fontSize: "13px",
+                              }}
+                            >
+                              <label
                                 style={{
-                                  padding: "8px",
-                                  marginBottom: "8px",
-                                  backgroundColor: "#ffffff",
-                                  borderRadius: "4px",
-                                  border: "1px solid #e5e7eb",
+                                  display: "flex",
+                                  alignItems: "center",
+                                  gap: "6px",
                                 }}
                               >
+                                Context:
+                                <select
+                                  value={thread.settings.context}
+                                  onChange={updateContext({
+                                    threadMetadata,
+                                    threadId: uiThreadId,
+                                  })}
+                                  style={{
+                                    padding: "4px 8px",
+                                    borderRadius: "4px",
+                                    border: "1px solid #d1d5db",
+                                    fontSize: "12px",
+                                  }}
+                                >
+                                  <option value="personal">Personal</option>
+                                  <option value="business">Business</option>
+                                  <option value="urgent">Urgent</option>
+                                </select>
+                              </label>
+                              <label
+                                style={{
+                                  display: "flex",
+                                  alignItems: "center",
+                                  gap: "6px",
+                                }}
+                              >
+                                Due after:
+                                <input
+                                  type="number"
+                                  value={thread.settings.daysThreshold}
+                                  onChange={updateDaysThreshold({
+                                    threadMetadata,
+                                    threadId: uiThreadId,
+                                    context: thread.settings.context,
+                                  })}
+                                  min="1"
+                                  max="30"
+                                  style={{
+                                    width: "50px",
+                                    padding: "4px 8px",
+                                    borderRadius: "4px",
+                                    border: "1px solid #d1d5db",
+                                    fontSize: "12px",
+                                  }}
+                                />
+                                days
+                              </label>
+                              <label
+                                style={{
+                                  display: "flex",
+                                  alignItems: "center",
+                                  gap: "6px",
+                                }}
+                              >
+                                Max pings:
+                                <input
+                                  type="number"
+                                  value={thread.settings.maxPings}
+                                  onChange={updateMaxPings({
+                                    threadMetadata,
+                                    threadId: uiThreadId,
+                                    context: thread.settings.context,
+                                  })}
+                                  min="1"
+                                  max="10"
+                                  style={{
+                                    width: "50px",
+                                    padding: "4px 8px",
+                                    borderRadius: "4px",
+                                    border: "1px solid #d1d5db",
+                                    fontSize: "12px",
+                                  }}
+                                />
+                              </label>
+                            </div>
+                          )
+                          : null}
+
+                        {/* Thread history (expandable) */}
+                        {isExpanded
+                          ? (
+                            <div
+                              style={{
+                                padding: "12px 16px",
+                                backgroundColor: "#f9fafb",
+                                borderBottom: "1px solid #e5e7eb",
+                                maxHeight: "200px",
+                                overflowY: "auto",
+                              }}
+                            >
+                              {computed(() =>
+                                thread.emails.map((email, i) => (
+                                  <div
+                                    key={i}
+                                    style={{
+                                      padding: "8px",
+                                      marginBottom: "8px",
+                                      backgroundColor: "#ffffff",
+                                      borderRadius: "4px",
+                                      border: "1px solid #e5e7eb",
+                                    }}
+                                  >
+                                    <div
+                                      style={{
+                                        display: "flex",
+                                        justifyContent: "space-between",
+                                        fontSize: "11px",
+                                        color: "#6b7280",
+                                        marginBottom: "4px",
+                                      }}
+                                    >
+                                      <span>{email.from}</span>
+                                      <span>{formatDate(email.date)}</span>
+                                    </div>
+                                    <div
+                                      style={{
+                                        fontSize: "12px",
+                                        color: "#374151",
+                                        whiteSpace: "pre-wrap",
+                                      }}
+                                    >
+                                      {email.snippet?.slice(0, 200)}
+                                      {(email.snippet?.length || 0) > 200
+                                        ? "..."
+                                        : ""}
+                                    </div>
+                                  </div>
+                                ))
+                              )}
+                            </div>
+                          )
+                          : null}
+
+                        {/* Draft / Send area */}
+                        <div style={{ padding: "12px 16px" }}>
+                          {isSendingThis
+                            // Gmail-sender UI shown inline when this thread is active
+                            ? (
+                              <div>
+                                {sender}
                                 <div
                                   style={{
                                     display: "flex",
-                                    justifyContent: "space-between",
-                                    fontSize: "11px",
-                                    color: "#6b7280",
-                                    marginBottom: "4px",
+                                    gap: "8px",
+                                    marginTop: "8px",
                                   }}
                                 >
-                                  <span>{email.from}</span>
-                                  <span>{formatDate(email.date)}</span>
-                                </div>
-                                <div
-                                  style={{
-                                    fontSize: "12px",
-                                    color: "#374151",
-                                    whiteSpace: "pre-wrap",
-                                  }}
-                                >
-                                  {email.snippet?.slice(0, 200)}
-                                  {(email.snippet?.length || 0) > 200
-                                    ? "..."
-                                    : ""}
+                                  <button
+                                    type="button"
+                                    onClick={cancelSendFlow({
+                                      senderDraft,
+                                      activeSendThread,
+                                    })}
+                                    style={{
+                                      padding: "8px 16px",
+                                      backgroundColor: "transparent",
+                                      color: "#6b7280",
+                                      border: "1px solid #d1d5db",
+                                      borderRadius: "6px",
+                                      cursor: "pointer",
+                                      fontSize: "13px",
+                                    }}
+                                  >
+                                    Cancel
+                                  </button>
                                 </div>
                               </div>
-                            )))}
-                        </div>,
-                        null,
-                      )}
-
-                      {/* Draft / Send area */}
-                      <div style={{ padding: "12px 16px" }}>
-                        {ifElse(
-                          isSendingThis,
-                          // Gmail-sender UI shown inline when this thread is active
-                          <div>
-                            {sender}
-                            <div
-                              style={{
-                                display: "flex",
-                                gap: "8px",
-                                marginTop: "8px",
-                              }}
-                            >
-                              <button
-                                type="button"
-                                onClick={cancelSendFlow({
-                                  senderDraft,
-                                  activeSendThread,
-                                })}
-                                style={{
-                                  padding: "8px 16px",
-                                  backgroundColor: "transparent",
-                                  color: "#6b7280",
-                                  border: "1px solid #d1d5db",
-                                  borderRadius: "6px",
-                                  cursor: "pointer",
-                                  fontSize: "13px",
-                                }}
-                              >
-                                Cancel
-                              </button>
-                            </div>
-                          </div>,
-                          // Draft editing UI
-                          (() => {
-                            const isGenerating = computed(() =>
-                              generatingDraftFor.get() === uiThreadId &&
-                              draftLlmResult.pending
-                            );
-                            const hasDraft = computed(() => {
-                              const d = drafts.get();
-                              if (d[uiThreadId]) return true;
-                              const genFor = generatingDraftFor.get();
-                              if (
-                                genFor === uiThreadId &&
-                                !draftLlmResult.pending &&
-                                draftLlmResult.result
-                              ) {
-                                return true;
-                              }
-                              return false;
-                            });
-                            const draftText = computed((): string => {
-                              const d = drafts.get();
-                              if (d[uiThreadId]) return String(d[uiThreadId]);
-                              const genFor = generatingDraftFor.get();
-                              if (genFor === uiThreadId) {
-                                const result = draftLlmResult.result;
-                                const error = draftLlmResult.error;
-                                return String(result || error || "");
-                              }
-                              return "";
-                            });
-
-                            return ifElse(
-                              isGenerating,
+                            )
+                            // Draft editing UI
+                            : isGenerating
+                            ? (
                               <div
                                 style={{
                                   padding: "12px",
@@ -1438,132 +1386,56 @@ Write only the email body, no subject line or greeting line (the greeting will b
                                 }}
                               >
                                 Generating follow-up draft...
-                              </div>,
-                              ifElse(
-                                hasDraft,
-                                <div>
-                                  <textarea
-                                    value={derive(
-                                      draftText,
-                                      (t) => String(t || ""),
-                                    )}
-                                    onChange={updateDraft({
+                              </div>
+                            )
+                            : hasDraft
+                            ? (
+                              <div>
+                                <textarea
+                                  value={String(draftText || "")}
+                                  onChange={updateDraft({
+                                    drafts,
+                                    threadId: uiThreadId,
+                                  })}
+                                  style={{
+                                    width: "100%",
+                                    minHeight: "100px",
+                                    padding: "8px 12px",
+                                    borderRadius: "6px",
+                                    border: "1px solid #d1d5db",
+                                    fontSize: "13px",
+                                    fontFamily: "inherit",
+                                    resize: "vertical",
+                                  }}
+                                />
+                                <div
+                                  style={{
+                                    display: "flex",
+                                    gap: "8px",
+                                    marginTop: "8px",
+                                  }}
+                                >
+                                  <button
+                                    type="button"
+                                    onClick={prepareSend({
+                                      senderDraft,
+                                      activeSendThread,
                                       drafts,
-                                      threadId: uiThreadId,
+                                      thread,
                                     })}
                                     style={{
-                                      width: "100%",
-                                      minHeight: "100px",
-                                      padding: "8px 12px",
+                                      padding: "8px 16px",
+                                      backgroundColor: "#10b981",
+                                      color: "white",
+                                      border: "none",
                                       borderRadius: "6px",
-                                      border: "1px solid #d1d5db",
+                                      cursor: "pointer",
                                       fontSize: "13px",
-                                      fontFamily: "inherit",
-                                      resize: "vertical",
-                                    }}
-                                  />
-                                  <div
-                                    style={{
-                                      display: "flex",
-                                      gap: "8px",
-                                      marginTop: "8px",
+                                      fontWeight: "500",
                                     }}
                                   >
-                                    <button
-                                      type="button"
-                                      onClick={prepareSend({
-                                        senderDraft,
-                                        activeSendThread,
-                                        drafts,
-                                        thread,
-                                      })}
-                                      style={{
-                                        padding: "8px 16px",
-                                        backgroundColor: "#10b981",
-                                        color: "white",
-                                        border: "none",
-                                        borderRadius: "6px",
-                                        cursor: "pointer",
-                                        fontSize: "13px",
-                                        fontWeight: "500",
-                                      }}
-                                    >
-                                      Send Follow-up
-                                    </button>
-                                    <button
-                                      type="button"
-                                      onClick={startDraftGeneration({
-                                        threadId: uiThreadId,
-                                        generatingDraftFor,
-                                        drafts,
-                                      })}
-                                      style={{
-                                        padding: "8px 16px",
-                                        backgroundColor: "transparent",
-                                        color: "#6366f1",
-                                        border: "1px solid #6366f1",
-                                        borderRadius: "6px",
-                                        cursor: "pointer",
-                                        fontSize: "13px",
-                                      }}
-                                    >
-                                      Regenerate
-                                    </button>
-                                    <button
-                                      type="button"
-                                      onClick={giveUp({
-                                        removeLabels: extractor.removeLabels,
-                                        thread,
-                                        expectResponseLabelId,
-                                        hiddenThreads,
-                                      })}
-                                      disabled={derive(
-                                        expectResponseLabelId,
-                                        (id) => !id,
-                                      )}
-                                      style={{
-                                        marginLeft: "auto",
-                                        padding: "8px 16px",
-                                        backgroundColor: derive(
-                                          thread,
-                                          (t) =>
-                                            t.shouldGiveUp
-                                              ? "#f97316"
-                                              : "transparent",
-                                        ),
-                                        color: derive(
-                                          thread,
-                                          (t) =>
-                                            t.shouldGiveUp
-                                              ? "white"
-                                              : "#f97316",
-                                        ),
-                                        border: derive(
-                                          thread,
-                                          (t) =>
-                                            t.shouldGiveUp
-                                              ? "none"
-                                              : "1px solid #f97316",
-                                        ),
-                                        borderRadius: "6px",
-                                        cursor: derive(
-                                          expectResponseLabelId,
-                                          (id) =>
-                                            id ? "pointer" : "not-allowed",
-                                        ),
-                                        fontSize: "13px",
-                                        fontWeight: derive(
-                                          thread,
-                                          (t) =>
-                                            t.shouldGiveUp ? "600" : "normal",
-                                        ),
-                                      }}
-                                    >
-                                      Give Up
-                                    </button>
-                                  </div>
-                                </div>,
-                                <div>
+                                    Send Follow-up
+                                  </button>
                                   <button
                                     type="button"
                                     onClick={startDraftGeneration({
@@ -1572,90 +1444,125 @@ Write only the email body, no subject line or greeting line (the greeting will b
                                       drafts,
                                     })}
                                     style={{
-                                      padding: "12px 24px",
-                                      backgroundColor: "#6366f1",
-                                      color: "white",
-                                      border: "none",
+                                      padding: "8px 16px",
+                                      backgroundColor: "transparent",
+                                      color: "#6366f1",
+                                      border: "1px solid #6366f1",
                                       borderRadius: "6px",
                                       cursor: "pointer",
-                                      fontSize: "14px",
-                                      fontWeight: "500",
-                                      width: "100%",
+                                      fontSize: "13px",
                                     }}
                                   >
-                                    Generate Follow-up Draft
+                                    Regenerate
                                   </button>
-                                  <div
+                                  <button
+                                    type="button"
+                                    onClick={giveUp({
+                                      removeLabels: extractor.removeLabels,
+                                      thread,
+                                      expectResponseLabelId,
+                                      hiddenThreads,
+                                    })}
+                                    disabled={!expectResponseLabelId.get()}
                                     style={{
-                                      display: "flex",
-                                      gap: "8px",
-                                      marginTop: "8px",
-                                      justifyContent: "flex-end",
+                                      marginLeft: "auto",
+                                      padding: "8px 16px",
+                                      backgroundColor: thread.shouldGiveUp
+                                        ? "#f97316"
+                                        : "transparent",
+                                      color: thread.shouldGiveUp
+                                        ? "white"
+                                        : "#f97316",
+                                      border: thread.shouldGiveUp
+                                        ? "none"
+                                        : "1px solid #f97316",
+                                      borderRadius: "6px",
+                                      cursor: expectResponseLabelId.get()
+                                        ? "pointer"
+                                        : "not-allowed",
+                                      fontSize: "13px",
+                                      fontWeight: thread.shouldGiveUp
+                                        ? "600"
+                                        : "normal",
                                     }}
                                   >
-                                    <button
-                                      type="button"
-                                      onClick={giveUp({
-                                        removeLabels: extractor.removeLabels,
-                                        thread,
-                                        expectResponseLabelId,
-                                        hiddenThreads,
-                                      })}
-                                      disabled={derive(
-                                        expectResponseLabelId,
-                                        (id) => !id,
-                                      )}
-                                      style={{
-                                        padding: "8px 16px",
-                                        backgroundColor: derive(
-                                          thread,
-                                          (t) =>
-                                            t.shouldGiveUp
-                                              ? "#f97316"
-                                              : "transparent",
-                                        ),
-                                        color: derive(
-                                          thread,
-                                          (t) =>
-                                            t.shouldGiveUp
-                                              ? "white"
-                                              : "#f97316",
-                                        ),
-                                        border: derive(
-                                          thread,
-                                          (t) =>
-                                            t.shouldGiveUp
-                                              ? "none"
-                                              : "1px solid #f97316",
-                                        ),
-                                        borderRadius: "6px",
-                                        cursor: derive(
-                                          expectResponseLabelId,
-                                          (id) =>
-                                            id ? "pointer" : "not-allowed",
-                                        ),
-                                        fontSize: "13px",
-                                        fontWeight: derive(
-                                          thread,
-                                          (t) =>
-                                            t.shouldGiveUp ? "600" : "normal",
-                                        ),
-                                      }}
-                                    >
-                                      Give Up
-                                    </button>
-                                  </div>
-                                </div>,
-                              ),
-                            );
-                          })(),
-                        )}
+                                    Give Up
+                                  </button>
+                                </div>
+                              </div>
+                            )
+                            : (
+                              <div>
+                                <button
+                                  type="button"
+                                  onClick={startDraftGeneration({
+                                    threadId: uiThreadId,
+                                    generatingDraftFor,
+                                    drafts,
+                                  })}
+                                  style={{
+                                    padding: "12px 24px",
+                                    backgroundColor: "#6366f1",
+                                    color: "white",
+                                    border: "none",
+                                    borderRadius: "6px",
+                                    cursor: "pointer",
+                                    fontSize: "14px",
+                                    fontWeight: "500",
+                                    width: "100%",
+                                  }}
+                                >
+                                  Generate Follow-up Draft
+                                </button>
+                                <div
+                                  style={{
+                                    display: "flex",
+                                    gap: "8px",
+                                    marginTop: "8px",
+                                    justifyContent: "flex-end",
+                                  }}
+                                >
+                                  <button
+                                    type="button"
+                                    onClick={giveUp({
+                                      removeLabels: extractor.removeLabels,
+                                      thread,
+                                      expectResponseLabelId,
+                                      hiddenThreads,
+                                    })}
+                                    disabled={!expectResponseLabelId.get()}
+                                    style={{
+                                      padding: "8px 16px",
+                                      backgroundColor: thread.shouldGiveUp
+                                        ? "#f97316"
+                                        : "transparent",
+                                      color: thread.shouldGiveUp
+                                        ? "white"
+                                        : "#f97316",
+                                      border: thread.shouldGiveUp
+                                        ? "none"
+                                        : "1px solid #f97316",
+                                      borderRadius: "6px",
+                                      cursor: expectResponseLabelId.get()
+                                        ? "pointer"
+                                        : "not-allowed",
+                                      fontSize: "13px",
+                                      fontWeight: thread.shouldGiveUp
+                                        ? "600"
+                                        : "normal",
+                                    }}
+                                  >
+                                    Give Up
+                                  </button>
+                                </div>
+                              </div>
+                            )}
+                        </div>
                       </div>
-                    </div>
-                  );
-                })}
-              </cf-vstack>,
-            )}
+                    );
+                  })}
+                </cf-vstack>
+              )}
           </cf-vstack>
         </cf-vscroll>
       </cf-screen>

--- a/packages/patterns/google/extractors/flight-calendar-bridge.tsx
+++ b/packages/patterns/google/extractors/flight-calendar-bridge.tsx
@@ -698,7 +698,7 @@ export default pattern<PatternInput, PatternOutput>(() => {
                     }}
                   >
                     {/* Travel To */}
-                    {!!group.travelTo
+                    {group.travelTo
                       ? (
                         <div
                           style={{
@@ -756,7 +756,7 @@ export default pattern<PatternInput, PatternOutput>(() => {
                     </div>
 
                     {/* Travel From */}
-                    {!!group.travelFrom
+                    {group.travelFrom
                       ? (
                         <div
                           style={{

--- a/packages/patterns/google/extractors/flight-calendar-bridge.tsx
+++ b/packages/patterns/google/extractors/flight-calendar-bridge.tsx
@@ -22,8 +22,6 @@
  */
 import {
   computed,
-  derive,
-  ifElse,
   NAME,
   pattern,
   toIndentedDebugString,
@@ -472,37 +470,28 @@ export default pattern<PatternInput, PatternOutput>(() => {
   const flightTrackerResult = flightTrackerWish.result;
   const profileResult = profileWish.result;
 
-  // Use derive to extract upcomingFlights from the piece result
-  const upcomingFlights = derive(
-    flightTrackerResult,
-    (tracker) => tracker?.upcomingFlights ?? [],
-  );
+  // Extract upcomingFlights from the piece result
+  const upcomingFlights = flightTrackerResult?.upcomingFlights ?? [];
 
-  // Extract home address from profile using derive
-  const homeAddress = derive(
-    profileResult,
-    (prof: ProfileOutput | undefined) => {
-      const addrs = prof?.addresses ?? [];
-      const home = addrs.find((a: Address) => a.label === "Home");
-      if (home && home.street) {
-        return `${home.street}, ${home.city}, ${home.state} ${home.zip}`.trim();
-      }
-      return null;
-    },
-  );
-
-  // Check if we have flight data
-  const isConnected = computed(() => {
-    return flightTrackerResult !== undefined;
+  // Extract home address from profile (statement body needs a computed)
+  const homeAddress = computed(() => {
+    const prof: ProfileOutput | undefined = profileResult;
+    const addrs = prof?.addresses ?? [];
+    const home = addrs.find((a: Address) => a.label === "Home");
+    if (home && home.street) {
+      return `${home.street}, ${home.city}, ${home.state} ${home.zip}`.trim();
+    }
+    return null;
   });
 
-  // Generate event groups for each flight
+  // Check if we have flight data
+  const isConnected = flightTrackerResult !== undefined;
+
+  // Generate event groups for each flight (whole-array map stays a computed)
   const eventGroups = computed(() => {
-    const flights = upcomingFlights;
-    const addr = homeAddress;
-    return flights
+    return upcomingFlights
       .filter((f) => f.status !== "cancelled")
-      .map((f) => generateFlightEvents(f, addr));
+      .map((f) => generateFlightEvents(f, homeAddress));
   });
 
   // Flatten to all events
@@ -516,26 +505,26 @@ export default pattern<PatternInput, PatternOutput>(() => {
     return events;
   });
 
-  // Just flight events
-  const flightEvents = computed(() => {
-    return allEvents.filter((e) => e.eventType === "flight");
-  });
+  // Just flight events (filter callback reads reactive fields → keep computed)
+  const flightEvents = computed(() =>
+    allEvents.filter((e) => e.eventType === "flight")
+  );
 
-  // Just travel events
-  const travelEvents = computed(() => {
-    return allEvents.filter(
+  // Just travel events (filter callback reads reactive fields → keep computed)
+  const travelEvents = computed(() =>
+    allEvents.filter(
       (e) => e.eventType === "travel-to" || e.eventType === "travel-from",
-    );
-  });
+    )
+  );
 
   // Flight count
-  const flightCount = computed(() => upcomingFlights?.length ?? 0);
+  const flightCount = upcomingFlights?.length ?? 0;
 
   // State for expanded sections (reserved for future debug UI)
   const _showDebug = new Writable(false);
 
   return {
-    [NAME]: computed(() => `Flight Calendar (${flightCount} flights)`),
+    [NAME]: `Flight Calendar (${flightCount} flights)`,
 
     flightCount,
     events: allEvents,
@@ -557,13 +546,9 @@ export default pattern<PatternInput, PatternOutput>(() => {
             <div
               style={{
                 padding: "12px 16px",
-                backgroundColor: computed(() =>
-                  isConnected ? "#d1fae5" : "#fef3c7"
-                ),
+                backgroundColor: isConnected ? "#d1fae5" : "#fef3c7",
                 borderRadius: "8px",
-                border: computed(() =>
-                  isConnected ? "1px solid #10b981" : "1px solid #f59e0b"
-                ),
+                border: isConnected ? "1px solid #10b981" : "1px solid #f59e0b",
               }}
             >
               <div
@@ -578,17 +563,13 @@ export default pattern<PatternInput, PatternOutput>(() => {
                     width: "10px",
                     height: "10px",
                     borderRadius: "50%",
-                    backgroundColor: computed(() =>
-                      isConnected ? "#10b981" : "#f59e0b"
-                    ),
+                    backgroundColor: isConnected ? "#10b981" : "#f59e0b",
                   }}
                 />
                 <span>
-                  {ifElse(
-                    isConnected,
-                    "Connected to flight tracker",
-                    "Looking for flight tracker (#unitedFlights)...",
-                  )}
+                  {isConnected
+                    ? "Connected to flight tracker"
+                    : "Looking for flight tracker (#unitedFlights)..."}
                 </span>
               </div>
             </div>
@@ -597,13 +578,9 @@ export default pattern<PatternInput, PatternOutput>(() => {
             <div
               style={{
                 padding: "12px 16px",
-                backgroundColor: computed(() =>
-                  homeAddress ? "#eff6ff" : "#f3f4f6"
-                ),
+                backgroundColor: homeAddress ? "#eff6ff" : "#f3f4f6",
                 borderRadius: "8px",
-                border: computed(() =>
-                  homeAddress ? "1px solid #3b82f6" : "1px solid #d1d5db"
-                ),
+                border: homeAddress ? "1px solid #3b82f6" : "1px solid #d1d5db",
               }}
             >
               <div
@@ -614,7 +591,7 @@ export default pattern<PatternInput, PatternOutput>(() => {
                 }}
               >
                 <span style={{ fontSize: "16px" }}>
-                  {ifElse(homeAddress, "Home address found", "No home address")}
+                  {homeAddress ? "Home address found" : "No home address"}
                 </span>
               </div>
               <div
@@ -622,7 +599,7 @@ export default pattern<PatternInput, PatternOutput>(() => {
                   fontSize: "12px",
                   color: "#6b7280",
                   marginTop: "4px",
-                  display: computed(() => (homeAddress ? "block" : "none")),
+                  display: homeAddress ? "block" : "none",
                 }}
               >
                 {homeAddress}
@@ -666,7 +643,7 @@ export default pattern<PatternInput, PatternOutput>(() => {
                     color: "#059669",
                   }}
                 >
-                  {computed(() => allEvents?.length ?? 0)}
+                  {allEvents?.length ?? 0}
                 </div>
                 <div style={{ fontSize: "12px", color: "#666" }}>
                   Calendar Events
@@ -685,7 +662,7 @@ export default pattern<PatternInput, PatternOutput>(() => {
                     color: "#d97706",
                   }}
                 >
-                  {computed(() => travelEvents?.length ?? 0)}
+                  {travelEvents?.length ?? 0}
                 </div>
                 <div style={{ fontSize: "12px", color: "#666" }}>
                   Travel Blocks
@@ -696,9 +673,7 @@ export default pattern<PatternInput, PatternOutput>(() => {
             {/* Event Groups */}
             <div
               style={{
-                display: computed(() =>
-                  eventGroups?.length > 0 ? "block" : "none"
-                ),
+                display: eventGroups?.length > 0 ? "block" : "none",
               }}
             >
               <h3
@@ -723,39 +698,37 @@ export default pattern<PatternInput, PatternOutput>(() => {
                     }}
                   >
                     {/* Travel To */}
-                    {ifElse(
-                      computed(() => !!group.travelTo),
-                      <div
-                        style={{
-                          display: "flex",
-                          alignItems: "center",
-                          gap: "12px",
-                          padding: "8px 12px",
-                          marginBottom: "8px",
-                          backgroundColor: computed(() =>
-                            group.travelTo?.color ?? "#f3f4f6"
-                          ),
-                          borderRadius: "8px",
-                        }}
-                      >
-                        <span style={{ fontSize: "16px" }}>car</span>
-                        <div style={{ flex: 1 }}>
-                          <div style={{ fontWeight: "600", fontSize: "14px" }}>
-                            {computed(() => group.travelTo?.title ?? "")}
-                          </div>
-                          <div style={{ fontSize: "12px", color: "#374151" }}>
-                            {computed(() =>
-                              group.travelTo
+                    {!!group.travelTo
+                      ? (
+                        <div
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: "12px",
+                            padding: "8px 12px",
+                            marginBottom: "8px",
+                            backgroundColor: group.travelTo?.color ?? "#f3f4f6",
+                            borderRadius: "8px",
+                          }}
+                        >
+                          <span style={{ fontSize: "16px" }}>car</span>
+                          <div style={{ flex: 1 }}>
+                            <div
+                              style={{ fontWeight: "600", fontSize: "14px" }}
+                            >
+                              {group.travelTo?.title ?? ""}
+                            </div>
+                            <div style={{ fontSize: "12px", color: "#374151" }}>
+                              {group.travelTo
                                 ? `${
                                   formatTime12h(group.travelTo.startTime)
                                 } - ${formatTime12h(group.travelTo.endTime)}`
-                                : ""
-                            )}
+                                : ""}
+                            </div>
                           </div>
                         </div>
-                      </div>,
-                      null,
-                    )}
+                      )
+                      : null}
 
                     {/* Flight */}
                     <div
@@ -783,39 +756,38 @@ export default pattern<PatternInput, PatternOutput>(() => {
                     </div>
 
                     {/* Travel From */}
-                    {ifElse(
-                      computed(() => !!group.travelFrom),
-                      <div
-                        style={{
-                          display: "flex",
-                          alignItems: "center",
-                          gap: "12px",
-                          padding: "8px 12px",
-                          marginTop: "8px",
-                          backgroundColor: computed(() =>
-                            group.travelFrom?.color ?? "#f3f4f6"
-                          ),
-                          borderRadius: "8px",
-                        }}
-                      >
-                        <span style={{ fontSize: "16px" }}>car</span>
-                        <div style={{ flex: 1 }}>
-                          <div style={{ fontWeight: "600", fontSize: "14px" }}>
-                            {computed(() => group.travelFrom?.title ?? "")}
-                          </div>
-                          <div style={{ fontSize: "12px", color: "#374151" }}>
-                            {computed(() =>
-                              group.travelFrom
+                    {!!group.travelFrom
+                      ? (
+                        <div
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: "12px",
+                            padding: "8px 12px",
+                            marginTop: "8px",
+                            backgroundColor: group.travelFrom?.color ??
+                              "#f3f4f6",
+                            borderRadius: "8px",
+                          }}
+                        >
+                          <span style={{ fontSize: "16px" }}>car</span>
+                          <div style={{ flex: 1 }}>
+                            <div
+                              style={{ fontWeight: "600", fontSize: "14px" }}
+                            >
+                              {group.travelFrom?.title ?? ""}
+                            </div>
+                            <div style={{ fontSize: "12px", color: "#374151" }}>
+                              {group.travelFrom
                                 ? `${
                                   formatTime12h(group.travelFrom.startTime)
                                 } - ${formatTime12h(group.travelFrom.endTime)}`
-                                : ""
-                            )}
+                                : ""}
+                            </div>
                           </div>
                         </div>
-                      </div>,
-                      null,
-                    )}
+                      )
+                      : null}
                   </div>
                 ))}
               </cf-vstack>
@@ -824,9 +796,7 @@ export default pattern<PatternInput, PatternOutput>(() => {
             {/* No flights message */}
             <div
               style={{
-                display: computed(() =>
-                  isConnected && flightCount === 0 ? "block" : "none"
-                ),
+                display: isConnected && flightCount === 0 ? "block" : "none",
                 padding: "24px",
                 textAlign: "center",
                 color: "#6b7280",
@@ -892,7 +862,7 @@ export default pattern<PatternInput, PatternOutput>(() => {
                       whiteSpace: "pre-wrap",
                     }}
                   >
-                    {computed(() => toIndentedDebugString(allEvents))}
+                    {toIndentedDebugString(allEvents)}
                   </pre>
                 </div>
               </div>

--- a/packages/patterns/google/extractors/hotel-membership-gmail-agent.tsx
+++ b/packages/patterns/google/extractors/hotel-membership-gmail-agent.tsx
@@ -7,10 +7,9 @@
  * Usage: wish({ query: "#hotelMemberships" }) to get discovered memberships.
  */
 import {
+  computed,
   Default,
-  derive,
   handler,
-  ifElse,
   NAME,
   pattern,
   UI,
@@ -237,53 +236,46 @@ const HotelMembershipExtractorV2 = pattern<
     const allMemberships = memberships;
 
     // Track counts (simplified without wish)
-    const localMembershipCount = derive(
-      memberships,
-      (list) => list?.length || 0,
-    );
+    const localMembershipCount = memberships?.length || 0;
 
     // ========================================================================
     // MULTI-ACCOUNT DETECTION
     // ========================================================================
 
     // Find brands with multiple different membership numbers
-    const brandsWithMultipleAccounts = derive(
-      allMemberships,
-      (list: MembershipRecord[]) => {
-        const brandNumbers: Record<string, Set<string>> = {};
+    const brandsWithMultipleAccounts = computed(() => {
+      const list = allMemberships as MembershipRecord[];
+      const brandNumbers: Record<string, Set<string>> = {};
 
-        for (const m of (list || [])) {
-          if (!m) continue; // Skip null/undefined entries during hydration
-          if (!brandNumbers[m.hotelBrand]) {
-            brandNumbers[m.hotelBrand] = new Set();
-          }
-          brandNumbers[m.hotelBrand].add(m.membershipNumber);
+      for (const m of (list || [])) {
+        if (!m) continue; // Skip null/undefined entries during hydration
+        if (!brandNumbers[m.hotelBrand]) {
+          brandNumbers[m.hotelBrand] = new Set();
         }
+        brandNumbers[m.hotelBrand].add(m.membershipNumber);
+      }
 
-        const multiAccountBrands: Record<
-          string,
-          { numbers: string[]; memberships: MembershipRecord[] }
-        > = {};
+      const multiAccountBrands: Record<
+        string,
+        { numbers: string[]; memberships: MembershipRecord[] }
+      > = {};
 
-        for (const [brand, numbers] of Object.entries(brandNumbers)) {
-          if (numbers.size > 1) {
-            multiAccountBrands[brand] = {
-              numbers: Array.from(numbers),
-              memberships: (list || []).filter((m) =>
-                m && m.hotelBrand === brand
-              ),
-            };
-          }
+      for (const [brand, numbers] of Object.entries(brandNumbers)) {
+        if (numbers.size > 1) {
+          multiAccountBrands[brand] = {
+            numbers: Array.from(numbers),
+            memberships: (list || []).filter((m) =>
+              m && m.hotelBrand === brand
+            ),
+          };
         }
+      }
 
-        return multiAccountBrands;
-      },
-    );
+      return multiAccountBrands;
+    });
 
-    const hasMultipleAccounts = derive(
-      brandsWithMultipleAccounts,
-      (brands) => Object.keys(brands).length > 0,
-    );
+    const hasMultipleAccounts =
+      Object.keys(brandsWithMultipleAccounts).length > 0;
 
     // ========================================================================
     // AGENT GOAL
@@ -291,68 +283,68 @@ const HotelMembershipExtractorV2 = pattern<
     // IMPORTANT: Do NOT derive from memberships! Changing the goal during a scan
     // triggers an infinite loop (goal changes → agent restarts → finds membership
     // → goal changes → agent restarts...). Only derive from scan settings.
-    const agentGoal = derive(
-      [maxSearches, currentScanMode],
-      ([max, scanMode]: [number, ScanMode]) => {
-        const isQuickMode = max > 0;
-        const isRecentMode = scanMode === "recent";
-        const dateFilter = isRecentMode ? getRecentDateFilter() : "";
+    const agentGoal = computed(() => {
+      const max = maxSearches;
+      const scanMode = currentScanMode;
+      const isQuickMode = max > 0;
+      const isRecentMode = scanMode === "recent";
+      const dateFilter = isRecentMode ? getRecentDateFilter() : "";
 
-        return `Find hotel loyalty program membership numbers in my Gmail.
+      return `Find hotel loyalty program membership numbers in my Gmail.
 
 ${
-          isRecentMode
-            ? `📅 RECENT SCAN MODE: Only searching emails from the last 7 days.
+        isRecentMode
+          ? `📅 RECENT SCAN MODE: Only searching emails from the last 7 days.
 Date filter to use: ${dateFilter}
 `
-            : ""
-        }
+          : ""
+      }
 ${
-          isQuickMode
-            ? `\n⚠️ QUICK TEST MODE: Limited to ${max} searches. Focus on high-value queries!\n`
-            : ""
-        }
+        isQuickMode
+          ? `\n⚠️ QUICK TEST MODE: Limited to ${max} searches. Focus on high-value queries!\n`
+          : ""
+      }
 
 Your task:
 1. Use searchGmail to search for hotel loyalty emails${
-          isRecentMode ? ` (ADD "${dateFilter}" to ALL queries!)` : ""
-        }
+        isRecentMode ? ` (ADD "${dateFilter}" to ALL queries!)` : ""
+      }
 2. Analyze the returned emails for membership numbers
 3. When you find a membership: IMMEDIATELY call reportMembership to save it
 4. Move on to the next brand after 1-2 queries per brand
 
 ${
-          isQuickMode
-            ? "PRIORITY QUERIES (use these first in quick mode):"
-            : "EFFECTIVE QUERIES (proven to find memberships):"
-        }
+        isQuickMode
+          ? "PRIORITY QUERIES (use these first in quick mode):"
+          : "EFFECTIVE QUERIES (proven to find memberships):"
+      }
 ${
-          EFFECTIVE_QUERIES.slice(0, isQuickMode ? 5 : EFFECTIVE_QUERIES.length)
-            .map((q, i) => {
-              const query = isRecentMode ? `(${q}) ${dateFilter}` : q;
-              return `${i + 1}. ${query}`;
-            }).join("\n")
-        }
+        EFFECTIVE_QUERIES.slice(0, isQuickMode ? 5 : EFFECTIVE_QUERIES.length)
+          .map((q, i) => {
+            const query = isRecentMode ? `(${q}) ${dateFilter}` : q;
+            return `${i + 1}. ${query}`;
+          }).join("\n")
+      }
 
 Hotel brands to search for:
 ${
-          ALL_BRANDS.map((b) => {
-            switch (b) {
-              case "Marriott":
-                return "- Marriott (Marriott Bonvoy)";
-              case "Hilton":
-                return "- Hilton (Hilton Honors)";
-              case "Hyatt":
-                return "- Hyatt (World of Hyatt)";
-              case "IHG":
-                return "- IHG (IHG One Rewards)";
-              case "Accor":
-                return "- Accor (ALL - Accor Live Limitless)";
-              default:
-                return "- " + b;
-            }
-          }).join("\n")
-        }
+        ALL_BRANDS.map((b) => {
+          switch (b) {
+            case "Marriott":
+              return "- Marriott (Marriott Bonvoy)";
+            case "Hilton":
+              return "- Hilton (Hilton Honors)";
+            case "Hyatt":
+              return "- Hyatt (World of Hyatt)";
+            case "IHG":
+              return "- IHG (IHG One Rewards)";
+            case "Accor":
+              return "- Accor (ALL - Accor Live Limitless)";
+            default:
+              return "- " + b;
+          }
+        }).join("\n")
+      }
 
 In email bodies, look for patterns like:
 - "Member #" or "Membership Number:" followed by digits
@@ -371,31 +363,30 @@ When you find a membership, call reportMembership with:
 
 IMPORTANT: Call reportMembership for EACH membership as you find it. Don't wait!
 ${
-          isRecentMode
-            ? "\nIMPORTANT: ALWAYS include the date filter in your search queries!"
-            : ""
-        }
+        isRecentMode
+          ? "\nIMPORTANT: ALWAYS include the date filter in your search queries!"
+          : ""
+      }
 ${
-          isQuickMode
-            ? "\nNote: If you hit the search limit, stop and return what you found."
-            : ""
-        }
+        isQuickMode
+          ? "\nNote: If you hit the search limit, stop and return what you found."
+          : ""
+      }
 
 ⚠️ STOPPING RULES - FOLLOW THESE STRICTLY:
 - Search each brand with AT MOST 2 queries, then move to the next brand
 - After checking all ${ALL_BRANDS.length} brands (${
-          ALL_BRANDS.join(", ")
-        }), STOP and return your summary
+        ALL_BRANDS.join(", ")
+      }), STOP and return your summary
 - Do NOT keep searching the same brand with variations
 - Do NOT search more than ~${
-          ALL_BRANDS.length * 2
-        } total queries (2 per brand max)
+        ALL_BRANDS.length * 2
+      } total queries (2 per brand max)
 - If a brand has no results after 1-2 tries, move on - don't keep trying
 - When you've covered all brands, IMMEDIATELY produce your final summary
 
 YOUR FINAL OUTPUT should summarize: which brands you searched, how many memberships found, and any issues.`;
-      },
-    );
+    });
 
     // ========================================================================
     // SHARED SIGNAL CELL (for foundItems feature)
@@ -404,7 +395,7 @@ YOUR FINAL OUTPUT should summarize: which brands you searched, how many membersh
     // This follows the "share cells by making them inputs" pattern
     // See: community-docs/superstitions/2025-12-04-share-cells-between-composed-patterns.md
     const itemFoundSignal = new Writable<number>(0);
-    // Track last membership count in a Writable (closure vars don't persist in derive)
+    // Track last membership count in a Writable (closure vars don't persist across recomputations)
     const lastMembershipCountCell = new Writable<number>(0);
 
     // ========================================================================
@@ -467,30 +458,27 @@ Report memberships as you find them. Don't wait until the end.`,
     // When reportMembership successfully adds a membership, signal the base pattern.
     // This is the idiomatic pattern: tool writes to state cell, parent watches and increments signal.
     // See: community-docs research on tool-to-parent communication patterns
-    // NOTE: Using Cells to track state because closure vars don't persist across derive executions
-    derive(
-      [memberships, lastMembershipCountCell],
-      ([list, _lastCountRef]: [MembershipRecord[], number]) => {
-        // NOTE: derive doesn't unwrap locally-created cells, only pattern input cells
-        // So we use .get() to read the actual value
-        // See: community-docs/superstitions/2025-12-08-locally-created-cells-not-unwrapped-in-derive.md
-        const currentCount = list?.length || 0;
-        const lastCount = lastMembershipCountCell.get() || 0;
-        if (currentCount > lastCount) {
-          // New membership was added - signal the base pattern to mark the query
-          if (DEBUG_HOTEL) {
-            console.log(
-              `[HotelMembership] New membership detected (${lastCount} -> ${currentCount}), signaling itemFoundSignal`,
-            );
-          }
-          // Increment the signal - base pattern watches this and marks the query
-          const currentSignal = itemFoundSignal.get() || 0;
-          itemFoundSignal.set(currentSignal + 1);
-          // Update last count cell - prevents this derive from running again with same condition
-          lastMembershipCountCell.set(currentCount);
+    // NOTE: Using Cells to track state because closure vars don't persist across recomputations.
+    // Side-effect-only reactive computation (return unused); statement body → computed.
+    computed(() => {
+      // Locally-created cells are read with .get(); pattern input cells (memberships)
+      // are read bare in a compute context.
+      const currentCount = memberships?.length || 0;
+      const lastCount = lastMembershipCountCell.get() || 0;
+      if (currentCount > lastCount) {
+        // New membership was added - signal the base pattern to mark the query
+        if (DEBUG_HOTEL) {
+          console.log(
+            `[HotelMembership] New membership detected (${lastCount} -> ${currentCount}), signaling itemFoundSignal`,
+          );
         }
-      },
-    );
+        // Increment the signal - base pattern watches this and marks the query
+        const currentSignal = itemFoundSignal.get() || 0;
+        itemFoundSignal.set(currentSignal + 1);
+        // Update last count cell - prevents this computation from running again with same condition
+        lastMembershipCountCell.set(currentCount);
+      }
+    });
 
     // ========================================================================
     // CUSTOM SCAN HANDLERS (with mode support)
@@ -521,49 +509,36 @@ Report memberships as you find them. Don't wait until the end.`,
     // DERIVED VALUES
     // ========================================================================
     // Use allMemberships (local + imported) for display
-    const totalMemberships = derive(
-      allMemberships,
-      (list) => list?.length || 0,
-    );
+    const totalMemberships = allMemberships?.length || 0;
 
-    // Pre-compute button label (outside ifElse to avoid reactive loops)
-    const fullScanLabel = derive(
-      maxSearches,
-      (max) => max > 0 ? "⚡ Quick Scan" : "🔍 Full Scan",
-    );
+    // Button label
+    const fullScanLabel = maxSearches > 0 ? "⚡ Quick Scan" : "🔍 Full Scan";
 
-    // Pre-compute scan mode message
-    const scanModeMessage = derive(
-      currentScanMode,
-      (mode: ScanMode) =>
-        mode === "recent"
-          ? "📅 Recent mode: searching last 7 days only"
-          : "🔍 Full mode: searching all emails",
-    );
+    // Scan mode message
+    const scanModeMessage = currentScanMode === "recent"
+      ? "📅 Recent mode: searching last 7 days only"
+      : "🔍 Full mode: searching all emails";
 
-    // Pre-compute scan mode short label for debug
-    const scanModeLabel = derive(
-      currentScanMode,
-      (mode: ScanMode) => mode === "recent" ? "📅 Recent" : "🔍 Full",
-    );
+    // Scan mode short label for debug
+    const scanModeLabel = currentScanMode === "recent"
+      ? "📅 Recent"
+      : "🔍 Full";
 
-    // Pre-compute button disabled state (just scanning for now - simpler)
+    // Button disabled state (just scanning for now - simpler)
     // Auth check is handled by showing auth UI first
-    const buttonsDisabled = derive(isScanning, (scanning: boolean) => scanning);
+    const buttonsDisabled = isScanning;
 
-    const groupedMemberships = derive(
-      allMemberships,
-      (list: MembershipRecord[]) => {
-        const groups: Record<string, MembershipRecord[]> = {};
-        if (!list) return groups;
-        for (const m of list) {
-          if (!m) continue; // Skip null/undefined entries during hydration
-          if (!groups[m.hotelBrand]) groups[m.hotelBrand] = [];
-          groups[m.hotelBrand].push(m);
-        }
-        return groups;
-      },
-    );
+    const groupedMemberships = computed(() => {
+      const list = allMemberships as MembershipRecord[];
+      const groups: Record<string, MembershipRecord[]> = {};
+      if (!list) return groups;
+      for (const m of list) {
+        if (!m) continue; // Skip null/undefined entries during hydration
+        if (!groups[m.hotelBrand]) groups[m.hotelBrand] = [];
+        groups[m.hotelBrand].push(m);
+      }
+      return groups;
+    });
 
     // ========================================================================
     // UI - Compose base searcher with custom membership display
@@ -591,91 +566,91 @@ Report memberships as you find them. Don't wait until the end.`,
               {searcher.ui.auth}
 
               {/* Scan Mode Selection - Only show when authenticated */}
-              {ifElse(
-                searcher.isAuthenticated,
-                <div
-                  style={{
-                    padding: "16px",
-                    background: "#f8fafc",
-                    borderRadius: "8px",
-                    border: "1px solid #e2e8f0",
-                  }}
-                >
+              {searcher.isAuthenticated
+                ? (
                   <div
                     style={{
-                      fontSize: "14px",
-                      fontWeight: "600",
-                      marginBottom: "12px",
-                      color: "#475569",
+                      padding: "16px",
+                      background: "#f8fafc",
+                      borderRadius: "8px",
+                      border: "1px solid #e2e8f0",
                     }}
                   >
-                    Scan Mode
-                  </div>
-                  <div style={{ display: "flex", gap: "8px" }}>
-                    <cf-button
-                      onClick={startFullScan}
-                      size="lg"
-                      style="flex: 1;"
-                      disabled={buttonsDisabled}
+                    <div
+                      style={{
+                        fontSize: "14px",
+                        fontWeight: "600",
+                        marginBottom: "12px",
+                        color: "#475569",
+                      }}
                     >
-                      {fullScanLabel}
-                    </cf-button>
-                    <cf-button
-                      onClick={startRecentScan}
-                      variant="secondary"
-                      size="lg"
-                      style="flex: 1;"
-                      disabled={buttonsDisabled}
+                      Scan Mode
+                    </div>
+                    <div style={{ display: "flex", gap: "8px" }}>
+                      <cf-button
+                        onClick={startFullScan}
+                        size="lg"
+                        style="flex: 1;"
+                        disabled={buttonsDisabled}
+                      >
+                        {fullScanLabel}
+                      </cf-button>
+                      <cf-button
+                        onClick={startRecentScan}
+                        variant="secondary"
+                        size="lg"
+                        style="flex: 1;"
+                        disabled={buttonsDisabled}
+                      >
+                        📅 Check Recent
+                      </cf-button>
+                    </div>
+                    <div
+                      style={{
+                        fontSize: "11px",
+                        color: "#94a3b8",
+                        marginTop: "8px",
+                        textAlign: "center",
+                      }}
                     >
-                      📅 Check Recent
-                    </cf-button>
+                      Full = all emails • Recent = last 7 days only
+                    </div>
                   </div>
+                )
+                : null}
+
+              {/* Stop button when scanning */}
+              {isScanning
+                ? (
+                  <cf-button
+                    onClick={searcher.stopScan}
+                    variant="secondary"
+                    size="lg"
+                    style="width: 100%;"
+                  >
+                    ⏹ Stop Scan
+                  </cf-button>
+                )
+                : null}
+
+              {/* Scan mode indicator during scan */}
+              {isScanning
+                ? (
                   <div
                     style={{
-                      fontSize: "11px",
-                      color: "#94a3b8",
-                      marginTop: "8px",
+                      padding: "8px 12px",
+                      background: "#f0fdf4",
+                      border: "1px solid #bbf7d0",
+                      borderRadius: "6px",
+                      fontSize: "13px",
+                      color: "#166534",
                       textAlign: "center",
                     }}
                   >
-                    Full = all emails • Recent = last 7 days only
+                    {scanModeMessage}
                   </div>
-                </div>,
-                null,
-              )}
-
-              {/* Stop button when scanning */}
-              {ifElse(
-                isScanning,
-                <cf-button
-                  onClick={searcher.stopScan}
-                  variant="secondary"
-                  size="lg"
-                  style="width: 100%;"
-                >
-                  ⏹ Stop Scan
-                </cf-button>,
-                null,
-              )}
-
-              {/* Scan mode indicator during scan */}
-              {ifElse(
-                isScanning,
-                <div
-                  style={{
-                    padding: "8px 12px",
-                    background: "#f0fdf4",
-                    border: "1px solid #bbf7d0",
-                    borderRadius: "6px",
-                    fontSize: "13px",
-                    color: "#166534",
-                    textAlign: "center",
-                  }}
-                >
-                  {scanModeMessage}
-                </div>,
-                null,
-              )}
+                )
+                : null}
 
               {/* Progress UI from base pattern */}
               {searcher.ui.progress}
@@ -686,115 +661,112 @@ Report memberships as you find them. Don't wait until the end.`,
               </div>
 
               {/* Multi-Account Warning */}
-              {derive(
-                [hasMultipleAccounts, brandsWithMultipleAccounts],
-                ([hasMulti, multiBrands]) =>
-                  hasMulti
-                    ? (
-                      <div
-                        style={{
-                          padding: "16px",
-                          background: "#fffbeb",
-                          border: "1px solid #fde68a",
-                          borderRadius: "8px",
-                        }}
-                      >
+              {hasMultipleAccounts
+                ? (
+                  <div
+                    style={{
+                      padding: "16px",
+                      background: "#fffbeb",
+                      border: "1px solid #fde68a",
+                      borderRadius: "8px",
+                    }}
+                  >
+                    <div
+                      style={{
+                        fontSize: "14px",
+                        fontWeight: "600",
+                        color: "#92400e",
+                        marginBottom: "8px",
+                      }}
+                    >
+                      Multiple Accounts Detected
+                    </div>
+                    <div style={{ fontSize: "13px", color: "#78350f" }}>
+                      {Object.entries(brandsWithMultipleAccounts).map((
+                        [brand, data],
+                        brandIdx,
+                      ) => (
                         <div
+                          key={brandIdx}
                           style={{
-                            fontSize: "14px",
-                            fontWeight: "600",
-                            color: "#92400e",
                             marginBottom: "8px",
+                            padding: "8px",
+                            background: "white",
+                            borderRadius: "4px",
                           }}
                         >
-                          Multiple Accounts Detected
-                        </div>
-                        <div style={{ fontSize: "13px", color: "#78350f" }}>
-                          {Object.entries(multiBrands).map((
-                            [brand, data],
-                            brandIdx,
-                          ) => (
-                            <div
-                              key={brandIdx}
+                          <div
+                            style={{
+                              fontWeight: "600",
+                              marginBottom: "4px",
+                            }}
+                          >
+                            {brand}
+                          </div>
+                          <div style={{ fontSize: "12px", color: "#666" }}>
+                            Found {data.numbers.length}{" "}
+                            different membership numbers:
+                            <ul
                               style={{
-                                marginBottom: "8px",
-                                padding: "8px",
-                                background: "white",
-                                borderRadius: "4px",
+                                margin: "4px 0 0 16px",
+                                padding: "0",
                               }}
                             >
-                              <div
-                                style={{
-                                  fontWeight: "600",
-                                  marginBottom: "4px",
-                                }}
-                              >
-                                {brand}
-                              </div>
-                              <div style={{ fontSize: "12px", color: "#666" }}>
-                                Found {data.numbers.length}{" "}
-                                different membership numbers:
-                                <ul
-                                  style={{
-                                    margin: "4px 0 0 16px",
-                                    padding: "0",
-                                  }}
-                                >
-                                  {data.numbers.map(
-                                    (num: string, i: number) => {
-                                      const membership = data.memberships.find((
-                                        m: MembershipRecord,
-                                      ) => m.membershipNumber === num);
-                                      return (
-                                        <li
-                                          key={i}
-                                          style={{ marginBottom: "2px" }}
-                                        >
-                                          <code
-                                            style={{
-                                              background: "#f3f4f6",
-                                              padding: "2px 6px",
-                                              borderRadius: "2px",
-                                            }}
-                                          >
-                                            {num}
-                                          </code>
-                                          {membership?.tier && (
-                                            <span style={{ marginLeft: "4px" }}>
-                                              ({membership.tier})
-                                            </span>
-                                          )}
-                                        </li>
-                                      );
-                                    },
-                                  )}
-                                </ul>
-                              </div>
-                              <div
-                                style={{
-                                  fontSize: "11px",
-                                  color: "#92400e",
-                                  marginTop: "4px",
-                                  fontStyle: "italic",
-                                }}
-                              >
-                                This could be: old vs new account, family
-                                member, or work vs personal
-                              </div>
-                            </div>
-                          ))}
+                              {data.numbers.map(
+                                (num: string, i: number) => {
+                                  const membership = data.memberships.find((
+                                    m: MembershipRecord,
+                                  ) => m.membershipNumber === num);
+                                  return (
+                                    <li
+                                      key={i}
+                                      style={{ marginBottom: "2px" }}
+                                    >
+                                      <code
+                                        style={{
+                                          background: "#f3f4f6",
+                                          padding: "2px 6px",
+                                          borderRadius: "2px",
+                                        }}
+                                      >
+                                        {num}
+                                      </code>
+                                      {membership?.tier && (
+                                        <span style={{ marginLeft: "4px" }}>
+                                          ({membership.tier})
+                                        </span>
+                                      )}
+                                    </li>
+                                  );
+                                },
+                              )}
+                            </ul>
+                          </div>
+                          <div
+                            style={{
+                              fontSize: "11px",
+                              color: "#92400e",
+                              marginTop: "4px",
+                              fontStyle: "italic",
+                            }}
+                          >
+                            This could be: old vs new account, family member, or
+                            work vs personal
+                          </div>
                         </div>
-                      </div>
-                    )
-                    : null,
-              )}
+                      ))}
+                    </div>
+                  </div>
+                )
+                : null}
 
               {/* Memberships List - Hotel-specific UI */}
               <div>
                 <h3 style={{ margin: "0 0 12px 0", fontSize: "15px" }}>
                   Your Memberships
                 </h3>
-                {derive(groupedMemberships, (groups) => {
+                {computed(() => {
+                  const groups = groupedMemberships;
                   const brands = Object.keys(groups).sort();
                   if (brands.length === 0) {
                     return (
@@ -927,30 +899,23 @@ Report memberships as you find them. Don't wait until the end.`,
                 </summary>
                 <cf-vstack gap={2} style="padding: 12px; fontSize: 12px;">
                   <div style={{ fontFamily: "monospace" }}>
-                    Is Authenticated: {derive(
-                      searcher.isAuthenticated,
-                      (a) => a ? "Yes ✓" : "No",
-                    )}
+                    Is Authenticated:{" "}
+                    {searcher.isAuthenticated ? "Yes ✓" : "No"}
                   </div>
                   <div style={{ fontFamily: "monospace" }}>
                     Auth Source: {searcher.authSource}
                   </div>
                   <div style={{ fontFamily: "monospace" }}>
-                    Is Scanning:{" "}
-                    {derive(searcher.isScanning, (s) => (s ? "Yes ⏳" : "No"))}
+                    Is Scanning: {searcher.isScanning ? "Yes ⏳" : "No"}
                   </div>
                   <div style={{ fontFamily: "monospace" }}>
                     Scan Mode: {scanModeLabel}
                   </div>
                   <div style={{ fontFamily: "monospace" }}>
-                    Agent Pending: {derive(
-                      searcher.agentPending,
-                      (p) => p ? "Yes ⏳" : "No ✓",
-                    )}
+                    Agent Pending: {searcher.agentPending ? "Yes ⏳" : "No ✓"}
                   </div>
                   <div style={{ fontFamily: "monospace" }}>
-                    Agent Result:{" "}
-                    {derive(searcher.agentResult, (r) => r ? "Yes ✓" : "No")}
+                    Agent Result: {searcher.agentResult ? "Yes ✓" : "No"}
                   </div>
                   <div style={{ fontFamily: "monospace" }}>
                     Max Searches: {maxSearches}
@@ -960,13 +925,11 @@ Report memberships as you find them. Don't wait until the end.`,
                   </div>
                   <div style={{ fontFamily: "monospace" }}>
                     Has Multiple Accounts:{" "}
-                    {derive(hasMultipleAccounts, (h) => h ? "Yes ⚠️" : "No")}
+                    {hasMultipleAccounts ? "Yes ⚠️" : "No"}
                   </div>
                   <div style={{ fontFamily: "monospace" }}>
-                    Pending Submissions: {derive(
-                      searcher.pendingSubmissions,
-                      (p) => (p || []).length,
-                    )}
+                    Pending Submissions:{" "}
+                    {(searcher.pendingSubmissions || []).length}
                   </div>
                 </cf-vstack>
               </details>

--- a/packages/patterns/nested-map-ifelse-test.tsx
+++ b/packages/patterns/nested-map-ifelse-test.tsx
@@ -16,7 +16,6 @@ import {
   Cell,
   computed,
   Default,
-  derive,
   handler,
   ifElse,
   NAME,
@@ -102,10 +101,10 @@ const resetItems = handler<
 );
 
 export default pattern<Input>(({ items, log }) => {
-  // Derive categories from items
-  const categories = derive({ items }, ({ items: arr }: { items: Item[] }) => {
+  // Categories from items
+  const categories = computed(() => {
     const cats = new Set<string>();
-    for (const item of arr) {
+    for (const item of items) {
       cats.add(item.category || "Uncategorized");
     }
     return Array.from(cats).sort();

--- a/packages/patterns/scope-bug-computed-vnode-blank/main.tsx
+++ b/packages/patterns/scope-bug-computed-vnode-blank/main.tsx
@@ -202,7 +202,7 @@ export default pattern<ReproInput, ReproOutput>(({ counter, name }) => {
           )}
       </div>
     ),
-    counter: derive(counter, (c) => c ?? 0),
+    counter: counter ?? 0,
     tick: boundTick,
   };
 });

--- a/packages/patterns/scope-bug-ct1597-reduce/main.tsx
+++ b/packages/patterns/scope-bug-ct1597-reduce/main.tsx
@@ -1,6 +1,17 @@
 /**
  * CT-1597 Reduction Log
  *
+ * MIGRATION NOTE (derive removal): the authored `derive()` calls below were
+ * later replaced with plain reactive expressions (bare projections / ternaries),
+ * which auto-wrap to the same lowered reactive computations. The repro is
+ * preserved: the nullable reactive value (`string | null` / `OptionTally | null`)
+ * captured by the JSX `computed()` block still emits the identical
+ * `{ "anyOf": [..., { "type": "null" }] }` input schema (verified via
+ * --show-transformed — same null-branch schema count as the original `derive()`
+ * form). The STEP log below records the original bisection, which was performed
+ * with `derive()`; the diagnosis (a null-typed reactive value captured by a
+ * computed() generating a null-branch schema) is unchanged by the migration.
+ *
  * STEP 0 - BASELINE: WIP from 93d545ad6 — BLANK (confirmed in browser)
  *
  * STEP 1: Replace <cf-screen> + slot="header" + <cf-vscroll> with plain <div>
@@ -70,7 +81,6 @@
 import {
   computed,
   Default,
-  derive,
   handler,
   NAME,
   nonPrivateRandom,
@@ -410,32 +420,18 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     const boundClearMyVote = clearMyVote({ votes, myName });
     const boundResetVotes = resetVotes({ votes, myName, adminName });
 
-    const userCount = derive(users, (u) => u.length);
-    const optionCount = derive(options, (o) => o.length);
-    const voteCount = derive(votes, (v) => v.length);
-    const isJoined = derive(myName, (n) => trimmedName(n) !== "");
-    const isAdmin = derive(
-      { myName, adminName },
-      ({ myName, adminName }) =>
-        trimmedName(myName) !== "" &&
-        trimmedName(myName) === trimmedName(adminName),
-    );
-    const ranked = derive(
-      { options, votes, users },
-      ({ options, votes, users }) => tallyOptions(options, votes, users),
-    );
+    const userCount = users.length;
+    const optionCount = options.length;
+    const voteCount = votes.length;
+    const isJoined = trimmedName(myName) !== "";
+    const isAdmin = trimmedName(myName) !== "" &&
+      trimmedName(myName) === trimmedName(adminName);
+    const ranked = tallyOptions(options, votes, users);
 
-    const _topChoice = derive(
-      { ranked, voteCount },
-      ({ ranked, voteCount }) =>
-        voteCount > 0 && ranked.length > 0 ? ranked[0] : null,
-    );
+    const _topChoice = voteCount > 0 && ranked.length > 0 ? ranked[0] : null;
 
-    // STEP 8: minimal nullable derive — simple string|null from options
-    const minimalNullable = derive(
-      options,
-      (o) => o.length > 0 ? o[0].title : null,
-    );
+    // STEP 8: minimal nullable reactive value — simple string|null from options
+    const minimalNullable = options.length > 0 ? options[0].title : null;
 
     return {
       [NAME]: "Cozy lunch poll",
@@ -530,7 +526,7 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                 </div>
 
                 {/* Top choice — only when there are votes */}
-                {/* STEP 8: does reading a simple string|null derive inside computed() blank? */}
+                {/* STEP 8: does reading a simple string|null reactive value inside computed() blank? */}
                 {computed(() => {
                   const v = minimalNullable;
                   return <div>minimal nullable: {v ?? "null"}</div>;
@@ -596,20 +592,13 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                 {options.map((option) => {
                   const oid = option.id;
                   const optionTitle = option.title;
-                  const myVote = derive(
-                    { votes, myName, optionId: oid },
-                    ({ votes, myName, optionId }) =>
-                      myVoteFor(votes, trimmedName(myName), optionId),
-                  );
-                  const rank = derive(
-                    { ranked, optionId: oid },
-                    ({ ranked, optionId }) => {
-                      const idx = ranked.findIndex(
-                        (t) => t.option.id === optionId,
-                      );
-                      return idx >= 0 ? idx + 1 : 0;
-                    },
-                  );
+                  const myVote = myVoteFor(votes, trimmedName(myName), oid);
+                  const rank = computed(() => {
+                    const idx = ranked.findIndex(
+                      (t) => t.option.id === oid,
+                    );
+                    return idx >= 0 ? idx + 1 : 0;
+                  });
                   return (
                     <div
                       style={{
@@ -747,12 +736,12 @@ export default pattern<CozyPollInput, CozyPollOutput>(
           </div>
         </cf-theme>
       ),
-      question: derive(question, (q) => q),
-      options: derive(options, (o) => o),
-      votes: derive(votes, (v) => v),
-      users: derive(users, (u) => u),
-      adminName: derive(adminName, (a) => a),
-      myName: derive(myName, (n) => n),
+      question,
+      options,
+      votes,
+      users,
+      adminName,
+      myName,
       userCount,
       optionCount,
       voteCount,

--- a/packages/patterns/scoped-group-chat/main-plain-inputs.tsx
+++ b/packages/patterns/scoped-group-chat/main-plain-inputs.tsx
@@ -1,6 +1,5 @@
 import {
   Default,
-  derive,
   handler,
   NAME,
   pattern,
@@ -290,9 +289,7 @@ export default pattern<ScopedGroupChatInput, ScopedGroupChatOutput>(
                         <cf-vstack gap="2">
                           {messagesInSelectedRoom.map((message) => {
                             const author = message.author;
-                            const isMine = derive({ author, name }, (
-                              { author, name },
-                            ) => author === senderName(name));
+                            const isMine = author === senderName(name);
                             return (
                               <div
                                 style={{

--- a/packages/patterns/scoped-group-chat/main-with-writable-inputs.tsx
+++ b/packages/patterns/scoped-group-chat/main-with-writable-inputs.tsx
@@ -1,7 +1,6 @@
 import {
   computed,
   Default,
-  derive,
   handler,
   NAME,
   pattern,
@@ -302,9 +301,7 @@ export default pattern<ScopedGroupChatInput, ScopedGroupChatOutput>(
                         <cf-vstack gap="2">
                           {messagesInSelectedRoom.map((message) => {
                             const author = message.author;
-                            const isMine = derive({ author, name }, (
-                              { author, name },
-                            ) => author === senderName(name.get()));
+                            const isMine = author === senderName(name.get());
                             return (
                               <div
                                 style={{

--- a/packages/patterns/scrabble/scrabble.tsx
+++ b/packages/patterns/scrabble/scrabble.tsx
@@ -8,7 +8,6 @@
 import {
   computed,
   Default,
-  derive,
   handler,
   NAME,
   nonPrivateRandom,
@@ -1112,10 +1111,8 @@ const ScrabbleGame = pattern<GameInput, GameOutput>(
     const joined = computed(() =>
       players.get().some((player) => player.name === trimmedName(myName.get()))
     );
-    const rackCount = computed(() => rack.get().length);
-    const bagCount = computed(() =>
-      Math.max(0, bag.get().length - bagIndex.get())
-    );
+    const rackCount = rack.get().length;
+    const bagCount = Math.max(0, bag.get().length - bagIndex.get());
     const rackTiles = computed<RackTileView[]>(() =>
       rack.get().map((letter, index) => ({ ...letter, index }))
     );
@@ -1167,7 +1164,7 @@ const ScrabbleGame = pattern<GameInput, GameOutput>(
     const clearPlaced = clearBoard({ rack, placed, message });
 
     return {
-      [NAME]: computed(() => `Scrabble: ${gameName}`),
+      [NAME]: `Scrabble: ${gameName}`,
       [UI]: (
         <div
           style={{
@@ -1277,10 +1274,8 @@ const ScrabbleGame = pattern<GameInput, GameOutput>(
                     </div>
 
                     {board.map((tile) => {
-                      const leftPx = derive({ col: tile.col }, ({ col }) =>
-                        `${col * cellWithGap}px`);
-                      const topPx = derive({ row: tile.row }, ({ row }) =>
-                        `${row * cellWithGap}px`);
+                      const leftPx = `${tile.col * cellWithGap}px`;
+                      const topPx = `${tile.row * cellWithGap}px`;
                       return (
                         <div
                           style={{
@@ -1322,10 +1317,8 @@ const ScrabbleGame = pattern<GameInput, GameOutput>(
                     })}
 
                     {placed.map((tile) => {
-                      const leftPx = derive({ col: tile.col }, ({ col }) =>
-                        `${col * cellWithGap}px`);
-                      const topPx = derive({ row: tile.row }, ({ row }) =>
-                        `${row * cellWithGap}px`);
+                      const leftPx = `${tile.col * cellWithGap}px`;
+                      const topPx = `${tile.row * cellWithGap}px`;
                       return (
                         <cf-drag-source
                           $cell={tile}
@@ -1547,15 +1540,15 @@ const ScrabbleGame = pattern<GameInput, GameOutput>(
           </aside>
         </div>
       ),
-      myName: computed(() => myName.get()),
-      board: computed(() => board.get()),
-      bag: computed(() => bag.get()),
-      bagIndex: computed(() => bagIndex.get()),
-      players: computed(() => players.get()),
-      gameEvents: computed(() => gameEvents.get()),
-      rack: computed(() => rack.get()),
-      placed: computed(() => placed.get()),
-      message: computed(() => message.get()),
+      myName,
+      board,
+      bag,
+      bagIndex,
+      players,
+      gameEvents,
+      rack,
+      placed,
+      message,
       joinGame,
       joinWithName,
       placeTile,

--- a/packages/patterns/shopping-list.tsx
+++ b/packages/patterns/shopping-list.tsx
@@ -356,7 +356,7 @@ export default pattern<Input, Output>(({ items, storeLayout }) => {
   const hasConnectedStore = storeLayout.get().trim().length > 0;
 
   // Effective layout: use connected store or demo fallback
-  const effectiveLayout = storeLayout.get().trim().length > 0
+  const effectiveLayout = hasConnectedStore
     ? storeLayout.get()
     : DEMO_STORE_LAYOUT;
 

--- a/packages/patterns/shopping-list.tsx
+++ b/packages/patterns/shopping-list.tsx
@@ -528,7 +528,7 @@ export default pattern<Input, Output>(({ items, storeLayout }) => {
                           {itemWithAisle.item.title}
                         </div>
                         {/* Show aisle - prefer user override, then AI result */}
-                        {!!itemWithAisle.item.aisleOverride
+                        {itemWithAisle.item.aisleOverride
                           ? (
                             <span
                               style={{

--- a/packages/patterns/shopping-list.tsx
+++ b/packages/patterns/shopping-list.tsx
@@ -10,11 +10,9 @@
 import {
   computed,
   Default,
-  derive,
   equals,
   generateObject,
   handler,
-  ifElse,
   NAME,
   navigateTo,
   OpaqueRef,
@@ -232,10 +230,8 @@ const searchItemsPattern = pattern<
   { items: ShoppingItem[]; query: string },
   ShoppingItem[]
 >(({ items, query }) => {
-  return computed(() =>
-    items.filter((item: ShoppingItem) =>
-      item.title.toLowerCase().includes(query.toLowerCase())
-    )
+  return items.filter((item: ShoppingItem) =>
+    item.title.toLowerCase().includes(query.toLowerCase())
   );
 });
 
@@ -344,49 +340,34 @@ export default pattern<Input, Output>(({ items, storeLayout }) => {
   // Create search tool for omnibot
   const searchItems = patternTool(searchItemsPattern, { items });
 
-  // Computed for whether correction panel is open
-  const isCorrecting = computed(() => correctionIndex.get() >= 0);
+  // Whether correction panel is open
+  const isCorrecting = correctionIndex.get() >= 0;
 
-  // Computed statistics
-  const totalCount = computed(() => items.get().length);
-  const doneCount = computed(() => items.get().filter((i) => i.done).length);
-  const remainingCount = derive(
-    [totalCount, doneCount],
-    ([total, done]) => total - done,
-  );
+  // Statistics
+  const totalCount = items.get().length;
+  const doneCount = items.get().filter((i) => i.done).length;
+  const remainingCount = totalCount - doneCount;
   // Combined stats string to avoid adjacent reactive text node rendering issues
-  const statsText = derive(
-    [remainingCount, doneCount],
-    ([remaining, done]) => {
-      const itemWord = remaining === 1 ? "item" : "items";
-      return `${remaining} ${itemWord} to get • ${done} checked off`;
-    },
-  );
+  const statsText = `${remainingCount} ${
+    remainingCount === 1 ? "item" : "items"
+  } to get • ${doneCount} checked off`;
 
   // Check if a real store layout is connected (not using demo fallback)
-  const hasConnectedStore = computed(() => storeLayout.get().trim().length > 0);
+  const hasConnectedStore = storeLayout.get().trim().length > 0;
 
   // Effective layout: use connected store or demo fallback
-  const effectiveLayout = derive(
-    storeLayout,
-    (layout: string) => layout.trim().length > 0 ? layout : DEMO_STORE_LAYOUT,
-  );
+  const effectiveLayout = storeLayout.get().trim().length > 0
+    ? storeLayout.get()
+    : DEMO_STORE_LAYOUT;
 
   // Valid locations derived from effective layout
-  const validLocations = derive(
-    effectiveLayout,
-    (layout: string) => extractLocations(layout),
-  );
+  const validLocations = extractLocations(effectiveLayout);
 
   // AI categorization for each item (uses effectiveLayout which always has a value)
   const itemsWithAisles = items.map((item) => {
     // Build prompt using effective layout + item
-    const categorizePrompt = derive(
-      [effectiveLayout, item.title, item.aisleSeed],
-      ([layout, title, seed]: [string, string, number]) => {
-        return `Store layout:\n${layout}\n\nItem: ${title}\n\nSeed: ${seed}\n\nWhich aisle or department is this item most likely to be in? Respond with the exact location name.`;
-      },
-    );
+    const categorizePrompt =
+      `Store layout:\n${effectiveLayout}\n\nItem: ${item.title}\n\nSeed: ${item.aisleSeed}\n\nWhich aisle or department is this item most likely to be in? Respond with the exact location name.`;
 
     // Generate location using AI (only if layout exists)
     const aisleResult = generateObject<AisleResult>({
@@ -458,238 +439,232 @@ export default pattern<Input, Output>(({ items, storeLayout }) => {
             </div>
 
             {/* QUICK LIST VIEW */}
-            {ifElse(
-              computed(() => viewMode.get() === "quick"),
-              <cf-vstack gap="2">
-                {/* Empty state */}
-                {ifElse(
-                  computed(() => items.get().length === 0),
-                  <div
-                    style={{
-                      textAlign: "center",
-                      color: "var(--cf-color-gray-500)",
-                      padding: "2rem",
-                    }}
-                  >
-                    Your shopping list is empty. Type above to add items!
-                  </div>,
-                  null,
-                )}
-
-                {/* Item list */}
-                {items.map((item) => (
-                  <cf-card>
-                    <cf-hstack gap="2" align="center">
-                      <cf-checkbox $checked={item.done} />
-                      <cf-input
-                        $value={item.title}
-                        placeholder="Enter item..."
-                        style={{
-                          flex: 1,
-                          border: "none",
-                          background: "transparent",
-                          textDecoration: item.done ? "line-through" : "none",
-                          opacity: item.done ? 0.6 : 1,
-                        }}
-                      />
-                      <cf-button
-                        variant="ghost"
-                        onClick={removeItem({ items, item })}
-                      >
-                        ×
-                      </cf-button>
-                    </cf-hstack>
-                  </cf-card>
-                ))}
-
-                {/* Demo layout notice */}
-                {ifElse(
-                  derive(hasConnectedStore, (connected: boolean) => !connected),
-                  <div
-                    style={{
-                      textAlign: "center",
-                      color: "#f59e0b",
-                      background: "#fef3c7",
-                      padding: "0.75rem",
-                      fontSize: "13px",
-                      borderRadius: "6px",
-                      border: "1px solid #fcd34d",
-                    }}
-                  >
-                    ⚠️ Using demo store layout (Andronico's). Connect a Store
-                    Mapper for your actual store.
-                  </div>,
-                  null,
-                )}
-              </cf-vstack>,
-              null,
-            )}
-
-            {/* SORTED VIEW - Shows items with their AI-assigned aisles */}
-            {ifElse(
-              computed(() => viewMode.get() === "sorted"),
-              <cf-vstack gap="2">
-                {/* Items with aisles */}
-                {itemsWithAisles.map((itemWithAisle) => (
-                  <cf-card>
-                    <cf-hstack gap="2" align="center">
-                      <cf-checkbox $checked={itemWithAisle.item.done} />
+            {viewMode.get() === "quick"
+              ? (
+                <cf-vstack gap="2">
+                  {/* Empty state */}
+                  {items.get().length === 0
+                    ? (
                       <div
                         style={{
-                          flex: 1,
-                          color: "#111827",
-                          textDecoration: itemWithAisle.item.done
-                            ? "line-through"
-                            : "none",
-                          opacity: itemWithAisle.item.done ? 0.6 : 1,
+                          textAlign: "center",
+                          color: "var(--cf-color-gray-500)",
+                          padding: "2rem",
                         }}
                       >
-                        {itemWithAisle.item.title}
+                        Your shopping list is empty. Type above to add items!
                       </div>
-                      {/* Show aisle - prefer user override, then AI result */}
-                      {ifElse(
-                        derive(
-                          itemWithAisle.item.aisleOverride,
-                          (override: string) => !!override,
-                        ),
-                        <span
+                    )
+                    : null}
+
+                  {/* Item list */}
+                  {items.map((item) => (
+                    <cf-card>
+                      <cf-hstack gap="2" align="center">
+                        <cf-checkbox $checked={item.done} />
+                        <cf-input
+                          $value={item.title}
+                          placeholder="Enter item..."
                           style={{
-                            fontSize: "12px",
-                            padding: "4px 8px",
-                            borderRadius: "4px",
-                            background: "var(--cf-color-green-100)",
-                            color: "var(--cf-color-green-700)",
+                            flex: 1,
+                            border: "none",
+                            background: "transparent",
+                            textDecoration: item.done ? "line-through" : "none",
+                            opacity: item.done ? 0.6 : 1,
+                          }}
+                        />
+                        <cf-button
+                          variant="ghost"
+                          onClick={removeItem({ items, item })}
+                        >
+                          ×
+                        </cf-button>
+                      </cf-hstack>
+                    </cf-card>
+                  ))}
+
+                  {/* Demo layout notice */}
+                  {!hasConnectedStore
+                    ? (
+                      <div
+                        style={{
+                          textAlign: "center",
+                          color: "#f59e0b",
+                          background: "#fef3c7",
+                          padding: "0.75rem",
+                          fontSize: "13px",
+                          borderRadius: "6px",
+                          border: "1px solid #fcd34d",
+                        }}
+                      >
+                        ⚠️ Using demo store layout (Andronico's). Connect a
+                        Store Mapper for your actual store.
+                      </div>
+                    )
+                    : null}
+                </cf-vstack>
+              )
+              : null}
+
+            {/* SORTED VIEW - Shows items with their AI-assigned aisles */}
+            {viewMode.get() === "sorted"
+              ? (
+                <cf-vstack gap="2">
+                  {/* Items with aisles */}
+                  {itemsWithAisles.map((itemWithAisle) => (
+                    <cf-card>
+                      <cf-hstack gap="2" align="center">
+                        <cf-checkbox $checked={itemWithAisle.item.done} />
+                        <div
+                          style={{
+                            flex: 1,
+                            color: "#111827",
+                            textDecoration: itemWithAisle.item.done
+                              ? "line-through"
+                              : "none",
+                            opacity: itemWithAisle.item.done ? 0.6 : 1,
                           }}
                         >
-                          {itemWithAisle.item.aisleOverride}
-                        </span>,
-                        ifElse(
-                          itemWithAisle.aisle.pending,
-                          <span
-                            style={{
-                              fontSize: "11px",
-                              color: "#667eea",
-                            }}
-                          >
-                            🔄 sorting...
-                          </span>,
-                          <span
-                            style={{
-                              fontSize: "12px",
-                              padding: "4px 8px",
-                              borderRadius: "4px",
-                              background: "var(--cf-color-blue-100)",
-                              color: "var(--cf-color-blue-700)",
-                            }}
-                          >
-                            {derive(
-                              itemWithAisle.aisle.result,
-                              (r: AisleResult | undefined) =>
-                                r?.location || "Other",
-                            )}
-                          </span>,
-                        ),
-                      )}
-                      {/* Correction button */}
-                      <cf-button
-                        variant="ghost"
-                        onClick={openCorrection({
-                          items,
-                          item: itemWithAisle.item,
-                          correctionIndex,
-                          correctionTitle,
-                        })}
-                        style="font-size: 12px; padding: 4px;"
-                      >
-                        ✏️
-                      </cf-button>
-                    </cf-hstack>
-                  </cf-card>
-                ))}
+                          {itemWithAisle.item.title}
+                        </div>
+                        {/* Show aisle - prefer user override, then AI result */}
+                        {!!itemWithAisle.item.aisleOverride
+                          ? (
+                            <span
+                              style={{
+                                fontSize: "12px",
+                                padding: "4px 8px",
+                                borderRadius: "4px",
+                                background: "var(--cf-color-green-100)",
+                                color: "var(--cf-color-green-700)",
+                              }}
+                            >
+                              {itemWithAisle.item.aisleOverride}
+                            </span>
+                          )
+                          : itemWithAisle.aisle.pending
+                          ? (
+                            <span
+                              style={{
+                                fontSize: "11px",
+                                color: "#667eea",
+                              }}
+                            >
+                              🔄 sorting...
+                            </span>
+                          )
+                          : (
+                            <span
+                              style={{
+                                fontSize: "12px",
+                                padding: "4px 8px",
+                                borderRadius: "4px",
+                                background: "var(--cf-color-blue-100)",
+                                color: "var(--cf-color-blue-700)",
+                              }}
+                            >
+                              {itemWithAisle.aisle.result?.location || "Other"}
+                            </span>
+                          )}
+                        {/* Correction button */}
+                        <cf-button
+                          variant="ghost"
+                          onClick={openCorrection({
+                            items,
+                            item: itemWithAisle.item,
+                            correctionIndex,
+                            correctionTitle,
+                          })}
+                          style="font-size: 12px; padding: 4px;"
+                        >
+                          ✏️
+                        </cf-button>
+                      </cf-hstack>
+                    </cf-card>
+                  ))}
 
-                {/* Demo layout notice */}
-                {ifElse(
-                  derive(hasConnectedStore, (connected: boolean) => !connected),
-                  <div
-                    style={{
-                      textAlign: "center",
-                      color: "#f59e0b",
-                      background: "#fef3c7",
-                      padding: "0.75rem",
-                      fontSize: "13px",
-                      borderRadius: "6px",
-                      border: "1px solid #fcd34d",
-                    }}
-                  >
-                    ⚠️ Using demo store layout (Andronico's). Connect a Store
-                    Mapper for your actual store.
-                  </div>,
-                  null,
-                )}
-              </cf-vstack>,
-              null,
-            )}
+                  {/* Demo layout notice */}
+                  {!hasConnectedStore
+                    ? (
+                      <div
+                        style={{
+                          textAlign: "center",
+                          color: "#f59e0b",
+                          background: "#fef3c7",
+                          padding: "0.75rem",
+                          fontSize: "13px",
+                          borderRadius: "6px",
+                          border: "1px solid #fcd34d",
+                        }}
+                      >
+                        ⚠️ Using demo store layout (Andronico's). Connect a
+                        Store Mapper for your actual store.
+                      </div>
+                    )
+                    : null}
+                </cf-vstack>
+              )
+              : null}
           </cf-vstack>
         </cf-vscroll>
 
         {/* Correction panel (shown when correcting an item) */}
-        {ifElse(
-          isCorrecting,
-          <div
-            style={{
-              position: "fixed",
-              bottom: 0,
-              left: 0,
-              right: 0,
-              background: "white",
-              borderTop: "3px solid #f59e0b",
-              boxShadow: "0 -4px 12px rgba(0,0,0,0.15)",
-              padding: "1rem",
-              maxHeight: "50vh",
-              overflow: "auto",
-              zIndex: 1000,
-            }}
-          >
-            <cf-vstack gap="2">
-              <cf-hstack justify="between" align="center">
-                <span style={{ fontWeight: 500 }}>
-                  Where is "{correctionTitle}" actually located?
-                </span>
-                <cf-button
-                  variant="ghost"
-                  onClick={closeCorrection({ correctionIndex })}
+        {isCorrecting
+          ? (
+            <div
+              style={{
+                position: "fixed",
+                bottom: 0,
+                left: 0,
+                right: 0,
+                background: "white",
+                borderTop: "3px solid #f59e0b",
+                boxShadow: "0 -4px 12px rgba(0,0,0,0.15)",
+                padding: "1rem",
+                maxHeight: "50vh",
+                overflow: "auto",
+                zIndex: 1000,
+              }}
+            >
+              <cf-vstack gap="2">
+                <cf-hstack justify="between" align="center">
+                  <span style={{ fontWeight: 500 }}>
+                    Where is "{correctionTitle}" actually located?
+                  </span>
+                  <cf-button
+                    variant="ghost"
+                    onClick={closeCorrection({ correctionIndex })}
+                  >
+                    ✕ Cancel
+                  </cf-button>
+                </cf-hstack>
+                <div
+                  style={{
+                    display: "grid",
+                    gridTemplateColumns:
+                      "repeat(auto-fill, minmax(120px, 1fr))",
+                    gap: "0.5rem",
+                  }}
                 >
-                  ✕ Cancel
-                </cf-button>
-              </cf-hstack>
-              <div
-                style={{
-                  display: "grid",
-                  gridTemplateColumns: "repeat(auto-fill, minmax(120px, 1fr))",
-                  gap: "0.5rem",
-                }}
-              >
-                {validLocations.map((location) => {
-                  // Extract raw location string for handler
-                  const locationStr = derive(location, (l: string) => l);
-                  return (
-                    <cf-button
-                      variant="secondary"
-                      onClick={selectAisle({
-                        items,
-                        correctionIndex,
-                        selectedAisle: locationStr,
-                      })}
-                    >
-                      {location}
-                    </cf-button>
-                  );
-                })}
-              </div>
-            </cf-vstack>
-          </div>,
-          null,
-        )}
+                  {validLocations.map((location) => {
+                    return (
+                      <cf-button
+                        variant="secondary"
+                        onClick={selectAisle({
+                          items,
+                          correctionIndex,
+                          selectedAisle: location,
+                        })}
+                      >
+                        {location}
+                      </cf-button>
+                    );
+                  })}
+                </div>
+              </cf-vstack>
+            </div>
+          )
+          : null}
       </cf-screen>
     ),
     items,

--- a/packages/patterns/store-mapper.tsx
+++ b/packages/patterns/store-mapper.tsx
@@ -12,11 +12,9 @@
 import {
   computed,
   Default,
-  derive,
   equals,
   generateObject,
   handler,
-  ifElse,
   NAME,
   pattern,
   safeDateNow,
@@ -327,9 +325,9 @@ export default pattern<Input, Output>(
       const extraction = generateObject({
         system:
           'You are analyzing photos from a grocery store. Your task is to extract ALL visible aisle signs and return them as JSON.\n\nIMPORTANT: You MUST return a JSON object with an "aisles" array, even if you only see one aisle or partial information.\n\nFor each aisle sign you see:\n- Extract ONLY the aisle number (e.g., "8", "12", "5A", "5B") - DO NOT include the word "Aisle"\n- Extract each product category as a separate item in the products array\n- Include partially visible signs - do your best to read them\n\nExample output:\n{\n  "aisles": [\n    {"name": "8", "products": ["Bread", "Cereal", "Coffee"]},\n    {"name": "9", "products": ["Snacks", "Chips"]}\n  ]\n}',
-        prompt: derive(photo, (p) => {
+        prompt: computed(() => {
           // Safety check: photo might be undefined after deletion
-          const image = p?.data || p?.url;
+          const image = photo?.data || photo?.url;
           if (!image) return [];
           return [
             { type: "image" as const, image },
@@ -372,20 +370,17 @@ export default pattern<Input, Output>(
       return {
         photo,
         photoName: photo.name,
-        extractedAisles: derive(
-          extraction.result,
-          (result: { aisles?: ExtractedAisle[] } | null) => ({
-            aisles: (result && result.aisles) || [],
-          }),
-        ),
+        extractedAisles: {
+          aisles: (extraction.result && extraction.result.aisles) || [],
+        },
         pending: extraction.pending,
         error: extraction.error,
       };
     });
 
     // Sorted aisles (natural numeric order)
-    const sortedAisles = derive(aisles, (aisleList: Aisle[]) => {
-      return [...aisleList].sort((a, b) => {
+    const sortedAisles = computed(() => {
+      return [...aisles.get()].sort((a, b) => {
         const numA = parseInt(a.name.match(/^\d+/)?.[0] || "999", 10);
         const numB = parseInt(b.name.match(/^\d+/)?.[0] || "999", 10);
         if (numA !== numB) return numA - numB;
@@ -442,10 +437,10 @@ export default pattern<Input, Output>(
     });
 
     // Counts for reactive arrays
-    const aisleCount = computed(() => aisles.get().length);
-    const deptCount = computed(() => departments.get().length);
-    const correctionCount = computed(() => itemLocations.get().length);
-    const entranceCount = computed(() => entrances.get().length);
+    const aisleCount = aisles.get().length;
+    const deptCount = departments.get().length;
+    const correctionCount = itemLocations.get().length;
+    const entranceCount = entrances.get().length;
 
     // Group departments and entrances by position for the visual map
     const itemsByPosition = computed((): ItemsByPos => {
@@ -483,8 +478,8 @@ export default pattern<Input, Output>(
     });
 
     // Gap detection for aisles
-    const detectedGaps = derive(aisles, (aisleList: Aisle[]) => {
-      const numbers = aisleList
+    const detectedGaps = computed(() => {
+      const numbers = aisles.get()
         .map((a) => parseInt(a.name.match(/^\d+/)?.[0] || "", 10))
         .filter((n) => !isNaN(n))
         .sort((a, b) => a - b);
@@ -535,9 +530,7 @@ export default pattern<Input, Output>(
                 marginTop: "0.5rem",
               }}
             >
-              {computed(() =>
-                `${aisleCount} aisles • ${deptCount} departments • ${entranceCount} entrances`
-              )}
+              {`${aisleCount} aisles • ${deptCount} departments • ${entranceCount} entrances`}
             </div>
           </div>
 
@@ -678,7 +671,8 @@ export default pattern<Input, Output>(
 
                         {/* Back wall (top - orange) */}
                         <div className="store-map-wall store-map-wall-horizontal store-map-wall-back">
-                          {derive(itemsByPosition, (items: ItemsByPos) => {
+                          {computed(() => {
+                            const items = itemsByPosition;
                             const hasBL =
                               (items["back-left"]?.entrances || []).length > 0;
                             const hasBC =
@@ -773,7 +767,8 @@ export default pattern<Input, Output>(
 
                         {/* Left wall (green) */}
                         <div className="store-map-wall store-map-wall-vertical store-map-wall-left">
-                          {derive(itemsByPosition, (items: ItemsByPos) => {
+                          {computed(() => {
+                            const items = itemsByPosition;
                             const hasLB =
                               (items["left-back"]?.entrances || []).length > 0;
                             const hasLC =
@@ -874,7 +869,8 @@ export default pattern<Input, Output>(
 
                         {/* Right wall (purple) */}
                         <div className="store-map-wall store-map-wall-vertical store-map-wall-right">
-                          {derive(itemsByPosition, (items: ItemsByPos) => {
+                          {computed(() => {
+                            const items = itemsByPosition;
                             const hasRB =
                               (items["right-back"]?.entrances || []).length > 0;
                             const hasRC =
@@ -970,7 +966,8 @@ export default pattern<Input, Output>(
 
                         {/* Front wall (bottom - blue) */}
                         <div className="store-map-wall store-map-wall-horizontal store-map-wall-front">
-                          {derive(itemsByPosition, (items: ItemsByPos) => {
+                          {computed(() => {
+                            const items = itemsByPosition;
                             const hasFL =
                               (items["front-left"]?.entrances || []).length > 0;
                             const hasFC =
@@ -1118,10 +1115,7 @@ export default pattern<Input, Output>(
                           size="sm"
                           variant="outline"
                           className="wall-btn-front"
-                          disabled={derive(
-                            entrancePositions,
-                            (p: Record<string, boolean>) => !!p["front-left"],
-                          )}
+                          disabled={!!entrancePositions["front-left"]}
                           onClick={addEntrance({
                             entrances,
                             position: "front-left",
@@ -1133,10 +1127,7 @@ export default pattern<Input, Output>(
                           size="sm"
                           variant="outline"
                           className="wall-btn-front"
-                          disabled={derive(
-                            entrancePositions,
-                            (p: Record<string, boolean>) => !!p["front-center"],
-                          )}
+                          disabled={!!entrancePositions["front-center"]}
                           onClick={addEntrance({
                             entrances,
                             position: "front-center",
@@ -1148,10 +1139,7 @@ export default pattern<Input, Output>(
                           size="sm"
                           variant="outline"
                           className="wall-btn-front"
-                          disabled={derive(
-                            entrancePositions,
-                            (p: Record<string, boolean>) => !!p["front-right"],
-                          )}
+                          disabled={!!entrancePositions["front-right"]}
                           onClick={addEntrance({
                             entrances,
                             position: "front-right",
@@ -1184,10 +1172,7 @@ export default pattern<Input, Output>(
                           size="sm"
                           variant="outline"
                           className="wall-btn-back"
-                          disabled={derive(
-                            entrancePositions,
-                            (p: Record<string, boolean>) => !!p["back-left"],
-                          )}
+                          disabled={!!entrancePositions["back-left"]}
                           onClick={addEntrance({
                             entrances,
                             position: "back-left",
@@ -1199,10 +1184,7 @@ export default pattern<Input, Output>(
                           size="sm"
                           variant="outline"
                           className="wall-btn-back"
-                          disabled={derive(
-                            entrancePositions,
-                            (p: Record<string, boolean>) => !!p["back-center"],
-                          )}
+                          disabled={!!entrancePositions["back-center"]}
                           onClick={addEntrance({
                             entrances,
                             position: "back-center",
@@ -1214,10 +1196,7 @@ export default pattern<Input, Output>(
                           size="sm"
                           variant="outline"
                           className="wall-btn-back"
-                          disabled={derive(
-                            entrancePositions,
-                            (p: Record<string, boolean>) => !!p["back-right"],
-                          )}
+                          disabled={!!entrancePositions["back-right"]}
                           onClick={addEntrance({
                             entrances,
                             position: "back-right",
@@ -1250,10 +1229,7 @@ export default pattern<Input, Output>(
                           size="sm"
                           variant="outline"
                           className="wall-btn-left"
-                          disabled={derive(
-                            entrancePositions,
-                            (p: Record<string, boolean>) => !!p["left-front"],
-                          )}
+                          disabled={!!entrancePositions["left-front"]}
                           onClick={addEntrance({
                             entrances,
                             position: "left-front",
@@ -1265,10 +1241,7 @@ export default pattern<Input, Output>(
                           size="sm"
                           variant="outline"
                           className="wall-btn-left"
-                          disabled={derive(
-                            entrancePositions,
-                            (p: Record<string, boolean>) => !!p["left-center"],
-                          )}
+                          disabled={!!entrancePositions["left-center"]}
                           onClick={addEntrance({
                             entrances,
                             position: "left-center",
@@ -1280,10 +1253,7 @@ export default pattern<Input, Output>(
                           size="sm"
                           variant="outline"
                           className="wall-btn-left"
-                          disabled={derive(
-                            entrancePositions,
-                            (p: Record<string, boolean>) => !!p["left-back"],
-                          )}
+                          disabled={!!entrancePositions["left-back"]}
                           onClick={addEntrance({
                             entrances,
                             position: "left-back",
@@ -1316,10 +1286,7 @@ export default pattern<Input, Output>(
                           size="sm"
                           variant="outline"
                           className="wall-btn-right"
-                          disabled={derive(
-                            entrancePositions,
-                            (p: Record<string, boolean>) => !!p["right-front"],
-                          )}
+                          disabled={!!entrancePositions["right-front"]}
                           onClick={addEntrance({
                             entrances,
                             position: "right-front",
@@ -1331,10 +1298,7 @@ export default pattern<Input, Output>(
                           size="sm"
                           variant="outline"
                           className="wall-btn-right"
-                          disabled={derive(
-                            entrancePositions,
-                            (p: Record<string, boolean>) => !!p["right-center"],
-                          )}
+                          disabled={!!entrancePositions["right-center"]}
                           onClick={addEntrance({
                             entrances,
                             position: "right-center",
@@ -1346,10 +1310,7 @@ export default pattern<Input, Output>(
                           size="sm"
                           variant="outline"
                           className="wall-btn-right"
-                          disabled={derive(
-                            entrancePositions,
-                            (p: Record<string, boolean>) => !!p["right-back"],
-                          )}
+                          disabled={!!entrancePositions["right-back"]}
                           onClick={addEntrance({
                             entrances,
                             position: "right-back",
@@ -1360,57 +1321,57 @@ export default pattern<Input, Output>(
                       </div>
 
                       {/* Show added entrances */}
-                      {ifElse(
-                        derive(entranceCount, (c: number) => c > 0),
-                        <div style={{ marginTop: "0.5rem" }}>
-                          <span
-                            style={{
-                              fontSize: "12px",
-                              fontWeight: 600,
-                              color: "#92400e",
-                            }}
-                          >
-                            Added ({entranceCount}):
-                          </span>
-                          <div
-                            style={{
-                              display: "flex",
-                              flexWrap: "wrap",
-                              gap: "0.5rem",
-                              marginTop: "0.5rem",
-                            }}
-                          >
-                            {entrances.map((entrance) => (
-                              <div
-                                style={{
-                                  display: "inline-flex",
-                                  alignItems: "center",
-                                  gap: "0.25rem",
-                                  padding: "4px 8px",
-                                  background: "white",
-                                  border: "1px solid #fbbf24",
-                                  borderRadius: "4px",
-                                  fontSize: "12px",
-                                }}
-                              >
-                                🚪 {entrance.position}
-                                <cf-button
-                                  size="sm"
-                                  variant="ghost"
-                                  onClick={removeEntrance({
-                                    entrances,
-                                    entrance,
-                                  })}
-                                  style="padding: 2px 4px; min-height: 0;"
+                      {entranceCount > 0
+                        ? (
+                          <div style={{ marginTop: "0.5rem" }}>
+                            <span
+                              style={{
+                                fontSize: "12px",
+                                fontWeight: 600,
+                                color: "#92400e",
+                              }}
+                            >
+                              Added ({entranceCount}):
+                            </span>
+                            <div
+                              style={{
+                                display: "flex",
+                                flexWrap: "wrap",
+                                gap: "0.5rem",
+                                marginTop: "0.5rem",
+                              }}
+                            >
+                              {entrances.map((entrance) => (
+                                <div
+                                  style={{
+                                    display: "inline-flex",
+                                    alignItems: "center",
+                                    gap: "0.25rem",
+                                    padding: "4px 8px",
+                                    background: "white",
+                                    border: "1px solid #fbbf24",
+                                    borderRadius: "4px",
+                                    fontSize: "12px",
+                                  }}
                                 >
-                                  ×
-                                </cf-button>
-                              </div>
-                            ))}
+                                  🚪 {entrance.position}
+                                  <cf-button
+                                    size="sm"
+                                    variant="ghost"
+                                    onClick={removeEntrance({
+                                      entrances,
+                                      entrance,
+                                    })}
+                                    style="padding: 2px 4px; min-height: 0;"
+                                  >
+                                    ×
+                                  </cf-button>
+                                </div>
+                              ))}
+                            </div>
                           </div>
-                        </div>,
-                        null,
-                      )}
+                        )
+                        : null}
                     </cf-vstack>
                   </cf-card>
 
@@ -1440,18 +1401,18 @@ export default pattern<Input, Output>(
               <cf-vscroll flex showScrollbar fadeEdges>
                 <cf-vstack gap="2" style="padding: 1rem; max-width: 800px;">
                   {/* Gap warning */}
-                  {ifElse(
-                    derive(detectedGaps, (gaps: number[]) => gaps.length > 0),
-                    <cf-card style="background: #fef3c7; border: 1px solid #fbbf24;">
-                      <cf-vstack gap="1">
-                        <span style={{ fontWeight: 500, color: "#92400e" }}>
-                          ⚠️ Missing aisle(s) detected:{" "}
-                          {derive(detectedGaps, (g: number[]) => g.join(", "))}
-                        </span>
-                      </cf-vstack>
-                    </cf-card>,
-                    null,
-                  )}
+                  {detectedGaps.length > 0
+                    ? (
+                      <cf-card style="background: #fef3c7; border: 1px solid #fbbf24;">
+                        <cf-vstack gap="1">
+                          <span style={{ fontWeight: 500, color: "#92400e" }}>
+                            ⚠️ Missing aisle(s) detected:{" "}
+                            {detectedGaps.join(", ")}
+                          </span>
+                        </cf-vstack>
+                      </cf-card>
+                    )
+                    : null}
 
                   {/* Aisle list */}
                   {sortedAisles.map((aisle) => (
@@ -1486,19 +1447,19 @@ export default pattern<Input, Output>(
                   ))}
 
                   {/* Empty state */}
-                  {ifElse(
-                    computed(() => aisles.get().length === 0),
-                    <div
-                      style={{
-                        textAlign: "center",
-                        color: "var(--cf-color-gray-500)",
-                        padding: "2rem",
-                      }}
-                    >
-                      No aisles yet. Add one below!
-                    </div>,
-                    null,
-                  )}
+                  {aisles.get().length === 0
+                    ? (
+                      <div
+                        style={{
+                          textAlign: "center",
+                          color: "var(--cf-color-gray-500)",
+                          padding: "2rem",
+                        }}
+                      >
+                        No aisles yet. Add one below!
+                      </div>
+                    )
+                    : null}
 
                   {/* Add aisle input */}
                   <cf-message-input
@@ -1540,211 +1501,211 @@ export default pattern<Input, Output>(
 
                       {/* Photo extraction results */}
                       {photoExtractions.map((extraction) =>
-                        ifElse(
-                          computed(() =>
-                            hiddenPhotoIds.get().includes(extraction.photo.id)
-                          ),
-                          null,
-                          <div
-                            style={{
-                              padding: "0.75rem",
-                              background: "white",
-                              borderRadius: "6px",
-                              border: "1px solid #86efac",
-                              marginTop: "0.5rem",
-                            }}
-                          >
-                            <cf-hstack
-                              justify="between"
-                              align="center"
-                              style="margin-bottom: 0.5rem;"
+                        hiddenPhotoIds.get().includes(extraction.photo.id)
+                          ? null
+                          : (
+                            <div
+                              style={{
+                                padding: "0.75rem",
+                                background: "white",
+                                borderRadius: "6px",
+                                border: "1px solid #86efac",
+                                marginTop: "0.5rem",
+                              }}
                             >
-                              <span
-                                style={{
-                                  fontSize: "12px",
-                                  fontWeight: 600,
-                                  color: "#166534",
-                                }}
+                              <cf-hstack
+                                justify="between"
+                                align="center"
+                                style="margin-bottom: 0.5rem;"
                               >
-                                📷 {extraction.photoName}
-                              </span>
-                              <cf-button
-                                size="sm"
-                                variant="ghost"
-                                onClick={hidePhoto({
-                                  hiddenPhotoIds,
-                                  photoId: extraction.photo.id,
-                                })}
-                              >
-                                ×
-                              </cf-button>
-                            </cf-hstack>
-
-                            {ifElse(
-                              extraction.pending,
-                              <div
-                                style={{
-                                  fontSize: "12px",
-                                  color: "#16a34a",
-                                  fontStyle: "italic",
-                                }}
-                              >
-                                Analyzing photo...
-                              </div>,
-                              ifElse(
-                                extraction.error,
-                                <div
+                                <span
                                   style={{
                                     fontSize: "12px",
-                                    color: "#dc2626",
-                                    fontStyle: "italic",
+                                    fontWeight: 600,
+                                    color: "#166534",
                                   }}
                                 >
-                                  Error analyzing photo. Please try removing and
-                                  re-uploading.
-                                </div>,
-                                computed(() => {
-                                  const extracted: {
-                                    aisles: ExtractedAisle[];
-                                  } = extraction.extractedAisles;
-                                  const currentAisles = aisles.get();
-                                  if (
-                                    !extracted?.aisles ||
-                                    extracted.aisles.length === 0
-                                  ) {
-                                    return (
-                                      <div
-                                        style={{
-                                          fontSize: "12px",
-                                          color: "#999",
-                                        }}
-                                      >
-                                        No aisles detected in photo
-                                      </div>
-                                    );
-                                  }
+                                  📷 {extraction.photoName}
+                                </span>
+                                <cf-button
+                                  size="sm"
+                                  variant="ghost"
+                                  onClick={hidePhoto({
+                                    hiddenPhotoIds,
+                                    photoId: extraction.photo.id,
+                                  })}
+                                >
+                                  ×
+                                </cf-button>
+                              </cf-hstack>
 
-                                  const sourceAisles: Aisle[] = Array.isArray(
-                                      currentAisles,
-                                    )
-                                    ? currentAisles
-                                    : [];
-                                  const existingAisleNames = sourceAisles.map(
-                                    (existing: Aisle) =>
-                                      existing?.name?.toLowerCase?.() ?? "",
-                                  );
-
-                                  // Count new aisles
-                                  const newCount = extracted.aisles.filter(
-                                    (e) =>
-                                      !existingAisleNames.includes(
-                                        e.name.toLowerCase(),
-                                      ),
-                                  ).length;
-
-                                  return (
-                                    <cf-vstack gap="1">
-                                      {/* Batch add button */}
-                                      {newCount > 0 && (
-                                        <cf-button
-                                          size="sm"
-                                          variant="primary"
-                                          onClick={addAllExtractedAisles({
-                                            aisles,
-                                            extractedList: extracted.aisles,
-                                            hiddenPhotoIds,
-                                            photoId: extraction.photo.id,
-                                          })}
-                                          style="margin-bottom: 0.5rem;"
+                              {extraction.pending
+                                ? (
+                                  <div
+                                    style={{
+                                      fontSize: "12px",
+                                      color: "#16a34a",
+                                      fontStyle: "italic",
+                                    }}
+                                  >
+                                    Analyzing photo...
+                                  </div>
+                                )
+                                : extraction.error
+                                ? (
+                                  <div
+                                    style={{
+                                      fontSize: "12px",
+                                      color: "#dc2626",
+                                      fontStyle: "italic",
+                                    }}
+                                  >
+                                    Error analyzing photo. Please try removing
+                                    and re-uploading.
+                                  </div>
+                                )
+                                : (
+                                  computed(() => {
+                                    const extracted: {
+                                      aisles: ExtractedAisle[];
+                                    } = extraction.extractedAisles;
+                                    const currentAisles = aisles.get();
+                                    if (
+                                      !extracted?.aisles ||
+                                      extracted.aisles.length === 0
+                                    ) {
+                                      return (
+                                        <div
+                                          style={{
+                                            fontSize: "12px",
+                                            color: "#999",
+                                          }}
                                         >
-                                          + Add All {newCount} New Aisles
-                                        </cf-button>
-                                      )}
+                                          No aisles detected in photo
+                                        </div>
+                                      );
+                                    }
 
-                                      {/* Individual aisle results */}
-                                      {extracted.aisles.map(
-                                        (extractedAisle: ExtractedAisle) => {
-                                          const exists = existingAisleNames
-                                            .includes(
-                                              extractedAisle.name
-                                                .toLowerCase(),
-                                            );
-                                          return (
-                                            <cf-hstack
-                                              gap="2"
-                                              align="center"
-                                              style={`padding: 0.5rem; background: ${
-                                                exists ? "#fef3c7" : "#dcfce7"
-                                              }; border-radius: 4px;`}
-                                            >
-                                              <div style={{ flex: 1 }}>
-                                                <strong>
-                                                  Aisle {extractedAisle.name}
-                                                </strong>
-                                                {exists && (
-                                                  <span
+                                    const sourceAisles: Aisle[] = Array.isArray(
+                                        currentAisles,
+                                      )
+                                      ? currentAisles
+                                      : [];
+                                    const existingAisleNames = sourceAisles.map(
+                                      (existing: Aisle) =>
+                                        existing?.name?.toLowerCase?.() ?? "",
+                                    );
+
+                                    // Count new aisles
+                                    const newCount = extracted.aisles.filter(
+                                      (e) =>
+                                        !existingAisleNames.includes(
+                                          e.name.toLowerCase(),
+                                        ),
+                                    ).length;
+
+                                    return (
+                                      <cf-vstack gap="1">
+                                        {/* Batch add button */}
+                                        {newCount > 0 && (
+                                          <cf-button
+                                            size="sm"
+                                            variant="primary"
+                                            onClick={addAllExtractedAisles({
+                                              aisles,
+                                              extractedList: extracted.aisles,
+                                              hiddenPhotoIds,
+                                              photoId: extraction.photo.id,
+                                            })}
+                                            style="margin-bottom: 0.5rem;"
+                                          >
+                                            + Add All {newCount} New Aisles
+                                          </cf-button>
+                                        )}
+
+                                        {/* Individual aisle results */}
+                                        {extracted.aisles.map(
+                                          (extractedAisle: ExtractedAisle) => {
+                                            const exists = existingAisleNames
+                                              .includes(
+                                                extractedAisle.name
+                                                  .toLowerCase(),
+                                              );
+                                            return (
+                                              <cf-hstack
+                                                gap="2"
+                                                align="center"
+                                                style={`padding: 0.5rem; background: ${
+                                                  exists ? "#fef3c7" : "#dcfce7"
+                                                }; border-radius: 4px;`}
+                                              >
+                                                <div style={{ flex: 1 }}>
+                                                  <strong>
+                                                    Aisle {extractedAisle.name}
+                                                  </strong>
+                                                  {exists && (
+                                                    <span
+                                                      style={{
+                                                        color: "#92400e",
+                                                        marginLeft: "0.5rem",
+                                                        fontSize: "11px",
+                                                      }}
+                                                    >
+                                                      (exists)
+                                                    </span>
+                                                  )}
+                                                  <div
                                                     style={{
-                                                      color: "#92400e",
-                                                      marginLeft: "0.5rem",
-                                                      fontSize: "11px",
+                                                      fontSize: "12px",
+                                                      color: "#6b7280",
                                                     }}
                                                   >
-                                                    (exists)
-                                                  </span>
-                                                )}
-                                                <div
-                                                  style={{
-                                                    fontSize: "12px",
-                                                    color: "#6b7280",
-                                                  }}
-                                                >
-                                                  {(extractedAisle.products ||
-                                                    []).join(", ") ||
-                                                    "(no products)"}
+                                                    {(extractedAisle.products ||
+                                                      []).join(", ") ||
+                                                      "(no products)"}
+                                                  </div>
                                                 </div>
-                                              </div>
-                                              {exists
-                                                ? (
-                                                  <cf-button
-                                                    size="sm"
-                                                    variant="secondary"
-                                                    onClick={mergeExtractedAisle(
-                                                      {
-                                                        aisles,
-                                                        extracted:
-                                                          extractedAisle,
-                                                      },
-                                                    )}
-                                                  >
-                                                    Merge
-                                                  </cf-button>
-                                                )
-                                                : (
-                                                  <cf-button
-                                                    size="sm"
-                                                    variant="primary"
-                                                    onClick={addExtractedAisle(
-                                                      {
-                                                        aisles,
-                                                        extracted:
-                                                          extractedAisle,
-                                                      },
-                                                    )}
-                                                  >
-                                                    Add
-                                                  </cf-button>
-                                                )}
-                                            </cf-hstack>
-                                          );
-                                        },
-                                      )}
-                                    </cf-vstack>
-                                  );
-                                }),
-                              ),
-                            )}
-                          </div>,
-                        )
+                                                {exists
+                                                  ? (
+                                                    <cf-button
+                                                      size="sm"
+                                                      variant="secondary"
+                                                      onClick={mergeExtractedAisle(
+                                                        {
+                                                          aisles,
+                                                          extracted:
+                                                            extractedAisle,
+                                                        },
+                                                      )}
+                                                    >
+                                                      Merge
+                                                    </cf-button>
+                                                  )
+                                                  : (
+                                                    <cf-button
+                                                      size="sm"
+                                                      variant="primary"
+                                                      onClick={addExtractedAisle(
+                                                        {
+                                                          aisles,
+                                                          extracted:
+                                                            extractedAisle,
+                                                        },
+                                                      )}
+                                                    >
+                                                      Add
+                                                    </cf-button>
+                                                  )}
+                                              </cf-hstack>
+                                            );
+                                          },
+                                        )}
+                                      </cf-vstack>
+                                    );
+                                  })
+                                )}
+                            </div>
+                          )
                       )}
                     </cf-vstack>
                   </cf-card>
@@ -1781,14 +1742,9 @@ export default pattern<Input, Output>(
                               fontSize: "12px",
                               padding: "4px 8px",
                               borderRadius: "4px",
-                              background: ifElse(
-                                derive(
-                                  dept.location,
-                                  (l: string) => l === "unassigned",
-                                ),
-                                "var(--cf-color-yellow-100)",
-                                "var(--cf-color-green-100)",
-                              ),
+                              background: dept.location === "unassigned"
+                                ? "var(--cf-color-yellow-100)"
+                                : "var(--cf-color-green-100)",
                             }}
                           >
                             {dept.location}
@@ -1817,11 +1773,9 @@ export default pattern<Input, Output>(
                             </span>
                             <cf-button
                               size="sm"
-                              variant={derive(
-                                dept.location,
-                                (l) =>
-                                  l === "front-left" ? "primary" : "outline",
-                              )}
+                              variant={dept.location === "front-left"
+                                ? "primary"
+                                : "outline"}
                               className="wall-btn-front"
                               onClick={setDepartmentLocation({
                                 departments,
@@ -1833,11 +1787,9 @@ export default pattern<Input, Output>(
                             </cf-button>
                             <cf-button
                               size="sm"
-                              variant={derive(
-                                dept.location,
-                                (l) =>
-                                  l === "front-center" ? "primary" : "outline",
-                              )}
+                              variant={dept.location === "front-center"
+                                ? "primary"
+                                : "outline"}
                               className="wall-btn-front"
                               onClick={setDepartmentLocation({
                                 departments,
@@ -1849,11 +1801,9 @@ export default pattern<Input, Output>(
                             </cf-button>
                             <cf-button
                               size="sm"
-                              variant={derive(
-                                dept.location,
-                                (l) =>
-                                  l === "front-right" ? "primary" : "outline",
-                              )}
+                              variant={dept.location === "front-right"
+                                ? "primary"
+                                : "outline"}
                               className="wall-btn-front"
                               onClick={setDepartmentLocation({
                                 departments,
@@ -1885,11 +1835,9 @@ export default pattern<Input, Output>(
                             </span>
                             <cf-button
                               size="sm"
-                              variant={derive(
-                                dept.location,
-                                (l) =>
-                                  l === "back-left" ? "primary" : "outline",
-                              )}
+                              variant={dept.location === "back-left"
+                                ? "primary"
+                                : "outline"}
                               className="wall-btn-back"
                               onClick={setDepartmentLocation({
                                 departments,
@@ -1901,11 +1849,9 @@ export default pattern<Input, Output>(
                             </cf-button>
                             <cf-button
                               size="sm"
-                              variant={derive(
-                                dept.location,
-                                (l) =>
-                                  l === "back-center" ? "primary" : "outline",
-                              )}
+                              variant={dept.location === "back-center"
+                                ? "primary"
+                                : "outline"}
                               className="wall-btn-back"
                               onClick={setDepartmentLocation({
                                 departments,
@@ -1917,11 +1863,9 @@ export default pattern<Input, Output>(
                             </cf-button>
                             <cf-button
                               size="sm"
-                              variant={derive(
-                                dept.location,
-                                (l) =>
-                                  l === "back-right" ? "primary" : "outline",
-                              )}
+                              variant={dept.location === "back-right"
+                                ? "primary"
+                                : "outline"}
                               className="wall-btn-back"
                               onClick={setDepartmentLocation({
                                 departments,
@@ -1953,11 +1897,9 @@ export default pattern<Input, Output>(
                             </span>
                             <cf-button
                               size="sm"
-                              variant={derive(
-                                dept.location,
-                                (l) =>
-                                  l === "left-front" ? "primary" : "outline",
-                              )}
+                              variant={dept.location === "left-front"
+                                ? "primary"
+                                : "outline"}
                               className="wall-btn-left"
                               onClick={setDepartmentLocation({
                                 departments,
@@ -1969,11 +1911,9 @@ export default pattern<Input, Output>(
                             </cf-button>
                             <cf-button
                               size="sm"
-                              variant={derive(
-                                dept.location,
-                                (l) =>
-                                  l === "left-center" ? "primary" : "outline",
-                              )}
+                              variant={dept.location === "left-center"
+                                ? "primary"
+                                : "outline"}
                               className="wall-btn-left"
                               onClick={setDepartmentLocation({
                                 departments,
@@ -1985,11 +1925,9 @@ export default pattern<Input, Output>(
                             </cf-button>
                             <cf-button
                               size="sm"
-                              variant={derive(
-                                dept.location,
-                                (l) =>
-                                  l === "left-back" ? "primary" : "outline",
-                              )}
+                              variant={dept.location === "left-back"
+                                ? "primary"
+                                : "outline"}
                               className="wall-btn-left"
                               onClick={setDepartmentLocation({
                                 departments,
@@ -2021,11 +1959,9 @@ export default pattern<Input, Output>(
                             </span>
                             <cf-button
                               size="sm"
-                              variant={derive(
-                                dept.location,
-                                (l) =>
-                                  l === "right-front" ? "primary" : "outline",
-                              )}
+                              variant={dept.location === "right-front"
+                                ? "primary"
+                                : "outline"}
                               className="wall-btn-right"
                               onClick={setDepartmentLocation({
                                 departments,
@@ -2037,11 +1973,9 @@ export default pattern<Input, Output>(
                             </cf-button>
                             <cf-button
                               size="sm"
-                              variant={derive(
-                                dept.location,
-                                (l) =>
-                                  l === "right-center" ? "primary" : "outline",
-                              )}
+                              variant={dept.location === "right-center"
+                                ? "primary"
+                                : "outline"}
                               className="wall-btn-right"
                               onClick={setDepartmentLocation({
                                 departments,
@@ -2053,11 +1987,9 @@ export default pattern<Input, Output>(
                             </cf-button>
                             <cf-button
                               size="sm"
-                              variant={derive(
-                                dept.location,
-                                (l) =>
-                                  l === "right-back" ? "primary" : "outline",
-                              )}
+                              variant={dept.location === "right-back"
+                                ? "primary"
+                                : "outline"}
                               className="wall-btn-right"
                               onClick={setDepartmentLocation({
                                 departments,
@@ -2089,13 +2021,9 @@ export default pattern<Input, Output>(
                             </span>
                             <cf-button
                               size="sm"
-                              variant={derive(
-                                dept.location,
-                                (l) =>
-                                  l === "in-center-aisle"
-                                    ? "primary"
-                                    : "outline",
-                              )}
+                              variant={dept.location === "in-center-aisle"
+                                ? "primary"
+                                : "outline"}
                               onClick={setDepartmentLocation({
                                 departments,
                                 dept,
@@ -2106,11 +2034,9 @@ export default pattern<Input, Output>(
                             </cf-button>
                             <cf-button
                               size="sm"
-                              variant={derive(
-                                dept.location,
-                                (l) =>
-                                  l === "not-in-store" ? "primary" : "outline",
-                              )}
+                              variant={dept.location === "not-in-store"
+                                ? "primary"
+                                : "outline"}
                               onClick={setDepartmentLocation({
                                 departments,
                                 dept,
@@ -2166,8 +2092,9 @@ export default pattern<Input, Output>(
                           if (item && aisle) {
                             const current = itemLocations.get();
                             const filtered = current.filter(
-                              (loc) => loc.itemName.toLowerCase() !==
-                                item.toLowerCase(),
+                              (loc) =>
+                                loc.itemName.toLowerCase() !==
+                                  item.toLowerCase(),
                             );
                             filtered.push({
                               itemName: item,
@@ -2187,52 +2114,55 @@ export default pattern<Input, Output>(
                   </cf-card>
 
                   {/* Existing corrections */}
-                  {ifElse(
-                    computed(() => itemLocations.get().length > 0),
-                    <cf-card>
-                      <cf-vstack gap="2">
-                        <span style={{ fontWeight: 500 }}>
-                          Saved Corrections
-                        </span>
-                        {itemLocations.map((loc) => (
-                          <cf-hstack
-                            gap="2"
-                            align="center"
-                            style="padding: 0.5rem; background: var(--cf-color-gray-50); border-radius: 6px;"
-                          >
-                            <span style={{ flex: 1 }}>
-                              <strong>{loc.itemName}</strong> →{" "}
-                              {loc.correctAisle}
-                            </span>
-                            <cf-button
-                              variant="ghost"
-                              onClick={() => {
-                                const current = itemLocations.get();
-                                const itemName = loc.itemName;
-                                itemLocations.set(
-                                  current.filter(
-                                    (l) => l.itemName.toLowerCase() !==
-                                      itemName.toLowerCase(),
-                                  ),
-                                );
-                              }}
+                  {itemLocations.get().length > 0
+                    ? (
+                      <cf-card>
+                        <cf-vstack gap="2">
+                          <span style={{ fontWeight: 500 }}>
+                            Saved Corrections
+                          </span>
+                          {itemLocations.map((loc) => (
+                            <cf-hstack
+                              gap="2"
+                              align="center"
+                              style="padding: 0.5rem; background: var(--cf-color-gray-50); border-radius: 6px;"
                             >
-                              ×
-                            </cf-button>
-                          </cf-hstack>
-                        ))}
-                      </cf-vstack>
-                    </cf-card>,
-                    <div
-                      style={{
-                        textAlign: "center",
-                        color: "var(--cf-color-gray-500)",
-                        padding: "2rem",
-                      }}
-                    >
-                      No corrections saved yet.
-                    </div>,
-                  )}
+                              <span style={{ flex: 1 }}>
+                                <strong>{loc.itemName}</strong> →{" "}
+                                {loc.correctAisle}
+                              </span>
+                              <cf-button
+                                variant="ghost"
+                                onClick={() => {
+                                  const current = itemLocations.get();
+                                  const itemName = loc.itemName;
+                                  itemLocations.set(
+                                    current.filter(
+                                      (l) =>
+                                        l.itemName.toLowerCase() !==
+                                          itemName.toLowerCase(),
+                                    ),
+                                  );
+                                }}
+                              >
+                                ×
+                              </cf-button>
+                            </cf-hstack>
+                          ))}
+                        </cf-vstack>
+                      </cf-card>
+                    )
+                    : (
+                      <div
+                        style={{
+                          textAlign: "center",
+                          color: "var(--cf-color-gray-500)",
+                          padding: "2rem",
+                        }}
+                      >
+                        No corrections saved yet.
+                      </div>
+                    )}
                 </cf-vstack>
               </cf-vscroll>
             </cf-tab-panel>


### PR DESCRIPTION
**Status: DRAFT / work in progress — not ready for review.** Opening early so we can share links to specific parts.

## Goal
Remove the `derive` builder from the pattern codebase entirely, leaning on the transformer's expression-site auto-wrapping (the overhaul that now lifts plain reactive expressions into `computed`/`lift` at most sites). While we're in each file, also clean up two adjacent redundancies that the auto-wrapping made possible. Net effect: plainer authored patterns, and `derive` becomes unreferenceable so its bespoke synthetic-node/type-recovery machinery (incl. `narrowedWrapperTypeRegistry`) can be deleted.

## The three transforms (all lower to identical reactive output)
1. **`derive` → plain expression** (inline the callback body; drop the wrapper) / **`computed`** for genuine statement bodies / a bare **ternary** for conditionals (auto-wraps to `ifElse`).
2. **Redundant authored `computed(() => expr)` → bare expression.** Keep `computed` only for genuine statement bodies, side-effect watchers, and array-transforms over reactive collections.
3. **Authored 3-arg `ifElse(cond, then, else)` → bare ternary.** (Schema'd/4-arg `ifElse` stays.)

Access rule: OpaqueRef (pattern inputs in compute context; `computed`/`lift`/`derive`/`ifElse` outputs) → **bare**; `Writable`/`Cell` → `.get()` (legal at any computation/JSX site after the binding-site fix in #3725).

## What's in this PR so far — two fully-migrated REFERENCE EXAMPLES
- **`packages/patterns/shopping-list.tsx`** — typical pattern. 0 derive / 0 ifElse / 1 `computed` (`summary`, a genuine statement body kept on purpose). 22/22 pattern tests pass.
- **`packages/patterns/google/core/experimental/gmail-agentic-search.tsx`** — the hardest file (55 derive sites, auth/CFC lore, side-effect watchers, a `schema:` derive). 0 derive / 0 ifElse / 17 `computed` (all justified). 14/14 pattern tests pass. Stale derive-workaround comments cleaned.

These two are intended as the canonical "correct result" examples; the remaining ~400 sites across the pattern codebase will follow the same recipe.

## Prerequisite already landed
- #3725 (auto-wrap `cell.get()` computations at binding sites) — merged; flattens the migration rule.

## Not yet done (tracked)
- [ ] Migrate the remaining ~30 live pattern files (fanning out, reviewing each diff + test).
- [ ] Remove the public `derive` export + runtime delegate + transformer `lowerDeriveCall` + `narrowedWrapperTypeRegistry`.
- [ ] `deprecated/` patterns (deferred; may not block).
- [ ] Docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes `derive` across the remaining patterns, replacing it with plain expressions, minimal `computed`, and ternaries that rely on transformer auto‑wrapping. Completes CT-1621 with no behavior changes; finishes the fan‑out with a final batch and a small lint cleanup.

- **Refactors**
  - Final batch: `packages/patterns/examples/llm.tsx`, `examples/profile-aware-writer.tsx`, `github-activity/main.tsx`, `experimental/folksonomy-demo.tsx`, `google/extractors/email-pattern-launcher.tsx`, `nested-map-ifelse-test.tsx`, `scoped-group-chat/main-with-writable-inputs.tsx`; removed dead `derive` imports.
  - Converted JSX derives to bare ternaries; kept `computed` only for statement bodies, side‑effect watchers, and array transforms; bared redundant authored booleans/titles where safe.
  - Tests: `email-pattern-launcher` 11/11 and `scoped-group-chat` 4/4; previously migrated suites remain green.

- **Bug Fixes**
  - Dropped redundant `!!` casts in JSX ternary conditions flagged by the linter; behavior unchanged.

<sup>Written for commit 9108d55ec7e218c07b74be74034542937eb4cd3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3731?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

