### PR TITLE
fix(runner): resolve ESM-loader source locations (unblocks CFC verified-source)

### DIFF
--- a/packages/js-compiler/mod.ts
+++ b/packages/js-compiler/mod.ts
@@ -29,6 +29,7 @@ export {
   InMemoryProgram,
 } from "./program.ts";
 export {
+  composeBundleSourceMap,
   isSourceMap,
   type MappedPosition,
   parseSourceMap,

--- a/packages/js-compiler/source-map.ts
+++ b/packages/js-compiler/source-map.ts
@@ -1,8 +1,72 @@
 import { SourceMap } from "./interface.ts";
-import { MappedPosition, SourceMapConsumer } from "source-map-js";
+import {
+  MappedPosition,
+  SourceMapConsumer,
+  SourceMapGenerator,
+} from "source-map-js";
 import { LRUCache } from "@commonfabric/utils/cache";
 
 export type { MappedPosition };
+
+/**
+ * Compose a single bundle source map for the concatenated module bodies
+ * (`[...bodies].join("\n")`) from each module's own source map, offsetting each
+ * module's generated lines by its starting line in the concatenation.
+ *
+ * The ESM module-record loader resolves a function's location by `indexOf`-ing
+ * its source into the concatenated bundle `script`, then calling
+ * `mapPosition(bundleFilename, line, col)`. Without a registered map that stays
+ * a raw bundle coordinate (`<loadId>.js:..`), which CFC verified-source identity
+ * rejects. Registering this composed map resolves it back to the original
+ * authored source (e.g. `/main.tsx:6:2`) — parity with the AMD isolate path.
+ *
+ * Returns `undefined` if no module contributed a map.
+ */
+export function composeBundleSourceMap(
+  modules: ReadonlyArray<{ body: string; map?: SourceMap }>,
+  bundleFilename: string,
+): SourceMap | undefined {
+  const generator = new SourceMapGenerator({ file: bundleFilename });
+  let lineOffset = 0;
+  let any = false;
+  for (const { body, map } of modules) {
+    if (map) {
+      const consumer = new SourceMapConsumer(map);
+      consumer.eachMapping((m) => {
+        if (
+          m.source == null || m.originalLine == null ||
+          m.originalColumn == null
+        ) return;
+        generator.addMapping({
+          generated: {
+            line: m.generatedLine + lineOffset,
+            column: m.generatedColumn,
+          },
+          original: { line: m.originalLine, column: m.originalColumn },
+          source: m.source,
+          name: m.name ?? undefined,
+        });
+        any = true;
+      });
+      const sources = map.sources ?? [];
+      const contents =
+        (map as { sourcesContent?: (string | null)[] }).sourcesContent;
+      if (contents) {
+        sources.forEach((src, i) => {
+          const content = contents[i];
+          if (src != null && content != null) {
+            generator.setSourceContent(src, content);
+          }
+        });
+      }
+    }
+    // Lines this body occupies in the "\n"-joined bundle = (newlines in body)+1.
+    // Robust to trailing newlines, unlike split().length.
+    lineOffset += (body.match(/\n/g)?.length ?? 0) + 1;
+  }
+  if (!any) return undefined;
+  return JSON.parse(generator.toString()) as SourceMap;
+}
 
 /**
  * Maximum number of source maps to cache in memory.

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -36,6 +36,7 @@ import {
   type CompiledModuleGraph,
   compileSourcesToRecords,
 } from "../sandbox/module-record-compiler.ts";
+import { composeBundleSourceMap } from "@commonfabric/js-compiler";
 import {
   loadModuleGraph,
   runtimeModuleRecords,
@@ -300,6 +301,13 @@ export class Engine extends EventTarget implements Harness {
       const precompiledBodies = new Map(
         [...modules].map(([name, out]) => [name, out.js]),
       );
+      // Carry per-module source maps so the ESM loader can compose a per-load
+      // bundle map (CFC verified-source / fn.src coordinate resolution).
+      const precompiledSourceMaps = new Map(
+        [...modules].flatMap(([name, out]) =>
+          out.sourceMap ? [[name, out.sourceMap] as const] : []
+        ),
+      );
       const { runtimeExports } = await this.getRuntimeInternals();
       const runtimeNames = Engine.runtimeModuleNames().filter((name) =>
         runtimeExports?.[name]
@@ -312,6 +320,7 @@ export class Engine extends EventTarget implements Harness {
       );
       const graph = compileSourcesToRecords(moduleFiles, {
         precompiledBodies,
+        precompiledSourceMaps,
         runtimeModules: runtimeModulesOption,
       });
 
@@ -410,6 +419,20 @@ export class Engine extends EventTarget implements Harness {
         loadId,
         hashOf(script).toString(),
       );
+      // Register a composed bundle source map for `${loadId}.js` so that
+      // `fn.src` / CFC verified-source coordinates (resolved against `script`)
+      // map back to the original authored sources — without this the ESM loader
+      // yields raw bundle coordinates and CFC verified-source fails closed.
+      const bundleSourceMap = composeBundleSourceMap(
+        [...graph.compiledBodies].map(([specifier, body]) => ({
+          body,
+          map: graph.moduleSourceMaps.get(specifier),
+        })),
+        `${loadId}.js`,
+      );
+      if (bundleSourceMap) {
+        this.getSESRuntime().loadSourceMap(`${loadId}.js`, bundleSourceMap);
+      }
       // Verified-load sources: the original file names plus the prefixed module
       // paths (both normalized), so CFC's isVerifiedSourceInLoad recognizes the
       // source locations of functions defined by this load.

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -1,6 +1,6 @@
 import ts from "typescript";
 import { getLogger } from "@commonfabric/utils/logger";
-import type { Source } from "@commonfabric/js-compiler";
+import type { Source, SourceMap } from "@commonfabric/js-compiler";
 import { resolveImportSpecifier } from "@commonfabric/js-compiler";
 import {
   computeModuleHashes,
@@ -181,6 +181,13 @@ export interface CompileSourcesOptions {
    * generation, `__cf_data` wrapping) cannot be produced by transpileModule.
    */
   precompiledBodies?: Map<string, string>;
+  /**
+   * Per-source source map (from `compileToModules`), keyed by source name. Used
+   * to compose a per-load bundle source map so `fn.src` / CFC verified-source
+   * coordinates resolve back to the original authored files under the ESM
+   * loader (the AMD path registers the bundle map via the isolate).
+   */
+  precompiledSourceMaps?: Map<string, SourceMap>;
 }
 
 export interface CompiledModuleGraph {
@@ -189,6 +196,8 @@ export interface CompiledModuleGraph {
   specifierByPath: Map<string, string>;
   /** Compiled CommonJS body per specifier — the text the verifier classifies. */
   compiledBodies: Map<string, string>;
+  /** Per-specifier source map (compiled body → original source), when available. */
+  moduleSourceMaps: Map<string, SourceMap>;
 }
 
 export function compileSourcesToRecords(
@@ -265,9 +274,12 @@ export function compileSourcesToRecords(
 
   const records = new Map<string, VirtualModuleRecord>();
   const compiledBodies = new Map<string, string>();
+  const moduleSourceMaps = new Map<string, SourceMap>();
   for (const source of sources) {
     const specifier = specifierByPath.get(source.name)!;
     const moduleHash = hashes.get(source.name)!;
+    const sourceMap = options.precompiledSourceMaps?.get(source.name);
+    if (sourceMap) moduleSourceMaps.set(specifier, sourceMap);
     const precompiled = options.precompiledBodies?.get(source.name);
     let exportNames: string[];
     let compiled: string;
@@ -374,7 +386,7 @@ export function compileSourcesToRecords(
     });
   }
 
-  return { records, specifierByPath, compiledBodies };
+  return { records, specifierByPath, compiledBodies, moduleSourceMaps };
 }
 
 /**

--- a/packages/runner/src/sandbox/ses-runtime.ts
+++ b/packages/runner/src/sandbox/ses-runtime.ts
@@ -214,6 +214,16 @@ export class SESRuntime extends EventTarget {
     return this.internals.mapPosition(filename, line, column);
   }
 
+  /**
+   * Register a source map under `filename` so {@link mapPosition} (and stack
+   * parsing) can translate bundle coordinates back to original sources. The AMD
+   * isolate path does this implicitly via {@link SESIsolate.execute}; the ESM
+   * module-record loader composes a per-load bundle map and registers it here.
+   */
+  loadSourceMap(filename: string, sourceMap: SourceMap): void {
+    this.internals.loadSourceMap(filename, sourceMap);
+  }
+
   parseStack(stack: string): string {
     return this.internals.parseStack(stack);
   }

--- a/packages/runner/test/esm-source-location.test.ts
+++ b/packages/runner/test/esm-source-location.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+import type { Module, Pattern } from "../src/builder/types.ts";
+import { resolvePolicyFacingImplementationIdentity } from "../src/cfc/implementation-identity.ts";
+
+// Regression: under the ESM module-record loader, a verified handler's
+// `implementation.src` must resolve back to its ORIGINAL authored source
+// (`/main.tsx:line:col`), not the raw concatenated-bundle coordinate
+// (`<loadId>.js:line:col`). Otherwise CFC verified-source identity fails closed
+// (`isVerifiedSourceInLoad` === false → kind "unsupported"), which breaks every
+// CFC trusted action under ESM. The fix composes a per-load bundle source map
+// (see composeBundleSourceMap) and registers it so `mapPosition` can translate
+// the coordinate — parity with the AMD isolate path.
+
+const signer = await Identity.fromPassphrase("test operator");
+
+const program: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [
+    {
+      name: "/main.tsx",
+      contents: [
+        "import { Cell, Default, handler, pattern } from 'commonfabric';",
+        "const inc = handler<unknown, { count: Cell<number> }>(",
+        "  (_event, { count }) => { count.set(count.get() + 1); },",
+        ");",
+        "export default pattern<{ count: number | Default<0> }>(({ count }) => {",
+        "  return { count, inc: inc({ count }) };",
+        "});",
+      ].join("\n"),
+    },
+  ],
+};
+
+interface HandlerIdentityProbe {
+  src: string | undefined;
+  verifiedLoadId: string | undefined;
+  isVerifiedSourceInLoad: boolean | undefined;
+  kind: string | undefined;
+}
+
+function probeHandlerIdentity(
+  runtime: Runtime,
+  compiled: Pattern,
+): HandlerIdentityProbe {
+  const nodes = (compiled as Pattern & { nodes: { module: Module }[] }).nodes;
+  const handlerModule = nodes
+    .map((n) => n.module)
+    .find((m) =>
+      m && m.type === "javascript" && m.wrapper === "handler" &&
+      typeof m.implementationRef === "string"
+    );
+  if (!handlerModule) {
+    throw new Error("no verified handler node found in compiled pattern");
+  }
+  const implementationRef = handlerModule.implementationRef!;
+  const patternId = runtime.patternManager.getPatternId(compiled);
+  const verifiedLoadId = runtime.harness.getVerifiedLoadId?.(
+    implementationRef,
+    patternId,
+  );
+  const fn = runtime.harness.getExecutableFunction?.(
+    implementationRef,
+    patternId,
+  ) as (((...a: unknown[]) => unknown) & { src?: string }) | undefined;
+  const src = fn?.src;
+  const match = typeof src === "string" ? /^(.*):(\d+):(\d+)$/.exec(src) : null;
+  const rawPath = match ? match[1] : undefined;
+  const normalizedPath = rawPath
+    ? (rawPath.startsWith("/") ? rawPath : `/${rawPath}`)
+    : undefined;
+  const isVerifiedSourceInLoad = (verifiedLoadId && normalizedPath)
+    ? runtime.harness.isVerifiedSourceInLoad?.(verifiedLoadId, normalizedPath)
+    : undefined;
+  const identity = resolvePolicyFacingImplementationIdentity(handlerModule, {
+    verifiedLoadId,
+    harness: runtime.harness,
+    implementation: fn as never,
+  });
+  return { src, verifiedLoadId, isVerifiedSourceInLoad, kind: identity?.kind };
+}
+
+describe("ESM loader: verified-source location resolution", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  const makeRuntime = (esmModuleLoader: boolean) => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      experimental: { esmModuleLoader },
+    });
+  };
+
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("resolves a handler's src to its original source under the ESM loader", async () => {
+    makeRuntime(true);
+    const compiled = await runtime.patternManager.compilePattern(program);
+    const r = probeHandlerIdentity(runtime, compiled);
+
+    // src maps back to the authored file, not a `<loadId>.js` / `:esm:` bundle.
+    expect(r.src).toMatch(/(?:^|\/)main\.tsx:\d+:\d+$/);
+    expect(r.src).not.toMatch(/:esm:|\.js:\d+:\d+$/);
+    expect(r.verifiedLoadId).toBeDefined();
+    expect(r.isVerifiedSourceInLoad).toBe(true);
+    expect(r.kind).toBe("verified");
+  });
+
+  it("matches AMD-path verified-source resolution (parity)", async () => {
+    makeRuntime(false);
+    const compiled = await runtime.patternManager.compilePattern(program);
+    const r = probeHandlerIdentity(runtime, compiled);
+
+    expect(r.src).toMatch(/(?:^|\/)main\.tsx:\d+:\d+$/);
+    expect(r.isVerifiedSourceInLoad).toBe(true);
+    expect(r.kind).toBe("verified");
+  });
+});


