### PR TITLE
ci: disable LLM gateway in tests and fix toolshed key env var name

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -237,7 +237,8 @@ jobs:
           TOOLSHED_PORT: 8000
         run: |
           chmod +x ./common-binaries/toolshed
-          CTTS_AI_LLM_ANTHROPIC_API_KEY=fake \
+          CFTS_AI_GATEWAY_URL="" \
+          CFTS_AI_LLM_ANTHROPIC_API_KEY=fake \
           ./common-binaries/toolshed --port="$TOOLSHED_PORT" &
 
       # For Astral
@@ -323,7 +324,7 @@ jobs:
           # Set tools to path
           # Integration script needs `cf`
           echo "${{ github.workspace }}/common-binaries" >> $GITHUB_PATH
-          MEMORY_URL="$TOOLSHED_URL" API_URL="$TOOLSHED_URL" ./common-binaries/toolshed --port="$TOOLSHED_PORT" &
+          CFTS_AI_GATEWAY_URL="" MEMORY_URL="$TOOLSHED_URL" API_URL="$TOOLSHED_URL" ./common-binaries/toolshed --port="$TOOLSHED_PORT" &
 
       - name: 📦 Install CLI integration dependencies
         env:
@@ -401,7 +402,8 @@ jobs:
       - name: 🚀 Start Toolshed server for testing
         run: |
           chmod +x ./common-binaries/toolshed
-          CTTS_AI_LLM_ANTHROPIC_API_KEY=fake \
+          CFTS_AI_GATEWAY_URL="" \
+          CFTS_AI_LLM_ANTHROPIC_API_KEY=fake \
           ./common-binaries/toolshed &
 
       # For Astral

--- a/packages/toolshed/.env.test
+++ b/packages/toolshed/.env.test
@@ -2,3 +2,6 @@ ENV=test
 PORT=9999
 LOG_LEVEL=silent
 IDENTITY=./test.key
+# Disable the Tailscale-only LLM gateway in tests; it is unreachable in CI and
+# its startup model-discovery fetch (models.ts) would otherwise time out.
+CFTS_AI_GATEWAY_URL=


### PR DESCRIPTION
## Problem

We saw CI failures because the LLM gateway wasn't accessible — surprising, since the LLM-exercising pattern tests are gated behind `TEST_LLM` and skipped in CI.

The cause is a config default, not a test change. Since [#3706](https://github.com/commontoolsinc/labs/pull/3706), toolshed's `CFTS_AI_GATEWAY_URL` **defaults** to the Tailscale-only gateway `https://llm.stage.commontools.dev`, and toolshed runs a top-level `await loadGatewayModels()` model-discovery fetch at startup (`packages/toolshed/routes/ai/llm/models.ts`). Off-Tailscale (CI), that fetch times out.

This was compounded by a stale env var name:

- CI starts toolshed with `CTTS_AI_LLM_ANTHROPIC_API_KEY=fake` — the legacy *Common Tools* prefix — but the env schema reads `CFTS_` (*Common Fabric*, renamed in #3177). The fake key was silently dropped, so **no direct provider registered** and the unreachable gateway became toolshed's only model source.
- The gateway was only configured because it's the schema default — CI never opted into it for tests.

## Fix

- **Disable the gateway in tests**: set `CFTS_AI_GATEWAY_URL=""` at all three CI toolshed start sites in `deno.yml` and in `packages/toolshed/.env.test`. The guard `if (env.CFTS_AI_GATEWAY_URL)` (models.ts) treats empty as disabled, so the startup fetch is skipped — no timeout, no Tailscale dependency. An empty model registry is non-fatal (`registerDefaultModel` just warns).
  - `.env.test` is needed because the toolshed unit-test job triggers the same fetch at import time: `generateText.test.ts` → `generateText.ts` → `models.ts`.
- **Fix the env var name**: `CTTS_AI_LLM_ANTHROPIC_API_KEY` → `CFTS_AI_LLM_ANTHROPIC_API_KEY`, so the fake key registers an Anthropic provider and a default model resolves.

None of the affected CI jobs actually call the LLM, so disabling the gateway and registering only a fake-keyed provider is safe.

## Follow-ups (not in this PR)

- `.github/workflows/evals.yml` has the same `CTTS_`-prefixed env var names (lines ~119-121, 143) feeding the toolshed binary — likely the same silent-drop bug, but it uses real repo secrets, so I left it for a separate, deliberate change.
- Longer term, LLM-exercising pattern tests should move to the runner's conversation-fixture mocks (`loadConversationFixtureFile`, see `packages/runner/test/llm-conversation-fixture.test.ts`) so they need no gateway at all and can run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disables the Tailscale-only LLM gateway in tests and fixes the Anthropic API key env var name in CI. This prevents toolshed startup timeouts and ensures a default model registers so tests pass.

- Bug Fixes
  - Set `CFTS_AI_GATEWAY_URL=""` in `.github/workflows/deno.yml` and `packages/toolshed/.env.test` to skip the startup model-discovery fetch.
  - Correct `CTTS_AI_LLM_ANTHROPIC_API_KEY` to `CFTS_AI_LLM_ANTHROPIC_API_KEY` so a fake-keyed Anthropic provider is registered.

<sup>Written for commit 4c3b08903825d14f6ab6151a6bd5eeadc3267fc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



---BEGIN COPY-PASTE---
NEW_PERF_BASELINE: step: Type check = 68s
NEW_PERF_BASELINE: job: Check = 91s
---END COPY-PASTE---
