### PR TITLE
perf(runner): convert-and-freeze internal/result state to elide a storage clone

### DIFF
--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -782,7 +782,9 @@ export class Runner {
         : {},
       isRecord(previousInternal) ? previousInternal : {},
     ) as FabricValue;
-    // Convert-and-freeze (default): a deep-frozen value lets the storage write
+    // Convert-and-freeze (default): the convert step is load-bearing -- it
+    // normalizes nested `toJSON`-bearing values (so this can't be a plain
+    // clone) -- and producing a deep-frozen result lets the storage write
     // boundary's `cloneIfNecessary` identity-pass instead of
     // deep-cloning-to-freeze.
     internalCell.setRawUntyped(fabricFromNativeValue(internal));

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -735,8 +735,11 @@ export class Runner {
         pattern.resultSchema,
         result,
       );
+      // Convert-and-freeze (default): a deep-frozen value lets the storage
+      // write boundary's `cloneIfNecessary` identity-pass instead of
+      // deep-cloning-to-freeze.
       writableResultCell.setRawUntyped(
-        fabricFromNativeValue(result, false),
+        fabricFromNativeValue(result),
       );
     }
   }
@@ -779,7 +782,10 @@ export class Runner {
         : {},
       isRecord(previousInternal) ? previousInternal : {},
     ) as FabricValue;
-    internalCell.setRawUntyped(fabricFromNativeValue(internal, false));
+    // Convert-and-freeze (default): a deep-frozen value lets the storage write
+    // boundary's `cloneIfNecessary` identity-pass instead of
+    // deep-cloning-to-freeze.
+    internalCell.setRawUntyped(fabricFromNativeValue(internal));
     if (internalLink === undefined) {
       setResultCell(internalCell, resultCell.asSchema(pattern.resultSchema));
       const newInternalCellLink = internalCell.getAsWriteRedirectLink({


### PR DESCRIPTION
## Summary

`applySetupState` and the result-projection update both called `fabricFromNativeValue(value, false)` — producing an **unfrozen** fabric tree, then handing it to `setRawUntyped`. Dropping the `false` (restoring the `frozen=true` default that every other `fabricFromNativeValue` caller uses) makes the value arrive already deep-frozen, which lets the storage write boundary skip a clone.

## The win

At the v2 storage write boundary, the written value is run through `cloneIfNecessary(value)` (frozen by default — `v2-transaction.ts` `isolatedValue`, line ~1096):

- **Before (`false`):** `fabricFromNativeValue` builds an *unfrozen* tree → the boundary `cloneIfNecessary` **deep-clones-and-freezes** it (a full extra traversal + allocation), per pattern setup / result-projection update.
- **After (default):** the modern converter freezes in its single build pass → the value arrives deep-frozen → the boundary `cloneIfNecessary` **identity-passes** (O(1) deep-frozen-cache hit).

Net: one elided deep-clone per setup, scaling with `internal`/`result` size.

## Safety

The only step between conversion and that boundary clone is `findAndInlineDataURILinks`, which is **copy-on-write / non-mutating** — it only reads its input, allocating fresh containers when it rewrites a `data:`-URI link. A frozen input flows through untouched. End state is identical (the stored value is deep-frozen either way); this just stops producing it unfrozen only to re-clone-and-freeze it one step later. The two sites are the only `fabricFromNativeValue(_, false)` calls in the tree; everything else already uses the frozen default.

## Test plan

- [x] `deno task test` (runner) — 476 / 0
- [x] `deno task integration` (runner) — 10 / 0
- [x] `deno task integration pattern-tests` — all 51 pass (exercise setup + read-back of internal/result state)
- [x] `deno fmt` / `deno check` on touched file

Note: setup-path change (pattern instantiation/rebind + result projection), so it won't register on steady-state benches/perf-check; perf-check deltas here are expected to be noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
