### PR TITLE
fix(runner): don't promote asCell entry scope to schema scope (CT-1623)

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1157,15 +1157,18 @@ export class CellImpl<T extends FabricValue>
       // Create a child link with extended path
       // When we have a childSchema, we need to preserve the schema that contains $defs
       // for resolving $ref references. If schema wasn't set, fall back to the parent schema.
+      //
+      // key() only extends the path and walks the schema. It must NOT change the
+      // link's scope: scope lives in the schema (top-level and asCell entries)
+      // and is resolved later as a follow cap during reads and as the target
+      // scope during writes. Stamping schema scope onto this link here would
+      // re-address the value to the wrong scoped instance of the container doc
+      // (see CT-1623).
       currentLink = {
         ...currentLink,
         path: [...currentLink.path, key.toString()] as string[],
         schema: childSchema,
       };
-
-      if (isRecord(childSchema) && isCellScope(childSchema.scope)) {
-        currentLink = { ...currentLink, scope: childSchema.scope };
-      }
     }
 
     // Determine the kind based on schema flags
@@ -1178,10 +1181,6 @@ export class CellImpl<T extends FabricValue>
         const asCellKind = ContextualFlowControl.getAsCellKind(asCellEntry);
         if (asCellKind !== undefined) {
           kind = asCellKind;
-        }
-        const asCellScope = ContextualFlowControl.getAsCellScope(asCellEntry);
-        if (isCellScope(asCellScope)) {
-          currentLink = { ...currentLink, scope: asCellScope };
         }
       }
     }
@@ -2543,7 +2542,7 @@ function schemaWithDefaultAndScope<T>(
   return scopedSchema;
 }
 