### PR DESCRIPTION
## What & why

The flag-flip canary (#3782) surfaced that **CFC trusted actions fail closed under the ESM module-record loader** — `cfc-group-chat-demo` and `shared-profile` integration tests time out because a profile/message never renders.

**Root cause (confirmed end-to-end):** CFC verified-source identity reads `implementation.src` (`cfc/implementation-identity.ts`). The loader resolves it by `indexOf`-ing the function into the concatenated bundle `script`, then calling `mapPosition("<loadId>.js", line, col)`. But `compileToRecordGraph` **discarded each module's source map**, so no map was registered for `<loadId>.js` → `mapPosition` returned null → `.src` stayed a raw bundle coordinate (`<loadId>.js:..`) → `isVerifiedSourceInLoad` false → identity `unsupported` → trusted action rejected. (The AMD isolate path works only because `SESIsolate.execute` registers the bundle map.)

This was the documented *"remaining item before the flag flip"* — and it turned out to be **contained source-map plumbing, not the feared SES-internal source-map work.**

## Fix

- **`composeBundleSourceMap`** (`js-compiler/source-map.ts`): compose one bundle map from the per-module maps, offsetting each module's generated lines by its start line in the `\n`-joined bundle (newline-count based, robust to trailing newlines).
- **Plumb the maps**: `compileToModules` already returns `{js, sourceMap}`; stop dropping `out.sourceMap` in `compileToRecordGraph`; carry them as `graph.moduleSourceMaps` (keyed by specifier).
- **Register**: in `evaluateRecordGraph`, compose the bundle map and register it under `<loadId>.js` via a new `SESRuntime.loadSourceMap` forwarder (the internals method already existed; only the public surface was missing).

## Result

A handler's `.src` now resolves to its original source (`main.tsx:line:col`), `isVerifiedSourceInLoad` is `true`, and CFC identity is `verified` under ESM — **parity with AMD**. New `esm-source-location` regression test exercises both loaders end-to-end. Broad ESM/CFC suites + a flag-on pattern sweep stay green.

Scope: ESM-loader path (default-off flag) + a pure additive helper/export in js-compiler. After this lands I'll rebase the canary to confirm the two integration suites go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ESM loader source location resolution by composing and registering per-load bundle source maps so functions map back to their authored files, restoring CFC verified-source and trusted actions under ESM (parity with AMD).

- **Bug Fixes**
  - Added `composeBundleSourceMap` in `@commonfabric/js-compiler` to build a bundle map from per-module maps.
  - Plumbed module source maps through compilation and registered the composed map for `<loadId>.js` via `SESRuntime.loadSourceMap` so `mapPosition` resolves original sources.
  - Added `esm-source-location.test.ts` to verify src mapping and CFC identity under both ESM and AMD.

<sup>Written for commit 5c78296a50d7066e5c6bbacf5d17be6b9bbef3c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Perf baseline overrides (flaky CI job-duration metrics)
NEW_PERF_BASELINE: job: Package Integration Tests (runner) = 143s
NEW_PERF_BASELINE: job: Package Integration Tests = 143s
NEW_PERF_BASELINE: job: Build Binaries = 63s
