### PR TITLE
fix(runner): write-once exports in the ESM loader (block init-time export corruption)

### DIFF
--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -25,6 +25,46 @@ import type { VirtualModuleRecord } from "./esm-module-loader.ts";
 
 const TARGET = ts.ScriptTarget.ES2023;
 
+/**
+ * Create a write-once exports target for a module body. Re-assigning,
+ * redefining, or deleting a property that already holds a real (non-`undefined`)
+ * value throws. A `void 0` placeholder — the TS `exports.x = void 0;` forward
+ * declaration — leaves the property unlocked so the subsequent real assignment
+ * is permitted, and the real assignment then locks it. This blocks export
+ * corruption smuggled into the evaluation of an otherwise-accepted expression,
+ * which the (deliberately AST-free) verifier cannot detect.
+ */
+export function createWriteOnceExports(): Record<string, unknown> {
+  const target: Record<string, unknown> = {};
+  const locked = new Set<string | symbol>();
+  const denyRelock = (key: string | symbol): never => {
+    throw new TypeError(
+      `Module export '${String(key)}' is write-once and was already assigned`,
+    );
+  };
+  return new Proxy(target, {
+    set(t, key, value) {
+      if (locked.has(key)) denyRelock(key);
+      (t as Record<string | symbol, unknown>)[key] = value;
+      if (value !== undefined) locked.add(key);
+      return true;
+    },
+    defineProperty(t, key, descriptor) {
+      if (locked.has(key)) denyRelock(key);
+      Reflect.defineProperty(t, key, descriptor);
+      const isUndefinedPlaceholder = "value" in descriptor &&
+        descriptor.value === undefined;
+      if (!isUndefinedPlaceholder) locked.add(key);
+      return true;
+    },
+    deleteProperty(_t, key) {
+      throw new TypeError(
+        `Module export '${String(key)}' cannot be deleted (write-once)`,
+      );
+    },
+  });
+}
+
 /** Per-module compiled artifact, cacheable by module hash (Phase 4). */
 export interface CompiledModuleArtifact {
   exports: string[];
@@ -232,19 +272,35 @@ export function compileSourcesToRecords(
           require: (specifier: string) => Record<string, unknown>,
           module: { exports: Record<string, unknown> },
         ) => void;
-        const localExports: Record<string, unknown> = {};
-        const moduleObject = { exports: localExports };
+        // The module body writes its exports into a WRITE-ONCE object rather
+        // than a plain mutable one. The verifier cannot see a write smuggled
+        // into an accepted expression's evaluation (e.g. a comma side effect
+        // inside a `__cf_data(...)` argument: `__cf_data((exports.x = evil, 1))`),
+        // so a body could otherwise overwrite an already-assigned export with an
+        // attacker-controlled value before we snapshot it into the namespace.
+        // Write-once makes any re-assignment / redefinition / deletion of an
+        // already-populated export throw, so the smuggle fails closed. A `void 0`
+        // forward declaration is treated as a placeholder, so the canonical
+        // `exports.x = void 0; … exports.x = real;` compiler shape is allowed.
+        const writeOnceExports = createWriteOnceExports();
+        const moduleObject = { exports: writeOnceExports };
         const requireShim = (specifier: string) =>
           compartment.importNow(resolvedImports[specifier] ?? specifier);
         // A throw here is terminal for this module: SES caches the error and
         // re-throws it on every subsequent importNow (the same contract as a
         // failed AMD factory).
-        factory(localExports, requireShim, moduleObject);
+        factory(writeOnceExports, requireShim, moduleObject);
         const finalExports = moduleObject.exports;
-        // Copy the declared exports onto the SES module namespace object.
-        // NOTE: this snapshots values at init time, so a later reassignment of
-        // an exported `let` is not reflected as a true ESM live binding. This is
-        // acceptable for compiled patterns; revisit with getters if needed.
+        // Copy the declared exports onto the SES module namespace object. SES
+        // already makes the namespace *bindings* immutable (a sibling cannot
+        // reassign or add `ns.x`), and verified plain data is already deep-frozen
+        // by `__cf_data`/`schema` (`freezeVerifiedPlainData`), so exported data
+        // internals are immutable too. We deliberately do NOT freeze the values
+        // here: the engine attaches metadata to exported pattern recipes after
+        // load (`value.program = program` in builder/factory.ts), so exported
+        // builder graphs must stay extensible. Snapshots values at init time, so
+        // a later reassignment of an exported `let` is not reflected as a true
+        // ESM live binding — acceptable for compiled patterns.
         for (const name of exportNames) {
           moduleExports[name] = finalExports[name];
         }

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -34,6 +34,46 @@ const TARGET = ts.ScriptTarget.ES2023;
  * corruption smuggled into the evaluation of an otherwise-accepted expression,
  * which the (deliberately AST-free) verifier cannot detect.
  */
+/**
+ * Run a compiled module factory against a write-once exports object and snapshot
+ * the declared exports onto `moduleExports` (the SES namespace target).
+ *
+ * Hardening:
+ * - The body writes into a WRITE-ONCE exports object (see
+ *   {@link createWriteOnceExports}), so a write smuggled into the evaluation of
+ *   an otherwise-accepted expression (e.g. `__cf_data((exports.x = evil, 1))`)
+ *   cannot overwrite an already-assigned export before the snapshot.
+ * - The `module` wrapper is frozen, so the wholesale twin
+ *   `__cf_data((module.exports = evil, 1))` throws in strict mode rather than
+ *   swapping out the write-once object behind our back.
+ * - We snapshot from the write-once object directly (never `module.exports`), so
+ *   the namespace can only reflect values that passed through write-once.
+ *
+ * We deliberately do NOT deep-freeze the exported values: SES already makes the
+ * namespace *bindings* immutable, verified plain data is already frozen by
+ * `__cf_data`/`schema`, and the engine attaches metadata to exported pattern
+ * recipes after load (`value.program = program` in builder/factory.ts), so
+ * exported builder graphs must stay extensible.
+ */
+export function populateModuleExports(
+  moduleExports: Record<string, unknown>,
+  exportNames: string[],
+  factory: (
+    exports: Record<string, unknown>,
+    require: (specifier: string) => Record<string, unknown>,
+    module: { exports: Record<string, unknown> },
+  ) => void,
+  requireShim: (specifier: string) => Record<string, unknown>,
+): void {
+  const writeOnceExports = createWriteOnceExports();
+  const moduleObject = Object.freeze({ exports: writeOnceExports });
+  factory(writeOnceExports, requireShim, moduleObject);
+  for (const name of exportNames) {
+    moduleExports[name] = writeOnceExports[name];
+  }
+  moduleExports.__esModule = true;
+}
+
 export function createWriteOnceExports(): Record<string, unknown> {
   const target: Record<string, unknown> = {};
   const locked = new Set<string | symbol>();
@@ -282,29 +322,17 @@ export function compileSourcesToRecords(
         // already-populated export throw, so the smuggle fails closed. A `void 0`
         // forward declaration is treated as a placeholder, so the canonical
         // `exports.x = void 0; … exports.x = real;` compiler shape is allowed.
-        const writeOnceExports = createWriteOnceExports();
-        const moduleObject = { exports: writeOnceExports };
         const requireShim = (specifier: string) =>
           compartment.importNow(resolvedImports[specifier] ?? specifier);
-        // A throw here is terminal for this module: SES caches the error and
-        // re-throws it on every subsequent importNow (the same contract as a
-        // failed AMD factory).
-        factory(writeOnceExports, requireShim, moduleObject);
-        const finalExports = moduleObject.exports;
-        // Copy the declared exports onto the SES module namespace object. SES
-        // already makes the namespace *bindings* immutable (a sibling cannot
-        // reassign or add `ns.x`), and verified plain data is already deep-frozen
-        // by `__cf_data`/`schema` (`freezeVerifiedPlainData`), so exported data
-        // internals are immutable too. We deliberately do NOT freeze the values
-        // here: the engine attaches metadata to exported pattern recipes after
-        // load (`value.program = program` in builder/factory.ts), so exported
-        // builder graphs must stay extensible. Snapshots values at init time, so
-        // a later reassignment of an exported `let` is not reflected as a true
-        // ESM live binding — acceptable for compiled patterns.
-        for (const name of exportNames) {
-          moduleExports[name] = finalExports[name];
-        }
-        moduleExports.__esModule = true;
+        // A throw inside the factory is terminal for this module: SES caches the
+        // error and re-throws it on every subsequent importNow (the same
+        // contract as a failed AMD factory).
+        populateModuleExports(
+          moduleExports,
+          exportNames,
+          factory,
+          requireShim,
+        );
       },
     });
   }

