### PR TITLE
docs(specs): SQLite builtins for patterns

### DIFF
--- a/docs/specs/sqlite-builtin/01-api.md
+++ b/docs/specs/sqlite-builtin/01-api.md
@@ -131,9 +131,14 @@ with no per-query annotation.
 Leaving DDL to the database (rather than the old manual `CREATE TABLE IF NOT
 EXISTS` in pattern code) avoids silent drift: `CREATE TABLE IF NOT EXISTS`
 no-ops when a table already exists with a *different* shape, hiding mismatches.
-Runtime-owned migration reconciles the declared schema instead. (Migration
-scope and SQLite `ALTER` limits are tracked in
-[08-open-questions.md](./08-open-questions.md).)
+Runtime-owned migration reconciles the declared schema instead. **V1 migration
+is additive-only:** create missing tables and `ADD COLUMN` for new
+nullable/defaulted columns; any destructive or ambiguous change (drop/rename/
+retype, constraint/PK change) **refuses to open the db** with an explicit error,
+because a declarative diff can't tell a rename from a drop+add. A post-V1 opt-in
+**migration callback** will let a database supply explicit reshape logic for
+older on-disk versions while still erroring by default. (See
+[08-open-questions.md](./08-open-questions.md) Q9.)
 
 ## `sqliteQuery<Row>(params)` — reactive read
 

--- a/docs/specs/sqlite-builtin/01-api.md
+++ b/docs/specs/sqlite-builtin/01-api.md
@@ -2,8 +2,8 @@
 
 ## Built-in vs. new Cell type — decision
 
-**Decision: built-ins, with a lightweight database *handle* that is an ordinary
-cell.** We do not introduce a new `Cell` subtype.
+**Decision: built-ins, with a lightweight, opaque database *handle*.** We do not
+introduce a new `Cell` subtype.
 
 The runtime's reactive I/O — `fetchData`, `generateText`, `streamData` — is all
 expressed as built-ins registered in
@@ -32,59 +32,119 @@ was considered and rejected for v1:
 The "database type" the author cares about is therefore expressed two ways,
 neither of which is a new Cell subclass:
 
-- The **handle** is a normal cell carrying a small descriptor (which source,
-  which db identity). Its TypeScript type is `Cell<SqliteDatabase>`.
-- The **table/row shape** is expressed as a JSON Schema the author passes to a
-  query/execute call (`rows` / table schema), which is where `_cf_link` columns
-  and future CFC labels are declared.
+- The **handle** is a branded, opaque value (`SqliteDatabase`) — see "The handle
+  type" below.
+- The **table/row shape** lives on the database (`sqliteDatabase({ tables })`),
+  with `sqliteQuery<T>` declaring divergent result shapes — see "Schema
+  ownership" and "TypeScript and table types".
 
-## `sqliteDatabase(source?)`
+## The handle type
 
-Builder factory that returns an opaque database handle. The handle selects one
-of three sources (Section [03](./03-database-sources.md)); with no argument it
-binds to a cell derived from the current pattern context (the default source).
+`SqliteDatabase` is a **branded, otherwise-empty type**: opaque to pattern code,
+a cell reference to the runtime.
 
 ```ts
-type SqliteDatabase = {
-  /** Reactivity token; bumped after every committed write to this database.
-   *  Pass to `sqliteQuery({ reactOn })` for "re-run on any write" behavior. */
-  readonly version: number;
-};
+declare const __sqliteDb: unique symbol;
+/** Opaque database handle. Empty to pattern code; carries a `toCell`
+ *  back-pointer to its handle cell at runtime. Patterns only ever *forward* it
+ *  (to sqliteQuery / sqliteExecute / reactOn), never read it. */
+type SqliteDatabase = { readonly [__sqliteDb]: true };
+```
 
+Why a branded value rather than `Cell<SqliteDatabase>` or `OpaqueCell<…>`:
+
+- A handle should be **forwarded, never read**. The database identity/source is
+  opaque to the pattern by design, so there are no fields to expose. A branded
+  empty type expresses exactly that.
+- It still travels as a **reference**, because every value materialized from a
+  cell carries a `toCell` back-pointer
+  ([`packages/runner/src/back-to-cell.ts`](../../../packages/runner/src/back-to-cell.ts);
+  query-result proxies expose `[toCell]: () => Cell<unknown>` —
+  [`packages/runner/src/query-result-proxy.ts`](../../../packages/runner/src/query-result-proxy.ts)).
+  So the runtime can always recover the handle cell — to name the database
+  (from its entity id), to resolve its source server-side, and to subscribe for
+  reactivity — without the pattern ever holding a readable `Cell`.
+- The handle cell's **readable value is empty**; the source descriptor lives as
+  **server-side state keyed by the handle cell's id** (Section
+  [03](./03-database-sources.md)), so even at runtime a pattern materializing the
+  handle gets `{}` + `[toCell]`, never the file path. The brand is truthful, not
+  cosmetic.
+
+## `sqliteDatabase(source?, options?)`
+
+Builder factory returning a handle. With no argument it binds to a cell derived
+from the current pattern context (the default, cell-derived source). The
+database's **table schema and DDL are owned here** (see "Schema ownership").
+
+```ts
 export declare function sqliteDatabase(
   source?: SqliteDatabaseSource,
-): OpaqueRef<SqliteDatabase>;
+  options?: { tables?: TableSchemas },
+): SqliteDatabase; // OpaqueRef<SqliteDatabase> in builder position
 
 type SqliteDatabaseSource =
   | undefined // default: cell-derived (Section 03.1)
   | { cell: OpaqueRef<unknown> } // explicit cell-derived
-  | { vm: OpaqueRef<VmHandle>; path: string } // VM file (stub, Section 03.2)
-  | { disk: OpaqueRef<DiskHandle> }; // on-disk via `cf` (stub, Section 03.3)
+  | { vm: OpaqueRef<VmHandle>; path: string }; // VM file (stub, Section 03.2)
+// NOTE: there is no `{ disk }` variant. On-disk databases are *injected* as a
+// pattern input via `cf piece link <piece> <field> sqlite:<path>` (Section 03.3),
+// not selected by the pattern.
 ```
 
-The handle is a cell so it can be passed between sub-patterns and stored, and so
-its `version` field participates in normal reactivity. The underlying database
-identity (file name / attach alias) is **opaque to the pattern** — it is derived
-from the handle cell's entity id (Section [03](./03-database-sources.md)) and
-never constructed by pattern code.
+The underlying database identity (file name / attach alias) is **opaque to the
+pattern** — derived from the handle cell's entity id (Section
+[03](./03-database-sources.md)) and never constructed by pattern code.
 
-## `sqliteQuery(params)` — reactive read
+## Schema ownership — the database owns its tables
+
+The table/column schema is a property of the **database**, not of an individual
+query, so it is declared once on `sqliteDatabase({ tables })` rather than
+re-stated per call. The runtime **owns table creation and migration** from this
+declaration, validating that `_cf_link` columns are `TEXT` and (later) attaching
+per-column CFC labels in one place.
+
+```tsx
+import { table, cfLink, sqliteDatabase } from "commonfabric";
+
+const db = sqliteDatabase(undefined, {
+  tables: {
+    messages: table({
+      id: "integer primary key",
+      body: "text",
+      ts: "integer",
+      author_cf_link: cfLink<User>(), // TEXT in SQLite, Cell<User> in TS
+    }),
+  },
+});
+```
+
+This is the single source of truth: the per-query `rows` argument is **gone**.
+Because result columns map back to declared columns by name, the runtime already
+knows which columns are `_cf_link` for a straightforward
+`SELECT … FROM messages`, and decodes them (Section [02](./02-cf-link-encoding.md))
+with no per-query annotation.
+
+Leaving DDL to the database (rather than the old manual `CREATE TABLE IF NOT
+EXISTS` in pattern code) avoids silent drift: `CREATE TABLE IF NOT EXISTS`
+no-ops when a table already exists with a *different* shape, hiding mismatches.
+Runtime-owned migration reconciles the declared schema instead. (Migration
+scope and SQLite `ALTER` limits are tracked in
+[08-open-questions.md](./08-open-questions.md).)
+
+## `sqliteQuery<Row>(params)` — reactive read
 
 ```ts
 type SqliteQueryParams = {
-  db: OpaqueRef<SqliteDatabase>;
+  db: SqliteDatabase;
   /** A single read-only statement. Multiple statements / write statements throw. */
   sql: string;
-  /** Positional (`?`) or named (`:name`) bindings. Cells are encoded per
-   *  Section 02 only when bound to a `_cf_link` parameter; otherwise a cell
-   *  binding throws. */
+  /** Positional (`?`) or named (`:name`) bindings. A cell bound to a `_cf_link`
+   *  column is encoded per Section 02; a cell bound anywhere else throws. */
   params?: unknown[] | Record<string, unknown>;
-  /** Reactivity input. Read wholesale as an `any` schema; when its committed
-   *  value changes, the query re-runs. Typically `db.version`. See Section 05. */
+  /** Reactivity input. Read wholesale (any schema); when its committed value
+   *  changes, the query re-runs. Pass the whole `db` for "any committed write
+   *  to this database re-runs". See Section 05. */
   reactOn?: unknown;
-  /** Optional JSON Schema describing a result row. Drives `_cf_link` decoding
-   *  and result typing. See "TypeScript and table types" below. */
-  rows?: JSONSchema;
 };
 
 type SqliteQueryState<Row = Record<string, unknown>> = {
@@ -99,28 +159,53 @@ export declare function sqliteQuery<Row = Record<string, unknown>>(
 ```
 
 `sqliteQuery` is **read-only**. The server rejects any statement that is not a
