### PR TITLE
docs(module-loading): refresh CT-1623 status + Phase 4 content-addressed cache plan & threat model

### DIFF
--- a/docs/specs/module-loading-implementation-plan.md
+++ b/docs/specs/module-loading-implementation-plan.md
@@ -6,7 +6,7 @@ steps with the files each touches, exit criteria, and validation commands.
 
 ## Last Updated
 
-2026-05-31
+2026-06-01
 
 ## Current status
 
@@ -14,12 +14,17 @@ steps with the files each touches, exit criteria, and validation commands.
 | --- | --- | --- |
 | 0 — Loader shape confirmation | Done | SES `importNow` + virtual (third-party) module records load synchronously, incl. cycles. `ModuleSource`/`StaticModuleRecord` are not exposed by this `ses` build, so the loader uses `{ imports, exports, execute }` records. |
 | 1 — Decouple identity | Done (merged) | Per-module Merkle hash; scheduler implementation fingerprint is content-addressed and entry-point/TCB independent. Shipped behind `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE`. |
-| 2 — ESM emission + SES module loading | Mechanism done (this PR, behind `esmModuleLoader`, default off) | `importModuleGraphNow` loader + `compileSourcesToRecords` adapter load real compiled multi-module programs end-to-end. **Remaining:** wire into `Engine.evaluate`, run the CF transformer pipeline (currently bare `ts.transpileModule`), and expand `export *` re-exports. |
-| 3 — Verifier port | Structural seam done (this PR) | `verifyModuleGraph` validates graph shape/wiring before load. **Remaining (security-critical):** port the SES_SANDBOXING module-item classification from the AMD parser. |
-| 4 — Per-module compilation cache | Done (this PR) | `ModuleRecordCache` keyed by module hash; hit reuses the compiled artifact. **Remaining:** persist via the existing compilation-cache backends. |
-| 5 — Default-on + AMD removal | Not started (intentionally) | Gated on Phase 3 classification parity + benchmarks. Flipping the default / removing AMD cannot land while keeping the build green, so it is a deliberate later rollout. The flag stays **off**. |
+| 2 — ESM emission + SES module loading | Done (behind `CF_ESM_MODULE_LOADER`, default off) | `compileToRecordGraph` + `evaluateRecordGraph` (`engine.ts`) run the full `CommonFabricTransformerPipeline` (not bare `transpileModule`), assemble content-addressed records, register per-load/per-module source maps, and load multi-module programs end-to-end. Engine integration, `export *` re-exports, live module-namespace bindings (#3797), and CFC verified-source location resolution (#3785, #3787) are all wired. The flag is now also plumbed to the browser client (#3796). |
+| 3 — Verifier port | Classification ported + wired; corpus parity oracle pending | The deep SES_SANDBOXING module-item classification (`verifyCompiledModuleBody`, reusing the shared `classifyModuleItems` core) runs **per module** in the ESM compile path (`engine.ts`). `verifyModuleGraph` validates graph shape/wiring. Additional hardening landed beyond the original plan: import-edge target validation (#3778), pattern provenance brand (#3779), frozen exported patterns (#3777). **Remaining (release gate):** the full-corpus differential parity oracle — `esm-verifier-parity.test.ts` currently covers crafted CF-shaped fixtures only, not every pattern-corpus verdict. |
+| 4 — Per-module compilation cache | In-memory done; persistence pending | `ModuleRecordCache` keyed by module hash reuses the compiled artifact in memory. The ESM path in `PatternManager.compilePattern` intentionally **bypasses the persistent compilation cache**. **Remaining:** persist ESM records via the existing compilation-cache backends. |
+| 5 — Default-on + AMD removal | Not started (intentionally) | Gated on the Phase 3 corpus parity oracle + a green full-suite flag-on sweep + benchmarks. The canary PR (#3782) is the standing CI signal for flag-on. The flag stays **off** by default. |
 
-Phase 1 merged separately; this PR adds the Phases 2–4 mechanism behind the default-off flag.
+Phases 0–1 merged earlier. Phases 2–4 mechanism merged behind the default-off
+flag (#3763), then substantially completed by follow-up work: ESM source-location
+/ CFC verified-source identity (#3785, #3787), security hardening (#3777–#3779),
+module-namespace live bindings (#3797), and client flag plumbing (#3796). The
+`cfc-group-chat-demo` integration test — the original end-to-end blocker — passes
+flag-on as of #3797.
 
 ## Guiding constraints
 
@@ -198,6 +203,14 @@ green with the scheduler flag on and off.
 
 ## Phase 2 — ESM emission + SES module loading (behind flag, dev/trusted only)
 
+> **Status: Done** (behind `CF_ESM_MODULE_LOADER`, default off). Implemented as
+> `Engine.compileToRecordGraph` + `Engine.evaluateRecordGraph` rather than a
+> branch inside the old `Engine.evaluate`. The sub-steps below are kept as the
+> design record; deviations: the CF transformer pipeline runs (not bare
+> `transpileModule`), source maps are composed per-load and per-module for CFC
+> verified-source identity (#3785, #3787), and the flag is plumbed to the
+> browser client (#3796).
+
 ### 2.1 ESM compiler mode
 
 - Add an ESM emit path to the compiler: `ModuleKind.ES2022`, no `outFile`. Keep
@@ -254,6 +267,13 @@ path); behavior parity with AMD.
 
 ## Phase 3 — Verifier port (gates default-on for untrusted code)
 
+> **Status: Classification ported and wired; corpus parity oracle pending.**
+> `verifyCompiledModuleBody` (reusing the shared `classifyModuleItems` core) runs
+> per module in the ESM compile path (`engine.ts`), and `verifyModuleGraph`
+> checks graph shape/wiring. The remaining release gate is the full-corpus
+> differential parity oracle — `packages/runner/test/esm-verifier-parity.test.ts`
+> exists but covers crafted CF-shaped fixtures, not every pattern-corpus verdict.
+
 The bundle verifier currently parses AMD `define()` calls and must verify
 `ModuleSource` records before ESM can run untrusted patterns by default.
 
@@ -277,6 +297,11 @@ untrusted execution.
 
 ## Phase 4 — Per-module compilation cache
 
+> **Status: In-memory done; persistence pending.** The in-memory per-module
+> record cache exists; the ESM path in `PatternManager.compilePattern`
+> intentionally bypasses the persistent compilation cache. Remaining: persist
+> ESM records via the existing compilation-cache backends.
+
 - Re-key the compilation cache and the `ModuleSource` cache by `moduleHash(M)`
   instead of whole-program `computeId`
   (`packages/runner/src/compilation-cache/`).
@@ -293,6 +318,11 @@ regression.
 ---
 
 ## Phase 5 — Default-on and cleanup
+
+> **Status: Not started.** Gated on the Phase 3 corpus parity oracle, a green
+> full-suite flag-on sweep (`CF_ESM_MODULE_LOADER=1 deno task test` +
+> `deno task integration` from the repo root), and benchmarks. The canary
+> PR (#3782) is the standing flag-on CI signal.
 
 - Flip `EXPERIMENTAL_ESM_MODULE_LOADER` default on after Phases 2–4 are green and
   benchmarks acceptable.

--- a/docs/specs/module-loading-implementation-plan.md
+++ b/docs/specs/module-loading-implementation-plan.md
@@ -16,7 +16,7 @@ steps with the files each touches, exit criteria, and validation commands.
 | 1 — Decouple identity | Done (merged) | Per-module Merkle hash; scheduler implementation fingerprint is content-addressed and entry-point/TCB independent. Shipped behind `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE`. |
 | 2 — ESM emission + SES module loading | Done (behind `CF_ESM_MODULE_LOADER`, default off) | `compileToRecordGraph` + `evaluateRecordGraph` (`engine.ts`) run the full `CommonFabricTransformerPipeline` (not bare `transpileModule`), assemble content-addressed records, register per-load/per-module source maps, and load multi-module programs end-to-end. Engine integration, `export *` re-exports, live module-namespace bindings (#3797), and CFC verified-source location resolution (#3785, #3787) are all wired. The flag is now also plumbed to the browser client (#3796). |
 | 3 — Verifier port | Classification ported + wired; corpus parity oracle pending | The deep SES_SANDBOXING module-item classification (`verifyCompiledModuleBody`, reusing the shared `classifyModuleItems` core) runs **per module** in the ESM compile path (`engine.ts`). `verifyModuleGraph` validates graph shape/wiring. Additional hardening landed beyond the original plan: import-edge target validation (#3778), pattern provenance brand (#3779), frozen exported patterns (#3777). **Remaining (release gate):** the full-corpus differential parity oracle — `esm-verifier-parity.test.ts` currently covers crafted CF-shaped fixtures only, not every pattern-corpus verdict. |
-| 4 — Per-module compilation cache | In-memory done; content-addressed persistence designed (Phase 4 below), not built | `ModuleRecordCache` reuses the compiled artifact in memory. The ESM path in `PatternManager.compilePattern` **bypasses the persistent compilation cache** (the only flag-on test failures are the two `pattern-manager.test.ts` cache cases). **Remaining:** the content-addressed cell cache (source set `pattern:<identity>` + compiled set `compileCache:<runtimeVersion>/<identity>`, per space, with CFC integrity on the compiled set) specified in Phase 4 below. |
+| 4 — Per-module compilation cache | Production ESM path not cached yet; content-addressed cache designed (Phase 4 below), not built | Neither cache is exercised flag-on: the whole-program `CachedCompiler` is AMD-only, and the per-module `ModuleRecordCache` is **bypassed whenever a precompiled CF-transformed body is present** — which `Engine.compileToRecordGraph` always supplies. So flag-on compiles recompile every time (the only flag-on failures are the two `pattern-manager.test.ts` AMD cache cases). **Remaining (two jobs):** make the production ESM path cacheable **and** persist it as the content-addressed cell cache (source set `pattern:<identity>` + compiled set `compileCache:<runtimeVersion>/<identity>`, per space, CFC integrity on the compiled set) — see Phase 4 below. |
 | 5 — Default-on + AMD removal | Not started (intentionally) | Gated on the Phase 3 corpus parity oracle + a green full-suite flag-on sweep + benchmarks. The canary PR (#3782) is the standing CI signal for flag-on. The flag stays **off** by default. |
 
 Phases 0–1 merged earlier. Phases 2–4 mechanism merged behind the default-off
@@ -297,14 +297,20 @@ untrusted execution.
 
 ## Phase 4 — Per-module compilation cache (content-addressed cells)
 
-> **Status: In-memory whole-program cache done; content-addressed persistence
-> designed below, not yet built.** The ESM path in
-> `PatternManager.compilePattern` currently bypasses the persistent compilation
-> cache (the only flag-on test failures are the two
-> `pattern-manager.test.ts` compilation-cache cases, which assume the AMD
-> jsScript/evaluate flow). This phase replaces the in-process whole-program
-> `CachedCompiler` (for the ESM path) with **content-addressed cells**, so the
-> cache is durable, deduplicated per module, and shareable.
+> **Status: production ESM path does no per-module caching yet; content-addressed
+> cache designed below, not built.** Two caches exist but neither is exercised by
+> a flag-on compile: the in-process whole-program `CachedCompiler` (AMD only — the
+> ESM branch of `PatternManager.compilePattern` skips it), and the per-module
+> `ModuleRecordCache`, which `compileSourcesToRecords` deliberately **bypasses
+> whenever a precompiled CF-transformed body is present**
+> (`sandbox/module-record-compiler.ts`) — and `Engine.compileToRecordGraph`
+> always passes `precompiledBodies` and no `recordCache`
+> (`harness/engine.ts`). So the only flag-on test failures today are the two
+> `pattern-manager.test.ts` compilation-cache cases (AMD jsScript/evaluate flow),
+> and the production ESM compile recompiles from scratch every time. This phase
+> therefore has **two** jobs, not one: (a) make the production ESM path
+> cacheable, and (b) persist it as **content-addressed cells** — durable,
+> deduplicated per module, and shareable.
 
 ### 4.0 Design — two content-addressed document sets, per space
 

--- a/docs/specs/module-loading-implementation-plan.md
+++ b/docs/specs/module-loading-implementation-plan.md
@@ -6,7 +6,7 @@ steps with the files each touches, exit criteria, and validation commands.
 
 ## Last Updated
 
-2026-06-01
+2026-06-02
 
 ## Current status
 
@@ -16,7 +16,7 @@ steps with the files each touches, exit criteria, and validation commands.
 | 1 — Decouple identity | Done (merged) | Per-module Merkle hash; scheduler implementation fingerprint is content-addressed and entry-point/TCB independent. Shipped behind `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE`. |
 | 2 — ESM emission + SES module loading | Done (behind `CF_ESM_MODULE_LOADER`, default off) | `compileToRecordGraph` + `evaluateRecordGraph` (`engine.ts`) run the full `CommonFabricTransformerPipeline` (not bare `transpileModule`), assemble content-addressed records, register per-load/per-module source maps, and load multi-module programs end-to-end. Engine integration, `export *` re-exports, live module-namespace bindings (#3797), and CFC verified-source location resolution (#3785, #3787) are all wired. The flag is now also plumbed to the browser client (#3796). |
 | 3 — Verifier port | Classification ported + wired; corpus parity oracle pending | The deep SES_SANDBOXING module-item classification (`verifyCompiledModuleBody`, reusing the shared `classifyModuleItems` core) runs **per module** in the ESM compile path (`engine.ts`). `verifyModuleGraph` validates graph shape/wiring. Additional hardening landed beyond the original plan: import-edge target validation (#3778), pattern provenance brand (#3779), frozen exported patterns (#3777). **Remaining (release gate):** the full-corpus differential parity oracle — `esm-verifier-parity.test.ts` currently covers crafted CF-shaped fixtures only, not every pattern-corpus verdict. |
-| 4 — Per-module compilation cache | In-memory done; persistence pending | `ModuleRecordCache` keyed by module hash reuses the compiled artifact in memory. The ESM path in `PatternManager.compilePattern` intentionally **bypasses the persistent compilation cache**. **Remaining:** persist ESM records via the existing compilation-cache backends. |
+| 4 — Per-module compilation cache | In-memory done; content-addressed persistence designed (Phase 4 below), not built | `ModuleRecordCache` reuses the compiled artifact in memory. The ESM path in `PatternManager.compilePattern` **bypasses the persistent compilation cache** (the only flag-on test failures are the two `pattern-manager.test.ts` cache cases). **Remaining:** the content-addressed cell cache (source set `pattern:<identity>` + compiled set `compileCache:<runtimeVersion>/<identity>`, per space, with CFC integrity on the compiled set) specified in Phase 4 below. |
 | 5 — Default-on + AMD removal | Not started (intentionally) | Gated on the Phase 3 corpus parity oracle + a green full-suite flag-on sweep + benchmarks. The canary PR (#3782) is the standing CI signal for flag-on. The flag stays **off** by default. |
 
 Phases 0–1 merged earlier. Phases 2–4 mechanism merged behind the default-off
@@ -295,25 +295,181 @@ untrusted execution.
 
 ---
 
-## Phase 4 — Per-module compilation cache
+## Phase 4 — Per-module compilation cache (content-addressed cells)
 
-> **Status: In-memory done; persistence pending.** The in-memory per-module
-> record cache exists; the ESM path in `PatternManager.compilePattern`
-> intentionally bypasses the persistent compilation cache. Remaining: persist
-> ESM records via the existing compilation-cache backends.
+> **Status: In-memory whole-program cache done; content-addressed persistence
+> designed below, not yet built.** The ESM path in
+> `PatternManager.compilePattern` currently bypasses the persistent compilation
+> cache (the only flag-on test failures are the two
+> `pattern-manager.test.ts` compilation-cache cases, which assume the AMD
+> jsScript/evaluate flow). This phase replaces the in-process whole-program
+> `CachedCompiler` (for the ESM path) with **content-addressed cells**, so the
+> cache is durable, deduplicated per module, and shareable.
 
-- Re-key the compilation cache and the `ModuleSource` cache by `moduleHash(M)`
-  instead of whole-program `computeId`
-  (`packages/runner/src/compilation-cache/`).
-- Editing one file invalidates only that module and its transitive importers;
-  untouched modules keep their cache entries and identities.
-- Carry over the compiler-version `fingerprint` and `sesValidated` gating per
-  module (`compilation-cache/storage.ts`).
+### 4.0 Design — two content-addressed document sets, per space
 
-**Validation:** cache test asserting single-file edits invalidate exactly the
-changed module + transitive importers; cold/warm compile benchmarks.
-**Exit:** measured cache-hit improvement on multi-file patterns; no correctness
-regression.
+Both sets are stored as **regular cells** in the **target space** (per-space;
+no global cache). Loading relies on the existing storage behavior that follows
+**sigil links** under a schema and transitively loads the closure — the same way
+ordinary linked data loads — so requesting the entry document pulls in its whole
+import graph. Cycles are handled by the loader's per-document dedup, as for any
+linked data.
+
+Each document, in either set, stores:
+
+```
+{
+  code: string,                                   // TS (set 1) or compiled JS (set 2)
+  filename: string,                               // authored module path
+  imports: Array<{ specifier: string; link: <sigil link to the dep's doc> }>,
+}
+```
+
+1. **Source documents — `pattern:<identity>`.** Authored TypeScript, keyed by the
+   module's content-addressed **identity** (the Phase 1 per-module Merkle hash,
+   already surfaced as `cf:module/<moduleHash>`; `computeModuleHashes` in
+   `harness/module-identity.ts`). `imports[].link` points at the dependency's
+   `pattern:<dep-identity>` doc. Runtime-version independent — written
+   essentially once ever.
+   - **Self-verifying:** a reader checks `hash(content) === <identity>`, so the
+     source set needs no separate integrity label — content-addressing is the
+     integrity.
+
+2. **Compiled documents — `compileCache:<runtimeVersion>/<identity>`.**
+   Compiled + verified JS, keyed by `(runtimeVersion, identity)`.
+   `imports[].link` points at the dependency's
+   `compileCache:<runtimeVersion>/<dep-identity>` doc. A runtime/transformer
+   upgrade changes `runtimeVersion`, so the compiled set is recompiled while the
+   source set persists.
+   - **Integrity, not content-addressing:** the key's `identity` is the *TS*
+     hash, which does **not** bind the JS bytes. The compiled doc therefore
+     carries a **CFC integrity label** (`addIntegrity` on write,
+     `requiredIntegrity` on read), which is the binding/provenance — see the
+     threat model in `module-loading.md`.
+
+`identity` is a one-way Merkle hash, so the `imports` links are **load-bearing,
+not derivable** — they are stored explicitly. But the parent hash *commits to*
+its children's identities, so on load the graph wiring is verifiable by
+recomputing identities from the loaded source set and checking each equals its
+document key (the content-addressed analog of `verifyModuleGraph`).
+
+### 4.1 Load flow (warm-full / partial / cold)
+
+1. Compute per-module identities for the program (`computeModuleHashes`).
+2. Request `compileCache:<runtimeVersion>/<entry-identity>` with a
+   link-following schema; the storage layer loads the reachable compiled closure.
+3. **Warm full hit** — every reachable compiled doc present and integrity-valid:
+   assemble the record graph from the cached bodies and `evaluateRecordGraph`
+   directly. **No TS compile and no SES re-verification.**
+4. **Partial / cold** — any module missing or integrity-invalid: fall back to the
+   source set (`pattern:<identity>`, or the program input on a total miss),
+   compile through the CF transformer pipeline, **SES-verify** the freshly
+   compiled bodies, reuse cached compiled bodies for unchanged-identity modules
+   during record assembly, then write back (4.2) the modules that were compiled.
+5. Evaluate via `evaluateRecordGraph` (unchanged).
+
+Fail-closed: a missing or invalid integrity label on a compiled doc is treated
+as a **cache miss → recompile from source**, never as a hard error. The SES
+verifier thus runs on the compile/miss path only; warm hits trust the integrity
+label. (Mirrors AMD's "skip evaluate-time validation for SES-validated hits".)
+
+### 4.2 Write flow (on compile)
+
+On any compile (cold or partial), write into the **target space**:
+
+- the source doc `pattern:<identity>` for each compiled module (idempotent;
+  content-addressed, so a re-write is a no-op);
+- the compiled doc `compileCache:<runtimeVersion>/<identity>` with the CFC
+  integrity label, for each compiled module.
+
+Dedup: a module shared by N programs (same identity) is written once per
+`(space, identity)` — programs are just different entry identities over a shared
+set of module docs.
+
+### 4.3 Ordered steps
+
+- **4.3.1 Cache-doc schemas + keys.** Define the source-doc and compiled-doc cell
+  schemas (`code`, `filename`, `imports: [{ specifier, link }]`), the
+  `pattern:<identity>` / `compileCache:<runtimeVersion>/<identity>` key scheme,
+  and the integrity-label constant. The import-link entries use sigil links and a
+  link-following schema. **Files:** new
+  `packages/runner/src/compilation-cache/cell-cache.ts` (schemas + read/write
+  helpers); `runtimeVersion` derives from the existing compiler/runtime
+  fingerprint (`compilation-cache/`).
+- **4.3.2 Source-set store.** Write/read `pattern:<identity>` cells; verify
+  `hash(content) === key` on read; expose a link-following schema so a request
+  loads the closure. **Files:** `cell-cache.ts`, `PatternManager`.
+- **4.3.3 Compiled-set store.** Write/read
+  `compileCache:<runtimeVersion>/<identity>` with `addIntegrity` on write and
+  `requiredIntegrity` on read (fail-closed → treat as miss). **Files:**
+  `cell-cache.ts`, `cfc/` integrity wiring.
+- **4.3.4 Engine seam.** Teach `Engine.compileToRecordGraph` to accept
+  `precompiledModules?: Map<path, { js; sourceMap? }>` (cached compiled bodies)
+  so it skips the TS compile for hit modules, and to return the serializable
+  per-module artifacts for write-back. **Files:**
+  `packages/runner/src/harness/engine.ts`.
+- **4.3.5 PatternManager ESM load.** Replace the direct
+  `compileAndEvaluateModules` call in the ESM branch of
+  `PatternManager.compilePattern` with: identity computation → compiled-set fetch
+  (link-following) → partial fallback (4.1) → assemble → `evaluateRecordGraph` →
+  write-back on miss (4.2). **Files:**
+  `packages/runner/src/pattern-manager.ts`.
+- **4.3.6 Graph-wiring verification.** On load, recompute module identities from
+  the loaded source set and assert each equals its doc key (content-addressed
+  `verifyModuleGraph` analog); keep `verifyCompiledModuleBody` on the compile
+  path. **Files:** `cell-cache.ts`, `sandbox/module-record-verifier.ts`.
+- **4.3.7 Replace whole-program pattern storage (gated).** The
+  `pattern:<patternId>` `PatternMeta` store (`PatternManager.savePattern` /
+  `loadPattern`, keyed by `createRef(pattern)`) is superseded by the
+  content-addressed source set after the flag flip. Behind the flag the two
+  coexist; Phase 5 removes the old store. (No migration: per the rollout, cache
+  and pattern data are cleared at the flip.)
+
+### 4.4 Tests
+
+- **Cold → warm.** First compile writes both doc sets into the space; second
+  load hits the compiled set with **no recompile** (assert via a compile spy /
+  the absence of TS-compile work), producing identical exports.
+- **Partial invalidation.** Editing one module in a multi-file program changes
+  only that module's identity (+ its transitive importers); untouched modules
+  keep their `pattern:`/`compileCache:` docs and are reused. Assert exactly the
+  changed module + importers are recompiled/rewritten.
+- **Per-module dedup.** Two programs importing the same util produce a single
+  `compileCache:<rtver>/<util-identity>` doc in the space.
+- **`Pattern.inSpace(...)` — A → B (required).** A pattern authored/loaded in
+  space A but instantiated through `PatternFactory.inSpace(B)` writes its source
+  and compiled docs into **space B**, with `imports` links resolving within B;
+  a subsequent load in B is a warm hit. Assert the docs land in B (not A), the
+  link closure resolves in B, and the compiled docs carry the required integrity.
+  Build on `packages/runner/test/pattern-scope.test.ts`, which already exercises
+  `inSpace`.
+- **Integrity fail-closed.** A compiled doc with a missing/invalid integrity
+  label is treated as a miss and recompiled from the (self-verifying) source doc;
+  only integrity-valid docs are reused without re-verification.
+- **Runtime-version bump.** Changing `runtimeVersion` misses the compiled set
+  (recompile) while the source set (`pattern:<identity>`) persists.
+- **Replace the AMD-shaped cache tests for ESM.** Make the two
+  `pattern-manager.test.ts` "compilation cache integration" cases loader-aware:
+  the AMD path keeps the `jsScript`/`harness.evaluate(skipBundleValidation)`
+  assertions; the ESM path asserts the content-addressed-cell behavior above.
+
+**Validation:**
+
+```
+deno test -A packages/runner/test/pattern-manager.test.ts
+deno test -A packages/runner/test/pattern-scope.test.ts
+CF_ESM_MODULE_LOADER=1 deno task test
+CF_ESM_MODULE_LOADER=1 deno task integration patterns
+```
+
+**Exit:** warm loads skip compilation; single-file edits invalidate exactly the
+changed module + transitive importers; the A→B `inSpace` test passes; the two
+compilation-cache tests pass under both loaders; no correctness regression.
+
+> **Future optimization (not gated on this phase):** truly isolated per-module
+> recompilation (compile only changed modules rather than re-running the TS
+> program pass and reusing cached bodies at assembly). The warm-full-hit path
+> already avoids all compilation; this only sharpens the partial-miss cost.
 
 ---
 

--- a/docs/specs/module-loading.md
+++ b/docs/specs/module-loading.md
@@ -30,7 +30,7 @@ rollout** (Phase 5). The AMD bundle path remains the default throughout.
 
 ## Last Updated
 
-2026-06-01
+2026-06-02
 
 ## Summary
 
@@ -353,8 +353,37 @@ The cache key moves from whole-program `computeId` to per-module
 - leaves the identities and cache entries of untouched modules stable;
 - yields strictly better hit rates than the current whole-program key.
 
-The existing compiler-version `fingerprint` and `sesValidated` gating on cache
-entries ([compilation-cache/storage.ts][c12]) carry over per module.
+### Storage model: two content-addressed document sets, per space
+
+The persistent cache is **content-addressed cells**, not an in-process map. Each
+module is stored as two regular cells, in the **target space** (per-space — there
+is no global cache), and the storage layer's existing **sigil-link following**
+under a schema loads the whole import closure transitively from a single request
+(cycles handled by per-document dedup, as for any linked data):
+
+1. **Source set — `pattern:<identity>`.** Authored TypeScript, keyed by the
+   per-module Merkle `moduleHash` (`cf:module/<hash>`). It is runtime-version
+   independent (written essentially once ever) and **self-verifying**: a reader
+   checks `hash(content) === <identity>`, so content-addressing *is* the
+   integrity — no separate label needed.
+2. **Compiled set — `compileCache:<runtimeVersion>/<identity>`.** Compiled +
+   verified JS, keyed by `(runtimeVersion, identity)`. A runtime/transformer
+   upgrade rolls `runtimeVersion`, recompiling this set while the source set
+   persists.
+
+Each document holds `{ code, filename, imports: [{ specifier, link }] }`, where
+`link` is a sigil link to the dependency's document in the same set. Because
+`identity` is a one-way Merkle hash, the `imports` links are load-bearing (stored
+explicitly), but the parent hash commits to its children's identities, so the
+graph wiring is verifiable on load by recomputing identities and checking each
+against its document key — the content-addressed analog of the structural graph
+verifier. A module shared by N programs is stored once per `(space, identity)`;
+a "program" is just an entry identity over a shared set of module documents.
+
+This replaces the whole-program `PatternMeta` store after the flag flip (the two
+coexist behind the flag until then). The compiler-version `fingerprint` and
+`sesValidated` gating carry over: `runtimeVersion` is the fingerprint, and the
+compiled set is only ever written from verified output (see the threat model).
 
 ## Verifiable Execution Implications
 
@@ -368,6 +397,46 @@ SES_SANDBOXING_SPEC requires than regex-scanning a concatenated bundle. The
 classification rules themselves (direct callbacks to trusted builders, safe
 top-level functions, verified module-safe data) are unchanged; only the parser
 that feeds them changes.
+
+## Threat Model — the persistent compilation cache
+
+Moving the compiled artifact into a **storage cell** changes the trust posture
+versus the in-process cache, because the runtime `eval`s the cell's contents.
+The cache is designed around this:
+
+- **Source set integrity is free.** `pattern:<identity>` is keyed by a hash of
+  its own contents, so a reader self-checks `hash(content) === <identity>`. A
+  tampered source document fails the check; a poisoned-but-different source would
+  not hash to the requested identity. Recompiling a source document also re-runs
+  the SES verifier, so a malformed source is rejected on the compile path.
+- **Compiled set integrity is a CFC label.** `compileCache:<runtimeVersion>/<identity>`
+  is keyed by the *source* identity, which does not bind the *JS* bytes.
+  The compiled document therefore carries a **CFC integrity label**, written with
+  the entry (`addIntegrity`) and **required on read** (`requiredIntegrity`). The
+  label — not the SES verifier — is the security boundary for cache hits.
+- **Fail-closed, not fail-hard.** A compiled document with a missing or invalid
+  integrity label is treated as a **cache miss** and recompiled from the
+  (self-verifying) source set, which re-runs the SES verifier. So the verifier
+  always guards the compile/miss path; only integrity-valid warm hits skip it.
+- **Why skip the SES verifier on a hit.** That verifier's guarantee is that no
+  data flows between components in a way the runtime does not track. An attacker
+  who can write arbitrary storage can already create such untracked flows
+  (writing data a pattern reads), so re-verifying integrity-labeled cache hits
+  adds no protection beyond the label while costing per-load work. Once the label
+  is unforgeable (below), re-verification is redundant.
+- **Per-space containment, then server-only writes.** The cache is per-space, so
+  cross-tenant poisoning is impossible — only a space's own writers can affect
+  its cache. While compilation is still client-side, the integrity label is
+  client-asserted, so within a space it amounts to self-poisoning (acceptable,
+  and contained by the per-space scope). The end state moves **compilation to the
+  server**: the server becomes the sole acceptor of that write integrity (it
+  only stamps the label from its own compilation step), making the label a hard
+  guarantee — with no change to the read path, which already requires it.
+- **CFC verified-source derives from the source set, not the cached JS.** A
+  poisoned-but-SES-safe JS document must not be able to spoof `fn.src` /
+  authorship, so the CFC verified-source identity is anchored to the
+  content-addressed `pattern:<identity>` source, never to the compiled
+  document's source maps.
 
 ## Source Maps and Diagnostics
 
@@ -467,6 +536,21 @@ Sequence identity first to retire the rehydration bug quickly, then the loader.
   entry point rehydrates clean (no rerun) where it previously missed.
 - Compilation-cache test: editing one file invalidates only that module and its
   transitive importers.
+- Content-addressed cache: a cold compile writes the source and compiled
+  document sets into the space; a warm load hits the compiled set with no
+  recompilation and identical exports. Two programs sharing a module produce a
+  single compiled document (per-module dedup).
+- Cross-space (`Pattern.inSpace`): a pattern authored/loaded in space A but
+  instantiated through `PatternFactory.inSpace(B)` writes its source and compiled
+  documents into **space B**, with import links resolving within B and the
+  compiled documents carrying the required CFC integrity; a later load in B is a
+  warm hit.
+- Cache integrity fail-closed: a compiled document with a missing/invalid
+  integrity label is treated as a miss and recompiled from the self-verifying
+  source document; only integrity-valid documents are reused without
+  re-verification.
+- Runtime-version bump misses the compiled set (recompile) while the source set
+  (`pattern:<identity>`) persists.
 
 ## Appendix: Current Pipeline Reference
 

--- a/docs/specs/module-loading.md
+++ b/docs/specs/module-loading.md
@@ -11,17 +11,26 @@ whose action implementation fingerprint is currently unstable across reloads.
 
 Implemented so far (see the implementation plan for the per-phase status):
 identity decoupling (Phase 1, live behind `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE`)
-is merged. The module-loading mechanism (Phases 2–4) — a synchronous SES
-virtual-module-record loader, a TS→record adapter, a per-module compilation
-cache, and a structural graph verifier, all behind a default-off
-`esmModuleLoader` flag — is implemented. Remaining: Engine integration with the
-CF transformer pipeline, the security-critical verifier classification port, and
-the default-on/AMD-removal rollout (Phase 5). The AMD bundle path remains the
-default throughout.
+is merged. The module-loading mechanism (Phases 2–4), behind the default-off
+`CF_ESM_MODULE_LOADER` flag, is implemented and Engine-integrated: a synchronous
+SES virtual-module-record loader, a TS→record adapter that runs the full CF
+transformer pipeline, per-load/per-module source maps with CFC verified-source
+identity (#3785, #3787), per-module SES classification wired into the compile
+path, an in-memory per-module cache, and a structural graph verifier. Security
+hardening landed alongside (frozen exported patterns #3777, import-edge
+validation #3778, provenance brand #3779), and the flag is plumbed through to the
+browser client (#3796). The `cfc-group-chat-demo` end-to-end integration test
+passes flag-on (#3797).
+
+Remaining before default-on: the full-corpus verifier **parity oracle** (ESM
+verdicts must match AMD across the whole pattern corpus — the current parity test
+covers crafted fixtures only), a green **full-suite flag-on sweep**, **per-module
+cache persistence** (Phase 4), benchmarks, and the **default-on/AMD-removal
+rollout** (Phase 5). The AMD bundle path remains the default throughout.
 
 ## Last Updated
 
-2026-05-30
+2026-06-01
 
 ## Summary
 

--- a/docs/specs/module-loading.md
+++ b/docs/specs/module-loading.md
@@ -16,7 +16,10 @@ is merged. The module-loading mechanism (Phases 2–4), behind the default-off
 SES virtual-module-record loader, a TS→record adapter that runs the full CF
 transformer pipeline, per-load/per-module source maps with CFC verified-source
 identity (#3785, #3787), per-module SES classification wired into the compile
-path, an in-memory per-module cache, and a structural graph verifier. Security
+path, and a structural graph verifier. (A per-module `ModuleRecordCache` exists
+but is **bypassed on the production ESM path** — precompiled CF-transformed
+bodies are authoritative — so flag-on compiles are not yet cached; see Phase 4.)
+Security
 hardening landed alongside (frozen exported patterns #3777, import-edge
 validation #3778, provenance brand #3779), and the flag is plumbed through to the
 browser client (#3796). The `cfc-group-chat-demo` end-to-end integration test
@@ -24,9 +27,10 @@ passes flag-on (#3797).
 
 Remaining before default-on: the full-corpus verifier **parity oracle** (ESM
 verdicts must match AMD across the whole pattern corpus — the current parity test
-covers crafted fixtures only), a green **full-suite flag-on sweep**, **per-module
-cache persistence** (Phase 4), benchmarks, and the **default-on/AMD-removal
-rollout** (Phase 5). The AMD bundle path remains the default throughout.
+covers crafted fixtures only), a green **full-suite flag-on sweep**, **making the
+production ESM path cacheable and persisting it** as content-addressed cells
+(Phase 4), benchmarks, and the **default-on/AMD-removal rollout** (Phase 5). The
+AMD bundle path remains the default throughout.
 
 ## Last Updated
 


### PR DESCRIPTION
Two doc updates to `docs/specs/module-loading.md` + `module-loading-implementation-plan.md` (docs-only).

## 1. Status refresh
The plan/spec status predated the recent CFC source-location, security-hardening, live-binding, and client-flag work. Updated to current `main`: Phase 2 done; Phase 3 classification wired per-module (corpus parity oracle = the remaining gate — see #3801); Phase 4 in-memory done / persistence designed below; Phase 5 not started. `cfc-group-chat-demo` passes flag-on (#3797); flag plumbed to the client (#3796).

## 2. Phase 4 — content-addressed cell cache (full implementation plan + threat model)
Design for persisting ESM compilation as **content-addressed cells**, per space, loaded via sigil-link following:
- **Source set `pattern:<identity>`** — authored TS keyed by the per-module Merkle hash; self-verifying (`hash(content) === key`).
- **Compiled set `compileCache:<runtimeVersion>/<identity>`** — verified JS keyed by (runtime version, identity), carrying a **CFC integrity label** (add-on-write, require-on-read, **fail-closed → recompile**).
- Per-module **dedup**; **warm-full hit** skips compile + SES re-verify; **partial/cold** falls back to source and recompiles only what's missing; graph wiring verified by recomputing identities against doc keys.

**Threat model** added to the spec: SES verifier runs on the compile/miss path only; warm hits trust the integrity label; per-space containment now, **server-only compilation** as the end state makes the label a hard guarantee (no read-path change); CFC verified-source anchored to the source set, not the cached JS.

Ordered steps (4.3.1–4.3.7) mapped onto the `PatternManager`/`Engine` seams, plus tests — including the required **`Pattern.inSpace` A→B** case (a pattern in space A writing its cache docs into space B), built on `pattern-scope.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)