### PR TITLE
Phase D3 (2/2): ESM evaluate + flag wiring — patterns run via esmModuleLoader

### DIFF
--- a/docs/specs/module-loading-verifier-and-engine-design.md
+++ b/docs/specs/module-loading-verifier-and-engine-design.md
@@ -236,9 +236,17 @@ ESM-emit variant); whether `export *` (Part C) needs a classification rule.
 - **Verifier parity is security-critical.** A missed classification = sandbox
   escape. Mitigation: the differential oracle is a hard release gate; do not flip
   the default until AMD and ESM verdicts match across the corpus.
-- **`fn.src` resolution under ESM.** If the executed artifact doesn't contain
-  function source verbatim / in order, both identity consumers silently degrade.
-  Mitigation: the dedicated differential `fn.src` test in Part B.
+- **`fn.src` resolution under ESM — KNOWN GAP (remaining before default-on).**
+  The ESM evaluate path loads each module via a bare `compartment.evaluate`; SES
+  `errorTaming` strips the `//# sourceURL` from stack traces, so `fn.src` does
+  not resolve and both identity consumers (scheduler implementation hash, CFC
+  verified-source) degrade gracefully (fall back / telemetry id) rather than
+  fail — patterns still compile, load, and run correctly. Full fidelity needs
+  SES-isolate-level source-map integration (load per-module maps + map eval
+  positions), the design's highest-risk piece. The record `sourceURL` tag and
+  `registerModuleHashes` wiring are in place as hooks; this is the last item to
+  close before the flag can be enabled by default. It does not block the
+  flag-off, manual-testing milestone.
 - **Shared-code drift.** Any edit to the transformer pipeline or source-location
   code risks the AMD path. Mitigation: keep ESM additive; rely on existing AMD
   tests as the regression guard.

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -475,6 +475,9 @@ export class Engine extends EventTarget implements Harness {
           });
         }
       }
+      // Capture the export map too, so verified values from non-entry modules
+      // are indexed by the registry exactly as on the AMD path.
+      this.executableRegistry.captureVerifiedValue(loadId, exportMap);
       this.runtimeInternals?.exportsCallback(exportsByValue);
 
       return { main, exportMap, loadId };

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -390,7 +390,10 @@ export class Engine extends EventTarget implements Harness {
         console: this.consoleShim,
       });
       // Concatenated module bodies give the source-location frame a `script`
