### PR TITLE
feat(cli): add `id from-mnemonic` matching browser mnemonic login

### DIFF
--- a/docs/development/SHARED_IDENTITY.md
+++ b/docs/development/SHARED_IDENTITY.md
@@ -31,24 +31,26 @@ act as the same DID.
 
 ## Existing Browser Mnemonic To CLI
 
-If the browser identity already exists and you need a matching CLI key, export a
-PKCS8 key from the browser mnemonic:
+If the browser identity already exists and you need a matching CLI key, derive a
+PKCS8 key from the browser recovery phrase with `cf id from-mnemonic`. Quote the
+whole phrase as a single argument:
 
 ```bash
-deno eval '
-import { Identity } from "./packages/identity/src/identity.ts";
-const mnemonic = "your 24-word mnemonic here";
-const id = await Identity.fromMnemonic(mnemonic, { implementation: "noble" });
-await Deno.writeFile(".cf/browser.key", id.toPkcs8());
-'
+deno run -A packages/cli/mod.ts id from-mnemonic "your 24-word mnemonic here" \
+  > .cf/browser.key
 
 export CF_IDENTITY="$PWD/.cf/browser.key"
 deno run -A packages/cli/mod.ts id did "$CF_IDENTITY"
 ```
 
-Do not use `cf id derive <mnemonic>` for this. Browser mnemonic login uses
-`Identity.fromMnemonic()`, while `cf id derive` uses
-`Identity.fromPassphrase()`. The same text produces different DIDs.
+Do not use `cf id derive <mnemonic>` for this. `from-mnemonic` uses
+`Identity.fromMnemonic()` (the same path as browser mnemonic login), while
+`cf id derive` uses `Identity.fromPassphrase()`. The same text produces
+different DIDs.
+
+> Use `deno run -A packages/cli/mod.ts`, not `deno task cf`, when redirecting to
+> a key file: the `deno task` wrapper prints colored preamble to stdout that
+> would corrupt the key.
 
 ## Existing CLI Key To Browser
 

--- a/packages/cli/commands/identity.ts
+++ b/packages/cli/commands/identity.ts
@@ -4,6 +4,7 @@ import { render } from "../lib/render.ts";
 import {
   getDidFromFile,
   pkcs8FromEntropy,
+  pkcs8FromMnemonic,
   pkcs8FromPassphrase,
 } from "../lib/identity.ts";
 
@@ -32,7 +33,20 @@ export const identity = new Command()
     'Create and store a keyfile at ./my.key derived from the string "common user".',
   )
   .arguments("<passphrase:string>")
