### PR TITLE
Make local dev startup verify readiness

### DIFF
--- a/docs/development/LOCAL_DEV_SERVERS.md
+++ b/docs/development/LOCAL_DEV_SERVERS.md
@@ -17,6 +17,10 @@
 ./scripts/check-local-dev.sh          # Health check both servers
 ```
 
+`start-local-dev.sh` validates required commands before launching anything and
+waits for both servers to return HTTP 200 before reporting success. Set
+`LOCAL_DEV_STARTUP_TIMEOUT` to adjust the readiness timeout in seconds.
+
 **URLs:**
 | What | URL |
 |------|-----|

--- a/scripts/start-local-dev.sh
+++ b/scripts/start-local-dev.sh
@@ -200,9 +200,13 @@ ensure_process_running() {
     local name=$1
     local pid=$2
     local log_file=$3
+    local process_state
 
     if kill -0 "$pid" 2>/dev/null; then
-        return
+        process_state=$(ps -p "$pid" -o stat= 2>/dev/null)
+        if [[ "$process_state" != *Z* ]]; then
+            return
+        fi
     fi
 
     wait "$pid" 2>/dev/null
@@ -218,14 +222,21 @@ wait_for_http() {
     local url=$2
     local pid=$3
     local log_file=$4
+    local deadline=$((SECONDS + LOCAL_DEV_STARTUP_TIMEOUT))
+    local remaining
     local status
 
     echo "Waiting for $name at $url..."
-    for _ in $(seq 1 "$LOCAL_DEV_STARTUP_TIMEOUT"); do
+    while (( SECONDS < deadline )); do
         ensure_process_running "$name" "$pid" "$log_file"
 
+        remaining=$((deadline - SECONDS))
+        if (( remaining > 2 )); then
+            remaining=2
+        fi
+
         status=$(
-            curl -s -o /dev/null -w "%{http_code}" --max-time 2 \
+            curl -s -o /dev/null -w "%{http_code}" --max-time "$remaining" \
                 "$url" 2>/dev/null
         )
         if [[ "$status" == "200" ]]; then
@@ -233,7 +244,9 @@ wait_for_http() {
             return
         fi
 
-        sleep 1
+        if (( SECONDS < deadline )); then
+            sleep 1
+        fi
     done
 
     fail_startup \
@@ -244,8 +257,6 @@ wait_for_http() {
 cd "$SCRIPT_DIR/../packages/shell"
 TOOLSHED_PORT="$TOOLSHED_PORT" deno task dev-local > "$SHELL_LOG" 2>&1 &
 SHELL_PID=$!
-
-wait_for_http "shell" "http://localhost:$SHELL_PORT" "$SHELL_PID" "$SHELL_LOG"
 
 # Start toolshed dev server in background
 # We pass --port= as CLI arg because deno --watch doesn't pass env vars to subprocess
@@ -267,6 +278,8 @@ SHELL_URL="http://localhost:$SHELL_PORT" \
         --env-file=.env index.ts --port="$TOOLSHED_PORT" \
         > "$TOOLSHED_LOG" 2>&1 &
 TOOLSHED_PID=$!
+
+wait_for_http "shell" "http://localhost:$SHELL_PORT" "$SHELL_PID" "$SHELL_LOG"
 
 # # Function to cleanup background processes
 # cleanup() {

--- a/scripts/start-local-dev.sh
+++ b/scripts/start-local-dev.sh
@@ -7,6 +7,19 @@ cd "$SCRIPT_DIR/.."
 source "$SCRIPT_DIR/common/port-utils.sh"
 read_base_ports
 
+require_command() {
+    local command_name=$1
+    local install_hint=$2
+
+    if ! command -v "$command_name" &>/dev/null; then
+        echo "Error: $command_name is required but not found." >&2
+        if [[ -n "$install_hint" ]]; then
+            echo "       $install_hint" >&2
+        fi
+        exit 1
+    fi
+}
+
 # Default ports and offset
 PORT_OFFSET=${PORT_OFFSET:-0}
 SHELL_PORT=${SHELL_PORT:-}
@@ -14,6 +27,7 @@ TOOLSHED_PORT=${TOOLSHED_PORT:-}
 INSPECT=false
 INSPECT_BRK=false
 INSPECT_PORT=${INSPECT_PORT:-}
+LOCAL_DEV_STARTUP_TIMEOUT=${LOCAL_DEV_STARTUP_TIMEOUT:-120}
 
 # Parse command line arguments
 FORCE=false
@@ -91,10 +105,22 @@ INSPECT_PORT=${INSPECT_PORT:-$((BASE_INSPECTOR_PORT + PORT_OFFSET))}
 export SHELL_PORT
 export TOOLSHED_PORT
 
+require_command "deno" \
+    "Run 'mise install' from the repo root or install Deno before starting local dev."
+require_command "curl" \
+    "Install curl so startup can verify that local dev servers reached HTTP 200."
+
 KEEP_ALIVE=false
 if [[ -n "${CODEX_SANDBOX:-}" ]]; then
     KEEP_ALIVE=true
 fi
+
+SHELL_LOG="$SCRIPT_DIR/../packages/shell/local-dev-shell.log"
+TOOLSHED_LOG="$SCRIPT_DIR/../packages/toolshed/local-dev-toolshed.log"
+BG_LOG="$SCRIPT_DIR/../packages/background-charm-service/local-dev-bg.log"
+SHELL_PID=""
+TOOLSHED_PID=""
+BG_PID=""
 
 # Check if port is free; kill processes if --force, otherwise error
 check_port() {
@@ -124,17 +150,106 @@ check_port() {
 check_port "$TOOLSHED_PORT"
 check_port "$SHELL_PORT"
 
+show_recent_log() {
+    local name=$1
+    local log_file=$2
+
+    if [[ -f "$log_file" ]]; then
+        echo "" >&2
+        echo "Last 40 lines from $name log ($log_file):" >&2
+        tail -n 40 "$log_file" >&2
+    fi
+}
+
+kill_port_listeners() {
+    local port=$1
+    local pids
+    pids=$(get_pids_on_port "$port")
+
+    for pid in $pids; do
+        kill "$pid" 2>/dev/null
+    done
+}
+
+cleanup_started_processes() {
+    if [[ -n "$BG_PID" ]]; then
+        kill "$BG_PID" 2>/dev/null
+    fi
+    if [[ -n "$TOOLSHED_PID" ]]; then
+        kill "$TOOLSHED_PID" 2>/dev/null
+    fi
+    if [[ -n "$SHELL_PID" ]]; then
+        kill "$SHELL_PID" 2>/dev/null
+    fi
+
+    kill_port_listeners "$TOOLSHED_PORT"
+    kill_port_listeners "$SHELL_PORT"
+}
+
+fail_startup() {
+    local message=$1
+
+    echo "Error: $message" >&2
+    cleanup_started_processes
+    show_recent_log "shell" "$SHELL_LOG"
+    show_recent_log "toolshed" "$TOOLSHED_LOG"
+    exit 1
+}
+
+ensure_process_running() {
+    local name=$1
+    local pid=$2
+    local log_file=$3
+
+    if kill -0 "$pid" 2>/dev/null; then
+        return
+    fi
+
+    wait "$pid" 2>/dev/null
+    local exit_status=$?
+    echo "Error: $name exited before it became ready (exit $exit_status)." >&2
+    cleanup_started_processes
+    show_recent_log "$name" "$log_file"
+    exit 1
+}
+
+wait_for_http() {
+    local name=$1
+    local url=$2
+    local pid=$3
+    local log_file=$4
+    local status
+
+    echo "Waiting for $name at $url..."
+    for _ in $(seq 1 "$LOCAL_DEV_STARTUP_TIMEOUT"); do
+        ensure_process_running "$name" "$pid" "$log_file"
+
+        status=$(
+            curl -s -o /dev/null -w "%{http_code}" --max-time 2 \
+                "$url" 2>/dev/null
+        )
+        if [[ "$status" == "200" ]]; then
+            echo "  $name is ready."
+            return
+        fi
+
+        sleep 1
+    done
+
+    fail_startup \
+        "$name did not become ready at $url within ${LOCAL_DEV_STARTUP_TIMEOUT}s."
+}
+
 # Start shell dev server in background
-cd packages/shell
-TOOLSHED_PORT="$TOOLSHED_PORT" deno task dev-local > local-dev-shell.log 2>&1 &
+cd "$SCRIPT_DIR/../packages/shell"
+TOOLSHED_PORT="$TOOLSHED_PORT" deno task dev-local > "$SHELL_LOG" 2>&1 &
 SHELL_PID=$!
 
-# Wait a moment for shell to start
-sleep 2
+wait_for_http "shell" "http://localhost:$SHELL_PORT" "$SHELL_PID" "$SHELL_LOG"
 
 # Start toolshed dev server in background
 # We pass --port= as CLI arg because deno --watch doesn't pass env vars to subprocess
-cd ../toolshed
+cd "$SCRIPT_DIR/../packages/toolshed"
 WATCH_FLAG=""
 if [[ "$WATCH" == "true" ]]; then
     WATCH_FLAG="--watch"
@@ -148,7 +263,9 @@ if [[ "$INSPECT" == "true" ]]; then
     fi
 fi
 SHELL_URL="http://localhost:$SHELL_PORT" \
-    deno run --unstable-otel -A $INSPECT_FLAG $WATCH_FLAG --env-file=.env index.ts --port="$TOOLSHED_PORT" > local-dev-toolshed.log 2>&1 &
+    deno run --unstable-otel -A $INSPECT_FLAG $WATCH_FLAG \
+        --env-file=.env index.ts --port="$TOOLSHED_PORT" \
+        > "$TOOLSHED_LOG" 2>&1 &
 TOOLSHED_PID=$!
 
 # # Function to cleanup background processes
@@ -160,8 +277,9 @@ TOOLSHED_PID=$!
 # # Set up trap to cleanup on script exit
 # trap cleanup EXIT INT TERM
 
-# Wait a moment for toolshed to start
-sleep 3
+wait_for_http \
+    "toolshed" "http://localhost:$TOOLSHED_PORT/_health" \
+    "$TOOLSHED_PID" "$TOOLSHED_LOG"
 
 # Print the toolshed URL on success (when not using --bg-updater, which prints after health check)
 if [[ "$BG_UPDATER" != "true" ]]; then
@@ -199,26 +317,17 @@ if [[ "$BG_UPDATER" == "true" ]]; then
         rm -f "$BG_PID_FILE"
     fi
 
-    # Wait for toolshed to be healthy before starting bg service
-    echo "  Waiting for toolshed to be ready..."
-    for i in $(seq 1 30); do
-        if curl -s -o /dev/null -w "%{http_code}" --max-time 2 "http://localhost:$TOOLSHED_PORT/_health" 2>/dev/null | grep -q "200"; then
-            echo "  Toolshed is ready!"
-            break
-        fi
-        if [[ $i -eq 30 ]]; then
-            echo "  Warning: Toolshed not ready after 30s, starting bg service anyway"
-        fi
-        sleep 1
-    done
+    echo "  Toolshed is ready."
 
     # Start the background service directly (not via deno task, for reliable PID tracking)
     cd "$SCRIPT_DIR/../packages/background-charm-service"
     OPERATOR_PASS="implicit trust" API_URL="http://localhost:$TOOLSHED_PORT" \
         deno run -A --unstable-worker-options src/main.ts \
-        > "$SCRIPT_DIR/../packages/background-charm-service/local-dev-bg.log" 2>&1 &
+        > "$BG_LOG" 2>&1 &
     BG_PID=$!
     cd "$SCRIPT_DIR/.."
+    sleep 2
+    ensure_process_running "background service" "$BG_PID" "$BG_LOG"
 
     # Save PID for stop script
     echo "$BG_PID" > "$BG_PID_FILE"


### PR DESCRIPTION
Summary:
- Add preflight checks for deno and curl before launching local dev servers.
- Wait for shell and toolshed to return HTTP 200 before printing startup success.
- Clean up partial starts and show recent logs when startup fails.
- Document LOCAL_DEV_STARTUP_TIMEOUT for onboarding/debugging.

Validation:
- bash -n scripts/start-local-dev.sh
- git diff --check -- scripts/start-local-dev.sh docs/development/LOCAL_DEV_SERVERS.md
- env PATH=/usr/bin:/bin:/usr/sbin ./scripts/start-local-dev.sh --shell-port 65173 --toolshed-port 65174
- env LOCAL_DEV_STARTUP_TIMEOUT=90 ./scripts/start-local-dev.sh --shell-port 65173 --toolshed-port 65174
- ./scripts/stop-local-dev.sh --shell-port 65173 --toolshed-port 65174
- pre-commit hook: deno fmt, deno lint

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Verify local dev servers are actually ready before reporting success, with clearer failures and automatic cleanup. The startup script now validates prerequisites, waits for HTTP 200 from `shell` and `toolshed`, and tails logs on errors.

- **New Features**
  - Preflight checks for `deno` and `curl` with install hints.
  - Readiness wait with early-exit detection: HTTP 200 from `shell` (/) and `toolshed` (/_health); configurable via `LOCAL_DEV_STARTUP_TIMEOUT` (default 120s).
  - Robust cleanup on failure: kills started processes and any port listeners.
  - Better debugging: tails last 40 log lines; standardized paths at `packages/shell/local-dev-shell.log`, `packages/toolshed/local-dev-toolshed.log`, and `packages/background-charm-service/local-dev-bg.log`.
  - Background service starts directly with PID tracking and verifies it stays running.

- **Migration**
  - Ensure `deno` and `curl` are installed (e.g., run `mise install`).
  - Optionally set `LOCAL_DEV_STARTUP_TIMEOUT` to adjust readiness wait time.

<sup>Written for commit f5fc8a85a4b6c04c54dcbfa877173337a01d629c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

