### PR TITLE
docs(data-model): src-side section-marker/HR conformance sweep

### DIFF
--- a/packages/data-model/src/fabric-value-modern.ts
+++ b/packages/data-model/src/fabric-value-modern.ts
@@ -466,9 +466,11 @@ export function isFabricValueModern(
   }
 }
 
-// ---------------------------------------------------------------------------
-// `isFabricCompatible()`: deep check for fabric compatibility
-// ---------------------------------------------------------------------------
+//
+// `isFabricCompatible()`
+//
+// Deep check for fabric compatibility.
+//
 
 /**
  * Returns `true` if `fabricFromNativeValue()` would succeed on the value --
@@ -493,9 +495,9 @@ export function isFabricCompatibleModern(
   return isFabricCompatibleInternal(value, new Set());
 }
 
-// ---------------------------------------------------------------------------
+//
 // Unified clone: `cloneIfNecessary()`
-// ---------------------------------------------------------------------------
+//
 
 function isFabricCompatibleInternal(
   value: unknown,
@@ -588,9 +590,9 @@ function isFabricCompatibleInternal(
   }
 }
 
-// ---------------------------------------------------------------------------
+//
 // Deep unwrap: `FabricValue` -> native JS types (modern path)
-// ---------------------------------------------------------------------------
+//
 
 /**
  * Recursively walks a `FabricValue` tree, unwrapping any

--- a/packages/data-model/src/interface.ts
+++ b/packages/data-model/src/interface.ts
@@ -10,9 +10,9 @@
  * corresponding declarations there.
  */
 
-// ===========================================================================
+//
 // `FabricSpecialObject`
-// ===========================================================================
+//
 
 /**
  * Abstract base class for all fabric-system value types. This is the common
@@ -24,9 +24,9 @@
  */
 export abstract class FabricSpecialObject {}
 
-// ===========================================================================
+//
 // Fabric instance protocol (`[DECONSTRUCT]` / `[RECONSTRUCT]` / `FabricInstance`)
