### PR TITLE
Switch to naming experiment flags generically.

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -35,11 +35,11 @@ and when **running the server** (for server-side flags):
 
 ```bash
 # Enable a single flag (build + run)
-EXPERIMENTAL_SOME_FLAG=true deno task dev
+EXPERIMENTAL_EXAMPLE_NAME=true deno task dev
 
 # Enable multiple flags
-EXPERIMENTAL_SOME_FLAG=true \
-EXPERIMENTAL_SOME_OTHER_FLAG=true \
+EXPERIMENTAL_EXAMPLE_NAME_1=true \
+EXPERIMENTAL_EXAMPLE_NAME_2=true \
 deno task dev
 ```
 

--- a/docs/development/LOCAL_DEV_SERVERS.md
+++ b/docs/development/LOCAL_DEV_SERVERS.md
@@ -27,9 +27,8 @@
 **Experimental flags:** Pass env vars to the start/restart scripts to enable
 experiments on both servers:
 ```bash
-EXPERIMENTAL_MODERN_DATA_MODEL=true \
-EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE=true \
-EXPERIMENTAL_EXAMPLE_EXPERIMENT=true \
+EXPERIMENTAL_EXAMPLE_NAME_1=true \
+EXPERIMENTAL_EXAMPLE_NAME_2=true \
 ./scripts/restart-local-dev.sh --force --dangerously-clear-all-spaces
 ```
 The same env vars must also be set when running `cf` CLI commands against the

--- a/docs/specs/persistent-scheduler-state.md
+++ b/docs/specs/persistent-scheduler-state.md
@@ -886,8 +886,8 @@ Current branch status:
 | Demand-targeted dirty recovery beyond subscription startup | Future work. |
 | Replication, retention, and mirror repair | Future work. |
 
-The version 1 implementation is gated by the same experimental-option plumbing
-as `EXPERIMENTAL_MODERN_DATA_MODEL`. With
+The version 1 implementation is gated by the project's common
+experimental-option plumbing. With
 `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE=false` or unset, the runner does not
 attach scheduler observations to transactions, memory clients do not request
 scheduler snapshots, and the memory server does not write scheduler observation

--- a/packages/cli/lib/utils.ts
+++ b/packages/cli/lib/utils.ts
@@ -61,8 +61,7 @@ export async function awaitSyncWithTimeout(
         new Error(
           `Sync timed out after ${timeoutMs / 1000}s. ` +
             `This often indicates a client/server configuration mismatch ` +
-            `(e.g., EXPERIMENTAL_MODERN_DATA_MODEL enabled on the server but not the CLI). ` +
-            `Also check EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE. ` +
+            `(e.g., an EXPERIMENTAL_* option enabled on the server but not the CLI). ` +
             `Check toolshed logs for AuthorizationError details.`,
         ),
       );

--- a/packages/toolshed/env.ts
+++ b/packages/toolshed/env.ts
@@ -199,7 +199,7 @@ const EnvSchema = z.object({
   SHELL_URL: z.string().optional(),
 
   // ===========================================================================
-  // Experimental space-model feature flags (see ExperimentalOptions in runner)
+  // Experimental feature flags (see ExperimentalOptions in runner)
   // Note: We intentionally avoid z.coerce.boolean() here. Zod's coerce uses
   // Boolean(), which treats any non-empty string as truthy -- so setting an
   // env var to "false" would incorrectly enable the flag. The other boolean

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -54,11 +54,13 @@ the CLI PKCS8/PEM key in the browser via `Import CLI Key`. See
 
 ```bash
 # Pass experiment env vars to CLI commands:
-EXPERIMENTAL_MODERN_DATA_MODEL=true \
+EXPERIMENTAL_EXAMPLE_NAME_1=true \
+EXPERIMENTAL_EXAMPLE_NAME_2=true \
 deno task cf piece new pattern.tsx ...
 ```
 
-See `docs/development/EXPERIMENTAL_OPTIONS.md` for all available flags.
+Replace `EXAMPLE_NAME_*` with an actual defined experiment name. See
+`docs/development/EXPERIMENTAL_OPTIONS.md` for all available flags.
 
 **Local servers**: See `docs/development/LOCAL_DEV_SERVERS.md`
 


### PR DESCRIPTION
...when in the context of examples or when formerly intending a reference to all experiment flags in the aggregate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized how we reference experimental flags by using generic names (`EXPERIMENTAL_*`) across docs and messages. This avoids implying specific flags in examples and reduces config confusion.

- **Refactors**
  - Replaced specific sample flags with generic placeholders (`EXPERIMENTAL_EXAMPLE_NAME`, `EXPERIMENTAL_EXAMPLE_NAME_1/2`) in examples and scripts.
  - Simplified CLI timeout error to reference a generic `EXPERIMENTAL_*` mismatch between server and CLI.
  - Clarified comments and spec wording about the shared experimental-option plumbing; added guidance to replace placeholders with actual experiment names.

<sup>Written for commit 7d6074fc3b0b5c9b25511b3b537555a3441de479. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

