### PR TITLE
feat(storage): opt-in multi-space writes with ordered split commit

### DIFF
--- a/packages/patterns/integration/cfc-group-chat-demo.test.ts
+++ b/packages/patterns/integration/cfc-group-chat-demo.test.ts
@@ -15,7 +15,11 @@ import {
 } from "./cfc-browser-helpers.ts";
 
 const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
-const CFC_GROUP_CHAT_TIMEOUT = 30_000;
+// 60s (was 30s): the imported-message authorship row completes in ~17s locally
+// but exceeds 30s on slower CI runners, causing intermittent timeouts in
+// `waitForInvalidAuthorshipState`. Bumping the headroom stabilizes CI; the test
+// logic is unchanged.
+const CFC_GROUP_CHAT_TIMEOUT = 60_000;
 const IMPORTED_MESSAGE_MARKERS = [
   "Jumping in late here.",
   "I think we already covered this above.",

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -293,6 +293,10 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     return digest;
   }
 
+  enableMultiSpaceWrites(order?: readonly MemorySpace[]): void {
+    this.tx.enableMultiSpaceWrites?.(order);
+  }
+
   setReadOnly(reason = "runtime.readTx()"): void {
     this.readOnlySource = reason;
     this.tx.setReadOnly?.(reason);
@@ -773,6 +777,10 @@ export class TransactionWrapper implements IExtendedStorageTransaction {
 
   enqueuePostCommitEffect(effect: PostCommitSideEffect): void {
     this.wrapped.enqueuePostCommitEffect(effect);
+  }
+
+  enableMultiSpaceWrites(order?: readonly MemorySpace[]): void {
+    this.wrapped.enableMultiSpaceWrites?.(order);
   }
 
   setReadOnly(reason?: string): void {

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -481,6 +481,21 @@ export interface IStorageTransaction {
    * provided order (or first-write order if omitted). The per-space commits run
    * sequentially with NO cross-space atomicity: if a later commit fails, earlier
    * ones are not rolled back (the failure is logged).
+   *
+   * `order` is a sequencing hint ONLY: it controls the order in which written
+   * spaces are committed (spaces listed first commit first). It does NOT
+   * restrict which spaces may be written — a written space absent from `order`
+   * still commits, appended in first-write order. Authorization is unchanged:
+   * each space commits through its own authenticated session exactly as a
+   * single-space commit would, so this opt-in cannot grant access the caller
+   * does not already hold. Calling this more than once is allowed; the last
+   * non-undefined `order` wins.
+   *
+   * Partial-failure contract: because there is no rollback, a multi-space commit
+   * error means the cross-space state is INDETERMINATE — some spaces may be
+   * durably committed and others not. Callers must treat the error accordingly
+   * (the first per-space error is surfaced as the overall result; all per-space
+   * failures are logged).
    */
   enableMultiSpaceWrites?(order?: readonly MemorySpace[]): void;
   /**

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -475,6 +475,15 @@ export interface IStorageTransaction {
    */
   immediate?: boolean;
   /**
+   * Opt the transaction into writing to more than one memory space. By default
+   * a transaction may write to a single space only. When enabled, commit()
+   * commits each written space's changes as a separate per-space commit, in the
+   * provided order (or first-write order if omitted). The per-space commits run
+   * sequentially with NO cross-space atomicity: if a later commit fails, earlier
+   * ones are not rolled back (the failure is logged).
+   */
+  enableMultiSpaceWrites?(order?: readonly MemorySpace[]): void;
+  /**
    * Optional read-only mode hook used by runtime-generated fallback read
    * transactions.
    */

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -479,8 +479,12 @@ export interface IStorageTransaction {
    * a transaction may write to a single space only. When enabled, commit()
    * commits each written space's changes as a separate per-space commit, in the
    * provided order (or first-write order if omitted). The per-space commits run
-   * sequentially with NO cross-space atomicity: if a later commit fails, earlier
-   * ones are not rolled back (the failure is logged).
+   * sequentially with NO cross-space atomicity, and STOP at the first per-space
+   * failure: spaces committed before the failure are durable and not rolled back
+   * (logged), while the failing space and every space after it are left
+   * uncommitted. (Stopping preserves the requested order — e.g. a child space
+   * before the parent that links to it — and avoids double-applying later writes
+   * on retry.)
    *
    * `order` is a sequencing hint ONLY: it controls the order in which written
    * spaces are committed (spaces listed first commit first). It does NOT

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -128,6 +128,21 @@ const logger = getLogger("storage.v2.transaction", {
   level: "error",
 });
 
+// Enabled so cross-space partial-commit failures (no rollback) are visible.
+const multiSpaceCommitLogger = getLogger("storage.v2.multi-space-commit", {
+  enabled: true,
+  level: "error",
+});
+
+const toStoreError = (error: unknown): StorageTransactionRejected => {
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    name: "StoreError" as const,
+    message,
+    cause: { name: "StoreError", message },
+  };
+};
+
 function withCommitTiming<T>(
   keys: string[],
   fn: () => T,
@@ -731,6 +746,13 @@ export class V2StorageTransaction implements IStorageTransaction {
   #reactivityLogCache?: TransactionReactivityLog;
   #schedulerObservation?: unknown;
   #writeSpace?: MemorySpace;
+  // Multi-space write opt-in (see enableMultiSpaceWrites). When disabled the
+  // transaction rejects writes to a second space; when enabled commit() splits
+  // into one per-space commit.
+  #multiSpaceWrites = false;
+  #commitOrder?: readonly MemorySpace[];
+  // Spaces written to, in first-write order. Used as the default commit order.
+  #writtenSpaces: MemorySpace[] = [];
   #readOnlySource?: string;
   #lastDocument?: {
     branch: SpaceBranch;
@@ -752,6 +774,14 @@ export class V2StorageTransaction implements IStorageTransaction {
 
   isReadOnly(): boolean {
     return this.#readOnlySource !== undefined;
+  }
+
+  enableMultiSpaceWrites(order?: readonly MemorySpace[]): void {
+    this.assertWritable("enableMultiSpaceWrites()");
+    this.#multiSpaceWrites = true;
+    if (order !== undefined) {
+      this.#commitOrder = order;
+    }
   }
 
   static create(manager: IStorageManager): IStorageTransaction {
@@ -867,7 +897,27 @@ export class V2StorageTransaction implements IStorageTransaction {
     if (ready.error) {
       return { error: ready.error };
     }
-    if (this.#writeSpace !== undefined && this.#writeSpace !== space) {
+    const claim = this.claimWriteSpace(space);
+    if (claim.error) {
+      return { error: claim.error };
+    }
+    const branch = this.branch(space);
+    branch.writer ??= new V2Writer(this, space);
+    return { ok: branch.writer };
+  }
+
+  /**
+   * Records `space` as a write target. Without the multi-space opt-in, rejects a
+   * second space with a write-isolation error (preserving the default
+   * single-space guarantee). With it enabled, tracks the space in first-write
+   * order for commit() to split on.
+   */
+  private claimWriteSpace(space: MemorySpace): Result<Unit, WriterError> {
+    if (
+      !this.#multiSpaceWrites &&
+      this.#writeSpace !== undefined &&
+      this.#writeSpace !== space
+    ) {
       return {
         error: WriteIsolationError({
           open: this.#writeSpace,
@@ -875,10 +925,13 @@ export class V2StorageTransaction implements IStorageTransaction {
         }),
       };
     }
-    this.#writeSpace = space;
-    const branch = this.branch(space);
-    branch.writer ??= new V2Writer(this, space);
-    return { ok: branch.writer };
+    if (this.#writeSpace === undefined) {
+      this.#writeSpace = space;
+    }
+    if (!this.#writtenSpaces.includes(space)) {
+      this.#writtenSpaces.push(space);
+    }
+    return { ok: {} };
   }
 
   read(
@@ -1382,6 +1435,13 @@ export class V2StorageTransaction implements IStorageTransaction {
       return { error: ready.error };
     }
 
+    // Genuine cross-space commits split into one per-space commit. A
+    // single-space transaction (the common case, even with the opt-in set) stays
+    // on the proven path below.
+    if (this.#multiSpaceWrites && this.#writtenSpaces.length > 1) {
+      return this.commitMultiSpace();
+    }
+
     const writeSpace = this.#writeSpace ??
       schedulerObservationCommitSpace(this.#schedulerObservation);
     if (!writeSpace) {
@@ -1429,20 +1489,109 @@ export class V2StorageTransaction implements IStorageTransaction {
       this.#state = { status: "done", result };
       return result;
     } catch (error) {
-      const storeError: StorageTransactionRejected = {
-        name: "StoreError" as const,
-        message: error instanceof Error ? error.message : String(error),
-        cause: {
-          name: "StoreError",
-          message: error instanceof Error ? error.message : String(error),
-        },
-      };
       const result: Result<Unit, StorageTransactionRejected> = {
-        error: storeError,
+        error: toStoreError(error),
       };
       this.#state = { status: "done", result };
       return result;
     }
+  }
+
+  /**
+   * Commits a multi-space transaction as one per-space commit each, in commit
+   * order (explicit or first-write). Commits run sequentially with no
+   * cross-space atomicity: a later failure does not roll back earlier spaces; it
+   * is logged and surfaced as the overall result.
+   */
+  private async commitMultiSpace(): Promise<Result<Unit, CommitError>> {
+    const commits: { space: MemorySpace; native: NativeStorageCommit }[] = [];
+    for (const space of this.orderedCommitSpaces()) {
+      const native = this.getNativeCommit(space);
+      const operations = native?.operations ?? [];
+      const hasSchedulerObservation =
+        native?.schedulerObservation !== undefined;
+      if (!native || (operations.length === 0 && !hasSchedulerObservation)) {
+        continue;
+      }
+      commits.push({ space, native });
+    }
+
+    if (commits.length === 0) {
+      const result = { ok: {} } satisfies Result<Unit, CommitError>;
+      this.#state = { status: "done", result };
+      return result;
+    }
+
+    const validation = this.validate();
+    if (validation.error) {
+      this.#state = { status: "done", result: { error: validation.error } };
+      return { error: validation.error };
+    }
+
+    const promise = this.runSplitCommits(commits);
+    this.#state = { status: "pending", promise };
+    const result = await promise;
+    this.#state = { status: "done", result };
+    return result;
+  }
+
+  /**
+   * The written spaces in commit order: the explicit order first (restricted to
+   * spaces actually written), then any remaining spaces in first-write order.
+   */
+  private orderedCommitSpaces(): MemorySpace[] {
+    if (this.#commitOrder === undefined) {
+      return [...this.#writtenSpaces];
+    }
+    const ordered: MemorySpace[] = [];
+    const seen = new Set<MemorySpace>();
+    for (const space of this.#commitOrder) {
+      if (!seen.has(space) && this.#writtenSpaces.includes(space)) {
+        ordered.push(space);
+        seen.add(space);
+      }
+    }
+    for (const space of this.#writtenSpaces) {
+      if (!seen.has(space)) {
+        ordered.push(space);
+        seen.add(space);
+      }
+    }
+    return ordered;
+  }
+
+  private async runSplitCommits(
+    commits: { space: MemorySpace; native: NativeStorageCommit }[],
+  ): Promise<Result<Unit, StorageTransactionRejected>> {
+    let firstError: StorageTransactionRejected | undefined;
+    for (const { space, native } of commits) {
+      const replica = this.storage.open(space).replica;
+      if (!replica.commitNative) {
+        throw new Error("memory v2 replica does not support commitNative()");
+      }
+      const commitNative = replica.commitNative.bind(replica);
+      try {
+        const result = await commitNative(native, this);
+        if (result.error) {
+          multiSpaceCommitLogger.error(
+            "multi-space-commit-failed",
+            `Cross-space commit to ${space} failed; earlier spaces are not ` +
+              `rolled back`,
+            result.error,
+          );
+          firstError ??= result.error;
+        }
+      } catch (error) {
+        multiSpaceCommitLogger.error(
+          "multi-space-commit-rejected",
+          `Cross-space commit to ${space} rejected; earlier spaces are not ` +
+            `rolled back`,
+          error,
+        );
+        firstError ??= toStoreError(error);
+      }
+    }
+    return firstError ? { error: firstError } : { ok: {} };
   }
 
   private schedulerObservationForNativeCommit(
@@ -1560,15 +1709,10 @@ export class V2StorageTransaction implements IStorageTransaction {
     if (ready.error) {
       return { error: ready.error };
     }
-    if (this.#writeSpace !== undefined && this.#writeSpace !== space) {
-      return {
-        error: WriteIsolationError({
-          open: this.#writeSpace,
-          requested: space,
-        }),
-      };
+    const claim = this.claimWriteSpace(space);
+    if (claim.error) {
+      return { error: claim.error };
     }
-    this.#writeSpace = space;
     return { ok: this.branch(space) };
   }
 

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -1574,35 +1574,42 @@ export class V2StorageTransaction implements IStorageTransaction {
   private async runSplitCommits(
     commits: { space: MemorySpace; native: NativeStorageCommit }[],
   ): Promise<Result<Unit, StorageTransactionRejected>> {
-    let firstError: StorageTransactionRejected | undefined;
-    for (const { space, native } of commits) {
+    for (let i = 0; i < commits.length; i++) {
+      const { space, native } = commits[i];
       const replica = this.storage.open(space).replica;
       if (!replica.commitNative) {
         throw new Error("memory v2 replica does not support commitNative()");
       }
       const commitNative = replica.commitNative.bind(replica);
+      // Stop at the first per-space failure rather than committing the
+      // remaining spaces. The commit order is meaningful (e.g. a child space
+      // before the parent that links to it), so once an earlier space fails we
+      // must not durably apply later ones: doing so would violate the order and
+      // double-apply those writes if the transaction is retried. Spaces already
+      // committed before the failure are not rolled back (logged); the failing
+      // space and everything after it are left uncommitted.
       try {
         const result = await commitNative(native, this);
         if (result.error) {
           multiSpaceCommitLogger.error(
             "multi-space-commit-failed",
-            `Cross-space commit to ${space} failed; earlier spaces are not ` +
-              `rolled back`,
+            `Cross-space commit to ${space} failed after ${i} space(s); ` +
+              `earlier spaces are not rolled back and later spaces are skipped`,
             result.error,
           );
-          firstError ??= result.error;
+          return { error: result.error };
         }
       } catch (error) {
         multiSpaceCommitLogger.error(
           "multi-space-commit-rejected",
-          `Cross-space commit to ${space} rejected; earlier spaces are not ` +
-            `rolled back`,
+          `Cross-space commit to ${space} rejected after ${i} space(s); ` +
+            `earlier spaces are not rolled back and later spaces are skipped`,
           error,
         );
-        firstError ??= toStoreError(error);
+        return { error: toStoreError(error) };
       }
     }
-    return firstError ? { error: firstError } : { ok: {} };
+    return { ok: {} };
   }
 
   private schedulerObservationForNativeCommit(

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -1530,9 +1530,20 @@ export class V2StorageTransaction implements IStorageTransaction {
 
     const promise = this.runSplitCommits(commits);
     this.#state = { status: "pending", promise };
-    const result = await promise;
-    this.#state = { status: "done", result };
-    return result;
+    try {
+      const result = await promise;
+      this.#state = { status: "done", result };
+      return result;
+    } catch (error) {
+      // Mirror the single-space path: a rejected commit must still transition
+      // the transaction to "done" with an error rather than leaving it stuck
+      // at "pending" (e.g. if a replica lacks commitNative()).
+      const result: Result<Unit, StorageTransactionRejected> = {
+        error: toStoreError(error),
+      };
+      this.#state = { status: "done", result };
+      return result;
+    }
   }
 
   /**

--- a/packages/runner/test/memory-v2-multi-space-write.test.ts
+++ b/packages/runner/test/memory-v2-multi-space-write.test.ts
@@ -114,4 +114,32 @@ describe("multi-space write transactions", () => {
     expect(result.error).toBeDefined();
     expect(tx.status().status).not.toBe("pending");
   });
+
+  it("does not roll back earlier spaces when a later space's commit fails", async () => {
+    const tx = runtime.edit();
+    // Order so space A commits (for real) before space B fails.
+    tx.enableMultiSpaceWrites?.([spaceA, spaceB]);
+    tx.writeValueOrThrow(addr(spaceA, "of:partial-a"), { v: 1 });
+    tx.writeValueOrThrow(addr(spaceB, "of:partial-b"), { v: 2 });
+
+    // Space B's native commit returns an error after space A is already durable.
+    const replicaB = storageManager.open(spaceB).replica as unknown as {
+      commitNative: (...args: unknown[]) => Promise<unknown>;
+    };
+    replicaB.commitNative = () =>
+      Promise.resolve({
+        error: { name: "StorageTransactionRejected", message: "space B failed" },
+      });
+
+    const result = await tx.commit();
+    // The first per-space error is surfaced as the overall result.
+    expect(result.error).toBeDefined();
+
+    // No rollback: space A's earlier write is durably present (the documented
+    // indeterminate-partial-state contract).
+    const verify = runtime.edit();
+    expect(verify.readValueOrThrow(addr(spaceA, "of:partial-a"))).toEqual({
+      v: 1,
+    });
+  });
 });

--- a/packages/runner/test/memory-v2-multi-space-write.test.ts
+++ b/packages/runner/test/memory-v2-multi-space-write.test.ts
@@ -95,4 +95,23 @@ describe("multi-space write transactions", () => {
       v: 7,
     });
   });
+
+  it("settles with an error when a per-space split commit throws", async () => {
+    const tx = runtime.edit();
+    tx.enableMultiSpaceWrites?.();
+    tx.writeValueOrThrow(addr(spaceA, "of:throw-a"), { v: 1 });
+    tx.writeValueOrThrow(addr(spaceB, "of:throw-b"), { v: 2 });
+
+    // A replica without commitNative() makes runSplitCommits throw (rather than
+    // return an error). The split commit must still settle the transaction with
+    // an error result instead of leaving it stuck at "pending".
+    const replicaB = storageManager.open(spaceB).replica as unknown as {
+      commitNative?: unknown;
+    };
+    replicaB.commitNative = undefined;
+
+    const result = await tx.commit();
+    expect(result.error).toBeDefined();
+    expect(tx.status().status).not.toBe("pending");
+  });
 });

--- a/packages/runner/test/memory-v2-multi-space-write.test.ts
+++ b/packages/runner/test/memory-v2-multi-space-write.test.ts
@@ -128,7 +128,10 @@ describe("multi-space write transactions", () => {
     };
     replicaB.commitNative = () =>
       Promise.resolve({
-        error: { name: "StorageTransactionRejected", message: "space B failed" },
+        error: {
+          name: "StorageTransactionRejected",
+          message: "space B failed",
+        },
       });
 
     const result = await tx.commit();

--- a/packages/runner/test/memory-v2-multi-space-write.test.ts
+++ b/packages/runner/test/memory-v2-multi-space-write.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import type { MemorySpace } from "../src/storage/interface.ts";
+
+const signerA = await Identity.fromPassphrase("multi-space-write-a");
+const signerB = await Identity.fromPassphrase("multi-space-write-b");
+const spaceA = signerA.did();
+const spaceB = signerB.did();
+
+const addr = (space: MemorySpace, id: `${string}:${string}`) => ({
+  space,
+  scope: "space" as const,
+  id,
+  path: [] as string[],
+});
+
+describe("multi-space write transactions", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signerA });
+    runtime = new Runtime({
+      storageManager,
+      apiUrl: new URL("http://localhost:8000"),
+    });
+  });
+
+  afterEach(async () => {
+    await runtime.dispose();
+    await storageManager.close();
+  });
+
+  it("rejects a write to a second space by default", () => {
+    const tx = runtime.edit();
+    tx.writeValueOrThrow(addr(spaceA, "of:default-a"), { v: 1 });
+    expect(() => tx.writeValueOrThrow(addr(spaceB, "of:default-b"), { v: 2 }))
+      .toThrow();
+  });
+
+  it("writes and commits to multiple spaces when opted in", async () => {
+    const tx = runtime.edit();
+    tx.enableMultiSpaceWrites?.();
+    tx.writeValueOrThrow(addr(spaceA, "of:multi-a"), { v: 1 });
+    tx.writeValueOrThrow(addr(spaceB, "of:multi-b"), { v: 2 });
+
+    // read-your-writes works across both spaces within the same transaction
+    expect(tx.readValueOrThrow(addr(spaceA, "of:multi-a"))).toEqual({ v: 1 });
+    expect(tx.readValueOrThrow(addr(spaceB, "of:multi-b"))).toEqual({ v: 2 });
+
+    const result = await tx.commit();
+    expect(result.error).toBeUndefined();
+
+    // both spaces are durable in a fresh transaction
+    const verify = runtime.edit();
+    expect(verify.readValueOrThrow(addr(spaceA, "of:multi-a"))).toEqual({
+      v: 1,
+    });
+    expect(verify.readValueOrThrow(addr(spaceB, "of:multi-b"))).toEqual({
+      v: 2,
+    });
+  });
+
+  it("commits each written space with an explicit order", async () => {
+    const tx = runtime.edit();
+    tx.enableMultiSpaceWrites?.([spaceB, spaceA]);
+    tx.writeValueOrThrow(addr(spaceA, "of:order-a"), { v: 10 });
+    tx.writeValueOrThrow(addr(spaceB, "of:order-b"), { v: 20 });
+
+    const result = await tx.commit();
+    expect(result.error).toBeUndefined();
+
+    const verify = runtime.edit();
+    expect(verify.readValueOrThrow(addr(spaceA, "of:order-a"))).toEqual({
+      v: 10,
+    });
+    expect(verify.readValueOrThrow(addr(spaceB, "of:order-b"))).toEqual({
+      v: 20,
+    });
+  });
+
+  it("still single-space commits when opted in but only one space written", async () => {
+    const tx = runtime.edit();
+    tx.enableMultiSpaceWrites?.();
+    tx.writeValueOrThrow(addr(spaceA, "of:single"), { v: 7 });
+
+    const result = await tx.commit();
+    expect(result.error).toBeUndefined();
+
+    const verify = runtime.edit();
+    expect(verify.readValueOrThrow(addr(spaceA, "of:single"))).toEqual({
+      v: 7,
+    });
+  });
+});

--- a/packages/runner/test/memory-v2-multi-space-write.test.ts
+++ b/packages/runner/test/memory-v2-multi-space-write.test.ts
@@ -145,4 +145,36 @@ describe("multi-space write transactions", () => {
       v: 1,
     });
   });
+
+  it("stops at the first failure and does not commit later spaces", async () => {
+    const tx = runtime.edit();
+    // Order so space A commits first; make it fail.
+    tx.enableMultiSpaceWrites?.([spaceA, spaceB]);
+    tx.writeValueOrThrow(addr(spaceA, "of:stop-a"), { v: 1 });
+    tx.writeValueOrThrow(addr(spaceB, "of:stop-b"), { v: 2 });
+
+    const replicaA = storageManager.open(spaceA).replica as unknown as {
+      commitNative: (...args: unknown[]) => Promise<unknown>;
+    };
+    replicaA.commitNative = () =>
+      Promise.resolve({
+        error: {
+          name: "StorageTransactionRejected",
+          message: "space A failed",
+        },
+      });
+
+    const result = await tx.commit();
+    expect(result.error).toBeDefined();
+
+    // Space B (ordered after the failed space A) must not have been committed.
+    const verify = runtime.edit();
+    let bValue: unknown;
+    try {
+      bValue = verify.readValueOrThrow(addr(spaceB, "of:stop-b"));
+    } catch {
+      bValue = undefined;
+    }
+    expect(bValue).not.toEqual({ v: 2 });
+  });
 });


### PR DESCRIPTION
**Stack 1/4** (base: `main`) — split out of #3722.

By default a V2 storage transaction may write to a single memory space. This adds `enableMultiSpaceWrites(order?)` to opt a transaction into writing to more than one space. When enabled, `commit()` splits into one per-space commit, applied sequentially in the given order (or first-write order if omitted), with **no** cross-space atomicity: a later per-space commit failing does not roll back earlier ones (the failure is logged).

- `V2StorageTransaction`: `claimWriteSpace` helper, `#multiSpaceWrites`/`#commitOrder`/`#writtenSpaces`, and `commitMultiSpace`/`orderedCommitSpaces`/`runSplitCommits`.
- `IStorageTransaction.enableMultiSpaceWrites?` (optional) with delegation on `ExtendedStorageTransaction` and `TransactionWrapper`.

This is the storage primitive underlying running a cross-space child pattern inline in a single transaction; no profile/runner coupling. Tested by `memory-v2-multi-space-write.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in multi-space writes to V2 storage transactions. Commits split into ordered per-space commits with no cross-space atomicity; on failure we stop at the first per-space error, earlier spaces remain committed, later spaces are skipped, and the transaction settles with an error.

- **New Features**
  - `enableMultiSpaceWrites(order?)` lets a transaction write to multiple spaces; `commit()` runs per-space commits sequentially in the given order or first-write order; default remains single-space (second-space writes are rejected unless opted in), and the single-space path is used when only one space is written.
  - Contract: `order` is a sequencing hint only; last non-undefined order wins; auth remains per-space; on failure we stop at the first per-space error — earlier spaces stay durable, the failing and later spaces are left uncommitted; cross-space state is indeterminate; the first error is returned and failures are logged. API: optional `IStorageTransaction.enableMultiSpaceWrites?` with delegation via `ExtendedStorageTransaction` and `TransactionWrapper`; internals include `claimWriteSpace`, `commitMultiSpace`, `orderedCommitSpaces`, `runSplitCommits`, and write-space tracking.

- **Bug Fixes**
  - Storage: stop committing after the first per-space failure to preserve order and avoid double-applying on retry; if a split commit throws, the transaction now settles as done with an error instead of staying pending.
  - CI: bump CFC group chat demo test timeout from 30s to 60s to reduce flakiness.

<sup>Written for commit 6724f24e5253cf3976dbe84aacb3bf173394bb04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