-function schemaCellScope(
+export function schemaCellScope(
   schema: JSONSchema | undefined,
 ): CellScope | undefined {
   return isRecord(schema) && isCellScope(schema.scope)

--- a/packages/runner/src/cfc.ts
+++ b/packages/runner/src/cfc.ts
@@ -8,6 +8,7 @@ import type {
   SchemaScope,
 } from "./builder/types.ts";
 import { CycleTracker } from "./traverse.ts";
+import { isSchemaScope } from "./scope.ts";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { uniqueCfcAtoms } from "./cfc/observation.ts";
 import {
@@ -522,5 +523,30 @@ export class ContextualFlowControl {
     entry: AsCellEntry | undefined,
   ): SchemaScope | undefined {
     return typeof entry === "string" ? undefined : entry?.scope;
+  }
+
+  /**
+   * The scope a schema declares at this level: the outermost `asCell` entry's
+   * scope if present, otherwise the top-level `scope`. The outermost `asCell`
+   * entry describes the immediate cell/slot (the addressing scope of the link
+   * to it, and the read follow-cap for that immediate hop); the top-level
+   * `scope` applies only when there is no `asCell` wrapper.
+   *
+   * This single precedence is used both for the read follow-cap (which link
+   * scopes a read may follow — see link-resolution.ts / traverse.ts) and for
+   * the write target scope (where content is stored — see data-updating.ts), so
+   * the two never disagree. It is a schema-level declaration only; it must never
+   * be stamped onto a navigated link's own scope (see CT-1623).
+   */
+  static getSchemaScopeCap(
+    schema: JSONSchema | undefined,
+  ): SchemaScope | undefined {
+    if (!isRecord(schema)) return undefined;
+    const entryScope = ContextualFlowControl.getAsCellScope(
+      ContextualFlowControl.getAsCellValues(schema).at(0),
+    );
+    if (isSchemaScope(entryScope)) return entryScope;
+    if (isSchemaScope(schema.scope)) return schema.scope;
+    return undefined;
   }
 }

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -9,7 +9,14 @@ import {
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { getLogger } from "@commonfabric/utils/logger";
-import { ID, ID_FIELD, type JSONSchema } from "./builder/types.ts";
+import {
+  type CellScope,
+  ID,
+  ID_FIELD,
+  type JSONSchema,
+} from "./builder/types.ts";
+import { ContextualFlowControl } from "./cfc.ts";
+import { isCellScope, scopeRank } from "./scope.ts";
 import { createRef } from "./create-ref.ts";
 import {
   CellImpl,
@@ -263,6 +270,24 @@ const stripCfcLabelViewFromPrimitiveLink = (value: unknown): unknown => {
  * @param context - The context of the change.
  * @returns Whether any changes were made.
  */
+/**
+ * The scope a cell's own schema declares for its content: the outermost
+ * `asCell` entry scope if present, otherwise the top-level `scope`. This is the
+ * scope at which the cell's data lives. It is distinct from a follow cap and
+ * from the link's base scope.
+ */
+function declaredCellScope(
+  schema: JSONSchema | undefined,
+): CellScope | undefined {
+  if (!isRecord(schema)) return undefined;
+  const asCellScope = ContextualFlowControl.getAsCellScope(
+    ContextualFlowControl.getAsCellValues(schema).at(0),
+  );
+  if (isCellScope(asCellScope)) return asCellScope;
+  if (isCellScope(schema.scope)) return schema.scope;
+  return undefined;
+}
+
 export function diffAndUpdate(
   runtime: Runtime,
   tx: IExtendedStorageTransaction,
@@ -353,6 +378,49 @@ export function normalizeAndDiff(
         `[SEEN_CHECK] Already seen object at path=${pathStr}, converting to cell`,
     );
     newValue = new CellImpl(runtime, tx, seen.get(newValue)!);
+  }
+
+  // Scope narrowing: if this slot's schema declares a scope narrower than the
+  // link's base scope, the content belongs in the narrower-scope instance and
+  // the broader-scope slot holds a link to it, so readers at the broader scope
+  // follow it to the narrower instance. A reference value (link/cell) is exempt:
+  // it already carries its own target scope. Both writes recurse back through
+  // normalizeAndDiff so they get the usual diffing, no-op detection, and CFC
+  // label/policy handling. Applying this at the top of normalizeAndDiff makes it
+  // compose to arbitrary depth (every nested descent re-enters here); for arrays
+  // it yields one link per element rather than a redirect of the whole array.
+  const declaredScope = declaredCellScope(link.schema);
+  if (
+    declaredScope !== undefined &&
+    scopeRank(declaredScope) > scopeRank(link.scope) &&
+    !isCellLink(newValue) &&
+    !isCell(newValue)
+  ) {
+    const scopedLink: NormalizedFullLink = { ...link, scope: declaredScope };
+    return [
+      // Content goes into the narrower-scope instance (its missing container
+      // structure is created by the storage write, which builds parents for the
+      // path). Diffed against the narrower instance's own current value.
+      ...normalizeAndDiff(
+        runtime,
+        tx,
+        scopedLink,
+        newValue,
+        context,
+        options,
+        seen,
+      ),
+      // The broader-scope slot points to that instance.
+      ...normalizeAndDiff(
+        runtime,
+        tx,
+        link,
+        createSigilLinkFromParsedLink(scopedLink, { base: link }) as unknown,
+        context,
+        options,
+        seen,
+      ),
+    ];
   }
 
   // ID_FIELD redirects to an existing field and we do something like DOM

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -256,6 +256,20 @@ const stripCfcLabelViewFromPrimitiveLink = (value: unknown): unknown => {
 };
 
 /**
+ * The scope at which a slot's content is stored (the write target scope). It
+ * shares its precedence with the read follow-cap (see
+ * `ContextualFlowControl.getSchemaScopeCap`) so writes and reads agree on which
+ * scoped instance a slot addresses. `any`/no constraint yields `undefined` —
+ * i.e. no narrowing. Distinct from the link's own base scope.
+ */
+function declaredCellScope(
+  schema: JSONSchema | undefined,
+): CellScope | undefined {
+  const cap = ContextualFlowControl.getSchemaScopeCap(schema);
+  return isCellScope(cap) ? cap : undefined;
+}
+
+/**
  * Traverses newValue and updates `current` and any relevant linked documents.
  *
  * Returns true if any changes were made.
@@ -270,24 +284,6 @@ const stripCfcLabelViewFromPrimitiveLink = (value: unknown): unknown => {
  * @param context - The context of the change.
  * @returns Whether any changes were made.
  */
-/**
- * The scope a cell's own schema declares for its content: the outermost
- * `asCell` entry scope if present, otherwise the top-level `scope`. This is the
- * scope at which the cell's data lives. It is distinct from a follow cap and
- * from the link's base scope.
- */
-function declaredCellScope(
-  schema: JSONSchema | undefined,
-): CellScope | undefined {
-  if (!isRecord(schema)) return undefined;
-  const asCellScope = ContextualFlowControl.getAsCellScope(
-    ContextualFlowControl.getAsCellValues(schema).at(0),
-  );
-  if (isCellScope(asCellScope)) return asCellScope;
-  if (isCellScope(schema.scope)) return schema.scope;
-  return undefined;
-}
-
 export function diffAndUpdate(
   runtime: Runtime,
   tx: IExtendedStorageTransaction,
@@ -387,8 +383,10 @@ export function normalizeAndDiff(
   // it already carries its own target scope. Both writes recurse back through
   // normalizeAndDiff so they get the usual diffing, no-op detection, and CFC
   // label/policy handling. Applying this at the top of normalizeAndDiff makes it
-  // compose to arbitrary depth (every nested descent re-enters here); for arrays
-  // it yields one link per element rather than a redirect of the whole array.
+  // compose to arbitrary depth (every nested descent re-enters here): narrowing
+  // fires at whatever slot declares it. Element-level scope (an array's `items`
+  // schema) therefore yields one redirect per element, while array-level scope
+  // (the array slot's own schema) redirects the whole array.
   const declaredScope = declaredCellScope(link.schema);
   if (
     declaredScope !== undefined &&

--- a/packages/runner/src/link-resolution.ts
+++ b/packages/runner/src/link-resolution.ts
@@ -17,7 +17,7 @@ import type {
 import { ContextualFlowControl } from "./cfc.ts";
 import type { Runtime } from "./runtime.ts";
 import type { CfcAddress } from "./cfc/types.ts";
-import { canFollowScopedLink, isSchemaScope } from "./scope.ts";
+import { canFollowScopedLink } from "./scope.ts";
 import type { SchemaScope } from "./builder/types.ts";
 
 const logger = getLogger("link-resolution");
@@ -66,19 +66,13 @@ const recordDereferenceHop = (
 };
 
 // The scope cap a link's schema imposes on the next link it permits a read to
-// follow. Honors an explicit top-level `scope`, falling back to the outermost
-// `asCell` entry scope. This caps *which* link scopes may be followed; it must
-// never be copied onto the followed link itself.
+// follow (see ContextualFlowControl.getSchemaScopeCap for the precedence). This
+// caps *which* link scopes may be followed; it must never be copied onto the
+// followed link itself.
 const schemaScopeForLink = (
   link: NormalizedFullLink,
-): SchemaScope | undefined => {
-  if (!isRecord(link.schema)) return undefined;
-  if (isSchemaScope(link.schema.scope)) return link.schema.scope;
-  const entryScope = ContextualFlowControl.getAsCellScope(
-    ContextualFlowControl.getAsCellValues(link.schema).at(0),
-  );
-  return isSchemaScope(entryScope) ? entryScope : undefined;
-};
+): SchemaScope | undefined =>
+  ContextualFlowControl.getSchemaScopeCap(link.schema);
 
 const undefinedDataLink = (link: NormalizedFullLink): NormalizedFullLink => ({
   ...link,

--- a/packages/runner/src/link-resolution.ts
+++ b/packages/runner/src/link-resolution.ts
@@ -18,6 +18,7 @@ import { ContextualFlowControl } from "./cfc.ts";
 import type { Runtime } from "./runtime.ts";
 import type { CfcAddress } from "./cfc/types.ts";
 import { canFollowScopedLink, isSchemaScope } from "./scope.ts";
+import type { SchemaScope } from "./builder/types.ts";
 
 const logger = getLogger("link-resolution");
 
@@ -64,10 +65,20 @@ const recordDereferenceHop = (
   });
 };
 
-const schemaScopeForLink = (link: NormalizedFullLink) =>
-  isRecord(link.schema) && isSchemaScope(link.schema.scope)
-    ? link.schema.scope
-    : undefined;
+// The scope cap a link's schema imposes on the next link it permits a read to
+// follow. Honors an explicit top-level `scope`, falling back to the outermost
+// `asCell` entry scope. This caps *which* link scopes may be followed; it must
+// never be copied onto the followed link itself.
+const schemaScopeForLink = (
+  link: NormalizedFullLink,
+): SchemaScope | undefined => {
+  if (!isRecord(link.schema)) return undefined;
+  if (isSchemaScope(link.schema.scope)) return link.schema.scope;
+  const entryScope = ContextualFlowControl.getAsCellScope(
+    ContextualFlowControl.getAsCellValues(link.schema).at(0),
+  );
+  return isSchemaScope(entryScope) ? entryScope : undefined;
+};
 
 const undefinedDataLink = (link: NormalizedFullLink): NormalizedFullLink => ({
   ...link,

--- a/packages/runner/src/link-utils.ts
+++ b/packages/runner/src/link-utils.ts
@@ -576,12 +576,13 @@ function recursiveStripAsCellFromSchema(
     } else {
       result = restSchema;
     }
-    const asCellScope = ContextualFlowControl.getAsCellScope(
-      asCellValues.at(0),
-    );
-    if (asCellScope !== undefined && result.scope === undefined) {
-      result = { ...result, scope: asCellScope };
-    }
+    // Do NOT promote the stripped asCell entry's scope onto the resulting
+    // schema's top-level `scope`. The scope of an asCell value belongs to the
+    // link to its target (which carries its own scope) and acts as a follow cap;
+    // promoting it here makes it look like an authored container scope, which is
+    // then stamped onto the *container* link on reads, addressing the wrong
+    // scoped instance (the read lands on an empty narrower instance). See
+    // CT-1623.
   }
 
   // Recursively process all object properties

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -35,7 +35,7 @@ import type {
   IStorageProvider,
   MemorySpace,
 } from "./storage/interface.ts";
-import { type Cell, createCell } from "./cell.ts";
+import { type Cell, createCell, schemaCellScope } from "./cell.ts";
 import { createRef, EntityId } from "./create-ref.ts";
 import { Action, Scheduler } from "./scheduler.ts";
 import { Engine } from "./harness/index.ts";
@@ -727,14 +727,19 @@ export class Runtime {
     cause: any,
     schema?: JSONSchema,
     tx?: IExtendedStorageTransaction,
-    scope: NormalizedFullLink["scope"] = "space",
+    scope?: NormalizedFullLink["scope"],
   ): Cell<any> {
+    // Creating a cell uses the schema to seed the initial link scope: an
+    // explicit scope wins, otherwise a top-level schema scope, otherwise space.
+    // (Per-property/asCell scopes are not a top-level concern here; they are
+    // resolved during read/write, see data-updating.ts and link-resolution.ts.)
+    const effectiveScope = scope ?? schemaCellScope(schema) ?? "space";
     return this.getCellFromLink(
       {
         id: toURI(createRef({}, cause)),
         path: [],
         space,
-        scope,
+        scope: effectiveScope,
       },
       schema,
       tx,

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -66,6 +66,10 @@ const cfcAddressFromLink = (link: NormalizedFullLink): CfcAddress => ({
   path: [...link.path],
 });
 
+// Creation-only: stamp the asCell entry's declared scope onto a newly created
+// cell's link. Never use this on a link that was followed/resolved during a
+// read — there the link's own storage-resolved scope is authoritative and
+// schema scope acts only as a follow cap (see link-resolution.ts).
 const linkWithAsCellScope = (
   link: NormalizedFullLink,
   entry:
@@ -605,6 +609,8 @@ export function processDefaultValue(
           cfcLabelView,
         );
       } else {
+        // This is a creation path (no default value to box): use the schema to
+        // set the new cell's initial scope from the asCell entry.
         return createCell(
           runtime,
           {
@@ -1176,10 +1182,14 @@ class TransformObjectCreator
           return undefined;
         }
         // TODO(@ubik2): deal with anyOf/oneOf with asCell/asStream
+        // This is a read/materialization path: keep the link's own
+        // storage-resolved scope. The asCell entry scope is honored as a
+        // follow cap during link resolution, never copied onto the link here
+        // (doing so would re-address the value to a different scoped instance).
         return createCell(
           this.runtime,
           {
-            ...linkWithAsCellScope(link, asCellEntry),
+            ...link,
             schema: {
               ...restSchema,
               ...(asCellValues.length > 1) && { asCell: asCellValues.slice(1) },

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -1026,7 +1026,14 @@ export class V2StorageTransaction implements IStorageTransaction {
     };
 
     for (const write of writes) {
-      const key = `${write.address.space}|${write.address.id}`;
+      // The run is flushed against a single document, fetched from the first
+      // write's address (see `writeBatchRun`). Documents are keyed by scope as
+      // well as id (`makeDocKey`), so the run key must include scope: otherwise
+      // writes to different scoped instances of the same id would be merged into
+      // one run and applied to whichever instance came first, corrupting both.
+      const key = `${write.address.space}|${
+        normalizeCellScope(write.address.scope)
+      }|${write.address.id}`;
       if (runKey === undefined || key === runKey) {
         run.push(write);
         runKey = key;

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -34,7 +34,12 @@ import {
   REJECTING_SELECTOR,
   schemaWithProperties,
 } from "@commonfabric/data-model/schema-utils";
-import type { CellScope, JSONObject, JSONSchema } from "./builder/types.ts";
+import type {
+  CellScope,
+  JSONObject,
+  JSONSchema,
+  SchemaScope,
+} from "./builder/types.ts";
 import {
   addressKey,
   createDataCellURI,
@@ -1229,9 +1234,23 @@ function notFound(
 }
 
 const schemaScopeForSelector = (selector?: SchemaPathSelector) =>
-  isRecord(selector?.schema) && isSchemaScope(selector.schema.scope)
-    ? selector.schema.scope
-    : undefined;
+  schemaFollowScopeCap(selector?.schema);
+
+/**
+ * The scope cap a schema imposes on the link it permits a read to follow.
+ * Honors an explicit top-level `scope`, falling back to the outermost `asCell`
+ * entry scope (so `asCell: [{ kind: "cell", scope: "session" }]` caps at
+ * session). This caps *which* link scopes may be followed; it must never be
+ * copied onto the followed link itself.
+ */
+const schemaFollowScopeCap = (schema: unknown): SchemaScope | undefined => {
+  if (!isRecord(schema)) return undefined;
+  if (isSchemaScope(schema.scope)) return schema.scope;
+  const entryScope = ContextualFlowControl.getAsCellScope(
+    ContextualFlowControl.getAsCellValues(schema as JSONSchema).at(0),
+  );
+  return isSchemaScope(entryScope) ? entryScope : undefined;
+};
 
 /**
  * Get a string to use as a key for the specified address

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -47,7 +47,7 @@ import {
   NormalizedFullLink,
   parseLink,
 } from "./link-utils.ts";
-import { canFollowScopedLink, isSchemaScope } from "./scope.ts";
+import { canFollowScopedLink } from "./scope.ts";
 import type {
   Activity,
   CommitError,
@@ -1237,20 +1237,14 @@ const schemaScopeForSelector = (selector?: SchemaPathSelector) =>
   schemaFollowScopeCap(selector?.schema);
 
 /**
- * The scope cap a schema imposes on the link it permits a read to follow.
- * Honors an explicit top-level `scope`, falling back to the outermost `asCell`
- * entry scope (so `asCell: [{ kind: "cell", scope: "session" }]` caps at
- * session). This caps *which* link scopes may be followed; it must never be
- * copied onto the followed link itself.
+ * The scope cap a schema imposes on the link it permits a read to follow (see
+ * ContextualFlowControl.getSchemaScopeCap for the precedence, e.g.
+ * `asCell: [{ kind: "cell", scope: "session" }]` caps at session). This caps
+ * *which* link scopes may be followed; it must never be copied onto the
+ * followed link itself.
  */
-const schemaFollowScopeCap = (schema: unknown): SchemaScope | undefined => {
-  if (!isRecord(schema)) return undefined;
-  if (isSchemaScope(schema.scope)) return schema.scope;
-  const entryScope = ContextualFlowControl.getAsCellScope(
-    ContextualFlowControl.getAsCellValues(schema as JSONSchema).at(0),
-  );
-  return isSchemaScope(entryScope) ? entryScope : undefined;
-};
+const schemaFollowScopeCap = (schema: unknown): SchemaScope | undefined =>
+  ContextualFlowControl.getSchemaScopeCap(schema as JSONSchema | undefined);
 
 /**
  * Get a string to use as a key for the specified address

--- a/packages/runner/test/link-utils.test.ts
+++ b/packages/runner/test/link-utils.test.ts
@@ -765,7 +765,12 @@ describe("link-utils", () => {
       });
     });
 
-    it("should preserve scope from stripped scoped asCell entries", () => {
+    it("does not promote stripped asCell entry scope to schema scope", () => {
+      // The scope of an asCell value belongs to the link to its target (the
+      // link carries its own scope) and acts as a follow cap. It must NOT be
+      // promoted onto the stripped schema's top-level `scope`: doing so makes it
+      // look like an authored container scope, which then gets stamped onto the
+      // container link on reads and addresses the wrong scoped instance (CT-1623).
       const schema = {
         type: "object",
         properties: {
@@ -789,11 +794,9 @@ describe("link-utils", () => {
           rack: {
             type: "array",
             items: { type: "string" },
-            scope: "user",
           },
           message: {
             type: "string",
-            scope: "session",
           },
         },
       });

--- a/packages/runner/test/pattern-scope.test.ts
+++ b/packages/runner/test/pattern-scope.test.ts
@@ -590,6 +590,103 @@ Deno.test("cross-space scoped links preserve target space and resolved scope", a
   }
 });
 
+Deno.test("lift can read session-scoped cell passed from pattern input", async () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const tx = runtime.edit();
+
+  try {
+    const { lift, pattern } = createTrustedBuilder(runtime).commonfabric;
+
+    const sessionTargetBase = runtime.getCell<string | null>(
+      space,
+      "lift captured session target",
+      undefined,
+      tx,
+    );
+    const sessionTarget = createCell<string | null>(
+      runtime,
+      { ...sessionTargetBase.getAsNormalizedFullLink(), scope: "session" },
+      tx,
+    );
+    sessionTarget.set("a");
+    const sessionTargetLink = sessionTarget.getAsNormalizedFullLink();
+    assertEquals(sessionTargetBase.getAsNormalizedFullLink().scope, "space");
+    assertEquals(sessionTargetLink.scope, "session");
+    assertEquals(sessionTarget.get(), "a");
+
+    const isSessionOpen = lift(
+      {
+        type: "object",
+        properties: {
+          sessionTarget: {
+            anyOf: [{ type: "string" }, { type: "null" }],
+            asCell: [{ kind: "cell", scope: "session" }],
+          },
+          id: { type: "string" },
+        },
+        required: ["sessionTarget", "id"],
+      },
+      { type: "boolean" },
+      (
+        { sessionTarget, id }: {
+          sessionTarget: Cell<string | null>;
+          id: string;
+        },
+      ) => sessionTarget.get() === id,
+    );
+
+    const Root = pattern<{ sessionTarget: Cell<string | null> }>(
+      ({ sessionTarget }) => ({
+        isOpen: isSessionOpen({ sessionTarget, id: "a" }),
+      }),
+      {
+        type: "object",
+        properties: {
+          sessionTarget: {
+            anyOf: [{ type: "string" }, { type: "null" }],
+            asCell: [{ kind: "cell", scope: "session" }],
+          },
+        },
+        required: ["sessionTarget"],
+      },
+    );
+
+    const resultCell = runtime.getCell(
+      space,
+      "lift reads session scoped cell passed from pattern input",
+      undefined,
+      tx,
+    );
+    const result = runtime.run(tx, Root, { sessionTarget }, resultCell);
+    runtime.prepareTxForCommit(tx);
+    await tx.commit();
+    await runtime.idle();
+    await runtime.storageManager.synced();
+    await result.pull();
+
+    // The stored argument link to the session-scoped cell must preserve its
+    // own scope (and point at that cell), not be re-scoped to the container.
+    const argumentCell = runtime.getCellFromLink(
+      getMetaLink(result, "argument")!,
+    );
+    const argTarget = argumentCell.key("sessionTarget");
+    const storedArgumentTargetLink = parseLink(argTarget.getRaw(), argTarget)!;
+    assertEquals(storedArgumentTargetLink.id, sessionTargetLink.id);
+    assertEquals(storedArgumentTargetLink.path, sessionTargetLink.path);
+    assertEquals(storedArgumentTargetLink.space, sessionTargetLink.space);
+    assertEquals(storedArgumentTargetLink.scope, sessionTargetLink.scope);
+
+    assertEquals(result.key("isOpen").get() as unknown, true);
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
 Deno.test("broad computed output links to narrower scoped result", async () => {
   const storageManager = StorageManager.emulate({ as: signer });
   const runtime = new Runtime({

--- a/packages/runner/test/pattern-scope.test.ts
+++ b/packages/runner/test/pattern-scope.test.ts
@@ -13,7 +13,7 @@ import { Cell, createCell } from "../src/cell.ts";
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
 
-Deno.test("Cell.key applies concrete scope from child schema", async () => {
+Deno.test("Cell.key keeps base scope; schema carries the scope", async () => {
   const storageManager = StorageManager.emulate({ as: signer });
   const runtime = new Runtime({
     apiUrl: new URL(import.meta.url),
@@ -41,14 +41,28 @@ Deno.test("Cell.key applies concrete scope from child schema", async () => {
       tx,
     );
 
+    // key() only extends the path; it never changes the link's scope. The
+    // declared scope lives in the schema and is realized on read (as a follow
+    // cap) and on write (content goes to the scoped instance with a base-scope
+    // redirect). It is not stamped onto the navigated link.
     assertEquals(cell.getAsNormalizedFullLink().scope, "space");
-    assertEquals(cell.key("name").getAsNormalizedFullLink().scope, "user");
+    assertEquals(cell.key("name").getAsNormalizedFullLink().scope, "space");
     assertEquals(
       cell.key("selectedRoom").getAsNormalizedFullLink().scope,
-      "session",
+      "space",
     );
     assertEquals(
       cell.key("selectedRoom", "room").getAsNormalizedFullLink().scope,
+      "space",
+    );
+
+    // The scope is carried on the schema of the navigated link.
+    assertEquals(
+      (cell.key("name").getAsNormalizedFullLink().schema as any)?.scope,
+      "user",
+    );
+    assertEquals(
+      (cell.key("selectedRoom").getAsNormalizedFullLink().schema as any)?.scope,
       "session",
     );
   } finally {
@@ -590,6 +604,59 @@ Deno.test("cross-space scoped links preserve target space and resolved scope", a
   }
 });
 
+Deno.test("key() does not stamp the asCell entry scope onto the container link", async () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const tx = runtime.edit();
+
+  try {
+    const outer = runtime.getCell(
+      space,
+      "key-ascell container",
+      {
+        type: "object",
+        properties: {
+          // asCell field: a reference whose link lives in the container at the
+          // container's own scope; the entry scope is a follow cap on the target.
+          current: {
+            type: "string",
+            asCell: [{ kind: "cell", scope: "session" }],
+          },
+          // inline scoped field: addressed at its scope via write-side narrowing
+          // + a base-scope redirect, not by stamping the navigated link.
+          plain: { type: "string", scope: "user" },
+        },
+      },
+      tx,
+    );
+
+    // key() only extends the path; it must NOT stamp the schema scope (asCell
+    // entry or inline) onto the navigated link. Scope is carried on the schema
+    // (a follow cap on reads, the target scope on writes); stamping it here reads
+    // the wrong, narrower, empty scoped instance of the container — see CT-1623.
+    const current = outer.key("current");
+    assertEquals(current.getAsNormalizedFullLink().scope, "space");
+    const currentSchema = current.getAsNormalizedFullLink().schema as any;
+    assertEquals(
+      currentSchema?.asCell?.[0]?.scope ?? currentSchema?.scope,
+      "session",
+    );
+
+    const plain = outer.key("plain");
+    assertEquals(plain.getAsNormalizedFullLink().scope, "space");
+    assertEquals(
+      (plain.getAsNormalizedFullLink().schema as any)?.scope,
+      "user",
+    );
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
 Deno.test("lift can read session-scoped cell passed from pattern input", async () => {
   const storageManager = StorageManager.emulate({ as: signer });
   const runtime = new Runtime({
@@ -854,18 +921,13 @@ Deno.test("opaque JS action result schema scope participates in effective output
     await runtime.storageManager.synced();
     await result.pull();
 
-    const internalLink = getMetaLink(result, "internal");
-    const internalCell = runtime.getCellFromLink(internalLink!);
-    const rawValue = internalCell?.key("value").getRaw();
-    const outputLink = parseLink(rawValue, internalCell!);
+    // The result schema's scope:session participates in the effective output
+    // scope: the output is addressed at the session instance. The output is
+    // reachable via the result's `value` link, which carries scope:session
+    // (the output's content lives in the session instance, not the base).
+    const outputLink = parseLink(result.key("value").getRaw(), result);
     assertEquals(outputLink?.scope, "session");
-
-    const scopedOutputCell = runtime.getCellFromLink(outputLink!);
-    const auxiliaryLink = parseLink(
-      scopedOutputCell.key("nested").getRaw(),
-      scopedOutputCell,
-    );
-    assertEquals(auxiliaryLink?.scope, "session");
+    // Following that link resolves the session-scoped structured output.
     assertEquals(result.key("value").get() as unknown, { nested: 42 });
   } finally {
     await runtime.dispose();

--- a/packages/runner/test/schema-basic.test.ts
+++ b/packages/runner/test/schema-basic.test.ts
@@ -725,7 +725,7 @@ describe("Schema - Basic Types and References", () => {
       expect(innerStringCell.get()).toBe("hello double asCell");
     });
 
-    it("should honor scoped asCell object entries", () => {
+    it("keeps the asCell entry scope on the schema, not stamped on the link", () => {
       const outer = runtime.getCell<{ current: Cell<string> }>(
         space,
         "scoped-ascell-object-entry",
@@ -742,8 +742,15 @@ describe("Schema - Basic Types and References", () => {
         tx,
       );
 
+      // key() must not stamp the asCell entry scope onto the container link: an
+      // asCell field is a reference whose link lives in the container at the
+      // container's own scope; the entry scope is a follow cap on the target
+      // (carried by the stored link). Stamping it here reads the wrong scoped
+      // instance of the container (see CT-1623).
       const currentCell = outer.key("current");
-      expect(currentCell.getAsNormalizedFullLink().scope).toBe("user");
+      expect(currentCell.getAsNormalizedFullLink().scope).toBe("space");
+      const schema = currentCell.getAsNormalizedFullLink().schema as any;
+      expect(schema?.asCell?.[0]?.scope ?? schema?.scope).toBe("user");
     });
 
     it("should preserve nested asCell wrappers through anyOf branches", () => {

--- a/packages/runner/test/schema-basic.test.ts
+++ b/packages/runner/test/schema-basic.test.ts
@@ -9,7 +9,38 @@ import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { type Cell, isCell } from "../src/cell.ts";
 import { type JSONSchema } from "../src/builder/types.ts";
 import { Runtime } from "../src/runtime.ts";
+import { ContextualFlowControl } from "../src/cfc.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+// The read follow-cap (link-resolution/traverse) and the write target scope
+// (data-updating) both derive from ContextualFlowControl.getSchemaScopeCap, so
+// they can never disagree about which scoped instance a slot addresses. This
+// pins the single precedence: outermost asCell entry scope first (the immediate
+// cell/slot), then the top-level `scope` (the value when there is no wrapper).
+Deno.test("getSchemaScopeCap precedence: asCell entry before top-level scope", () => {
+  const cap = (schema: JSONSchema) =>
+    ContextualFlowControl.getSchemaScopeCap(schema);
+  assertSchemaScope(
+    cap({ type: "string", asCell: [{ kind: "cell", scope: "session" }] }),
+    "session",
+  );
+  assertSchemaScope(cap({ type: "string", scope: "user" }), "user");
+  // When both are present, the immediate (asCell) cell scope wins.
+  assertSchemaScope(
+    cap({
+      type: "object",
+      scope: "user",
+      asCell: [{ kind: "cell", scope: "session" }],
+    }),
+    "session",
+  );
+  assertSchemaScope(cap({ type: "string" }), undefined);
+  assertSchemaScope(cap({ type: "string", scope: "any" }), "any");
+});
+
+function assertSchemaScope(actual: unknown, expected: unknown) {
+  expect(actual).toBe(expected);
+}
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();

--- a/tasks/select-pattern-integration-files.test.ts
+++ b/tasks/select-pattern-integration-files.test.ts
@@ -22,16 +22,22 @@ Deno.test("parseShard rejects invalid shard notation", () => {
 });
 
 Deno.test("pattern integration four-way shard keeps slow files balanced", () => {
+  // The heaviest end-to-end tests are spread one per shard so no shard
+  // dominates: group-chat (shard 2), parking-coordinator (shard 3), and
+  // spec-gallery (shard 4); `all` runs alone on shard 1.
   assertEquals(shardForPatternIntegrationFile("all.test.ts", 4), 1);
   assertEquals(
-    shardForPatternIntegrationFile("cfc-spec-gallery.test.ts", 4),
+    shardForPatternIntegrationFile("cfc-group-chat-demo.test.ts", 4),
     2,
   );
   assertEquals(
-    shardForPatternIntegrationFile("cfc-authorized-save.test.ts", 4),
+    shardForPatternIntegrationFile("parking-coordinator-admin-view.test.ts", 4),
     3,
   );
-  assertEquals(shardForPatternIntegrationFile("nested-counter.test.ts", 4), 4);
+  assertEquals(
+    shardForPatternIntegrationFile("cfc-spec-gallery.test.ts", 4),
+    4,
+  );
 });
 
 Deno.test("unknown pattern integration files are assigned deterministically", () => {

--- a/tasks/select-pattern-integration-files.ts
+++ b/tasks/select-pattern-integration-files.ts
@@ -5,24 +5,31 @@ type Shard = {
   total: number;
 };
 
+// Explicit assignments balance the four browser-integration shards by
+// wall-time. The heaviest end-to-end tests (~45-52s each) are spread one per
+// shard so no single shard dominates. `all.test.ts` is the heaviest single
+// file and gets its own shard. Approx test wall-times (excluding ~35s
+// server/browser startup per shard) keep shards within ~100-115s of each other.
 const FOUR_SHARD_ASSIGNMENTS: Record<string, number> = {
-  "all.test.ts": 1,
+  "all.test.ts": 1, // ~heavy, runs alone
 
-  "cfc-spec-gallery.test.ts": 2,
-  "default-app.test.ts": 2,
-  "chat-note.test.ts": 2,
-  "fetch-data.test.ts": 2,
-  "instantiate-pattern.test.ts": 2,
+  "cfc-group-chat-demo.test.ts": 2, // ~52s
+  "default-app.test.ts": 2, // ~47s
+  "chat-note.test.ts": 2, // tiny
+  "fetch-data.test.ts": 2, // tiny
+  "instantiate-pattern.test.ts": 2, // ~1s
 
-  "cfc-authorized-save.test.ts": 3,
-  "cfc-staged-publish.test.ts": 3,
-  "cfc-render-policy-demo.test.ts": 3,
-  "llm.test.ts": 3,
+  "cfc-authorized-save.test.ts": 3, // ~25s
+  "cfc-staged-publish.test.ts": 3, // ~24s
+  "cfc-render-policy-demo.test.ts": 3, // ~17s
+  "llm.test.ts": 3, // tiny
+  "parking-coordinator-admin-view.test.ts": 3, // ~42s
 
-  "nested-counter.test.ts": 4,
-  "counter.test.ts": 4,
-  "cfc-authorship-chat.test.ts": 4,
-  "chatbot.test.ts": 4,
+  "nested-counter.test.ts": 4, // ~21s
+  "counter.test.ts": 4, // ~21s
+  "cfc-authorship-chat.test.ts": 4, // ~22s
+  "chatbot.test.ts": 4, // tiny
+  "cfc-spec-gallery.test.ts": 4, // ~45s
 };
 
 export function parseShard(raw: string): Shard {


### PR DESCRIPTION
## Summary

Fixes [CT-1623](https://linear.app/common-tools/issue/CT-1623): a `lift` (or any node) that reads a session-scoped cell passed via pattern input silently read `undefined`. More broadly, this aligns scoped-cell addressing with `docs/specs/scoped-cell-instances.md`.

Built fresh on current `main` (the prior branch #3752 predated main's process-cell-removal / scoped-cell rework).

## The spec, and what was wrong

`docs/specs/scoped-cell-instances.md` defines **two distinct scope dimensions**:

> `SchemaScope` controls traversal restrictions. `LinkScope` controls how a link selects the scoped instance of its target id.

- **Schema scope** (a schema's `scope`, and each `asCell` entry's `scope`) is a **read follow-cap** ("the narrowest link scope reads are allowed to follow") and, for writes, the target scope. It is a *traversal restriction* — never an addressing instruction.
- **Link scope** is the **addressing** dimension — it selects which scoped instance of the target id a link resolves to.

main **conflated the two**: it stamped schema scope onto links during navigation, and used that single stamp for **both** reads and writes. There was no base-scope link/redirect — scoped content lived in the scoped instance and was reachable *only* via the stamp.

That works when a field's read and write use the same stamped scope, but breaks when they differ. The lift hit exactly that: the argument binding wrote the link to the session cell into the **space** instance of the container, while the read addressed the **session** instance (via the stamped/promoted scope) — finding nothing.

## Changes

### 1. Don't promote a stripped `asCell` entry scope to a top-level schema scope (`link-utils.ts`)
`sanitizeSchemaForLinks` / `recursiveStripAsCellFromSchema` promoted a stripped `asCell` entry's scope onto the resulting schema's top-level `scope`. The scope of an `asCell` value belongs to the **link** to its target (which carries its own scope) and acts as a follow cap; promoting it makes it look like an authored container scope, which then gets stamped onto the container link on reads. Removed the promotion.

### 2. `key()` never stamps scope (`cell.ts`)
Path navigation only extends the path and walks the schema. It no longer stamps the child schema's scope — neither an inline `scope` nor an `asCell` entry `scope` — onto the navigated link. Scope is carried on the schema and realized later (as a follow cap on reads, as the target scope on writes).

### 3. The follow cap honors the `asCell` entry scope (`traverse.ts`, `link-resolution.ts`)
The read follow-cap now considers the outermost `asCell` entry scope in addition to a schema's top-level `scope`, so `asCell: [{ scope: "session" }]` correctly permits following a session link.

### 4. Writes narrow content to its scoped instance + base-scope redirect (`data-updating.ts`)
When writing **content** into a slot whose schema declares a scope narrower than the link's base scope, the content is written into the narrower-scope instance and a **redirect link** is left in the broader-scope slot. This is what makes scoped data reachable without a read-time stamp: readers address at base scope and follow the redirect. Applied at the top of `normalizeAndDiff` so it composes to any depth; for arrays it yields one link per element rather than a whole-array redirect. **Reference values (links/cells) are exempt** — a reference already carries its own target scope.

### 5. Write batches are keyed by scope (`storage/v2-transaction.ts`)
A write-batch "run" is flushed against a single document fetched from the first write's address, and documents are keyed by scope key as well as id. The run key omitted scope, so interleaved writes to different scoped instances of the same id (now produced by #4) were merged into one run and corrupted each other. The run key now includes scope.

### 6. `getCell` seeds base scope from a top-level schema scope (`runtime.ts`)
Creating a cell uses the schema to set the initial link scope: explicit scope, else a top-level schema scope, else `space`.

Together: addressing flows through **link scope + write-side redirects**, and schema scope is used only as a follow cap — the spec's model.

## Why this is the right shape (battleship)

An intermediate version that only removed the `link-utils` promotion fixed the lift but **regressed `battleship/multiplayer/lobby`**, whose per-user reads relied on the stamp for addressing. The full model above fixes the lift **and** keeps battleship working, because per-user content now lands in the user instance with a base redirect and is addressed via the link rather than a read-time stamp.

## Tests

- New runner test: a `lift` reads a session-scoped cell passed via pattern input — asserts the stored argument link keeps its own scope and the read resolves.
- New runner test: `key()` does not stamp the asCell entry scope onto the container link (scope stays at base; the asCell scope is carried on the schema).
- Updated scope tests that asserted stamping-based addressing to the spec-aligned behavior (`Cell.key keeps base scope; schema carries the scope`, `opaque JS action result schema scope participates…`, `keeps the asCell entry scope on the schema…`, and the `sanitizeSchemaForLinks` unit test).

## Verification

- **Full runner suite: 478 passed, 0 failed.**
- **`deno task integration`: 8/8** — including `battleship/multiplayer/lobby` (the regression), `room`, `pass-and-play`, and shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Perf baseline (intentional shard rebalance)

`tasks/select-pattern-integration-files.ts` rebalances the pattern integration shards: the four heaviest browser tests were all on shard 2/4 (~224s, tripping the "much slower than nearby jobs" heuristic), so they're now spread one per shard. This intentionally raises shards 3/4 (which received load) above their historical baselines while dropping the slowest shard 224s → 144s. Accepting the new per-shard baselines:

NEW_PERF_BASELINE: job: Pattern Integration Tests (4/4) = 144s
NEW_PERF_BASELINE: job: Pattern Integration Tests (3/4) = 144s

