### PR TITLE
feat(runner): pattern provenance brand (forged pattern-shaped data can't launder trust)

### DIFF
--- a/packages/runner/src/builder/factory.ts
+++ b/packages/runner/src/builder/factory.ts
@@ -16,7 +16,6 @@ import {
   FS,
   ID,
   ID_FIELD,
-  isPattern,
   NAME,
   schema as schemaIdentity,
   SELF,
@@ -48,7 +47,7 @@ import { cellConstructorFactory } from "../cell.ts";
 import { getEntityId } from "../create-ref.ts";
 import { getPatternEnvironment } from "./env.ts";
 import type { RuntimeProgram } from "../harness/types.ts";
-import { setPatternProgram } from "./pattern-metadata.ts";
+import { isTrustedPattern, setPatternProgram } from "./pattern-metadata.ts";
 import {
   FabricInstance,
   FabricPrimitive,
@@ -130,7 +129,10 @@ export const createBuilder = (options: CreateBuilderOptions = {}): {
   // instantiated. This way they get saved with a way to rehydrate them.
   const exportsCallback = (exports: Map<any, RuntimeProgram>) => {
     for (const [value, program] of exports) {
-      if (isPattern(value)) {
+      // `isTrustedPattern` (not the structural `isPattern`): only a value the
+      // trusted builder produced may acquire a rehydration program, so a
+      // `__cf_data`-forged pattern-shaped export cannot launder trust metadata.
+      if (isTrustedPattern(value)) {
         // Associate the program with the pattern via the side-table so it works
         // even when the exported pattern has been frozen by the loader.
         setPatternProgram(value, program);

--- a/packages/runner/src/builder/pattern-metadata.ts
+++ b/packages/runner/src/builder/pattern-metadata.ts
@@ -1,4 +1,5 @@
 import type { RuntimeProgram } from "../harness/types.ts";
+import { isPattern, type Pattern } from "./types.ts";
 
 /**
  * Side-table storage for pattern metadata that is associated *after* a pattern
@@ -21,6 +22,17 @@ import type { RuntimeProgram } from "../harness/types.ts";
 
 const programByPattern = new WeakMap<object, RuntimeProgram>();
 const verifiedLoadIdByValue = new WeakMap<object, string>();
+
+// Provenance brand: a value is added here ONLY by the trusted `pattern()`
+// builder (see builder/pattern.ts). `isPattern` is a purely structural check
+// (`{argumentSchema, resultSchema, nodes}`), so an attacker can forge that shape
+// via `__cf_data({...})` — a frozen plain object that passes `isPattern`.
+// Trust-granting sites (program / verified-load-id association, entry-pattern
+// selection) must use `isTrustedPattern` instead, so forged pattern-shaped data
+// cannot launder itself into the trust side-tables. The runner's own
+// instantiation logic keeps using structural `isPattern` (it operates on
+// derivation copies and independently re-resolves node implementations).
+const trustedPatterns = new WeakSet<object>();
 
 function asKey(value: unknown): object | undefined {
   if (value === null) return undefined;
@@ -56,4 +68,22 @@ export function getVerifiedLoadId(value: unknown): string | undefined {
 export function setVerifiedLoadId(value: unknown, id: string): void {
   const key = asKey(value);
   if (key) verifiedLoadIdByValue.set(key, id);
+}
+
+/** Stamp a value as produced by the trusted `pattern()` builder. */
+export function brandTrustedPattern<T>(value: T): T {
+  const key = asKey(value);
+  if (key) trustedPatterns.add(key);
+  return value;
+}
+
+/**
+ * True only for a value that is both structurally a pattern AND was produced by
+ * the trusted builder (carries the provenance brand). Use this at trust-granting
+ * sites; a `__cf_data`-forged pattern-shaped object is `isPattern` but NOT
+ * `isTrustedPattern`.
+ */
+export function isTrustedPattern(value: unknown): value is Pattern {
+  const key = asKey(value);
+  return key !== undefined && trustedPatterns.has(key) && isPattern(value);
 }

--- a/packages/runner/src/builder/pattern-metadata.ts
+++ b/packages/runner/src/builder/pattern-metadata.ts
@@ -1,5 +1,5 @@
 import type { RuntimeProgram } from "../harness/types.ts";
-import { isPattern, type Pattern } from "./types.ts";
+import { isPattern, type Pattern, unsafe_originalPattern } from "./types.ts";
 
 /**
  * Side-table storage for pattern metadata that is associated *after* a pattern
@@ -78,12 +78,26 @@ export function brandTrustedPattern<T>(value: T): T {
 }
 
 /**
- * True only for a value that is both structurally a pattern AND was produced by
- * the trusted builder (carries the provenance brand). Use this at trust-granting
- * sites; a `__cf_data`-forged pattern-shaped object is `isPattern` but NOT
- * `isTrustedPattern`.
+ * True only for a value that is structurally a pattern AND has trusted builder
+ * provenance — either it carries the brand directly, or it is a derivation /
+ * serialized copy whose `unsafe_originalPattern` chain reaches a branded
+ * original. Use this at trust-granting sites; a `__cf_data`-forged pattern-shaped
+ * object is `isPattern` but NOT `isTrustedPattern` (it carries no brand, and the
+ * `unsafe_originalPattern` symbol is module-private — authored code cannot set
+ * it to point at a real pattern).
  */
 export function isTrustedPattern(value: unknown): value is Pattern {
-  const key = asKey(value);
-  return key !== undefined && trustedPatterns.has(key) && isPattern(value);
+  if (!isPattern(value)) return false;
+  // Walk the original-pattern chain; a branded ancestor confers trust on copies.
+  let current: unknown = value;
+  const seen = new Set<unknown>();
+  while (
+    current && (typeof current === "object" || typeof current === "function")
+  ) {
+    if (trustedPatterns.has(current as object)) return true;
+    if (seen.has(current)) break;
+    seen.add(current);
+    current = (current as Record<symbol, unknown>)[unsafe_originalPattern];
+  }
+  return false;
 }

--- a/packages/runner/src/builder/pattern.ts
+++ b/packages/runner/src/builder/pattern.ts
@@ -20,6 +20,7 @@ import {
   type UnsafeBinding,
 } from "./types.ts";
 import { opaqueRef } from "./opaque-ref.ts";
+import { brandTrustedPattern } from "./pattern-metadata.ts";
 import {
   applyArgumentIfcToResult,
   applyInputIfcToOutput,
@@ -442,6 +443,10 @@ function factoryFromPattern<T, R>(
       makePatternFactory(scope, defaultSpace);
     factory.inSpace = (space?: string | unknown) =>
       makePatternFactory(defaultScope, space ?? "");
+    // Provenance brand: only the trusted builder stamps a pattern. Trust-granting
+    // sites check `isTrustedPattern` so a `__cf_data`-forged pattern-shaped
+    // object cannot acquire program / verified-load-id metadata.
+    brandTrustedPattern(factory);
     return factory;
   };
 

--- a/packages/runner/src/harness/executable-registry.ts
+++ b/packages/runner/src/harness/executable-registry.ts
@@ -297,16 +297,12 @@ export class ExecutableRegistry {
   private annotateVerifiedPatterns(
     value: unknown,
     loadId: string,
-    seen = new Set<unknown>(),
+    seen = new Map<unknown, boolean>(),
     trusted = false,
   ): void {
     if (!value || (typeof value !== "object" && typeof value !== "function")) {
       return;
     }
-    if (seen.has(value)) {
-      return;
-    }
-    seen.add(value);
 
     // Trust is rooted at a builder-produced (`isTrustedPattern`) value; once
     // inside a trusted pattern's subtree, nested (serialized, unbranded)
@@ -314,6 +310,16 @@ export class ExecutableRegistry {
     // pattern-shaped value at the top level (trusted === false) is never
     // annotated, so it cannot launder a CFC identity into the side-table.
     const subtreeTrusted = trusted || isTrustedPattern(value);
+
+    // `seen` records the trust level a node was visited at, so a node reached
+    // first via an untrusted path is still re-processed when later reached via a
+    // trusted path — order-independent. A trusted visit is final.
+    const prior = seen.get(value);
+    if (prior === true || (prior === false && !subtreeTrusted)) {
+      return;
+    }
+    seen.set(value, subtreeTrusted);
+
     if (subtreeTrusted && isPattern(value)) {
       // Side-table storage works on frozen patterns too (no own-property write).
       setVerifiedLoadId(value, loadId);

--- a/packages/runner/src/harness/executable-registry.ts
+++ b/packages/runner/src/harness/executable-registry.ts
@@ -1,5 +1,8 @@
 import { isPattern } from "../builder/types.ts";
-import { setVerifiedLoadId } from "../builder/pattern-metadata.ts";
+import {
+  isTrustedPattern,
+  setVerifiedLoadId,
+} from "../builder/pattern-metadata.ts";
 import { hardenVerifiedFunction } from "../sandbox/function-hardening.ts";
 import { VERIFIED_BINDING_METADATA_FIELD } from "@commonfabric/utils/sandbox-contract";
 import type { UnsafeHostTrustOptions } from "../unsafe-host-trust.ts";
@@ -295,6 +298,7 @@ export class ExecutableRegistry {
     value: unknown,
     loadId: string,
     seen = new Set<unknown>(),
+    trusted = false,
   ): void {
     if (!value || (typeof value !== "object" && typeof value !== "function")) {
       return;
@@ -304,7 +308,13 @@ export class ExecutableRegistry {
     }
     seen.add(value);
 
-    if (isPattern(value)) {
+    // Trust is rooted at a builder-produced (`isTrustedPattern`) value; once
+    // inside a trusted pattern's subtree, nested (serialized, unbranded)
+    // subpatterns inherit the id via structural `isPattern`. A `__cf_data`-forged
+    // pattern-shaped value at the top level (trusted === false) is never
+    // annotated, so it cannot launder a CFC identity into the side-table.
+    const subtreeTrusted = trusted || isTrustedPattern(value);
+    if (subtreeTrusted && isPattern(value)) {
       // Side-table storage works on frozen patterns too (no own-property write).
       setVerifiedLoadId(value, loadId);
     }
@@ -314,7 +324,12 @@ export class ExecutableRegistry {
       if (!descriptor || !("value" in descriptor)) {
         continue;
       }
-      this.annotateVerifiedPatterns(descriptor.value, loadId, seen);
+      this.annotateVerifiedPatterns(
+        descriptor.value,
+        loadId,
+        seen,
+        subtreeTrusted,
+      );
     }
   }
 

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -170,16 +170,12 @@ export class PatternManager {
   private seedVerifiedLoadIds(
     value: unknown,
     verifiedLoadId: string,
-    seen = new Set<unknown>(),
+    seen = new Map<unknown, boolean>(),
     trusted = false,
   ): void {
     if (!value || (typeof value !== "object" && typeof value !== "function")) {
       return;
     }
-    if (seen.has(value)) {
-      return;
-    }
-    seen.add(value);
 
     // Trust is rooted at a builder-produced (`isTrustedPattern`) value; nested
     // subpatterns within a trusted pattern's serialized node graph are legit
@@ -188,6 +184,16 @@ export class PatternManager {
     // value at the top level (trusted === false) is never seeded, so it cannot
     // launder a CFC identity into the side-tables.
     const subtreeTrusted = trusted || isTrustedPattern(value);
+
+    // `seen` records the trust level a node was visited at, so a node reached
+    // first via an untrusted path is still re-processed (and seeded) when later
+    // reached via a trusted path — order-independent. A trusted visit is final.
+    const prior = seen.get(value);
+    if (prior === true || (prior === false && !subtreeTrusted)) {
+      return;
+    }
+    seen.set(value, subtreeTrusted);
+
     if (subtreeTrusted && isPattern(value)) {
       const originalPattern = this.findOriginalPattern(value);
       if (!this.patternToVerifiedLoadId.has(originalPattern)) {

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -9,6 +9,7 @@ import {
 import {
   getPatternProgram,
   getVerifiedLoadId,
+  isTrustedPattern,
   setPatternProgram,
   setVerifiedLoadId,
 } from "./builder/pattern-metadata.ts";
@@ -170,6 +171,7 @@ export class PatternManager {
     value: unknown,
     verifiedLoadId: string,
     seen = new Set<unknown>(),
+    trusted = false,
   ): void {
     if (!value || (typeof value !== "object" && typeof value !== "function")) {
       return;
@@ -179,7 +181,14 @@ export class PatternManager {
     }
     seen.add(value);
 
-    if (isPattern(value)) {
+    // Trust is rooted at a builder-produced (`isTrustedPattern`) value; nested
+    // subpatterns within a trusted pattern's serialized node graph are legit
+    // (and unbranded), so once inside a trusted subtree we propagate to
+    // structurally-`isPattern` values too. A `__cf_data`-forged pattern-shaped
+    // value at the top level (trusted === false) is never seeded, so it cannot
+    // launder a CFC identity into the side-tables.
+    const subtreeTrusted = trusted || isTrustedPattern(value);
+    if (subtreeTrusted && isPattern(value)) {
       const originalPattern = this.findOriginalPattern(value);
       if (!this.patternToVerifiedLoadId.has(originalPattern)) {
         this.patternToVerifiedLoadId.set(originalPattern, verifiedLoadId);
@@ -200,6 +209,7 @@ export class PatternManager {
         descriptor.value,
         verifiedLoadId,
         seen,
+        subtreeTrusted,
       );
     }
   }
@@ -501,9 +511,14 @@ export class PatternManager {
       );
     }
     const pattern = main[exportName] as Pattern;
-    setPatternProgram(pattern, program);
-    if (loadId) {
-      this.seedVerifiedLoadIds(pattern, loadId);
+    // Only a trusted (builder-produced) entry pattern receives rehydration /
+    // verified-load metadata; a forged pattern-shaped export gets none and so
+    // cannot masquerade as a verified-loaded pattern in the side-tables.
+    if (isTrustedPattern(pattern)) {
+      setPatternProgram(pattern, program);
+      if (loadId) {
+        this.seedVerifiedLoadIds(pattern, loadId);
+      }
     }
     return pattern;
   }

--- a/packages/runner/test/pattern-provenance.test.ts
+++ b/packages/runner/test/pattern-provenance.test.ts
@@ -1,0 +1,48 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { isPattern } from "../src/builder/types.ts";
+import {
+  brandTrustedPattern,
+  isTrustedPattern,
+} from "../src/builder/pattern-metadata.ts";
+import { freezeVerifiedPlainData } from "../src/sandbox/plain-data.ts";
+
+// `isPattern` is a purely structural check, so an attacker can forge the shape
+// via `__cf_data({...})` (a frozen plain object). Trust-granting sites use
+// `isTrustedPattern`, which additionally requires the value to carry the
+// provenance brand stamped only by the trusted `pattern()` builder — so a forged
+// pattern-shaped export cannot launder program / verified-load-id metadata.
+
+describe("pattern provenance brand", () => {
+  const patternShape = {
+    argumentSchema: {},
+    resultSchema: {},
+    result: {},
+    nodes: [] as unknown[],
+  };
+
+  it("a __cf_data-forged pattern shape is isPattern but NOT isTrustedPattern", () => {
+    const forged = freezeVerifiedPlainData({ ...patternShape });
+    expect(isPattern(forged)).toBe(true); // structural check passes…
+    expect(isTrustedPattern(forged)).toBe(false); // …but it carries no brand
+  });
+
+  it("a branded pattern shape is a trusted pattern", () => {
+    const branded = brandTrustedPattern({ ...patternShape });
+    expect(isPattern(branded)).toBe(true);
+    expect(isTrustedPattern(branded)).toBe(true);
+  });
+
+  it("branding a non-pattern-shaped object does not make it trusted", () => {
+    const notAPattern = brandTrustedPattern({ foo: 1 });
+    expect(isTrustedPattern(notAPattern)).toBe(false); // fails the shape check
+  });
+
+  it("plain / primitive values are never trusted patterns", () => {
+    expect(isTrustedPattern({})).toBe(false);
+    expect(isTrustedPattern(null)).toBe(false);
+    expect(isTrustedPattern(42)).toBe(false);
+    expect(isTrustedPattern(() => {})).toBe(false);
+  });
+});


### PR DESCRIPTION
## Context

Follow-up to the "is write-once sufficient?" question. A rigorous investigation confirmed: export *values* are verified and only declared names are lifted, so the plain fake-export path is safe — **but** `isPattern` is a purely structural check (`{argumentSchema, resultSchema, nodes}`), so an attacker can forge that shape via `__cf_data({...})` (a frozen plain object). Such a forged top-level export then:
- acquired a `program` (`exportsCallback`),
- acquired a CFC `verifiedLoadId` (`annotateVerifiedPatterns` / `seedVerifiedLoadIds`),
- and was selected as the entry pattern with no re-check,

masquerading as a *verified-loaded pattern* in the trust side-tables. No escalation today (the runner re-resolves every node's implementation through the verified/host index or a SES-sandboxed eval, and data-only nodes throw) — but a latent footgun for any future sink that trusts `isPattern`-shape as provenance.

## Fix

A **provenance brand** — a `WeakSet` stamped *only* by the trusted `pattern()` builder (`builder/pattern.ts` `makePatternFactory`, covering `asScope`/`inSpace` variants; rehydrated patterns re-run through the builder, so they re-brand). Trust-granting sites switch from structural `isPattern` to `isTrustedPattern` (= branded **and** structurally a pattern):
- `exportsCallback` (program association)
- `patternFromEvaluation` entry selection
- `seedVerifiedLoadIds` / `annotateVerifiedPatterns`

The two recursive verified-load-id walks gate the **root** on `isTrustedPattern`, then propagate to structurally-`isPattern` values *within a trusted subtree* — because nested subpatterns are serialized/unbranded but are legit parts of a trusted pattern. So a forged **top-level** export is never seeded, while nested-subpattern id propagation is preserved.

The runner's instantiation logic deliberately keeps structural `isPattern` (it operates on derivation copies and re-resolves node implementations independently).

## Scope & validation

Path-agnostic (the brand + trust gates apply to both AMD and ESM). New `pattern-provenance` suite (forged shape is `isPattern` but not `isTrustedPattern`; branded is trusted; non-shape/primitive aren't). Regression-validated: the nested-verified-load-id propagation test (caught an over-gating attempt and drove the trusted-subtree design), CFC implementation-identity, pattern composition (`derive`-returns-pattern), binding, scope, serialization, and the ESM engine/pattern-run suites — all green (124+ steps in the sweep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a provenance brand to patterns so only builder-produced values (and their derived copies) are trusted. Blocks `__cf_data`-forged pattern-shaped exports from acquiring programs and verified load IDs.

- **Bug Fixes**
  - Introduced `isTrustedPattern` (brand + shape) that also walks the `unsafe_originalPattern` chain to accept derivations/serialized copies of a branded pattern; builder stamps new patterns.
  - Switched `exportsCallback`, entry selection, and verified-load-id walks to root on `isTrustedPattern`, while still propagating to structural `isPattern` nodes within a trusted subtree.
  - Made verified-load-id propagation order-independent with per-node trust tracking (`Map`); added `pattern-provenance.test.ts`.

<sup>Written for commit 7ca4f2298b23af579e307a807caf2ecc42495e91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

