### PR TITLE
docs(data-model): backtick true/false + rephrase adjacent-backtick in fabric-instances test labels

### DIFF
--- a/packages/data-model/test/fabric-instances/FabricError.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricError.test.ts
@@ -181,7 +181,7 @@ describe("FabricError", () => {
     });
 
     describe("toNativeValue()", () => {
-      it("returns a frozen `Error` projection when `frozen` is true", () => {
+      it("returns a frozen `Error` projection when `frozen` is `true`", () => {
         const err = new Error("native");
         const se = FabricError.fromNativeError(err);
         const result = se.toNativeValue(true);
@@ -204,7 +204,7 @@ describe("FabricError", () => {
         expect(Object.isFrozen(a)).toBe(true);
       });
 
-      it("returns a fresh unfrozen `Error` projection when `frozen` is false", () => {
+      it("returns a fresh unfrozen `Error` projection when `frozen` is `false`", () => {
         const se = FabricError.fromNativeError(new Error("native"));
         const result = se.toNativeValue(false);
         expect(result).toBeInstanceOf(Error);
@@ -212,7 +212,7 @@ describe("FabricError", () => {
         expect(Object.isFrozen(result)).toBe(false);
       });
 
-      it("returns a fresh copy each call when `frozen` is false", () => {
+      it("returns a fresh copy each call when `frozen` is `false`", () => {
         const se = FabricError.fromNativeError(new Error("native"));
         const a = se.toNativeValue(false);
         const b = se.toNativeValue(false);
@@ -244,7 +244,7 @@ describe("FabricError", () => {
         expect(Object.isFrozen(childObj)).toBe(true);
       });
 
-      it("via dispatch: `[IS_DEEP_FROZEN]` true only when wrapper + cause are frozen", () => {
+      it("via dispatch: `[IS_DEEP_FROZEN]` `true` only when wrapper + cause are frozen", () => {
         const fe = FabricError.fromNativeError(new Error("test"));
         expect(isDeepFrozenFabricValue(fe)).toBe(false);
         Object.freeze(fe); // wrapper only; some descendants still mutable
@@ -276,7 +276,7 @@ describe("FabricError", () => {
         expect(Object.isFrozen(childObj)).toBe(true);
       });
 
-      it("via direct member invocation: `[IS_DEEP_FROZEN]` true only when wrapper is frozen", () => {
+      it("via direct member invocation: `[IS_DEEP_FROZEN]` `true` only when wrapper is frozen", () => {
         const fe = FabricError.fromNativeError(new Error("test"));
         expect(fe[IS_DEEP_FROZEN](subIsDeepFrozen)).toBe(false);
         fe[DEEP_FREEZE](subFreeze);

--- a/packages/data-model/test/fabric-instances/FabricError.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricError.test.ts
@@ -244,7 +244,7 @@ describe("FabricError", () => {
         expect(Object.isFrozen(childObj)).toBe(true);
       });
 
-      it("via dispatch: `[IS_DEEP_FROZEN]` `true` only when wrapper + cause are frozen", () => {
+      it("via dispatch: `[IS_DEEP_FROZEN]` is `true` only when wrapper + cause are frozen", () => {
         const fe = FabricError.fromNativeError(new Error("test"));
         expect(isDeepFrozenFabricValue(fe)).toBe(false);
         Object.freeze(fe); // wrapper only; some descendants still mutable
@@ -276,7 +276,7 @@ describe("FabricError", () => {
         expect(Object.isFrozen(childObj)).toBe(true);
       });
 
-      it("via direct member invocation: `[IS_DEEP_FROZEN]` `true` only when wrapper is frozen", () => {
+      it("via direct member invocation: `[IS_DEEP_FROZEN]` is `true` only when wrapper is frozen", () => {
         const fe = FabricError.fromNativeError(new Error("test"));
         expect(fe[IS_DEEP_FROZEN](subIsDeepFrozen)).toBe(false);
         fe[DEEP_FREEZE](subFreeze);

--- a/packages/data-model/test/fabric-instances/FabricMap.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricMap.test.ts
@@ -37,7 +37,7 @@ describe("FabricMap", () => {
     });
 
     describe("toNativeValue()", () => {
-      it("returns a `FrozenMap` when `frozen` is true", () => {
+      it("returns a `FrozenMap` when `frozen` is `true`", () => {
         const map = new Map<FabricValue, FabricValue>([["a", 1]]);
         const sm = new FabricMap(map);
         const result = sm.toNativeValue(true);
@@ -45,7 +45,7 @@ describe("FabricMap", () => {
         expect((result as FrozenMap<string, number>).get("a")).toBe(1);
       });
 
-      it("returns the original `Map` when `frozen` is false", () => {
+      it("returns the original `Map` when `frozen` is `false`", () => {
         const map = new Map<FabricValue, FabricValue>([["a", 1]]);
         const sm = new FabricMap(map);
         const result = sm.toNativeValue(false);

--- a/packages/data-model/test/fabric-instances/FabricRegExp.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricRegExp.test.ts
@@ -130,7 +130,7 @@ describe("FabricRegExp", () => {
     });
 
     describe("toNativeValue()", () => {
-      it("returns a frozen `RegExp` (copy of unfrozen) when `frozen` is true", () => {
+      it("returns a frozen `RegExp` (copy of unfrozen) when `frozen` is `true`", () => {
         const re = /abc/gi;
         const sr = new FabricRegExp(re);
         const result = sr.toNativeValue(true);
@@ -149,7 +149,7 @@ describe("FabricRegExp", () => {
         expect(result).toBe(re); // same reference
       });
 
-      it("returns the original unfrozen `RegExp` when `frozen` is false", () => {
+      it("returns the original unfrozen `RegExp` when `frozen` is `false`", () => {
         const re = /abc/gi;
         const sr = new FabricRegExp(re);
         const result = sr.toNativeValue(false);
@@ -157,7 +157,7 @@ describe("FabricRegExp", () => {
         expect(Object.isFrozen(result)).toBe(false);
       });
 
-      it("returns an unfrozen copy of a frozen `RegExp` when `frozen` is false", () => {
+      it("returns an unfrozen copy of a frozen `RegExp` when `frozen` is `false`", () => {
         const re = Object.freeze(/abc/gi);
         const sr = new FabricRegExp(re);
         const result = sr.toNativeValue(false);
@@ -179,7 +179,7 @@ describe("FabricRegExp", () => {
         expect(Object.isFrozen(fr.regex)).toBe(true);
       });
 
-      it("via dispatch: `[IS_DEEP_FROZEN]` true only when wrapper + `RegExp` frozen", () => {
+      it("via dispatch: `[IS_DEEP_FROZEN]` `true` only when wrapper + `RegExp` frozen", () => {
         const fr = new FabricRegExp(/abc/g);
         expect(isDeepFrozenFabricValue(fr)).toBe(false);
         deepFreeze(fr);
@@ -195,7 +195,7 @@ describe("FabricRegExp", () => {
         expect(Object.isFrozen(fr.regex)).toBe(true);
       });
 
-      it("via direct member invocation: `[IS_DEEP_FROZEN]` true only when wrapper + `RegExp` frozen", () => {
+      it("via direct member invocation: `[IS_DEEP_FROZEN]` `true` only when wrapper + `RegExp` frozen", () => {
         const fr = new FabricRegExp(/abc/g);
         expect(fr[IS_DEEP_FROZEN](subIsDeepFrozen)).toBe(false);
         fr[DEEP_FREEZE](subFreeze);
@@ -276,7 +276,7 @@ describe("FabricRegExp", () => {
       expect(tagFromNativeClass(RegExp)).toBe(NATIVE_TAGS.RegExp);
     });
 
-    it("`isConvertibleNativeInstance()` returns true for `RegExp`", () => {
+    it("`isConvertibleNativeInstance()` returns `true` for `RegExp`", () => {
       expect(isConvertibleNativeInstance(/abc/)).toBe(true);
       expect(isConvertibleNativeInstance(new RegExp("test", "gi"))).toBe(true);
     });
@@ -290,11 +290,11 @@ describe("FabricRegExp", () => {
       resetDataModelConfig();
     });
 
-    it("returns true for a plain `RegExp`", () => {
+    it("returns `true` for a plain `RegExp`", () => {
       expect(isFabricCompatible(/abc/gi)).toBe(true);
     });
 
-    it("returns true for a `RegExp` nested in objects", () => {
+    it("returns `true` for a `RegExp` nested in objects", () => {
       expect(isFabricCompatible({ pattern: /abc/gi })).toBe(true);
     });
   });

--- a/packages/data-model/test/fabric-instances/FabricRegExp.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricRegExp.test.ts
@@ -179,7 +179,7 @@ describe("FabricRegExp", () => {
         expect(Object.isFrozen(fr.regex)).toBe(true);
       });
 
-      it("via dispatch: `[IS_DEEP_FROZEN]` `true` only when wrapper + `RegExp` frozen", () => {
+      it("via dispatch: `[IS_DEEP_FROZEN]` is `true` only when wrapper + `RegExp` frozen", () => {
         const fr = new FabricRegExp(/abc/g);
         expect(isDeepFrozenFabricValue(fr)).toBe(false);
         deepFreeze(fr);
@@ -195,7 +195,7 @@ describe("FabricRegExp", () => {
         expect(Object.isFrozen(fr.regex)).toBe(true);
       });
 
-      it("via direct member invocation: `[IS_DEEP_FROZEN]` `true` only when wrapper + `RegExp` frozen", () => {
+      it("via direct member invocation: `[IS_DEEP_FROZEN]` is `true` only when wrapper + `RegExp` frozen", () => {
         const fr = new FabricRegExp(/abc/g);
         expect(fr[IS_DEEP_FROZEN](subIsDeepFrozen)).toBe(false);
         fr[DEEP_FREEZE](subFreeze);
@@ -215,7 +215,7 @@ describe("FabricRegExp", () => {
         expect(result.flavor).toBe("es2025");
       });
 
-      it("defaults to empty `source`, `flags`, and `es2025` `flavor`", () => {
+      it("defaults to empty `source`, `flags`, and `es2025` flavor", () => {
         const state = {} as FabricValue;
         const result = FabricRegExp[RECONSTRUCT](state, dummyContext);
         expect(result.regex.source).toBe("(?:)");

--- a/packages/data-model/test/fabric-instances/FabricSet.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricSet.test.ts
@@ -30,7 +30,7 @@ describe("FabricSet", () => {
     });
 
     describe("toNativeValue()", () => {
-      it("returns a `FrozenSet` when `frozen` is true", () => {
+      it("returns a `FrozenSet` when `frozen` is `true`", () => {
         const set = new Set<FabricValue>([1, 2]);
         const ss = new FabricSet(set);
         const result = ss.toNativeValue(true);
@@ -38,7 +38,7 @@ describe("FabricSet", () => {
         expect((result as FrozenSet<number>).has(1)).toBe(true);
       });
 
-      it("returns the original `Set` when `frozen` is false", () => {
+      it("returns the original `Set` when `frozen` is `false`", () => {
         const set = new Set<FabricValue>([1, 2]);
         const ss = new FabricSet(set);
         const result = ss.toNativeValue(false);

--- a/packages/data-model/test/fabric-instances/native-instance-utils.test.ts
+++ b/packages/data-model/test/fabric-instances/native-instance-utils.test.ts
@@ -493,7 +493,7 @@ describe("native-instance-utils", () => {
     const frozenCtx = new DummyReconstructionContext(true);
     const mutableCtx = new DummyReconstructionContext(false);
 
-    it("`FabricError`: `shouldDeepFreeze` `true` => deep-frozen, `false` => mutable", () => {
+    it("`FabricError`: `shouldDeepFreeze` is `true` => deep-frozen, `false` => mutable", () => {
       const state = {
         type: "Error",
         name: null,
@@ -505,7 +505,7 @@ describe("native-instance-utils", () => {
       expect(Object.isFrozen(mutable)).toBe(false);
     });
 
-    it("`FabricRegExp`: `shouldDeepFreeze` `true` => deep-frozen, `false` => mutable", () => {
+    it("`FabricRegExp`: `shouldDeepFreeze` is `true` => deep-frozen, `false` => mutable", () => {
       const state = {
         source: "abc",
         flags: "g",
@@ -518,7 +518,7 @@ describe("native-instance-utils", () => {
       expect(Object.isFrozen(mutable)).toBe(false);
     });
 
-    it("`ProblematicValue`: `shouldDeepFreeze` `true` => deep-frozen, `false` => mutable", () => {
+    it("`ProblematicValue`: `shouldDeepFreeze` is `true` => deep-frozen, `false` => mutable", () => {
       const state = {
         type: "Bad@1",
         state: { x: 1 },
@@ -530,7 +530,7 @@ describe("native-instance-utils", () => {
       expect(Object.isFrozen(mutable)).toBe(false);
     });
 
-    it("`UnknownValue`: `shouldDeepFreeze` `true` => deep-frozen, `false` => mutable", () => {
+    it("`UnknownValue`: `shouldDeepFreeze` is `true` => deep-frozen, `false` => mutable", () => {
       const state = { type: "Fancy@3", state: { y: 2 } } as unknown as {
         type: string;
         state: FabricValue;

--- a/packages/data-model/test/fabric-instances/native-instance-utils.test.ts
+++ b/packages/data-model/test/fabric-instances/native-instance-utils.test.ts
@@ -398,7 +398,7 @@ describe("native-instance-utils", () => {
   });
 
   describe("isConvertibleNativeInstance", () => {
-    it("returns true for all convertible types", () => {
+    it("returns `true` for all convertible types", () => {
       expect(isConvertibleNativeInstance(new Error("e"))).toBe(true);
       expect(isConvertibleNativeInstance(new TypeError("e"))).toBe(true);
       expect(isConvertibleNativeInstance(new Map())).toBe(true);
@@ -407,57 +407,57 @@ describe("native-instance-utils", () => {
       expect(isConvertibleNativeInstance(new Uint8Array())).toBe(true);
     });
 
-    it("returns true for exotic Error subclass", () => {
+    it("returns `true` for exotic `Error` subclass", () => {
       class WeirdError extends RangeError {}
       expect(isConvertibleNativeInstance(new WeirdError("weird"))).toBe(true);
     });
 
-    it("returns true for RegExp", () => {
+    it("returns `true` for `RegExp`", () => {
       expect(isConvertibleNativeInstance(/abc/)).toBe(true);
     });
 
-    it("returns false for non-convertible types", () => {
+    it("returns `false` for non-convertible types", () => {
       expect(isConvertibleNativeInstance({})).toBe(false);
       expect(isConvertibleNativeInstance([])).toBe(false);
       expect(isConvertibleNativeInstance(new WeakMap())).toBe(false);
     });
 
-    it("returns false for objects with `toJSON()`", () => {
+    it("returns `false` for objects with `toJSON()`", () => {
       expect(isConvertibleNativeInstance({ toJSON: () => "x" })).toBe(false);
     });
   });
 
   describe("FabricInstance instanceof checks", () => {
-    it("returns false for `null`", () => {
+    it("returns `false` for `null`", () => {
       expect((null as unknown) instanceof FabricInstance).toBe(false);
     });
 
-    it("returns false for `undefined`", () => {
+    it("returns `false` for `undefined`", () => {
       expect((undefined as unknown) instanceof FabricInstance).toBe(false);
     });
 
-    it("returns false for primitives", () => {
+    it("returns `false` for primitives", () => {
       expect((42 as unknown) instanceof FabricInstance).toBe(false);
       expect(("hello" as unknown) instanceof FabricInstance).toBe(false);
       expect((true as unknown) instanceof FabricInstance).toBe(false);
     });
 
-    it("returns false for plain objects", () => {
+    it("returns `false` for plain objects", () => {
       expect(({} as unknown) instanceof FabricInstance).toBe(false);
       expect(({ a: 1 } as unknown) instanceof FabricInstance).toBe(false);
     });
 
-    it("returns true for `UnknownValue`", () => {
+    it("returns `true` for `UnknownValue`", () => {
       const us = new UnknownValue("Test@1", null);
       expect(us instanceof FabricInstance).toBe(true);
     });
 
-    it("returns true for `ProblematicValue`", () => {
+    it("returns `true` for `ProblematicValue`", () => {
       const ps = new ProblematicValue("Test@1", null, "oops");
       expect(ps instanceof FabricInstance).toBe(true);
     });
 
-    it("returns true for custom `FabricInstance` subclass", () => {
+    it("returns `true` for custom `FabricInstance` subclass", () => {
       class CustomFabInst extends BaseFabricInstance {
         [DECONSTRUCT](): FabricValue {
           return { value: 42 };
@@ -483,7 +483,7 @@ describe("native-instance-utils", () => {
       expect(instance instanceof FabricInstance).toBe(true);
     });
 
-    it("returns true for `FabricError`", () => {
+    it("returns `true` for `FabricError`", () => {
       const se = FabricError.fromNativeError(new Error("test"));
       expect(se instanceof FabricInstance).toBe(true);
     });
@@ -493,7 +493,7 @@ describe("native-instance-utils", () => {
     const frozenCtx = new DummyReconstructionContext(true);
     const mutableCtx = new DummyReconstructionContext(false);
 
-    it("`FabricError`: `shouldDeepFreeze` true => deep-frozen, false => mutable", () => {
+    it("`FabricError`: `shouldDeepFreeze` `true` => deep-frozen, `false` => mutable", () => {
       const state = {
         type: "Error",
         name: null,
@@ -505,7 +505,7 @@ describe("native-instance-utils", () => {
       expect(Object.isFrozen(mutable)).toBe(false);
     });
 
-    it("`FabricRegExp`: `shouldDeepFreeze` true => deep-frozen, false => mutable", () => {
+    it("`FabricRegExp`: `shouldDeepFreeze` `true` => deep-frozen, `false` => mutable", () => {
       const state = {
         source: "abc",
         flags: "g",
@@ -518,7 +518,7 @@ describe("native-instance-utils", () => {
       expect(Object.isFrozen(mutable)).toBe(false);
     });
 
-    it("`ProblematicValue`: `shouldDeepFreeze` true => deep-frozen, false => mutable", () => {
+    it("`ProblematicValue`: `shouldDeepFreeze` `true` => deep-frozen, `false` => mutable", () => {
       const state = {
         type: "Bad@1",
         state: { x: 1 },
@@ -530,7 +530,7 @@ describe("native-instance-utils", () => {
       expect(Object.isFrozen(mutable)).toBe(false);
     });
 
-    it("`UnknownValue`: `shouldDeepFreeze` true => deep-frozen, false => mutable", () => {
+    it("`UnknownValue`: `shouldDeepFreeze` `true` => deep-frozen, `false` => mutable", () => {
       const state = { type: "Fancy@3", state: { y: 2 } } as unknown as {
         type: string;
         state: FabricValue;


### PR DESCRIPTION
Follow-up to the `fabric-instances` conformance pass (#3723): applies
the two convention refinements that landed *after* #3723's train —
backtick **constant-referring true/false** in labels (err toward
backticks), and the **adjacent-backtick rephrase** rule — across the
`fabric-instances` test files.

- Backtick constant-referring `true`/`false` in `describe()`/`it()`
  label strings.
- Rephrase adjacent-backtick spans (where two backticked tokens would
  abut) for readability, per the ratified rule.

Markup-only — no behavior or test-semantics change; `it()`-count
unchanged (163).

Scope: 5 `fabric-instances` test files (`FabricError`, `FabricMap`,
`FabricRegExp`, `FabricSet`, `native-instance-utils`), +35/-35 (net vs
`main`, two-dot). Conservation: `it()`-count 163 unchanged; full
data-model suite 37 passed / 1788 steps / 0 failed; `fmt`/`lint`/`check`
clean. Flux pre-vetted the true/false core.

Closes the `fabric-instances` markup loop left by #3723 (which predated
these two ratified conventions).

Co-Authored-By: coder-colt (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
