### PR TITLE
refactor(ts-transformers): rename internal derive→lift-applied label; retire derive from diagnostics (CT-1643, PR 1 of 2)

### DIFF
--- a/packages/ts-transformers/src/ast/call-kind.ts
+++ b/packages/ts-transformers/src/ast/call-kind.ts
@@ -2,7 +2,7 @@
  * Call Kind Detection
  *
  * This module identifies compiler-significant call families. Most are
- * Common Fabric-specific calls (derive, ifElse, pattern, etc.), but array-method
+ * Common Fabric-specific calls (lift, ifElse, pattern, etc.), but array-method
  * families are also classified because they establish callback/container
  * boundaries relevant to analysis and lowering.
  *

--- a/packages/ts-transformers/src/ast/reactive-context.ts
+++ b/packages/ts-transformers/src/ast/reactive-context.ts
@@ -9,7 +9,7 @@ export type ReactiveContextOwner =
   | "render"
   | "array-method"
   | "computed"
-  | "derive"
+  | "lift-applied"
   | "action"
   | "lift"
   | "handler"
@@ -39,11 +39,15 @@ export const RESTRICTED_CONTEXT_BUILDERS = new Set([
 
 /**
  * Builder names that establish compute context.
+ *
+ * NOTE: this set currently has no consumers in the repo (it is exported from
+ * ast/mod.ts but never read). Left in place pending a separate dead-export
+ * audit; the former `"derive"` entry was removed here as part of retiring
+ * `derive` (CT-1643) — derive is no longer a recognized builder name.
  */
 export const SAFE_WRAPPER_BUILDERS = new Set([
   "computed",
   "action",
-  "derive",
   "lift",
   "handler",
 ]);
@@ -88,7 +92,7 @@ function getMarkedSyntheticCallbackContext(
         ) {
           const callKind = detectCallKind(callParent, checker);
           if (callKind?.kind === "lift-applied") {
-            return { kind: "compute", owner: "derive", inJsxExpression };
+            return { kind: "compute", owner: "lift-applied", inJsxExpression };
           }
           if (callKind?.kind === "builder") {
             const builderContext = getBuilderContext(callKind.builderName);

--- a/packages/ts-transformers/src/ast/type-inference.ts
+++ b/packages/ts-transformers/src/ast/type-inference.ts
@@ -10,7 +10,7 @@ import {
 
 /**
  * Type inference utilities for function signatures
- * Used primarily by schema-injection to infer types for lift/derive/handler
+ * Used primarily by schema-injection to infer types for lift/handler
  */
 
 const TYPE_NODE_FLAGS = ts.NodeBuilderFlags.NoTruncation |

--- a/packages/ts-transformers/src/closures/strategies/array-method-policy.ts
+++ b/packages/ts-transformers/src/closures/strategies/array-method-policy.ts
@@ -97,11 +97,11 @@ function hasSharedReactiveCollectionProvenance(
  * Check if an array method call should be transformed to its WithPattern variant.
  *
  * Type-based approach with context awareness (CT-1186 fix):
- * 1. derive() calls always return OpaqueRef at runtime -> TRANSFORM
- * 2. Inside safe wrappers (computed/derive/etc), OpaqueRef gets auto-unwrapped
+ * 1. computed()/lift() calls always return OpaqueRef at runtime -> TRANSFORM
+ * 2. Inside safe wrappers (computed/lift/etc), OpaqueRef gets auto-unwrapped
  *    to a plain array, so we should NOT transform OpaqueRef method calls there.
  *    However, Cell and Stream do NOT get auto-unwrapped, so we still transform those.
- * 3. Local aliases created by nested computed()/derive() calls inside the current
+ * 3. Local aliases created by nested computed()/lift() calls inside the current
  *    compute callback become opaque again and should transform.
  * 4. Outside safe wrappers, transform all cell-like types (OpaqueRef, Cell, Stream).
  */

--- a/packages/ts-transformers/src/core/cf-helpers.ts
+++ b/packages/ts-transformers/src/core/cf-helpers.ts
@@ -148,7 +148,7 @@ const CF_DISABLE_TRANSFORM_DIRECTIVE_RE =
   /^\/\/\/\s*<cf-disable-transform\s*\/>/m;
 
 // Rewrite a leading transform directive line, or inject helpers by default,
-// so the AST transformer pipeline has access to helpers like `derive`.
+// so the AST transformer pipeline has access to helpers like `lift`.
 // This operates on strings, and to be used outside of
 // the TypeScript transformer pipeline, since symbol binding
 // occurs before transformers run.

--- a/packages/ts-transformers/src/policy/callback-boundary.ts
+++ b/packages/ts-transformers/src/policy/callback-boundary.ts
@@ -18,7 +18,7 @@ export type SupportedCallbackBoundaryKind =
   | "plain-array-value"
   | "pattern-builder"
   | "render-builder"
-  | "derive"
+  | "lift-applied"
   | "pattern-tool"
   | "computed-builder"
   | "action-builder"
@@ -39,7 +39,7 @@ type CallbackBoundaryBodyContext =
       | "render"
       | "array-method"
       | "computed"
-      | "derive"
+      | "lift-applied"
       | "action"
       | "lift"
       | "handler"
@@ -129,11 +129,11 @@ export function classifyCallbackBoundary(
   if (callKind?.kind === "lift-applied") {
     return {
       kind: "supported",
-      boundaryKind: "derive",
+      boundaryKind: "lift-applied",
       bodyContext: {
         strategy: "explicit",
         kind: "compute",
-        owner: "derive",
+        owner: "lift-applied",
       },
     };
   }
@@ -327,7 +327,7 @@ export function getCallbackBoundarySemantics(
       supportedKind !== "event-handler" &&
       supportedKind !== "pattern-builder" &&
       supportedKind !== "render-builder",
-    establishesLocalReactiveAliasScope: supportedKind === "derive" ||
+    establishesLocalReactiveAliasScope: supportedKind === "lift-applied" ||
       supportedKind === "computed-builder",
   };
 }

--- a/packages/ts-transformers/src/transformers/builder-callback-hoisting.ts
+++ b/packages/ts-transformers/src/transformers/builder-callback-hoisting.ts
@@ -3,7 +3,7 @@ import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
 import { hoistModuleScopedBuilderCallbacks } from "../closures/module-scope-callback-hoisting.ts";
 
 /**
- * Hoist builder callbacks (derive/handler/lift/pattern/patternTool)
+ * Hoist builder callbacks (handler/lift/pattern/patternTool)
  * whose body closes only over module-level symbols. The hoisted form
  * becomes `const __cfModuleCallback_N = ...` at module scope, replacing
  * the inline callback at the call site with a reference to the new

--- a/packages/ts-transformers/src/transformers/call-root-support.ts
+++ b/packages/ts-transformers/src/transformers/call-root-support.ts
@@ -20,12 +20,17 @@ export type CallRootPolicyDecision =
   | { kind: "unsupported"; unsupportedKind: UnsupportedCallRootKind }
   | { kind: "none" };
 
+// NOTE (CT-1643): a former `"derive"` member was removed here. It was dead —
+// matched against `detectCallKind().kind`, which never returns "derive" (the
+// canonical lowered form is `kind: "lift-applied"`; CallKind has no derive kind).
+// Whether the lowered lift-applied form SHOULD be treated as a helper boundary
+// at expression sites is a separate, open question (see CT-1643 notes); removing
+// the dead entry is byte-identical and does not pre-judge that.
 export type ExpressionSiteHelperBoundaryKind =
   | "ifElse"
   | "when"
   | "unless"
   | "builder"
-  | "derive"
   | "pattern-tool";
 
 export type ExpressionSiteCallRootKind =

--- a/packages/ts-transformers/src/transformers/expression-rewrite/rewrite-expression.ts
+++ b/packages/ts-transformers/src/transformers/expression-rewrite/rewrite-expression.ts
@@ -180,7 +180,7 @@ function rewriteChildExpressions(
 
       const analysis = analyze(child);
       if (analysis.containsOpaqueRef && analysis.requiresRewrite) {
-        // Skip wrapping if inside a safe callback wrapper (computed/derive/action/etc.)
+        // Skip wrapping if inside a safe callback wrapper (computed/lift/action/etc.)
         // This prevents double-wrapping expressions already in a reactive context
         if (isInsideKnownSafeCallbackWrapper(child, context)) {
           return visitEachChildWithJsx(child, visitor, context.tsContext);

--- a/packages/ts-transformers/src/transformers/expression-site-lowering.ts
+++ b/packages/ts-transformers/src/transformers/expression-site-lowering.ts
@@ -298,7 +298,8 @@ export function rewriteExpressionSite(
     if (containerKind === "jsx-expression") {
       context.reportDiagnostic({
         type: "opaque-ref:jsx-expression",
-        message: "JSX expression with OpaqueRef computation should use derive",
+        message:
+          "JSX expression with OpaqueRef computation should use computed()",
         node: expression,
       });
     }
@@ -375,7 +376,8 @@ export function rewriteOwnedPreClosureJsxExpressionSite(
   if (context.options.mode === "error") {
     context.reportDiagnostic({
       type: "opaque-ref:jsx-expression",
-      message: "JSX expression with OpaqueRef computation should use derive",
+      message:
+        "JSX expression with OpaqueRef computation should use computed()",
       node: expression,
     });
     return expression;

--- a/packages/ts-transformers/src/transformers/expression-site-policy.ts
+++ b/packages/ts-transformers/src/transformers/expression-site-policy.ts
@@ -644,7 +644,6 @@ const HELPER_BOUNDARY_KINDS = new Set<ExpressionSiteHelperBoundaryKind>([
   "when",
   "unless",
   "builder",
-  "derive",
   "pattern-tool",
 ]);
 

--- a/packages/ts-transformers/src/transformers/opaque-get-validation.ts
+++ b/packages/ts-transformers/src/transformers/opaque-get-validation.ts
@@ -96,7 +96,7 @@ export class OpaqueGetValidationTransformer extends HelpersOnlyTransformer {
    * - pattern/render callback inputs
    * - local variables initialized from reactive origin calls
    *
-   * Lift/handler/action/derive callback parameters keep their declared cell
+   * Lift/handler/action callback parameters keep their declared cell
    * semantics and must not be inferred as opaque from structure alone.
    */
   private isReactiveExpression(

--- a/packages/ts-transformers/src/transformers/pattern-body-reactive-root-lowering.ts
+++ b/packages/ts-transformers/src/transformers/pattern-body-reactive-root-lowering.ts
@@ -860,7 +860,7 @@ function rewriteTrackedOpaquePatternBody(
           reportOnce(
             visited,
             "receiver-method",
-            "Method calls on reactive values are not yet supported directly in non-JSX pattern bodies. Move this call into computed(() => ...), derive(...), or another safe wrapper.",
+            "Method calls on reactive values are not yet supported directly in non-JSX pattern bodies. Move this call into computed(() => ...), module-scope lift(), or another safe wrapper.",
           );
         } else {
           reportOnce(
@@ -925,7 +925,7 @@ function rewriteTrackedOpaquePatternBody(
 
 /**
  * Recursively process lift-applied callback bodies (the lowered form of
- * derive()/computed() callbacks) to rewrite property accesses on
+ * computed() callbacks) to rewrite property accesses on
  * locally-declared OpaqueRef variables (e.g., const foo = computed(...);
  * foo.bar → foo.key("bar")).
  *
@@ -935,7 +935,7 @@ function rewriteTrackedOpaquePatternBody(
  * applies the tracked-opaque rewrite to each callback body
  * with empty opaque roots (since lift-applied callbacks receive unwrapped
  * captures).
- * Local variables initialized from derive/computed/lift calls within the callback
+ * Local variables initialized from computed/lift calls within the callback
  * will be detected as opaque roots by the tracked-opaque body's variable
  * tracking.
  */

--- a/packages/ts-transformers/src/transformers/pattern-callback-lowering.ts
+++ b/packages/ts-transformers/src/transformers/pattern-callback-lowering.ts
@@ -256,7 +256,7 @@ export class PatternCallbackLoweringTransformer extends HelpersOnlyTransformer {
 
     // ── Module-extracted callback post-pass ────────────────────────────
     // ClosureTransformer hoists reactive callback bodies (from lift-applied
-    // forms — the lowered shape of `computed(...)`, `derive(...)`, etc.)
+    // forms — the lowered shape of `computed(...)`, etc.)
     // into top-level
     // `const __cfModuleCallback_N = (() => { ... })` declarations. The
     // main pass above only walks INSIDE pattern callbacks, so those

--- a/packages/ts-transformers/src/transformers/pattern-context-validation.ts
+++ b/packages/ts-transformers/src/transformers/pattern-context-validation.ts
@@ -12,13 +12,12 @@
  * - Reading from opaques IS allowed in:
  *   - computed()
  *   - action()
- *   - derive()
  *   - lift()
  *   - handler()
  *   - JSX expressions and other lowerable expression sites
- * - Local values created by computed()/derive() inside the current
- *   computed()/derive() callback remain reactive and cannot be used as plain
- *   values until a nested computed()/derive() consumes them.
+ * - Local values created by computed()/lift() inside the current
+ *   computed()/lift() callback remain reactive and cannot be used as plain
+ *   values until a nested computed()/lift() consumes them.
  *
  * - Function creation is NOT allowed in pattern context (must be at module scope)
  * - lift() and handler() must be defined at module scope, not inside patterns
@@ -32,8 +31,8 @@
  * - Calling .get() on cells: ERROR (must wrap in computed())
  * - Function creation in pattern context: ERROR (move to module scope)
  * - lift()/handler() inside pattern: ERROR (move to module scope)
- * - Local computed()/derive() aliases used as plain values in the same
- *   callback: ERROR (use a nested computed()/derive())
+ * - Local computed()/lift() aliases used as plain values in the same
+ *   callback: ERROR (use a nested computed()/lift())
  */
 import ts from "typescript";
 import { COMMONFABRIC_REACTIVE_ORIGIN_BUILDER_NAMES } from "../core/commonfabric-runtime-registry.ts";
@@ -76,7 +75,7 @@ const SES_SELF_CONTAINED_CALLBACK_BOUNDARIES = new Set<
   "pattern-tool",
   "pattern-builder",
   "render-builder",
-  "derive",
+  "lift-applied",
   "computed-builder",
   "action-builder",
   "lift-builder",
@@ -382,9 +381,9 @@ export class PatternContextValidationTransformer
         severity: "error",
         type: "compute-context:local-reactive-use",
         message: `Reactive value '${culprit.getText()}' is created in this ` +
-          `computed()/derive() callback and cannot be used as a plain value ` +
+          `computed()/lift() callback and cannot be used as a plain value ` +
           `here. Move this use into a nested computed(() => ...) or ` +
-          `derive(() => ...) callback.`,
+          `module-scope lift() callback.`,
         node: culprit,
       });
     };
@@ -441,7 +440,7 @@ export class PatternContextValidationTransformer
    *
    * This applies to any callback body that still classifies as pattern context
    * at validation time, which intentionally includes pattern-owned array method
-   * callbacks while excluding compute-owned wrappers like computed()/derive().
+   * callbacks while excluding compute-owned wrappers like computed()/lift().
    */
   private validateSupportedPatternStatements(
     func: ts.ArrowFunction | ts.FunctionExpression,
@@ -511,7 +510,7 @@ export class PatternContextValidationTransformer
             node,
             "pattern-context:let-declaration",
             `let declarations are not supported in pattern-owned callback bodies. ` +
-              `Use const, or move mutable logic into computed(), derive(), or a helper.`,
+              `Use const, or move mutable logic into computed(), module-scope lift(), or a helper.`,
           );
         } else if (
           (node.flags & (ts.NodeFlags.Let | ts.NodeFlags.Const)) === 0
@@ -520,7 +519,7 @@ export class PatternContextValidationTransformer
             node,
             "pattern-context:var-declaration",
             `var declarations are not supported in pattern-owned callback bodies. ` +
-              `Use const, or move mutable logic into computed(), derive(), or a module-scope helper.`,
+              `Use const, or move mutable logic into computed(), module-scope lift(), or a module-scope helper.`,
           );
         }
       }
@@ -536,7 +535,7 @@ export class PatternContextValidationTransformer
           node,
           "pattern-context:loop",
           `Loop statements are not supported in pattern-owned callback bodies. ` +
-            `Use array methods, helper-owned expressions, or move imperative iteration into computed(), derive(), or a helper.`,
+            `Use array methods, helper-owned expressions, or move imperative iteration into computed(), module-scope lift(), or a helper.`,
         );
       }
 
@@ -549,7 +548,7 @@ export class PatternContextValidationTransformer
           node,
           "pattern-context:assignment",
           `Reassignment is not supported in pattern-owned callback bodies. ` +
-            `Use straight-line data construction, or move mutable logic into computed(), derive(), or a helper.`,
+            `Use straight-line data construction, or move mutable logic into computed(), module-scope lift(), or a helper.`,
         );
       }
 
@@ -561,7 +560,7 @@ export class PatternContextValidationTransformer
 
   /**
    * Validates that functions are not created directly in pattern context.
-   * Functions inside safe wrappers (computed, action, derive, lift, handler)
+   * Functions inside safe wrappers (computed, action, lift, handler)
    * and inside JSX expressions are allowed since they get transformed.
    */
   private validateFunctionCreation(
@@ -569,7 +568,7 @@ export class PatternContextValidationTransformer
     context: TransformationContext,
     checker: ts.TypeChecker,
   ): void {
-    // Skip if inside safe wrapper callback (computed, action, derive, lift, handler)
+    // Skip if inside safe wrapper callback (computed, action, lift, handler)
     if (isInsideSafeCallbackWrapper(node, checker, context)) return;
 
     const boundarySemantics = !ts.isFunctionDeclaration(node)
@@ -597,7 +596,7 @@ export class PatternContextValidationTransformer
           type: "pattern-context:callback-container",
           message:
             `Callbacks passed to unsupported containers in pattern-facing JSX are not supported. ` +
-            `Use a supported array method/value call, an event handler, or move this work into computed(() => ...), derive(...), or a helper.`,
+            `Use a supported array method/value call, an event handler, or move this work into computed(() => ...), module-scope lift(), or a helper.`,
           node,
         });
       }
