### PR TITLE
Change the metadata related reads to not trigger the scheduler

### DIFF
--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -61,6 +61,7 @@ import type {
   WriterError,
 } from "./storage/interface.ts";
 import { createReadOnlyTransactionError } from "./storage/interface.ts";
+import { ignoreReadForScheduling } from "./storage/reactivity-log.ts";
 import { resolve } from "./storage/transaction/attestation.ts";
 import {
   type IMemorySpaceValueAddress,
@@ -1447,9 +1448,11 @@ function trackVisitedDoc(
   }
   // Load the metadata-linked docs recursively unless we're a retracted fact.
   if (context.includeMeta) {
-    // Loading metadata requires the full doc. This could be narrowed, but it
-    // happens in a non-reactive context.
-    const { ok: fullDoc } = tx.read({ ...target, path: [] });
+    // Loading metadata requires the full doc. Ignore this read for scheduling.
+    const { ok: fullDoc } = tx.read(
+      { ...target, path: [] },
+      { meta: ignoreReadForScheduling },
+    );
     if (fullDoc) {
       loadMetaLinkedDocs(
         tx,
@@ -1498,8 +1501,9 @@ export function loadMetaLinkedDoc(
   if (address === undefined) {
     return undefined;
   }
-  // This only happens in the query path, so don't worry about scheduler
-  const result = tx.read(address);
+  // This read only loads the linked metadata doc so traversal can inspect it.
+  // The schema-guided traversal below records the real scheduling reads.
+  const result = tx.read(address, { meta: ignoreReadForScheduling });
   if (result.error) {
     return undefined;
   }


### PR DESCRIPTION
Top level reads of docs to get metadata resulted in excessive dependencies.

Ran into this while investigating the excess actions in the Pattern Reload Integration test.
This doesn't actually change that, but our dependency graph triggers were really messy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop scheduling on metadata-only reads to reduce unnecessary dependencies and recomputations. This cuts scheduler churn during traversal when loading metadata. 

- **Bug Fixes**
  - Pass `{ meta: ignoreReadForScheduling }` to `tx.read` for full-doc metadata loads and meta-linked doc loads.
  - Keeps schema-driven traversal as the source of real scheduling reads.

<sup>Written for commit 9e117cebcf67fb31c2a2aef7025f2e0b75f063ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3739?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

