### PR TITLE
Add fair-share pattern: a shared group expense ledger

### DIFF
--- a/packages/patterns/fair-share/main.tsx
+++ b/packages/patterns/fair-share/main.tsx
@@ -249,19 +249,23 @@ export default pattern<State>(({ people, expenses, myName }) => {
                     const idx = cur.findIndex((p) => equals(person, p));
                     if (idx < 0) return;
                     const name = { ...cur[idx] }.name;
-                    people.set(cur.toSpliced(idx, 1));
                     // Cascade-clean so balances stay zero-sum: drop expenses
                     // they paid (money has no creditor now) and remove them
-                    // from every other split.
-                    const cleaned = expenses.get()
-                      .filter((e) => e.paidBy !== name)
-                      .map((e) => {
-                        const sharedBy = e.sharedBy.filter((s) => s !== name);
-                        return sharedBy.length === e.sharedBy.length
-                          ? e
-                          : { ...e, sharedBy };
-                      })
-                      .filter((e) => e.sharedBy.length > 0);
+                    // from every other split. Built with a plain for-loop and
+                    // explicit array spreads — chaining .filter()/.map() on the
+                    // reactive .get() array makes the transformer rewrite them
+                    // to .filterWithPattern()/.mapWithPattern(), which throw at
+                    // runtime here.
+                    const cleaned: Expense[] = [];
+                    for (const e of expenses.get()) {
+                      if (e.paidBy === name) continue;
+                      const shared = [...(e.sharedBy ?? [])].filter((s) =>
+                        s !== name
+                      );
+                      if (shared.length === 0) continue;
+                      cleaned.push({ ...e, sharedBy: shared });
+                    }
+                    people.set(cur.toSpliced(idx, 1));
                     expenses.set(cleaned);
                   }}
                 />
