### PR TITLE
fix(runner): walk module-namespace live bindings for verified-value graphs (CT-1623)

### DIFF
--- a/packages/runner/src/harness/executable-registry.ts
+++ b/packages/runner/src/harness/executable-registry.ts
@@ -517,15 +517,24 @@ export function* verifiedWalkChildValues(value: object): Generator<unknown> {
  * We must not use `Object.prototype.toString.call(value)` or read
  * `value[Symbol.toStringTag]`: both perform a `[[Get]]` that would invoke a
  * user-defined `@@toStringTag` getter as a side effect on every value walked —
- * exactly the side-effect-free property this traversal is meant to preserve. A
- * real module namespace exposes `@@toStringTag` as a (non-configurable) data
- * property whose value is "Module"; reading its own descriptor never invokes a
- * getter, so an ordinary object that exposes `@@toStringTag` via an accessor is
- * correctly NOT treated as a module namespace and its getters are never run.
+ * exactly the side-effect-free property this traversal is meant to preserve.
+ *
+ * Instead we match the exact `@@toStringTag` shape of a Module Namespace Exotic
+ * Object (ECMAScript 28.3 / 10.4.6): an own, non-writable, non-enumerable,
+ * non-configurable DATA property whose value is "Module" (verified: SES
+ * namespaces expose precisely this). Reading the own descriptor never invokes a
+ * getter, and the strict attribute match keeps the classifier from being
+ * tricked by an ordinary object that merely carries a (writable/enumerable/
+ * configurable) `@@toStringTag` data property or exposes one via an accessor —
+ * so getters on non-namespace objects are never run.
  */
 function isModuleNamespaceObject(value: object): boolean {
   const tag = Object.getOwnPropertyDescriptor(value, Symbol.toStringTag);
-  return tag !== undefined && "value" in tag && tag.value === "Module";
+  return tag !== undefined &&
+    "value" in tag && tag.value === "Module" &&
+    tag.writable === false &&
+    tag.enumerable === false &&
+    tag.configurable === false;
 }
 
 function readVerifiedBindingMetadata(

--- a/packages/runner/src/harness/executable-registry.ts
+++ b/packages/runner/src/harness/executable-registry.ts
@@ -274,12 +274,8 @@ export class ExecutableRegistry {
       }
     }
 
-    for (const key of Reflect.ownKeys(value as object)) {
-      const descriptor = Object.getOwnPropertyDescriptor(value as object, key);
-      if (!descriptor || !("value" in descriptor)) {
-        continue;
-      }
-      this.recordVerifiedFunctions(loadId, descriptor.value, seen);
+    for (const child of verifiedWalkChildValues(value as object)) {
+      this.recordVerifiedFunctions(loadId, child, seen);
     }
   }
 
@@ -325,13 +321,9 @@ export class ExecutableRegistry {
       setVerifiedLoadId(value, loadId);
     }
 
-    for (const key of Reflect.ownKeys(value as object)) {
-      const descriptor = Object.getOwnPropertyDescriptor(value as object, key);
-      if (!descriptor || !("value" in descriptor)) {
-        continue;
-      }
+    for (const child of verifiedWalkChildValues(value as object)) {
       this.annotateVerifiedPatterns(
-        descriptor.value,
+        child,
         loadId,
         seen,
         subtreeTrusted,
@@ -385,13 +377,9 @@ export class ExecutableRegistry {
       registry.set(associated.implementationRef, associated.implementation);
     }
 
-    for (const key of Reflect.ownKeys(value as object)) {
-      const descriptor = Object.getOwnPropertyDescriptor(value as object, key);
-      if (!descriptor || !("value" in descriptor)) {
-        continue;
-      }
+    for (const child of verifiedWalkChildValues(value as object)) {
       this.collectAssociatedFunctions(
-        descriptor.value,
+        child,
         registry,
         seen,
         fallbackLookup,
@@ -479,6 +467,47 @@ export class ExecutableRegistry {
     }
     hardenVerifiedFunction(implementation as (...args: any[]) => unknown);
     return implementationRef;
+  }
+}
+
+/**
+ * Yield the child values to recurse into when walking a verified value graph
+ * (used by {@link ExecutableRegistry.recordVerifiedFunctions},
+ * `annotateVerifiedPatterns`, and `collectAssociatedFunctions`).
+ *
+ * Data properties — the AMD/CommonJS bundle shape (`exports.x = …`) — expose
+ * their value directly. SES module-namespace exports — the ESM module-record
+ * loader shape — are live-binding ACCESSOR properties (`get`/`set`, no `value`).
+ * Reading only `descriptor.value` therefore never descends into an ESM module's
+ * exports, so verified functions, their binding metadata
+ * (`__cfVerifiedBindingIdentity`), and exported patterns defined by ESM-loaded
+ * modules were never registered/annotated. That left the writer's verified
+ * binding identity (`sourceFile`/`bindingPath`) unresolved, so CFC
+ * `writeAuthorizedBy` rejected trusted-action writes under the ESM loader
+ * (CT-1623).
+ *
+ * Reading via [[Get]] is scoped to genuine module namespaces (`[object
+ * Module]`), whose getters are spec-defined live bindings with no
+ * user-controlled side effects. Getters on ordinary objects are deliberately
+ * NOT invoked, preserving the side-effect-free walk over data values.
+ */
+export function* verifiedWalkChildValues(value: object): Generator<unknown> {
+  const isModuleNamespace =
+    Object.prototype.toString.call(value) === "[object Module]";
+  for (const key of Reflect.ownKeys(value)) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (!descriptor) {
+      continue;
+    }
+    if ("value" in descriptor) {
+      yield descriptor.value;
+    } else if (isModuleNamespace && typeof descriptor.get === "function") {
+      try {
+        yield (value as Record<PropertyKey, unknown>)[key];
+      } catch {
+        // A live binding that throws on read carries nothing to register.
+      }
+    }
   }
 }
 

--- a/packages/runner/src/harness/executable-registry.ts
+++ b/packages/runner/src/harness/executable-registry.ts
@@ -486,14 +486,14 @@ export class ExecutableRegistry {
  * `writeAuthorizedBy` rejected trusted-action writes under the ESM loader
  * (CT-1623).
  *
- * Reading via [[Get]] is scoped to genuine module namespaces (`[object
- * Module]`), whose getters are spec-defined live bindings with no
- * user-controlled side effects. Getters on ordinary objects are deliberately
- * NOT invoked, preserving the side-effect-free walk over data values.
+ * Reading via [[Get]] is scoped to genuine module namespaces (see
+ * {@link isModuleNamespaceObject}), whose getters are spec-defined live bindings
+ * with no user-controlled side effects. Getters on ordinary objects are
+ * deliberately NOT invoked, preserving the side-effect-free walk over data
+ * values.
  */
 export function* verifiedWalkChildValues(value: object): Generator<unknown> {
-  const isModuleNamespace =
-    Object.prototype.toString.call(value) === "[object Module]";
+  const isModuleNamespace = isModuleNamespaceObject(value);
   for (const key of Reflect.ownKeys(value)) {
     const descriptor = Object.getOwnPropertyDescriptor(value, key);
     if (!descriptor) {
@@ -509,6 +509,23 @@ export function* verifiedWalkChildValues(value: object): Generator<unknown> {
       }
     }
   }
+}
+
+/**
+ * Detect a module-namespace object WITHOUT invoking user code.
+ *
+ * We must not use `Object.prototype.toString.call(value)` or read
+ * `value[Symbol.toStringTag]`: both perform a `[[Get]]` that would invoke a
+ * user-defined `@@toStringTag` getter as a side effect on every value walked —
+ * exactly the side-effect-free property this traversal is meant to preserve. A
+ * real module namespace exposes `@@toStringTag` as a (non-configurable) data
+ * property whose value is "Module"; reading its own descriptor never invokes a
+ * getter, so an ordinary object that exposes `@@toStringTag` via an accessor is
+ * correctly NOT treated as a module namespace and its getters are never run.
+ */
+function isModuleNamespaceObject(value: object): boolean {
+  const tag = Object.getOwnPropertyDescriptor(value, Symbol.toStringTag);
+  return tag !== undefined && "value" in tag && tag.value === "Module";
 }
 
 function readVerifiedBindingMetadata(

--- a/packages/runner/test/verified-walk-child-values.test.ts
+++ b/packages/runner/test/verified-walk-child-values.test.ts
@@ -66,6 +66,36 @@ describe("verifiedWalkChildValues (CT-1623)", () => {
     expect(yielded.length).toBe(0);
   });
 
+  it("does NOT invoke a Symbol.toStringTag getter while detecting module namespaces", () => {
+    // Regression for the review note: detecting a module namespace must not
+    // perform a [[Get]] on @@toStringTag, or it would run user getters as a
+    // side effect on every walked value.
+    let tagInvoked = false;
+    let exportInvoked = false;
+    const obj = {};
+    Object.defineProperty(obj, Symbol.toStringTag, {
+      get: () => {
+        tagInvoked = true;
+        return "Module"; // a real namespace uses a data property, not a getter
+      },
+      enumerable: false,
+    });
+    Object.defineProperty(obj, "export", {
+      get: () => {
+        exportInvoked = true;
+        return () => {};
+      },
+      enumerable: true,
+    });
+
+    const yielded = collect(obj);
+    // The toStringTag getter must never run; the object is not a real module
+    // namespace, so its accessor export must not be followed either.
+    expect(tagInvoked).toBe(false);
+    expect(exportInvoked).toBe(false);
+    expect(yielded.length).toBe(0);
+  });
+
   it("ignores a live binding that throws on read", () => {
     const ns: Record<PropertyKey, unknown> = {};
     Object.defineProperty(ns, Symbol.toStringTag, { value: "Module" });

--- a/packages/runner/test/verified-walk-child-values.test.ts
+++ b/packages/runner/test/verified-walk-child-values.test.ts
@@ -1,0 +1,83 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { verifiedWalkChildValues } from "../src/harness/executable-registry.ts";
+
+// Regression for CT-1623.
+//
+// The verified-value walks (recordVerifiedFunctions / annotateVerifiedPatterns /
+// collectAssociatedFunctions) recurse through `verifiedWalkChildValues`. The
+// AMD/CommonJS bundle exposes exports as data properties; the ESM module-record
+// loader exposes them as SES module-namespace *live-binding accessors* (no
+// `value`). The walk must follow those accessors, otherwise verified functions
+// and their binding metadata (`__cfVerifiedBindingIdentity`) defined by
+// ESM-loaded modules are never registered, leaving the writer's verified
+// binding identity unresolved and breaking CFC `writeAuthorizedBy` for
+// trusted-action writes.
+
+const collect = (
+  value: object,
+): unknown[] => [...verifiedWalkChildValues(value)];
+
+describe("verifiedWalkChildValues (CT-1623)", () => {
+  it("yields data property values (AMD/CommonJS export shape)", () => {
+    const fn = () => {};
+    const exportsObj = { a: fn, b: 7, c: { nested: true } };
+    const yielded = collect(exportsObj);
+    expect(yielded).toContain(fn);
+    expect(yielded).toContain(7);
+    expect(yielded.length).toBe(3);
+  });
+
+  it("follows live-binding accessors on module namespaces (ESM export shape)", () => {
+    const handler = () => {};
+    // Mimic a SES module namespace: tagged `[object Module]` with exports
+    // exposed as getters (live bindings) rather than data properties.
+    const ns: Record<PropertyKey, unknown> = {};
+    Object.defineProperty(ns, Symbol.toStringTag, {
+      value: "Module",
+      configurable: false,
+    });
+    Object.defineProperty(ns, "commit", {
+      get: () => handler,
+      enumerable: true,
+    });
+    Object.defineProperty(ns, "__esModule", {
+      get: () => true,
+      enumerable: true,
+    });
+
+    expect(Object.prototype.toString.call(ns)).toBe("[object Module]");
+    const yielded = collect(ns);
+    expect(yielded).toContain(handler);
+  });
+
+  it("does NOT invoke getters on ordinary (non-module) objects", () => {
+    let invoked = false;
+    const obj = {};
+    Object.defineProperty(obj, "trap", {
+      get: () => {
+        invoked = true;
+        return {};
+      },
+      enumerable: true,
+    });
+    const yielded = collect(obj);
+    expect(invoked).toBe(false);
+    expect(yielded.length).toBe(0);
+  });
+
+  it("ignores a live binding that throws on read", () => {
+    const ns: Record<PropertyKey, unknown> = {};
+    Object.defineProperty(ns, Symbol.toStringTag, { value: "Module" });
+    Object.defineProperty(ns, "boom", {
+      get: () => {
+        throw new Error("unreadable");
+      },
+      enumerable: true,
+    });
+    const good = () => {};
+    Object.defineProperty(ns, "ok", { get: () => good, enumerable: true });
+    const yielded = collect(ns);
+    expect(yielded).toContain(good);
+  });
+});

--- a/packages/runner/test/verified-walk-child-values.test.ts
+++ b/packages/runner/test/verified-walk-child-values.test.ts
@@ -96,6 +96,30 @@ describe("verifiedWalkChildValues (CT-1623)", () => {
     expect(yielded.length).toBe(0);
   });
 
+  it("does NOT treat an ordinary object with a casual toStringTag 'Module' as a namespace", () => {
+    // A real Module Namespace Exotic Object exposes @@toStringTag as a
+    // non-writable/non-enumerable/non-configurable data property. An ordinary
+    // object that merely assigns `[Symbol.toStringTag] = "Module"` (writable,
+    // enumerable, configurable) must NOT be classified as a namespace, so its
+    // accessor properties' getters are never invoked.
+    let exportInvoked = false;
+    const obj: Record<PropertyKey, unknown> = {
+      [Symbol.toStringTag]: "Module",
+    };
+    Object.defineProperty(obj, "export", {
+      get: () => {
+        exportInvoked = true;
+        return () => {};
+      },
+      enumerable: true,
+    });
+    const yielded = collect(obj);
+    expect(exportInvoked).toBe(false);
+    // Only the data property (the toStringTag string) is yielded, not the
+    // accessor export.
+    expect(yielded).toEqual(["Module"]);
+  });
+
   it("ignores a live binding that throws on read", () => {
     const ns: Record<PropertyKey, unknown> = {};
     Object.defineProperty(ns, Symbol.toStringTag, { value: "Module" });


### PR DESCRIPTION
## Problem

Under the **ESM module-record loader** (`esmModuleLoader` / the flag-flip canary), trusted-action writes silently fail to persist. In `packages/patterns/integration/cfc-group-chat-demo.test.ts`, clicking **Save name** never updates `#trusted-profile-status` (stays "Name not set", times out at `waitForText(..., "Alice")`). The AMD bundle path is fine.

The handler runs and the in-transaction read-back is correct, CFC surfaces no rejection reason, but the commit never persists — the event handler retries `DEFAULT_RETRIES_FOR_EVENTS` (5) times, each minting a fresh `Writable.for("profile")` cell, and `myProfile` stays `undefined`.

## Root cause

The verified-value walks in `ExecutableRegistry` — `recordVerifiedFunctions`, `annotateVerifiedPatterns`, and `collectAssociatedFunctions` — recursed with `Object.getOwnPropertyDescriptor` and **skipped any descriptor without a `value` key**.

- The **AMD/CommonJS bundle** exposes module exports as **data properties** (`exports.x = …`) → walked fine.
- The **ESM loader** exposes them as SES **module-namespace live-binding accessors** (`[object Module]`, `get`/`set`, no `value`) → silently skipped.

So under ESM the walk never descended into a module's exports. Verified functions, their binding metadata (`__cfVerifiedBindingIdentity = {sourceFile, bindingPath}`), and exported patterns defined by ESM-loaded modules were **never registered/annotated**. `resolvePolicyFacingImplementationIdentity` then produced a `verified` identity **missing `sourceFile`/`bindingPath`** (only `codeHash`/`sourceLocation`), and the CFC `writeAuthorizedBy` / `__ctWriterIdentityOf` gate **correctly failed closed** — dropping the trusted write.

Confirmed directly: AMD records the trusted handlers with `{sourceFile, bindingPath}`; ESM recorded 0; the ESM namespace export descriptor is `["get","set","enumerable","configurable"]` on an `[object Module]`.

## Fix

A shared `verifiedWalkChildValues` helper used by all three walks. It yields data-property values as before, and **additionally follows live-binding accessors on genuine module namespaces** (`[object Module]`), read via `[[Get]]` (spec-defined live bindings, side-effect-free). Getters on **ordinary** data objects are deliberately **not** invoked, preserving the side-effect-free walk.

This restores AMD-equivalent verified-identity resolution under the ESM loader, so trusted writes are authorized and persist — **without relaxing the CFC check**, matching the CFC spec's "stable verified binding identity" guidance (verified user code must resolve to its stable binding identity; degraded identities fail closed).

## Verification

- New regression unit test (`verified-walk-child-values.test.ts`): data props, module-namespace accessors followed, ordinary getters not invoked, throwing live binding ignored.
- `cfc-group-chat-demo` integration test **passes** with the ESM loader active (was timing out).
- Full runner suite green (506 passed, 0 failed) — incl. `cfc-implementation-identity`, `profile-owner-cfc`, `cfc-boundary`, `cfc-ui-contract`, `esm-pattern-run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ESM loader trusted writes not persisting by walking SES module-namespace live bindings in verified-value graphs and strictly detecting genuine module namespaces without invoking `@@toStringTag` getters. Addresses CT-1623; AMD and ESM now behave the same and trusted-action commits persist.

- **Bug Fixes**
  - Root cause: walkers only recursed into data props, skipping ESM module-namespace accessors, so verified functions/patterns weren’t registered; writer identity lacked `sourceFile`/`bindingPath`, and CFC failed closed.
  - Added `verifiedWalkChildValues` for `recordVerifiedFunctions`, `annotateVerifiedPatterns`, and `collectAssociatedFunctions`; it yields data props and, for genuine module namespaces, follows live-binding getters via [[Get]]; ordinary getters aren’t invoked; throws are ignored.
  - Tightened namespace detection: checks the own `Symbol.toStringTag` descriptor is the exact Module Namespace Exotic Object shape — data property with value "Module" and non-writable, non-enumerable, non-configurable — so objects with accessor or casual data `@@toStringTag` aren’t treated as modules and their getters never run.
  - Result: Restores AMD-equivalent verified binding identity under the ESM loader; `cfc-group-chat-demo` passes; regression tests cover data props, module accessors, no ordinary/`@@toStringTag` getter invocation, throwing bindings, and casual `@@toStringTag` misclassification; full runner suite green.

<sup>Written for commit 21e927d03ee3d338a127060037aa00ae077e4a0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

