### PR TITLE
[codex] Allow cf-harness browser console and error inspection

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -301,8 +301,8 @@ use the leased endpoint, for example
 `agent-browser open` / `snapshot` launches are denied so the child cannot race
 the host's live browser profile. `agent-browser` is fail-closed to a small
 positive allowlist: `open` for HTTP(S) URLs, `snapshot`, `get title/url/text`,
-bounded `wait`, and ref-based `fill`, `type`, `select`, `check`, `click`, and
-`press`.
+read-only `console` / `errors` inspection without mutation flags, bounded
+`wait`, and ref-based `fill`, `type`, `select`, `check`, `click`, and `press`.
 
 Host-target skill scripts run with a cleared subprocess environment plus a
 controlled `PATH` and explicit `CF_HARNESS_*` / `SKILL_*` variables. They do not

--- a/packages/cf-harness/src/tools/browser-host-command-policy.ts
+++ b/packages/cf-harness/src/tools/browser-host-command-policy.ts
@@ -132,6 +132,8 @@ const AGENT_BROWSER_LOCAL_COMMANDS = new Set([
 const AGENT_BROWSER_PAGE_COMMANDS = new Set([
   "check",
   "click",
+  "console",
+  "errors",
   "fill",
   "get",
   "open",
@@ -290,6 +292,9 @@ const validateAgentBrowserPageCommand = (
       return validateAgentBrowserSnapshot(args);
     case "get":
       return validateAgentBrowserGet(args);
+    case "console":
+    case "errors":
+      return validateAgentBrowserReadOnlyDiagnostic(commandName, args);
     case "wait":
       return validateAgentBrowserWait(args);
     case "click":
@@ -348,6 +353,14 @@ const validateAgentBrowserGet = (
   }
   return "agent-browser get only allows title, url, or text";
 };
+
+const validateAgentBrowserReadOnlyDiagnostic = (
+  commandName: string,
+  args: readonly string[],
+): string | undefined =>
+  args.length === 0
+    ? undefined
+    : `agent-browser ${commandName} only allows read-only inspection without flags`;
 
 const validateAgentBrowserWait = (
   args: readonly string[],

--- a/packages/cf-harness/test/browser-host-command-policy.test.ts
+++ b/packages/cf-harness/test/browser-host-command-policy.test.ts
@@ -42,6 +42,8 @@ Deno.test("validateBrowserHostCommand allows agent-browser invocations", () => {
   assertAllowed(
     "agent-browser --cdp http://host.docker.internal:9362 get text body",
   );
+  assertAllowed("agent-browser --cdp http://host.docker.internal:9362 console");
+  assertAllowed("agent-browser --cdp http://host.docker.internal:9362 errors");
   assertAllowed(
     "agent-browser --cdp http://host.docker.internal:9362 click @e1",
   );
@@ -149,6 +151,12 @@ Deno.test("validateBrowserHostCommand rejects high-risk agent-browser host surfa
   assertDenied("agent-browser --cdp http://host.docker.internal:9362 network");
   assertDenied("agent-browser --cdp http://host.docker.internal:9362 har");
   assertDenied(
+    "agent-browser --cdp http://host.docker.internal:9362 console --clear",
+  );
+  assertDenied(
+    "agent-browser --cdp http://host.docker.internal:9362 errors --clear",
+  );
+  assertDenied(
     "agent-browser --cdp http://host.docker.internal:9362 wait --download",
   );
   assertDenied(
@@ -162,6 +170,8 @@ Deno.test("validateBrowserHostCommand rejects high-risk agent-browser host surfa
 Deno.test("validateBrowserHostCommand requires local CDP for page commands", () => {
   assertDenied('agent-browser open "https://example.com"');
   assertDenied("agent-browser snapshot -i");
+  assertDenied("agent-browser console");
+  assertDenied("agent-browser errors");
   assertDenied('agent-browser find role button click "Submit"');
   assertDenied("agent-browser click '@e1'");
   assertDenied("agent-browser get title");
@@ -187,6 +197,14 @@ Deno.test("validateBrowserHostCommand binds page commands to Browser Access leas
   );
   assertDenied(
     "agent-browser --cdp http://host.docker.internal:9444 snapshot -i",
+    "http://host.docker.internal:9362",
+  );
+  assertDenied(
+    "agent-browser --cdp http://host.docker.internal:9444 console",
+    "http://host.docker.internal:9362",
+  );
+  assertDenied(
+    "agent-browser --cdp http://host.docker.internal:9444 errors",
     "http://host.docker.internal:9362",
   );
   assertEquals(


### PR DESCRIPTION
## Summary

- allow cf-harness browser subagents to run lease-bound `agent-browser console`
- allow cf-harness browser subagents to run lease-bound `agent-browser errors`
- keep diagnostics read-only by denying command arguments such as `--clear`

## Security Notes

This PR should receive security review before merge.

The policy remains fail-closed:

- `console` and `errors` are page commands, so they still require a Browser Access lease.
- Commands must use `--cdp` with the exact leased local CDP endpoint.
- Bare `agent-browser console` / `agent-browser errors` remain denied.
- Mismatched CDP endpoints remain denied.
- `console --clear` and `errors --clear` are denied because they mutate browser diagnostic state.
- Host command output still flows through the existing `bash-no-sandbox` truncation path.

## Verification

- `deno fmt packages/cf-harness/src/tools/browser-host-command-policy.ts packages/cf-harness/test/browser-host-command-policy.test.ts packages/cf-harness/README.md`
- `deno test -A packages/cf-harness/test/browser-host-command-policy.test.ts packages/cf-harness/test/tools-execution.test.ts`
- `deno check packages/cf-harness/src/main.ts`
- `deno fmt --check packages/cf-harness/src/tools/browser-host-command-policy.ts packages/cf-harness/test/browser-host-command-policy.test.ts packages/cf-harness/README.md`
- `git diff --check`
- `cd packages/cf-harness && deno task test`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable cf-harness browser subagents to inspect page console logs and errors in a lease-bound, read-only way. Keeps the policy fail-closed and tied to the exact leased CDP endpoint.

- **New Features**
  - Allow `agent-browser console` and `agent-browser errors` only with `--cdp` set to the leased local endpoint.
  - Deny mutation flags like `--clear`, bare commands without `--cdp`, and mismatched CDP endpoints.
  - Updated policy, tests, and `packages/cf-harness/README.md`; existing `bash-no-sandbox` output truncation remains.

<sup>Written for commit 35d664b449eee2d02fbdc7aa79c07a13e18eca23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

