### PR TITLE
feat(shell): pass CF_ESM_MODULE_LOADER through to the client runtime

### DIFF
--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -133,6 +133,7 @@ export interface InitializationData {
   experimental?: {
     modernDataModel?: boolean;
     persistentSchedulerState?: boolean;
+    esmModuleLoader?: boolean;
   };
   // Commit-boundary CFC mode for the worker runtime.
   cfcEnforcementMode?:

--- a/packages/shell/felt.config.ts
+++ b/packages/shell/felt.config.ts
@@ -47,6 +47,11 @@ const config: Config = {
       "$EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE": Deno.env.get(
         "EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE",
       ),
+      // The ESM module-record loader shares one env var with the server/runner
+      // side (`CF_ESM_MODULE_LOADER`), unlike the `EXPERIMENTAL_*`-named flags
+      // above, so the same var toggles it for both the Deno runtime and the
+      // browser worker.
+      "$EXPERIMENTAL_ESM_MODULE_LOADER": Deno.env.get("CF_ESM_MODULE_LOADER"),
       "$COMPILATION_CACHE_CLIENT": Deno.env.get(
         "COMPILATION_CACHE_CLIENT",
       ) ?? "true",

--- a/packages/shell/src/lib/env.ts
+++ b/packages/shell/src/lib/env.ts
@@ -4,6 +4,7 @@ declare global {
   var $COMMIT_SHA: string | undefined;
   var $EXPERIMENTAL_MODERN_DATA_MODEL: string | undefined;
   var $EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE: string | undefined;
+  var $EXPERIMENTAL_ESM_MODULE_LOADER: string | undefined;
   var $COMPILATION_CACHE_CLIENT: string | undefined;
 }
 
@@ -21,6 +22,10 @@ const EXPERIMENTAL_MODERN_DATA_MODEL_DEFINE =
 const EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE_DEFINE =
   typeof $EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE === "string"
     ? $EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE
+    : undefined;
+const EXPERIMENTAL_ESM_MODULE_LOADER_DEFINE =
+  typeof $EXPERIMENTAL_ESM_MODULE_LOADER === "string"
+    ? $EXPERIMENTAL_ESM_MODULE_LOADER
     : undefined;
 const COMPILATION_CACHE_CLIENT_DEFINE =
   typeof $COMPILATION_CACHE_CLIENT === "string"
@@ -44,12 +49,25 @@ function flagValue(flag: string | undefined): boolean | undefined {
   return (typeof flag === "string") ? (flag === "true") : undefined;
 }
 
+/**
+ * Like {@link flagValue} but mirrors the runner's `CF_ESM_MODULE_LOADER`
+ * parsing (`readEnvDefault` in esm-loader-config.ts), which accepts `"1"` as
+ * well as `"true"`, so the same env var enables the ESM loader identically on
+ * the server and in the browser worker.
+ */
+function esmLoaderFlagValue(flag: string | undefined): boolean | undefined {
+  return (typeof flag === "string")
+    ? (flag === "1" || flag === "true")
+    : undefined;
+}
+
 /** Build-time experimental flags, injected via felt.config.ts defines. */
 export const EXPERIMENTAL = {
   modernDataModel: flagValue(EXPERIMENTAL_MODERN_DATA_MODEL_DEFINE),
   persistentSchedulerState: flagValue(
     EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE_DEFINE,
   ),
+  esmModuleLoader: esmLoaderFlagValue(EXPERIMENTAL_ESM_MODULE_LOADER_DEFINE),
 };
 
 export const COMPILATION_CACHE_CLIENT =

--- a/packages/shell/test/env.test.ts
+++ b/packages/shell/test/env.test.ts
@@ -43,3 +43,37 @@ Deno.test({
     });
   },
 });
+
+Deno.test({
+  name:
+    "shell env reads the ESM module loader flag (CF_ESM_MODULE_LOADER, '1'|'true')",
+  permissions: { read: true },
+  async fn() {
+    // Accepts "1" (matching the runner's readEnvDefault), not just "true".
+    const enabled = await withPatchedGlobals({
+      $API_URL: "http://shell.test/",
+      $EXPERIMENTAL_ESM_MODULE_LOADER: "1",
+    }, importFreshEnvModule);
+    expect(enabled.EXPERIMENTAL.esmModuleLoader).toBe(true);
+
+    const enabledTrue = await withPatchedGlobals({
+      $API_URL: "http://shell.test/",
+      $EXPERIMENTAL_ESM_MODULE_LOADER: "true",
+    }, importFreshEnvModule);
+    expect(enabledTrue.EXPERIMENTAL.esmModuleLoader).toBe(true);
+
+    // Any other set value is explicitly off.
+    const disabled = await withPatchedGlobals({
+      $API_URL: "http://shell.test/",
+      $EXPERIMENTAL_ESM_MODULE_LOADER: "0",
+    }, importFreshEnvModule);
+    expect(disabled.EXPERIMENTAL.esmModuleLoader).toBe(false);
+
+    // Unset → undefined (runtime falls back to its own default).
+    const unset = await withPatchedGlobals({
+      $API_URL: "http://shell.test/",
+      $EXPERIMENTAL_ESM_MODULE_LOADER: undefined,
+    }, importFreshEnvModule);
+    expect(unset.EXPERIMENTAL.esmModuleLoader).toBe(undefined);
+  },
+});


### PR DESCRIPTION
## What

The ESM module-record loader flag (`CF_ESM_MODULE_LOADER`) was honored **server-side** (the runner's `readEnvDefault` in `esm-loader-config.ts`) but never reached the **browser worker** — the shell build didn't inject it, so the client always fell back to its built-in default. This wires it through the client exactly like the other experimental flags (`modernDataModel`, `persistentSchedulerState`).

## Changes

- **`packages/shell/felt.config.ts`** — inject `$EXPERIMENTAL_ESM_MODULE_LOADER` from the `CF_ESM_MODULE_LOADER` env var. (It shares one env var with the server/runner side, unlike the `EXPERIMENTAL_*`-named build vars, so the same var toggles both.)
- **`packages/shell/src/lib/env.ts`** — expose `EXPERIMENTAL.esmModuleLoader`, parsed with the same `"1"`/`"true"` semantics as the runner's `readEnvDefault` (so server and client agree on the same env var).
- **`packages/runtime-client/protocol/types.ts`** — add `experimental.esmModuleLoader?` to `InitializationData`; it flows to the worker Runtime via the existing `experimental` spread (shell) + `data.experimental` passthrough (runtime-processor).

## Effect

`CF_ESM_MODULE_LOADER=1` now enables the loader for **both** the Deno runtime and the browser worker. Server hosts (toolshed, bg-charm, cli) already pick it up via the runner default, so no change there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass `CF_ESM_MODULE_LOADER` through the shell so the browser worker uses the same ESM module-record loader setting as the server. Adds tests to verify parsing: "1"/"true" enable, other values disable, unset is undefined.

- **New Features**
  - Inject `$EXPERIMENTAL_ESM_MODULE_LOADER` from `CF_ESM_MODULE_LOADER` in `packages/shell/felt.config.ts`.
  - Expose `EXPERIMENTAL.esmModuleLoader` in `packages/shell/src/lib/env.ts` (accepts "1"/"true"); add tests in `packages/shell/test/env.test.ts`.
  - Add `experimental.esmModuleLoader?` to `InitializationData` in `packages/runtime-client/protocol/types.ts` and pass it to the worker.

<sup>Written for commit 1c90cb509735d3c19734c8fa58e1e03cb8aec8b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---

NEW_PERF_BASELINE: job: Pattern Integration Tests (4/4) = 178s
