### PR TITLE
test(runner): make esm-loader-config test env-independent

### DIFF
--- a/packages/runner/test/esm-loader-config.test.ts
+++ b/packages/runner/test/esm-loader-config.test.ts
@@ -7,31 +7,42 @@ import {
   setEsmModuleLoaderConfig,
 } from "../src/sandbox/esm-loader-config.ts";
 
-// CF_ESM_MODULE_LOADER is unset in the normal test process, so the env-seeded
-// default is `false`. (The env-on path is exercised by running the suite with
-// CF_ESM_MODULE_LOADER=1 — the regression cross-check.)
+// The env-seeded default depends on CF_ESM_MODULE_LOADER, which is unset in the
+// normal test process but SET during the flag-on cross-check
+// (CF_ESM_MODULE_LOADER=1). Compute the expected default from the env so these
+// assertions are deterministic under both — testing the set/get/reset mechanics
+// relative to whatever the env default is, not a hardcoded value.
+const envDefault: boolean = (() => {
+  try {
+    const v = (globalThis as {
+      Deno?: { env?: { get(name: string): string | undefined } };
+    }).Deno?.env?.get?.("CF_ESM_MODULE_LOADER");
+    return v === "1" || v === "true";
+  } catch {
+    return false;
+  }
+})();
+
 describe("esm-loader-config", () => {
   afterEach(() => resetEsmModuleLoaderConfig());
 
-  it("defaults off when CF_ESM_MODULE_LOADER is unset", () => {
+  it("defaults to the CF_ESM_MODULE_LOADER env value", () => {
     resetEsmModuleLoaderConfig();
-    expect(getEsmModuleLoaderConfig()).toBe(false);
+    expect(getEsmModuleLoaderConfig()).toBe(envDefault);
   });
 
   it("an explicit option overrides; undefined falls back to the env default", () => {
-    setEsmModuleLoaderConfig(true);
-    expect(getEsmModuleLoaderConfig()).toBe(true);
-    // No prior-value inheritance: undefined re-reads the env default (off here),
-    // so a Runtime without the option never sees a stale override.
-    setEsmModuleLoaderConfig(undefined);
-    expect(getEsmModuleLoaderConfig()).toBe(false);
-    setEsmModuleLoaderConfig(false);
-    expect(getEsmModuleLoaderConfig()).toBe(false);
+    setEsmModuleLoaderConfig(!envDefault); // explicit, opposite of env default
+    expect(getEsmModuleLoaderConfig()).toBe(!envDefault);
+    setEsmModuleLoaderConfig(undefined); // no stale inheritance → env default
+    expect(getEsmModuleLoaderConfig()).toBe(envDefault);
+    setEsmModuleLoaderConfig(envDefault);
+    expect(getEsmModuleLoaderConfig()).toBe(envDefault);
   });
 
   it("reset restores the env-seeded default", () => {
-    setEsmModuleLoaderConfig(true);
+    setEsmModuleLoaderConfig(!envDefault);
     resetEsmModuleLoaderConfig();
-    expect(getEsmModuleLoaderConfig()).toBe(false);
+    expect(getEsmModuleLoaderConfig()).toBe(envDefault);
   });
 });


### PR DESCRIPTION
The local flag-on cross-check (`CF_ESM_MODULE_LOADER=1`, full runner suite) surfaced one env-dependent test of my own: `esm-loader-config.test.ts` hardcoded the *off* default, so its 3 assertions flip under the flag (where the env-seeded default is *on*).

Fix: compute the expected default from `CF_ESM_MODULE_LOADER` and assert the set/get/reset mechanics relative to it — deterministic whether the env var is set or not. Verified passing under both `env unset` and `CF_ESM_MODULE_LOADER=1`.

## Cross-check result (full runner suite, ESM path)

`CF_ESM_MODULE_LOADER=1 ENV=test deno test … test/*.test.ts` → **502 passed (2753 steps), 0 real regressions.** Before this fix there were 2 failed files; both non-regressions:
- `compilation-cache` — AMD-only feature; the ESM path bypasses the persistent compile cache by design.
- `esm-loader-config` — this env-dependent test (fixed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `esm-loader-config` tests environment-independent by deriving the default from CF_ESM_MODULE_LOADER and asserting set/get/reset behavior relative to it. This removes false failures in the flag-on cross-check (CF_ESM_MODULE_LOADER=1) and keeps the tests deterministic with or without the env var.

<sup>Written for commit 8787731439528112e9d8b49c9d00a064c5b9fcc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

