### PR TITLE
test(runner): adversarial corpus for the ESM module verifier (+ fix helper-shadow bypass)

### DIFF
--- a/packages/runner/src/sandbox/module-record-verifier.ts
+++ b/packages/runner/src/sandbox/module-record-verifier.ts
@@ -3,7 +3,13 @@ import {
   type BindingInfo,
   classifyModuleItems,
 } from "./compiled-bundle-verifier.ts";
-import { parseFunctionText } from "./compiled-js-parser.ts";
+import {
+  findTopLevelEquals,
+  parseFunctionText,
+  splitTopLevelCommaList,
+  type StatementChunk,
+  trimRange,
+} from "./compiled-js-parser.ts";
 import {
   isAllowedAuthoredImportSpecifier,
   isRuntimeModuleIdentifier,
@@ -57,6 +63,50 @@ const SIDE_EFFECT_REQUIRE = /^require\(\s*["']([^"']+)["']\s*\)\s*;?$/;
 const EXPORT_STAR_REQUIRE =
   /^__exportStar\(\s*require\(\s*["']([^"']+)["']\s*\)\s*,\s*exports\s*\)\s*;?$/;
 
+const SIMPLE_IDENTIFIER = /^[A-Za-z_$][\w$]*$/;
+
+/**
+ * The top-level binding names a statement introduces, restricted to the simple
+ * cases the verifier would otherwise *accept* (so a shadow could go unnoticed):
+ * function/class declarations and `const`/`let`/`var` declarators. Multi-
+ * declarator lists (`const a = 1, __exportStar = …`) are split depth-aware via
+ * the shared comma/equals parsers — a leading-anchored regex would only see the
+ * first declarator and miss the rest.
+ *
+ * Malformed or destructuring declarators throw out of the parsers; those are
+ * rejected by `classifyModuleItems` regardless, so returning no names here stays
+ * fail-closed.
+ */
+function shadowNamesInStatement(
+  source: string,
+  statement: StatementChunk,
+  text: string,
+): string[] {
+  const fn = /^(?:async\s+)?function\s*\*?\s*([A-Za-z_$][\w$]*)/.exec(text);
+  if (fn) return [fn[1]];
+  const cls = /^class\s+([A-Za-z_$][\w$]*)/.exec(text);
+  if (cls) return [cls[1]];
+  const kind = /^(?:const|let|var)\b/.exec(text)?.[0];
+  if (!kind) return [];
+  try {
+    const trimmed = trimRange(source, statement.start, statement.end);
+    const listStart = trimmed.start + kind.length;
+    let listEnd = trimmed.end;
+    while (listEnd > listStart && /\s/.test(source[listEnd - 1])) listEnd--;
+    if (listEnd > listStart && source[listEnd - 1] === ";") listEnd--;
+    const names: string[] = [];
+    for (const range of splitTopLevelCommaList(source, listStart, listEnd)) {
+      const equals = findTopLevelEquals(source, range.start, range.end);
+      const nameRange = trimRange(source, range.start, equals ?? range.end);
+      const name = source.slice(nameRange.start, nameRange.end);
+      if (SIMPLE_IDENTIFIER.test(name)) names.push(name);
+    }
+    return names;
+  } catch {
+    return [];
+  }
+}
+
 /**
  * Security-classify a module's compiled-CommonJS body (Phase D2). It recognizes
  * the `const x = require("…")` import preamble — seeding `env` with import
@@ -90,20 +140,19 @@ export function verifyCompiledModuleBody(
   //
   // Canonical TS interop helper declarations (`var __exportStar = (this && …)`)
   // are the trusted helpers themselves, not shadows, so they are excluded.
-  const declaresLocalBinding = (name: string): boolean =>
-    statementTexts.some((t) => {
-      if (isAllowedTsLibHelperDeclaration(normalizeExact(t))) return false;
-      return (
-        new RegExp(`^(?:const|let|var)\\s+${name}\\b`).test(t) ||
-        new RegExp(`^(?:async\\s+)?function\\s*\\*?\\s*${name}\\b`).test(t) ||
-        new RegExp(`^class\\s+${name}\\b`).test(t)
-      );
-    });
+  const shadowed = new Set<string>();
+  parsed.body.statements.forEach((statement, index) => {
+    const text = statementTexts[index];
+    if (isAllowedTsLibHelperDeclaration(normalizeExact(text))) return;
+    for (const name of shadowNamesInStatement(wrapped, statement, text)) {
+      shadowed.add(name);
+    }
+  });
 
-  const requireShadowed = declaresLocalBinding("require");
-  const exportStarShadowed = declaresLocalBinding("__exportStar");
-  const importHelperShadowed = declaresLocalBinding("__importDefault") ||
-    declaresLocalBinding("__importStar");
+  const requireShadowed = shadowed.has("require");
+  const exportStarShadowed = shadowed.has("__exportStar");
+  const importDefaultShadowed = shadowed.has("__importDefault");
+  const importStarShadowed = shadowed.has("__importStar");
 
   const env = new Map<string, BindingInfo>();
   const classifiable: typeof parsed.body.statements = [];
@@ -123,10 +172,13 @@ export function verifyCompiledModuleBody(
     if (!requireShadowed) {
       const bound = REQUIRE_IMPORT.exec(text);
       // A helper-wrapped import (`__importDefault(require(...))` /
-      // `__importStar(require(...))`) must not be fast-pathed if that helper is
-      // locally shadowed — the shadow would run instead of the trusted helper.
-      const usesShadowedImportHelper = importHelperShadowed &&
-        /\b(?:__importDefault|__importStar)\s*\(/.test(text);
+      // `__importStar(require(...))`) must not be fast-pathed if *that specific*
+      // helper is locally shadowed — the shadow would run instead of the
+      // trusted helper. Checked per-helper so shadowing one does not
+      // unnecessarily disable a legitimate import using the other.
+      const usesShadowedImportHelper =
+        (importDefaultShadowed && /\b__importDefault\s*\(/.test(text)) ||
+        (importStarShadowed && /\b__importStar\s*\(/.test(text));
       if (
         bound && !usesShadowedImportHelper &&
         isAllowedAuthoredImportSpecifier(bound[2])

--- a/packages/runner/src/sandbox/module-record-verifier.ts
+++ b/packages/runner/src/sandbox/module-record-verifier.ts
@@ -78,16 +78,32 @@ export function verifyCompiledModuleBody(
     wrapped.slice(s.start, s.end).trim()
   );
 
-  // If the body shadows `require` with its own top-level binding, the
-  // `const x = require(...)` fast-path would mis-trust an arbitrary call.
-  // Disable the fast-path entirely so those statements fall through to
-  // classifyModuleItems (which rejects the call result) — matching AMD, where
-  // a non-canonical require has no special treatment.
-  const requireShadowed = statementTexts.some((t) =>
-    /^(?:const|let|var)\s+require\b/.test(t) ||
-    /^(?:async\s+)?function\s*\*?\s*require\b/.test(t) ||
-    /^class\s+require\b/.test(t)
-  );
+  // If the body declares its own top-level binding for one of the identifiers a
+  // fast-path trusts (`require`, or the TS interop helpers `__exportStar` /
+  // `__importDefault` / `__importStar`), the corresponding fast-path would
+  // mis-trust a call into attacker-controlled code (e.g. a local
+  // `function __exportStar(m){ globalThis.steal = m; }` invoked by an
+  // `__exportStar(require("./m"), exports)` re-export). Detect such shadows and
+  // disable the affected fast-path so the statement falls through to
+  // classifyModuleItems, which rejects the call as a local-callable result —
+  // matching AMD, where a non-canonical helper has no special treatment.
+  //
+  // Canonical TS interop helper declarations (`var __exportStar = (this && …)`)
+  // are the trusted helpers themselves, not shadows, so they are excluded.
+  const declaresLocalBinding = (name: string): boolean =>
+    statementTexts.some((t) => {
+      if (isAllowedTsLibHelperDeclaration(normalizeExact(t))) return false;
+      return (
+        new RegExp(`^(?:const|let|var)\\s+${name}\\b`).test(t) ||
+        new RegExp(`^(?:async\\s+)?function\\s*\\*?\\s*${name}\\b`).test(t) ||
+        new RegExp(`^class\\s+${name}\\b`).test(t)
+      );
+    });
+
+  const requireShadowed = declaresLocalBinding("require");
+  const exportStarShadowed = declaresLocalBinding("__exportStar");
+  const importHelperShadowed = declaresLocalBinding("__importDefault") ||
+    declaresLocalBinding("__importStar");
 
   const env = new Map<string, BindingInfo>();
   const classifiable: typeof parsed.body.statements = [];
@@ -106,7 +122,15 @@ export function verifyCompiledModuleBody(
     }
     if (!requireShadowed) {
       const bound = REQUIRE_IMPORT.exec(text);
-      if (bound && isAllowedAuthoredImportSpecifier(bound[2])) {
+      // A helper-wrapped import (`__importDefault(require(...))` /
+      // `__importStar(require(...))`) must not be fast-pathed if that helper is
+      // locally shadowed — the shadow would run instead of the trusted helper.
+      const usesShadowedImportHelper = importHelperShadowed &&
+        /\b(?:__importDefault|__importStar)\s*\(/.test(text);
+      if (
+        bound && !usesShadowedImportHelper &&
+        isAllowedAuthoredImportSpecifier(bound[2])
+      ) {
         const [, binding, specifier] = bound;
         env.set(binding, {
           kind: "import",
@@ -123,7 +147,10 @@ export function verifyCompiledModuleBody(
         return; // side-effect import binds nothing
       }
       const exportStar = EXPORT_STAR_REQUIRE.exec(text);
-      if (exportStar && isAllowedAuthoredImportSpecifier(exportStar[1])) {
+      if (
+        exportStar && !exportStarShadowed &&
+        isAllowedAuthoredImportSpecifier(exportStar[1])
+      ) {
         return; // `export * from "<allowed>"` re-export; binds nothing
       }
     }

--- a/packages/runner/test/esm-verifier-adversarial.test.ts
+++ b/packages/runner/test/esm-verifier-adversarial.test.ts
@@ -1,0 +1,276 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { verifyCompiledModuleBody } from "../src/sandbox/module-record-verifier.ts";
+
+// Adversarial corpus against the ESM module verifier (`verifyCompiledModuleBody`).
+// Each fixture is a compiled-CommonJS body an attacker might hand-craft to defeat
+// the verifier — the same bytes the SES compartment would evaluate. Brainstormed
+// red-team style (no execution); most must be REJECTED. A few legitimate forms
+// are negative controls (accept). The reject cases double as bypass detectors:
+// if the verifier accepts one, that's a real gap.
+
+const IMPORT = `const cf = require("commonfabric");`;
+
+interface Attack {
+  name: string;
+  body: string;
+  accept?: boolean; // default: must be rejected (verifier throws)
+}
+
+// Canonical TS interop helpers (the verifier recognizes these as trusted), so
+// fixtures that use __exportStar in a non-canonical way can be realistic.
+const EXPORT_STAR_HELPERS =
+  `var __createBinding = (this && this.__createBinding) || (function(o,m,k,k2){if(k2===undefined)k2=k;o[k2]=m[k];});\n` +
+  `var __exportStar = (this && this.__exportStar) || function(m, exports) { for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p); };`;
+
+const ATTACKS: Attack[] = [
+  // --- ASI / statement-merge desync (splitter only `}`-terminates block keywords) ---
+  {
+    name: "ASI: const builder call then side-effect require, no semicolons",
+    body:
+      `${IMPORT}\nconst v = (0, cf.pattern)((s) => ({ d: s }))\nglobalThis.pwned = require("commonfabric")`,
+  },
+  {
+    name:
+      "ASI: exports assignment with comma-sequence side effect, no semicolons",
+    body:
+      `${IMPORT}\nconst a = (0, cf.computed)(() => 1)\nexports.x = (globalThis.fetch("//evil"), a)`,
+  },
+  {
+    name: "U+2028 line separator used to merge a side effect onto a const",
+    body: `${IMPORT}\nconst a = (0, cf.pattern)(() => 1) globalThis.pwned = 1`,
+  },
+  {
+    name: "U+2029 paragraph separator statement merge",
+    body: `${IMPORT}\nconst a = (0, cf.pattern)(() => 1) globalThis.pwned = 1`,
+  },
+
+  // --- tokenizer confusion ---
+  {
+    name: "regex-vs-divide: division parsed as regex to swallow a semicolon",
+    body:
+      `${IMPORT}\nconst x = cf;\nconst y = 4 /1/g, evil = require("commonfabric"); exports.e = evil`,
+  },
+  {
+    name: "nested template literal in a __cf_data arg",
+    body: `${IMPORT}\nexports.x = cf.__cf_data(\`\${\`\${ {a:1} }\`}\`);`,
+    accept: true, // opaque __cf_data data; the concern is split divergence, not acceptance
+  },
+  {
+    name: "template with embedded close-brace string confusing depth tracking",
+    body: `${IMPORT}\nexports.v = (0, cf.pattern)((s) => \`\${"}"}\`);`,
+    accept: true, // legitimate: a direct callback whose body is a template
+  },
+
+  // --- shadowing trusted names ---
+  {
+    name: "shadow `require` then call it as an arbitrary function",
+    body:
+      `const require = (x) => globalThis;\nconst evil = require("anything");`,
+  },
+  {
+    name: "shadow `require` with var + hoisting",
+    body: `const leaked = require("./secret.ts");\nvar require = 0;`,
+  },
+  {
+    name: "local function __cf_data passthrough wrapping mutable state",
+    body:
+      `function __cf_data(x) { return globalThis.mutate(x); }\nconst state = __cf_data({ count: 0 });`,
+  },
+  {
+    name: "shadow __exportStar with a malicious local then re-export",
+    body:
+      `function __exportStar(m, e) { globalThis.steal = m; }\n__exportStar(require("./m.ts"), exports);`,
+  },
+
+  // --- __cf_data / schema opaque-argument boundary (shared design with AMD) ---
+  {
+    name: "legit __cf_data-wrapped plain object (negative control)",
+    body: `${IMPORT}\nexports.config = cf.__cf_data({ a: 1, b: 2 });`,
+    accept: true,
+  },
+  {
+    // KNOWN BOUNDARY (shared with the AMD verifier): __cf_data/schema arguments
+    // are treated as opaque verified data — `verifyTrustedDataCall` checks only
+    // the argument *count*, never recurses into the argument expression. So a
+    // side-effecting computed value inside the wrapped literal is accepted by
+    // the (deliberately AST-free) verifier; the runtime data-freeze is the
+    // backstop for the value itself. This is NOT reachable from authored TS via
+    // the trusted transformer (it only wraps statically-classified data), and
+    // tightening it to a purity check is tracked as separate hardening work.
+    // The test pins the current behavior so a future change is a conscious one.
+    name: "__cf_data argument is opaque (side-effecting value accepted)",
+    body:
+      `${IMPORT}\nexports.x = cf.__cf_data({ y: (globalThis.fetch("//evil"), 1) });`,
+    accept: true,
+  },
+  {
+    name: "schema() argument is opaque (side-effecting value accepted)",
+    body:
+      `${IMPORT}\nexports.x = cf.schema({ default: (globalThis.fetch("//x"), {}) });`,
+    accept: true,
+  },
+
+  // --- reexport getter abuse ---
+  {
+    name: "reexport getter returning a call expression",
+    body:
+      `Object.defineProperty(exports, "x", { enumerable: true, get: function () { return globalThis.fetch("//x"); } });`,
+  },
+
+  // --- default export laundering ---
+  {
+    name: "default export of comma-sequence with a side effect",
+    body:
+      `${IMPORT}\nexports.default = (globalThis.fetch("//x"), (0, cf.pattern)((s) => s));`,
+  },
+  {
+    name: "default export re-exporting the runtime namespace",
+    body: `${IMPORT}\nexports.default = exports.v = cf.require;`,
+  },
+
+  // --- trusted-builder callback indirection ---
+  {
+    name: "builder callback is a member of an import (indirect)",
+    body:
+      `${IMPORT}\nconst other = require("./other.ts");\nexports.v = cf.pattern(other.makeBody);`,
+  },
+  {
+    name: "builder callback is non-function data via binding-identity helper",
+    body:
+      `${IMPORT}\nconst sneaky = cf.someData;\nexports.v = cf.pattern(__cfBindVerifiedBinding(sneaky, {}));`,
+  },
+  {
+    name: "fake (non-canonical) __cfHardenFn laundering a callback",
+    body:
+      `${IMPORT}\nfunction __cfHardenFn(fn) { globalThis.steal = fn; return fn; }\nconst cb = () => 1;\nexports.v = cf.pattern(__cfHardenFn(cb));`,
+  },
+  {
+    name: "legit named direct-function callback (negative control)",
+    body:
+      `${IMPORT}\nconst cb = (s) => ({ n: s.n });\nexports.v = cf.pattern(cb);`,
+    accept: true,
+  },
+  {
+    name: "optional-chaining builder call",
+    body:
+      `${IMPORT}\nexports.x = cf?.pattern?.(() => globalThis.fetch("//x"));`,
+  },
+  {
+    name: "lift with a callback smuggled into a value slot (arity abuse)",
+    body:
+      `${IMPORT}\nexports.v = cf.lift((x) => globalThis.fetch("//x"), (y) => y, (z) => z);`,
+  },
+  {
+    name: "handler with a function in the non-callback value slot",
+    body:
+      `${IMPORT}\nconst cb = () => 1;\nexports.h = cf.handler(cb, () => globalThis.fetch("//x"), 0);`,
+  },
+
+  // --- top-level executable / mutable forms ---
+  {
+    name: "IIFE disguised as a parenthesized arrow",
+    body: `exports.x = (() => { globalThis.fetch("//x"); return 1; })();`,
+  },
+  {
+    name: "new-expression top-level side effect",
+    body: `${IMPORT}\nexports.x = new (cf.Evil)();`,
+  },
+  {
+    name: "tagged template literal at module scope",
+    body: `${IMPORT}\nexports.x = cf.pattern\`\${globalThis.fetch("//x")}\`;`,
+  },
+  {
+    name: "let mutable top-level binding",
+    body: `let counter = 0;\nexports.counter = counter;`,
+  },
+  {
+    name: "class expression assigned to a const with side-effecting static",
+    body:
+      `const x = class { static y = globalThis.fetch("//x"); };\nexports.x = x;`,
+  },
+  {
+    name: "top-level class declaration with static initializer",
+    body: `class C { static x = globalThis.fetch("//x"); }\nexports.C = C;`,
+  },
+  {
+    name: "generator function declaration",
+    body: `function* gen() { globalThis.fetch("//x"); }\nexports.gen = gen;`,
+  },
+  {
+    name: "do/while top-level loop",
+    body: `do { globalThis.fetch("//x"); } while (0);`,
+  },
+  {
+    name: "for-loop header side effect",
+    body: `for (globalThis.fetch("//x"); false; ) { }`,
+  },
+  {
+    // Top-level function declarations are allowed by design: the body is not
+    // executed at module init, and SES lockdown governs which globals exist, so
+    // a body that references `globalThis.fetch` is harmless until invoked. This
+    // mirrors the accepted plain-function case (generators, by contrast, are
+    // rejected). Negative control to pin that async declarations are accepted.
+    name: "async function declaration is allowed (not executed at init)",
+    body: `async function go() { globalThis.fetch("//x"); }\nexports.go = go;`,
+    accept: true,
+  },
+
+  // --- export form abuse ---
+  { name: "module.exports = runtime", body: `${IMPORT}\nmodule.exports = cf;` },
+  {
+    name: "computed-key export assignment",
+    body: `${IMPORT}\nexports[globalThis.k] = (0, cf.pattern)((s) => s);`,
+  },
+  {
+    name: "legit bracket-literal-key export (negative control)",
+    body: `${IMPORT}\nexports["x"] = (0, cf.pattern)((s) => s);`,
+    accept: true,
+  },
+  {
+    name: "unicode-escaped trusted builder name",
+    body: `${IMPORT}\nexports.x = cf.\\u0070attern(() => 1);`,
+  },
+
+  // --- import fast-path / require boundary abuse ---
+  {
+    name: "side-effect require with quote-escape break-out attempt",
+    body: `require("./a.ts\\");globalThis.pwned=(\\"");`,
+  },
+  {
+    name: "require of a disallowed specifier",
+    body: `const fs_1 = require("node:fs");\nexports.fs = fs_1;`,
+  },
+  {
+    name: "bare side-effect require of a disallowed specifier",
+    body: `require("node:child_process");`,
+  },
+  {
+    name: "export-star require of a disallowed specifier",
+    body: `${EXPORT_STAR_HELPERS}\n__exportStar(require("node:fs"), exports);`,
+  },
+  {
+    name: "multi-declarator const smuggling a call in the second declarator",
+    body:
+      `${IMPORT}\nconst cf2 = require("commonfabric"), evil = cf2.pattern(globalThis.fetch);`,
+  },
+  {
+    name: "require fast-path defeated by trailing declarator",
+    body: `const x = require("commonfabric"), y = globalThis;`,
+  },
+];
+
+describe("ESM verifier adversarial corpus", () => {
+  for (const attack of ATTACKS) {
+    const verb = attack.accept ? "allows (control)" : "rejects";
+    it(`${verb}: ${attack.name}`, () => {
+      const run = () => verifyCompiledModuleBody(attack.body, "/m.ts");
+      if (attack.accept) {
+        expect(run).not.toThrow();
+      } else {
+        expect(run).toThrow();
+      }
+    });
+  }
+});

--- a/packages/runner/test/esm-verifier-adversarial.test.ts
+++ b/packages/runner/test/esm-verifier-adversarial.test.ts
@@ -18,12 +18,6 @@ interface Attack {
   accept?: boolean; // default: must be rejected (verifier throws)
 }
 
-// Canonical TS interop helpers (the verifier recognizes these as trusted), so
-// fixtures that use __exportStar in a non-canonical way can be realistic.
-const EXPORT_STAR_HELPERS =
-  `var __createBinding = (this && this.__createBinding) || (function(o,m,k,k2){if(k2===undefined)k2=k;o[k2]=m[k];});\n` +
-  `var __exportStar = (this && this.__exportStar) || function(m, exports) { for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p); };`;
-
 const ATTACKS: Attack[] = [
   // --- ASI / statement-merge desync (splitter only `}`-terminates block keywords) ---
   {
@@ -82,6 +76,21 @@ const ATTACKS: Attack[] = [
     name: "shadow __exportStar with a malicious local then re-export",
     body:
       `function __exportStar(m, e) { globalThis.steal = m; }\n__exportStar(require("./m.ts"), exports);`,
+  },
+  {
+    name: "multi-declarator shadow of __exportStar (non-first declarator)",
+    body:
+      `const a = 1, __exportStar = (m, e) => { globalThis.steal = m; };\n__exportStar(require("./m.ts"), exports);`,
+  },
+  {
+    name: "multi-declarator shadow of require (non-first declarator)",
+    body:
+      `const a = 1, require = (x) => globalThis;\nconst evil = require("commonfabric");`,
+  },
+  {
+    name: "multi-declarator shadow of __importStar (non-first declarator)",
+    body:
+      `const a = 1, __importStar = (m) => globalThis;\nconst ns = __importStar(require("commonfabric"));`,
   },
 
   // --- __cf_data / schema opaque-argument boundary (shared design with AMD) ---
@@ -248,7 +257,7 @@ const ATTACKS: Attack[] = [
   },
   {
     name: "export-star require of a disallowed specifier",
-    body: `${EXPORT_STAR_HELPERS}\n__exportStar(require("node:fs"), exports);`,
+    body: `__exportStar(require("node:fs"), exports);`,
   },
   {
     name: "multi-declarator const smuggling a call in the second declarator",


### PR DESCRIPTION
## What

Hardens the SES ESM module verifier (`verifyCompiledModuleBody`, the security boundary) with a red-team adversarial test corpus, and fixes one real bypass the corpus surfaced.

A sub-agent brainstormed 40+ creative attacks (no execution) across: ASI/statement-merge desync, tokenizer confusion (regex-vs-divide, nested templates, U+2028/2029), trusted-name shadowing, trusted-builder callback indirection, `__cf_data`/`schema` argument smuggling, default-export & reexport-getter laundering, top-level executable/mutable forms, export-form abuse, and import-fast-path / require-boundary escapes. They are encoded as 44 fixtures in `packages/runner/test/esm-verifier-adversarial.test.ts` — reject cases double as bypass detectors; a handful of legitimate forms are pinned as negative controls.

## Real bypass found & fixed

The `__exportStar(require(...), exports)` re-export fast-path (and the `__importDefault`/`__importStar` require-import forms) trusted the helper *identifier* unconditionally. A module could declare a local `function __exportStar(m){ globalThis.steal = m; }` — registered as a normal top-level function — and the fast-path would skip the call, so the **malicious local ran at module init**.

**Fix:** generalize shadow detection (previously `require`-only) to the TS interop helper identifiers the fast-paths trust, *excluding* canonical tslib helper declarations (which are the trusted helpers themselves, not shadows). When a helper is locally shadowed, its fast-path is disabled and the statement falls through to `classifyModuleItems`, which rejects the call as a local-callable result — fail-closed, matching AMD.

## Documented, not changed

`__cf_data`/`schema` arguments are opaque — `verifyTrustedDataCall` checks only the argument *count*, never recurses — so a side-effecting computed value inside the wrapped literal is accepted. This is a deliberate, AST-free boundary **shared with the AMD verifier**, is not reachable via the trusted transformer (it only wraps statically-classified data), and the runtime data-freeze is the backstop for the value itself. A purity check is tracked as separate hardening work. The two fixtures pin the current behavior so a future change is a conscious one.

## Scope

- Behind the existing default-off `esmModuleLoader` flag; no behavior change to the AMD enforcement path.
- New tests + a contained verifier fix; all existing verifier suites (`esm-module-body-verifier`, `esm-verifier-parity`) still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an adversarial test corpus for the ESM module verifier and closes a helper-shadow bypass with multi-declarator shadow detection and per-helper fast-path gating. No AMD-path change; the ESM path stays behind the default-off `esmModuleLoader` flag.

- **New Features**
  - Added adversarial fixtures covering ASI merges, tokenizer tricks, helper shadowing (incl. non-first declarators), import fast-paths, top-level executable/mutable forms, and export abuse; reject cases act as bypass detectors.
  - Pinned a few legit cases as negative controls, including opaque `__cf_data`/`schema` arguments; all existing verifier suites remain green.

- **Bug Fixes**
  - Detect top-level shadows of `require`, `__exportStar`, `__importDefault`, and `__importStar` across function/class names and every declarator in `const`/`let`/`var` lists using depth-aware parsing; exclude canonical `tslib` helper declarations.
  - Gate import-helper fast-paths per-helper; if a helper is shadowed, disable only that fast-path and fall through to classification, closing the `__exportStar(require(...), exports)` re-export bypass.

<sup>Written for commit 21fb7966052a8799a5dee854ec85a854e8c26e5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

