### PR TITLE
refactor(memory): route v2 patch ops through cloneForMutation

### DIFF
--- a/packages/memory/test/v2-patch-test.ts
+++ b/packages/memory/test/v2-patch-test.ts
@@ -273,6 +273,53 @@ Deno.test("memory v2 patch rejects missing array indices in parent traversal", (
   });
 });
 
+Deno.test("memory v2 patch rejects add through a missing key into an array index", () => {
+  // The intermediate `0` would land inside a freshly-created (empty) array,
+  // which has no element 0 to traverse into -- so this must be rejected, not
+  // silently fabricated.
+  const original = {};
+
+  let error: Error | null = null;
+  try {
+    applyPatch(original, [
+      { op: "add", path: "/missingKey/0/x", value: 1 },
+    ]);
+  } catch (caught) {
+    error = caught as Error;
+  }
+
+  assertEquals(error instanceof Error, true);
+  assertEquals(original, {});
+});
+
+Deno.test("memory v2 patch rejects add through a missing key into an array append marker", () => {
+  const original = {};
+
+  let error: Error | null = null;
+  try {
+    applyPatch(original, [
+      { op: "add", path: "/missingKey/-/x", value: 1 },
+    ]);
+  } catch (caught) {
+    error = caught as Error;
+  }
+
+  assertEquals(error instanceof Error, true);
+  assertEquals(original, {});
+});
+
+Deno.test("memory v2 patch appends via the `-` marker on an existing array", () => {
+  const original = { items: ["a"] };
+
+  const out = applyPatch(original, [
+    { op: "add", path: "/items/-", value: "b" },
+  ]) as typeof original;
+
+  assertEquals(out, { items: ["a", "b"] });
+  // Input untouched.
+  assertEquals(original, { items: ["a"] });
+});
+
 Deno.test("memory v2 patch reuses unchanged branches across sibling updates", () => {
   const original = {
     left: {

--- a/packages/memory/v2/patch.ts
+++ b/packages/memory/v2/patch.ts
@@ -150,14 +150,28 @@ const replaceAtPath = (
  */
 const validateAddSpine = (root: FabricValue, path: string[]): void => {
   let current: FabricValue = root;
+  // Becomes true once we pass a missing object key: everything below is freshly
+  // created, so all containers from there down are empty.
+  let creating = false;
   for (let i = 0; i < path.length - 1; i++) {
     const segment = path[i]!;
+    if (creating) {
+      // A freshly-created array is empty, so an intermediate array index (or the
+      // `-` append marker) can never resolve to an existing element to traverse
+      // into -- reject it rather than fabricate one. Plain object keys are fine;
+      // they get created on the way down.
+      if (isArraySegment(segment) || segment === "-") {
+        throw new Error(`missing path ${encodePointer(path)}`);
+      }
+      continue;
+    }
     if (Array.isArray(current)) {
       current = current[requireExistingArrayIndex(current, segment, path)];
     } else if (isPatchObject(current)) {
-      // Once a key is missing, everything below it is freshly created, so there
-      // is nothing further to validate.
-      if (!Object.hasOwn(current, segment)) return;
+      if (!Object.hasOwn(current, segment)) {
+        creating = true;
+        continue;
+      }
       current = current[segment];
     } else {
       throw new Error(`path is not traversable at ${encodePointer(path)}`);

--- a/packages/memory/v2/patch.ts
+++ b/packages/memory/v2/patch.ts
@@ -1,8 +1,9 @@
 import type { FabricValue } from "../interface.ts";
 import { deepFreeze } from "@commonfabric/data-model/deep-freeze";
 import {
+  cloneForMutation,
+  CloneForMutationError,
   cloneIfNecessary,
-  shallowMutableClone,
 } from "@commonfabric/data-model/fabric-value";
 import { isInstance, isObject } from "@commonfabric/utils/types";
 import type { PatchOp } from "../v2.ts";
@@ -45,14 +46,13 @@ const cloneValue = (value: FabricValue): FabricValue => cloneIfNecessary(value);
  * The function is therefore on the hot path for any read that reconstructs
  * a document from its stored patch list.
  *
- * Mutation discipline: each `applyOp` call uses `shallowMutableClone()` to
- * produce a new top-level copy of the container being modified, then
- * recurses into the path; containers off the modified path remain
- * frozen-by-reference. The returned tree is then fully deep-frozen at the
- * function boundary, completing the shallow-clone / mutate / deep-freeze
- * pattern: shallow clones at the immediate containers on the modified
- * path, deep-freeze of the assembled result before it leaves the function.
- * Callers can rely on the return value being deeply frozen.
+ * Mutation discipline: each op is applied via a copy-on-write descent. The
+ * spine of containers from the root down to the mutated container is thawed to
+ * fresh mutable copies (via `cloneForMutation()`), the leaf operation is applied
+ * to that mutable container, and subtrees off the spine stay frozen-by-reference
+ * (structural sharing). The assembled tree is then fully deep-frozen at the
+ * `applyPatch` boundary, so callers can rely on the return value being deeply
+ * frozen.
  */
 export const applyPatch = (
   state: FabricValue,
@@ -86,158 +86,135 @@ const applyOp = (state: FabricValue, op: PatchOp): FabricValue => {
   }
 };
 
+/**
+ * Copy-on-write thaw of the spine of `root` down to `thawPath`, returning the
+ * new root and the mutable container at `thawPath`. Subtrees off the spine are
+ * shared by identity (structural sharing); the caller's input is left untouched
+ * (`cloneForMutation` defaults to `force: true`). `cloneForMutation`'s typed
+ * errors are translated into this module's path-style messages, and a
+ * value-at-path that isn't a plain container is rejected (patch ops only mutate
+ * objects/arrays). `fullPath` is used for error messages.
+ */
+const thawSpine = (
+  root: FabricValue,
+  thawPath: string[],
+  fullPath: string[],
+  options?: { createMissing?: boolean; nextKeyAfterPath?: string },
+): { root: FabricValue; container: PatchContainer } => {
+  let value: FabricValue;
+  let pathValue: FabricValue;
+  try {
+    ({ value, pathValue } = cloneForMutation(root, thawPath, options));
+  } catch (e) {
+    if (e instanceof CloneForMutationError) {
+      throw new Error(
+        e.kind === "missing-segment"
+          ? `missing path ${encodePointer(fullPath)}`
+          : `path is not traversable at ${encodePointer(fullPath)}`,
+      );
+    }
+    throw e;
+  }
+  if (!isContainer(pathValue)) {
+    throw new Error(`path is not traversable at ${encodePointer(fullPath)}`);
+  }
+  return { root: value, container: pathValue };
+};
+
 const replaceAtPath = (
   root: FabricValue,
   path: string[],
   value: FabricValue,
-  fullPath: string[] = path,
 ): FabricValue => {
   if (path.length === 0) {
     return cloneValue(value);
   }
+  const { root: newRoot, container } = thawSpine(root, path.slice(0, -1), path);
+  const key = path[path.length - 1]!;
+  if (Array.isArray(container)) {
+    container[requireExistingArrayIndex(container, key, path)] = cloneValue(
+      value,
+    );
+  } else {
+    container[key] = cloneValue(value);
+  }
+  return newRoot;
+};
 
-  if (Array.isArray(root)) {
-    const index = requireExistingArrayIndex(root, path[0]!, fullPath);
-    const next = shallowMutableClone(root) as FabricValue[];
-    if (path.length === 1) {
-      next[index] = cloneValue(value);
-      return next;
+/**
+ * Read-only check of `add`'s spine: missing *object* keys are fine (they get
+ * created during the mutating descent), but a present array must already contain
+ * any index traversed through, and a present non-container can't be traversed.
+ * This is what keeps `add` from fabricating missing array indices (which
+ * `cloneForMutation`'s `createMissing` would otherwise do).
+ */
+const validateAddSpine = (root: FabricValue, path: string[]): void => {
+  let current: FabricValue = root;
+  for (let i = 0; i < path.length - 1; i++) {
+    const segment = path[i]!;
+    if (Array.isArray(current)) {
+      current = current[requireExistingArrayIndex(current, segment, path)];
+    } else if (isPatchObject(current)) {
+      // Once a key is missing, everything below it is freshly created, so there
+      // is nothing further to validate.
+      if (!Object.hasOwn(current, segment)) return;
+      current = current[segment];
+    } else {
+      throw new Error(`path is not traversable at ${encodePointer(path)}`);
     }
-
-    const child = root[index];
-    if (!isContainer(child)) {
-      throw new Error(`path is not traversable at ${encodePointer(fullPath)}`);
-    }
-    next[index] = replaceAtPath(child, path.slice(1), value, fullPath);
-    return next;
   }
-
-  if (!isPatchObject(root)) {
-    throw new Error(`path is not traversable at ${encodePointer(fullPath)}`);
-  }
-
-  const next = shallowMutableClone(root) as PatchObject;
-  const key = path[0]!;
-  if (path.length === 1) {
-    next[key] = cloneValue(value);
-    return next;
-  }
-
-  if (!Object.hasOwn(root, key)) {
-    throw new Error(`missing path ${encodePointer(fullPath)}`);
-  }
-
-  const child = root[key];
-  if (!isContainer(child)) {
-    throw new Error(`path is not traversable at ${encodePointer(fullPath)}`);
-  }
-  next[key] = replaceAtPath(child, path.slice(1), value, fullPath);
-  return next;
 };
 
 const addAtPath = (
   root: FabricValue,
   path: string[],
   value: FabricValue,
-  fullPath: string[] = path,
 ): FabricValue => {
   if (path.length === 0) {
     return cloneValue(value);
   }
-
-  if (Array.isArray(root)) {
-    const next = shallowMutableClone(root) as FabricValue[];
-    const segment = path[0]!;
-    if (path.length === 1) {
-      if (segment === "-") {
-        next.push(cloneValue(value));
-      } else {
-        const index = parseArrayInsertIndex(segment, root.length);
-        next.splice(index, 0, cloneValue(value));
-      }
-      return next;
+  validateAddSpine(root, path);
+  const key = path[path.length - 1]!;
+  const { root: newRoot, container } = thawSpine(
+    root,
+    path.slice(0, -1),
+    path,
+    {
+      createMissing: true,
+      nextKeyAfterPath: key,
+    },
+  );
+  if (Array.isArray(container)) {
+    if (key === "-") {
+      container.push(cloneValue(value));
+    } else {
+      container.splice(
+        parseArrayInsertIndex(key, container.length),
+        0,
+        cloneValue(value),
+      );
     }
-
-    const index = requireExistingArrayIndex(root, segment, fullPath);
-    const child = root[index];
-    if (!isContainer(child)) {
-      throw new Error(`path is not traversable at ${encodePointer(fullPath)}`);
-    }
-    next[index] = addAtPath(child, path.slice(1), value, fullPath);
-    return next;
+  } else {
+    container[key] = cloneValue(value);
   }
-
-  if (!isPatchObject(root)) {
-    throw new Error(`path is not traversable at ${encodePointer(fullPath)}`);
-  }
-
-  const next = shallowMutableClone(root) as PatchObject;
-  const key = path[0]!;
-  if (path.length === 1) {
-    next[key] = cloneValue(value);
-    return next;
-  }
-
-  const child = Object.hasOwn(root, key)
-    ? root[key]
-    : createContainer(path[1]!);
-  if (!isContainer(child)) {
-    throw new Error(`path is not traversable at ${encodePointer(fullPath)}`);
-  }
-
-  next[key] = addAtPath(child, path.slice(1), value, fullPath);
-  return next;
+  return newRoot;
 };
 
-const removeAtPath = (
-  root: FabricValue,
-  path: string[],
-  fullPath: string[] = path,
-): FabricValue => {
+const removeAtPath = (root: FabricValue, path: string[]): FabricValue => {
   if (path.length === 0) {
     throw new Error("root remove must be represented as a delete operation");
   }
-
-  if (Array.isArray(root)) {
-    const index = requireExistingArrayIndex(root, path[0]!, fullPath);
-    const next = shallowMutableClone(root) as FabricValue[];
-    if (path.length === 1) {
-      next.splice(index, 1);
-      return next;
+  const { root: newRoot, container } = thawSpine(root, path.slice(0, -1), path);
+  const key = path[path.length - 1]!;
+  if (Array.isArray(container)) {
+    container.splice(requireExistingArrayIndex(container, key, path), 1);
+  } else {
+    if (!Object.hasOwn(container, key)) {
+      throw new Error(`missing object key at ${encodePointer(path)}`);
     }
-
-    const child = root[index];
-    if (!isContainer(child)) {
-      throw new Error(`path is not traversable at ${encodePointer(fullPath)}`);
-    }
-    next[index] = removeAtPath(child, path.slice(1), fullPath);
-    return next;
+    delete container[key];
   }
-
-  if (!isPatchObject(root)) {
-    throw new Error(`path is not traversable at ${encodePointer(fullPath)}`);
-  }
-
-  const next = shallowMutableClone(root) as PatchObject;
-  const key = path[0]!;
-  if (path.length === 1) {
-    if (!Object.hasOwn(root, key)) {
-      throw new Error(`missing object key at ${encodePointer(fullPath)}`);
-    }
-    delete next[key];
-    return next;
-  }
-
-  if (!Object.hasOwn(root, key)) {
-    throw new Error(`missing path ${encodePointer(fullPath)}`);
-  }
-
-  const child = root[key];
-  if (!isContainer(child)) {
-    throw new Error(`path is not traversable at ${encodePointer(fullPath)}`);
-  }
-  next[key] = removeAtPath(child, path.slice(1), fullPath);
-  return next;
+  return newRoot;
 };
 
 const moveValue = (
@@ -262,57 +239,16 @@ const spliceAtPath = (
   index: number,
   remove: number,
   add: FabricValue[],
-  fullPath: string[] = path,
 ): FabricValue => {
-  if (path.length === 0) {
-    if (!Array.isArray(root)) {
-      throw new Error(
-        `splice target is not an array at ${encodePointer(fullPath)}`,
-      );
-    }
-    if (index < 0 || remove < 0 || index > root.length) {
-      throw new Error(`invalid splice at ${encodePointer(fullPath)}`);
-    }
-    const next = shallowMutableClone(root) as FabricValue[];
-    next.splice(index, remove, ...add.map((value) => cloneValue(value)));
-    return next;
+  const { root: newRoot, container } = thawSpine(root, path, path);
+  if (!Array.isArray(container)) {
+    throw new Error(`splice target is not an array at ${encodePointer(path)}`);
   }
-
-  if (Array.isArray(root)) {
-    const next = shallowMutableClone(root) as FabricValue[];
-    const pathIndex = requireExistingArrayIndex(root, path[0]!, fullPath);
-    const child = root[pathIndex];
-    if (!isContainer(child)) {
-      throw new Error(`path is not traversable at ${encodePointer(fullPath)}`);
-    }
-    next[pathIndex] = spliceAtPath(
-      child,
-      path.slice(1),
-      index,
-      remove,
-      add,
-      fullPath,
-    );
-    return next;
+  if (index < 0 || remove < 0 || index > container.length) {
+    throw new Error(`invalid splice at ${encodePointer(path)}`);
   }
-
-  if (!isPatchObject(root)) {
-    throw new Error(`path is not traversable at ${encodePointer(fullPath)}`);
-  }
-
-  const key = path[0]!;
-  if (!Object.hasOwn(root, key)) {
-    throw new Error(`missing path ${encodePointer(fullPath)}`);
-  }
-
-  const child = root[key];
-  if (!isContainer(child)) {
-    throw new Error(`path is not traversable at ${encodePointer(fullPath)}`);
-  }
-
-  const next = shallowMutableClone(root) as PatchObject;
-  next[key] = spliceAtPath(child, path.slice(1), index, remove, add, fullPath);
-  return next;
+  container.splice(index, remove, ...add.map((value) => cloneValue(value)));
+  return newRoot;
 };
 
 const getAtPath = (root: FabricValue, path: string[]): FabricValue => {
@@ -327,10 +263,6 @@ const getAtPath = (root: FabricValue, path: string[]): FabricValue => {
     }
   }
   return current;
-};
-
-const createContainer = (nextSegment: string): PatchContainer => {
-  return isArraySegment(nextSegment) || nextSegment === "-" ? [] : {};
 };
 
 const parseArrayIndex = (segment: string): number => {


### PR DESCRIPTION
## Summary
- Replaces the hand-rolled recursive copy-on-write in `applyPatch`'s replace/add/remove/splice with a single `cloneForMutation()`-based `thawSpine` helper plus flat leaf ops, removing ~230 lines of duplicated spine traversal while preserving behavior — including off-spine **structural sharing** (unchanged sibling branches keep their identity).
- `add` keeps its asymmetric create-missing semantics (fabricate missing object keys; reject missing array indices) via a small read-only `validateAddSpine` pre-walk before `cloneForMutation(createMissing: true)`. `move` is unchanged (remove + add). Local `shallowMutableClone` / `createContainer` usage is gone.
- `cloneForMutation` / `CloneForMutationError` / `cloneIfNecessary` already exist on `main` and are used unmodified, so this stands alone (no dependency on other in-flight cloning/freezing work).

## Test plan
- [x] memory v2 patch unit tests — 13 / 0 (incl. the structural-sharing test)
- [x] `deno task test` (memory) — 142 / 0
- [x] `deno task integration` (runner; exercises patch.ts via document materialization) — 10 / 0
- [x] `deno fmt --check` / `deno check` on patch.ts
- [ ] perf-check (this PR is the isolated change so its hot-path impact — document-materialization replay — can be measured cleanly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Performance Baseline

This PR net reduces code. It _does_ introduce a small amount of duplicative work in validating add paths in `patch.ts`, but it does not seem to correlate with any perf degradation. Over N runs, different steps have triggered a perf check failure, nothing consistent. And a temporary microbenchmark indicates that we'd need to end up running the code in question about 200 million times to see the perf difference that is being recorded. So, the following accounts for what really seems to be a spurious report:

NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/google/core/gmail-importer.test.tsx = 24s


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor v2 patch ops to use `cloneForMutation()` for copy-on-write spine thawing, removing ~230 lines while preserving behavior and structural sharing.

- **Refactors**
  - Added `thawSpine` helper using `cloneForMutation()`; apply leaf ops on the thawed container; keep off-spine identity.
  - Kept `add` semantics via `validateAddSpine` + `createMissing: true`.
  - Routed `splice` through the same flow; `move` stays remove + add; removed `shallowMutableClone` and local `createContainer` in favor of `@commonfabric/data-model/fabric-value`.

- **Bug Fixes**
  - Fixed `add` validation to keep checking after the first missing key and reject intermediate array-index or `-` segments in newly created subtrees; added tests and preserved `-` append on existing arrays.

<sup>Written for commit 4fa7d08aaef2ec48c6e8c13ea7c8186a0bdfa1f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