-      // for fn.src `indexOf` resolution.
+      // for fn.src `indexOf` resolution. (Insertion order need not match the
+      // import-execution order; resolveLocationFromFunctionSource falls back to
+      // a from-zero scan, and any mis-attribution degrades fail-closed at the
+      // CFC identity layer — see the fn.src note in the design doc.)
       const script = [...graph.compiledBodies.values()].join("\n");
       this.executableRegistry.setVerifiedLoadBundleId(
         loadId,
@@ -457,6 +460,14 @@ export class Engine extends EventTarget implements Harness {
           : path;
         exportMap[fileName] = namespace;
         for (const [exportName, value] of Object.entries(namespace)) {
+          // Only object/function exports are sub-pattern candidates. Skip the
+          // `__esModule` flag and primitives, which would otherwise collide in
+          // this value-keyed map (e.g. every module's `true`).
+          if (exportName === "__esModule") continue;
+          if (typeof value !== "object" && typeof value !== "function") {
+            continue;
+          }
+          if (value === null) continue;
           exportsByValue.set(value, {
             main: fileName,
             mainExport: exportName,

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -380,6 +380,11 @@ export class Engine extends EventTarget implements Harness {
     try {
       const loadId = `${id}:esm:${this.nextLoadId++}`;
       this.executableRegistry.beginVerifiedLoad(loadId);
+      // Register per-module content hashes for parity with the AMD evaluate
+      // path. This wires the scheduler's content-addressed implementation hash;
+      // it becomes effective once source-location resolution under the ESM
+      // loader is wired (see the sourceURL note in module-record-compiler.ts).
+      this.registerModuleHashes(id, files);
 
       const globals = createModuleCompartmentGlobals({
         console: this.consoleShim,

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -2,6 +2,7 @@ import { Console } from "./console.ts";
 import {
   type CompileResult,
   type EvaluateOptions,
+  type EvaluateResult,
   type Exports,
   type Harness,
   type HarnessedFunction,
@@ -36,6 +37,7 @@ import {
   compileSourcesToRecords,
 } from "../sandbox/module-record-compiler.ts";
 import {
+  loadModuleGraph,
   runtimeModuleRecords,
   type VirtualModuleRecord,
 } from "../sandbox/esm-module-loader.ts";
@@ -338,6 +340,102 @@ export class Engine extends EventTarget implements Harness {
       return { id, graph, mainSpecifier };
     } finally {
       logger.timeEnd("compileToRecordGraph");
+    }
+  }
+
+  /**
+   * Compile + evaluate a program through the ESM module-record path (the
+   * `esmModuleLoader` route). Returns the same `{ main, exportMap, loadId }`
+   * shape as {@link evaluate}, so callers can branch on the flag and treat the
+   * result identically.
+   */
+  async compileAndEvaluateModules(
+    program: RuntimeProgram,
+    options: TypeScriptHarnessProcessOptions = {},
+  ): Promise<EvaluateResult> {
+    // Ensure runtime exports + exportsCallback are initialized.
+    await this.getRuntimeInternals();
+    const { id, graph, mainSpecifier } = await this.compileToRecordGraph(
+      program,
+      options,
+    );
+    return this.evaluateRecordGraph(id, graph, mainSpecifier, program.files);
+  }
+
+  /**
+   * Evaluate a verified ESM record graph: load it synchronously via `importNow`
+   * in a locked-down compartment whose globals are the hardened runtime globals
+   * (runtime-module records, already in the graph, supply the trusted host
+   * APIs), and return the entry namespace as `main` plus the per-module export
+   * map. The graph was security-verified at compile time, so verification is
+   * not repeated.
+   */
+  private evaluateRecordGraph(
+    id: string,
+    graph: CompiledModuleGraph,
+    mainSpecifier: string,
+    files: Source[],
+  ): EvaluateResult {
+    logger.timeStart("evaluateRecordGraph");
+    try {
+      const loadId = `${id}:esm:${this.nextLoadId++}`;
+      this.executableRegistry.beginVerifiedLoad(loadId);
+
+      const globals = createModuleCompartmentGlobals({
+        console: this.consoleShim,
+      });
+      // Concatenated module bodies give the source-location frame a `script`
+      // for fn.src `indexOf` resolution.
+      const script = [...graph.compiledBodies.values()].join("\n");
+      const frame = pushFrame({
+        runtime: this.ctRuntime,
+        verifiedLoadId: loadId,
+        sourceLocationContext: {
+          script,
+          filename: `${loadId}.js`,
+          nextSearchOffset: 0,
+        },
+      });
+
+      let loaded: ReturnType<typeof loadModuleGraph>;
+      try {
+        loaded = loadModuleGraph(mainSpecifier, {
+          records: graph.records,
+          globals,
+          verify: false, // already verified at compile time
+        });
+      } finally {
+        popFrame(frame);
+      }
+
+      const main = loaded.namespace as Exports;
+      this.executableRegistry.captureVerifiedValue(loadId, main);
+
+      // Build the per-module export map (keyed by original source path, prefix
+      // stripped) from the SAME load, and map each exported value back to its
+      // RuntimeProgram for sub-pattern resolution.
+      const prefix = `/${id}`;
+      const exportMap: Record<string, Exports> = {};
+      const exportsByValue = new Map<unknown, RuntimeProgram>();
+      for (const [path, specifier] of graph.specifierByPath) {
+        const namespace = loaded.importNow(specifier) as Exports;
+        const fileName = path.startsWith(prefix)
+          ? path.slice(prefix.length)
+          : path;
+        exportMap[fileName] = namespace;
+        for (const [exportName, value] of Object.entries(namespace)) {
+          exportsByValue.set(value, {
+            main: fileName,
+            mainExport: exportName,
+            files,
+          });
+        }
+      }
+      this.runtimeInternals?.exportsCallback(exportsByValue);
+
+      return { main, exportMap, loadId };
+    } finally {
+      logger.timeEnd("evaluateRecordGraph");
     }
   }
 

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -387,6 +387,33 @@ export class Engine extends EventTarget implements Harness {
       // Concatenated module bodies give the source-location frame a `script`
       // for fn.src `indexOf` resolution.
       const script = [...graph.compiledBodies.values()].join("\n");
+      this.executableRegistry.setVerifiedLoadBundleId(
+        loadId,
+        hashOf(script).toString(),
+      );
+      // Verified-load sources: the original file names plus the prefixed module
+      // paths (both normalized), so CFC's isVerifiedSourceInLoad recognizes the
+      // source locations of functions defined by this load.
+      const verifiedSources = new Set<string>();
+      const addVerifiedSource = (value: string | undefined) => {
+        if (typeof value !== "string" || value.length === 0) return;
+        verifiedSources.add(normalizeVerifiedSource(value));
+        const prefixed = `/${id}/`;
+        if (value.startsWith(prefixed)) {
+          verifiedSources.add(
+            normalizeVerifiedSource(value.slice(id.length + 1)),
+          );
+        }
+      };
+      for (const file of files) addVerifiedSource(file.name);
+      for (const path of graph.specifierByPath.keys()) addVerifiedSource(path);
+      this.executableRegistry.setVerifiedLoadSources(loadId, verifiedSources);
+
+      // Register functions defined during this load as verified, mirroring the
+      // AMD path's verified-execution model.
+      const restoreVerifiedFunctionRegistrar = setVerifiedFunctionRegistrar(
+        this.executableRegistry.createVerifiedFunctionRegistrar(loadId),
+      );
       const frame = pushFrame({
         runtime: this.ctRuntime,
         verifiedLoadId: loadId,
@@ -406,6 +433,7 @@ export class Engine extends EventTarget implements Harness {
         });
       } finally {
         popFrame(frame);
+        restoreVerifiedFunctionRegistrar();
       }
 
       const main = loaded.namespace as Exports;

--- a/packages/runner/src/harness/types.ts
+++ b/packages/runner/src/harness/types.ts
@@ -74,6 +74,14 @@ export interface Harness extends EventTarget {
     options?: EvaluateOptions,
   ): Promise<EvaluateResult>;
 
+  // Compile + evaluate a program through the ESM module-record path (the
+  // `esmModuleLoader` flag route), returning the same shape as `evaluate`.
+  // Optional: present only on harnesses that implement the ESM loader.
+  compileAndEvaluateModules?(
+    program: RuntimeProgram,
+    options?: TypeScriptHarnessProcessOptions,
+  ): Promise<EvaluateResult>;
+
   // Resolves a `ProgramResolver` into a `Program` using the engine's
   // configuration.
   resolve(

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -11,7 +11,7 @@ import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { Cell, createCell } from "./cell.ts";
 import type { MemorySpace, Runtime } from "./runtime.ts";
 import { createRef } from "./create-ref.ts";
-import type { CompileResult } from "./harness/types.ts";
+import type { CompileResult, EvaluateResult } from "./harness/types.ts";
 import { RuntimeProgram } from "./harness/types.ts";
 import type { IExtendedStorageTransaction } from "./storage/interface.ts";
 import { getTopFrame } from "./builder/pattern.ts";
@@ -435,6 +435,18 @@ export class PatternManager {
       program = input;
     }
 
+    // ESM module-record loader path (experimental, default off). Bypasses the
+    // AMD bundle compile/evaluate and the persistent compile cache.
+    if (
+      this.runtime.experimental.esmModuleLoader === true &&
+      this.runtime.harness.compileAndEvaluateModules
+    ) {
+      const result = await this.runtime.harness.compileAndEvaluateModules(
+        program,
+      );
+      return this.patternFromEvaluation(result, program);
+    }
+
     const { cachedCompiler } = this.runtime;
     if (cachedCompiler) {
       const programHash = createRef(
@@ -464,12 +476,20 @@ export class PatternManager {
     program: RuntimeProgram,
     options?: { skipBundleValidation?: boolean },
   ): Promise<Pattern> {
-    const { main, loadId } = await this.runtime.harness.evaluate(
+    const result = await this.runtime.harness.evaluate(
       id,
       jsScript,
       program.files,
       options,
     );
+    return this.patternFromEvaluation(result, program);
+  }
+
+  // Resolve a Pattern from an evaluate result (shared by the AMD and ESM paths).
+  private patternFromEvaluation(
+    { main, loadId }: EvaluateResult,
+    program: RuntimeProgram,
+  ): Pattern {
     if (!main) {
       throw new Error("Pattern compilation produced no exports.");
     }

--- a/packages/runner/src/sandbox/esm-module-loader.ts
+++ b/packages/runner/src/sandbox/esm-module-loader.ts
@@ -90,6 +90,22 @@ export function importModuleGraphNow(
   entrySpecifier: string,
   options: SesModuleLoaderOptions,
 ): Record<string, unknown> {
+  return loadModuleGraph(entrySpecifier, options).namespace;
+}
+
+/**
+ * Like {@link importModuleGraphNow} but returns the loaded entry namespace plus
+ * an `importNow` bound to the SAME compartment, so additional already-loaded
+ * module specifiers can be retrieved (as singletons) without re-instantiating
+ * the graph. Used by the Engine to build the per-module export map from one load.
+ */
+export function loadModuleGraph(
+  entrySpecifier: string,
+  options: SesModuleLoaderOptions,
+): {
+  namespace: Record<string, unknown>;
+  importNow: (specifier: string) => Record<string, unknown>;
+} {
   ensureSESLockdown();
   const { records, globals = {}, name = "cf:esm", verify = true } = options;
 
@@ -125,7 +141,10 @@ export function importModuleGraphNow(
   // siblings. Mirror createCompartment() in ses-runtime.ts.
   Object.freeze(compartment.globalThis);
 
-  return compartment.importNow(entrySpecifier);
+  return {
+    namespace: compartment.importNow(entrySpecifier),
+    importNow: (specifier: string) => compartment.importNow(specifier),
+  };
 }
 
 /**

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -157,7 +157,12 @@ export function compileSourcesToRecords(
     // implementation hash / CFC verified-source check) requires SES-isolate-
     // level source-map integration and is tracked as the remaining item before
     // the flag can be enabled by default. The tag is the hook for that work.
-    const sourceUrl = source.name;
+    //
+    // SECURITY: strip JS line terminators before interpolating into the
+    // `//# sourceURL=` line comment. A newline (or U+2028/U+2029) in
+    // `source.name` would otherwise end the comment and let the remainder of
+    // the name execute as code inside the compartment.
+    const sourceUrl = source.name.replace(/[\r\n\u2028\u2029]/g, "_");
     records.set(specifier, {
       imports: importSpecs,
       exports: namespaceExports,

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -150,6 +150,14 @@ export function compileSourcesToRecords(
     // rather than wrapping the whole namespace. Authored sources are ESM.
     const namespaceExports = [...exportNames, "__esModule"];
 
+    // Tag the eval with a sourceURL = the (prefixed) source path. NOTE: under
+    // SES `errorTaming` this is currently stripped from stack traces, so it
+    // does NOT yet make `fn.src` resolve — full source-location fidelity under
+    // the ESM loader (stack traces, and thus the scheduler's content-addressed
+    // implementation hash / CFC verified-source check) requires SES-isolate-
+    // level source-map integration and is tracked as the remaining item before
+    // the flag can be enabled by default. The tag is the hook for that work.
+    const sourceUrl = source.name;
     records.set(specifier, {
       imports: importSpecs,
       exports: namespaceExports,
@@ -158,7 +166,7 @@ export function compileSourcesToRecords(
         // Evaluate the compiled CommonJS body inside the SES compartment so it
         // runs under lockdown with confined globals.
         const factory = compartment.evaluate(
-          `(function (exports, require, module) {\n${compiled}\n})`,
+          `(function (exports, require, module) {\n${compiled}\n})\n//# sourceURL=${sourceUrl}`,
         ) as (
           exports: Record<string, unknown>,
           require: (specifier: string) => Record<string, unknown>,

--- a/packages/runner/test/esm-engine.test.ts
+++ b/packages/runner/test/esm-engine.test.ts
@@ -45,6 +45,40 @@ describe("Engine.compileToRecordGraph", () => {
     // here means all authored bodies passed the ESM security verifier.)
   });
 
+  it("compiles + evaluates a program through the ESM path", async () => {
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [{
+        name: "/main.tsx",
+        contents:
+          "export const answer = 42;\nexport const make = () => answer;\nexport default make;",
+      }],
+    };
+    const { main, loadId } = await engine.compileAndEvaluateModules(program);
+    expect(loadId).toBeTruthy();
+    expect(main).toBeDefined();
+    expect((main as { answer: number }).answer).toBe(42);
+    expect((main as { make(): number }).make()).toBe(42);
+    // default export resolves to the same function.
+    expect((main as { default(): number }).default()).toBe(42);
+  });
+
+  it("evaluates a multi-module program across an internal import", async () => {
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [
+        { name: "/dep.ts", contents: "export const base = (): number => 20;" },
+        {
+          name: "/main.tsx",
+          contents:
+            `import { base } from "./dep.ts";\nexport const total = () => base() + 22;\nexport default total;`,
+        },
+      ],
+    };
+    const { main } = await engine.compileAndEvaluateModules(program);
+    expect((main as { total(): number }).total()).toBe(42);
+  });
+
   it("rejects a program whose module contains disallowed top-level code", async () => {
     const program: RuntimeProgram = {
       main: "/main.tsx",

--- a/packages/runner/test/esm-pattern-run.test.ts
+++ b/packages/runner/test/esm-pattern-run.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+const signer = await Identity.fromPassphrase("test operator");
+const space = signer.did();
+
+// End-to-end: with `esmModuleLoader` enabled, a real reactive pattern compiles
+// AND runs through the ESM module-record loader path (compileToRecordGraph +
+// evaluateRecordGraph), producing correct reactive output — not just loading.
+describe("Pattern run via esmModuleLoader", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      experimental: { esmModuleLoader: true },
+    });
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("compiles and runs a multi-file pattern through the ESM loader", async () => {
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/util.ts",
+          contents: "export const double = (x:number)=>x*2;",
+        },
+        {
+          name: "/main.tsx",
+          contents: [
+            "import { pattern, lift } from 'commonfabric';",
+            "import { double } from './util.ts';",
+            "const dbl = lift((x:number)=>double(x));",
+            "export default pattern<{ value: number }>(({ value }) => {",
+            "  return { result: dbl(value) };",
+            "});",
+          ].join("\n"),
+        },
+      ],
+    };
+
+    const compiled = await runtime.patternManager.compilePattern(program);
+    expect(compiled.program?.main).toEqual("/main.tsx");
+
+    const resultCell = runtime.getCell<{ result: number }>(
+      space,
+      "esm pattern run",
+      undefined,
+      tx,
+    );
+    const result = runtime.run(tx, compiled, { value: 3 }, resultCell);
+    await tx.commit();
+    tx = runtime.edit();
+    await result.pull();
+    expect(result.getAsQueryResult()).toEqual({ result: 6 });
+  });
+});

--- a/packages/runner/test/module-record-compiler.test.ts
+++ b/packages/runner/test/module-record-compiler.test.ts
@@ -50,6 +50,25 @@ describe("compileSourcesToRecords + importModuleGraphNow (end to end)", () => {
     expect(ns.default()).toBe(42);
   });
 
+  it("does not let a newline in a source name inject code via sourceURL", () => {
+    // A file name with a newline must not break out of the `//# sourceURL=`
+    // line comment and execute as code.
+    (globalThis as Record<string, unknown>).__esm_injection_canary = false;
+    const sources = files({
+      "/evil.ts\nglobalThis.__esm_injection_canary = true;//":
+        `export const x = 1;`,
+    });
+    const { records, specifierByPath } = compileSourcesToRecords(sources);
+    const spec = specifierByPath.get(
+      "/evil.ts\nglobalThis.__esm_injection_canary = true;//",
+    )!;
+    importModuleGraphNow(spec, { records });
+    expect((globalThis as Record<string, unknown>).__esm_injection_canary).toBe(
+      false,
+    );
+    delete (globalThis as Record<string, unknown>).__esm_injection_canary;
+  });
+
   it("resolves runtime-module imports via runtimeModuleRecords", () => {
     const sources = files({
       "/main.ts":


### PR DESCRIPTION
## What (Phase D3 part 2 — ESM **evaluate** + flag wiring, behind the flag)

Builds on merged D1/D2/D3-pt1. Completes the ESM loader so that **flipping `esmModuleLoader` actually loads and runs patterns** via the module-record path. Default off; AMD remains the default.

### Changes
- **`loadModuleGraph`** (esm-module-loader) — like `importModuleGraphNow` but returns the entry namespace + an `importNow` bound to the **same** compartment, so the Engine reads every module's namespace from one load (singletons) instead of re-instantiating per module.
- **`Engine.evaluateRecordGraph`** — loads the verified graph synchronously via `importNow` in a locked-down compartment with the hardened runtime globals (runtime-module records supply host APIs); returns `{main, exportMap, loadId}`, builds the per-module export map + `exportsByValue` (sub-pattern resolution) from the single load. Mirrors the AMD verified-execution model: verified-load bundle id + sources, and `setVerifiedFunctionRegistrar` around the load.
- **`Engine.compileAndEvaluateModules`** — compile → verify → evaluate in one call, same shape as `evaluate`.
- **Flag wiring** — `PatternManager.compilePattern` routes through the ESM path when `experimental.esmModuleLoader` is on (bypasses the AMD bundle + persistent compile cache); shared `patternFromEvaluation` for both paths; optional `compileAndEvaluateModules` on the `Harness` interface.

### Tests
- **End-to-end**: with the flag on, a real multi-file reactive pattern (`pattern` + `lift` + cross-module import) **compiles and runs**, producing correct reactive output (`result: 6`).
- Engine compile+evaluate (named/default/factory exports, multi-module imports); disallowed code rejected.

### Known limitation (documented, tracked — remaining before default-on)
`fn.src` source-location resolution: SES `errorTaming` strips the per-module `//# sourceURL` from stack traces, so `fn.src` doesn't resolve under the ESM loader and the scheduler implementation hash / CFC verified-source checks **degrade gracefully** (fall back / telemetry id) — patterns still compile, load, and run correctly. Full fidelity needs SES-isolate source-map integration (the design's flagged highest-risk piece). The `sourceURL` tag + `registerModuleHashes` are in place as hooks. This does **not** block the flag-off manual-testing milestone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables the ESM evaluate path behind the `experimental.esmModuleLoader` flag so patterns compile, load, and run via module records, with verified-execution tracking preserved. Adds security hardening by sanitizing module `sourceURL` tags.

- **New Features**
  - `loadModuleGraph` returns the entry namespace plus `importNow` bound to the same compartment for singleton modules and export-map building.
  - `Engine.evaluateRecordGraph` loads the verified graph in a locked-down compartment and returns `{ main, exportMap, loadId }`; sets verified-load bundle id/sources, registers per-module hashes, builds `exportsByValue` (skips `__esModule` and primitives), captures `exportMap` in the registry, and tags evals with `//# sourceURL` for future source-map integration.
  - Adds `compileAndEvaluateModules` and updates the `Harness` interface (optional).
  - `PatternManager.compilePattern` routes through the ESM path when `experimental.esmModuleLoader` is true, bypassing the AMD bundle/cache; shared `patternFromEvaluation`. Docs note the known `fn.src` gap under SES (graceful fallback).

- **Bug Fixes**
  - Sanitize ESM record `sourceURL` by stripping JS line terminators to prevent code injection; regression test added.

<sup>Written for commit 5544cf6d5ad7d6a2008d5668229ebfed2d05c50c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

