### PR TITLE
[codex] Add Browser Access lease profile metadata

### DIFF
--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -15,7 +15,9 @@ import {
 } from "./image-attachments.ts";
 import type { HarnessImageAttachment } from "./contracts/image.ts";
 import {
+  HARNESS_BROWSER_ACCESS_ACCOUNT_ACCESS,
   HARNESS_BROWSER_ACCESS_LEASE_TYPE,
+  HARNESS_BROWSER_ACCESS_PROFILE_MODES,
   type HarnessBrowserAccessLease,
 } from "./contracts/browser-access.ts";
 import {
@@ -107,6 +109,8 @@ const CLI_STRING_FLAGS = [
   "browser-access-cdp-url",
   "browser-access-owner",
   "browser-access-expires-at",
+  "browser-access-profile-mode",
+  "browser-access-account-access",
 ] as const;
 const CLI_BOOLEAN_FLAGS = [
   "help",
@@ -312,6 +316,8 @@ Options:
   --browser-access-cdp-url <url> Local CDP origin for the Browser Access lease
   --browser-access-owner <name>  Optional owner label for the Browser Access lease
   --browser-access-expires-at <t> Optional lease expiry timestamp
+  --browser-access-profile-mode <mode> persistent | transient
+  --browser-access-account-access <access> available | none
   --cfc-enforcement-mode <mode> disabled | observe | enforce-explicit | enforce-strict
   --sandbox-image <image>       Docker image for the runsc-cfc sandbox (default: ${DEFAULT_DOCKER_RUNSC_IMAGE})
   --fabric-mount <path>         Host path for a Fabric FUSE mount (mounted at /fabric in the sandbox)
@@ -501,6 +507,20 @@ const optionalStringArg = (
   return typeof raw === "string" ? raw.trim() : undefined;
 };
 
+const optionalStringValue = <T extends string>(
+  value: string | undefined,
+  allowed: readonly T[],
+  flagName: string,
+): T | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+  if ((allowed as readonly string[]).includes(value)) {
+    return value as T;
+  }
+  throw new Error(`${flagName} must be one of: ${allowed.join(", ")}`);
+};
+
 const parseBrowserAccessLease = (
   args: ReturnType<typeof parseArgs>,
 ): HarnessBrowserAccessLease | undefined => {
@@ -508,10 +528,22 @@ const parseBrowserAccessLease = (
   const cdpUrl = optionalStringArg(args, "browser-access-cdp-url");
   const owner = optionalStringArg(args, "browser-access-owner");
   const expiresAt = optionalStringArg(args, "browser-access-expires-at");
+  const profileMode = optionalStringValue(
+    optionalStringArg(args, "browser-access-profile-mode"),
+    HARNESS_BROWSER_ACCESS_PROFILE_MODES,
+    "--browser-access-profile-mode",
+  );
+  const accountAccess = optionalStringValue(
+    optionalStringArg(args, "browser-access-account-access"),
+    HARNESS_BROWSER_ACCESS_ACCOUNT_ACCESS,
+    "--browser-access-account-access",
+  );
   const anyProvided = leaseId !== undefined ||
     cdpUrl !== undefined ||
     owner !== undefined ||
-    expiresAt !== undefined;
+    expiresAt !== undefined ||
+    profileMode !== undefined ||
+    accountAccess !== undefined;
   if (!anyProvided) {
     return undefined;
   }
@@ -537,6 +569,8 @@ const parseBrowserAccessLease = (
     cdpUrl: normalizedCdpUrl,
     ...(owner !== undefined && owner.length > 0 ? { owner } : {}),
     ...(expiresAt !== undefined && expiresAt.length > 0 ? { expiresAt } : {}),
+    ...(profileMode !== undefined ? { profileMode } : {}),
+    ...(accountAccess !== undefined ? { accountAccess } : {}),
   };
 };
 

--- a/packages/cf-harness/src/contracts/browser-access.ts
+++ b/packages/cf-harness/src/contracts/browser-access.ts
@@ -1,10 +1,28 @@
 export const HARNESS_BROWSER_ACCESS_LEASE_TYPE =
   "cf-harness.chat.browser-access-lease" as const;
 
+export const HARNESS_BROWSER_ACCESS_PROFILE_MODES = [
+  "persistent",
+  "transient",
+] as const;
+
+export type HarnessBrowserAccessProfileMode =
+  typeof HARNESS_BROWSER_ACCESS_PROFILE_MODES[number];
+
+export const HARNESS_BROWSER_ACCESS_ACCOUNT_ACCESS = [
+  "available",
+  "none",
+] as const;
+
+export type HarnessBrowserAccessAccountAccess =
+  typeof HARNESS_BROWSER_ACCESS_ACCOUNT_ACCESS[number];
+
 export interface HarnessBrowserAccessLease {
   type: typeof HARNESS_BROWSER_ACCESS_LEASE_TYPE;
   leaseId: string;
   cdpUrl: string;
   owner?: string;
   expiresAt?: string;
+  profileMode?: HarnessBrowserAccessProfileMode;
+  accountAccess?: HarnessBrowserAccessAccountAccess;
 }

--- a/packages/cf-harness/src/interactive-chat-stdio.ts
+++ b/packages/cf-harness/src/interactive-chat-stdio.ts
@@ -9,7 +9,11 @@ import {
   type HarnessChatRequestMethod,
   type HarnessChatResponse,
 } from "./contracts/interactive-chat.ts";
-import { HARNESS_BROWSER_ACCESS_LEASE_TYPE } from "./contracts/browser-access.ts";
+import {
+  HARNESS_BROWSER_ACCESS_ACCOUNT_ACCESS,
+  HARNESS_BROWSER_ACCESS_LEASE_TYPE,
+  HARNESS_BROWSER_ACCESS_PROFILE_MODES,
+} from "./contracts/browser-access.ts";
 import { normalizePromptSlotBinding } from "./contracts/prompt-slot.ts";
 import {
   HARNESS_SUBAGENT_PROFILES,
@@ -175,6 +179,14 @@ const hasOptionalString = (
   key: string,
 ): boolean => value[key] === undefined || typeof value[key] === "string";
 
+const hasOptionalStringIn = (
+  value: Record<string, unknown>,
+  key: string,
+  allowedValues: readonly string[],
+): boolean =>
+  value[key] === undefined ||
+  (typeof value[key] === "string" && allowedValues.includes(value[key]));
+
 const hasOptionalNonNegativeInteger = (
   value: Record<string, unknown>,
   key: string,
@@ -226,7 +238,17 @@ const isValidBrowserAccessParam = (value: unknown): boolean =>
   isNonEmptyString(value.leaseId) &&
   isNonEmptyString(value.cdpUrl) &&
   hasOptionalString(value, "owner") &&
-  hasOptionalString(value, "expiresAt");
+  hasOptionalString(value, "expiresAt") &&
+  hasOptionalStringIn(
+    value,
+    "profileMode",
+    HARNESS_BROWSER_ACCESS_PROFILE_MODES,
+  ) &&
+  hasOptionalStringIn(
+    value,
+    "accountAccess",
+    HARNESS_BROWSER_ACCESS_ACCOUNT_ACCESS,
+  );
 
 const isValidChatPolicyParam = (value: unknown): boolean =>
   isRecord(value) &&

--- a/packages/cf-harness/src/prompt-loop.ts
+++ b/packages/cf-harness/src/prompt-loop.ts
@@ -756,6 +756,21 @@ const buildSubagentSystemPrompt = (
               ? [
                 `Browser Access lease: ${options.browserAccess.leaseId}`,
                 `Browser Access CDP endpoint: ${options.browserAccess.cdpUrl}`,
+                `Browser Access profile mode: ${
+                  options.browserAccess.profileMode ?? "persistent"
+                }`,
+                `Browser Access account access: ${
+                  options.browserAccess.accountAccess ??
+                    (options.browserAccess.profileMode === "transient"
+                      ? "none"
+                      : "available")
+                }`,
+                ...(options.browserAccess.profileMode === "transient" ||
+                    options.browserAccess.accountAccess === "none"
+                  ? [
+                    "This Browser Access lease uses a temporary no-login profile. Do not assume cookies, logged-in accounts, saved sessions, or user account state are available.",
+                  ]
+                  : []),
                 `Use agent-browser --cdp ${options.browserAccess.cdpUrl} for page commands. Do not use any other CDP endpoint.`,
               ]
               : [

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -753,6 +753,10 @@ Deno.test("parseCfHarnessCliArgs supports a Browser Access lease", async () => {
       "pattern-factory",
       "--browser-access-expires-at",
       "2026-05-29T22:00:00Z",
+      "--browser-access-profile-mode",
+      "transient",
+      "--browser-access-account-access",
+      "none",
     ],
     {
       cwd: "/tmp/project",
@@ -769,6 +773,8 @@ Deno.test("parseCfHarnessCliArgs supports a Browser Access lease", async () => {
     cdpUrl: "http://127.0.0.1:9363",
     owner: "pattern-factory",
     expiresAt: "2026-05-29T22:00:00Z",
+    profileMode: "transient",
+    accountAccess: "none",
   });
 });
 
@@ -825,6 +831,69 @@ Deno.test("parseCfHarnessCliArgs rejects malformed Browser Access leases", async
       ),
     Error,
     "--browser-access-cdp-url must be an http:// local origin with an explicit port",
+  );
+  await assertRejects(
+    () =>
+      parseCfHarnessCliArgs(
+        [
+          "--prompt",
+          "hi",
+          "--browser-access-lease-id",
+          "pf-run-1",
+          "--browser-access-cdp-url",
+          "http://127.0.0.1:9363",
+          "--browser-access-profile-mode",
+          "loggedout",
+        ],
+        {
+          cwd: "/tmp/project",
+          env: {},
+        },
+      ),
+    Error,
+    "--browser-access-profile-mode must be one of: persistent, transient",
+  );
+  await assertRejects(
+    () =>
+      parseCfHarnessCliArgs(
+        [
+          "--prompt",
+          "hi",
+          "--browser-access-lease-id",
+          "pf-run-1",
+          "--browser-access-cdp-url",
+          "http://127.0.0.1:9363",
+          "--browser-access-profile-mode",
+          "",
+        ],
+        {
+          cwd: "/tmp/project",
+          env: {},
+        },
+      ),
+    Error,
+    "--browser-access-profile-mode must be one of: persistent, transient",
+  );
+  await assertRejects(
+    () =>
+      parseCfHarnessCliArgs(
+        [
+          "--prompt",
+          "hi",
+          "--browser-access-lease-id",
+          "pf-run-1",
+          "--browser-access-cdp-url",
+          "http://127.0.0.1:9363",
+          "--browser-access-account-access",
+          "",
+        ],
+        {
+          cwd: "/tmp/project",
+          env: {},
+        },
+      ),
+    Error,
+    "--browser-access-account-access must be one of: available, none",
   );
 });
 
@@ -1218,6 +1287,10 @@ Deno.test("runCfHarnessCli prints machine-readable capabilities", async () => {
   );
   assertEquals(
     capabilities.cliFlags.includes("--browser-access-cdp-url"),
+    true,
+  );
+  assertEquals(
+    capabilities.cliFlags.includes("--browser-access-profile-mode"),
     true,
   );
   assertEquals(capabilities.cliFlags.includes("--describe-capabilities"), true);

--- a/packages/cf-harness/test/interactive-chat-stdio.test.ts
+++ b/packages/cf-harness/test/interactive-chat-stdio.test.ts
@@ -995,6 +995,8 @@ Deno.test("interactive NDJSON transport accepts valid Browser Access leases", as
             leaseId: "lease-1",
             cdpUrl: "http://127.0.0.1:9222",
             owner: "loom",
+            profileMode: "transient",
+            accountAccess: "none",
           },
         },
       }),
@@ -1010,5 +1012,39 @@ Deno.test("interactive NDJSON transport accepts valid Browser Access leases", as
   assertEquals(
     response !== undefined && "ok" in response ? response.ok : false,
     true,
+  );
+});
+
+Deno.test("interactive NDJSON transport rejects invalid Browser Access profile mode", async () => {
+  const output: string[] = [];
+  await runHarnessInteractiveChatNdjsonTransport({
+    lines: [
+      JSON.stringify({
+        type: HARNESS_CHAT_REQUEST_TYPE,
+        protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+        requestId: "req-bad-browser-mode",
+        method: "start_session",
+        params: {
+          sessionId: "session-1",
+          workspace: { hostPath: "/workspace" },
+          browserAccess: {
+            type: HARNESS_BROWSER_ACCESS_LEASE_TYPE,
+            leaseId: "lease-1",
+            cdpUrl: "http://127.0.0.1:9222",
+            profileMode: "loggedout",
+          },
+        },
+      }),
+    ],
+    writeLine: (line) => {
+      output.push(line);
+    },
+  });
+
+  const response = decodeLines(output)[0];
+  assertEquals("ok" in response ? response.ok : true, false);
+  assertEquals(
+    "ok" in response && response.ok === false ? response.error.code : "",
+    "invalid_request",
   );
 });

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -2338,6 +2338,8 @@ Deno.test("CfHarnessPromptLoop includes Browser Access lease instructions for br
       leaseId: "lease-browser-1",
       cdpUrl: "http://127.0.0.1:9222",
       owner: "loom",
+      profileMode: "transient",
+      accountAccess: "none",
     },
     engine: new CfHarnessEngine({
       sandboxRuntime: new FakeSandboxRuntime(),
@@ -2411,6 +2413,18 @@ Deno.test("CfHarnessPromptLoop includes Browser Access lease instructions for br
   assertStringIncludes(
     childSystemPrompt,
     "Browser Access CDP endpoint: http://127.0.0.1:9222",
+  );
+  assertStringIncludes(
+    childSystemPrompt,
+    "Browser Access profile mode: transient",
+  );
+  assertStringIncludes(
+    childSystemPrompt,
+    "Browser Access account access: none",
+  );
+  assertStringIncludes(
+    childSystemPrompt,
+    "temporary no-login profile",
   );
   assertStringIncludes(
     childSystemPrompt,


### PR DESCRIPTION
## Summary

Adds explicit Browser Access lease metadata for cf-harness so callers can distinguish authenticated persistent browser leases from transient no-login leases before Loom starts selecting between those lanes.

Changes include:
- extend `HarnessBrowserAccessLease` with optional `profileMode` (`persistent`/`transient`) and `accountAccess` (`available`/`none`) fields
- add `--browser-access-profile-mode` and `--browser-access-account-access` CLI flags and expose them in capabilities output
- validate the new fields in the interactive chat NDJSON transport boundary
- thread the metadata into browser subagent instructions, including explicit no-cookie/no-login guidance for transient/no-account leases

## Validation

- `deno fmt --check packages/cf-harness/src/contracts/browser-access.ts packages/cf-harness/src/cli.ts packages/cf-harness/src/interactive-chat-stdio.ts packages/cf-harness/src/prompt-loop.ts packages/cf-harness/test/cli.test.ts packages/cf-harness/test/interactive-chat-stdio.test.ts packages/cf-harness/test/prompt-loop.test.ts`
- `deno check packages/cf-harness/src/contracts/browser-access.ts packages/cf-harness/src/cli.ts packages/cf-harness/src/interactive-chat-stdio.ts packages/cf-harness/src/prompt-loop.ts packages/cf-harness/test/cli.test.ts packages/cf-harness/test/interactive-chat-stdio.test.ts packages/cf-harness/test/prompt-loop.test.ts`
- `deno lint packages/cf-harness/src/contracts/browser-access.ts packages/cf-harness/src/cli.ts packages/cf-harness/src/interactive-chat-stdio.ts packages/cf-harness/src/prompt-loop.ts packages/cf-harness/test/cli.test.ts packages/cf-harness/test/interactive-chat-stdio.test.ts packages/cf-harness/test/prompt-loop.test.ts`
- `deno task test` in `packages/cf-harness`: 381 passed, 0 failed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Browser Access lease profile metadata to `cf-harness` so callers and subagents can tell persistent vs transient sessions and whether account access is available. This reduces login/cookie assumptions and guides the browser subagent accordingly.

- **New Features**
  - Extend `HarnessBrowserAccessLease` with optional `profileMode` (`persistent` | `transient`) and `accountAccess` (`available` | `none`).
  - Add CLI flags: `--browser-access-profile-mode` and `--browser-access-account-access`; included in capabilities output.
  - Validate these fields in the interactive NDJSON API and CLI parsing, with clear errors on invalid values.
  - Include the metadata in subagent system prompts with safe defaults (profileMode defaults to `persistent`; accountAccess defaults to `none` when `transient`, otherwise `available`) and explicit no-cookie/no-login guidance for transient/no-account leases.

<sup>Written for commit 65fec7d65fe088bf9a6bd4a00d97de49730faba7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

