### PR TITLE
fix(cf-harness): enforce browser access lease expiry

### DIFF
--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -19,6 +19,7 @@ import {
   HARNESS_BROWSER_ACCESS_LEASE_TYPE,
   HARNESS_BROWSER_ACCESS_PROFILE_MODES,
   type HarnessBrowserAccessLease,
+  parseBrowserAccessExpiresAt,
 } from "./contracts/browser-access.ts";
 import {
   readHarnessRunArtifacts,
@@ -561,6 +562,14 @@ const parseBrowserAccessLease = (
   if (normalizedCdpUrl === undefined) {
     throw new Error(
       "--browser-access-cdp-url must be an http:// local origin with an explicit port",
+    );
+  }
+  if (
+    expiresAt !== undefined && expiresAt.length > 0 &&
+    parseBrowserAccessExpiresAt(expiresAt) === undefined
+  ) {
+    throw new Error(
+      "--browser-access-expires-at must be a valid timestamp",
     );
   }
   return {

--- a/packages/cf-harness/src/contracts/browser-access.ts
+++ b/packages/cf-harness/src/contracts/browser-access.ts
@@ -26,3 +26,28 @@ export interface HarnessBrowserAccessLease {
   profileMode?: HarnessBrowserAccessProfileMode;
   accountAccess?: HarnessBrowserAccessAccountAccess;
 }
+
+export const parseBrowserAccessExpiresAt = (
+  expiresAt: string,
+): Date | undefined => {
+  const timestampMs = Date.parse(expiresAt);
+  return Number.isFinite(timestampMs) ? new Date(timestampMs) : undefined;
+};
+
+export const validateBrowserAccessLeaseFreshness = (
+  expiresAt: string | undefined,
+  options: { now?: Date } = {},
+): string | undefined => {
+  if (expiresAt === undefined || expiresAt.trim() === "") {
+    return undefined;
+  }
+  const expiresAtDate = parseBrowserAccessExpiresAt(expiresAt);
+  if (expiresAtDate === undefined) {
+    return "Browser Access lease expiry is invalid";
+  }
+  const now = options.now ?? new Date();
+  if (expiresAtDate.getTime() <= now.getTime()) {
+    return "Browser Access lease has expired";
+  }
+  return undefined;
+};

--- a/packages/cf-harness/src/tools/bash-no-sandbox.ts
+++ b/packages/cf-harness/src/tools/bash-no-sandbox.ts
@@ -57,6 +57,7 @@ export const bashNoSandboxTool: HarnessToolDefinition<
       : context.currentDir;
     const policyResult = validateBrowserHostCommand(input.command, {
       browserAccessCdpUrl: context.browserAccess?.cdpUrl,
+      browserAccessExpiresAt: context.browserAccess?.expiresAt,
     });
     if (!policyResult.allowed) {
       context.setCurrentDir(commandCwd);

--- a/packages/cf-harness/src/tools/browser-host-command-policy.ts
+++ b/packages/cf-harness/src/tools/browser-host-command-policy.ts
@@ -1,3 +1,5 @@
+import { validateBrowserAccessLeaseFreshness } from "../contracts/browser-access.ts";
+
 export interface BrowserHostCommandPolicyResult {
   allowed: boolean;
   reason?: string;
@@ -11,6 +13,7 @@ export interface BrowserHostCommandPlan {
 
 export interface BrowserHostCommandPolicyOptions {
   browserAccessCdpUrl?: string;
+  browserAccessExpiresAt?: string;
 }
 
 export const BROWSER_HOST_COMMAND_DENIED_EXIT_CODE = 126;
@@ -74,6 +77,12 @@ const validateAgentBrowserCommand = (
   args: readonly string[],
   options: BrowserHostCommandPolicyOptions,
 ): BrowserHostCommandPolicyResult => {
+  const expiryError = validateBrowserAccessLeaseFreshness(
+    options.browserAccessExpiresAt,
+  );
+  if (expiryError !== undefined) {
+    return deny(expiryError);
+  }
   const expectedCdpOrigin = normalizeCdpOrigin(options.browserAccessCdpUrl);
   if (
     options.browserAccessCdpUrl !== undefined && expectedCdpOrigin === undefined

--- a/packages/cf-harness/src/tools/run-skill-script.ts
+++ b/packages/cf-harness/src/tools/run-skill-script.ts
@@ -11,6 +11,7 @@ import type {
   HarnessSkillScriptRuntime,
 } from "../contracts/skill.ts";
 import type { HarnessToolDescriptor } from "../contracts/tool-descriptor.ts";
+import { validateBrowserAccessLeaseFreshness } from "../contracts/browser-access.ts";
 import {
   isSkillScriptAllowlisted,
   normalizeSkillScriptPath,
@@ -249,7 +250,14 @@ const findCdpArg = (
 const validateHostAgentBrowserScriptArgs = (
   args: readonly string[],
   expectedCdpUrl: string | undefined,
+  browserAccessExpiresAt: string | undefined,
 ): string | undefined => {
+  const expiryError = validateBrowserAccessLeaseFreshness(
+    browserAccessExpiresAt,
+  );
+  if (expiryError !== undefined) {
+    return expiryError;
+  }
   const expectedCdpOrigin = normalizeCdpOrigin(expectedCdpUrl);
   if (expectedCdpOrigin === undefined) {
     return "host agent-browser skill scripts require a Browser Access lease endpoint";
@@ -1093,6 +1101,7 @@ export const runSkillScriptTool: HarnessToolDefinition<
       const browserLeaseError = validateHostAgentBrowserScriptArgs(
         args,
         context.browserAccess?.cdpUrl,
+        context.browserAccess?.expiresAt,
       );
       if (browserLeaseError !== undefined) {
         const output = errorOutput({

--- a/packages/cf-harness/test/browser-host-command-policy.test.ts
+++ b/packages/cf-harness/test/browser-host-command-policy.test.ts
@@ -181,9 +181,15 @@ Deno.test("validateBrowserHostCommand requires local CDP for page commands", () 
 });
 
 Deno.test("validateBrowserHostCommand binds page commands to Browser Access lease", () => {
-  assertAllowed(
-    "agent-browser --cdp http://host.docker.internal:9362 snapshot -i",
-    "http://host.docker.internal:9362",
+  assertEquals(
+    validateBrowserHostCommand(
+      "agent-browser --cdp http://host.docker.internal:9362 snapshot -i",
+      {
+        browserAccessCdpUrl: "http://host.docker.internal:9362",
+        browserAccessExpiresAt: "2099-01-01T00:00:00.000Z",
+      },
+    ).allowed,
+    true,
   );
   assertDenied(
     "agent-browser --cdp http://host.docker.internal:9444 snapshot -i",
@@ -193,6 +199,45 @@ Deno.test("validateBrowserHostCommand binds page commands to Browser Access leas
     validateBrowserHostCommand(
       "agent-browser --cdp http://host.docker.internal:9362 snapshot -i",
     ).allowed,
+    false,
+  );
+});
+
+Deno.test("validateBrowserHostCommand rejects expired Browser Access leases", () => {
+  assertEquals(
+    validateBrowserHostCommand(
+      "agent-browser --cdp http://host.docker.internal:9362 snapshot -i",
+      {
+        browserAccessCdpUrl: "http://host.docker.internal:9362",
+        browserAccessExpiresAt: "2000-01-01T00:00:00.000Z",
+      },
+    ),
+    {
+      allowed: false,
+      reason: "Browser Access lease has expired",
+    },
+  );
+  assertEquals(
+    validateBrowserHostCommand(
+      "agent-browser --cdp http://host.docker.internal:9362 snapshot -i",
+      {
+        browserAccessCdpUrl: "http://host.docker.internal:9362",
+        browserAccessExpiresAt: "not-a-timestamp",
+      },
+    ),
+    {
+      allowed: false,
+      reason: "Browser Access lease expiry is invalid",
+    },
+  );
+  assertAllowed(
+    "agent-browser --cdp http://host.docker.internal:9362 snapshot -i",
+    "http://host.docker.internal:9362",
+  );
+  assertEquals(
+    validateBrowserHostCommand("agent-browser --help", {
+      browserAccessExpiresAt: "2000-01-01T00:00:00.000Z",
+    }).allowed,
     false,
   );
 });

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -895,6 +895,27 @@ Deno.test("parseCfHarnessCliArgs rejects malformed Browser Access leases", async
     Error,
     "--browser-access-account-access must be one of: available, none",
   );
+  await assertRejects(
+    () =>
+      parseCfHarnessCliArgs(
+        [
+          "--prompt",
+          "hi",
+          "--browser-access-lease-id",
+          "pf-run-1",
+          "--browser-access-cdp-url",
+          "http://127.0.0.1:9363",
+          "--browser-access-expires-at",
+          "not-a-timestamp",
+        ],
+        {
+          cwd: "/tmp/project",
+          env: {},
+        },
+      ),
+    Error,
+    "--browser-access-expires-at must be a valid timestamp",
+  );
 });
 
 Deno.test("parseCfHarnessCliArgs supports explicit web_fetch subagent profile authorization", async () => {

--- a/packages/cf-harness/test/tools-execution.test.ts
+++ b/packages/cf-harness/test/tools-execution.test.ts
@@ -1329,6 +1329,43 @@ Deno.test("bash-no-sandbox denies host commands outside the browser policy", asy
   assertEquals(context.currentDir, "/workspace/repo/browser");
 });
 
+Deno.test("bash-no-sandbox denies expired Browser Access leases", async () => {
+  const hostRunner = new FakeProcessRunner();
+  const context = createContext(
+    new FakeSandboxRuntime(),
+    "/workspace/repo",
+    hostRunner,
+    "observe",
+    undefined,
+    undefined,
+    [],
+    "/tmp/cf-harness-workspace",
+    undefined,
+    undefined,
+    [],
+    "sandbox",
+    {
+      type: "cf-harness.chat.browser-access-lease",
+      leaseId: "lease-1",
+      cdpUrl: "http://localhost:9362",
+      expiresAt: "2000-01-01T00:00:00.000Z",
+    },
+  );
+
+  const output = await bashNoSandboxTool.invoke(context, {
+    command: "agent-browser --cdp http://localhost:9362 snapshot -i",
+  });
+
+  assertEquals(hostRunner.calls, []);
+  assertEquals(output, {
+    outputId: "run-1:bash-no-sandbox:1",
+    stdout: "",
+    stderr: "bash-no-sandbox command denied: Browser Access lease has expired",
+    exitCode: 126,
+    cwd: "/workspace/repo",
+  });
+});
+
 Deno.test("read_file tool resolves relative paths from the session currentDir", async () => {
   const sandbox = new FakeSandboxRuntime([{
     stdout: "hello",
@@ -2178,6 +2215,7 @@ Deno.test({
           type: "cf-harness.chat.browser-access-lease",
           leaseId: "lease-1",
           cdpUrl: "http://localhost:9362",
+          expiresAt: "2099-01-01T00:00:00.000Z",
         },
       );
       const output = await runSkillScriptTool.invoke(context, {
@@ -2247,6 +2285,43 @@ Deno.test({
       );
       assertEquals(hostRunner.calls.length, 1);
       assertEquals(executions[1].status, "error");
+
+      const expiredContext = createContext(
+        sandbox,
+        "/workspace/subdir",
+        hostRunner,
+        "observe",
+        undefined,
+        registry,
+        [],
+        workspace,
+        activations,
+        [{ skill: "agent-browser", path: "scripts/capture-workflow.sh" }],
+        executions,
+        "host",
+        {
+          type: "cf-harness.chat.browser-access-lease",
+          leaseId: "lease-1",
+          cdpUrl: "http://localhost:9362",
+          expiresAt: "2000-01-01T00:00:00.000Z",
+        },
+      );
+      const expiredOutput = await runSkillScriptTool.invoke(expiredContext, {
+        skill: "agent-browser",
+        path: "scripts/capture-workflow.sh",
+        args: [
+          "--cdp",
+          "http://localhost:9362",
+          "http://localhost:8000/piece",
+        ],
+      });
+      assertEquals(expiredOutput.status, "error");
+      assertEquals(expiredOutput.error?.code, "permission_denied");
+      assertStringIncludes(
+        expiredOutput.error?.message ?? "",
+        "Browser Access lease has expired",
+      );
+      assertEquals(hostRunner.calls.length, 1);
     } finally {
       await Deno.remove(workspace, { recursive: true });
     }


### PR DESCRIPTION
## Summary

- validate `--browser-access-expires-at` timestamp syntax during cf-harness CLI parsing
- reject expired or malformed Browser Access leases before `agent-browser` host command execution
- apply the same freshness check to host-target `agent-browser` skill scripts

## Verification

- `deno fmt --check packages/cf-harness/src/contracts/browser-access.ts packages/cf-harness/src/cli.ts packages/cf-harness/src/tools/browser-host-command-policy.ts packages/cf-harness/src/tools/bash-no-sandbox.ts packages/cf-harness/src/tools/run-skill-script.ts packages/cf-harness/test/cli.test.ts packages/cf-harness/test/browser-host-command-policy.test.ts packages/cf-harness/test/tools-execution.test.ts`
- `deno check packages/cf-harness/src/cli.ts packages/cf-harness/src/tools/browser-host-command-policy.ts packages/cf-harness/src/tools/run-skill-script.ts`
- `deno test -A packages/cf-harness/test/cli.test.ts packages/cf-harness/test/browser-host-command-policy.test.ts packages/cf-harness/test/tools-execution.test.ts`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces Browser Access lease expiry in `cf-harness`. CLI validates `--browser-access-expires-at`; host `agent-browser` commands and host-target skill scripts are denied when the lease is expired or invalid.

- **Bug Fixes**
  - CLI rejects invalid `--browser-access-expires-at` timestamps.
  - Denies `agent-browser` host commands and host-target skill scripts when the lease is expired or invalid.
  - Returns clear reasons (“Browser Access lease has expired” / “Browser Access lease expiry is invalid”) and binds allowed page commands to the lease’s CDP origin.

<sup>Written for commit 4abbe9887c3007761375b1375f1a279979d689b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