--- a/packages/runner/test/module-export-write-once.test.ts
+++ b/packages/runner/test/module-export-write-once.test.ts
@@ -1,7 +1,14 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
-import { createWriteOnceExports } from "../src/sandbox/module-record-compiler.ts";
+import {
+  createWriteOnceExports,
+  populateModuleExports,
+} from "../src/sandbox/module-record-compiler.ts";
+
+const noRequire = (s: string): Record<string, unknown> => {
+  throw new Error(`unexpected require(${s})`);
+};
 
 // The ESM loader hands the module body a write-once exports object so a write
 // smuggled into the evaluation of an otherwise-accepted expression (e.g. a
@@ -88,5 +95,79 @@ describe("createWriteOnceExports", () => {
     expect(() => {
       exports.a = 3;
     }).toThrow();
+  });
+});
+
+describe("populateModuleExports", () => {
+  it("snapshots only the declared exports onto the namespace", () => {
+    const ns: Record<string, unknown> = {};
+    populateModuleExports(ns, ["a"], (exports) => {
+      exports.a = "data";
+      // A non-declared stash is written to the throwaway write-once object…
+      exports.secret = () => "pwned";
+    }, noRequire);
+    expect(ns.a).toBe("data");
+    // …but is never lifted onto the namespace.
+    expect("secret" in ns).toBe(false);
+    expect(ns.__esModule).toBe(true);
+  });
+
+  it("fails closed on `module.exports = evil` under strict mode (frozen wrapper)", () => {
+    const ns: Record<string, unknown> = {};
+    // The `__cf_data((module.exports = evil, 1))` twin. Compiled module bodies
+    // are strict (TS emits "use strict"), so assigning to the frozen module
+    // wrapper throws — the module fails closed. Strict directive must be the
+    // first statement to take effect.
+    const strictFactory = function (
+      exports: Record<string, unknown>,
+      _require: unknown,
+      module: { exports: Record<string, unknown> },
+    ) {
+      "use strict";
+      exports.x = "verified";
+      module.exports = { x: () => "pwned" };
+    };
+    expect(() => {
+      populateModuleExports(
+        ns,
+        ["x"],
+        strictFactory as Parameters<typeof populateModuleExports>[2],
+        noRequire,
+      );
+    }).toThrow();
+  });
+
+  it("snapshots from write-once even if `module.exports` is swapped (sloppy mode)", () => {
+    const ns: Record<string, unknown> = {};
+    // Even where the reassignment does not throw (sloppy mode: the frozen-object
+    // write silently no-ops), the namespace snapshots from the write-once object
+    // directly, never `module.exports`, so the swap cannot corrupt it.
+    populateModuleExports(ns, ["x"], (exports, _require, module) => {
+      exports.x = "verified";
+      try {
+        module.exports = { x: () => "pwned" };
+      } catch { /* frozen wrapper in strict mode */ }
+    }, noRequire);
+    expect(ns.x).toBe("verified");
+  });
+
+  it("snapshots from the write-once object, not module.exports", () => {
+    const ns: Record<string, unknown> = {};
+    populateModuleExports(ns, ["x"], (exports, _require, module) => {
+      exports.x = "verified";
+      // Reading module.exports is fine and returns the write-once object.
+      expect(module.exports).toBe(exports);
+    }, noRequire);
+    expect(ns.x).toBe("verified");
+  });
+
+  it("propagates a write-once violation as a module load failure", () => {
+    const ns: Record<string, unknown> = {};
+    expect(() => {
+      populateModuleExports(ns, ["x"], (exports) => {
+        exports.x = "verified";
+        exports.x = () => "pwned"; // smuggled overwrite
+      }, noRequire);
+    }).toThrow(/write-once/);
   });
 });

