### PR TITLE
feat(runner): env-backed CF_ESM_MODULE_LOADER toggle (+ ESM-path regression cross-check)

### DIFF
--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -24,6 +24,11 @@ import {
   resetPersistentSchedulerStateConfig,
   setPersistentSchedulerStateConfig,
 } from "@commonfabric/memory/v2";
+import {
+  getEsmModuleLoaderConfig,
+  resetEsmModuleLoaderConfig,
+  setEsmModuleLoaderConfig,
+} from "./sandbox/esm-loader-config.ts";
 import { PatternEnvironment, setPatternEnvironment } from "./builder/env.ts";
 import { AsyncSemaphoreQueue, type QueueConfig } from "./queue.ts";
 import type {
@@ -354,6 +359,9 @@ export class Runtime {
     );
     this.experimental.persistentSchedulerState =
       getPersistentSchedulerStateConfig();
+    // Env-seeded default (CF_ESM_MODULE_LOADER) unless an explicit option is set.
+    setEsmModuleLoaderConfig(this.experimental.esmModuleLoader);
+    this.experimental.esmModuleLoader = getEsmModuleLoaderConfig();
 
     this.id = options.storageManager.id;
     this.apiUrl = new URL(options.apiUrl);
@@ -532,6 +540,7 @@ export class Runtime {
     // Reset experimental config to defaults.
     resetDataModelConfig();
     resetPersistentSchedulerStateConfig();
+    resetEsmModuleLoaderConfig();
 
     // Clear the current runtime reference
     // Removed setCurrentRuntime call - no longer using singleton pattern

--- a/packages/runner/src/sandbox/esm-loader-config.ts
+++ b/packages/runner/src/sandbox/esm-loader-config.ts
@@ -26,13 +26,14 @@ function readEnvDefault(): boolean {
 let esmModuleLoaderEnabled = readEnvDefault();
 
 /**
- * Propagate an explicit `esmModuleLoader` option. A `undefined` value is a no-op
- * so the env-seeded default stands (matching setDataModelConfig semantics).
+ * Propagate an explicit `esmModuleLoader` option. `undefined` (no option) falls
+ * back to the env-seeded default rather than leaving a prior value in place, so
+ * a Runtime created without the option never inherits a stale override from an
+ * earlier Runtime — the effective value is always either this Runtime's explicit
+ * option or `CF_ESM_MODULE_LOADER`.
  */
 export function setEsmModuleLoaderConfig(enabled?: boolean): void {
-  if (enabled !== undefined) {
-    esmModuleLoaderEnabled = enabled;
-  }
+  esmModuleLoaderEnabled = enabled ?? readEnvDefault();
 }
 
 /** The effective ESM-loader flag (explicit option, else `CF_ESM_MODULE_LOADER`). */

--- a/packages/runner/src/sandbox/esm-loader-config.ts
+++ b/packages/runner/src/sandbox/esm-loader-config.ts
@@ -1,0 +1,47 @@
+/**
+ * Ambient runtime flag for the experimental ESM module-record loader (the
+ * `esmModuleLoader` experimental option). Mirrors the modern-data-model and
+ * persistent-scheduler-state ambient flags: the `Runtime` constructor
+ * propagates the explicit option here and reads the effective value back.
+ *
+ * Unlike those two, the default is seeded from the `CF_ESM_MODULE_LOADER`
+ * environment variable, so the ESM loader can be exercised suite-wide (e.g. a
+ * regression cross-check) without threading the option through every `Runtime`
+ * construction. The production default stays OFF (the env var is unset), so this
+ * is NOT the flag flip — it only makes the flag toggleable from the environment.
+ */
+
+function readEnvDefault(): boolean {
+  try {
+    const value = (globalThis as {
+      Deno?: { env?: { get(name: string): string | undefined } };
+    }).Deno?.env?.get?.("CF_ESM_MODULE_LOADER");
+    return value === "1" || value === "true";
+  } catch {
+    // Env access may be denied (no --allow-env); treat as unset / off.
+    return false;
+  }
+}
+
+let esmModuleLoaderEnabled = readEnvDefault();
+
+/**
+ * Propagate an explicit `esmModuleLoader` option. A `undefined` value is a no-op
+ * so the env-seeded default stands (matching setDataModelConfig semantics).
+ */
+export function setEsmModuleLoaderConfig(enabled?: boolean): void {
+  if (enabled !== undefined) {
+    esmModuleLoaderEnabled = enabled;
+  }
+}
+
+/** The effective ESM-loader flag (explicit option, else `CF_ESM_MODULE_LOADER`). */
+export function getEsmModuleLoaderConfig(): boolean {
+  return esmModuleLoaderEnabled;
+}
+
+/** Restore the env-seeded default. Called on `Runtime.dispose()` so the flag
+ * does not leak between runtime instances or test runs. */
+export function resetEsmModuleLoaderConfig(): void {
+  esmModuleLoaderEnabled = readEnvDefault();
+}

--- a/packages/runner/test/esm-loader-config.test.ts
+++ b/packages/runner/test/esm-loader-config.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import {
+  getEsmModuleLoaderConfig,
+  resetEsmModuleLoaderConfig,
+  setEsmModuleLoaderConfig,
+} from "../src/sandbox/esm-loader-config.ts";
+
+// CF_ESM_MODULE_LOADER is unset in the normal test process, so the env-seeded
+// default is `false`. (The env-on path is exercised by running the suite with
+// CF_ESM_MODULE_LOADER=1 — the regression cross-check.)
+describe("esm-loader-config", () => {
+  afterEach(() => resetEsmModuleLoaderConfig());
+
+  it("defaults off when CF_ESM_MODULE_LOADER is unset", () => {
+    resetEsmModuleLoaderConfig();
+    expect(getEsmModuleLoaderConfig()).toBe(false);
+  });
+
+  it("an explicit option overrides; undefined is a no-op", () => {
+    setEsmModuleLoaderConfig(true);
+    expect(getEsmModuleLoaderConfig()).toBe(true);
+    setEsmModuleLoaderConfig(undefined); // keep the current value
+    expect(getEsmModuleLoaderConfig()).toBe(true);
+    setEsmModuleLoaderConfig(false);
+    expect(getEsmModuleLoaderConfig()).toBe(false);
+  });
+
+  it("reset restores the env-seeded default", () => {
+    setEsmModuleLoaderConfig(true);
+    resetEsmModuleLoaderConfig();
+    expect(getEsmModuleLoaderConfig()).toBe(false);
+  });
+});

--- a/packages/runner/test/esm-loader-config.test.ts
+++ b/packages/runner/test/esm-loader-config.test.ts
@@ -18,11 +18,13 @@ describe("esm-loader-config", () => {
     expect(getEsmModuleLoaderConfig()).toBe(false);
   });
 
-  it("an explicit option overrides; undefined is a no-op", () => {
+  it("an explicit option overrides; undefined falls back to the env default", () => {
     setEsmModuleLoaderConfig(true);
     expect(getEsmModuleLoaderConfig()).toBe(true);
-    setEsmModuleLoaderConfig(undefined); // keep the current value
-    expect(getEsmModuleLoaderConfig()).toBe(true);
+    // No prior-value inheritance: undefined re-reads the env default (off here),
+    // so a Runtime without the option never sees a stale override.
+    setEsmModuleLoaderConfig(undefined);
+    expect(getEsmModuleLoaderConfig()).toBe(false);
     setEsmModuleLoaderConfig(false);
     expect(getEsmModuleLoaderConfig()).toBe(false);
   });

--- a/packages/runner/test/experimental-options.test.ts
+++ b/packages/runner/test/experimental-options.test.ts
@@ -45,6 +45,7 @@ describe("ExperimentalOptions", () => {
         modernDataModel: false,
         persistentSchedulerState: false,
         schedulerHistoricalMightWrite: undefined,
+        esmModuleLoader: false,
       });
       await runtime.dispose();
       await sm.close();
@@ -63,6 +64,7 @@ describe("ExperimentalOptions", () => {
         modernDataModel: true,
         persistentSchedulerState: false,
         schedulerHistoricalMightWrite: undefined,
+        esmModuleLoader: false,
       });
       await runtime.dispose();
       await sm.close();
@@ -81,6 +83,7 @@ describe("ExperimentalOptions", () => {
         modernDataModel: true,
         persistentSchedulerState: false,
         schedulerHistoricalMightWrite: undefined,
+        esmModuleLoader: false,
       });
       await runtime.dispose();
       await sm.close();

--- a/packages/runner/test/experimental-options.test.ts
+++ b/packages/runner/test/experimental-options.test.ts
@@ -39,6 +39,9 @@ describe("ExperimentalOptions", () => {
         storageManager: sm,
         experimental: {
           modernDataModel: false,
+          // Explicit so the assertion is deterministic regardless of the
+          // CF_ESM_MODULE_LOADER env (e.g. during the flag-on cross-check).
+          esmModuleLoader: false,
         },
       });
       expect(runtime.experimental).toEqual({
@@ -58,6 +61,7 @@ describe("ExperimentalOptions", () => {
         storageManager: sm,
         experimental: {
           modernDataModel: true,
+          esmModuleLoader: false, // explicit: deterministic regardless of env
         },
       });
       expect(runtime.experimental).toEqual({
@@ -77,6 +81,7 @@ describe("ExperimentalOptions", () => {
         storageManager: sm,
         experimental: {
           modernDataModel: true,
+          esmModuleLoader: false, // explicit: deterministic regardless of env
         },
       });
       expect(runtime.experimental).toEqual({
@@ -306,6 +311,7 @@ describe("ExperimentalOptions", () => {
         storageManager: sm,
         experimental: {
           modernDataModel: true,
+          esmModuleLoader: false, // explicit: deterministic regardless of env
         },
       });
 


### PR DESCRIPTION
## What

Adds an **env-backed toggle** for the `esmModuleLoader` experimental flag, following the `modernDataModel` / `persistentSchedulerState` ambient-config pattern (`set/get/resetEsmModuleLoaderConfig`, propagated from the `Runtime` constructor, reset on `dispose`) — but the default is seeded from the **`CF_ESM_MODULE_LOADER`** env var.

The production default stays **off** (env unset → `false`), so this is **not** the flag flip — it just makes the flag toggleable from the environment. An explicit `experimental.esmModuleLoader` option still wins; `undefined` keeps the env default. Env access is permission-guarded (no `--allow-env` → off).

This lets the whole suite run through the ESM path without threading the option through every `Runtime` construction:
```
CF_ESM_MODULE_LOADER=1 deno test --allow-env ...
```

## Regression cross-check (the reason for this)

The ESM loader is default-off, so CI's integration suites all run AMD — the ESM path + all its hardening (write-once exports, harden-frozen exports, graph-target verification, pattern provenance brand) had no broad regression signal. Using this toggle I ran the ESM-relevant suites flag-on and confirmed the path actually routes ESM (the AMD-compile-cache test fails under the flag because ESM bypasses the cache; a direct probe shows the effective flag flips with the env var):

- **15 runner pattern suites — 87 steps, 0 failures** (core, lift, handlers, if/else, schemas, async, dynamic, reduce, findindex, self, regressions, …).
- **Broad sweep — 278 steps, 0 failures** (patterns, binding, scope, CFC, implementation-identity, json-utils, engine-verified-functions, when/unless, esm-engine, provenance).
- **Only failure anywhere:** the AMD compilation-cache integration test, which the ESM path bypasses by design — not a behavior regression.

So real reactive patterns compile and run correctly through the ESM loader with all hardening active.

## Scope

`runtime.ts` wiring + a small ambient-config module + a unit test for the set/get/reset/env-default semantics. No CI matrix job yet (deferred per discussion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an env-backed toggle for the experimental ESM module loader and resolves the flag in `Runtime`, so you can run the suite through the ESM path without wiring options. Production default stays off.

- **New Features**
  - Seed and resolve `experimental.esmModuleLoader` from `CF_ESM_MODULE_LOADER` (default off; `CF_ESM_MODULE_LOADER=1 deno test --allow-env`). Env access is permission-guarded.
  - Exposed on `runtime.experimental.esmModuleLoader` (false when off).
  - Precedence: an explicit option wins; `undefined` reads the env default.
  - Ambient `set/get/resetEsmModuleLoaderConfig`, wired in `Runtime` and reset on `dispose`.

- **Bug Fixes**
  - `setEsmModuleLoaderConfig(undefined)` now re-reads the env default to avoid stale overrides across runtimes.
  - `experimental-options` tests set `esmModuleLoader` explicitly for deterministic assertions under env-on/off.

<sup>Written for commit aceebe665e6db521fe76a3e1e8cae386836379b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

