### PR TITLE
fix(cfc): correct writeAuthorizedBy verification for owner-protected fields

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -1547,6 +1547,7 @@ export type JSONSchemaObj = {
     readonly addIntegrity?: readonly ImmutableJSONValue[];
     readonly requiredIntegrity?: readonly ImmutableJSONValue[];
     readonly maxConfidentiality?: readonly ImmutableJSONValue[];
+    readonly ownerPrincipal?: string | { readonly __ctCurrentPrincipal: true };
     readonly writeAuthorizedBy?:
       | readonly string[]
       | {

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -194,6 +194,31 @@ const hasLiteralDidCurrentPrincipalClaim = (value: unknown): boolean => {
   return false;
 };
 
+const literalDidSubjectsForPrincipalClaim = (
+  value: unknown,
+  kind: string,
+  subjects: string[] = [],
+): string[] => {
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      literalDidSubjectsForPrincipalClaim(entry, kind, subjects);
+    }
+    return subjects;
+  }
+  if (isCurrentPrincipalClaimAtom(value) && value.kind === kind) {
+    if (typeof value.subject === "string" && value.subject.startsWith("did:")) {
+      subjects.push(value.subject);
+    }
+    return subjects;
+  }
+  if (isRecord(value)) {
+    for (const entry of Object.values(value)) {
+      literalDidSubjectsForPrincipalClaim(entry, kind, subjects);
+    }
+  }
+  return subjects;
+};
+
 const metadataAppliesToPath = (
   metadata: CfcMetadata,
   path: readonly string[],
@@ -247,6 +272,7 @@ const writeAuthorizedByReason = (
   tx: IExtendedStorageTransaction,
   schema: JSONSchema,
   path: readonly string[],
+  targetIdentity?: ImplementationIdentity,
 ): string | undefined => {
   if (!isRecord(schema) || !isRecord(schema.ifc)) {
     return undefined;
@@ -261,7 +287,9 @@ const writeAuthorizedByReason = (
     return `writeAuthorizedBy requires a trust snapshot at /${path.join("/")}`;
   }
 
-  const identity = tx.getCfcState().implementationIdentity;
+  // Verify against the identity that authored this target's writes, falling
+  // back to the transaction's current identity for writes recorded without one.
+  const identity = targetIdentity ?? tx.getCfcState().implementationIdentity;
   if (
     Array.isArray(claim) && claim.every((entry) => typeof entry === "string")
   ) {
@@ -406,6 +434,60 @@ const setupProjectionSourceMatchesValue = (
   );
 };
 
+// `writeAuthorizedBy` is a *modification* gate (CFC spec §8.15.10): it restricts
+// who may edit an existing owner-protected value. It does not govern the trusted
+// instantiation that first projects and initializes a field (§8.15.4 — defaults
+// are installed by trusted runtime/pattern instantiation; write authorization
+// applies to *subsequent* modifications).
+//
+// When the runtime instantiates a pattern whose result declares owner-protected
+// fields, it records a setup-projection marker on the result cell whose
+// `sources` point at the pattern's own projected (internal) cells — the cells
+// that hold the field's value and carry its `writeAuthorizedBy` schema. The
+// pattern initializing those fields (e.g. `avatar = ""`, `elements = []`) is its
+// own trusted creation step, authored by the runtime's result projection, not by
+// the per-field edit handler. Recognize a target as that trusted-creation site
+// when it is the redirect *source* of a setup-projection marker recorded in this
+// transaction, covering the field path.
+//
+// This is safe because the marker is recorded ONLY by the runtime's result
+// projection — never by an arbitrary `cell.set` — and only when the projection
+// STRUCTURE is established (instantiation), not on value edits (which leave the
+// projection unchanged and so record no marker). Direct untrusted writes, no-op
+// re-writes, and later field edits therefore remain fully enforced; the slot the
+// pattern result is placed into is independently gated by its own
+// `writeAuthorizedBy`, and the owner binding by `currentPrincipalIntegrityReason`.
+const writeIsPatternSetupInitialization = (
+  tx: IExtendedStorageTransaction,
+  target: {
+    space: MemorySpace;
+    id: URI;
+    scope: ReturnType<typeof normalizeCellScope>;
+  },
+  path: readonly string[],
+): boolean => {
+  const logicalPath = canonicalizeLogicalPath(path);
+  return tx.getCfcState().writePolicyInputs.some((input) =>
+    input.kind === "structural-provenance" &&
+    input.claim === CFC_STRUCTURAL_PROVENANCE_SETUP_PROJECTION &&
+    input.sources.some((source) => {
+      if (source.space !== target.space || source.id !== target.id) {
+        return false;
+      }
+      // Only the redirect target itself, or a field nested under it, counts as
+      // this pattern's trusted initialization: the marker's `source` path must
+      // be a prefix of (or equal to) the field being written. We deliberately do
+      // not exempt writes to an *ancestor* of the redirect target, which would
+      // cover more than the projected field. (`concretePathHasPrefix(path,
+      // prefix)` tests whether `prefix` is a prefix of `path`.)
+      return concretePathHasPrefix(
+        logicalPath,
+        canonicalizeLogicalPath(source.path),
+      );
+    })
+  );
+};
+
 const storedMetadataFor = (
   tx: IExtendedStorageTransaction,
   space: MemorySpace,
@@ -432,7 +514,9 @@ const storedMetadataFor = (
  */
 const candidateSchemasByTarget = (
   inputs: readonly WritePolicyInput[],
-  implementationIdentity?: ImplementationIdentity,
+  identityForInput: (input: WritePolicyInput) =>
+    | ImplementationIdentity
+    | undefined,
 ): Map<string, JSONSchema> => {
   const result = new Map<string, JSONSchema>();
   for (const input of inputs) {
@@ -442,7 +526,7 @@ const candidateSchemasByTarget = (
     const key = targetKey(input.target);
     const schema = rebindWriteAuthorizedByClaims(
       input.schema,
-      implementationIdentity,
+      identityForInput(input),
     );
     const candidate = schemaEnvelopeForTargetPath(
       schema,
@@ -457,6 +541,31 @@ const candidateSchemasByTarget = (
         ? existing
         : mergeCfcSchemaEnvelopes(existing, candidate), // Guaranteed interned.
     );
+  }
+  return result;
+};
+
+/**
+ * Maps each write target to the implementation identity that authored it
+ * (captured when its write-policy inputs were recorded). Used to verify
+ * writeAuthorizedBy per target rather than against the transaction's last
+ * implementation identity.
+ */
+const identitiesByTarget = (
+  inputs: readonly WritePolicyInput[],
+  identityForInput: (input: WritePolicyInput) =>
+    | ImplementationIdentity
+    | undefined,
+): Map<string, ImplementationIdentity | undefined> => {
+  const result = new Map<string, ImplementationIdentity | undefined>();
+  for (const input of inputs) {
+    if (!("target" in input) || input.target === undefined) {
+      continue;
+    }
+    const key = targetKey(input.target);
+    if (!result.has(key)) {
+      result.set(key, identityForInput(input));
+    }
   }
   return result;
 };
@@ -905,6 +1014,52 @@ const currentPrincipalIntegrityReason = (
   const integrity = Array.isArray(ifc.integrity) ? ifc.integrity : [];
   const addIntegrity = Array.isArray(ifc.addIntegrity) ? ifc.addIntegrity : [];
   const currentPrincipalValues = [...integrity, ...addIntegrity];
+  const ownerPrincipalSpec = ifc.ownerPrincipal;
+  if (ownerPrincipalSpec !== undefined) {
+    const trustSnapshot = tx.getCfcState().trustSnapshot;
+    if (trustSnapshot === undefined) {
+      return `ownerPrincipal requires a trust snapshot at /${path.join("/")}`;
+    }
+    if (!trustSnapshot.id) {
+      return `ownerPrincipal requires a trust snapshot id at /${
+        path.join("/")
+      }`;
+    }
+    if (!trustSnapshot.actingPrincipal) {
+      return `ownerPrincipal requires an acting principal at /${
+        path.join("/")
+      }`;
+    }
+    const ownerPrincipal = isCurrentPrincipalPlaceholder(ownerPrincipalSpec)
+      ? trustSnapshot.actingPrincipal
+      : ownerPrincipalSpec;
+    if (
+      typeof ownerPrincipal !== "string" ||
+      !ownerPrincipal.startsWith("did:")
+    ) {
+      return `ownerPrincipal must be a DID at /${path.join("/")}`;
+    }
+    const resolvedCurrentPrincipalValues = resolveCurrentPrincipalLabelValues(
+      currentPrincipalValues,
+      trustSnapshot.actingPrincipal,
+    ) ?? currentPrincipalValues;
+    const representedOwners = literalDidSubjectsForPrincipalClaim(
+      resolvedCurrentPrincipalValues,
+      "represents-principal",
+    );
+    if (!representedOwners.some((subject) => subject === ownerPrincipal)) {
+      return `ownerPrincipal requires matching represents-principal integrity at /${
+        path.join("/")
+      }`;
+    }
+    if (trustSnapshot.actingPrincipal !== ownerPrincipal) {
+      return `ownerPrincipal mismatch at /${path.join("/")}`;
+    }
+    if (ifc.writeAuthorizedBy === undefined) {
+      return `ownerPrincipal requires writeAuthorizedBy at /${path.join("/")}`;
+    }
+    return undefined;
+  }
   if (currentPrincipalValues.length === 0) {
     return undefined;
   }
@@ -1474,6 +1629,7 @@ const verifyInputRequirements = (
     id: URI;
     scope: ReturnType<typeof normalizeCellScope>;
   },
+  targetIdentity?: ImplementationIdentity,
 ): string | undefined => {
   const consumed = [...(tx.getReadActivities?.() ?? [])].filter((read) =>
     !isInternalVerifierRead(read.meta)
@@ -1518,12 +1674,13 @@ const verifyInputRequirements = (
       tx,
       entry.schema,
       entry.path,
+      targetIdentity,
     );
     const setupProjection = setupProjectionSourceMatchesValue(
       tx,
       target,
       entry.path,
-    );
+    ) || writeIsPatternSetupInitialization(tx, target, entry.path);
     if (writeAuthorizedByFailure !== undefined && !setupProjection) {
       return writeAuthorizedByFailure;
     }
@@ -1861,11 +2018,20 @@ export const prepareBoundaryCommit = (
   tx: IExtendedStorageTransaction,
 ): string[] => {
   const reasons: string[] = [];
+  const state = tx.getCfcState();
+  const identityForInput = (
+    input: WritePolicyInput,
+  ): ImplementationIdentity | undefined =>
+    state.writePolicyInputIdentities.get(input) ?? state.implementationIdentity;
   const candidates = candidateSchemasByTarget(
-    tx.getCfcState().writePolicyInputs,
-    tx.getCfcState().implementationIdentity,
+    state.writePolicyInputs,
+    identityForInput,
   );
-  const linkWrites = linkWritesByTarget(tx.getCfcState().writePolicyInputs);
+  const targetIdentities = identitiesByTarget(
+    state.writePolicyInputs,
+    identityForInput,
+  );
+  const linkWrites = linkWritesByTarget(state.writePolicyInputs);
   for (const [key, target] of valueWriteTargets(tx)) {
     if (candidates.has(key)) {
       continue;
@@ -1959,6 +2125,7 @@ export const prepareBoundaryCommit = (
       tx,
       verificationSchema,
       target,
+      targetIdentities.get(key),
     );
     if (requirementFailure) {
       reasons.push(requirementFailure);

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -471,7 +471,10 @@ const writeIsPatternSetupInitialization = (
     input.kind === "structural-provenance" &&
     input.claim === CFC_STRUCTURAL_PROVENANCE_SETUP_PROJECTION &&
     input.sources.some((source) => {
-      if (source.space !== target.space || source.id !== target.id) {
+      if (
+        source.space !== target.space || source.id !== target.id ||
+        normalizeCellScope(source.scope) !== target.scope
+      ) {
         return false;
       }
       // Only the redirect target itself, or a field nested under it, counts as
@@ -546,28 +549,74 @@ const candidateSchemasByTarget = (
 };
 
 /**
- * Maps each write target to the implementation identity that authored it
- * (captured when its write-policy inputs were recorded). Used to verify
- * writeAuthorizedBy per target rather than against the transaction's last
- * implementation identity.
+ * Maps each write target cell to the list of its `schema` write-policy inputs
+ * (path + the implementation identity that authored each, captured when the
+ * input was recorded). `writeAuthorizedBy` is verified per field, so we must
+ * keep each schema input's identity separately rather than collapsing a cell to
+ * a single identity: a cell may carry several protected fields written under
+ * different identities, and only `schema` inputs (not trusted-event/structural
+ * ones) author the IFC entries that `writeAuthorizedBy` checks.
  */
-const identitiesByTarget = (
+const schemaInputIdentitiesByTarget = (
   inputs: readonly WritePolicyInput[],
   identityForInput: (input: WritePolicyInput) =>
     | ImplementationIdentity
     | undefined,
-): Map<string, ImplementationIdentity | undefined> => {
-  const result = new Map<string, ImplementationIdentity | undefined>();
+): Map<
+  string,
+  Array<
+    { path: readonly string[]; identity: ImplementationIdentity | undefined }
+  >
+> => {
+  const result = new Map<
+    string,
+    Array<
+      { path: readonly string[]; identity: ImplementationIdentity | undefined }
+    >
+  >();
   for (const input of inputs) {
-    if (!("target" in input) || input.target === undefined) {
+    if (input.kind !== "schema") {
       continue;
     }
     const key = targetKey(input.target);
-    if (!result.has(key)) {
-      result.set(key, identityForInput(input));
-    }
+    const list = result.get(key) ?? [];
+    list.push({
+      path: canonicalizeLogicalPath(input.target.path),
+      identity: identityForInput(input),
+    });
+    result.set(key, list);
   }
   return result;
+};
+
+/**
+ * The authoring identity for a field path: the schema input on this cell whose
+ * own path is the longest prefix of (or equal to) the field path. That input is
+ * the one whose schema contributed the IFC entry at this path, so its identity
+ * is the one `writeAuthorizedBy` must be verified against.
+ */
+const identityForSchemaPath = (
+  entries:
+    | Array<
+      { path: readonly string[]; identity: ImplementationIdentity | undefined }
+    >
+    | undefined,
+  path: readonly string[],
+): ImplementationIdentity | undefined => {
+  if (entries === undefined) {
+    return undefined;
+  }
+  let bestLength = -1;
+  let bestIdentity: ImplementationIdentity | undefined;
+  for (const entry of entries) {
+    if (
+      concretePathHasPrefix(path, entry.path) && entry.path.length > bestLength
+    ) {
+      bestLength = entry.path.length;
+      bestIdentity = entry.identity;
+    }
+  }
+  return bestIdentity;
 };
 
 const targetKey = (target: {
@@ -1629,7 +1678,14 @@ const verifyInputRequirements = (
     id: URI;
     scope: ReturnType<typeof normalizeCellScope>;
   },
-  targetIdentity?: ImplementationIdentity,
+  // Resolves the implementation identity that authored the schema write-policy
+  // input covering a given field path (the longest-prefix schema input on this
+  // cell). `writeAuthorizedBy` is verified per field against its authoring
+  // identity, so two protected fields on the same cell written under different
+  // identities are each checked against the correct one.
+  identityForPath?: (
+    path: readonly string[],
+  ) => ImplementationIdentity | undefined,
 ): string | undefined => {
   const consumed = [...(tx.getReadActivities?.() ?? [])].filter((read) =>
     !isInternalVerifierRead(read.meta)
@@ -1674,7 +1730,7 @@ const verifyInputRequirements = (
       tx,
       entry.schema,
       entry.path,
-      targetIdentity,
+      identityForPath?.(entry.path),
     );
     const setupProjection = setupProjectionSourceMatchesValue(
       tx,
@@ -2027,7 +2083,7 @@ export const prepareBoundaryCommit = (
     state.writePolicyInputs,
     identityForInput,
   );
-  const targetIdentities = identitiesByTarget(
+  const schemaIdentities = schemaInputIdentitiesByTarget(
     state.writePolicyInputs,
     identityForInput,
   );
@@ -2125,7 +2181,7 @@ export const prepareBoundaryCommit = (
       tx,
       verificationSchema,
       target,
-      targetIdentities.get(key),
+      (path) => identityForSchemaPath(schemaIdentities.get(key), path),
     );
     if (requirementFailure) {
       reasons.push(requirementFailure);

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -549,15 +549,19 @@ const candidateSchemasByTarget = (
 };
 
 /**
- * Maps each write target cell to the list of its `schema` write-policy inputs
+ * Maps each write target cell to the list of its write-authority-bearing inputs
  * (path + the implementation identity that authored each, captured when the
- * input was recorded). `writeAuthorizedBy` is verified per field, so we must
- * keep each schema input's identity separately rather than collapsing a cell to
- * a single identity: a cell may carry several protected fields written under
- * different identities, and only `schema` inputs (not trusted-event/structural
- * ones) author the IFC entries that `writeAuthorizedBy` checks.
+ * input was recorded). `writeAuthorizedBy` is verified per field, so we keep
+ * each input's identity separately rather than collapsing a cell to a single
+ * identity: a cell may carry several protected fields written under different
+ * identities. Only `schema` and `link-write` inputs author the IFC entries that
+ * `writeAuthorizedBy` checks (a value write and a link write into a protected
+ * slot respectively); `trusted-event`, `structural-provenance` (setup markers),
+ * `custom`, and `sink-request` inputs do not, so they must not contribute an
+ * authoring identity (including them would let an unrelated input's identity be
+ * borrowed for the writeAuthorizedBy check).
  */
-const schemaInputIdentitiesByTarget = (
+const writePolicyIdentitiesByTarget = (
   inputs: readonly WritePolicyInput[],
   identityForInput: (input: WritePolicyInput) =>
     | ImplementationIdentity
@@ -575,7 +579,7 @@ const schemaInputIdentitiesByTarget = (
     >
   >();
   for (const input of inputs) {
-    if (input.kind !== "schema") {
+    if (input.kind !== "schema" && input.kind !== "link-write") {
       continue;
     }
     const key = targetKey(input.target);
@@ -2083,7 +2087,7 @@ export const prepareBoundaryCommit = (
     state.writePolicyInputs,
     identityForInput,
   );
-  const schemaIdentities = schemaInputIdentitiesByTarget(
+  const writeAuthorIdentities = writePolicyIdentitiesByTarget(
     state.writePolicyInputs,
     identityForInput,
   );
@@ -2181,7 +2185,7 @@ export const prepareBoundaryCommit = (
       tx,
       verificationSchema,
       target,
-      (path) => identityForSchemaPath(schemaIdentities.get(key), path),
+      (path) => identityForSchemaPath(writeAuthorIdentities.get(key), path),
     );
     if (requirementFailure) {
       reasons.push(requirementFailure);

--- a/packages/runner/src/cfc/schema-merge.ts
+++ b/packages/runner/src/cfc/schema-merge.ts
@@ -9,6 +9,7 @@ const IFC_KEYS = [
   "addIntegrity",
   "requiredIntegrity",
   "maxConfidentiality",
+  "ownerPrincipal",
   "writeAuthorizedBy",
   "exactCopyOf",
   "projection",
@@ -105,6 +106,7 @@ const mergeSetLikeIfcArray = (
     case "exactCopyOf":
     case "projection":
     case "collection":
+    case "ownerPrincipal":
       if (!deepEqual(existing, candidate)) {
         throw new Error(`${key} must remain stable at ${path || "/"}`);
       }

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -242,6 +242,14 @@ export type CfcTxState = {
   prepare: CfcPrepareState;
   dereferenceTraces: CfcDereferenceTrace[];
   writePolicyInputs: WritePolicyInput[];
+  // Implementation identity active when each write-policy input was recorded.
+  // A single transaction may legitimately span multiple trust contexts (e.g. a
+  // handler plus a child pattern it runs); writeAuthorizedBy must be verified
+  // against the identity that authored each write, not the last one active.
+  writePolicyInputIdentities: Map<
+    WritePolicyInput,
+    ImplementationIdentity | undefined
+  >;
   trustSnapshot?: TrustSnapshot;
   implementationIdentity?: ImplementationIdentity;
   outbox: PostCommitSideEffect[];

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -99,6 +99,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     prepare: { status: "unprepared" },
     dereferenceTraces: [],
     writePolicyInputs: [],
+    writePolicyInputIdentities: new Map(),
     outbox: [],
     diagnostics: [],
   };
@@ -196,7 +197,15 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     // identity-stable, which lets `hashStringOf()` cache its hash on the
     // existing WeakMap. The within-sort tiebreaker in
     // `compareWritePolicyInput` then re-hashes each element via the cache.
-    this.cfcState.writePolicyInputs.push(deepFreeze(input));
+    const frozen = deepFreeze(input);
+    this.cfcState.writePolicyInputs.push(frozen);
+    // Capture the identity active right now so writeAuthorizedBy is verified
+    // against the trust context that authored this write, even if a later run
+    // in the same transaction changes the identity.
+    this.cfcState.writePolicyInputIdentities.set(
+      frozen,
+      this.cfcState.implementationIdentity,
+    );
     if (this.cfcState.prepare.status === "prepared") {
       this.invalidateCfc("write-policy-input-added");
     }

--- a/packages/runner/test/profile-owner-cfc.test.ts
+++ b/packages/runner/test/profile-owner-cfc.test.ts
@@ -422,4 +422,122 @@ describe("profile owner CFC policy", () => {
       await storageManager.close();
     }
   });
+
+  it("rejects the same owner-protected write without a setup-projection marker", async () => {
+    // Negative twin of the test above: identical write under a non-writer
+    // identity, but WITHOUT recording the setup-projection marker. Proves the
+    // marker is load-bearing — the exemption is not an unconditional bypass.
+    const { runtime, storageManager } = createRuntime();
+    try {
+      const tx = runtime.edit();
+      tx.setCfcEnforcementMode("enforce-explicit");
+      tx.setCfcTrustSnapshot({ id: "no-marker", actingPrincipal: alice.did() });
+      tx.setCfcImplementationIdentity({
+        kind: "builtin",
+        builtinId: "system.not-the-profile-writer",
+      });
+      const cell = runtime.getCell(
+        alice.did(),
+        "owner-init-no-marker",
+        profileSchema(alice.did()),
+        tx,
+      );
+      cell.set({ name: "Ada", avatar: "", elements: [] });
+      const target = cell.getAsNormalizedFullLink();
+      recordTrustedEdit(tx, target, ["name"]);
+      recordTrustedEdit(tx, target, ["avatar"]);
+      recordTrustedEdit(tx, target, ["elements"]);
+      // No setup-projection marker recorded.
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error?.message).toContain("writeAuthorizedBy");
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("verifies writeAuthorizedBy per field against the authoring identity", async () => {
+    // Two protected fields on one cell, each authorized by a different builtin,
+    // written under their respective identities. writeAuthorizedBy must be
+    // verified per field against the identity that authored that field's write,
+    // not collapsed to the first identity seen for the cell.
+    const twoFieldSchema: JSONSchema = {
+      type: "object",
+      properties: {
+        x: { type: "string", ifc: { writeAuthorizedBy: ["writer.x"] } },
+        y: { type: "string", ifc: { writeAuthorizedBy: ["writer.y"] } },
+      },
+      required: ["x", "y"],
+    };
+    const { runtime, storageManager } = createRuntime();
+    try {
+      const tx = runtime.edit();
+      tx.setCfcEnforcementMode("enforce-explicit");
+      tx.setCfcTrustSnapshot({ id: "per-path", actingPrincipal: alice.did() });
+      const cell = runtime.getCell(
+        alice.did(),
+        "per-path-identity",
+        twoFieldSchema,
+        tx,
+      );
+      tx.setCfcImplementationIdentity({
+        kind: "builtin",
+        builtinId: "writer.x",
+      });
+      cell.key("x").set("vx");
+      tx.setCfcImplementationIdentity({
+        kind: "builtin",
+        builtinId: "writer.y",
+      });
+      cell.key("y").set("vy");
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error).toBeUndefined();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("rejects a field written under another field's authorized identity", async () => {
+    // Field y written under writer.x (authorized only for x). Must be rejected:
+    // the per-field identity must not be borrowed from another field's write.
+    const twoFieldSchema: JSONSchema = {
+      type: "object",
+      properties: {
+        x: { type: "string", ifc: { writeAuthorizedBy: ["writer.x"] } },
+        y: { type: "string", ifc: { writeAuthorizedBy: ["writer.y"] } },
+      },
+      required: ["x", "y"],
+    };
+    const { runtime, storageManager } = createRuntime();
+    try {
+      const tx = runtime.edit();
+      tx.setCfcEnforcementMode("enforce-explicit");
+      tx.setCfcTrustSnapshot({
+        id: "per-path-neg",
+        actingPrincipal: alice.did(),
+      });
+      const cell = runtime.getCell(
+        alice.did(),
+        "per-path-identity-neg",
+        twoFieldSchema,
+        tx,
+      );
+      // Both fields written under writer.x; y is not authorized for writer.x.
+      tx.setCfcImplementationIdentity({
+        kind: "builtin",
+        builtinId: "writer.x",
+      });
+      cell.key("x").set("vx");
+      cell.key("y").set("vy");
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error?.message).toContain("writeAuthorizedBy");
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
 });

--- a/packages/runner/test/profile-owner-cfc.test.ts
+++ b/packages/runner/test/profile-owner-cfc.test.ts
@@ -1,0 +1,425 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import type { NormalizedFullLink } from "../src/link-utils.ts";
+
+const alice = await Identity.fromPassphrase(
+  "runner-profile-owner-cfc-alice",
+);
+const bob = await Identity.fromPassphrase("runner-profile-owner-cfc-bob");
+
+const PROFILE_WRITER = "system.profile-home";
+
+const ownerAtom = (ownerDid: string) => ({
+  kind: "represents-principal",
+  subject: ownerDid,
+});
+
+const ownerProtectedString = (ownerDid: string): JSONSchema => ({
+  type: "string",
+  ifc: {
+    ownerPrincipal: ownerDid,
+    addIntegrity: [ownerAtom(ownerDid)],
+    writeAuthorizedBy: [PROFILE_WRITER],
+    uiContract: {
+      helper: "UiAction",
+      action: "EditProfile",
+      trustedPattern: "ProfileHome",
+      requiredEventIntegrity: ["ProfileHome"],
+    },
+  },
+});
+
+const ownerProtectedElements = (ownerDid: string): JSONSchema => ({
+  type: "array",
+  items: {
+    type: "object",
+    properties: {
+      tag: { type: "string" },
+      userTags: {
+        type: "array",
+        items: { type: "string" },
+      },
+    },
+  },
+  ifc: {
+    ownerPrincipal: ownerDid,
+    addIntegrity: [ownerAtom(ownerDid)],
+    writeAuthorizedBy: [PROFILE_WRITER],
+    uiContract: {
+      helper: "UiAction",
+      action: "EditProfile",
+      trustedPattern: "ProfileHome",
+      requiredEventIntegrity: ["ProfileHome"],
+    },
+  },
+});
+
+const profileSchema = (ownerDid: string): JSONSchema => ({
+  type: "object",
+  properties: {
+    name: ownerProtectedString(ownerDid),
+    avatar: ownerProtectedString(ownerDid),
+    elements: ownerProtectedElements(ownerDid),
+  },
+  required: ["name", "avatar", "elements"],
+});
+
+const createRuntime = () => {
+  const storageManager = StorageManager.emulate({ as: alice });
+  const runtime = new Runtime({
+    apiUrl: new URL("https://example.com"),
+    storageManager,
+  });
+  return { runtime, storageManager };
+};
+
+const setTrustedProfileWriter = (
+  tx: IExtendedStorageTransaction,
+  actingPrincipal?: string,
+) => {
+  tx.setCfcEnforcementMode("enforce-explicit");
+  if (actingPrincipal !== undefined) {
+    tx.setCfcTrustSnapshot({
+      id: `profile-trust-${actingPrincipal}`,
+      actingPrincipal,
+    });
+  }
+  tx.setCfcImplementationIdentity({
+    kind: "builtin",
+    builtinId: PROFILE_WRITER,
+  });
+};
+
+const recordTrustedEdit = (
+  tx: IExtendedStorageTransaction,
+  target: NormalizedFullLink,
+  path: string[],
+) => {
+  tx.recordCfcWritePolicyInput({
+    kind: "trusted-event",
+    target: {
+      space: target.space,
+      scope: target.scope,
+      id: target.id,
+      path,
+    },
+    eventId: `trusted-profile-edit-${path.join("-")}`,
+    provenance: {
+      origin: "dom",
+      trusted: true,
+      ui: {
+        pattern: "ProfileHome",
+        eventIntegrity: ["ProfileHome"],
+        uiContractDataset: { uiAction: "EditProfile" },
+      },
+    },
+  });
+};
+
+describe("profile owner CFC policy", () => {
+  it("persists Alice owner integrity on profile default fields", async () => {
+    const { runtime, storageManager } = createRuntime();
+    try {
+      const tx = runtime.edit();
+      setTrustedProfileWriter(tx, alice.did());
+
+      const cell = runtime.getCell(
+        alice.did(),
+        "profile-owner-cfc-alice",
+        profileSchema(alice.did()),
+        tx,
+      );
+      cell.set({ name: "Ada", avatar: "ada.png", elements: [] });
+      const target = cell.getAsNormalizedFullLink();
+      recordTrustedEdit(tx, target, ["name"]);
+      recordTrustedEdit(tx, target, ["avatar"]);
+      recordTrustedEdit(tx, target, ["elements"]);
+
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.ok).toBeDefined();
+
+      const verify = runtime.edit();
+      const stored = verify.readOrThrow({
+        space: target.space,
+        scope: target.scope,
+        id: target.id,
+        path: [],
+      }) as { cfc?: { labelMap?: { entries?: unknown[] } } };
+      expect(stored.cfc?.labelMap?.entries).toContainEqual({
+        path: ["name"],
+        label: { integrity: [ownerAtom(alice.did())] },
+      });
+      expect(stored.cfc?.labelMap?.entries).toContainEqual({
+        path: ["avatar"],
+        label: { integrity: [ownerAtom(alice.did())] },
+      });
+      expect(stored.cfc?.labelMap?.entries).toContainEqual({
+        path: ["elements"],
+        label: { integrity: [ownerAtom(alice.did())] },
+      });
+      verify.abort();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("keeps an authorized write valid after a later same-tx run changes the implementation identity", async () => {
+    // Mirrors running a child pattern inline in the same transaction: the
+    // handler authorizes a protected write under its identity, then a later run
+    // changes the transaction's implementation identity. The earlier write was
+    // valid when made and must stay valid — CFC must verify each write against
+    // the identity that was active when it was recorded, not the last one.
+    const { runtime, storageManager } = createRuntime();
+    try {
+      const tx = runtime.edit();
+      setTrustedProfileWriter(tx, alice.did());
+      const cell = runtime.getCell(
+        alice.did(),
+        "profile-owner-cfc-identity-clobber",
+        profileSchema(alice.did()),
+        tx,
+      );
+      cell.set({ name: "Ada", avatar: "ada.png", elements: [] });
+      const target = cell.getAsNormalizedFullLink();
+      recordTrustedEdit(tx, target, ["name"]);
+      recordTrustedEdit(tx, target, ["avatar"]);
+      recordTrustedEdit(tx, target, ["elements"]);
+
+      // A second run in the same transaction (e.g. an inline child pattern)
+      // changes the transaction-level implementation identity.
+      tx.setCfcImplementationIdentity({
+        kind: "builtin",
+        builtinId: "system.unrelated-writer",
+      });
+
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error).toBeUndefined();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("rejects Bob writing Alice's protected profile fields", async () => {
+    const { runtime, storageManager } = createRuntime();
+    try {
+      const seed = runtime.edit();
+      setTrustedProfileWriter(seed, alice.did());
+      const seededCell = runtime.getCell(
+        alice.did(),
+        "profile-owner-cfc-bob-rejected",
+        profileSchema(alice.did()),
+        seed,
+      );
+      seededCell.set({ name: "Ada", avatar: "ada.png", elements: [] });
+      const target = seededCell.getAsNormalizedFullLink();
+      recordTrustedEdit(seed, target, ["name"]);
+      recordTrustedEdit(seed, target, ["avatar"]);
+      recordTrustedEdit(seed, target, ["elements"]);
+      seed.prepareCfc();
+      expect((await seed.commit()).ok).toBeDefined();
+
+      const tx = runtime.edit();
+      setTrustedProfileWriter(tx, bob.did());
+      const cell = runtime.getCell(
+        alice.did(),
+        "profile-owner-cfc-bob-rejected",
+        profileSchema(alice.did()),
+        tx,
+      );
+      cell.key("name").set("Mallory");
+      recordTrustedEdit(tx, target, ["name"]);
+
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error?.message).toContain("ownerPrincipal");
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("rejects unauthenticated owner-protected profile writes", async () => {
+    const { runtime, storageManager } = createRuntime();
+    try {
+      const tx = runtime.edit();
+      tx.setCfcEnforcementMode("enforce-explicit");
+      tx.setCfcTrustSnapshot(undefined);
+      tx.setCfcImplementationIdentity({
+        kind: "builtin",
+        builtinId: PROFILE_WRITER,
+      });
+      const cell = runtime.getCell(
+        alice.did(),
+        "profile-owner-cfc-unauthenticated",
+        profileSchema(alice.did()),
+        tx,
+      );
+      cell.set({ name: "Ada", avatar: "ada.png", elements: [] });
+      const target = cell.getAsNormalizedFullLink();
+      recordTrustedEdit(tx, target, ["name"]);
+      recordTrustedEdit(tx, target, ["avatar"]);
+      recordTrustedEdit(tx, target, ["elements"]);
+
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error?.message).toContain("ownerPrincipal");
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("rejects untrusted owner-protected profile writes", async () => {
+    const { runtime, storageManager } = createRuntime();
+    try {
+      const tx = runtime.edit();
+      tx.setCfcEnforcementMode("enforce-explicit");
+      tx.setCfcTrustSnapshot({
+        id: "profile-trust-untrusted",
+        actingPrincipal: alice.did(),
+      });
+
+      const cell = runtime.getCell(
+        alice.did(),
+        "profile-owner-cfc-untrusted",
+        profileSchema(alice.did()),
+        tx,
+      );
+      cell.set({ name: "Ada", avatar: "ada.png", elements: [] });
+      const target = cell.getAsNormalizedFullLink();
+      recordTrustedEdit(tx, target, ["name"]);
+      recordTrustedEdit(tx, target, ["avatar"]);
+      recordTrustedEdit(tx, target, ["elements"]);
+
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error?.message).toContain(
+        "writeAuthorizedBy requires a trusted builtin identity",
+      );
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("rejects ownerPrincipal schemas without matching integrity claims", async () => {
+    const { runtime, storageManager } = createRuntime();
+    try {
+      const tx = runtime.edit();
+      tx.setCfcEnforcementMode("enforce-explicit");
+      tx.setCfcTrustSnapshot({
+        id: "profile-trust-owner-without-integrity",
+        actingPrincipal: alice.did(),
+      });
+      tx.setCfcImplementationIdentity({
+        kind: "builtin",
+        builtinId: PROFILE_WRITER,
+      });
+
+      const cell = runtime.getCell(
+        alice.did(),
+        "profile-owner-cfc-without-integrity",
+        {
+          type: "object",
+          properties: {
+            name: {
+              type: "string",
+              ifc: {
+                ownerPrincipal: alice.did(),
+                writeAuthorizedBy: [PROFILE_WRITER],
+              },
+            },
+          },
+          required: ["name"],
+        },
+        tx,
+      );
+      cell.set({ name: "Ada" });
+
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error?.message).toContain("ownerPrincipal");
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("allows initializing owner-protected fields marked as a pattern setup projection", async () => {
+    // When the runtime instantiates a pattern whose result declares
+    // owner-protected fields, it records a `runtime.setup.result-projection`
+    // marker whose `sources` point at the cells holding those fields. A creating
+    // context that is not the per-field edit handler may then initialize them:
+    // `writeAuthorizedBy` is a modification gate, not a creation gate (CFC spec
+    // §8.15.4 / §8.15.10). This exercises that exemption directly: an identity
+    // that does NOT satisfy `writeAuthorizedBy` is allowed solely because the
+    // owner-protected fields are recorded as this pattern's setup projection.
+    const { runtime, storageManager } = createRuntime();
+    try {
+      const tx = runtime.edit();
+      tx.setCfcEnforcementMode("enforce-explicit");
+      tx.setCfcTrustSnapshot({
+        id: "setup-projection",
+        actingPrincipal: alice.did(),
+      });
+      tx.setCfcImplementationIdentity({
+        kind: "builtin",
+        builtinId: "system.not-the-profile-writer",
+      });
+      const cell = runtime.getCell(
+        alice.did(),
+        "owner-init-setup-projection",
+        profileSchema(alice.did()),
+        tx,
+      );
+      cell.set({ name: "Ada", avatar: "", elements: [] });
+      const target = cell.getAsNormalizedFullLink();
+      recordTrustedEdit(tx, target, ["name"]);
+      recordTrustedEdit(tx, target, ["avatar"]);
+      recordTrustedEdit(tx, target, ["elements"]);
+      // The pattern's result cell redirects these owner-protected fields to
+      // `cell`; record the trusted setup-projection marker with `cell` as the
+      // redirect source, as the runtime does during instantiation.
+      const resultCell = runtime.getCell(
+        alice.did(),
+        "owner-init-setup-projection-result",
+        undefined,
+        tx,
+      );
+      const resultTarget = resultCell.getAsNormalizedFullLink();
+      for (const path of [["name"], ["avatar"], ["elements"]]) {
+        tx.recordCfcWritePolicyInput({
+          kind: "structural-provenance",
+          target: {
+            space: resultTarget.space,
+            scope: resultTarget.scope,
+            id: resultTarget.id,
+            path,
+          },
+          claim: "runtime.setup.result-projection",
+          sources: [{
+            space: target.space,
+            scope: target.scope,
+            id: target.id,
+            path,
+          }],
+        });
+      }
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error).toBeUndefined();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+});


### PR DESCRIPTION
**Stack 2/4** (base: `split/01-storage-multi-space`, #3759) — split out of #3722.

Three related CFC write-authority fixes, motivated by owner-protected fields (`ownerPrincipal` + `writeAuthorizedBy`) but general to any pattern:

1. **Owner integrity / `ownerPrincipal`** (`prepare.ts`, `schema-merge.ts`, `api/index.ts` adds the `ownerPrincipal` IFC key): a field may bind itself to the current principal so its stored value carries owner integrity.
2. **Verify `writeAuthorizedBy` per write, not per transaction** (`prepare.ts`, `types.ts`, `extended-storage-transaction.ts`): a transaction may span multiple trust contexts (a handler plus a child pattern it runs). Capture the implementation identity active when each write-policy input is recorded (`writePolicyInputIdentities`) and verify each write against the identity that authored it, not whichever is active at commit.
3. **`writeAuthorizedBy` is a modification gate, not a creation gate** (`prepare.ts`): per CFC spec §8.15.10 (modification vs replacement) and §8.15.4 (initialization is trusted instantiation; write authorization applies to *subsequent* modifications), a pattern initializing the owner-protected fields it declares must not be rejected. Detected from the `runtime.setup.result-projection` marker the runtime records during instantiation: a write whose target is the redirect *source* of such a marker (recorded in this tx, at/below the field path) is the pattern's own trusted initialization. The marker is recorded only by the runtime's result projection — never by an arbitrary `cell.set`, and only when the projection structure is established (not on value edits) — so direct untrusted writes, no-op re-writes, and later edits remain enforced.

⚠️ **Security-sensitive** — please sanity-check fix 3's exemption against the CFC spec. `cfc-boundary.test.ts` confirms forged setup-projection provenance cannot bypass `writeAuthorizedBy` or uiContract requirements; `profile-owner-cfc.test.ts` (self-contained inline fixtures) covers per-write identity stability, the exemption, and the owner-protection rejections (Bob/unauthenticated/untrusted/unmatched ownerPrincipal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CFC write authority for owner-protected fields by adding `ownerPrincipal` and verifying `writeAuthorizedBy` per field against the identity that authored it, including link writes. Trusted setup projections can initialize owner fields without being blocked, with scope-aware checks.

- **New Features**
  - Added `ifc.ownerPrincipal` (string or `{ "__ctCurrentPrincipal": true }`) to bind a field’s value to the current principal for owner integrity.

- **Bug Fixes**
  - Verify `writeAuthorizedBy` per field using the identity that authored the field’s policy input (longest-prefix match), covering both `schema` and `link-write` inputs; not per cell or last-tx identity. Prevents identity borrowing across fields and stays stable across same-tx identity changes.
  - Treat `writeAuthorizedBy` as a modification gate; allow initialization when the write is part of a `runtime.setup.result-projection`, and require source matches on space, id, path, and scope.
  - Enforce owner integrity: require a trust snapshot with an acting principal, require `writeAuthorizedBy`, ensure `represents-principal` matches the `ownerPrincipal` DID and the acting principal equals `ownerPrincipal`, and keep merge-time stability for `ownerPrincipal`.

<sup>Written for commit e7bc9f304c39f8daa88e9c47243237f97c5538e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---

NEW_PERF_BASELINE: job: Runner Tests (3/4) = 95s
NEW_PERF_BASELINE: step: runner tests = 79s
NEW_PERF_BASELINE: job: Runner Tests = 95s

_The runner-tests timing delta is inherited from the base (this PR sits on a newer main incl. #3763/#3758 that the perf baseline predates); the CFC change itself adds no broad overhead — its tests run in ~2.3s total._