### PR TITLE
Phase D3 (1/2): ESM compile path — compileToModules + verified record graph

### DIFF
--- a/packages/js-compiler/test/typescript.compiler.test.ts
+++ b/packages/js-compiler/test/typescript.compiler.test.ts
@@ -73,6 +73,31 @@ describe("TypeScriptCompiler", () => {
     expect(compiled.sourceMap).toBeDefined();
   });
 
+  it("compileToModules emits per-module CommonJS for each source", async () => {
+    const compiler = new TypeScriptCompiler(types);
+    const program = new InMemoryProgram("/main.tsx", {
+      "/main.tsx":
+        "import { sub } from './math/subtract.ts';export const run = () => sub(10,2);export default run;",
+      "/utils.ts": "export const add=(x:number,y:number):number =>x+y;",
+      "/math/subtract.ts":
+        "import { add } from '../utils.ts';export const sub = (x:number,y:number)=>add(x,y*-1)",
+    });
+    const resolved = await compiler.resolveProgram(program);
+    const modules = compiler.compileToModules(resolved);
+
+    // One compiled CommonJS body per source file (no bundle).
+    expect(new Set(modules.keys())).toEqual(
+      new Set(["/main.tsx", "/utils.ts", "/math/subtract.ts"]),
+    );
+    const main = modules.get("/main.tsx")!;
+    expect(main.js).toContain('require("./math/subtract.ts")');
+    expect(main.js).toContain("exports.run");
+    expect(main.sourceMap).toBeDefined();
+    // No AMD wrapper / define() — this is bare CommonJS.
+    expect(main.js).not.toContain("define(");
+    expect(modules.get("/utils.ts")!.js).toContain("exports.add");
+  });
+
   it("Typechecks a runtime dependency, providing typedefs", async () => {
     const compiler = new TypeScriptCompiler(types);
     const program = new InMemoryProgram("/main.tsx", {

--- a/packages/js-compiler/typescript/compiler.ts
+++ b/packages/js-compiler/typescript/compiler.ts
@@ -23,6 +23,7 @@ import { getLogger } from "@commonfabric/utils/logger";
 import { getCompilerOptions, TARGET } from "./options.ts";
 import { bundleAMDOutput } from "./bundler/mod.ts";
 import { parseSourceMap } from "../source-map.ts";
+import type { SourceMap } from "../interface.ts";
 import { resolveProgram } from "./resolver.ts";
 import {
   Checker,
@@ -299,6 +300,93 @@ export class TypeScriptCompiler implements Compiler<TypeScriptCompilerOptions> {
   ): Promise<JsScript> {
     const program = await this.resolveProgram(resolver, options);
     return await this.compile(program, options);
+  }
+
+  /**
+   * Compile a program to per-module CommonJS, running the SAME type-check and
+   * Common Fabric transformer pipeline as {@link compile}, but emitting one
+   * CommonJS file per source (no AMD `outFile` bundle). Returns the compiled
+   * body + source map per original source name — the inputs the ESM module-
+   * record loader and verifier consume. Used by the `esmModuleLoader` path.
+   */
+  compileToModules(
+    program: Program,
+    inputOptions: TypeScriptCompilerOptions = {},
+  ): Map<string, { js: string; sourceMap?: SourceMap }> {
+    const noCheck = inputOptions.noCheck ?? false;
+    const runtimeModules = inputOptions.runtimeModules ?? [];
+
+    validateSource(program);
+    const sourceNames = program.files.map(({ name }) => name);
+    const tsOptions = getCompilerOptions();
+    // Per-module CommonJS instead of the bundled AMD output.
+    tsOptions.module = ts.ModuleKind.CommonJS;
+    tsOptions.esModuleInterop = true;
+    delete tsOptions.outFile;
+    delete tsOptions.ignoreDeprecations;
+    // The bundled `outFile` path tolerates the trimmed virtual lib .d.ts files;
+    // the multi-file path type-checks them and surfaces lib-internal errors
+    // (e.g. FormData in dom.d.ts). We only need to type-check authored code, so
+    // skip checking the declaration libs themselves.
+    tsOptions.skipLibCheck = true;
+
+    const host = new TypeScriptHost(program, this.typeLibs, runtimeModules);
+    const tsProgram = ts.createProgram(sourceNames, tsOptions, host);
+
+    const checker = new Checker(tsProgram, {
+      messageTransformer: inputOptions.diagnosticMessageTransformer,
+    });
+    if (!noCheck) {
+      checker.typeCheck();
+    }
+    checker.declarationCheck();
+
+    const { beforeTransformers, getDiagnostics } = createTransformers(
+      tsProgram,
+      inputOptions,
+    );
+
+    // Emit ALL source files (not just main), so every module gets a body.
+    const { diagnostics, emitSkipped } = tsProgram.emit(
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { before: beforeTransformers },
+    );
+    checker.check(diagnostics);
+
+    if (getDiagnostics) {
+      const errors = getDiagnostics().filter((d) => d.severity === "error");
+      if (errors.length > 0) {
+        const sources = new Map<string, string>();
+        for (const file of program.files) sources.set(file.name, file.contents);
+        throw new TransformerError(errors, sources);
+      }
+    }
+    if (emitSkipped) {
+      throw new Error("Emit skipped. Check diagnostics.");
+    }
+
+    // Map emitted `<name>.js` outputs back to their original source names.
+    const sourceByStem = new Map<string, string>();
+    for (const name of sourceNames) {
+      if (name.endsWith(".d.ts")) continue;
+      sourceByStem.set(name.replace(/\.[^./]+$/, ""), name);
+    }
+    const writes = host.getWrites();
+    const result = new Map<string, { js: string; sourceMap?: SourceMap }>();
+    for (const [outName, contents] of Object.entries(writes)) {
+      if (!outName.endsWith(".js")) continue;
+      const stem = outName.replace(/\.js$/, "");
+      const sourceName = sourceByStem.get(stem);
+      if (sourceName === undefined) continue;
+      result.set(sourceName, {
+        js: contents,
+        sourceMap: parseSourceMap(writes[`${outName}.map`]),
+      });
+    }
+    return result;
   }
 
   // Compiles `source` into `JsArtifact`.

--- a/packages/js-compiler/typescript/compiler.ts
+++ b/packages/js-compiler/typescript/compiler.ts
@@ -372,7 +372,16 @@ export class TypeScriptCompiler implements Compiler<TypeScriptCompilerOptions> {
     const sourceByStem = new Map<string, string>();
     for (const name of sourceNames) {
       if (name.endsWith(".d.ts")) continue;
-      sourceByStem.set(name.replace(/\.[^./]+$/, ""), name);
+      const stem = name.replace(/\.[^./]+$/, "");
+      const existing = sourceByStem.get(stem);
+      if (existing !== undefined) {
+        // Two sources emit to the same `<stem>.js` (e.g. `/a.ts` and `/a.tsx`).
+        // The output→source mapping would be ambiguous; fail loudly.
+        throw new Error(
+          `Ambiguous emit target: '${existing}' and '${name}' both compile to '${stem}.js'`,
+        );
+      }
+      sourceByStem.set(stem, name);
     }
     const writes = host.getWrites();
     const result = new Map<string, { js: string; sourceMap?: SourceMap }>();

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -26,8 +26,20 @@ import { getLogger } from "@commonfabric/utils/logger";
 import { Runtime } from "../runtime.ts";
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import { StaticCache } from "@commonfabric/static";
-import { pretransformProgram } from "./pretransform.ts";
+import {
+  pretransformProgram,
+  pretransformProgramForModules,
+} from "./pretransform.ts";
 import { computeModuleHashes } from "./module-identity.ts";
+import {
+  type CompiledModuleGraph,
+  compileSourcesToRecords,
+} from "../sandbox/module-record-compiler.ts";
+import {
+  runtimeModuleRecords,
+  type VirtualModuleRecord,
+} from "../sandbox/esm-module-loader.ts";
+import { verifyCompiledModuleBody } from "../sandbox/module-record-verifier.ts";
 import { popFrame, pushFrame } from "../builder/pattern.ts";
 import {
   ensureSESLockdown,
@@ -228,6 +240,96 @@ export class Engine extends EventTarget implements Harness {
       return { id, jsScript, sesValidated: true };
     } finally {
       logger.timeEnd("compile");
+    }
+  }
+
+  /**
+   * Compile a program to a verified ESM module-record graph (the
+   * `esmModuleLoader` compile path). Runs the same resolution + CF transformer
+   * pipeline as {@link compile}, emits per-module CommonJS via
+   * `compileToModules`, assembles content-addressed records (plus runtime-
+   * module records), and security-verifies every authored module body with
+   * the ESM verifier. Returns the graph and the entry specifier for evaluation.
+   */
+  async compileToRecordGraph(
+    program: RuntimeProgram,
+    options: TypeScriptHarnessProcessOptions = {},
+  ): Promise<
+    { id: string; graph: CompiledModuleGraph; mainSpecifier: string }
+  > {
+    logger.timeStart("compileToRecordGraph");
+    try {
+      const id = options.identifier ?? computeId(program);
+      const mappedProgram = pretransformProgramForModules(program, id);
+      const resolver = new EngineProgramResolver(
+        mappedProgram,
+        this.ctRuntime.staticCache,
+      );
+      const { compiler } = await this.getCompilerInternals();
+      const resolvedProgram = await this.resolve(resolver);
+
+      const modules = compiler.compileToModules(resolvedProgram, {
+        noCheck: options.noCheck,
+        runtimeModules: Engine.runtimeModuleNames(),
+        beforeTransformers: (program) => {
+          const pipeline = new CommonFabricTransformerPipeline();
+          return {
+            factories: pipeline.toFactories(program),
+            getDiagnostics: () => pipeline.getDiagnostics(),
+          };
+        },
+      });
+
+      // Build records from the CF-transformed per-module bodies.
+      const moduleFiles = resolvedProgram.files.filter((f) =>
+        modules.has(f.name)
+      );
+      const precompiledBodies = new Map(
+        [...modules].map(([name, out]) => [name, out.js]),
+      );
+      const { runtimeExports } = await this.getRuntimeInternals();
+      const runtimeNames = Engine.runtimeModuleNames().filter((name) =>
+        runtimeExports?.[name]
+      );
+      const runtimeModulesOption = Object.fromEntries(
+        runtimeNames.map((name) => [
+          name,
+          Object.keys(runtimeExports?.[name] ?? {}),
+        ]),
+      );
+      const graph = compileSourcesToRecords(moduleFiles, {
+        precompiledBodies,
+        runtimeModules: runtimeModulesOption,
+      });
+
+      // Register runtime-module records so cf:runtime/* imports resolve.
+      const runtimeRecordExports: Record<string, Record<string, unknown>> = {};
+      for (const name of runtimeNames) {
+        runtimeRecordExports[name] = runtimeExports?.[name] as Record<
+          string,
+          unknown
+        >;
+      }
+      for (
+        const [spec, record] of runtimeModuleRecords(runtimeRecordExports)
+      ) {
+        graph.records.set(spec, record as VirtualModuleRecord);
+      }
+
+      // Security-verify every authored module body before it can execute.
+      for (const [specifier, body] of graph.compiledBodies) {
+        verifyCompiledModuleBody(body, specifier);
+      }
+
+      const mainSpecifier = graph.specifierByPath.get(mappedProgram.main);
+      if (mainSpecifier === undefined) {
+        throw new Error(
+          "ESM compile produced no record for the program entry",
+        );
+      }
+      return { id, graph, mainSpecifier };
+    } finally {
+      logger.timeEnd("compileToRecordGraph");
     }
   }
 

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -280,10 +280,18 @@ export class Engine extends EventTarget implements Harness {
         },
       });
 
-      // Build records from the CF-transformed per-module bodies.
+      // Every authored (non-.d.ts) source must have an emitted body; a missing
+      // one would otherwise be silently dropped and only fail later at import.
       const moduleFiles = resolvedProgram.files.filter((f) =>
-        modules.has(f.name)
+        !f.name.endsWith(".d.ts")
       );
+      for (const file of moduleFiles) {
+        if (!modules.has(file.name)) {
+          throw new Error(
+            `ESM compile produced no module body for '${file.name}'`,
+          );
+        }
+      }
       const precompiledBodies = new Map(
         [...modules].map(([name, out]) => [name, out.js]),
       );

--- a/packages/runner/src/harness/pretransform.ts
+++ b/packages/runner/src/harness/pretransform.ts
@@ -57,6 +57,28 @@ export function transformProgramWithPrefix(
   };
 }
 
+// ESM variant: inject the helper import and prefix files with `id` (so source
+// locations / identity match the AMD path), but DO NOT add the synthetic
+// `/index.ts` re-export. That index exists only to defeat `outFile` prefix
+// flattening in the AMD bundler; a per-module ESM graph has no bundle, so the
+// program entry is simply the prefixed main module.
+export function pretransformProgramForModules(
+  program: RuntimeProgram,
+  id: string,
+): RuntimeProgram {
+  program = transformInjectHelperModule(program);
+  return {
+    main: prefix(program.main, id),
+    files: program.files.map((source) => ({
+      name: prefix(source.name, id),
+      contents: source.contents,
+    })),
+    ...(program.mainExport !== undefined
+      ? { mainExport: program.mainExport }
+      : {}),
+  };
+}
+
 function prefix(filename: string, id: string): string {
   return `/${id}${filename}`;
 }

--- a/packages/runner/src/sandbox/bundle-preflight.ts
+++ b/packages/runner/src/sandbox/bundle-preflight.ts
@@ -186,7 +186,14 @@ function isBootstrapStatement(
     isAllowedTsLibHelperDeclaration(normalized);
 }
 
-function isAllowedTsLibHelperDeclaration(normalized: string): boolean {
+/**
+ * True when `normalized` (a `normalizeExact`-normalized statement) is one of the
+ * canonical TypeScript interop helper declarations the compiler emits
+ * (`__importDefault`, `__createBinding`, `__exportStar`, `__setModuleDefault`).
+ * Shared with the per-module ESM verifier, where these helpers appear inline in
+ * each module that uses default/namespace imports or re-exports.
+ */
+export function isAllowedTsLibHelperDeclaration(normalized: string): boolean {
   const match = normalized.match(/^var([A-Za-z_$][\w$]*)=/);
   if (!match || !ALLOWED_TSLIB_HELPERS.has(match[1])) {
     return false;
@@ -234,7 +241,7 @@ function isExportMapAssignment(normalized: string): boolean {
   return /^exportMap\[(["']).+\1\]=require\((['"]).+\2\);?$/.test(normalized);
 }
 
-function normalizeExact(
+export function normalizeExact(
   source: string,
   start = 0,
   end = source.length,

--- a/packages/runner/src/sandbox/esm-module-loader.ts
+++ b/packages/runner/src/sandbox/esm-module-loader.ts
@@ -127,3 +127,33 @@ export function importModuleGraphNow(
 
   return compartment.importNow(entrySpecifier);
 }
+
+/**
+ * Build virtual module records for the runtime modules (`commonfabric`, …) from
+ * the host's `runtimeExports` map, keyed by `cf:runtime/<specifier>` to match
+ * the content-addressed specifiers the adapter resolves runtime imports to.
+ * Each record simply copies the (already frozen) runtime namespace onto its
+ * module exports — these are the trusted host APIs, not authored code.
+ */
+export function runtimeModuleRecords(
+  runtimeExports: Record<string, Record<string, unknown>>,
+): Map<string, VirtualModuleRecord> {
+  const records = new Map<string, VirtualModuleRecord>();
+  for (const [specifier, namespace] of Object.entries(runtimeExports)) {
+    const exportNames = Object.keys(namespace);
+    const declared = exportNames.includes("__esModule")
+      ? exportNames
+      : [...exportNames, "__esModule"];
+    records.set(`cf:runtime/${specifier}`, {
+      imports: [],
+      exports: declared,
+      execute: (moduleExports) => {
+        for (const name of exportNames) {
+          moduleExports[name] = namespace[name];
+        }
+        moduleExports.__esModule = true;
+      },
+    });
+  }
+  return records;
+}

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -56,6 +56,14 @@ export interface CompileSourcesOptions {
   runtimeFingerprint?: string;
   /** Optional per-module compiled-artifact cache, keyed by module hash. */
   recordCache?: ModuleRecordCache;
+  /**
+   * Pre-compiled CommonJS body per source name. When provided (e.g. from
+   * `TypeScriptCompiler.compileToModules`, which runs the full CF transformer
+   * pipeline), the adapter uses it instead of the bare `ts.transpileModule`
+   * fallback. Required for real patterns, whose transformer output (schema
+   * generation, `__cf_data` wrapping) cannot be produced by transpileModule.
+   */
+  precompiledBodies?: Map<string, string>;
 }
 
 export interface CompiledModuleGraph {
@@ -96,7 +104,8 @@ export function compileSourcesToRecords(
       compiled = cached.compiled;
     } else {
       exportNames = collectExportNames(source);
-      compiled = ts.transpileModule(source.contents, {
+      const precompiled = options.precompiledBodies?.get(source.name);
+      compiled = precompiled ?? ts.transpileModule(source.contents, {
         fileName: source.name,
         compilerOptions: {
           module: ts.ModuleKind.CommonJS,

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -96,16 +96,24 @@ export function compileSourcesToRecords(
   for (const source of sources) {
     const specifier = specifierByPath.get(source.name)!;
     const moduleHash = hashes.get(source.name)!;
-    const cached = options.recordCache?.get(moduleHash);
+    const precompiled = options.precompiledBodies?.get(source.name);
     let exportNames: string[];
     let compiled: string;
-    if (cached) {
+    // A precompiled (CF-transformed) body is authoritative. Do NOT consult or
+    // populate the shared cache: it may hold a bare-transpiled body under the
+    // same content-hash key (different compilation mode), which must not mix.
+    const cached = precompiled === undefined
+      ? options.recordCache?.get(moduleHash)
+      : undefined;
+    if (precompiled !== undefined) {
+      exportNames = collectExportNames(source);
+      compiled = precompiled;
+    } else if (cached) {
       exportNames = cached.exports;
       compiled = cached.compiled;
     } else {
       exportNames = collectExportNames(source);
-      const precompiled = options.precompiledBodies?.get(source.name);
-      compiled = precompiled ?? ts.transpileModule(source.contents, {
+      compiled = ts.transpileModule(source.contents, {
         fileName: source.name,
         compilerOptions: {
           module: ts.ModuleKind.CommonJS,

--- a/packages/runner/src/sandbox/module-record-verifier.ts
+++ b/packages/runner/src/sandbox/module-record-verifier.ts
@@ -8,6 +8,10 @@ import {
   isAllowedAuthoredImportSpecifier,
   isRuntimeModuleIdentifier,
 } from "./runtime-module-policy.ts";
+import {
+  isAllowedTsLibHelperDeclaration,
+  normalizeExact,
+} from "./bundle-preflight.ts";
 
 /**
  * Structural pre-flight verification for a module-record graph (Phase 3 of
@@ -86,6 +90,13 @@ export function verifyCompiledModuleBody(
     // local path); arbitrary specifiers (e.g. "node:fs") fall through and are
     // rejected by classification, matching the AMD dependency allowlist. The
     // fast-path is disabled entirely when `require` is shadowed.
+    // Inline TS interop helper declarations (`var __importDefault = …`, etc.)
+    // are emitted per-module for default/namespace imports and re-exports. They
+    // are canonical compiler output (byte-matched), trusted, and `var` — skip
+    // them before classification, which would otherwise reject the `var`.
+    if (isAllowedTsLibHelperDeclaration(normalizeExact(text))) {
+      return;
+    }
     if (!requireShadowed) {
       const bound = REQUIRE_IMPORT.exec(text);
       if (bound && isAllowedAuthoredImportSpecifier(bound[2])) {

--- a/packages/runner/test/esm-engine.test.ts
+++ b/packages/runner/test/esm-engine.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import { Engine } from "../src/harness/engine.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+const signer = await Identity.fromPassphrase("test operator");
+
+// Phase D3.2: the Engine ESM compile path (compileToRecordGraph) runs the real
+// CF transformer pipeline, emits per-module CommonJS, assembles content-
+// addressed records + runtime records, and security-verifies every body.
+describe("Engine.compileToRecordGraph", () => {
+  let runtime: Runtime;
+  let engine: Engine;
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({ apiUrl: new URL(import.meta.url), storageManager });
+    engine = runtime.harness as Engine;
+  });
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("compiles a simple program into a verified record graph", async () => {
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [{ name: "/main.tsx", contents: "export default 42;" }],
+    };
+    const { graph, mainSpecifier } = await engine.compileToRecordGraph(program);
+
+    expect(mainSpecifier.startsWith("cf:module/")).toBe(true);
+    expect(graph.records.has(mainSpecifier)).toBe(true);
+    // Every authored module has a compiled body and a record.
+    expect(graph.compiledBodies.size).toBeGreaterThan(0);
+    // Runtime-module records are registered for cf:runtime/commonfabric.
+    expect(graph.records.has("cf:runtime/commonfabric")).toBe(true);
+    // (compileToRecordGraph throws if any body fails verification — reaching
+    // here means all authored bodies passed the ESM security verifier.)
+  });
+
+  it("rejects a program whose module contains disallowed top-level code", async () => {
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [{
+        name: "/main.tsx",
+        // Unwrapped top-level mutable export — the verifier must reject it.
+        contents: "export const leaked = globalThis;\nexport default leaked;",
+      }],
+    };
+    await expect(engine.compileToRecordGraph(program)).rejects.toThrow();
+  });
+});

--- a/packages/runner/test/esm-module-body-verifier.test.ts
+++ b/packages/runner/test/esm-module-body-verifier.test.ts
@@ -31,6 +31,18 @@ describe("verifyCompiledModuleBody", () => {
     expect(() => verifyCompiledModuleBody(body, "/main.tsx")).not.toThrow();
   });
 
+  it("accepts a module with a default import (inline __importDefault helper)", () => {
+    // Default imports make the compiler emit an inline `var __importDefault =
+    // …` helper; the verifier must allow that canonical declaration.
+    const body = compiledBody({
+      "/dep.ts": `const v = 7;\nexport default v;`,
+      "/main.ts":
+        `import dep from "./dep.ts";\nexport const run = (): number => dep + 1;`,
+    }, "/main.ts");
+    expect(body).toContain("__importDefault"); // sanity: the helper is present
+    expect(() => verifyCompiledModuleBody(body, "/main.ts")).not.toThrow();
+  });
+
   it("accepts the imported leaf module", () => {
     const body = compiledBody({
       "/util.ts": `export const dbl = (x: number): number => x * 2;`,

--- a/packages/runner/test/module-record-compiler.test.ts
+++ b/packages/runner/test/module-record-compiler.test.ts
@@ -121,6 +121,31 @@ describe("compileSourcesToRecords + importModuleGraphNow (end to end)", () => {
     expect(cache.hits).toBe(1);
   });
 
+  it("prefers a precompiled body over a cached (bare-transpiled) one", () => {
+    const sources = files({
+      "/main.ts": `export const run = (): number => 1;`,
+    });
+    const cache = new MapRecordCache();
+    // Seed the cache with a stale bare-transpiled artifact.
+    compileSourcesToRecords(sources, { recordCache: cache });
+    expect(cache.store.size).toBe(1);
+
+    // With a precompiled body provided, the cache must be ignored (different
+    // compilation mode) and the precompiled body used.
+    const precompiledBodies = new Map([[
+      "/main.ts",
+      `Object.defineProperty(exports, "__esModule", { value: true });\nexports.run = () => 99;`,
+    ]]);
+    const { records, specifierByPath } = compileSourcesToRecords(sources, {
+      recordCache: cache,
+      precompiledBodies,
+    });
+    const ns = importModuleGraphNow(specifierByPath.get("/main.ts")!, {
+      records,
+    }) as { run(): number };
+    expect(ns.run()).toBe(99);
+  });
+
   it("uses the cached compiled artifact (cache is authoritative on hit)", () => {
     const sources = files({
       "/main.ts": `export const run = (): number => 1;`,

--- a/packages/runner/test/module-record-compiler.test.ts
+++ b/packages/runner/test/module-record-compiler.test.ts
@@ -7,7 +7,10 @@ import {
   compileSourcesToRecords,
   type ModuleRecordCache,
 } from "../src/sandbox/module-record-compiler.ts";
-import { importModuleGraphNow } from "../src/sandbox/esm-module-loader.ts";
+import {
+  importModuleGraphNow,
+  runtimeModuleRecords,
+} from "../src/sandbox/esm-module-loader.ts";
 
 class MapRecordCache implements ModuleRecordCache {
   store = new Map<string, CompiledModuleArtifact>();
@@ -45,6 +48,28 @@ describe("compileSourcesToRecords + importModuleGraphNow (end to end)", () => {
 
     expect(ns.run()).toBe(42);
     expect(ns.default()).toBe(42);
+  });
+
+  it("resolves runtime-module imports via runtimeModuleRecords", () => {
+    const sources = files({
+      "/main.ts":
+        `import { dbl } from "commonfabric";\nexport const run = (): number => dbl(21);`,
+    });
+    const { records, specifierByPath } = compileSourcesToRecords(sources, {
+      runtimeModules: { commonfabric: ["dbl"] },
+    });
+    // Merge the runtime-module record built from the host's runtime exports.
+    for (
+      const [spec, rec] of runtimeModuleRecords({
+        commonfabric: { dbl: (x: number) => x * 2 },
+      })
+    ) {
+      records.set(spec, rec);
+    }
+    const ns = importModuleGraphNow(specifierByPath.get("/main.ts")!, {
+      records,
+    }) as { run(): number };
+    expect(ns.run()).toBe(42);
   });
 
   it("resolves a default import across modules (esModuleInterop)", () => {


### PR DESCRIPTION
## What (Phase D3, part 1 — the ESM **compile** path, behind the flag)

Builds on merged D1 (`classifyModuleItems`) and D2 (ESM verifier). Adds the compile half of the Engine ESM loader path. All dormant behind `esmModuleLoader` (default off); AMD remains the default. **Nothing in production calls this yet** — the evaluate execution + flag wiring follow in part 2.

### Changes
- **`TypeScriptCompiler.compileToModules`** (D3.1) — runs the *same* type-check + CF transformer pipeline as `compile()` but emits one CommonJS file per source (no AMD `outFile` bundle). The bare `ts.transpileModule` the record adapter used can't run the CF pipeline (schema generation needs a type-checked Program); this produces real CF-transformed per-module bodies. (`skipLibCheck` on this multi-file path; it surfaces lib-internal errors the bundled path tolerates.)
- **Adapter `precompiledBodies`** (D3.2a) — `compileSourcesToRecords` uses provided CF-transformed bodies instead of `transpileModule`.
- **`runtimeModuleRecords`** (D3.2b) — builds `cf:runtime/*` records from the host's `runtimeExports`.
- **`Engine.compileToRecordGraph`** (D3.2) — composes the above: resolve → `compileToModules` (CF pipeline) → records (+ runtime records) → **security-verify every authored body** with `verifyCompiledModuleBody` → returns the graph + entry specifier.
- **`pretransformProgramForModules`** — injects the CF helper import and applies the `/<id>/` prefix (so source locations/identity match the AMD path) but omits the synthetic `/index.ts` re-export (an AMD-`outFile` workaround that has no place in a per-module ESM graph).

### Tests
Per-module CJS emit; precompiled-body + runtime-module records; and an end-to-end Engine test (real CF pipeline → verified graph with `cf:runtime/commonfabric`; disallowed top-level code rejected).

### Next (part 2)
Evaluate execution (`importModuleGraphNow` → `{main, exportMap, loadId}`), the `fn.src`/source-map integration (the design's flagged risk — keeps both the scheduler fingerprint and CFC verified-load identity working), and the `esmModuleLoader` flag wiring in `Engine.evaluate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the compile half of the ESM loader behind the `esmModuleLoader` flag, emitting CF‑transformed per‑module CommonJS and producing a verified module‑record graph. AMD stays default; this path is not used in production.

- **New Features**
  - `TypeScriptCompiler.compileToModules`: per‑module CommonJS emit with full type‑check + CF transformers; returns `{js, sourceMap}`.
  - Adapter + runtime: `compileSourcesToRecords` accepts `precompiledBodies`; `runtimeModuleRecords` builds `cf:runtime/*` virtual records from host `runtimeExports`.
  - Engine path: `Engine.compileToRecordGraph` resolves, runs `compileToModules`, assembles records + runtime records, verifies each authored body; `pretransformProgramForModules` injects the CF helper and `/<id>/` prefix without a synthetic `/index.ts`.

- **Bug Fixes**
  - ESM verifier allows canonical inline TS interop helper declarations (`__importDefault`, `__createBinding`, `__exportStar`, `__setModuleDefault`) by reusing the exported normalizer.
  - `precompiledBodies` are authoritative and bypass the cache; added guards to assert every authored module emits a body and to throw on ambiguous `.js` emit‑target stems.

<sup>Written for commit 4103067bbe2321714cc0a70c0dbb31b0ade37d87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