@@ -731,7 +730,7 @@ export class PatternContextValidationTransformer
 
   /**
    * Validates that standalone functions don't use reactive operations like
-   * computed(), derive(), or .map() on CellLike types.
+   * computed(), lift(), or .map() on CellLike types.
    *
    * Standalone functions cannot have their closures captured automatically.
    * Users should either:
@@ -805,14 +804,16 @@ export class PatternContextValidationTransformer
             return;
           }
 
-          // Check for lift-applied calls (the lowered form of user-source derive())
+          // Check for lift-applied calls (the lowered form of computed() and
+          // other reactive lifted-function computations).
           if (callKind.kind === "lift-applied") {
             context.reportDiagnostic({
               severity: "error",
               type: "standalone-function:reactive-operation",
-              message: `derive() is not allowed inside standalone functions. ` +
+              message:
+                `Reactive computations are not allowed inside standalone functions. ` +
                 `Standalone functions cannot capture reactive closures. ` +
-                `Move the derive() call to the pattern body, or use patternTool() to enable automatic closure capture.`,
+                `Move the computed() call to the pattern body, or use patternTool() to enable automatic closure capture.`,
               node,
             });
             return;

--- a/packages/ts-transformers/src/transformers/schema-injection.ts
+++ b/packages/ts-transformers/src/transformers/schema-injection.ts
@@ -63,8 +63,9 @@ const SCOPE_ALIAS_TO_CELL_SCOPE: ReadonlyMap<string, CellScope | "any"> =
 /**
  * Schema Injection Transformer - TypeRegistry Integration
  *
- * This transformer injects JSON schemas for Common Fabric core functions (pattern, derive,
- * pattern, handler, lift) by analyzing TypeScript types and converting them to runtime schemas.
+ * This transformer injects JSON schemas for Common Fabric core functions
+ * (pattern, handler, lift) by analyzing TypeScript types and converting them to
+ * runtime schemas.
  *
  * ## TypeRegistry Integration (Unified Approach)
  *

--- a/packages/ts-transformers/test/opaque-ref/runtime-style.test.ts
+++ b/packages/ts-transformers/test/opaque-ref/runtime-style.test.ts
@@ -25,7 +25,7 @@ export default pattern<{ count: number }>((state) => {
       expect(diagnostics.length).toBeGreaterThan(0);
       expect(
         diagnostics.some((d) =>
-          d.message.includes("OpaqueRef computation should use derive")
+          d.message.includes("OpaqueRef computation should use computed()")
         ),
       ).toBe(true);
     });


### PR DESCRIPTION
Part of [CT-1643](https://linear.app/common-tools/issue/CT-1643) — retire `derive` from `ts-transformers/src` now that the decision is to drop it entirely. **PR 1 of 2.**

## The finding that shaped this

`derive` is gone from the authoring surface + runtime (CT-1621 / #3748). Tracing `ts-transformers/src` showed the remaining `"derive"` references were **not authored-derive detection** — that's genuinely unreachable (derive is unexported, unregistered, never emitted as output; `CallKind` has no `derive` kind; the call-kind tests pin that a shadowed local `derive` is *not* detected as reactive). They were a **misnomer**: the internal boundary/owner label produced when `detectCallKind` returns `kind: "lift-applied"` (the current lowered form of `computed()` / lift-applied computations).

## What this PR does — **no behavior change, byte-identical transformed output**

- **Rename** the misnamed internal label `"derive"` → `"lift-applied"`, in lockstep across producers, type-union members, and the one behavioral consumer (`establishesLocalReactiveAliasScope`): `callback-boundary.ts`, `reactive-context.ts`, `call-root-support.ts`, `pattern-context-validation.ts`. (TypeScript's union types force every site to update together — the safety net.)
- **Delete two genuinely-dead `"derive"` set entries** that can never match `detectCallKind().kind`: `HELPER_BOUNDARY_KINDS` + its union member, and the unused `SAFE_WRAPPER_BUILDERS` entry. A note is left re: whether lift-applied *should* be a helper boundary (a separate latent question — deleting the dead entry is byte-identical and doesn't pre-judge it).
- **Retire `derive` from user-facing diagnostics.** They told users to "move this into `derive(...)`", which is impossible now → they now point at `computed()` / module-scope `lift()`. Updated the one test asserting the old message text.
- **Sweep "derive is a current helper" comments** to `lift`/`computed`.

## Out of scope → **PR 2 of 2**

Removing the now-**dead** "legacy derive shape" *code* branches (`call-kind.ts:405+`, and the parallel handling in `schema-injection.ts` / `pattern-body-reactive-root-lowering.ts`). I confirmed they're unreachable (`detectCallKind` only returns `lift-applied` for a CallExpression-target curry; no `derive` registry entry), but removing them is delicate and deserves its own PR with per-branch reachability proofs. Their explanatory comments are intentionally left in place until that code is removed *with* them.

## Verification

- `deno check src/**/*.ts`: 0 errors.
- `deno task test`: **292 passed / 0 failed** — unchanged from baseline (the fixture `.expected.jsx` byte-comparisons all pass, confirming byte-identical output).
- pre-commit `deno fmt` + `deno lint`: pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retires `derive` from `ts-transformers/src` by renaming the internal boundary label to "lift-applied" and updating diagnostics to point to `computed()` or module-scope `lift()`. No behavior changes; output is byte-identical. Part of CT-1643 (PR 1 of 2).

- **Refactors**
  - Renamed the internal label "derive" → "lift-applied" across producers, union types, and the callback-boundary consumer.
  - Removed dead "derive" entries from helper-boundary sets and the unused `SAFE_WRAPPER_BUILDERS` export.
  - Updated diagnostics to recommend `computed()` or module-scope `lift()`; adjusted the related test.
  - Left legacy "derive" code paths in place; they will be removed in PR 2 for CT-1643.

<sup>Written for commit ad5fa2562da77e29949d1f4fd191dc40b36f1269. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

