### PR TITLE
feat(runner): content-addressed ESM compilation cache (CT-1623 Phase 4)

### DIFF
--- a/docs/specs/module-loading-implementation-plan.md
+++ b/docs/specs/module-loading-implementation-plan.md
@@ -16,7 +16,7 @@ steps with the files each touches, exit criteria, and validation commands.
 | 1 — Decouple identity | Done (merged) | Per-module Merkle hash; scheduler implementation fingerprint is content-addressed and entry-point/TCB independent. Shipped behind `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE`. |
 | 2 — ESM emission + SES module loading | Done (behind `CF_ESM_MODULE_LOADER`, default off) | `compileToRecordGraph` + `evaluateRecordGraph` (`engine.ts`) run the full `CommonFabricTransformerPipeline` (not bare `transpileModule`), assemble content-addressed records, register per-load/per-module source maps, and load multi-module programs end-to-end. Engine integration, `export *` re-exports, live module-namespace bindings (#3797), and CFC verified-source location resolution (#3785, #3787) are all wired. The flag is now also plumbed to the browser client (#3796). |
 | 3 — Verifier port | Classification ported + wired; corpus parity oracle pending | The deep SES_SANDBOXING module-item classification (`verifyCompiledModuleBody`, reusing the shared `classifyModuleItems` core) runs **per module** in the ESM compile path (`engine.ts`). `verifyModuleGraph` validates graph shape/wiring. Additional hardening landed beyond the original plan: import-edge target validation (#3778), pattern provenance brand (#3779), frozen exported patterns (#3777). **Remaining (release gate):** the full-corpus differential parity oracle — `esm-verifier-parity.test.ts` currently covers crafted CF-shaped fixtures only, not every pattern-corpus verdict. |
-| 4 — Per-module compilation cache | Production ESM path not cached yet; content-addressed cache designed (Phase 4 below), not built | Neither cache is exercised flag-on: the whole-program `CachedCompiler` is AMD-only, and the per-module `ModuleRecordCache` is **bypassed whenever a precompiled CF-transformed body is present** — which `Engine.compileToRecordGraph` always supplies. So flag-on compiles recompile every time (the only flag-on failures are the two `pattern-manager.test.ts` AMD cache cases). **Remaining (two jobs):** make the production ESM path cacheable **and** persist it as the content-addressed cell cache (source set `pattern:<identity>` + compiled set `compileCache:<runtimeVersion>/<identity>`, per space, CFC integrity on the compiled set) — see Phase 4 below. |
+| 4 — Per-module compilation cache | Done (behind `CF_ESM_MODULE_LOADER`, default off) | Content-addressed cell cache built and wired into the ESM `PatternManager` load path (`compilation-cache/cell-cache.ts`, `pattern-manager.ts`). Per space: source set `pattern:<identity>` (self-verifying via Merkle recompute) + compiled set `compileCache:<runtimeVersion>/<identity>` (CFC `addIntegrity` on write, fail-closed on read). A warm full hit feeds cached bodies back through `compileToRecordGraph` and skips the TypeScript compile / transformer pipeline; a miss compiles and writes both sets back on a fresh transaction. Gated on `cfcEnforcementMode !== "disabled"`. **Divergence from the original design:** the plan assumed the per-module `cf:module/<hash>` identity was already entry-point independent, but the ESM compile path resolved a `/<computeId>/`-prefixed program, leaking the whole-program prefix into the identity — so cross-program dedup and the spec's entry-point-independence guarantee did not actually hold. Step 5a (`computeModuleIdentities` in `module-record-compiler.ts`) strips the prefix for identity computation only, making identities prefix-free/dedupable while leaving source maps + `fn.src` resolution on the prefixed path untouched. Full runner suite green flag-on and flag-off. |
 | 5 — Default-on + AMD removal | Not started (intentionally) | Gated on the Phase 3 corpus parity oracle + a green full-suite flag-on sweep + benchmarks. The canary PR (#3782) is the standing CI signal for flag-on. The flag stays **off** by default. |
 
 Phases 0–1 merged earlier. Phases 2–4 mechanism merged behind the default-off
@@ -297,20 +297,27 @@ untrusted execution.
 
 ## Phase 4 — Per-module compilation cache (content-addressed cells)
 
-> **Status: production ESM path does no per-module caching yet; content-addressed
-> cache designed below, not built.** Two caches exist but neither is exercised by
-> a flag-on compile: the in-process whole-program `CachedCompiler` (AMD only — the
-> ESM branch of `PatternManager.compilePattern` skips it), and the per-module
-> `ModuleRecordCache`, which `compileSourcesToRecords` deliberately **bypasses
-> whenever a precompiled CF-transformed body is present**
-> (`sandbox/module-record-compiler.ts`) — and `Engine.compileToRecordGraph`
-> always passes `precompiledBodies` and no `recordCache`
-> (`harness/engine.ts`). So the only flag-on test failures today are the two
-> `pattern-manager.test.ts` compilation-cache cases (AMD jsScript/evaluate flow),
-> and the production ESM compile recompiles from scratch every time. This phase
-> therefore has **two** jobs, not one: (a) make the production ESM path
-> cacheable, and (b) persist it as **content-addressed cells** — durable,
-> deduplicated per module, and shareable.
+> **Status: Done** (behind `CF_ESM_MODULE_LOADER`, default off). Both jobs
+> shipped: the production ESM path is now cacheable **and** persisted as
+> content-addressed cells. The cell cache (`compilation-cache/cell-cache.ts`) is
+> wired into `PatternManager.compileViaCellCache`; on a warm full hit the cached
+> per-module bodies are fed back through `compileToRecordGraph` (via the
+> `precompiledModulesFor` seam) so the TypeScript compile + transformer pipeline
+> are skipped, and on a miss both document sets are written back on a fresh,
+> CFC-prepared transaction. The full runner suite passes both flag-on and
+> flag-off (incl. the formerly-failing `pattern-manager.test.ts` AMD cases, now
+> pinned to the AMD loader).
+>
+> **One design assumption proved false during implementation** and was corrected
+> in step 5a: the per-module `cf:module/<hash>` identity was *not* actually
+> entry-point independent on the ESM path — `compileSourcesToRecords` hashed the
+> resolved program whose files carry the whole-program `/<computeId>/` prefix, so
+> the prefix leaked into the identity (no cross-program dedup; contradicting the
+> entry-point-independence guarantee in `module-loading.md`). The fix strips the
+> prefix for identity computation only (`computeModuleIdentities`), leaving record
+> source URLs, source-map keys, and `fn.src` resolution on the prefixed path.
+> The injected, already-unprefixed `cfc.ts` helper is reached on load via a
+> synthetic root link from the entry document (nothing imports it at runtime).
 
 ### 4.0 Design — two content-addressed document sets, per space
 
@@ -394,42 +401,43 @@ set of module docs.
 
 ### 4.3 Ordered steps
 
-- **4.3.1 Cache-doc schemas + keys.** Define the source-doc and compiled-doc cell
+- **4.3.1 Cache-doc schemas + keys.** ✅ Done. Source-doc / compiled-doc cell
   schemas (`code`, `filename`, `imports: [{ specifier, link }]`), the
   `pattern:<identity>` / `compileCache:<runtimeVersion>/<identity>` key scheme,
-  and the integrity-label constant. The import-link entries use sigil links and a
-  link-following schema. **Files:** new
-  `packages/runner/src/compilation-cache/cell-cache.ts` (schemas + read/write
-  helpers); `runtimeVersion` derives from the existing compiler/runtime
-  fingerprint (`compilation-cache/`).
-- **4.3.2 Source-set store.** Write/read `pattern:<identity>` cells; verify
-  `hash(content) === key` on read; expose a link-following schema so a request
-  loads the closure. **Files:** `cell-cache.ts`, `PatternManager`.
-- **4.3.3 Compiled-set store.** Write/read
-  `compileCache:<runtimeVersion>/<identity>` with `addIntegrity` on write and
-  `requiredIntegrity` on read (fail-closed → treat as miss). **Files:**
-  `cell-cache.ts`, `cfc/` integrity wiring.
-- **4.3.4 Engine seam.** Teach `Engine.compileToRecordGraph` to accept
-  `precompiledModules?: Map<path, { js; sourceMap? }>` (cached compiled bodies)
-  so it skips the TS compile for hit modules, and to return the serializable
-  per-module artifacts for write-back. **Files:**
-  `packages/runner/src/harness/engine.ts`.
-- **4.3.5 PatternManager ESM load.** Replace the direct
-  `compileAndEvaluateModules` call in the ESM branch of
-  `PatternManager.compilePattern` with: identity computation → compiled-set fetch
-  (link-following) → partial fallback (4.1) → assemble → `evaluateRecordGraph` →
-  write-back on miss (4.2). **Files:**
-  `packages/runner/src/pattern-manager.ts`.
-- **4.3.6 Graph-wiring verification.** On load, recompute module identities from
-  the loaded source set and assert each equals its doc key (content-addressed
-  `verifyModuleGraph` analog); keep `verifyCompiledModuleBody` on the compile
-  path. **Files:** `cell-cache.ts`, `sandbox/module-record-verifier.ts`.
-- **4.3.7 Replace whole-program pattern storage (gated).** The
-  `pattern:<patternId>` `PatternMeta` store (`PatternManager.savePattern` /
-  `loadPattern`, keyed by `createRef(pattern)`) is superseded by the
-  content-addressed source set after the flag flip. Behind the flag the two
-  coexist; Phase 5 removes the old store. (No migration: per the rollout, cache
-  and pattern data are cleared at the flip.)
+  and the integrity-label constant live in
+  `packages/runner/src/compilation-cache/cell-cache.ts`. Import-link entries use
+  sigil links (`asCell`) + a link-following schema. `runtimeVersion` is the
+  manually-bumped `COMPILE_CACHE_RUNTIME_VERSION` constant (no automatic build
+  fingerprint exists at runtime).
+- **4.3.2 Source-set store.** ✅ Done. `writeSourceDocs` / `loadSourceClosure`
+  (link-following, `sync()`-ing each cell for cross-session loads) +
+  `verifySourceDocs` (Merkle `hash(content) === key` recompute). **Files:**
+  `cell-cache.ts`.
+- **4.3.3 Compiled-set store.** ✅ Done. `writeCompiledDocs` stamps
+  `cf-compiled-by:<did>` via `ifc.addIntegrity`; `loadCompiledClosure` fail-closes
+  on a missing/mismatched label (treated as a miss). Requires an enforcing CFC
+  mode + `prepareCfc()` + commit. **Files:** `cell-cache.ts`, `cfc/metadata.ts`.
+- **4.3.4 Engine seam.** ✅ Done. `Engine.compileToRecordGraph` accepts
+  `precompiledModules` / `precompiledModulesFor` (cached bodies keyed by
+  **content identity**, not path) and returns `entryIdentity` +
+  `modules: CacheableModule[]` for write-back; a full hit skips the TS compile.
+  **Files:** `packages/runner/src/harness/engine.ts`, `harness/types.ts`. (The
+  identity-space keying + prefix normalization are step 5a, above.)
+- **4.3.5 PatternManager ESM load.** ✅ Done. `compileViaCellCache`:
+  identity-keyed compiled-set fetch (lazy, via `precompiledModulesFor`) → warm
+  full hit OR full recompile → `evaluateRecordGraph` → write-back on miss
+  (fire-and-forget, fresh tx). Threaded `{ space, tx }` from `compilePatternOnce`.
+  **Files:** `packages/runner/src/pattern-manager.ts`.
+- **4.3.6 Graph-wiring verification.** ✅ Done. `loadVerifiedSourceClosure`
+  recomputes each module's Merkle identity from the loaded source set and
+  requires it to equal its doc key; `verifyCompiledModuleBody` + `verifyModuleGraph`
+  still run on every emitted body on the warm path (defense-in-depth while the
+  integrity label is client-asserted). **Files:** `cell-cache.ts`,
+  `sandbox/module-record-verifier.ts`.
+- **4.3.7 Replace whole-program pattern storage (gated).** Deferred to Phase 5
+  (intentional). The `pattern:<patternId>` `PatternMeta` store and the new
+  content-addressed source set coexist behind the flag; Phase 5 removes the old
+  store. (No migration: cache + pattern data are cleared at the flip.)
 
 ### 4.4 Tests
 

--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -1,8 +1,5 @@
-import type { Program } from "@commonfabric/js-compiler";
-import {
-  computeModuleHashes,
-  resolveModuleImports,
-} from "../harness/module-identity.ts";
+import { computeModuleHashes } from "../harness/module-identity.ts";
+import type { CacheableModule } from "../harness/types.ts";
 import type { MemorySpace, Runtime } from "../runtime.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import { type Cell, isCell } from "../cell.ts";
@@ -71,40 +68,80 @@ export function compiledDocKey(
 }
 
 /**
- * Per-module identities for a program: `path → identity`. Wraps
- * `computeModuleHashes` so the cache and the loader agree on identity.
+ * Synthetic import specifier prefix for a link the cache adds from the entry
+ * document to a module that is part of the emitted program but not reachable
+ * from the entry through the natural import graph (e.g. the injected `cfc.ts`
+ * helper, pulled in via a `.d.ts` re-export with no runtime import edge).
+ * Without it the link-following loader would never fetch such a module, so a
+ * warm closure would always be incomplete. These links carry no authored
+ * specifier, so they are ignored by the Merkle identity recompute (which
+ * resolves a module's edges from its own source, not its stored links).
  */
-export function moduleIdentities(
-  program: Program,
-  runtimeFingerprint = "",
-): Map<string, string> {
-  return computeModuleHashes(program, { runtimeFingerprint });
+export const ROOT_LINK_SPECIFIER = "cf:cache-root/";
+
+/** Identities of emitted modules not reachable from the entry via imports. */
+function unreachedRoots(
+  modules: readonly CacheableModule[],
+  entryIdentity: string,
+): string[] {
+  const byId = new Map(modules.map((m) => [m.identity, m]));
+  const seen = new Set<string>();
+  const queue: string[] = [entryIdentity];
+  while (queue.length > 0) {
+    const id = queue.shift()!;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    for (const imp of byId.get(id)?.imports ?? []) {
+      queue.push(imp.targetIdentity);
+    }
+  }
+  return modules.filter((m) => !seen.has(m.identity)).map((m) => m.identity);
 }
 
 /**
- * Build the source-set documents for a program, keyed by module identity. Each
- * document's `imports` resolve internal edges to the imported module's identity
- * (so a reader can follow links to the dependency documents).
+ * The resolved internal-import edges to store on a module's document, augmented
+ * (for the entry module only) with synthetic root links to any otherwise-
+ * unreachable emitted module so the link-following loader fetches the whole set.
+ */
+function storedImportRefs(
+  module: CacheableModule,
+  entryIdentity: string,
+  extraRoots: readonly string[],
+): ModuleImportRef[] {
+  const refs: ModuleImportRef[] = module.imports.map((imp) => ({
+    specifier: imp.specifier,
+    identity: imp.targetIdentity,
+  }));
+  if (module.identity === entryIdentity) {
+    for (const rootIdentity of extraRoots) {
+      refs.push({
+        specifier: `${ROOT_LINK_SPECIFIER}${rootIdentity}`,
+        identity: rootIdentity,
+      });
+    }
+  }
+  return refs;
+}
+
+/**
+ * Build the source-set documents for an emitted module set, keyed by module
+ * identity. Each document's `imports` resolve internal edges to the imported
+ * module's identity (so a reader can follow links to the dependency documents);
+ * the entry document additionally links any module unreachable through the
+ * natural import graph (see {@link ROOT_LINK_SPECIFIER}).
  */
 export function buildSourceDocs(
-  program: Program,
-  runtimeFingerprint = "",
+  modules: readonly CacheableModule[],
+  entryIdentity: string,
 ): Map<string, SourceDoc> {
-  const ids = moduleIdentities(program, runtimeFingerprint);
-  const edges = resolveModuleImports(program);
+  const extraRoots = unreachedRoots(modules, entryIdentity);
   const out = new Map<string, SourceDoc>();
-  for (const file of program.files) {
-    const identity = ids.get(file.name);
-    if (identity === undefined) continue;
-    const imports = (edges.get(file.name)?.internalDeps ?? []).map((dep) => ({
-      specifier: dep.specifier,
-      identity: ids.get(dep.target)!,
-    }));
-    out.set(identity, {
+  for (const module of modules) {
+    out.set(module.identity, {
       kind: "source",
-      code: file.contents,
-      filename: file.name,
-      imports,
+      code: module.source,
+      filename: module.filename,
+      imports: storedImportRefs(module, entryIdentity, extraRoots),
     });
   }
   return out;
@@ -148,9 +185,9 @@ export function verifySourceDocs(
     name: doc.filename,
     contents: doc.code,
   }));
-  const recomputed = moduleIdentities(
+  const recomputed = computeModuleHashes(
     { main: entry.filename, files },
-    runtimeFingerprint,
+    { runtimeFingerprint },
   );
 
   const mismatches: string[] = [];
@@ -211,18 +248,19 @@ export const SOURCE_DOC_SCHEMA = {
 } as const satisfies JSONSchema;
 
 /**
- * Write every module of `program` as a `pattern:<identity>` cell into `space`,
- * each import a sigil link to its dependency cell. Idempotent (content-addressed
- * keys). The caller owns the transaction's commit.
+ * Write every emitted module as a `pattern:<identity>` cell into `space`, each
+ * import a sigil link to its dependency cell (the entry additionally linking any
+ * otherwise-unreachable module). Idempotent (content-addressed keys). The caller
+ * owns the transaction's commit.
  */
 export function writeSourceDocs(
   runtime: Runtime,
   space: MemorySpace,
-  program: Program,
+  modules: readonly CacheableModule[],
+  entryIdentity: string,
   tx: IExtendedStorageTransaction,
-  runtimeFingerprint = "",
 ): void {
-  const docs = buildSourceDocs(program, runtimeFingerprint);
+  const docs = buildSourceDocs(modules, entryIdentity);
   for (const [identity, doc] of docs) {
     const cell = runtime.getCell(
       space,
@@ -294,14 +332,6 @@ export function loadSourceClosure(
 }
 
 // --- Compiled-set store (4.3.3): `compileCache:<rtver>/<identity>` + CFC ------
-
-/**
- * Compiled artifacts produced by a fresh compile, keyed by authored path.
- */
-export type CompiledArtifacts = Map<
-  string,
-  { js: string; sourceMap?: unknown }
->;
 
 /**
  * The CFC integrity atom stamped on a compiled document. A plain literal string
@@ -379,54 +409,49 @@ function cellCarriesIntegrity(
 }
 
 /**
- * Write every module's compiled artifact as a
+ * Write every emitted module's compiled body as a
  * `compileCache:<runtimeVersion>/<identity>` cell into `space`, stamped with the
- * compiler integrity atom, imports linked to dependency compiled cells. The
- * caller must `prepareCfc()` + commit the tx under an enforcing CFC mode for the
- * integrity label to persist.
+ * compiler integrity atom, imports linked to dependency compiled cells (the
+ * entry additionally linking any otherwise-unreachable module). The caller must
+ * `prepareCfc()` + commit the tx under an enforcing CFC mode for the integrity
+ * label to persist.
  */
 export function writeCompiledDocs(
   runtime: Runtime,
   space: MemorySpace,
-  program: Program,
-  artifacts: CompiledArtifacts,
-  opts: {
-    runtimeVersion: string;
-    compilerDid: string;
-    runtimeFingerprint?: string;
-  },
+  modules: readonly CacheableModule[],
+  entryIdentity: string,
+  opts: { runtimeVersion: string; compilerDid: string },
   tx: IExtendedStorageTransaction,
 ): void {
-  const ids = moduleIdentities(program, opts.runtimeFingerprint);
-  const edges = resolveModuleImports(program);
+  const extraRoots = unreachedRoots(modules, entryIdentity);
   const schema = compiledDocWriteSchema(opts.compilerDid);
-  for (const file of program.files) {
-    const identity = ids.get(file.name);
-    const artifact = artifacts.get(file.name);
-    if (identity === undefined || artifact === undefined) continue;
+  for (const module of modules) {
     const cell = runtime.getCell(
       space,
-      compiledDocKey(opts.runtimeVersion, identity),
+      compiledDocKey(opts.runtimeVersion, module.identity),
       schema,
       tx,
     );
     cell.set({
       kind: "compiled",
-      identity,
-      code: artifact.js,
-      filename: file.name,
-      ...(artifact.sourceMap !== undefined
-        ? { sourceMap: artifact.sourceMap }
+      identity: module.identity,
+      code: module.js,
+      filename: module.filename,
+      ...(module.sourceMap !== undefined
+        ? { sourceMap: module.sourceMap }
         : {}),
-      imports: (edges.get(file.name)?.internalDeps ?? []).map((dep) => ({
-        specifier: dep.specifier,
-        link: runtime.getCell(
-          space,
-          compiledDocKey(opts.runtimeVersion, ids.get(dep.target)!),
-          undefined,
-          tx,
-        ).getAsLink(),
-      })),
+      imports: storedImportRefs(module, entryIdentity, extraRoots).map(
+        (ref) => ({
+          specifier: ref.specifier,
+          link: runtime.getCell(
+            space,
+            compiledDocKey(opts.runtimeVersion, ref.identity),
+            undefined,
+            tx,
+          ).getAsLink(),
+        }),
+      ),
     } as StoredCompiledDoc);
   }
 }

--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -1,3 +1,4 @@
+import { getLogger } from "@commonfabric/utils/logger";
 import { computeModuleHashes } from "../harness/module-identity.ts";
 import type { CacheableModule } from "../harness/types.ts";
 import type { MemorySpace, Runtime } from "../runtime.ts";
@@ -5,6 +6,8 @@ import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import { type Cell, isCell } from "../cell.ts";
 import type { JSONSchema } from "../builder/types.ts";
 import { readStoredCfcMetadata } from "../cfc/metadata.ts";
+
+const logger = getLogger("cell-cache");
 
 /**
  * Content-addressed compilation cache — document model and key scheme.
@@ -343,6 +346,40 @@ export async function loadSourceClosure(
     }
   }
   return out;
+}
+
+/**
+ * Load the source closure (see {@link loadSourceClosure}) and **graph-wiring
+ * verify** it (step 4.3.6): recompute every module's Merkle identity from the
+ * loaded source + import graph and require it to equal its document key. This is
+ * the content-addressed analog of `verifyModuleGraph` — the source set is
+ * self-verifying (content-addressing IS the integrity), so a tampered source, a
+ * rewired link, or an incomplete closure is rejected here. Resolves to the
+ * verified closure, or `undefined` if the entry is absent or verification fails.
+ */
+export async function loadVerifiedSourceClosure(
+  runtime: Runtime,
+  space: MemorySpace,
+  entryIdentity: string,
+  tx: IExtendedStorageTransaction,
+  runtimeFingerprint = "",
+): Promise<Map<string, SourceDoc> | undefined> {
+  const closure = await loadSourceClosure(runtime, space, entryIdentity, tx);
+  if (closure === undefined) return undefined;
+  const verification = verifySourceDocs(
+    entryIdentity,
+    closure,
+    runtimeFingerprint,
+  );
+  if (!verification.ok) {
+    logger.warn("source-closure-verify-failed", () => [
+      `entry=${entryIdentity}`,
+      `mismatches=${verification.mismatches.length}`,
+      `missing=${verification.missing.length}`,
+    ]);
+    return undefined;
+  }
+  return closure;
 }
 
 // --- Compiled-set store (4.3.3): `compileCache:<rtver>/<identity>` + CFC ------

--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -510,9 +510,17 @@ export function writeCompiledDocs(
 /**
  * Load the integrity-valid compiled documents reachable from `entryIdentity` by
  * following import links. Each cell is `sync()`d before reading so a closure
- * persisted in a prior session loads from storage. Fail-closed: a document whose
- * persisted CFC label does not carry the compiler integrity atom is dropped
- * (treated as a cache miss for that module, so the caller recompiles it).
+ * persisted in a prior session loads from storage.
+ *
+ * Fail-closed and link-faithful: the BFS walks the *actual linked cells* (never
+ * re-deriving a cell from a stored `identity` field), and a cell is read only
+ * after its own persisted CFC label is confirmed to carry the compiler
+ * integrity atom. So every document in the result — and every import edge — came
+ * from an integrity-stamped cell that the parent's sigil link actually points
+ * at; an unstamped/tampered child is dropped along with the edge to it (treated
+ * as a cache miss, so the caller recompiles). The entry is the one cell looked
+ * up by key, from the caller's trusted `entryIdentity`.
+ *
  * Resolves to the valid documents keyed by their stored identity (empty map if
  * the entry itself is missing/unstamped).
  */
@@ -526,35 +534,45 @@ export async function loadCompiledClosure(
   const atom = compiledIntegrityAtom(opts.compilerDid);
   const out = new Map<string, CompiledDoc>();
   const visited = new Set<string>();
-  const queue: string[] = [entryIdentity];
-  while (queue.length > 0) {
-    const identity = queue.shift()!;
-    if (visited.has(identity)) continue;
-    visited.add(identity);
 
-    const cell = runtime.getCell(
-      space,
-      compiledDocKey(opts.runtimeVersion, identity),
-      COMPILED_DOC_SCHEMA,
-      tx,
-    );
+  // Integrity-check a cell, returning its stored doc only if the cell carries
+  // the compiler atom (fail-closed). The cell is synced first.
+  const readVerified = async (
+    cell: Cell<unknown>,
+  ): Promise<StoredCompiledDoc | undefined> => {
     await cell.sync();
-    // Fail-closed: only integrity-stamped documents are trusted.
-    if (!cellCarriesIntegrity(cell, atom, tx)) continue;
+    if (!cellCarriesIntegrity(cell, atom, tx)) return undefined;
     const doc = cell.get() as StoredCompiledDoc | undefined;
-    if (!doc || typeof doc.identity !== "string") continue;
+    return doc && typeof doc.identity === "string" ? doc : undefined;
+  };
+
+  const entryCell = runtime.getCell(
+    space,
+    compiledDocKey(opts.runtimeVersion, entryIdentity),
+    COMPILED_DOC_SCHEMA,
+    tx,
+  );
+  const entryDoc = await readVerified(entryCell);
+  if (entryDoc === undefined) return out;
+
+  const queue: { doc: StoredCompiledDoc }[] = [{ doc: entryDoc }];
+  while (queue.length > 0) {
+    const { doc } = queue.shift()!;
+    if (visited.has(doc.identity)) continue;
+    visited.add(doc.identity);
 
     const imports: ModuleImportRef[] = [];
     for (const imp of doc.imports ?? []) {
       if (!isCell(imp.link)) continue;
+      // Follow the actual linked cell and integrity-check IT before trusting
+      // either the edge or the child's content (no re-lookup by stored id).
       const childCell = (imp.link as Cell<unknown>).asSchema(
         COMPILED_DOC_SCHEMA,
       );
-      await childCell.sync();
-      const child = childCell.get() as StoredCompiledDoc | undefined;
-      if (!child || typeof child.identity !== "string") continue;
+      const child = await readVerified(childCell);
+      if (child === undefined) continue;
       imports.push({ specifier: imp.specifier, identity: child.identity });
-      if (!visited.has(child.identity)) queue.push(child.identity);
+      if (!visited.has(child.identity)) queue.push({ doc: child });
     }
     out.set(doc.identity, {
       kind: "compiled",

--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -7,6 +7,7 @@ import type { MemorySpace, Runtime } from "../runtime.ts";
 import type { IExtendedStorageTransaction } from "../storage/interface.ts";
 import { type Cell, isCell } from "../cell.ts";
 import type { JSONSchema } from "../builder/types.ts";
+import { readStoredCfcMetadata } from "../cfc/metadata.ts";
 
 /**
  * Content-addressed compilation cache — document model and key scheme.
@@ -288,6 +289,199 @@ export function loadSourceClosure(
     for (const child of childDocs) {
       if (!out.has(child.identity)) queue.push({ doc: child });
     }
+  }
+  return out;
+}
+
+// --- Compiled-set store (4.3.3): `compileCache:<rtver>/<identity>` + CFC ------
+
+/**
+ * Compiled artifacts produced by a fresh compile, keyed by authored path.
+ */
+export type CompiledArtifacts = Map<
+  string,
+  { js: string; sourceMap?: unknown }
+>;
+
+/**
+ * The CFC integrity atom stamped on a compiled document. A plain literal string
+ * bound to the compiler's principal DID: structured `represents-principal`
+ * atoms are runtime-resolved and rejected/owner-coupled, so the DID is baked
+ * into the string instead. In the interim the label is client-asserted (a
+ * same-space writer could stamp it); the hard guarantee lands when the server
+ * becomes the sole acceptor of this write integrity. See the threat model in
+ * docs/specs/module-loading.md.
+ */
+export function compiledIntegrityAtom(compilerDid: string): string {
+  return `cf-compiled-by:${compilerDid}`;
+}
+
+const compiledDocProperties = {
+  kind: { type: "string" },
+  identity: { type: "string" },
+  code: { type: "string" },
+  filename: { type: "string" },
+  sourceMap: {},
+  imports: {
+    type: "array",
+    items: {
+      type: "object",
+      properties: {
+        specifier: { type: "string" },
+        link: { asCell: ["cell"] },
+      },
+    },
+  },
+} as const;
+
+/** Read schema for a compiled document (`imports[].link` auto-loads). */
+export const COMPILED_DOC_SCHEMA = {
+  type: "object",
+  properties: compiledDocProperties,
+} as const satisfies JSONSchema;
+
+/** Write schema: stamps the compiler integrity atom on the stored value. */
+export function compiledDocWriteSchema(compilerDid: string): JSONSchema {
+  return {
+    type: "object",
+    properties: compiledDocProperties,
+    ifc: { addIntegrity: [compiledIntegrityAtom(compilerDid)] },
+  };
+}
+
+interface StoredCompiledDoc {
+  kind: "compiled";
+  identity: string;
+  code: string;
+  filename: string;
+  sourceMap?: unknown;
+  imports: { specifier: string; link: unknown }[];
+}
+
+/** Whether a cell's persisted CFC label carries `atom` at its root path. */
+function cellCarriesIntegrity(
+  cell: Cell<unknown>,
+  atom: string,
+  tx: IExtendedStorageTransaction,
+): boolean {
+  const link = cell.getAsNormalizedFullLink();
+  const metadata = readStoredCfcMetadata(tx, {
+    space: link.space,
+    id: link.id,
+    scope: link.scope,
+  });
+  if (metadata === undefined) return false;
+  return metadata.labelMap.entries.some((entry) =>
+    entry.path.length === 0 &&
+    Array.isArray(entry.label.integrity) &&
+    entry.label.integrity.some((a) => a === atom)
+  );
+}
+
+/**
+ * Write every module's compiled artifact as a
+ * `compileCache:<runtimeVersion>/<identity>` cell into `space`, stamped with the
+ * compiler integrity atom, imports linked to dependency compiled cells. The
+ * caller must `prepareCfc()` + commit the tx under an enforcing CFC mode for the
+ * integrity label to persist.
+ */
+export function writeCompiledDocs(
+  runtime: Runtime,
+  space: MemorySpace,
+  program: Program,
+  artifacts: CompiledArtifacts,
+  opts: {
+    runtimeVersion: string;
+    compilerDid: string;
+    runtimeFingerprint?: string;
+  },
+  tx: IExtendedStorageTransaction,
+): void {
+  const ids = moduleIdentities(program, opts.runtimeFingerprint);
+  const edges = resolveModuleImports(program);
+  const schema = compiledDocWriteSchema(opts.compilerDid);
+  for (const file of program.files) {
+    const identity = ids.get(file.name);
+    const artifact = artifacts.get(file.name);
+    if (identity === undefined || artifact === undefined) continue;
+    const cell = runtime.getCell(
+      space,
+      compiledDocKey(opts.runtimeVersion, identity),
+      schema,
+      tx,
+    );
+    cell.set({
+      kind: "compiled",
+      identity,
+      code: artifact.js,
+      filename: file.name,
+      ...(artifact.sourceMap !== undefined
+        ? { sourceMap: artifact.sourceMap }
+        : {}),
+      imports: (edges.get(file.name)?.internalDeps ?? []).map((dep) => ({
+        specifier: dep.specifier,
+        link: runtime.getCell(
+          space,
+          compiledDocKey(opts.runtimeVersion, ids.get(dep.target)!),
+          undefined,
+          tx,
+        ).getAsLink(),
+      })),
+    } as StoredCompiledDoc);
+  }
+}
+
+/**
+ * Load the integrity-valid compiled documents reachable from `entryIdentity` by
+ * following import links. Fail-closed: a document whose persisted CFC label does
+ * not carry the compiler integrity atom is dropped (treated as a cache miss for
+ * that module, so the caller recompiles it). Returns the valid documents keyed
+ * by their stored identity (empty map if the entry itself is missing/unstamped).
+ */
+export function loadCompiledClosure(
+  runtime: Runtime,
+  space: MemorySpace,
+  entryIdentity: string,
+  opts: { runtimeVersion: string; compilerDid: string },
+  tx: IExtendedStorageTransaction,
+): Map<string, CompiledDoc> {
+  const atom = compiledIntegrityAtom(opts.compilerDid);
+  const out = new Map<string, CompiledDoc>();
+  const visited = new Set<string>();
+  const queue: string[] = [entryIdentity];
+  while (queue.length > 0) {
+    const identity = queue.shift()!;
+    if (visited.has(identity)) continue;
+    visited.add(identity);
+
+    const cell = runtime.getCell(
+      space,
+      compiledDocKey(opts.runtimeVersion, identity),
+      COMPILED_DOC_SCHEMA,
+      tx,
+    );
+    // Fail-closed: only integrity-stamped documents are trusted.
+    if (!cellCarriesIntegrity(cell, atom, tx)) continue;
+    const doc = cell.get() as StoredCompiledDoc | undefined;
+    if (!doc || typeof doc.identity !== "string") continue;
+
+    const imports: ModuleImportRef[] = [];
+    for (const imp of doc.imports ?? []) {
+      if (!isCell(imp.link)) continue;
+      const child = (imp.link as Cell<unknown>)
+        .asSchema(COMPILED_DOC_SCHEMA)
+        .get() as StoredCompiledDoc | undefined;
+      if (!child || typeof child.identity !== "string") continue;
+      imports.push({ specifier: imp.specifier, identity: child.identity });
+      if (!visited.has(child.identity)) queue.push(child.identity);
+    }
+    out.set(doc.identity, {
+      kind: "compiled",
+      code: doc.code,
+      filename: doc.filename,
+      ...(doc.sourceMap !== undefined ? { sourceMap: doc.sourceMap } : {}),
+      imports,
+    });
   }
   return out;
 }

--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -1,0 +1,168 @@
+import type { Program } from "@commonfabric/js-compiler";
+import {
+  computeModuleHashes,
+  resolveModuleImports,
+} from "../harness/module-identity.ts";
+
+/**
+ * Content-addressed compilation cache — document model and key scheme.
+ *
+ * Phase 4 of docs/specs/module-loading.md. The persistent cache is a pair of
+ * per-module document sets stored as regular cells in the target space:
+ *
+ *  - **Source set** `pattern:<identity>` — authored TypeScript, keyed by the
+ *    per-module Merkle identity (`computeModuleHashes`). Runtime-version
+ *    independent.
+ *  - **Compiled set** `compileCache:<runtimeVersion>/<identity>` — verified
+ *    compiled JS, keyed by `(runtimeVersion, identity)`.
+ *
+ * Each document records its `code`, authored `filename`, and the resolved
+ * internal `imports` (`{ specifier, identity }`) — the identity is what the
+ * document's sigil link points at (`sourceDocKey`/`compiledDocKey` of the
+ * dependency). This module owns the pure key/identity/verification logic; the
+ * cell read/write + link wiring layer builds on it.
+ */
+
+/** A resolved internal import edge of a cached module. */
+export interface ModuleImportRef {
+  /** Authored import specifier, e.g. `"./util.ts"`. */
+  readonly specifier: string;
+  /** Content-addressed identity of the imported module's document. */
+  readonly identity: string;
+}
+
+interface ModuleDocBase {
+  /** Module code: authored TS (source set) or compiled JS (compiled set). */
+  readonly code: string;
+  /** Authored module path, e.g. `/main.tsx`. */
+  readonly filename: string;
+  /** Resolved internal imports; each points at another document by identity. */
+  readonly imports: readonly ModuleImportRef[];
+}
+
+/** A source-set document (`pattern:<identity>`). */
+export interface SourceDoc extends ModuleDocBase {
+  readonly kind: "source";
+}
+
+/** A compiled-set document (`compileCache:<runtimeVersion>/<identity>`). */
+export interface CompiledDoc extends ModuleDocBase {
+  readonly kind: "compiled";
+  /** Per-module source map, if any (registered for fn.src / CFC resolution). */
+  readonly sourceMap?: unknown;
+}
+
+/** Cell key (id) for a source-set document. */
+export function sourceDocKey(identity: string): string {
+  return `pattern:${identity}`;
+}
+
+/** Cell key (id) for a compiled-set document. */
+export function compiledDocKey(
+  runtimeVersion: string,
+  identity: string,
+): string {
+  return `compileCache:${runtimeVersion}/${identity}`;
+}
+
+/**
+ * Per-module identities for a program: `path → identity`. Wraps
+ * `computeModuleHashes` so the cache and the loader agree on identity.
+ */
+export function moduleIdentities(
+  program: Program,
+  runtimeFingerprint = "",
+): Map<string, string> {
+  return computeModuleHashes(program, { runtimeFingerprint });
+}
+
+/**
+ * Build the source-set documents for a program, keyed by module identity. Each
+ * document's `imports` resolve internal edges to the imported module's identity
+ * (so a reader can follow links to the dependency documents).
+ */
+export function buildSourceDocs(
+  program: Program,
+  runtimeFingerprint = "",
+): Map<string, SourceDoc> {
+  const ids = moduleIdentities(program, runtimeFingerprint);
+  const edges = resolveModuleImports(program);
+  const out = new Map<string, SourceDoc>();
+  for (const file of program.files) {
+    const identity = ids.get(file.name);
+    if (identity === undefined) continue;
+    const imports = (edges.get(file.name)?.internalDeps ?? []).map((dep) => ({
+      specifier: dep.specifier,
+      identity: ids.get(dep.target)!,
+    }));
+    out.set(identity, {
+      kind: "source",
+      code: file.contents,
+      filename: file.name,
+      imports,
+    });
+  }
+  return out;
+}
+
+/** Result of verifying a loaded source-document closure. */
+export interface SourceDocVerification {
+  readonly ok: boolean;
+  /** The entry document's authored filename, when present. */
+  readonly entryFilename?: string;
+  /** Identities whose recomputed Merkle hash does not match their key. */
+  readonly mismatches: readonly string[];
+  /** Import-link target identities absent from the loaded document set. */
+  readonly missing: readonly string[];
+}
+
+/**
+ * Verify a loaded source-document closure by **recomputing** each module's
+ * Merkle identity from the documents' authored source and import graph and
+ * checking it equals the identity the document is keyed by. This is the
+ * content-addressed analog of the structural graph verifier: because the
+ * identity is a one-way Merkle hash over `(source, import identities)`, a
+ * single document's content does not determine its key — the whole closure
+ * must recompute consistently. Tampering with any source, or rewiring an
+ * import link, makes the recomputed identity diverge from the key.
+ *
+ * Extra unrelated documents in the set are harmless: a module's identity
+ * depends only on its own reachable closure, so siblings do not perturb it.
+ */
+export function verifySourceDocs(
+  entryIdentity: string,
+  docsByIdentity: ReadonlyMap<string, SourceDoc>,
+  runtimeFingerprint = "",
+): SourceDocVerification {
+  const entry = docsByIdentity.get(entryIdentity);
+  if (entry === undefined) {
+    return { ok: false, mismatches: [], missing: [entryIdentity] };
+  }
+
+  const files = [...docsByIdentity.values()].map((doc) => ({
+    name: doc.filename,
+    contents: doc.code,
+  }));
+  const recomputed = moduleIdentities(
+    { main: entry.filename, files },
+    runtimeFingerprint,
+  );
+
+  const mismatches: string[] = [];
+  const missing: string[] = [];
+  for (const [identity, doc] of docsByIdentity) {
+    if (recomputed.get(doc.filename) !== identity) {
+      mismatches.push(identity);
+    }
+    for (const imp of doc.imports) {
+      if (!docsByIdentity.has(imp.identity)) missing.push(imp.identity);
+    }
+  }
+
+  return {
+    ok: mismatches.length === 0 && missing.length === 0,
+    entryFilename: entry.filename,
+    mismatches,
+    missing,
+  };
+}

--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -3,6 +3,10 @@ import {
   computeModuleHashes,
   resolveModuleImports,
 } from "../harness/module-identity.ts";
+import type { MemorySpace, Runtime } from "../runtime.ts";
+import type { IExtendedStorageTransaction } from "../storage/interface.ts";
+import { type Cell, isCell } from "../cell.ts";
+import type { JSONSchema } from "../builder/types.ts";
 
 /**
  * Content-addressed compilation cache — document model and key scheme.
@@ -165,4 +169,125 @@ export function verifySourceDocs(
     mismatches,
     missing,
   };
+}
+
+// --- Source-set store (4.3.2): write/read `pattern:<identity>` cells ---------
+
+/**
+ * Stored shape of a source-set cell. Mirrors {@link SourceDoc} but each import
+ * carries a sigil **link** to the dependency's cell (so the storage layer
+ * follows it and loads the closure), plus the module's own `identity` for
+ * read-side keying. The stored identity is not trusted — {@link verifySourceDocs}
+ * recomputes it.
+ */
+interface StoredSourceDoc {
+  kind: "source";
+  identity: string;
+  code: string;
+  filename: string;
+  imports: { specifier: string; link: unknown }[];
+}
+
+/** Schema for a source-set document; `imports[].link` auto-loads as a cell. */
+export const SOURCE_DOC_SCHEMA = {
+  type: "object",
+  properties: {
+    kind: { type: "string" },
+    identity: { type: "string" },
+    code: { type: "string" },
+    filename: { type: "string" },
+    imports: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          specifier: { type: "string" },
+          link: { asCell: ["cell"] },
+        },
+      },
+    },
+  },
+} as const satisfies JSONSchema;
+
+/**
+ * Write every module of `program` as a `pattern:<identity>` cell into `space`,
+ * each import a sigil link to its dependency cell. Idempotent (content-addressed
+ * keys). The caller owns the transaction's commit.
+ */
+export function writeSourceDocs(
+  runtime: Runtime,
+  space: MemorySpace,
+  program: Program,
+  tx: IExtendedStorageTransaction,
+  runtimeFingerprint = "",
+): void {
+  const docs = buildSourceDocs(program, runtimeFingerprint);
+  for (const [identity, doc] of docs) {
+    const cell = runtime.getCell(
+      space,
+      sourceDocKey(identity),
+      SOURCE_DOC_SCHEMA,
+      tx,
+    );
+    cell.set({
+      kind: "source",
+      identity,
+      code: doc.code,
+      filename: doc.filename,
+      imports: doc.imports.map((imp) => ({
+        specifier: imp.specifier,
+        link: runtime.getCell(space, sourceDocKey(imp.identity), undefined, tx)
+          .getAsLink(),
+      })),
+    } as StoredSourceDoc);
+  }
+}
+
+/**
+ * Load the source-document closure reachable from `entryIdentity` in `space` by
+ * following import links. Returns the raw documents keyed by their **stored**
+ * identity (verify with {@link verifySourceDocs} before trusting). Returns
+ * `undefined` if the entry document is absent.
+ */
+export function loadSourceClosure(
+  runtime: Runtime,
+  space: MemorySpace,
+  entryIdentity: string,
+  tx: IExtendedStorageTransaction,
+): Map<string, SourceDoc> | undefined {
+  const entry = runtime.getCell(
+    space,
+    sourceDocKey(entryIdentity),
+    SOURCE_DOC_SCHEMA,
+    tx,
+  );
+  const root = entry.get() as StoredSourceDoc | undefined;
+  if (!root || typeof root.identity !== "string") return undefined;
+
+  const out = new Map<string, SourceDoc>();
+  const queue: { doc: StoredSourceDoc }[] = [{ doc: root }];
+  while (queue.length > 0) {
+    const { doc } = queue.shift()!;
+    if (out.has(doc.identity)) continue;
+    const imports: ModuleImportRef[] = [];
+    const childDocs: StoredSourceDoc[] = [];
+    for (const imp of doc.imports ?? []) {
+      if (!isCell(imp.link)) continue;
+      const childCell = (imp.link as Cell<unknown>).asSchema(SOURCE_DOC_SCHEMA);
+      const child = childCell.get() as StoredSourceDoc | undefined;
+      if (!child || typeof child.identity !== "string") continue;
+      imports.push({ specifier: imp.specifier, identity: child.identity });
+      childDocs.push(child);
+    }
+    out.set(doc.identity, {
+      kind: "source",
+      code: doc.code,
+      filename: doc.filename,
+      imports,
+    });
+    for (const child of childDocs) {
+      if (!out.has(child.identity)) queue.push({ doc: child });
+    }
+  }
+  return out;
 }

--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -54,6 +54,16 @@ export interface CompiledDoc extends ModuleDocBase {
   readonly sourceMap?: unknown;
 }
 
+/**
+ * Version tag for the compiled-set axis (`compileCache:<runtimeVersion>/...`).
+ * A compiled document is only reused under a matching tag, so bumping this
+ * invalidates the whole compiled set after any change to the compiler /
+ * transformer pipeline or SES verifier that alters emitted bytes (the source
+ * set, keyed by content identity alone, persists across the bump). There is no
+ * automatic build fingerprint at runtime, so this is bumped by hand.
+ */
+export const COMPILE_CACHE_RUNTIME_VERSION = "cf/esm-compile/v1";
+
 /** Cell key (id) for a source-set document. */
 export function sourceDocKey(identity: string): string {
   return `pattern:${identity}`;
@@ -284,22 +294,24 @@ export function writeSourceDocs(
 
 /**
  * Load the source-document closure reachable from `entryIdentity` in `space` by
- * following import links. Returns the raw documents keyed by their **stored**
- * identity (verify with {@link verifySourceDocs} before trusting). Returns
- * `undefined` if the entry document is absent.
+ * following import links. Each cell is `sync()`d before reading so a closure
+ * persisted in a prior session loads from storage. Returns the raw documents
+ * keyed by their **stored** identity (verify with {@link verifySourceDocs}
+ * before trusting). Resolves to `undefined` if the entry document is absent.
  */
-export function loadSourceClosure(
+export async function loadSourceClosure(
   runtime: Runtime,
   space: MemorySpace,
   entryIdentity: string,
   tx: IExtendedStorageTransaction,
-): Map<string, SourceDoc> | undefined {
+): Promise<Map<string, SourceDoc> | undefined> {
   const entry = runtime.getCell(
     space,
     sourceDocKey(entryIdentity),
     SOURCE_DOC_SCHEMA,
     tx,
   );
+  await entry.sync();
   const root = entry.get() as StoredSourceDoc | undefined;
   if (!root || typeof root.identity !== "string") return undefined;
 
@@ -313,6 +325,8 @@ export function loadSourceClosure(
     for (const imp of doc.imports ?? []) {
       if (!isCell(imp.link)) continue;
       const childCell = (imp.link as Cell<unknown>).asSchema(SOURCE_DOC_SCHEMA);
+      // A linked cell is not synced transitively by the parent — sync each.
+      await childCell.sync();
       const child = childCell.get() as StoredSourceDoc | undefined;
       if (!child || typeof child.identity !== "string") continue;
       imports.push({ specifier: imp.specifier, identity: child.identity });
@@ -458,18 +472,20 @@ export function writeCompiledDocs(
 
 /**
  * Load the integrity-valid compiled documents reachable from `entryIdentity` by
- * following import links. Fail-closed: a document whose persisted CFC label does
- * not carry the compiler integrity atom is dropped (treated as a cache miss for
- * that module, so the caller recompiles it). Returns the valid documents keyed
- * by their stored identity (empty map if the entry itself is missing/unstamped).
+ * following import links. Each cell is `sync()`d before reading so a closure
+ * persisted in a prior session loads from storage. Fail-closed: a document whose
+ * persisted CFC label does not carry the compiler integrity atom is dropped
+ * (treated as a cache miss for that module, so the caller recompiles it).
+ * Resolves to the valid documents keyed by their stored identity (empty map if
+ * the entry itself is missing/unstamped).
  */
-export function loadCompiledClosure(
+export async function loadCompiledClosure(
   runtime: Runtime,
   space: MemorySpace,
   entryIdentity: string,
   opts: { runtimeVersion: string; compilerDid: string },
   tx: IExtendedStorageTransaction,
-): Map<string, CompiledDoc> {
+): Promise<Map<string, CompiledDoc>> {
   const atom = compiledIntegrityAtom(opts.compilerDid);
   const out = new Map<string, CompiledDoc>();
   const visited = new Set<string>();
@@ -485,6 +501,7 @@ export function loadCompiledClosure(
       COMPILED_DOC_SCHEMA,
       tx,
     );
+    await cell.sync();
     // Fail-closed: only integrity-stamped documents are trusted.
     if (!cellCarriesIntegrity(cell, atom, tx)) continue;
     const doc = cell.get() as StoredCompiledDoc | undefined;
@@ -493,9 +510,11 @@ export function loadCompiledClosure(
     const imports: ModuleImportRef[] = [];
     for (const imp of doc.imports ?? []) {
       if (!isCell(imp.link)) continue;
-      const child = (imp.link as Cell<unknown>)
-        .asSchema(COMPILED_DOC_SCHEMA)
-        .get() as StoredCompiledDoc | undefined;
+      const childCell = (imp.link as Cell<unknown>).asSchema(
+        COMPILED_DOC_SCHEMA,
+      );
+      await childCell.sync();
+      const child = childCell.get() as StoredCompiledDoc | undefined;
       if (!child || typeof child.identity !== "string") continue;
       imports.push({ specifier: imp.specifier, identity: child.identity });
       if (!visited.has(child.identity)) queue.push(child.identity);

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -1,6 +1,6 @@
 import { Console } from "./console.ts";
 import {
-  type CompiledModuleArtifact,
+  type CacheableModule,
   type CompileResult,
   type EvaluateOptions,
   type EvaluateResult,
@@ -32,10 +32,14 @@ import {
   pretransformProgram,
   pretransformProgramForModules,
 } from "./pretransform.ts";
-import { computeModuleHashes } from "./module-identity.ts";
+import {
+  computeModuleHashes,
+  resolveModuleImports,
+} from "./module-identity.ts";
 import {
   type CompiledModuleGraph,
   compileSourcesToRecords,
+  computeModuleIdentities,
 } from "../sandbox/module-record-compiler.ts";
 import {
   composeBundleSourceMap,
@@ -269,7 +273,8 @@ export class Engine extends EventTarget implements Harness {
       id: string;
       graph: CompiledModuleGraph;
       mainSpecifier: string;
-      compiledArtifacts: Map<string, CompiledModuleArtifact>;
+      entryIdentity: string;
+      modules: CacheableModule[];
     }
   > {
     logger.timeStart("compileToRecordGraph");
@@ -287,13 +292,21 @@ export class Engine extends EventTarget implements Harness {
         !f.name.endsWith(".d.ts")
       );
 
-      // Cache hit: every authored module already has a cached compiled body, so
-      // skip the TypeScript compile entirely and build the record graph from
-      // the cached artifacts. Per-module identities are transitively sensitive,
-      // so a partial set cannot be trusted — fall back to a full recompile.
+      // Prefix-free content identity per resolved module path. Computed here
+      // (cheap, no TS compile) so the cache-hit check and the write-back
+      // descriptors agree with the graph's `cf:module/<hash>` specifiers.
+      const identityByPath = computeModuleIdentities(moduleFiles, {
+        idPrefix: `/${id}`,
+      });
+
+      // Cache hit: every emitted module already has a cached compiled body
+      // (keyed by identity), so skip the TypeScript compile entirely and build
+      // the record graph from the cached bodies. Per-module identities are
+      // transitively sensitive, so a partial set cannot be trusted — fall back
+      // to a full recompile.
       const cached = options.precompiledModules;
       const fullHit = cached !== undefined &&
-        moduleFiles.every((f) => cached.has(f.name));
+        moduleFiles.every((f) => cached.has(identityByPath.get(f.name)!));
 
       const precompiledBodies = new Map<string, string>();
       // Carry per-module source maps so the ESM loader can compose a per-load
@@ -303,7 +316,7 @@ export class Engine extends EventTarget implements Harness {
       if (fullHit) {
         logger.info("compile-cache-hit", () => ["compileToRecordGraph", id]);
         for (const file of moduleFiles) {
-          const artifact = cached!.get(file.name)!;
+          const artifact = cached!.get(identityByPath.get(file.name)!)!;
           precompiledBodies.set(file.name, artifact.js);
           if (artifact.sourceMap !== undefined) {
             precompiledSourceMaps.set(
@@ -393,19 +406,37 @@ export class Engine extends EventTarget implements Harness {
       // verification happens once, at compile time, before any module executes.
       verifyModuleGraph(graph.records, mainSpecifier);
 
-      // Serializable per-module artifacts for write-back to the compiled-set
-      // cache. Keyed by authored path; the caller maps each to its content
-      // identity. On a cache hit these are exactly the artifacts just loaded.
-      const compiledArtifacts = new Map<string, CompiledModuleArtifact>();
-      for (const [name, js] of precompiledBodies) {
-        const sourceMap = precompiledSourceMaps.get(name);
-        compiledArtifacts.set(
-          name,
-          sourceMap === undefined ? { js } : { js, sourceMap },
-        );
-      }
+      // Serializable per-module descriptors for write-back to the cache, in
+      // identity space (the engine's `/<id>` path prefix never leaks out). Each
+      // carries the resolved TS source (for the source set), the compiled JS
+      // (for the compiled set), and the internal import edges as
+      // specifier → dependency-identity links. On a cache hit these mirror the
+      // artifacts just loaded.
+      const importEdges = resolveModuleImports({
+        main: "",
+        files: moduleFiles,
+      });
+      const modules: CacheableModule[] = moduleFiles.map((file) => {
+        const identity = identityByPath.get(file.name)!;
+        const sourceMap = precompiledSourceMaps.get(file.name);
+        const imports = (importEdges.get(file.name)?.internalDeps ?? []).map((
+          dep,
+        ) => ({
+          specifier: dep.specifier,
+          targetIdentity: identityByPath.get(dep.target)!,
+        }));
+        return {
+          identity,
+          filename: stripModuleIdPrefix(file.name, id),
+          source: file.contents,
+          js: precompiledBodies.get(file.name)!,
+          ...(sourceMap === undefined ? {} : { sourceMap }),
+          imports,
+        };
+      });
+      const entryIdentity = identityByPath.get(mappedProgram.main)!;
 
-      return { id, graph, mainSpecifier, compiledArtifacts };
+      return { id, graph, mainSpecifier, entryIdentity, modules };
     } finally {
       logger.timeEnd("compileToRecordGraph");
     }
@@ -954,4 +985,14 @@ function computeId(program: Program): string {
     ...program.files.filter(({ name }) => !name.endsWith(".d.ts")),
   ];
   return hashOf(source).toString();
+}
+
+/**
+ * Strip the whole-program `/<id>` prefix from a resolved module path to recover
+ * the normalized authored path (e.g. `/<id>/main.tsx` → `/main.tsx`). Modules
+ * resolved without the prefix (the injected `cfc.ts` helper) are returned as-is.
+ */
+function stripModuleIdPrefix(name: string, id: string): string {
+  const prefix = `/${id}`;
+  return name.startsWith(`${prefix}/`) ? name.slice(prefix.length) : name;
 }

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -354,6 +354,10 @@ export class Engine extends EventTarget implements Harness {
         precompiledBodies,
         precompiledSourceMaps,
         runtimeModules: runtimeModulesOption,
+        // Strip the whole-program `/<id>` prefix from per-module identities so
+        // `cf:module/<hash>` is entry-point independent and dedupes across
+        // programs (the content-addressed cache keys off these identities).
+        idPrefix: `/${id}`,
       });
 
       // Register runtime-module records so cf:runtime/* imports resolve.

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -1,5 +1,6 @@
 import { Console } from "./console.ts";
 import {
+  type CompiledModuleArtifact,
   type CompileResult,
   type EvaluateOptions,
   type EvaluateResult,
@@ -36,7 +37,10 @@ import {
   type CompiledModuleGraph,
   compileSourcesToRecords,
 } from "../sandbox/module-record-compiler.ts";
-import { composeBundleSourceMap } from "@commonfabric/js-compiler";
+import {
+  composeBundleSourceMap,
+  type SourceMap,
+} from "@commonfabric/js-compiler";
 import {
   loadModuleGraph,
   runtimeModuleRecords,
@@ -261,7 +265,12 @@ export class Engine extends EventTarget implements Harness {
     program: RuntimeProgram,
     options: TypeScriptHarnessProcessOptions = {},
   ): Promise<
-    { id: string; graph: CompiledModuleGraph; mainSpecifier: string }
+    {
+      id: string;
+      graph: CompiledModuleGraph;
+      mainSpecifier: string;
+      compiledArtifacts: Map<string, CompiledModuleArtifact>;
+    }
   > {
     logger.timeStart("compileToRecordGraph");
     try {
@@ -271,43 +280,66 @@ export class Engine extends EventTarget implements Harness {
         mappedProgram,
         this.ctRuntime.staticCache,
       );
-      const { compiler } = await this.getCompilerInternals();
       const resolvedProgram = await this.resolve(resolver);
 
-      const modules = compiler.compileToModules(resolvedProgram, {
-        noCheck: options.noCheck,
-        runtimeModules: Engine.runtimeModuleNames(),
-        beforeTransformers: (program) => {
-          const pipeline = new CommonFabricTransformerPipeline();
-          return {
-            factories: pipeline.toFactories(program),
-            getDiagnostics: () => pipeline.getDiagnostics(),
-          };
-        },
-      });
-
-      // Every authored (non-.d.ts) source must have an emitted body; a missing
-      // one would otherwise be silently dropped and only fail later at import.
+      // Authored (non-.d.ts) sources are the modules that must have a body.
       const moduleFiles = resolvedProgram.files.filter((f) =>
         !f.name.endsWith(".d.ts")
       );
-      for (const file of moduleFiles) {
-        if (!modules.has(file.name)) {
-          throw new Error(
-            `ESM compile produced no module body for '${file.name}'`,
-          );
-        }
-      }
-      const precompiledBodies = new Map(
-        [...modules].map(([name, out]) => [name, out.js]),
-      );
+
+      // Cache hit: every authored module already has a cached compiled body, so
+      // skip the TypeScript compile entirely and build the record graph from
+      // the cached artifacts. Per-module identities are transitively sensitive,
+      // so a partial set cannot be trusted — fall back to a full recompile.
+      const cached = options.precompiledModules;
+      const fullHit = cached !== undefined &&
+        moduleFiles.every((f) => cached.has(f.name));
+
+      const precompiledBodies = new Map<string, string>();
       // Carry per-module source maps so the ESM loader can compose a per-load
       // bundle map (CFC verified-source / fn.src coordinate resolution).
-      const precompiledSourceMaps = new Map(
-        [...modules].flatMap(([name, out]) =>
-          out.sourceMap ? [[name, out.sourceMap] as const] : []
-        ),
-      );
+      const precompiledSourceMaps = new Map<string, SourceMap>();
+
+      if (fullHit) {
+        logger.info("compile-cache-hit", () => ["compileToRecordGraph", id]);
+        for (const file of moduleFiles) {
+          const artifact = cached!.get(file.name)!;
+          precompiledBodies.set(file.name, artifact.js);
+          if (artifact.sourceMap !== undefined) {
+            precompiledSourceMaps.set(
+              file.name,
+              artifact.sourceMap as SourceMap,
+            );
+          }
+        }
+      } else {
+        const { compiler } = await this.getCompilerInternals();
+        const modules = compiler.compileToModules(resolvedProgram, {
+          noCheck: options.noCheck,
+          runtimeModules: Engine.runtimeModuleNames(),
+          beforeTransformers: (program) => {
+            const pipeline = new CommonFabricTransformerPipeline();
+            return {
+              factories: pipeline.toFactories(program),
+              getDiagnostics: () => pipeline.getDiagnostics(),
+            };
+          },
+        });
+
+        // Every authored source must have an emitted body; a missing one would
+        // otherwise be silently dropped and only fail later at import.
+        for (const file of moduleFiles) {
+          if (!modules.has(file.name)) {
+            throw new Error(
+              `ESM compile produced no module body for '${file.name}'`,
+            );
+          }
+        }
+        for (const [name, out] of modules) {
+          precompiledBodies.set(name, out.js);
+          if (out.sourceMap) precompiledSourceMaps.set(name, out.sourceMap);
+        }
+      }
       const { runtimeExports } = await this.getRuntimeInternals();
       const runtimeNames = Engine.runtimeModuleNames().filter((name) =>
         runtimeExports?.[name]
@@ -357,7 +389,19 @@ export class Engine extends EventTarget implements Harness {
       // verification happens once, at compile time, before any module executes.
       verifyModuleGraph(graph.records, mainSpecifier);
 
-      return { id, graph, mainSpecifier };
+      // Serializable per-module artifacts for write-back to the compiled-set
+      // cache. Keyed by authored path; the caller maps each to its content
+      // identity. On a cache hit these are exactly the artifacts just loaded.
+      const compiledArtifacts = new Map<string, CompiledModuleArtifact>();
+      for (const [name, js] of precompiledBodies) {
+        const sourceMap = precompiledSourceMaps.get(name);
+        compiledArtifacts.set(
+          name,
+          sourceMap === undefined ? { js } : { js, sourceMap },
+        );
+      }
+
+      return { id, graph, mainSpecifier, compiledArtifacts };
     } finally {
       logger.timeEnd("compileToRecordGraph");
     }

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -298,13 +298,21 @@ export class Engine extends EventTarget implements Harness {
       const identityByPath = computeModuleIdentities(moduleFiles, {
         idPrefix: `/${id}`,
       });
+      const entryIdentity = identityByPath.get(mappedProgram.main)!;
 
       // Cache hit: every emitted module already has a cached compiled body
       // (keyed by identity), so skip the TypeScript compile entirely and build
       // the record graph from the cached bodies. Per-module identities are
       // transitively sensitive, so a partial set cannot be trusted — fall back
-      // to a full recompile.
-      const cached = options.precompiledModules;
+      // to a full recompile. The cache is queried by identity (directly, or
+      // lazily once identities are known) without leaking the engine's prefix.
+      const cached = options.precompiledModules ??
+        (options.precompiledModulesFor
+          ? await options.precompiledModulesFor({
+            entryIdentity,
+            identities: [...new Set(identityByPath.values())],
+          })
+          : undefined);
       const fullHit = cached !== undefined &&
         moduleFiles.every((f) => cached.has(identityByPath.get(f.name)!));
 
@@ -434,7 +442,6 @@ export class Engine extends EventTarget implements Harness {
           imports,
         };
       });
-      const entryIdentity = identityByPath.get(mappedProgram.main)!;
 
       return { id, graph, mainSpecifier, entryIdentity, modules };
     } finally {
@@ -469,7 +476,11 @@ export class Engine extends EventTarget implements Harness {
    * map. The graph was security-verified at compile time, so verification is
    * not repeated.
    */
-  private evaluateRecordGraph(
+  /**
+   * Evaluate a verified ESM record graph (public so the PatternManager can run
+   * compile → cache write-back → evaluate as discrete steps).
+   */
+  evaluateRecordGraph(
     id: string,
     graph: CompiledModuleGraph,
     mainSpecifier: string,

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -379,6 +379,9 @@ export class Engine extends EventTarget implements Harness {
         // `cf:module/<hash>` is entry-point independent and dedupes across
         // programs (the content-addressed cache keys off these identities).
         idPrefix: `/${id}`,
+        // Reuse the identities already computed above (cache-hit check); avoids
+        // a second hashing/import-resolution pass over the module set.
+        identityByPath,
       });
 
       // Register runtime-module records so cf:runtime/* imports resolve.

--- a/packages/runner/src/harness/module-identity.ts
+++ b/packages/runner/src/harness/module-identity.ts
@@ -73,18 +73,25 @@ interface ModuleNode {
   externalDeps: string[];
 }
 
-/**
- * Compute a stable content hash for every module in `program`.
- * Returns a map from each file's path to its hash.
- */
-export function computeModuleHashes(
-  program: Program,
-  options: ModuleIdentityOptions = {},
-): Map<string, string> {
-  const runtimeFingerprint = options.runtimeFingerprint ?? "";
-  const fileNames = new Set(program.files.map((f) => f.name));
-  const nodes = new Map<string, ModuleNode>();
+/** Resolved import edges of a single module. */
+export interface ModuleImportEdges {
+  /** Imports resolving to another file in the program (specifier → target path). */
+  internalDeps: { specifier: string; target: string }[];
+  /** Imports that do not resolve to a program file (bare/runtime specifiers). */
+  externalDeps: string[];
+}
 
+/**
+ * Resolve every module's import edges against the program's file set, split into
+ * internal (program-file) and external (bare/runtime) deps. Shared by the
+ * identity hash and the content-addressed cache's import links so they agree on
+ * what counts as an internal edge. Self-imports are dropped.
+ */
+export function resolveModuleImports(
+  program: Program,
+): Map<string, ModuleImportEdges> {
+  const fileNames = new Set(program.files.map((f) => f.name));
+  const edges = new Map<string, ModuleImportEdges>();
   for (const file of program.files) {
     const internalDeps: { specifier: string; target: string }[] = [];
     const externalDeps: string[] = [];
@@ -98,6 +105,25 @@ export function computeModuleHashes(
       }
       // A self-import contributes nothing.
     }
+    edges.set(file.name, { internalDeps, externalDeps });
+  }
+  return edges;
+}
+
+/**
+ * Compute a stable content hash for every module in `program`.
+ * Returns a map from each file's path to its hash.
+ */
+export function computeModuleHashes(
+  program: Program,
+  options: ModuleIdentityOptions = {},
+): Map<string, string> {
+  const runtimeFingerprint = options.runtimeFingerprint ?? "";
+  const edges = resolveModuleImports(program);
+  const nodes = new Map<string, ModuleNode>();
+
+  for (const file of program.files) {
+    const { internalDeps, externalDeps } = edges.get(file.name)!;
     nodes.set(file.name, {
       path: file.name,
       src: normalizeSource(file.contents),

--- a/packages/runner/src/harness/types.ts
+++ b/packages/runner/src/harness/types.ts
@@ -27,11 +27,12 @@ export interface TypeScriptHarnessProcessOptions {
   getTransformedProgram?: (program: Program) => void;
   // Show verbose TypeScript error messages instead of simplified hints.
   verboseErrors?: boolean;
-  // Cached per-module compiled bodies keyed by authored (bundle-relative) path.
-  // Used only on the ESM record-graph path: when every authored module is
-  // present, `compileToRecordGraph` skips the TypeScript compile and builds the
-  // record graph from these bodies instead. A partial set is ignored (the
-  // engine recompiles the whole program) because per-module identities are
+  // Cached per-module compiled bodies keyed by content-addressed module
+  // identity (the prefix-free `cf:module/<hash>` minus the scheme). Used only on
+  // the ESM record-graph path: when every emitted module is present,
+  // `compileToRecordGraph` skips the TypeScript compile and builds the record
+  // graph from these bodies instead. A partial set is ignored (the engine
+  // recompiles the whole program) because per-module identities are
   // transitively sensitive — a closure either hits in full or not at all.
   precompiledModules?: Map<string, CompiledModuleArtifact>;
 }
@@ -40,6 +41,26 @@ export interface TypeScriptHarnessProcessOptions {
 export interface CompiledModuleArtifact {
   js: string;
   sourceMap?: unknown;
+}
+
+/**
+ * Everything the content-addressed compilation cache needs to persist (and
+ * later reload) one module, surfaced by `compileToRecordGraph` in identity
+ * space — callers never see the engine's internal `/<id>` path prefix.
+ */
+export interface CacheableModule {
+  /** Prefix-free content identity (the `cf:module/<hash>` hash, no scheme). */
+  identity: string;
+  /** Normalized authored module path (no `/<id>` prefix; e.g. `/main.tsx`). */
+  filename: string;
+  /** Resolved TypeScript source whose bytes are folded into `identity`. */
+  source: string;
+  /** Compiled CommonJS body. */
+  js: string;
+  /** Per-module source map, when available. */
+  sourceMap?: unknown;
+  /** Internal import edges: specifier → the dependency module's identity. */
+  imports: { specifier: string; targetIdentity: string }[];
 }
 
 export type Exports = Record<string, any>;

--- a/packages/runner/src/harness/types.ts
+++ b/packages/runner/src/harness/types.ts
@@ -4,6 +4,7 @@ import type {
   ProgramResolver,
   Source,
 } from "@commonfabric/js-compiler";
+import type { CompiledModuleGraph } from "../sandbox/module-record-compiler.ts";
 import type { UnsafeHostTrustOptions } from "../unsafe-host-trust.ts";
 
 export type HarnessedFunction = (input: any) => void;
@@ -35,6 +36,15 @@ export interface TypeScriptHarnessProcessOptions {
   // recompiles the whole program) because per-module identities are
   // transitively sensitive — a closure either hits in full or not at all.
   precompiledModules?: Map<string, CompiledModuleArtifact>;
+  // Lazy variant of `precompiledModules`: invoked once, after the engine has
+  // resolved the program and computed per-module identities (so the cache can
+  // be queried by content identity without a separate resolve pass). Returns the
+  // identity-keyed cached bodies, or undefined for a miss. `precompiledModules`
+  // takes precedence when both are set.
+  precompiledModulesFor?: (info: {
+    entryIdentity: string;
+    identities: string[];
+  }) => Promise<Map<string, CompiledModuleArtifact> | undefined>;
 }
 
 /** A cached/compiled per-module artifact: emitted JS plus optional source map. */
@@ -115,6 +125,29 @@ export interface Harness extends EventTarget {
     program: RuntimeProgram,
     options?: TypeScriptHarnessProcessOptions,
   ): Promise<EvaluateResult>;
+
+  // Compile a program to a verified ESM record graph, returning the graph plus
+  // the per-module cache descriptors (in content-identity space). Split from
+  // evaluation so a caller can write the descriptors to the content-addressed
+  // cache between compile and evaluate. Optional (ESM-loader harnesses only).
+  compileToRecordGraph?(
+    program: RuntimeProgram,
+    options?: TypeScriptHarnessProcessOptions,
+  ): Promise<{
+    id: string;
+    graph: CompiledModuleGraph;
+    mainSpecifier: string;
+    entryIdentity: string;
+    modules: CacheableModule[];
+  }>;
+
+  // Evaluate a verified ESM record graph produced by `compileToRecordGraph`.
+  evaluateRecordGraph?(
+    id: string,
+    graph: CompiledModuleGraph,
+    mainSpecifier: string,
+    files: Source[],
+  ): EvaluateResult;
 
   // Resolves a `ProgramResolver` into a `Program` using the engine's
   // configuration.

--- a/packages/runner/src/harness/types.ts
+++ b/packages/runner/src/harness/types.ts
@@ -27,6 +27,19 @@ export interface TypeScriptHarnessProcessOptions {
   getTransformedProgram?: (program: Program) => void;
   // Show verbose TypeScript error messages instead of simplified hints.
   verboseErrors?: boolean;
+  // Cached per-module compiled bodies keyed by authored (bundle-relative) path.
+  // Used only on the ESM record-graph path: when every authored module is
+  // present, `compileToRecordGraph` skips the TypeScript compile and builds the
+  // record graph from these bodies instead. A partial set is ignored (the
+  // engine recompiles the whole program) because per-module identities are
+  // transitively sensitive — a closure either hits in full or not at all.
+  precompiledModules?: Map<string, CompiledModuleArtifact>;
+}
+
+/** A cached/compiled per-module artifact: emitted JS plus optional source map. */
+export interface CompiledModuleArtifact {
+  js: string;
+  sourceMap?: unknown;
 }
 
 export type Exports = Record<string, any>;

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -546,14 +546,17 @@ export class PatternManager {
       runtimeVersion: COMPILE_CACHE_RUNTIME_VERSION,
       compilerDid,
     };
-    // Read the cache on a dedicated read-only transaction so cache-cell reads
-    // never enter the caller's transaction (whose commit must not gain
-    // dependencies on, or race, the fire-and-forget write-back).
-    const readTx = this.runtime.readTx();
+    // Read the cache on a dedicated, owned transaction (used read-only — the
+    // load path only reads, and it is aborted below, never committed) so
+    // cache-cell reads never enter the caller's transaction (whose commit must
+    // not gain dependencies on, or race, the fire-and-forget write-back), and
+    // so repeated compiles don't accumulate open transactions.
+    const readTx = this.runtime.edit();
 
     let warmHit = false;
-    const { id, graph, mainSpecifier, entryIdentity, modules } = await harness
-      .compileToRecordGraph!(program, {
+    let compiled;
+    try {
+      compiled = await harness.compileToRecordGraph!(program, {
         precompiledModulesFor: async ({ entryIdentity, identities }) => {
           const closure = await loadCompiledClosure(
             this.runtime,
@@ -581,6 +584,12 @@ export class PatternManager {
           return bodies;
         },
       });
+    } finally {
+      // Release the read-only cache transaction (no commit needed) so repeated
+      // compiles don't accumulate open transactions.
+      readTx.abort?.("compile-cache read complete");
+    }
+    const { id, graph, mainSpecifier, entryIdentity, modules } = compiled;
 
     const result = harness.evaluateRecordGraph!(
       id,

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -17,9 +17,20 @@ import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { Cell, createCell } from "./cell.ts";
 import type { MemorySpace, Runtime } from "./runtime.ts";
 import { createRef } from "./create-ref.ts";
-import type { CompileResult, EvaluateResult } from "./harness/types.ts";
+import type {
+  CacheableModule,
+  CompiledModuleArtifact,
+  CompileResult,
+  EvaluateResult,
+} from "./harness/types.ts";
 import { RuntimeProgram } from "./harness/types.ts";
 import type { IExtendedStorageTransaction } from "./storage/interface.ts";
+import {
+  COMPILE_CACHE_RUNTIME_VERSION,
+  loadCompiledClosure,
+  writeCompiledDocs,
+  writeSourceDocs,
+} from "./compilation-cache/cell-cache.ts";
 import { getTopFrame } from "./builder/pattern.ts";
 import { URI } from "./sigil-types.ts";
 import { toURI } from "./uri-utils.ts";
@@ -77,8 +88,23 @@ export class PatternManager {
   private patternToVerifiedLoadId = new WeakMap<Pattern, string>();
   // Pending metadata set before the meta cell exists (e.g., spec, parents)
   private pendingMetaById = new Map<URI, Partial<PatternMeta>>();
+  // ESM content-addressed compile-cache instrumentation.
+  private esmCacheStats = { hits: 0, misses: 0 };
+  // In-flight compiled-cache write-backs (fire-and-forget); awaited by
+  // flushCompileCacheWrites() for graceful shutdown / deterministic tests.
+  private compileCacheWrites = new Set<Promise<unknown>>();
 
   constructor(readonly runtime: Runtime) {}
+
+  /** Hit/miss counts for the ESM content-addressed compile cache. */
+  getCompileCacheStats(): { hits: number; misses: number } {
+    return { ...this.esmCacheStats };
+  }
+
+  /** Resolve once all in-flight compiled-cache write-backs have settled. */
+  async flushCompileCacheWrites(): Promise<void> {
+    await Promise.allSettled([...this.compileCacheWrites]);
+  }
 
   /**
    * Evict oldest patterns if cache exceeds MAX_PATTERN_CACHE_SIZE.
@@ -441,7 +467,10 @@ export class PatternManager {
     return pattern;
   }
 
-  async compilePattern(input: string | RuntimeProgram): Promise<Pattern> {
+  async compilePattern(
+    input: string | RuntimeProgram,
+    cacheCtx?: { space: MemorySpace; tx?: IExtendedStorageTransaction },
+  ): Promise<Pattern> {
     let program: RuntimeProgram;
     if (typeof input === "string") {
       program = {
@@ -452,14 +481,25 @@ export class PatternManager {
       program = input;
     }
 
-    // ESM module-record loader path (experimental, default off). Bypasses the
-    // AMD bundle compile/evaluate and the persistent compile cache.
+    // ESM module-record loader path (experimental, default off).
     if (
       this.runtime.experimental.esmModuleLoader === true &&
-      this.runtime.harness.compileAndEvaluateModules
+      this.runtime.harness.compileToRecordGraph &&
+      this.runtime.harness.evaluateRecordGraph
     ) {
-      const result = await this.runtime.harness.compileAndEvaluateModules(
-        program,
+      // Use the content-addressed cell cache when we have a target space and
+      // CFC is enforced (the compiled-set integrity label only persists — and
+      // is only trusted on read — under an enforcing mode; see cell-cache).
+      if (cacheCtx && this.runtime.cfcEnforcementMode !== "disabled") {
+        return await this.compileViaCellCache(program, cacheCtx);
+      }
+      const { id, graph, mainSpecifier } = await this.runtime.harness
+        .compileToRecordGraph(program);
+      const result = this.runtime.harness.evaluateRecordGraph(
+        id,
+        graph,
+        mainSpecifier,
+        program.files,
       );
       return this.patternFromEvaluation(result, program);
     }
@@ -486,6 +526,106 @@ export class PatternManager {
     // No persistent cache — compile and evaluate directly
     const compileResult = await this.runtime.harness.compile(program);
     return this.evaluateToPattern(compileResult, program);
+  }
+
+  /**
+   * ESM compile + evaluate backed by the content-addressed cell cache in
+   * `cacheCtx.space`. On a warm full hit the per-module compiled bodies are
+   * reused (no TypeScript compile / transformer pipeline / SES re-verify); on a
+   * miss the program is compiled and its modules are written back (source +
+   * integrity-stamped compiled docs) on a fresh transaction, fire-and-forget.
+   */
+  private async compileViaCellCache(
+    program: RuntimeProgram,
+    cacheCtx: { space: MemorySpace; tx?: IExtendedStorageTransaction },
+  ): Promise<Pattern> {
+    const harness = this.runtime.harness;
+    const { space } = cacheCtx;
+    const compilerDid = this.runtime.userIdentityDID;
+    const cacheOpts = {
+      runtimeVersion: COMPILE_CACHE_RUNTIME_VERSION,
+      compilerDid,
+    };
+    // Read the cache on a dedicated read-only transaction so cache-cell reads
+    // never enter the caller's transaction (whose commit must not gain
+    // dependencies on, or race, the fire-and-forget write-back).
+    const readTx = this.runtime.readTx();
+
+    let warmHit = false;
+    const { id, graph, mainSpecifier, entryIdentity, modules } = await harness
+      .compileToRecordGraph!(program, {
+        precompiledModulesFor: async ({ entryIdentity, identities }) => {
+          const closure = await loadCompiledClosure(
+            this.runtime,
+            space,
+            entryIdentity,
+            cacheOpts,
+            readTx,
+          );
+          // Full hit only: every emitted module must be present (and
+          // integrity-valid). A partial set cannot be trusted (transitively
+          // sensitive identities), so fall back to a full recompile.
+          if (!identities.every((identity) => closure.has(identity))) {
+            return undefined;
+          }
+          const bodies = new Map<string, CompiledModuleArtifact>();
+          for (const [identity, doc] of closure) {
+            bodies.set(
+              identity,
+              doc.sourceMap === undefined
+                ? { js: doc.code }
+                : { js: doc.code, sourceMap: doc.sourceMap },
+            );
+          }
+          warmHit = true;
+          return bodies;
+        },
+      });
+
+    const result = harness.evaluateRecordGraph!(
+      id,
+      graph,
+      mainSpecifier,
+      program.files,
+    );
+
+    if (warmHit) {
+      this.esmCacheStats.hits++;
+    } else {
+      this.esmCacheStats.misses++;
+      // Cold/partial: persist the freshly compiled module set for next time,
+      // fire-and-forget on its own transaction (tracked for flush/shutdown).
+      const writeBack = this.writeBackCompileCache(
+        space,
+        modules,
+        entryIdentity,
+        cacheOpts,
+      ).catch((error) => {
+        logger.warn("compile-cache-writeback-failed", () => [String(error)]);
+      });
+      this.compileCacheWrites.add(writeBack);
+      writeBack.finally(() => this.compileCacheWrites.delete(writeBack));
+    }
+
+    return this.patternFromEvaluation(result, program);
+  }
+
+  /**
+   * Write the source + compiled document sets for an emitted module set into
+   * `space` on a fresh transaction and commit it (CFC-prepared so the compiled
+   * docs' integrity label persists). Independent of the caller's transaction.
+   */
+  private async writeBackCompileCache(
+    space: MemorySpace,
+    modules: CacheableModule[],
+    entryIdentity: string,
+    opts: { runtimeVersion: string; compilerDid: string },
+  ): Promise<void> {
+    const tx = this.runtime.edit();
+    writeSourceDocs(this.runtime, space, modules, entryIdentity, tx);
+    writeCompiledDocs(this.runtime, space, modules, entryIdentity, opts, tx);
+    this.runtime.prepareTxForCommit(tx);
+    await tx.commit();
   }
 
   private async evaluateToPattern(
@@ -620,7 +760,8 @@ export class PatternManager {
     }
 
     const source = patternMeta.program!;
-    const pattern = await this.compilePattern(source);
+    // Pass the target space so the ESM path can use the per-space cell cache.
+    const pattern = await this.compilePattern(source, { space, tx });
     this.patternIdMap.set(patternId, pattern);
     this.patternToIdMap.set(pattern, patternId);
     this.patternMetaCellById.set(patternId, metaCell.withTx());

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -188,6 +188,19 @@ export interface CompileSourcesOptions {
    * loader (the AMD path registers the bundle map via the isolate).
    */
   precompiledSourceMaps?: Map<string, SourceMap>;
+  /**
+   * Whole-program path prefix (`/<id>`, no trailing slash) to strip from each
+   * module's path *for content-addressed identity only*. The ESM compile path
+   * resolves a program whose files are prefixed with `/<computeId>/...` (a
+   * whole-program hash) so source locations match the AMD bundle. Folding that
+   * prefix into the per-module identity would make `cf:module/<hash>`
+   * whole-program-dependent — defeating cross-program dedup and diverging from
+   * the entry-point-independent identity the spec mandates
+   * (docs/specs/module-loading.md). Stripping it here yields stable, dedupable
+   * identities while every other artifact (record sourceUrls, source-map keys,
+   * `fn.src` resolution) keeps the prefixed path untouched.
+   */
+  idPrefix?: string;
 }
 
 export interface CompiledModuleGraph {
@@ -205,8 +218,19 @@ export function compileSourcesToRecords(
   options: CompileSourcesOptions = {},
 ): CompiledModuleGraph {
   const runtimeModules = options.runtimeModules ?? {};
+  // Strip the whole-program `/<id>` prefix for identity computation only, so
+  // `cf:module/<hash>` is entry-point independent and dedupes across programs.
+  // Relative-import resolution inside `computeModuleHashes` stays consistent
+  // because every path is normalized the same way; unprefixed modules (e.g.
+  // the injected `cfc.ts` helper) are left untouched.
+  const prefix = options.idPrefix;
+  const identityName = (name: string): string =>
+    prefix && name.startsWith(`${prefix}/`) ? name.slice(prefix.length) : name;
   const hashes = computeModuleHashes(
-    { main: "", files: sources },
+    {
+      main: "",
+      files: sources.map((s) => ({ ...s, name: identityName(s.name) })),
+    },
     options.runtimeFingerprint !== undefined
       ? { runtimeFingerprint: options.runtimeFingerprint }
       : {},
@@ -214,7 +238,10 @@ export function compileSourcesToRecords(
   const fileNames = new Set(sources.map((s) => s.name));
   const specifierByPath = new Map<string, string>();
   for (const source of sources) {
-    specifierByPath.set(source.name, `cf:module/${hashes.get(source.name)}`);
+    specifierByPath.set(
+      source.name,
+      `cf:module/${hashes.get(identityName(source.name))}`,
+    );
   }
   const sourceByName = new Map(sources.map((s) => [s.name, s]));
 
@@ -277,7 +304,7 @@ export function compileSourcesToRecords(
   const moduleSourceMaps = new Map<string, SourceMap>();
   for (const source of sources) {
     const specifier = specifierByPath.get(source.name)!;
-    const moduleHash = hashes.get(source.name)!;
+    const moduleHash = hashes.get(identityName(source.name))!;
     const sourceMap = options.precompiledSourceMaps?.get(source.name);
     if (sourceMap) moduleSourceMaps.set(specifier, sourceMap);
     const precompiled = options.precompiledBodies?.get(source.name);

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -201,6 +201,13 @@ export interface CompileSourcesOptions {
    * `fn.src` resolution) keeps the prefixed path untouched.
    */
   idPrefix?: string;
+  /**
+   * Precomputed per-path module identities (from {@link computeModuleIdentities}).
+   * When the caller already derived these (e.g. the Engine, for its cache-hit
+   * check), passing them here avoids recomputing the hashes a second time. Must
+   * be consistent with `idPrefix` / `runtimeFingerprint`.
+   */
+  identityByPath?: Map<string, string>;
 }
 
 export interface CompiledModuleGraph {
@@ -264,12 +271,14 @@ export function compileSourcesToRecords(
   const runtimeModules = options.runtimeModules ?? {};
   // Identities are computed prefix-free (see computeModuleIdentities) so
   // `cf:module/<hash>` is entry-point independent and dedupes across programs.
-  const identityByPath = computeModuleIdentities(sources, {
-    ...(options.idPrefix !== undefined ? { idPrefix: options.idPrefix } : {}),
-    ...(options.runtimeFingerprint !== undefined
-      ? { runtimeFingerprint: options.runtimeFingerprint }
-      : {}),
-  });
+  // Reuse the caller's precomputed map when supplied (avoids a second hash pass).
+  const identityByPath = options.identityByPath ??
+    computeModuleIdentities(sources, {
+      ...(options.idPrefix !== undefined ? { idPrefix: options.idPrefix } : {}),
+      ...(options.runtimeFingerprint !== undefined
+        ? { runtimeFingerprint: options.runtimeFingerprint }
+        : {}),
+    });
   const fileNames = new Set(sources.map((s) => s.name));
   const specifierByPath = new Map<string, string>();
   for (const source of sources) {

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -213,34 +213,69 @@ export interface CompiledModuleGraph {
   moduleSourceMaps: Map<string, SourceMap>;
 }
 
-export function compileSourcesToRecords(
+/**
+ * Strip the whole-program `/<idPrefix>` segment from a resolved module path, so
+ * its content-addressed identity is entry-point independent. Unprefixed modules
+ * (e.g. the injected `cfc.ts` helper) are returned unchanged.
+ */
+function stripIdentityPrefix(name: string, idPrefix?: string): string {
+  return idPrefix && name.startsWith(`${idPrefix}/`)
+    ? name.slice(idPrefix.length)
+    : name;
+}
+
+/**
+ * Per-module content-addressed identity (`cf:module/<hash>` minus the `cf:module/`
+ * scheme) for every source path, computed prefix-free so identities dedupe
+ * across programs. Shared by {@link compileSourcesToRecords} and the Engine's
+ * cache-hit check so both agree on the identity of each module. Keyed by the
+ * resolved (prefixed) path; the value is the prefix-free hash.
+ */
+export function computeModuleIdentities(
   sources: Source[],
-  options: CompileSourcesOptions = {},
-): CompiledModuleGraph {
-  const runtimeModules = options.runtimeModules ?? {};
-  // Strip the whole-program `/<id>` prefix for identity computation only, so
-  // `cf:module/<hash>` is entry-point independent and dedupes across programs.
-  // Relative-import resolution inside `computeModuleHashes` stays consistent
-  // because every path is normalized the same way; unprefixed modules (e.g.
-  // the injected `cfc.ts` helper) are left untouched.
-  const prefix = options.idPrefix;
-  const identityName = (name: string): string =>
-    prefix && name.startsWith(`${prefix}/`) ? name.slice(prefix.length) : name;
+  options: { idPrefix?: string; runtimeFingerprint?: string } = {},
+): Map<string, string> {
   const hashes = computeModuleHashes(
     {
       main: "",
-      files: sources.map((s) => ({ ...s, name: identityName(s.name) })),
+      files: sources.map((s) => ({
+        ...s,
+        name: stripIdentityPrefix(s.name, options.idPrefix),
+      })),
     },
     options.runtimeFingerprint !== undefined
       ? { runtimeFingerprint: options.runtimeFingerprint }
       : {},
   );
+  const identityByPath = new Map<string, string>();
+  for (const source of sources) {
+    identityByPath.set(
+      source.name,
+      hashes.get(stripIdentityPrefix(source.name, options.idPrefix))!,
+    );
+  }
+  return identityByPath;
+}
+
+export function compileSourcesToRecords(
+  sources: Source[],
+  options: CompileSourcesOptions = {},
+): CompiledModuleGraph {
+  const runtimeModules = options.runtimeModules ?? {};
+  // Identities are computed prefix-free (see computeModuleIdentities) so
+  // `cf:module/<hash>` is entry-point independent and dedupes across programs.
+  const identityByPath = computeModuleIdentities(sources, {
+    ...(options.idPrefix !== undefined ? { idPrefix: options.idPrefix } : {}),
+    ...(options.runtimeFingerprint !== undefined
+      ? { runtimeFingerprint: options.runtimeFingerprint }
+      : {}),
+  });
   const fileNames = new Set(sources.map((s) => s.name));
   const specifierByPath = new Map<string, string>();
   for (const source of sources) {
     specifierByPath.set(
       source.name,
-      `cf:module/${hashes.get(identityName(source.name))}`,
+      `cf:module/${identityByPath.get(source.name)}`,
     );
   }
   const sourceByName = new Map(sources.map((s) => [s.name, s]));
@@ -304,7 +339,7 @@ export function compileSourcesToRecords(
   const moduleSourceMaps = new Map<string, SourceMap>();
   for (const source of sources) {
     const specifier = specifierByPath.get(source.name)!;
-    const moduleHash = hashes.get(identityName(source.name))!;
+    const moduleHash = identityByPath.get(source.name)!;
     const sourceMap = options.precompiledSourceMaps?.get(source.name);
     if (sourceMap) moduleSourceMaps.set(specifier, sourceMap);
     const precompiled = options.precompiledBodies?.get(source.name);

--- a/packages/runner/test/cell-cache.test.ts
+++ b/packages/runner/test/cell-cache.test.ts
@@ -15,6 +15,7 @@ import {
   compiledIntegrityAtom,
   loadCompiledClosure,
   loadSourceClosure,
+  loadVerifiedSourceClosure,
   ROOT_LINK_SPECIFIER,
   sourceDocKey,
   verifySourceDocs,
@@ -207,6 +208,38 @@ describe("cell-cache: source-set store (per space, link-following)", () => {
       tx,
     );
     expect(loaded).toBe(undefined);
+  });
+
+  it("loadVerifiedSourceClosure returns a faithful closure but rejects a tampered one", async () => {
+    const { modules, entryIdentity } = toModules(PROGRAM);
+    const tx = runtime.edit();
+    writeSourceDocs(runtime, spaceA, modules, entryIdentity, tx);
+
+    // Happy path: the written closure graph-wiring-verifies.
+    const ok = await loadVerifiedSourceClosure(
+      runtime,
+      spaceA,
+      entryIdentity,
+      tx,
+    );
+    expect(ok?.size).toBe(3);
+
+    // Tamper util's stored source (keep its key) → recomputed identity diverges.
+    const utilIdentity = identityOf(PROGRAM, "/util.ts");
+    runtime.getCell(spaceA, sourceDocKey(utilIdentity), undefined, tx).set({
+      kind: "source",
+      identity: utilIdentity,
+      code: "export const helper = (n) => n + 999;",
+      filename: "/util.ts",
+      imports: [],
+    });
+    const tampered = await loadVerifiedSourceClosure(
+      runtime,
+      spaceA,
+      entryIdentity,
+      tx,
+    );
+    expect(tampered).toBe(undefined);
   });
 });
 

--- a/packages/runner/test/cell-cache.test.ts
+++ b/packages/runner/test/cell-cache.test.ts
@@ -177,12 +177,17 @@ describe("cell-cache: source-set store (per space, link-following)", () => {
     await storageManager?.close();
   });
 
-  it("writes the closure and loads it back via import links", () => {
+  it("writes the closure and loads it back via import links", async () => {
     const { modules, entryIdentity } = toModules(PROGRAM);
     const tx = runtime.edit();
     writeSourceDocs(runtime, spaceA, modules, entryIdentity, tx);
 
-    const loaded = loadSourceClosure(runtime, spaceA, entryIdentity, tx)!;
+    const loaded = (await loadSourceClosure(
+      runtime,
+      spaceA,
+      entryIdentity,
+      tx,
+    ))!;
 
     // All three modules reached by following links from the entry.
     expect(loaded.size).toBe(3);
@@ -193,9 +198,14 @@ describe("cell-cache: source-set store (per space, link-following)", () => {
     expect(verifySourceDocs(entryIdentity, loaded).ok).toBe(true);
   });
 
-  it("is empty for an entry that was never written", () => {
+  it("is empty for an entry that was never written", async () => {
     const tx = runtime.edit();
-    const loaded = loadSourceClosure(runtime, spaceA, "no-such-identity", tx);
+    const loaded = await loadSourceClosure(
+      runtime,
+      spaceA,
+      "no-such-identity",
+      tx,
+    );
     expect(loaded).toBe(undefined);
   });
 });
@@ -234,7 +244,7 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
     await wtx.commit();
 
     const rtx = runtime.edit();
-    const loaded = loadCompiledClosure(
+    const loaded = await loadCompiledClosure(
       runtime,
       spaceA,
       entryIdentity,
@@ -273,7 +283,7 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
     await wtx.commit();
 
     const rtx = runtime.edit();
-    const loaded = loadCompiledClosure(
+    const loaded = await loadCompiledClosure(
       runtime,
       spaceA,
       entryIdentity,
@@ -303,7 +313,7 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
 
     // Loading util directly as the entry: present but unstamped → dropped.
     const rtx = runtime.edit();
-    const loaded = loadCompiledClosure(
+    const loaded = await loadCompiledClosure(
       runtime,
       spaceA,
       utilIdentity,
@@ -326,7 +336,7 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
       compiledIntegrityAtom(compilerDid),
     );
     const rtx = runtime.edit();
-    const loaded = loadCompiledClosure(
+    const loaded = await loadCompiledClosure(
       runtime,
       spaceA,
       entryIdentity,

--- a/packages/runner/test/cell-cache.test.ts
+++ b/packages/runner/test/cell-cache.test.ts
@@ -6,11 +6,15 @@ import { Runtime } from "../src/runtime.ts";
 
 import {
   buildSourceDocs,
+  type CompiledArtifacts,
   compiledDocKey,
+  compiledIntegrityAtom,
+  loadCompiledClosure,
   loadSourceClosure,
   moduleIdentities,
   sourceDocKey,
   verifySourceDocs,
+  writeCompiledDocs,
   writeSourceDocs,
 } from "../src/compilation-cache/cell-cache.ts";
 
@@ -150,5 +154,129 @@ describe("cell-cache: source-set store (per space, link-following)", () => {
     const tx = runtime.edit();
     const loaded = loadSourceClosure(runtime, spaceA, "no-such-identity", tx);
     expect(loaded).toBe(undefined);
+  });
+});
+
+describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  const spaceA = signer.did();
+  const compilerDid = signer.did();
+  const RTVER = "rt-test-1";
+
+  const artifactsFor = (program: typeof PROGRAM): CompiledArtifacts => {
+    const m = new Map();
+    for (const f of program.files) {
+      m.set(f.name, { js: `/* compiled */ ${f.name}` });
+    }
+    return m;
+  };
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+      trustSnapshotProvider: () => ({
+        id: "cell-cache-test",
+        actingPrincipal: signer.did(),
+      }),
+    });
+  });
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  const opts = () => ({ runtimeVersion: RTVER, compilerDid });
+
+  it("writes compiled docs with integrity and loads them back (warm hit)", async () => {
+    const wtx = runtime.edit();
+    writeCompiledDocs(
+      runtime,
+      spaceA,
+      PROGRAM,
+      artifactsFor(PROGRAM),
+      opts(),
+      wtx,
+    );
+    wtx.prepareCfc();
+    await wtx.commit();
+
+    const rtx = runtime.edit();
+    const loaded = loadCompiledClosure(
+      runtime,
+      spaceA,
+      identityOf(PROGRAM, "/main.tsx"),
+      opts(),
+      rtx,
+    );
+    rtx.abort?.();
+
+    expect(loaded.size).toBe(3);
+    const main = loaded.get(identityOf(PROGRAM, "/main.tsx"))!;
+    expect(main.code).toBe("/* compiled */ /main.tsx");
+    expect(new Set([...loaded.values()].map((d) => d.filename))).toEqual(
+      new Set(["/main.tsx", "/util.ts", "/types.ts"]),
+    );
+  });
+
+  it("fail-closed: an unstamped compiled cell is not accepted", async () => {
+    const utilIdentity = identityOf(PROGRAM, "/util.ts");
+    // Write util's compiled cell PLAINLY (no addIntegrity schema → no label).
+    const wtx = runtime.edit();
+    runtime.getCell(spaceA, compiledDocKey(RTVER, utilIdentity), undefined, wtx)
+      .set({
+        kind: "compiled",
+        identity: utilIdentity,
+        code: "/* unstamped */",
+        filename: "/util.ts",
+        imports: [],
+      });
+    wtx.prepareCfc();
+    await wtx.commit();
+
+    // Loading util directly as the entry: present but unstamped → dropped.
+    const rtx = runtime.edit();
+    const loaded = loadCompiledClosure(
+      runtime,
+      spaceA,
+      utilIdentity,
+      opts(),
+      rtx,
+    );
+    rtx.abort?.();
+    expect(loaded.size).toBe(0);
+  });
+
+  it("fail-closed: a different compiler principal is not accepted", async () => {
+    const wtx = runtime.edit();
+    writeCompiledDocs(
+      runtime,
+      spaceA,
+      PROGRAM,
+      artifactsFor(PROGRAM),
+      opts(),
+      wtx,
+    );
+    wtx.prepareCfc();
+    await wtx.commit();
+
+    // A loader expecting a different compiler DID requires a different atom.
+    const otherDid = "did:key:someone-else";
+    expect(compiledIntegrityAtom(otherDid)).not.toBe(
+      compiledIntegrityAtom(compilerDid),
+    );
+    const rtx = runtime.edit();
+    const loaded = loadCompiledClosure(
+      runtime,
+      spaceA,
+      identityOf(PROGRAM, "/main.tsx"),
+      { runtimeVersion: RTVER, compilerDid: otherDid },
+      rtx,
+    );
+    rtx.abort?.();
+    expect(loaded.size).toBe(0);
   });
 });

--- a/packages/runner/test/cell-cache.test.ts
+++ b/packages/runner/test/cell-cache.test.ts
@@ -3,15 +3,19 @@ import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
+import {
+  computeModuleHashes,
+  resolveModuleImports,
+} from "../src/harness/module-identity.ts";
+import type { CacheableModule } from "../src/harness/types.ts";
 
 import {
   buildSourceDocs,
-  type CompiledArtifacts,
   compiledDocKey,
   compiledIntegrityAtom,
   loadCompiledClosure,
   loadSourceClosure,
-  moduleIdentities,
+  ROOT_LINK_SPECIFIER,
   sourceDocKey,
   verifySourceDocs,
   writeCompiledDocs,
@@ -20,9 +24,10 @@ import {
 
 const signer = await Identity.fromPassphrase("cell-cache test");
 
-// Step 4.3.1 — content-addressed cache document model: key scheme, per-module
-// identity, source-document construction, and the Merkle self-verification of a
-// loaded source closure.
+// Step 4.3.1–4.3.3 — content-addressed cache document model. The cache operates
+// in identity space on the engine's `CacheableModule[]`; these tests synthesize
+// an equivalent module set from a small program (computing the same per-module
+// identities + import edges the engine would).
 
 const PROGRAM = {
   main: "/main.tsx",
@@ -43,8 +48,27 @@ const PROGRAM = {
   ],
 };
 
+/** Synthesize the engine's `CacheableModule[]` from an authored program. */
+function toModules(
+  program: typeof PROGRAM,
+): { modules: CacheableModule[]; entryIdentity: string } {
+  const ids = computeModuleHashes(program);
+  const edges = resolveModuleImports(program);
+  const modules = program.files.map((f) => ({
+    identity: ids.get(f.name)!,
+    filename: f.name,
+    source: f.contents,
+    js: `/* compiled */ ${f.name}`,
+    imports: (edges.get(f.name)?.internalDeps ?? []).map((d) => ({
+      specifier: d.specifier,
+      targetIdentity: ids.get(d.target)!,
+    })),
+  }));
+  return { modules, entryIdentity: ids.get(program.main)! };
+}
+
 const identityOf = (program: typeof PROGRAM, path: string) =>
-  moduleIdentities(program).get(path)!;
+  computeModuleHashes(program).get(path)!;
 
 describe("cell-cache: keys", () => {
   it("formats source and compiled document keys", () => {
@@ -55,14 +79,11 @@ describe("cell-cache: keys", () => {
 
 describe("cell-cache: buildSourceDocs", () => {
   it("keys each module by its identity and records resolved import links", () => {
-    const ids = moduleIdentities(PROGRAM);
-    const docs = buildSourceDocs(PROGRAM);
+    const { modules, entryIdentity } = toModules(PROGRAM);
+    const docs = buildSourceDocs(modules, entryIdentity);
 
-    // One document per program file, keyed by identity.
+    // One document per module, keyed by identity.
     expect(docs.size).toBe(3);
-    for (const [identity, doc] of docs) {
-      expect(ids.get(doc.filename)).toBe(identity);
-    }
 
     const entry = docs.get(identityOf(PROGRAM, "/main.tsx"))!;
     expect(entry.kind).toBe("source");
@@ -76,12 +97,33 @@ describe("cell-cache: buildSourceDocs", () => {
       `./util.ts->${identityOf(PROGRAM, "/util.ts")}`,
     ]);
   });
+
+  it("links otherwise-unreachable modules from the entry document", () => {
+    const { modules, entryIdentity } = toModules(PROGRAM);
+    // Append an isolated module (like the injected cfc.ts helper): part of the
+    // emitted set, but with no incoming import edge.
+    const isolated: CacheableModule = {
+      identity: "iso-identity",
+      filename: "cfc.ts",
+      source: "export {};",
+      js: "/* iso */",
+      imports: [],
+    };
+    const docs = buildSourceDocs([...modules, isolated], entryIdentity);
+    const entry = docs.get(entryIdentity)!;
+    // The entry now carries a synthetic root link to the isolated module.
+    const rootLink = entry.imports.find((i) =>
+      i.specifier === `${ROOT_LINK_SPECIFIER}iso-identity`
+    );
+    expect(rootLink?.identity).toBe("iso-identity");
+  });
 });
 
 describe("cell-cache: verifySourceDocs (Merkle self-verification)", () => {
   it("accepts a faithfully-built closure", () => {
-    const docs = buildSourceDocs(PROGRAM);
-    const v = verifySourceDocs(identityOf(PROGRAM, "/main.tsx"), docs);
+    const { modules, entryIdentity } = toModules(PROGRAM);
+    const docs = buildSourceDocs(modules, entryIdentity);
+    const v = verifySourceDocs(entryIdentity, docs);
     expect(v.ok).toBe(true);
     expect(v.entryFilename).toBe("/main.tsx");
     expect(v.mismatches).toEqual([]);
@@ -89,7 +131,8 @@ describe("cell-cache: verifySourceDocs (Merkle self-verification)", () => {
   });
 
   it("rejects a tampered document (recomputed identity != key)", () => {
-    const docs = new Map(buildSourceDocs(PROGRAM));
+    const { modules, entryIdentity } = toModules(PROGRAM);
+    const docs = new Map(buildSourceDocs(modules, entryIdentity));
     const utilIdentity = identityOf(PROGRAM, "/util.ts");
     const util = docs.get(utilIdentity)!;
     // Keep the key, change the body — content no longer hashes to its key.
@@ -98,24 +141,24 @@ describe("cell-cache: verifySourceDocs (Merkle self-verification)", () => {
       code: `export const helper = (n) => n + 999;`,
     });
 
-    const v = verifySourceDocs(identityOf(PROGRAM, "/main.tsx"), docs);
+    const v = verifySourceDocs(entryIdentity, docs);
     expect(v.ok).toBe(false);
     expect(v.mismatches).toContain(utilIdentity);
   });
 
   it("flags a missing import-link target", () => {
-    const docs = new Map(buildSourceDocs(PROGRAM));
+    const { modules, entryIdentity } = toModules(PROGRAM);
+    const docs = new Map(buildSourceDocs(modules, entryIdentity));
     docs.delete(identityOf(PROGRAM, "/util.ts"));
-    const v = verifySourceDocs(identityOf(PROGRAM, "/main.tsx"), docs);
+    const v = verifySourceDocs(entryIdentity, docs);
     expect(v.ok).toBe(false);
     expect(v.missing).toContain(identityOf(PROGRAM, "/util.ts"));
   });
 
   it("is entry-point independent (util identity is stable across entries)", () => {
     const viaMain = identityOf(PROGRAM, "/util.ts");
-    // Compile the same files with util as the entry point.
     const utilEntry = { ...PROGRAM, main: "/util.ts" };
-    const viaUtil = moduleIdentities(utilEntry).get("/util.ts")!;
+    const viaUtil = computeModuleHashes(utilEntry).get("/util.ts")!;
     expect(viaUtil).toBe(viaMain);
   });
 });
@@ -135,10 +178,10 @@ describe("cell-cache: source-set store (per space, link-following)", () => {
   });
 
   it("writes the closure and loads it back via import links", () => {
+    const { modules, entryIdentity } = toModules(PROGRAM);
     const tx = runtime.edit();
-    writeSourceDocs(runtime, spaceA, PROGRAM, tx);
+    writeSourceDocs(runtime, spaceA, modules, entryIdentity, tx);
 
-    const entryIdentity = identityOf(PROGRAM, "/main.tsx");
     const loaded = loadSourceClosure(runtime, spaceA, entryIdentity, tx)!;
 
     // All three modules reached by following links from the entry.
@@ -164,14 +207,6 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
   const compilerDid = signer.did();
   const RTVER = "rt-test-1";
 
-  const artifactsFor = (program: typeof PROGRAM): CompiledArtifacts => {
-    const m = new Map();
-    for (const f of program.files) {
-      m.set(f.name, { js: `/* compiled */ ${f.name}` });
-    }
-    return m;
-  };
-
   beforeEach(() => {
     storageManager = StorageManager.emulate({ as: signer });
     runtime = new Runtime({
@@ -192,12 +227,45 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
   const opts = () => ({ runtimeVersion: RTVER, compilerDid });
 
   it("writes compiled docs with integrity and loads them back (warm hit)", async () => {
+    const { modules, entryIdentity } = toModules(PROGRAM);
+    const wtx = runtime.edit();
+    writeCompiledDocs(runtime, spaceA, modules, entryIdentity, opts(), wtx);
+    wtx.prepareCfc();
+    await wtx.commit();
+
+    const rtx = runtime.edit();
+    const loaded = loadCompiledClosure(
+      runtime,
+      spaceA,
+      entryIdentity,
+      opts(),
+      rtx,
+    );
+    rtx.abort?.();
+
+    expect(loaded.size).toBe(3);
+    const main = loaded.get(entryIdentity)!;
+    expect(main.code).toBe("/* compiled */ /main.tsx");
+    expect(new Set([...loaded.values()].map((d) => d.filename))).toEqual(
+      new Set(["/main.tsx", "/util.ts", "/types.ts"]),
+    );
+  });
+
+  it("reaches an otherwise-unreachable module via the entry root link", async () => {
+    const { modules, entryIdentity } = toModules(PROGRAM);
+    const isolated: CacheableModule = {
+      identity: "iso-compiled-identity",
+      filename: "cfc.ts",
+      source: "export {};",
+      js: "/* iso compiled */",
+      imports: [],
+    };
     const wtx = runtime.edit();
     writeCompiledDocs(
       runtime,
       spaceA,
-      PROGRAM,
-      artifactsFor(PROGRAM),
+      [...modules, isolated],
+      entryIdentity,
       opts(),
       wtx,
     );
@@ -208,18 +276,14 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
     const loaded = loadCompiledClosure(
       runtime,
       spaceA,
-      identityOf(PROGRAM, "/main.tsx"),
+      entryIdentity,
       opts(),
       rtx,
     );
     rtx.abort?.();
-
-    expect(loaded.size).toBe(3);
-    const main = loaded.get(identityOf(PROGRAM, "/main.tsx"))!;
-    expect(main.code).toBe("/* compiled */ /main.tsx");
-    expect(new Set([...loaded.values()].map((d) => d.filename))).toEqual(
-      new Set(["/main.tsx", "/util.ts", "/types.ts"]),
-    );
+    // The isolated module is reached only because the entry links it.
+    expect(loaded.has("iso-compiled-identity")).toBe(true);
+    expect(loaded.size).toBe(4);
   });
 
   it("fail-closed: an unstamped compiled cell is not accepted", async () => {
@@ -251,19 +315,12 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
   });
 
   it("fail-closed: a different compiler principal is not accepted", async () => {
+    const { modules, entryIdentity } = toModules(PROGRAM);
     const wtx = runtime.edit();
-    writeCompiledDocs(
-      runtime,
-      spaceA,
-      PROGRAM,
-      artifactsFor(PROGRAM),
-      opts(),
-      wtx,
-    );
+    writeCompiledDocs(runtime, spaceA, modules, entryIdentity, opts(), wtx);
     wtx.prepareCfc();
     await wtx.commit();
 
-    // A loader expecting a different compiler DID requires a different atom.
     const otherDid = "did:key:someone-else";
     expect(compiledIntegrityAtom(otherDid)).not.toBe(
       compiledIntegrityAtom(compilerDid),
@@ -272,7 +329,7 @@ describe("cell-cache: compiled-set store (CFC integrity, fail-closed)", () => {
     const loaded = loadCompiledClosure(
       runtime,
       spaceA,
-      identityOf(PROGRAM, "/main.tsx"),
+      entryIdentity,
       { runtimeVersion: RTVER, compilerDid: otherDid },
       rtx,
     );

--- a/packages/runner/test/cell-cache.test.ts
+++ b/packages/runner/test/cell-cache.test.ts
@@ -1,13 +1,20 @@
-import { describe, it } from "@std/testing/bdd";
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
 
 import {
   buildSourceDocs,
   compiledDocKey,
+  loadSourceClosure,
   moduleIdentities,
   sourceDocKey,
   verifySourceDocs,
+  writeSourceDocs,
 } from "../src/compilation-cache/cell-cache.ts";
+
+const signer = await Identity.fromPassphrase("cell-cache test");
 
 // Step 4.3.1 — content-addressed cache document model: key scheme, per-module
 // identity, source-document construction, and the Merkle self-verification of a
@@ -106,5 +113,42 @@ describe("cell-cache: verifySourceDocs (Merkle self-verification)", () => {
     const utilEntry = { ...PROGRAM, main: "/util.ts" };
     const viaUtil = moduleIdentities(utilEntry).get("/util.ts")!;
     expect(viaUtil).toBe(viaMain);
+  });
+});
+
+describe("cell-cache: source-set store (per space, link-following)", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  const spaceA = signer.did();
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({ apiUrl: new URL(import.meta.url), storageManager });
+  });
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("writes the closure and loads it back via import links", () => {
+    const tx = runtime.edit();
+    writeSourceDocs(runtime, spaceA, PROGRAM, tx);
+
+    const entryIdentity = identityOf(PROGRAM, "/main.tsx");
+    const loaded = loadSourceClosure(runtime, spaceA, entryIdentity, tx)!;
+
+    // All three modules reached by following links from the entry.
+    expect(loaded.size).toBe(3);
+    expect(new Set([...loaded.values()].map((d) => d.filename))).toEqual(
+      new Set(["/main.tsx", "/util.ts", "/types.ts"]),
+    );
+    // Loaded closure self-verifies (recomputed identities match the keys).
+    expect(verifySourceDocs(entryIdentity, loaded).ok).toBe(true);
+  });
+
+  it("is empty for an entry that was never written", () => {
+    const tx = runtime.edit();
+    const loaded = loadSourceClosure(runtime, spaceA, "no-such-identity", tx);
+    expect(loaded).toBe(undefined);
   });
 });

--- a/packages/runner/test/cell-cache.test.ts
+++ b/packages/runner/test/cell-cache.test.ts
@@ -1,0 +1,110 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import {
+  buildSourceDocs,
+  compiledDocKey,
+  moduleIdentities,
+  sourceDocKey,
+  verifySourceDocs,
+} from "../src/compilation-cache/cell-cache.ts";
+
+// Step 4.3.1 — content-addressed cache document model: key scheme, per-module
+// identity, source-document construction, and the Merkle self-verification of a
+// loaded source closure.
+
+const PROGRAM = {
+  main: "/main.tsx",
+  files: [
+    {
+      name: "/main.tsx",
+      contents: [
+        `import { helper } from "./util.ts";`,
+        `import type { Thing } from "./types.ts";`,
+        `export const run = (t: Thing) => helper(t.n);`,
+      ].join("\n"),
+    },
+    {
+      name: "/util.ts",
+      contents: `export const helper = (n: number) => n + 1;`,
+    },
+    { name: "/types.ts", contents: `export interface Thing { n: number; }` },
+  ],
+};
+
+const identityOf = (program: typeof PROGRAM, path: string) =>
+  moduleIdentities(program).get(path)!;
+
+describe("cell-cache: keys", () => {
+  it("formats source and compiled document keys", () => {
+    expect(sourceDocKey("abc")).toBe("pattern:abc");
+    expect(compiledDocKey("rt1", "abc")).toBe("compileCache:rt1/abc");
+  });
+});
+
+describe("cell-cache: buildSourceDocs", () => {
+  it("keys each module by its identity and records resolved import links", () => {
+    const ids = moduleIdentities(PROGRAM);
+    const docs = buildSourceDocs(PROGRAM);
+
+    // One document per program file, keyed by identity.
+    expect(docs.size).toBe(3);
+    for (const [identity, doc] of docs) {
+      expect(ids.get(doc.filename)).toBe(identity);
+    }
+
+    const entry = docs.get(identityOf(PROGRAM, "/main.tsx"))!;
+    expect(entry.kind).toBe("source");
+    expect(entry.filename).toBe("/main.tsx");
+    // Both the value import (util) and the type import (types) are linked.
+    const linked = entry.imports
+      .map((i) => `${i.specifier}->${i.identity}`)
+      .sort();
+    expect(linked).toEqual([
+      `./types.ts->${identityOf(PROGRAM, "/types.ts")}`,
+      `./util.ts->${identityOf(PROGRAM, "/util.ts")}`,
+    ]);
+  });
+});
+
+describe("cell-cache: verifySourceDocs (Merkle self-verification)", () => {
+  it("accepts a faithfully-built closure", () => {
+    const docs = buildSourceDocs(PROGRAM);
+    const v = verifySourceDocs(identityOf(PROGRAM, "/main.tsx"), docs);
+    expect(v.ok).toBe(true);
+    expect(v.entryFilename).toBe("/main.tsx");
+    expect(v.mismatches).toEqual([]);
+    expect(v.missing).toEqual([]);
+  });
+
+  it("rejects a tampered document (recomputed identity != key)", () => {
+    const docs = new Map(buildSourceDocs(PROGRAM));
+    const utilIdentity = identityOf(PROGRAM, "/util.ts");
+    const util = docs.get(utilIdentity)!;
+    // Keep the key, change the body — content no longer hashes to its key.
+    docs.set(utilIdentity, {
+      ...util,
+      code: `export const helper = (n) => n + 999;`,
+    });
+
+    const v = verifySourceDocs(identityOf(PROGRAM, "/main.tsx"), docs);
+    expect(v.ok).toBe(false);
+    expect(v.mismatches).toContain(utilIdentity);
+  });
+
+  it("flags a missing import-link target", () => {
+    const docs = new Map(buildSourceDocs(PROGRAM));
+    docs.delete(identityOf(PROGRAM, "/util.ts"));
+    const v = verifySourceDocs(identityOf(PROGRAM, "/main.tsx"), docs);
+    expect(v.ok).toBe(false);
+    expect(v.missing).toContain(identityOf(PROGRAM, "/util.ts"));
+  });
+
+  it("is entry-point independent (util identity is stable across entries)", () => {
+    const viaMain = identityOf(PROGRAM, "/util.ts");
+    // Compile the same files with util as the entry point.
+    const utilEntry = { ...PROGRAM, main: "/util.ts" };
+    const viaUtil = moduleIdentities(utilEntry).get("/util.ts")!;
+    expect(viaUtil).toBe(viaMain);
+  });
+});

--- a/packages/runner/test/esm-cell-cache-integration.test.ts
+++ b/packages/runner/test/esm-cell-cache-integration.test.ts
@@ -4,8 +4,14 @@ import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
+import type { Engine } from "../src/harness/engine.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
 import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import {
+  COMPILE_CACHE_RUNTIME_VERSION,
+  loadCompiledClosure,
+  loadVerifiedSourceClosure,
+} from "../src/compilation-cache/cell-cache.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
@@ -129,6 +135,142 @@ describe("ESM compile via content-addressed cell cache", () => {
     } finally {
       await dtx.commit();
       await disabled.dispose();
+    }
+  });
+});
+
+// Step 4.4 (required): a pattern compiled bound to space B writes its source +
+// compiled docs into B (not the ambient space A), the link closure resolves in
+// B, and the compiled docs carry the required integrity. This is exactly the
+// per-space routing `PatternFactory.inSpace(B)` relies on: instantiating a child
+// in space B loads it via `loadPattern(id, rootCell.space === B)`, whose core is
+// `compilePattern(source, { space: B })`.
+describe("ESM compile cache — Pattern.inSpace A → B routing", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  const spaceA = signer.did();
+
+  const PROGRAM: RuntimeProgram = {
+    main: "/main.tsx",
+    files: [
+      { name: "/util.ts", contents: "export const triple = (x:number)=>x*3;" },
+      {
+        name: "/main.tsx",
+        contents: [
+          "import { pattern, lift } from 'commonfabric';",
+          "import { triple } from './util.ts';",
+          "const t = lift((x:number)=>triple(x));",
+          "export default pattern<{ value: number }>(({ value }) => {",
+          "  return { result: t(value) };",
+          "});",
+        ].join("\n"),
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+  });
+  afterEach(async () => {
+    await storageManager?.close();
+  });
+
+  it("writes source + compiled docs into the target space B, not A", async () => {
+    const spaceB = (await Identity.fromPassphrase("inSpace target B")).did();
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      experimental: { esmModuleLoader: true },
+    });
+    const tx = runtime.edit();
+    const compilerDid = runtime.userIdentityDID;
+    const cacheOpts = {
+      runtimeVersion: COMPILE_CACHE_RUNTIME_VERSION,
+      compilerDid,
+    };
+    try {
+      // The entry identity is loader-internal; recover it via a no-cache compile.
+      const { entryIdentity } = await (runtime.harness as Engine)
+        .compileToRecordGraph(PROGRAM);
+
+      const pm = runtime.patternManager;
+      await pm.compilePattern(PROGRAM, { space: spaceB, tx });
+      await pm.flushCompileCacheWrites();
+
+      const readTx = runtime.edit();
+      // Compiled docs landed in B: full, integrity-valid closure.
+      const inB = await loadCompiledClosure(
+        runtime,
+        spaceB,
+        entryIdentity,
+        cacheOpts,
+        readTx,
+      );
+      expect(inB.size).toBeGreaterThanOrEqual(2);
+      expect(inB.has(entryIdentity)).toBe(true);
+
+      // Source closure resolves + graph-wiring-verifies in B.
+      const srcB = await loadVerifiedSourceClosure(
+        runtime,
+        spaceB,
+        entryIdentity,
+        readTx,
+      );
+      expect(srcB?.has(entryIdentity)).toBe(true);
+
+      // Nothing leaked into the ambient space A.
+      const inA = await loadCompiledClosure(
+        runtime,
+        spaceA,
+        entryIdentity,
+        cacheOpts,
+        readTx,
+      );
+      expect(inA.size).toBe(0);
+      readTx.abort?.();
+    } finally {
+      await tx.commit();
+      await runtime.dispose();
+    }
+  });
+
+  it("a fresh runtime warm-hits from space B (cross-session, per space)", async () => {
+    const spaceB = (await Identity.fromPassphrase("inSpace target B2")).did();
+    // Session 1: compile bound to B, write back, flush to storage.
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      experimental: { esmModuleLoader: true },
+    });
+    const tx1 = rt1.edit();
+    let rt2: Runtime | undefined;
+    try {
+      await rt1.patternManager.compilePattern(PROGRAM, {
+        space: spaceB,
+        tx: tx1,
+      });
+      await rt1.patternManager.flushCompileCacheWrites();
+      await tx1.commit();
+      await rt1.storageManager.synced();
+
+      // Session 2: fresh runtime, same storage → warm hit when loading into B.
+      rt2 = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager,
+        experimental: { esmModuleLoader: true },
+      });
+      const tx2 = rt2.edit();
+      await rt2.patternManager.compilePattern(PROGRAM, {
+        space: spaceB,
+        tx: tx2,
+      });
+      expect(rt2.patternManager.getCompileCacheStats()).toEqual({
+        hits: 1,
+        misses: 0,
+      });
+      await tx2.commit();
+    } finally {
+      await rt2?.dispose();
+      await rt1.dispose();
     }
   });
 });

--- a/packages/runner/test/esm-cell-cache-integration.test.ts
+++ b/packages/runner/test/esm-cell-cache-integration.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+const signer = await Identity.fromPassphrase("test operator");
+const space = signer.did();
+
+// Step 5: PatternManager drives the content-addressed cell cache on the ESM
+// path — cold compiles write the module set back (CFC-stamped), warm compiles
+// reuse it, and the cache is gated on CFC enforcement.
+describe("ESM compile via content-addressed cell cache", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+
+  const PROGRAM: RuntimeProgram = {
+    main: "/main.tsx",
+    files: [
+      { name: "/util.ts", contents: "export const double = (x:number)=>x*2;" },
+      {
+        name: "/main.tsx",
+        contents: [
+          "import { pattern, lift } from 'commonfabric';",
+          "import { double } from './util.ts';",
+          "const dbl = lift((x:number)=>double(x));",
+          "export default pattern<{ value: number }>(({ value }) => {",
+          "  return { result: dbl(value) };",
+          "});",
+        ].join("\n"),
+      },
+    ],
+  };
+
+  const newRuntime = (esm: boolean) =>
+    new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      experimental: { esmModuleLoader: esm },
+    });
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = newRuntime(true);
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await runtime?.patternManager.flushCompileCacheWrites();
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  const run = async (compiled: unknown, value: number): Promise<unknown> => {
+    const resultCell = runtime.getCell<{ result: number }>(
+      space,
+      `cell-cache run ${value}`,
+      undefined,
+      tx,
+    );
+    // deno-lint-ignore no-explicit-any
+    const result = runtime.run(tx, compiled as any, { value }, resultCell);
+    await tx.commit();
+    tx = runtime.edit();
+    await result.pull();
+    return result.getAsQueryResult();
+  };
+
+  it("cold compile writes back, warm compile is a hit, both run correctly", async () => {
+    const pm = runtime.patternManager;
+
+    // Cold compile (miss): evaluates correctly and triggers write-back.
+    const cold = await pm.compilePattern(PROGRAM, { space, tx });
+    expect(await run(cold, 3)).toEqual({ result: 6 });
+    expect(pm.getCompileCacheStats()).toEqual({ hits: 0, misses: 1 });
+
+    // Wait for the fire-and-forget write-back to commit.
+    await pm.flushCompileCacheWrites();
+
+    // Warm compile (hit): served from the cache, still evaluates correctly.
+    const warm = await pm.compilePattern(PROGRAM, { space, tx });
+    expect(pm.getCompileCacheStats()).toEqual({ hits: 1, misses: 1 });
+    expect(await run(warm, 5)).toEqual({ result: 10 });
+  });
+
+  it("warm hit reuses the cached body across a fresh runtime (cross-session)", async () => {
+    // Session 1: cold compile + write-back.
+    const pm1 = runtime.patternManager;
+    await pm1.compilePattern(PROGRAM, { space, tx });
+    await pm1.flushCompileCacheWrites();
+    expect(pm1.getCompileCacheStats().misses).toBe(1);
+    await tx.commit();
+
+    // Session 2: a brand-new runtime on the same storage warms from the cache.
+    const runtime2 = newRuntime(true);
+    const tx2 = runtime2.edit();
+    try {
+      const pm2 = runtime2.patternManager;
+      const warm = await pm2.compilePattern(PROGRAM, { space, tx: tx2 });
+      expect(pm2.getCompileCacheStats()).toEqual({ hits: 1, misses: 0 });
+      // The cache-served pattern is a real, frozen pattern.
+      expect(typeof warm).toBe("function");
+    } finally {
+      await tx2.commit();
+      await runtime2.dispose();
+    }
+  });
+
+  it("does not use the cache when CFC enforcement is disabled", async () => {
+    const disabled = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      experimental: { esmModuleLoader: true },
+      cfcEnforcementMode: "disabled",
+    });
+    const dtx = disabled.edit();
+    try {
+      const pm = disabled.patternManager;
+      const compiled = await pm.compilePattern(PROGRAM, { space, tx: dtx });
+      await pm.flushCompileCacheWrites();
+      // Cache path is skipped entirely → no hit/miss bookkeeping.
+      expect(pm.getCompileCacheStats()).toEqual({ hits: 0, misses: 0 });
+      expect(typeof compiled).toBe("function");
+    } finally {
+      await dtx.commit();
+      await disabled.dispose();
+    }
+  });
+});

--- a/packages/runner/test/esm-engine.test.ts
+++ b/packages/runner/test/esm-engine.test.ts
@@ -91,6 +91,63 @@ describe("Engine.compileToRecordGraph", () => {
     await expect(engine.compileToRecordGraph(program)).rejects.toThrow();
   });
 
+  // Step 5 (option C): per-module identities (`cf:module/<hash>`) are
+  // entry-point independent — the whole-program `/<id>` prefix is stripped for
+  // identity computation, so a byte-identical module shared by two different
+  // programs gets the SAME identity (content-addressed cross-program dedup).
+  describe("entry-point-independent module identities", () => {
+    const depContents = "export const base = (): number => 20;";
+
+    const specifierFor = async (
+      program: RuntimeProgram,
+      path: string,
+    ): Promise<string> => {
+      const { graph } = await engine.compileToRecordGraph(program);
+      // specifierByPath is keyed by the resolved/prefixed path; find the entry
+      // whose path ends with the authored path.
+      for (const [p, spec] of graph.specifierByPath) {
+        if (p.endsWith(path)) return spec;
+      }
+      throw new Error(`no specifier for ${path}`);
+    };
+
+    it("gives a shared module the same identity across different programs", async () => {
+      const progA: RuntimeProgram = {
+        main: "/main.tsx",
+        files: [
+          { name: "/dep.ts", contents: depContents },
+          {
+            name: "/main.tsx",
+            contents:
+              `import { base } from "./dep.ts";\nexport default () => base() + 1;`,
+          },
+        ],
+      };
+      const progB: RuntimeProgram = {
+        main: "/main.tsx",
+        files: [
+          { name: "/dep.ts", contents: depContents },
+          {
+            name: "/main.tsx",
+            // Different entry → different whole-program id, same dep.ts bytes.
+            contents:
+              `import { base } from "./dep.ts";\nexport default () => base() * 99;`,
+          },
+        ],
+      };
+      const depA = await specifierFor(progA, "/dep.ts");
+      const depB = await specifierFor(progB, "/dep.ts");
+      expect(depA).toBe(depB);
+      // The prefix is gone from the identity: no whole-program hash leaks in.
+      expect(depA.startsWith("cf:module/")).toBe(true);
+
+      // The entry modules differ (different content), so their identities differ.
+      const mainA = await specifierFor(progA, "/main.tsx");
+      const mainB = await specifierFor(progB, "/main.tsx");
+      expect(mainA).not.toBe(mainB);
+    });
+  });
+
   // Step 4.3.4: compileToRecordGraph returns serializable per-module artifacts
   // and accepts a full set of cached bodies to skip the TypeScript compile.
   describe("precompiled-module seam", () => {

--- a/packages/runner/test/esm-engine.test.ts
+++ b/packages/runner/test/esm-engine.test.ts
@@ -163,42 +163,51 @@ describe("Engine.compileToRecordGraph", () => {
       ],
     };
 
-    it("returns a non-empty compiled artifact for every emitted module", async () => {
-      const { compiledArtifacts, graph } = await engine.compileToRecordGraph(
-        MULTI,
+    // Build an identity-keyed precompiled set from a prior compile's module
+    // descriptors, tagging each body so we can prove it was reused verbatim.
+    const taggedFrom = (modules: { identity: string; js: string }[]) =>
+      new Map(
+        modules.map((
+          m,
+        ) => [m.identity, { js: `${m.js}\n//cached:${m.identity}` }]),
       );
-      // One artifact per authored module body in the graph; both authored
-      // sources (resolved/prefixed) appear among the keys.
-      expect(compiledArtifacts.size).toBeGreaterThanOrEqual(2);
-      const keys = [...compiledArtifacts.keys()];
-      expect(keys.some((k) => k.endsWith("/main.tsx"))).toBe(true);
-      expect(keys.some((k) => k.endsWith("/dep.ts"))).toBe(true);
-      // The artifact set matches the graph's compiled bodies count.
-      expect(compiledArtifacts.size).toBe(graph.compiledBodies.size);
-      for (const a of compiledArtifacts.values()) {
-        expect(typeof a.js).toBe("string");
-        expect(a.js.length).toBeGreaterThan(0);
+
+    it("returns a descriptor per emitted module in identity space", async () => {
+      const { modules, entryIdentity, graph } = await engine
+        .compileToRecordGraph(MULTI);
+      // One descriptor per compiled body in the graph.
+      expect(modules.length).toBe(graph.compiledBodies.size);
+      // Filenames are normalized (no `/<id>` prefix leaks out).
+      const filenames = modules.map((m) => m.filename);
+      expect(filenames).toContain("/main.tsx");
+      expect(filenames).toContain("/dep.ts");
+      for (const f of filenames) {
+        expect(f).not.toMatch(/^\/[A-Za-z0-9_-]{20,}\//);
       }
+      // The entry's identity is among the module identities.
+      expect(modules.some((m) => m.identity === entryIdentity)).toBe(true);
+      // Each descriptor carries non-empty source + js; main links to dep.
+      for (const m of modules) {
+        expect(m.source.length).toBeGreaterThan(0);
+        expect(m.js.length).toBeGreaterThan(0);
+      }
+      const main = modules.find((m) => m.filename === "/main.tsx")!;
+      const dep = modules.find((m) => m.filename === "/dep.ts")!;
+      expect(main.imports.some((i) => i.targetIdentity === dep.identity)).toBe(
+        true,
+      );
     });
 
     it("reuses a full set of precompiled bodies (cache hit) and still evaluates", async () => {
       const first = await engine.compileToRecordGraph(MULTI);
+      const tagged = taggedFrom(first.modules);
 
-      // Feed every artifact back, tagged so we can prove the body was used
-      // verbatim rather than recompiled from source.
-      const tagged = new Map(
-        [...first.compiledArtifacts].map(([name, a]) => [
-          name,
-          { js: `${a.js}\n//cached:${name}`, sourceMap: a.sourceMap },
-        ]),
-      );
       const hit = await engine.compileToRecordGraph(MULTI, {
         precompiledModules: tagged,
       });
-
-      // The returned artifacts are exactly the cached bodies (no recompile).
-      for (const [name, a] of hit.compiledArtifacts) {
-        expect(a.js).toContain(`//cached:${name}`);
+      // Every returned body is exactly the cached body (no recompile).
+      for (const m of hit.modules) {
+        expect(m.js).toContain(`//cached:${m.identity}`);
       }
 
       // And a cache-hit graph still evaluates correctly.
@@ -211,18 +220,13 @@ describe("Engine.compileToRecordGraph", () => {
     it("ignores a partial precompiled set and recompiles the whole program", async () => {
       const first = await engine.compileToRecordGraph(MULTI);
       // Supply all but one module → not a full hit; the engine recompiles.
-      const names = [...first.compiledArtifacts.keys()];
-      const partial = new Map(
-        names.slice(1).map((name) => [name, {
-          js: `${first.compiledArtifacts.get(name)!.js}\n//cached:${name}`,
-        }]),
-      );
+      const partial = taggedFrom(first.modules.slice(1));
       const result = await engine.compileToRecordGraph(MULTI, {
         precompiledModules: partial,
       });
       // Recompiled from source: no body carries the cache tag.
-      for (const a of result.compiledArtifacts.values()) {
-        expect(a.js).not.toContain("//cached");
+      for (const m of result.modules) {
+        expect(m.js).not.toContain("//cached");
       }
     });
   });

--- a/packages/runner/test/esm-engine.test.ts
+++ b/packages/runner/test/esm-engine.test.ts
@@ -90,4 +90,83 @@ describe("Engine.compileToRecordGraph", () => {
     };
     await expect(engine.compileToRecordGraph(program)).rejects.toThrow();
   });
+
+  // Step 4.3.4: compileToRecordGraph returns serializable per-module artifacts
+  // and accepts a full set of cached bodies to skip the TypeScript compile.
+  describe("precompiled-module seam", () => {
+    const MULTI: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [
+        { name: "/dep.ts", contents: "export const base = (): number => 20;" },
+        {
+          name: "/main.tsx",
+          contents:
+            `import { base } from "./dep.ts";\nexport const total = () => base() + 22;\nexport default total;`,
+        },
+      ],
+    };
+
+    it("returns a non-empty compiled artifact for every emitted module", async () => {
+      const { compiledArtifacts, graph } = await engine.compileToRecordGraph(
+        MULTI,
+      );
+      // One artifact per authored module body in the graph; both authored
+      // sources (resolved/prefixed) appear among the keys.
+      expect(compiledArtifacts.size).toBeGreaterThanOrEqual(2);
+      const keys = [...compiledArtifacts.keys()];
+      expect(keys.some((k) => k.endsWith("/main.tsx"))).toBe(true);
+      expect(keys.some((k) => k.endsWith("/dep.ts"))).toBe(true);
+      // The artifact set matches the graph's compiled bodies count.
+      expect(compiledArtifacts.size).toBe(graph.compiledBodies.size);
+      for (const a of compiledArtifacts.values()) {
+        expect(typeof a.js).toBe("string");
+        expect(a.js.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("reuses a full set of precompiled bodies (cache hit) and still evaluates", async () => {
+      const first = await engine.compileToRecordGraph(MULTI);
+
+      // Feed every artifact back, tagged so we can prove the body was used
+      // verbatim rather than recompiled from source.
+      const tagged = new Map(
+        [...first.compiledArtifacts].map(([name, a]) => [
+          name,
+          { js: `${a.js}\n//cached:${name}`, sourceMap: a.sourceMap },
+        ]),
+      );
+      const hit = await engine.compileToRecordGraph(MULTI, {
+        precompiledModules: tagged,
+      });
+
+      // The returned artifacts are exactly the cached bodies (no recompile).
+      for (const [name, a] of hit.compiledArtifacts) {
+        expect(a.js).toContain(`//cached:${name}`);
+      }
+
+      // And a cache-hit graph still evaluates correctly.
+      const { main } = await engine.compileAndEvaluateModules(MULTI, {
+        precompiledModules: tagged,
+      });
+      expect((main as { total(): number }).total()).toBe(42);
+    });
+
+    it("ignores a partial precompiled set and recompiles the whole program", async () => {
+      const first = await engine.compileToRecordGraph(MULTI);
+      // Supply all but one module → not a full hit; the engine recompiles.
+      const names = [...first.compiledArtifacts.keys()];
+      const partial = new Map(
+        names.slice(1).map((name) => [name, {
+          js: `${first.compiledArtifacts.get(name)!.js}\n//cached:${name}`,
+        }]),
+      );
+      const result = await engine.compileToRecordGraph(MULTI, {
+        precompiledModules: partial,
+      });
+      // Recompiled from source: no body carries the cache tag.
+      for (const a of result.compiledArtifacts.values()) {
+        expect(a.js).not.toContain("//cached");
+      }
+    });
+  });
 });

--- a/packages/runner/test/esm-engine.test.ts
+++ b/packages/runner/test/esm-engine.test.ts
@@ -217,6 +217,23 @@ describe("Engine.compileToRecordGraph", () => {
       expect((main as { total(): number }).total()).toBe(42);
     });
 
+    it("still security-verifies cached bodies on a warm hit (no blind trust)", async () => {
+      // Step 4.3.6 / threat model: while the compiled-set integrity label is
+      // only client-asserted, a warm hit must NOT blindly trust cached bytes —
+      // the engine re-runs the ESM body verifier on every emitted body. Feed a
+      // full (so fullHit) set where one body has disallowed top-level code.
+      const first = await engine.compileToRecordGraph(MULTI);
+      const tampered = new Map(
+        first.modules.map((m) => [m.identity, { js: m.js }]),
+      );
+      tampered.set(first.entryIdentity, {
+        js: `"use strict";\nfetch("https://evil.example");\n`,
+      });
+      await expect(
+        engine.compileToRecordGraph(MULTI, { precompiledModules: tampered }),
+      ).rejects.toThrow();
+    });
+
     it("ignores a partial precompiled set and recompiles the whole program", async () => {
       const first = await engine.compileToRecordGraph(MULTI);
       // Supply all but one module → not a full hit; the engine recompiles.

--- a/packages/runner/test/pattern-manager.test.ts
+++ b/packages/runner/test/pattern-manager.test.ts
@@ -460,6 +460,10 @@ describe("PatternManager compilation cache integration (AMD bundle cache)", () =
       apiUrl: new URL(import.meta.url),
       storageManager,
       cachedCompiler,
+      // Pin the AMD bundle-cache path regardless of CF_ESM_MODULE_LOADER: this
+      // suite asserts CachedCompiler behavior. The ESM cell-cache equivalent is
+      // covered in esm-cell-cache-integration.test.ts.
+      experimental: { esmModuleLoader: false },
     });
   });
 

--- a/packages/runner/test/pattern-manager.test.ts
+++ b/packages/runner/test/pattern-manager.test.ts
@@ -427,7 +427,13 @@ describe("PatternManager.compileOrGetPattern", () => {
   });
 });
 
-describe("PatternManager compilation cache integration", () => {
+// AMD bundle-cache path (esmModuleLoader OFF): the persistent CachedCompiler
+// stores a whole-bundle jsScript keyed by program hash and skips evaluate-time
+// SES bundle validation on a hit. The ESM loader path uses an entirely
+// different cache — the per-module content-addressed cell cache — whose
+// cold→warm / cross-session / per-space(inSpace A→B) / CFC fail-closed behavior
+// is covered in esm-cell-cache-integration.test.ts.
+describe("PatternManager compilation cache integration (AMD bundle cache)", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let cacheStorage: MemoryCompilationCache;
   let cachedCompiler: CachedCompiler;


### PR DESCRIPTION
## CT-1623 Phase 4 — content-addressed ESM compilation cache

Builds and wires the per-module, content-addressed compilation cell cache into
the ESM module-loader path (behind `CF_ESM_MODULE_LOADER`, default off). Steps
4.3.1–4.3.6 of `docs/specs/module-loading-implementation-plan.md`; 4.3.7 stays
deferred to Phase 5 as planned.

### What it does
Two per-space cell-document sets, keyed by per-module content identity:
- **Source set** `pattern:<identity>` — authored/resolved TS, self-verifying
  (Merkle recompute = the integrity).
- **Compiled set** `compileCache:<runtimeVersion>/<identity>` — compiled JS,
  bound by a **CFC integrity label** (`cf-compiled-by:<did>` via `addIntegrity`
  on write, **fail-closed** on read).

On an ESM pattern load, `PatternManager.compileViaCellCache` fetches the
compiled closure by entry identity (link-following). A **warm full hit** feeds
the cached bodies back through `compileToRecordGraph` and skips the TypeScript
compile + transformer pipeline; a **miss** compiles and writes both sets back on
a fresh, CFC-prepared transaction (fire-and-forget). Gated on
`cfcEnforcementMode !== "disabled"` (the integrity label only persists / is only
trusted under an enforcing mode).

### Notable design correction (step 5a)
The plan assumed the per-module `cf:module/<hash>` identity was already
entry-point independent. It wasn't: the ESM compile path resolves a
`/<computeId>/`-prefixed program, leaking the whole-program prefix into the
identity (no cross-program dedup; contradicting the entry-point-independence
guarantee in the spec). `computeModuleIdentities` now strips the prefix for
identity computation **only** — record source URLs, source-map keys, and
`fn.src` resolution stay on the prefixed path. The injected, unprefixed `cfc.ts`
helper (nothing imports it at runtime) is reached on load via a synthetic root
link from the entry document.

### Safety
While the integrity label is still client-asserted (server-only-write is the
end state), warm hits do **not** blindly trust cached bytes: the engine re-runs
`verifyCompiledModuleBody` + `verifyModuleGraph` on every emitted body even on a
hit. `loadVerifiedSourceClosure` graph-wiring-verifies the source set
(content-addressed `verifyModuleGraph` analog).

### Tests
- cell-cache unit: keys, source/compiled stores, Merkle self-verify, CFC
  fail-closed (unstamped + wrong principal), root-link reachability, source
  graph-wiring verify.
- engine: entry-point-independent identities (cross-program dedup), the
  precompiled-module seam (full-hit reuse, partial recompile, warm-hit still
  security-verified).
- integration: cold→warm (same runtime), cross-session warm hit (fresh runtime),
  CFC-disabled runs uncached, and **`Pattern.inSpace` A→B** (docs land in space
  B not A, closure resolves in B with integrity, cross-session warm hit per
  space).
- The two `pattern-manager.test.ts` AMD cache cases are pinned to the AMD loader
  (relabeled), with the ESM equivalent covered above.

Full runner suite green **both** flag-on and flag-off (513 passed).
