### PR TITLE
feat(runner): flip esmModuleLoader on by default (CT-1623 Phase 5)

### DIFF
--- a/packages/runner/src/sandbox/esm-loader-config.ts
+++ b/packages/runner/src/sandbox/esm-loader-config.ts
@@ -4,11 +4,11 @@
  * persistent-scheduler-state ambient flag: the `Runtime` constructor
  * propagates the explicit option here and reads the effective value back.
  *
- * Unlike that one, the default is seeded from the `CF_ESM_MODULE_LOADER`
- * environment variable, so the ESM loader can be exercised suite-wide (e.g. a
+ * The default is ON: the ESM module-record loader is the production default.
+ * Set `CF_ESM_MODULE_LOADER=0` (or `false`) to opt back into the legacy AMD
+ * bundle loader. The env var also lets the loader be selected suite-wide (e.g. a
  * regression cross-check) without threading the option through every `Runtime`
- * construction. The production default stays OFF (the env var is unset), so this
- * is NOT the flag flip — it only makes the flag toggleable from the environment.
+ * construction.
  */
 
 function readEnvDefault(): boolean {
@@ -16,10 +16,12 @@ function readEnvDefault(): boolean {
     const value = (globalThis as {
       Deno?: { env?: { get(name: string): string | undefined } };
     }).Deno?.env?.get?.("CF_ESM_MODULE_LOADER");
-    return value === "1" || value === "true";
+    // Default ON: the ESM module-record loader is the default loader; opt out
+    // with CF_ESM_MODULE_LOADER=0 (or "false").
+    return value !== "0" && value !== "false";
   } catch {
-    // Env access may be denied (no --allow-env); treat as unset / off.
-    return false;
+    // Env access denied (no --allow-env): use the default (ON).
+    return true;
   }
 }
 

--- a/packages/runner/test/esm-loader-config.test.ts
+++ b/packages/runner/test/esm-loader-config.test.ts
@@ -17,9 +17,10 @@ const envDefault: boolean = (() => {
     const v = (globalThis as {
       Deno?: { env?: { get(name: string): string | undefined } };
     }).Deno?.env?.get?.("CF_ESM_MODULE_LOADER");
-    return v === "1" || v === "true";
+    // Mirror readEnvDefault: ON by default unless explicitly "0"/"false".
+    return v !== "0" && v !== "false";
   } catch {
-    return false;
+    return true;
   }
 })();
 


### PR DESCRIPTION
## CT-1623 Phase 5 — flip `esmModuleLoader` on by default

Makes the ESM module-record loader the **default** loader for pattern
compile/evaluate. `readEnvDefault()` now returns ON unless
`CF_ESM_MODULE_LOADER=0` (or `false`) opts back into the legacy AMD bundle
loader.

### Why now
The supporting phases are merged behind the (until-now default-off) flag:
- **Phase 2** — ESM emission + SES module-record loading (`compileToRecordGraph`
  / `evaluateRecordGraph`, full CF transformer pipeline, content-addressed
  records, source maps, live namespace bindings).
- **Phase 3** — per-module SES verifier (`verifyCompiledModuleBody` +
  `verifyModuleGraph`); ESM↔AMD differential parity oracle (#3801).
- **Phase 4** — content-addressed compilation **cell cache** (#3810): per-space
  source set `pattern:<identity>` (self-verifying) + compiled set
  `compileCache:<runtimeVersion>/<identity>` (CFC integrity, fail-closed), with
  warm-hit reuse that skips the TS compile / transformer pipeline.

So the default flip routes all pattern loading through the ESM path, now backed
by per-module caching + integrity rather than recompiling every time.

### Scope
- Flips the default only. **Legacy AMD bundle loader removal is a separate
  follow-up** (both paths still coexist; opt back into AMD with
  `CF_ESM_MODULE_LOADER=0`).
- The full suite passes through the ESM path (this branch has been the standing
  flag-on CI signal).

### Not addressed here
- **Performance Check is intentionally left for review** — this PR surfaces the
  real end-to-end perf impact of making the ESM loader the default, and that
  delta is being examined before any baseline decisions. No `NEW_PERF_BASELINE`
  overrides are applied.
