### PR TITLE
fix(cozy-poll-scoped): restore vote dimming (resolve myName at top level)

### DIFF
--- a/packages/patterns/cozy-poll-scoped/main.tsx
+++ b/packages/patterns/cozy-poll-scoped/main.tsx
@@ -610,6 +610,12 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     const recentHistory = computed(() =>
       [...history].sort((a, b) => b.wentAt - a.wentAt).slice(0, 8)
     );
+    // Resolve the viewer's name ONCE here at the top level. PerUser `myName`
+    // resolves in this scope, but NOT inside the per-option `options.map(...)`
+    // lift — there `trimmedName(myName)` was handed an unresolved ref and threw
+    // `(n ?? "").trim is not a function`, silently nulling out each option's
+    // `myVote` (so nothing dimmed). Passing this resolved value down avoids it.
+    const me = trimmedName(myName);
     const isJoined = trimmedName(myName) !== "";
     const isAdmin = trimmedName(myName) !== "" &&
       trimmedName(myName) === trimmedName(adminName);
@@ -1073,7 +1079,10 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                 {options.map((option) => {
                   const oid = option.id;
                   const optionTitle = option.title;
-                  const myVote = myVoteFor(votes, trimmedName(myName), oid);
+                  // Use the top-level-resolved `me`, not `trimmedName(myName)`:
+                  // the raw PerUser ref doesn't resolve inside this per-option
+                  // lift (see `me` above).
+                  const myVote = myVoteFor(votes, me, oid);
                   const rank = computed(() => {
                     const idx = ranked.findIndex(
                       (t) => t.option.id === oid,


### PR DESCRIPTION
## What

Restores the per-option vote dimming: clicking 🟢/🟡/🔴 on a line should dim the
other two color buttons to highlight your choice. It had silently stopped
working — every button stayed at full strength regardless of your vote.

## Root cause

`myVote` is computed per option inside `options.map(...)` as
`myVoteFor(votes, trimmedName(myName), oid)`. The **PerUser `myName` ref
resolves at the recipe top level** (e.g. `isJoined = trimmedName(myName) !== ""`
works) **but NOT inside that per-option lift** — there `trimmedName(myName)`
received an unresolved ref and threw `(n ?? "").trim is not a function`. The
lift swallowed the throw, so every `myVote` came back `undefined` (no console
error) and the dim/highlight style expression was always empty.

Confirmed by a temporary `str` readout of `trimmedName(myName)` inside the row,
which crashed loudly with that `.trim` error while the silent per-option lift
hid it.

## Fix

Resolve the viewer's name **once at the top level**
(`const me = trimmedName(myName)`, same scope where `isJoined` already works)
and pass that plain value into the per-option lookup
(`myVoteFor(votes, me, oid)`), so the per-option lift never touches the
unresolved PerUser ref. +10 / −1, no schema or behavior changes elsewhere.

## Not in scope / notes

- The `aria-hidden` console warning observed alongside this comes from the
  `cf-button` web component's own shadow-DOM design (it aria-hides its inner
  `<button>`); it is unrelated to the dimming logic and not addressed here.
- Verified locally (join → vote → dim/clear). Pattern tests `16/16`, `deno fmt
  --check` clean, `deno task cf check … --no-run` clean.

Thanks to @mpsalisbury for the report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores per-option vote dimming in `cozy-poll-scoped`. Selecting 🟢/🟡/🔴 now dims the other two buttons as intended.

- **Bug Fixes**
  - Root cause: `trimmedName(myName)` didn’t resolve inside `options.map(...)`, throwing and leaving `myVote` undefined.
  - Fix: resolve the viewer name once at the top level (`const me = trimmedName(myName)`) and pass `me` to `myVoteFor(votes, me, oid)`.

<sup>Written for commit e049c39596df561f7cefcc2c6585116bab460c6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

