### PR TITLE
docs(data-model): fix Markdown-in-code conformance in fabric-primitives test labels

### DIFF
--- a/packages/data-model/test/fabric-primitives/FabricEpochDays.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochDays.test.ts
@@ -30,7 +30,7 @@ describe("FabricEpochDays", () => {
 
   describe("instance members", () => {
     describe(".value", () => {
-      it("wraps a bigint value", () => {
+      it("wraps a `bigint` value", () => {
         const sd = new FabricEpochDays(19723n);
         expect(sd.value).toBe(19723n);
       });
@@ -50,7 +50,7 @@ describe("FabricEpochDays", () => {
   // Exercises the free `shallowFabricFromNativeValue()` rather than a member
   // of the class, so it lives directly under the class `describe()`.
   describe("shallowFabricFromNativeValue() integration", () => {
-    it("passes through unchanged even with freeze=false", () => {
+    it("passes through unchanged even with `freeze=false`", () => {
       setDataModelConfig(true);
       try {
         const days = new FabricEpochDays(456n);

--- a/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
@@ -30,7 +30,7 @@ describe("FabricEpochNsec", () => {
 
   describe("instance members", () => {
     describe(".value", () => {
-      it("wraps a bigint value", () => {
+      it("wraps a `bigint` value", () => {
         const sn = new FabricEpochNsec(1234567890000000000n);
         expect(sn.value).toBe(1234567890000000000n);
       });
@@ -56,7 +56,7 @@ describe("FabricEpochNsec", () => {
   // Exercises the free `shallowFabricFromNativeValue()` rather than a member
   // of the class, so it lives directly under the class `describe()`.
   describe("shallowFabricFromNativeValue() integration", () => {
-    it("passes through unchanged even with freeze=false", () => {
+    it("passes through unchanged even with `freeze=false`", () => {
       setDataModelConfig(true);
       try {
         const nsec = new FabricEpochNsec(123n);

--- a/packages/data-model/test/fabric-primitives/FabricHash.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricHash.test.ts
@@ -115,7 +115,7 @@ describe("FabricHash", () => {
 
   describe("static members", () => {
     describe("fromJson()", () => {
-      it("works on the result of the instance method toJSON()", () => {
+      it("works on the result of the instance method `toJSON()`", () => {
         const original = new FabricHash(SAMPLE_HASH, "fid1");
         const json = original.toJSON();
         const reconstructed = FabricHash.fromJson(json);
@@ -127,7 +127,7 @@ describe("FabricHash", () => {
     });
 
     describe("fromString()", () => {
-      it("works on the result of the instance method toString()", () => {
+      it("works on the result of the instance method `toString()`", () => {
         // Use a non-fid1 tag to verify the parser doesn't hardcode it.
         const original = new FabricHash(SAMPLE_HASH, "sha3");
         const str = original.toString();


### PR DESCRIPTION
PR-D (TASK-0030) — the final item-2 strand. Markup-only Markdown-in-code
conformance on the `fabric-primitives` **test** labels (the 4th and last
test subdir of the sweep), 6 sites across 3 files:

- `FabricEpochDays.test.ts` / `FabricEpochNsec.test.ts`: backtick the
  `bigint` value + the `freeze=false` snippet.
- `FabricHash.test.ts`: backtick the bare callables `toJSON()` /
  `toString()` in the `fromJson()` / `fromString()` `it()` labels.

`FabricBytes.test.ts` was already conformant (no change).
`FabricHash.test.ts:90` `base64url` left bare (prose format-name, not a
code symbol). Per the ratified backticking convention + adjacent-backtick
rule (zero adjacent spans). No behavior or test-semantics change;
`it()`-count unchanged (38).

Scope: 3 `fabric-primitives` test files, +6/-6 (net vs `main`, two-dot).
Conservation: `it()`-count 38 unchanged; full data-model suite 37 passed
/ 1788 steps / 0 failed; `fmt`/`lint`/`check` clean.

Closes the data-model test-label Markdown-in-code conformance sweep
(item-2) — the 4th/last test subdir after `fabric-instances` (#3723 +
#3744), `json-wire` (#3727), and the top-level clusters (#3729 / #3741).

Co-Authored-By: coder-colt (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backticked code references in `fabric-primitives` test labels to meet Markdown-in-code conformance, completing TASK-0030 item-2. Docs-only changes; no runtime or test behavior changes.

- **Refactors**
  - `FabricEpochDays.test.ts` and `FabricEpochNsec.test.ts`: backticked `bigint` and `freeze=false`.
  - `FabricHash.test.ts`: backticked `toJSON()` and `toString()`; left `base64url` plain per convention.

<sup>Written for commit 50cf994285726a5fa816acbaae125923642bba66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

