### PR TITLE
fix(runner): align CFC integrity propagation

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1347,7 +1347,9 @@ export class CellImpl<T extends FabricValue>
       this.tx,
       this.synced,
       undefined,
-      mergeCfcLabelViews([this._cfcLabelView, dereferenceView]),
+      mergeCfcLabelViews([this._cfcLabelView, dereferenceView], {
+        integrity: "intersection",
+      }),
     );
   }
 

--- a/packages/runner/src/cfc/label-view-core.ts
+++ b/packages/runner/src/cfc/label-view-core.ts
@@ -1,4 +1,5 @@
 import { encodePointer } from "../../../memory/v2/path.ts";
+import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { uniqueCfcAtoms } from "./observation.ts";
 
 export type IFCLabel = {
@@ -68,28 +69,61 @@ const sortEntries = (entries: CfcLabelViewEntry[]): CfcLabelViewEntry[] =>
 const mergeLabel = (
   left: IFCLabel | undefined,
   right: IFCLabel,
+  options: MergeCfcLabelViewsOptions,
 ): IFCLabel => {
   const merged: IFCLabel = {};
-  for (const key of LABEL_KEYS) {
-    const values = [
-      ...(Array.isArray(left?.[key]) ? left[key] : []),
-      ...(Array.isArray(right[key]) ? right[key] : []),
-    ];
-    // Dedup structurally via `uniqueCfcAtoms()` rather than by reference
-    // (`new Set()`). Atoms can be fabric-converted clones (each call to
-    // `cloneIfNecessary()` produces a fresh frozen object), so two
-    // logically-identical caveats may not share a JS reference. The
-    // reference-keyed approach would leave duplicates that callers
-    // observe as both `confidentiality` bloat and -- since downstream
-    // entry-merging compares labels structurally -- as label entries
-    // failing to coalesce at the right path.
-    const unique = uniqueCfcAtoms(values);
-    if (unique.length > 0) {
-      merged[key] = unique;
-    }
+  const confidentiality = uniqueCfcAtoms([
+    ...(Array.isArray(left?.confidentiality) ? left.confidentiality : []),
+    ...(Array.isArray(right.confidentiality) ? right.confidentiality : []),
+  ]);
+  if (confidentiality.length > 0) {
+    merged.confidentiality = confidentiality;
+  }
+
+  const integrity = options.integrity === "intersection" && left !== undefined
+    ? intersectCfcAtoms(left.integrity, right.integrity)
+    : uniqueCfcAtoms([
+      ...(Array.isArray(left?.integrity) ? left.integrity : []),
+      ...(Array.isArray(right.integrity) ? right.integrity : []),
+    ]);
+  if (integrity.length > 0) {
+    merged.integrity = integrity;
   }
   return merged;
 };
+
+const intersectCfcAtoms = (
+  left: readonly unknown[] | undefined,
+  right: readonly unknown[] | undefined,
+): unknown[] => {
+  if (!Array.isArray(left) || !Array.isArray(right)) {
+    return [];
+  }
+  const uniqueLeft = uniqueCfcAtoms(left);
+  const common = uniqueLeft.filter((atom) =>
+    right.some((candidate) => deepEqual(candidate, atom))
+  );
+  return uniqueCfcAtoms(common);
+};
+
+export type MergeCfcLabelViewsOptions = {
+  /**
+   * Integrity is unioned when reconciling labels for the same value, but
+   * intersected when combining distinct contributing values per CFC 8.6/8.9.
+   */
+  integrity?: "union" | "intersection";
+};
+
+const DEFAULT_MERGE_OPTIONS: Required<MergeCfcLabelViewsOptions> = {
+  integrity: "union",
+};
+
+const normalizeMergeOptions = (
+  options?: MergeCfcLabelViewsOptions,
+): Required<MergeCfcLabelViewsOptions> => ({
+  ...DEFAULT_MERGE_OPTIONS,
+  ...options,
+});
 
 export const cloneCfcLabelView = (
   view: CfcLabelView | undefined,
@@ -108,7 +142,9 @@ export const cloneCfcLabelView = (
 
 export const mergeCfcLabelViews = (
   views: Array<CfcLabelView | undefined>,
+  options?: MergeCfcLabelViewsOptions,
 ): CfcLabelView | undefined => {
+  const mergeOptions = normalizeMergeOptions(options);
   const byPath = new Map<string, CfcLabelViewEntry>();
   for (const view of views) {
     if (!view) {
@@ -120,7 +156,7 @@ export const mergeCfcLabelViews = (
       const existing = byPath.get(key);
       byPath.set(key, {
         path,
-        label: mergeLabel(existing?.label, entry.label),
+        label: mergeLabel(existing?.label, entry.label, mergeOptions),
       });
     }
   }

--- a/packages/runner/src/cfc/label-view-state.ts
+++ b/packages/runner/src/cfc/label-view-state.ts
@@ -73,7 +73,7 @@ export const cfcLabelViewForDereference = (
   mergeCfcLabelViews([
     cfcLabelViewForAddress(tx, source),
     cfcLabelViewForAddress(tx, target),
-  ]);
+  ], { integrity: "intersection" });
 
 export const cfcLabelViewForDereferenceTraces = (
   tx: IExtendedStorageTransaction,
@@ -83,6 +83,7 @@ export const cfcLabelViewForDereferenceTraces = (
     traces.map((trace) =>
       cfcLabelViewForDereference(tx, trace.source, trace.target)
     ),
+    { integrity: "intersection" },
   );
 
 export const getCarriedCfcLabelView = (

--- a/packages/runner/src/cfc/label-view.ts
+++ b/packages/runner/src/cfc/label-view.ts
@@ -120,5 +120,5 @@ export const cfcLabelViewForCell = (
     metadataView,
     linkedValueView,
     getCarriedCfcLabelView(cell),
-  ]);
+  ], { integrity: "intersection" });
 };

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -873,9 +873,11 @@ const unsupportedTrustSensitiveReason = (
   const unsupportedKeys = [
     "projection",
     "collection",
+    "flowPrecisionClaim",
   ] as const;
+  const ifc = schema.ifc as Record<string, unknown>;
   for (const key of unsupportedKeys) {
-    const value = schema.ifc[key];
+    const value = ifc[key];
     if (value !== undefined) {
       return `unsupported trust-sensitive claim ${key} at /${path.join("/")}`;
     }
@@ -1694,7 +1696,11 @@ const mergeLabels = (
     left?.confidentiality,
     right?.confidentiality,
   ),
-  integrity: mergeLabelValues(left?.integrity, right?.integrity),
+  integrity: left === undefined
+    ? mergeLabelValues(right?.integrity)
+    : right === undefined
+    ? mergeLabelValues(left.integrity)
+    : mergeLabelValues(left.integrity, right.integrity),
 });
 
 const linkReferenceIntegrity = (input: LinkWritePolicyInput): unknown => ({

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -160,7 +160,7 @@ export function createQueryResultProxy<T>(
       readTx,
       readTx.getCfcState().dereferenceTraces.slice(traceStart),
     ),
-  ]);
+  ], { integrity: "intersection" });
   const value = readTx.readValueOrThrow(link) as any;
 
   // If the value is a stream marker ({ $stream: true }), return a Cell with

--- a/packages/runner/test/cfc-boundary.test.ts
+++ b/packages/runner/test/cfc-boundary.test.ts
@@ -1731,7 +1731,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     const { runtime, storageManager } = createRuntime();
     try {
       const tx = runtime.edit();
-      tx.setCfcEnforcementMode("enforce-explicit");
+      tx.setCfcEnforcementMode("observe");
       const schema = flowPrecisionSchemaForBuiltin("map");
       const cell = runtime.getCell(
         signer.did(),
@@ -1742,6 +1742,9 @@ describe("ExtendedStorageTransaction CFC gate", () => {
       cell.set([1, 2, 3]);
       runtime.prepareTxForCommit(tx);
       expect((await tx.commit()).ok).toBeDefined();
+      expect(tx.getCfcState().diagnostics).toContain(
+        "unsupported trust-sensitive claim flowPrecisionClaim at /",
+      );
 
       const link = cell.getAsNormalizedFullLink();
       const verify = runtime.edit();
@@ -1751,6 +1754,31 @@ describe("ExtendedStorageTransaction CFC gate", () => {
       expect(stored.cfc).toBeUndefined();
       expect(storedCfcMetadataAppliesToPath(verify, link)).toBe(false);
       verify.abort();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("fails closed on flow-precision claims in enforcing modes", async () => {
+    const { runtime, storageManager } = createRuntime();
+    try {
+      const tx = runtime.edit();
+      tx.setCfcEnforcementMode("enforce-explicit");
+      const schema = flowPrecisionSchemaForBuiltin("map");
+      const cell = runtime.getCell(
+        signer.did(),
+        "cfc-flow-precision-enforce-fail-closed",
+        schema,
+        tx,
+      );
+      cell.set([1, 2, 3]);
+
+      runtime.prepareTxForCommit(tx);
+      const result = await tx.commit();
+      expect(result.error?.message).toContain(
+        "unsupported trust-sensitive claim flowPrecisionClaim",
+      );
     } finally {
       await runtime.dispose();
       await storageManager.close();
@@ -2154,7 +2182,16 @@ describe("ExtendedStorageTransaction CFC gate", () => {
       const source = runtime.getCell(
         signer.did(),
         "cfc-link-carried-only-source",
-        undefined,
+        {
+          type: "object",
+          ifc: {
+            confidentiality: ["source-confidentiality"],
+            integrity: ["source-integrity"],
+          },
+          properties: {
+            title: { type: "string" },
+          },
+        },
         seed,
       );
       source.set({ title: "plain source" });
@@ -2201,7 +2238,16 @@ describe("ExtendedStorageTransaction CFC gate", () => {
         expect.arrayContaining([
           expect.objectContaining({
             path: [],
-            label: { integrity: ["selected-by-alice"] },
+            label: expect.objectContaining({
+              confidentiality: ["source-confidentiality"],
+              integrity: expect.arrayContaining([
+                "source-integrity",
+                "selected-by-alice",
+                expect.objectContaining({
+                  type: "https://commonfabric.org/cfc/atom/LinkReference",
+                }),
+              ]),
+            }),
           }),
           expect.objectContaining({
             path: ["title"],
@@ -4776,6 +4822,44 @@ describe("ExtendedStorageTransaction CFC gate", () => {
       const cell = runtime.getCell(
         signer.did(),
         "cfc-unsupported-trust-claim",
+        {
+          type: "object",
+          properties: {
+            value: {
+              type: "string",
+              ifc: { writeAuthorizedBy: ["trusted-handler"] },
+            },
+          },
+          required: ["value"],
+        },
+        tx,
+      );
+      cell.set({ value: "secret" });
+
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error?.message).toContain(
+        "writeAuthorizedBy requires a trusted builtin identity",
+      );
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("does not let a trust snapshot alone authorize writeAuthorizedBy", async () => {
+    const { runtime, storageManager } = createRuntime();
+    try {
+      const tx = runtime.edit();
+      tx.setCfcEnforcementMode("enforce-explicit");
+      tx.setCfcTrustSnapshot({
+        id: "trust-snapshot-without-implementation",
+        actingPrincipal: signer.did(),
+      });
+
+      const cell = runtime.getCell(
+        signer.did(),
+        "cfc-trust-snapshot-without-implementation",
         {
           type: "object",
           properties: {

--- a/packages/runner/test/cfc-label-view.test.ts
+++ b/packages/runner/test/cfc-label-view.test.ts
@@ -3,6 +3,7 @@ import { expect } from "@std/expect";
 import {
   cfcLabelViewForCell,
   cfcLabelViewFromMetadata,
+  mergeCfcLabelViews,
 } from "../src/cfc/label-view.ts";
 import type { CfcMetadata } from "../src/cfc/types.ts";
 import { Identity } from "@commonfabric/identity";
@@ -15,6 +16,62 @@ import { UI } from "../src/builder/types.ts";
 import { LINK_V1_TAG } from "../src/sigil-types.ts";
 
 describe("CFC label view helpers", () => {
+  it("intersects integrity when combining distinct label views", () => {
+    expect(mergeCfcLabelViews([
+      {
+        version: 1,
+        entries: [{
+          path: [],
+          label: {
+            confidentiality: ["left-confidential"],
+            integrity: ["left-only", "shared-integrity"],
+          },
+        }],
+      },
+      {
+        version: 1,
+        entries: [{
+          path: [],
+          label: {
+            confidentiality: ["right-confidential"],
+            integrity: ["right-only", "shared-integrity"],
+          },
+        }],
+      },
+    ], { integrity: "intersection" })).toEqual({
+      version: 1,
+      entries: [{
+        path: [],
+        label: {
+          confidentiality: expect.arrayContaining([
+            "left-confidential",
+            "right-confidential",
+          ]),
+          integrity: ["shared-integrity"],
+        },
+      }],
+    });
+  });
+
+  it("keeps union integrity for same-value label reconciliation", () => {
+    expect(mergeCfcLabelViews([
+      {
+        version: 1,
+        entries: [{ path: [], label: { integrity: ["left-only"] } }],
+      },
+      {
+        version: 1,
+        entries: [{ path: [], label: { integrity: ["right-only"] } }],
+      },
+    ])).toEqual({
+      version: 1,
+      entries: [{
+        path: [],
+        label: { integrity: ["left-only", "right-only"] },
+      }],
+    });
+  });
+
   it("collects labels that apply to a logical value path", () => {
     const metadata: CfcMetadata = {
       version: 1,
@@ -272,10 +329,6 @@ describe("CFC label view helpers", () => {
               "shared-space",
               "target-detail",
             ]),
-            integrity: expect.arrayContaining([
-              "authored-by-bob",
-              "selected-detail",
-            ]),
           },
         }],
       });
@@ -446,10 +499,6 @@ describe("CFC label view helpers", () => {
               "personal-space",
               "shared-space",
             ]),
-            integrity: expect.arrayContaining([
-              "selected-by-alice",
-              "authored-by-bob",
-            ]),
           },
         }, {
           path: ["details"],
@@ -476,10 +525,6 @@ describe("CFC label view helpers", () => {
               "shared-space",
               "target-detail",
             ]),
-            integrity: expect.arrayContaining([
-              "selected-by-alice",
-              "authored-by-bob",
-            ]),
           },
         }],
       });
@@ -489,7 +534,7 @@ describe("CFC label view helpers", () => {
     }
   });
 
-  it("keeps accumulated link labels on cells recovered from query results", async () => {
+  it("does not union link integrity on cells recovered from query results", async () => {
     const signer = await Identity.fromPassphrase(
       "cfc label view query result to cell",
     );
@@ -563,10 +608,7 @@ describe("CFC label view helpers", () => {
         entries: [{
           path: [],
           label: {
-            integrity: expect.arrayContaining([
-              "selected-by-alice",
-              "authored-by-bob",
-            ]),
+            integrity: ["authored-by-bob"],
           },
         }],
       });
@@ -576,7 +618,7 @@ describe("CFC label view helpers", () => {
     }
   });
 
-  it("keeps accumulated link labels on schema asCell materialization", async () => {
+  it("does not union link integrity on schema asCell materialization", async () => {
     const signer = await Identity.fromPassphrase(
       "cfc label view schema asCell",
     );
@@ -653,10 +695,7 @@ describe("CFC label view helpers", () => {
         entries: [{
           path: [],
           label: {
-            integrity: expect.arrayContaining([
-              "selected-by-alice",
-              "authored-by-bob",
-            ]),
+            integrity: ["authored-by-bob"],
           },
         }],
       });
@@ -744,7 +783,7 @@ describe("CFC label view helpers", () => {
     }
   });
 
-  it("keeps accumulated link labels on default-created asCell values", async () => {
+  it("does not union link integrity on default-created asCell values", async () => {
     const signer = await Identity.fromPassphrase(
       "cfc label view default asCell",
     );
@@ -827,10 +866,7 @@ describe("CFC label view helpers", () => {
         entries: [{
           path: [],
           label: {
-            integrity: expect.arrayContaining([
-              "selected-by-alice",
-              "authored-by-bob",
-            ]),
+            integrity: ["authored-by-bob"],
           },
         }],
       });
@@ -840,7 +876,7 @@ describe("CFC label view helpers", () => {
     }
   });
 
-  it("keeps per-element labels through native array map proxies", async () => {
+  it("keeps source per-element integrity through native array map proxies", async () => {
     const signer = await Identity.fromPassphrase(
       "cfc label view array map proxies",
     );
@@ -932,10 +968,7 @@ describe("CFC label view helpers", () => {
         entries: [{
           path: [],
           label: {
-            integrity: expect.arrayContaining([
-              "selected-first",
-              "authored-first",
-            ]),
+            integrity: ["authored-first"],
           },
         }],
       });
@@ -944,10 +977,7 @@ describe("CFC label view helpers", () => {
         entries: [{
           path: [],
           label: {
-            integrity: expect.arrayContaining([
-              "selected-second",
-              "authored-second",
-            ]),
+            integrity: ["authored-second"],
           },
         }],
       });
@@ -1035,10 +1065,7 @@ describe("CFC label view helpers", () => {
         entries: [{
           path: [],
           label: {
-            integrity: expect.arrayContaining([
-              "selected-first",
-              "authored-shared",
-            ]),
+            integrity: ["authored-shared"],
           },
         }],
       });
@@ -1047,10 +1074,7 @@ describe("CFC label view helpers", () => {
         entries: [{
           path: [],
           label: {
-            integrity: expect.arrayContaining([
-              "selected-second",
-              "authored-shared",
-            ]),
+            integrity: ["authored-shared"],
           },
         }],
       });


### PR DESCRIPTION
## Summary
- Verified each untrusted report against the sibling CFC specs and the runner implementation.
- Fixed confirmed label propagation and enforcement gaps, with regression tests.
- Added a scoped negative regression for the write-authority report because the broad trust-boundary claim was not confirmed.

## Problems investigated and spec references

### G1 — Integrity unions for combined label views: confirmed and fixed

**Problem:** Distinct dereference/display label-view combinations were preserving the union of integrity atoms. That can overstate whole-output integrity when multiple consumed observations contribute to one value.

**Spec coverage:**
- `specs/cfc/08-06-combination-rules.md` §8.6.2 says integrity combination is a meet: atoms **intersect**, not union.
- `specs/cfc/08-09-runtime-label-propagation.md` §8.9.2 applies that rule to `combinedFrom`: confidentiality is CNF-joined and integrity uses `intersectAtoms(...)`.
- `specs/cfc/04-label-representation.md` §4.2.2 also states that joining multiple consumed observations intersects integrity atoms.

**Change:** Label-view merging now supports explicit integrity modes. Same-value reconciliation/exact-copy style merges keep union semantics, while distinct consumed-observation joins use intersection in dereference/display paths.

### G2 — `flowPrecisionClaim` accepted as advisory-only: confirmed and fixed

**Problem:** `flowPrecisionClaim` was trust-gated metadata, but no evaluator consumed the claim. In enforcing modes, silently accepting an unsupported precision claim could make the boundary appear more precise than the runtime can prove.

**Spec coverage:**
- `specs/cfc/08-09-runtime-label-propagation.md` §8.9.1 says precision claims that are less restrictive than the conservative default must be gated by trust in the implementation identity for `https://commonfabric.org/cfc/concepts/flow-taint-precision`.
- The same section says if the trust check fails the runtime MUST use the conservative default or reject, not the claim. Because this runner does not yet evaluate the claim into a conservative-vs-claimed label choice, enforcing modes must fail closed.
- `specs/cfc/08-10-validation-at-boundaries.md` §8.10.1 requires boundary attempts to reject/abort when verification fails.

**Change:** Enforcement modes now treat `flowPrecisionClaim` as an unsupported trust-sensitive claim and reject it fail-closed instead of accepting it as advisory-only.

### G3 — `writeAuthorizedBy` trust-boundary concern: broad claim not confirmed; regression added

**Problem investigated:** The report suggested `writeAuthorizedBy` could be satisfied through attacker-controlled trusted metadata/trust snapshots. The implementation still authorizes protected writes from trusted runtime transaction state and implementation identity, not from a trust snapshot alone, so the broad implementation bug was not confirmed.

**Spec coverage:**
- `specs/cfc/08-15-write-authority.md` §8.15.6 defines write authorization as the handler identity being present in the field `writeAuthorizedBy` set.
- `specs/cfc/08-15-write-authority.md` §8.15.9 describes the two-layer model: event integrity may trigger the handler, but write authorization separately checks whether the handler identity is authorized for the field.
- `specs/cfc/08-10-validation-at-boundaries.md` §8.10.1 requires write boundaries to derive attempted writes from the transaction write log and verify before commit.

**Change:** Added a negative regression proving that a trusted `trustSnapshot` alone does not authorize a `writeAuthorizedBy`-protected write.

### Persisted link-reference provenance: guarded regression from review

**Problem:** While fixing G1, a naive global intersection during persisted metadata coalescing would have dropped legitimate same-value/link-reference provenance. That path is same-value reconciliation, not a distinct-input combination.

**Spec coverage:**
- `specs/cfc/08-06-combination-rules.md` §8.6.2 and `specs/cfc/08-09-runtime-label-propagation.md` §8.9.2 cover distinct input combination.
- `specs/cfc/08-09-runtime-label-propagation.md` §8.9.2 exact-copy handling preserves the input label when the runtime verifies referential equality, so same-value preservation should not be weakened by the distinct-input meet rule.

**Change:** Kept persisted metadata coalescing on union semantics and added a regression that carried-link metadata retains both same-value provenance atoms.

## Tests
- `deno test --allow-ffi --allow-env --allow-read --allow-write=/tmp,/var/folders --allow-run=git test/cfc-boundary.test.ts test/cfc-label-view.test.ts test/cfc-flow-precision.test.ts`
- `deno task check`
