### PR TITLE
Make another spot more generic wrt experiment names and variables, etc.

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -68,12 +68,15 @@ directly to `new Runtime({ experimental: { ... } })`.
 ```
 Server Process (Deno)
   |
-  +-- ENV: EXPERIMENTAL_MODERN_DATA_MODEL=true
+  +-- ENV: EXPERIMENTAL_EXAMPLE_NAME_1=<value>
+  |        EXPERIMENTAL_EXAMPLE_NAME_2=<value>
+  |        ...
   |
   +-- toolshed/env.ts        --> Zod parses env vars
   +-- toolshed/index.ts      --> new Runtime({ experimental: { ... } })
-                                    +-- setDataModelConfig(...)
-                                    +-- setPersistentSchedulerStateConfig(...)
+                                    +-- setExperimentName1Config(...)
+                                    +-- setExperimentName2Config(...)
+                                    ...
 ```
 
 ### Browser-side (build-time injection)
@@ -84,10 +87,12 @@ via the IPC protocol:
 ```
 Build Time (shell)
   |
-  +-- ENV: EXPERIMENTAL_MODERN_DATA_MODEL=true
+  +-- ENV: EXPERIMENTAL_EXAMPLE_NAME_1=<value>
+  |        EXPERIMENTAL_EXAMPLE_NAME_2=<value>
+  |        ...
   |
-  +-- felt.config.ts          --> esbuild define: $EXPERIMENTAL_MODERN_DATA_MODEL
-  +-- src/lib/env.ts           --> EXPERIMENTAL.modernDataModel = true
+  +-- felt.config.ts          --> esbuild define: $EXPERIMENTAL_*
+  +-- src/lib/env.ts          --> EXPERIMENTAL.exampleName* = true
   |
 Browser (Main Thread)
   |
@@ -96,17 +101,16 @@ Browser (Main Thread)
   +-- RuntimeClient.initialize(transport, { ..., experimental: EXPERIMENTAL })
         |
         | postMessage (IPC)
-        | InitializationData { ..., experimental: { modernDataModel: true } }
+        | InitializationData { ..., experimental: { exampleName*: true } }
         |
         v
 Browser Web Worker
   |
   +-- RuntimeProcessor.initialize(data)
         +-- new Runtime({ ..., experimental: data.experimental })
-              +-- setDataModelConfig(true)
-              +-- setPersistentSchedulerStateConfig(...)
-              |    +-- modernDataModelEnabled = true
-              |         +-- fabricFromNativeValue() checks modernDataModelEnabled
+              +-- setExperimentName1Config(...)
+              +-- setExperimentName2Config(...)
+              ...
 ```
 
 Key points:


### PR DESCRIPTION
Make another spot more generic wrt experiment names and variables, etc. (I missed a spot in the last PR.)

## Performance Baseline

This PR is doc-only, so the following accounts for a spurious perf check failure:

NEW_PERF_BASELINE: job: CLI Integration Tests (fuse) = 132s


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Generalized the experimental options docs to use generic experiment names and variables instead of the specific `modernDataModel` example. Diagrams now show `EXPERIMENTAL_EXAMPLE_NAME_*`, `EXPERIMENTAL_*` build defines, and `setExperimentName*Config(...)` across server, build-time, and worker flows to clarify support for multiple experiments.

<sup>Written for commit 58112d66da2011b63acf92941bda0ea13af75195. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

