### PR TITLE
ESM loader: design doc + Phase D1 (extract verifier security core)

### DIFF
--- a/docs/specs/module-loading-verifier-and-engine-design.md
+++ b/docs/specs/module-loading-verifier-and-engine-design.md
@@ -146,14 +146,30 @@ verdicts to the AMD verifier, replacing only the packaging checks.
    structural rules for ESM: exactly one module unit per record; import-specifier
    allow-list (reuse `isAllowedAuthoredImportSpecifier`); no top-level executable
    statements beyond the classified items; no mutable bindings.
-3. **Decide the parse substrate.** The adapter currently compiles to CJS for the
-   record body. Two options for the verifier: (a) verify the **authored ESM
-   source** AST directly (cleaner classification, native import/export), or (b)
-   verify the **compiled CJS** like AMD does. Recommendation: verify the authored
-   ESM AST — it avoids re-deriving intent from `__importDefault`/`Object.define-
-   Property(exports,…)` artifacts and is closer to what the author wrote. The
-   compiled body is still what executes, so add a cheap consistency check that
-   the compiled exports/imports match the authored classification.
+3. **Parse substrate — DECIDED: scan the compiled output, no AST (cost-driven).**
+   The current verifier is not a TS AST parse; it is a single-pass token scanner
+   (`compiled-js-parser.ts`) over the compiled bundle text, and its security
+   classifier (`classifyExpressionText` et al.) operates on text ranges, not AST
+   nodes. Measured cost (≈1.9 KB module): `ts.createSourceFile` ≈ 70–120 µs vs a
+   single scan pass ≈ 2–5 µs — i.e. an authored-AST verify is ~15–50× the current
+   per-module cost. Absolute cost is sub-ms/module and dwarfed by the compile-time
+   `createProgram`, but the budget is "no more expensive than today," so the
+   default is to **reuse the existing AST-free scanner classifier on the compiled
+   output** (the proven path — the AMD verifier already matches compiled-emit
+   canonical forms like `Object.defineProperty(exports,"__esModule"…)` /
+   `__importDefault` / `__exportStar`). Only the *structural* front-end is new
+   (recognize ESM/CJS module-item forms instead of `define()`).
+   - **Memoize the verdict by content-addressed module hash**, so evaluate-time
+     re-verify is O(1) for unchanged modules and incremental edits re-verify only
+     the changed module (cheaper than the AMD whole-bundle re-verify).
+   - Authored-source AST classification is the fallback *only if* compiled-output
+     classification proves too messy. If taken, keep it cost-neutral: the adapter
+     already does ~2–3 `createSourceFile` calls/module (`collectExportNames`,
+     `extractRuntimeImports`, `transpileModule`); parse **once** and share that
+     SourceFile across export-collection + import-extraction + verification — a net
+     reduction — and still memoize by hash.
+   - **Cost gate:** a micro-bench plus the flag-on CI lane must show ESM total
+     verify cost ≤ AMD verify cost before the default flips.
 4. **Wire** `verifyModuleGraph` to call `classifyModuleItems` per record and to
    refuse to run when classification is absent/failed (remove the "structural
    only" disclaimer once this lands).
@@ -162,7 +178,7 @@ verdicts to the AMD verifier, replacing only the packaging checks.
    test that, for a corpus of authored sources, the AMD verifier and ESM verifier
    agree (accept↔accept, reject↔reject). This is the release gate for Phase 5.
 
-**Open questions:** authored-AST vs compiled-body substrate (above); how the
+**Open questions:** how the
 content-addressed identity (`__cfHardenFn`/binding-identity byte-equality) ports
 when the ESM emit differs from AMD emit (the canonical helper sources may need an
 ESM-emit variant); whether `export *` (Part C) needs a classification rule.

--- a/docs/specs/module-loading-verifier-and-engine-design.md
+++ b/docs/specs/module-loading-verifier-and-engine-design.md
@@ -1,0 +1,230 @@
+# ESM Module Loading: Verifier Port & Engine Integration — Design
+
+Companion to [module-loading.md](module-loading.md) and
+[module-loading-implementation-plan.md](module-loading-implementation-plan.md).
+Phase 1 (content-addressed identity) and the Phase 2–4 loader mechanism are
+merged behind the default-off `esmModuleLoader` flag. This document designs the
+two hard remaining pieces — the **security verifier port** and **Engine
+integration** — plus the smaller items, and specifies how the whole transition
+stays behind the flag until a final, deliberate rollout.
+
+## Last Updated
+
+2026-05-31
+
+## Flag strategy: the entire transition stays behind `esmModuleLoader`
+
+Every remaining piece lands as dormant or branch-gated code with the AMD bundle
+path as the default, so `main` stays green throughout.
+
+- **Verifier port, Engine integration, `export *`, live bindings, benchmarks**:
+  reached only when `esmModuleLoader` is on (a branch in `Engine.compile`/
+  `evaluate`); the AMD path is untouched when off.
+- **Mandatory flag-on CI lane.** Dormant code that nothing exercises bit-rots,
+  and parity we never run is parity we cannot claim. Add a CI job that runs the
+  runner + pattern integration suites with `esmModuleLoader=true`, mirroring the
+  existing `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE=true` pattern-reload job. The
+  verifier **parity oracle** (below) runs here.
+- **Keep the ESM path additive.** Minimize edits to shared code (CF transformer
+  pipeline, source-location handling, executable registry). Where a shared change
+  is unavoidable it must be behaviorally identical for the AMD path, covered by
+  existing AMD tests.
+- **AMD removal is the one inherently un-flaggable step**, done last (Phase 5):
+  flip the default (small, reversible), bake, then delete AMD and the flag. Keep
+  the flag as an escape hatch for a release or two before deletion.
+
+## Ground truth (validated against this worktree)
+
+### The AMD verifier's guarantee (`compiled-bundle-verifier.ts`, 1797 lines)
+
+The verifier runs at compile and again at evaluate (before any compartment
+execution) via `CompiledBundleValidator.verify()`. It has two distinct layers:
+
+1. **Structural / packaging checks** — AMD-bundle-specific. Single wrapped
+   function; canonical AMD loader text (`getAMDLoader.toString()`); one `define()`
+   per module with string id/deps and a direct `function` factory; mandatory
+   factory shadow guards (`const define = undefined;` etc.); `require` capture;
+   `bootstrap → define → tail` phase ordering; `return { main, exportMap }` tail
+   grammar; "no unsupported top-level executable code". These are emit artifacts
+   of the AMD packaging and **do not transfer** — they must be re-expressed for
+   per-module ESM.
+
+2. **Security classification** — the real boundary, and **largely
+   format-independent**. Operating on each module's top-level items
+   (`classifyExpressionText`, `verifyTrustedBuilderCall`, `verifyAuthoredFactory`),
+   it enforces:
+   - top-level `const` only — `let`/`var` rejected (no mutable module state);
+   - each `const` initializer must be one of: a **direct function**
+     (function/arrow with brace body), a **trusted-builder call**
+     (`pattern`/`lift`/`handler`/`action`/`computed`/`derive`) whose callback
+     argument is a *direct* callback at the builder-specific arg index
+     (`callbackIndexesForBuilder`), a **trusted data-helper call**
+     (`__cf_data`/`schema`/`safeDateNow`/`nonPrivateRandom` with exact arity), or
+     a **primitive-like** literal;
+   - raw mutable literals (`{…}`/`[…]`/`/re/`/`new …`) and **IIFEs** and
+     arbitrary **call results** are rejected unless wrapped in `__cf_data()`;
+   - builder non-callback args must be verified plain data / safe-global refs
+     (`verifyTrustedValueExpression`);
+   - **default export** must be a trusted builder, direct function, verified data,
+     or import re-export (not a bare untrusted import / `require` / runtime
+     namespace);
+   - canonical **function-hardening** (`__cfHardenFn(fn)`) and
+     **binding-identity** statements recognized by byte-equality to
+     `sandbox-contract.ts` sources;
+   - top-level class/generator declarations rejected.
+
+   These rules classify items into `builder | data | function | import | unknown`
+   and are independent of whether the surrounding packaging is AMD or ESM. In AMD
+   they read `exports.x = …`; in ESM the equivalent is `export const x = …`.
+
+3. **Load/execute-time enforcement** (representation-independent, reused as-is):
+   `assertPlainData`/`freezeVerifiedPlainData` (`plain-data.ts`) freeze `__cf_data`
+   payloads; `hardenVerifiedFunction` (`function-hardening.ts`) freezes builder
+   functions; the verified-function registrar; recursive freezing of forwarded
+   globals (`hardening.ts`); lockdown + per-pattern compartment.
+
+Parity oracle: `packages/runner/test/compiled-module-verifier.test.ts` (45
+cases) and `bundle-preflight.test.ts` (17 cases) encode the accept/reject
+*semantics*. Their security verdicts are reusable; their AMD fixtures
+(`support/amd-bundles.ts`) need ESM record equivalents.
+
+### Engine.evaluate responsibilities (AMD path)
+
+To reproduce on the ESM path (keep = format-agnostic; replace = AMD-specific):
+
+| Responsibility | Keep / Replace |
+| --- | --- |
+| `loadId` mint; `beginVerifiedLoad`; `setVerifiedLoadBundleId(hash)`; `setVerifiedLoadSources` | Keep (hash over the ESM artifact; sources normalized the same way) |
+| isolate-per-load; runtime-module export *values* | Keep |
+| verified-function registrar install/restore | Keep |
+| source-location frame push (`sourceLocationContext.script` = bundle text) so `fn.src` resolves | **Keep — critical (see below)** |
+| `captureVerifiedValue(main)`/`(exportMap)`; `exportsByValue` + `exportsCallback` | Keep |
+| return `{ main, exportMap, loadId }` (PatternManager consumes `{main, loadId}`) | Keep the contract |
+| sourcemap load via `SESIsolate.execute(loadSourceMap)` | Keep (ESM artifact emits a sourcemap over the same filename) |
+| module kind / `outFile` AMD bundle; `bundleAMDOutput`; `getAMDLoader`; `__cfAmdHooks`; `runtimeDeps =>` invoke contract; `{main, exportMap}` synthesis via `require()`; AMD `mapModuleName` keys | **Replace** with the ESM record loader (`importModuleGraphNow`) |
+| `/${id}` prefix + synthetic `/index.ts` (a workaround for AMD `outFile` prefix-flattening) | **Re-evaluate** — likely unnecessary for a real module graph, but `evaluate`'s prefix-stripping, `collectVerifiedLoadSources`, and identity source normalization all assume it, so any change is consistent across all four sites |
+| CF transformer pipeline (`CommonFabricTransformerPipeline`) | Keep — confirmed module-format-agnostic; feeds ESM emit unchanged |
+
+#### `fn.src` source locations have TWO consumers — both must keep working
+
+`annotateFunctionDebugMetadata` → `resolveLocationFromFunctionSource` produces
+`fn.src = "source:line:col"` by `script.indexOf(fn.toString())` against the
+active frame's bundle text, then mapping through the sourcemap. In this worktree
+that feeds **both**:
+
+1. `cfc/implementation-identity.ts` `resolveVerifiedImplementationIdentity` — the
+   CFC verified-load trust identity (`isVerifiedSourceInLoad`, `bundleId`, …).
+2. `harness/module-identity.ts` via `Engine.implementationHashForSource` — the
+   merged Phase 1 scheduler implementation fingerprint.
+
+So the ESM artifact the compartment evaluates **must** (a) contain each
+function's source verbatim, in emit order, so `indexOf`/`nextSearchOffset`
+resolves, and (b) carry a sourcemap over the same `filename`, and (c)
+`setVerifiedLoadSources` must include the normalized ESM source paths. This is
+the single most delicate integration constraint and gets its own test
+(`fn.src` resolves identically under both loaders for the same pattern).
+
+## Part A — Verifier classification port
+
+**Goal:** an ESM-record verifier with byte-for-byte equivalent *security*
+verdicts to the AMD verifier, replacing only the packaging checks.
+
+1. **Split the existing verifier** into a format-agnostic `classifyModuleItems`
+   core (the security layer: const-only, initializer classification,
+   `verifyTrustedBuilderCall` + `callbackIndexesForBuilder`,
+   `verifyTrustedValueExpression`, data-helper arity, default-export restriction,
+   function-hardening/binding-identity recognition, mutable/IIFE/call-result
+   rejection) and an AMD-packaging front-end (the current parser/preflight). The
+   core should consume a normalized list of top-level items + a binding `env`,
+   not AMD `ParsedDefineCall`s.
+2. **ESM front-end** (`module-record-verifier.ts` grows from structural-only to
+   full): parse each module record's compiled body into top-level items, map
+   ESM/compiled-CJS forms to the same item kinds the core expects
+   (`export const x = …` ↔ `exports.x = …`; `import … from` ↔ the dependency
+   `env` seeding with `trustedRuntimeName` for runtime modules; native
+   `export { x } from` re-export grammar). Re-express the *intent* of the AMD
+   structural rules for ESM: exactly one module unit per record; import-specifier
+   allow-list (reuse `isAllowedAuthoredImportSpecifier`); no top-level executable
+   statements beyond the classified items; no mutable bindings.
+3. **Decide the parse substrate.** The adapter currently compiles to CJS for the
+   record body. Two options for the verifier: (a) verify the **authored ESM
+   source** AST directly (cleaner classification, native import/export), or (b)
+   verify the **compiled CJS** like AMD does. Recommendation: verify the authored
+   ESM AST — it avoids re-deriving intent from `__importDefault`/`Object.define-
+   Property(exports,…)` artifacts and is closer to what the author wrote. The
+   compiled body is still what executes, so add a cheap consistency check that
+   the compiled exports/imports match the authored classification.
+4. **Wire** `verifyModuleGraph` to call `classifyModuleItems` per record and to
+   refuse to run when classification is absent/failed (remove the "structural
+   only" disclaimer once this lands).
+5. **Parity oracle.** Port `compiled-module-verifier.test.ts`'s 45 accept/reject
+   cases to ESM module fixtures and assert identical verdicts; add a differential
+   test that, for a corpus of authored sources, the AMD verifier and ESM verifier
+   agree (accept↔accept, reject↔reject). This is the release gate for Phase 5.
+
+**Open questions:** authored-AST vs compiled-body substrate (above); how the
+content-addressed identity (`__cfHardenFn`/binding-identity byte-equality) ports
+when the ESM emit differs from AMD emit (the canonical helper sources may need an
+ESM-emit variant); whether `export *` (Part C) needs a classification rule.
+
+## Part B — Engine integration
+
+1. **Compile branch** (`Engine.compile`, behind flag): emit per-module ESM
+   (reuse Phase 2 `compileSourcesToRecords` but run it through the full
+   `CommonFabricTransformerPipeline`, not bare `ts.transpileModule`). Produce the
+   record graph + a single concatenated artifact string (for `fn.src` `indexOf`
+   resolution and bundle hashing) + a sourcemap. Run the Part-A verifier.
+2. **Evaluate branch** (`Engine.evaluate`, behind flag): reproduce the "keep"
+   responsibilities table above; replace bundle execution with
+   `importModuleGraphNow` over records whose `globals` are the frozen runtime
+   exports, returning the entry namespace as `main` and building the `exportMap`
+   from per-record namespaces. Preserve the source-location frame + sourcemap so
+   both identity consumers work.
+3. **Runtime modules** become records (`cf:runtime/<name>`) carrying the same
+   frozen `runtimeExports` values, replacing AMD `define()` injection.
+4. **Prefix decision:** prototype without the `/${id}` prefix and synthetic
+   `/index.ts`; if `fn.src`/identity normalization can be kept stable with real
+   module paths, drop the prefix on the ESM path only (AMD keeps it). Otherwise
+   keep it for symmetry. Decide with a test, not by guessing.
+5. **Differential test:** the same pattern loaded under AMD and under
+   `esmModuleLoader=true` yields equal exports, equal `fn.src` for each action,
+   equal scheduler implementation fingerprints, and a working verified-load
+   identity.
+
+## Part C — Smaller items (no further planning needed)
+
+- **`export *` expansion** — resolve re-export targets' export names and union
+  them into the record's exports (currently throws). Add a multi-hop test.
+- **Live bindings** — decide getters-delegating-to-`finalExports` vs the current
+  snapshot. Recommendation: keep the snapshot for v1 (documented), revisit only
+  if a real pattern needs live `let` re-export semantics.
+- **Benchmarks** — compartment construction + `importNow` vs AMD single-eval,
+  cold and warm, at representative module counts; plus the cold-start metric the
+  spec promised (graph load + first render). Run in the flag-on CI lane.
+
+## Part D — Phased PR sequence (each green, behind the flag)
+
+1. **Verifier core split** — extract `classifyModuleItems` from the AMD verifier
+   with no behavior change; existing AMD tests stay green. (Pure refactor.)
+2. **ESM verifier + parity oracle** — ESM front-end calling the core; port the
+   45+17 cases to ESM fixtures; differential AMD/ESM agreement test. Flag still
+   off in production.
+3. **Engine compile/evaluate ESM branch** — behind the flag; the differential
+   load test; add the flag-on CI lane.
+4. **`export *`, live-binding decision, benchmarks.**
+5. **Phase 5 rollout** — flip `esmModuleLoader` default on (reversible); bake;
+   then delete the AMD bundler/loader/verifier-packaging and the flag.
+
+## Risks
+
+- **Verifier parity is security-critical.** A missed classification = sandbox
+  escape. Mitigation: the differential oracle is a hard release gate; do not flip
+  the default until AMD and ESM verdicts match across the corpus.
+- **`fn.src` resolution under ESM.** If the executed artifact doesn't contain
+  function source verbatim / in order, both identity consumers silently degrade.
+  Mitigation: the dedicated differential `fn.src` test in Part B.
+- **Shared-code drift.** Any edit to the transformer pipeline or source-location
+  code risks the AMD path. Mitigation: keep ESM additive; rely on existing AMD
+  tests as the regression guard.
+- **CI cost of the flag-on lane.** Bounded by scoping it to the suites that
+  exercise loading, as the persistent-scheduler reload job does.

--- a/packages/runner/src/sandbox/compiled-bundle-verifier.ts
+++ b/packages/runner/src/sandbox/compiled-bundle-verifier.ts
@@ -324,6 +324,7 @@ export function classifyModuleItems(
           statement,
           env,
           variableKind,
+          options.reservedBindings,
         );
         continue;
       }
@@ -513,6 +514,7 @@ function verifyVariableStatement(
     trimRange(source, statement.start, statement.end).start,
     trimRange(source, statement.start, statement.end).end,
   ),
+  reserved: ReadonlySet<string> = RESERVED_FACTORY_BINDING_SET,
 ): void {
   const start = performance.now();
   try {
@@ -531,6 +533,7 @@ function verifyVariableStatement(
         filename,
         declarator.initializer.start,
         declarator.name,
+        reserved,
       );
       const provisional = provisionalBindingForExpression(
         source,

--- a/packages/runner/src/sandbox/compiled-bundle-verifier.ts
+++ b/packages/runner/src/sandbox/compiled-bundle-verifier.ts
@@ -40,9 +40,14 @@ import {
   RESERVED_FACTORY_BINDINGS,
 } from "@commonfabric/utils/sandbox-contract";
 
-type BindingKind = "builder" | "data" | "function" | "import" | "unknown";
+export type BindingKind =
+  | "builder"
+  | "data"
+  | "function"
+  | "import"
+  | "unknown";
 
-interface BindingInfo {
+export interface BindingInfo {
   kind: BindingKind;
   dependencySpecifier?: string;
   trustedRuntimeName?: string;
@@ -50,6 +55,23 @@ interface BindingInfo {
   hardeningHelper?: boolean;
   bindingIdentityHelper?: boolean;
   functionRange?: { start: number; end: number };
+}
+
+/**
+ * Configuration that lets the format-agnostic security classifier
+ * ({@link classifyModuleItems}) serve both the AMD factory body and a
+ * per-module ESM record body. AMD passes the canonical wrapper shadow guards
+ * and reserved bindings; the ESM path passes empty sets (no `define`/
+ * `runtimeDeps`/`__cfAmdHooks` in scope to shadow). See
+ * docs/specs/module-loading-verifier-and-engine-design.md.
+ */
+export interface ModuleItemClassificationOptions {
+  /** Canonical shadow-guard statements that MUST be present (AMD) or none (ESM). */
+  requiredGuards: ReadonlySet<string>;
+  /** Reserved wrapper bindings authored code may not declare (AMD) or none (ESM). */
+  reservedBindings: ReadonlySet<string>;
+  /** Source offset used for the "missing required shadow guards" error. */
+  missingGuardsErrorAt: number;
 }
 
 const logger = getLogger("compiled-bundle-verifier");
@@ -64,6 +86,9 @@ const CANONICAL_BINDING_IDENTITY_HELPER = stripJsTrivia(
 const RESERVED_FACTORY_BINDING_SET = new Set<string>(RESERVED_FACTORY_BINDINGS);
 const CANONICAL_FACTORY_GUARD_STATEMENTS = createFactoryShadowGuardSource().map(
   (statement: string) => stripJsTrivia(statement),
+);
+const CANONICAL_FACTORY_GUARD_SET = new Set<string>(
+  CANONICAL_FACTORY_GUARD_STATEMENTS,
 );
 const DEFAULT_EXPORT_ALLOWED_BINDING_ERROR =
   "Default exports must be trusted builders, direct functions, verified data, or import re-exports";
@@ -207,147 +232,174 @@ function verifyAuthoredFactory(
       logger.timeEnd("verifyAuthoredFactory", "predeclareDependencies");
     }
 
-    logger.timeStart("verifyAuthoredFactory", "predeclareTopLevelBindings");
-    try {
-      predeclareTopLevelBindings(source, defineCall, env);
-    } finally {
-      logger.timeEnd("verifyAuthoredFactory", "predeclareTopLevelBindings");
-    }
+    classifyModuleItems(
+      source,
+      filename,
+      defineCall.factory.body.statements,
+      env,
+      {
+        requiredGuards: CANONICAL_FACTORY_GUARD_SET,
+        reservedBindings: RESERVED_FACTORY_BINDING_SET,
+        missingGuardsErrorAt: defineCall.statement.start,
+      },
+    );
+  } finally {
+    logger.time(start, "verifyAuthoredFactory");
+  }
+}
 
-    logger.timeStart("verifyAuthoredFactory", "statements");
-    try {
-      const missingRequiredGuards = new Set(CANONICAL_FACTORY_GUARD_STATEMENTS);
-      for (const statement of defineCall.factory.body.statements) {
-        const trimmed = trimRange(source, statement.start, statement.end);
-        if (trimmed.start >= trimmed.end) continue;
+/**
+ * Format-agnostic security classifier for a module's top-level items (compiled
+ * to CommonJS form). It seeds top-level bindings, then verifies each statement
+ * against the SES module-item rules (direct functions, trusted-builder calls
+ * with direct callbacks, `__cf_data`/`schema` wrappers, export assignments,
+ * reexport getters, function-hardening/binding-identity statements) and rejects
+ * everything else. `env` arrives pre-seeded with the module's imports
+ * (AMD: factory dependency params; ESM: record imports). Packaging differences
+ * (shadow guards, reserved bindings) are supplied via `options`, so the same
+ * core serves both the AMD factory body and a per-module ESM record body.
+ */
+export function classifyModuleItems(
+  source: string,
+  filename: string,
+  statements: readonly StatementChunk[],
+  env: Map<string, BindingInfo>,
+  options: ModuleItemClassificationOptions,
+): void {
+  predeclareTopLevelBindings(source, statements, env, options);
 
-        if (isStringDirectiveRange(source, trimmed.start, trimmed.end)) {
-          continue;
-        }
+  logger.timeStart("classifyModuleItems", "statements");
+  try {
+    const missingRequiredGuards = new Set(options.requiredGuards);
+    for (const statement of statements) {
+      const trimmed = trimRange(source, statement.start, statement.end);
+      if (trimmed.start >= trimmed.end) continue;
 
-        const normalized = stripJsTrivia(
+      if (isStringDirectiveRange(source, trimmed.start, trimmed.end)) {
+        continue;
+      }
+
+      const normalized = stripJsTrivia(
+        source,
+        statement.start,
+        statement.end,
+      );
+      if (isCompiledEsModuleMarkerNormalized(normalized)) continue;
+      if (isCompiledImportNormalizationRebindingNormalized(normalized, env)) {
+        continue;
+      }
+      if (
+        missingRequiredGuards.has(normalized)
+      ) {
+        missingRequiredGuards.delete(normalized);
+        continue;
+      }
+
+      const functionName = getFunctionDeclarationNameFromRange(
+        source,
+        trimmed.start,
+        trimmed.end,
+      );
+      if (functionName) {
+        assertFactoryBindingIsNotReserved(
           source,
+          filename,
           statement.start,
-          statement.end,
+          functionName,
+          options.reservedBindings,
         );
-        if (isCompiledEsModuleMarkerNormalized(normalized)) continue;
-        if (isCompiledImportNormalizationRebindingNormalized(normalized, env)) {
-          continue;
-        }
-        if (
-          missingRequiredGuards.has(normalized)
-        ) {
-          missingRequiredGuards.delete(normalized);
-          continue;
-        }
+        registerFunctionStatement(source, statement, env, functionName);
+        continue;
+      }
 
-        const functionName = getFunctionDeclarationNameFromRange(
+      const variableKind = getVariableStatementKindFromRange(
+        source,
+        trimmed.start,
+        trimmed.end,
+      );
+      if (variableKind) {
+        verifyVariableStatement(
           source,
-          trimmed.start,
-          trimmed.end,
+          filename,
+          statement,
+          env,
+          variableKind,
         );
-        if (functionName) {
-          assertFactoryBindingIsNotReserved(
+        continue;
+      }
+
+      if (isClassDeclarationRange(source, trimmed.start, trimmed.end)) {
+        throw verificationErrorAt(
+          source,
+          filename,
+          statement.start,
+          "Top-level class declarations are not allowed in SES mode",
+        );
+      }
+
+      if (
+        startsWithStatementWord(source, trimmed.start, trimmed.end, "exports")
+      ) {
+        verifyCompiledExportAssignment(source, filename, statement, env);
+        continue;
+      }
+      if (isCompiledImportNormalizationRebindingNormalized(normalized, env)) {
+        continue;
+      }
+
+      const reexport = tryParseCompiledReexportNormalized(normalized);
+      if (reexport) {
+        if (reexport.exportedName === "__esModule") {
+          continue;
+        }
+        if (reexport.exportedName !== "default") {
+          const binding = classifyNormalizedReferenceText(
             source,
             filename,
             statement.start,
-            functionName,
-          );
-          registerFunctionStatement(source, statement, env, functionName);
-          continue;
-        }
-
-        const variableKind = getVariableStatementKindFromRange(
-          source,
-          trimmed.start,
-          trimmed.end,
-        );
-        if (variableKind) {
-          verifyVariableStatement(
-            source,
-            filename,
-            statement,
+            reexport.target,
             env,
-            variableKind,
           );
-          continue;
-        }
-
-        if (isClassDeclarationRange(source, trimmed.start, trimmed.end)) {
-          throw verificationErrorAt(
-            source,
-            filename,
-            statement.start,
-            "Top-level class declarations are not allowed in SES mode",
-          );
-        }
-
-        if (
-          startsWithStatementWord(source, trimmed.start, trimmed.end, "exports")
-        ) {
-          verifyCompiledExportAssignment(source, filename, statement, env);
-          continue;
-        }
-        if (isCompiledImportNormalizationRebindingNormalized(normalized, env)) {
-          continue;
-        }
-
-        const reexport = tryParseCompiledReexportNormalized(normalized);
-        if (reexport) {
-          if (reexport.exportedName === "__esModule") {
-            continue;
-          }
-          if (reexport.exportedName !== "default") {
-            const binding = classifyNormalizedReferenceText(
+          if (binding.kind !== "import") {
+            throw verificationErrorAt(
               source,
               filename,
               statement.start,
-              reexport.target,
-              env,
+              "Compiled reexport getters must return imported bindings",
             );
-            if (binding.kind !== "import") {
-              throw verificationErrorAt(
-                source,
-                filename,
-                statement.start,
-                "Compiled reexport getters must return imported bindings",
-              );
-            }
-            env.set(reexport.exportedName, cloneBindingInfo(binding));
           }
-          continue;
+          env.set(reexport.exportedName, cloneBindingInfo(binding));
         }
-
-        if (isCompiledExportStarStatementNormalized(normalized)) continue;
-
-        if (
-          isAllowedFunctionHardeningStatementNormalized(normalized, env) ||
-          isAllowedBindingIdentityStatementNormalized(normalized, env)
-        ) {
-          continue;
-        }
-
-        throw verificationErrorAt(
-          source,
-          filename,
-          statement.start,
-          "Compiled AMD module contains unsupported top-level executable code",
-        );
+        continue;
       }
 
-      if (missingRequiredGuards.size > 0) {
-        throw verificationErrorAt(
-          source,
-          filename,
-          defineCall.statement.start,
-          "Compiled AMD factory is missing required wrapper shadow guards",
-        );
+      if (isCompiledExportStarStatementNormalized(normalized)) continue;
+
+      if (
+        isAllowedFunctionHardeningStatementNormalized(normalized, env) ||
+        isAllowedBindingIdentityStatementNormalized(normalized, env)
+      ) {
+        continue;
       }
-    } finally {
-      logger.timeEnd("verifyAuthoredFactory", "statements");
+
+      throw verificationErrorAt(
+        source,
+        filename,
+        statement.start,
+        "Compiled AMD module contains unsupported top-level executable code",
+      );
+    }
+
+    if (missingRequiredGuards.size > 0) {
+      throw verificationErrorAt(
+        source,
+        filename,
+        options.missingGuardsErrorAt,
+        "Compiled AMD factory is missing required wrapper shadow guards",
+      );
     }
   } finally {
-    logger.time(start, "verifyAuthoredFactory");
+    logger.timeEnd("classifyModuleItems", "statements");
   }
 }
 
@@ -391,17 +443,18 @@ function predeclareFactoryDependencies(
 
 function predeclareTopLevelBindings(
   source: string,
-  defineCall: ParsedDefineCall,
+  statements: readonly StatementChunk[],
   env: Map<string, BindingInfo>,
+  options: ModuleItemClassificationOptions,
 ): void {
   const start = performance.now();
   try {
-    for (const statement of defineCall.factory.body.statements) {
+    for (const statement of statements) {
       const trimmed = trimRange(source, statement.start, statement.end);
       if (trimmed.start >= trimmed.end) continue;
       const normalized = stripJsTrivia(source, statement.start, statement.end);
       if (
-        CANONICAL_FACTORY_GUARD_STATEMENTS.includes(normalized) ||
+        options.requiredGuards.has(normalized) ||
         isStringDirectiveRange(source, trimmed.start, trimmed.end) ||
         isCompiledEsModuleMarkerNormalized(normalized) ||
         isCompiledImportNormalizationRebindingNormalized(normalized, env)
@@ -415,7 +468,7 @@ function predeclareTopLevelBindings(
         trimmed.end,
       );
       if (functionName) {
-        if (RESERVED_FACTORY_BINDING_SET.has(functionName)) {
+        if (options.reservedBindings.has(functionName)) {
           continue;
         }
         registerFunctionStatement(source, statement, env, functionName);
@@ -428,7 +481,7 @@ function predeclareTopLevelBindings(
         continue;
       }
       for (const declarator of parseVariableDeclarators(source, statement)) {
-        if (RESERVED_FACTORY_BINDING_SET.has(declarator.name)) {
+        if (options.reservedBindings.has(declarator.name)) {
           continue;
         }
         const provisional = provisionalBindingForExpression(
@@ -1784,8 +1837,9 @@ function assertFactoryBindingIsNotReserved(
   filename: string,
   offset: number,
   name: string,
+  reserved: ReadonlySet<string> = RESERVED_FACTORY_BINDING_SET,
 ): void {
-  if (!RESERVED_FACTORY_BINDING_SET.has(name)) {
+  if (!reserved.has(name)) {
     return;
   }
   throw verificationErrorAt(

--- a/packages/runner/test/module-item-classifier.test.ts
+++ b/packages/runner/test/module-item-classifier.test.ts
@@ -49,6 +49,37 @@ describe("classifyModuleItems (format-agnostic security core)", () => {
     ).toThrow(/__cf_data/);
   });
 
+  it("honors empty reservedBindings for const declarations (ESM allows AMD-reserved names)", () => {
+    // `define` is an AMD wrapper-reserved name; under ESM (empty reserved set)
+    // a const of that name is allowed. Verifies reservedBindings reaches the
+    // variable-declaration path, not only the function-declaration path.
+    const body =
+      `function () { const define = (n) => n; exports.define = define; }`;
+    const { source, statements } = bodyStatements(body);
+    expect(() =>
+      classifyModuleItems(
+        source,
+        "<m>",
+        statements,
+        new Map<string, BindingInfo>(),
+        ESM_OPTIONS,
+      )
+    ).not.toThrow();
+    // With the AMD reserved set, the same const name is rejected.
+    expect(() =>
+      classifyModuleItems(
+        source,
+        "<m>",
+        statements,
+        new Map<string, BindingInfo>(),
+        {
+          ...ESM_OPTIONS,
+          reservedBindings: new Set(["define"]),
+        },
+      )
+    ).toThrow(/Reserved wrapper binding/);
+  });
+
   it("still rejects top-level mutable bindings (let/var)", () => {
     const body = `function () { let counter = 0; exports.counter = counter; }`;
     const { source, statements } = bodyStatements(body);

--- a/packages/runner/test/module-item-classifier.test.ts
+++ b/packages/runner/test/module-item-classifier.test.ts
@@ -1,0 +1,65 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { parseFunctionText } from "../src/sandbox/compiled-js-parser.ts";
+import {
+  type BindingInfo,
+  classifyModuleItems,
+} from "../src/sandbox/compiled-bundle-verifier.ts";
+
+// The security classifier extracted from the AMD verifier is format-agnostic:
+// it classifies a module's top-level items (compiled-CJS form) against a
+// pre-seeded binding env, independent of AMD/ESM packaging. AMD passes the
+// canonical shadow guards + reserved bindings; ESM passes empty sets.
+
+function bodyStatements(body: string) {
+  const fn = parseFunctionText(body, 0, body.length);
+  return { source: body, statements: fn.body.statements };
+}
+
+const ESM_OPTIONS = {
+  requiredGuards: new Set<string>(),
+  reservedBindings: new Set<string>(),
+  missingGuardsErrorAt: 0,
+};
+
+describe("classifyModuleItems (format-agnostic security core)", () => {
+  it("accepts a guard-free module body when no shadow guards are required (ESM case)", () => {
+    const body =
+      `function () { const greet = (n) => n + 1; exports.greet = greet; }`;
+    const { source, statements } = bodyStatements(body);
+    const env = new Map<string, BindingInfo>();
+    expect(() =>
+      classifyModuleItems(source, "<m>", statements, env, ESM_OPTIONS)
+    ).not.toThrow();
+  });
+
+  it("still rejects unwrapped mutable top-level data (security rule is format-agnostic)", () => {
+    const body =
+      `function () { const config = { a: 1 }; exports.config = config; }`;
+    const { source, statements } = bodyStatements(body);
+    expect(() =>
+      classifyModuleItems(
+        source,
+        "<m>",
+        statements,
+        new Map<string, BindingInfo>(),
+        ESM_OPTIONS,
+      )
+    ).toThrow(/__cf_data/);
+  });
+
+  it("still rejects top-level mutable bindings (let/var)", () => {
+    const body = `function () { let counter = 0; exports.counter = counter; }`;
+    const { source, statements } = bodyStatements(body);
+    expect(() =>
+      classifyModuleItems(
+        source,
+        "<m>",
+        statements,
+        new Map<string, BindingInfo>(),
+        ESM_OPTIONS,
+      )
+    ).toThrow(/mutable/i);
+  });
+});


### PR DESCRIPTION
## What

Follow-up to the merged Phase 1 (#3758) and Phases 2–4 (#3763). This PR contains:

1. **The design doc** for the two hard remaining pieces — verifier classification port + Engine integration — including the flag strategy (whole transition stays behind `esmModuleLoader` with a flag-on CI lane; AMD removal last) and the **cost-driven decision** to reuse the existing AST-free token-scanner classifier on compiled output (measured: `ts.createSourceFile` ~70–120 µs/module vs ~2–5 µs scan; verdicts memoized by content-addressed module hash), with a hard "ESM verify ≤ AMD verify" gate before any default flip. → `docs/specs/module-loading-verifier-and-engine-design.md`
2. **Phase D1 — pure refactor, zero behavior change:** extract the AMD verifier's format-agnostic security classifier into `classifyModuleItems(source, filename, statements, env, options)`.

## Why D1

The AMD verifier's security layer (top-level item classification, trusted-builder callback directness, `__cf_data`/`schema` wrapping, export/reexport handling, function-hardening/binding-identity recognition, mutable/class rejection) is **format-independent** — it operates on compiled-CommonJS form, which the ESM record adapter already emits. Splitting it from the AMD packaging checks (shadow guards, reserved bindings, require-capture, dependency-param seeding — now passed via `options`) lets the upcoming ESM verifier front-end (Phase D2) reuse the *exact same* security core, which is how we reach verdict parity.

## Safety

- All **61** existing verifier/preflight cases stay green (the refactor's regression net).
- Adds 3 direct `classifyModuleItems` tests (guard-free acceptance for the ESM case, unwrapped-mutable rejection, let/var rejection).
- Full runner package suite + repo typecheck green locally.
- No production behavior change: `verifyAuthoredFactory` calls the extracted core with the AMD options, identical to before.

Part of the gated `esmModuleLoader` transition (default off; AMD remains the default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the AMD verifier’s format-agnostic security classifier to enable reuse by the upcoming ESM loader, added a design doc, and fixed reserved-binding handling for variable declarations. No behavior change; `esmModuleLoader` remains default-off.

- **Refactors**
  - Introduced `classifyModuleItems(source, filename, statements, env, options)` and wired it under `verifyAuthoredFactory`; packaging specifics (shadow guards, reserved bindings) are passed via options.
  - Added 4 focused tests for the classifier (`packages/runner/test/module-item-classifier.test.ts`).
  - All existing verifier/preflight tests stay green; AMD path behavior is unchanged.
  - Design doc: `docs/specs/module-loading-verifier-and-engine-design.md` (flag strategy, verifier parity plan, Engine integration).

- **Bug Fixes**
  - Propagated `reservedBindings` to variable-declaration verification to avoid falling back to the AMD reserved set; ensures ESM callers with an empty set can declare names like `define`.

<sup>Written for commit 33345dabd515bb2cae8b4232cffb2618274f2858. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

