### PR TITLE
Phases 2-4: SES module-graph loader behind esmModuleLoader flag (default off)

### DIFF
--- a/docs/specs/module-loading-implementation-plan.md
+++ b/docs/specs/module-loading-implementation-plan.md
@@ -13,13 +13,13 @@ steps with the files each touches, exit criteria, and validation commands.
 | Phase | Status | Notes |
 | --- | --- | --- |
 | 0 — Loader shape confirmation | Done | SES `importNow` + virtual (third-party) module records load synchronously, incl. cycles. `ModuleSource`/`StaticModuleRecord` are not exposed by this `ses` build, so the loader uses `{ imports, exports, execute }` records. |
-| 1 — Decouple identity | Done (this PR) | Per-module Merkle hash; scheduler implementation fingerprint is content-addressed and entry-point/TCB independent. Shipped behind `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE`. |
-| 2 — ESM emission + SES module loading | Mechanism done, lands in a follow-up PR (behind `esmModuleLoader`, default off) | `importModuleGraphNow` loader + `compileSourcesToRecords` adapter load real compiled multi-module programs end-to-end. **Remaining:** wire into `Engine.evaluate`, run the CF transformer pipeline (currently bare `ts.transpileModule`), and expand `export *` re-exports. |
-| 3 — Verifier port | Structural seam done, follow-up PR | `verifyModuleGraph` validates graph shape/wiring before load. **Remaining (security-critical):** port the SES_SANDBOXING module-item classification from the AMD parser. |
-| 4 — Per-module compilation cache | Done, follow-up PR | `ModuleRecordCache` keyed by module hash; hit reuses the compiled artifact. **Remaining:** persist via the existing compilation-cache backends. |
+| 1 — Decouple identity | Done (merged) | Per-module Merkle hash; scheduler implementation fingerprint is content-addressed and entry-point/TCB independent. Shipped behind `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE`. |
+| 2 — ESM emission + SES module loading | Mechanism done (this PR, behind `esmModuleLoader`, default off) | `importModuleGraphNow` loader + `compileSourcesToRecords` adapter load real compiled multi-module programs end-to-end. **Remaining:** wire into `Engine.evaluate`, run the CF transformer pipeline (currently bare `ts.transpileModule`), and expand `export *` re-exports. |
+| 3 — Verifier port | Structural seam done (this PR) | `verifyModuleGraph` validates graph shape/wiring before load. **Remaining (security-critical):** port the SES_SANDBOXING module-item classification from the AMD parser. |
+| 4 — Per-module compilation cache | Done (this PR) | `ModuleRecordCache` keyed by module hash; hit reuses the compiled artifact. **Remaining:** persist via the existing compilation-cache backends. |
 | 5 — Default-on + AMD removal | Not started (intentionally) | Gated on Phase 3 classification parity + benchmarks. Flipping the default / removing AMD cannot land while keeping the build green, so it is a deliberate later rollout. The flag stays **off**. |
 
-This PR contains Phase 1 only; Phases 2–5 land in a separate follow-up PR.
+Phase 1 merged separately; this PR adds the Phases 2–4 mechanism behind the default-off flag.
 
 ## Guiding constraints
 

--- a/docs/specs/module-loading.md
+++ b/docs/specs/module-loading.md
@@ -11,13 +11,13 @@ whose action implementation fingerprint is currently unstable across reloads.
 
 Implemented so far (see the implementation plan for the per-phase status):
 identity decoupling (Phase 1, live behind `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE`)
-is merged. The module-loading mechanism (Phases 2–5) — a synchronous SES
+is merged. The module-loading mechanism (Phases 2–4) — a synchronous SES
 virtual-module-record loader, a TS→record adapter, a per-module compilation
 cache, and a structural graph verifier, all behind a default-off
-`esmModuleLoader` flag — lands in a separate follow-up PR. Remaining beyond that:
-Engine integration with the CF transformer pipeline, the security-critical
-verifier classification port, and the default-on/AMD-removal rollout. The AMD
-bundle path remains the default throughout.
+`esmModuleLoader` flag — is implemented. Remaining: Engine integration with the
+CF transformer pipeline, the security-critical verifier classification port, and
+the default-on/AMD-removal rollout (Phase 5). The AMD bundle path remains the
+default throughout.
 
 ## Last Updated
 

