### PR TITLE
fix(runner): validate module-graph import-edge targets (red-team finding)

### DIFF
--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -41,7 +41,10 @@ import {
   runtimeModuleRecords,
   type VirtualModuleRecord,
 } from "../sandbox/esm-module-loader.ts";
-import { verifyCompiledModuleBody } from "../sandbox/module-record-verifier.ts";
+import {
+  verifyCompiledModuleBody,
+  verifyModuleGraph,
+} from "../sandbox/module-record-verifier.ts";
 import { popFrame, pushFrame } from "../builder/pattern.ts";
 import {
   ensureSESLockdown,
@@ -337,6 +340,14 @@ export class Engine extends EventTarget implements Harness {
           "ESM compile produced no record for the program entry",
         );
       }
+
+      // Structurally verify the whole record graph (content-addressed
+      // specifiers, well-formed records, and that every import edge resolves to
+      // a content-addressed target). This must run here because the loader is
+      // invoked with `verify: false` in evaluateRecordGraph — graph
+      // verification happens once, at compile time, before any module executes.
+      verifyModuleGraph(graph.records, mainSpecifier);
+
       return { id, graph, mainSpecifier };
     } finally {
       logger.timeEnd("compileToRecordGraph");

--- a/packages/runner/src/sandbox/module-record-verifier.ts
+++ b/packages/runner/src/sandbox/module-record-verifier.ts
@@ -276,6 +276,21 @@ export function verifyModuleGraph(
           `Record ${specifier} has a non-content-addressed import target "${importSpecifier}" -> "${target}"`,
         );
       }
