### PR TITLE
Phase D2: ESM module verifier (classifyModuleItems reuse + parity oracle)

### DIFF
--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -62,6 +62,8 @@ export interface CompiledModuleGraph {
   records: Map<string, VirtualModuleRecord>;
   /** Content-addressed specifier for each original file path. */
   specifierByPath: Map<string, string>;
+  /** Compiled CommonJS body per specifier — the text the verifier classifies. */
+  compiledBodies: Map<string, string>;
 }
 
 export function compileSourcesToRecords(
@@ -82,6 +84,7 @@ export function compileSourcesToRecords(
   }
 
   const records = new Map<string, VirtualModuleRecord>();
+  const compiledBodies = new Map<string, string>();
   for (const source of sources) {
     const specifier = specifierByPath.get(source.name)!;
     const moduleHash = hashes.get(source.name)!;
@@ -109,6 +112,7 @@ export function compileSourcesToRecords(
     // erased by the compiler and never appear here, so they correctly do not
     // become record edges — unlike `collectImportSpecifiers`, which includes
     // them for module *identity*.
+    compiledBodies.set(specifier, compiled);
     const importSpecs = extractRuntimeImports(compiled);
     const resolutions: Record<string, string> = {};
     for (const spec of importSpecs) {
@@ -164,7 +168,7 @@ export function compileSourcesToRecords(
     });
   }
 
-  return { records, specifierByPath };
+  return { records, specifierByPath, compiledBodies };
 }
 
 /**

--- a/packages/runner/src/sandbox/module-record-verifier.ts
+++ b/packages/runner/src/sandbox/module-record-verifier.ts
@@ -74,7 +74,8 @@ export function verifyCompiledModuleBody(
   // a non-canonical require has no special treatment.
   const requireShadowed = statementTexts.some((t) =>
     /^(?:const|let|var)\s+require\b/.test(t) ||
-    /^function\s*\*?\s*require\b/.test(t)
+    /^(?:async\s+)?function\s*\*?\s*require\b/.test(t) ||
+    /^class\s+require\b/.test(t)
   );
 
   const env = new Map<string, BindingInfo>();

--- a/packages/runner/src/sandbox/module-record-verifier.ts
+++ b/packages/runner/src/sandbox/module-record-verifier.ts
@@ -40,6 +40,12 @@ const REQUIRE_IMPORT = new RegExp(
     "require\\(\\s*[\"']([^\"']+)[\"']\\s*\\)\\s*\\)?\\s*;?$",
 );
 
+// A bare side-effect import preamble statement, e.g. `require("./styles.ts");`
+// (compiled from `import "./styles.ts"`). It binds nothing; AMD treats this as
+// a plain dependency, so for parity it is allowed (when the specifier is) and
+// skipped rather than classified as executable code.
+const SIDE_EFFECT_REQUIRE = /^require\(\s*["']([^"']+)["']\s*\)\s*;?$/;
+
 /**
  * Security-classify a module's compiled-CommonJS body (Phase D2). It recognizes
  * the `const x = require("…")` import preamble — seeding `env` with import
@@ -74,23 +80,29 @@ export function verifyCompiledModuleBody(
   const env = new Map<string, BindingInfo>();
   const classifiable: typeof parsed.body.statements = [];
   parsed.body.statements.forEach((statement, index) => {
-    const match = requireShadowed
-      ? null
-      : REQUIRE_IMPORT.exec(statementTexts[index]);
+    const text = statementTexts[index];
     // Only fast-path imports whose specifier is allowed (runtime module or a
     // local path); arbitrary specifiers (e.g. "node:fs") fall through and are
-    // rejected by classification, matching the AMD dependency allowlist.
-    if (match && isAllowedAuthoredImportSpecifier(match[2])) {
-      const [, binding, specifier] = match;
-      env.set(binding, {
-        kind: "import",
-        dependencySpecifier: specifier,
-        namespaceImport: true,
-        trustedRuntimeName: isRuntimeModuleIdentifier(specifier)
-          ? specifier
-          : undefined,
-      });
-      return;
+    // rejected by classification, matching the AMD dependency allowlist. The
+    // fast-path is disabled entirely when `require` is shadowed.
+    if (!requireShadowed) {
+      const bound = REQUIRE_IMPORT.exec(text);
+      if (bound && isAllowedAuthoredImportSpecifier(bound[2])) {
+        const [, binding, specifier] = bound;
+        env.set(binding, {
+          kind: "import",
+          dependencySpecifier: specifier,
+          namespaceImport: true,
+          trustedRuntimeName: isRuntimeModuleIdentifier(specifier)
+            ? specifier
+            : undefined,
+        });
+        return;
+      }
+      const sideEffect = SIDE_EFFECT_REQUIRE.exec(text);
+      if (sideEffect && isAllowedAuthoredImportSpecifier(sideEffect[1])) {
+        return; // side-effect import binds nothing
+      }
     }
     classifiable.push(statement);
   });

--- a/packages/runner/src/sandbox/module-record-verifier.ts
+++ b/packages/runner/src/sandbox/module-record-verifier.ts
@@ -4,7 +4,10 @@ import {
   classifyModuleItems,
 } from "./compiled-bundle-verifier.ts";
 import { parseFunctionText } from "./compiled-js-parser.ts";
-import { isRuntimeModuleIdentifier } from "./runtime-module-policy.ts";
+import {
+  isAllowedAuthoredImportSpecifier,
+  isRuntimeModuleIdentifier,
+} from "./runtime-module-policy.ts";
 
 /**
  * Structural pre-flight verification for a module-record graph (Phase 3 of
@@ -54,13 +57,30 @@ export function verifyCompiledModuleBody(
   // body; offsets stay consistent with `wrapped` for classification.
   const wrapped = `function () {\n${compiled}\n}`;
   const parsed = parseFunctionText(wrapped, 0, wrapped.length);
+  const statementTexts = parsed.body.statements.map((s) =>
+    wrapped.slice(s.start, s.end).trim()
+  );
+
+  // If the body shadows `require` with its own top-level binding, the
+  // `const x = require(...)` fast-path would mis-trust an arbitrary call.
+  // Disable the fast-path entirely so those statements fall through to
+  // classifyModuleItems (which rejects the call result) — matching AMD, where
+  // a non-canonical require has no special treatment.
+  const requireShadowed = statementTexts.some((t) =>
+    /^(?:const|let|var)\s+require\b/.test(t) ||
+    /^function\s*\*?\s*require\b/.test(t)
+  );
 
   const env = new Map<string, BindingInfo>();
   const classifiable: typeof parsed.body.statements = [];
-  for (const statement of parsed.body.statements) {
-    const text = wrapped.slice(statement.start, statement.end).trim();
-    const match = REQUIRE_IMPORT.exec(text);
-    if (match) {
+  parsed.body.statements.forEach((statement, index) => {
+    const match = requireShadowed
+      ? null
+      : REQUIRE_IMPORT.exec(statementTexts[index]);
+    // Only fast-path imports whose specifier is allowed (runtime module or a
+    // local path); arbitrary specifiers (e.g. "node:fs") fall through and are
+    // rejected by classification, matching the AMD dependency allowlist.
+    if (match && isAllowedAuthoredImportSpecifier(match[2])) {
       const [, binding, specifier] = match;
       env.set(binding, {
         kind: "import",
@@ -70,10 +90,10 @@ export function verifyCompiledModuleBody(
           ? specifier
           : undefined,
       });
-      continue;
+      return;
     }
     classifiable.push(statement);
-  }
+  });
 
   classifyModuleItems(wrapped, filename, classifiable, env, {
     requiredGuards: EMPTY_BINDING_SET,

--- a/packages/runner/src/sandbox/module-record-verifier.ts
+++ b/packages/runner/src/sandbox/module-record-verifier.ts
@@ -1,4 +1,10 @@
 import type { VirtualModuleRecord } from "./esm-module-loader.ts";
+import {
+  type BindingInfo,
+  classifyModuleItems,
+} from "./compiled-bundle-verifier.ts";
+import { parseFunctionText } from "./compiled-js-parser.ts";
+import { isRuntimeModuleIdentifier } from "./runtime-module-policy.ts";
 
 /**
  * Structural pre-flight verification for a module-record graph (Phase 3 of
@@ -9,15 +15,72 @@ import type { VirtualModuleRecord } from "./esm-module-loader.ts";
  * before any module executes — every specifier is content-addressed, every
  * record is well-formed, and every resolved import points at a present record.
  *
- * NOTE: the deep SES_SANDBOXING module-item classification (direct callbacks to
- * trusted builders, safe top-level functions, verified module-safe data) is the
- * security-critical part of the verifier port and is NOT yet implemented here.
- * It must be ported from the AMD `define()` parser before the ESM loader can
- * run untrusted code by default. Until then the `esmModuleLoader` flag stays
- * off and the AMD verifier remains the enforcement path.
+ * The deep SES_SANDBOXING module-item classification is provided by
+ * {@link verifyCompiledModuleBody}, which reuses the shared `classifyModuleItems`
+ * core extracted from the AMD verifier. The `esmModuleLoader` flag stays off and
+ * the AMD verifier remains the enforcement path until the differential parity
+ * oracle confirms ESM and AMD verdicts match across the corpus.
  */
 
 const VALID_SPECIFIER = /^cf:(module|runtime)\//;
+
+const EMPTY_BINDING_SET: ReadonlySet<string> = new Set<string>();
+
+// A compiled-CommonJS import preamble statement, e.g.
+//   const util_ts_1 = require("./util.ts");
+//   const cf_1 = __importDefault(require("commonfabric"));
+//   const ns_1 = __importStar(require("./ns.ts"));
+// Captures the local binding name and the imported specifier.
+const REQUIRE_IMPORT = new RegExp(
+  "^const\\s+([A-Za-z_$][\\w$]*)\\s*=\\s*" +
+    "(?:__importDefault|__importStar)?\\s*\\(?\\s*" +
+    "require\\(\\s*[\"']([^\"']+)[\"']\\s*\\)\\s*\\)?\\s*;?$",
+);
+
+/**
+ * Security-classify a module's compiled-CommonJS body (Phase D2). It recognizes
+ * the `const x = require("…")` import preamble — seeding `env` with import
+ * bindings (marking runtime modules as trusted) — and hands the remaining
+ * top-level items to the shared {@link classifyModuleItems} core with empty
+ * shadow-guard / reserved-binding sets (ESM modules have no AMD wrapper to
+ * shadow). Throws on any violation; the byte-level rules are identical to the
+ * AMD path, so a malicious module is rejected the same way under either loader.
+ */
+export function verifyCompiledModuleBody(
+  compiled: string,
+  filename = "<module>",
+): void {
+  // Wrap so the AMD parser can extract the top-level statements as a function
+  // body; offsets stay consistent with `wrapped` for classification.
+  const wrapped = `function () {\n${compiled}\n}`;
+  const parsed = parseFunctionText(wrapped, 0, wrapped.length);
+
+  const env = new Map<string, BindingInfo>();
+  const classifiable: typeof parsed.body.statements = [];
+  for (const statement of parsed.body.statements) {
+    const text = wrapped.slice(statement.start, statement.end).trim();
+    const match = REQUIRE_IMPORT.exec(text);
+    if (match) {
+      const [, binding, specifier] = match;
+      env.set(binding, {
+        kind: "import",
+        dependencySpecifier: specifier,
+        namespaceImport: true,
+        trustedRuntimeName: isRuntimeModuleIdentifier(specifier)
+          ? specifier
+          : undefined,
+      });
+      continue;
+    }
+    classifiable.push(statement);
+  }
+
+  classifyModuleItems(wrapped, filename, classifiable, env, {
+    requiredGuards: EMPTY_BINDING_SET,
+    reservedBindings: EMPTY_BINDING_SET,
+    missingGuardsErrorAt: 0,
+  });
+}
 
 export class ModuleGraphVerificationError extends Error {
   override name = "ModuleGraphVerificationError";

--- a/packages/runner/test/esm-module-body-verifier.test.ts
+++ b/packages/runner/test/esm-module-body-verifier.test.ts
@@ -1,0 +1,57 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { compileSourcesToRecords } from "../src/sandbox/module-record-compiler.ts";
+import { verifyCompiledModuleBody } from "../src/sandbox/module-record-verifier.ts";
+
+// D2: the ESM verifier front-end classifies each module's compiled-CommonJS
+// body. Unlike the AMD factory (deps are params), the CJS body has a
+// `const x = require("...")` import preamble that the front-end must recognize
+// (seeding env with import bindings) before handing the rest to the shared
+// classifyModuleItems core.
+
+function compiledBody(files: Record<string, string>, path: string): string {
+  const sources = Object.entries(files).map(([name, contents]) => ({
+    name,
+    contents,
+  }));
+  const { specifierByPath, compiledBodies } = compileSourcesToRecords(sources, {
+    runtimeModules: { commonfabric: ["pattern", "lift", "handler", "derive"] },
+  });
+  return compiledBodies.get(specifierByPath.get(path)!)!;
+}
+
+describe("verifyCompiledModuleBody", () => {
+  it("accepts a benign multi-import pattern module", () => {
+    const body = compiledBody({
+      "/util.ts": `export const dbl = (x: number): number => x * 2;`,
+      "/main.tsx":
+        `import { dbl } from "./util.ts";\nimport { pattern, lift } from "commonfabric";\nexport const helper = (x: number) => dbl(x);\nexport const v = pattern((s: { n: number }) => ({ d: lift((c: number) => dbl(c))(s.n) }));\nexport default v;\n`,
+    }, "/main.tsx");
+    expect(() => verifyCompiledModuleBody(body, "/main.tsx")).not.toThrow();
+  });
+
+  it("accepts the imported leaf module", () => {
+    const body = compiledBody({
+      "/util.ts": `export const dbl = (x: number): number => x * 2;`,
+    }, "/util.ts");
+    expect(() => verifyCompiledModuleBody(body, "/util.ts")).not.toThrow();
+  });
+
+  it("rejects unwrapped mutable top-level data", () => {
+    const body = compiledBody({
+      "/main.ts": `export const config = { a: 1, b: 2 };`,
+    }, "/main.ts");
+    expect(() => verifyCompiledModuleBody(body, "/main.ts")).toThrow(
+      /__cf_data/,
+    );
+  });
+
+  it("rejects a top-level call result that is not a trusted builder/data", () => {
+    const body = compiledBody({
+      "/main.ts":
+        `const leaked = fetch("https://evil.example");\nexport const x = 1;\n`,
+    }, "/main.ts");
+    expect(() => verifyCompiledModuleBody(body, "/main.ts")).toThrow();
+  });
+});

--- a/packages/runner/test/esm-verifier-parity.test.ts
+++ b/packages/runner/test/esm-verifier-parity.test.ts
@@ -116,6 +116,12 @@ const REJECT: Case[] = [
     reject: /.*/,
   },
   {
+    name: "shadowed require via async function declaration",
+    body:
+      `async function require(x) { return globalThis; }\nconst g = require("commonfabric");\nexports.g = g;`,
+    reject: /.*/,
+  },
+  {
     name: "require of a disallowed specifier (node:fs)",
     body: `const fs_1 = require("node:fs");\nexports.fs = fs_1;`,
     reject: /.*/,

--- a/packages/runner/test/esm-verifier-parity.test.ts
+++ b/packages/runner/test/esm-verifier-parity.test.ts
@@ -60,6 +60,11 @@ const ACCEPT: Case[] = [
     body:
       `const cf_1 = __importStar(require("commonfabric"));\nconst d_1 = __importDefault(require("./dep.ts"));\nexports.v = (0, cf_1.pattern)(() => ({}));`,
   },
+  {
+    name: "bare side-effect import of an allowed specifier",
+    body:
+      `require("./styles.ts");\nconst helper = (x) => x;\nexports.helper = helper;`,
+  },
 ];
 
 const REJECT: Case[] = [
@@ -113,6 +118,11 @@ const REJECT: Case[] = [
   {
     name: "require of a disallowed specifier (node:fs)",
     body: `const fs_1 = require("node:fs");\nexports.fs = fs_1;`,
+    reject: /.*/,
+  },
+  {
+    name: "bare side-effect import of a disallowed specifier",
+    body: `require("node:child_process");\nexports.x = 1;`,
     reject: /.*/,
   },
 ];

--- a/packages/runner/test/esm-verifier-parity.test.ts
+++ b/packages/runner/test/esm-verifier-parity.test.ts
@@ -55,6 +55,11 @@ const ACCEPT: Case[] = [
     body:
       `"use strict";\nObject.defineProperty(exports, "__esModule", { value: true });\nexports.v = void 0;\n${IMPORT}\nexports.v = (0, cf_1.pattern)(() => ({}));`,
   },
+  {
+    name: "__importDefault / __importStar require preamble forms",
+    body:
+      `const cf_1 = __importStar(require("commonfabric"));\nconst d_1 = __importDefault(require("./dep.ts"));\nexports.v = (0, cf_1.pattern)(() => ({}));`,
+  },
 ];
 
 const REJECT: Case[] = [
@@ -98,6 +103,17 @@ const REJECT: Case[] = [
     name: "default export of a runtime namespace",
     body: `${IMPORT}\nexports.default = cf_1;`,
     reject: /Default exports/i,
+  },
+  {
+    name: "shadowed require defeating the import fast-path",
+    body:
+      `const require = (x) => globalThis;\nconst g = require("commonfabric");\nexports.g = g;`,
+    reject: /.*/,
+  },
+  {
+    name: "require of a disallowed specifier (node:fs)",
+    body: `const fs_1 = require("node:fs");\nexports.fs = fs_1;`,
+    reject: /.*/,
   },
 ];
 

--- a/packages/runner/test/esm-verifier-parity.test.ts
+++ b/packages/runner/test/esm-verifier-parity.test.ts
@@ -1,0 +1,115 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { verifyCompiledModuleBody } from "../src/sandbox/module-record-verifier.ts";
+
+// Verifier-level parity oracle (Phase D2.2). These are crafted compiled-
+// CommonJS module bodies that mimic CF-transformed output (the same way the AMD
+// verifier is tested with crafted AMD fixtures). They assert that the ESM body
+// verifier reproduces the AMD verifier's accept/reject *semantics* for the
+// format-agnostic SES module-item rules. The end-to-end differential (same
+// authored source through both the AMD and ESM compile paths) lands in D3 once
+// the adapter runs the CF transformer pipeline.
+
+const IMPORT = `const cf_1 = require("commonfabric");`;
+
+interface Case {
+  name: string;
+  body: string;
+  reject?: RegExp; // present => expected to throw (matching), else expected to pass
+}
+
+const ACCEPT: Case[] = [
+  {
+    name: "direct builder callback",
+    body: `${IMPORT}\nexports.v = (0, cf_1.pattern)((s) => ({ n: s.n }));`,
+  },
+  {
+    name: "top-level direct function used as a builder callback",
+    body:
+      `${IMPORT}\nconst cb = (s) => ({ n: s.n });\nexports.v = (0, cf_1.pattern)(cb);`,
+  },
+  {
+    name: "plain top-level function + export",
+    body: `const helper = (x) => x + 1;\nexports.helper = helper;`,
+  },
+  {
+    name: "__cf_data-wrapped mutable object",
+    body: `${IMPORT}\nexports.config = (0, cf_1.__cf_data)({ a: 1, b: 2 });`,
+  },
+  {
+    name: "schema()-wrapped value",
+    body: `${IMPORT}\nexports.s = (0, cf_1.schema)({ type: "object" });`,
+  },
+  {
+    name: "named reexport getter from an internal import",
+    body:
+      `const inner_1 = require("./inner.ts");\nObject.defineProperty(exports, "x", { enumerable: true, get: function () { return inner_1.x; } });`,
+  },
+  {
+    name: "ambient safe global inside a builder callback",
+    body: `${IMPORT}\nexports.v = (0, cf_1.pattern)((s) => fetch(s.url));`,
+  },
+  {
+    name: "es-module marker + void-0 export forward decl preamble",
+    body:
+      `"use strict";\nObject.defineProperty(exports, "__esModule", { value: true });\nexports.v = void 0;\n${IMPORT}\nexports.v = (0, cf_1.pattern)(() => ({}));`,
+  },
+];
+
+const REJECT: Case[] = [
+  {
+    name: "raw mutable object export without __cf_data",
+    body: `const config = { a: 1, b: 2 };\nexports.config = config;`,
+    reject: /__cf_data/,
+  },
+  {
+    name: "top-level mutable binding (let)",
+    body: `let counter = 0;\nexports.counter = counter;`,
+    reject: /mutable/i,
+  },
+  {
+    name: "state-hiding IIFE",
+    body: `const x = (() => ({ a: 1 }))();\nexports.x = x;`,
+    reject: /.*/,
+  },
+  {
+    name: "top-level class declaration",
+    body: `class Foo {}\nexports.Foo = Foo;`,
+    reject: /class declarations/i,
+  },
+  {
+    name: "top-level generator declaration",
+    body: `function* gen() {}\nexports.gen = gen;`,
+    reject: /.*/,
+  },
+  {
+    name: "unwrapped top-level call result",
+    body: `const leaked = JSON.parse("{}");\nexports.leaked = leaked;`,
+    reject: /module scope|call results|__cf_data/i,
+  },
+  {
+    name: "indirect (non-function) builder callback",
+    body:
+      `${IMPORT}\nconst data = (0, cf_1.__cf_data)({});\nexports.v = (0, cf_1.pattern)(data);`,
+    reject: /direct callback/i,
+  },
+  {
+    name: "default export of a runtime namespace",
+    body: `${IMPORT}\nexports.default = cf_1;`,
+    reject: /Default exports/i,
+  },
+];
+
+describe("ESM verifier parity oracle (crafted CF-shaped bodies)", () => {
+  for (const c of ACCEPT) {
+    it(`accepts: ${c.name}`, () => {
+      expect(() => verifyCompiledModuleBody(c.body, "/m.ts")).not.toThrow();
+    });
+  }
+  for (const c of REJECT) {
+    it(`rejects: ${c.name}`, () => {
+      expect(() => verifyCompiledModuleBody(c.body, "/m.ts")).toThrow(c.reject);
+    });
+  }
+});


### PR DESCRIPTION
## What (Phase D2 — ESM verifier port, behind the flag)

Builds on the merged D1 (`classifyModuleItems` extraction, #3765). Adds the **security classifier for the ESM module path**, reusing the shared core so verdicts match the AMD verifier.

- `verifyCompiledModuleBody(compiled, filename)` (`module-record-verifier.ts`): security-classifies a module's compiled-CommonJS body. The CJS body differs from the AMD factory in one way — imports appear as a `const x = require("…")` preamble rather than factory params — so the front-end recognizes those statements, seeds `env` with import bindings (runtime modules marked trusted via `isRuntimeModuleIdentifier`), and hands the remaining items to the shared `classifyModuleItems` with empty guard/reserved sets (ESM has no AMD wrapper to shadow). Every other rule (direct-callback builders, `__cf_data`/`schema` wrapping, mutable/IIFE/class/generator/call-result rejection, default-export restriction) is enforced by the shared core unchanged.
- `compileSourcesToRecords` now exposes `compiledBodies` per specifier — the exact text the loader executes — so the verifier classifies what runs.

## Tests
- `esm-module-body-verifier.test.ts`: against **real adapter output** — accepts benign multi-import patterns + leaf modules; rejects unwrapped mutable data and untrusted top-level call results.
- `esm-verifier-parity.test.ts`: the **verifier-level parity oracle** — 16 crafted CF-shaped CJS fixtures (8 accept / 8 reject) confirming the ESM verifier reproduces the AMD verifier's accept/reject semantics.

## Not in this PR
- **Wiring** `verifyCompiledModuleBody` into the load path + running the CF transformer pipeline in the adapter → **D3** (Engine integration). The end-to-end differential (same authored source through both compile paths) lands there.
- The `esmModuleLoader` flag stays **off**; AMD remains the default. This is dormant capability.

## Note
This is the SES security boundary for the ESM path — reviewing for verdict parity with the AMD verifier is the key concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an ESM module body verifier that reuses `classifyModuleItems`, and closes parity gaps (shadowed `require`, specifier allowlist, bare side-effect `require`) so ESM verdicts match AMD. Ships behind `esmModuleLoader`; not wired into the loader yet.

- **New Features**
  - `verifyCompiledModuleBody(compiled, filename)`: detects `const x = require("…")` import preambles, seeds import bindings (runtime imports trusted via `isRuntimeModuleIdentifier`), then classifies remaining items via `classifyModuleItems` with empty guard/reserved sets.
  - `compileSourcesToRecords` now returns `compiledBodies` per specifier so we verify the exact executed text.
  - Tests: adapter-output cases pass; parity oracle expanded (accepts `__importStar`/`__importDefault` preambles and bare side-effect `require` of allowed specs; now 10 accept / 12 reject) to confirm ESM/AMD parity.

- **Bug Fixes**
  - Disable the import fast-path if `require` is shadowed, including `async function require` and `class require`; those calls are classified and rejected, matching AMD.
  - Apply `isAllowedAuthoredImportSpecifier` to the fast-path so disallowed specifiers (e.g. `node:fs`) fall through and are rejected.
  - Accept bare side-effect `require("<allowed>")` (binds nothing); disallowed specifiers still fall through and are rejected.

<sup>Written for commit ca75a465b874a0449f3016b4631b75ef8621bd75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

