### PR TITLE
perf(runner): drop redundant deep copies in applySetupState

### DIFF
--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -70,7 +70,6 @@ import "./builtins/index.ts";
 import { isCellResult } from "./query-result-proxy.ts";
 import { isCellScope, narrowestScope } from "./scope.ts";
 import {
-  cellAwareDeepCopy,
   describePatternOrModule,
   extractDefaultValues,
   getSigilLink,
@@ -766,18 +765,19 @@ export class Runner {
     );
     const previousInternal = internalCell.getRawUntyped({
       meta: ignoreReadForScheduling,
-      frozen: false,
     });
+    // `fabricFromNativeValue()` below rebuilds a fresh tree from `internal`
+    // without mutating its inputs (true on both the modern and legacy paths),
+    // and `internal` isn't used after that. So the operands can be merged by
+    // reference: no defensive deep copy of `defaults` / `pattern.initial`, and
+    // no mutable (`frozen: false`) read of `previousInternal`, is needed --
+    // `Object.assign` only reads their top-level keys.
     const internal = Object.assign(
       {},
-      cellAwareDeepCopy(
-        (defaults as unknown as { internal: FabricValue })?.internal,
-      ),
-      cellAwareDeepCopy(
-        isRecord(pattern.initial) && isRecord(pattern.initial.internal)
-          ? pattern.initial.internal
-          : {},
-      ),
+      (defaults as unknown as { internal?: FabricValue })?.internal,
+      isRecord(pattern.initial) && isRecord(pattern.initial.internal)
+        ? pattern.initial.internal
+        : {},
       isRecord(previousInternal) ? previousInternal : {},
     ) as FabricValue;
     internalCell.setRawUntyped(fabricFromNativeValue(internal, false));

--- a/packages/runner/test/frozen-mutation.test.ts
+++ b/packages/runner/test/frozen-mutation.test.ts
@@ -129,50 +129,6 @@ describe("frozen-object safety contracts", () => {
     });
   });
 
-  describe("setupInternal deep-copies frozen previousInternal", () => {
-    // setupInternal uses Object.assign({}, deepCopy(defaults), deepCopy(initial),
-    // previousInternal) to merge internal state. When modernDataModel is ON,
-    // previousInternal (read from storage) may be deep-frozen. Object.assign
-    // copies properties shallowly, so frozen nested references propagate into
-    // the mutable result. Deep-copying previousInternal ensures the merged
-    // object is fully mutable.
-
-    it("Object.assign propagates frozen nested references", () => {
-      const frozen = Object.freeze({
-        counter: 0,
-        nested: Object.freeze({ items: [1, 2, 3] }),
-      });
-
-      // Object.assign copies properties shallowly -- the nested reference
-      // is still frozen.
-      const merged = Object.assign({}, frozen);
-      expect(Object.isFrozen(merged)).toBe(false); // target is mutable
-      expect(Object.isFrozen(merged.nested)).toBe(true); // but nested is frozen
-
-      // Mutating the nested reference throws.
-      expect(() => {
-        (merged.nested as Record<string, unknown>).newProp = "value";
-      }).toThrow(TypeError);
-    });
-
-    it("deep copy of frozen object produces fully mutable result", () => {
-      // cellAwareDeepCopy deep-clones the frozen structure, yielding a fully
-      // mutable result. Verified here with structuredClone as a stand-in.
-      const frozen = Object.freeze({
-        counter: 0,
-        nested: Object.freeze({ items: Object.freeze([1, 2, 3]) }),
-      });
-
-      // Deep copy yields fully mutable result.
-      const copied = structuredClone(frozen) as Record<string, unknown>;
-      expect(Object.isFrozen(copied)).toBe(false);
-      const nested = (copied as { nested: Record<string, unknown> }).nested;
-      expect(Object.isFrozen(nested)).toBe(false);
-      nested.newProp = "value";
-      expect(nested.newProp).toBe("value");
-    });
-  });
-
   describe("createObject clones frozen values before injecting defaults", () => {
     // createObject (schema.ts) injects missing default properties into objects.
     // When the input object is frozen, it must be cloned first. These tests


### PR DESCRIPTION
## Summary

`applySetupState` (`runner.ts`) built the merged internal state via:

```ts
const previousInternal = internalCell.getRawUntyped({ …, frozen: false }); // deep mutable clone
const internal = Object.assign(
  {},
  cellAwareDeepCopy(defaults.internal),
  cellAwareDeepCopy(pattern.initial.internal),
  previousInternal,
) as FabricValue;
internalCell.setRawUntyped(fabricFromNativeValue(internal, false));
```

The two `cellAwareDeepCopy` calls and the `{ frozen: false }` (deep-thaw) read are redundant throwaway allocation. Merge the operands by reference and read `previousInternal` frozen (default).

## Why it's safe

- `internal` is passed straight to `fabricFromNativeValue(internal, false)` and **never used again**.
- `fabricFromNativeValue` **rebuilds a fresh tree** from its input's structure and never mutates the input — verified on both flag paths (modern: `resultArray = []` / `Object.create(proto)`; legacy: `new Array` / `Object.fromEntries`).
- `Object.assign` only reads top-level keys; it never mutates its sources.

So the stored result is determined entirely by `fabricFromNativeValue` over the merged *structure* — identical whether operands are shared by reference or pre-deep-copied. The deep copies only ever provided mutation-isolation that nothing here needs (no write to `internal`/sources happens after the merge), and `previousInternal` is only read.

## CellLink-neutral (the subtle part)

`cellAwareDeepCopy`'s special job is preserving `CellLink`s by identity, so dropping it warrants scrutiny:
- It ran *before* `fabricFromNativeValue`, which already normalizes the whole tree — so links flowed through `fabricFromNativeValue` in the old code too. My change doesn't alter their treatment.
- A `CellLink` round-trips through `fabricFromNativeValue` **structurally intact** (verified): sigils are pure JSON (`LINK_V1_TAG` is the string `"link@1"`), so the naive deep-conversion rebuilds an equal, still-recognized link.
- Link lookup/dedup is **structural** (`areNormalizedLinksSame`: `id`+`space`+`scope`+`path`) or string-keyed — nothing relies on `CellLink` JS object identity. (And reference identity never survives the `setRawUntyped` storage write regardless.)

## Test plan

- [x] `deno task test` (runner) — 477 / 0
- [x] `deno task integration` (runner) — 10 / 0
- [x] `deno task integration pattern-tests` — all 50 pass (exercise pattern setup incl. cell references)
- [x] Dropped now-dead `cellAwareDeepCopy` import + an obsolete `frozen-mutation.test.ts` block whose premise no longer holds
- [x] `deno fmt` / `deno check` / `deno lint` on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up runner setup by removing deep copies and the mutable read when merging internal state in applySetupState. Merges by reference and relies on `fabricFromNativeValue` to rebuild the stored tree without mutating inputs.

- **Refactors**
  - Merge defaults, initial, and previous internal via Object.assign without `cellAwareDeepCopy`; read `previousInternal` in its default frozen form.
  - Preserve behavior, including `CellLink`s, since link handling is structural and the tree is re-normalized by `fabricFromNativeValue`.
  - Remove the unused `cellAwareDeepCopy` import and delete the obsolete frozen-mutation test block.

<sup>Written for commit 3d65e54aa678a611ea838ac43c46976d765d4c36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3736?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

