### PR TITLE
fix(runner): register per-module source maps under eval sourceURL (browser CFC under ESM)

### DIFF
--- a/packages/js-compiler/source-map.ts
+++ b/packages/js-compiler/source-map.ts
@@ -23,7 +23,12 @@ export type { MappedPosition };
  * Returns `undefined` if no module contributed a map.
  */
 export function composeBundleSourceMap(
-  modules: ReadonlyArray<{ body: string; map?: SourceMap }>,
+  // `source`, when set, overrides the map's recorded source path for ALL of that
+  // module's mappings. The per-module compiler maps record only the basename
+  // (e.g. `main.tsx`), but the CFC verified-source set is keyed by the full
+  // module path (e.g. `/<id>/dir/main.tsx`); overriding makes resolved
+  // coordinates match the set so verified-source identity holds.
+  modules: ReadonlyArray<{ body: string; map?: SourceMap; source?: string }>,
   bundleFilename: string,
   // Generated-line offset applied to the FIRST module. Use this when the
   // generated text is wrapped by a fixed prefix of N lines (e.g. the ESM
@@ -35,7 +40,7 @@ export function composeBundleSourceMap(
   const generator = new SourceMapGenerator({ file: bundleFilename });
   let lineOffset = startLineOffset;
   let any = false;
-  for (const { body, map } of modules) {
+  for (const { body, map, source } of modules) {
     if (map) {
       const consumer = new SourceMapConsumer(map);
       consumer.eachMapping((m) => {
@@ -49,21 +54,23 @@ export function composeBundleSourceMap(
             column: m.generatedColumn,
           },
           original: { line: m.originalLine, column: m.originalColumn },
-          source: m.source,
+          source: source ?? m.source,
           name: m.name ?? undefined,
         });
         any = true;
       });
-      const sources = map.sources ?? [];
-      const contents =
-        (map as { sourcesContent?: (string | null)[] }).sourcesContent;
-      if (contents) {
-        sources.forEach((src, i) => {
-          const content = contents[i];
-          if (src != null && content != null) {
-            generator.setSourceContent(src, content);
-          }
-        });
+      if (!source) {
+        const sources = map.sources ?? [];
+        const contents =
+          (map as { sourcesContent?: (string | null)[] }).sourcesContent;
+        if (contents) {
+          sources.forEach((src, i) => {
+            const content = contents[i];
+            if (src != null && content != null) {
+              generator.setSourceContent(src, content);
+            }
+          });
+        }
       }
     }
     // Lines this body occupies in the "\n"-joined bundle = (newlines in body)+1.

--- a/packages/js-compiler/source-map.ts
+++ b/packages/js-compiler/source-map.ts
@@ -25,9 +25,15 @@ export type { MappedPosition };
 export function composeBundleSourceMap(
   modules: ReadonlyArray<{ body: string; map?: SourceMap }>,
   bundleFilename: string,
+  // Generated-line offset applied to the FIRST module. Use this when the
+  // generated text is wrapped by a fixed prefix of N lines (e.g. the ESM
+  // loader's `(function (exports, require, module) {\n` factory wrapper adds 1
+  // line before the compiled body), so coordinates from `new Error().stack`
+  // (1-based, relative to the eval'd string) map correctly.
+  startLineOffset = 0,
 ): SourceMap | undefined {
   const generator = new SourceMapGenerator({ file: bundleFilename });
-  let lineOffset = 0;
+  let lineOffset = startLineOffset;
   let any = false;
   for (const { body, map } of modules) {
     if (map) {

--- a/packages/js-compiler/source-map.ts
+++ b/packages/js-compiler/source-map.ts
@@ -84,9 +84,20 @@ export function composeBundleSourceMap(
 /**
  * Maximum number of source maps to cache in memory.
  * When exceeded, oldest (least recently used) entries are evicted.
- * Set conservatively to prevent OOM in long-running processes.
+ *
+ * Sized for the ESM module-record loader, which registers ONE map per load —
+ * the composed `${loadId}.js` bundle map — PLUS one map per module (keyed by the
+ * module's eval `//# sourceURL`) so the browser stack path can resolve each
+ * module's eval frame. A single multi-file load therefore registers
+ * `1 + moduleCount` entries that must all stay live until `loadModuleGraph`
+ * annotates functions; a small cap (the old value was 50) would evict the bundle
+ * map — and early per-module maps — mid-load for larger graphs, regressing
+ * `fn.src` to raw bundle coordinates and breaking CFC verified-source identity.
+ * This bound comfortably exceeds realistic per-load module counts while still
+ * capping total memory across loads (stale maps from superseded loads evict via
+ * LRU; the parser is also fully cleared on runtime dispose).
  */
-const MAX_SOURCE_MAP_CACHE_SIZE = 50;
+const MAX_SOURCE_MAP_CACHE_SIZE = 1024;
 
 // Parses strings like the following into function, filename, line and columns:
 /// ```

--- a/packages/js-compiler/source-map.ts
+++ b/packages/js-compiler/source-map.ts
@@ -59,10 +59,17 @@ export function composeBundleSourceMap(
         });
         any = true;
       });
-      if (!source) {
+      const contents =
+        (map as { sourcesContent?: (string | null)[] }).sourcesContent;
+      if (source) {
+        // Source overridden to a single full module path: register that
+        // module's content under the override name so DevTools can still show
+        // the authored text (parity with the AMD bundle map). Per-module
+        // compiler maps carry exactly one source, so the first content is it.
+        const content = contents?.find((c) => c != null);
+        if (content != null) generator.setSourceContent(source, content);
+      } else {
         const sources = map.sources ?? [];
-        const contents =
-          (map as { sourcesContent?: (string | null)[] }).sourcesContent;
         if (contents) {
           sources.forEach((src, i) => {
             const content = contents[i];

--- a/packages/js-compiler/test/source-map.test.ts
+++ b/packages/js-compiler/test/source-map.test.ts
@@ -357,4 +357,23 @@ describe("composeBundleSourceMap", () => {
     expect(pos.source).toBe("/id/dir/main.tsx");
     expect(pos.line).toBe(10);
   });
+
+  it("preserves sourcesContent under the overridden source name", () => {
+    const g = new SourceMapGenerator({ file: "a.js" });
+    g.addMapping({
+      generated: { line: 1, column: 0 },
+      original: { line: 10, column: 0 },
+      source: "main.tsx",
+    });
+    g.setSourceContent("main.tsx", "const authored = 1;");
+    const mapA = JSON.parse(g.toString());
+    const composed = composeBundleSourceMap(
+      [{ body: "x", map: mapA, source: "/id/dir/main.tsx" }],
+      "m.js",
+    )!;
+    // Content must be reachable under the OVERRIDDEN name (what the mappings
+    // now point at), so DevTools can display the authored source.
+    expect(composed.sourcesContent?.[composed.sources.indexOf("/id/dir/main.tsx")])
+      .toBe("const authored = 1;");
+  });
 });

--- a/packages/js-compiler/test/source-map.test.ts
+++ b/packages/js-compiler/test/source-map.test.ts
@@ -343,4 +343,18 @@ describe("composeBundleSourceMap", () => {
   it("returns undefined when no module has a map", () => {
     expect(composeBundleSourceMap([{ body: "x" }], "m.js")).toBe(undefined);
   });
+
+  it("overrides the recorded source path when `source` is given", () => {
+    // Compiler maps record only the basename; the override rewrites it to the
+    // full module path so resolved coordinates match the verified-source set.
+    const mapA = buildMap("a.js", [{ gen: 1, src: "main.tsx", orig: 10 }]);
+    const composed = composeBundleSourceMap(
+      [{ body: "x", map: mapA, source: "/id/dir/main.tsx" }],
+      "m.js",
+    )!;
+    const consumer = new SourceMapConsumer(composed);
+    const pos = consumer.originalPositionFor({ line: 1, column: 0 });
+    expect(pos.source).toBe("/id/dir/main.tsx");
+    expect(pos.line).toBe(10);
+  });
 });

--- a/packages/js-compiler/test/source-map.test.ts
+++ b/packages/js-compiler/test/source-map.test.ts
@@ -373,7 +373,9 @@ describe("composeBundleSourceMap", () => {
     )!;
     // Content must be reachable under the OVERRIDDEN name (what the mappings
     // now point at), so DevTools can display the authored source.
-    expect(composed.sourcesContent?.[composed.sources.indexOf("/id/dir/main.tsx")])
+    expect(
+      composed.sourcesContent?.[composed.sources.indexOf("/id/dir/main.tsx")],
+    )
       .toBe("const authored = 1;");
   });
 });

--- a/packages/js-compiler/test/source-map.test.ts
+++ b/packages/js-compiler/test/source-map.test.ts
@@ -1,13 +1,14 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
+  composeBundleSourceMap,
   getTypeScriptEnvironmentTypes,
   InMemoryProgram,
   SourceMapParser,
   TypeScriptCompiler,
 } from "../mod.ts";
 import { StaticCacheFS } from "@commonfabric/static";
-import { SourceMapConsumer } from "source-map-js";
+import { SourceMapConsumer, SourceMapGenerator } from "source-map-js";
 
 const staticCache = new StaticCacheFS();
 const types = await getTypeScriptEnvironmentTypes(staticCache);
@@ -282,5 +283,64 @@ export default errorOnLine6;
     // External files should be preserved unchanged
     expect(parsed).toContain("other-file.js:100:50");
     expect(parsed).toContain("https://example.com/lib.js:200:30");
+  });
+});
+
+describe("composeBundleSourceMap", () => {
+  const buildMap = (
+    file: string,
+    mappings: Array<{ gen: number; src: string; orig: number }>,
+  ) => {
+    const g = new SourceMapGenerator({ file });
+    for (const m of mappings) {
+      g.addMapping({
+        generated: { line: m.gen, column: 0 },
+        original: { line: m.orig, column: 0 },
+        source: m.src,
+      });
+    }
+    return JSON.parse(g.toString());
+  };
+
+  it("offsets each module's generated lines by its start in the joined bundle", () => {
+    const mapA = buildMap("a.js", [
+      { gen: 1, src: "a.ts", orig: 10 },
+      { gen: 2, src: "a.ts", orig: 11 },
+    ]);
+    const mapB = buildMap("b.js", [{ gen: 1, src: "b.ts", orig: 20 }]);
+    // Bodies joined with "\n": A occupies bundle lines 1..3 (3 lines), so B's
+    // gen line 1 lands at bundle line 4.
+    const composed = composeBundleSourceMap(
+      [{ body: "x\ny\nz", map: mapA }, { body: "p\nq", map: mapB }],
+      "bundle.js",
+    )!;
+    const consumer = new SourceMapConsumer(composed);
+    expect(consumer.originalPositionFor({ line: 1, column: 0 }).source).toBe(
+      "a.ts",
+    );
+    expect(consumer.originalPositionFor({ line: 1, column: 0 }).line).toBe(10);
+    const b = consumer.originalPositionFor({ line: 4, column: 0 });
+    expect(b.source).toBe("b.ts");
+    expect(b.line).toBe(20);
+  });
+
+  it("applies startLineOffset to the first module (eval wrapper line)", () => {
+    const mapA = buildMap("a.js", [{ gen: 1, src: "a.ts", orig: 10 }]);
+    // startLineOffset 1 mirrors the `(function (...) {` wrapper: the body's
+    // gen line 1 maps to bundle line 2.
+    const composed = composeBundleSourceMap(
+      [{ body: "x", map: mapA }],
+      "m.js",
+      1,
+    )!;
+    const consumer = new SourceMapConsumer(composed);
+    expect(consumer.originalPositionFor({ line: 2, column: 0 }).source).toBe(
+      "a.ts",
+    );
+    expect(consumer.originalPositionFor({ line: 2, column: 0 }).line).toBe(10);
+  });
+
+  it("returns undefined when no module has a map", () => {
+    expect(composeBundleSourceMap([{ body: "x" }], "m.js")).toBe(undefined);
   });
 });

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -423,10 +423,17 @@ export class Engine extends EventTarget implements Harness {
       // `fn.src` / CFC verified-source coordinates (resolved against `script`)
       // map back to the original authored sources — without this the ESM loader
       // yields raw bundle coordinates and CFC verified-source fails closed.
+      // Full module path per specifier (the verified-source set is keyed by
+      // these, not the basename the compiler records in the map's `sources`).
+      const sourceNameBySpecifier = new Map<string, string>();
+      for (const [name, specifier] of graph.specifierByPath) {
+        sourceNameBySpecifier.set(specifier, name);
+      }
       const bundleSourceMap = composeBundleSourceMap(
         [...graph.compiledBodies].map(([specifier, body]) => ({
           body,
           map: graph.moduleSourceMaps.get(specifier),
+          source: sourceNameBySpecifier.get(specifier),
         })),
         `${loadId}.js`,
       );
@@ -446,7 +453,7 @@ export class Engine extends EventTarget implements Harness {
         if (!map) continue;
         const sourceUrl = name.replace(/[\r\n\u2028\u2029]/g, "_");
         const moduleMap = composeBundleSourceMap(
-          [{ body: "", map }],
+          [{ body: "", map, source: name }],
           sourceUrl,
           1, // the `(function (exports, require, module) {` wrapper line
         );

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -433,6 +433,25 @@ export class Engine extends EventTarget implements Harness {
       if (bundleSourceMap) {
         this.getSESRuntime().loadSourceMap(`${loadId}.js`, bundleSourceMap);
       }
+      // ALSO register each module's map under its eval `//# sourceURL` (its
+      // sanitized source name). The browser surfaces the per-module eval frame
+      // in `new Error().stack`, and `annotateFunctionDebugMetadata` resolves
+      // `fn.src` from that frame FIRST (the indexOf-into-`script` fallback that
+      // `${loadId}.js` covers only wins when the stack frame is absent, e.g.
+      // under Deno's tamed SES stacks). The frame is keyed on the per-module
+      // sourceURL with eval-relative line numbers, so register the per-module
+      // map shifted by the factory-wrapper line (`(function (...) {\n` = +1).
+      for (const [name, specifier] of graph.specifierByPath) {
+        const map = graph.moduleSourceMaps.get(specifier);
+        if (!map) continue;
+        const sourceUrl = name.replace(/[\r\n\u2028\u2029]/g, "_");
+        const moduleMap = composeBundleSourceMap(
+          [{ body: "", map }],
+          sourceUrl,
+          1, // the `(function (exports, require, module) {` wrapper line
+        );
+        if (moduleMap) this.getSESRuntime().loadSourceMap(sourceUrl, moduleMap);
+      }
       // Verified-load sources: the original file names plus the prefixed module
       // paths (both normalized), so CFC's isVerifiedSourceInLoad recognizes the
       // source locations of functions defined by this load.


### PR DESCRIPTION
## Context

Follow-up to #3785. The canary (#3782) showed #3785 cleared the CLI path (`fuse`) but **browser** CFC tests (`cfc-group-chat-demo`, `shared-profile`) still timed out under ESM.

**Root cause (traced):** `annotateFunctionDebugMetadata` resolves `fn.src` from **two** paths — the `new Error().stack` frame (tried first) and the `indexOf`-into-concatenated-`script` fallback. #3785 registered the composed map only under `${loadId}.js` (the fallback's key). Under **Deno**, SES tames the stack so the stack path returns null and the fixed fallback wins (why #3785's Deno test passes). Under the **browser**, V8 surfaces the per-module eval frame (`//# sourceURL=/<id>/main.tsx`) → the stack path runs, keyed on the per-module sourceURL where **no map is registered** → raw bundle coordinate → CFC verified-source fails closed → trusted action hangs.

## Fix

In `evaluateRecordGraph`, also register each module's source map under its eval `sourceURL` (sanitized source name), shifted by the factory-wrapper line (`(function (exports, require, module) {\n` = **+1**) so eval-relative stack coordinates map to authored source. Adds a `startLineOffset` param to `composeBundleSourceMap`. The `${loadId}.js` composed map stays for the Deno fallback path.

## Validation

- Unit tests for `composeBundleSourceMap` (line-offset composition + `startLineOffset`).
- #3785's Deno e2e regression still passes (no regression to the fallback path).
- **Browser proof:** the flag-flip canary (#3782), rebased onto this branch, must show `cfc-group-chat-demo` + `shared-profile` go green under ESM. (Linked in a comment once CI runs.)

Scope: ESM-loader path only (default-off flag) + an additive `startLineOffset` param in js-compiler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ESM source mapping by registering per-module maps under their eval `sourceURL` with a +1 wrapper offset and by overriding map sources to full module paths in the composed bundle. Also raises the source-map cache to avoid evictions during large ESM loads, restoring browser CFC verified-source while keeping the Deno fallback intact.

- **Bug Fixes**
  - Register per-module maps under eval `sourceURL` (sanitized) and shift +1 line for the factory wrapper.
  - Add `startLineOffset` and a `source` override to `composeBundleSourceMap`; pass full module paths so resolved coordinates match verified-source; preserve `sourcesContent` under the overridden source name for DevTools.
  - Keep the `${loadId}.js` composed map for the Deno fallback; raise the source-map cache to 1024; add tests for offsets, source override, and `sourcesContent`.

<sup>Written for commit 79daaa7c9fa5234df6e4ed58214f4afcf0d6a6a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