--- a/packages/runner/src/harness/module-identity.ts
+++ b/packages/runner/src/harness/module-identity.ts
@@ -158,8 +158,10 @@ export function computeModuleHashes(
 /**
  * Match a resolved (relative) import path against a concrete file name in the
  * program, trying TypeScript-style extension and directory-index candidates.
+ * Shared by module identity and the ESM record adapter so they agree on what
+ * counts as an internal edge.
  */
-function findInternalTarget(
+export function findInternalTarget(
   fileNames: Set<string>,
   resolved: string,
 ): string | undefined {

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -175,6 +175,13 @@ export interface ExperimentalOptions {
   persistentSchedulerState?: boolean | undefined;
   /** Preserve cumulative scheduler write history instead of using current-known writes. */
   schedulerHistoricalMightWrite?: boolean | undefined;
+  /**
+   * Load compiled patterns as a graph of per-module records through the SES
+   * Compartment module system (synchronous `importNow`) instead of evaluating
+   * one flattened AMD bundle. Default off; the AMD path remains the default.
+   * See docs/specs/module-loading.md (Phases 2–5).
+   */
+  esmModuleLoader?: boolean | undefined;
 }
 
 export interface RuntimeOptions {
@@ -313,6 +320,7 @@ export class Runtime {
       modernDataModel: undefined,
       persistentSchedulerState: undefined,
       schedulerHistoricalMightWrite: undefined,
+      esmModuleLoader: undefined,
       ...options.experimental,
     };
 

--- a/packages/runner/src/sandbox/esm-module-loader.ts
+++ b/packages/runner/src/sandbox/esm-module-loader.ts
@@ -1,0 +1,118 @@
+import { ensureSESLockdown } from "./ses-runtime.ts";
+import { verifyModuleGraph } from "./module-record-verifier.ts";
+
+/**
+ * SES module-graph loader (Phase 2 of docs/specs/module-loading.md).
+ *
+ * Loads a graph of per-module records through the SES Compartment module
+ * system using synchronous `importNow`, instead of evaluating one flattened
+ * AMD bundle. Modules are addressed by content-addressed specifiers
+ * (`cf:module/<hash>`), and runtime modules (`commonfabric`, …) are ordinary
+ * records in the same graph.
+ *
+ * This version uses SES "virtual" (third-party) module records — `{ imports,
+ * exports, execute }` — because this build of `ses` does not expose a
+ * `ModuleSource`/`StaticModuleRecord` constructor. Records load synchronously,
+ * preserving the scheduler's synchronous execution contract, and import cycles
+ * resolve through lazy `compartment.importNow` inside `execute`.
+ *
+ * This is gated behind the `esmModuleLoader` experimental flag; the AMD bundle
+ * path remains the default.
+ */
+
+/** A SES third-party (virtual) module record. */
+export interface VirtualModuleRecord {
+  /** Specifiers this module imports (as written in the module). */
+  imports: string[];
+  /** Names this module exports. */
+  exports: string[];
+  /**
+   * Maps each of this module's import specifiers to the absolute
+   * (content-addressed) specifier it resolves to. When omitted, an import
+   * specifier resolves to itself (used by runtime-module records whose imports
+   * are already absolute).
+   */
+  resolutions?: Record<string, string>;
+  /**
+   * Populate `moduleExports`. Use `compartment.importNow(resolvedImports[spec])`
+   * to obtain an imported module's namespace.
+   */
+  execute(
+    moduleExports: Record<string, unknown>,
+    compartment: SesCompartment,
+    resolvedImports: Record<string, string>,
+  ): void;
+}
+
+interface SesCompartment {
+  importNow(specifier: string): Record<string, unknown>;
+  evaluate(source: string): unknown;
+}
+
+interface SesCompartmentCtor {
+  new (
+    globals: Record<string, unknown>,
+    moduleMap: Record<string, unknown>,
+    options: {
+      name?: string;
+      resolveHook(importSpecifier: string, referrer: string): string;
+      importNowHook(specifier: string): VirtualModuleRecord;
+    },
+  ): SesCompartment;
+}
+
+export interface SesModuleLoaderOptions {
+  /** Records keyed by absolute (content-addressed) specifier. */
+  records: Map<string, VirtualModuleRecord>;
+  /** Global endowments for the compartment. */
+  globals?: Record<string, unknown>;
+  /** Optional compartment name, for diagnostics. */
+  name?: string;
+  /**
+   * Run structural graph verification before loading. Default true. The deep
+   * SES classification port is still pending (see module-record-verifier.ts).
+   */
+  verify?: boolean;
+}
+
+/**
+ * Load `entrySpecifier` and its transitive dependencies synchronously,
+ * returning the entry module's namespace.
+ */
+export function importModuleGraphNow(
+  entrySpecifier: string,
+  options: SesModuleLoaderOptions,
+): Record<string, unknown> {
+  ensureSESLockdown();
+  const { records, globals = {}, name = "cf:esm", verify = true } = options;
+
+  if (verify) {
+    verifyModuleGraph(records, entrySpecifier);
+  }
+
+  const CompartmentCtor = (globalThis as { Compartment?: SesCompartmentCtor })
+    .Compartment;
+  if (!CompartmentCtor) {
+    throw new Error("SES Compartment is unavailable");
+  }
+
+  const compartment = new CompartmentCtor({ ...globals }, {}, {
+    name,
+    // Resolve an import specifier against the referrer's resolution map. Runtime
+    // modules and hand-built records whose imports are already absolute omit
+    // `resolutions`, in which case resolution is the identity function.
+    resolveHook: (importSpecifier: string, referrer: string) => {
+      const resolutions = records.get(referrer)?.resolutions;
+      return resolutions?.[importSpecifier] ?? importSpecifier;
+    },
+    importNowHook: (specifier: string) => {
+      const record = records.get(specifier);
+      if (!record) {
+        throw new Error(`Unknown module specifier: ${specifier}`);
+      }
+      return record;
+    },
+  });
+
+  return compartment.importNow(entrySpecifier);
+}

--- a/packages/runner/src/sandbox/esm-module-loader.ts
+++ b/packages/runner/src/sandbox/esm-module-loader.ts
@@ -47,6 +47,7 @@ export interface VirtualModuleRecord {
 interface SesCompartment {
   importNow(specifier: string): Record<string, unknown>;
   evaluate(source: string): unknown;
+  globalThis: Record<string, unknown>;
 }
 
 interface SesCompartmentCtor {
@@ -78,6 +79,12 @@ export interface SesModuleLoaderOptions {
 /**
  * Load `entrySpecifier` and its transitive dependencies synchronously,
  * returning the entry module's namespace.
+ *
+ * SECURITY: `verify` performs only *structural* validation. It is NOT a
+ * security boundary — the SES_SANDBOXING module-item classification has not yet
+ * been ported to records (see module-record-verifier.ts). Callers must treat
+ * the module graph as trusted/already-classified. This is why the
+ * `esmModuleLoader` flag is off and nothing in `src/` calls this yet.
  */
 export function importModuleGraphNow(
   entrySpecifier: string,
@@ -113,6 +120,10 @@ export function importModuleGraphNow(
       return record;
     },
   });
+  // SES freezes intrinsics, but compartment global bindings remain writable
+  // unless explicitly locked down, so a module could poison globals seen by
+  // siblings. Mirror createCompartment() in ses-runtime.ts.
+  Object.freeze(compartment.globalThis);
 
   return compartment.importNow(entrySpecifier);
 }

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -1,9 +1,6 @@
 import ts from "typescript";
 import type { Source } from "@commonfabric/js-compiler";
-import {
-  collectImportSpecifiers,
-  resolveImportSpecifier,
-} from "@commonfabric/js-compiler";
+import { resolveImportSpecifier } from "@commonfabric/js-compiler";
 import {
   computeModuleHashes,
   findInternalTarget,
@@ -87,21 +84,6 @@ export function compileSourcesToRecords(
   const records = new Map<string, VirtualModuleRecord>();
   for (const source of sources) {
     const specifier = specifierByPath.get(source.name)!;
-    const importSpecs = collectImportSpecifiers(source, TARGET);
-    const resolutions: Record<string, string> = {};
-    for (const spec of importSpecs) {
-      const resolved = resolveImportSpecifier(spec, source);
-      const internal = findInternalTarget(fileNames, resolved);
-      if (internal !== undefined) {
-        resolutions[spec] = specifierByPath.get(internal)!;
-      } else if (spec in runtimeModules) {
-        resolutions[spec] = `cf:runtime/${spec}`;
-      } else {
-        // Unknown external; leave as-is so a missing-record error is explicit.
-        resolutions[spec] = spec;
-      }
-    }
-
     const moduleHash = hashes.get(source.name)!;
     const cached = options.recordCache?.get(moduleHash);
     let exportNames: string[];
@@ -120,6 +102,26 @@ export function compileSourcesToRecords(
         },
       }).outputText;
       options.recordCache?.set(moduleHash, { exports: exportNames, compiled });
+    }
+
+    // Runtime imports are exactly the `require()` calls in the compiled output.
+    // Type-only imports (`import type`, inline `import("…")` type refs) are
+    // erased by the compiler and never appear here, so they correctly do not
+    // become record edges — unlike `collectImportSpecifiers`, which includes
+    // them for module *identity*.
+    const importSpecs = extractRuntimeImports(compiled);
+    const resolutions: Record<string, string> = {};
+    for (const spec of importSpecs) {
+      const resolved = resolveImportSpecifier(spec, source);
+      const internal = findInternalTarget(fileNames, resolved);
+      if (internal !== undefined) {
+        resolutions[spec] = specifierByPath.get(internal)!;
+      } else if (spec in runtimeModules) {
+        resolutions[spec] = `cf:runtime/${spec}`;
+      } else {
+        // Unknown external; leave as-is so a missing-record error is explicit.
+        resolutions[spec] = spec;
+      }
     }
 
     // Expose `__esModule` on the namespace so that an importer compiled with
@@ -163,6 +165,21 @@ export function compileSourcesToRecords(
   }
 
   return { records, specifierByPath };
+}
+
+/**
+ * Extract the runtime import specifiers actually emitted as `require()` calls
+ * in the compiled CommonJS body. This is the precise runtime dependency set;
+ * type-only imports have already been erased by the compiler.
+ */
+function extractRuntimeImports(compiled: string): string[] {
+  const re = /\brequire\(\s*["']([^"']+)["']\s*\)/g;
+  const out = new Set<string>();
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(compiled)) !== null) {
+    out.add(match[1]);
+  }
+  return [...out];
 }
 
 /** Collect bound identifier names from a (possibly destructuring) binding. */
@@ -231,11 +248,17 @@ function collectExportNames(source: Source): string[] {
       }
       names.add("default"); // `export default <expr>`
     } else if (ts.isExportDeclaration(statement)) {
+      // `export type ...` re-exports are compile-time only; ignore them.
+      if (statement.isTypeOnly) {
+        continue;
+      }
       const clause = statement.exportClause;
       if (clause && ts.isNamedExports(clause)) {
-        // `export { a, b }` or `export { a } from "./m"`.
+        // `export { a, b }` or `export { a } from "./m"`; skip `export { type T }`.
         for (const element of clause.elements) {
-          names.add(element.name.text);
+          if (!element.isTypeOnly) {
+            names.add(element.name.text);
+          }
         }
       } else if (clause && ts.isNamespaceExport(clause)) {
         // `export * as ns from "./m"`.

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -145,9 +145,15 @@ export function compileSourcesToRecords(
         const moduleObject = { exports: localExports };
         const requireShim = (specifier: string) =>
           compartment.importNow(resolvedImports[specifier] ?? specifier);
+        // A throw here is terminal for this module: SES caches the error and
+        // re-throws it on every subsequent importNow (the same contract as a
+        // failed AMD factory).
         factory(localExports, requireShim, moduleObject);
         const finalExports = moduleObject.exports;
         // Copy the declared exports onto the SES module namespace object.
+        // NOTE: this snapshots values at init time, so a later reassignment of
+        // an exported `let` is not reflected as a true ESM live binding. This is
+        // acceptable for compiled patterns; revisit with getters if needed.
         for (const name of exportNames) {
           moduleExports[name] = finalExports[name];
         }
@@ -159,7 +165,25 @@ export function compileSourcesToRecords(
   return { records, specifierByPath };
 }
 
-/** Statically collect the names a module exports (named + default). */
+/** Collect bound identifier names from a (possibly destructuring) binding. */
+function collectBindingNames(name: ts.BindingName, out: Set<string>): void {
+  if (ts.isIdentifier(name)) {
+    out.add(name.text);
+    return;
+  }
+  // Object/array binding patterns: `export const { a, b } = …` / `[x] = …`.
+  for (const element of name.elements) {
+    if (ts.isBindingElement(element)) {
+      collectBindingNames(element.name, out);
+    }
+  }
+}
+
+/**
+ * Statically collect the names a module exports (named, default, enum,
+ * namespace, destructured). Throws loudly on forms this adapter does not yet
+ * support, rather than producing a silently-incomplete namespace.
+ */
 function collectExportNames(source: Source): string[] {
   const sourceFile = ts.createSourceFile(
     source.name,
@@ -188,24 +212,41 @@ function collectExportNames(source: Source): string[] {
       } else if (statement.name) {
         names.add(statement.name.text);
       }
+    } else if (
+      (ts.isEnumDeclaration(statement) ||
+        ts.isModuleDeclaration(statement)) && isExported
+    ) {
+      if (statement.name && ts.isIdentifier(statement.name)) {
+        names.add(statement.name.text);
+      }
     } else if (ts.isVariableStatement(statement) && isExported) {
       for (const decl of statement.declarationList.declarations) {
-        if (ts.isIdentifier(decl.name)) {
-          names.add(decl.name.text);
-        }
+        collectBindingNames(decl.name, names);
       }
     } else if (ts.isExportAssignment(statement)) {
-      // `export default <expr>` or `export = <expr>`
-      names.add("default");
+      if (statement.isExportEquals) {
+        throw new Error(
+          `${source.name}: 'export =' is not supported by the ESM module-record adapter (authored sources must be ES modules)`,
+        );
+      }
+      names.add("default"); // `export default <expr>`
     } else if (ts.isExportDeclaration(statement)) {
       const clause = statement.exportClause;
       if (clause && ts.isNamedExports(clause)) {
+        // `export { a, b }` or `export { a } from "./m"`.
         for (const element of clause.elements) {
           names.add(element.name.text);
         }
+      } else if (clause && ts.isNamespaceExport(clause)) {
+        // `export * as ns from "./m"`.
+        names.add(clause.name.text);
+      } else if (statement.moduleSpecifier) {
+        // Bare `export * from "./m"` cannot be enumerated without resolving the
+        // target's exports; fail loudly rather than drop names silently.
+        throw new Error(
+          `${source.name}: 'export * from' re-exports are not yet supported by the ESM module-record adapter`,
+        );
       }
-      // `export * from "..."` cannot be statically enumerated here; not
-      // supported in this adapter scope.
     }
   }
 

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -171,14 +171,34 @@ export function compileSourcesToRecords(
  * Extract the runtime import specifiers actually emitted as `require()` calls
  * in the compiled CommonJS body. This is the precise runtime dependency set;
  * type-only imports have already been erased by the compiler.
+ *
+ * Parses the emitted JS AST and matches `require("literal")` call expressions,
+ * rather than scanning text — so a `require(...)` appearing inside a string
+ * literal, template literal, or comment in the authored source is NOT mistaken
+ * for a real dependency edge.
  */
 function extractRuntimeImports(compiled: string): string[] {
-  const re = /\brequire\(\s*["']([^"']+)["']\s*\)/g;
+  const sourceFile = ts.createSourceFile(
+    "compiled.js",
+    compiled,
+    TARGET,
+    true,
+    ts.ScriptKind.JS,
+  );
   const out = new Set<string>();
-  let match: RegExpExecArray | null;
-  while ((match = re.exec(compiled)) !== null) {
-    out.add(match[1]);
+  function visit(node: ts.Node): void {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === "require" &&
+      node.arguments.length === 1 &&
+      ts.isStringLiteralLike(node.arguments[0])
+    ) {
+      out.add((node.arguments[0] as ts.StringLiteralLike).text);
+    }
+    ts.forEachChild(node, visit);
   }
+  visit(sourceFile);
   return [...out];
 }
 

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -1,0 +1,213 @@
+import ts from "typescript";
+import type { Source } from "@commonfabric/js-compiler";
+import {
+  collectImportSpecifiers,
+  resolveImportSpecifier,
+} from "@commonfabric/js-compiler";
+import {
+  computeModuleHashes,
+  findInternalTarget,
+} from "../harness/module-identity.ts";
+import type { VirtualModuleRecord } from "./esm-module-loader.ts";
+
+/**
+ * Adapter from authored TypeScript sources to SES virtual module records
+ * (Phase 2 of docs/specs/module-loading.md).
+ *
+ * Each module is compiled independently to CommonJS, content-addressed by its
+ * module hash (`cf:module/<hash>`), and wrapped in a {@link VirtualModuleRecord}
+ * whose `execute` evaluates the compiled body inside the SES compartment with a
+ * `require` shim that delegates to `compartment.importNow`.
+ *
+ * Scope: this adapter handles the common module shapes (named `export`s,
+ * `export default`, relative imports, and bare runtime-module imports). It does
+ * not yet run the Common Fabric transformer pipeline (that wiring is staged
+ * with the Engine integration) and does not statically expand `export *`
+ * re-exports.
+ */
+
+const TARGET = ts.ScriptTarget.ES2023;
+
+/** Per-module compiled artifact, cacheable by module hash (Phase 4). */
+export interface CompiledModuleArtifact {
+  exports: string[];
+  compiled: string;
+}
+
+/**
+ * Cache of compiled module artifacts keyed by content-addressed module hash.
+ * Because the hash already folds in the transitive import closure, a cached
+ * artifact is valid as long as its key matches — editing one file invalidates
+ * only that module (and its importers, whose hashes change).
+ *
+ * The cache assumes the fixed compiler options used by this adapter (CommonJS,
+ * ES2023, esModuleInterop). A caller sharing one cache across differing
+ * compiler options would need to fold an options tag into the key.
+ */
+export interface ModuleRecordCache {
+  get(moduleHash: string): CompiledModuleArtifact | undefined;
+  set(moduleHash: string, artifact: CompiledModuleArtifact): void;
+}
+
+export interface CompileSourcesOptions {
+  /**
+   * Names exported by each bare runtime module specifier (e.g.
+   * `{ commonfabric: ["h", "lift"] }`). Runtime modules resolve to
+   * `cf:runtime/<specifier>`; the caller must register a matching record.
+   */
+  runtimeModules?: Record<string, string[]>;
+  runtimeFingerprint?: string;
+  /** Optional per-module compiled-artifact cache, keyed by module hash. */
+  recordCache?: ModuleRecordCache;
+}
+
+export interface CompiledModuleGraph {
+  records: Map<string, VirtualModuleRecord>;
+  /** Content-addressed specifier for each original file path. */
+  specifierByPath: Map<string, string>;
+}
+
+export function compileSourcesToRecords(
+  sources: Source[],
+  options: CompileSourcesOptions = {},
+): CompiledModuleGraph {
+  const runtimeModules = options.runtimeModules ?? {};
+  const hashes = computeModuleHashes(
+    { main: "", files: sources },
+    options.runtimeFingerprint !== undefined
+      ? { runtimeFingerprint: options.runtimeFingerprint }
+      : {},
+  );
+  const fileNames = new Set(sources.map((s) => s.name));
+  const specifierByPath = new Map<string, string>();
+  for (const source of sources) {
+    specifierByPath.set(source.name, `cf:module/${hashes.get(source.name)}`);
+  }
+
+  const records = new Map<string, VirtualModuleRecord>();
+  for (const source of sources) {
+    const specifier = specifierByPath.get(source.name)!;
+    const importSpecs = collectImportSpecifiers(source, TARGET);
+    const resolutions: Record<string, string> = {};
+    for (const spec of importSpecs) {
+      const resolved = resolveImportSpecifier(spec, source);
+      const internal = findInternalTarget(fileNames, resolved);
+      if (internal !== undefined) {
+        resolutions[spec] = specifierByPath.get(internal)!;
+      } else if (spec in runtimeModules) {
+        resolutions[spec] = `cf:runtime/${spec}`;
+      } else {
+        // Unknown external; leave as-is so a missing-record error is explicit.
+        resolutions[spec] = spec;
+      }
+    }
+
+    const moduleHash = hashes.get(source.name)!;
+    const cached = options.recordCache?.get(moduleHash);
+    let exportNames: string[];
+    let compiled: string;
+    if (cached) {
+      exportNames = cached.exports;
+      compiled = cached.compiled;
+    } else {
+      exportNames = collectExportNames(source);
+      compiled = ts.transpileModule(source.contents, {
+        fileName: source.name,
+        compilerOptions: {
+          module: ts.ModuleKind.CommonJS,
+          target: TARGET,
+          esModuleInterop: true,
+        },
+      }).outputText;
+      options.recordCache?.set(moduleHash, { exports: exportNames, compiled });
+    }
+
+    // Expose `__esModule` on the namespace so that an importer compiled with
+    // esModuleInterop (`__importDefault`) reads this module's `default` export
+    // rather than wrapping the whole namespace. Authored sources are ESM.
+    const namespaceExports = [...exportNames, "__esModule"];
+
+    records.set(specifier, {
+      imports: importSpecs,
+      exports: namespaceExports,
+      resolutions,
+      execute: (moduleExports, compartment, resolvedImports) => {
+        // Evaluate the compiled CommonJS body inside the SES compartment so it
+        // runs under lockdown with confined globals.
+        const factory = compartment.evaluate(
+          `(function (exports, require, module) {\n${compiled}\n})`,
+        ) as (
+          exports: Record<string, unknown>,
+          require: (specifier: string) => Record<string, unknown>,
+          module: { exports: Record<string, unknown> },
+        ) => void;
+        const localExports: Record<string, unknown> = {};
+        const moduleObject = { exports: localExports };
+        const requireShim = (specifier: string) =>
+          compartment.importNow(resolvedImports[specifier] ?? specifier);
+        factory(localExports, requireShim, moduleObject);
+        const finalExports = moduleObject.exports;
+        // Copy the declared exports onto the SES module namespace object.
+        for (const name of exportNames) {
+          moduleExports[name] = finalExports[name];
+        }
+        moduleExports.__esModule = true;
+      },
+    });
+  }
+
+  return { records, specifierByPath };
+}
+
+/** Statically collect the names a module exports (named + default). */
+function collectExportNames(source: Source): string[] {
+  const sourceFile = ts.createSourceFile(
+    source.name,
+    source.contents,
+    TARGET,
+    true,
+  );
+  const names = new Set<string>();
+
+  for (const statement of sourceFile.statements) {
+    const isExported = ts.canHaveModifiers(statement) &&
+      ts.getModifiers(statement)?.some((m) =>
+        m.kind === ts.SyntaxKind.ExportKeyword
+      );
+    const isDefault = ts.canHaveModifiers(statement) &&
+      ts.getModifiers(statement)?.some((m) =>
+        m.kind === ts.SyntaxKind.DefaultKeyword
+      );
+
+    if (
+      (ts.isFunctionDeclaration(statement) ||
+        ts.isClassDeclaration(statement)) && isExported
+    ) {
+      if (isDefault) {
+        names.add("default");
+      } else if (statement.name) {
+        names.add(statement.name.text);
+      }
+    } else if (ts.isVariableStatement(statement) && isExported) {
+      for (const decl of statement.declarationList.declarations) {
+        if (ts.isIdentifier(decl.name)) {
+          names.add(decl.name.text);
+        }
+      }
+    } else if (ts.isExportAssignment(statement)) {
+      // `export default <expr>` or `export = <expr>`
+      names.add("default");
+    } else if (ts.isExportDeclaration(statement)) {
+      const clause = statement.exportClause;
+      if (clause && ts.isNamedExports(clause)) {
+        for (const element of clause.elements) {
+          names.add(element.name.text);
+        }
+      }
+      // `export * from "..."` cannot be statically enumerated here; not
+      // supported in this adapter scope.
+    }
+  }
+
+  return [...names];
+}

--- a/packages/runner/src/sandbox/module-record-verifier.ts
+++ b/packages/runner/src/sandbox/module-record-verifier.ts
@@ -1,0 +1,66 @@
+import type { VirtualModuleRecord } from "./esm-module-loader.ts";
+
+/**
+ * Structural pre-flight verification for a module-record graph (Phase 3 of
+ * docs/specs/module-loading.md).
+ *
+ * This is the record-path analogue of the AMD bundle pre-flight
+ * (`bundle-preflight.ts`): it validates the *shape and wiring* of the graph
+ * before any module executes — every specifier is content-addressed, every
+ * record is well-formed, and every resolved import points at a present record.
+ *
+ * NOTE: the deep SES_SANDBOXING module-item classification (direct callbacks to
+ * trusted builders, safe top-level functions, verified module-safe data) is the
+ * security-critical part of the verifier port and is NOT yet implemented here.
+ * It must be ported from the AMD `define()` parser before the ESM loader can
+ * run untrusted code by default. Until then the `esmModuleLoader` flag stays
+ * off and the AMD verifier remains the enforcement path.
+ */
+
+const VALID_SPECIFIER = /^cf:(module|runtime)\//;
+
+export class ModuleGraphVerificationError extends Error {
+  override name = "ModuleGraphVerificationError";
+}
+
+export function verifyModuleGraph(
+  records: Map<string, VirtualModuleRecord>,
+  entrySpecifier: string,
+): void {
+  if (!records.has(entrySpecifier)) {
+    throw new ModuleGraphVerificationError(
+      `Module graph entry specifier is not present: ${entrySpecifier}`,
+    );
+  }
+
+  for (const [specifier, record] of records) {
+    if (!VALID_SPECIFIER.test(specifier)) {
+      throw new ModuleGraphVerificationError(
+        `Non-content-addressed module specifier: ${specifier}`,
+      );
+    }
+    if (!Array.isArray(record.imports)) {
+      throw new ModuleGraphVerificationError(
+        `Record ${specifier} has a non-array imports list`,
+      );
+    }
+    if (!Array.isArray(record.exports)) {
+      throw new ModuleGraphVerificationError(
+        `Record ${specifier} has a non-array exports list`,
+      );
+    }
+    if (typeof record.execute !== "function") {
+      throw new ModuleGraphVerificationError(
+        `Record ${specifier} has a non-function execute`,
+      );
+    }
+    for (const importSpecifier of record.imports) {
+      const target = record.resolutions?.[importSpecifier] ?? importSpecifier;
+      if (!records.has(target)) {
+        throw new ModuleGraphVerificationError(
+          `Record ${specifier} has an unresolved import "${importSpecifier}" -> "${target}"`,
+        );
+      }
+    }
+  }
+}

--- a/packages/runner/test/esm-module-loader.test.ts
+++ b/packages/runner/test/esm-module-loader.test.ts
@@ -1,0 +1,109 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import {
+  importModuleGraphNow,
+  type VirtualModuleRecord,
+} from "../src/sandbox/esm-module-loader.ts";
+
+function record(
+  imports: string[],
+  exports: string[],
+  execute: VirtualModuleRecord["execute"],
+): VirtualModuleRecord {
+  return { imports, exports, execute };
+}
+
+describe("importModuleGraphNow", () => {
+  it("loads a multi-module graph synchronously and resolves cross-module calls", () => {
+    const records = new Map<string, VirtualModuleRecord>([
+      [
+        "cf:module/main",
+        record(
+          ["cf:module/util"],
+          ["run"],
+          (exports, compartment, resolved) => {
+            const util = compartment.importNow(resolved["cf:module/util"]) as {
+              double(n: number): number;
+            };
+            exports.run = () => util.double(21);
+          },
+        ),
+      ],
+      [
+        "cf:module/util",
+        record([], ["double"], (exports) => {
+          exports.double = (n: number) => n * 2;
+        }),
+      ],
+    ]);
+
+    const ns = importModuleGraphNow("cf:module/main", { records }) as {
+      run(): number;
+    };
+    expect(ns.run()).toBe(42);
+  });
+
+  it("exposes host endowments through runtime-module records", () => {
+    const records = new Map<string, VirtualModuleRecord>([
+      [
+        "cf:runtime/host",
+        record([], ["greet"], (exports) => {
+          exports.greet = (name: string) => `hi ${name}`;
+        }),
+      ],
+      [
+        "cf:module/main",
+        record(
+          ["cf:runtime/host"],
+          ["value"],
+          (exports, compartment, resolved) => {
+            const host = compartment.importNow(resolved["cf:runtime/host"]) as {
+              greet(n: string): string;
+            };
+            exports.value = host.greet("world");
+          },
+        ),
+      ],
+    ]);
+
+    const ns = importModuleGraphNow("cf:module/main", { records }) as {
+      value: string;
+    };
+    expect(ns.value).toBe("hi world");
+  });
+
+  it("loads import cycles deterministically", () => {
+    // a <-> b: a.first() calls b.second() lazily, so the cycle resolves.
+    const records = new Map<string, VirtualModuleRecord>([
+      [
+        "cf:module/a",
+        record(["cf:module/b"], ["first"], (exports, compartment, resolved) => {
+          exports.first = () => {
+            const b = compartment.importNow(resolved["cf:module/b"]) as {
+              second(): string;
+            };
+            return "a" + b.second();
+          };
+        }),
+      ],
+      [
+        "cf:module/b",
+        record(["cf:module/a"], ["second"], (exports) => {
+          exports.second = () => "b";
+        }),
+      ],
+    ]);
+
+    const ns = importModuleGraphNow("cf:module/a", { records }) as {
+      first(): string;
+    };
+    expect(ns.first()).toBe("ab");
+  });
+
+  it("throws for an unknown specifier", () => {
+    const records = new Map<string, VirtualModuleRecord>();
+    expect(() => importModuleGraphNow("cf:module/missing", { records }))
+      .toThrow();
+  });
+});

--- a/packages/runner/test/module-record-compiler.test.ts
+++ b/packages/runner/test/module-record-compiler.test.ts
@@ -142,6 +142,47 @@ describe("compileSourcesToRecords + importModuleGraphNow (end to end)", () => {
     expect(ns.b).toBe(2);
   });
 
+  it("does not turn a type-only import into a runtime record edge", () => {
+    // `import type` from a module that is NOT in the graph must not create a
+    // dangling resolution / runtime import.
+    const sources = files({
+      "/main.ts":
+        `import type { Foo } from "external-types";\nexport const run = (x: Foo): number => 1;`,
+    });
+    const { records, specifierByPath } = compileSourcesToRecords(sources);
+    const record = records.get(specifierByPath.get("/main.ts")!)!;
+    expect(record.imports).not.toContain("external-types");
+    // Loads cleanly (verifier sees no dangling edge).
+    const ns = importModuleGraphNow(specifierByPath.get("/main.ts")!, {
+      records,
+    }) as { run(x: unknown): number };
+    expect(ns.run(undefined)).toBe(1);
+  });
+
+  it("collects enum exports", () => {
+    const sources = files({
+      "/main.ts": `export enum Color { Red = 1, Blue = 2 }`,
+    });
+    const { records, specifierByPath } = compileSourcesToRecords(sources);
+    const ns = importModuleGraphNow(specifierByPath.get("/main.ts")!, {
+      records,
+    }) as { Color: Record<string, unknown> };
+    expect(ns.Color.Red).toBe(1);
+  });
+
+  it("ignores type-only re-exports instead of throwing", () => {
+    const sources = files({
+      "/types.ts": `export interface Foo { n: number }`,
+      "/main.ts":
+        `export type * from "./types.ts";\nexport const run = (): number => 1;`,
+    });
+    const { records, specifierByPath } = compileSourcesToRecords(sources);
+    const ns = importModuleGraphNow(specifierByPath.get("/main.ts")!, {
+      records,
+    }) as { run(): number };
+    expect(ns.run()).toBe(1);
+  });
+
   it("throws loudly on unsupported `export * from`", () => {
     const sources = files({
       "/inner.ts": `export const x = 1;`,

--- a/packages/runner/test/module-record-compiler.test.ts
+++ b/packages/runner/test/module-record-compiler.test.ts
@@ -1,0 +1,129 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import type { Source } from "@commonfabric/js-compiler";
+import {
+  type CompiledModuleArtifact,
+  compileSourcesToRecords,
+  type ModuleRecordCache,
+} from "../src/sandbox/module-record-compiler.ts";
+import { importModuleGraphNow } from "../src/sandbox/esm-module-loader.ts";
+
+class MapRecordCache implements ModuleRecordCache {
+  store = new Map<string, CompiledModuleArtifact>();
+  hits = 0;
+  misses = 0;
+  get(hash: string): CompiledModuleArtifact | undefined {
+    const v = this.store.get(hash);
+    if (v) this.hits++;
+    else this.misses++;
+    return v;
+  }
+  set(hash: string, artifact: CompiledModuleArtifact): void {
+    this.store.set(hash, artifact);
+  }
+}
+
+function files(map: Record<string, string>): Source[] {
+  return Object.entries(map).map(([name, contents]) => ({ name, contents }));
+}
+
+describe("compileSourcesToRecords + importModuleGraphNow (end to end)", () => {
+  it("loads a multi-module compiled program through the SES module graph", () => {
+    const sources = files({
+      "/util.ts": `export const double = (n: number): number => n * 2;`,
+      "/main.ts":
+        `import { double } from "./util.ts";\nexport const run = (): number => double(21);\nexport default run;`,
+    });
+
+    const { records, specifierByPath } = compileSourcesToRecords(sources);
+    const entry = specifierByPath.get("/main.ts")!;
+    const ns = importModuleGraphNow(entry, { records }) as {
+      run(): number;
+      default(): number;
+    };
+
+    expect(ns.run()).toBe(42);
+    expect(ns.default()).toBe(42);
+  });
+
+  it("resolves a default import across modules (esModuleInterop)", () => {
+    const sources = files({
+      "/dep.ts": `const value = 7;\nexport default value;`,
+      "/main.ts":
+        `import dep from "./dep.ts";\nexport const run = (): number => dep + 1;`,
+    });
+    const { records, specifierByPath } = compileSourcesToRecords(sources);
+    const ns = importModuleGraphNow(specifierByPath.get("/main.ts")!, {
+      records,
+    }) as { run(): number };
+    expect(ns.run()).toBe(8);
+  });
+
+  it("supports a runtime-module record injected into the graph", () => {
+    const sources = files({
+      "/main.ts":
+        `import { greet } from "host";\nexport const value = greet("world");`,
+    });
+
+    const { records, specifierByPath } = compileSourcesToRecords(sources, {
+      runtimeModules: { host: ["greet"] },
+    });
+    // Provide the runtime module's implementation as a record.
+    records.set("cf:runtime/host", {
+      imports: [],
+      exports: ["greet"],
+      execute: (exports) => {
+        exports.greet = (n: string) => `hi ${n}`;
+      },
+    });
+
+    const entry = specifierByPath.get("/main.ts")!;
+    const ns = importModuleGraphNow(entry, { records }) as { value: string };
+    expect(ns.value).toBe("hi world");
+  });
+
+  it("populates the per-module cache on a miss and reuses it on a hit", () => {
+    const sources = files({ "/main.ts": `export const x = () => 1;` });
+    const cache = new MapRecordCache();
+
+    compileSourcesToRecords(sources, { recordCache: cache });
+    expect(cache.misses).toBe(1);
+    expect(cache.store.size).toBe(1);
+
+    // Second compile of identical sources hits the cache (no recompile).
+    compileSourcesToRecords(sources, { recordCache: cache });
+    expect(cache.hits).toBe(1);
+  });
+
+  it("uses the cached compiled artifact (cache is authoritative on hit)", () => {
+    const sources = files({
+      "/main.ts": `export const run = (): number => 1;`,
+    });
+    // Pre-seed the cache with a sentinel artifact so we can prove it is used.
+    const cache = new MapRecordCache();
+    const { specifierByPath: probe } = compileSourcesToRecords(sources);
+    const hash = probe.get("/main.ts")!.replace("cf:module/", "");
+    cache.store.set(hash, {
+      exports: ["run"],
+      compiled: `exports.run = function () { return 99; };`,
+    });
+
+    const { records, specifierByPath } = compileSourcesToRecords(sources, {
+      recordCache: cache,
+    });
+    const ns = importModuleGraphNow(specifierByPath.get("/main.ts")!, {
+      records,
+    }) as { run(): number };
+    expect(ns.run()).toBe(99);
+  });
+
+  it("assigns content-addressed specifiers (cf:module/<hash>)", () => {
+    const { specifierByPath } = compileSourcesToRecords(
+      files({ "/main.ts": `export const x = 1;` }),
+    );
+    expect(specifierByPath.get("/main.ts")!.startsWith("cf:module/")).toBe(
+      true,
+    );
+  });
+});

--- a/packages/runner/test/module-record-compiler.test.ts
+++ b/packages/runner/test/module-record-compiler.test.ts
@@ -159,6 +159,26 @@ describe("compileSourcesToRecords + importModuleGraphNow (end to end)", () => {
     expect(ns.run(undefined)).toBe(1);
   });
 
+  it("does not create edges for require(...) text in strings or comments", () => {
+    // `./ghost.ts` is a real sibling — a regex over the compiled text would
+    // wrongly pull it in as an eagerly-executed dependency.
+    const sources = files({
+      "/ghost.ts": `export const boom = 1;`,
+      "/main.ts": [
+        `// require("./ghost.ts") in a comment must be ignored`,
+        `export const s = 'see require("./ghost.ts") for details';`,
+        `export const run = (): number => 1;`,
+      ].join("\n"),
+    });
+    const { records, specifierByPath } = compileSourcesToRecords(sources);
+    const record = records.get(specifierByPath.get("/main.ts")!)!;
+    expect(record.imports).not.toContain("./ghost.ts");
+    const ns = importModuleGraphNow(specifierByPath.get("/main.ts")!, {
+      records,
+    }) as { run(): number };
+    expect(ns.run()).toBe(1);
+  });
+
   it("collects enum exports", () => {
     const sources = files({
       "/main.ts": `export enum Color { Red = 1, Blue = 2 }`,

--- a/packages/runner/test/module-record-compiler.test.ts
+++ b/packages/runner/test/module-record-compiler.test.ts
@@ -118,6 +118,38 @@ describe("compileSourcesToRecords + importModuleGraphNow (end to end)", () => {
     expect(ns.run()).toBe(99);
   });
 
+  it("wires a named re-export from another module (export { x } from)", () => {
+    const sources = files({
+      "/inner.ts": `export const x = (): number => 5;`,
+      "/main.ts": `export { x } from "./inner.ts";`,
+    });
+    const { records, specifierByPath } = compileSourcesToRecords(sources);
+    const ns = importModuleGraphNow(specifierByPath.get("/main.ts")!, {
+      records,
+    }) as { x(): number };
+    expect(ns.x()).toBe(5);
+  });
+
+  it("collects destructured variable exports", () => {
+    const sources = files({
+      "/main.ts": `const o = { a: 1, b: 2 };\nexport const { a, b } = o;`,
+    });
+    const { records, specifierByPath } = compileSourcesToRecords(sources);
+    const ns = importModuleGraphNow(specifierByPath.get("/main.ts")!, {
+      records,
+    }) as { a: number; b: number };
+    expect(ns.a).toBe(1);
+    expect(ns.b).toBe(2);
+  });
+
+  it("throws loudly on unsupported `export * from`", () => {
+    const sources = files({
+      "/inner.ts": `export const x = 1;`,
+      "/main.ts": `export * from "./inner.ts";`,
+    });
+    expect(() => compileSourcesToRecords(sources)).toThrow(/export \* from/);
+  });
+
   it("assigns content-addressed specifiers (cf:module/<hash>)", () => {
     const { specifierByPath } = compileSourcesToRecords(
       files({ "/main.ts": `export const x = 1;` }),

--- a/packages/runner/test/module-record-verifier.test.ts
+++ b/packages/runner/test/module-record-verifier.test.ts
@@ -1,0 +1,74 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import type { VirtualModuleRecord } from "../src/sandbox/esm-module-loader.ts";
+import { verifyModuleGraph } from "../src/sandbox/module-record-verifier.ts";
+
+function rec(over: Partial<VirtualModuleRecord> = {}): VirtualModuleRecord {
+  return {
+    imports: [],
+    exports: [],
+    execute: () => {},
+    ...over,
+  };
+}
+
+function graph(
+  entries: [string, VirtualModuleRecord][],
+): Map<string, VirtualModuleRecord> {
+  return new Map(entries);
+}
+
+describe("verifyModuleGraph", () => {
+  it("accepts a well-formed graph", () => {
+    const g = graph([
+      [
+        "cf:module/main",
+        rec({
+          imports: ["./util.ts"],
+          exports: ["run"],
+          resolutions: { "./util.ts": "cf:module/util" },
+        }),
+      ],
+      ["cf:module/util", rec({ exports: ["double"] })],
+    ]);
+    expect(() => verifyModuleGraph(g, "cf:module/main")).not.toThrow();
+  });
+
+  it("rejects a missing entry specifier", () => {
+    const g = graph([["cf:module/util", rec()]]);
+    expect(() => verifyModuleGraph(g, "cf:module/main")).toThrow(
+      /entry/i,
+    );
+  });
+
+  it("rejects a dangling resolution target", () => {
+    const g = graph([
+      [
+        "cf:module/main",
+        rec({
+          imports: ["./missing.ts"],
+          resolutions: { "./missing.ts": "cf:module/missing" },
+        }),
+      ],
+    ]);
+    expect(() => verifyModuleGraph(g, "cf:module/main")).toThrow(
+      /unresolved|missing/i,
+    );
+  });
+
+  it("rejects a non-content-addressed specifier", () => {
+    const g = graph([["/raw/path.ts", rec()]]);
+    expect(() => verifyModuleGraph(g, "/raw/path.ts")).toThrow(
+      /specifier/i,
+    );
+  });
+
+  it("rejects a record with a non-function execute", () => {
+    const g = graph([[
+      "cf:module/main",
+      { imports: [], exports: [], execute: undefined as unknown as () => void },
+    ]]);
+    expect(() => verifyModuleGraph(g, "cf:module/main")).toThrow(/execute/i);
+  });
+});


### PR DESCRIPTION
## Why

Follow-up to the merged **Phase 1** (content-addressed module identity, [#3758](https://github.com/commontoolsinc/labs/pull/3758)). This PR adds the module-loading mechanism from [`docs/specs/module-loading.md`](docs/specs/module-loading.md) — Phases 2–4 — **entirely behind the default-off `esmModuleLoader` flag.** The AMD bundle path remains the default, so this is inert in production.

## What

- **Loader** (`packages/runner/src/sandbox/esm-module-loader.ts`): `importModuleGraphNow` loads a graph of per-module records through the SES Compartment module system using **synchronous `importNow`** (preserving the scheduler's sync contract). This `ses` build doesn't expose `ModuleSource`, so it uses SES virtual (third-party) module records (`{ imports, exports, execute }`). Validated to load multi-module graphs, host endowments, and import cycles synchronously.
- **Adapter** (`module-record-compiler.ts`): compiles each module to CommonJS, content-addresses it (`cf:module/<hash>`), resolves relative/runtime imports to absolute specifiers, and wraps it in a record whose `execute` evaluates the body inside the compartment with a `require`→`importNow` shim. Sets `__esModule` for cross-module default-import interop.
- **Cache** (Phase 4): optional `ModuleRecordCache` keyed by module hash; a hit reuses the compiled artifact, so editing one file invalidates only its module.
- **Verifier** (Phase 3): `verifyModuleGraph` structural pre-flight (content-addressed specifiers, well-formed records, resolved imports), wired into the loader.

## Explicitly remaining (not in this PR)
- **Verifier classification port** — the security-critical SES_SANDBOXING module-item classification must be ported from the AMD parser before the loader can run untrusted code by default (called out in `module-record-verifier.ts`). The loader is currently dormant — nothing reads the flag yet.
- **Engine integration** — wiring `esmModuleLoader` into `Engine.evaluate` with the full CF transformer pipeline (the adapter currently uses bare `ts.transpileModule`); `export *` expansion.
- **Phase 5** — default-on + AMD removal, gated on the above + benchmarks.

## Tests (red→green TDD)
`esm-module-loader` (multi-module load, host endowments, cycles, unknown-specifier), `module-record-compiler` (end-to-end load, default-import interop, runtime module, cache hit/miss + authority), `module-record-verifier` (structural rejections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a synchronous SES ESM module-graph loader, TS→record adapter, per-module cache, and structural verifier behind the default-off `esmModuleLoader` flag. AMD remains the default path with no production impact.

- **New Features**
  - Loader: `importModuleGraphNow` loads content-addressed records (`cf:module/<hash>`) via `ses` `Compartment.importNow`, supports cycles and runtime records (`cf:runtime/*`), and freezes `compartment.globalThis` to prevent cross-module global poisoning.
  - Adapter: compiles TS to CommonJS with `typescript`, resolves imports to absolute specifiers, derives runtime imports by parsing the compiled JS AST for `require("...")` calls (ignores type-only imports and text in strings/comments), and sets `__esModule` for default-import interop; collects export names including enums, namespaces, and destructured variables; ignores type-only re-exports; throws on `export * from` and `export =`; re-exports `findInternalTarget` for shared resolution.
  - Cache: optional `ModuleRecordCache` keyed by module hash to reuse compiled artifacts.
  - Verifier: `verifyModuleGraph` validates graph shape and resolutions; structural only (not a security boundary) — the SES_SANDBOXING classification port is still pending.
  - Runtime flag and coverage: adds `experimental.esmModuleLoader` (default off); tests cover multi-module load, cycles, runtime modules, default-import interop, cache hits/misses, verifier rejections, named re-exports, destructured exports, type-only import/re-export handling, and ignoring `require(...)` text in strings/comments; docs/specs mark Phases 2–4 as implemented.

<sup>Written for commit d58f330e082e7e6c934271ac3f5d4a5a2da4282e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

