### PR TITLE
fix(runner): resolve cell scope from schema, not by stamping links (CT-1623)

### DIFF
--- a/docs/specs/scoped-cell-instances.md
+++ b/docs/specs/scoped-cell-instances.md
@@ -278,6 +278,42 @@ scope-dependent.
 This behavior applies equally when a broader scoped output contains a link to a
 narrower scoped computation result.
 
+### Navigation Does Not Carry Scope
+
+Path navigation (for example `cell.key(...)`) only extends the link's path and
+walks the schema to the child schema. It must not change the link's scope, and
+it must not read storage. Scope lives in the schema: it is resolved lazily as a
+follow cap on reads and as the target scope on writes. The link's own `scope`
+remains the base scope established when the cell was created (from an explicit
+scope, a top-level schema scope, or `space`).
+
+Stamping a child schema's scope onto the navigated link is incorrect: the link
+addresses the containing instance, so stamping a narrower scope would read or
+write the wrong scoped instance of the container.
+
+### Scoped Write Placement
+
+A write places content in the instance whose scope the content's schema
+declares, at every nesting level, not only at the top of the write:
+
+- When a field's schema declares a scope narrower than the instance being
+  written, the field's content is written into the narrower-scope instance (same
+  id, same path, narrower scope key) and the broader-scope slot holds a link to
+  it. Readers at the broader scope follow that link to the narrower instance.
+- For arrays whose items declare a narrower scope, each element is an
+  independent link to its narrower-scope element instance. The array container —
+  including its length — stays in the broader scope; there is no single redirect
+  for the whole array. This mirrors the `map` rule: an input-list-scoped array of
+  links to narrower scoped element instances.
+- Writing a link or cell reference is exempt: a reference already carries its own
+  target scope, so it is stored as-is at the broader slot.
+
+The narrower-scope instance is a different scoped instance of the same id, so
+its container structure (the value root and any intermediate objects/arrays
+along the written path) is created as needed; the broader instance keeps the
+non-scoped data and the links. Writes to different scope instances of one id are
+applied as separate operations, never merged into a single document write.
+
 ## Schema Semantics
 
 `JSONSchemaObj` gains an optional Common Fabric extension:

--- a/docs/specs/scoped-cell-instances.md
+++ b/docs/specs/scoped-cell-instances.md
@@ -310,9 +310,10 @@ declares, at every nesting level, not only at the top of the write:
 
 The narrower-scope instance is a different scoped instance of the same id, so
 its container structure (the value root and any intermediate objects/arrays
-along the written path) is created as needed; the broader instance keeps the
-non-scoped data and the links. Writes to different scope instances of one id are
-applied as separate operations, never merged into a single document write.
+along the written path) is created as needed by the storage write; the broader
+instance keeps the non-scoped data and the links. The storage layer keys
+documents — and batches writes — by scope key as well as id, so writes to
+different scoped instances of one id are never merged into a single document.
 
 ## Schema Semantics
 

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1162,15 +1162,18 @@ export class CellImpl<T extends FabricValue>
       // Create a child link with extended path
       // When we have a childSchema, we need to preserve the schema that contains $defs
       // for resolving $ref references. If schema wasn't set, fall back to the parent schema.
+      //
+      // key() only extends the path and walks the schema. It must NOT change the
+      // link's scope: scope lives in the schema (top-level and asCell entries)
+      // and is resolved later as a follow cap during reads and as the target
+      // scope during writes. Stamping schema scope onto this link here would
+      // re-address the value to the wrong scoped instance of the container doc
+      // (see CT-1623).
       currentLink = {
         ...currentLink,
         path: [...currentLink.path, key.toString()] as string[],
         schema: childSchema,
       };
-
-      if (isRecord(childSchema) && isCellScope(childSchema.scope)) {
-        currentLink = { ...currentLink, scope: childSchema.scope };
-      }
     }
 
     // Determine the kind based on schema flags
@@ -1183,10 +1186,6 @@ export class CellImpl<T extends FabricValue>
         const asCellKind = ContextualFlowControl.getAsCellKind(asCellEntry);
         if (asCellKind !== undefined) {
           kind = asCellKind;
-        }
-        const asCellScope = ContextualFlowControl.getAsCellScope(asCellEntry);
-        if (isCellScope(asCellScope)) {
-          currentLink = { ...currentLink, scope: asCellScope };
         }
       }
     }

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -2561,7 +2561,7 @@ function schemaWithDefaultAndScope<T>(
   return scopedSchema;
 }
 
