### PR TITLE
docs: drop the obsolete shared-profile implementation plan

### DIFF
--- a/docs/specs/shared-profile-space.md
+++ b/docs/specs/shared-profile-space.md
@@ -424,25 +424,6 @@ Add focused runner tests for `wish()`:
   of the scheduler action
 - `wish({ query: "#profile" })` returns the profile default pattern
 
-## Implementation Plan
-
-1. Add schemas and helper types for the profile default-pattern link and
-   `ProfileDefaultPattern` / `ProfileElement`.
-2. Add `PatternFactory.inSpace(...)` and use it for profile-space creation.
-3. Add the profile default pattern at
-   `packages/patterns/system/profile-home.tsx`.
-4. Add profile default-pattern creation in `packages/piece` for explicit
-   profile-space controller flows.
-5. Update the home pattern to render missing and linked profile states.
-6. Update `WishParams.scope`, `wish()` parsing, and hashtag search for
-   `"profile"`.
-7. Add explicit profile well-known targets: `#profileSpace`, `#profileName`,
-   and `#profileAvatar`.
-8. Add runner tests for wish behavior.
-9. Add the browser integration test and demo pattern.
-10. Update `docs/common/conventions/wish.md` and
-    `docs/common/conventions/HOME_SPACE.md` after behavior lands.
-
 ## Open Questions
 
 - Should profile spaces be readable by all collaborators by default, or private


### PR DESCRIPTION
The shared-profile feature is implemented and merged (#3759–#3762), so the step-by-step **Implementation Plan** section in `docs/specs/shared-profile-space.md` is stale.

Removes just that section. The rest of the spec is unchanged — including the **Open Questions** (one of which, the cross-user profile read exposure, is tracked as CT-1630).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the obsolete Implementation Plan from `docs/specs/shared-profile-space.md` now that shared-profile is implemented. Open Questions remain unchanged, including the cross-user profile read exposure tracked in CT-1630.

<sup>Written for commit 38df6050e017f3aa94f05eb51aa614b5d3387d95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