+      // A trusted runtime import must resolve to ITS matching runtime record,
+      // not an arbitrary content-addressed sibling. The body verifier marks
+      // `require("commonfabric")` as a trusted runtime binding based on the
+      // authored specifier; without this, a record could declare
+      // `imports: ["commonfabric"]` with `resolutions: { commonfabric:
+      // "cf:module/evil" }` and be handed a sibling module's namespace under a
+      // trusted-runtime binding (rewire-to-sibling for host APIs).
+      if (
+        isRuntimeModuleIdentifier(importSpecifier) &&
+        target !== `cf:runtime/${importSpecifier}`
+      ) {
+        throw new ModuleGraphVerificationError(
+          `Record ${specifier} resolves runtime import "${importSpecifier}" to "${target}" instead of "cf:runtime/${importSpecifier}"`,
+        );
+      }
       if (!records.has(target)) {
         throw new ModuleGraphVerificationError(
           `Record ${specifier} has an unresolved import "${importSpecifier}" -> "${target}"`,

--- a/packages/runner/src/sandbox/module-record-verifier.ts
+++ b/packages/runner/src/sandbox/module-record-verifier.ts
@@ -251,8 +251,31 @@ export function verifyModuleGraph(
         `Record ${specifier} has a non-function execute`,
       );
     }
+    // Every resolution must remap a *declared* import — a resolution for a
+    // specifier the record never imports is a smuggled edge.
+    if (record.resolutions) {
+      for (const key of Object.keys(record.resolutions)) {
+        if (!record.imports.includes(key)) {
+          throw new ModuleGraphVerificationError(
+            `Record ${specifier} resolves an undeclared import "${key}"`,
+          );
+        }
+      }
+    }
     for (const importSpecifier of record.imports) {
       const target = record.resolutions?.[importSpecifier] ?? importSpecifier;
+      // The resolved target must itself be content-addressed (a cf:module/ or
+      // cf:runtime/ specifier), not an arbitrary string. Without this, a record
+      // could rewire an import edge to ANY present key — e.g. an unresolved
+      // `/x` / `node:fs` left verbatim by the compiler's fallback branch, or a
+      // sibling's specifier — and inherit a trusted (runtime) record's
+      // namespace. Presence alone is not enough; the edge must point into the
+      // content-addressed namespace.
+      if (!VALID_SPECIFIER.test(target)) {
+        throw new ModuleGraphVerificationError(
+          `Record ${specifier} has a non-content-addressed import target "${importSpecifier}" -> "${target}"`,
+        );
+      }
       if (!records.has(target)) {
         throw new ModuleGraphVerificationError(
           `Record ${specifier} has an unresolved import "${importSpecifier}" -> "${target}"`,

--- a/packages/runner/test/module-record-verifier.test.ts
+++ b/packages/runner/test/module-record-verifier.test.ts
@@ -122,6 +122,25 @@ describe("verifyModuleGraph", () => {
     );
   });
 
+  it("rejects a runtime import rewired to a sibling module", () => {
+    // `require("commonfabric")` is trusted as a runtime binding by the body
+    // verifier; the edge must point at cf:runtime/commonfabric, not a sibling
+    // module's namespace, even though that sibling is content-addressed+present.
+    const g = graph([
+      [
+        "cf:module/main",
+        rec({
+          imports: ["commonfabric"],
+          resolutions: { commonfabric: "cf:module/evil" },
+        }),
+      ],
+      ["cf:module/evil", rec({ exports: ["pattern"] })],
+    ]);
+    expect(() => verifyModuleGraph(g, "cf:module/main")).toThrow(
+      /runtime import .* instead of "cf:runtime\/commonfabric"/i,
+    );
+  });
+
   it("accepts cf:runtime/ import targets", () => {
     const g = graph([
       [

--- a/packages/runner/test/module-record-verifier.test.ts
+++ b/packages/runner/test/module-record-verifier.test.ts
@@ -85,11 +85,13 @@ describe("verifyModuleGraph", () => {
     );
   });
 
-  it("rejects an import edge rewired to a foreign present record", () => {
-    // A record must not resolve one of its imports to an arbitrary other key.
-    // Here the target IS present and content-addressed, but the deeper invariant
-    // is covered by the undeclared-resolution and target-shape checks; a bare
-    // `node:fs` target (present or not) is rejected for not being cf:-addressed.
+  it("rejects an import edge targeting a bare/builtin specifier (node:fs)", () => {
+    // A `node:`/bare target left verbatim by the compiler's fallback is not
+    // content-addressed, so it is rejected regardless of presence — closing the
+    // capability-reach via a smuggled non-cf edge. (Reaching another *present*
+    // cf:module record is not a privilege crossing: all authored modules share
+    // one trust level, and a cf:module/<hash> target is, by content-addressing,
+    // exactly the module whose source hashes to it.)
     const g = graph([
       [
         "cf:module/main",

--- a/packages/runner/test/module-record-verifier.test.ts
+++ b/packages/runner/test/module-record-verifier.test.ts
@@ -64,6 +64,76 @@ describe("verifyModuleGraph", () => {
     );
   });
 
+  it("rejects an import edge resolved to a non-content-addressed target", () => {
+    // The compiler's fallback leaves an unknown specifier verbatim; the verifier
+    // must reject a target that is not a cf:module/ or cf:runtime/ specifier,
+    // rather than relying on it merely being absent from the records map.
+    const g = graph([
+      [
+        "cf:module/main",
+        rec({
+          imports: ["/cf:runtime/commonfabric"],
+          resolutions: {
+            "/cf:runtime/commonfabric": "/cf:runtime/commonfabric",
+          },
+        }),
+      ],
+      ["/cf:runtime/commonfabric", rec({ exports: ["pattern"] })],
+    ]);
+    expect(() => verifyModuleGraph(g, "cf:module/main")).toThrow(
+      /non-content-addressed import target/i,
+    );
+  });
+
+  it("rejects an import edge rewired to a foreign present record", () => {
+    // A record must not resolve one of its imports to an arbitrary other key.
+    // Here the target IS present and content-addressed, but the deeper invariant
+    // is covered by the undeclared-resolution and target-shape checks; a bare
+    // `node:fs` target (present or not) is rejected for not being cf:-addressed.
+    const g = graph([
+      [
+        "cf:module/main",
+        rec({ imports: ["node:fs"], resolutions: { "node:fs": "node:fs" } }),
+      ],
+    ]);
+    expect(() => verifyModuleGraph(g, "cf:module/main")).toThrow(
+      /non-content-addressed import target/i,
+    );
+  });
+
+  it("rejects a resolution for an undeclared import", () => {
+    const g = graph([
+      [
+        "cf:module/main",
+        rec({
+          imports: ["./util.ts"],
+          resolutions: {
+            "./util.ts": "cf:module/util",
+            "./extra.ts": "cf:module/util",
+          },
+        }),
+      ],
+      ["cf:module/util", rec({ exports: ["x"] })],
+    ]);
+    expect(() => verifyModuleGraph(g, "cf:module/main")).toThrow(
+      /undeclared import/i,
+    );
+  });
+
+  it("accepts cf:runtime/ import targets", () => {
+    const g = graph([
+      [
+        "cf:module/main",
+        rec({
+          imports: ["commonfabric"],
+          resolutions: { commonfabric: "cf:runtime/commonfabric" },
+        }),
+      ],
+      ["cf:runtime/commonfabric", rec({ exports: ["pattern"] })],
+    ]);
+    expect(() => verifyModuleGraph(g, "cf:module/main")).not.toThrow();
+  });
+
   it("rejects a record with a non-function execute", () => {
     const g = graph([[
       "cf:module/main",


### PR DESCRIPTION
## Context

A fresh red-team pass on the ESM **module-loading / identity / capability** surface (the wiring we hadn't hammered, vs. the verifier body-classification the prior corpus covered). The clearest confirmed gap:

## The gap

`verifyModuleGraph` (the structural graph verifier) checked only that each resolved import target was **present** in the records map (`records.has(target)`) — never that the target was itself **content-addressed**. Combined with two facts:
- the compiler's resolution fallback leaves an unknown specifier **verbatim** (`resolutions[spec] = spec`), and
- the authored-import allowlist admits `/`-prefixed specifiers,

a record could carry an import edge whose target is an arbitrary string (`/cf:runtime/commonfabric`, `node:fs`, a sibling's key). Under the untrusted-compiler threat model (records derived from attacker-controlled compiled output), a record could rewire an edge to a **trusted runtime record** and inherit its namespace — with presence being the only, incidental, backstop.

## Fix

`verifyModuleGraph` now:
1. requires every resolved import **target** to match the content-addressed `VALID_SPECIFIER` (`cf:module/` | `cf:runtime/`) **before** the presence check, and
2. rejects any `resolutions` entry that remaps a specifier the record does not declare in `imports`.

The structural verifier now enforces the content-addressing invariant on **edges**, not just keys — closing the reachability hole regardless of the allowlist or the compiler's verbatim fallback.

## Other red-team findings (triaged, not in this PR)

- **Module identity excludes the compiled body** (only authored TS is hashed): *intentional* (TCB-independence, by design); the CFC verified-load bundle id does cover compiled output, so the security-relevant identity covers behavior.
- **`fetch` endowed into the module compartment** (load-time reach via opaque `__cf_data` arg): already covered by the planned separate mitigation (fetch bails during this phase).
- **harden fail-closed DoS via `export *` from a malicious dependency**: a deny-load you'd only hit by `export *`-ing from code you already trust; noted as a possible follow-up.
- **Hash external-leaf string concat** (`runtime:<spec>@<fp>`) collision: suspected, depends on the value-hash serialization; possible follow-up.

## Scope & validation

ESM-loader path only (default-off `esmModuleLoader`). New `verifyModuleGraph` tests (reject non-cf target, reject undeclared-import resolution, accept cf:runtime target); the real ESM execution path (which builds genuine resolutions) and the loader/compiler/engine/pattern-run suites are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened ESM module graph verification to prevent import-edge rewiring. Import targets must be content-addressed, runtime imports must resolve to their exact `cf:runtime/<id>`, and the graph is now verified at compile time in the ESM engine.

- **Bug Fixes**
  - Validate import targets with `VALID_SPECIFIER` before the presence check in `verifyModuleGraph`.
  - Reject `resolutions` entries for specifiers not declared in `imports`.
  - Require runtime-identifier imports to resolve exactly to `cf:runtime/<specifier>` (no rewires to `cf:module/*`).
  - Run `verifyModuleGraph` during `Engine.compileToRecordGraph` so structural checks apply in production.
  - Added tests for non-`cf:` targets (`/cf:runtime/...`, `node:fs`), undeclared remaps, runtime rewire rejection, and valid `cf:runtime/...` targets.

<sup>Written for commit c7e39a56b46bea375858620a749ae3b8bf2b5989. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