-function schemaCellScope(
+export function schemaCellScope(
   schema: JSONSchema | undefined,
 ): CellScope | undefined {
   return isRecord(schema) && isCellScope(schema.scope)

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -9,7 +9,14 @@ import {
 } from "@commonfabric/data-model/fabric-value";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { getLogger } from "@commonfabric/utils/logger";
-import { ID, ID_FIELD, type JSONSchema } from "./builder/types.ts";
+import {
+  type CellScope,
+  ID,
+  ID_FIELD,
+  type JSONSchema,
+} from "./builder/types.ts";
+import { ContextualFlowControl } from "./cfc.ts";
+import { isCellScope, scopeRank } from "./scope.ts";
 import { createRef } from "./create-ref.ts";
 import {
   CellImpl,
@@ -263,6 +270,24 @@ const stripCfcLabelViewFromPrimitiveLink = (value: unknown): unknown => {
  * @param context - The context of the change.
  * @returns Whether any changes were made.
  */
+/**
+ * The scope a cell's own schema declares for its content: the outermost
+ * `asCell` entry scope if present, otherwise the top-level `scope`. This is the
+ * scope at which the cell's data lives. It is distinct from a follow cap and
+ * from the link's base scope.
+ */
+function declaredCellScope(
+  schema: JSONSchema | undefined,
+): CellScope | undefined {
+  if (!isRecord(schema)) return undefined;
+  const asCellScope = ContextualFlowControl.getAsCellScope(
+    ContextualFlowControl.getAsCellValues(schema).at(0),
+  );
+  if (isCellScope(asCellScope)) return asCellScope;
+  if (isCellScope(schema.scope)) return schema.scope;
+  return undefined;
+}
+
 export function diffAndUpdate(
   runtime: Runtime,
   tx: IExtendedStorageTransaction,
@@ -271,6 +296,31 @@ export function diffAndUpdate(
   context?: unknown,
   options?: IReadOptions,
 ): boolean {
+  // Never write content into a scope broader than the data's own declared
+  // scope. If the target cell's schema declares a narrower scope than the
+  // link's base scope, write the content into the narrower-scope instance and
+  // leave a redirect link in the broader-scope location, so readers at the
+  // broader scope follow it to the narrower instance. This does not apply when
+  // writing a link value (a reference carries its own target scope) — only when
+  // writing the cell's own content. The check lives here, at the top-level
+  // write entry, so it only narrows the write target and not every nested path
+  // (recursion goes through `normalizeAndDiff`).
+  const declared = declaredCellScope(link.schema);
+  if (
+    declared !== undefined &&
+    scopeRank(declared) > scopeRank(link.scope) &&
+    !isCellLink(newValue) &&
+    !isCell(newValue)
+  ) {
+    const scopedLink: NormalizedFullLink = { ...link, scope: declared };
+    diffAndUpdate(runtime, tx, scopedLink, newValue, context, options);
+    tx.writeValueOrThrow(
+      link,
+      createSigilLinkFromParsedLink(scopedLink, { base: link }) as FabricValue,
+    );
+    return true;
+  }
+
   const readOptions: IReadOptions = {
     ...options,
     meta: {

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -36,7 +36,6 @@ import {
   isWriteRedirectLink,
   type NormalizedFullLink,
   parseLink,
-  toMemorySpaceAddress,
 } from "./link-utils.ts";
 import {
   getCellOrThrow,
@@ -289,55 +288,6 @@ function declaredCellScope(
   return undefined;
 }
 
-const ARRAY_INDEX_RE = /^(?:0|[1-9][0-9]*)$/;
-
-/**
- * Ensure the narrower-scope instance has the container structure (objects /
- * arrays) along the ancestors of `scopedLink.path`, so a nested content write
- * has a place to live. Storage does not auto-create parents, and the narrow
- * instance is a different scoped instance than the broad one whose structure the
- * normal recursion builds.
- *
- * Missing ancestors are written immediately (not via the returned change set) so
- * that sibling narrowed writes in the same transaction observe them and don't
- * re-initialize a shared ancestor, which would clobber an earlier sibling's
- * value. Ancestors that already exist (from this transaction or a prior commit)
- * are left untouched so existing narrow data is preserved.
- *
- * TODO: this side-effects inside the diff computation; fold into the planned
- * normalizeAndDiff refactor so the narrow instance is built by a normal
- * root-descending pass instead.
- */
-function ensureNarrowAncestorContainers(
-  tx: IExtendedStorageTransaction,
-  scopedLink: NormalizedFullLink,
-  options: IReadOptions | undefined,
-): ChangeSet {
-  const changes: ChangeSet = [];
-  for (let i = 0; i < scopedLink.path.length; i++) {
-    const ancestorLink: NormalizedFullLink = {
-      ...scopedLink,
-      path: scopedLink.path.slice(0, i),
-      schema: undefined,
-    };
-    const current = tx.read(toMemorySpaceAddress(ancestorLink), options);
-    if (
-      current.ok &&
-      (isRecord(current.ok.value) || Array.isArray(current.ok.value))
-    ) {
-      continue;
-    }
-    // The child segment along this path decides whether the container that must
-    // hold it is an array (numeric index) or an object.
-    const isArrayParent = ARRAY_INDEX_RE.test(scopedLink.path[i]);
-    changes.push({
-      location: ancestorLink,
-      value: (isArrayParent ? [] : {}) as FabricValue,
-    });
-  }
-  return changes;
-}
-
 export function diffAndUpdate(
   runtime: Runtime,
   tx: IExtendedStorageTransaction,
@@ -447,15 +397,10 @@ export function normalizeAndDiff(
     !isCell(newValue)
   ) {
     const scopedLink: NormalizedFullLink = { ...link, scope: declaredScope };
-    // Apply the narrower-scope instance's writes immediately, as their own
-    // single-scope batch. Writes to different scope instances of the same id
-    // must not share one batch, and applying now means sibling narrowed writes
-    // observe the ancestors this created (so they don't re-init and clobber).
-    // Only the broad-scope redirect joins the caller's (broad) change set.
-    applyChangeSet(tx, [
-      ...(scopedLink.path.length > 0
-        ? ensureNarrowAncestorContainers(tx, scopedLink, options)
-        : []),
+    return [
+      // Content goes into the narrower-scope instance (its missing container
+      // structure is created by the storage write, which builds parents for the
+      // path). Diffed against the narrower instance's own current value.
       ...normalizeAndDiff(
         runtime,
         tx,
@@ -465,16 +410,17 @@ export function normalizeAndDiff(
         options,
         seen,
       ),
-    ]);
-    return normalizeAndDiff(
-      runtime,
-      tx,
-      link,
-      createSigilLinkFromParsedLink(scopedLink, { base: link }) as unknown,
-      context,
-      options,
-      seen,
-    );
+      // The broader-scope slot points to that instance.
+      ...normalizeAndDiff(
+        runtime,
+        tx,
+        link,
+        createSigilLinkFromParsedLink(scopedLink, { base: link }) as unknown,
+        context,
+        options,
+        seen,
+      ),
+    ];
   }
 
   // ID_FIELD redirects to an existing field and we do something like DOM

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -36,6 +36,7 @@ import {
   isWriteRedirectLink,
   type NormalizedFullLink,
   parseLink,
+  toMemorySpaceAddress,
 } from "./link-utils.ts";
 import {
   getCellOrThrow,
@@ -288,6 +289,55 @@ function declaredCellScope(
   return undefined;
 }
 
+const ARRAY_INDEX_RE = /^(?:0|[1-9][0-9]*)$/;
+
+/**
+ * Ensure the narrower-scope instance has the container structure (objects /
+ * arrays) along the ancestors of `scopedLink.path`, so a nested content write
+ * has a place to live. Storage does not auto-create parents, and the narrow
+ * instance is a different scoped instance than the broad one whose structure the
+ * normal recursion builds.
+ *
+ * Missing ancestors are written immediately (not via the returned change set) so
+ * that sibling narrowed writes in the same transaction observe them and don't
+ * re-initialize a shared ancestor, which would clobber an earlier sibling's
+ * value. Ancestors that already exist (from this transaction or a prior commit)
+ * are left untouched so existing narrow data is preserved.
+ *
+ * TODO: this side-effects inside the diff computation; fold into the planned
+ * normalizeAndDiff refactor so the narrow instance is built by a normal
+ * root-descending pass instead.
+ */
+function ensureNarrowAncestorContainers(
+  tx: IExtendedStorageTransaction,
+  scopedLink: NormalizedFullLink,
+  options: IReadOptions | undefined,
+): ChangeSet {
+  const changes: ChangeSet = [];
+  for (let i = 0; i < scopedLink.path.length; i++) {
+    const ancestorLink: NormalizedFullLink = {
+      ...scopedLink,
+      path: scopedLink.path.slice(0, i),
+      schema: undefined,
+    };
+    const current = tx.read(toMemorySpaceAddress(ancestorLink), options);
+    if (
+      current.ok &&
+      (isRecord(current.ok.value) || Array.isArray(current.ok.value))
+    ) {
+      continue;
+    }
+    // The child segment along this path decides whether the container that must
+    // hold it is an array (numeric index) or an object.
+    const isArrayParent = ARRAY_INDEX_RE.test(scopedLink.path[i]);
+    changes.push({
+      location: ancestorLink,
+      value: (isArrayParent ? [] : {}) as FabricValue,
+    });
+  }
+  return changes;
+}
+
 export function diffAndUpdate(
   runtime: Runtime,
   tx: IExtendedStorageTransaction,
@@ -296,31 +346,6 @@ export function diffAndUpdate(
   context?: unknown,
   options?: IReadOptions,
 ): boolean {
-  // Never write content into a scope broader than the data's own declared
-  // scope. If the target cell's schema declares a narrower scope than the
-  // link's base scope, write the content into the narrower-scope instance and
-  // leave a redirect link in the broader-scope location, so readers at the
-  // broader scope follow it to the narrower instance. This does not apply when
-  // writing a link value (a reference carries its own target scope) — only when
-  // writing the cell's own content. The check lives here, at the top-level
-  // write entry, so it only narrows the write target and not every nested path
-  // (recursion goes through `normalizeAndDiff`).
-  const declared = declaredCellScope(link.schema);
-  if (
-    declared !== undefined &&
-    scopeRank(declared) > scopeRank(link.scope) &&
-    !isCellLink(newValue) &&
-    !isCell(newValue)
-  ) {
-    const scopedLink: NormalizedFullLink = { ...link, scope: declared };
-    diffAndUpdate(runtime, tx, scopedLink, newValue, context, options);
-    tx.writeValueOrThrow(
-      link,
-      createSigilLinkFromParsedLink(scopedLink, { base: link }) as FabricValue,
-    );
-    return true;
-  }
-
   const readOptions: IReadOptions = {
     ...options,
     meta: {
@@ -403,6 +428,53 @@ export function normalizeAndDiff(
         `[SEEN_CHECK] Already seen object at path=${pathStr}, converting to cell`,
     );
     newValue = new CellImpl(runtime, tx, seen.get(newValue)!);
+  }
+
+  // Scope narrowing: if this slot's schema declares a scope narrower than the
+  // link's base scope, the content belongs in the narrower-scope instance and
+  // the broader-scope slot holds a link to it, so readers at the broader scope
+  // follow it to the narrower instance. A reference value (link/cell) is exempt:
+  // it already carries its own target scope. Both writes recurse back through
+  // normalizeAndDiff so they get the usual diffing, no-op detection, and CFC
+  // label/policy handling. Applying this at the top of normalizeAndDiff makes it
+  // compose to arbitrary depth (every nested descent re-enters here); for arrays
+  // it yields one link per element rather than a redirect of the whole array.
+  const declaredScope = declaredCellScope(link.schema);
+  if (
+    declaredScope !== undefined &&
+    scopeRank(declaredScope) > scopeRank(link.scope) &&
+    !isCellLink(newValue) &&
+    !isCell(newValue)
+  ) {
+    const scopedLink: NormalizedFullLink = { ...link, scope: declaredScope };
+    // Apply the narrower-scope instance's writes immediately, as their own
+    // single-scope batch. Writes to different scope instances of the same id
+    // must not share one batch, and applying now means sibling narrowed writes
+    // observe the ancestors this created (so they don't re-init and clobber).
+    // Only the broad-scope redirect joins the caller's (broad) change set.
+    applyChangeSet(tx, [
+      ...(scopedLink.path.length > 0
+        ? ensureNarrowAncestorContainers(tx, scopedLink, options)
+        : []),
+      ...normalizeAndDiff(
+        runtime,
+        tx,
+        scopedLink,
+        newValue,
+        context,
+        options,
+        seen,
+      ),
+    ]);
+    return normalizeAndDiff(
+      runtime,
+      tx,
+      link,
+      createSigilLinkFromParsedLink(scopedLink, { base: link }) as unknown,
+      context,
+      options,
+      seen,
+    );
   }
 
   // ID_FIELD redirects to an existing field and we do something like DOM

--- a/packages/runner/src/link-resolution.ts
+++ b/packages/runner/src/link-resolution.ts
@@ -18,6 +18,7 @@ import { ContextualFlowControl } from "./cfc.ts";
 import type { Runtime } from "./runtime.ts";
 import type { CfcAddress } from "./cfc/types.ts";
 import { canFollowScopedLink, isSchemaScope } from "./scope.ts";
+import type { SchemaScope } from "./builder/types.ts";
 
 const logger = getLogger("link-resolution");
 
@@ -64,10 +65,20 @@ const recordDereferenceHop = (
   });
 };
 
-const schemaScopeForLink = (link: NormalizedFullLink) =>
-  isRecord(link.schema) && isSchemaScope(link.schema.scope)
-    ? link.schema.scope
-    : undefined;
+// The scope cap a link's schema imposes on the next link it permits a read to
+// follow. Honors an explicit top-level `scope`, falling back to the outermost
+// `asCell` entry scope. This caps *which* link scopes may be followed; it must
+// never be copied onto the followed link itself.
+const schemaScopeForLink = (
+  link: NormalizedFullLink,
+): SchemaScope | undefined => {
+  if (!isRecord(link.schema)) return undefined;
+  if (isSchemaScope(link.schema.scope)) return link.schema.scope;
+  const entryScope = ContextualFlowControl.getAsCellScope(
+    ContextualFlowControl.getAsCellValues(link.schema).at(0),
+  );
+  return isSchemaScope(entryScope) ? entryScope : undefined;
+};
 
 const undefinedDataLink = (link: NormalizedFullLink): NormalizedFullLink => ({
   ...link,

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -30,7 +30,7 @@ import type {
   IStorageProvider,
   MemorySpace,
 } from "./storage/interface.ts";
-import { type Cell, createCell } from "./cell.ts";
+import { type Cell, createCell, schemaCellScope } from "./cell.ts";
 import { createRef, EntityId } from "./create-ref.ts";
 import { Action, Scheduler } from "./scheduler.ts";
 import { Engine } from "./harness/index.ts";
@@ -708,14 +708,19 @@ export class Runtime {
     cause: any,
     schema?: JSONSchema,
     tx?: IExtendedStorageTransaction,
-    scope: NormalizedFullLink["scope"] = "space",
+    scope?: NormalizedFullLink["scope"],
   ): Cell<any> {
+    // Creating a cell uses the schema to seed the initial link scope: an
+    // explicit scope wins, otherwise a top-level schema scope, otherwise space.
+    // (Per-property/asCell scopes are not a top-level concern here; they are
+    // resolved during read/write, see data-updating.ts and link-resolution.ts.)
+    const effectiveScope = scope ?? schemaCellScope(schema) ?? "space";
     return this.getCellFromLink(
       {
         id: toURI(createRef({}, cause)),
         path: [],
         space,
-        scope,
+        scope: effectiveScope,
       },
       schema,
       tx,

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -64,6 +64,10 @@ const cfcAddressFromLink = (link: NormalizedFullLink): CfcAddress => ({
   path: [...link.path],
 });
 
+// Creation-only: stamp the asCell entry's declared scope onto a newly created
+// cell's link. Never use this on a link that was followed/resolved during a
+// read — there the link's own storage-resolved scope is authoritative and
+// schema scope acts only as a follow cap (see link-resolution.ts).
 const linkWithAsCellScope = (
   link: NormalizedFullLink,
   entry:
@@ -603,6 +607,8 @@ export function processDefaultValue(
           cfcLabelView,
         );
       } else {
+        // This is a creation path (no default value to box): use the schema to
+        // set the new cell's initial scope from the asCell entry.
         return createCell(
           runtime,
           {
@@ -1180,10 +1186,14 @@ class TransformObjectCreator
           return undefined;
         }
         // TODO(@ubik2): deal with anyOf/oneOf with asCell/asStream
+        // This is a read/materialization path: keep the link's own
+        // storage-resolved scope. The asCell entry scope is honored as a
+        // follow cap during link resolution, never copied onto the link here
+        // (doing so would re-address the value to a different scoped instance).
         return createCell(
           this.runtime,
           {
-            ...linkWithAsCellScope(link, asCellEntry),
+            ...link,
             schema: {
               ...restSchema,
               ...(asCellValues.length > 1) && { asCell: asCellValues.slice(1) },

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -1133,7 +1133,14 @@ export class V2StorageTransaction implements IStorageTransaction {
     };
 
     for (const write of writes) {
-      const key = `${write.address.space}|${write.address.id}`;
+      // The run is flushed against a single document, fetched from the first
+      // write's address (see `writeBatchRun`). Documents are keyed by scope as
+      // well as id (`makeDocKey`), so the run key must include scope: otherwise
+      // writes to different scoped instances of the same id would be merged into
+      // one run and applied to whichever instance came first, corrupting both.
+      const key = `${write.address.space}|${
+        normalizeCellScope(write.address.scope)
+      }|${write.address.id}`;
       if (runKey === undefined || key === runKey) {
         run.push(write);
         runKey = key;

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -37,7 +37,12 @@ import {
   REJECTING_SELECTOR,
   schemaWithProperties,
 } from "@commonfabric/data-model/schema-utils";
-import type { CellScope, JSONObject, JSONSchema } from "./builder/types.ts";
+import type {
+  CellScope,
+  JSONObject,
+  JSONSchema,
+  SchemaScope,
+} from "./builder/types.ts";
 import {
   addressKey,
   createDataCellURI,
@@ -1207,9 +1212,23 @@ function notFound(
 }
 
 const schemaScopeForSelector = (selector?: SchemaPathSelector) =>
-  isRecord(selector?.schema) && isSchemaScope(selector.schema.scope)
-    ? selector.schema.scope
-    : undefined;
+  schemaFollowScopeCap(selector?.schema);
+
+/**
+ * The scope cap a schema imposes on the link it permits a read to follow.
+ * Honors an explicit top-level `scope`, falling back to the outermost `asCell`
+ * entry scope (so `asCell: [{ kind: "cell", scope: "session" }]` caps at
+ * session). This caps *which* link scopes may be followed; it must never be
+ * copied onto the followed link itself.
+ */
+const schemaFollowScopeCap = (schema: unknown): SchemaScope | undefined => {
+  if (!isRecord(schema)) return undefined;
+  if (isSchemaScope(schema.scope)) return schema.scope;
+  const entryScope = ContextualFlowControl.getAsCellScope(
+    ContextualFlowControl.getAsCellValues(schema as JSONSchema).at(0),
+  );
+  return isSchemaScope(entryScope) ? entryScope : undefined;
+};
 
 /**
  * Get a string to use as a key for the specified address

--- a/packages/runner/test/pattern-scope.test.ts
+++ b/packages/runner/test/pattern-scope.test.ts
@@ -9,7 +9,7 @@ import { type Cell, createCell } from "../src/cell.ts";
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
 
-Deno.test("Cell.key applies concrete scope from child schema", async () => {
+Deno.test("Cell.key keeps base scope; schema carries the scope", async () => {
   const storageManager = StorageManager.emulate({ as: signer });
   const runtime = new Runtime({
     apiUrl: new URL(import.meta.url),
@@ -37,14 +37,27 @@ Deno.test("Cell.key applies concrete scope from child schema", async () => {
       tx,
     );
 
+    // key() only extends the path; it never changes the link's scope. The
+    // declared scope lives in the schema and is realized on read/write (via
+    // redirect links), not stamped onto the navigated link.
     assertEquals(cell.getAsNormalizedFullLink().scope, "space");
-    assertEquals(cell.key("name").getAsNormalizedFullLink().scope, "user");
+    assertEquals(cell.key("name").getAsNormalizedFullLink().scope, "space");
     assertEquals(
       cell.key("selectedRoom").getAsNormalizedFullLink().scope,
-      "session",
+      "space",
     );
     assertEquals(
       cell.key("selectedRoom", "room").getAsNormalizedFullLink().scope,
+      "space",
+    );
+
+    // The scope is carried on the schema of the navigated link.
+    assertEquals(
+      (cell.key("name").getAsNormalizedFullLink().schema as any)?.scope,
+      "user",
+    );
+    assertEquals(
+      (cell.key("selectedRoom").getAsNormalizedFullLink().schema as any)?.scope,
       "session",
     );
   } finally {

--- a/packages/runner/test/pattern-scope.test.ts
+++ b/packages/runner/test/pattern-scope.test.ts
@@ -581,6 +581,110 @@ Deno.test("cross-space scoped links preserve target space and resolved scope", a
   }
 });
 
+Deno.test("lift can read session-scoped cell passed from pattern input", async () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const tx = runtime.edit();
+
+  try {
+    const { lift, pattern } = createTrustedBuilder(runtime).commonfabric;
+    const sessionTargetBase = runtime.getCell<string | null>(
+      space,
+      "lift captured session target",
+      undefined,
+      tx,
+    );
+    const sessionTarget = createCell<string | null>(
+      runtime,
+      { ...sessionTargetBase.getAsNormalizedFullLink(), scope: "session" },
+      tx,
+    );
+    sessionTarget.set("a");
+    const sessionTargetBaseLink = sessionTargetBase.getAsNormalizedFullLink();
+    const sessionTargetLink = sessionTarget.getAsNormalizedFullLink();
+    assertEquals(sessionTargetBaseLink.scope, "space");
+    assertEquals(sessionTargetLink, {
+      ...sessionTargetBaseLink,
+      scope: "session",
+    });
+    assertEquals(sessionTarget.get(), "a");
+
+    const inputSchema = {
+      type: "object",
+      properties: {
+        sessionTarget: {
+          anyOf: [{ type: "string" }, { type: "null" }],
+          asCell: [{ kind: "cell", scope: "session" }],
+        },
+      },
+      required: ["sessionTarget"],
+    } as const;
+
+    const isSessionOpen = lift(
+      {
+        type: "object",
+        properties: {
+          sessionTarget: {
+            anyOf: [{ type: "string" }, { type: "null" }],
+            asCell: [{ kind: "cell", scope: "session" }],
+          },
+          id: { type: "string" },
+        },
+        required: ["sessionTarget", "id"],
+      },
+      { type: "boolean" },
+      (
+        { sessionTarget, id }: {
+          sessionTarget: Cell<string | null>;
+          id: string;
+        },
+      ) => sessionTarget.get() === id,
+    );
+
+    const Root = pattern<{
+      sessionTarget: Cell<string | null>;
+    }>(({ sessionTarget }) => ({
+      isOpen: isSessionOpen({
+        sessionTarget,
+        id: "a",
+      }),
+    }), inputSchema);
+
+    const resultCell = runtime.getCell(
+      space,
+      "lift reads session scoped cell passed from pattern input",
+      undefined,
+      tx,
+    );
+
+    const result = runtime.run(tx, Root, {
+      sessionTarget,
+    }, resultCell);
+
+    const sourceCell = result.getSourceCell();
+    const argTarget = sourceCell!.key("argument").key("sessionTarget");
+    const storedArgumentTargetLink = parseLink(argTarget.getRaw(), argTarget)!;
+    assertEquals(storedArgumentTargetLink.id, sessionTargetLink.id);
+    assertEquals(storedArgumentTargetLink.path, sessionTargetLink.path);
+    assertEquals(storedArgumentTargetLink.space, sessionTargetLink.space);
+    assertEquals(storedArgumentTargetLink.scope, sessionTargetLink.scope);
+
+    runtime.prepareTxForCommit(tx);
+    await tx.commit();
+    await runtime.idle();
+    await runtime.storageManager.synced();
+    await result.pull();
+
+    assertEquals(result.key("isOpen").get() as unknown, true);
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
 Deno.test("broad computed output links to narrower scoped result", async () => {
   const storageManager = StorageManager.emulate({ as: signer });
   const runtime = new Runtime({

--- a/packages/runner/test/pattern-scope.test.ts
+++ b/packages/runner/test/pattern-scope.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
@@ -8,6 +8,74 @@ import { type Cell, createCell } from "../src/cell.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
+
+Deno.test("bulk write routes nested scoped fields to their scope instances", async () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const tx = runtime.edit();
+
+  try {
+    const cell = runtime.getCell(
+      space,
+      "bulk nested scope",
+      {
+        type: "object",
+        properties: {
+          theme: { type: "string" },
+          draft: { type: "string", scope: "session" },
+          tags: {
+            type: "array",
+            items: { type: "string", scope: "session" },
+          },
+        },
+      },
+      tx,
+    );
+
+    // One bulk write containing a space field, a nested session field, and an
+    // array whose items are session-scoped.
+    cell.set({ theme: "dark", draft: "hello", tags: ["x", "y"] });
+
+    const id = cell.getAsNormalizedFullLink().id;
+    const at = (scope: "space" | "session", ...path: string[]) =>
+      tx.read({
+        space,
+        id,
+        scope,
+        type: "application/json",
+        path: ["value", ...path],
+      }).ok?.value;
+
+    // Object field: content in the session instance, a link at the space slot.
+    assertEquals(at("session", "draft"), "hello");
+    const draftBroad = at("space", "draft");
+    const draftLink = parseLink(draftBroad, cell.key("draft") as any);
+    assert(draftLink !== undefined, "space draft slot should hold a link");
+    assertEquals(draftLink!.scope, "session");
+
+    // Space field stays in the space instance.
+    assertEquals(at("space", "theme"), "dark");
+
+    // Array: container stays in space (length is space-scoped), each element is
+    // a link to the session-scoped element instance (no whole-array redirect).
+    assertEquals(at("space", "tags", "length"), 2);
+    assertEquals(at("session", "tags", "0"), "x");
+    const tag0Broad = at("space", "tags", "0");
+    const tag0Link = parseLink(tag0Broad, cell.key("tags", "0") as any);
+    assert(tag0Link !== undefined, "space tags[0] slot should hold a link");
+    assertEquals(tag0Link!.scope, "session");
+
+    // Reads resolve through the links.
+    assertEquals(cell.key("draft").get() as unknown, "hello");
+    assertEquals(cell.key("tags").get() as unknown, ["x", "y"]);
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
 
 Deno.test("getCell seeds base scope from a top-level schema scope", async () => {
   const storageManager = StorageManager.emulate({ as: signer });

--- a/packages/runner/test/pattern-scope.test.ts
+++ b/packages/runner/test/pattern-scope.test.ts
@@ -9,6 +9,48 @@ import { type Cell, createCell } from "../src/cell.ts";
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
 
+Deno.test("getCell seeds base scope from a top-level schema scope", async () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const tx = runtime.edit();
+
+  try {
+    // No top-level scope -> space.
+    const spaceCell = runtime.getCell(
+      space,
+      "getcell-scope-default",
+      { type: "object", properties: { v: { type: "string" } } },
+      tx,
+    );
+    assertEquals(spaceCell.getAsNormalizedFullLink().scope, "space");
+
+    // Top-level schema scope seeds the created cell's base scope.
+    const userCell = runtime.getCell(
+      space,
+      "getcell-scope-user",
+      { type: "object", scope: "user", properties: { v: { type: "string" } } },
+      tx,
+    );
+    assertEquals(userCell.getAsNormalizedFullLink().scope, "user");
+
+    // An explicit scope argument still wins over the schema.
+    const explicitCell = runtime.getCell(
+      space,
+      "getcell-scope-explicit",
+      { type: "object", scope: "user", properties: { v: { type: "string" } } },
+      tx,
+      "session",
+    );
+    assertEquals(explicitCell.getAsNormalizedFullLink().scope, "session");
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
 Deno.test("Cell.key keeps base scope; schema carries the scope", async () => {
   const storageManager = StorageManager.emulate({ as: signer });
   const runtime = new Runtime({

--- a/packages/runner/test/schema-basic.test.ts
+++ b/packages/runner/test/schema-basic.test.ts
@@ -7,6 +7,7 @@ import "@commonfabric/utils/equal-ignoring-symbols";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { type Cell, isCell } from "../src/cell.ts";
+import { ContextualFlowControl } from "../src/cfc.ts";
 import { type JSONSchema } from "../src/builder/types.ts";
 import { Runtime } from "../src/runtime.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
@@ -742,8 +743,79 @@ describe("Schema - Basic Types and References", () => {
         tx,
       );
 
+      // key() does not stamp the asCell entry scope onto the navigated link:
+      // the link stays at the container's base scope, with the declared scope
+      // carried on the schema (where it is honored as a follow cap on reads and
+      // as the target scope on writes).
       const currentCell = outer.key("current");
-      expect(currentCell.getAsNormalizedFullLink().scope).toBe("user");
+      const link = currentCell.getAsNormalizedFullLink();
+      expect(link.scope).toBe("space");
+      expect(
+        ContextualFlowControl.getAsCellScope(
+          ContextualFlowControl.getAsCellValues(link.schema).at(0),
+        ),
+      ).toBe("user");
+    });
+
+    it("key() only extends the path and walks the schema, never the scope, without reading", () => {
+      // .key() is a pure link/schema transformation: it appends to the path and
+      // walks the schema, and it must NOT read storage NOR change the link's
+      // scope. Scope lives only in the schema (top-level and asCell entries) and
+      // is resolved later (as a follow cap on reads, as the target scope on
+      // writes). We assert on a document with no committed data so any read
+      // would be observable via the transaction's read activities.
+      const root = runtime.getCell(
+        space,
+        "key-no-read-scope-walk",
+        {
+          type: "object",
+          properties: {
+            account: {
+              type: "object",
+              scope: "user",
+              properties: {
+                draft: {
+                  type: "string",
+                  asCell: [{ kind: "cell", scope: "session" }],
+                },
+                name: { type: "string" },
+              },
+            },
+          },
+        } as const satisfies JSONSchema,
+        tx,
+      );
+
+      const getReadActivities = tx.getReadActivities;
+      expect(getReadActivities).toBeDefined();
+      const readCountBefore = [...getReadActivities!.call(tx)].length;
+
+      // The link scope stays at the cell's base scope through every key()...
+      const account = root.key("account");
+      expect(account.getAsNormalizedFullLink().path).toEqual(["account"]);
+      expect(account.getAsNormalizedFullLink().scope).toBe("space");
+
+      const name = root.key("account", "name");
+      expect(name.getAsNormalizedFullLink().path).toEqual(["account", "name"]);
+      expect(name.getAsNormalizedFullLink().scope).toBe("space");
+
+      const draft = root.key("account", "draft");
+      expect(draft.getAsNormalizedFullLink().path).toEqual([
+        "account",
+        "draft",
+      ]);
+      expect(draft.getAsNormalizedFullLink().scope).toBe("space");
+
+      // ...while the scope it walked to is carried on the link's schema, where
+      // reads/writes resolve it.
+      expect(
+        (account.getAsNormalizedFullLink().schema as JSONSchema as any)
+          ?.scope,
+      ).toBe("user");
+
+      // key() performed no storage reads.
+      const readCountAfter = [...getReadActivities!.call(tx)].length;
+      expect(readCountAfter).toBe(readCountBefore);
     });
 
     it("should preserve nested asCell wrappers through anyOf branches", () => {


### PR DESCRIPTION
## Summary

Fixes [CT-1623](https://linear.app/common-tools/issue/CT-1623): reading a `perSession` cell from a broader (space) reading context silently returned nothing (dead UI, no error).

**Root cause:** cell scope was eagerly *stamped onto links during navigation* (`key()`, `validateAndTransform`). When a session-scoped cell was reached through a space-scoped container, the stamped scope re-addressed the *container's* link to its empty session instance, so the read silently returned `undefined`. The follow-scope cap also ignored `asCell` entry scope, and writes didn't move data to its declared scope.

This moves to the model in `docs/specs/scoped-cell-instances.md`: **scope lives in the schema; links carry only a base scope; the effective scope is realized on read (as a follow cap) and on write (via redirect links).**

## Changes

- **Follow-scope cap honors `asCell` entry scope** (`traverse.ts`, `link-resolution.ts`): a value declared `asCell:[{kind:"cell",scope:"session"}]` now permits following session links, while a `user` cap still blocks them.
- **`key()` only extends the path, never the scope** (`cell.ts`): scope is no longer stamped onto the navigated link (neither inline nor `asCell` entry scope). Stamping made reads hit the wrong scoped instance of the container.
- **`validateAndTransform` keeps the followed link's own resolved scope** instead of overwriting it with the `asCell` scope (`schema.ts`); the default-value creation path still seeds scope.
- **`diffAndUpdate` enforces the narrow-write rule in one general place** (`data-updating.ts`): when a cell's schema declares a narrower scope than the link's base scope, content writes go into the narrower-scope instance and a redirect link is left at the base scope so broader-scope readers follow it. Writing a link value is exempt (a reference carries its own target scope).
- **`getCell` seeds base scope from a top-level schema scope** (`runtime.ts`).

## Tests

- New failing-then-passing repro: a `lift` reading a session-scoped cell passed via pattern input.
- Updated the two tests that asserted the old eager-stamping; added a test pinning that `key()` changes only the path, carries scope on the schema, and performs no reads; added a `getCell` base-scope test.
- **Full runner suite: 468 passed, 0 failed.**
- Latent `.tsx` patterns (`parking-coordinator`, `cozy-poll-scoped`) transform/typecheck cleanly.

## Notes

- The `narrowestReadScope` narrowing in `pattern-binding.ts` (computation-output concern) is intentionally kept separate; folding it into `diffAndUpdate` would over-narrow unrelated writes. The schema-declared-scope rule from the spec now lives centrally in `diffAndUpdate`.
- The bug report's literal closure-in-`.map()` shape can't be reproduced at the runner level (the TS transformer lifts such closures into explicit inputs — exactly the lift form the minimal repro covers). Full in-browser reactive verification of the latent patterns would need a running toolshed; the underlying scope-follow mechanism they rely on is covered by the green tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CT-1623 by resolving cell scope from the schema instead of stamping it onto links, so session-scoped cells read and write correctly even when reached from space-scoped containers. Also keys write batches by scope to prevent cross-scope write corruption and make nested scope-narrowing compose cleanly.

- **Bug Fixes**
  - Follow-scope cap now honors a top-level `scope` or the outermost `asCell` entry scope.
  - `Cell.key()` only extends the path and walks the schema; it never changes link scope or reads storage.
  - Materialization keeps the followed link’s storage-resolved scope; creation paths still seed scope from `asCell` as needed. `Runtime.getCell` seeds base scope from an explicit arg, else a top-level schema scope, else `space`.
  - `diffAndUpdate` enforces schema-declared scope at all depths: narrower fields write to their narrower-scope instance and leave a redirect at the broad slot; arrays keep the container broad and store per-element links to narrower items; writing link/cell values is exempt. Narrowed content and the broad redirect are applied in one change set, and storage creates any missing ancestor containers.
  - Storage: write-batch grouping now includes scope so writes to different scoped instances of the same id aren’t merged and misapplied.
  - Tests: added bulk nested-scope write routing, `key()` no-read and scope-carry tests, `getCell` base-scope seeding, and a repro for a lift reading a session-scoped input; updated prior scope-stamping assertions. All runner tests pass.

<sup>Written for commit b2b4d8ab320894d46394d340d1abded252ac4e18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

