### PR TITLE
test(patterns): tune reload scheduler regression budget

### DIFF
--- a/packages/patterns/integration/reload/default-app-notebook.test.ts
+++ b/packages/patterns/integration/reload/default-app-notebook.test.ts
@@ -12,8 +12,8 @@ import {
 const { FRONTEND_URL } = env;
 // Keep these as guardrails rather than exact budgets; CI reload runs vary
 // slightly while still exercising persisted scheduler-state reuse.
-const NOTEBOOK_RELOAD_GRAPH_ACTION_RUN_LIMIT = 125;
-const NOTEBOOK_RELOAD_COMPUTATION_RUN_LIMIT = 70;
+const NOTEBOOK_RELOAD_TOTAL_ACTION_RUN_LIMIT = 150;
+const NOTEBOOK_RELOAD_COMPUTATION_RUN_LIMIT = 80;
 const NOTEBOOK_RELOAD_TIMEOUT_MS = 180_000;
 
 const EXPECT_PERSISTENT_SCHEDULER_STATE = (() => {
@@ -111,9 +111,9 @@ describe("default-app notebook reload integration test", () => {
     if (!EXPECT_PERSISTENT_SCHEDULER_STATE) return;
 
     assert(
-      schedulerSummary.graph.actionRunsFromStats <=
-        NOTEBOOK_RELOAD_GRAPH_ACTION_RUN_LIMIT,
-      `Expected notebook reload to stay within <= ${NOTEBOOK_RELOAD_GRAPH_ACTION_RUN_LIMIT} current graph action runs, saw ${schedulerSummary.graph.actionRunsFromStats}`,
+      schedulerSummary.graph.actionRuns <=
+        NOTEBOOK_RELOAD_TOTAL_ACTION_RUN_LIMIT,
+      `Expected notebook reload to stay within <= ${NOTEBOOK_RELOAD_TOTAL_ACTION_RUN_LIMIT} total action runs, saw ${schedulerSummary.graph.actionRuns}`,
     );
     assert(
       schedulerSummary.graph.computationRunsFromStats <=

--- a/packages/patterns/integration/reload/default-app-notebook.test.ts
+++ b/packages/patterns/integration/reload/default-app-notebook.test.ts
@@ -12,8 +12,8 @@ import {
 const { FRONTEND_URL } = env;
 // Keep these as guardrails rather than exact budgets; CI reload runs vary
 // slightly while still exercising persisted scheduler-state reuse.
-const NOTEBOOK_RELOAD_TOTAL_ACTION_RUN_LIMIT = 160;
-const NOTEBOOK_RELOAD_COMPUTATION_RUN_LIMIT = 90;
+const NOTEBOOK_RELOAD_GRAPH_ACTION_RUN_LIMIT = 125;
+const NOTEBOOK_RELOAD_COMPUTATION_RUN_LIMIT = 70;
 const NOTEBOOK_RELOAD_TIMEOUT_MS = 180_000;
 
 const EXPECT_PERSISTENT_SCHEDULER_STATE = (() => {
@@ -111,9 +111,9 @@ describe("default-app notebook reload integration test", () => {
     if (!EXPECT_PERSISTENT_SCHEDULER_STATE) return;
 
     assert(
-      schedulerSummary.graph.actionRuns <=
-        NOTEBOOK_RELOAD_TOTAL_ACTION_RUN_LIMIT,
-      `Expected notebook reload to stay within <= ${NOTEBOOK_RELOAD_TOTAL_ACTION_RUN_LIMIT} total action runs, saw ${schedulerSummary.graph.actionRuns}`,
+      schedulerSummary.graph.actionRunsFromStats <=
+        NOTEBOOK_RELOAD_GRAPH_ACTION_RUN_LIMIT,
+      `Expected notebook reload to stay within <= ${NOTEBOOK_RELOAD_GRAPH_ACTION_RUN_LIMIT} current graph action runs, saw ${schedulerSummary.graph.actionRunsFromStats}`,
     );
     assert(
       schedulerSummary.graph.computationRunsFromStats <=


### PR DESCRIPTION
## Summary

- tune the notebook reload integration guardrail to catch a full persistent-scheduler rehydration regression
- assert total raw scheduler action runs stay under 150 and computation runs stay under 80
- keep the final reload render assertion so the test verifies all 7 notes render after reload

## Validation

- `deno fmt --check packages/patterns/integration/reload/default-app-notebook.test.ts`
- `deno lint packages/patterns/integration/reload/default-app-notebook.test.ts`
- `HEADLESS=1 PIPE_CONSOLE=1 deno task integration --port-offset=893 patterns-reload`

## Notes

The local comparison was roughly 136 raw action runs / 61 computation runs with persisted scheduler state enabled, versus 163 raw action runs / 84-85 computation runs with it disabled. The new limits are intended to fail the full-regression path while leaving CI variance headroom.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightened the notebook reload integration test guardrails to catch full regressions in persisted scheduler rehydration while keeping CI variance headroom. Lowered budgets to 150 total action runs (from 160) and 80 computation runs (from 90), and kept the final reload assertion to verify all 7 notes render.

<sup>Written for commit 5cd145d81afdab1b7f3bf7c350f1c8b1eac024aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3746?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