--- a/packages/runner/test/module-export-write-once.test.ts
+++ b/packages/runner/test/module-export-write-once.test.ts
@@ -1,0 +1,92 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { createWriteOnceExports } from "../src/sandbox/module-record-compiler.ts";
+
+// The ESM loader hands the module body a write-once exports object so a write
+// smuggled into the evaluation of an otherwise-accepted expression (e.g. a
+// comma side effect inside a `__cf_data(...)` argument) cannot overwrite an
+// already-assigned export with attacker-controlled state before the loader
+// snapshots it into the (SES-immutable) namespace. These tests pin that
+// behavior, plus the legitimate compiler shapes that must still work.
+
+describe("createWriteOnceExports", () => {
+  it("locks a property after a real assignment (blocks the overwrite smuggle)", () => {
+    const exports = createWriteOnceExports();
+    exports.token = "verified-data";
+    // The smuggled `exports.token = evilClosure` inside a later accepted
+    // expression must throw rather than silently corrupt the export.
+    expect(() => {
+      exports.token = () => "pwned";
+    }).toThrow(/write-once/);
+    expect(exports.token).toBe("verified-data");
+  });
+
+  it("allows the `exports.x = void 0; … exports.x = real;` forward-decl shape", () => {
+    const exports = createWriteOnceExports();
+    // TS CommonJS output forward-declares exports as `void 0` in the preamble.
+    exports.value = undefined;
+    exports.value = undefined; // chained `exports.a = exports.b = void 0`
+    // The real assignment is permitted and then locks the binding.
+    exports.value = 42;
+    expect(exports.value).toBe(42);
+    expect(() => {
+      exports.value = 99;
+    }).toThrow(/write-once/);
+  });
+
+  it("allows a re-export getter to be defined once, blocks redefinition", () => {
+    const exports = createWriteOnceExports();
+    Object.defineProperty(exports, "reexported", {
+      enumerable: true,
+      configurable: true,
+      get: () => "from-dep",
+    });
+    expect(exports.reexported).toBe("from-dep");
+    // A second define (e.g. smuggled `Object.defineProperty(exports, …)`) throws.
+    expect(() => {
+      Object.defineProperty(exports, "reexported", { value: () => "pwned" });
+    }).toThrow(/write-once/);
+  });
+
+  it("allows the __esModule marker and locks it", () => {
+    const exports = createWriteOnceExports();
+    Object.defineProperty(exports, "__esModule", { value: true });
+    expect(exports.__esModule).toBe(true);
+    expect(() => {
+      exports.__esModule = false;
+    }).toThrow(/write-once/);
+  });
+
+  it("blocks deletion of an export (e.g. `delete exports.__esModule`)", () => {
+    const exports = createWriteOnceExports();
+    exports.keep = 1;
+    expect(() => {
+      delete exports.keep;
+    }).toThrow(/cannot be deleted/);
+    expect(exports.keep).toBe(1);
+  });
+
+  it("fails closed when a smuggle assigns before the real assignment", () => {
+    const exports = createWriteOnceExports();
+    // Smuggle runs first (e.g. an import-preamble data arg evaluated early),
+    // setting a real value and locking the binding…
+    exports.api = () => "pwned";
+    // …so the module's own legitimate assignment then throws — the module fails
+    // to load rather than exporting a corrupted-but-accepted value.
+    expect(() => {
+      exports.api = "verified-data";
+    }).toThrow(/write-once/);
+  });
+
+  it("treats distinct exports independently", () => {
+    const exports = createWriteOnceExports();
+    exports.a = 1;
+    exports.b = 2;
+    expect(exports.a).toBe(1);
+    expect(exports.b).toBe(2);
+    expect(() => {
+      exports.a = 3;
+    }).toThrow();
+  });
+});