-// ===========================================================================
+//
 
 /**
  * Well-known symbol for deconstructing a fabric instance into its essential
@@ -152,9 +152,9 @@ export abstract class FabricInstance extends FabricSpecialObject {
   abstract shallowClone(frozen: boolean): FabricInstance;
 }
 
-// ===========================================================================
+//
 // Fabric primitive base class
-// ===========================================================================
+//
 
 /**
  * Abstract base class for "special primitive" fabric types -- values that
@@ -179,9 +179,9 @@ export abstract class FabricPrimitive extends FabricSpecialObject {
   }
 }
 
-// ===========================================================================
+//
 // Type definitions
-// ===========================================================================
+//
 
 /**
  * The full set of values that the fabric storage layer can represent. This
@@ -275,9 +275,9 @@ export type FabricNativeObject =
   | Uint8Array
   | { toJSON(): unknown };
 
-// ===========================================================================
+//
 // Fabric protocol interfaces
-// ===========================================================================
+//
 
 /**
  * Interface for classes that can reconstruct fabric instances from essential

--- a/packages/data-model/src/json-wire/JsonEncodingContext.ts
+++ b/packages/data-model/src/json-wire/JsonEncodingContext.ts
@@ -158,9 +158,9 @@ export class JsonEncodingContext implements SerializationContext<string> {
     return this.deserialize(parsed, runtime);
   }
 
-  // -------------------------------------------------------------------------
+  //
   // Static helpers
-  // -------------------------------------------------------------------------
+  //
 
   /**
    * Indicates if the given text has a "first-blush" appearance as valid JSON
@@ -171,9 +171,9 @@ export class JsonEncodingContext implements SerializationContext<string> {
     return value.startsWith(ENCODING_PREFIX_TAG);
   }
 
-  // -------------------------------------------------------------------------
+  //
   // Byte-level boundary (public for now -- used by serializeToBytes tests)
-  // -------------------------------------------------------------------------
+  //
 
   /**
    * Serializes a fabric value to UTF-8 JSON bytes.
@@ -193,9 +193,9 @@ export class JsonEncodingContext implements SerializationContext<string> {
     return this.deserialize(tree, runtime);
   }
 
-  // -------------------------------------------------------------------------
+  //
   // Tag wrapping/unwrapping (private)
-  // -------------------------------------------------------------------------
+  //
 
   /** Returns the wire format tag for a fabric instance's type. */
   private getTagFor(value: FabricInstance): string {
@@ -253,9 +253,9 @@ export class JsonEncodingContext implements SerializationContext<string> {
     return { tag, state };
   }
 
-  // -------------------------------------------------------------------------
+  //
   // Byte conversion (private)
-  // -------------------------------------------------------------------------
+  //
 
   /** Converts a wire-format tree to UTF-8-encoded JSON bytes. */
   private toBytes(data: JsonWireValue): Uint8Array {
@@ -271,9 +271,6 @@ export class JsonEncodingContext implements SerializationContext<string> {
   //
   // Tree-walking serialization (private)
   //
-  // Moved from serialization.ts. These methods walk the value tree,
-  // dispatching to type handlers and applying structural escaping.
-  //
 
   /**
    * Serializes a fabric value into wire format. Recursively processes nested
@@ -284,7 +281,7 @@ export class JsonEncodingContext implements SerializationContext<string> {
     _seen?: Set<object>,
     registry: TypeHandlerRegistry = defaultRegistry,
   ): JsonWireValue {
-    // --- Try type handlers first ---
+    // Try type handlers first
     const handler = registry.findSerializer(value);
     if (handler) {
       const seen = _seen ?? new Set<object>();
@@ -309,7 +306,7 @@ export class JsonEncodingContext implements SerializationContext<string> {
       return result;
     }
 
-    // Primitives.
+    // Primitives
     if (
       value === null || typeof value === "boolean" ||
       typeof value === "number" || typeof value === "string"
@@ -317,7 +314,7 @@ export class JsonEncodingContext implements SerializationContext<string> {
       return value as JsonWireValue;
     }
 
-    // --- Arrays ---
+    // Arrays
     if (Array.isArray(value)) {
       const seen = _seen ?? new Set<object>();
       if (seen.has(value)) {
@@ -347,7 +344,7 @@ export class JsonEncodingContext implements SerializationContext<string> {
       return result as JsonWireValue;
     }
 
-    // --- Plain objects ---
+    // Plain objects
     const seen = _seen ?? new Set<object>();
     if (seen.has(value as object)) {
       throw new Error("Circular reference detected during serialization");
@@ -385,9 +382,9 @@ export class JsonEncodingContext implements SerializationContext<string> {
     return result as JsonWireValue;
   }
 
-  // -------------------------------------------------------------------------
+  //
   // Tree-walking deserialization (private)
-  // -------------------------------------------------------------------------
+  //
 
   /**
    * Deserializes a wire-format value back into modern runtime types.
@@ -434,7 +431,7 @@ export class JsonEncodingContext implements SerializationContext<string> {
         return state as FabricValue;
       }
 
-      // Type handler dispatch.
+      // Type handler dispatch
       //
       // `TypeHandler.deserialize()` makes a contractual guarantee that its
       // results are deep-frozen, rather than relying on every caller to
@@ -470,7 +467,7 @@ export class JsonEncodingContext implements SerializationContext<string> {
         ));
       }
 
-      // --- Class registry fallback ---
+      // Class registry fallback
       const cls = this.getClassFor(tag);
       const deserializedState = this.deserialize(state, runtime, registry);
 

--- a/packages/data-model/src/json-wire/JsonEncodingContext.ts
+++ b/packages/data-model/src/json-wire/JsonEncodingContext.ts
@@ -129,9 +129,9 @@ export class JsonEncodingContext implements SerializationContext<string> {
     this.registry.set(TAGS.RegExp, FabricRegExp);
   }
 
-  // -------------------------------------------------------------------------
+  //
   // `SerializationContext<string>` -- public boundary interface
-  // -------------------------------------------------------------------------
+  //
 
   /**
    * Encodes a fabric value to a JSON string. Serializes modern types into
@@ -268,12 +268,12 @@ export class JsonEncodingContext implements SerializationContext<string> {
     return JsonEncodingContext.#parseWireText(json);
   }
 
-  // -------------------------------------------------------------------------
+  //
   // Tree-walking serialization (private)
   //
   // Moved from serialization.ts. These methods walk the value tree,
   // dispatching to type handlers and applying structural escaping.
-  // -------------------------------------------------------------------------
+  //
 
   /**
    * Serializes a fabric value into wire format. Recursively processes nested
@@ -309,7 +309,7 @@ export class JsonEncodingContext implements SerializationContext<string> {
       return result;
     }
 
-    // --- Primitives ---
+    // Primitives.
     if (
       value === null || typeof value === "boolean" ||
       typeof value === "number" || typeof value === "string"
@@ -434,7 +434,7 @@ export class JsonEncodingContext implements SerializationContext<string> {
         return state as FabricValue;
       }
 
-      // --- Type handler dispatch ---
+      // Type handler dispatch.
       //
       // `TypeHandler.deserialize()` makes a contractual guarantee that its
       // results are deep-frozen, rather than relying on every caller to

--- a/packages/data-model/src/json-wire/makeProblematic.ts
+++ b/packages/data-model/src/json-wire/makeProblematic.ts
@@ -2,10 +2,6 @@ import type { FabricValue } from "../interface.ts";
 import { ProblematicValue } from "../fabric-instances/ProblematicValue.ts";
 import type { JsonWireValue } from "./interface.ts";
 
-// ---------------------------------------------------------------------------
-// Utility: `ProblematicValue` factory
-// ---------------------------------------------------------------------------
-
 /**
  * Creates a `ProblematicValue` for a deserialization failure. The type tag
  * is preserved for round-tripping; the message provides human-readable

--- a/packages/data-model/src/native-instance-utils.ts
+++ b/packages/data-model/src/native-instance-utils.ts
@@ -1,10 +1,6 @@
 import { NATIVE_TAGS, tagFromNativeValue } from "./native-type-tags.ts";
 import { FrozenSet } from "./frozen-builtins.ts";
 
-// ---------------------------------------------------------------------------
-// Utility: native-instance type guard
-// ---------------------------------------------------------------------------
-
 /**
  * Returns `true` if the value is a native JS object type that the fabric
  * system knows how to wrap. These are the "wild-west" instances that get
@@ -30,19 +26,11 @@ export function isConvertibleNativeInstance(value: object): boolean {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Utility: safe property copy
-// ---------------------------------------------------------------------------
-
 /** Keys that must never be copied to prevent prototype pollution. */
 export const UNSAFE_KEYS: FrozenSet<string> = new FrozenSet([
   "__proto__",
   "constructor",
 ]);
-
-// ---------------------------------------------------------------------------
-// Utility: `Error` class lookup
-// ---------------------------------------------------------------------------
 
 /** Map from Error subclass name to its constructor. */
 const ERROR_CLASS_BY_TYPE: ReadonlyMap<string, ErrorConstructor> = new Map([

--- a/packages/data-model/src/schema-hash.ts
+++ b/packages/data-model/src/schema-hash.ts
@@ -9,9 +9,11 @@ import { SchemaAndHash } from "./SchemaAndHash.ts";
 import { toDeepFrozenSchema } from "./schema-utils.ts";
 import { hashOf, hashStringOf } from "./value-hash.ts";
 
-// ---------------------------------------------------------------------------
-// Hash computation: Passes through to `value-hash.ts`.
-// ---------------------------------------------------------------------------
+//
+// Hash computation
+//
+// Passes through to `value-hash.ts`.
+//
 
 /**
  * Computes a deterministic hash of a JSONSchema. Structurally-equal schemas
@@ -25,9 +27,9 @@ export function hashSchema(schema: JSONSchema): string {
   return hashStringOf(schema);
 }
 
-// ---------------------------------------------------------------------------
+//
 // Schema interning
-// ---------------------------------------------------------------------------
+//
 
 /**
  * Bidirectional intern cache for schemas.

--- a/packages/data-model/src/value-clone.ts
+++ b/packages/data-model/src/value-clone.ts
@@ -439,7 +439,7 @@ export function cloneForMutation<T extends FabricValue>(
   // final value-at-`path` thaw if it's a plain container or `FabricInstance`.
   const cloneOpts = { frozen: false as const, deep: false as const, force };
 
-  // --- Empty-path fast path ---------------------------------------------
+  // Empty-path fast path
   if (path.length === 0) {
     if (!isMutableHandle(value)) {
       throw new CloneForMutationError(
@@ -454,10 +454,9 @@ export function cloneForMutation<T extends FabricValue>(
     return { value: newRoot, pathValue: newRoot };
   }
 
-  // --- Non-empty path ---------------------------------------------------
-  // The root must be a plain container; descent through a `FabricInstance`
-  // root would have nowhere to go (path-style access into FabricInstance
-  // internals isn't supported).
+  // Non-empty path: The root must be a plain container; descent through a
+  // `FabricInstance` root would have nowhere to go (path-style access into
+  // FabricInstance internals isn't supported).
   if (!isPlainContainer(value)) {
     throw new CloneForMutationError(
       "non-container-root",

--- a/packages/data-model/src/value-hash.ts
+++ b/packages/data-model/src/value-hash.ts
@@ -23,9 +23,9 @@ import { bigintToMinimalTwosComplement } from "@commonfabric/utils/bigint";
 import { LRUCache } from "@commonfabric/utils/cache";
 import { utf8SortedKeysOf } from "@commonfabric/utils/utf8";
 
-// ---------------------------------------------------------------------------
+//
 // Type tag bytes (Section 2 of the byte-level spec)
-// ---------------------------------------------------------------------------
+//
 
 // Meta (0x0N)
 const TAG_END = 0x00;
@@ -52,9 +52,9 @@ const TAG_SYMBOL = 0x2a;
 // Special for hashing:
 const TAG_STRING_HASH = 0xf0;
 
-// ---------------------------------------------------------------------------
+//
 // Pre-allocated tag byte arrays (avoids per-call allocation)
-// ---------------------------------------------------------------------------
+//
 
 const TAG_END_BYTES = new Uint8Array([TAG_END]);
 const TAG_HOLE_BYTES = new Uint8Array([TAG_HOLE]);
@@ -73,9 +73,9 @@ const TAG_EPOCH_DAYS_BYTES = new Uint8Array([TAG_EPOCH_DAYS]);
 const TAG_CONTENT_HASH_BYTES = new Uint8Array([TAG_CONTENT_HASH]);
 const TAG_SYMBOL_BYTES = new Uint8Array([TAG_SYMBOL]);
 
-// ---------------------------------------------------------------------------
+//
 // Core: recursive value feeding
-// ---------------------------------------------------------------------------
+//
 
 /**
  * Maximum encoded length of a string which is represented in just-encoded form.
@@ -383,9 +383,9 @@ function feedPlainObject(
   hasher.update(TAG_END_BYTES);
 }
 
-// ---------------------------------------------------------------------------
+//
 // Uncached hash computation
-// ---------------------------------------------------------------------------
+//
 
 /**
  * Computes the hash of a value without consulting or populating any cache.
@@ -406,9 +406,9 @@ function computeHashAsString(value: unknown): string {
   return hasher.digest("base64url");
 }
 
-// ---------------------------------------------------------------------------
+//
 // Caches
-// ---------------------------------------------------------------------------
+//
 
 /** Pre-computed constant hashes (these values never change). */
 const NULL_HASH = computeHash(null);
@@ -452,9 +452,9 @@ function cachedPrimitiveHash(
   return result;
 }
 
-// ---------------------------------------------------------------------------
+//
 // Public API
-// ---------------------------------------------------------------------------
+//
 
 /**
  * Common helper for the two exported hash functions, which _might_ return a


### PR DESCRIPTION
Src-side conformance sweep over `packages/data-model/src/`: convert/remove section-marker & horizontal-rule comments per `coordination/rules/code-conventions.md` L61-89.

**Scope expansion (Dan's verbatim direction after merging #3755):** *"just merged #3755. it also ended up touching `schema-utils.ts` and some unit test files. please do include rework as appropriate to all of these (including unit tests) in this PR."* — so `value-clone.ts` is now in scope (its exclusion lifted; the L432 disposition-(c) anchor finally applies to its own file), and the 2 test files #3755 touched (`test/schema-utils.test.ts` + `test/shallowMutableClone.test.ts`) are verify-only against the #3747 calibrated test-side shape. This temporarily crosses the test/src boundary per Dan's explicit direction for this PR.

## Calibrated shape (Dan-ratified on #3754's draft pilot)

Per the four calibration questions Dan answered on the original pilot:

1. **(a) follow-up: omit when redundant.** Bare-title-only when the immediately-following code (or JSDocs) carries the meaning. Keep the optional grammatical description only when it adds something the code doesn't.
2. **Title format: Capital then lower, NO period.** Applies to both (a) bookend titles and (c) inline titles.
3. **(c) with-description split:** multi-paragraph "why" → `// Title` + blank + prose. One-line "why" → `// Title: explanation` (the `value-clone.ts:432` anchor pattern, now applied to itself).
4. **Per-function markers don't exist.** Per rule L78-83 ("Do not use a section marker as a header that merely serves to separate out things like individual functions"), per-function markers are deleted entirely — JSDocs are the docstring.

## (b) negative-space finding

**Zero bare-HR-no-header sites across the whole data-model src tree.** No (b) calibration needed; the round is (a)+(c) only.

## Files swept (8 src + 2 test verify-only)

- `src/json-wire/JsonEncodingContext.ts` — 6 (a) major-section bookends (all bare-title; one with-description at L437 kept the deep-freeze-contract prose) + 6 (c) inline bare titles (code-is-the-why for all).
- `src/interface.ts` — 5 (a) major-section bookends (bare-title).
- `src/value-hash.ts` — 6 (a) major-section bookends (bare-title).
- `src/schema-hash.ts` — 2 (a) bookends; the "Hash computation" one rendered with-description, "Schema interning" bare.
- `src/fabric-value-modern.ts` — 3 (a) major-section bookends; `isFabricCompatible()` rendered with-description, others bare.
- `src/native-instance-utils.ts` — 3 per-function markers DELETED entirely (per rule L78-83).
- `src/json-wire/makeProblematic.ts` — 1 per-function marker DELETED entirely.
- **`src/value-clone.ts` — 2 (c) inline conversions (L442 bare; L457 colon-prefix, the canonical anchor pattern applied to its own file).**

**Verify-only on #3755-touched test files (no rework needed — both already conformant to #3747 shape):**
- `test/schema-utils.test.ts` — 1 top-level describe (L352 collapse intact from #3747), 0 markers, #3755's 2 label rewrites verb-led.
- `test/shallowMutableClone.test.ts` — 1 top-level describe, 0 markers, #3755's 4 label rewrites/additions verb-led.

## Resync

Branch merged with `origin/main` at `cfae39be1` (incl. #3755 "shallowMutableClone() now deep-freezes children"); zero conflicts despite the touched-file overlap — the ort strategy handled all 4 #3755-touched files cleanly.

## Conservation

Comment-only changes, behavior-preserving. Full data-model suite **29 passed / 1824 steps / 0 failed**; `deno fmt --check` + `deno lint` + `deno check` clean over the package. `gh pr view 3754 --json mergeable` = `MERGEABLE`. TASK-0032 collapsed into TASK-0031.

Co-Authored-By: coder-colt (Claude Opus 4.7 (1M context)) <noreply@anthropic.com>