-single `SELECT` (or read-only CTE). Result columns named `*_cf_link` are decoded
-back into live cells before the rows reach the pattern (Section
+single `SELECT` (or read-only CTE). `_cf_link` columns are decoded back into
+live cells before the rows reach the pattern (Section
 [02](./02-cf-link-encoding.md)).
 
-Reactivity is **explicit and coarse** in v1: the query re-runs when `reactOn`'s
-committed value changes. The built-in reads `reactOn` under an `any` schema, so
-*any* change to that value (or anything it transitively links to) invalidates
-the query — the "maintain parallel cells that change when the query should be
-redone" strategy. Passing `db.version` gives "re-run on any write to this
-database"; passing a narrower cell scopes invalidation more tightly.
+The **`Row` type argument replaces the old `rows` schema**. In this codebase a
+type argument can be lowered to a runtime JSON Schema by the transformer — that
+is exactly what `toSchema<T>()` does (a compile-time call the transformer
+rewrites; the runtime stub throws if the transformer didn't run —
+[`packages/runner/src/builder/factory.ts`](../../../packages/runner/src/builder/factory.ts)).
+`sqliteQuery<Row>` is wired the same way: the transformer lowers `Row` into the
+runtime schema the built-in receives, so **one type argument gives both the
+author-facing return type and the runtime decode/CFC schema** — they cannot
+drift, because they are the same `Row`.
+
+This also handles projections the table schema can't: because `Cell<T>` lowers
+to `asCell`, declaring a result field as `Cell<User>` tells the runtime that
+column is cell-bearing **even when an alias hides the `_cf_link` suffix**:
+
+```tsx
+sqliteQuery<{ who: Cell<User>; n: number }>({
+  db,
+  sql: "SELECT author_cf_link AS who, count(*) AS n FROM messages GROUP BY author_cf_link",
+  reactOn: db,
+});
+// `who` carries asCell -> the stored sigil link is decoded into Cell<User>,
+// even though the projection aliased away the _cf_link suffix.
+```
+
+For a straightforward `SELECT … FROM <declared table>`, omit `Row` and let the
+database's table schema drive decoding. Reach for `<Row>` when the projection
+diverges (joins, aliases, computed columns).
+
+> **Transformer dependency.** `sqliteQuery<Row>` requires the ts-transformer to
+> lower its type argument into a schema (alongside `toSchema<T>`). Without that
+> support the generic is erased and carries no runtime decode/CFC info. This is
+> a transformer feature, not just a signature — confirm with the
+> ts-transformers owner. See [08-open-questions.md](./08-open-questions.md).
 
 ## `sqliteExecute(params)` — write
 
 ```ts
 type SqliteExecuteParams = {
-  db: OpaqueRef<SqliteDatabase>;
-  /** One or more write statements (INSERT/UPDATE/DELETE/DDL). */
+  db: SqliteDatabase;
+  /** One or more write statements (INSERT/UPDATE/DELETE). DDL is owned by the
+   *  database, not issued here. */
   sql: string;
   params?: unknown[] | Record<string, unknown>;
-  /** Optional JSON Schema for the bound parameters; declares which params are
-   *  `_cf_link` and (future) carries CFC labels. */
-  bind?: JSONSchema;
 };
 
 type SqliteExecuteState = {
@@ -140,62 +225,36 @@ export declare function sqliteExecute(
 [`packages/runner/src/builtins/index.ts`](../../../packages/runner/src/builtins/index.ts))
 and its writes are folded into the surrounding commit transaction so they are
 atomic with cell writes (Section [04](./04-server-execution-and-transactions.md)).
-A cell bound to a parameter is encoded to a sigil link **only** when that
-parameter targets a `_cf_link` column; otherwise binding a cell throws (Section
-[02](./02-cf-link-encoding.md)).
 
-## TypeScript and table types
+There is **no per-call `bind` schema**: the database's table schema already
+declares which columns are `_cf_link`, so for `INSERT INTO messages
+(author_cf_link, …)` the runtime maps each parameter position to its column and
+encodes link parameters accordingly. A cell bound to a parameter is encoded to a
+sigil link **only** when that parameter targets a `_cf_link` column; otherwise
+binding a cell throws (Section [02](./02-cf-link-encoding.md)).
 
-The most useful TypeScript surface is **row/column declaration**, not full
-inference over arbitrary SQL.
+## TypeScript and table types — why these boundaries
 
-Why we stop short of typing query inputs/outputs from the SQL text:
+- **Table/column declaration** lives on the database (`table(...)`,
+  `cfLink<T>()`), because it is a property of the database and is the natural
+  home for `_cf_link` markers and future per-column CFC labels (the same `ifc`
+  mechanism schemas already support —
+  [`packages/api/index.ts`](../../../packages/api/index.ts) `ifc` field).
+- **Result-row typing** is the `sqliteQuery<Row>` type argument, lowered to a
+  runtime schema by the transformer — needed only when a projection diverges
+  from a declared table.
+- **We do not infer types from the SQL string.** An in-type SQL parser
+  (dialect, expressions, joins, aliases) is brittle and out of proportion to the
+  value. Parameter tuples remain author-annotated.
 
-- Inferring the parameter tuple and result-row type from a `sql` string would
-  require an in-type SQL parser. It is brittle (dialect, expressions, joins,
-  aliases) and out of proportion to the value.
-- The author already knows the row shape they expect. Letting them declare it is
-  simpler and is exactly the hook CFC needs.
-
-So v1 offers a table-schema helper whose primary jobs are (a) marking `_cf_link`
-columns, (b) typing the rows a query returns, and (c) (future) carrying CFC
-labels — the same `ifc` mechanism schemas already support
-([`packages/api/index.ts`](../../../packages/api/index.ts) `ifc` field).
-
-```tsx
-import { table, cfLink, type Default } from "commonfabric";
-
-// `table(...)` is a thin helper returning a JSONSchema for one row, with
-// `_cf_link` columns typed as Cell<T> and (future) per-column `ifc` labels.
-const MessageRowSchema = table({
-  id: "integer",
-  body: "text",
-  ts: "integer",
-  // A `_cf_link` column: stored as TEXT, surfaces as Cell<User>.
-  author_cf_link: cfLink<User>(),
-});
-
-type MessageRow = RowOf<typeof MessageRowSchema>;
-// => { id: number; body: string; ts: number; author_cf_link: Cell<User> }
-
-const recent = sqliteQuery<MessageRow>({
-  db,
-  sql: "SELECT id, body, ts, author_cf_link FROM messages",
-  reactOn: db.version,
-  rows: MessageRowSchema,
-});
-```
-
-`table(...)` and `cfLink<T>()` compile to plain JSON Schema; `cfLink<T>()`
-emits `{ type: "string" }` plus an internal marker (e.g. `cfLink: true`) the
-runtime uses to drive encode/decode and to enforce the "single string field
-ending in `_cf_link`" rule (Section [02](./02-cf-link-encoding.md)). Query
-parameter tuples and free-form result columns remain `unknown`/author-annotated;
-we do not attempt to derive them from the SQL string.
+`table(...)` and `cfLink<T>()` compile to plain JSON Schema; `cfLink<T>()` emits
+`{ type: "string" }` plus an internal marker (e.g. `cfLink: true`) the runtime
+uses to drive encode/decode and to enforce the "single string field ending in
+`_cf_link`" rule (Section [02](./02-cf-link-encoding.md)).
 
 ## Registration & wiring (implementation note)
 
-Following the conventions reported for existing built-ins:
+Following the conventions of existing built-ins:
 
 1. Implementations in `packages/runner/src/builtins/sqlite-query.ts` and
    `packages/runner/src/builtins/sqlite-execute.ts`, each exporting an `Action`
@@ -208,3 +267,5 @@ Following the conventions reported for existing built-ins:
    in `packages/runner/src/builder/built-in.ts`, exported from
    `packages/runner/src/builder/factory.ts`.
 4. Public types in [`packages/api/index.ts`](../../../packages/api/index.ts).
+5. Teach the ts-transformer to lower the `sqliteQuery<Row>` type argument to a
+   runtime schema (alongside `toSchema<T>`).

--- a/docs/specs/sqlite-builtin/01-api.md
+++ b/docs/specs/sqlite-builtin/01-api.md
@@ -195,11 +195,11 @@ For a straightforward `SELECT … FROM <declared table>`, omit `Row` and let the
 database's table schema drive decoding. Reach for `<Row>` when the projection
 diverges (joins, aliases, computed columns).
 
-> **Transformer dependency.** `sqliteQuery<Row>` requires the ts-transformer to
-> lower its type argument into a schema (alongside `toSchema<T>`). Without that
-> support the generic is erased and carries no runtime decode/CFC info. This is
-> a transformer feature, not just a signature — confirm with the
-> ts-transformers owner. See [08-open-questions.md](./08-open-questions.md).
+> **Transformer note.** `sqliteQuery<Row>` relies on the ts-transformer lowering
+> its type argument into a runtime schema (alongside `toSchema<T>`,
+> `generateObject`, `lift`). This is a routine addition — register the export and
+> add a schema-injection rule per
+> [`packages/ts-transformers/docs/adding-type-arg-schema-lowering.md`](../../../packages/ts-transformers/docs/adding-type-arg-schema-lowering.md).
 
 ## `sqliteExecute(params)` — write
 

--- a/docs/specs/sqlite-builtin/01-api.md
+++ b/docs/specs/sqlite-builtin/01-api.md
@@ -70,25 +70,29 @@ Why a branded value rather than `Cell<SqliteDatabase>` or `OpaqueCell<…>`:
   handle gets `{}` + `[toCell]`, never the file path. The brand is truthful, not
   cosmetic.
 
-## `sqliteDatabase(source?, options?)`
+## `sqliteDatabase(options?, source?)`
 
-Builder factory returning a handle. With no argument it binds to a cell derived
-from the current pattern context (the default, cell-derived source). The
-database's **table schema and DDL are owned here** (see "Schema ownership").
+Builder factory returning a handle. The **table schema and DDL are owned here**
+(see "Schema ownership") — passed first because they are the common case. The
+optional **source** comes second because it is rarely non-default; with no
+source the handle binds to a cell allocated for it in the current pattern
+context (the default, cell-derived source).
 
 ```ts
 export declare function sqliteDatabase(
-  source?: SqliteDatabaseSource,
   options?: { tables?: TableSchemas },
+  source?: SqliteDatabaseSource,
 ): SqliteDatabase; // OpaqueRef<SqliteDatabase> in builder position
 
 type SqliteDatabaseSource =
-  | undefined // default: cell-derived (Section 03.1)
-  | { cell: OpaqueRef<unknown> } // explicit cell-derived
+  | undefined // default: cell-derived from the pattern's own context (Section 03.1)
   | { vm: OpaqueRef<VmHandle>; path: string }; // VM file (stub, Section 03.2)
-// NOTE: there is no `{ disk }` variant. On-disk databases are *injected* as a
-// pattern input via `cf piece link <piece> <field> sqlite:<path>` (Section 03.3),
-// not selected by the pattern.
+// NOTE: there is no way to point a database at an arbitrary cell. The
+// cell-derived handle is always the one the runtime allocates for this call —
+// targeting some other cell would re-introduce ambient authority. There is also
+// no `{ disk }` variant: on-disk databases are *injected* as a pattern input via
+// `cf piece link <piece> <field> sqlite:<path>` (Section 03.3), not selected by
+// the pattern.
 ```
 
 The underlying database identity (file name / attach alias) is **opaque to the
@@ -106,7 +110,7 @@ per-column CFC labels in one place.
 ```tsx
 import { table, cfLink, sqliteDatabase } from "commonfabric";
 
-const db = sqliteDatabase(undefined, {
+const db = sqliteDatabase({
   tables: {
     messages: table({
       id: "integer primary key",

--- a/docs/specs/sqlite-builtin/01-api.md
+++ b/docs/specs/sqlite-builtin/01-api.md
@@ -1,0 +1,210 @@
+# 01 — TypeScript API
+
+## Built-in vs. new Cell type — decision
+
+**Decision: built-ins, with a lightweight database *handle* that is an ordinary
+cell.** We do not introduce a new `Cell` subtype.
+
+The runtime's reactive I/O — `fetchData`, `generateText`, `streamData` — is all
+expressed as built-ins registered in
+[`packages/runner/src/builtins/index.ts`](../../../packages/runner/src/builtins/index.ts)
+and surfaced as builder factories in
+[`packages/runner/src/builder/built-in.ts`](../../../packages/runner/src/builder/built-in.ts).
+A built-in returns an `OpaqueRef<{ pending, result, error }>` and re-runs when
+its inputs change. A SQLite query is the same shape, so it slots into the
+existing machinery: read-tracking, scheduler subscription, post-commit effects,
+request hashing, and the CFC write-policy sink (Section
+[06](./06-cfc.md)) are all reused rather than re-implemented.
+
+A new `Cell` *subclass* (e.g. `SqliteCell` with `.query()`/`.execute()` methods)
+was considered and rejected for v1:
+
+- `Cell` is deeply woven into schema inference
+  ([`packages/api/schema.ts`](../../../packages/api/schema.ts)), link
+  serialization ([`packages/runner/src/cell.ts`](../../../packages/runner/src/cell.ts)),
+  and `asCell` wrapping. A new subtype touches all of it.
+- Methods that *create graph nodes* (so they participate in reactivity) don't
+  belong on a value handle — node creation is the builder's job. Sugar methods
+  would just forward to the built-ins anyway.
+- Read and write must be **separately gated** by CFC. Two built-ins make the
+  capability boundary explicit; methods on one object blur it.
+
+The "database type" the author cares about is therefore expressed two ways,
+neither of which is a new Cell subclass:
+
+- The **handle** is a normal cell carrying a small descriptor (which source,
+  which db identity). Its TypeScript type is `Cell<SqliteDatabase>`.
+- The **table/row shape** is expressed as a JSON Schema the author passes to a
+  query/execute call (`rows` / table schema), which is where `_cf_link` columns
+  and future CFC labels are declared.
+
+## `sqliteDatabase(source?)`
+
+Builder factory that returns an opaque database handle. The handle selects one
+of three sources (Section [03](./03-database-sources.md)); with no argument it
+binds to a cell derived from the current pattern context (the default source).
+
+```ts
+type SqliteDatabase = {
+  /** Reactivity token; bumped after every committed write to this database.
+   *  Pass to `sqliteQuery({ reactOn })` for "re-run on any write" behavior. */
+  readonly version: number;
+};
+
+export declare function sqliteDatabase(
+  source?: SqliteDatabaseSource,
+): OpaqueRef<SqliteDatabase>;
+
+type SqliteDatabaseSource =
+  | undefined // default: cell-derived (Section 03.1)
+  | { cell: OpaqueRef<unknown> } // explicit cell-derived
+  | { vm: OpaqueRef<VmHandle>; path: string } // VM file (stub, Section 03.2)
+  | { disk: OpaqueRef<DiskHandle> }; // on-disk via `cf` (stub, Section 03.3)
+```
+
+The handle is a cell so it can be passed between sub-patterns and stored, and so
+its `version` field participates in normal reactivity. The underlying database
+identity (file name / attach alias) is **opaque to the pattern** — it is derived
+from the handle cell's entity id (Section [03](./03-database-sources.md)) and
+never constructed by pattern code.
+
+## `sqliteQuery(params)` — reactive read
+
+```ts
+type SqliteQueryParams = {
+  db: OpaqueRef<SqliteDatabase>;
+  /** A single read-only statement. Multiple statements / write statements throw. */
+  sql: string;
+  /** Positional (`?`) or named (`:name`) bindings. Cells are encoded per
+   *  Section 02 only when bound to a `_cf_link` parameter; otherwise a cell
+   *  binding throws. */
+  params?: unknown[] | Record<string, unknown>;
+  /** Reactivity input. Read wholesale as an `any` schema; when its committed
+   *  value changes, the query re-runs. Typically `db.version`. See Section 05. */
+  reactOn?: unknown;
+  /** Optional JSON Schema describing a result row. Drives `_cf_link` decoding
+   *  and result typing. See "TypeScript and table types" below. */
+  rows?: JSONSchema;
+};
+
+type SqliteQueryState<Row = Record<string, unknown>> = {
+  pending: boolean;
+  result?: Row[];
+  error?: unknown;
+};
+
+export declare function sqliteQuery<Row = Record<string, unknown>>(
+  params: SqliteQueryParams,
+): OpaqueRef<SqliteQueryState<Row>>;
+```
+
+`sqliteQuery` is **read-only**. The server rejects any statement that is not a
+single `SELECT` (or read-only CTE). Result columns named `*_cf_link` are decoded
+back into live cells before the rows reach the pattern (Section
+[02](./02-cf-link-encoding.md)).
+
+Reactivity is **explicit and coarse** in v1: the query re-runs when `reactOn`'s
+committed value changes. The built-in reads `reactOn` under an `any` schema, so
+*any* change to that value (or anything it transitively links to) invalidates
+the query — the "maintain parallel cells that change when the query should be
+redone" strategy. Passing `db.version` gives "re-run on any write to this
+database"; passing a narrower cell scopes invalidation more tightly.
+
+## `sqliteExecute(params)` — write
+
+```ts
+type SqliteExecuteParams = {
+  db: OpaqueRef<SqliteDatabase>;
+  /** One or more write statements (INSERT/UPDATE/DELETE/DDL). */
+  sql: string;
+  params?: unknown[] | Record<string, unknown>;
+  /** Optional JSON Schema for the bound parameters; declares which params are
+   *  `_cf_link` and (future) carries CFC labels. */
+  bind?: JSONSchema;
+};
+
+type SqliteExecuteState = {
+  pending: boolean;
+  /** rowid of the last inserted row, and number of changed rows, after commit. */
+  result?: { lastInsertRowid?: number; changes: number };
+  error?: unknown;
+};
+
+export declare function sqliteExecute(
+  params: SqliteExecuteParams,
+): OpaqueRef<SqliteExecuteState>;
+```
+
+`sqliteExecute` is **effectful**. It is registered with `isEffect: true` (as
+`llm`/`generateText` are in
+[`packages/runner/src/builtins/index.ts`](../../../packages/runner/src/builtins/index.ts))
+and its writes are folded into the surrounding commit transaction so they are
+atomic with cell writes (Section [04](./04-server-execution-and-transactions.md)).
+A cell bound to a parameter is encoded to a sigil link **only** when that
+parameter targets a `_cf_link` column; otherwise binding a cell throws (Section
+[02](./02-cf-link-encoding.md)).
+
+## TypeScript and table types
+
+The most useful TypeScript surface is **row/column declaration**, not full
+inference over arbitrary SQL.
+
+Why we stop short of typing query inputs/outputs from the SQL text:
+
+- Inferring the parameter tuple and result-row type from a `sql` string would
+  require an in-type SQL parser. It is brittle (dialect, expressions, joins,
+  aliases) and out of proportion to the value.
+- The author already knows the row shape they expect. Letting them declare it is
+  simpler and is exactly the hook CFC needs.
+
+So v1 offers a table-schema helper whose primary jobs are (a) marking `_cf_link`
+columns, (b) typing the rows a query returns, and (c) (future) carrying CFC
+labels — the same `ifc` mechanism schemas already support
+([`packages/api/index.ts`](../../../packages/api/index.ts) `ifc` field).
+
+```tsx
+import { table, cfLink, type Default } from "commonfabric";
+
+// `table(...)` is a thin helper returning a JSONSchema for one row, with
+// `_cf_link` columns typed as Cell<T> and (future) per-column `ifc` labels.
+const MessageRowSchema = table({
+  id: "integer",
+  body: "text",
+  ts: "integer",
+  // A `_cf_link` column: stored as TEXT, surfaces as Cell<User>.
+  author_cf_link: cfLink<User>(),
+});
+
+type MessageRow = RowOf<typeof MessageRowSchema>;
+// => { id: number; body: string; ts: number; author_cf_link: Cell<User> }
+
+const recent = sqliteQuery<MessageRow>({
+  db,
+  sql: "SELECT id, body, ts, author_cf_link FROM messages",
+  reactOn: db.version,
+  rows: MessageRowSchema,
+});
+```
+
+`table(...)` and `cfLink<T>()` compile to plain JSON Schema; `cfLink<T>()`
+emits `{ type: "string" }` plus an internal marker (e.g. `cfLink: true`) the
+runtime uses to drive encode/decode and to enforce the "single string field
+ending in `_cf_link`" rule (Section [02](./02-cf-link-encoding.md)). Query
+parameter tuples and free-form result columns remain `unknown`/author-annotated;
+we do not attempt to derive them from the SQL string.
+
+## Registration & wiring (implementation note)
+
+Following the conventions reported for existing built-ins:
+
+1. Implementations in `packages/runner/src/builtins/sqlite-query.ts` and
+   `packages/runner/src/builtins/sqlite-execute.ts`, each exporting an `Action`
+   factory `(inputsCell, sendResult, addCancel, cause, parentCell, runtime)`.
+2. Register in
+   [`packages/runner/src/builtins/index.ts`](../../../packages/runner/src/builtins/index.ts):
+   `addModuleByRef("sqliteQuery", raw(sqliteQuery))` and
+   `addModuleByRef("sqliteExecute", raw(sqliteExecute, { isEffect: true }))`.
+3. Builder factories via `createNodeFactory({ type: "ref", implementation: ... })`
+   in `packages/runner/src/builder/built-in.ts`, exported from
+   `packages/runner/src/builder/factory.ts`.
+4. Public types in [`packages/api/index.ts`](../../../packages/api/index.ts).

--- a/docs/specs/sqlite-builtin/02-cf-link-encoding.md
+++ b/docs/specs/sqlite-builtin/02-cf-link-encoding.md
@@ -8,8 +8,9 @@ scalars. This section defines how a cell crosses that boundary losslessly.
 A column (or bound parameter) is a **link column** iff **both**:
 
 1. its name ends with the suffix `_cf_link`, and
-2. it is declared (in the `rows` / `bind` schema, or by SQLite column affinity)
-   as `string`/`TEXT`.
+2. it is declared `TEXT` — by the database's table schema
+   (`cfLink<T>()`, Section [01](./01-api.md)), by a `sqliteQuery<Row>` result
+   field typed `Cell<T>`, or by SQLite column affinity.
 
 For a link column:
 
@@ -76,9 +77,10 @@ Rationale for absolute links:
 Executed during the write built-in's mutation phase, before the statement is
 queued into the commit (Section [04](./04-server-execution-and-transactions.md)):
 
-1. Determine which parameters target link columns, from the `bind`/`rows`
-   schema (`cfLink` marker) or, lacking a schema, from the `*_cf_link` parameter
-   name when the SQL names columns explicitly.
+1. Determine which parameters target link columns by mapping each parameter to
+   its column (from the statement's named columns) and checking the database's
+   table schema (`cfLink` marker); lacking that, fall back to the `*_cf_link`
+   column name when the SQL names columns explicitly.
 2. For each link parameter:
    - If the value is not a cell reference → **throw**.
    - Resolve it to a `NormalizedFullLink`, build an absolute `SigilLink` via
@@ -95,16 +97,17 @@ encoded string is stable regardless of where the row is later read.
 Executed in the query built-in after rows return from the server, before
 `sendResult`:
 
-1. Identify link columns from the `rows` schema (`cfLink` marker), or fall back
-   to the `*_cf_link` column-name convention from the result set.
+1. Identify link columns from, in order: the `sqliteQuery<Row>` schema (a field
+   typed `Cell<T>` → `asCell`), the database's table schema (`cfLink` marker),
+   or the `*_cf_link` column-name convention from the result set.
 2. For each link column value:
    - `null` → `null`.
    - Else `JSON.parse` and validate it is a single `link@1` sigil. If not →
      **throw** into the query `error`.
    - Reconstruct a `Cell` from the normalized link via the runtime (the same
      path `Cell.fromLink`/link resolution uses), carrying the column's declared
-     element schema (from `cfLink<T>()`) so downstream `.get()`/`.key()` are
-     typed.
+     element schema (from `cfLink<T>()` or the `Cell<T>` in `Row`) so downstream
+     `.get()`/`.key()` are typed.
 3. Non-link columns pass through unchanged.
 
 The decoded `Cell` is a normal reactive cell: reading it later subscribes to
@@ -114,8 +117,10 @@ The decoded `Cell` is a normal reactive cell: reading it later subscribes to
 ## Why a naming convention rather than schema-only
 
 The `*_cf_link` suffix makes the contract legible directly in SQL and in raw
-table dumps, and lets the encode/decode rules apply even when a query omits a
-`rows` schema. The schema (`cfLink<T>()`) refines it with the element type and,
-later, CFC labels — but the suffix is the load-bearing, self-documenting marker.
+table dumps, and lets the encode/decode rules apply even when neither the table
+schema nor a `sqliteQuery<Row>` type covers a column. The schemas
+(`cfLink<T>()`, or a `Cell<T>` field in `Row`) refine it with the element type
+and, later, CFC labels — but the suffix is the load-bearing, self-documenting
+marker.
 This mirrors how the runtime already keys behavior off structural conventions
 rather than out-of-band registration.

--- a/docs/specs/sqlite-builtin/02-cf-link-encoding.md
+++ b/docs/specs/sqlite-builtin/02-cf-link-encoding.md
@@ -1,0 +1,121 @@
+# 02 — `_cf_link` column encoding
+
+Cell references are first-class values in patterns, but SQLite only stores
+scalars. This section defines how a cell crosses that boundary losslessly.
+
+## The rule
+
+A column (or bound parameter) is a **link column** iff **both**:
+
+1. its name ends with the suffix `_cf_link`, and
+2. it is declared (in the `rows` / `bind` schema, or by SQLite column affinity)
+   as `string`/`TEXT`.
+
+For a link column:
+
+- **On write**, the bound value **must** be a cell reference (a `Cell`, an
+  `OpaqueRef` to a cell, or anything that resolves to a link). It is opaquely
+  encoded to a **full sigil link string** before the `INSERT`/`UPDATE`.
+- **On read**, the stored string is transparently decoded back into a live
+  `Cell` before the row reaches the pattern.
+
+The encoding is **opaque to the pattern**: pattern code binds a cell and reads a
+cell; the string form is never exposed.
+
+## Throw conditions
+
+The system fails loudly rather than silently mis-storing data:
+
+| Condition | Result |
+| --- | --- |
+| Binding a cell reference to a **non-`_cf_link`** column/parameter | **throw** — cells may only be persisted via link columns. |
+| A column named `*_cf_link` that is **not** declared/affined as `string` | **throw** — link columns must be a single string field. |
+| Binding a **non-cell** value to a `_cf_link` column | **throw** — link columns store cells only. |
+| Reading a `_cf_link` column whose value is non-null and **not a parseable sigil link** | **throw** (surfaced as the query's `error`). |
+| A `_cf_link` value that is itself multi-field / not a single scalar string | **throw** — "they must be a single field of type string and end with `_cf_link`". |
+
+`NULL` in a link column is allowed and decodes to `null` (an absent cell).
+
+## Encoding format
+
+The stored string is a **fully-qualified, absolute** serialization of the
+runtime's sigil link — absolute so the row is portable and resolvable
+independent of any base document or space.
+
+The runtime already produces this shape. `Cell.getAsLink()` returns a `SigilLink`
+(see [`packages/runner/src/cell.ts`](../../../packages/runner/src/cell.ts) and
+[`packages/runner/src/link-utils.ts`](../../../packages/runner/src/link-utils.ts)
+`createSigilLinkFromParsedLink`). For storage we serialize it with **no `base`**
+so `id`, `space`, and `scope` are always present:
+
+```jsonc
+// JSON.stringify of the SigilLink, stored as TEXT in the _cf_link column:
+{
+  "/": {
+    "link@1": {
+      "id":    "of:bafy2bzace…",                 // entity id, always present
+      "space": "did:key:z6Mk…",                   // owning space DID, always present
+      "scope": "space",                            // resolved scope, always present
+      "path":  ["author", "name"]                  // optional value-relative path
+      // NOTE: `schema` and any asCell flags are stripped before storage.
+    }
+  }
+}
+```
+
+Rationale for absolute links:
+
+- A database may be ATTACHed by transactions originating in different documents;
+  a base-relative link would be ambiguous.
+- The VM-file and on-disk sources (Section [03](./03-database-sources.md)) may
+  outlive or be shared beyond the originating space; absolute links keep stored
+  references meaningful.
+
+## Encode path (write)
+
+Executed during the write built-in's mutation phase, before the statement is
+queued into the commit (Section [04](./04-server-execution-and-transactions.md)):
+
+1. Determine which parameters target link columns, from the `bind`/`rows`
+   schema (`cfLink` marker) or, lacking a schema, from the `*_cf_link` parameter
+   name when the SQL names columns explicitly.
+2. For each link parameter:
+   - If the value is not a cell reference → **throw**.
+   - Resolve it to a `NormalizedFullLink`, build an absolute `SigilLink` via
+     `createSigilLinkFromParsedLink(link, { includeSchema: false })` (no base),
+     and `JSON.stringify` it.
+3. For each non-link parameter: if the value is a cell reference → **throw**;
+   otherwise pass through as a SQLite scalar.
+
+Because the cell's `space`/`id` are captured at encode time on the client, the
+encoded string is stable regardless of where the row is later read.
+
+## Decode path (read)
+
+Executed in the query built-in after rows return from the server, before
+`sendResult`:
+
+1. Identify link columns from the `rows` schema (`cfLink` marker), or fall back
+   to the `*_cf_link` column-name convention from the result set.
+2. For each link column value:
+   - `null` → `null`.
+   - Else `JSON.parse` and validate it is a single `link@1` sigil. If not →
+     **throw** into the query `error`.
+   - Reconstruct a `Cell` from the normalized link via the runtime (the same
+     path `Cell.fromLink`/link resolution uses), carrying the column's declared
+     element schema (from `cfLink<T>()`) so downstream `.get()`/`.key()` are
+     typed.
+3. Non-link columns pass through unchanged.
+
+The decoded `Cell` is a normal reactive cell: reading it later subscribes to
+*its* contents independently of the SQL query's own reactivity (Section
+[05](./05-reactivity.md)).
+
+## Why a naming convention rather than schema-only
+
+The `*_cf_link` suffix makes the contract legible directly in SQL and in raw
+table dumps, and lets the encode/decode rules apply even when a query omits a
+`rows` schema. The schema (`cfLink<T>()`) refines it with the element type and,
+later, CFC labels — but the suffix is the load-bearing, self-documenting marker.
+This mirrors how the runtime already keys behavior off structural conventions
+rather than out-of-band registration.

--- a/docs/specs/sqlite-builtin/03-database-sources.md
+++ b/docs/specs/sqlite-builtin/03-database-sources.md
@@ -1,11 +1,21 @@
 # 03 — Database sources
 
-`sqliteDatabase(source?)` resolves a handle to one of three physical databases.
-Only the first is fully specified for v1; the other two are stubbed behind
-opaque handles so the API is stable when their backends land.
+A handle resolves to one of three physical databases. They split by **who
+chooses the source**:
+
+- **Pattern-chosen** sources come from the `sqliteDatabase(...)` builder — the
+  pattern owns the database (cell-derived default, or VM file).
+- **Injected** sources are wired into a pattern *input* from outside; the
+  pattern is source-agnostic and an operator connects a database via `cf`
+  (on-disk).
+
+Only the cell-derived source is fully specified for v1; the others are stubbed
+so the API is stable when their backends land.
 
 In all cases the **physical identity of the database is opaque to the pattern**.
-Pattern code holds a handle cell; it never names a file or attach alias.
+The handle's readable value is empty (Section [01](./01-api.md#the-handle-type));
+the source descriptor lives as server-side state keyed by the handle cell's id.
+Pattern code holds an opaque handle; it never names a file or attach alias.
 
 ## 03.1 Cell-derived (default)
 
@@ -35,13 +45,11 @@ entity id** — which is itself causal to creation and opaque to the pattern.
 
 Lifecycle:
 
-- **Create on first use.** The first `sqliteExecute` (typically a `CREATE TABLE`)
-  against a fresh handle creates the file. A query against a database with no
-  tables yet returns an empty result, not an error, for the "table exists" check
-  is deferred to the statement.
-- **Schema ownership.** v1 leaves DDL to the pattern (run `CREATE TABLE
-  IF NOT EXISTS …` via `sqliteExecute`). A future revision may let
-  `sqliteDatabase({ schema })` declare tables up front and run migrations.
+- **Create/migrate from the declared schema.** The runtime creates the file and
+  reconciles tables from `sqliteDatabase({ tables })` (Section
+  [01](./01-api.md#schema-ownership--the-database-owns-its-tables)) — patterns do
+  not run `CREATE TABLE`. Migration scope and SQLite `ALTER` limits are tracked
+  in [08-open-questions.md](./08-open-questions.md).
 - **GC.** Because the file is keyed to a cell, its lifetime can later be tied to
   that cell's lifetime. v1 does not garbage-collect; this is noted in
   [08-open-questions.md](./08-open-questions.md).
@@ -74,32 +82,64 @@ transaction. When implemented, VM-file writes will run as a post-commit effect
 commit. This limitation is intentional and called out so callers don't assume
 cross-store atomicity they won't get.
 
-## 03.3 On-disk file via `cf` (stub)
+## 03.3 On-disk file, injected via `cf` (stub)
 
-```ts
-const db = sqliteDatabase({ disk: diskHandle });
+A database that is a **plain file on disk**, opaque to the pattern. The pattern
+does **not** select it with the builder; instead it declares a database
+**input** and an operator connects a file to it via `cf`:
+
+```tsx
+// The pattern is source-agnostic — it just consumes whatever is wired into `db`.
+pattern<{ db: SqliteDatabase }>(({ db }) => {
+  const rows = sqliteQuery({ db, sql: "SELECT … FROM lookup", reactOn: db });
+  // Until connected, `rows.pending` stays true (Section 05 / Example 07-#5).
+});
 ```
 
-A database that is a **plain file on disk**, opaque to the pattern and linked in
-out-of-band via `cf` binary calls (the CLI; see the `cf` skill and
-[`packages/cli`](../../../packages/cli)). The pattern never sees the path; an
-operator runs something like `cf sqlite link ./local.db --into <cell>` to bind a
-real file to an opaque `diskHandle` cell, which the pattern then passes to
-`sqliteDatabase({ disk })`.
+```bash
+# Operator wires an on-disk SQLite file into the piece's `db` input.
+cf piece link <piece-id> db sqlite:/abs/path/reference-data.db
+```
 
-v1 contract: handle type and call shape fixed; server returns `not-implemented`
-until the `cf` linking command exists. Like the VM source, an on-disk file the
-server can co-locate with the space *could* be ATTACHed and made atomic; whether
-to require co-location is an open question
+How the `sqlite:` scheme works (it reuses `cf piece link`'s source parsing —
+[`parseLink`](../../../packages/cli/commands/piece.ts) — alongside existing
+schemes like `of:`, `did:key:`, and the `data:` URI links the runtime already
+resolves):
+
+1. `cf` recognizes the `sqlite:` scheme and **create-if-absents a handle cell**
+   whose id is **content-derived from `(space DID, absolute path)`** — the same
+   content-addressing as
+   [`createRef`](../../../packages/runner/src/create-ref.ts). The cell lives in
+   an operator/service space; the source descriptor (`{ disk: { path } }`) is
+   stored as server-side registration state (webhook-ingress style), not in the
+   cell's readable value.
+2. `cf` then writes a **normal sigil link** from the piece's `db` input field to
+   that handle cell. Because the id is deterministic, this is a genuine
+   cell-to-cell link, not a special value-write — and linking the same path
+   twice resolves to the same handle, so multiple pieces share one handle cell.
+
+**Pending-until-connected** falls out of reactivity: an unpopulated `db` input
+is an empty cell, so `sqliteQuery` reports `pending: true`; when `cf` writes the
+link, the input cell changes, the query action re-runs, and it connects. (A
+populated-but-unreachable database surfaces `error` instead.)
+
+v1 contract: the `sqlite:` registration is **stubbed** — the server returns
+`not-implemented` until on-disk attach + the `cf` command exist. Like the VM
+source, an on-disk file the server can co-locate with the space *could* be
+ATTACHed and made atomic; whether to require co-location is an open question
 ([08-open-questions.md](./08-open-questions.md)). Until then, treat on-disk
-writes as non-atomic post-commit effects.
+writes as non-atomic post-commit effects. Reactive re-query for injected
+service-space handles also carries a cross-space dirty-signal wrinkle (Section
+[05](./05-reactivity.md)); injected datasets are usually read-mostly
+(`reactOn` omitted), so this does not block v1.
 
 ## Source comparison
 
 | | Cell-derived (03.1) | VM file (03.2) | On-disk via `cf` (03.3) |
 | --- | --- | --- | --- |
-| v1 status | **Implemented** | Stub (opaque handle) | Stub (opaque handle) |
-| Identity | Cell entity id | VM handle + path | `cf`-linked disk handle |
+| v1 status | **Implemented** | Stub (builder) | Stub (injected input) |
+| Chosen by | Pattern (`sqliteDatabase()`) | Pattern (`sqliteDatabase({ vm })`) | Operator (`cf piece link sqlite:`) |
+| Identity | Handle cell entity id | VM handle + path | Handle cell id from `(space, path)` |
 | Co-located with space | Yes | No | Maybe |
 | Atomic with cell writes | **Yes** (ATTACH) | No (post-commit effect) | TBD |
 | Typical use | Pattern-owned data | Sandboxed app data | Operator-provided datasets |

--- a/docs/specs/sqlite-builtin/03-database-sources.md
+++ b/docs/specs/sqlite-builtin/03-database-sources.md
@@ -20,19 +20,23 @@ Pattern code holds an opaque handle; it never names a file or attach alias.
 ## 03.1 Cell-derived (default)
 
 ```ts
-const db = sqliteDatabase();                 // bound to the pattern's context cell
-const db = sqliteDatabase({ cell: someCell }); // bound to an explicit cell
+const db = sqliteDatabase({ tables }); // bound to a cell the runtime allocates here
 ```
 
-The database is tied to a cell, and its **name is derived from that cell's
-entity id** — which is itself causal to creation and opaque to the pattern.
+The database is tied to a cell the runtime allocates for this call, and its
+**name is derived from that cell's entity id** — which is itself causal to
+creation and opaque to the pattern.
 
+- There is **no way to point the database at an arbitrary cell**. A pattern
+  cannot pass "some other cell" as the database's identity; doing so would
+  re-introduce ambient authority (a pattern naming a cell it was never granted).
+  The handle is always the one the runtime allocates for the call (cell-derived)
+  or one injected into an input from outside (Section 03.3).
 - Cell ids are content-addressed and causally derived
   ([`packages/runner/src/create-ref.ts`](../../../packages/runner/src/create-ref.ts)).
-  When `sqliteDatabase()` is called with no argument, the runtime allocates (or
-  reuses) a handle cell in the current frame the same way other built-ins
-  allocate their result cells, so the identity is stable across re-runs and
-  rehydration but never chosen by the pattern.
+  The runtime allocates (or reuses) the handle cell in the current frame the same
+  way other built-ins allocate their result cells, so the identity is stable
+  across re-runs and rehydration but never chosen by the pattern.
 - The physical file lives in the **same space's storage directory** as the cell.
   Spaces are already stored one-SQLite-file-per-space under `engine-v3/`
   (`{encodeURIComponent(spaceDid)}.sqlite`, see

--- a/docs/specs/sqlite-builtin/03-database-sources.md
+++ b/docs/specs/sqlite-builtin/03-database-sources.md
@@ -55,11 +55,12 @@ creation and opaque to the pattern.
 
 Lifecycle:
 
-- **Create/migrate from the declared schema.** The runtime creates the file and
-  reconciles tables from `sqliteDatabase({ tables })` (Section
-  [01](./01-api.md#schema-ownership--the-database-owns-its-tables)) — patterns do
-  not run `CREATE TABLE`. Migration scope and SQLite `ALTER` limits are tracked
-  in [08-open-questions.md](./08-open-questions.md).
+- **Create/migrate from the declared schema (additive-only in V1).** The runtime
+  creates the file and reconciles tables from `sqliteDatabase({ tables })`
+  (Section [01](./01-api.md#schema-ownership--the-database-owns-its-tables)) —
+  patterns do not run `CREATE TABLE`. V1 creates missing tables and adds new
+  columns; destructive/ambiguous changes refuse to open the db (post-V1 opt-in
+  migration callback). See [08-open-questions.md](./08-open-questions.md) Q9.
 - **GC.** Because the file is keyed to a cell, its lifetime can later be tied to
   that cell's lifetime. v1 does not garbage-collect; this is noted in
   [08-open-questions.md](./08-open-questions.md).

--- a/docs/specs/sqlite-builtin/03-database-sources.md
+++ b/docs/specs/sqlite-builtin/03-database-sources.md
@@ -37,15 +37,21 @@ creation and opaque to the pattern.
   The runtime allocates (or reuses) the handle cell in the current frame the same
   way other built-ins allocate their result cells, so the identity is stable
   across re-runs and rehydration but never chosen by the pattern.
-- The physical file lives in the **same space's storage directory** as the cell.
-  Spaces are already stored one-SQLite-file-per-space under `engine-v3/`
+- **One file per database** (Q6 → Option A). The physical file lives in the
+  **same space's storage directory** as the cell. Spaces are already stored
+  one-SQLite-file-per-space under `engine-v3/`
   (`{encodeURIComponent(spaceDid)}.sqlite`, see
   [`packages/memory/v2/storage-path.ts`](../../../packages/memory/v2/storage-path.ts)).
   A cell-derived database is a **sibling file** in that directory, named from
-  the cell id, e.g. `cell-<entityhash>.sqlite`.
-- It is **ATTACHed** to the space engine's connection for the duration of any
-  transaction that writes to it, which is what makes cells-plus-rows atomic
-  (Section [04](./04-server-execution-and-transactions.md)).
+  the cell id, e.g. `cell-<entityhash>.sqlite`. Per-file gives the cleanest
+  isolation, lets the file boundary act as the SQL namespace (no identifier
+  rewriting), and makes GC/export a file operation (`backup()` / delete).
+- It is **ATTACHed** to the space engine's connection (via an attach/detach LRU
+  cache) for the duration of any transaction that touches it — which is what
+  makes cells-plus-rows atomic. Isolation against the core store relies on the
+  file boundary, the core-table-rename flag, and a tokenizer-level statement
+  guard, all detailed in Section
+  [04](./04-server-execution-and-transactions.md#isolation-namespacing--the-statement-guard).
 
 Lifecycle:
 

--- a/docs/specs/sqlite-builtin/03-database-sources.md
+++ b/docs/specs/sqlite-builtin/03-database-sources.md
@@ -1,0 +1,105 @@
+# 03 — Database sources
+
+`sqliteDatabase(source?)` resolves a handle to one of three physical databases.
+Only the first is fully specified for v1; the other two are stubbed behind
+opaque handles so the API is stable when their backends land.
+
+In all cases the **physical identity of the database is opaque to the pattern**.
+Pattern code holds a handle cell; it never names a file or attach alias.
+
+## 03.1 Cell-derived (default)
+
+```ts
+const db = sqliteDatabase();                 // bound to the pattern's context cell
+const db = sqliteDatabase({ cell: someCell }); // bound to an explicit cell
+```
+
+The database is tied to a cell, and its **name is derived from that cell's
+entity id** — which is itself causal to creation and opaque to the pattern.
+
+- Cell ids are content-addressed and causally derived
+  ([`packages/runner/src/create-ref.ts`](../../../packages/runner/src/create-ref.ts)).
+  When `sqliteDatabase()` is called with no argument, the runtime allocates (or
+  reuses) a handle cell in the current frame the same way other built-ins
+  allocate their result cells, so the identity is stable across re-runs and
+  rehydration but never chosen by the pattern.
+- The physical file lives in the **same space's storage directory** as the cell.
+  Spaces are already stored one-SQLite-file-per-space under `engine-v3/`
+  (`{encodeURIComponent(spaceDid)}.sqlite`, see
+  [`packages/memory/v2/storage-path.ts`](../../../packages/memory/v2/storage-path.ts)).
+  A cell-derived database is a **sibling file** in that directory, named from
+  the cell id, e.g. `cell-<entityhash>.sqlite`.
+- It is **ATTACHed** to the space engine's connection for the duration of any
+  transaction that writes to it, which is what makes cells-plus-rows atomic
+  (Section [04](./04-server-execution-and-transactions.md)).
+
+Lifecycle:
+
+- **Create on first use.** The first `sqliteExecute` (typically a `CREATE TABLE`)
+  against a fresh handle creates the file. A query against a database with no
+  tables yet returns an empty result, not an error, for the "table exists" check
+  is deferred to the statement.
+- **Schema ownership.** v1 leaves DDL to the pattern (run `CREATE TABLE
+  IF NOT EXISTS …` via `sqliteExecute`). A future revision may let
+  `sqliteDatabase({ schema })` declare tables up front and run migrations.
+- **GC.** Because the file is keyed to a cell, its lifetime can later be tied to
+  that cell's lifetime. v1 does not garbage-collect; this is noted in
+  [08-open-questions.md](./08-open-questions.md).
+
+This is the recommended source for almost all pattern use: durable, per-space,
+and atomic with the pattern's cells.
+
+## 03.2 VM file (stub)
+
+```ts
+const db = sqliteDatabase({ vm: vmHandle, path: "/data/app.db" });
+```
+
+A database that is a **file inside a VM**. Today VM files are reached through
+toolshed `/api` calls, which we intend to improve regardless. For this spec the
+source is **stubbed**: it assumes
+
+- an **opaque, cell-based handle to a VM** (`vmHandle: OpaqueRef<VmHandle>`),
+  resolved server-side to a concrete VM the same way other opaque
+  capability handles are, and
+- a **file path within that VM** (`path: string`).
+
+v1 contract: the handle type and call shape are fixed now; the server rejects VM
+sources with a `not-implemented` error until the improved VM file API exists.
+Atomicity guarantees (Section [04](./04-server-execution-and-transactions.md))
+are **not** offered for VM sources in v1 — a VM file cannot be ATTACHed to the
+space engine's connection, so writes to it cannot join the space commit
+transaction. When implemented, VM-file writes will run as a post-commit effect
+(like `fetchData`) with at-least-once semantics, not as part of the atomic
+commit. This limitation is intentional and called out so callers don't assume
+cross-store atomicity they won't get.
+
+## 03.3 On-disk file via `cf` (stub)
+
+```ts
+const db = sqliteDatabase({ disk: diskHandle });
+```
+
+A database that is a **plain file on disk**, opaque to the pattern and linked in
+out-of-band via `cf` binary calls (the CLI; see the `cf` skill and
+[`packages/cli`](../../../packages/cli)). The pattern never sees the path; an
+operator runs something like `cf sqlite link ./local.db --into <cell>` to bind a
+real file to an opaque `diskHandle` cell, which the pattern then passes to
+`sqliteDatabase({ disk })`.
+
+v1 contract: handle type and call shape fixed; server returns `not-implemented`
+until the `cf` linking command exists. Like the VM source, an on-disk file the
+server can co-locate with the space *could* be ATTACHed and made atomic; whether
+to require co-location is an open question
+([08-open-questions.md](./08-open-questions.md)). Until then, treat on-disk
+writes as non-atomic post-commit effects.
+
+## Source comparison
+
+| | Cell-derived (03.1) | VM file (03.2) | On-disk via `cf` (03.3) |
+| --- | --- | --- | --- |
+| v1 status | **Implemented** | Stub (opaque handle) | Stub (opaque handle) |
+| Identity | Cell entity id | VM handle + path | `cf`-linked disk handle |
+| Co-located with space | Yes | No | Maybe |
+| Atomic with cell writes | **Yes** (ATTACH) | No (post-commit effect) | TBD |
+| Typical use | Pattern-owned data | Sandboxed app data | Operator-provided datasets |

--- a/docs/specs/sqlite-builtin/04-server-execution-and-transactions.md
+++ b/docs/specs/sqlite-builtin/04-server-execution-and-transactions.md
@@ -166,27 +166,25 @@ Goal: transactions are **atomic across cells and the attached SQLite database**.
   `PRAGMAS`). With WAL, cross-file atomic commit is **not guaranteed across a
   crash** mid-commit: one file's WAL frame may be durable while the other's is
   not. In normal (no-crash) operation the commit is atomic.
-- **Post-crash reconciliation.** To preserve the invariant despite the WAL
-  caveat, each cross-store commit records an **in-doubt marker** keyed by the
-  space `seq` before the SQLite write, cleared on successful commit. On startup,
-  the engine scans for in-doubt markers and **rolls back** any SQLite-side
-  changes for a `seq` that did not also land on the space side (and vice
-  versa), bringing the two stores back into agreement. This is the
-  "rollback things that are in doubt, just in case" flow.
-
-  Concretely: the commit table already records each `seq`
-  ([`packages/memory/v2/engine.ts`](../../../packages/memory/v2/engine.ts)
-  `insertCommit`). The attached db gets a small `_cf_commit_watermark` table
-  recording the last `seq` whose SQLite writes are known-durable. On open, if the
-  space's committed `seq` and the attached watermark disagree, the in-doubt
-  range is reverted on whichever side raced ahead.
+- **Post-crash safety (V1: detect + quarantine).** Each attached db carries a
+  small `_cf_commit_watermark(seq)` row, written **inside** the commit txn and
+  advanced on commit; the commit also **persists its `sqlite` ops** in the commit
+  record. On open, the engine compares the space's committed `seq` (the `commit`
+  table, [`packages/memory/v2/engine.ts`](../../../packages/memory/v2/engine.ts)
+  `insertCommit`) against each attached db's watermark. If they **disagree** —
+  the only thing the WAL crash window can cause — the engine **quarantines** that
+  pattern db: it fails the db's queries with a clear error and logs loudly,
+  rather than serving divergent data. It does **not** silently proceed.
+- **Auto-repair is deferred** (fast-follow): replay the persisted ops for a db
+  that is *behind*, truncate orphaned in-doubt writes for one that is *ahead*,
+  then lift the quarantine. Persisting ops + the watermark in V1 means this needs
+  no later schema migration.
 
 > Implementation reality check: `@db/sqlite` exposes a single synchronous
-> connection per `Database`; ATTACH + shared-connection transactions are the
-> mechanism that buys normal-operation atomicity here. The watermark/in-doubt
-> scan is the safety net for the crash window WAL leaves open. The exact
-> revert-on-open algorithm is sketched, not finalized — see
-> [08-open-questions.md](./08-open-questions.md).
+> connection per `Database`; ATTACH + shared-connection transactions buy
+> normal-operation atomicity. Per-commit checkpoint+fsync of both files was
+> rejected — it doesn't close the crash window and kills WAL throughput. See
+> [08-open-questions.md](./08-open-questions.md) Q7.
 
 ## Concurrency
 

--- a/docs/specs/sqlite-builtin/04-server-execution-and-transactions.md
+++ b/docs/specs/sqlite-builtin/04-server-execution-and-transactions.md
@@ -16,13 +16,47 @@ and `session.watch.*`.
   ([`packages/toolshed/routes/storage/memory/memory.routes.ts`](../../../packages/toolshed/routes/storage/memory/memory.routes.ts)),
   authorized via UCAN on session open.
 - Cell-derived SQLite databases (Section [03](./03-database-sources.md)) are
-  sibling files in the same storage directory and are **ATTACHed** to
-  `engine.database` so SQL statements against them share the engine's
-  connection and transactions.
+  **one sibling file per database** in the same storage directory (Q6 → Option
+  A) and are **ATTACHed** to `engine.database` so SQL statements against them
+  share the engine's connection and transactions.
 
 Because we ride the same connection, queries inherit the session's existing
 authorization; no new auth surface is added in v1. (CFC will later refine *what*
 within the space a query may touch — Section [06](./06-cfc.md).)
+
+## Isolation, namespacing & the statement guard
+
+A pattern's SQL runs on the same connection as the authoritative memory store,
+so isolation is load-bearing. The design relies on three things, none of which
+needs a full SQL parser:
+
+- **File boundary = namespace.** SQLite's only namespace primitive is the
+  attached-database alias, so one file per cell-derived db *is* the namespace.
+  We ATTACH only the handle's own db for a given statement/commit; an unqualified
+  `messages` resolves to it (SQLite resolves `main → temp → attached-in-order`),
+  with **no identifier rewriting**.
+- **Core-table rename flag.** To remove the risk that an unqualified pattern name
+  shadows/leaks a core table (`commit`, `revision`, `head`, `snapshot`,
+  `branch`, `scheduler_*`, `blob_store`), rename the engine's core tables to
+  include the space DID (e.g. `commit__<did>`), behind a flag. Pre-production we
+  may ship unflagged and tolerate shadowing temporarily.
+- **Tokenizer-level statement guard.** `@db/sqlite` exposes **no authorizer**
+  (`sqlite3_set_authorizer` is not bound — confirmed against the library), so we
+  cannot get SQLite to enumerate accessed objects for us. Instead the guard
+  rejects: any **schema-qualified** reference (`other.table`), `ATTACH`/`DETACH`/
+  `PRAGMA`, and **multiple statements**; `sqliteQuery` additionally requires a
+  single `SELECT`/read-only CTE. Because we never rewrite identifiers, this is a
+  tokenizer-level check, not full resolution. (A future hardening option: bind
+  `sqlite3_set_authorizer` ourselves via Deno FFI against the `unsafeHandle`
+  pointer — defense-in-depth, not required for v1.)
+
+**Attach/detach cache.** `@db/sqlite` exposes no `sqlite3_limit` binding, so
+`SQLITE_LIMIT_ATTACHED` stays at the compiled default (≈10). An **LRU
+attach/detach cache** attaches a db on demand and `DETACH`es the least-recently-
+used near the limit. Manage it at **transaction boundaries** (ATTACH before
+`BEGIN`; DETACH only when idle — a db in use / inside a transaction cannot be
+detached). A single commit almost always touches one pattern db (2 schemas),
+far under the limit; a transaction that would span more is rejected or split.
 
 ## Protocol extension
 
@@ -56,10 +90,11 @@ Server handling (mirrors `Server.transact` / `Server.queryGraph`):
 1. Route the new `type` in `Connection.receiveOrdered`, guarded by
    `requireSession`.
 2. `const engine = await this.openEngine(space)`.
-3. ATTACH the db file if not already attached for this connection.
-4. **Reject non-read statements.** Parse/inspect to confirm a single `SELECT` or
-   read-only CTE; reject `INSERT`/`UPDATE`/`DELETE`/`PRAGMA`/`ATTACH`/multiple
-   statements with a `read-only-violation` error.
+3. ATTACH the db file via the attach/detach cache (above) if not already
+   attached.
+4. **Apply the statement guard** (above): single `SELECT`/read-only CTE; reject
+   DML/DDL, schema-qualified references, `PRAGMA`/`ATTACH`/`DETACH`, and multiple
+   statements, with a `read-only-violation` / `guard-violation` error.
 5. `engine.database.prepare(sql).all(params)` → rows.
 6. Reply with `{ type: "response", requestId, ok: { rows } }`.
 

--- a/docs/specs/sqlite-builtin/04-server-execution-and-transactions.md
+++ b/docs/specs/sqlite-builtin/04-server-execution-and-transactions.md
@@ -1,0 +1,166 @@
+# 04 — Server-side execution & transactions
+
+Queries and writes execute **inside toolshed**, which already hosts the space
+and owns its SQLite engine. The runtime reaches them over the **existing
+space-scoped websocket** — the same connection used for `transact`, `graph.query`,
+and `session.watch.*`.
+
+## Where execution happens
+
+- Each space is a single `@db/sqlite` `Database` opened by the memory engine
+  ([`packages/memory/v2/engine.ts`](../../../packages/memory/v2/engine.ts),
+  `open()` → `engine.database`), cached one-per-space by the server
+  ([`packages/memory/v2/server.ts`](../../../packages/memory/v2/server.ts),
+  `openEngine(space)`).
+- The space websocket is served at `/api/storage/memory?space=<did>`
+  ([`packages/toolshed/routes/storage/memory/memory.routes.ts`](../../../packages/toolshed/routes/storage/memory/memory.routes.ts)),
+  authorized via UCAN on session open.
+- Cell-derived SQLite databases (Section [03](./03-database-sources.md)) are
+  sibling files in the same storage directory and are **ATTACHed** to
+  `engine.database` so SQL statements against them share the engine's
+  connection and transactions.
+
+Because we ride the same connection, queries inherit the session's existing
+authorization; no new auth surface is added in v1. (CFC will later refine *what*
+within the space a query may touch — Section [06](./06-cfc.md).)
+
+## Protocol extension
+
+The v2 protocol is a discriminated union of message `type`s
+([`packages/memory/v2.ts`](../../../packages/memory/v2.ts), `ClientMessage` /
+server messages; parsed in `parseClientMessage`, routed in
+`Connection.receiveOrdered`, correlated by `requestId` in
+[`packages/memory/v2/client.ts`](../../../packages/memory/v2/client.ts)). It is
+extensible by adding variants. We add **one new read verb** and **fold writes
+into the existing `transact` commit**.
+
+### Reads: `sqlite.query` (new verb)
+
+```ts
+interface SqliteQueryRequest {
+  type: "sqlite.query";
+  requestId: string;
+  space: string;
+  sessionId: SessionId;
+  db: SqliteDbRef;            // resolved source descriptor (Section 03)
+  sql: string;               // single read-only statement
+  params?: unknown[] | Record<string, unknown>;
+}
+
+// Response rides the existing ResponseMessage envelope:
+//   { type: "response", requestId, ok?: { rows: unknown[] }, error?: V2Error }
+```
+
+Server handling (mirrors `Server.transact` / `Server.queryGraph`):
+
+1. Route the new `type` in `Connection.receiveOrdered`, guarded by
+   `requireSession`.
+2. `const engine = await this.openEngine(space)`.
+3. ATTACH the db file if not already attached for this connection.
+4. **Reject non-read statements.** Parse/inspect to confirm a single `SELECT` or
+   read-only CTE; reject `INSERT`/`UPDATE`/`DELETE`/`PRAGMA`/`ATTACH`/multiple
+   statements with a `read-only-violation` error.
+5. `engine.database.prepare(sql).all(params)` → rows.
+6. Reply with `{ type: "response", requestId, ok: { rows } }`.
+
+`_cf_link` decoding (Section [02](./02-cf-link-encoding.md)) happens **on the
+client** after the rows return, because reconstructing a `Cell` needs the
+runtime. The server returns raw strings.
+
+### Writes: folded into `transact`
+
+Writes are **not** a separate RPC. They are appended to the commit that the
+write built-in's transaction already produces, so they apply in the **same
+SQLite transaction** as the cell writes.
+
+The client commit (`ClientCommit` in
+[`packages/memory/v2.ts`](../../../packages/memory/v2.ts)) carries an
+`operations: Operation[]` list applied inside
+`engine.database.transaction(applyCommitTransaction).immediate(...)`
+([`packages/memory/v2/engine.ts`](../../../packages/memory/v2/engine.ts)
+`applyCommit` → `applyCommitTransaction`, which iterates operations through
+`writeOperation`). We add a new operation kind:
+
+```ts
+interface SqliteOperation {
+  op: "sqlite";
+  db: SqliteDbRef;       // which attached database
+  sql: string;           // write statement(s)
+  params?: unknown[] | Record<string, unknown>; // _cf_link params pre-encoded by client
+}
+```
+
+`writeOperation` gains a `case "sqlite"` that, for a cell-derived db:
+
+1. Ensures the db is ATTACHed to `engine.database` (the connection already
+   inside the open transaction).
+2. Executes the statement via the same connection — so it is part of the very
+   `.immediate()` transaction that writes cell revisions. Either everything
+   commits or everything rolls back.
+
+`_cf_link` parameters are **encoded on the client** (Section
+[02](./02-cf-link-encoding.md)) before the operation is placed in the commit, so
+the server stores ready-made link strings and never needs runtime cell access.
+
+This keeps the atomicity property the runtime already relies on: a commit is one
+SQLite transaction with a single global `seq`. Cell writes and SQLite writes
+land together.
+
+## Ordering within a commit
+
+Per the goals, **writes are executed after** the rest of the commit's cell
+operations, and **read-after-write within the same transaction fails**:
+
+- `sqlite` operations are ordered last among the commit's operations.
+- A `sqlite.query` issued from inside the same transaction that has pending
+  (uncommitted) `sqlite` writes is rejected with a `read-after-write-unsupported`
+  error. v1 does not simulate the pending write. (The write built-in records
+  that its db has pending writes in the current transaction; a query against
+  that db in the same transaction throws rather than reading stale state.)
+
+## Atomicity across cells and SQLite (and WAL caveat)
+
+Goal: transactions are **atomic across cells and the attached SQLite database**.
+
+- **Normal operation.** Because the attached db shares the engine connection,
+  `BEGIN … COMMIT` spans the main space db and the attached db. SQLite commits
+  attached databases atomically when they share a connection and journal
+  coordination — so in the no-crash path, cells and rows commit together.
+- **WAL caveat.** The engine runs `PRAGMA journal_mode = WAL`
+  ([`packages/memory/v2/engine.ts`](../../../packages/memory/v2/engine.ts)
+  `PRAGMAS`). With WAL, cross-file atomic commit is **not guaranteed across a
+  crash** mid-commit: one file's WAL frame may be durable while the other's is
+  not. In normal (no-crash) operation the commit is atomic.
+- **Post-crash reconciliation.** To preserve the invariant despite the WAL
+  caveat, each cross-store commit records an **in-doubt marker** keyed by the
+  space `seq` before the SQLite write, cleared on successful commit. On startup,
+  the engine scans for in-doubt markers and **rolls back** any SQLite-side
+  changes for a `seq` that did not also land on the space side (and vice
+  versa), bringing the two stores back into agreement. This is the
+  "rollback things that are in doubt, just in case" flow.
+
+  Concretely: the commit table already records each `seq`
+  ([`packages/memory/v2/engine.ts`](../../../packages/memory/v2/engine.ts)
+  `insertCommit`). The attached db gets a small `_cf_commit_watermark` table
+  recording the last `seq` whose SQLite writes are known-durable. On open, if the
+  space's committed `seq` and the attached watermark disagree, the in-doubt
+  range is reverted on whichever side raced ahead.
+
+> Implementation reality check: `@db/sqlite` exposes a single synchronous
+> connection per `Database`; ATTACH + shared-connection transactions are the
+> mechanism that buys normal-operation atomicity here. The watermark/in-doubt
+> scan is the safety net for the crash window WAL leaves open. The exact
+> revert-on-open algorithm is sketched, not finalized — see
+> [08-open-questions.md](./08-open-questions.md).
+
+## Concurrency
+
+- The engine connection is single-threaded/synchronous; `sqlite.query` reads and
+  `transact`-folded writes serialize on it like all other engine work. Long
+  queries therefore block the space; v1 should guard with a statement timeout
+  and (later) consider a read replica or a separate read connection in WAL mode.
+- Multi-tab / multi-client coordination for the *write* side is inherited from
+  the existing commit model (seq-based validation, optimistic local commit,
+  server confirmation), so no new mutex is needed for writes. (Contrast
+  `fetchData`, which needs `tryClaimMutex` because it has no transactional
+  backstop.)

--- a/docs/specs/sqlite-builtin/05-reactivity.md
+++ b/docs/specs/sqlite-builtin/05-reactivity.md
@@ -1,9 +1,9 @@
 # 05 — Reactivity
 
 SQLite is not itself reactive: nothing in the runtime's read-tracking observes a
-`SELECT`. v1 makes queries reactive with an explicit, coarse mechanism —
-**parallel reactivity cells that change when a query should be redone** — which
-gets us a long way without a query-dependency analyzer.
+`SELECT`. v1 makes queries reactive with an explicit, coarse mechanism — **the
+handle cell itself stands in for "this database changed"** — which gets us a
+long way without a query-dependency analyzer.
 
 ## The model
 
@@ -12,18 +12,21 @@ gets us a long way without a query-dependency analyzer.
   everything it transitively links to. When `reactOn`'s **committed** value
   changes, the scheduler re-runs the query action, which re-issues
   `sqlite.query` and writes fresh rows into its result cell.
-- Every database handle exposes a `version: number` field. The **write path
-  bumps `db.version` after the write commits durably** (see "Committed, not
-  in-flight" below). A query with `reactOn: db.version` therefore re-runs after
-  any committed write to that database — the simplest correct default.
+- Pass **the whole `db` handle** as `reactOn`. The built-in recovers its handle
+  cell (via `toCell`, Section [01](./01-api.md#the-handle-type)) and subscribes
+  to it. The **write path marks that handle cell dirty after the write commits
+  durably** (see "Committed, not in-flight"), so `reactOn: db` means "any
+  committed write to this database re-runs the query." There is **no readable
+  `version` field** — nothing for code to depend on out of band; the handle cell
+  is the token.
 - Authors who want tighter invalidation pass a narrower cell as `reactOn` (e.g. a
-  per-table or per-topic version cell they bump themselves from the same handler
-  that writes), trading precision for manual bookkeeping. v1 does not parse SQL
-  to compute fine-grained read sets.
+  per-table or per-topic cell they bump themselves from the same handler that
+  writes), trading precision for manual bookkeeping. v1 does not parse SQL to
+  compute fine-grained read sets.
 
 This is deliberately the same shape the runtime uses elsewhere: reactivity is
-driven by observing cells, and the SQL layer manufactures a cell (`version`)
-whose changes stand in for "the query's underlying data may have changed."
+driven by observing cells, and the handle cell's post-commit dirtying stands in
+for "the query's underlying data may have changed."
 
 ## Committed, not in-flight
 
@@ -38,31 +41,37 @@ in-flight writes. This matters because:
   transaction has actually run on the server. Re-running the query against an
   optimistic local state would read rows that don't exist server-side yet.
 
-Therefore `db.version` must be bumped **on durable commit**, not on the
+Therefore the handle cell must be dirtied **on durable commit**, not on the
 optimistic local write. Two viable mechanisms, in preference order:
 
 1. **Server-driven (preferred).** When `applyCommitTransaction` applies a
    `sqlite` operation (Section [04](./04-server-execution-and-transactions.md)),
-   the server marks the database's reactivity key dirty for the space — exactly
-   how cell writes mark entities dirty
+   the server marks the **handle cell's entity** dirty — exactly how cell writes
+   mark entities dirty
    ([`packages/memory/v2/server.ts`](../../../packages/memory/v2/server.ts)
-   `markSpaceDirty`). The session push (`session/effect`) carries the new
-   `version`, which lands in the handle cell only after the commit is durable.
-   The query, watching `db.version`, re-runs. This naturally satisfies
-   "committed only," because the value only changes via the server's
-   post-commit sync.
-
-2. **Client post-commit bump.** Failing a server hook, the write built-in bumps
-   `db.version` from a **post-commit effect** rather than inline — the same
-   `enqueueSinkRequestPostCommitEffect` seam `fetchData`/`llm` use
+   `markSpaceDirty`, which already works per entity id). The session push
+   (`session/effect`) reaches the query only after the commit is durable, so the
+   re-run sees committed state. For the cell-derived default the handle cell
+   lives in the same space as the commit, so this is a same-space dirty signal.
+2. **Client post-commit bump.** Failing a server hook, the write built-in
+   touches the handle cell from a **post-commit effect** rather than inline — the
+   same `enqueueSinkRequestPostCommitEffect` seam `fetchData`/`llm` use
    ([`packages/runner/src/builtins/fetch-data.ts`](../../../packages/runner/src/builtins/fetch-data.ts),
    [`packages/runner/src/cfc/sink-request.ts`](../../../packages/runner/src/cfc/sink-request.ts)).
-   The effect runs only after the surrounding transaction commits, so the bump —
-   and the dependent re-query — sees committed state.
+   The effect runs only after the surrounding transaction commits, so the
+   dependent re-query sees committed state.
 
 Either way, the **reactive part waits for fully-committed writes**, which (as
 the goals note) may require going through a path other than the regular
 scheduler's in-flight propagation.
+
+**Injected service-space handles (cross-space wrinkle).** For a `cf`-injected
+on-disk database (Section [03.3](./03-database-sources.md)), the handle cell
+lives in an operator/service space while the SQLite write rides the *pattern's*
+space commit — so the post-commit dirty signal must cross spaces. That is an
+extra mechanism beyond same-space `markSpaceDirty`; it lands with the rest of
+the injected-source stub. Injected datasets are usually read-mostly (`reactOn`
+omitted), so this does not block v1.
 
 ## A general feature this motivates
 
@@ -71,7 +80,7 @@ The clean way to express "re-run only on committed inputs" is to let an action
 re-run the action on transient/optimistic changes to those inputs and wait for
 the committed value. That is a generally useful scheduler capability beyond
 SQLite (any effect that must not act on speculative state benefits). v1 emulates
-it with the post-commit `version` bump; a follow-up could promote it to a
+it with the post-commit handle-cell dirtying; a follow-up could promote it to a
 first-class scheduler annotation (e.g. `committedReads`), at which point
 `sqliteQuery` would declare `reactOn` as commit-only and drop the manual bump.
 Tracked in [08-open-questions.md](./08-open-questions.md).
@@ -84,4 +93,4 @@ Tracked in [08-open-questions.md](./08-open-questions.md).
   reads it will update when *it* changes, independent of the query. This keeps
   query re-execution coarse while still letting per-cell reactivity flow through
   normally.
-- Writes to *other* databases do not bump this `db.version`.
+- Writes to *other* databases dirty *their* handle cells, not this one.

--- a/docs/specs/sqlite-builtin/05-reactivity.md
+++ b/docs/specs/sqlite-builtin/05-reactivity.md
@@ -1,0 +1,87 @@
+# 05 — Reactivity
+
+SQLite is not itself reactive: nothing in the runtime's read-tracking observes a
+`SELECT`. v1 makes queries reactive with an explicit, coarse mechanism —
+**parallel reactivity cells that change when a query should be redone** — which
+gets us a long way without a query-dependency analyzer.
+
+## The model
+
+- `sqliteQuery` takes a `reactOn` input. The built-in reads it **wholesale under
+  an `any` schema**, so the scheduler records a dependency on that value and
+  everything it transitively links to. When `reactOn`'s **committed** value
+  changes, the scheduler re-runs the query action, which re-issues
+  `sqlite.query` and writes fresh rows into its result cell.
+- Every database handle exposes a `version: number` field. The **write path
+  bumps `db.version` after the write commits durably** (see "Committed, not
+  in-flight" below). A query with `reactOn: db.version` therefore re-runs after
+  any committed write to that database — the simplest correct default.
+- Authors who want tighter invalidation pass a narrower cell as `reactOn` (e.g. a
+  per-table or per-topic version cell they bump themselves from the same handler
+  that writes), trading precision for manual bookkeeping. v1 does not parse SQL
+  to compute fine-grained read sets.
+
+This is deliberately the same shape the runtime uses elsewhere: reactivity is
+driven by observing cells, and the SQL layer manufactures a cell (`version`)
+whose changes stand in for "the query's underlying data may have changed."
+
+## Committed, not in-flight
+
+The query must re-run against **fully-committed** data, never optimistic
+in-flight writes. This matters because:
+
+- The scheduler lets an action see its *own* uncommitted writes within a
+  transaction, and propagates to other readers only after commit (per the
+  scheduler's transaction model and own-commit-source skip in
+  [`packages/runner/src/scheduler/`](../../../packages/runner/src/scheduler/)).
+- A SQLite write only becomes visible to a `sqlite.query` once its commit
+  transaction has actually run on the server. Re-running the query against an
+  optimistic local state would read rows that don't exist server-side yet.
+
+Therefore `db.version` must be bumped **on durable commit**, not on the
+optimistic local write. Two viable mechanisms, in preference order:
+
+1. **Server-driven (preferred).** When `applyCommitTransaction` applies a
+   `sqlite` operation (Section [04](./04-server-execution-and-transactions.md)),
+   the server marks the database's reactivity key dirty for the space — exactly
+   how cell writes mark entities dirty
+   ([`packages/memory/v2/server.ts`](../../../packages/memory/v2/server.ts)
+   `markSpaceDirty`). The session push (`session/effect`) carries the new
+   `version`, which lands in the handle cell only after the commit is durable.
+   The query, watching `db.version`, re-runs. This naturally satisfies
+   "committed only," because the value only changes via the server's
+   post-commit sync.
+
+2. **Client post-commit bump.** Failing a server hook, the write built-in bumps
+   `db.version` from a **post-commit effect** rather than inline — the same
+   `enqueueSinkRequestPostCommitEffect` seam `fetchData`/`llm` use
+   ([`packages/runner/src/builtins/fetch-data.ts`](../../../packages/runner/src/builtins/fetch-data.ts),
+   [`packages/runner/src/cfc/sink-request.ts`](../../../packages/runner/src/cfc/sink-request.ts)).
+   The effect runs only after the surrounding transaction commits, so the bump —
+   and the dependent re-query — sees committed state.
+
+Either way, the **reactive part waits for fully-committed writes**, which (as
+the goals note) may require going through a path other than the regular
+scheduler's in-flight propagation.
+
+## A general feature this motivates
+
+The clean way to express "re-run only on committed inputs" is to let an action
+**declare specific inputs as commit-only** — the scheduler would refuse to
+re-run the action on transient/optimistic changes to those inputs and wait for
+the committed value. That is a generally useful scheduler capability beyond
+SQLite (any effect that must not act on speculative state benefits). v1 emulates
+it with the post-commit `version` bump; a follow-up could promote it to a
+first-class scheduler annotation (e.g. `committedReads`), at which point
+`sqliteQuery` would declare `reactOn` as commit-only and drop the manual bump.
+Tracked in [08-open-questions.md](./08-open-questions.md).
+
+## What does *not* trigger re-run
+
+- Changes to the **contents of cells referenced by `_cf_link` columns** do not,
+  by themselves, re-run the query — the query only re-reads rows. A decoded
+  `Cell` in a result row is, however, a normal reactive cell: a `derive` that
+  reads it will update when *it* changes, independent of the query. This keeps
+  query re-execution coarse while still letting per-cell reactivity flow through
+  normally.
+- Writes to *other* databases do not bump this `db.version`.

--- a/docs/specs/sqlite-builtin/06-cfc.md
+++ b/docs/specs/sqlite-builtin/06-cfc.md
@@ -30,9 +30,10 @@ which is the seam SQLite writes will use.
 
 ## Per-column labels
 
-A column's label is declared on the table/row schema's `ifc`, reusing the exact
-mechanism schemas already support. `cfLink<T>()` and `table(...)` (Section
-[01](./01-api.md)) pass `ifc` through per field:
+A column's label is declared on the database's table schema's `ifc`, reusing the
+exact mechanism schemas already support. `cfLink<T>()` and `table(...)` (the
+schemas registered via `sqliteDatabase({ tables })`, Section [01](./01-api.md))
+pass `ifc` through per field:
 
 ```tsx
 const EmailRowSchema = table({

--- a/docs/specs/sqlite-builtin/06-cfc.md
+++ b/docs/specs/sqlite-builtin/06-cfc.md
@@ -1,0 +1,119 @@
+# 06 — CFC (deferred phase)
+
+CFC enforcement is **out of scope for v1** but the API is shaped so it slots in
+without rework. Once added, it covers **both confidentiality and integrity**,
+**per column** and **per row**.
+
+## Background: the existing label model
+
+CFC labels are open-ended sets of **atoms** (immutable JSON values), not a fixed
+classification lattice
+([`packages/runner/src/cfc.ts`](../../../packages/runner/src/cfc.ts);
+`packages/api/cfc-atoms.ts`). A schema attaches labels through its `ifc` field
+([`packages/api/index.ts`](../../../packages/api/index.ts)):
+
+- `confidentiality` — who may read (set of atoms; principals are common atoms,
+  e.g. `did:mailto:…`, `did:key:…`).
+- `integrity` / `addIntegrity` / `requiredIntegrity` — provenance/authenticity
+  guarantees.
+- `maxConfidentiality` — a ceiling the output may not exceed.
+- `ownerPrincipal`, `writeAuthorizedBy` — access/authorization control;
+  `{ __ctCurrentPrincipal: true }` resolves to the acting principal at
+  prepare-time.
+
+Labels join by **union with structural dedup** (`deepEqual`), and confidentiality
+is checked by "every atom in the label fits under the destination's
+`maxConfidentiality` ceiling." Async effects already declare a **write policy**
+before committing side effects via the sink-request mechanism
+([`packages/runner/src/cfc/sink-request.ts`](../../../packages/runner/src/cfc/sink-request.ts)),
+which is the seam SQLite writes will use.
+
+## Per-column labels
+
+A column's label is declared on the table/row schema's `ifc`, reusing the exact
+mechanism schemas already support. `cfLink<T>()` and `table(...)` (Section
+[01](./01-api.md)) pass `ifc` through per field:
+
+```tsx
+const EmailRowSchema = table({
+  id: "integer",
+  subject: { type: "text" },
+  // body is confidential to a fixed support principal
+  body: { type: "text", ifc: { confidentiality: [supportPrincipalAtom] } },
+  from_email: { type: "text" },
+});
+```
+
+On **read**, columns labeled confidential contribute their atoms to the result
+cell's label, so a `derive` consuming them inherits the confidentiality (label
+propagation, exactly as for cell reads today). On **write**, a value bound to a
+labeled column must satisfy that column's `requiredIntegrity` / ceiling.
+
+This is a clean fit because the row schema is *already* a JSON Schema and `ifc`
+is *already* understood by `ContextualFlowControl`.
+
+## Per-row labels derived from a field
+
+The motivating case: an email row's confidentiality should be to the user, the
+sender, and all recipients — constructed from row data, e.g.
+`"did:mailto:" + from_email`. This is **data-dependent**, so it cannot be a
+static schema label; it must be computed from the row's values at write time and
+re-derived at read time.
+
+Proposed surface: a **row-label rule** on the table schema that maps row fields
+to label atoms. It is a declarative projection (so it can run on the server
+during the commit and during reads) rather than arbitrary pattern code:
+
+```tsx
+const EmailRowSchema = table(
+  {
+    id: "integer",
+    from_email: "text",
+    to_emails: "text", // JSON array of addresses
+    body: "text",
+  },
+  {
+    // Per-row confidentiality derived from row fields.
+    rowConfidentiality: (row) => [
+      principal(row.from_email),          // "did:mailto:" + from_email
+      ...jsonArray(row.to_emails).map(principal),
+      currentUserPrincipal(),             // resolves to the viewing/owning user
+    ],
+  },
+);
+```
+
+Semantics:
+
+- **On write**, the rule is evaluated against the inserted/updated row to
+  produce the row's confidentiality atom set, recorded as the write's CFC
+  policy input via the sink-request path before commit. The write is rejected if
+  it would exceed the destination ceiling or fail required integrity.
+- **On read**, the same rule re-derives each row's label from its column values,
+  and the row's cell label is the **join** of the per-column labels and the
+  per-row label. Rows the reader is not cleared for are filtered (or the query
+  fails closed), per the standard confidentiality check.
+- The rule must be a **pure projection over the row's own fields** (plus
+  runtime-resolved principals like `currentUserPrincipal()`), so it is
+  evaluable both server-side at commit and client-side at read without running
+  pattern code. Helpers like `principal(field)` compile to
+  `"did:mailto:" + field` (or `did:key:` etc. by helper variant).
+
+## Why this stays declarative
+
+Keeping row labels as a declarative projection (rather than a callback into
+pattern code) lets the **server** evaluate them at commit time — necessary
+because the atomic write happens inside `applyCommitTransaction` server-side
+(Section [04](./04-server-execution-and-transactions.md)), where pattern code
+does not run. It also makes labels auditable: a row's confidentiality is a pure
+function of its stored columns, recomputable at any time.
+
+## Phasing
+
+1. **v1 (this spec):** no enforcement; `_cf_link` round-tripping only. Schemas
+   *may* carry `ifc` but it is ignored.
+2. **Phase 2 — per-column:** honor static `ifc` on columns for read-label
+   propagation and write-time checks, reusing `ContextualFlowControl` and the
+   sink-request write policy.
+3. **Phase 3 — per-row:** add the row-label projection, evaluated at commit and
+   read; integrate with row-level filtering/fail-closed reads.

--- a/docs/specs/sqlite-builtin/07-examples.md
+++ b/docs/specs/sqlite-builtin/07-examples.md
@@ -26,7 +26,7 @@ interface User { name: string; avatarUrl: string }
 export default pattern<{ me: Cell<User> }>(({ me }) => {
   // Cell-derived, per-space, atomic. Tables are declared once here; the runtime
   // owns creation/migration — no CREATE TABLE in pattern code.
-  const db = sqliteDatabase(undefined, {
+  const db = sqliteDatabase({
     tables: {
       messages: table({
         id: "integer primary key",

--- a/docs/specs/sqlite-builtin/07-examples.md
+++ b/docs/specs/sqlite-builtin/07-examples.md
@@ -23,33 +23,26 @@ import {
 
 interface User { name: string; avatarUrl: string }
 
-const MessageRow = table({
-  id: "integer",
-  body: "text",
-  ts: "integer",
-  author_cf_link: cfLink<User>(), // TEXT in SQLite, Cell<User> in TS
-});
-type MessageRow = RowOf<typeof MessageRow>;
-
 export default pattern<{ me: Cell<User> }>(({ me }) => {
-  const db = sqliteDatabase(); // cell-derived, per-space, atomic
-
-  // One-time-ish schema setup (idempotent).
-  sqliteExecute({
-    db,
-    sql: `CREATE TABLE IF NOT EXISTS messages (
-            id INTEGER PRIMARY KEY,
-            author_cf_link TEXT,
-            body TEXT,
-            ts INTEGER
-          )`,
+  // Cell-derived, per-space, atomic. Tables are declared once here; the runtime
+  // owns creation/migration — no CREATE TABLE in pattern code.
+  const db = sqliteDatabase(undefined, {
+    tables: {
+      messages: table({
+        id: "integer primary key",
+        author_cf_link: cfLink<User>(), // TEXT in SQLite, Cell<User> in TS
+        body: "text",
+        ts: "integer",
+      }),
+    },
   });
 
-  const recent = sqliteQuery<MessageRow>({
+  // No <Row> needed: the projection maps 1:1 to the declared `messages` table,
+  // so the runtime already knows `author_cf_link` is a link column.
+  const recent = sqliteQuery({
     db,
     sql: "SELECT id, body, ts, author_cf_link FROM messages ORDER BY ts DESC LIMIT 20",
-    reactOn: db.version, // re-run after any committed write to this db
-    rows: MessageRow,
+    reactOn: db, // re-run after any committed write to this db
   });
 
   const send = handler<{ body: string }, { author: Cell<User> }>(
@@ -57,8 +50,7 @@ export default pattern<{ me: Cell<User> }>(({ me }) => {
       sqliteExecute({
         db,
         sql: "INSERT INTO messages (author_cf_link, body, ts) VALUES (?, ?, ?)",
-        params: [author, body, Date.now()], // `author` Cell -> sigil link
-        bind: MessageRow, // tells the runtime param 1 is a _cf_link
+        params: [author, body, Date.now()], // `author` Cell -> sigil link (param 1 targets a _cf_link column)
       });
     },
   );
@@ -78,30 +70,38 @@ export default pattern<{ me: Cell<User> }>(({ me }) => {
 
 Key points:
 
-- `params: [author, …]` binds a `Cell<User>` to the `author_cf_link` column; the
-  runtime encodes it to an absolute sigil link string (Section
-  [02](./02-cf-link-encoding.md)). Binding the same cell to `body` would throw.
-- `recent` re-runs only after the `INSERT` **commits durably** (Section
-  [05](./05-reactivity.md)), so it never shows phantom rows.
+- The database owns the `messages` schema, so `author_cf_link` is known to be a
+  link column without any per-query/per-write annotation. Binding the `author`
+  cell to a non-link column (e.g. `body`) would throw (Section
+  [02](./02-cf-link-encoding.md)).
+- `reactOn: db` subscribes to the handle cell; the `INSERT` marks it dirty only
+  after it **commits durably** (Section [05](./05-reactivity.md)), so `recent`
+  never shows phantom rows.
 - Each `m.author_cf_link` decodes to a `Cell<User>`; the inner `derive` updates
   if that user's name changes, without re-running the SQL query.
 
-## Example 2 — Pending/error handling and parameters
+## Example 2 — A projection that needs `<Row>`
+
+When the result shape diverges from a declared table (joins, aliases, computed
+columns), declare it with the `sqliteQuery<Row>` type argument. A `Cell<T>`
+field marks a decoded link column even when the alias drops the `_cf_link`
+suffix.
 
 ```tsx
-const results = sqliteQuery<{ id: number; title: string }>({
+const leaderboard = sqliteQuery<{ author: Cell<User>; n: number }>({
   db,
-  sql: "SELECT id, title FROM docs WHERE owner = :owner AND archived = 0",
-  params: { owner: ownerId },
-  reactOn: db.version,
+  sql: `SELECT author_cf_link AS author, count(*) AS n
+        FROM messages GROUP BY author_cf_link ORDER BY n DESC LIMIT 10`,
+  reactOn: db,
 });
 
 return derive(
-  { rows: results.result, pending: results.pending, error: results.error },
+  { rows: leaderboard.result, pending: leaderboard.pending, error: leaderboard.error },
   ({ rows, pending, error }) => {
     if (pending) return "Loading…";
     if (error) return `Query failed: ${String(error)}`;
-    return rows!.map((r) => r.title);
+    // `author` decoded back into Cell<User> despite the `AS author` alias.
+    return rows!.map((r) => ({ name: derive(r.author, (u) => u?.name), count: r.n }));
   },
 );
 ```
@@ -112,7 +112,7 @@ The handler mutates a cell and inserts a row. Both land in the same commit, so
 an observer never sees the counter incremented without the row (or vice versa).
 
 ```tsx
-const bump = handler<{ body: string }, { count: Cell<number>; db: Cell<SqliteDatabase> }>(
+const bump = handler<{ body: string }, { count: Cell<number>; db: SqliteDatabase }>(
   ({ body }, { count, db }) => {
     count.set(count.get() + 1);                 // cell write
     sqliteExecute({                              // SQLite write, same transaction
@@ -131,26 +131,42 @@ ensures the row and the counter agree.
 ## Example 4 — VM-file source (stubbed)
 
 ```tsx
-// vmHandle is an opaque capability cell to a VM; path is inside that VM.
+// vmHandle is an opaque capability handle to a VM; path is inside that VM.
 const db = sqliteDatabase({ vm: vmHandle, path: "/var/lib/app/data.db" });
 
-// In v1 this resolves but server returns `not-implemented` for VM sources.
-const rows = sqliteQuery({ db, sql: "SELECT * FROM kv", reactOn: db.version });
+// In v1 this resolves but the server returns `not-implemented` for VM sources.
+const rows = sqliteQuery({ db, sql: "SELECT * FROM kv", reactOn: db });
 ```
 
-## Example 5 — On-disk source linked via `cf` (stubbed)
+## Example 5 — On-disk source injected via `cf` (stubbed)
 
-```bash
-# Operator links a real file on disk to an opaque cell the pattern can reference.
-cf sqlite link ./reference-data.db --into did:key:z6Mk…/diskHandle
-```
+The pattern is **source-agnostic**: it declares a `db` *input* and consumes it.
+It never names a file or picks a source — an operator connects one.
 
 ```tsx
-const db = sqliteDatabase({ disk: diskHandle });
-const lookup = sqliteQuery({
-  db,
-  sql: "SELECT value FROM lookup WHERE key = ?",
-  params: [key],
-  // No reactOn: a static reference dataset the operator manages out of band.
+export default pattern<{ db: SqliteDatabase }>(({ db }) => {
+  const lookup = sqliteQuery<{ value: string }>({
+    db,
+    sql: "SELECT value FROM lookup WHERE key = ?",
+    params: [key],
+    // No reactOn: a static reference dataset the operator manages out of band.
+  });
+
+  return derive(
+    { rows: lookup.result, pending: lookup.pending, error: lookup.error },
+    ({ rows, pending, error }) => {
+      if (pending) return "Waiting for a database to be connected…"; // until cf wires it
+      if (error) return `Database error: ${String(error)}`;
+      return rows?.[0]?.value;
+    },
+  );
 });
+```
+
+```bash
+# Operator wires an on-disk SQLite file into the piece's `db` input. The sqlite:
+# scheme create-if-absents a handle cell (id derived from space DID + abs path)
+# and writes a normal sigil link to it. (Stubbed in v1; see Section 03.3.)
+cf piece link <piece-id> db sqlite:/abs/path/reference-data.db
+# Before this runs, the pattern renders "Waiting for a database to be connected…".
 ```

--- a/docs/specs/sqlite-builtin/07-examples.md
+++ b/docs/specs/sqlite-builtin/07-examples.md
@@ -1,0 +1,156 @@
+# 07 — Usage examples
+
+These illustrate the intended authoring surface. They are aspirational pattern
+code, not yet runnable.
+
+## Example 1 — A reactive message log with cell references
+
+A pattern that stores messages in SQLite, references the author as a live cell
+via a `_cf_link` column, and renders the 20 most recent messages reactively.
+
+```tsx
+import {
+  sqliteDatabase,
+  sqliteQuery,
+  sqliteExecute,
+  table,
+  cfLink,
+  handler,
+  derive,
+  pattern,
+  type Cell,
+} from "commonfabric";
+
+interface User { name: string; avatarUrl: string }
+
+const MessageRow = table({
+  id: "integer",
+  body: "text",
+  ts: "integer",
+  author_cf_link: cfLink<User>(), // TEXT in SQLite, Cell<User> in TS
+});
+type MessageRow = RowOf<typeof MessageRow>;
+
+export default pattern<{ me: Cell<User> }>(({ me }) => {
+  const db = sqliteDatabase(); // cell-derived, per-space, atomic
+
+  // One-time-ish schema setup (idempotent).
+  sqliteExecute({
+    db,
+    sql: `CREATE TABLE IF NOT EXISTS messages (
+            id INTEGER PRIMARY KEY,
+            author_cf_link TEXT,
+            body TEXT,
+            ts INTEGER
+          )`,
+  });
+
+  const recent = sqliteQuery<MessageRow>({
+    db,
+    sql: "SELECT id, body, ts, author_cf_link FROM messages ORDER BY ts DESC LIMIT 20",
+    reactOn: db.version, // re-run after any committed write to this db
+    rows: MessageRow,
+  });
+
+  const send = handler<{ body: string }, { author: Cell<User> }>(
+    ({ body }, { author }) => {
+      sqliteExecute({
+        db,
+        sql: "INSERT INTO messages (author_cf_link, body, ts) VALUES (?, ?, ?)",
+        params: [author, body, Date.now()], // `author` Cell -> sigil link
+        bind: MessageRow, // tells the runtime param 1 is a _cf_link
+      });
+    },
+  );
+
+  return {
+    [UI]: derive(recent.result, (rows) =>
+      (rows ?? []).map((m) => (
+        // m.author_cf_link is a live Cell<User>; reading it is independently reactive
+        <div>
+          <b>{derive(m.author_cf_link, (u) => u?.name)}</b>: {m.body}
+        </div>
+      ))),
+    send: send.with({ author: me }),
+  };
+});
+```
+
+Key points:
+
+- `params: [author, …]` binds a `Cell<User>` to the `author_cf_link` column; the
+  runtime encodes it to an absolute sigil link string (Section
+  [02](./02-cf-link-encoding.md)). Binding the same cell to `body` would throw.
+- `recent` re-runs only after the `INSERT` **commits durably** (Section
+  [05](./05-reactivity.md)), so it never shows phantom rows.
+- Each `m.author_cf_link` decodes to a `Cell<User>`; the inner `derive` updates
+  if that user's name changes, without re-running the SQL query.
+
+## Example 2 — Pending/error handling and parameters
+
+```tsx
+const results = sqliteQuery<{ id: number; title: string }>({
+  db,
+  sql: "SELECT id, title FROM docs WHERE owner = :owner AND archived = 0",
+  params: { owner: ownerId },
+  reactOn: db.version,
+});
+
+return derive(
+  { rows: results.result, pending: results.pending, error: results.error },
+  ({ rows, pending, error }) => {
+    if (pending) return "Loading…";
+    if (error) return `Query failed: ${String(error)}`;
+    return rows!.map((r) => r.title);
+  },
+);
+```
+
+## Example 3 — Atomic cell + SQLite write in one handler
+
+The handler mutates a cell and inserts a row. Both land in the same commit, so
+an observer never sees the counter incremented without the row (or vice versa).
+
+```tsx
+const bump = handler<{ body: string }, { count: Cell<number>; db: Cell<SqliteDatabase> }>(
+  ({ body }, { count, db }) => {
+    count.set(count.get() + 1);                 // cell write
+    sqliteExecute({                              // SQLite write, same transaction
+      db,
+      sql: "INSERT INTO events (body, ts) VALUES (?, ?)",
+      params: [body, Date.now()],
+    });
+  },
+);
+```
+
+If the commit is rejected (seq conflict) or the process crashes mid-commit, the
+post-crash reconciliation (Section [04](./04-server-execution-and-transactions.md))
+ensures the row and the counter agree.
+
+## Example 4 — VM-file source (stubbed)
+
+```tsx
+// vmHandle is an opaque capability cell to a VM; path is inside that VM.
+const db = sqliteDatabase({ vm: vmHandle, path: "/var/lib/app/data.db" });
+
+// In v1 this resolves but server returns `not-implemented` for VM sources.
+const rows = sqliteQuery({ db, sql: "SELECT * FROM kv", reactOn: db.version });
+```
+
+## Example 5 — On-disk source linked via `cf` (stubbed)
+
+```bash
+# Operator links a real file on disk to an opaque cell the pattern can reference.
+cf sqlite link ./reference-data.db --into did:key:z6Mk…/diskHandle
+```
+
+```tsx
+const db = sqliteDatabase({ disk: diskHandle });
+const lookup = sqliteQuery({
+  db,
+  sql: "SELECT value FROM lookup WHERE key = ?",
+  params: [key],
+  // No reactOn: a static reference dataset the operator manages out of band.
+});
+```

--- a/docs/specs/sqlite-builtin/08-open-questions.md
+++ b/docs/specs/sqlite-builtin/08-open-questions.md
@@ -50,37 +50,59 @@ during design are marked **[resolved]** with the decision.
    **Depends on** the core-table-rename flag (below) to remove `main` shadowing,
    and an attach/detach LRU cache for the attach limit. Trade-off accepted:
    per-file WAL reconciliation (Q7) is per-written-db rather than a single pair.
-7. **WAL crash reconciliation.** The `_cf_commit_watermark` + in-doubt rollback
-   sketch (Section [04](./04-server-execution-and-transactions.md)) needs a
-   precise algorithm: how to revert SQLite-side changes for an in-doubt `seq`
-   when only forward WAL frames exist. Do we instead checkpoint+fsync both files
-   under a single coordinating lock per commit and accept the latency?
+7. **[resolved — V1 cut] WAL crash reconciliation → detect + quarantine.** Normal
+   operation is atomic; only a crash *during* a multi-file COMMIT can leave
+   `main` and a pattern db disagreeing for one `seq`. V1: write a
+   `_cf_commit_watermark(seq)` inside the same txn (no hot-path cost) and
+   **persist each commit's `sqlite` ops in the commit record** (small, avoids a
+   later migration). On open, compare the watermark to the space's committed
+   `seq`; on mismatch, **quarantine that pattern db** (fail its queries with a
+   clear error + loud log) rather than serve divergent data.
+   *Deferred (fast-follow):* auto-repair — replay missing seqs' persisted ops for
+   a behind db, truncate orphaned in-doubt writes for an ahead one. Rejected:
+   per-commit checkpoint+fsync of both files (doesn't actually close the crash
+   window and kills WAL throughput).
 8. **Connection contention.** `@db/sqlite` is a single synchronous connection
    per `Database`. Long queries block the space. Do we need a separate read
    connection (WAL readers don't block writers), a statement timeout, or a
    query cost limit for v1?
-8a. **Attach limit & core-table rename (decisions for Option A).**
-   - `@db/sqlite` exposes no `sqlite3_limit` binding, so `SQLITE_LIMIT_ATTACHED`
-     is fixed at the compiled default (10 unless their build raised it; **probe
-     to confirm**). Mitigation: an **attach/detach LRU cache** — attach a pattern
-     db on demand, evict (`DETACH DATABASE`) the least-recently-used near the
-     limit. Manage it at **transaction boundaries** (attach before `BEGIN`,
-     detach only when idle); a single commit almost always touches one pattern db
-     (2 schemas), far under the limit. Reject/split a transaction that would span
-     more than the limit at once.
-   - **Core-table rename flag:** rename the engine's core tables to include the
-     space DID (e.g. `commit__<did>`), behind a flag, to remove `main` shadowing
-     so a pattern's unqualified `messages` can never resolve to a core table.
-     Ship the rest unflagged; without the flag we tolerate shadowing temporarily
-     (pre-production). The statement guard still rejects schema-qualified
-     references, `ATTACH`/`DETACH`/`PRAGMA`, and multiple statements.
-9. **[resolved] DDL ownership.** The database owns table creation/migration via
-   `sqliteDatabase({ tables })` (Section
+8a. **[resolved — V1 cut] Attach limit & core-table shadowing (Option A).**
+   - **Attach limit:** `@db/sqlite` exposes no `sqlite3_limit` binding, so
+     `SQLITE_LIMIT_ATTACHED` is fixed at the compiled default (assume 10). V1:
+     design within 10 with an **attach/detach LRU cache** — attach a pattern db
+     on demand, evict (`DETACH DATABASE`) the least-recently-used near the limit,
+     managed at **transaction boundaries** (attach before `BEGIN`, detach only
+     when idle). A commit almost always touches one pattern db (2 schemas), far
+     under the limit; reject/split a transaction that would span more at once.
+     A one-time startup **probe only logs** the real limit (no dependency on
+     headroom).
+   - **Core-table shadowing:** V1 ships **without** the core-table rename. Cheap
+     mitigations now: the statement guard rejects schema-qualified references,
+     `ATTACH`/`DETACH`/`PRAGMA`, and multiple statements; patterns may **not
+     declare** a table whose name collides with the core set, and the guard
+     **rejects statements that reference a core-table identifier**. Residual,
+     documented pre-production gap: tokenizer-level reference checking has minor
+     false positives/negatives (e.g. a column literally named `commit`).
+     *Deferred (production hardening, behind a flag):* rename the engine's core
+     tables to include the space DID (e.g. `commit__<did>`), which removes
+     shadowing structurally and drops the name-based guarding. Kept out of the
+     feature's critical path because it's an invasive core-store migration.
+9. **[resolved — V1 cut] DDL ownership + migration scope → additive-only.** The
+   database owns DDL via `sqliteDatabase({ tables })` (Section
    [01](./01-api.md#schema-ownership--the-database-owns-its-tables)); patterns do
-   not run `CREATE TABLE`. **Still open:** the *migration* algorithm — how far to
-   reconcile a changed `tables` declaration given SQLite's limited `ALTER`
-   (add-column is easy; drop/rename/retype need table-rebuild). Define the
-   supported migration set and the failure mode for unsupported changes.
+   not run `CREATE TABLE`. On open, the runtime diffs declared `tables` against
+   `PRAGMA table_info`: **create missing tables**, **`ADD COLUMN`** for new
+   nullable/defaulted columns, and validate `_cf_link` columns are `TEXT`. Any
+   **destructive or ambiguous** change (drop/rename/retype, constraint/PK change)
+   → **refuse to open the db with an explicit "unsupported migration" error**.
+   Rationale: a *declarative* diff can't distinguish a rename from a drop+add, so
+   auto-applying destructive ops is unsafe; `ADD COLUMN` also can't add `NOT
+   NULL` without a default (documented).
+   *Deferred (post-V1):* keep erroring by default, but let a database opt in to a
+   **migration callback** — author-supplied logic invoked when the on-disk schema
+   version is older than the declared one, to perform the reshape (table-rebuild,
+   data copy) explicitly. This preserves "no silent destructive migration" while
+   giving an escape hatch for evolving older databases.
 
 ## Reactivity
 

--- a/docs/specs/sqlite-builtin/08-open-questions.md
+++ b/docs/specs/sqlite-builtin/08-open-questions.md
@@ -35,10 +35,21 @@ during design are marked **[resolved]** with the decision.
 
 ## Transactions & storage
 
-6. **ATTACH model.** One sibling `.sqlite` file per cell-derived db, ATTACHed
-   on demand — vs. tables inside the space's own db (namespaced), vs. one shared
-   "patterns" db per space. Per-file gives isolation and easy GC; a shared db
-   simplifies ATTACH and transaction coordination. Which wins?
+6. **[resolved] ATTACH model → one sibling `.sqlite` file per cell-derived db**
+   (Option A), ATTACHed on demand. Considered: tables inside the space's own db
+   (rejected — co-mingles untrusted pattern schema with the authoritative store),
+   and one shared per-space "patterns" db (viable, but forces full SQL
+   parse-and-rewrite for table-name namespacing). A wins because:
+   - SQLite's only namespace primitive is the attached-db alias, so the file
+     boundary gives per-pattern namespacing **for free** — unqualified names
+     resolve to the (solely) attached pattern db, **no identifier rewriting**.
+   - `@db/sqlite` exposes **no authorizer** (confirmed — see Section
+     [04](./04-server-execution-and-transactions.md)), so a shared db would need
+     a full parser anyway; A needs only a tokenizer-level guard.
+   - Best isolation, file-delete/`backup()` GC and export.
+   **Depends on** the core-table-rename flag (below) to remove `main` shadowing,
+   and an attach/detach LRU cache for the attach limit. Trade-off accepted:
+   per-file WAL reconciliation (Q7) is per-written-db rather than a single pair.
 7. **WAL crash reconciliation.** The `_cf_commit_watermark` + in-doubt rollback
    sketch (Section [04](./04-server-execution-and-transactions.md)) needs a
    precise algorithm: how to revert SQLite-side changes for an in-doubt `seq`
@@ -48,6 +59,21 @@ during design are marked **[resolved]** with the decision.
    per `Database`. Long queries block the space. Do we need a separate read
    connection (WAL readers don't block writers), a statement timeout, or a
    query cost limit for v1?
+8a. **Attach limit & core-table rename (decisions for Option A).**
+   - `@db/sqlite` exposes no `sqlite3_limit` binding, so `SQLITE_LIMIT_ATTACHED`
+     is fixed at the compiled default (10 unless their build raised it; **probe
+     to confirm**). Mitigation: an **attach/detach LRU cache** — attach a pattern
+     db on demand, evict (`DETACH DATABASE`) the least-recently-used near the
+     limit. Manage it at **transaction boundaries** (attach before `BEGIN`,
+     detach only when idle); a single commit almost always touches one pattern db
+     (2 schemas), far under the limit. Reject/split a transaction that would span
+     more than the limit at once.
+   - **Core-table rename flag:** rename the engine's core tables to include the
+     space DID (e.g. `commit__<did>`), behind a flag, to remove `main` shadowing
+     so a pattern's unqualified `messages` can never resolve to a core table.
+     Ship the rest unflagged; without the flag we tolerate shadowing temporarily
+     (pre-production). The statement guard still rejects schema-qualified
+     references, `ATTACH`/`DETACH`/`PRAGMA`, and multiple statements.
 9. **[resolved] DDL ownership.** The database owns table creation/migration via
    `sqliteDatabase({ tables })` (Section
    [01](./01-api.md#schema-ownership--the-database-owns-its-tables)); patterns do

--- a/docs/specs/sqlite-builtin/08-open-questions.md
+++ b/docs/specs/sqlite-builtin/08-open-questions.md
@@ -13,13 +13,12 @@ during design are marked **[resolved]** with the decision.
 2. **Multi-statement writes.** Should `sqliteExecute` accept multiple statements
    in one `sql`, or one statement per call (clearer atomicity story, easier
    `_cf_link` param mapping)?
-3. **Transformer support for `sqliteQuery<Row>`.** Result typing relies on the
-   ts-transformer lowering the `Row` type argument into a runtime schema, the
-   way `toSchema<T>()` works (Section
-   [01](./01-api.md#sqlitequeryrowparams--reactive-read)). This must be added to
-   the transformer's type-arg-lowering list — confirm feasibility and effort
-   with the ts-transformers owner. Without it the generic is erased and carries
-   no runtime decode/CFC info.
+3. **[resolved] Transformer support for `sqliteQuery<Row>`.** Routine: the
+   transformer already lowers type arguments to schemas for `toSchema<T>`,
+   `generateObject`, and `lift`. Add a registry entry + a schema-injection rule —
+   see [`packages/ts-transformers/docs/adding-type-arg-schema-lowering.md`](../../../packages/ts-transformers/docs/adding-type-arg-schema-lowering.md)
+   and Phase 5 of the [implementation plan](./implementation-plan.md). Not a
+   gating risk.
 
 ## `_cf_link`
 

--- a/docs/specs/sqlite-builtin/08-open-questions.md
+++ b/docs/specs/sqlite-builtin/08-open-questions.md
@@ -1,0 +1,79 @@
+# 08 — Open questions
+
+Unresolved items for framework-author review, grouped by area.
+
+## API surface
+
+1. **Handle methods vs. free built-ins.** We chose free built-ins
+   (`sqliteQuery`/`sqliteExecute`) over methods on the handle (Section
+   [01](./01-api.md)). Is ergonomic sugar (`db.query(...)` / `db.execute(...)`)
+   worth adding as a thin forwarder, or does that re-blur the read/write
+   capability split CFC wants kept separate?
+2. **Multi-statement writes.** Should `sqliteExecute` accept multiple statements
+   in one `sql`, or one statement per call (clearer atomicity story, easier
+   `_cf_link` param mapping)?
+3. **Result typing.** Is the author-annotated `rows`/`RowOf<>` approach
+   (Section [01](./01-api.md#typescript-and-table-types)) enough, or do we want
+   a heavier `cf` codegen step that reads a live schema and emits row types?
+
+## `_cf_link`
+
+4. **Suffix vs. schema-only.** v1 keys off the `*_cf_link` column-name suffix so
+   the contract is visible in raw SQL. Is the implicit naming convention
+   acceptable, or should link columns be required to come with a `cfLink`
+   schema (no behavior from naming alone)?
+5. **Schema in stored links.** We strip `schema`/`asCell` from the stored sigil
+   (Section [02](./02-cf-link-encoding.md)) and re-attach the element schema
+   from `cfLink<T>()` on read. If a query omits `rows`, the decoded cell has no
+   schema — acceptable, or should we store a minimal schema reference?
+
+## Transactions & storage
+
+6. **ATTACH model.** One sibling `.sqlite` file per cell-derived db, ATTACHed
+   on demand — vs. tables inside the space's own db (namespaced), vs. one shared
+   "patterns" db per space. Per-file gives isolation and easy GC; a shared db
+   simplifies ATTACH and transaction coordination. Which wins?
+7. **WAL crash reconciliation.** The `_cf_commit_watermark` + in-doubt rollback
+   sketch (Section [04](./04-server-execution-and-transactions.md)) needs a
+   precise algorithm: how to revert SQLite-side changes for an in-doubt `seq`
+   when only forward WAL frames exist. Do we instead checkpoint+fsync both files
+   under a single coordinating lock per commit and accept the latency?
+8. **Connection contention.** `@db/sqlite` is a single synchronous connection
+   per `Database`. Long queries block the space. Do we need a separate read
+   connection (WAL readers don't block writers), a statement timeout, or a
+   query cost limit for v1?
+9. **DDL ownership.** v1 leaves `CREATE TABLE` to patterns. Should
+   `sqliteDatabase({ schema })` own table creation/migration instead, so the
+   runtime can validate `_cf_link` columns and (later) CFC labels up front?
+
+## Reactivity
+
+10. **Commit-only inputs as a scheduler primitive.** Section
+    [05](./05-reactivity.md) emulates "re-run only on committed inputs" with a
+    post-commit `version` bump. Should the scheduler gain a first-class
+    `committedReads` annotation, and would `sqliteQuery` then drop the manual
+    bump entirely?
+11. **Finer invalidation.** Is coarse `db.version` invalidation good enough for
+    v1, or do we want table-level version cells (bumped per touched table) out
+    of the box, parsed from the write SQL?
+
+## Sources
+
+12. **VM-file API.** What is the improved VM file interface, and can a VM file
+    ever be ATTACHed to the space connection for atomicity, or is it always a
+    non-atomic post-commit effect (Section [03](./03-database-sources.md))?
+13. **On-disk co-location.** Should `cf`-linked on-disk databases be required to
+    live where toolshed can ATTACH them (enabling atomicity), or are they always
+    read-mostly external datasets?
+14. **GC of cell-derived dbs.** When the owning cell is collected, who deletes
+    the sibling `.sqlite` file, and when?
+
+## CFC (future)
+
+15. **Row-label projection language.** Section [06](./06-cfc.md) proposes a pure
+    declarative projection (`principal(field)`, `jsonArray(field)`) so the
+    server can evaluate row labels at commit. Is that expressive enough for real
+    policies (e.g. recipients stored as a join table rather than a JSON column)?
+16. **Read-time filtering vs. fail-closed.** When a reader lacks clearance for
+    some rows, do we silently filter them out of the result set, or fail the
+    whole query closed? Filtering leaks row counts; failing closed is coarse.

--- a/docs/specs/sqlite-builtin/08-open-questions.md
+++ b/docs/specs/sqlite-builtin/08-open-questions.md
@@ -1,6 +1,7 @@
 # 08 — Open questions
 
-Unresolved items for framework-author review, grouped by area.
+Unresolved items for framework-author review, grouped by area. Items resolved
+during design are marked **[resolved]** with the decision.
 
 ## API surface
 
@@ -12,20 +13,26 @@ Unresolved items for framework-author review, grouped by area.
 2. **Multi-statement writes.** Should `sqliteExecute` accept multiple statements
    in one `sql`, or one statement per call (clearer atomicity story, easier
    `_cf_link` param mapping)?
-3. **Result typing.** Is the author-annotated `rows`/`RowOf<>` approach
-   (Section [01](./01-api.md#typescript-and-table-types)) enough, or do we want
-   a heavier `cf` codegen step that reads a live schema and emits row types?
+3. **Transformer support for `sqliteQuery<Row>`.** Result typing relies on the
+   ts-transformer lowering the `Row` type argument into a runtime schema, the
+   way `toSchema<T>()` works (Section
+   [01](./01-api.md#sqlitequeryrowparams--reactive-read)). This must be added to
+   the transformer's type-arg-lowering list — confirm feasibility and effort
+   with the ts-transformers owner. Without it the generic is erased and carries
+   no runtime decode/CFC info.
 
 ## `_cf_link`
 
-4. **Suffix vs. schema-only.** v1 keys off the `*_cf_link` column-name suffix so
-   the contract is visible in raw SQL. Is the implicit naming convention
-   acceptable, or should link columns be required to come with a `cfLink`
-   schema (no behavior from naming alone)?
+4. **[resolved] Suffix vs. schema-only.** Keep both: the `*_cf_link` suffix is
+   the self-documenting fallback (legible in raw SQL); the database table schema
+   (`cfLink<T>()`) and `sqliteQuery<Row>` `Cell<T>` fields refine it with element
+   type and CFC labels and take precedence. The suffix is not required when a
+   schema covers the column, but remains the default driver when none does.
 5. **Schema in stored links.** We strip `schema`/`asCell` from the stored sigil
-   (Section [02](./02-cf-link-encoding.md)) and re-attach the element schema
-   from `cfLink<T>()` on read. If a query omits `rows`, the decoded cell has no
-   schema — acceptable, or should we store a minimal schema reference?
+   (Section [02](./02-cf-link-encoding.md)) and re-attach the element schema from
+   the table schema or `Row` on read. If neither covers a column, the decoded
+   cell has no schema — acceptable, or should we store a minimal schema
+   reference?
 
 ## Transactions & storage
 
@@ -42,38 +49,49 @@ Unresolved items for framework-author review, grouped by area.
    per `Database`. Long queries block the space. Do we need a separate read
    connection (WAL readers don't block writers), a statement timeout, or a
    query cost limit for v1?
-9. **DDL ownership.** v1 leaves `CREATE TABLE` to patterns. Should
-   `sqliteDatabase({ schema })` own table creation/migration instead, so the
-   runtime can validate `_cf_link` columns and (later) CFC labels up front?
+9. **[resolved] DDL ownership.** The database owns table creation/migration via
+   `sqliteDatabase({ tables })` (Section
+   [01](./01-api.md#schema-ownership--the-database-owns-its-tables)); patterns do
+   not run `CREATE TABLE`. **Still open:** the *migration* algorithm — how far to
+   reconcile a changed `tables` declaration given SQLite's limited `ALTER`
+   (add-column is easy; drop/rename/retype need table-rebuild). Define the
+   supported migration set and the failure mode for unsupported changes.
 
 ## Reactivity
 
 10. **Commit-only inputs as a scheduler primitive.** Section
-    [05](./05-reactivity.md) emulates "re-run only on committed inputs" with a
-    post-commit `version` bump. Should the scheduler gain a first-class
+    [05](./05-reactivity.md) emulates "re-run only on committed inputs" with the
+    post-commit handle-cell dirtying. Should the scheduler gain a first-class
     `committedReads` annotation, and would `sqliteQuery` then drop the manual
     bump entirely?
-11. **Finer invalidation.** Is coarse `db.version` invalidation good enough for
-    v1, or do we want table-level version cells (bumped per touched table) out
-    of the box, parsed from the write SQL?
+11. **Finer invalidation.** Is coarse `reactOn: db` (whole-database) invalidation
+    good enough for v1, or do we want table-level handle cells (dirtied per
+    touched table) out of the box, parsed from the write SQL?
+12. **Cross-space dirty signal for injected handles.** A `cf`-injected on-disk
+    handle cell lives in a service space while its writes ride the pattern's
+    space commit (Section [05](./05-reactivity.md)). The post-commit dirty signal
+    must cross spaces — define that mechanism, or restrict injected sources to
+    read-only (no `reactOn`).
 
 ## Sources
 
-12. **VM-file API.** What is the improved VM file interface, and can a VM file
+13. **VM-file API.** What is the improved VM file interface, and can a VM file
     ever be ATTACHed to the space connection for atomicity, or is it always a
     non-atomic post-commit effect (Section [03](./03-database-sources.md))?
-13. **On-disk co-location.** Should `cf`-linked on-disk databases be required to
+14. **On-disk co-location.** Should `cf`-linked on-disk databases be required to
     live where toolshed can ATTACH them (enabling atomicity), or are they always
-    read-mostly external datasets?
-14. **GC of cell-derived dbs.** When the owning cell is collected, who deletes
+    read-mostly external datasets? (Partly informed by the `sqlite:` injection
+    model in Section [03.3](./03-database-sources.md), which fixes *addressing*
+    but not co-location.)
+15. **GC of cell-derived dbs.** When the owning cell is collected, who deletes
     the sibling `.sqlite` file, and when?
 
 ## CFC (future)
 
-15. **Row-label projection language.** Section [06](./06-cfc.md) proposes a pure
+16. **Row-label projection language.** Section [06](./06-cfc.md) proposes a pure
     declarative projection (`principal(field)`, `jsonArray(field)`) so the
     server can evaluate row labels at commit. Is that expressive enough for real
     policies (e.g. recipients stored as a join table rather than a JSON column)?
-16. **Read-time filtering vs. fail-closed.** When a reader lacks clearance for
+17. **Read-time filtering vs. fail-closed.** When a reader lacks clearance for
     some rows, do we silently filter them out of the result set, or fail the
     whole query closed? Filtering leaks row counts; failing closed is coarse.

--- a/docs/specs/sqlite-builtin/README.md
+++ b/docs/specs/sqlite-builtin/README.md
@@ -1,0 +1,120 @@
+# SQLite Builtins for Patterns
+
+## Status
+
+Draft — seeking framework author review. Targets a v1 that ships reading +
+writing with reactive re-query, with CFC (Contextual Flow Control) integration
+deferred to a follow-up phase (Section [06](./06-cfc.md)).
+
+## Overview
+
+This spec introduces a pair of built-in functions that let patterns run SQLite
+queries against databases hosted alongside the space. Patterns already reach
+external state through reactive built-ins like `fetchData` and `generateText`
+(see [`packages/runner/src/builtins/fetch-data.ts`](../../../packages/runner/src/builtins/fetch-data.ts)
+and [`packages/runner/src/builtins/llm.ts`](../../../packages/runner/src/builtins/llm.ts)).
+SQLite access follows the same shape: a parameterized request in, a reactive
+`{ pending, result, error }` out.
+
+Two capabilities are exposed, with **separate built-ins for read and write** so
+they can be protected independently once CFC lands:
+
+- **`sqliteQuery`** — read-only `SELECT` queries. Reactive: re-runs when a
+  declared reactivity input changes.
+- **`sqliteExecute`** — writes (`INSERT`/`UPDATE`/`DELETE`/DDL). Effectful;
+  participates in the same transaction as the cell writes around it.
+
+Both operate on an opaque **database handle** produced by a `sqliteDatabase(...)`
+builder, which selects one of three database sources (Section
+[03](./03-database-sources.md)).
+
+Two cross-cutting rules make cell references first-class inside SQLite:
+
+- Writing a cell reference into a column whose name ends in `_cf_link` (and is
+  declared `string`) **opaquely encodes it as a full sigil link**. Any other
+  attempt to write a cell reference throws. (Section [02](./02-cf-link-encoding.md))
+- Reading a `_cf_link` column **transparently decodes** the stored string back
+  into a live `Cell`.
+
+## Design goals
+
+1. **Reuse the existing reactive-builtin machinery.** Scheduler integration,
+   post-commit effects, request hashing/deduplication, and the CFC write-policy
+   sink are all already solved for `fetchData`/`llm`. SQLite access plugs into
+   the same seams rather than inventing parallel infrastructure.
+2. **Server-side execution.** Queries run inside toolshed, which already hosts
+   the space and owns the SQLite engine
+   ([`packages/memory/v2/engine.ts`](../../../packages/memory/v2/engine.ts)).
+   The runtime reaches them over the **existing space-scoped websocket** — no
+   new connection, no new auth path.
+3. **Atomic writes across cells and SQLite.** SQLite writes ride the *same*
+   commit transaction that applies cell writes, so a commit either lands fully
+   (cells + rows) or not at all, in normal operation. (Section
+   [04](./04-server-execution-and-transactions.md))
+4. **Reactivity that waits for durable writes.** A query re-runs only against
+   fully-committed state, never in-flight/optimistic writes. (Section
+   [05](./05-reactivity.md))
+5. **Cell references survive the round-trip.** A cell written into a `_cf_link`
+   column reads back as the same cell, across spaces.
+6. **A path to per-column and per-row CFC.** The schema surface is designed so
+   confidentiality/integrity labels can be attached per column, and per-row
+   labels can be derived from field values, without reworking the API. (Section
+   [06](./06-cfc.md))
+
+## Non-goals for v1
+
+- **CFC enforcement.** v1 carries the schema annotations but does not enforce
+  them. Confidentiality and integrity checks land in the follow-up phase.
+- **Read-after-write within a single transaction.** A `sqliteQuery` issued in
+  the same transaction as a not-yet-committed `sqliteExecute` is defined to
+  fail (Section [04](./04-server-execution-and-transactions.md)). Simulating
+  the pending write is out of scope.
+- **Full VM-file and on-disk source implementations.** Both are stubbed behind
+  opaque handles (Section [03](./03-database-sources.md)); only the
+  cell-derived default source is fully specified for v1.
+- **Auto-derived TypeScript types for query parameters and result rows.** The
+  author annotates row shapes; we do not parse SQL to infer types (Section
+  [01](./01-api.md#typescript-and-table-types)).
+
+## Document map
+
+| File | Contents |
+| --- | --- |
+| [01-api.md](./01-api.md) | TypeScript-facing API: `sqliteDatabase`, `sqliteQuery`, `sqliteExecute`; the new-builtin-vs-new-Cell-type decision; table-type helpers. |
+| [02-cf-link-encoding.md](./02-cf-link-encoding.md) | `_cf_link` column encode/decode rules and the throw conditions. |
+| [03-database-sources.md](./03-database-sources.md) | The three database sources: cell-derived (default), VM file (stub), on-disk via `cf` (stub). |
+| [04-server-execution-and-transactions.md](./04-server-execution-and-transactions.md) | Protocol extension, server-side execution, ATTACH, atomic cells+SQLite commits, WAL crash recovery. |
+| [05-reactivity.md](./05-reactivity.md) | Reactive re-query via parallel reactivity cells; committed-vs-transient inputs. |
+| [06-cfc.md](./06-cfc.md) | Future per-column and per-row CFC labels. |
+| [07-examples.md](./07-examples.md) | End-to-end usage examples. |
+| [08-open-questions.md](./08-open-questions.md) | Unresolved design questions for review. |
+
+## At a glance
+
+```tsx
+import { sqliteDatabase, sqliteQuery, sqliteExecute, handler, derive } from "commonfabric";
+
+// A database tied to this pattern's own cell (default source).
+const db = sqliteDatabase();
+
+// Reactive read. Re-runs whenever `db.version` changes (bumped on commit).
+const recent = sqliteQuery({
+  db,
+  sql: "SELECT id, author_cf_link, body FROM messages ORDER BY ts DESC LIMIT 20",
+  reactOn: db.version,
+  rows: MessageRowSchema, // declares column types + which columns are _cf_link
+});
+
+// Effectful write, atomic with any surrounding cell writes.
+const post = handler<{ body: string }, { author: Cell<User> }>(
+  ({ body }, { author }) => {
+    sqliteExecute({
+      db,
+      sql: "INSERT INTO messages (author_cf_link, body, ts) VALUES (?, ?, ?)",
+      params: [author, body, Date.now()], // `author` (a Cell) → full sigil link
+    });
+  },
+);
+
+return derive(recent.result, (rows) => rows ?? []);
+```

--- a/docs/specs/sqlite-builtin/README.md
+++ b/docs/specs/sqlite-builtin/README.md
@@ -92,6 +92,7 @@ Two cross-cutting rules make cell references first-class inside SQLite:
 | [06-cfc.md](./06-cfc.md) | Future per-column and per-row CFC labels. |
 | [07-examples.md](./07-examples.md) | End-to-end usage examples. |
 | [08-open-questions.md](./08-open-questions.md) | Unresolved design questions for review. |
+| [implementation-plan.md](./implementation-plan.md) | Ordered workstreams, milestones, and dependency/gating map for building the feature. |
 
 ## At a glance
 

--- a/docs/specs/sqlite-builtin/README.md
+++ b/docs/specs/sqlite-builtin/README.md
@@ -101,7 +101,7 @@ import { sqliteDatabase, sqliteQuery, sqliteExecute, table, cfLink, handler, der
 
 // A database tied to this pattern's own cell (default source). Tables (and the
 // _cf_link columns) are declared once, here; the runtime owns DDL/migration.
-const db = sqliteDatabase(undefined, {
+const db = sqliteDatabase({
   tables: {
     messages: table({
       id: "integer primary key",

--- a/docs/specs/sqlite-builtin/README.md
+++ b/docs/specs/sqlite-builtin/README.md
@@ -24,9 +24,12 @@ they can be protected independently once CFC lands:
 - **`sqliteExecute`** — writes (`INSERT`/`UPDATE`/`DELETE`/DDL). Effectful;
   participates in the same transaction as the cell writes around it.
 
-Both operate on an opaque **database handle** produced by a `sqliteDatabase(...)`
-builder, which selects one of three database sources (Section
-[03](./03-database-sources.md)).
+Both operate on an opaque **database handle** — a branded, otherwise-empty
+`SqliteDatabase` value that patterns only forward, never read. It is produced by
+a `sqliteDatabase(...)` builder (cell-derived or VM sources), or **injected as a
+pattern input** for on-disk databases linked via `cf` (Section
+[03](./03-database-sources.md)). The handle's table schema and DDL are owned by
+the database, declared once.
 
 Two cross-cutting rules make cell references first-class inside SQLite:
 
@@ -72,9 +75,10 @@ Two cross-cutting rules make cell references first-class inside SQLite:
 - **Full VM-file and on-disk source implementations.** Both are stubbed behind
   opaque handles (Section [03](./03-database-sources.md)); only the
   cell-derived default source is fully specified for v1.
-- **Auto-derived TypeScript types for query parameters and result rows.** The
-  author annotates row shapes; we do not parse SQL to infer types (Section
-  [01](./01-api.md#typescript-and-table-types)).
+- **Auto-derived TypeScript types from the SQL string.** Tables are declared on
+  the database and result rows via the `sqliteQuery<Row>` type argument; we do
+  not parse SQL to infer parameter/result types (Section
+  [01](./01-api.md#typescript-and-table-types--why-these-boundaries)).
 
 ## Document map
 
@@ -92,17 +96,26 @@ Two cross-cutting rules make cell references first-class inside SQLite:
 ## At a glance
 
 ```tsx
-import { sqliteDatabase, sqliteQuery, sqliteExecute, handler, derive } from "commonfabric";
+import { sqliteDatabase, sqliteQuery, sqliteExecute, table, cfLink, handler, derive } from "commonfabric";
 
-// A database tied to this pattern's own cell (default source).
-const db = sqliteDatabase();
+// A database tied to this pattern's own cell (default source). Tables (and the
+// _cf_link columns) are declared once, here; the runtime owns DDL/migration.
+const db = sqliteDatabase(undefined, {
+  tables: {
+    messages: table({
+      id: "integer primary key",
+      author_cf_link: cfLink<User>(),
+      body: "text",
+      ts: "integer",
+    }),
+  },
+});
 
-// Reactive read. Re-runs whenever `db.version` changes (bumped on commit).
+// Reactive read. Passing the whole `db` means "any committed write re-runs".
 const recent = sqliteQuery({
   db,
   sql: "SELECT id, author_cf_link, body FROM messages ORDER BY ts DESC LIMIT 20",
-  reactOn: db.version,
-  rows: MessageRowSchema, // declares column types + which columns are _cf_link
+  reactOn: db,
 });
 
 // Effectful write, atomic with any surrounding cell writes.

--- a/docs/specs/sqlite-builtin/implementation-plan.md
+++ b/docs/specs/sqlite-builtin/implementation-plan.md
@@ -167,11 +167,17 @@ cells + rows commit atomically.
      uncommitted `sqlite` writes in the same transaction, reject with
      `read-after-write-unsupported` (spec Section 04).
 
-4. **DDL / migration from `tables`.**
-   - Runtime creates/migrates tables from `sqliteDatabase({ tables })` on first
-     server-side open of the db: `CREATE TABLE` when absent; **add-column**
-     migrations. Validate `_cf_link` columns are `TEXT`. Unsupported changes
-     (drop/rename/retype) fail loudly. **[gated on Q9 — migration scope.]**
+4. **DDL / migration from `tables` — additive-only (Q9 → V1 cut).**
+   - On first server-side open, diff declared `tables` vs `PRAGMA table_info`:
+     `CREATE TABLE` when absent, `ALTER TABLE ADD COLUMN` for new
+     nullable/defaulted columns, validate `_cf_link` columns are `TEXT`.
+   - **Destructive/ambiguous changes** (drop/rename/retype, constraint/PK change)
+     → **refuse to open the db** with an explicit "unsupported migration" error
+     (a declarative diff can't tell rename from drop+add). Document that
+     `ADD COLUMN` can't add `NOT NULL` without a default.
+   - *Deferred (post-V1):* opt-in **migration callback** — keep erroring by
+     default, but let a db supply author logic invoked when the on-disk schema
+     version is older than the declared one, to perform the reshape explicitly.
 
 **Tests**
 
@@ -272,24 +278,40 @@ decode case from Example 07-#2.
 
 ---
 
-## Phase 6 — WAL crash reconciliation
+## Phase 6 — WAL crash safety: detect + quarantine (Q7 → V1 cut)
 
-**Goal (M4a):** cells and rows agree after a crash mid-commit despite WAL's
-cross-file gap. **[gated on Q7 — reconciliation algorithm.]**
+**Goal (M4a):** never serve divergent cell/row state after a crash mid-commit.
+V1 detects and quarantines; auto-repair is a fast-follow.
+
+Two pieces of Phase 6 land **early, in Phase 2**, so they don't require a later
+migration: writing the watermark in-txn, and persisting each commit's `sqlite`
+ops in the commit record.
 
 **Files & work**
 
-- [`packages/memory/v2/engine.ts`](../../../packages/memory/v2/engine.ts) — add a
-  `_cf_commit_watermark` table in each attached db; record the in-doubt `seq`
-  before the SQLite write and clear it on commit. On `open()` (~line 1335),
-  compare the space's committed `seq` (`commit` table) against the attached
-  watermark and roll back the in-doubt range on whichever side raced ahead.
-- Decide reconciliation vs. single-lock checkpoint+fsync per commit (Q7).
+- [`packages/memory/v2/engine.ts`](../../../packages/memory/v2/engine.ts):
+  - Add a `_cf_commit_watermark(seq)` row in each attached db, written **inside**
+    the commit txn and advanced on commit (done in Phase 2; no hot-path cost).
+  - **Persist the commit's `sqlite` ops** in the commit record (Phase 2) so a
+    behind db can later be replayed without a schema migration.
+  - On `open()` (~line 1335), compare the space's committed `seq` (`commit`
+    table) against each attached db's watermark. **On mismatch → quarantine**
+    that pattern db: fail its queries with a clear error and log loudly. Do
+    **not** serve it.
+- Rejected alternative: per-commit checkpoint+fsync of both files under a lock —
+  doesn't close the crash window and kills WAL throughput.
 
-**Tests:** fault-injection test that interleaves WAL frames and asserts
-post-open agreement.
+**Deferred (fast-follow): auto-repair.** Replay the persisted ops for the missing
+seqs when a pattern db is *behind*; truncate orphaned in-doubt writes when it is
+*ahead* (needs per-row seq tagging or a rebuild). Lifts the quarantine
+automatically.
 
-**Exit:** no divergence between cells and rows after simulated crash.
+**Tests:** fault-injection that interleaves WAL durability across the two files
+and asserts (V1) the db is quarantined, not silently divergent; (later) that
+auto-repair restores agreement.
+
+**Exit:** a crash never yields silently divergent cells/rows — the affected
+pattern db is quarantined and flagged.
 
 ---
 
@@ -383,9 +405,9 @@ remain deferred).
 | Risk / decision | Gates | Open question |
 | --- | --- | --- |
 | ATTACH model → **resolved: one file per db (A)** | — | Q6 |
-| Attach-limit probe + core-table-rename flag | Phase 1, 2 | Q8a |
-| Migration scope (SQLite `ALTER` limits) | Phase 2 | Q9 |
-| WAL reconciliation algorithm vs. single-lock fsync | Phase 6 | Q7 |
+| Attach limit (LRU cache, probe-and-log) + shadowing guards; DID-rename deferred behind flag | Phase 1, 2 | Q8a |
+| Migration → **resolved: additive-only**; callback deferred | Phase 2 | Q9 |
+| WAL crash safety → **resolved: detect + quarantine**; auto-repair deferred | Phase 2, 6 | Q7 |
 | On-disk co-location & cross-space dirty | Phase 7 | Q12, Q13, Q14 |
 | Connection contention / timeouts | Cross-cutting | Q8 |
 | Row-label projection expressiveness; read filtering | Phase 9 | Q16, Q17 |

--- a/docs/specs/sqlite-builtin/implementation-plan.md
+++ b/docs/specs/sqlite-builtin/implementation-plan.md
@@ -92,12 +92,19 @@ builtin plumbing.
 2. **Server execution & ATTACH.**
    - [`packages/memory/v2/engine.ts`](../../../packages/memory/v2/engine.ts) —
      `Server.sqliteQuery` calls `openEngine(space)` (~line 1456), ATTACHes the
-     cell-derived db file if not already attached for the connection, enforces a
-     **read-only guard** (single `SELECT`/read-only CTE; reject DML/DDL/PRAGMA/
-     multi-statement), then `engine.database.prepare(sql).all(params)`.
+     cell-derived db file via the attach/detach cache, applies the **statement
+     guard** (single `SELECT`/read-only CTE; reject DML/DDL, schema-qualified
+     refs, `PRAGMA`/`ATTACH`/`DETACH`, multi-statement), then
+     `engine.database.prepare(sql).all(params)`. The guard is tokenizer-level —
+     **confirmed: `@db/sqlite@0.12.0` exposes no authorizer** (Section
+     [04](./04-server-execution-and-transactions.md#isolation-namespacing--the-statement-guard)).
    - [`packages/memory/v2/storage-path.ts`](../../../packages/memory/v2/storage-path.ts)
      — add sibling-file naming `cell-<entityhash>.sqlite` next to the space file
-     (`engine-v3/…`). **[gated on Q6 — ATTACH model.]**
+     (`engine-v3/…`). (Q6 resolved → Option A, one file per db.)
+   - **Attach/detach LRU cache** + **core-table-rename flag** (Q6/Q8a): probe the
+     compiled `SQLITE_LIMIT_ATTACHED` (no `sqlite3_limit` binding to set it);
+     manage attaches at transaction boundaries; rename core tables to include the
+     space DID behind a flag (ship unflagged pre-production).
 
 3. **Runner builtin — `sqlite-query.ts`.**
    - Read `db`, `sql`, `params` from `inputsCell`. Recover the handle cell from
@@ -339,15 +346,22 @@ remain deferred).
   write-policy sink ([`sink-request.ts`](../../../packages/runner/src/cfc/sink-request.ts)).
 - **9b — per-row:** declarative row-label projection evaluated server-side at
   commit and on read; row-level filtering / fail-closed reads. **[gated on
-  Q16/Q17.]**
+  Q16/Q17.]** Implementation note: `@db/sqlite` exposes custom scalar/aggregate
+  function registration (`function()`/`aggregate()`), so projection helpers like
+  `principal(field)` (`"did:mailto:" + field`) can be **registered SQL
+  functions** evaluated in-engine at commit — no separate expression interpreter.
 
 ---
 
 ## Cross-cutting work
 
-- **Read-only enforcement** must be robust against statement smuggling (comments,
-  multiple statements, PRAGMA). Prefer SQLite's `authorizer`/`prepare`-level
-  checks over string parsing where possible.
+- **Statement guard** must be robust against smuggling (comments, multiple
+  statements, `PRAGMA`, schema-qualified references). `@db/sqlite` exposes **no
+  authorizer**, so this is a tokenizer-level guard (Section
+  [04](./04-server-execution-and-transactions.md#isolation-namespacing--the-statement-guard)),
+  not a `prepare`-time authorizer. Future hardening: bind
+  `sqlite3_set_authorizer` via Deno FFI against `Database.unsafeHandle` for
+  defense-in-depth.
 - **Concurrency:** `@db/sqlite` is one synchronous connection per `Database`;
   long queries block the space. Add a statement timeout, and evaluate a separate
   WAL read connection. **[gated on Q8.]**
@@ -368,7 +382,8 @@ remain deferred).
 
 | Risk / decision | Gates | Open question |
 | --- | --- | --- |
-| ATTACH-per-file vs shared/namespaced db | Phase 1, 2 | Q6 |
+| ATTACH model → **resolved: one file per db (A)** | — | Q6 |
+| Attach-limit probe + core-table-rename flag | Phase 1, 2 | Q8a |
 | Migration scope (SQLite `ALTER` limits) | Phase 2 | Q9 |
 | WAL reconciliation algorithm vs. single-lock fsync | Phase 6 | Q7 |
 | On-disk co-location & cross-space dirty | Phase 7 | Q12, Q13, Q14 |

--- a/docs/specs/sqlite-builtin/implementation-plan.md
+++ b/docs/specs/sqlite-builtin/implementation-plan.md
@@ -236,17 +236,26 @@ cross-space; every throw condition; `NULL` → `null`.
 ## Phase 5 — `sqliteQuery<Row>` transformer support
 
 **Goal (M3b):** the `Row` type argument is lowered to a runtime schema; `Cell<T>`
-fields drive decode through aliases/joins. **[gated on Q3 — transformer owner.]**
+fields drive decode through aliases/joins.
+
+This is a **routine, well-trodden change**, not a research item: the transformer
+already lowers type arguments to schemas for `toSchema<T>`, `generateObject`, and
+`lift`. Follow the existing path — see
+[`packages/ts-transformers/docs/adding-type-arg-schema-lowering.md`](../../../packages/ts-transformers/docs/adding-type-arg-schema-lowering.md)
+(added alongside this spec).
 
 **Files & work**
 
+- [`packages/ts-transformers/src/core/commonfabric-runtime-registry.ts`](../../../packages/ts-transformers/src/core/commonfabric-runtime-registry.ts)
+  — register `sqliteQuery` (a `runtime-call` entry is enough).
 - [`packages/ts-transformers/src/transformers/schema-injection.ts`](../../../packages/ts-transformers/src/transformers/schema-injection.ts)
-  and [`schema-generator.ts`](../../../packages/ts-transformers/src/transformers/schema-generator.ts)
-  — extend the `toSchema<T>` lowering machinery to recognize `sqliteQuery<Row>`
-  and inject the lowered schema as a runtime argument (the runtime stub pattern
-  is [`packages/runner/src/builder/factory.ts`](../../../packages/runner/src/builder/factory.ts) line 73).
+  — recognize the `sqliteQuery<Row>` call (`detectCallKind` + single type arg)
+  and inject the lowered schema via `createSchemaCallWithRegistryTransfer`,
+  exactly as `generate-object` injects its result schema. `schema-generator.ts`
+  emits the literal off the registry transfer; no change expected there.
 - `sqlite-query.ts` — accept the injected `Row` schema; use it as the
   highest-precedence source for `_cf_link` decode and result shaping.
+- Add a `test/fixtures/schema-transform/` fixture pair for `sqliteQuery<Row>`.
 
 **Tests:** transformer fixture pair (`input.tsx` → `expected.jsx`) under
 `packages/ts-transformers/test/fixtures/`; runtime test of the aliased-column
@@ -361,7 +370,6 @@ remain deferred).
 | --- | --- | --- |
 | ATTACH-per-file vs shared/namespaced db | Phase 1, 2 | Q6 |
 | Migration scope (SQLite `ALTER` limits) | Phase 2 | Q9 |
-| Transformer lowering of `sqliteQuery<Row>` | Phase 5 | Q3 |
 | WAL reconciliation algorithm vs. single-lock fsync | Phase 6 | Q7 |
 | On-disk co-location & cross-space dirty | Phase 7 | Q12, Q13, Q14 |
 | Connection contention / timeouts | Cross-cutting | Q8 |

--- a/docs/specs/sqlite-builtin/implementation-plan.md
+++ b/docs/specs/sqlite-builtin/implementation-plan.md
@@ -1,0 +1,368 @@
+# Implementation plan — SQLite builtins
+
+Ordered workstreams for building the feature specified in this directory. Each
+phase lists its goal, the files it touches (with the integration points already
+located in the codebase), the work, tests, and exit criteria. Phases are ordered
+to land a thin vertical slice early and defer the hardest/most-deferred pieces.
+
+**Status:** not started. This plan accompanies a design that is itself in review
+([README](./README.md)); items marked **[gated]** depend on an open question
+([08-open-questions.md](./08-open-questions.md)) being resolved first.
+
+## Milestones at a glance
+
+| Milestone | Phases | Delivers |
+| --- | --- | --- |
+| **M1 — Vertical slice** | 0, 1 | A pattern issues a server-side `SELECT` over the space websocket and gets rows. Proves protocol + builtin + ATTACH wiring end to end. |
+| **M2 — Atomic writes** | 2, 3 | `sqliteExecute` writes that commit atomically with cell writes, plus reactive `reactOn: db` re-query. The core value proposition. |
+| **M3 — Cell references & typed rows** | 4, 5 | `_cf_link` round-trip and `sqliteQuery<Row>` transformer typing. |
+| **M4 — Durability & sources** | 6, 7, 8 | WAL crash reconciliation; injected on-disk and VM sources (stub → partial). |
+| **M5 — CFC** | 9 | Per-column then per-row labels (separate follow-up). |
+
+## Dependency graph
+
+```
+0 ──▶ 1 ──▶ 2 ──▶ 3
+            │
+            ├──▶ 4 ──▶ 5
+            └──▶ 6
+       7 (cf inject)  ── depends on 1; partial, mostly independent
+       8 (vm)         ── depends on 1; stub
+       9 (cfc)        ── depends on 4 (per-column), 2 (per-row write hook)
+```
+
+---
+
+## Phase 0 — API surface & scaffolding
+
+**Goal:** patterns type-check against the new API; builtins are registered but
+return `not-implemented`. No behavior yet. De-risks the type design.
+
+**Files**
+
+- [`packages/api/index.ts`](../../../packages/api/index.ts) — add the public
+  types: branded `SqliteDatabase`, `SqliteDatabaseSource`, `SqliteQueryParams`,
+  `SqliteQueryState<Row>`, `SqliteExecuteParams`, `SqliteExecuteState`, and the
+  function declarations (`sqliteDatabase`, `sqliteQuery`, `sqliteExecute`).
+  Follow the existing `FetchDataFunction` / `GenerateTextFunction` declaration
+  style.
+- `packages/api/` — `table(...)` and `cfLink<T>()` helper types (compile to
+  `JSONSchema`; `cfLink` emits `{ type: "string", cfLink: true }`).
+- [`packages/runner/src/builder/built-in.ts`](../../../packages/runner/src/builder/built-in.ts)
+  — builder factories via `createNodeFactory({ type: "ref", implementation })`.
+- [`packages/runner/src/builder/factory.ts`](../../../packages/runner/src/builder/factory.ts)
+  — export `sqliteDatabase`/`sqliteQuery`/`sqliteExecute`/`table`/`cfLink` on the
+  `commonfabric` object.
+- [`packages/runner/src/builtins/index.ts`](../../../packages/runner/src/builtins/index.ts)
+  — `registerBuiltins` registers `sqliteQuery` (`raw`) and `sqliteExecute`
+  (`raw(..., { isEffect: true })`), initially pointing at stubs that throw
+  `not-implemented`.
+- `packages/runner/src/builtins/sqlite-query.ts`, `.../sqlite-execute.ts` — stub
+  `Action` factories with the canonical signature
+  `(inputsCell, sendResult, addCancel, cause, parentCell, runtime)`.
+
+**Tests:** type-only fixtures that import and call each function; a pattern that
+references them compiles. No runtime assertions yet.
+
+**Exit:** `deno task check` passes on a sample pattern using the full API.
+
+---
+
+## Phase 1 — Read path (cell-derived, no reactivity, no `_cf_link`)
+
+**Goal (M1):** a `SELECT` runs server-side against a cell-derived database and
+returns plain rows to the pattern. The thin slice that proves the protocol and
+builtin plumbing.
+
+**Files & work**
+
+1. **Protocol — new `sqlite.query` verb.**
+   - [`packages/memory/v2.ts`](../../../packages/memory/v2.ts) — add
+     `SqliteQueryRequest` to the `ClientMessage` union (near line 396), and a
+     `{ rows: unknown[] }` payload on the existing `ResponseMessage`.
+   - [`packages/memory/v2/server.ts`](../../../packages/memory/v2/server.ts) —
+     parse the new `type` in `parseClientMessage`, route it in
+     `Connection.receiveOrdered` (guarded by `requireSession`, like the
+     `transact`/`graph.query` cases), and add `Server.sqliteQuery(message)`
+     modelled on `Server.queryGraph` (~line 444 client / server handler).
+   - [`packages/memory/v2/client.ts`](../../../packages/memory/v2/client.ts) —
+     add `SpaceSession.sqliteQuery(...)` mirroring `queryGraph` (~line 444),
+     using the existing `client.request<T>()` requestId correlation (~line 145).
+
+2. **Server execution & ATTACH.**
+   - [`packages/memory/v2/engine.ts`](../../../packages/memory/v2/engine.ts) —
+     `Server.sqliteQuery` calls `openEngine(space)` (~line 1456), ATTACHes the
+     cell-derived db file if not already attached for the connection, enforces a
+     **read-only guard** (single `SELECT`/read-only CTE; reject DML/DDL/PRAGMA/
+     multi-statement), then `engine.database.prepare(sql).all(params)`.
+   - [`packages/memory/v2/storage-path.ts`](../../../packages/memory/v2/storage-path.ts)
+     — add sibling-file naming `cell-<entityhash>.sqlite` next to the space file
+     (`engine-v3/…`). **[gated on Q6 — ATTACH model.]**
+
+3. **Runner builtin — `sqlite-query.ts`.**
+   - Read `db`, `sql`, `params` from `inputsCell`. Recover the handle cell from
+     `db` via the `toCell` back-pointer
+     ([`packages/runner/src/back-to-cell.ts`](../../../packages/runner/src/back-to-cell.ts);
+     [`query-result-proxy.ts`](../../../packages/runner/src/query-result-proxy.ts)).
+   - Allocate `{ pending, result, error }` output cells (model on
+     [`packages/runner/src/builtins/fetch-data.ts`](../../../packages/runner/src/builtins/fetch-data.ts)).
+   - Issue the query over the space session (the runner's storage client) and
+     write the result back. (Reads are non-mutating, so no post-commit effect is
+     needed for the read path itself.)
+
+4. **Handle creation — cell-derived.**
+   - `sqliteDatabase()` (no source) allocates a handle cell in the current frame
+     (as builtins allocate result cells), with an **empty readable value**; the
+     db name derives from its entity id
+     ([`packages/runner/src/create-ref.ts`](../../../packages/runner/src/create-ref.ts)).
+
+**Tests**
+
+- `packages/memory` unit: `sqlite.query` returns rows; read-only guard rejects
+  DML.
+- `packages/runner` integration (model on `generate-text.test.ts`): a pattern
+  queries an (empty) cell-derived db → `result: []`, `pending` settles false.
+- `packages/generated-patterns` fixture once a real table exists (after Phase 2).
+
+**Exit:** a pattern `SELECT`s from a cell-derived db over the live websocket and
+receives rows; non-`SELECT` statements are rejected server-side.
+
+---
+
+## Phase 2 — Write path & atomicity (cell-derived)
+
+**Goal (M2a):** `sqliteExecute` writes ride the existing commit transaction, so
+cells + rows commit atomically.
+
+**Files & work**
+
+1. **Commit operation kind.**
+   - [`packages/memory/v2.ts`](../../../packages/memory/v2.ts) — add
+     `SqliteOperation { op: "sqlite"; db; sql; params }` to the `Operation`
+     union (currently `SetOperation | PatchOperation | DeleteOperation`, lines
+     69–89).
+   - [`packages/memory/v2/engine.ts`](../../../packages/memory/v2/engine.ts) —
+     add `case "sqlite"` to `writeOperation` (line 3241): ensure the db is
+     ATTACHed to `engine.database` (already inside the open transaction from
+     `applyCommit` → `applyCommitTransaction`, lines 1510 / 3068), then execute
+     the statement on that connection so it is part of the same `.immediate()`
+     transaction. Order `sqlite` ops **last** among a commit's operations.
+
+2. **Runner builtin — `sqlite-execute.ts` (`isEffect`).**
+   - Append a `sqlite` operation to the transaction the effect runs in, rather
+     than performing a separate RPC. Encode `_cf_link` params is deferred to
+     Phase 4; for now reject cell-valued params.
+   - Record that the db has pending writes in the current transaction, to support
+     the read-after-write guard.
+
+3. **Read-after-write guard.**
+   - In `sqlite-query.ts` / server, if a `sqlite.query` targets a db with
+     uncommitted `sqlite` writes in the same transaction, reject with
+     `read-after-write-unsupported` (spec Section 04).
+
+4. **DDL / migration from `tables`.**
+   - Runtime creates/migrates tables from `sqliteDatabase({ tables })` on first
+     server-side open of the db: `CREATE TABLE` when absent; **add-column**
+     migrations. Validate `_cf_link` columns are `TEXT`. Unsupported changes
+     (drop/rename/retype) fail loudly. **[gated on Q9 — migration scope.]**
+
+**Tests**
+
+- Atomic commit: a handler that sets a cell and inserts a row → both visible
+  after commit; a rejected commit (seq conflict) leaves neither.
+- Read-after-write in the same tx throws.
+- DDL: declaring `{ tables }` creates them; add-column migrates; drop-column
+  errors.
+
+**Exit:** a pattern INSERTs and the row + surrounding cell writes are atomic.
+
+---
+
+## Phase 3 — Reactivity (`reactOn: db`)
+
+**Goal (M2b):** queries re-run after committed writes, never on optimistic
+state.
+
+**Files & work**
+
+- [`packages/memory/v2/engine.ts`](../../../packages/memory/v2/engine.ts) /
+  [`server.ts`](../../../packages/memory/v2/server.ts) — when
+  `applyCommitTransaction` applies a `sqlite` op, mark the **handle cell's
+  entity** dirty via `markSpaceDirty` (line ~1280; already per-entity). The
+  session sync (`syncSessionForConnection`, ~line 1152) pushes only after the
+  commit is durable.
+- `sqlite-query.ts` — read `reactOn` wholesale (any schema) so the scheduler
+  subscribes to the handle cell; re-issue the query when it is dirtied. Confirm
+  via the scheduler's own-commit-source / committed-state semantics
+  ([`packages/runner/src/scheduler/`](../../../packages/runner/src/scheduler/)).
+- Fallback: if a server hook is not viable, bump the handle cell from a
+  post-commit effect (`enqueueSinkRequestPostCommitEffect`,
+  [`packages/runner/src/cfc/sink-request.ts`](../../../packages/runner/src/cfc/sink-request.ts)).
+
+**Tests:** write → dependent `sqliteQuery` re-runs after commit; assert no
+re-run against optimistic in-flight state (no phantom rows).
+
+**Exit:** reactive re-query works for cell-derived dbs.
+
+---
+
+## Phase 4 — `_cf_link` encode/decode
+
+**Goal (M3a):** cells survive a write/read round-trip as live cells.
+
+**Files & work**
+
+- `table()` / `cfLink<T>()` finalize their JSON-schema output and the
+  `cfLink: true` marker + the "single string field ending in `_cf_link`"
+  validation.
+- **Encode (write builtin):** map each param to its column (from the statement's
+  named columns) against the db table schema; for a link column, require a cell
+  and serialize an **absolute** sigil link via
+  `createSigilLinkFromParsedLink(link, { includeSchema: false })`
+  ([`packages/runner/src/link-utils.ts`](../../../packages/runner/src/link-utils.ts);
+  cf. `Cell.getAsLink`, [`packages/runner/src/cell.ts`](../../../packages/runner/src/cell.ts) ~1400).
+  Enforce all throw conditions (Section 02).
+- **Decode (query builtin):** identify link columns (Row schema `Cell<T>` → table
+  `cfLink` → `*_cf_link` suffix); `JSON.parse`, validate single `link@1`,
+  reconstruct a `Cell` via the runtime's link resolution. Throw on malformed.
+
+**Tests:** round-trip a `Cell<User>` through a `_cf_link` column, including
+cross-space; every throw condition; `NULL` → `null`.
+
+**Exit:** `_cf_link` columns behave as specified.
+
+---
+
+## Phase 5 — `sqliteQuery<Row>` transformer support
+
+**Goal (M3b):** the `Row` type argument is lowered to a runtime schema; `Cell<T>`
+fields drive decode through aliases/joins. **[gated on Q3 — transformer owner.]**
+
+**Files & work**
+
+- [`packages/ts-transformers/src/transformers/schema-injection.ts`](../../../packages/ts-transformers/src/transformers/schema-injection.ts)
+  and [`schema-generator.ts`](../../../packages/ts-transformers/src/transformers/schema-generator.ts)
+  — extend the `toSchema<T>` lowering machinery to recognize `sqliteQuery<Row>`
+  and inject the lowered schema as a runtime argument (the runtime stub pattern
+  is [`packages/runner/src/builder/factory.ts`](../../../packages/runner/src/builder/factory.ts) line 73).
+- `sqlite-query.ts` — accept the injected `Row` schema; use it as the
+  highest-precedence source for `_cf_link` decode and result shaping.
+
+**Tests:** transformer fixture pair (`input.tsx` → `expected.jsx`) under
+`packages/ts-transformers/test/fixtures/`; runtime test of the aliased-column
+decode case from Example 07-#2.
+
+**Exit:** `<Row>` drives decode; omitting it falls back to the table schema.
+
+---
+
+## Phase 6 — WAL crash reconciliation
+
+**Goal (M4a):** cells and rows agree after a crash mid-commit despite WAL's
+cross-file gap. **[gated on Q7 — reconciliation algorithm.]**
+
+**Files & work**
+
+- [`packages/memory/v2/engine.ts`](../../../packages/memory/v2/engine.ts) — add a
+  `_cf_commit_watermark` table in each attached db; record the in-doubt `seq`
+  before the SQLite write and clear it on commit. On `open()` (~line 1335),
+  compare the space's committed `seq` (`commit` table) against the attached
+  watermark and roll back the in-doubt range on whichever side raced ahead.
+- Decide reconciliation vs. single-lock checkpoint+fsync per commit (Q7).
+
+**Tests:** fault-injection test that interleaves WAL frames and asserts
+post-open agreement.
+
+**Exit:** no divergence between cells and rows after simulated crash.
+
+---
+
+## Phase 7 — Injected on-disk source via `cf` (stub → partial)
+
+**Goal (M4b):** operators connect an on-disk db to a pattern input; pattern is
+source-agnostic. **[gated on Q13/Q14 — co-location, cross-space dirty.]**
+
+**Files & work**
+
+- [`packages/cli/commands/piece.ts`](../../../packages/cli/commands/piece.ts) /
+  `parseLink` — recognize the `sqlite:` scheme in `cf piece link`. Create-if-absent
+  a handle cell with id from `createRef(space, absPath)` in a service space,
+  store the `{ disk: { path } }` descriptor as server-side registration (not in
+  the cell value), then write a normal sigil link to the input field.
+- Server — resolve `disk:` descriptors to reachable/attachable files; return
+  `not-implemented` until co-location is settled.
+- Reactivity — cross-space dirty signal for the service-space handle, or restrict
+  injected dbs to read-only (`reactOn` omitted) for v1 (Q12).
+- Pending-until-connected already falls out of an empty input (Phase 1/3).
+
+**Tests:** `cf piece link sqlite:` is idempotent (same `(space, path)` → same
+handle); pattern shows pending until linked, then resolves.
+
+**Exit:** read-only injected on-disk dbs work end to end (writes/atomicity may
+remain deferred).
+
+---
+
+## Phase 8 — VM-file source (stub)
+
+**Goal:** `sqliteDatabase({ vm, path })` resolves; server returns
+`not-implemented` until the improved VM file API exists. **[gated on Q13.]**
+
+**Files & work**
+
+- Wire the `{ vm, path }` descriptor through the handle and server resolver.
+- When implemented, VM-file writes run as a **non-atomic post-commit effect**
+  (like `fetchData`), not part of the commit transaction (Section 03.2).
+
+**Exit:** API stable; explicit `not-implemented` until backend lands.
+
+---
+
+## Phase 9 — CFC (separate follow-up)
+
+**Goal (M5):** per-column then per-row confidentiality/integrity. See
+[06-cfc.md](./06-cfc.md) and cross-reference
+[`docs/plans/runner_cfc_implementation.md`](../../../docs/plans/runner_cfc_implementation.md).
+
+- **9a — per-column:** honor static `ifc` on table columns for read-label
+  propagation and write-time checks, reusing `ContextualFlowControl`
+  ([`packages/runner/src/cfc.ts`](../../../packages/runner/src/cfc.ts)) and the
+  write-policy sink ([`sink-request.ts`](../../../packages/runner/src/cfc/sink-request.ts)).
+- **9b — per-row:** declarative row-label projection evaluated server-side at
+  commit and on read; row-level filtering / fail-closed reads. **[gated on
+  Q16/Q17.]**
+
+---
+
+## Cross-cutting work
+
+- **Read-only enforcement** must be robust against statement smuggling (comments,
+  multiple statements, PRAGMA). Prefer SQLite's `authorizer`/`prepare`-level
+  checks over string parsing where possible.
+- **Concurrency:** `@db/sqlite` is one synchronous connection per `Database`;
+  long queries block the space. Add a statement timeout, and evaluate a separate
+  WAL read connection. **[gated on Q8.]**
+- **Telemetry/tracing:** emit query/exec spans consistent with existing builtins.
+- **Docs:** a `pattern-dev` skill note and a catalog/story example once M3 lands.
+
+## Test strategy
+
+- **Per-package unit:** `packages/memory` (protocol, engine ops, reconciliation),
+  `packages/runner` (builtin behavior), `packages/ts-transformers` (fixtures).
+- **Integration:** `packages/generated-patterns/integration/patterns/` — a
+  `sqlite-*.pattern.ts` exercising query + execute + reactivity end to end
+  against a live toolshed, mirroring the `ct-1334-fetchdata-*` patterns.
+- Every new workspace package (none expected here) would need a `test` task per
+  `AGENTS.md`; this feature extends existing packages only.
+
+## Risks & gating summary
+
+| Risk / decision | Gates | Open question |
+| --- | --- | --- |
+| ATTACH-per-file vs shared/namespaced db | Phase 1, 2 | Q6 |
+| Migration scope (SQLite `ALTER` limits) | Phase 2 | Q9 |
+| Transformer lowering of `sqliteQuery<Row>` | Phase 5 | Q3 |
+| WAL reconciliation algorithm vs. single-lock fsync | Phase 6 | Q7 |
+| On-disk co-location & cross-space dirty | Phase 7 | Q12, Q13, Q14 |
+| Connection contention / timeouts | Cross-cutting | Q8 |
+| Row-label projection expressiveness; read filtering | Phase 9 | Q16, Q17 |

--- a/packages/ts-transformers/docs/adding-type-arg-schema-lowering.md
+++ b/packages/ts-transformers/docs/adding-type-arg-schema-lowering.md
@@ -1,0 +1,92 @@
+# Adding type-argument → schema lowering for a builtin
+
+Several Common Fabric builtins accept a TypeScript **type argument** that the
+transformer lowers into a runtime JSON Schema, so the runtime receives a real
+schema even though generics are otherwise erased. `toSchema<T>()` is the
+user-facing version of this; `generateObject` and `lift` use it internally to
+turn a result/IO type into a schema argument.
+
+This doc shows how to give a new builtin the same treatment — e.g. so
+`myBuiltin<Row>(args)` injects `toSchema<Row>()` as a runtime argument.
+
+## The moving parts
+
+1. **Runtime registry** —
+   [`src/core/commonfabric-runtime-registry.ts`](../src/core/commonfabric-runtime-registry.ts).
+   Every recognized export has an entry with a `category` and, for calls, a
+   `callKind`. The transformer keys behavior off this. Add (or reuse) an entry
+   for your export.
+
+2. **`detectCallKind(node, checker)`** — resolves a call expression to its
+   registry `callKind`. Use it to recognize your call site.
+
+3. **Schema-injection helpers** —
+   [`src/transformers/schema-injection.ts`](../src/transformers/schema-injection.ts):
+   - `createToSchemaCall(context, typeNode)` — builds a `toSchema()` call
+     expression from a `ts.TypeNode`.
+   - `createSchemaCallWithRegistryTransfer(...)` — same, but transfers the
+     resolved `ts.Type` into the `TypeRegistry` so later stages
+     (`schema-generator.ts`) can emit the concrete JSON Schema. Use this when the
+     type must survive into code generation (the usual case).
+   - The first type argument is read with the `node.typeArguments?.[0]` pattern
+     (see the `getFirstTypeArgument` helper).
+
+4. **Schema generator** —
+   [`src/transformers/schema-generator.ts`](../src/transformers/schema-generator.ts)
+   walks the `TypeRegistry` entries created above and emits the final schema
+   literals. You usually do **not** touch this — registry transfer wires it up.
+
+## Recipe
+
+To lower `myBuiltin<Row>(args)` into `myBuiltin(args, /* injected */ toSchema<Row>())`:
+
+1. **Register the export.** In `commonfabric-runtime-registry.ts`, add an entry:
+   ```ts
+   { exportName: "myBuiltin", category: "call", callKind: "runtime-call", reactiveOrigin: true }
+   ```
+   (Add a dedicated `callKind` only if you need call-site-specific handling
+   beyond schema injection; `"runtime-call"` is usually enough.)
+
+2. **Recognize the call** in `schema-injection.ts`'s visitor: guard on
+   `detectCallKind(node, checker)` matching your export, and on
+   `node.typeArguments?.length === 1`.
+
+3. **Build and inject the schema argument:**
+   ```ts
+   const rowType = node.typeArguments![0];
+   const schemaCall = createSchemaCallWithRegistryTransfer(context, rowType, checker);
+   // append (or splice) schemaCall into the call's argument list
+   return ts.factory.updateCallExpression(
+     node, node.expression, /* typeArguments */ undefined,
+     [...node.arguments, schemaCall],
+   );
+   ```
+   Drop the `typeArguments` on the emitted call (they've been lowered). Mirror
+   the argument *position* your runtime builtin expects.
+
+4. **Read it at runtime.** The builtin's runner-side implementation receives the
+   injected schema as a normal argument; use it like any other schema.
+
+## Reference implementations
+
+- **`toSchema<T>()`** — the canonical case. Search `toSchema` in
+  `schema-injection.ts` (the `createToSchemaCall` definition and its call sites).
+  The runtime stub that throws when the transformer didn't run is in
+  [`packages/runner/src/builder/factory.ts`](../../runner/src/builder/factory.ts).
+- **`generateObject` / `generate-object`** — injects a *result* schema from a
+  type argument; the closest analog to "result row" lowering. See the
+  function-first argument-order handling
+  (`[function, inputSchema, resultSchema]`) in `schema-injection.ts`.
+- **`lift` / `lift-applied`** — input + result schema injection from two type
+  arguments.
+
+## Tests
+
+Add a fixture pair under
+[`test/fixtures/schema-transform/`](../test/fixtures/) (or
+`ast-transform/` for full-pipeline cases): a `*.input.tsx` calling your builtin
+with a type argument and a `*.expected.jsx` showing the injected `toSchema`/
+schema literal. The fixture-based test runner
+([`test/fixture-based.test.ts`](../test/fixture-based.test.ts)) picks them up.
+See `lift-explicit-toschema.{input,expected}` and
+`pattern-with-types.{input,expected}` for the shape.


### PR DESCRIPTION
## Summary

Design spec under `docs/specs/sqlite-builtin/` for new built-in functions that let patterns run SQLite queries against databases hosted alongside the space — plus a full implementation plan. No runtime code in this PR (spec only; implementation tracked on a follow-up branch).

Shape follows existing reactive built-ins (`fetchData`, `llm`): a parameterized request in, a reactive `{ pending, result, error }` out. **`sqliteQuery<Row>`** (read, reactive) and **`sqliteExecute`** (write, folded into the commit transaction) operate on an opaque branded **`SqliteDatabase`** handle.

## Condensed example

```tsx
const db = sqliteDatabase({
  tables: { messages: table({ id: "integer primary key", author_cf_link: cfLink<User>(), body: "text", ts: "integer" }) },
});

const recent = sqliteQuery({ db, sql: "SELECT id, body, ts, author_cf_link FROM messages ORDER BY ts DESC LIMIT 20", reactOn: db });

const send = handler<{ body: string }, { author: Cell<User> }>(({ body }, { author }) => {
  sqliteExecute({ db, sql: "INSERT INTO messages (author_cf_link, body, ts) VALUES (?, ?, ?)", params: [author, body, Date.now()] });
});
```

`sqliteExecute` writes commit atomically with surrounding cell writes; `reactOn: db` re-runs only after that commit is durable; `author_cf_link` round-trips a `Cell<User>` as an opaque sigil link.

## Key design decisions

- **Built-ins, not a new `Cell` subtype.** Read/write are separate builtins (independently gateable for CFC); reuse scheduler / post-commit-effect / CFC-sink machinery.
- **Opaque handle.** `SqliteDatabase` is a branded, empty-to-code type; a cell reference to the runtime via the `toCell` back-pointer. Source descriptor is server-side state; the handle cell's readable value is empty.
- **Database owns its tables.** `sqliteDatabase({ tables })` is the single source of truth (column types, `_cf_link`, future CFC labels); runtime owns DDL/migration. `sqliteQuery<Row>` (transformer-lowered, like `toSchema<T>`) types divergent projections and drives `_cf_link` decode through aliases.
- **`_cf_link` columns** encode a bound cell to an absolute sigil link on write, decode to a live `Cell` on read; binding a cell elsewhere throws.
- **Server-side over the existing space websocket.** Reads add a `sqlite.query` verb; writes fold into the existing `transact` commit as a new op kind, executed in the same `engine.database.transaction(...).immediate()` against an ATTACHed per-cell-db file — cells + rows atomic.
- **Reactivity: `reactOn: db`** — the write path marks the handle cell dirty post-commit, so re-query never sees optimistic state. No readable `version` field.
- **Three sources:** cell-derived (default), VM-file (stub), on-disk (operator-injected via `cf piece link <piece> <field> sqlite:<path>`, pending-until-connected).

## Resolved during review

- **Q3 transformer support** → routine; added [`packages/ts-transformers/docs/adding-type-arg-schema-lowering.md`](../blob/feat/sqlite-builtin/packages/ts-transformers/docs/adding-type-arg-schema-lowering.md).
- **Q6 storage layout** → **one `.sqlite` file per cell-db (Option A)**: file boundary = SQL namespace (no rewriting). `@db/sqlite` exposes no authorizer/`sqlite3_limit` (confirmed), so a shared db would have needed a full parser.
- **Q7 WAL crash safety** → **detect + quarantine** (watermark + persisted ops in V1; auto-repair deferred).
- **Q8a attach limit / shadowing** → LRU attach/detach cache within limit 10 + probe-and-log; ship without the core-table rename (guard + blocklist), DID-rename deferred behind a flag.
- **Q9 migration** → **additive-only** (create + `ADD COLUMN`); destructive/ambiguous diffs refuse to open; opt-in migration callback deferred.

## Document map

`README.md` · `01-api.md` · `02-cf-link-encoding.md` · `03-database-sources.md` · `04-server-execution-and-transactions.md` · `05-reactivity.md` · `06-cfc.md` · `07-examples.md` · `08-open-questions.md` · `implementation-plan.md`

Remaining open questions (genuinely later): connection contention/timeouts (Q8), on-disk co-location & cross-space dirty (Q12–14), CFC row-label projection & read filtering (Q16–17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)