### PR TITLE
feat(runner): freeze exported patterns in the ESM loader (metadata → WeakMaps)

### DIFF
--- a/packages/runner/src/builder/factory.ts
+++ b/packages/runner/src/builder/factory.ts
@@ -48,6 +48,7 @@ import { cellConstructorFactory } from "../cell.ts";
 import { getEntityId } from "../create-ref.ts";
 import { getPatternEnvironment } from "./env.ts";
 import type { RuntimeProgram } from "../harness/types.ts";
+import { setPatternProgram } from "./pattern-metadata.ts";
 import {
   FabricInstance,
   FabricPrimitive,
@@ -130,8 +131,9 @@ export const createBuilder = (options: CreateBuilderOptions = {}): {
   const exportsCallback = (exports: Map<any, RuntimeProgram>) => {
     for (const [value, program] of exports) {
       if (isPattern(value)) {
-        // This will associate the program with the pattern
-        value.program = program;
+        // Associate the program with the pattern via the side-table so it works
+        // even when the exported pattern has been frozen by the loader.
+        setPatternProgram(value, program);
       }
     }
   };

--- a/packages/runner/src/builder/json-utils.ts
+++ b/packages/runner/src/builder/json-utils.ts
@@ -18,6 +18,7 @@ import {
   unsafe_originalPattern,
 } from "./types.ts";
 import { getTopFrame } from "./pattern.ts";
+import { getPatternProgram } from "./pattern-metadata.ts";
 import { deepEqual } from "@commonfabric/utils/deep-equal";
 import { Runtime } from "../runtime.ts";
 import {
@@ -450,6 +451,6 @@ export function patternToJSON(pattern: Pattern) {
     ...(pattern.initial ? { initial: pattern.initial } : {}),
     result: pattern.result,
     nodes: pattern.nodes,
-    program: pattern.program,
+    program: getPatternProgram(pattern),
   };
 }

--- a/packages/runner/src/builder/pattern-metadata.ts
+++ b/packages/runner/src/builder/pattern-metadata.ts
@@ -1,0 +1,59 @@
+import type { RuntimeProgram } from "../harness/types.ts";
+
+/**
+ * Side-table storage for pattern metadata that is associated *after* a pattern
+ * is exported from its module:
+ *
+ * - `program` — the rehydration source (`RuntimeProgram`) attached by the engine
+ *   after compilation/eval and at registration time.
+ * - `verifiedLoadId` — the CFC verified-load identity attached by the engine
+ *   while seeding verified-load ids.
+ *
+ * These used to live as an own data property (`pattern.program`) and a symbol
+ * property (`pattern[unsafe_verifiedLoadId]`) on the pattern object. Storing
+ * them in module-level WeakMaps instead lets the ESM loader `harden()` exported
+ * pattern values at the module boundary: the associations are still attached
+ * later, but a WeakMap write does not mutate the (now frozen) object. Keyed by
+ * `object` (patterns are callable objects, and derivation copies / bound values
+ * also carry the verified-load id), with WeakMap GC semantics so a value's
+ * metadata is collected with the value.
+ */
+
+const programByPattern = new WeakMap<object, RuntimeProgram>();
+const verifiedLoadIdByValue = new WeakMap<object, string>();
+
+function asKey(value: unknown): object | undefined {
+  if (value === null) return undefined;
+  return (typeof value === "object" || typeof value === "function")
+    ? (value as object)
+    : undefined;
+}
+
+/** The rehydration source associated with a pattern, if any. */
+export function getPatternProgram(
+  pattern: unknown,
+): RuntimeProgram | undefined {
+  const key = asKey(pattern);
+  return key ? programByPattern.get(key) : undefined;
+}
+
+/** Associate a rehydration source with a pattern (works on frozen patterns). */
+export function setPatternProgram(
+  pattern: unknown,
+  program: RuntimeProgram,
+): void {
+  const key = asKey(pattern);
+  if (key) programByPattern.set(key, program);
+}
+
+/** The CFC verified-load id associated with a value, if any. */
+export function getVerifiedLoadId(value: unknown): string | undefined {
+  const key = asKey(value);
+  return key ? verifiedLoadIdByValue.get(key) : undefined;
+}
+
+/** Associate a CFC verified-load id with a value (works on frozen values). */
+export function setVerifiedLoadId(value: unknown, id: string): void {
+  const key = asKey(value);
+  if (key) verifiedLoadIdByValue.set(key, id);
+}

--- a/packages/runner/src/builder/types.ts
+++ b/packages/runner/src/builder/types.ts
@@ -62,7 +62,6 @@ import {
   type IExtendedStorageTransaction,
   type MemorySpace,
 } from "../storage/interface.ts";
-import { type RuntimeProgram } from "../harness/types.ts";
 import { type Runtime } from "../runtime.ts";
 
 // Define runtime constants here - actual runtime values
@@ -220,7 +219,6 @@ export type Node = {
 
 // Used to get back to original pattern from a JSONified representation.
 export const unsafe_originalPattern = Symbol("unsafe_originalPattern");
-export const unsafe_verifiedLoadId = Symbol("unsafe_verifiedLoadId");
 export const unsafe_parentPattern = Symbol("unsafe_parentPattern");
 
 declare module "@commonfabric/api" {
@@ -231,9 +229,11 @@ declare module "@commonfabric/api" {
     initial?: JSONValue;
     result: JSONValue;
     nodes: Node[];
-    program?: RuntimeProgram;
+    // NOTE: `program` (rehydration source) and the verified-load id are no
+    // longer stored on the pattern object — they live in WeakMaps in
+    // ./pattern-metadata.ts so exported patterns can be frozen. Use
+    // get/setPatternProgram and get/setVerifiedLoadId.
     [unsafe_originalPattern]?: Pattern;
-    [unsafe_verifiedLoadId]?: string;
     [unsafe_parentPattern]?: Pattern;
   }
 }

--- a/packages/runner/src/harness/executable-registry.ts
+++ b/packages/runner/src/harness/executable-registry.ts
@@ -1,4 +1,5 @@
-import { isPattern, unsafe_verifiedLoadId } from "../builder/types.ts";
+import { isPattern } from "../builder/types.ts";
+import { setVerifiedLoadId } from "../builder/pattern-metadata.ts";
 import { hardenVerifiedFunction } from "../sandbox/function-hardening.ts";
 import { VERIFIED_BINDING_METADATA_FIELD } from "@commonfabric/utils/sandbox-contract";
 import type { UnsafeHostTrustOptions } from "../unsafe-host-trust.ts";
@@ -303,11 +304,9 @@ export class ExecutableRegistry {
     }
     seen.add(value);
 
-    if (isPattern(value) && Object.isExtensible(value)) {
-      Object.defineProperty(value, unsafe_verifiedLoadId, {
-        value: loadId,
-        configurable: true,
-      });
+    if (isPattern(value)) {
+      // Side-table storage works on frozen patterns too (no own-property write).
+      setVerifiedLoadId(value, loadId);
     }
 
     for (const key of Reflect.ownKeys(value as object)) {

--- a/packages/runner/src/pattern-binding.ts
+++ b/packages/runner/src/pattern-binding.ts
@@ -6,8 +6,11 @@ import {
   type Pattern,
   unsafe_originalPattern,
   unsafe_parentPattern,
-  unsafe_verifiedLoadId,
 } from "./builder/types.ts";
+import {
+  getVerifiedLoadId,
+  setVerifiedLoadId,
+} from "./builder/pattern-metadata.ts";
 import { type AnyCell } from "./cell.ts";
 import { resolveLink } from "./link-resolution.ts";
 import { diffAndUpdate } from "./data-updating.ts";
@@ -330,8 +333,9 @@ export function unwrapOneLevelAndBindtoDoc<T, U>(
       if (binding[unsafe_originalPattern]) {
         result[unsafe_originalPattern] = binding[unsafe_originalPattern];
       }
-      if (binding[unsafe_verifiedLoadId]) {
-        result[unsafe_verifiedLoadId] = binding[unsafe_verifiedLoadId];
+      const verifiedLoadId = getVerifiedLoadId(binding);
+      if (verifiedLoadId) {
+        setVerifiedLoadId(result, verifiedLoadId);
       }
       return result;
     } else return binding;

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -5,8 +5,13 @@ import {
   Pattern,
   Schema,
   unsafe_originalPattern,
-  unsafe_verifiedLoadId,
 } from "./builder/types.ts";
+import {
+  getPatternProgram,
+  getVerifiedLoadId,
+  setPatternProgram,
+  setVerifiedLoadId,
+} from "./builder/pattern-metadata.ts";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { Cell, createCell } from "./cell.ts";
 import type { MemorySpace, Runtime } from "./runtime.ts";
@@ -179,14 +184,10 @@ export class PatternManager {
       if (!this.patternToVerifiedLoadId.has(originalPattern)) {
         this.patternToVerifiedLoadId.set(originalPattern, verifiedLoadId);
       }
-      if (
-        Object.isExtensible(value) &&
-        (value as Pattern)[unsafe_verifiedLoadId] !== verifiedLoadId
-      ) {
-        Object.defineProperty(value, unsafe_verifiedLoadId, {
-          value: verifiedLoadId,
-          configurable: true,
-        });
+      // Side-table storage works even when `value` has been frozen by the
+      // loader (no own-property write needed).
+      if (getVerifiedLoadId(value) !== verifiedLoadId) {
+        setVerifiedLoadId(value, verifiedLoadId);
       }
     }
 
@@ -253,7 +254,7 @@ export class PatternManager {
 
     // If we don't have a stored cell yet, return whatever pending/meta we have
     const pending = this.pendingMetaById.get(patternId) ?? {};
-    const source = this.patternIdMap.get(patternId)?.program;
+    const source = getPatternProgram(this.patternIdMap.get(patternId));
     if (!source && Object.keys(pending).length === 0) {
       throw new Error(`Pattern ${patternId} has no metadata available`);
     }
@@ -272,19 +273,19 @@ export class PatternManager {
     pattern = this.findOriginalPattern(pattern as Pattern);
     const verifiedLoadId = getTopFrame()?.verifiedLoadId ??
       this.patternToVerifiedLoadId.get(pattern as Pattern) ??
-      (pattern as Pattern)[unsafe_verifiedLoadId];
+      getVerifiedLoadId(pattern as Pattern);
     if (verifiedLoadId) {
       this.seedVerifiedLoadIds(pattern as Pattern, verifiedLoadId);
     }
 
-    if (src && !pattern.program) {
+    if (src && !getPatternProgram(pattern)) {
       if (typeof src === "string") {
-        pattern.program = {
+        setPatternProgram(pattern, {
           main: "/main.tsx",
           files: [{ name: "/main.tsx", contents: src }],
-        };
+        });
       } else {
-        pattern.program = src;
+        setPatternProgram(pattern, src);
       }
     }
 
@@ -335,7 +336,7 @@ export class PatternManager {
       return true;
     }
 
-    const program = this.patternIdMap.get(patternId)?.program;
+    const program = getPatternProgram(this.patternIdMap.get(patternId));
     if (!program) return false;
 
     const pending = this.pendingMetaById.get(patternId) ?? {};
@@ -500,7 +501,7 @@ export class PatternManager {
       );
     }
     const pattern = main[exportName] as Pattern;
-    pattern.program = program;
+    setPatternProgram(pattern, program);
     if (loadId) {
       this.seedVerifiedLoadIds(pattern, loadId);
     }
@@ -657,13 +658,9 @@ export class PatternManager {
     patternId: URI,
     value: Pattern | Module,
   ): void {
-    const originalPattern = this.findOriginalPattern(value as Pattern) as
-      & Pattern
-      & {
-        program?: RuntimeProgram;
-      };
+    const originalPattern = this.findOriginalPattern(value as Pattern);
     const verifiedLoadId = this.patternToVerifiedLoadId.get(originalPattern);
-    if (!originalPattern.program && !verifiedLoadId) {
+    if (!getPatternProgram(originalPattern) && !verifiedLoadId) {
       return;
     }
     this.runtime.harness.associatePattern(

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -49,11 +49,12 @@ const TARGET = ts.ScriptTarget.ES2023;
  * - We snapshot from the write-once object directly (never `module.exports`), so
  *   the namespace can only reflect values that passed through write-once.
  *
- * We deliberately do NOT deep-freeze the exported values: SES already makes the
- * namespace *bindings* immutable, verified plain data is already frozen by
- * `__cf_data`/`schema`, and the engine attaches metadata to exported pattern
- * recipes after load (`value.program = program` in builder/factory.ts), so
- * exported builder graphs must stay extensible.
+ * Each exported value is `harden()`ed (transitive freeze) so a consumer cannot
+ * mutate the internals of an exported object/array/pattern graph either. This is
+ * only possible because the metadata the engine associates after load —
+ * `program` (rehydration source) and the CFC verified-load id — now lives in
+ * WeakMaps (see builder/pattern-metadata.ts) rather than as properties written
+ * onto the exported object, so hardening no longer blocks those associations.
  */
 export function populateModuleExports(
   moduleExports: Record<string, unknown>,
@@ -69,9 +70,27 @@ export function populateModuleExports(
   const moduleObject = Object.freeze({ exports: writeOnceExports });
   factory(writeOnceExports, requireShim, moduleObject);
   for (const name of exportNames) {
-    moduleExports[name] = writeOnceExports[name];
+    moduleExports[name] = hardenExportedValue(writeOnceExports[name]);
   }
   moduleExports.__esModule = true;
+}
+
+/**
+ * Transitively freeze an exported value. Uses SES `harden` (available after
+ * lockdown, which the ESM loader ensures) — it no-ops on already-frozen shared
+ * intrinsics, so it freezes only the value's own reachable graph. If `harden`
+ * is somehow unavailable, the value is returned unfrozen rather than failing the
+ * load (the namespace binding is still SES-immutable, and verified plain data is
+ * already frozen by `__cf_data`).
+ */
+function hardenExportedValue<T>(value: T): T {
+  const hardenFn = (globalThis as { harden?: <V>(v: V) => V }).harden;
+  if (typeof hardenFn !== "function") return value;
+  try {
+    return hardenFn(value);
+  } catch {
+    return value;
+  }
 }
 
 export function createWriteOnceExports(): Record<string, unknown> {

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -96,13 +96,18 @@ function hardenExportedValue<T>(value: T): T {
     logger.warn("harden() unavailable; exported value not frozen");
     return value;
   }
+  // Fail CLOSED: if hardening throws (e.g. an exotic reachable value harden
+  // refuses), we cannot guarantee the export is immutable, so reject the module
+  // rather than silently shipping a mutable (corruptible) export. A throw here
+  // is terminal for the module — SES caches it and re-throws on every
+  // subsequent importNow, matching a failed factory.
   try {
     return hardenFn(value);
   } catch (error) {
-    // harden() can reject an exotic reachable value (e.g. a Proxy it refuses).
-    // Surface it as a warning so it is observable rather than a silent gap.
-    logger.warn(`harden() failed for exported value: ${String(error)}`);
-    return value;
+    throw new Error(
+      `Failed to harden exported module value: ${String(error)}`,
+      { cause: error },
+    );
   }
 }
 

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -1,4 +1,5 @@
 import ts from "typescript";
+import { getLogger } from "@commonfabric/utils/logger";
 import type { Source } from "@commonfabric/js-compiler";
 import { resolveImportSpecifier } from "@commonfabric/js-compiler";
 import {
@@ -24,6 +25,8 @@ import type { VirtualModuleRecord } from "./esm-module-loader.ts";
  */
 
 const TARGET = ts.ScriptTarget.ES2023;
+
+const logger = getLogger("module-record-compiler");
 
 /**
  * Create a write-once exports target for a module body. Re-assigning,
@@ -85,10 +88,20 @@ export function populateModuleExports(
  */
 function hardenExportedValue<T>(value: T): T {
   const hardenFn = (globalThis as { harden?: <V>(v: V) => V }).harden;
-  if (typeof hardenFn !== "function") return value;
+  if (typeof hardenFn !== "function") {
+    // On the real ESM-loader path the engine calls ensureSESLockdown() before
+    // any module evaluates, so `harden` is always present. Reaching here means
+    // lockdown did not run (a regression, or a direct call outside the engine
+    // path): warn rather than silently shipping unfrozen exports.
+    logger.warn("harden() unavailable; exported value not frozen");
+    return value;
+  }
   try {
     return hardenFn(value);
-  } catch {
+  } catch (error) {
+    // harden() can reject an exotic reachable value (e.g. a Proxy it refuses).
+    // Surface it as a warning so it is observable rather than a silent gap.
+    logger.warn(`harden() failed for exported value: ${String(error)}`);
     return value;
   }
 }

--- a/packages/runner/test/esm-pattern-run.test.ts
+++ b/packages/runner/test/esm-pattern-run.test.ts
@@ -5,6 +5,7 @@ import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
+import { getPatternProgram } from "../src/builder/pattern-metadata.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
@@ -57,7 +58,11 @@ describe("Pattern run via esmModuleLoader", () => {
     };
 
     const compiled = await runtime.patternManager.compilePattern(program);
-    expect(compiled.program?.main).toEqual("/main.tsx");
+    // The exported pattern is hardened (transitively frozen) at the module
+    // boundary, yet its rehydration program still associates afterward — proving
+    // the metadata moved off the (now frozen) object into the WeakMap side-table.
+    expect(Object.isFrozen(compiled)).toBe(true);
+    expect(getPatternProgram(compiled)?.main).toEqual("/main.tsx");
 
     const resultCell = runtime.getCell<{ result: number }>(
       space,

--- a/packages/runner/test/esm-pattern-run.test.ts
+++ b/packages/runner/test/esm-pattern-run.test.ts
@@ -76,4 +76,53 @@ describe("Pattern run via esmModuleLoader", () => {
     await result.pull();
     expect(result.getAsQueryResult()).toEqual({ result: 6 });
   });
+
+  it("composes a frozen sub-pattern imported from another module", async () => {
+    // The sub-pattern is exported from /sub.tsx (and hardened at the module
+    // boundary), then imported and instantiated INSIDE the parent pattern. This
+    // drives a frozen exported pattern through instantiatePatternNode — the path
+    // where harden-safety matters (binding/parent-noting must operate on mutable
+    // copies, never the frozen original).
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/sub.tsx",
+          contents: [
+            "import { pattern, lift } from 'commonfabric';",
+            "const inc = lift((x:number)=>x+1);",
+            "export const sub = pattern<{ n: number }>(({ n }) => {",
+            "  return { out: inc(n) };",
+            "});",
+          ].join("\n"),
+        },
+        {
+          name: "/main.tsx",
+          contents: [
+            "import { pattern } from 'commonfabric';",
+            "import { sub } from './sub.tsx';",
+            "export default pattern<{ value: number }>(({ value }) => {",
+            "  const child = sub({ n: value });",
+            "  return { result: child.out };",
+            "});",
+          ].join("\n"),
+        },
+      ],
+    };
+
+    const compiled = await runtime.patternManager.compilePattern(program);
+    expect(Object.isFrozen(compiled)).toBe(true);
+
+    const resultCell = runtime.getCell<{ result: number }>(
+      space,
+      "esm composed pattern run",
+      undefined,
+      tx,
+    );
+    const result = runtime.run(tx, compiled, { value: 4 }, resultCell);
+    await tx.commit();
+    tx = runtime.edit();
+    await result.pull();
+    expect(result.getAsQueryResult()).toEqual({ result: 5 });
+  });
 });

--- a/packages/runner/test/pattern-manager.test.ts
+++ b/packages/runner/test/pattern-manager.test.ts
@@ -13,6 +13,7 @@ import {
   MemoryCompilationCache,
 } from "../src/compilation-cache/mod.ts";
 import { popFrame, pushFrame } from "../src/builder/pattern.ts";
+import { getPatternProgram } from "../src/builder/pattern-metadata.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
@@ -60,10 +61,12 @@ describe("PatternManager program persistence", () => {
     };
 
     const compiled = await runtime.patternManager.compilePattern(program);
-    expect(compiled.program).toBeDefined();
-    expect(compiled.program?.main).toEqual("/main.tsx");
+    expect(getPatternProgram(compiled)).toBeDefined();
+    expect(getPatternProgram(compiled)?.main).toEqual("/main.tsx");
     // Ensure original file names are preserved (no injected prefix leaked here)
-    const fileNames = (compiled.program?.files ?? []).map((f) => f.name).sort();
+    const fileNames = (getPatternProgram(compiled)?.files ?? []).map((f) =>
+      f.name
+    ).sort();
     expect(fileNames).toEqual(["/main.tsx", "/util.ts"].sort());
 
     const patternId = runtime.patternManager.registerPattern(compiled, program);
@@ -281,8 +284,8 @@ describe("PatternManager.compileOrGetPattern", () => {
       simpleProgram,
     );
     expect(pattern).toBeDefined();
-    expect(pattern.program).toBeDefined();
-    expect(pattern.program?.main).toEqual("/main.ts");
+    expect(getPatternProgram(pattern)).toBeDefined();
+    expect(getPatternProgram(pattern)?.main).toEqual("/main.ts");
   });
 
   it("returns cached pattern on second call (same instance)", async () => {
@@ -379,8 +382,8 @@ describe("PatternManager.compileOrGetPattern", () => {
 
     // Should be different pattern instances
     expect(second).not.toBe(first);
-    expect(first.program?.files[0].contents).toContain("doubled");
-    expect(second.program?.files[0].contents).toContain("tripled");
+    expect(getPatternProgram(first)?.files[0].contents).toContain("doubled");
+    expect(getPatternProgram(second)?.files[0].contents).toContain("tripled");
   });
 
   it("single-flight: concurrent calls share one compilation", async () => {
@@ -404,7 +407,7 @@ describe("PatternManager.compileOrGetPattern", () => {
 
     const pattern = await runtime.patternManager.compileOrGetPattern(source);
     expect(pattern).toBeDefined();
-    expect(pattern.program?.main).toEqual("/main.tsx");
+    expect(getPatternProgram(pattern)?.main).toEqual("/main.tsx");
   });
 
   it("pattern is cached and returns same instance on subsequent calls", async () => {
@@ -419,8 +422,8 @@ describe("PatternManager.compileOrGetPattern", () => {
     expect(pattern2).toBe(pattern);
 
     // And the pattern should have its program attached
-    expect(pattern.program).toBeDefined();
-    expect(pattern.program?.main).toEqual("/main.ts");
+    expect(getPatternProgram(pattern)).toBeDefined();
+    expect(getPatternProgram(pattern)?.main).toEqual("/main.ts");
   });
 });
 
@@ -465,7 +468,7 @@ describe("PatternManager compilation cache integration", () => {
     // First compile — cache miss, should write an entry
     const first = await runtime.patternManager.compilePattern(simpleProgram);
     expect(first).toBeDefined();
-    expect(first.program?.main).toEqual("/main.ts");
+    expect(getPatternProgram(first)?.main).toEqual("/main.ts");
     expect(await cacheStorage.count()).toBe(1);
     expect(cachedCompiler.getStats().misses).toBe(1);
     expect(cachedCompiler.getStats().writes).toBe(1);
@@ -473,7 +476,7 @@ describe("PatternManager compilation cache integration", () => {
     // Second compile — cache hit, no new writes
     const second = await runtime.patternManager.compilePattern(simpleProgram);
     expect(second).toBeDefined();
-    expect(second.program?.main).toEqual("/main.ts");
+    expect(getPatternProgram(second)?.main).toEqual("/main.ts");
     expect(await cacheStorage.count()).toBe(1);
     expect(cachedCompiler.getStats().hits).toBe(1);
     expect(cachedCompiler.getStats().writes).toBe(1);


### PR DESCRIPTION
## Context

Closes the residual export-surface gap left by the write-once work (#3775): exported pattern recipes / functions were still **mutable**, so an importing module could corrupt their internals (`importedPattern.nodes.push(...)`, stash a closure on an exported function, overwrite `program`). We now `harden()` (transitively freeze) every value the ESM loader exports.

## Why it wasn't possible before

The engine attaches metadata to exported patterns **after** load, which a freeze would block:
- `pattern.program` — rehydration source, set by `exportsCallback` and at registration.
- `pattern[unsafe_verifiedLoadId]` — CFC verified-load identity, set via `Object.defineProperty` while the pattern was extensible.

## The change

Both move into module-level **WeakMaps** (`builder/pattern-metadata.ts`) via `get/setPatternProgram` and `get/setVerifiedLoadId`. A WeakMap write doesn't mutate the (now frozen) object, so the associations still attach after `harden()` — sequencing works because the loader freezes during import, and the engine's `exportsCallback`/`seedVerifiedLoadIds` run afterward using the side-table.

The `program?` field and `unsafe_verifiedLoadId` symbol are **removed from the `Pattern` type**, so the type checker flagged every access site; all were converted (`factory`, `pattern-manager`, `json-utils`, `pattern-binding`, `executable-registry`).

## Why freezing is safe

Patterns are static definitions (schemas + node graph), not live reactive state. Derivation/binding creates fresh mutable copies, and the remaining `unsafe_originalPattern`/`unsafe_parentPattern` markers are set on those copies, never the frozen original.

## Scope & validation

- The **freeze** is ESM-loader-only (`populateModuleExports`, behind the default-off `esmModuleLoader` flag). The **WeakMap metadata move** is path-agnostic and behavior-preserving.
- E2E: a real multi-file reactive pattern compiles, is confirmed `Object.isFrozen`, **still runs** through the ESM loader, and still associates its rehydration `program` via the WeakMap.
- Green: CFC implementation-identity, engine-verified-functions, JSON serialization, pattern-binding, pattern-composition (`derive`-returns-pattern), pattern-manager (program/verified-load-id + persistence), and the ESM execution/write-once suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Freeze all exported values in the ESM loader to prevent mutation of imported patterns, and move pattern metadata to WeakMaps so `program` and verified-load IDs still attach after load. If `harden()` is unavailable we warn; if `harden()` throws, we fail closed and the module does not load.

- **New Features**
  - ESM loader now `harden()`s exported values to block pattern graph mutation (behind default-off `esmModuleLoader`).
  - Warn when `harden` is missing; throw on harden failure so mutable exports never ship.
  - WeakMap side tables preserve late `program` and verified-load ID attachment.
  - E2E tests cover frozen exports, composed frozen sub-pattern import/instantiate, and `program` access via side-table.

- **Refactors**
  - Added `builder/pattern-metadata.ts` with `get/setPatternProgram` and `get/setVerifiedLoadId`.
  - Removed `program?` and `unsafe_verifiedLoadId` from `Pattern`; updated call sites (`factory`, `pattern-manager`, `json-utils`, `pattern-binding`, `executable-registry`).
  - Behavior unchanged on non-ESM paths.

<sup>Written for commit 751e6652a7929f9a3f2911c66a8c781524cb37cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

