### PR TITLE
refactor(ts-transformers): fold internal per-node channels into NodeLinks (CT-1621, step 5)

### DIFF
--- a/packages/ts-transformers/src/core/context.ts
+++ b/packages/ts-transformers/src/core/context.ts
@@ -176,7 +176,7 @@ export class TransformationContext {
    * Mark a builder call/new node that SchemaInjection has finalized, so a
    * later re-traversal of the transformer's own output skips re-injection.
    * Replaces the arg-count idempotency guards in schema-injection.ts. See
-   * `schemaInjectedRegistry` docs in core/mod.ts (CT-1621).
+   * the `nodeLinks.schemaInjected` docs in core/mod.ts (CT-1621).
    */
   markSchemaInjected(node: ts.Node): void {
     this.options.state?.markSchemaInjected(node);
@@ -213,8 +213,8 @@ export class TransformationContext {
   /**
    * Record a per-function capability summary computed by
    * PatternCallbackLoweringTransformer (expensive interprocedural analysis;
-   * cached here for SchemaInjection to reuse). See `CapabilitySummaryRegistry`
-   * docs in core/mod.ts.
+   * cached here for SchemaInjection to reuse). See the
+   * `nodeLinks.capabilitySummary` docs in core/mod.ts.
    */
   recordCapabilitySummary(
     fn: ts.Node,

--- a/packages/ts-transformers/src/core/cross-stage-state.ts
+++ b/packages/ts-transformers/src/core/cross-stage-state.ts
@@ -1,12 +1,36 @@
 import ts from "typescript";
 import type {
-  CapabilitySummaryRegistry,
   FunctionCapabilitySummary,
   SchemaHint,
   SchemaHints,
   SyntheticReactiveCollectionRegistry,
   TypeRegistry,
 } from "./transformers.ts";
+
+/**
+ * Per-node side table, mirroring the TypeScript compiler's internal `NodeLinks`
+ * pattern (src/compiler/types.ts): one struct of optional derived facts keyed by
+ * node identity, lazily populated. It holds the transformer-internal,
+ * non-cache-invalidating channels that are keyed by `ts.Node` and never cross the
+ * schema-generator package boundary.
+ *
+ * Deliberately NOT exported from `core/mod.ts`: the schema-generator package must
+ * not depend on this type (it reads only the bare `typeRegistry` / `schemaHints`
+ * maps — the published boundary contract). Channels that cross that boundary, or
+ * that are coupled to the context's reactive-analysis cache invalidation, stay as
+ * their own maps/sets; see the registry doc block in `core/mod.ts`.
+ */
+export interface NodeTypeLinks {
+  /** Cached per-function capability summary (was `capabilitySummaryRegistry`). */
+  capabilitySummary?: FunctionCapabilitySummary;
+  /**
+   * Whether SchemaInjection has finalized this builder call/new node (was
+   * `schemaInjectedRegistry`). A bare presence flag with NO getOriginalNode
+   * fallback — it tags synthetic nodes we produce, whose original is the
+   * pre-injection user call, which must NOT read as injected.
+   */
+  schemaInjected?: true;
+}
 
 /**
  * CrossStageState — the single owner of the pipeline's cross-transformer
@@ -16,32 +40,60 @@ import type {
  * Each registry is keyed by AST node or symbol identity, preserved across
  * `ts.transform()` stages. See `core/mod.ts` for the per-registry contract.
  *
+ * Storage is organized into three families (see `core/mod.ts` for the full
+ * rationale):
+ *   1. Bare cross-package maps — `typeRegistry`, `schemaHints`. The published
+ *      boundary contract: the separate schema-generator package reads them
+ *      directly as plain WeakMaps and must not depend on this class or on
+ *      `NodeTypeLinks`. They stay their own maps deliberately (mirrors how the
+ *      TS compiler keeps `NodeLinks` private and exposes narrow accessors).
+ *   2. `nodeLinks` — the NodeLinks-shaped side table for the internal,
+ *      non-cache-invalidating per-node channels (capabilitySummary,
+ *      schemaInjected), reached only through the record/lookup/mark/is methods.
+ *   3. The marker family — node/symbol-keyed WeakSets whose mutators are
+ *      coupled to the context's reactive-analysis cache invalidation.
+ *
  * Division of responsibility with `TransformationContext`:
- *   - CrossStageState owns the DATA (the WeakMaps/WeakSets) and exposes pure
- *     data operations (record/lookup/mark/is). It performs NO cache
- *     invalidation — it has no knowledge of the context's analysis caches.
+ *   - CrossStageState owns the DATA and exposes pure data operations
+ *     (record/lookup/mark/is). It performs NO cache invalidation — it has no
+ *     knowledge of the context's analysis caches.
  *   - TransformationContext keeps the public mark/record methods. For the
  *     four marker-set mutators it delegates to CrossStageState AND then calls
  *     its own `invalidateReactiveAnalysisCaches()`. Invalidation stays a
  *     context concern; this object stays a pure data holder. (This is why the
  *     `mark*` methods here do not invalidate — the context wrapper does.)
- *
- * The raw maps are also exposed as readonly properties because the heavily
- * used `typeRegistry` and the cross-package `schemaHints` are read directly by
- * many call sites (and by the separate schema-generator package, which is not
- * a transformer stage and must not depend on this type — it receives the bare
- * map). Those two are the documented package boundary.
  */
 export class CrossStageState {
+  /**
+   * Bare cross-package channels (the published boundary contract). Read
+   * directly by the schema-generator package as plain WeakMaps; they must NOT
+   * be folded into `nodeLinks`. See `core/mod.ts`.
+   */
   readonly typeRegistry: TypeRegistry = new WeakMap();
+  readonly schemaHints: SchemaHints = new WeakMap();
+
+  /**
+   * NodeLinks-shaped side table for the transformer-internal,
+   * non-cache-invalidating per-node channels (capabilitySummary, schemaInjected).
+   */
+  readonly nodeLinks = new WeakMap<ts.Node, NodeTypeLinks>();
+
+  /** Marker family — keyed by node/symbol identity; cache-coupled via context. */
   readonly mapCallbackRegistry = new WeakSet<ts.Node>();
   readonly syntheticComputeCallbackRegistry = new WeakSet<ts.Node>();
   readonly syntheticComputeOwnedNodeRegistry = new WeakSet<ts.Node>();
   readonly syntheticReactiveCollectionRegistry:
     SyntheticReactiveCollectionRegistry = new WeakSet();
-  readonly schemaHints: SchemaHints = new WeakMap();
-  readonly capabilitySummaryRegistry: CapabilitySummaryRegistry = new WeakMap();
-  readonly schemaInjectedRegistry = new WeakSet<ts.Node>();
+
+  /** Get-or-create the links entry for a node (lazy, like getNodeLinks). */
+  #linksFor(node: ts.Node): NodeTypeLinks {
+    let links = this.nodeLinks.get(node);
+    if (!links) {
+      links = {};
+      this.nodeLinks.set(node, links);
+    }
+    return links;
+  }
 
   // --- mapCallbackRegistry ---
 
@@ -103,37 +155,39 @@ export class CrossStageState {
       this.schemaHints.get(ts.getOriginalNode(node));
   }
 
-  // --- capabilitySummaryRegistry ---
+  // --- capabilitySummary (nodeLinks-backed) ---
 
   recordCapabilitySummary(
     fn: ts.Node,
     summary: FunctionCapabilitySummary,
   ): void {
-    this.capabilitySummaryRegistry.set(fn, summary);
+    this.#linksFor(fn).capabilitySummary = summary;
   }
 
   lookupCapabilitySummary(fn: ts.Node): FunctionCapabilitySummary | undefined {
-    return this.capabilitySummaryRegistry.get(fn);
+    return this.nodeLinks.get(fn)?.capabilitySummary;
   }
 
-  // --- schemaInjectedRegistry ---
+  // --- schemaInjected (nodeLinks-backed) ---
   //
   // Marks builder call/new nodes that SchemaInjection has already finalized,
   // so a later re-traversal of the transformer's own output skips re-injection
   // instead of re-deriving "already injected?" from argument count. Replaces
   // the scattered arg-count idempotency guards (e.g. `args.length >= 5`).
   //
-  // Unlike the other marker sets, this one uses a plain `.has` with NO
-  // `getOriginalNode` fallback: it tags SYNTHETIC nodes WE produced, whose
-  // original (if any) is the *pre-injection* user call. Falling back to the
-  // original would wrongly report a not-yet-injected user node as injected.
+  // Uses a plain presence check with NO `getOriginalNode` fallback: it tags
+  // SYNTHETIC nodes WE produced, whose original (if any) is the *pre-injection*
+  // user call. Falling back to the original would wrongly report a
+  // not-yet-injected user node as injected. (This is why it is a `nodeLinks`
+  // field rather than a member of the getOriginalNode-fallback marker family.)
 
   markSchemaInjected(node: ts.Node): void {
-    this.schemaInjectedRegistry.add(node);
+    this.#linksFor(node).schemaInjected = true;
   }
 
   isSchemaInjected(node: ts.Node): boolean {
-    return this.schemaInjectedRegistry.has(node);
+    // Plain presence check with NO getOriginalNode fallback (see field doc).
+    return this.nodeLinks.get(node)?.schemaInjected === true;
   }
 
   // --- shared helper: membership check with getOriginalNode fallback ---

--- a/packages/ts-transformers/src/core/mod.ts
+++ b/packages/ts-transformers/src/core/mod.ts
@@ -1,17 +1,34 @@
 /**
- * Cross-transformer communication registries.
+ * Cross-transformer communication state.
  *
- * The pipeline creates eight shared registries in CommonFabricTransformerPipeline
- * (cf-pipeline.ts). Each is keyed by AST node or symbol identity, which is
- * preserved when transformers are applied in sequence via ts.transform().
+ * `CrossStageState` (cross-stage-state.ts) owns the pipeline's cross-transformer
+ * channels. Each is keyed by AST node or symbol identity, which is preserved
+ * when transformers are applied in sequence via ts.transform(). The channels are
+ * organized into three families:
  *
- * (Two former members no longer exist: `syntheticLiftAppliedCallRegistry`, removed
- * in the registry-unification effort after being verified functionally inert (see
+ *   1. Bare cross-package maps — `typeRegistry`, `schemaHints`. The published
+ *      boundary contract: the separate schema-generator package reads these
+ *      directly as plain WeakMaps and must not depend on `CrossStageState` or
+ *      `NodeTypeLinks`. They deliberately stay their own maps; see the
+ *      "schema-generator boundary" note below.
+ *   2. `nodeLinks` (WeakMap<ts.Node, NodeTypeLinks>) — a NodeLinks-shaped side
+ *      table (mirroring the TS compiler's internal NodeLinks: one struct of
+ *      optional derived facts per node, lazily populated) holding the
+ *      transformer-internal, non-cache-invalidating per-node channels:
+ *      `capabilitySummary` and `schemaInjected`. Reached only through the
+ *      record/lookup/mark/is methods on CrossStageState.
+ *   3. The marker family — node/symbol-keyed WeakSets whose context-level
+ *      mutators are coupled to reactive-analysis cache invalidation
+ *      (mapCallbackRegistry, syntheticComputeCallbackRegistry,
+ *      syntheticComputeOwnedNodeRegistry, syntheticReactiveCollectionRegistry).
+ *
+ * (Former members no longer exist: `syntheticLiftAppliedCallRegistry`, removed
+ * after being verified functionally inert (see
  * docs/scratch/12-registry-unification-design.md); and `narrowedWrapperTypeRegistry`,
  * removed in PR #3788 by detecting and short-circuiting the synthetic
  * capability-wrapper re-entry in schema-injection that was its sole consumer —
- * see the `schemaInjectedRegistry` entry below for the current idempotency model.
- * The current eighth member is `schemaInjectedRegistry`, added in CT-1621.)
+ * see the `nodeLinks.schemaInjected` entry below for the current idempotency
+ * model.)
  *
  * TypeRegistry (WeakMap<ts.Node, ts.Type>)
  *   Preserves and recovers synthetic typing across the pipeline. Serves three
@@ -71,13 +88,18 @@
  *   Writers: capture analysis in schema-injection
  *   Readers: schema-generator
  *
- * CapabilitySummaryRegistry (WeakMap<ts.Node, FunctionCapabilitySummary>)
+ * nodeLinks.capabilitySummary (NodeTypeLinks field; was CapabilitySummaryRegistry)
  *   Caches per-function capability summaries (read/write paths, capability
- *   classification) computed by PatternCallbackLoweringTransformer.
- *   Writers: pattern-callback lowering (registerCapabilitySummary)
- *   Readers: schema-injection (findCapabilitySummaryForParameter)
+ *   classification) computed by PatternCallbackLoweringTransformer. Internal
+ *   only — never crosses the schema-generator boundary; reached through the
+ *   record/lookup methods, never as a raw map (the bare-map channel was retired
+ *   in step 5 — schema-injection no longer threads a `capabilityRegistry`
+ *   parameter, it reads via context.lookupCapabilitySummary()).
+ *   Writers: context.recordCapabilitySummary() (pattern-callback lowering)
+ *   Readers: context.lookupCapabilitySummary() (schema-injection
+ *            findCapabilitySummaryForParameter)
  *
- * schemaInjectedRegistry (WeakSet<ts.Node>)
+ * nodeLinks.schemaInjected (NodeTypeLinks field; was schemaInjectedRegistry)
  *   Marks builder call/new nodes that SchemaInjection has already finalized.
  *   The single top-of-visit guard in SchemaInjectionTransformer skips
  *   re-processing a marked node (descending only into its children to reach
@@ -86,15 +108,30 @@
  *   re-detection fails" trick, etc.) with one explicit signal, and plugs the
  *   lift `isToSchemaCall` branch's missing idempotency guard — eliminating the
  *   redundant self-re-entry re-narrowing that CT-1621 targeted. NOTE: this
- *   marks SYNTHETIC nodes we produce; unlike the other marker sets it uses a
- *   plain `.has` (no getOriginalNode fallback) because a marked node's original
- *   is the *pre-injection* user call, which must NOT read as injected.
+ *   marks SYNTHETIC nodes we produce; unlike the marker family it uses a plain
+ *   presence check (no getOriginalNode fallback) because a marked node's
+ *   original is the *pre-injection* user call, which must NOT read as injected.
+ *   That no-fallback semantics is WHY it is a nodeLinks field and not a member
+ *   of the getOriginalNode-fallback marker family.
  *   Some arg-count guards remain DELIBERATELY: the cell-factory/wish `>= 2`
  *   checks also protect USER-supplied schemas (which this marker can't cover),
  *   and the `!== 2`/`!== 3` checks are dispatch (input-shape) guards, not
  *   idempotency.
  *   Writers: context.markSchemaInjected() (SchemaInjection producer sites)
  *   Readers: context.isSchemaInjected() (SchemaInjection top-of-visit guard)
+ *
+ * --- schema-generator boundary ---
+ *
+ * `typeRegistry` and `schemaHints` are the ONLY channels read by the separate
+ * schema-generator package (not a transformer stage). It receives them as bare
+ * `WeakMap<ts.Node, …>` instances and calls only `.get`/`.has` on them; it must
+ * NOT learn about `CrossStageState` or `NodeTypeLinks`. They therefore stay as
+ * their own maps rather than folding into `nodeLinks` — adapter "views" cast
+ * across the package line would re-introduce the very maps they claim to remove,
+ * for zero structural win, and would lie to the typechecker at the boundary.
+ * This mirrors the TS compiler, which keeps its NodeLinks table private and
+ * exposes narrow typed accessors (getTypeAtLocation) instead of the table. The
+ * bare boundary maps are our analogue of that narrow published contract.
  *
  * --- Cache invalidation contract ---
  *
@@ -109,10 +146,11 @@
  * (createDataFlowAnalyzer's `analysisCache`) lives inside its closure and
  * would otherwise return stale pre-mutation verdicts after a registry write.
  *
- * schemaHints and capabilitySummaryRegistry are accessed through context
- * record/lookup methods (recordSchemaHint/lookupSchemaHint,
- * recordCapabilitySummary/lookupCapabilitySummary) but do not invalidate
- * caches (no analysis cache depends on them). typeRegistry is still mutated via direct .set() at call
+ * schemaHints and the nodeLinks fields (capabilitySummary, schemaInjected) are
+ * accessed through record/lookup/mark/is methods (recordSchemaHint/
+ * lookupSchemaHint, recordCapabilitySummary/lookupCapabilitySummary,
+ * markSchemaInjected/isSchemaInjected) but do not invalidate caches (no analysis
+ * cache depends on them). typeRegistry is still mutated via direct .set() at call
  * sites; same caveat applies. If you add a cache that depends on any of these,
  * route the mutation through a method that invalidates it (or extend
  * invalidateReactiveAnalysisCaches).
@@ -124,10 +162,10 @@
  * analyzer instance is dropped together, so any state captured in its
  * closure is GC'd.
  *
- * --- Registry unification (in progress, 2026-05) ---
+ * --- Registry unification (complete, 2026-06) ---
  *
- * This registry layer is being consolidated into a single CrossStageState
- * abstraction. The plan and rationale live in
+ * This registry layer was consolidated into the CrossStageState abstraction.
+ * The plan and rationale live in
  * `docs/scratch/12-registry-unification-design.md` (supersedes the earlier
  * audit in `07-registry-audit.md`). Sequence:
  *   1. (done) doc refresh: count fix + mark the inert registry.
@@ -143,21 +181,28 @@
  *      (`argumentType.pos < 0 && isCellLikeTypeNode(argumentType)`) and
  *      short-circuiting the re-shrink, which left the channel without a
  *      consumer and let `narrowedWrapperTypeRegistry` be deleted entirely.
- *   3. (done) Lifted schemaHints + capabilitySummaryRegistry to context
- *      record/lookup methods. typeRegistry stays on direct .set (its split
- *      was dropped in step 2, so there's no per-use method to route through).
+ *   3. (done) Lifted schemaHints + capabilitySummary to context record/lookup
+ *      methods. typeRegistry stays on direct .set (its split was dropped in
+ *      step 2, so there's no per-use method to route through).
  *   4. (done) Removed syntheticLiftAppliedCallRegistry (verified inert).
- *   5. (pending) Fold the transformer-internal channels into CrossStageState;
- *      keep typeRegistry + schemaHints as loose maps at the schema-generator
- *      package boundary (the only channels that package reads), so no
- *      CrossStageState type crosses into schema-generator.
+ *   5. (done) Folded the transformer-internal, non-cache-invalidating per-node
+ *      channels (capabilitySummary, schemaInjected) into a single NodeLinks-
+ *      shaped `nodeLinks` WeakMap, reached only through methods. As part of this
+ *      the `capabilityRegistry` bare-map parameter that schema-injection threaded
+ *      through ~14 functions was removed — reads now go through
+ *      context.lookupCapabilitySummary(), and the `CapabilitySummaryRegistry`
+ *      type was retired. typeRegistry + schemaHints intentionally stay as bare
+ *      maps at the schema-generator boundary (see the "schema-generator boundary"
+ *      note above), so no CrossStageState/NodeTypeLinks type crosses into
+ *      schema-generator. Research (CT-1621 arc) confirmed this matches how the TS
+ *      compiler itself structures NodeLinks: one private per-node struct, narrow
+ *      public accessors, the table never handed out.
  */
 export { TransformationContext } from "./context.ts";
 export { CrossStageState } from "./cross-stage-state.ts";
 export type {
   CapabilityParamDefault,
   CapabilityParamSummary,
-  CapabilitySummaryRegistry,
   DiagnosticInput,
   DiagnosticSeverity,
   FunctionCapabilitySummary,

--- a/packages/ts-transformers/src/core/transformers.ts
+++ b/packages/ts-transformers/src/core/transformers.ts
@@ -64,10 +64,6 @@ export interface FunctionCapabilitySummary {
  * Type is used in multiple places with different access patterns.
  */
 export type SchemaHints = WeakMap<ts.Node, SchemaHint>;
-export type CapabilitySummaryRegistry = WeakMap<
-  ts.Node,
-  FunctionCapabilitySummary
->;
 export type SyntheticReactiveCollectionRegistry = WeakSet<ts.Symbol>;
 
 export interface TransformationOptions {

--- a/packages/ts-transformers/src/transformers/pattern-callback-transform.ts
+++ b/packages/ts-transformers/src/transformers/pattern-callback-transform.ts
@@ -89,8 +89,8 @@ export function registerCapabilitySummary(
   interprocedural: boolean,
   defaultsByParamName?: ReadonlyMap<string, readonly CapabilityParamDefault[]>,
 ): void {
-  const registry = context.options.state?.capabilitySummaryRegistry;
-  if (!registry) return;
+  // No cross-stage state → nowhere to record; skip the analysis work entirely.
+  if (!context.options.state) return;
 
   const summary = analyzeFunctionCapabilities(callback, {
     checker: context.checker,
@@ -98,11 +98,11 @@ export function registerCapabilitySummary(
   });
 
   if (!defaultsByParamName || defaultsByParamName.size === 0) {
-    registry.set(callback, summary);
+    context.recordCapabilitySummary(callback, summary);
     return;
   }
 
-  registry.set(callback, {
+  context.recordCapabilitySummary(callback, {
     ...summary,
     params: summary.params.map((param) => {
       const defaults = defaultsByParamName.get(param.name);

--- a/packages/ts-transformers/src/transformers/schema-injection.ts
+++ b/packages/ts-transformers/src/transformers/schema-injection.ts
@@ -31,7 +31,6 @@ import {
 import { unwrapExpression } from "../utils/expression.ts";
 import {
   type CapabilityParamSummary,
-  type CapabilitySummaryRegistry,
   HelpersOnlyTransformer,
   type SchemaHint,
   type SchemaHints,
@@ -205,7 +204,7 @@ function getSymbolTypeAtSource(
 function findCapabilitySummaryForParameter(
   fn: ts.ArrowFunction | ts.FunctionExpression,
   index: number,
-  capabilityRegistry?: CapabilitySummaryRegistry,
+  context?: TransformationContext,
   options?: {
     readonly checker?: ts.TypeChecker;
     readonly includeNestedCallbacks?: boolean;
@@ -216,8 +215,8 @@ function findCapabilitySummaryForParameter(
       checker: options.checker,
       includeNestedCallbacks: true,
     })
-    : capabilityRegistry
-    ? (capabilityRegistry.get(fn) ?? analyzeFunctionCapabilities(fn))
+    : context
+    ? (context.lookupCapabilitySummary(fn) ?? analyzeFunctionCapabilities(fn))
     : analyzeFunctionCapabilities(fn, {
       checker: options?.checker,
     });
@@ -237,7 +236,6 @@ function applyCapabilitySummaryToArgument(
   checker: ts.TypeChecker,
   sourceFile: ts.SourceFile,
   factory: ts.NodeFactory,
-  capabilityRegistry?: CapabilitySummaryRegistry,
   mode: CapabilitySummaryApplicationMode = "full",
   context?: TransformationContext,
   fnNode?: ts.Node,
@@ -247,7 +245,7 @@ function applyCapabilitySummaryToArgument(
   const paramSummary = findCapabilitySummaryForParameter(
     fn,
     0,
-    capabilityRegistry,
+    context,
     (argumentNode.pos < 0 || argumentNode.end < 0) &&
       context?.isSyntheticComputeCallback?.(fnNode ?? fn)
       ? {
@@ -307,7 +305,6 @@ function applyCapabilitySummaryToParameter(
   checker: ts.TypeChecker,
   sourceFile: ts.SourceFile,
   factory: ts.NodeFactory,
-  capabilityRegistry?: CapabilitySummaryRegistry,
   context?: TransformationContext,
   fnNode?: ts.Node,
 ): ts.TypeNode | undefined {
@@ -316,7 +313,7 @@ function applyCapabilitySummaryToParameter(
   const paramSummary = findCapabilitySummaryForParameter(
     fn,
     parameterIndex,
-    capabilityRegistry,
+    context,
     {
       checker,
       includeNestedCallbacks: true,
@@ -367,7 +364,6 @@ function collectFunctionSchemaTypeNodes(
   factory: ts.NodeFactory,
   fallbackArgType?: ts.Type,
   typeRegistry?: TypeRegistry,
-  capabilityRegistry?: CapabilitySummaryRegistry,
   argumentCapabilityMode: CapabilitySummaryApplicationMode = "full",
   context?: TransformationContext,
 ): {
@@ -424,7 +420,6 @@ function collectFunctionSchemaTypeNodes(
     checker,
     sourceFile,
     factory,
-    capabilityRegistry,
     argumentCapabilityMode,
     context,
     fn,
@@ -534,7 +529,6 @@ function collectFunctionSchemaTypeNodes(
       sourceFile,
       factory,
       typeRegistry,
-      capabilityRegistry,
       context,
     );
     if (synthesizedResult) {
@@ -560,7 +554,6 @@ function collectFunctionSchemaTypeNodes(
       sourceFile,
       factory,
       typeRegistry,
-      capabilityRegistry,
       context,
     );
     if (scopedResult) {
@@ -595,7 +588,6 @@ function collectFunctionSchemaTypeNodes(
         sourceFile,
         factory,
         typeRegistry,
-        capabilityRegistry,
         context,
       );
       if (recoveredNode) {
@@ -1143,7 +1135,6 @@ function applyCallbackBuilderArgumentCapabilitySummary(
   checker: ts.TypeChecker,
   sourceFile: ts.SourceFile,
   factory: ts.NodeFactory,
-  capabilityRegistry: CapabilitySummaryRegistry | undefined,
   context: TransformationContext,
 ): {
   argumentTypeNode: ts.TypeNode;
@@ -1160,7 +1151,6 @@ function applyCallbackBuilderArgumentCapabilitySummary(
     checker,
     sourceFile,
     factory,
-    capabilityRegistry,
     "full",
     context,
     callback,
@@ -1184,7 +1174,6 @@ function resolveDualSchemaBuilderTypes(
   sourceFile: ts.SourceFile,
   factory: ts.NodeFactory,
   typeRegistry: TypeRegistry | undefined,
-  capabilityRegistry: CapabilitySummaryRegistry | undefined,
   context: TransformationContext,
   options?: {
     readonly fallbackArgumentType?: ts.Type;
@@ -1218,7 +1207,6 @@ function resolveDualSchemaBuilderTypes(
       checker,
       sourceFile,
       factory,
-      capabilityRegistry,
       context,
     ));
   }
@@ -1237,7 +1225,6 @@ function resolveDualSchemaBuilderTypes(
       factory,
       options?.fallbackArgumentType,
       typeRegistry,
-      capabilityRegistry,
       options?.capabilityMode ?? "full",
       context,
     );
@@ -1277,7 +1264,6 @@ function resolveDualSchemaBuilderTypes(
         checker,
         sourceFile,
         factory,
-        capabilityRegistry,
         context,
       ));
     } else {
@@ -1308,7 +1294,6 @@ function resolveDualSchemaBuilderTypes(
         checker,
         sourceFile,
         factory,
-        capabilityRegistry,
         context,
       ));
     }
@@ -1434,7 +1419,6 @@ function inferLiftFactoryResultType(
   sourceFile: ts.SourceFile,
   factory: ts.NodeFactory,
   typeRegistry?: TypeRegistry,
-  capabilityRegistry?: CapabilitySummaryRegistry,
   context?: TransformationContext,
 ): ts.Type | undefined {
   const valueInitializer = getVariableInitializer(node, checker);
@@ -1483,7 +1467,6 @@ function inferLiftFactoryResultType(
     factory,
     fallbackArgType,
     typeRegistry,
-    capabilityRegistry,
     "full",
     context,
   );
@@ -1627,7 +1610,6 @@ function inferLiftAppliedResultTypeFromInitializer(
   sourceFile: ts.SourceFile,
   factory: ts.NodeFactory,
   typeRegistry?: TypeRegistry,
-  capabilityRegistry?: CapabilitySummaryRegistry,
   context?: TransformationContext,
 ): ts.Type | undefined {
   const initializer = getVariableInitializer(node, checker);
@@ -1660,7 +1642,6 @@ function inferLiftAppliedResultTypeFromInitializer(
       sourceFile,
       factory,
       typeRegistry,
-      capabilityRegistry,
       context,
     );
     if (recoveredArgumentType && !isAnyOrUnknownType(recoveredArgumentType)) {
@@ -1675,7 +1656,6 @@ function inferLiftAppliedResultTypeFromInitializer(
     factory,
     argumentType,
     typeRegistry,
-    capabilityRegistry,
     "full",
     context,
   );
@@ -1699,7 +1679,6 @@ function inferExpressionTypeWithInitializerFallback(
   sourceFile: ts.SourceFile,
   factory: ts.NodeFactory,
   typeRegistry?: TypeRegistry,
-  capabilityRegistry?: CapabilitySummaryRegistry,
   context?: TransformationContext,
 ): ts.Type | undefined {
   const type = getTypeAtLocationWithFallback(expr, checker, typeRegistry) ??
@@ -1714,7 +1693,6 @@ function inferExpressionTypeWithInitializerFallback(
     sourceFile,
     factory,
     typeRegistry,
-    capabilityRegistry,
     context,
   );
   if (fromLift && !isAnyOrUnknownType(fromLift)) {
@@ -1727,7 +1705,6 @@ function inferExpressionTypeWithInitializerFallback(
     sourceFile,
     factory,
     typeRegistry,
-    capabilityRegistry,
     context,
   );
   if (fromLiftApplied && !isAnyOrUnknownType(fromLiftApplied)) {
@@ -1743,7 +1720,6 @@ function buildObjectLiteralReturnTypeNode(
   sourceFile: ts.SourceFile,
   factory: ts.NodeFactory,
   typeRegistry?: TypeRegistry,
-  capabilityRegistry?: CapabilitySummaryRegistry,
   context?: TransformationContext,
 ): ts.TypeNode | undefined {
   const members: ts.TypeElement[] = [];
@@ -1765,7 +1741,6 @@ function buildObjectLiteralReturnTypeNode(
       sourceFile,
       factory,
       typeRegistry,
-      capabilityRegistry,
       context,
     );
     if (!valueType || isAnyOrUnknownType(valueType)) {
@@ -2573,7 +2548,6 @@ function handlePatternSchemaInjection(
 ): ts.Node | undefined {
   const { factory, checker, sourceFile, tsContext: transformation } = context;
   const typeArgs = node.typeArguments;
-  const capabilityRegistry = context.options.state?.capabilitySummaryRegistry;
   const argsArray = Array.from(node.arguments);
 
   // Find the function argument
@@ -2670,7 +2644,6 @@ function handlePatternSchemaInjection(
       factory,
       undefined,
       typeRegistry,
-      capabilityRegistry,
       argumentCapabilityMode,
       context,
     );
@@ -2712,7 +2685,6 @@ function handlePatternSchemaInjection(
         factory,
         undefined,
         typeRegistry,
-        capabilityRegistry,
         argumentCapabilityMode,
         context,
       );
@@ -2772,7 +2744,6 @@ function handlePatternSchemaInjection(
         factory,
         undefined,
         typeRegistry,
-        capabilityRegistry,
         argumentCapabilityMode,
         context,
       );
@@ -2811,7 +2782,6 @@ function handlePatternSchemaInjection(
     checker,
     sourceFile,
     factory,
-    capabilityRegistry,
     argumentCapabilityMode,
     context,
     builderFunction,
@@ -2876,7 +2846,6 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
   transform(context: TransformationContext): ts.SourceFile {
     const { sourceFile, tsContext: transformation, checker } = context;
     const typeRegistry = context.options.state?.typeRegistry;
-    const capabilityRegistry = context.options.state?.capabilitySummaryRegistry;
 
     const visit = (node: ts.Node): ts.Node => {
       // Single idempotency guard: if SchemaInjection already finalized this
@@ -2926,7 +2895,6 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
                   sourceFile,
                   factory,
                   typeRegistry,
-                  capabilityRegistry,
                   context,
                 );
                 return valueType && !isUnresolvedSchemaType(valueType)
@@ -3035,7 +3003,6 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
               checker,
               sourceFile,
               factory,
-              capabilityRegistry,
               context,
               handlerFn,
             ) ?? eventType;
@@ -3048,14 +3015,13 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
               checker,
               sourceFile,
               factory,
-              capabilityRegistry,
               context,
               handlerFn,
             ) ?? stateType;
             const stateSummary = findCapabilitySummaryForParameter(
               handlerFn,
               1,
-              capabilityRegistry,
+              context,
               { checker, includeNestedCallbacks: true },
             );
             applyIdentityArrayItemSchemaHints(
@@ -3104,7 +3070,6 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
               factory,
               undefined,
               typeRegistry,
-              capabilityRegistry,
               "full",
               context,
             );
@@ -3125,7 +3090,6 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
                 checker,
                 sourceFile,
                 factory,
-                capabilityRegistry,
                 undefined,
                 handlerFn,
               ) ?? eventTypeBase;
@@ -3150,14 +3114,13 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
               checker,
               sourceFile,
               factory,
-              capabilityRegistry,
               context,
               handlerFn,
             ) ?? stateTypeBase;
             const stateSummary = findCapabilitySummaryForParameter(
               handlerFn,
               1,
-              capabilityRegistry,
+              context,
               { checker, includeNestedCallbacks: true },
             );
             applyIdentityArrayItemSchemaHints(
@@ -3228,7 +3191,6 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
             sourceFile,
             factory,
             typeRegistry,
-            capabilityRegistry,
             context,
             {
               explicitArgumentTypeNode: argumentType,
@@ -3290,7 +3252,6 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
                 sourceFile,
                 factory,
                 typeRegistry,
-                capabilityRegistry,
                 context,
               );
               if (
@@ -3308,7 +3269,6 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
             sourceFile,
             factory,
             typeRegistry,
-            capabilityRegistry,
             context,
             {
               fallbackArgumentType: fallbackArgType,
@@ -3365,7 +3325,7 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
             // Authored `lift(toSchema<T>(), fn)` has a real-source T (pos >= 0)
             // that the checker resolves, so it falls through to the normal path.
             //
-            // This is layered with the top-of-visit `schemaInjectedRegistry`
+            // This is layered with the top-of-visit `nodeLinks.schemaInjected`
             // guard (see SchemaInjectionTransformer.transform) as defense-in-
             // depth: that guard catches re-entries on nodes whose mark survived
             // reconstruction; this one catches the structural re-entry case
@@ -3393,7 +3353,6 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
               checker,
               sourceFile,
               factory,
-              capabilityRegistry,
               context,
             );
             const inputSchema = createSchemaCallWithRegistryTransfer(
@@ -3435,7 +3394,6 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
             sourceFile,
             factory,
             typeRegistry,
-            capabilityRegistry,
             context,
             {
               explicitArgumentTypeNode: argumentType,
@@ -3483,7 +3441,6 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
             sourceFile,
             factory,
             typeRegistry,
-            capabilityRegistry,
             context,
             {
               fallbackArgumentType: getTypeFromTypeNodeWithFallback(
@@ -3530,7 +3487,6 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
             sourceFile,
             factory,
             typeRegistry,
-            capabilityRegistry,
             context,
             {
               fallbackArgumentNode: getParameterSchemaType(
@@ -3585,7 +3541,6 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
                 sourceFile,
                 factory,
                 typeRegistry,
-                capabilityRegistry,
                 context,
               );
               return valueType && !isUnresolvedSchemaType(valueType)


### PR DESCRIPTION
## What

Step 5 (final) of the registry-unification plan documented in `core/mod.ts`. Collapses the two transformer-internal, non-cache-invalidating per-node channels — `capabilitySummary` and `schemaInjected` — into a single NodeLinks-shaped `WeakMap<ts.Node, NodeTypeLinks>` on `CrossStageState`, mirroring the TypeScript compiler's internal `NodeLinks` pattern (one private per-node struct of optional derived facts, reached only through narrow accessors).

```ts
interface NodeTypeLinks {
  capabilitySummary?: FunctionCapabilitySummary;  // was capabilitySummaryRegistry
  schemaInjected?: true;                          // was schemaInjectedRegistry
}
```

## Why this shape (and not "one map for everything")

`typeRegistry` and `schemaHints` **intentionally stay as bare `WeakMap`s** at the schema-generator package boundary. They are the published contract that package reads directly (`.get`/`.has` on bare maps) and must not depend on `CrossStageState` or `NodeTypeLinks`. This mirrors how the TS compiler keeps its `NodeLinks` table private while exposing `getTypeAtLocation`-style accessors — it never hands out the table. External research during the CT-1621 arc confirmed this is the state-of-the-art shape and exactly why the cross-package channels differ from the internal ones; folding them in would either leak the internal struct across the boundary or require adapter "views" cast across the package line for zero structural win.

## Notable cleanup

The `capabilityRegistry` bare-map parameter that `schema-injection.ts` threaded through ~14 functions was **removed**, not retyped: it was always a projection of the `TransformationContext` sitting beside it in every signature (verified — both origin sites read `context.options.state?.capabilitySummaryRegistry`, no aliasing). Reads now go through `context.lookupCapabilitySummary()`, and the `CapabilitySummaryRegistry` type was retired. This is the bulk of the `schema-injection.ts` net −61 lines.

`schemaInjected` keeps its **no-`getOriginalNode`-fallback** semantics (it tags synthetic nodes we produce, whose original is the pre-injection user call) — which is precisely why it's a `nodeLinks` field and not a member of the fallback-bearing marker family.

## Invariants preserved

- **Byte-identical emitted output** — refactor only.
- The four cache-invalidating markers and the data/invalidation split (state owns data, context owns invalidation) are untouched.
- The `typeRegistry` three-uses-one-map invariant is unchanged (not re-split).
- schema-generator package learns nothing about `CrossStageState`/`NodeTypeLinks`.

## Verification

- `deno check src/**/*.ts`: 0 errors.
- ts-transformers: **292 passed / 0 failed** — unchanged from baseline (includes the `.expected.*` fixture byte-comparisons).
- schema-generator: **24 passed / 0 failed** — unchanged (confirms the bare-map boundary is genuinely untouched).
- `cf check --show-transformed --no-run` over a representative pattern corpus (handlers/capability-summaries, schema injection, lift, JSX, computed) produces **byte-identical transformed code** when diffed against the pre-change commit.

## Out of scope

Phase 2 (hoist every `lift` to module scope) — its new per-node channel becomes a `NodeTypeLinks` field rather than a 9th WeakMap, which is the payoff this consolidation sets up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapses the internal per-node channels into `nodeLinks` on `CrossStageState`, mirroring TS `NodeLinks`, to simplify state while keeping behavior identical. Part of CT-1621 registry unification; `typeRegistry` and `schemaHints` stay bare maps for the `schema-generator` boundary.

- **Refactors**
  - Added `nodeLinks: WeakMap<ts.Node, NodeTypeLinks>` with `capabilitySummary` and `schemaInjected` (no `getOriginalNode` fallback).
  - Removed `CapabilitySummaryRegistry` and the threaded `capabilityRegistry` param; switched to `context.recordCapabilitySummary()` and `context.lookupCapabilitySummary()` in `schema-injection.ts` and `pattern-callback-transform.ts`.
  - Kept marker sets and cache invalidation unchanged; `typeRegistry` and `schemaHints` remain bare `WeakMap`s consumed by `schema-generator`.

<sup>Written for commit 754372f6bb37992236eee4d5fc84f20dff6f38e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