@@ -447,33 +451,42 @@ export default pattern<State>(({ people, expenses, myName }) => {
         <cf-card>
           <cf-vstack gap="3">
             <cf-heading level={4}>Balances</cf-heading>
+            {
+              /* Render the list as a stable array and keep the empty state as a
+                separate sibling. A single computed() that returns an array OR a
+                single node makes the reactive diff transition array<->object,
+                which throws TypeMismatchError. */
+            }
+            {computed(() =>
+              balances.map((b) => (
+                <cf-hstack
+                  align="center"
+                  style={{
+                    justifyContent: "space-between",
+                    fontWeight: b.name === me ? "700" : "400",
+                  }}
+                >
+                  <span>{b.name === me ? `${b.name} (you)` : b.name}</span>
+                  <cf-badge
+                    color={b.net > 0
+                      ? "accent"
+                      : b.net < 0
+                      ? "danger"
+                      : "neutral"}
+                  >
+                    {b.net > 0
+                      ? `is owed ${money(b.net)}`
+                      : b.net < 0
+                      ? `owes ${money(-b.net)}`
+                      : "settled"}
+                  </cf-badge>
+                </cf-hstack>
+              ))
+            )}
             {computed(() =>
               balances.length === 0
                 ? <cf-text tone="muted">No balances to show.</cf-text>
-                : balances.map((b) => (
-                  <cf-hstack
-                    align="center"
-                    style={{
-                      justifyContent: "space-between",
-                      fontWeight: b.name === me ? "700" : "400",
-                    }}
-                  >
-                    <span>{b.name === me ? `${b.name} (you)` : b.name}</span>
-                    <cf-badge
-                      color={b.net > 0
-                        ? "accent"
-                        : b.net < 0
-                        ? "danger"
-                        : "neutral"}
-                    >
-                      {b.net > 0
-                        ? `is owed ${money(b.net)}`
-                        : b.net < 0
-                        ? `owes ${money(-b.net)}`
-                        : "settled"}
-                    </cf-badge>
-                  </cf-hstack>
-                ))
+                : null
             )}
           </cf-vstack>
         </cf-card>
@@ -482,14 +495,8 @@ export default pattern<State>(({ people, expenses, myName }) => {
         <cf-card>
           <cf-vstack gap="3">
             <cf-heading level={4}>Settle up</cf-heading>
-            {computed(() => {
-              const plan = settlements;
-              if (plan.length === 0) {
-                return (
-                  <cf-text tone="muted">Everyone is settled up. 🎉</cf-text>
-                );
-              }
-              return plan.map((s) => (
+            {computed(() =>
+              settlements.map((s) => (
                 <cf-hstack gap="2" align="center">
                   <cf-badge color="danger">{s.from}</cf-badge>
                   <span>→</span>
@@ -498,8 +505,13 @@ export default pattern<State>(({ people, expenses, myName }) => {
                     {money(s.amount)}
                   </span>
                 </cf-hstack>
-              ));
-            })}
+              ))
+            )}
+            {computed(() =>
+              settlements.length === 0
+                ? <cf-text tone="muted">Everyone is settled up. 🎉</cf-text>
+                : null
+            )}
           </cf-vstack>
         </cf-card>
       </cf-vstack>

--- a/packages/patterns/fair-share/main.tsx
+++ b/packages/patterns/fair-share/main.tsx
@@ -1,0 +1,421 @@
+/**
+ * Fair Share — a shared expense ledger.
+ *
+ * Track who paid for what in a group, split each expense among the people who
+ * shared it, and see net balances plus a minimal "settle up" plan of who should
+ * pay whom. Inspired by group expense-splitting apps.
+ */
+import {
+  computed,
+  Default,
+  NAME,
+  nonPrivateRandom,
+  pattern,
+  safeDateNow,
+  UI,
+  Writable,
+} from "commonfabric";
+
+// ============ TYPES ============
+
+interface Person {
+  id: string;
+  name: string;
+}
+
+interface Expense {
+  id: string;
+  description: string;
+  amount: number;
+  paidBy: string; // Person.id
+  sharedBy: string[]; // Person.id[]; empty => split among everyone
+  date: string; // YYYY-MM-DD
+}
+
+interface Balance {
+  id: string;
+  name: string;
+  paid: number;
+  share: number;
+  net: number; // paid - share; positive => is owed, negative => owes
+}
+
+interface Settlement {
+  from: string; // debtor name
+  to: string; // creditor name
+  amount: number;
+}
+
+interface State {
+  people: Writable<Person[] | Default<[]>>;
+  expenses: Writable<Expense[] | Default<[]>>;
+}
+
+// ============ HELPERS ============
+
+const newId = (prefix: string): string =>
+  `${prefix}_${safeDateNow().toString(36)}_${
+    Math.floor(nonPrivateRandom() * 1e6).toString(36)
+  }`;
+
+const getTodayDate = (): string => new Date().toISOString().split("T")[0];
+
+const money = (n: number): string => `$${(n || 0).toFixed(2)}`;
+
+// Tolerance for floating-point cents when settling.
+const EPS = 0.005;
+
+const computeSettlements = (balances: Balance[]): Settlement[] => {
+  const creditors = balances
+    .filter((b) => b.net > EPS)
+    .map((b) => ({ name: b.name, rem: b.net }))
+    .sort((a, b) => b.rem - a.rem);
+  const debtors = balances
+    .filter((b) => b.net < -EPS)
+    .map((b) => ({ name: b.name, rem: -b.net }))
+    .sort((a, b) => b.rem - a.rem);
+
+  const result: Settlement[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < debtors.length && j < creditors.length) {
+    const d = debtors[i];
+    const c = creditors[j];
+    const amount = Math.min(d.rem, c.rem);
+    if (amount > EPS) {
+      result.push({ from: d.name, to: c.name, amount });
+    }
+    d.rem -= amount;
+    c.rem -= amount;
+    if (d.rem <= EPS) i++;
+    if (c.rem <= EPS) j++;
+  }
+  return result;
+};
+
+// ============ PATTERN ============
+
+export default pattern<State>(({ people, expenses }) => {
+  // --- Local form state ---
+  const newPersonName = new Writable("");
+  const newDescription = new Writable("");
+  const newAmount = new Writable("");
+  const newPaidBy = new Writable(""); // Person.id
+  const splitWith = new Writable<string[]>([]); // Person.id[]; empty => everyone
+
+  // --- Derived data ---
+  const peopleOptions = computed(() =>
+    people.get().map((p) => ({ label: p.name, value: p.id }))
+  );
+
+  const total = computed(() =>
+    expenses.get().reduce((sum, e) => sum + (e.amount || 0), 0)
+  );
+
+  const nameById = computed(() => {
+    const map: Record<string, string> = {};
+    for (const p of people.get()) map[p.id] = p.name;
+    return map;
+  });
+
+  const balances = computed<Balance[]>(() => {
+    const ppl = people.get();
+    const exps = expenses.get();
+    const acc = new Map<string, Balance>(
+      ppl.map((
+        p,
+      ) => [p.id, { id: p.id, name: p.name, paid: 0, share: 0, net: 0 }]),
+    );
+
+    for (const e of exps) {
+      const payer = acc.get(e.paidBy);
+      if (payer) payer.paid += e.amount || 0;
+
+      const everyone = ppl.map((p) => p.id);
+      const shareIds = (e.sharedBy && e.sharedBy.length ? e.sharedBy : everyone)
+        .filter((id) => acc.has(id));
+      if (shareIds.length === 0) continue;
+
+      const per = (e.amount || 0) / shareIds.length;
+      for (const id of shareIds) {
+        const b = acc.get(id);
+        if (b) b.share += per;
+      }
+    }
+
+    return ppl.map((p) => {
+      const b = acc.get(p.id)!;
+      return { ...b, net: b.paid - b.share };
+    });
+  });
+
+  const settlements = computed(() => computeSettlements(balances));
+
+  // --- Display helpers for the "split with" chips in the form ---
+  const splitChips = computed(() =>
+    people.get().map((p) => ({
+      id: p.id,
+      name: p.name,
+      included: splitWith.get().length === 0 || splitWith.get().includes(p.id),
+    }))
+  );
+
+  return {
+    [NAME]: "Fair Share",
+    [UI]: (
+      <cf-vstack gap="4" style={{ padding: "1rem", maxWidth: "720px" }}>
+        <cf-heading level={2}>Fair Share</cf-heading>
+        <cf-text tone="muted">
+          A shared ledger for group expenses — track who paid, split fairly, and
+          settle up.
+        </cf-text>
+
+        {/* ===== People ===== */}
+        <cf-card>
+          <cf-vstack gap="3">
+            <cf-heading level={4}>People</cf-heading>
+
+            <cf-hstack gap="2" wrap>
+              {people.map((person) => (
+                <cf-chip
+                  label={person.name}
+                  removable
+                  oncf-remove={() => {
+                    const cur = people.get();
+                    const idx = cur.findIndex((el) => el.id === person.id);
+                    if (idx >= 0) people.set(cur.toSpliced(idx, 1));
+                  }}
+                />
+              ))}
+            </cf-hstack>
+
+            <cf-hstack gap="2" align="center">
+              <cf-input
+                $value={newPersonName}
+                placeholder="Add a person…"
+                style={{ flex: 1 }}
+              />
+              <cf-button
+                color="primary"
+                variant="solid"
+                onClick={() => {
+                  const name = newPersonName.get().trim();
+                  if (!name) return;
+                  if (people.get().some((p) => p.name === name)) return;
+                  people.push({ id: newId("p"), name });
+                  newPersonName.set("");
+                }}
+              >
+                Add
+              </cf-button>
+            </cf-hstack>
+          </cf-vstack>
+        </cf-card>
+
+        {/* ===== Add expense ===== */}
+        <cf-card>
+          <cf-vstack gap="3">
+            <cf-heading level={4}>Add expense</cf-heading>
+
+            <cf-vstack gap="1">
+              <cf-label>Description</cf-label>
+              <cf-input $value={newDescription} placeholder="Dinner, taxi, …" />
+            </cf-vstack>
+
+            <cf-hstack gap="3" wrap>
+              <cf-vstack gap="1" style={{ flex: 1 }}>
+                <cf-label>Amount</cf-label>
+                <cf-input $value={newAmount} placeholder="0.00" />
+              </cf-vstack>
+              <cf-vstack gap="1" style={{ flex: 1 }}>
+                <cf-label>Paid by</cf-label>
+                <cf-select $value={newPaidBy} items={peopleOptions} />
+              </cf-vstack>
+            </cf-hstack>
+
+            <cf-vstack gap="1">
+              <cf-label>Split between</cf-label>
+              <cf-hstack gap="2" wrap>
+                {computed(() =>
+                  splitChips.map((c) => (
+                    <cf-chip
+                      label={c.name}
+                      interactive
+                      onClick={() => {
+                        const cur = splitWith.get();
+                        // First explicit toggle starts from "everyone".
+                        const base = cur.length === 0
+                          ? people.get().map((p) => p.id)
+                          : cur;
+                        splitWith.set(
+                          base.includes(c.id)
+                            ? base.filter((x) => x !== c.id)
+                            : [...base, c.id],
+                        );
+                      }}
+                      style={{
+                        opacity: c.included ? "1" : "0.4",
+                      }}
+                    />
+                  ))
+                )}
+              </cf-hstack>
+              <cf-text variant="caption" tone="muted">
+                Tap to toggle. Everyone is included by default.
+              </cf-text>
+            </cf-vstack>
+
+            <cf-button
+              color="primary"
+              variant="solid"
+              onClick={() => {
+                const description = newDescription.get().trim();
+                const amount = parseFloat(newAmount.get());
+                const paidBy = newPaidBy.get();
+                if (!description || isNaN(amount) || amount <= 0 || !paidBy) {
+                  return;
+                }
+                const everyone = people.get().map((p) => p.id);
+                const selected = splitWith.get();
+                const sharedBy: string[] = [
+                  ...(selected.length === 0 ? everyone : selected),
+                ];
+                expenses.push({
+                  id: newId("e"),
+                  description,
+                  amount,
+                  paidBy,
+                  sharedBy,
+                  date: getTodayDate(),
+                });
+                newDescription.set("");
+                newAmount.set("");
+                splitWith.set([]);
+              }}
+            >
+              Add expense
+            </cf-button>
+          </cf-vstack>
+        </cf-card>
+
+        {/* ===== Expense list ===== */}
+        <cf-card>
+          <cf-vstack gap="3">
+            <cf-hstack
+              align="center"
+              style={{ justifyContent: "space-between" }}
+            >
+              <cf-heading level={4}>Expenses</cf-heading>
+              <cf-text style={{ fontWeight: "600" }}>
+                Total {computed(() => money(total))}
+              </cf-text>
+            </cf-hstack>
+
+            {expenses.map((expense) => (
+              <cf-hstack
+                gap="3"
+                align="center"
+                style={{
+                  justifyContent: "space-between",
+                  borderBottom: "1px solid #eee",
+                  paddingBottom: "0.5rem",
+                }}
+              >
+                <cf-vstack gap="0" style={{ flex: 1 }}>
+                  <span style={{ fontWeight: "600" }}>
+                    {expense.description}
+                  </span>
+                  <cf-text variant="caption" tone="muted">
+                    {computed(() => {
+                      const names = nameById;
+                      const payer = names[expense.paidBy] ?? "?";
+                      const n = expense.sharedBy?.length || 0;
+                      return `${payer} paid · split ${n} way${
+                        n === 1 ? "" : "s"
+                      } · ${expense.date}`;
+                    })}
+                  </cf-text>
+                </cf-vstack>
+                <span style={{ fontWeight: "600" }}>
+                  {computed(() => money(expense.amount))}
+                </span>
+                <cf-button
+                  variant="ghost"
+                  color="danger"
+                  onClick={() => {
+                    const cur = expenses.get();
+                    const idx = cur.findIndex((el) => el.id === expense.id);
+                    if (idx >= 0) expenses.set(cur.toSpliced(idx, 1));
+                  }}
+                >
+                  ×
+                </cf-button>
+              </cf-hstack>
+            ))}
+          </cf-vstack>
+        </cf-card>
+
+        {/* ===== Balances ===== */}
+        <cf-card>
+          <cf-vstack gap="3">
+            <cf-heading level={4}>Balances</cf-heading>
+            {computed(() =>
+              balances.map((b) => (
+                <cf-hstack
+                  align="center"
+                  style={{ justifyContent: "space-between" }}
+                >
+                  <span>{b.name}</span>
+                  <cf-badge
+                    color={b.net > EPS
+                      ? "accent"
+                      : b.net < -EPS
+                      ? "danger"
+                      : "neutral"}
+                  >
+                    {b.net > EPS
+                      ? `is owed ${money(b.net)}`
+                      : b.net < -EPS
+                      ? `owes ${money(-b.net)}`
+                      : "settled"}
+                  </cf-badge>
+                </cf-hstack>
+              ))
+            )}
+          </cf-vstack>
+        </cf-card>
+
+        {/* ===== Settle up ===== */}
+        <cf-card>
+          <cf-vstack gap="3">
+            <cf-heading level={4}>Settle up</cf-heading>
+            {computed(() => {
+              const plan = settlements;
+              if (plan.length === 0) {
+                return (
+                  <cf-text tone="muted">Everyone is settled up. 🎉</cf-text>
+                );
+              }
+              return plan.map((s) => (
+                <cf-hstack gap="2" align="center">
+                  <cf-badge color="danger">{s.from}</cf-badge>
+                  <span>→</span>
+                  <cf-badge color="accent">{s.to}</cf-badge>
+                  <span style={{ fontWeight: "600", marginLeft: "auto" }}>
+                    {money(s.amount)}
+                  </span>
+                </cf-hstack>
+              ));
+            })}
+          </cf-vstack>
+        </cf-card>
+      </cf-vstack>
+    ),
+
+    people,
+    expenses,
+    balances,
+    settlements,
+    total,
+  };
+});

--- a/packages/patterns/fair-share/main.tsx
+++ b/packages/patterns/fair-share/main.tsx
@@ -5,13 +5,17 @@
  * shared it, and see net balances plus a minimal "settle up" plan of who should
  * pay whom. Inspired by group expense-splitting apps.
  *
- * Scope (cozy-poll idiom):
- * - `people` and `expenses` are a per-space shared ledger anyone in the space
- *   sees and edits.
+ * Scope:
+ * - `people` and `expenses` are the shared ledger. Cells default to per-space
+ *   scope, so anyone in the space sees and edits the same ledger.
  * - `myName` is per-user: each viewer picks which person they are, which powers
- *   a personal "you are owed / you owe" summary and row highlight.
- * - Form drafts are per-session local cells, so concurrent viewers don't share
- *   each other's half-typed input or chip toggles.
+ *   a personal "you are owed / you owe" summary and a row highlight.
+ * - Form drafts are per-session cells, so concurrent viewers don't share each
+ *   other's half-typed input or chip toggles.
+ *
+ * Identity: items are matched with `equals()` (the pattern idiom) — never via
+ * synthetic id fields, which read as Cells inside `.map()` and break `===`.
+ * People are referenced from expenses by their (unique) name, the natural key.
  *
  * Money is computed in integer cents with largest-remainder allocation, so
  * displayed shares always sum back to the total and balances tie out exactly.
@@ -19,11 +23,9 @@
 import {
   computed,
   Default,
-  handler,
+  equals,
   NAME,
-  nonPrivateRandom,
   pattern,
-  type PerSpace,
   type PerUser,
   safeDateNow,
   UI,
@@ -33,21 +35,18 @@ import {
 // ============ TYPES ============
 
 interface Person {
-  id: string;
   name: string;
 }
 
 interface Expense {
-  id: string;
   description: string;
   amount: number;
-  paidBy: string; // Person.id
-  sharedBy: string[]; // Person.id[]; empty => split among everyone
+  paidBy: string; // Person.name
+  sharedBy: string[]; // Person.name[]; empty => split among everyone
   date: string; // YYYY-MM-DD
 }
 
 interface Balance {
-  id: string;
   name: string;
   paid: number;
   share: number;
@@ -55,38 +54,18 @@ interface Balance {
 }
 
 interface Settlement {
-  fromId: string;
   from: string; // debtor name
-  toId: string;
   to: string; // creditor name
   amount: number;
 }
 
-// Per-space shared ledger + per-user identity. Writes go through the
-// module-scope handlers below (which re-type these as Writable cells).
 interface State {
-  people: PerSpace<Person[] | Default<[]>>;
-  expenses: PerSpace<Expense[] | Default<[]>>;
+  people: Writable<Person[] | Default<[]>>;
+  expenses: Writable<Expense[] | Default<[]>>;
   myName: PerUser<string | Default<"">>;
 }
 
-// Cell aliases for handler contexts (cozy-poll idiom).
-type PeopleCell = Writable<Person[] | Default<[]>>;
-type ExpensesCell = Writable<Expense[] | Default<[]>>;
-type TextCell = Writable<string>;
-type IdsCell = Writable<string[]>;
-
-type EmptyEvent = Record<string, never>;
-interface IdEvent {
-  id: string;
-}
-
 // ============ HELPERS ============
-
-const newId = (prefix: string): string =>
-  `${prefix}_${safeDateNow().toString(36)}_${
-    Math.floor(nonPrivateRandom() * 1e6).toString(36)
-  }`;
 
 const getTodayDate = (): string =>
   new Date(safeDateNow()).toISOString().split("T")[0];
@@ -95,25 +74,25 @@ const toCents = (n: number): number => Math.round((n || 0) * 100);
 
 const money = (n: number): string => `$${(n || 0).toFixed(2)}`;
 
-// Allocate `cents` across `ids` so the parts sum back to `cents` exactly.
-// Largest-remainder: the first `remainder` ids get one extra cent.
-const splitCents = (cents: number, ids: string[]): Map<string, number> => {
+// Allocate `cents` across `names` so the parts sum back to `cents` exactly.
+// Largest-remainder: the first `remainder` recipients get one extra cent.
+const splitCents = (cents: number, names: string[]): Map<string, number> => {
   const out = new Map<string, number>();
-  const n = ids.length;
+  const n = names.length;
   if (n === 0) return out;
   const base = Math.floor(cents / n);
   const remainder = cents - base * n;
-  ids.forEach((id, i) => out.set(id, base + (i < remainder ? 1 : 0)));
+  names.forEach((name, i) => out.set(name, base + (i < remainder ? 1 : 0)));
   return out;
 };
 
 const computeSettlements = (balances: Balance[]): Settlement[] => {
   const creditors = balances
-    .map((b) => ({ id: b.id, name: b.name, rem: Math.round(b.net * 100) }))
+    .map((b) => ({ name: b.name, rem: Math.round(b.net * 100) }))
     .filter((b) => b.rem > 0)
     .sort((a, b) => b.rem - a.rem);
   const debtors = balances
-    .map((b) => ({ id: b.id, name: b.name, rem: -Math.round(b.net * 100) }))
+    .map((b) => ({ name: b.name, rem: -Math.round(b.net * 100) }))
     .filter((b) => b.rem > 0)
     .sort((a, b) => b.rem - a.rem);
 
@@ -125,13 +104,7 @@ const computeSettlements = (balances: Balance[]): Settlement[] => {
     const c = creditors[j];
     const cents = Math.min(d.rem, c.rem);
     if (cents > 0) {
-      result.push({
-        fromId: d.id,
-        from: d.name,
-        toId: c.id,
-        to: c.name,
-        amount: cents / 100,
-      });
+      result.push({ from: d.name, to: c.name, amount: cents / 100 });
     }
     d.rem -= cents;
     c.rem -= cents;
@@ -141,103 +114,6 @@ const computeSettlements = (balances: Balance[]): Settlement[] => {
   return result;
 };
 
-// ============ HANDLERS (module scope; write per-space state) ============
-
-const addPerson = handler<EmptyEvent, { people: PeopleCell; draft: TextCell }>(
-  (_event, { people, draft }) => {
-    const name = draft.get().trim();
-    if (!name) return;
-    if (people.get().some((p) => p.name === name)) return;
-    people.push({ id: newId("p"), name });
-    draft.set("");
-  },
-);
-
-// Removing a person cascade-cleans the ledger so balances stay zero-sum:
-// expenses they *paid* are dropped (the money has no creditor anymore), and
-// they are removed from every other expense's `sharedBy` (dropping any expense
-// left with no sharers).
-const removePerson = handler<
-  IdEvent,
-  { people: PeopleCell; expenses: ExpensesCell }
->(({ id }, { people, expenses }) => {
-  const ppl = people.get();
-  const idx = ppl.findIndex((p) => p.id === id);
-  if (idx < 0) return;
-  people.set(ppl.toSpliced(idx, 1));
-
-  const cleaned = expenses.get()
-    .filter((e) => e.paidBy !== id)
-    .map((e) => {
-      const sharedBy = e.sharedBy.filter((s) => s !== id);
-      return sharedBy.length === e.sharedBy.length ? e : { ...e, sharedBy };
-    })
-    .filter((e) => e.sharedBy.length > 0);
-  expenses.set(cleaned);
-});
-
-const addExpense = handler<EmptyEvent, {
-  people: PeopleCell;
-  expenses: ExpensesCell;
-  descDraft: TextCell;
-  amountDraft: TextCell;
-  paidByDraft: TextCell;
-  splitWith: IdsCell;
-}>(
-  (
-    _event,
-    { people, expenses, descDraft, amountDraft, paidByDraft, splitWith },
-  ) => {
-    const description = descDraft.get().trim();
-    const amount = toCents(parseFloat(amountDraft.get())) / 100; // snap to cents
-    const paidBy = paidByDraft.get();
-    const ppl = people.get();
-    if (!description || isNaN(amount) || amount <= 0) return;
-    if (!ppl.some((p) => p.id === paidBy)) return; // payer must exist
-
-    const everyone = ppl.map((p) => p.id);
-    const selected = splitWith.get().filter((sid) =>
-      ppl.some((p) => p.id === sid)
-    );
-    const sharedBy = selected.length === 0 ? everyone : selected;
-    if (sharedBy.length === 0) return;
-
-    expenses.push({
-      id: newId("e"),
-      description,
-      amount,
-      paidBy,
-      sharedBy,
-      date: getTodayDate(),
-    });
-    descDraft.set("");
-    amountDraft.set("");
-    splitWith.set([]);
-  },
-);
-
-const removeExpense = handler<IdEvent, { expenses: ExpensesCell }>(
-  ({ id }, { expenses }) => {
-    const cur = expenses.get();
-    const idx = cur.findIndex((e) => e.id === id);
-    if (idx >= 0) expenses.set(cur.toSpliced(idx, 1));
-  },
-);
-
-const toggleSplit = handler<
-  IdEvent,
-  { people: PeopleCell; splitWith: IdsCell }
->(
-  ({ id }, { people, splitWith }) => {
-    const cur = splitWith.get();
-    // First explicit toggle starts from "everyone selected".
-    const base = cur.length === 0 ? people.get().map((p) => p.id) : cur;
-    splitWith.set(
-      base.includes(id) ? base.filter((x) => x !== id) : [...base, id],
-    );
-  },
-);
-
 // ============ PATTERN ============
 
 export default pattern<State>(({ people, expenses, myName }) => {
@@ -245,73 +121,51 @@ export default pattern<State>(({ people, expenses, myName }) => {
   const personDraft = Writable.perSession.of<string>("");
   const descDraft = Writable.perSession.of<string>("");
   const amountDraft = Writable.perSession.of<string>("");
-  const paidByDraft = Writable.perSession.of<string>("");
-  const splitWith = Writable.perSession.of<string[]>([]);
-
-  // --- Bound handlers ---
-  const boundAddPerson = addPerson({ people, draft: personDraft });
-  const boundRemovePerson = removePerson({ people, expenses });
-  const boundAddExpense = addExpense({
-    people,
-    expenses,
-    descDraft,
-    amountDraft,
-    paidByDraft,
-    splitWith,
-  });
-  const boundRemoveExpense = removeExpense({ expenses });
-  const boundToggleSplit = toggleSplit({ people, splitWith });
+  const paidByDraft = Writable.perSession.of<string>(""); // Person.name
+  const splitWith = Writable.perSession.of<string[]>([]); // Person.name[]
 
   // --- Identity (resolve per-user name once at top level) ---
   const me = (myName ?? "").trim();
 
   // --- Derived data ---
-  const payerOptions = computed(() =>
-    people.map((p) => ({ label: p.name, value: p.id }))
-  );
-  const identityOptions = computed(() =>
-    people.map((p) => ({ label: p.name, value: p.name }))
+  const peopleOptions = computed(() =>
+    people.get().map((p) => ({ label: p.name, value: p.name }))
   );
 
   const total = computed(() => {
     let cents = 0;
-    for (const e of expenses) cents += toCents(e.amount);
+    for (const e of expenses.get()) cents += toCents(e.amount);
     return cents / 100;
   });
 
-  const nameById = computed(() => {
-    const map: Record<string, string> = {};
-    for (const p of people) map[p.id] = p.name;
-    return map;
-  });
-
   const balances = computed<Balance[]>(() => {
+    const ppl = people.get();
     const paidCents = new Map<string, number>();
     const shareCents = new Map<string, number>();
-    for (const p of people) {
-      paidCents.set(p.id, 0);
-      shareCents.set(p.id, 0);
+    for (const p of ppl) {
+      paidCents.set(p.name, 0);
+      shareCents.set(p.name, 0);
     }
 
-    for (const e of expenses) {
+    for (const e of expenses.get()) {
       const cents = toCents(e.amount);
       if (paidCents.has(e.paidBy)) {
         paidCents.set(e.paidBy, paidCents.get(e.paidBy)! + cents);
       }
-      const everyone = people.map((p) => p.id);
-      const ids = (e.sharedBy && e.sharedBy.length ? e.sharedBy : everyone)
-        .filter((id) => shareCents.has(id));
-      if (ids.length === 0) continue;
-      const alloc = splitCents(cents, ids);
-      for (const id of ids) {
-        shareCents.set(id, shareCents.get(id)! + (alloc.get(id) ?? 0));
+      const everyone = ppl.map((p) => p.name);
+      const names = (e.sharedBy && e.sharedBy.length ? e.sharedBy : everyone)
+        .filter((name) => shareCents.has(name));
+      if (names.length === 0) continue;
+      const alloc = splitCents(cents, names);
+      for (const name of names) {
+        shareCents.set(name, shareCents.get(name)! + (alloc.get(name) ?? 0));
       }
     }
 
-    return people.map((p) => {
-      const paid = (paidCents.get(p.id) ?? 0) / 100;
-      const share = (shareCents.get(p.id) ?? 0) / 100;
-      return { id: p.id, name: p.name, paid, share, net: paid - share };
+    return ppl.map((p) => {
+      const paid = (paidCents.get(p.name) ?? 0) / 100;
+      const share = (shareCents.get(p.name) ?? 0) / 100;
+      return { name: p.name, paid, share, net: paid - share };
     });
   });
 
@@ -325,10 +179,10 @@ export default pattern<State>(({ people, expenses, myName }) => {
 
   // Display helper for the "split with" chips in the form.
   const splitChips = computed(() =>
-    people.map((p) => ({
-      id: p.id,
+    people.get().map((p) => ({
       name: p.name,
-      included: splitWith.get().length === 0 || splitWith.get().includes(p.id),
+      included: splitWith.get().length === 0 ||
+        splitWith.get().includes(p.name),
     }))
   );
 
@@ -348,7 +202,7 @@ export default pattern<State>(({ people, expenses, myName }) => {
             <cf-label>You are</cf-label>
             <cf-select
               $value={myName}
-              items={identityOptions}
+              items={peopleOptions}
               style={{ minWidth: "160px" }}
             />
             {computed(() => {
@@ -381,7 +235,7 @@ export default pattern<State>(({ people, expenses, myName }) => {
             <cf-heading level={4}>People</cf-heading>
 
             {computed(() =>
-              people.length === 0
+              people.get().length === 0
                 ? <cf-text tone="muted">Add people to get started.</cf-text>
                 : (
                   <cf-hstack gap="2" wrap>
@@ -389,8 +243,28 @@ export default pattern<State>(({ people, expenses, myName }) => {
                       <cf-chip
                         label={person.name}
                         removable
-                        oncf-remove={() =>
-                          boundRemovePerson.send({ id: person.id })}
+                        oncf-remove={() => {
+                          const cur = people.get();
+                          const idx = cur.findIndex((p) => equals(person, p));
+                          if (idx < 0) return;
+                          const name = { ...cur[idx] }.name;
+                          people.set(cur.toSpliced(idx, 1));
+                          // Cascade-clean so balances stay zero-sum: drop
+                          // expenses they paid (money has no creditor now) and
+                          // remove them from every other split.
+                          const cleaned = expenses.get()
+                            .filter((e) => e.paidBy !== name)
+                            .map((e) => {
+                              const sharedBy = e.sharedBy.filter((s) =>
+                                s !== name
+                              );
+                              return sharedBy.length === e.sharedBy.length
+                                ? e
+                                : { ...e, sharedBy };
+                            })
+                            .filter((e) => e.sharedBy.length > 0);
+                          expenses.set(cleaned);
+                        }}
                       />
                     ))}
                   </cf-hstack>
@@ -406,7 +280,13 @@ export default pattern<State>(({ people, expenses, myName }) => {
               <cf-button
                 color="primary"
                 variant="solid"
-                onClick={boundAddPerson}
+                onClick={() => {
+                  const name = personDraft.get().trim();
+                  if (!name) return;
+                  if (people.get().some((p) => p.name === name)) return;
+                  people.push({ name });
+                  personDraft.set("");
+                }}
               >
                 Add
               </cf-button>
@@ -431,7 +311,7 @@ export default pattern<State>(({ people, expenses, myName }) => {
               </cf-vstack>
               <cf-vstack gap="1" style={{ flex: 1 }}>
                 <cf-label>Paid by</cf-label>
-                <cf-select $value={paidByDraft} items={payerOptions} />
+                <cf-select $value={paidByDraft} items={peopleOptions} />
               </cf-vstack>
             </cf-hstack>
 
@@ -443,7 +323,18 @@ export default pattern<State>(({ people, expenses, myName }) => {
                     <cf-chip
                       label={c.name}
                       interactive
-                      onClick={() => boundToggleSplit.send({ id: c.id })}
+                      onClick={() => {
+                        const cur = splitWith.get();
+                        // First explicit toggle starts from "everyone".
+                        const base = cur.length === 0
+                          ? people.get().map((p) => p.name)
+                          : cur;
+                        splitWith.set(
+                          base.includes(c.name)
+                            ? base.filter((x) => x !== c.name)
+                            : [...base, c.name],
+                        );
+                      }}
                       style={{ opacity: c.included ? "1" : "0.4" }}
                     />
                   ))
@@ -457,7 +348,32 @@ export default pattern<State>(({ people, expenses, myName }) => {
             <cf-button
               color="primary"
               variant="solid"
-              onClick={boundAddExpense}
+              onClick={() => {
+                const description = descDraft.get().trim();
+                const amount = toCents(parseFloat(amountDraft.get())) / 100;
+                const paidBy = paidByDraft.get();
+                const ppl = people.get();
+                if (!description || isNaN(amount) || amount <= 0) return;
+                if (!ppl.some((p) => p.name === paidBy)) return;
+
+                const everyone = ppl.map((p) => p.name);
+                const selected = splitWith.get().filter((nm) =>
+                  ppl.some((p) => p.name === nm)
+                );
+                const sharedBy = selected.length === 0 ? everyone : selected;
+                if (sharedBy.length === 0) return;
+
+                expenses.push({
+                  description,
+                  amount,
+                  paidBy,
+                  sharedBy,
+                  date: getTodayDate(),
+                });
+                descDraft.set("");
+                amountDraft.set("");
+                splitWith.set([]);
+              }}
             >
               Add expense
             </cf-button>
@@ -478,7 +394,7 @@ export default pattern<State>(({ people, expenses, myName }) => {
             </cf-hstack>
 
             {computed(() =>
-              expenses.length === 0
+              expenses.get().length === 0
                 ? <cf-text tone="muted">No expenses yet.</cf-text>
                 : expenses.map((expense) => (
                   <cf-hstack
@@ -496,10 +412,8 @@ export default pattern<State>(({ people, expenses, myName }) => {
                       </span>
                       <cf-text variant="caption" tone="muted">
                         {computed(() => {
-                          const names = nameById;
-                          const payer = names[expense.paidBy] ?? "?";
                           const n = expense.sharedBy?.length || 0;
-                          return `${payer} paid · split ${n} way${
+                          return `${expense.paidBy} paid · split ${n} way${
                             n === 1 ? "" : "s"
                           } · ${expense.date}`;
                         })}
@@ -511,8 +425,11 @@ export default pattern<State>(({ people, expenses, myName }) => {
                     <cf-button
                       variant="ghost"
                       color="danger"
-                      onClick={() =>
-                        boundRemoveExpense.send({ id: expense.id })}
+                      onClick={() => {
+                        const cur = expenses.get();
+                        const idx = cur.findIndex((el) => equals(expense, el));
+                        if (idx >= 0) expenses.set(cur.toSpliced(idx, 1));
+                      }}
                     >
                       ×
                     </cf-button>
@@ -584,18 +501,12 @@ export default pattern<State>(({ people, expenses, myName }) => {
       </cf-vstack>
     ),
 
-    // Per-space ledger + per-user identity (re-exported for cross-piece reads).
+    // Shared ledger + per-user identity (re-exported for cross-piece reads).
     people,
     expenses,
     myName,
     balances,
     settlements,
     total,
-
-    // Mutations exposed as streams for composition.
-    addPerson: boundAddPerson,
-    removePerson: boundRemovePerson,
-    addExpense: boundAddExpense,
-    removeExpense: boundRemoveExpense,
   };
 });

--- a/packages/patterns/fair-share/main.tsx
+++ b/packages/patterns/fair-share/main.tsx
@@ -124,6 +124,12 @@ export default pattern<State>(({ people, expenses, myName }) => {
   const paidByDraft = Writable.perSession.of<string>(""); // Person.name
   const splitWith = Writable.perSession.of<string[]>([]); // Person.name[]
 
+  // Locally retype without Default<>: the transformer only infers `comparable`
+  // array items (required for equals()) when the array type has no Default<>
+  // union member. The cells are the same; this just sharpens the static type.
+  const peopleList: Writable<Person[]> = people;
+  const expensesList: Writable<Expense[]> = expenses;
+
   // --- Identity (resolve per-user name once at top level) ---
   const me = (myName ?? "").trim();
 
@@ -234,41 +240,43 @@ export default pattern<State>(({ people, expenses, myName }) => {
           <cf-vstack gap="3">
             <cf-heading level={4}>People</cf-heading>
 
+            {
+              /* Bare .map() — wrapping it in computed() breaks the transformer's
+                equals() schema inference (array items lose `comparable`), which
+                silently breaks removal. Empty state is a separate sibling. */
+            }
+            <cf-hstack gap="2" wrap>
+              {peopleList.map((person) => (
+                <cf-chip
+                  label={person.name}
+                  removable
+                  oncf-remove={() => {
+                    const cur = peopleList.get();
+                    const idx = cur.findIndex((p) => equals(person, p));
+                    if (idx < 0) return;
+                    const name = { ...cur[idx] }.name;
+                    peopleList.set(cur.toSpliced(idx, 1));
+                    // Cascade-clean so balances stay zero-sum: drop expenses
+                    // they paid (money has no creditor now) and remove them
+                    // from every other split.
+                    const cleaned = expenses.get()
+                      .filter((e) => e.paidBy !== name)
+                      .map((e) => {
+                        const sharedBy = e.sharedBy.filter((s) => s !== name);
+                        return sharedBy.length === e.sharedBy.length
+                          ? e
+                          : { ...e, sharedBy };
+                      })
+                      .filter((e) => e.sharedBy.length > 0);
+                    expenses.set(cleaned);
+                  }}
+                />
+              ))}
+            </cf-hstack>
             {computed(() =>
               people.get().length === 0
                 ? <cf-text tone="muted">Add people to get started.</cf-text>
-                : (
-                  <cf-hstack gap="2" wrap>
-                    {people.map((person) => (
-                      <cf-chip
-                        label={person.name}
-                        removable
-                        oncf-remove={() => {
-                          const cur = people.get();
-                          const idx = cur.findIndex((p) => equals(person, p));
-                          if (idx < 0) return;
-                          const name = { ...cur[idx] }.name;
-                          people.set(cur.toSpliced(idx, 1));
-                          // Cascade-clean so balances stay zero-sum: drop
-                          // expenses they paid (money has no creditor now) and
-                          // remove them from every other split.
-                          const cleaned = expenses.get()
-                            .filter((e) => e.paidBy !== name)
-                            .map((e) => {
-                              const sharedBy = e.sharedBy.filter((s) =>
-                                s !== name
-                              );
-                              return sharedBy.length === e.sharedBy.length
-                                ? e
-                                : { ...e, sharedBy };
-                            })
-                            .filter((e) => e.sharedBy.length > 0);
-                          expenses.set(cleaned);
-                        }}
-                      />
-                    ))}
-                  </cf-hstack>
-                )
+                : null
             )}
 
             <cf-hstack gap="2" align="center">
@@ -393,48 +401,50 @@ export default pattern<State>(({ people, expenses, myName }) => {
               </cf-text>
             </cf-hstack>
 
+            {/* Bare .map() — see People note above. */}
+            {expensesList.map((expense) => (
+              <cf-hstack
+                gap="3"
+                align="center"
+                style={{
+                  justifyContent: "space-between",
+                  borderBottom: "1px solid #eee",
+                  paddingBottom: "0.5rem",
+                }}
+              >
+                <cf-vstack gap="0" style={{ flex: 1 }}>
+                  <span style={{ fontWeight: "600" }}>
+                    {expense.description}
+                  </span>
+                  <cf-text variant="caption" tone="muted">
+                    {computed(() => {
+                      const n = expense.sharedBy?.length || 0;
+                      return `${expense.paidBy} paid · split ${n} way${
+                        n === 1 ? "" : "s"
+                      } · ${expense.date}`;
+                    })}
+                  </cf-text>
+                </cf-vstack>
+                <span style={{ fontWeight: "600" }}>
+                  {computed(() => money(expense.amount))}
+                </span>
+                <cf-button
+                  variant="ghost"
+                  color="danger"
+                  onClick={() => {
+                    const cur = expensesList.get();
+                    const idx = cur.findIndex((el) => equals(expense, el));
+                    if (idx >= 0) expensesList.set(cur.toSpliced(idx, 1));
+                  }}
+                >
+                  ×
+                </cf-button>
+              </cf-hstack>
+            ))}
             {computed(() =>
               expenses.get().length === 0
                 ? <cf-text tone="muted">No expenses yet.</cf-text>
-                : expenses.map((expense) => (
-                  <cf-hstack
-                    gap="3"
-                    align="center"
-                    style={{
-                      justifyContent: "space-between",
-                      borderBottom: "1px solid #eee",
-                      paddingBottom: "0.5rem",
-                    }}
-                  >
-                    <cf-vstack gap="0" style={{ flex: 1 }}>
-                      <span style={{ fontWeight: "600" }}>
-                        {expense.description}
-                      </span>
-                      <cf-text variant="caption" tone="muted">
-                        {computed(() => {
-                          const n = expense.sharedBy?.length || 0;
-                          return `${expense.paidBy} paid · split ${n} way${
-                            n === 1 ? "" : "s"
-                          } · ${expense.date}`;
-                        })}
-                      </cf-text>
-                    </cf-vstack>
-                    <span style={{ fontWeight: "600" }}>
-                      {computed(() => money(expense.amount))}
-                    </span>
-                    <cf-button
-                      variant="ghost"
-                      color="danger"
-                      onClick={() => {
-                        const cur = expenses.get();
-                        const idx = cur.findIndex((el) => equals(expense, el));
-                        if (idx >= 0) expenses.set(cur.toSpliced(idx, 1));
-                      }}
-                    >
-                      ×
-                    </cf-button>
-                  </cf-hstack>
-                ))
+                : null
             )}
           </cf-vstack>
         </cf-card>

--- a/packages/patterns/fair-share/main.tsx
+++ b/packages/patterns/fair-share/main.tsx
@@ -124,12 +124,6 @@ export default pattern<State>(({ people, expenses, myName }) => {
   const paidByDraft = Writable.perSession.of<string>(""); // Person.name
   const splitWith = Writable.perSession.of<string[]>([]); // Person.name[]
 
-  // Locally retype without Default<>: the transformer only infers `comparable`
-  // array items (required for equals()) when the array type has no Default<>
-  // union member. The cells are the same; this just sharpens the static type.
-  const peopleList: Writable<Person[]> = people;
-  const expensesList: Writable<Expense[]> = expenses;
-
   // --- Identity (resolve per-user name once at top level) ---
   const me = (myName ?? "").trim();
 
@@ -246,16 +240,16 @@ export default pattern<State>(({ people, expenses, myName }) => {
                 silently breaks removal. Empty state is a separate sibling. */
             }
             <cf-hstack gap="2" wrap>
-              {peopleList.map((person) => (
+              {people.map((person) => (
                 <cf-chip
                   label={person.name}
                   removable
                   oncf-remove={() => {
-                    const cur = peopleList.get();
+                    const cur = people.get();
                     const idx = cur.findIndex((p) => equals(person, p));
                     if (idx < 0) return;
                     const name = { ...cur[idx] }.name;
-                    peopleList.set(cur.toSpliced(idx, 1));
+                    people.set(cur.toSpliced(idx, 1));
                     // Cascade-clean so balances stay zero-sum: drop expenses
                     // they paid (money has no creditor now) and remove them
                     // from every other split.
@@ -402,7 +396,7 @@ export default pattern<State>(({ people, expenses, myName }) => {
             </cf-hstack>
 
             {/* Bare .map() — see People note above. */}
-            {expensesList.map((expense) => (
+            {expenses.map((expense) => (
               <cf-hstack
                 gap="3"
                 align="center"
@@ -432,9 +426,9 @@ export default pattern<State>(({ people, expenses, myName }) => {
                   variant="ghost"
                   color="danger"
                   onClick={() => {
-                    const cur = expensesList.get();
+                    const cur = expenses.get();
                     const idx = cur.findIndex((el) => equals(expense, el));
-                    if (idx >= 0) expensesList.set(cur.toSpliced(idx, 1));
+                    if (idx >= 0) expenses.set(cur.toSpliced(idx, 1));
                   }}
                 >
                   ×

--- a/packages/patterns/fair-share/main.tsx
+++ b/packages/patterns/fair-share/main.tsx
@@ -259,9 +259,15 @@ export default pattern<State>(({ people, expenses, myName }) => {
                     const cleaned: Expense[] = [];
                     for (const e of expenses.get()) {
                       if (e.paidBy === name) continue;
-                      const shared = [...(e.sharedBy ?? [])].filter((s) =>
-                        s !== name
-                      );
+                      const had = [...(e.sharedBy ?? [])];
+                      // Empty sharedBy means "split among everyone" — it stays
+                      // implicit-everyone (now a smaller group), so keep it as-is.
+                      if (had.length === 0) {
+                        cleaned.push({ ...e });
+                        continue;
+                      }
+                      const shared = had.filter((s) => s !== name);
+                      // An explicit split emptied by this removal is dropped.
                       if (shared.length === 0) continue;
                       cleaned.push({ ...e, sharedBy: shared });
                     }
@@ -359,7 +365,11 @@ export default pattern<State>(({ people, expenses, myName }) => {
                 const amount = toCents(parseFloat(amountDraft.get())) / 100;
                 const paidBy = paidByDraft.get();
                 const ppl = people.get();
-                if (!description || isNaN(amount) || amount <= 0) return;
+                // Number.isFinite rejects NaN AND ±Infinity (e.g. "1e999"),
+                // which would otherwise poison totals/splits.
+                if (!description || !Number.isFinite(amount) || amount <= 0) {
+                  return;
+                }
                 if (!ppl.some((p) => p.name === paidBy)) return;
 
                 const everyone = ppl.map((p) => p.name);

--- a/packages/patterns/fair-share/main.tsx
+++ b/packages/patterns/fair-share/main.tsx
@@ -4,13 +4,27 @@
  * Track who paid for what in a group, split each expense among the people who
  * shared it, and see net balances plus a minimal "settle up" plan of who should
  * pay whom. Inspired by group expense-splitting apps.
+ *
+ * Scope (cozy-poll idiom):
+ * - `people` and `expenses` are a per-space shared ledger anyone in the space
+ *   sees and edits.
+ * - `myName` is per-user: each viewer picks which person they are, which powers
+ *   a personal "you are owed / you owe" summary and row highlight.
+ * - Form drafts are per-session local cells, so concurrent viewers don't share
+ *   each other's half-typed input or chip toggles.
+ *
+ * Money is computed in integer cents with largest-remainder allocation, so
+ * displayed shares always sum back to the total and balances tie out exactly.
  */
 import {
   computed,
   Default,
+  handler,
   NAME,
   nonPrivateRandom,
   pattern,
+  type PerSpace,
+  type PerUser,
   safeDateNow,
   UI,
   Writable,
@@ -41,14 +55,30 @@ interface Balance {
 }
 
 interface Settlement {
+  fromId: string;
   from: string; // debtor name
+  toId: string;
   to: string; // creditor name
   amount: number;
 }
 
+// Per-space shared ledger + per-user identity. Writes go through the
+// module-scope handlers below (which re-type these as Writable cells).
 interface State {
-  people: Writable<Person[] | Default<[]>>;
-  expenses: Writable<Expense[] | Default<[]>>;
+  people: PerSpace<Person[] | Default<[]>>;
+  expenses: PerSpace<Expense[] | Default<[]>>;
+  myName: PerUser<string | Default<"">>;
+}
+
+// Cell aliases for handler contexts (cozy-poll idiom).
+type PeopleCell = Writable<Person[] | Default<[]>>;
+type ExpensesCell = Writable<Expense[] | Default<[]>>;
+type TextCell = Writable<string>;
+type IdsCell = Writable<string[]>;
+
+type EmptyEvent = Record<string, never>;
+interface IdEvent {
+  id: string;
 }
 
 // ============ HELPERS ============
@@ -58,21 +88,33 @@ const newId = (prefix: string): string =>
     Math.floor(nonPrivateRandom() * 1e6).toString(36)
   }`;
 
-const getTodayDate = (): string => new Date().toISOString().split("T")[0];
+const getTodayDate = (): string =>
+  new Date(safeDateNow()).toISOString().split("T")[0];
+
+const toCents = (n: number): number => Math.round((n || 0) * 100);
 
 const money = (n: number): string => `$${(n || 0).toFixed(2)}`;
 
-// Tolerance for floating-point cents when settling.
-const EPS = 0.005;
+// Allocate `cents` across `ids` so the parts sum back to `cents` exactly.
+// Largest-remainder: the first `remainder` ids get one extra cent.
+const splitCents = (cents: number, ids: string[]): Map<string, number> => {
+  const out = new Map<string, number>();
+  const n = ids.length;
+  if (n === 0) return out;
+  const base = Math.floor(cents / n);
+  const remainder = cents - base * n;
+  ids.forEach((id, i) => out.set(id, base + (i < remainder ? 1 : 0)));
+  return out;
+};
 
 const computeSettlements = (balances: Balance[]): Settlement[] => {
   const creditors = balances
-    .filter((b) => b.net > EPS)
-    .map((b) => ({ name: b.name, rem: b.net }))
+    .map((b) => ({ id: b.id, name: b.name, rem: Math.round(b.net * 100) }))
+    .filter((b) => b.rem > 0)
     .sort((a, b) => b.rem - a.rem);
   const debtors = balances
-    .filter((b) => b.net < -EPS)
-    .map((b) => ({ name: b.name, rem: -b.net }))
+    .map((b) => ({ id: b.id, name: b.name, rem: -Math.round(b.net * 100) }))
+    .filter((b) => b.rem > 0)
     .sort((a, b) => b.rem - a.rem);
 
   const result: Settlement[] = [];
@@ -81,79 +123,209 @@ const computeSettlements = (balances: Balance[]): Settlement[] => {
   while (i < debtors.length && j < creditors.length) {
     const d = debtors[i];
     const c = creditors[j];
-    const amount = Math.min(d.rem, c.rem);
-    if (amount > EPS) {
-      result.push({ from: d.name, to: c.name, amount });
+    const cents = Math.min(d.rem, c.rem);
+    if (cents > 0) {
+      result.push({
+        fromId: d.id,
+        from: d.name,
+        toId: c.id,
+        to: c.name,
+        amount: cents / 100,
+      });
     }
-    d.rem -= amount;
-    c.rem -= amount;
-    if (d.rem <= EPS) i++;
-    if (c.rem <= EPS) j++;
+    d.rem -= cents;
+    c.rem -= cents;
+    if (d.rem === 0) i++;
+    if (c.rem === 0) j++;
   }
   return result;
 };
 
+// ============ HANDLERS (module scope; write per-space state) ============
+
+const addPerson = handler<EmptyEvent, { people: PeopleCell; draft: TextCell }>(
+  (_event, { people, draft }) => {
+    const name = draft.get().trim();
+    if (!name) return;
+    if (people.get().some((p) => p.name === name)) return;
+    people.push({ id: newId("p"), name });
+    draft.set("");
+  },
+);
+
+// Removing a person cascade-cleans the ledger so balances stay zero-sum:
+// expenses they *paid* are dropped (the money has no creditor anymore), and
+// they are removed from every other expense's `sharedBy` (dropping any expense
+// left with no sharers).
+const removePerson = handler<
+  IdEvent,
+  { people: PeopleCell; expenses: ExpensesCell }
+>(({ id }, { people, expenses }) => {
+  const ppl = people.get();
+  const idx = ppl.findIndex((p) => p.id === id);
+  if (idx < 0) return;
+  people.set(ppl.toSpliced(idx, 1));
+
+  const cleaned = expenses.get()
+    .filter((e) => e.paidBy !== id)
+    .map((e) => {
+      const sharedBy = e.sharedBy.filter((s) => s !== id);
+      return sharedBy.length === e.sharedBy.length ? e : { ...e, sharedBy };
+    })
+    .filter((e) => e.sharedBy.length > 0);
+  expenses.set(cleaned);
+});
+
+const addExpense = handler<EmptyEvent, {
+  people: PeopleCell;
+  expenses: ExpensesCell;
+  descDraft: TextCell;
+  amountDraft: TextCell;
+  paidByDraft: TextCell;
+  splitWith: IdsCell;
+}>(
+  (
+    _event,
+    { people, expenses, descDraft, amountDraft, paidByDraft, splitWith },
+  ) => {
+    const description = descDraft.get().trim();
+    const amount = toCents(parseFloat(amountDraft.get())) / 100; // snap to cents
+    const paidBy = paidByDraft.get();
+    const ppl = people.get();
+    if (!description || isNaN(amount) || amount <= 0) return;
+    if (!ppl.some((p) => p.id === paidBy)) return; // payer must exist
+
+    const everyone = ppl.map((p) => p.id);
+    const selected = splitWith.get().filter((sid) =>
+      ppl.some((p) => p.id === sid)
+    );
+    const sharedBy = selected.length === 0 ? everyone : selected;
+    if (sharedBy.length === 0) return;
+
+    expenses.push({
+      id: newId("e"),
+      description,
+      amount,
+      paidBy,
+      sharedBy,
+      date: getTodayDate(),
+    });
+    descDraft.set("");
+    amountDraft.set("");
+    splitWith.set([]);
+  },
+);
+
+const removeExpense = handler<IdEvent, { expenses: ExpensesCell }>(
+  ({ id }, { expenses }) => {
+    const cur = expenses.get();
+    const idx = cur.findIndex((e) => e.id === id);
+    if (idx >= 0) expenses.set(cur.toSpliced(idx, 1));
+  },
+);
+
+const toggleSplit = handler<
+  IdEvent,
+  { people: PeopleCell; splitWith: IdsCell }
+>(
+  ({ id }, { people, splitWith }) => {
+    const cur = splitWith.get();
+    // First explicit toggle starts from "everyone selected".
+    const base = cur.length === 0 ? people.get().map((p) => p.id) : cur;
+    splitWith.set(
+      base.includes(id) ? base.filter((x) => x !== id) : [...base, id],
+    );
+  },
+);
+
 // ============ PATTERN ============
 
-export default pattern<State>(({ people, expenses }) => {
-  // --- Local form state ---
-  const newPersonName = new Writable("");
-  const newDescription = new Writable("");
-  const newAmount = new Writable("");
-  const newPaidBy = new Writable(""); // Person.id
-  const splitWith = new Writable<string[]>([]); // Person.id[]; empty => everyone
+export default pattern<State>(({ people, expenses, myName }) => {
+  // --- Per-session form drafts (local to each viewer) ---
+  const personDraft = Writable.perSession.of<string>("");
+  const descDraft = Writable.perSession.of<string>("");
+  const amountDraft = Writable.perSession.of<string>("");
+  const paidByDraft = Writable.perSession.of<string>("");
+  const splitWith = Writable.perSession.of<string[]>([]);
+
+  // --- Bound handlers ---
+  const boundAddPerson = addPerson({ people, draft: personDraft });
+  const boundRemovePerson = removePerson({ people, expenses });
+  const boundAddExpense = addExpense({
+    people,
+    expenses,
+    descDraft,
+    amountDraft,
+    paidByDraft,
+    splitWith,
+  });
+  const boundRemoveExpense = removeExpense({ expenses });
+  const boundToggleSplit = toggleSplit({ people, splitWith });
+
+  // --- Identity (resolve per-user name once at top level) ---
+  const me = (myName ?? "").trim();
 
   // --- Derived data ---
-  const peopleOptions = computed(() =>
-    people.get().map((p) => ({ label: p.name, value: p.id }))
+  const payerOptions = computed(() =>
+    people.map((p) => ({ label: p.name, value: p.id }))
+  );
+  const identityOptions = computed(() =>
+    people.map((p) => ({ label: p.name, value: p.name }))
   );
 
-  const total = computed(() =>
-    expenses.get().reduce((sum, e) => sum + (e.amount || 0), 0)
-  );
+  const total = computed(() => {
+    let cents = 0;
+    for (const e of expenses) cents += toCents(e.amount);
+    return cents / 100;
+  });
 
   const nameById = computed(() => {
     const map: Record<string, string> = {};
-    for (const p of people.get()) map[p.id] = p.name;
+    for (const p of people) map[p.id] = p.name;
     return map;
   });
 
   const balances = computed<Balance[]>(() => {
-    const ppl = people.get();
-    const exps = expenses.get();
-    const acc = new Map<string, Balance>(
-      ppl.map((
-        p,
-      ) => [p.id, { id: p.id, name: p.name, paid: 0, share: 0, net: 0 }]),
-    );
+    const paidCents = new Map<string, number>();
+    const shareCents = new Map<string, number>();
+    for (const p of people) {
+      paidCents.set(p.id, 0);
+      shareCents.set(p.id, 0);
+    }
 
-    for (const e of exps) {
-      const payer = acc.get(e.paidBy);
-      if (payer) payer.paid += e.amount || 0;
-
-      const everyone = ppl.map((p) => p.id);
-      const shareIds = (e.sharedBy && e.sharedBy.length ? e.sharedBy : everyone)
-        .filter((id) => acc.has(id));
-      if (shareIds.length === 0) continue;
-
-      const per = (e.amount || 0) / shareIds.length;
-      for (const id of shareIds) {
-        const b = acc.get(id);
-        if (b) b.share += per;
+    for (const e of expenses) {
+      const cents = toCents(e.amount);
+      if (paidCents.has(e.paidBy)) {
+        paidCents.set(e.paidBy, paidCents.get(e.paidBy)! + cents);
+      }
+      const everyone = people.map((p) => p.id);
+      const ids = (e.sharedBy && e.sharedBy.length ? e.sharedBy : everyone)
+        .filter((id) => shareCents.has(id));
+      if (ids.length === 0) continue;
+      const alloc = splitCents(cents, ids);
+      for (const id of ids) {
+        shareCents.set(id, shareCents.get(id)! + (alloc.get(id) ?? 0));
       }
     }
 
-    return ppl.map((p) => {
-      const b = acc.get(p.id)!;
-      return { ...b, net: b.paid - b.share };
+    return people.map((p) => {
+      const paid = (paidCents.get(p.id) ?? 0) / 100;
+      const share = (shareCents.get(p.id) ?? 0) / 100;
+      return { id: p.id, name: p.name, paid, share, net: paid - share };
     });
   });
 
   const settlements = computed(() => computeSettlements(balances));
 
-  // --- Display helpers for the "split with" chips in the form ---
+  const myNet = computed(() => {
+    if (!me) return null;
+    const mine = balances.find((b) => b.name === me);
+    return mine ? mine.net : null;
+  });
+
+  // Display helper for the "split with" chips in the form.
   const splitChips = computed(() =>
-    people.get().map((p) => ({
+    people.map((p) => ({
       id: p.id,
       name: p.name,
       included: splitWith.get().length === 0 || splitWith.get().includes(p.id),
@@ -170,41 +342,71 @@ export default pattern<State>(({ people, expenses }) => {
           settle up.
         </cf-text>
 
+        {/* ===== You ===== */}
+        <cf-card>
+          <cf-hstack gap="3" align="center" wrap>
+            <cf-label>You are</cf-label>
+            <cf-select
+              $value={myName}
+              items={identityOptions}
+              style={{ minWidth: "160px" }}
+            />
+            {computed(() => {
+              const net = myNet;
+              if (net === null) {
+                return (
+                  <cf-text tone="muted">
+                    Pick who you are to see your balance.
+                  </cf-text>
+                );
+              }
+              return (
+                <cf-badge
+                  color={net > 0 ? "accent" : net < 0 ? "danger" : "neutral"}
+                >
+                  {net > 0
+                    ? `You are owed ${money(net)}`
+                    : net < 0
+                    ? `You owe ${money(-net)}`
+                    : "You're settled up"}
+                </cf-badge>
+              );
+            })}
+          </cf-hstack>
+        </cf-card>
+
         {/* ===== People ===== */}
         <cf-card>
           <cf-vstack gap="3">
             <cf-heading level={4}>People</cf-heading>
 
-            <cf-hstack gap="2" wrap>
-              {people.map((person) => (
-                <cf-chip
-                  label={person.name}
-                  removable
-                  oncf-remove={() => {
-                    const cur = people.get();
-                    const idx = cur.findIndex((el) => el.id === person.id);
-                    if (idx >= 0) people.set(cur.toSpliced(idx, 1));
-                  }}
-                />
-              ))}
-            </cf-hstack>
+            {computed(() =>
+              people.length === 0
+                ? <cf-text tone="muted">Add people to get started.</cf-text>
+                : (
+                  <cf-hstack gap="2" wrap>
+                    {people.map((person) => (
+                      <cf-chip
+                        label={person.name}
+                        removable
+                        oncf-remove={() =>
+                          boundRemovePerson.send({ id: person.id })}
+                      />
+                    ))}
+                  </cf-hstack>
+                )
+            )}
 
             <cf-hstack gap="2" align="center">
               <cf-input
-                $value={newPersonName}
+                $value={personDraft}
                 placeholder="Add a person…"
                 style={{ flex: 1 }}
               />
               <cf-button
                 color="primary"
                 variant="solid"
-                onClick={() => {
-                  const name = newPersonName.get().trim();
-                  if (!name) return;
-                  if (people.get().some((p) => p.name === name)) return;
-                  people.push({ id: newId("p"), name });
-                  newPersonName.set("");
-                }}
+                onClick={boundAddPerson}
               >
                 Add
               </cf-button>
@@ -219,17 +421,17 @@ export default pattern<State>(({ people, expenses }) => {
 
             <cf-vstack gap="1">
               <cf-label>Description</cf-label>
-              <cf-input $value={newDescription} placeholder="Dinner, taxi, …" />
+              <cf-input $value={descDraft} placeholder="Dinner, taxi, …" />
             </cf-vstack>
 
             <cf-hstack gap="3" wrap>
               <cf-vstack gap="1" style={{ flex: 1 }}>
                 <cf-label>Amount</cf-label>
-                <cf-input $value={newAmount} placeholder="0.00" />
+                <cf-input $value={amountDraft} placeholder="0.00" />
               </cf-vstack>
               <cf-vstack gap="1" style={{ flex: 1 }}>
                 <cf-label>Paid by</cf-label>
-                <cf-select $value={newPaidBy} items={peopleOptions} />
+                <cf-select $value={paidByDraft} items={payerOptions} />
               </cf-vstack>
             </cf-hstack>
 
@@ -241,21 +443,8 @@ export default pattern<State>(({ people, expenses }) => {
                     <cf-chip
                       label={c.name}
                       interactive
-                      onClick={() => {
-                        const cur = splitWith.get();
-                        // First explicit toggle starts from "everyone".
-                        const base = cur.length === 0
-                          ? people.get().map((p) => p.id)
-                          : cur;
-                        splitWith.set(
-                          base.includes(c.id)
-                            ? base.filter((x) => x !== c.id)
-                            : [...base, c.id],
-                        );
-                      }}
-                      style={{
-                        opacity: c.included ? "1" : "0.4",
-                      }}
+                      onClick={() => boundToggleSplit.send({ id: c.id })}
+                      style={{ opacity: c.included ? "1" : "0.4" }}
                     />
                   ))
                 )}
@@ -268,30 +457,7 @@ export default pattern<State>(({ people, expenses }) => {
             <cf-button
               color="primary"
               variant="solid"
-              onClick={() => {
-                const description = newDescription.get().trim();
-                const amount = parseFloat(newAmount.get());
-                const paidBy = newPaidBy.get();
-                if (!description || isNaN(amount) || amount <= 0 || !paidBy) {
-                  return;
-                }
-                const everyone = people.get().map((p) => p.id);
-                const selected = splitWith.get();
-                const sharedBy: string[] = [
-                  ...(selected.length === 0 ? everyone : selected),
-                ];
-                expenses.push({
-                  id: newId("e"),
-                  description,
-                  amount,
-                  paidBy,
-                  sharedBy,
-                  date: getTodayDate(),
-                });
-                newDescription.set("");
-                newAmount.set("");
-                splitWith.set([]);
-              }}
+              onClick={boundAddExpense}
             >
               Add expense
             </cf-button>
@@ -311,47 +477,48 @@ export default pattern<State>(({ people, expenses }) => {
               </cf-text>
             </cf-hstack>
 
-            {expenses.map((expense) => (
-              <cf-hstack
-                gap="3"
-                align="center"
-                style={{
-                  justifyContent: "space-between",
-                  borderBottom: "1px solid #eee",
-                  paddingBottom: "0.5rem",
-                }}
-              >
-                <cf-vstack gap="0" style={{ flex: 1 }}>
-                  <span style={{ fontWeight: "600" }}>
-                    {expense.description}
-                  </span>
-                  <cf-text variant="caption" tone="muted">
-                    {computed(() => {
-                      const names = nameById;
-                      const payer = names[expense.paidBy] ?? "?";
-                      const n = expense.sharedBy?.length || 0;
-                      return `${payer} paid · split ${n} way${
-                        n === 1 ? "" : "s"
-                      } · ${expense.date}`;
-                    })}
-                  </cf-text>
-                </cf-vstack>
-                <span style={{ fontWeight: "600" }}>
-                  {computed(() => money(expense.amount))}
-                </span>
-                <cf-button
-                  variant="ghost"
-                  color="danger"
-                  onClick={() => {
-                    const cur = expenses.get();
-                    const idx = cur.findIndex((el) => el.id === expense.id);
-                    if (idx >= 0) expenses.set(cur.toSpliced(idx, 1));
-                  }}
-                >
-                  ×
-                </cf-button>
-              </cf-hstack>
-            ))}
+            {computed(() =>
+              expenses.length === 0
+                ? <cf-text tone="muted">No expenses yet.</cf-text>
+                : expenses.map((expense) => (
+                  <cf-hstack
+                    gap="3"
+                    align="center"
+                    style={{
+                      justifyContent: "space-between",
+                      borderBottom: "1px solid #eee",
+                      paddingBottom: "0.5rem",
+                    }}
+                  >
+                    <cf-vstack gap="0" style={{ flex: 1 }}>
+                      <span style={{ fontWeight: "600" }}>
+                        {expense.description}
+                      </span>
+                      <cf-text variant="caption" tone="muted">
+                        {computed(() => {
+                          const names = nameById;
+                          const payer = names[expense.paidBy] ?? "?";
+                          const n = expense.sharedBy?.length || 0;
+                          return `${payer} paid · split ${n} way${
+                            n === 1 ? "" : "s"
+                          } · ${expense.date}`;
+                        })}
+                      </cf-text>
+                    </cf-vstack>
+                    <span style={{ fontWeight: "600" }}>
+                      {computed(() => money(expense.amount))}
+                    </span>
+                    <cf-button
+                      variant="ghost"
+                      color="danger"
+                      onClick={() =>
+                        boundRemoveExpense.send({ id: expense.id })}
+                    >
+                      ×
+                    </cf-button>
+                  </cf-hstack>
+                ))
+            )}
           </cf-vstack>
         </cf-card>
 
@@ -360,27 +527,32 @@ export default pattern<State>(({ people, expenses }) => {
           <cf-vstack gap="3">
             <cf-heading level={4}>Balances</cf-heading>
             {computed(() =>
-              balances.map((b) => (
-                <cf-hstack
-                  align="center"
-                  style={{ justifyContent: "space-between" }}
-                >
-                  <span>{b.name}</span>
-                  <cf-badge
-                    color={b.net > EPS
-                      ? "accent"
-                      : b.net < -EPS
-                      ? "danger"
-                      : "neutral"}
+              balances.length === 0
+                ? <cf-text tone="muted">No balances to show.</cf-text>
+                : balances.map((b) => (
+                  <cf-hstack
+                    align="center"
+                    style={{
+                      justifyContent: "space-between",
+                      fontWeight: b.name === me ? "700" : "400",
+                    }}
                   >
-                    {b.net > EPS
-                      ? `is owed ${money(b.net)}`
-                      : b.net < -EPS
-                      ? `owes ${money(-b.net)}`
-                      : "settled"}
-                  </cf-badge>
-                </cf-hstack>
-              ))
+                    <span>{b.name === me ? `${b.name} (you)` : b.name}</span>
+                    <cf-badge
+                      color={b.net > 0
+                        ? "accent"
+                        : b.net < 0
+                        ? "danger"
+                        : "neutral"}
+                    >
+                      {b.net > 0
+                        ? `is owed ${money(b.net)}`
+                        : b.net < 0
+                        ? `owes ${money(-b.net)}`
+                        : "settled"}
+                    </cf-badge>
+                  </cf-hstack>
+                ))
             )}
           </cf-vstack>
         </cf-card>
@@ -412,10 +584,18 @@ export default pattern<State>(({ people, expenses }) => {
       </cf-vstack>
     ),
 
+    // Per-space ledger + per-user identity (re-exported for cross-piece reads).
     people,
     expenses,
+    myName,
     balances,
     settlements,
     total,
+
+    // Mutations exposed as streams for composition.
+    addPerson: boundAddPerson,
+    removePerson: boundRemovePerson,
+    addExpense: boundAddExpense,
+    removeExpense: boundRemoveExpense,
   };
 });

--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -632,6 +632,67 @@ interface Output {
 }
 ```
 
+## `fair-share/main.tsx`
+
+A shared group expense ledger (Splitwise-inspired). Track who paid for each
+expense and who shared it, see reactive net balances, and a minimal greedy
+"settle up" plan of who pays whom. Per-space ledger, per-user `myName` identity
+("you are owed / you owe"), per-session form drafts. Money is computed in
+integer cents with largest-remainder allocation so shares sum to the total and
+balances tie out exactly. Identity uses `equals()` (no synthetic id fields);
+people are referenced from expenses by their unique name.
+
+**Keywords:** expenses, split, settle up, balances, group, shared ledger,
+per-user, equals, money
+
+### Input Schema
+
+```ts
+interface Person {
+  name: string;
+}
+
+interface Expense {
+  description: string;
+  amount: number;
+  paidBy: string; // Person.name
+  sharedBy: string[]; // Person.name[]; empty => split among everyone
+  date: string; // YYYY-MM-DD
+}
+
+interface Input {
+  people: Writable<Person[] | Default<[]>>;
+  expenses: Writable<Expense[] | Default<[]>>;
+  myName: PerUser<string | Default<"">>;
+}
+```
+
+### Output Schema
+
+```ts
+interface Balance {
+  name: string;
+  paid: number;
+  share: number;
+  net: number; // positive => is owed, negative => owes
+}
+
+interface Settlement {
+  from: string;
+  to: string;
+  amount: number;
+}
+
+interface Output {
+  people: Person[];
+  expenses: Expense[];
+  myName: string;
+  balances: Balance[];
+  settlements: Settlement[];
+  total: number;
+}
+```
+
 ## `cfc-agent-prompt-injection-demo/main.tsx`
 
 Interactive side-by-side chatbot demo for the new observation ceiling and


### PR DESCRIPTION
## What

A new pattern, `packages/patterns/fair-share/main.tsx` — **Fair Share**, a Splitwise-inspired shared expense ledger. Add people, log expenses (who paid, amount, who shared it), and see reactive net balances plus a minimal greedy "settle up" plan of who pays whom.

## Features

- **People** — add/remove group members (chips).
- **Add expense** — description, amount, "paid by" selector, and a "split between" toggle row (defaults to everyone).
- **Balances** — reactive per-person net (*is owed / owes / settled*).
- **Settle up** — greedy minimal who-pays-whom plan.
- **Identity** — `PerUser` "You are" selector → personal "you are owed / you owe" summary + a bold `(you)` row.

## Design notes

- **Scope:** `people`/`expenses` are the shared ledger (cells default to per-space). `myName` is `PerUser`. Form drafts are `PerSession` so concurrent viewers don't share half-typed input or chip toggles.
- **Identity via `equals()`, not ids:** items are matched with `equals(item, el)` (the pattern idiom); no synthetic `id` fields. People are referenced from expenses by their unique name (natural key).
- **Penny-exact money:** all math in integer cents with largest-remainder allocation, so displayed shares sum to the total and balances tie out to exactly `$0.00`.
- **Cascade delete:** removing a person drops expenses they paid and strips them from other splits, preserving the zero-sum invariant.

## Verification

- `deno task cf check packages/patterns/fair-share/main.tsx` passes (typecheck + instantiation).
- Deployed locally and browser-tested: add/remove person (+ cascade), add/remove expense, balances + settle-up math confirmed correct (e.g. Alice pays $10 split 3 ways → shares 3.34/3.33/3.33, nets sum to $0.00), identity/personal-balance, no console errors.

## Footguns found while building this (filed for the runtime team)

This pattern surfaced several transformer/runtime sharp edges, now filed with minimal repros: CT-1639 (`equals()` removal silently broken by `Default<>`/computed-wrapped `.map()`), CT-1640 (`Default<[]>` → `never` element type), CT-1641 (misleading transformer write error), CT-1642 (silent narrower-scope link follow in lifts). The pattern works around CT-1639 with a no-`Default` local alias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Fair Share, a Splitwise-like shared expense ledger in `packages/patterns/fair-share/main.tsx`, and adds it to the pattern catalog in `packages/patterns/index.md`. Add people, log expenses, see exact balances, and get a minimal settle‑up plan.

- **New Features**
  - People: add/remove members; compares via `equals()` (no synthetic ids).
  - Expenses: description, amount, paid by, split between (defaults to everyone), auto date.
  - Balances: reactive per-person net; personal view via `PerUser` “You are”.
  - Settle up: greedy minimal who-pays-whom plan.
  - Money: integer cents with largest-remainder splits (penny-exact).
  - Safety: cascade delete on person removal; preserves zero-sum.
  - Scope/UX: per-space ledger, `PerUser` identity, per-session drafts, empty states, running total.

- **Bug Fixes**
  - Stable empty-state rendering for Balances/Settle up to avoid list→empty crashes.
  - Safer cascade delete: read all cells before writes; rebuild expenses via simple loops to avoid desyncs.
  - Preserve expenses with empty `sharedBy` on person removal (implicit “split among everyone”); only drop explicitly emptied splits.
  - Reject non-finite amounts in Add expense (use `Number.isFinite`) to prevent poisoned totals/splits.

<sup>Written for commit c92a34ee8325cc4f7aeb3e4b18f2824c856cb38f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