### PR DESCRIPTION
## Context

Follow-up to the verifier adversarial-hardening work (#3774), under a sharpened threat model: **the TS compiler and CF transformer are untrusted** — the verifier sees arbitrary attacker-controlled compiled CJS. Three red-team passes converged on a single residual class the (deliberately AST-free) verifier cannot catch: a **write smuggled into the evaluation of an otherwise-accepted expression**.

Flagship: `const x = cf.__cf_data((exports.token = evilClosure, 1));` — the comma side effect overwrites an already-assigned export with a live, un-copied closure, then `__cf_data` copies only `1`. `verifyTrustedDataCall` checks argument *count* only, so the write is invisible to verification.

## What is already covered (verified — no change)

- **SES namespace immutability**: a sibling cannot reassign or add `ns.x` (`Cannot set property … of module exports namespace`). Confirmed by probe.
- **SES lockdown** hardens shared intrinsics (`Object`/`Array`/`Function.prototype`) and the compartment `globalThis` is `Object.freeze`d → prototype-pollution and global-stash writes throw.
- **`__cf_data`/`schema`** (= `freezeVerifiedPlainData`) deep-freeze their result and throw on functions → exported plain-data internals are immutable and closures are stripped from results.

## The gap & fix

Unprotected: a smuggled overwrite of a **declared export's value during the module's own init**, before the loader snapshots values into the (then-frozen) namespace.

The ESM loader now hands the body a **write-once exports** object: re-assigning / redefining / deleting an already-populated export throws → the smuggle fails closed. The `void 0` forward-declaration placeholder is preserved (canonical `exports.x = void 0; … exports.x = real;` still works); re-export getters and the `__esModule` marker define exactly once.

## Deliberately *not* done: deep-freeze exported values

Evaluated per discussion and **rejected empirically** — it breaks the runtime, which attaches metadata to exported pattern recipes after load (`value.program = program` in `builder/factory.ts`), so exported builder graphs must stay extensible. Namespace-binding immutability (SES) + data freezing (`__cf_data`) already cover the value surface; deep-freeze would add breakage without adding protection here.

## Scope

- Behind the default-off `esmModuleLoader` flag (only the ESM loader's `execute` uses this path); no change to the AMD enforcement path.
- New unit tests pin write-once semantics (overwrite/stash/delete blocked; forward-decl, re-export getter, `__esModule` allowed; fails-closed on smuggle-before-real). Full ESM verifier/loader/engine/pattern-run suite green (175 steps), including a real multi-file pattern running through the ESM loader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the ESM loader with write-once `exports` and a frozen `module` wrapper to block init-time export corruption and `module.exports` swap bypasses. Prevents smuggled writes like `(exports.token = evil, 1)` and `(__cf_data((module.exports = evil, 1)))` from corrupting exports before snapshot.

- **Bug Fixes**
  - Module body receives a write-once `exports` proxy; reassign/redefine/delete after a real value throws.
  - Supports TS forward-decl (`exports.x = void 0; … exports.x = real`); allows defining a re-export getter and `__esModule` exactly once.
  - Freeze the `module` wrapper and snapshot declared exports directly from the write-once object (never from `module.exports`); ignores undeclared stashes.
  - Exported values are not deep-frozen to avoid breaking runtime metadata; SES namespace immutability and `__cf_data` deep-freezing still apply.
  - Scoped to the ESM path behind the `esmModuleLoader` flag (default off); added tests covering write-once semantics, declared-only snapshot, and the `module.exports` swap bypass.

<sup>Written for commit 46ed1f909e59f7b647649f6ef665d7612053e6ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

