### PR TITLE
refactor(ts-transformers): remove dead legacy-derive-shape branches (CT-1643, PR 2 of 2)

### DIFF
--- a/packages/ts-transformers/src/ast/call-kind.ts
+++ b/packages/ts-transformers/src/ast/call-kind.ts
@@ -14,7 +14,7 @@
  *    Common Fabric declarations or imports.
  *
  * 2. **Alias following**: Follow stable const aliases and call signatures to
- *    preserve detection for `const alias = derive` and `declare const alias:
+ *    preserve detection for `const alias = lift` and `declare const alias:
  *    typeof ifElse` style code.
  *
  * 3. **Synthetic helper support**: Recognize internal `__cfHelpers.*` calls
@@ -317,13 +317,12 @@ export function getCapabilitySummaryCallbackArgument(
 
   let callbackArg: ts.Expression | undefined;
   if (callKind.kind === "lift-applied") {
-    // For lift-applied shape (lift(cb)(input)), the callback lives on the
-    // inner lift call. For legacy derive shape, on the outer call itself.
+    // Lift-applied shape `lift(cb)(input)`: the callback lives on the inner
+    // lift call (the outer call's callee is always that inner CallExpression).
     const innerCallee = stripWrappers(call.expression);
-    const argSource = ts.isCallExpression(innerCallee)
-      ? innerCallee.arguments
-      : call.arguments;
-    callbackArg = argSource[argSource.length - 1];
+    if (ts.isCallExpression(innerCallee)) {
+      callbackArg = innerCallee.arguments[innerCallee.arguments.length - 1];
+    }
   } else if (
     callKind.kind === "builder" &&
     (
@@ -373,38 +372,18 @@ export function getLiftAppliedInputAndCallback(
     return undefined;
   }
 
-  // Two shapes are recognized as kind:"lift-applied":
-  //   (a) Legacy derive shape: __cfHelpers.derive(input, cb) or
-  //       __cfHelpers.derive(argSchema, resSchema, input, cb). Recognized
-  //       defensively for any unlowered legacy emission that reaches here.
-  //   (b) Canonical lift-applied shape: __cfHelpers.lift(cb)(input) or
-  //       __cfHelpers.lift(argSchema, resSchema, cb)(input).
-  // The lift-applied shape's outer call has the callee as a CallExpression.
+  // The lift-applied shape `__cfHelpers.lift(...)(input)` always has the outer
+  // call's callee as a CallExpression (the inner `lift(...)` factory). That is
+  // the only way detectCallKind produces kind:"lift-applied" — see its
+  // recognition in resolveExpressionKind (requires ts.isCallExpression(target)).
+  // The callback is the last arg of the inner lift call; the input is the first
+  // arg of the outer applied call.
   const innerCallee = stripWrappers(call.expression);
-  if (ts.isCallExpression(innerCallee)) {
-    // Lift-applied: callback is the last arg of the inner lift call; input
-    // is the first arg of the outer applied call.
-    const innerCall = innerCallee;
-    const callbackIndex = innerCall.arguments.length - 1;
-    const callbackArg = innerCall.arguments[callbackIndex];
-    const callback = callbackArg
-      ? resolveCallbackFunctionExpression(callbackArg, checker)
-      : undefined;
-    if (!callback) {
-      return undefined;
-    }
-
-    const input = call.arguments[0];
-    if (!input) {
-      return undefined;
-    }
-
-    return { input, callback };
+  if (!ts.isCallExpression(innerCallee)) {
+    return undefined;
   }
-
-  // Legacy derive shape.
-  const callbackIndex = call.arguments.length - 1;
-  const callbackArg = call.arguments[callbackIndex];
+  const callbackIndex = innerCallee.arguments.length - 1;
+  const callbackArg = innerCallee.arguments[callbackIndex];
   const callback = callbackArg
     ? resolveCallbackFunctionExpression(callbackArg, checker)
     : undefined;
@@ -412,8 +391,7 @@ export function getLiftAppliedInputAndCallback(
     return undefined;
   }
 
-  const inputIndex = callbackIndex === 1 ? 0 : callbackIndex === 3 ? 2 : -1;
-  const input = inputIndex >= 0 ? call.arguments[inputIndex] : undefined;
+  const input = call.arguments[0];
   if (!input) {
     return undefined;
   }
@@ -1148,9 +1126,9 @@ function resolveExpressionKind(
   if (builderKind) {
     // Lift-applied recognition: when the callee is itself a call to lift
     // (e.g. __cfHelpers.lift(cb)({})), the *outer* call applies the lift
-    // factory to inputs and is semantically the lowered form of the
-    // user-source derive(input, cb). Return kind:"lift-applied" so
-    // downstream dispatchers handle it.
+    // factory to inputs and is the canonical lowered form of a reactive
+    // lifted-function computation (e.g. from computed()). Return
+    // kind:"lift-applied" so downstream dispatchers handle it.
     //
     // The plain unapplied builder case (e.g. __cfHelpers.lift(cb) on its
     // own, or a pattern() call) has `target` not as a CallExpression.

--- a/packages/ts-transformers/src/closures/module-scope-callback-hoisting.ts
+++ b/packages/ts-transformers/src/closures/module-scope-callback-hoisting.ts
@@ -232,13 +232,8 @@ function getBuilderCallbackIndices(
     ? callee.name.text
     : undefined;
 
-  // After CT-1615 Phase 1, the hoister deliberately does NOT handle `derive`.
-  // LiftLoweringTransformer rewrites every supported derive shape (2-arg and
-  // 4-arg) into the lift-applied form well before this pass runs, so a
-  // canonically-shaped derive should never reach here. Malformed shapes
-  // (1-arg `derive(fn)` etc.) pass through to validation; refusing to hoist
-  // them is correct. `derive` is intentionally omitted from
-  // `HOISTABLE_BUILDER_NAMES` to enforce this.
+  // Only the builders in `HOISTABLE_BUILDER_NAMES` are hoisted; anything else
+  // (or a malformed call) passes through to validation untouched.
   if (!builderName || !HOISTABLE_BUILDER_NAMES.has(builderName)) {
     return [];
   }

--- a/packages/ts-transformers/src/closures/strategies/lift-applied-strategy.ts
+++ b/packages/ts-transformers/src/closures/strategies/lift-applied-strategy.ts
@@ -103,7 +103,7 @@ export class LiftAppliedStrategy implements ClosureTransformationStrategy {
 
 /**
  * Check if a call expression is a lift-applied call (the lowered form of a
- * user-source derive() / computed() call) from commonfabric.
+ * user-source computed() call) from commonfabric.
  */
 export function isLiftAppliedCall(
   node: ts.CallExpression,
@@ -190,7 +190,7 @@ function resolveLiftAppliedCaptureNameCollisions(
  * Example: {value, multiplier} where value is the original input and multiplier is a capture.
  *
  * When hadZeroParameters is true, skip the original input and only include captures.
- * This handles the case where the user wrote derive({}, () => ...) (which lowers to
+ * This handles the case where the user wrote computed(() => ...) (which lowers to
  * lift(() => ...)({})) and we only need captures.
  */
 function buildLiftAppliedInputObject(

--- a/packages/ts-transformers/src/closures/strategies/patternTool-strategy.ts
+++ b/packages/ts-transformers/src/closures/strategies/patternTool-strategy.ts
@@ -21,7 +21,7 @@ import { buildCallbackWithTopLevelCaptures } from "../utils/pattern-builder.ts";
  * const content = cell("Hello");
  * const grepTool = patternTool(
  *   ({ query }: { query: string }) => {
- *     return derive({ query }, ({ query }) => {
+ *     return computed(() => {
  *       return content.split("\n").filter((c) => c.includes(query));
  *     });
  *   }
@@ -33,7 +33,7 @@ import { buildCallbackWithTopLevelCaptures } from "../utils/pattern-builder.ts";
  * const content = cell("Hello");
  * const grepTool = patternTool(
  *   ({ query, content }: { query: string; content: string }) => {
- *     return derive({ query }, ({ query }) => {
+ *     return computed(() => {
  *       return content.split("\n").filter((c) => c.includes(query));
  *     });
  *   },

--- a/packages/ts-transformers/src/lift/transformer.ts
+++ b/packages/ts-transformers/src/lift/transformer.ts
@@ -1,6 +1,6 @@
 import ts from "typescript";
 
-import { detectCallKind, getLiftAppliedInnerCall } from "../ast/call-kind.ts";
+import { detectCallKind } from "../ast/call-kind.ts";
 import { setParentPointers } from "../ast/utils.ts";
 import { registerLiftAppliedCallType } from "../ast/type-inference.ts";
 import { HelpersOnlyTransformer } from "../core/transformers.ts";
@@ -160,13 +160,6 @@ function sourceContainsLowerableCall(
       if (
         callKind?.kind === "builder" &&
         callKind.builderName === "computed"
-      ) {
-        found = true;
-        return;
-      }
-      if (
-        callKind?.kind === "lift-applied" &&
-        !getLiftAppliedInnerCall(node)
       ) {
         found = true;
         return;

--- a/packages/ts-transformers/src/transformers/builtins/lift-applied.ts
+++ b/packages/ts-transformers/src/transformers/builtins/lift-applied.ts
@@ -234,7 +234,7 @@ export function createLiftAppliedCall(
   // callback (and type arguments, since lift<In, Out> is the generic) live
   // on the inner lift call. This matches the canonical post-Phase-1 shape
   // produced by LiftLoweringTransformer (see src/lift/transformer.ts) for
-  // user-authored derive(...) calls.
+  // user-authored computed() calls.
   const [inputObject] = createLiftAppliedInputArgs(
     factory,
     captureTree,

--- a/packages/ts-transformers/src/transformers/pattern-body-reactive-root-lowering.ts
+++ b/packages/ts-transformers/src/transformers/pattern-body-reactive-root-lowering.ts
@@ -955,9 +955,10 @@ function rewriteNestedLiftAppliedCallbackBodies(
     if (!liftAppliedArgs) return visited;
     const { callback: callbackArg } = liftAppliedArgs;
 
-    // The callback can live on either the outer call (legacy derive shape:
-    // derive(input, cb)) or the inner call (lift-applied shape:
-    // lift(cb)(input)). Detect which by searching both argument lists.
+    // The callback lives on the inner lift call (lift(cb)(input)). When
+    // getLiftAppliedInputAndCallback succeeds the inner call is always present
+    // — both gate on the outer call's callee being a CallExpression — so
+    // getLiftAppliedInnerCall is non-undefined here.
     const innerCall = getLiftAppliedInnerCall(visited);
     const callbackHostArgs = innerCall
       ? innerCall.arguments

--- a/packages/ts-transformers/src/transformers/schema-injection.ts
+++ b/packages/ts-transformers/src/transformers/schema-injection.ts
@@ -2298,42 +2298,27 @@ function resolveLiftAppliedInputAndCallback(
     return undefined;
   }
 
-  // See getLiftAppliedInputAndCallback in src/ast/call-kind.ts for the
-  // two recognized shapes (legacy derive vs lift-applied).
+  // Lift-applied `lift(...)(input)`: callback is the last arg of the inner lift
+  // call; input is the first arg of the outer applied call. The outer call's
+  // callee is always the inner CallExpression — that is the only shape
+  // detectCallKind classifies as lift-applied (see getLiftAppliedInputAndCallback
+  // in src/ast/call-kind.ts).
   const innerCall = getLiftAppliedInnerCall(call);
-  if (innerCall) {
-    // Lift-applied: callback is the last arg of the inner lift call; input
-    // is the first arg of the outer applied call.
-    const callbackIndex = innerCall.arguments.length - 1;
-    const callbackExpression = innerCall.arguments[callbackIndex];
-    const callback = callbackExpression
-      ? resolveFunctionLikeExpression(callbackExpression, checker, sourceFile)
-      : undefined;
-    if (!callback) {
-      return undefined;
-    }
-    const input = call.arguments[0];
-    if (!input) {
-      return undefined;
-    }
-    return { input, callback };
+  if (!innerCall) {
+    return undefined;
   }
-
-  const callbackIndex = call.arguments.length - 1;
-  const callbackExpression = call.arguments[callbackIndex];
+  const callbackIndex = innerCall.arguments.length - 1;
+  const callbackExpression = innerCall.arguments[callbackIndex];
   const callback = callbackExpression
     ? resolveFunctionLikeExpression(callbackExpression, checker, sourceFile)
     : undefined;
   if (!callback) {
     return undefined;
   }
-
-  const inputIndex = callbackIndex === 1 ? 0 : callbackIndex === 3 ? 2 : -1;
-  const input = inputIndex >= 0 ? call.arguments[inputIndex] : undefined;
+  const input = call.arguments[0];
   if (!input) {
     return undefined;
   }
-
   return { input, callback };
 }
 
@@ -3163,10 +3148,19 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
           sourceFile,
         );
 
-        // For lift-applied shape (callee is itself a call), the generic
+        // For the lift-applied shape (callee is itself a call), the generic
         // type arguments live on the *inner* lift call, not on the outer
-        // applied call. The legacy derive shape kept them on the call
-        // itself. Read from whichever holds them.
+        // applied call — the lowering builds the outer call with `undefined`
+        // type args (see lift/transformer.ts). The `?? node.typeArguments`
+        // fallback reads them off the outer call defensively.
+        //
+        // UNCERTAIN whether the fallback is still reachable: dropping it kept
+        // the full fixture suite green (CT-1643), and the main lowering path
+        // never puts type args on the outer call. But this wasn't proven dead
+        // across all three lift-applied construction sites + schema-injection
+        // re-entry, so it's kept as a cheap robustness guard rather than
+        // removed. (It is NOT derive-specific; the prior comment misattributed
+        // it to the removed "legacy derive shape.")
         const innerLiftCall = getLiftAppliedInnerCall(node);
         const sourceTypeArguments = innerLiftCall?.typeArguments ??
           node.typeArguments;


### PR DESCRIPTION
Completes [CT-1643](https://linear.app/common-tools/issue/CT-1643) — removing `derive` handling from `ts-transformers/src`. Follows #3809 (PR 1 of 2).

## Proof of deadness

Every "legacy derive shape" branch is gated on `detectCallKind(call) === "lift-applied"` and then handles the case where the call's callee is **not** a CallExpression (the old `derive(input, cb)` shape, vs. the canonical `lift(cb)(input)` whose callee is the inner `lift(...)` CallExpression).

But `kind: "lift-applied"` is **only** produced by `resolveExpressionKind`, inside `if (builderName === "lift" && ts.isCallExpression(target) && !isMultiApplicationChain(target))` — it requires `ts.isCallExpression(target)`. The other producer (`createNamedCallKind`) never emits lift-applied (no runtime-registry entry has `callKind: "lift-applied"`). **So a lift-applied call always has a CallExpression callee, and the non-CallExpression branches are unreachable.** Corroborated: `derive` is unexported / unregistered / never emitted as output, and 0 fixtures import or author it (established in PR-1).

## Removed dead branches (each simplifies to the live inner-call path)

- `ast/call-kind.ts`: the legacy fallback in `getLiftAppliedInputAndCallback`; the dead `: call.arguments` ternary branch in `getCapabilitySummaryCallbackArgument`.
- `transformers/schema-injection.ts`: the legacy fallback in `resolveLiftAppliedInputAndCallback`.
- `transformers/pattern-body-reactive-root-lowering.ts`: the outer-call callback-host branch (once `getLiftAppliedInputAndCallback` succeeds the inner call is always present — both gate on the same condition). Documented; the ternary is kept defensively.
- `lift/transformer.ts`: `sourceContainsLowerableCall`'s `lift-applied && !innerCall` branch (impossible); dropped the now-unused import.

## Comments

Swept remaining stale `derive` comments/docstrings to `computed()` / lift-applied. Left **accurate historical-rationale** comments intact (e.g. "the CT-1615 discriminator was `derive`", the flag-naming history).

## One thing flagged, not removed

The `?? node.typeArguments` fallback in schema-injection (reading type args off the *outer* applied call) is **kept** with a comment flagging **uncertain reachability**: dropping it kept the full suite green and the main lowering path never puts type args on the outer call, but it wasn't proven dead across all three lift-applied construction sites — so it stays as a cheap robustness guard. (It is not derive-specific; a prior comment misattributed it to the "legacy derive shape.")

## Verification

- `deno check` / `deno lint` / `deno fmt`: clean.
- `deno task test`: **292 passed / 0 failed** — byte-identical (the `.expected.jsx` fixture comparisons all pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes unreachable “legacy derive shape” handling across ts-transformers, simplifying all lift-applied paths to the inner-call form. Completes CT-1643 with no behavior changes (tests unchanged).

- **Refactors**
  - Removed legacy `derive(input, cb)` fallbacks; `lift(cb)(input)` is the only lift-applied shape.
  - Consolidated callback/input resolution to the inner-call path in call analysis and schema injection.
  - Kept a defensive `?? node.typeArguments` fallback in schema injection, flagged as uncertain but non-derive-specific.
  - Deleted impossible branches and an unused import in `lift/transformer.ts`.
  - Updated comments/examples to use computed()/lift-applied and removed stale `derive` references.

<sup>Written for commit 1154f25cffbc22103a5cccce4752f70a5b9e3e5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