-  .action(deriveIdentity);
+  .action(deriveIdentity)
+  /* id from-mnemonic */
+  .command(
+    "from-mnemonic",
+    "Derives a keyfile from a BIP-39 mnemonic phrase, matching browser " +
+      "mnemonic login.",
+  )
+  .example(
+    cliText('cf id from-mnemonic "word1 word2 ... word24" > ./my.key'),
+    "Create a keyfile whose DID matches a browser identity registered with " +
+      "the given recovery phrase. Quote the whole phrase as one argument.",
+  )
+  .arguments("<mnemonic:string>")
+  .action(identityFromMnemonic);
 
 async function createIdentity() {
   const pkcs8Material = await pkcs8FromEntropy();
@@ -46,5 +60,10 @@ async function getDid(_: void, keypath: string) {
 
 async function deriveIdentity(_: void, passphrase: string) {
   const pkcs8Material = await pkcs8FromPassphrase(passphrase);
+  render(pkcs8Material);
+}
+
+async function identityFromMnemonic(_: void, mnemonic: string) {
+  const pkcs8Material = await pkcs8FromMnemonic(mnemonic);
   render(pkcs8Material);
 }

--- a/packages/cli/lib/identity.ts
+++ b/packages/cli/lib/identity.ts
@@ -10,6 +10,15 @@ export async function pkcs8FromPassphrase(
   return decode(identity.toPkcs8());
 }
 
+export async function pkcs8FromMnemonic(
+  mnemonic: string,
+): Promise<string> {
+  const identity = await Identity.fromMnemonic(mnemonic.trim(), {
+    implementation: "noble",
+  });
+  return decode(identity.toPkcs8());
+}
+
 export async function pkcs8FromEntropy(): Promise<string> {
   return decode(await Identity.generatePkcs8());
 }

--- a/packages/cli/test/id.test.ts
+++ b/packages/cli/test/id.test.ts
@@ -14,6 +14,15 @@ const PKCS8_KEY_DID =
 const COMMON_USER_DID =
   "did:key:z6Mkj5HyygpAVo2baUcx7kwTRoUbbBmk5egUQPHnV8arQ3SY";
 
+// Canonical BIP-39 all-zero-entropy 24-word test vector, and the DID that
+// `Identity.fromMnemonic` (the browser's mnemonic login path) produces from it.
+const TEST_MNEMONIC =
+  "abandon abandon abandon abandon abandon abandon abandon abandon abandon " +
+  "abandon abandon abandon abandon abandon abandon abandon abandon abandon " +
+  "abandon abandon abandon abandon abandon art";
+const TEST_MNEMONIC_DID =
+  "did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp";
+
 describe("cli id", () => {
   it("Creates a new key", async () => {
     const { code, stdout, stderr } = await cf("id new");
@@ -38,6 +47,28 @@ describe("cli id", () => {
     const keyBuffer = encode(stdout.join("\n"));
     const identity = await Identity.fromPkcs8(keyBuffer);
     expect(identity.did()).toBe(COMMON_USER_DID);
+    expect(code).toBe(0);
+    checkStderr(stderr);
+  });
+
+  it("Derives a key from a mnemonic matching browser login", async () => {
+    const { code, stdout, stderr } = await cf(
+      `id from-mnemonic "${TEST_MNEMONIC}"`,
+    );
+    const keyBuffer = encode(stdout.join("\n"));
+    const identity = await Identity.fromPkcs8(keyBuffer);
+    expect(identity.did()).toBe(TEST_MNEMONIC_DID);
+    // Must match the browser's mnemonic-login derivation...
+    const browser = await Identity.fromMnemonic(TEST_MNEMONIC, {
+      implementation: "noble",
+    });
+    expect(identity.did()).toBe(browser.did());
+    // ...and must NOT collide with `id derive` (fromPassphrase) of the same
+    // text, which is the footgun this command exists to avoid.
+    const passphrase = await Identity.fromPassphrase(TEST_MNEMONIC, {
+      implementation: "noble",
+    });
+    expect(identity.did()).not.toBe(passphrase.did());
     expect(code).toBe(0);
     checkStderr(stderr);
   });

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -30,7 +30,15 @@ deno run -A packages/cli/mod.ts id derive "implicit trust" > cf.key
 
 # For a fresh random key (e.g., against production):
 deno run -A packages/cli/mod.ts id new > cf.key
+
+# To match a browser identity registered with a recovery phrase:
+deno run -A packages/cli/mod.ts id from-mnemonic "word1 word2 ... word24" > cf.key
 ```
+
+Note: `id derive` (passphrase) and `id from-mnemonic` (BIP-39 phrase) use
+different derivations and produce different DIDs from the same text. Use
+`from-mnemonic` to match browser mnemonic login; see
+`docs/development/SHARED_IDENTITY.md`.
 
 **IMPORTANT:** Do NOT use `deno task cf id new > file` — the `deno task` wrapper
 prints ANSI-colored preamble to stdout, which pollutes the key file. Always use


### PR DESCRIPTION
`cf id derive` uses Identity.fromPassphrase(), but browser mnemonic login uses Identity.fromMnemonic() — the same text yields different DIDs. Getting a CLI key matching a browser identity registered with a recovery phrase previously required a manual `deno eval` snippet.

Add `cf id from-mnemonic <mnemonic>` that derives the PKCS8 key via Identity.fromMnemonic(), so it matches browser login. Update SHARED_IDENTITY.md and the cf skill to recommend it over the eval workaround, and add a test asserting the derived DID matches fromMnemonic and differs from fromPassphrase.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `cf id from-mnemonic` to derive a PKCS8 key from a BIP‑39 recovery phrase so the DID matches the browser’s mnemonic login. Replaces the old `deno eval` workaround and updates docs and tests.

- **New Features**
  - New command: `id from-mnemonic "<24-word phrase>"` derives via `Identity.fromMnemonic()` and outputs PKCS8 for `cf` use.
  - Added `pkcs8FromMnemonic` in `packages/cli` and tests that the DID matches `fromMnemonic` and differs from `fromPassphrase`.

- **Migration**
  - To match a browser identity: `deno run -A packages/cli/mod.ts id from-mnemonic "word1 word2 ... word24" > cf.key`. Do not use `id derive` for this case (`Identity.fromPassphrase()` produces a different DID).
  - When redirecting output, use `deno run -A packages/cli/mod.ts` (not `deno task`) to avoid stdout preamble corrupting the key.

<sup>Written for commit 85b6dfc4c23b9439b049129321a7b06328d6e7d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

