### PR TITLE
[codex] Test cf-harness stdio close error priority

### DIFF
--- a/packages/cf-harness/test/interactive-chat-stdio.test.ts
+++ b/packages/cf-harness/test/interactive-chat-stdio.test.ts
@@ -259,6 +259,47 @@ Deno.test("interactive NDJSON transport waits for active turns before close afte
   assertEquals(closeBeforeLoopFinished, false);
 });
 
+Deno.test("interactive NDJSON transport preserves write failure over close hook failure", async () => {
+  let closeCalls = 0;
+  const service = new HarnessInteractiveChatService({
+    onEvent: async () => {},
+  });
+
+  await assertRejects(
+    () =>
+      runHarnessInteractiveChatNdjsonTransport({
+        lines: [
+          JSON.stringify({
+            type: HARNESS_CHAT_REQUEST_TYPE,
+            protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+            requestId: "req-start-session",
+            method: "start_session",
+            params: {
+              sessionId: "session-1",
+              workspace: { hostPath: "/workspace" },
+              model: "gpt-test",
+            },
+          }),
+        ],
+        createService: () => service,
+        closeService: () => {
+          closeCalls += 1;
+          throw new Error("simulated close failure");
+        },
+        writeLine: (line) => {
+          const envelope = JSON.parse(line) as Record<string, unknown>;
+          if (envelope.requestId === "req-start-session") {
+            throw new Error("simulated stdout failure");
+          }
+        },
+      }),
+    Error,
+    "simulated stdout failure",
+  );
+
+  assertEquals(closeCalls, 1);
+});
+
 Deno.test("interactive NDJSON transport calls close hook after normal completion", async () => {
   const output: string[] = [];
   let closeCalls = 0;


### PR DESCRIPTION
## Summary

Adds a focused regression test for cf-harness interactive chat stdio transport cleanup/error priority.

The test covers the case where writing a response fails and `closeService` also throws during cleanup. The expected behavior is that the original transport/write failure is preserved while the close hook still runs.

## Validation

- `deno fmt packages/cf-harness/test/interactive-chat-stdio.test.ts`
- `deno check packages/cf-harness/src/interactive-chat-stdio.ts packages/cf-harness/test/interactive-chat-stdio.test.ts`
- `deno test --allow-read --allow-write --allow-run --allow-ffi --allow-net --allow-env packages/cf-harness/test/interactive-chat-stdio.test.ts`
- `deno lint packages/cf-harness/test/interactive-chat-stdio.test.ts`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a focused regression test to `cf-harness` interactive NDJSON stdio transport to ensure a response write error takes priority over a close hook error, while the close hook still runs once. Guards against masking the original transport failure during cleanup.

<sup>Written for commit 63845a00f94e85d816d2b8f78fcc2c1a34e15a15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

