### PR TITLE
feat(runner): PatternFactory.inSpace and inline cross-space child instantiation

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -1384,6 +1384,7 @@ export type PatternFactory<T, R> =
   & toJSON
   & {
     asScope(scope: CellScope): PatternFactory<T, R>;
+    inSpace(space?: string | AnyCell<unknown>): PatternFactory<T, R>;
   };
 
 export type ModuleFactory<T, R> =

--- a/packages/runner/src/builder/pattern.ts
+++ b/packages/runner/src/builder/pattern.ts
@@ -37,7 +37,9 @@ import {
   getCellOrThrow,
   isCellResultForDereferencing,
 } from "../query-result-proxy.ts";
-import { isCell } from "../cell.ts";
+import { isCell, setCellUnlinkedSpace } from "../cell.ts";
+import { createRef } from "../create-ref.ts";
+import { toURI } from "../uri-utils.ts";
 import { closureCaptureErrorMessage } from "./closure-capture-diagnostic.ts";
 import { Runtime } from "../runtime.ts";
 import type { ImplementationIdentity } from "../cfc/types.ts";
@@ -395,6 +397,7 @@ function factoryFromPattern<T, R>(
 
   const makePatternFactory = (
     defaultScope?: CellScope,
+    defaultSpace?: string | unknown,
   ): PatternFactory<T, R> => {
     const factory = Object.assign(
       (inputs: Opaque<T>): OpaqueRef<R> => {
@@ -408,11 +411,19 @@ function factoryFromPattern<T, R>(
         };
 
         const outputs = opaqueRef<R>();
+        const frame = getTopFrame();
+        if (defaultSpace !== undefined) {
+          const targetSpace = resolveInSpaceTargetSpace(defaultSpace, frame);
+          if (targetSpace !== undefined) {
+            setCellUnlinkedSpace(outputs, targetSpace);
+            module.targetSpace = targetSpace;
+          }
+        }
         const node: NodeRef = {
           module,
           inputs,
           outputs,
-          frame: getTopFrame(),
+          frame,
         };
 
         connectInputAndOutputs(node);
@@ -427,7 +438,10 @@ function factoryFromPattern<T, R>(
       } as Pattern & toJSON,
     ) as PatternFactory<T, R>;
 
-    factory.asScope = (scope: CellScope) => makePatternFactory(scope);
+    factory.asScope = (scope: CellScope) =>
+      makePatternFactory(scope, defaultSpace);
+    factory.inSpace = (space?: string | unknown) =>
+      makePatternFactory(defaultScope, space ?? "");
     return factory;
   };
 
@@ -454,6 +468,53 @@ function getStableInternalPathSegment(cause: unknown): PropertyKey | undefined {
   }
 
   return undefined;
+}
+
+/**
+ * Resolves a `PatternFactory.inSpace(...)` target to a concrete space DID at
+ * graph-construction time.
+ *
+ * - A DID string or a cell resolves synchronously.
+ * - A named string (or the anonymous case below) is resolved from the runtime's
+ *   space-name cache. On a cache miss the name is recorded on the frame as
+ *   pending and `undefined` is returned; the runner resolves pending names after
+ *   the run and re-runs the handler/action (RetryImmediately), at which point
+ *   the cache hits and the target resolves synchronously.
+ * - The anonymous case (`inSpace()` / empty string) derives a stable per-call
+ *   name by hashing the frame's cause together with a per-frame counter, so each
+ *   call site gets its own deterministic space that survives re-runs — mirroring
+ *   how cell ids are derived from causes.
+ */
+function resolveInSpaceTargetSpace(
+  space: unknown,
+  frame: Frame | undefined,
+): MemorySpace | undefined {
+  if (typeof space === "string" && /^did:[^:]+:.+/.test(space)) {
+    return space as MemorySpace;
+  }
+  if (isCell(space)) {
+    return space.getAsNormalizedFullLink().space;
+  }
+  const runtime = frame?.runtime;
+  if (!runtime) return undefined;
+  const name = typeof space === "string" && space.length > 0
+    ? space
+    : anonymousSpaceName(frame!);
+  const resolved = runtime.resolveSpaceNameSync(name);
+  if (resolved !== undefined) return resolved;
+  (frame!.pendingSpaceNames ??= new Set<string>()).add(name);
+  return undefined;
+}
+
+/**
+ * Derives a stable, unique name for an anonymous `inSpace()` call from the
+ * frame's cause and a per-frame counter, so repeated calls in one run get
+ * distinct spaces while re-runs of the same call site stay deterministic.
+ */
+function anonymousSpaceName(frame: Frame): string {
+  const ordinal = frame.inSpaceCounter ?? 0;
+  frame.inSpaceCounter = ordinal + 1;
+  return toURI(createRef({ inSpace: ordinal }, frame.cause));
 }
 
 function formatStableCauseSegment(cause: unknown): string {

--- a/packages/runner/src/builder/pattern.ts
+++ b/packages/runner/src/builder/pattern.ts
@@ -510,6 +510,14 @@ function resolveInSpaceTargetSpace(
  * Derives a stable, unique name for an anonymous `inSpace()` call from the
  * frame's cause and a per-frame counter, so repeated calls in one run get
  * distinct spaces while re-runs of the same call site stay deterministic.
+ *
+ * Determinism caveat: the per-frame counter is position-based, so a handler
+ * must call `inSpace()` the same number of times (and in the same order) on
+ * every run for a given logical child to keep mapping to the same space. A
+ * handler that conditionally varies its anonymous `inSpace()` call count across
+ * reactive re-runs would remap a child to a different space and orphan its prior
+ * data. Deterministic handler bodies (the norm) are unaffected; name your spaces
+ * with `inSpace("name")` if call counts may vary.
  */
 function anonymousSpaceName(frame: Frame): string {
   const ordinal = frame.inSpaceCounter ?? 0;

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -199,6 +199,8 @@ declare module "@commonfabric/api" {
     materializerWriteEnvelopes?: readonly NormalizedFullLink[];
     /** Input paths whose writable cells should become materializer envelopes */
     materializerWriteInputPaths?: readonly (readonly string[])[];
+    /** Run this module's result in a specific space. */
+    targetSpace?: MemorySpace;
   }
 }
 
@@ -273,6 +275,14 @@ export type Frame = {
   opaqueRefs: Set<OpaqueRef<any>>;
   unsafe_binding?: UnsafeBinding;
   sourceLocationContext?: SourceLocationContext;
+  /**
+   * Named/anonymous `PatternFactory.inSpace(...)` targets encountered during
+   * this frame whose space DID was not yet cached. The runner resolves these
+   * after the run and re-runs (see RetryImmediately).
+   */
+  pendingSpaceNames?: Set<string>;
+  /** Per-frame counter giving each anonymous `inSpace()` call a stable name. */
+  inSpaceCounter?: number;
 };
 
 // Builder functions interface

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -35,6 +35,7 @@ import {
   type IsThisObject,
   type IStreamable,
   type JSONSchema,
+  type Module,
   type NodeFactory,
   type NodeRef,
   type Opaque,
@@ -582,6 +583,25 @@ export class CellImpl<T extends FabricValue>
     this._causeContainer.cause = cause;
 
     return this as unknown as Cell<T>;
+  }
+
+  /**
+   * Pins this (not-yet-linked) cell to a space before its id exists, and routes
+   * any pattern nodes attached to it into that target space. Used by the pattern
+   * builder to implement `PatternFactory.inSpace(...)`. Throws if the cell has
+   * already been linked.
+   */
+  setUnlinkedSpace(space: MemorySpace): void {
+    if (this._causeContainer.id || this._link.id) {
+      throw new Error(
+        "Cannot set space: cell already has a link.",
+      );
+    }
+    this._causeContainer.space = space;
+    this._link = { ...this._link, space };
+    for (const node of cellNodes.get(this._causeContainer.cell) ?? []) {
+      (node.module as Module).targetSpace = space;
+    }
   }
 
   /**
@@ -1923,6 +1943,23 @@ export class CellImpl<T extends FabricValue>
       "Copy trap: Something is trying to traverse a cell.",
     );
   }
+}
+
+export function setCellUnlinkedSpace(
+  cell: unknown,
+  space: MemorySpace,
+): void {
+  asCellImpl(cell)?.setUnlinkedSpace(space);
+}
+
+function asCellImpl(cell: unknown): CellImpl<FabricValue> | undefined {
+  if (cell === null || cell === undefined) return undefined;
+  const maybeToCell = (cell as { [toCell]?: () => Cell<unknown> })[toCell];
+  const unproxied = typeof maybeToCell === "function"
+    ? maybeToCell.call(cell)
+    : cell;
+  if (!isCell(unproxied)) return undefined;
+  return unproxied as unknown as CellImpl<FabricValue>;
 }
 
 function subscribeToReferencedDocs<T>(

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -235,7 +235,9 @@ export class PatternManager {
     let patternId: URI | undefined;
     if ("patternId" in input) {
       patternId = input.patternId;
-    } else if (input && typeof input === "object") {
+    } else if (
+      input && (typeof input === "object" || typeof input === "function")
+    ) {
       patternId = this.patternToIdMap.get(
         this.findOriginalPattern(input as Pattern),
       );
@@ -244,7 +246,10 @@ export class PatternManager {
     if (!patternId) throw new Error("Pattern is not registered");
 
     const cell = this.patternMetaCellById.get(patternId);
-    if (cell) return cell.get();
+    if (cell) {
+      const meta = cell.get();
+      if (meta) return meta;
+    }
 
     // If we don't have a stored cell yet, return whatever pending/meta we have
     const pending = this.pendingMetaById.get(patternId) ?? {};

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -498,6 +498,16 @@ export class Runner {
     `${MemorySpace}/${CellScope}/${URI}`,
     string
   >();
+  // Per-transaction accumulator of cross-space child spaces, so that when a
+  // parent materializes several `Child.inSpace(...)` results into different
+  // spaces we commit ALL child spaces before the parent (the parent's link to
+  // each child must never be durable before that child's target). Each call
+  // re-supplies the full order rather than replacing it with just the latest
+  // child + parent. Keyed weakly by transaction so it is reclaimed with the tx.
+  private crossSpaceChildSpaces = new WeakMap<
+    IExtendedStorageTransaction,
+    MemorySpace[]
+  >();
 
   constructor(readonly runtime: Runtime) {
     this.runtime.storageManager.subscribe(this.createStorageSubscription());
@@ -2397,6 +2407,31 @@ export class Runner {
     );
   }
 
+  /**
+   * Opt `tx` into multi-space writes for a cross-space child, accumulating the
+   * commit order so every child space committed in this transaction is ordered
+   * before `parentSpace`. Without accumulation, a second cross-space child would
+   * replace the order with `[child2, parent]`, dropping `child1` to after the
+   * parent (orderedCommitSpaces appends unlisted written spaces), which would
+   * make the parent's link to `child1` durable before `child1`'s target.
+   */
+  private enableCrossSpaceChildCommit(
+    tx: IExtendedStorageTransaction,
+    childSpace: MemorySpace,
+    parentSpace: MemorySpace,
+  ): void {
+    let childSpaces = this.crossSpaceChildSpaces.get(tx);
+    if (childSpaces === undefined) {
+      childSpaces = [];
+      this.crossSpaceChildSpaces.set(tx, childSpaces);
+    }
+    if (childSpace !== parentSpace && !childSpaces.includes(childSpace)) {
+      childSpaces.push(childSpace);
+    }
+    // All accumulated child spaces first, parent last.
+    tx.enableMultiSpaceWrites?.([...childSpaces, parentSpace]);
+  }
+
   private handleJavaScriptHandlerResult(
     tx: IExtendedStorageTransaction,
     result: any,
@@ -2451,7 +2486,7 @@ export class Runner {
     if (crossSpace && !deferForNavigate) {
       // Commit the child space first so the originating space's link to it is
       // never durable before its target.
-      tx.enableMultiSpaceWrites?.([resultSpace, processCell.space]);
+      this.enableCrossSpaceChildCommit(tx, resultSpace, processCell.space);
     }
 
     const resultCell = deferForNavigate
@@ -3729,7 +3764,11 @@ export class Runner {
       // (child space committed first) rather than re-instantiating it in a
       // deferred second transaction, which would lose its verified-function
       // identity. The journal allows the cross-space write once opted in.
-      tx.enableMultiSpaceWrites?.([resultCell.space, resultCellLink.space]);
+      this.enableCrossSpaceChildCommit(
+        tx,
+        resultCell.space,
+        resultCellLink.space,
+      );
     }
     this.run(tx, patternImpl, inputs, resultCell);
 

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -31,6 +31,7 @@ import {
 } from "./builder/pattern.ts";
 import { type Cell, createCell, isCell } from "./cell.ts";
 import { type Action } from "./scheduler.ts";
+import { RetryImmediately } from "./scheduler/retry-immediately.ts";
 import {
   findAllWriteRedirectCells,
   unsafe_noteParentOnPatterns,
@@ -1348,6 +1349,59 @@ export class Runner {
     });
   }
 
+  private runPatternAfterSuccessfulCommit<T = any>(
+    tx: IExtendedStorageTransaction,
+    resultCell: Cell<T>,
+    pattern: Pattern,
+    inputs: FabricValue,
+    pullOnceAfterStart = false,
+  ): void {
+    const resultLink = resultCell.getAsNormalizedFullLink();
+    tx.addCommitCallback((_committedTx, result) => {
+      if (result.error) return;
+
+      const startTx = this.runtime.edit();
+      const committedResultCell = this.runtime.getCellFromLink<T>(
+        resultLink,
+        pattern.resultSchema,
+        startTx,
+      );
+      try {
+        this.run(startTx, pattern, inputs, committedResultCell);
+        this.runtime.prepareTxForCommit(startTx);
+        startTx.commit().then(({ error }) => {
+          if (error) {
+            this.stop(committedResultCell);
+            logger.error(
+              "tx-commit-error",
+              "Error committing deferred cross-space pattern transaction",
+              error,
+            );
+            return;
+          }
+          if (pullOnceAfterStart) {
+            this.pullCellOnceInPullMode(committedResultCell);
+          }
+        }).catch((error) => {
+          this.stop(committedResultCell);
+          logger.error(
+            "tx-commit-error",
+            "Deferred cross-space pattern transaction rejected",
+            error,
+          );
+        });
+      } catch (error) {
+        startTx.abort(error);
+        logger.error(
+          "runner-start",
+          "Deferred cross-space pattern failed",
+          error,
+        );
+        throw error;
+      }
+    });
+  }
+
   /**
    * Run a pattern.
    *
@@ -2361,13 +2415,50 @@ export class Runner {
     }
 
     const resultPattern = patternFromFrame(() => result);
-    const resultCell = this.handlerResultPatternMustStartAfterCommit(
+    const resultSpace = result === undefined
+      ? this.handlerResultPatternMaterializationSpace(
         resultPattern,
+        processCell.space,
       )
+      : processCell.space;
+    // navigateTo result patterns must start after the handler's transaction
+    // commits so the navigation target is durable. Cross-space children, by
+    // contrast, run inline in a multi-space transaction (below) so they keep
+    // their verified-function identity instead of being re-instantiated.
+    const deferForNavigate = this.handlerResultPatternHasNavigateTo(
+      resultPattern,
+    );
+    const crossSpace = resultSpace !== processCell.space;
+
+    if (deferForNavigate && result === undefined) {
+      const resultCell = this.runtime.getCell(
+        resultSpace,
+        { resultFor: cause },
+        undefined,
+        tx,
+      );
+      this.runPatternAfterSuccessfulCommit(
+        tx,
+        resultCell,
+        resultPattern,
+        undefined,
+        true,
+      );
+      addCancel(() => this.stop(resultCell));
+      return result;
+    }
+
+    if (crossSpace && !deferForNavigate) {
+      // Commit the child space first so the originating space's link to it is
+      // never durable before its target.
+      tx.enableMultiSpaceWrites?.([resultSpace, processCell.space]);
+    }
+
+    const resultCell = deferForNavigate
       ? this.setupDeferredHandlerResultPattern(
         tx,
         resultPattern,
-        processCell,
+        resultSpace,
         cause,
       )
       : this.run(
@@ -2375,7 +2466,7 @@ export class Runner {
         resultPattern,
         undefined,
         this.runtime.getCell(
-          processCell.space,
+          resultSpace,
           { resultFor: cause },
           undefined,
           tx,
@@ -2421,20 +2512,55 @@ export class Runner {
     return result;
   }
 
-  private handlerResultPatternMustStartAfterCommit(pattern: Pattern): boolean {
+  /**
+   * Resolves any `PatternFactory.inSpace("name")` targets that the just-finished
+   * handler/action referenced but whose space DID was not yet cached, then
+   * throws {@link RetryImmediately} so the scheduler re-runs the handler/action.
+   * On the re-run the names resolve synchronously from the runtime cache (see
+   * the pattern builder's resolveInSpaceTargetSpace), so the child results are
+   * routed into the correct spaces from the start — no link rewriting required.
+   */
+  private async resolvePendingSpaceNamesAndRetry(
+    frame: Frame,
+  ): Promise<never> {
+    const names = [...(frame.pendingSpaceNames ?? [])];
+    await Promise.all(
+      names.map((name) => this.runtime.resolveSpaceName(name)),
+    );
+    throw new RetryImmediately(
+      `Resolving in-space target spaces: ${names.join(", ")}`,
+    );
+  }
+
+  private handlerResultPatternHasNavigateTo(
+    pattern: Pattern,
+  ): boolean {
     return pattern.nodes.some(({ module }) =>
       module.type === "ref" && module.implementation === "navigateTo"
     );
   }
 
+  private handlerResultPatternMaterializationSpace(
+    pattern: Pattern,
+    fallback: MemorySpace,
+  ): MemorySpace {
+    const targetSpaces = new Set<MemorySpace>();
+    for (const { module } of pattern.nodes) {
+      if (module.targetSpace !== undefined) {
+        targetSpaces.add(module.targetSpace);
+      }
+    }
+    return targetSpaces.size === 1 ? [...targetSpaces][0] : fallback;
+  }
+
   private setupDeferredHandlerResultPattern(
     tx: IExtendedStorageTransaction,
     resultPattern: Pattern,
-    processCell: Cell<any>,
+    resultSpace: MemorySpace,
     cause: Record<string, any>,
   ): Cell<any> {
     const resultCell = this.runtime.getCell(
-      processCell.space,
+      resultSpace,
       { resultFor: cause },
       undefined,
       tx,
@@ -2667,6 +2793,7 @@ export class Runner {
         tx.setCfcImplementationIdentity(policyFacingIdentity);
       }
 
+      let popFrameAfterReturn = true;
       try {
         const inputsCell = this.runtime.getImmutableCell(
           processCell.space,
@@ -2743,6 +2870,9 @@ export class Runner {
         const postRun = (result: any) => {
           logger.timeStart("stream", "postRun");
           try {
+            if (frame.pendingSpaceNames && frame.pendingSpaceNames.size > 0) {
+              return this.resolvePendingSpaceNamesAndRetry(frame);
+            }
             return this.handleJavaScriptHandlerResult(
               tx,
               result,
@@ -2758,14 +2888,30 @@ export class Runner {
           }
         };
 
-        return result instanceof Promise
+        const postRunResult = result instanceof Promise
           ? result.then(postRun)
           : postRun(result);
+        if (postRunResult instanceof Promise) {
+          popFrameAfterReturn = false;
+          return postRunResult.finally(() => popFrame(frame));
+        }
+        return postRunResult;
       } catch (error) {
+        // The handler body may throw while materializing a not-yet-resolved
+        // inSpace("name") child (e.g. set into a cell). If so, resolve the
+        // pending names and retry instead of surfacing the error.
+        if (
+          !(error instanceof RetryImmediately) &&
+          frame.pendingSpaceNames && frame.pendingSpaceNames.size > 0
+        ) {
+          popFrameAfterReturn = false;
+          return this.resolvePendingSpaceNamesAndRetry(frame)
+            .finally(() => popFrame(frame));
+        }
         (error as Error & { frame?: Frame }).frame = frame;
         throw error;
       } finally {
-        popFrame(frame);
+        if (popFrameAfterReturn) popFrame(frame);
       }
     };
 
@@ -2891,6 +3037,10 @@ export class Runner {
       const resultCell = patternResultCell;
 
       const handleErrorOutput = (error: unknown) => {
+        // RetryImmediately is an internal control-flow signal: re-throw it
+        // untouched so the scheduler re-runs the action instead of writing an
+        // error result into the binding.
+        if (error instanceof RetryImmediately) throw error;
         if (
           error !== null &&
           (typeof error === "object" || typeof error === "function")
@@ -2916,6 +3066,7 @@ export class Runner {
         throw error;
       };
 
+      let popFrameAfterReturn = true;
       try {
         logger.timeStart("action", "readInputs");
         tx.resetNarrowestReadScope();
@@ -2987,6 +3138,9 @@ export class Runner {
         const postRun = (result: any) => {
           logger.timeStart("action", "postRun");
           try {
+            if (frame.pendingSpaceNames && frame.pendingSpaceNames.size > 0) {
+              return this.resolvePendingSpaceNamesAndRetry(frame);
+            }
             return this.writeJavaScriptActionResult(
               tx,
               module.resultSchema,
@@ -3005,13 +3159,29 @@ export class Runner {
           }
         };
 
-        return result instanceof Promise
+        const postRunResult = result instanceof Promise
           ? result.then(postRun).catch(handleErrorOutput)
           : postRun(result);
+        if (postRunResult instanceof Promise) {
+          popFrameAfterReturn = false;
+          return postRunResult.finally(() => popFrame(frame));
+        }
+        return postRunResult;
       } catch (error) {
+        // The action body may throw while materializing a not-yet-resolved
+        // inSpace("name") child. If so, resolve the pending names and retry
+        // instead of surfacing the error.
+        if (
+          !(error instanceof RetryImmediately) &&
+          frame.pendingSpaceNames && frame.pendingSpaceNames.size > 0
+        ) {
+          popFrameAfterReturn = false;
+          return this.resolvePendingSpaceNamesAndRetry(frame)
+            .finally(() => popFrame(frame));
+        }
         handleErrorOutput(error);
       } finally {
-        popFrame(frame);
+        if (popFrameAfterReturn) popFrame(frame);
       }
     };
 
@@ -3521,8 +3691,11 @@ export class Runner {
       );
       sendToBindings = false;
     } else {
+      const resultScope = patternDefaultScope(patternImpl) ??
+        module.defaultScope;
+      const targetSpace = module.targetSpace ?? resultCell.space;
       const baseResultCell = this.runtime.getCell(
-        resultCell.space,
+        targetSpace,
         {
           pattern: module.implementation,
           parent: resultCell.entityId,
@@ -3532,8 +3705,6 @@ export class Runner {
         patternImpl.resultSchema,
         tx,
       );
-      const resultScope = patternDefaultScope(patternImpl) ??
-        module.defaultScope;
       resultCell = baseResultCell;
       if (resultScope !== undefined && resultScope !== "space") {
         let resultCellLink = baseResultCell.getAsNormalizedFullLink();
@@ -3553,6 +3724,13 @@ export class Runner {
       `sendToBindings=${sendToBindings}`,
     ]);
 
+    if (resultCell.space !== resultCellLink.space) {
+      // Cross-space child pattern: run it inline in a multi-space transaction
+      // (child space committed first) rather than re-instantiating it in a
+      // deferred second transaction, which would lose its verified-function
+      // identity. The journal allows the cross-space write once opted in.
+      tx.enableMultiSpaceWrites?.([resultCell.space, resultCellLink.space]);
+    }
     this.run(tx, patternImpl, inputs, resultCell);
 
     if (sendToBindings) {

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -962,6 +962,12 @@ export class Runtime {
       identity: this.storageManager.as as unknown as Identity,
       spaceName: name,
     });
+    // SECURITY INVARIANT: consume ONLY the resolved space DID. `createSession`
+    // may also derive a per-name space identity (private key); we must never
+    // adopt it as a signer here. Writes to the resolved space stay authorized
+    // as the active user (`storageManager.as`) and are gated per-space by the
+    // memory server's ACL, so resolving a name can never grant write access the
+    // caller does not already hold.
     const did = session.space as MemorySpace;
     this.spaceNameToDid.set(name, did);
     return did;

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -37,6 +37,7 @@ import type {
 } from "./storage/interface.ts";
 import { type Cell, createCell, schemaCellScope } from "./cell.ts";
 import { createRef, EntityId } from "./create-ref.ts";
+import { createSession, Identity } from "@commonfabric/identity";
 import { Action, Scheduler } from "./scheduler.ts";
 import { Engine } from "./harness/index.ts";
 import {
@@ -270,6 +271,10 @@ export interface SpaceCellContents {
   defaultPattern: Cell<unknown>;
 }
 
+function isMemorySpaceDID(value: string): boolean {
+  return /^did:[^:]+:.+/.test(value);
+}
+
 /**
  * Main Runtime class that orchestrates all services in the runner package.
  *
@@ -310,6 +315,8 @@ export class Runtime {
   readonly experimental: ExperimentalOptions;
   readonly apiUrl: URL;
   readonly userIdentityDID: DID;
+  /** Cache of resolved PatternFactory.inSpace("name") space DIDs. */
+  private readonly spaceNameToDid = new Map<string, MemorySpace>();
   private defaultFrame?: Frame;
   private queues = new Map<string, AsyncSemaphoreQueue>();
   private writeDebugContext = new WriteDebugContextStorage<string>();
@@ -923,6 +930,41 @@ export class Runtime {
       spaceCellSchema,
       tx,
     ) as Cell<SpaceCellContents>;
+  }
+
+  /**
+   * Returns the DID for a named `PatternFactory.inSpace("name")` target if it
+   * has already been resolved (or is itself a DID), otherwise `undefined`.
+   *
+   * Synchronous so the pattern builder can route a child result into the target
+   * space at graph-construction time. On a miss, the caller records the name as
+   * pending and the runner resolves it via {@link resolveSpaceName} before
+   * re-running the handler/action (see RetryImmediately).
+   */
+  resolveSpaceNameSync(name: string): MemorySpace | undefined {
+    if (isMemorySpaceDID(name)) return name as MemorySpace;
+    return this.spaceNameToDid.get(name);
+  }
+
+  /**
+   * Resolves a named `inSpace` target to a DID, caching the result.
+   *
+   * NOTE(#1): The derivation is intentionally name-based for now — `createSession`
+   * derives the space key from the name alone (the identity is ignored on the
+   * `spaceName` path), so equal names map to the same shared space across users.
+   * This is the deliberate "shared profile space" behaviour today; revisit once
+   * we can derive unique space DIDs from a string.
+   */
+  async resolveSpaceName(name: string): Promise<MemorySpace> {
+    const cached = this.resolveSpaceNameSync(name);
+    if (cached !== undefined) return cached;
+    const session = await createSession({
+      identity: this.storageManager.as as unknown as Identity,
+      spaceName: name,
+    });
+    const did = session.space as MemorySpace;
+    this.spaceNameToDid.set(name, did);
+    return did;
   }
 
   // Convenience methods that delegate to the runner

--- a/packages/runner/src/scheduler/action-run.ts
+++ b/packages/runner/src/scheduler/action-run.ts
@@ -18,6 +18,7 @@ import {
   type DiagnosisRecord,
   runIdempotencyRecheck,
 } from "./diagnosis.ts";
+import { RetryImmediately } from "./retry-immediately.ts";
 import { toActionRunTraceAddress } from "./diagnostics.ts";
 import { buildSchedulerActionObservation } from "./persistent-observation.ts";
 import { filterIgnoredAddresses, txToReactivityLog } from "./reactivity.ts";
@@ -375,6 +376,14 @@ function finalizeSchedulerAction(
   state.pullDemandedFirstRunComputations.delete(args.action);
   state.pullDemandedContinuationComputations.delete(args.action);
 
+  // A RetryImmediately signal means the action referenced an inSpace("name")
+  // target that has now been resolved into the runtime cache. Abort this run's
+  // transaction and re-run the action so it resolves the name synchronously.
+  if (args.error instanceof RetryImmediately) {
+    rescheduleActionForImmediateRetry(state, args);
+    return;
+  }
+
   try {
     if (args.error) {
       logger.error("schedule-error", () => [
@@ -386,6 +395,34 @@ function finalizeSchedulerAction(
   } finally {
     finalizeReactiveActionCommit(state, args, elapsed);
   }
+}
+
+function rescheduleActionForImmediateRetry(
+  state: SchedulerActionRunState,
+  args: {
+    readonly action: Action;
+    readonly actionId: string;
+    readonly tx: IExtendedStorageTransaction;
+    readonly error?: unknown;
+    readonly resolve: (value: unknown) => void;
+  },
+): void {
+  if (args.tx.status().status === "ready") args.tx.abort(args.error);
+  removeInFlightSource(state.inFlightSourceState, args.action, args.tx.tx);
+  const retries = (state.retries.get(args.action) ?? 0) + 1;
+  state.retries.set(args.action, retries);
+  if (retries < MAX_RETRIES_FOR_REACTIVE) {
+    state.markDirectDirty(args.action);
+    state.pending.add(args.action);
+    state.queueExecution();
+  } else {
+    state.retries.delete(args.action);
+    logger.error(
+      "schedule-error",
+      `Action ${args.actionId} exhausted retries resolving inSpace names`,
+    );
+  }
+  args.resolve(undefined);
 }
 
 function normalizeThrownError(error: unknown): Error {

--- a/packages/runner/src/scheduler/events.ts
+++ b/packages/runner/src/scheduler/events.ts
@@ -13,6 +13,7 @@ import type {
 } from "../telemetry.ts";
 import { createDirtyDependencyTraceContext } from "./diagnostics.ts";
 import { planEventDirtyDependencyScheduling } from "./execution.ts";
+import { RetryImmediately } from "./retry-immediately.ts";
 import {
   hasAnnotatedWrites,
   trustedEventWriteCandidatesFromTransaction,
@@ -444,6 +445,35 @@ export async function dispatchQueuedEvent(state: {
   };
 
   const finalize = (error?: unknown): void => {
+    // A RetryImmediately signal means the handler referenced an inSpace("name")
+    // target that has now been resolved into the runtime cache. Abort this run's
+    // transaction and re-queue the event so the handler re-runs and resolves the
+    // name synchronously.
+    if (error instanceof RetryImmediately) {
+      if (tx.status().status === "ready") {
+        tx.abort(error);
+      }
+      if (retriesLeft > 0) {
+        state.eventQueue.unshift({
+          action,
+          eventLink: queuedEvent.eventLink,
+          handler,
+          event: eventValue,
+          retriesLeft: retriesLeft - 1,
+          onCommit,
+        });
+        state.queueExecution();
+      } else {
+        logger.error(
+          "scheduler",
+          "Event handler exhausted retries resolving inSpace names",
+          { handlerId },
+        );
+        runFinalCommitCallback();
+      }
+      return;
+    }
+
     if (error) {
       try {
         state.handleError(error as Error, action);

--- a/packages/runner/src/scheduler/retry-immediately.ts
+++ b/packages/runner/src/scheduler/retry-immediately.ts
@@ -1,0 +1,20 @@
+/**
+ * Thrown from a handler/action `postRun` when the run referenced a pattern space
+ * by name (`PatternFactory.inSpace("name")`) whose DID had not yet been
+ * resolved. Before throwing, the runner resolves the pending name(s) into the
+ * runtime's space-name cache; the scheduler then aborts the current transaction
+ * and re-runs the same handler/action, which now resolves the name(s)
+ * synchronously from the cache and proceeds normally.
+ *
+ * This is an internal control-flow signal, not a user-facing error.
+ */
+export class RetryImmediately extends Error {
+  constructor(message = "Retry action immediately") {
+    super(message);
+    this.name = "RetryImmediately";
+  }
+}
+
+export function isRetryImmediately(error: unknown): error is RetryImmediately {
+  return error instanceof RetryImmediately;
+}

--- a/packages/runner/test/pattern-manager.test.ts
+++ b/packages/runner/test/pattern-manager.test.ts
@@ -174,6 +174,28 @@ describe("PatternManager program persistence", () => {
     const meta = await runtime.patternManager.loadPatternMeta(patternId, space);
     expect(meta.program?.main).toEqual("/legacy.ts");
   });
+
+  it("returns metadata for a registered compiled pattern factory", async () => {
+    const program: RuntimeProgram = {
+      main: "/main.ts",
+      files: [
+        {
+          name: "/main.ts",
+          contents: [
+            "import { pattern } from 'commonfabric';",
+            "export default pattern(() => ({ name: 'factory meta' }));",
+          ].join("\n"),
+        },
+      ],
+    };
+
+    const compiled = await runtime.patternManager.compilePattern(program);
+    const patternId = runtime.patternManager.registerPattern(compiled, program);
+    const meta = runtime.patternManager.getPatternMeta(compiled);
+
+    expect(patternId).toBeDefined();
+    expect(meta.program?.main).toEqual("/main.ts");
+  });
 });
 
 describe("PatternManager.loadPattern error handling", () => {

--- a/packages/runner/test/pattern-scope.test.ts
+++ b/packages/runner/test/pattern-scope.test.ts
@@ -1,5 +1,5 @@
 import { assertEquals } from "@std/assert";
-import { Identity } from "@commonfabric/identity";
+import { createSession, Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
 import {
@@ -8,7 +8,7 @@ import {
   toMemorySpaceAddress,
 } from "../src/link-utils.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
-import { Cell, createCell } from "../src/cell.ts";
+import { type Cell, createCell } from "../src/cell.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
@@ -461,14 +461,459 @@ Deno.test("pattern factory .asScope() sets child pattern result scope", async ()
     await runtime.storageManager.synced();
     await result.pull();
 
-    const childLink = parseLink(
-      result.key("child").getRaw({ lastNode: "writeRedirect" }),
-      result,
-    );
+    const childLink = result.key("child").resolveAsCell()
+      .getAsNormalizedFullLink();
     assertEquals(childLink?.scope, "user");
     assertEquals(
       runtime.getCellFromLink(childLink!)?.getAsNormalizedFullLink().scope,
       "user",
+    );
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("pattern factory .inSpace() routes child pattern result to DID space", async () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const tx = runtime.edit();
+  const targetSpace = (await Identity.fromPassphrase(
+    "pattern factory inSpace child target",
+  )).did();
+
+  try {
+    const { pattern } = createTrustedBuilder(runtime).commonfabric;
+
+    const Child = pattern<{ value: string }>(({ value }) => ({ value }));
+    const Root = pattern(() => ({
+      child: Child.inSpace(targetSpace)({ value: "child" }),
+    }));
+
+    const resultCell = runtime.getCell(
+      space,
+      "pattern factory inSpace child result",
+      undefined,
+      tx,
+    );
+
+    const result = runtime.run(tx, Root, {}, resultCell);
+    await tx.commit();
+    await runtime.idle();
+    await runtime.storageManager.synced();
+    await result.pull();
+
+    const childLink = result.key("child").resolveAsCell()
+      .getAsNormalizedFullLink();
+    assertEquals(childLink?.space, targetSpace);
+    assertEquals(await result.key("child", "value").pull(), "child" as any);
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("pattern factory .inSpace() resolves named spaces during action postRun", async () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const tx = runtime.edit();
+  const spaceName = `pattern-factory-in-space-${crypto.randomUUID()}`;
+  const expectedSpace = (await createSession({
+    identity: signer,
+    spaceName,
+  })).space;
+
+  try {
+    const { lift, pattern } = createTrustedBuilder(runtime).commonfabric;
+
+    const Child = pattern<{ value: string }>(({ value }) => ({ value }));
+    const makeChild = lift(({ value }: { value: string }) =>
+      Child.inSpace(spaceName)({ value })
+    );
+    const Root = pattern<{ value: string }>((state) => ({
+      child: makeChild({ value: state.value }),
+    }));
+
+    const resultCell = runtime.getCell(
+      space,
+      "pattern factory named inSpace action result",
+      undefined,
+      tx,
+    );
+
+    const result = runtime.run(tx, Root, { value: "named child" }, resultCell);
+    await tx.commit();
+    await runtime.idle();
+    await runtime.storageManager.synced();
+    await result.pull();
+
+    const actionLink = parseLink(result.key("child").getRaw(), result);
+    const actionResult = runtime.getCellFromLink(actionLink!);
+    const childLink = actionResult.resolveAsCell().getAsNormalizedFullLink();
+    assertEquals(childLink?.space, expectedSpace);
+    assertEquals(
+      await result.key("child", "value").pull(),
+      "named child" as any,
+    );
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("pattern factory .inSpace() handler side effect can write linked child across spaces", async () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const tx = runtime.edit();
+  const targetSpace = (await Identity.fromPassphrase(
+    "pattern factory handler inSpace linked child target",
+  )).did();
+
+  try {
+    const { handler, pattern } = createTrustedBuilder(runtime).commonfabric;
+
+    const Child = pattern<{ value: string }>(({ value }) => ({ value }));
+    const createChild = handler<
+      { value: string },
+      { profile: Cell<unknown> }
+    >({
+      type: "object",
+      properties: { value: { type: "string" } },
+      required: ["value"],
+    }, {
+      type: "object",
+      properties: { profile: { asCell: ["cell"] } },
+      required: ["profile"],
+    }, ({ value }, { profile }) => {
+      profile.set(Child.inSpace(targetSpace)({ value }));
+    });
+    const Root = pattern<{ profile: Cell<unknown> }>(
+      ({ profile }) => ({
+        profile,
+        createChild: createChild({ profile }),
+      }),
+      {
+        type: "object",
+        properties: {
+          profile: { asCell: ["cell"] },
+        },
+        required: ["profile"],
+      } as const,
+    );
+
+    const profile = runtime.getCell(
+      signer.did(),
+      "pattern factory handler inSpace profile link",
+      undefined,
+      tx,
+    );
+    const resultCell = runtime.getCell(
+      space,
+      "pattern factory handler inSpace linked child result",
+      undefined,
+      tx,
+    );
+
+    const result = runtime.run(tx, Root, { profile }, resultCell);
+    runtime.prepareTxForCommit(tx);
+    await tx.commit();
+    await runtime.idle();
+    await runtime.storageManager.synced();
+    await result.pull();
+
+    result.key("createChild").send({ value: "linked child" });
+    await runtime.idle();
+    await runtime.storageManager.synced();
+    await result.pull();
+    await profile.pull();
+
+    const childLink = parseLink(profile.getRaw(), profile);
+    assertEquals(childLink?.space, targetSpace);
+    assertEquals(await profile.key("value").pull(), "linked child" as any);
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("pattern factory .inSpace() resolves named handler children to DIDs", async () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const tx = runtime.edit();
+  const spaceName =
+    `pattern-factory-in-space-annotation-${crypto.randomUUID()}`;
+  const expectedSpace = (await createSession({
+    identity: signer,
+    spaceName,
+  })).space;
+
+  try {
+    const { handler, pattern } = createTrustedBuilder(runtime).commonfabric;
+
+    const Child = pattern<{ value: string }>(({ value }) => ({ value }));
+    const createChild = handler<
+      { value: string },
+      { target: Cell<unknown> }
+    >({
+      type: "object",
+      properties: { value: { type: "string" } },
+      required: ["value"],
+    }, {
+      type: "object",
+      properties: { target: { asCell: ["cell"] } },
+      required: ["target"],
+    }, ({ value }, { target }) => {
+      target.set(Child.inSpace(spaceName)({ value }));
+    });
+    const Root = pattern<{ target: Cell<unknown> }>(
+      ({ target }) => ({
+        target,
+        createChild: createChild({ target }),
+      }),
+      {
+        type: "object",
+        properties: {
+          target: { asCell: ["cell"] },
+        },
+        required: ["target"],
+      } as const,
+    );
+
+    const target = runtime.getCell(
+      signer.did(),
+      "pattern factory handler inSpace annotation target",
+      undefined,
+      tx,
+    );
+    const resultCell = runtime.getCell(
+      space,
+      "pattern factory handler inSpace annotation result",
+      undefined,
+      tx,
+    );
+
+    const result = runtime.run(tx, Root, { target }, resultCell);
+    runtime.prepareTxForCommit(tx);
+    await tx.commit();
+    await runtime.idle();
+    await runtime.storageManager.synced();
+    await result.pull();
+
+    result.key("createChild").send({ value: "annotated child" });
+    await runtime.idle();
+    await runtime.storageManager.synced();
+    await result.pull();
+    await target.pull();
+
+    // The child space is resolved before the handler write lands, so the
+    // target holds a direct link to the child in the resolved space.
+    const childLink = parseLink(target.getRaw(), target);
+    assertEquals(childLink?.space, expectedSpace);
+    assertEquals(
+      await target.key("value").pull(),
+      "annotated child" as any,
+    );
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("pattern factory .inSpace() rewrites named child links through writeonly bindings", async () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const tx = runtime.edit();
+  const spaceName = `pattern-factory-in-space-writeonly-${crypto.randomUUID()}`;
+  const expectedSpace = (await createSession({
+    identity: signer,
+    spaceName,
+  })).space;
+
+  try {
+    const { handler, pattern } = createTrustedBuilder(runtime).commonfabric;
+
+    const childSchema = {
+      type: "object",
+      properties: { value: { type: "string" } },
+      required: ["value"],
+    } as const;
+    const Child = pattern<{ value: string }>(({ value }) => ({ value }));
+    const createChild = handler<
+      { value: string },
+      { target: Cell<unknown> }
+    >({
+      type: "object",
+      properties: { value: { type: "string" } },
+      required: ["value"],
+    }, {
+      type: "object",
+      properties: {
+        target: { ...childSchema, asCell: ["writeonly"] },
+      },
+      required: ["target"],
+    }, ({ value }, { target }) => {
+      target.set(Child.inSpace(spaceName)({ value }));
+    });
+    const Root = pattern<{ target: Cell<unknown> }>(
+      ({ target }) => ({
+        target,
+        createChild: createChild({ target }),
+      }),
+      {
+        type: "object",
+        properties: {
+          target: { ...childSchema, asCell: ["cell"] },
+        },
+        required: ["target"],
+      } as const,
+    );
+
+    const target = runtime.getCell(
+      signer.did(),
+      "pattern factory handler inSpace writeonly target",
+      undefined,
+      tx,
+    );
+    const resultCell = runtime.getCell(
+      space,
+      "pattern factory handler inSpace writeonly result",
+      undefined,
+      tx,
+    );
+
+    const result = runtime.run(tx, Root, { target }, resultCell);
+    runtime.prepareTxForCommit(tx);
+    await tx.commit();
+    await runtime.idle();
+    await runtime.storageManager.synced();
+    await result.pull();
+
+    result.key("createChild").send({ value: "writeonly child" });
+    await runtime.idle();
+    await runtime.storageManager.synced();
+    await result.pull();
+    await target.pull();
+
+    // The child space is resolved before the writeonly handler write lands, so
+    // the target holds a direct link to the child in the resolved space.
+    const childLink = parseLink(target.getRaw(), target);
+    assertEquals(childLink?.space, expectedSpace);
+    assertEquals(
+      await target.key("value").pull(),
+      "writeonly child" as any,
+    );
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("pattern factory .inSpace() with a cell uses that cell's space", async () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const tx = runtime.edit();
+  const targetSpace = (await Identity.fromPassphrase(
+    "pattern factory inSpace anchor cell target",
+  )).did();
+
+  try {
+    const anchor = runtime.getCell(
+      targetSpace,
+      "inSpace anchor",
+      undefined,
+      tx,
+    );
+    const { pattern } = createTrustedBuilder(runtime).commonfabric;
+
+    const Child = pattern<{ value: string }>(({ value }) => ({ value }));
+    const Root = pattern(() => ({
+      child: Child.inSpace(anchor)({ value: "anchored child" }),
+    }));
+
+    const resultCell = runtime.getCell(
+      space,
+      "pattern factory cell inSpace result",
+      undefined,
+      tx,
+    );
+
+    const result = runtime.run(tx, Root, {}, resultCell);
+    await tx.commit();
+    await runtime.idle();
+    await runtime.storageManager.synced();
+    await result.pull();
+
+    const childLink = result.key("child").resolveAsCell()
+      .getAsNormalizedFullLink();
+    assertEquals(childLink?.space, targetSpace);
+    assertEquals(
+      await result.key("child", "value").pull(),
+      "anchored child" as any,
+    );
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("pattern factory .inSpace() without a space creates a fresh DID space during action postRun", async () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const tx = runtime.edit();
+
+  try {
+    const { lift, pattern } = createTrustedBuilder(runtime).commonfabric;
+
+    const Child = pattern<{ value: string }>(({ value }) => ({ value }));
+    const makeChild = lift(({ value }: { value: string }) =>
+      Child.inSpace()({ value })
+    );
+    const Root = pattern<{ value: string }>((state) => ({
+      child: makeChild({ value: state.value }),
+    }));
+
+    const resultCell = runtime.getCell(
+      space,
+      "pattern factory random inSpace action result",
+      undefined,
+      tx,
+    );
+
+    const result = runtime.run(tx, Root, { value: "random child" }, resultCell);
+    await tx.commit();
+    await runtime.idle();
+    await runtime.storageManager.synced();
+    await result.pull();
+
+    const actionLink = parseLink(result.key("child").getRaw(), result);
+    const actionResult = runtime.getCellFromLink(actionLink!);
+    const childLink = actionResult.resolveAsCell().getAsNormalizedFullLink();
+    assertEquals(childLink?.space.startsWith("did:key:"), true);
+    assertEquals(childLink?.space === space, false);
+    assertEquals(
+      await result.key("child", "value").pull(),
+      "random child" as any,
     );
   } finally {
     await runtime.dispose();

--- a/packages/runner/test/space-cell.test.ts
+++ b/packages/runner/test/space-cell.test.ts
@@ -112,7 +112,7 @@ describe("Runtime.getSpaceCell", () => {
   });
 
   describe("schema handling", () => {
-    it("should use spaceCellSchema by default", () => {
+    it("should expose defaultPattern in spaceCellSchema by default", () => {
       // Verify the default schema structure
       const schema = spaceCellSchema as {
         type: string;


### PR DESCRIPTION
**Stack 3/4** (base: `split/02-cfc-write-authority`, #3760) — split out of #3722.

Instantiate a child pattern into a different memory space and run it inline within the triggering transaction.

- **`PatternFactory.inSpace(space?)`** (`builder/pattern.ts`, `builder/types.ts`, `cell.ts`, `api/index.ts`): target a child pattern at a named space or a space cell. Anonymous `inSpace()` derives a stable space from the current frame's cause (with a per-frame counter), analogous to how causes become cell ids.
- **Runtime space-name resolution** (`runtime.ts`): cache `inSpace("name")` → DID; `resolveSpaceNameSync`/`resolveSpaceName`. Equal names map to the same shared space (the deliberate shared-space behaviour).
- **Inline cross-space children** (`runner.ts`): when a handler/action result or pattern node targets another space, opt the tx into multi-space writes (child space committed first, via #3759) and run the child inline rather than re-instantiating it in a deferred second transaction (which loses its verified-function identity).
- **`RetryImmediately`** (`scheduler/retry-immediately.ts`, `action-run.ts`, `events.ts`): when a run references an `inSpace("name")` whose DID isn't cached yet, resolve the names and re-run the same function in a fresh transaction.
- `pattern-manager.ts`: accept function inputs and fall back through empty meta.

Depends on the storage multi-space primitive (#3759). Tested by `pattern-scope.test.ts`, `pattern-manager.test.ts`, `space-cell.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `PatternFactory.inSpace(...)` to target child patterns at another memory space and runs cross-space children inline in the same transaction. Accumulates child-space commit order so all children commit before the parent, and tightens space-name resolution behavior.

- **New Features**
  - `inSpace(space?)` on pattern factories: accept a DID string, a space cell, a name (e.g. "profile"), or no arg for an anonymous per-call space.
  - Anonymous `inSpace()` derives a stable name from the frame cause plus a per-frame counter; use a named space if call counts may vary across runs.
  - Cells can be pinned to a space pre-link via `setUnlinkedSpace`, propagating `targetSpace` to attached nodes.
  - `@commonfabric/api`: `PatternFactory` now includes `inSpace(...)`.

- **Runner and Scheduler**
  - Runtime caches space-name → DID (`resolveSpaceNameSync` / `resolveSpaceName`); only the resolved space DID is consumed (no per-name signer adoption). Equal names map to the same shared space by design.
  - Cross-space children run inline with multi-space writes; commit order is accumulated per transaction so all child spaces commit before the parent.
  - `navigateTo` results still defer until after commit.
  - Introduces `RetryImmediately`: when a run references `inSpace("name")` not yet cached, resolve names, abort the tx, and re-run the same handler/action; schedulers treat this as an immediate internal retry.
  - Handler result materialization uses a single consistent `targetSpace` when present; otherwise falls back to the originating space.
  - `pattern-manager`: accept function inputs and return pending/empty meta when stored meta is absent.

<sup>Written for commit 8f61afe9cc4385b069007cbbfbd09f0158b4e1be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

