### PR TITLE
[DO NOT MERGE] verify CT-1623 fix under ESM loader (flag default ON)

### DIFF
--- a/packages/runner/src/sandbox/esm-loader-config.ts
+++ b/packages/runner/src/sandbox/esm-loader-config.ts
@@ -16,10 +16,11 @@ function readEnvDefault(): boolean {
     const value = (globalThis as {
       Deno?: { env?: { get(name: string): string | undefined } };
     }).Deno?.env?.get?.("CF_ESM_MODULE_LOADER");
-    return value === "1" || value === "true";
+    // VERIFY BRANCH (DO NOT MERGE): ESM loader default ON to run the whole
+    // suite through the ESM path with the CT-1623 fix applied.
+    return value !== "0" && value !== "false";
   } catch {
-    // Env access may be denied (no --allow-env); treat as unset / off.
-    return false;
+    return true;
   }
 }
 


### PR DESCRIPTION
**Do not merge.** Verification-only branch for [#3797](https://github.com/commontoolsinc/labs/pull/3797).

This branch = the CT-1623 fix (`fix-ct-1623-esm-persist`) **plus** a single commit flipping the `esmModuleLoader` default **ON** (same change as the flag-flip canary). Purpose: run the full unit + integration suite through the **ESM module-record loader** to confirm the fix holds under the flag, while the real PR keeps the flag default **OFF**.

Expected known failure unrelated to the fix: `PatternManager compilation cache integration` (AMD persistent compile-cache tests) — the ESM loader bypasses the AMD bundle cache by design, so those cache-hit/count assertions can't hold under ESM (the canary auto-skips this AMD suite).

Will close once CI provides the ESM-path signal.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run the full test suite with the ESM module-record loader ON to verify the CT-1623 fix. The walk now follows ESM live bindings safely and restores trusted writes under ESM.

- **Bug Fixes**
  - Add `verifiedWalkChildValues` and use it across the registry; follow SES module-namespace live bindings, skip getters on ordinary objects, and ignore bindings that throw.
  - Detect real module namespaces by matching the own `@@toStringTag` data property (non-writable, non-enumerable, non-configurable); never perform [[Get]] on `@@toStringTag`.
  - Flip `esmModuleLoader` default ON in `esm-loader-config` for this verification run; treat env as ON unless `CF_ESM_MODULE_LOADER` is "0"/"false", and default ON if env access is denied. Known expected failures: `esm-loader-config.test.ts` (prod default OFF) and AMD compile-cache integration (ESM bypasses AMD cache).

<sup>Written for commit e073d6297bb3912e736346d40311f4f17a9b690a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

