### PR TITLE
refactor(runner): ACLManager.get() returns a frozen view; set/remove build fresh

### DIFF
--- a/packages/runner/src/acl-manager.ts
+++ b/packages/runner/src/acl-manager.ts
@@ -1,8 +1,8 @@
 import { ACL, ACLUser, DID } from "@commonfabric/memory/acl";
 import { Capability } from "@commonfabric/memory/interface";
 import {
-  cloneIfNecessary,
   type FabricValue,
+  shallowMutableClone,
 } from "@commonfabric/data-model/fabric-value";
 import type { Cell } from "./cell.ts";
 import type { Runtime } from "./runtime.ts";
@@ -26,7 +26,9 @@ export class ACLManager {
       throw new Error("No ACL initialized for space.");
     }
 
-    return cloneIfNecessary(aclData as FabricValue, { frozen: false }) as ACL;
+    // `set`/`remove` only write or delete a single top-level entry, so a
+    // mutable top-level copy is all that's needed.
+    return shallowMutableClone(aclData as FabricValue) as ACL;
   }
 
   async set(user: ACLUser, capability: Capability): Promise<void> {

--- a/packages/runner/src/acl-manager.ts
+++ b/packages/runner/src/acl-manager.ts
@@ -1,8 +1,8 @@
 import { ACL, ACLUser, DID } from "@commonfabric/memory/acl";
 import { Capability } from "@commonfabric/memory/interface";
 import {
+  cloneIfNecessary,
   type FabricValue,
-  shallowMutableClone,
 } from "@commonfabric/data-model/fabric-value";
 import type { Cell } from "./cell.ts";
 import type { Runtime } from "./runtime.ts";
@@ -26,21 +26,21 @@ export class ACLManager {
       throw new Error("No ACL initialized for space.");
     }
 
-    // `set`/`remove` only write or delete a single top-level entry, so a
-    // mutable top-level copy is all that's needed.
-    return shallowMutableClone(aclData as FabricValue) as ACL;
+    // Return an immutable, isolated view: `cloneIfNecessary` (frozen by
+    // default) identity-passes the already-deep-frozen stored value (zero-copy)
+    // and otherwise freezes a clone. Callers that change the ACL (`set` /
+    // `remove`) build a fresh object rather than mutating this.
+    return cloneIfNecessary(aclData as FabricValue) as ACL;
   }
 
   async set(user: ACLUser, capability: Capability): Promise<void> {
     const acl = await this.get();
-    acl[user] = capability;
-    await this.#write(acl);
+    await this.#write({ ...acl, [user]: capability });
   }
 
   async remove(user: ACLUser): Promise<void> {
-    const acl = await this.get();
-    delete acl[user];
-    await this.#write(acl);
+    const { [user]: _removed, ...rest } = await this.get();
+    await this.#write(rest);
   }
 
   async #write(acl: ACL): Promise<void> {


### PR DESCRIPTION
## Summary

`ACLManager.get()` returned a **deep mutable clone** of the stored ACL (`cloneIfNecessary(aclData, { frozen: false })`) — purely so `set`/`remove` could mutate it in place before writing. But `get()`'s only external consumer reads it read-only (the CLI `acl` command renders a table from it). So the result doesn't need to be mutable.

- **`get()`** now returns an immutable, isolated view: `cloneIfNecessary(aclData)` (frozen default) **identity-passes the already-deep-frozen stored value (zero-copy)** on the common read path, and freezes a clone otherwise — versus an unconditional deep mutable clone on every call.
- **`set`/`remove`** build a fresh ACL instead of mutating the view: spread to add/replace (`{ ...acl, [user]: capability }`), destructuring-omit to remove (`const { [user]: _removed, ...rest } = acl`).

Net: the read path is allocation-free, writes cost the same single shallow object as before, and the public `get()` result is immutable (mutation attempts surface loudly rather than silently editing a throwaway copy).

`ACL` is flat (`{ [user]?: "READ"|"WRITE"|"OWNER" }`), so the spread/omit builds are exact and wrapper-safe.

## Test plan

- [x] `deno task test` (runner) — 476 / 0
- [x] `deno check` (runner `acl-manager.ts` + the CLI `getAcl` consumer) + `deno lint`
- [x] Confirmed the only mutators of `get()`'s result are internal (`set`/`remove`); the external consumer (`cli/commands/acl.ts`) is read-only.

Note: setup/admin-path code (ACL reads/writes are infrequent), so no perf-check signal expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
