### PR TITLE
fix(data-model): canonicalize `internPathSelector` schema; frozen-input contract

### DIFF
--- a/packages/data-model/src/schema-utils.ts
+++ b/packages/data-model/src/schema-utils.ts
@@ -300,11 +300,21 @@ export function emptySchemaObject() {
 }
 
 /**
- * Returns the given `SchemaPathSelector` with its `schema` (if any) interned
- * and with both its `path` array and the selector object itself deep-frozen
- * in place. The input reference is returned — this function does not clone.
- * Idempotent on repeat calls:
- * `internPathSelector(internPathSelector(x)) === internPathSelector(x)`.
+ * Returns a deep-frozen `SchemaPathSelector` whose `schema` (if any) is the
+ * canonical interned instance and whose `path` array is frozen.
+ *
+ * Usually the input reference itself is canonicalized in place — its `schema`
+ * replaced with the interned instance if needed, then it and its `path` frozen
+ * — and returned. The one exception: when the input is **already frozen** and
+ * its `schema` is not the canonical interned instance, the schema cannot be
+ * written back, so a new deep-frozen selector is allocated and returned.
+ * Therefore the result is NOT guaranteed to be `===` to the input. (It is `===`
+ * whenever the input is mutable, or its `schema` is already interned or
+ * `undefined`.)
+ *
+ * Idempotent: re-interning a result returns that same result
+ * (`internPathSelector(internPathSelector(x)) === internPathSelector(x)`),
+ * since a returned selector's `schema` is already canonical.
  *
  * Exists so that callers who feed selectors into `MapSetStringToPathSelectors`
  * (or any other cache keyed on `hashStringOf()` of a selector) can hand in an
@@ -315,8 +325,26 @@ export function emptySchemaObject() {
 export function internPathSelector(
   selector: SchemaPathSelector,
 ): SchemaPathSelector {
-  if (selector.schema !== undefined) internSchema(selector.schema);
-  Object.freeze(selector.path);
+  const { path, schema } = selector;
+
+  if (schema !== undefined) {
+    const interned = internSchema(schema);
+    if (interned !== schema) {
+      // Canonical schema differs from what the selector holds. Swap it in place
+      // if the selector is mutable; if it's frozen, we can't, so allocate a new
+      // deep-frozen selector carrying the canonical schema (sharing the now-
+      // frozen `path` array).
+      if (Object.isFrozen(selector)) {
+        return Object.freeze({
+          path: Object.freeze(path),
+          schema: interned,
+        }) as SchemaPathSelector;
+      }
+      selector.schema = interned;
+    }
+  }
+
+  Object.freeze(path);
   Object.freeze(selector);
   return selector;
 }

--- a/packages/data-model/test/schema-utils.test.ts
+++ b/packages/data-model/test/schema-utils.test.ts
@@ -950,6 +950,58 @@ describe("schema-utils", () => {
       expect(isDeepFrozen(schema)).toBe(true);
     });
 
+    it("canonicalizes `selector.schema` to the interned instance", () => {
+      const title = `internPathSelectorCanonAt${Date.now()}-${Math.random()}`;
+      // Establish the canonical interned instance from one distinct object...
+      const canonical = internSchema({ type: "object", title });
+      // ...then intern a selector holding a structurally-equal but distinct
+      // schema object. After interning, `selector.schema` should be the shared
+      // canonical instance, not the (now-redundant) input object.
+      const selector: SchemaPathSelector = {
+        path: ["x"],
+        schema: { type: "object", title },
+      };
+      expect(selector.schema).not.toBe(canonical);
+      internPathSelector(selector);
+      expect(selector.schema).toBe(canonical);
+    });
+
+    it("returns a new selector when a frozen input's schema must be canonicalized", () => {
+      const title = `internPathSelectorFrozenAt${Date.now()}-${Math.random()}`;
+      // Establish the canonical interned instance from one distinct object...
+      const canonical = internSchema({ type: "object", title });
+      // ...then build a *frozen* selector holding a structurally-equal but
+      // distinct (non-canonical) schema object. Since the input is frozen, its
+      // schema can't be replaced in place, so interning must allocate and
+      // return a new selector carrying the canonical schema.
+      const selector = Object.freeze({
+        path: Object.freeze(["x"]),
+        schema: Object.freeze({ type: "object", title }),
+      }) as SchemaPathSelector;
+      expect(selector.schema).not.toBe(canonical);
+      const result = internPathSelector(selector);
+      expect(result).not.toBe(selector);
+      expect(result.schema).toBe(canonical);
+      expect(result.path).toEqual(["x"]);
+      expect(isDeepFrozen(result)).toBe(true);
+    });
+
+    it("returns the input reference when `selector.schema` is already interned", () => {
+      const title =
+        `internPathSelectorPreInternedAt${Date.now()}-${Math.random()}`;
+      const interned = internSchema({ type: "object", title });
+      expect(isInternedSchema(interned)).toBe(true);
+      // Even a frozen selector is returned as-is when its schema is already the
+      // canonical interned instance: there is nothing to replace, so no clone.
+      const selector = Object.freeze({
+        path: Object.freeze(["x"]),
+        schema: interned,
+      }) as SchemaPathSelector;
+      const result = internPathSelector(selector);
+      expect(result).toBe(selector);
+      expect(result.schema).toBe(interned);
+    });
+
     it("handles selectors whose `schema` is undefined", () => {
       const selector: SchemaPathSelector = { path: ["p"] };
       // Must not throw — `internSchema(undefined)` would, and the guard


### PR DESCRIPTION
## What

`internPathSelector()` called `internSchema(selector.schema)` but **discarded
the return value**, so `selector.schema` was never swapped to the canonical
interned instance. Two structurally-equal selectors kept distinct schema
references — defeating the identity-keyed hash caching the function exists to
enable (its `WeakMap` hash-cache and `MapSetStringToPathSelectors` keys).

## Fix

Assign the interned schema back. Because the canonical instance can differ from
the input's schema, **and** the input may itself be frozen (interning an
already-frozen selector is a reasonable thing to do), the assignment can't
always happen in place:

- **Mutable input** → swap `selector.schema` in place, freeze, return the input.
- **Frozen input whose schema differs** from the canonical → can't write it
  back, so allocate and return a **new** deep-frozen selector carrying the
  canonical schema.

So the result is **no longer guaranteed `===` to the input**. The doc contract
is updated to say so. It remains `===` whenever the input is mutable, or its
schema is already interned or `undefined`. Idempotency is preserved
(`internPathSelector(internPathSelector(x)) === internPathSelector(x)`), since a
returned selector's schema is already canonical.

## Tests

Three new cases in `schema-utils.test.ts`, written red-green:

- canonicalizes `selector.schema` to the interned instance (mutable) — was red
- returns a new selector when a frozen input's schema must be canonicalized —
  was red
- returns the input reference when `selector.schema` is already interned
  (fast-path guard) — green throughout

## Verification

- All 7 `internPathSelector` call sites consume the return value, so the
  non-`===` contract change is safe for callers.
- Full repo `deno task test` green; `deno fmt` clean.

## Follow-up (not in this PR)

A pre-existing fast path near `traverse.ts:331` uses `Object.isFrozen(selector)`
as a proxy for "already interned," which a frozen-but-non-canonical schema
defeats. The correct guard is `isInternedSchema(selector.schema)`. Flagged for a
later fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Canonicalizes `internPathSelector` schemas and fixes handling of frozen inputs to restore correct hash-cache behavior and performance.

- **Bug Fixes**
  - Assigns the result of `internSchema()` back to `selector.schema` to ensure canonical instances and stable cache keys.
  - If the input selector is frozen and its schema is non-canonical, returns a new deep-frozen selector with the canonical schema; otherwise freezes in place.
  - Result may not be `===` to the input; idempotency is preserved.
  - Adds tests for mutable canonicalization, frozen-input cloning, and already-interned fast path.

<sup>Written for commit 99ad70d7698c140ba572d644c0a200139c9f80f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

