### PR TITLE
Define a new "modern cell representation" experiment flag

### DIFF
--- a/docs/development/CONFIGURATION.md
+++ b/docs/development/CONFIGURATION.md
@@ -220,6 +220,7 @@ Currently defined:
 
 | Flag | Env var |
 |---|---|
+| `modernCellRep` | `EXPERIMENTAL_MODERN_CELL_REP` |
 | `modernDataModel` | `EXPERIMENTAL_MODERN_DATA_MODEL` |
 | `schedulerHistoricalMightWrite` | _(runtime-only; pass via `new Runtime({ experimental: { ... } })`)_ |
 
@@ -236,6 +237,7 @@ Most shell config is **build-time**: esbuild injects defines in
 | `PRODUCTION` | `$ENVIRONMENT` (`"production"` if set, else `"development"`) | _(unset = dev)_ | Triggers minified bundle and disables sourcemaps. |
 | `API_URL` | `$API_URL` | falls back to `location.origin` | Backend the shell calls. |
 | `COMMIT_SHA` | `$COMMIT_SHA` | _(unset)_ | Surfaced for debugging. |
+| `EXPERIMENTAL_MODERN_CELL_REP` | `EXPERIMENTAL.modernCellRep` | _(unset)_ | See experimental flags. |
 | `EXPERIMENTAL_MODERN_DATA_MODEL` | `EXPERIMENTAL.modernDataModel` | _(unset)_ | See experimental flags. |
 | `COMPILATION_CACHE_CLIENT` | `$COMPILATION_CACHE_CLIENT` | `"true"` | See compilation cache. |
 | `SHELL_PORT` | _(server-only)_ | `5173` (from `ports.json`) | Dev server port. |
@@ -293,6 +295,7 @@ Passed before the CLI args; rarely needed:
 | `OPERATOR_PASS` | `"implicit trust"` | Passphrase for implicit identity. Must match toolshed's identity in dev. |
 | `IDENTITY` | _(unset)_ | Path to keyfile; takes precedence over `OPERATOR_PASS`. |
 | `API_URL` | `http://localhost:8000` | Toolshed URL the service calls. |
+| `EXPERIMENTAL_MODERN_CELL_REP` | _(unset)_ | See experimental flags. |
 | `EXPERIMENTAL_MODERN_DATA_MODEL` | _(unset)_ | See experimental flags. |
 
 ---

--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -7,6 +7,7 @@ various major features.
 
 | Flag | Env Var | Description |
 |------|---------|-------------|
+| `modernCellRep` | `EXPERIMENTAL_MODERN_CELL_REP` | Enables new "cell representation" classes |
 | `modernDataModel` | `EXPERIMENTAL_MODERN_DATA_MODEL` | Enables the new fabric value type system (`bigint`, `Map`, `Set`, `Uint8Array`, `Date`, `FabricInstance`). |
 | `persistentSchedulerState` | `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE` | Enables durable scheduler observations, dirty state, and scheduler rehydration through memory-v2. |
 | `schedulerHistoricalMightWrite` | n/a (`RuntimeOptions` only) | Preserves the scheduler's legacy cumulative write history for dependency scheduling instead of the default current-known write set. |
@@ -170,8 +171,7 @@ deno test --allow-ffi --allow-env --allow-read test/experimental-options.test.ts
 ```
 
 These tests verify that `Runtime` construction correctly sets and resets the
-ambient config, and that `fabricFromNativeValue()` dispatches based on the
-`modernDataModel` flag.
+ambient config.
 
 ## Implementation Details
 
@@ -180,15 +180,8 @@ The flags are defined in `packages/runner/src/runtime.ts` as the
 with defaults (all `false`) and stores the resolved result as
 `runtime.experimental` (type `Required<ExperimentalOptions>`).
 
-The memory layer uses module-level ambient config variables:
-`modernDataModelEnabled` in `packages/data-model/fabric-value.ts` (set by
-`setDataModelConfig()`). This means:
-
 - Only one set of experimental flags is active per JavaScript context at a time.
 - In the browser, the Web Worker is a separate JS context, so its flags are
   independent of the main thread.
 - Creating a new `Runtime` overwrites the ambient config; disposing it resets
   to defaults.
-
-See the formal spec at `docs/specs/space-model-formal-spec/` for the full
-data model specification that these flags gate.

--- a/packages/background-charm-service/src/env.ts
+++ b/packages/background-charm-service/src/env.ts
@@ -43,6 +43,7 @@ const envSchema = z.object({
   // `Boolean()`, which treats any non-empty string as truthy -- so setting an
   // env var to the string `"false"` would incorrectly enable the flag. The
   // other boolean env vars in this file have the same latent bug.
+  EXPERIMENTAL_MODERN_CELL_REP: flagValue(),
   EXPERIMENTAL_MODERN_DATA_MODEL: flagValue(),
   EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE: flagValue(),
   // Background Charm Service: default is public space "toolshed-system"

--- a/packages/background-charm-service/src/main.ts
+++ b/packages/background-charm-service/src/main.ts
@@ -32,6 +32,7 @@ const runtime = new Runtime({
     address: new URL("/api/storage/memory", env.API_URL),
   }),
   experimental: {
+    modernCellRep: env.EXPERIMENTAL_MODERN_CELL_REP,
     modernDataModel: env.EXPERIMENTAL_MODERN_DATA_MODEL,
     persistentSchedulerState: env.EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE,
   },

--- a/packages/background-charm-service/src/worker-controller.ts
+++ b/packages/background-charm-service/src/worker-controller.ts
@@ -25,6 +25,7 @@ export interface WorkerOptions {
   identity: Identity;
   timeoutMs?: number;
   experimental?: {
+    modernCellRep?: boolean;
     modernDataModel?: boolean;
     persistentSchedulerState?: boolean;
   };

--- a/packages/background-charm-service/src/worker-ipc.ts
+++ b/packages/background-charm-service/src/worker-ipc.ts
@@ -12,6 +12,7 @@ export type InitializationData = {
   toolshedUrl: string;
   rawIdentity: KeyPairRaw;
   experimental?: {
+    modernCellRep?: boolean;
     modernDataModel?: boolean;
     persistentSchedulerState?: boolean;
   };

--- a/packages/cli/lib/utils.ts
+++ b/packages/cli/lib/utils.ts
@@ -25,6 +25,7 @@ export function experimentalOptionsFromEnv(): ExperimentalOptions {
     return v === undefined ? undefined : v === "true";
   };
   const opts: ExperimentalOptions = {
+    modernCellRep: read("EXPERIMENTAL_MODERN_CELL_REP"),
     modernDataModel: read("EXPERIMENTAL_MODERN_DATA_MODEL"),
     persistentSchedulerState: read(
       "EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE",

--- a/packages/data-model/deno.json
+++ b/packages/data-model/deno.json
@@ -25,6 +25,7 @@
   },
   "exports": {
     "./BaseReconstructionContext": "./src/BaseReconstructionContext.ts",
+    "./cell-rep": "./src/cell-rep.ts",
     "./deep-freeze": "./src/deep-freeze.ts",
     "./EmptyReconstructionContext": "./src/EmptyReconstructionContext.ts",
     "./fabric-instances": "./src/fabric-instances/index.ts",

--- a/packages/data-model/src/cell-rep.ts
+++ b/packages/data-model/src/cell-rep.ts
@@ -12,18 +12,18 @@
 let modernCellRepEnabled = false;
 
 /** Activates or deactivates the modern cell representation flag. */
-export function setCellRepConfig(enabled?: boolean): void {
+export function setModernCellRepConfig(enabled?: boolean): void {
   if (enabled !== undefined) {
     modernCellRepEnabled = enabled ?? false;
   }
 }
 
 /** Returns whether the modern cell representation flag is currently enabled. */
-export function getCellRepConfig(): boolean {
+export function getModernCellRepConfig(): boolean {
   return modernCellRepEnabled;
 }
 
 /** Restores the modern cell representation flag to its default. */
-export function resetCellRepConfig(): void {
+export function resetModernCellRepConfig(): void {
   modernCellRepEnabled = false;
 }

--- a/packages/data-model/src/cell-rep.ts
+++ b/packages/data-model/src/cell-rep.ts
@@ -1,0 +1,29 @@
+/**
+ * Stub for the nascent "modern cell representation" classes.
+ */
+
+//
+// Configuration flags
+//
+
+/**
+ * Module-level flag for the modern cell representation.
+ */
+let modernCellRepEnabled = false;
+
+/** Activates or deactivates the modern cell representation flag. */
+export function setCellRepConfig(enabled?: boolean): void {
+  if (enabled !== undefined) {
+    modernCellRepEnabled = enabled ?? false;
+  }
+}
+
+/** Returns whether the modern cell representation flag is currently enabled. */
+export function getCellRepConfig(): boolean {
+  return modernCellRepEnabled;
+}
+
+/** Restores the modern cell representation flag to its default. */
+export function resetCellRepConfig(): void {
+  modernCellRepEnabled = false;
+}

--- a/packages/memory/test/v2-client-test.ts
+++ b/packages/memory/test/v2-client-test.ts
@@ -1622,6 +1622,7 @@ Deno.test("memory v2 client rejects hello.ok when flags disagree", async () => {
           type: "hello.ok",
           protocol: MEMORY_PROTOCOL,
           flags: {
+            modernCellRep: !getMemoryProtocolFlags().modernCellRep,
             modernDataModel: !getMemoryProtocolFlags().modernDataModel,
           },
         }));

--- a/packages/memory/test/v2-server-test.ts
+++ b/packages/memory/test/v2-server-test.ts
@@ -546,6 +546,7 @@ Deno.test("memory v2 server rejects handshakes when data-model flags disagree", 
       type: "hello",
       protocol: MEMORY_PROTOCOL,
       flags: {
+        modernCellRep: !HELLO_FLAGS.modernCellRep,
         modernDataModel: !HELLO_FLAGS.modernDataModel,
       },
     }));
@@ -557,6 +558,7 @@ Deno.test("memory v2 server rejects handshakes when data-model flags disagree", 
         name: "ProtocolError",
         message: `memory flag mismatch: client=${
           JSON.stringify({
+            modernCellRep: !HELLO_FLAGS.modernCellRep,
             modernDataModel: !HELLO_FLAGS.modernDataModel,
           })
         } server=${JSON.stringify(HELLO_FLAGS)}`,
@@ -611,6 +613,7 @@ Deno.test("memory v2 server accepts legacy richStorableValues flag name and echo
       type: "hello.ok",
       protocol: MEMORY_PROTOCOL,
       flags: {
+        modernCellRep: !HELLO_FLAGS.modernCellRep,
         richStorableValues: HELLO_FLAGS.modernDataModel,
         persistentSchedulerState: HELLO_FLAGS.persistentSchedulerState,
       },

--- a/packages/memory/test/v2-server-test.ts
+++ b/packages/memory/test/v2-server-test.ts
@@ -613,7 +613,7 @@ Deno.test("memory v2 server accepts legacy richStorableValues flag name and echo
       type: "hello.ok",
       protocol: MEMORY_PROTOCOL,
       flags: {
-        modernCellRep: !HELLO_FLAGS.modernCellRep,
+        modernCellRep: HELLO_FLAGS.modernCellRep,
         richStorableValues: HELLO_FLAGS.modernDataModel,
         persistentSchedulerState: HELLO_FLAGS.persistentSchedulerState,
       },

--- a/packages/memory/test/v2-test.ts
+++ b/packages/memory/test/v2-test.ts
@@ -5,6 +5,10 @@ import {
   setDataModelConfig,
 } from "@commonfabric/data-model/fabric-value";
 import {
+  resetModernCellRepConfig,
+  setModernCellRepConfig,
+} from "@commonfabric/data-model/cell-rep";
+import {
   compatibleMemoryProtocolFlags,
   decodeMemoryBoundary,
   DEFAULT_BRANCH,
@@ -110,48 +114,65 @@ describe("memory v2 source links", () => {
 
 describe("memory v2 flags", () => {
   it("reflects the active runtime storage flags", () => {
+    resetModernCellRepConfig();
     resetDataModelConfig();
     resetPersistentSchedulerStateConfig();
+    setModernCellRepConfig(false);
     setDataModelConfig(false);
     setPersistentSchedulerStateConfig(false);
 
     assertEquals(getMemoryProtocolFlags(), {
+      modernCellRep: false,
       modernDataModel: false,
       persistentSchedulerState: false,
     });
 
+    setModernCellRepConfig(true);
     setDataModelConfig(true);
     setPersistentSchedulerStateConfig(true);
 
     assertEquals(getMemoryProtocolFlags(), {
+      modernCellRep: true,
       modernDataModel: true,
       persistentSchedulerState: true,
     });
 
+    resetModernCellRepConfig();
     resetDataModelConfig();
     resetPersistentSchedulerStateConfig();
   });
 
   it("treats scheduler-state persistence as an optional capability", () => {
     assert(compatibleMemoryProtocolFlags(
-      { modernDataModel: true, persistentSchedulerState: true },
-      { modernDataModel: true, persistentSchedulerState: false },
+      { modernCellRep: true, modernDataModel: true, persistentSchedulerState: true },
+      { modernCellRep: true, modernDataModel: true, persistentSchedulerState: false },
     ));
     assertFalse(compatibleMemoryProtocolFlags(
-      { modernDataModel: true, persistentSchedulerState: true },
-      { modernDataModel: false, persistentSchedulerState: true },
+      { modernCellRep: true, modernDataModel: true, persistentSchedulerState: true },
+      { modernCellRep: true, modernDataModel: false, persistentSchedulerState: true },
     ));
   });
 });
 
 describe("parseMemoryProtocolFlags", () => {
+  it("accepts the modernCellRep key", () => {
+    assertEquals(parseMemoryProtocolFlags({ modernCellRep: true }), {
+      flags: { modernCellRep: true, modernDataModel: false, persistentSchedulerState: false },
+      wireKey: "modernDataModel",
+    });
+    assertEquals(parseMemoryProtocolFlags({ modernCellRep: false }), {
+      flags: { modernCellRep: false, modernDataModel: false, persistentSchedulerState: false },
+      wireKey: "modernDataModel",
+    });
+  });
+
   it("accepts the canonical modernDataModel key", () => {
     assertEquals(parseMemoryProtocolFlags({ modernDataModel: true }), {
-      flags: { modernDataModel: true, persistentSchedulerState: false },
+      flags: { modernCellRep: false, modernDataModel: true, persistentSchedulerState: false },
       wireKey: "modernDataModel",
     });
     assertEquals(parseMemoryProtocolFlags({ modernDataModel: false }), {
-      flags: { modernDataModel: false, persistentSchedulerState: false },
+      flags: { modernCellRep: false, modernDataModel: false, persistentSchedulerState: false },
       wireKey: "modernDataModel",
     });
   });
@@ -159,11 +180,10 @@ describe("parseMemoryProtocolFlags", () => {
   it("accepts the canonical persistentSchedulerState key", () => {
     assertEquals(
       parseMemoryProtocolFlags({
-        modernDataModel: false,
         persistentSchedulerState: true,
       }),
       {
-        flags: { modernDataModel: false, persistentSchedulerState: true },
+        flags: { modernCellRep: false, modernDataModel: false, persistentSchedulerState: true },
         wireKey: "modernDataModel",
       },
     );
@@ -171,11 +191,11 @@ describe("parseMemoryProtocolFlags", () => {
 
   it("accepts the legacy richStorableValues key and normalizes it", () => {
     assertEquals(parseMemoryProtocolFlags({ richStorableValues: true }), {
-      flags: { modernDataModel: true, persistentSchedulerState: false },
+      flags: { modernCellRep: false, modernDataModel: true, persistentSchedulerState: false },
       wireKey: "richStorableValues",
     });
     assertEquals(parseMemoryProtocolFlags({ richStorableValues: false }), {
-      flags: { modernDataModel: false, persistentSchedulerState: false },
+      flags: { modernCellRep: false, modernDataModel: false, persistentSchedulerState: false },
       wireKey: "richStorableValues",
     });
   });
@@ -187,7 +207,7 @@ describe("parseMemoryProtocolFlags", () => {
         richStorableValues: false,
       }),
       {
-        flags: { modernDataModel: true, persistentSchedulerState: false },
+        flags: { modernCellRep: false, modernDataModel: true, persistentSchedulerState: false },
         wireKey: "modernDataModel",
       },
     );

--- a/packages/memory/test/v2-test.ts
+++ b/packages/memory/test/v2-test.ts
@@ -266,7 +266,6 @@ describe("parseMemoryProtocolFlags", () => {
     assertEquals(parseMemoryProtocolFlags(undefined), null);
     assertEquals(parseMemoryProtocolFlags("modernDataModel"), null);
     assertEquals(parseMemoryProtocolFlags([true]), null);
-    assertEquals(parseMemoryProtocolFlags({}), null);
     assertEquals(parseMemoryProtocolFlags({ modernDataModel: "true" }), null);
     assertEquals(
       parseMemoryProtocolFlags({

--- a/packages/memory/test/v2-test.ts
+++ b/packages/memory/test/v2-test.ts
@@ -144,12 +144,28 @@ describe("memory v2 flags", () => {
 
   it("treats scheduler-state persistence as an optional capability", () => {
     assert(compatibleMemoryProtocolFlags(
-      { modernCellRep: true, modernDataModel: true, persistentSchedulerState: true },
-      { modernCellRep: true, modernDataModel: true, persistentSchedulerState: false },
+      {
+        modernCellRep: true,
+        modernDataModel: true,
+        persistentSchedulerState: true,
+      },
+      {
+        modernCellRep: true,
+        modernDataModel: true,
+        persistentSchedulerState: false,
+      },
     ));
     assertFalse(compatibleMemoryProtocolFlags(
-      { modernCellRep: true, modernDataModel: true, persistentSchedulerState: true },
-      { modernCellRep: true, modernDataModel: false, persistentSchedulerState: true },
+      {
+        modernCellRep: true,
+        modernDataModel: true,
+        persistentSchedulerState: true,
+      },
+      {
+        modernCellRep: true,
+        modernDataModel: false,
+        persistentSchedulerState: true,
+      },
     ));
   });
 });
@@ -157,22 +173,38 @@ describe("memory v2 flags", () => {
 describe("parseMemoryProtocolFlags", () => {
   it("accepts the modernCellRep key", () => {
     assertEquals(parseMemoryProtocolFlags({ modernCellRep: true }), {
-      flags: { modernCellRep: true, modernDataModel: false, persistentSchedulerState: false },
+      flags: {
+        modernCellRep: true,
+        modernDataModel: false,
+        persistentSchedulerState: false,
+      },
       wireKey: "modernDataModel",
     });
     assertEquals(parseMemoryProtocolFlags({ modernCellRep: false }), {
-      flags: { modernCellRep: false, modernDataModel: false, persistentSchedulerState: false },
+      flags: {
+        modernCellRep: false,
+        modernDataModel: false,
+        persistentSchedulerState: false,
+      },
       wireKey: "modernDataModel",
     });
   });
 
   it("accepts the canonical modernDataModel key", () => {
     assertEquals(parseMemoryProtocolFlags({ modernDataModel: true }), {
-      flags: { modernCellRep: false, modernDataModel: true, persistentSchedulerState: false },
+      flags: {
+        modernCellRep: false,
+        modernDataModel: true,
+        persistentSchedulerState: false,
+      },
       wireKey: "modernDataModel",
     });
     assertEquals(parseMemoryProtocolFlags({ modernDataModel: false }), {
-      flags: { modernCellRep: false, modernDataModel: false, persistentSchedulerState: false },
+      flags: {
+        modernCellRep: false,
+        modernDataModel: false,
+        persistentSchedulerState: false,
+      },
       wireKey: "modernDataModel",
     });
   });
@@ -183,7 +215,11 @@ describe("parseMemoryProtocolFlags", () => {
         persistentSchedulerState: true,
       }),
       {
-        flags: { modernCellRep: false, modernDataModel: false, persistentSchedulerState: true },
+        flags: {
+          modernCellRep: false,
+          modernDataModel: false,
+          persistentSchedulerState: true,
+        },
         wireKey: "modernDataModel",
       },
     );
@@ -191,11 +227,19 @@ describe("parseMemoryProtocolFlags", () => {
 
   it("accepts the legacy richStorableValues key and normalizes it", () => {
     assertEquals(parseMemoryProtocolFlags({ richStorableValues: true }), {
-      flags: { modernCellRep: false, modernDataModel: true, persistentSchedulerState: false },
+      flags: {
+        modernCellRep: false,
+        modernDataModel: true,
+        persistentSchedulerState: false,
+      },
       wireKey: "richStorableValues",
     });
     assertEquals(parseMemoryProtocolFlags({ richStorableValues: false }), {
-      flags: { modernCellRep: false, modernDataModel: false, persistentSchedulerState: false },
+      flags: {
+        modernCellRep: false,
+        modernDataModel: false,
+        persistentSchedulerState: false,
+      },
       wireKey: "richStorableValues",
     });
   });
@@ -207,7 +251,11 @@ describe("parseMemoryProtocolFlags", () => {
         richStorableValues: false,
       }),
       {
-        flags: { modernCellRep: false, modernDataModel: true, persistentSchedulerState: false },
+        flags: {
+          modernCellRep: false,
+          modernDataModel: true,
+          persistentSchedulerState: false,
+        },
         wireKey: "modernDataModel",
       },
     );

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -515,6 +515,20 @@ export const parseMemoryProtocolFlags = (
     };
   }
 
+  if (
+    (value.modernDataModel === undefined) &&
+    (value[LEGACY_MODERN_DATA_MODEL_KEY] === undefined)
+  ) {
+    return {
+      flags: {
+        modernCellRep: modernCellRep === true,
+        modernDataModel: false,
+        persistentSchedulerState: persistentSchedulerState === true,
+      },
+      wireKey: "modernDataModel",
+    };
+  }
+
   return null;
 };
 

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -1,4 +1,5 @@
 import { getDataModelConfig } from "@commonfabric/data-model/fabric-value";
+import { getModernCellRepConfig } from "@commonfabric/data-model/cell-rep";
 import {
   jsonFromValue,
   valueFromJson,
@@ -153,6 +154,7 @@ export interface SessionOpenResult {
 }
 
 export interface MemoryProtocolFlags {
+  modernCellRep: boolean;
   modernDataModel: boolean;
   persistentSchedulerState: boolean;
 }
@@ -169,6 +171,7 @@ export type WireFlagsKey = "modernDataModel" | "richStorableValues";
  */
 export type WireMemoryProtocolFlags =
   & { [K in WireFlagsKey]?: boolean }
+  & { modernCellRep?: boolean }
   & { persistentSchedulerState?: boolean };
 
 export interface HelloMessage {
@@ -433,6 +436,7 @@ export function resetPersistentSchedulerStateConfig(): void {
 }
 
 export const getMemoryProtocolFlags = (): MemoryProtocolFlags => ({
+  modernCellRep: getModernCellRepConfig(),
   modernDataModel: getDataModelConfig(),
   persistentSchedulerState: getPersistentSchedulerStateConfig(),
 });
@@ -441,6 +445,7 @@ export const sameMemoryProtocolFlags = (
   left: MemoryProtocolFlags,
   right: MemoryProtocolFlags,
 ): boolean =>
+  left.modernCellRep === right.modernCellRep &&
   left.modernDataModel === right.modernDataModel &&
   left.persistentSchedulerState === right.persistentSchedulerState;
 
@@ -453,7 +458,9 @@ export const sameMemoryProtocolFlags = (
 export const compatibleMemoryProtocolFlags = (
   left: MemoryProtocolFlags,
   right: MemoryProtocolFlags,
-): boolean => left.modernDataModel === right.modernDataModel;
+): boolean =>
+  (left.modernCellRep === right.modernCellRep) &&
+  (left.modernDataModel === right.modernDataModel);
 
 /**
  * Parses and normalizes incoming wire-protocol flags. Accepts either the
@@ -477,9 +484,18 @@ export const parseMemoryProtocolFlags = (
     return null;
   }
 
+  const modernCellRep = value.modernCellRep;
+  if (
+    modernCellRep !== undefined &&
+    typeof modernCellRep !== "boolean"
+  ) {
+    return null;
+  }
+
   if (typeof value.modernDataModel === "boolean") {
     return {
       flags: {
+        modernCellRep: modernCellRep === true,
         modernDataModel: value.modernDataModel,
         persistentSchedulerState: persistentSchedulerState === true,
       },
@@ -491,6 +507,7 @@ export const parseMemoryProtocolFlags = (
   if (typeof legacy === "boolean") {
     return {
       flags: {
+        modernCellRep: modernCellRep === true,
         modernDataModel: legacy,
         persistentSchedulerState: persistentSchedulerState === true,
       },
@@ -512,6 +529,7 @@ export const wireMemoryProtocolFlags = (
   wireKey: WireFlagsKey = "modernDataModel",
 ): WireMemoryProtocolFlags => ({
   [wireKey]: flags.modernDataModel,
+  modernCellRep: flags.modernCellRep,
   persistentSchedulerState: flags.persistentSchedulerState,
 });
 

--- a/packages/runner/integration/array_push.test.ts
+++ b/packages/runner/integration/array_push.test.ts
@@ -66,6 +66,7 @@ function createRuntime(identity: Identity, base: URL): Runtime {
       address: new URL("/api/storage/memory", base),
     }),
     experimental: {
+      modernCellRep: readExperimentalFlag("EXPERIMENTAL_MODERN_CELL_REP"),
       modernDataModel: readExperimentalFlag("EXPERIMENTAL_MODERN_DATA_MODEL"),
       persistentSchedulerState: readExperimentalFlag(
         "EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE",

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -20,6 +20,11 @@ import {
   setDataModelConfig,
 } from "@commonfabric/data-model/fabric-value";
 import {
+  getModernCellRepConfig,
+  resetModernCellRepConfig,
+  setModernCellRepConfig,
+} from "@commonfabric/data-model/cell-rep";
+import {
   getPersistentSchedulerStateConfig,
   resetPersistentSchedulerStateConfig,
   setPersistentSchedulerStateConfig,
@@ -175,6 +180,8 @@ export type PieceCreatedCallback = (piece: Cell<any>) => void;
  * See the formal spec at `docs/specs/space-model-formal-spec/`.
  */
 export interface ExperimentalOptions {
+  /** Enable the modern "cell representation" classes. */
+  modernCellRep?: boolean | undefined;
   /** Enable the new fabric value type system (bigint, Map, Set, Uint8Array, Date, FabricInstance). */
   modernDataModel?: boolean | undefined;
   /** Persist scheduler observations and use them for scheduler rehydration. */
@@ -329,6 +336,7 @@ export class Runtime {
 
   constructor(options: RuntimeOptions) {
     this.experimental = {
+      modernCellRep: undefined,
       modernDataModel: undefined,
       persistentSchedulerState: undefined,
       schedulerHistoricalMightWrite: undefined,
@@ -352,6 +360,8 @@ export class Runtime {
     // explicit value — without this, consumers like `createQueryResultProxy`
     // see `undefined` and treat the runtime as legacy even when the global
     // default is modern).
+    setModernCellRepConfig(this.experimental.modernCellRep);
+    this.experimental.modernCellRep = getModernCellRepConfig();
     setDataModelConfig(this.experimental.modernDataModel);
     this.experimental.modernDataModel = getDataModelConfig();
     setPersistentSchedulerStateConfig(
@@ -538,6 +548,7 @@ export class Runtime {
     this.harness.dispose();
 
     // Reset experimental config to defaults.
+    resetModernCellRepConfig();
     resetDataModelConfig();
     resetPersistentSchedulerStateConfig();
     resetEsmModuleLoaderConfig();

--- a/packages/runner/test/experimental-options.test.ts
+++ b/packages/runner/test/experimental-options.test.ts
@@ -38,6 +38,7 @@ describe("ExperimentalOptions", () => {
         apiUrl: new URL(import.meta.url),
         storageManager: sm,
         experimental: {
+          modernCellRep: false,
           modernDataModel: false,
           // Explicit so the assertion is deterministic regardless of the
           // CF_ESM_MODULE_LOADER env (e.g. during the flag-on cross-check).
@@ -45,6 +46,7 @@ describe("ExperimentalOptions", () => {
         },
       });
       expect(runtime.experimental).toEqual({
+        modernCellRep: false,
         modernDataModel: false,
         persistentSchedulerState: false,
         schedulerHistoricalMightWrite: undefined,
@@ -60,11 +62,13 @@ describe("ExperimentalOptions", () => {
         apiUrl: new URL(import.meta.url),
         storageManager: sm,
         experimental: {
+          modernCellRep: true,
           modernDataModel: true,
           esmModuleLoader: false, // explicit: deterministic regardless of env
         },
       });
       expect(runtime.experimental).toEqual({
+        modernCellRep: true,
         modernDataModel: true,
         persistentSchedulerState: false,
         schedulerHistoricalMightWrite: undefined,

--- a/packages/runner/test/experimental-options.test.ts
+++ b/packages/runner/test/experimental-options.test.ts
@@ -89,6 +89,7 @@ describe("ExperimentalOptions", () => {
         },
       });
       expect(runtime.experimental).toEqual({
+        modernCellRep: false,
         modernDataModel: true,
         persistentSchedulerState: false,
         schedulerHistoricalMightWrite: undefined,

--- a/packages/shell/felt.config.ts
+++ b/packages/shell/felt.config.ts
@@ -41,6 +41,9 @@ const config: Config = {
       "$ENVIRONMENT": ENVIRONMENT,
       "$API_URL": Deno.env.get("API_URL"),
       "$COMMIT_SHA": Deno.env.get("COMMIT_SHA"),
+      "$EXPERIMENTAL_MODERN_CELL_REP": Deno.env.get(
+        "EXPERIMENTAL_MODERN_CELL_REP",
+      ),
       "$EXPERIMENTAL_MODERN_DATA_MODEL": Deno.env.get(
         "EXPERIMENTAL_MODERN_DATA_MODEL",
       ),

--- a/packages/shell/src/lib/env.ts
+++ b/packages/shell/src/lib/env.ts
@@ -2,6 +2,7 @@ declare global {
   var $ENVIRONMENT: string | undefined;
   var $API_URL: string | undefined;
   var $COMMIT_SHA: string | undefined;
+  var $EXPERIMENTAL_MODERN_CELL_REP: string | undefined;
   var $EXPERIMENTAL_MODERN_DATA_MODEL: string | undefined;
   var $EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE: string | undefined;
   var $EXPERIMENTAL_ESM_MODULE_LOADER: string | undefined;
@@ -15,6 +16,10 @@ const API_URL_DEFINE = typeof $API_URL === "string" ? $API_URL : undefined;
 const COMMIT_SHA_DEFINE = typeof $COMMIT_SHA === "string"
   ? $COMMIT_SHA
   : undefined;
+const EXPERIMENTAL_MODERN_CELL_REP_DEFINE =
+  typeof $EXPERIMENTAL_MODERN_CELL_REP === "string"
+    ? $EXPERIMENTAL_MODERN_CELL_REP
+    : undefined;
 const EXPERIMENTAL_MODERN_DATA_MODEL_DEFINE =
   typeof $EXPERIMENTAL_MODERN_DATA_MODEL === "string"
     ? $EXPERIMENTAL_MODERN_DATA_MODEL
@@ -63,6 +68,7 @@ function esmLoaderFlagValue(flag: string | undefined): boolean | undefined {
 
 /** Build-time experimental flags, injected via felt.config.ts defines. */
 export const EXPERIMENTAL = {
+  modernCellRep: flagValue(EXPERIMENTAL_MODERN_CELL_REP_DEFINE),
   modernDataModel: flagValue(EXPERIMENTAL_MODERN_DATA_MODEL_DEFINE),
   persistentSchedulerState: flagValue(
     EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE_DEFINE,

--- a/packages/shell/test/env.test.ts
+++ b/packages/shell/test/env.test.ts
@@ -33,11 +33,13 @@ Deno.test({
   async fn() {
     const mod = await withPatchedGlobals({
       $API_URL: "http://shell.test/",
+      $EXPERIMENTAL_MODERN_CELL_REP: "true",
       $EXPERIMENTAL_MODERN_DATA_MODEL: "true",
       $EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE: "true",
     }, importFreshEnvModule);
 
     expect(mod.EXPERIMENTAL).toEqual({
+      modernCellRep: true,
       modernDataModel: true,
       persistentSchedulerState: true,
     });

--- a/packages/shell/test/felt-config.test.ts
+++ b/packages/shell/test/felt-config.test.ts
@@ -42,11 +42,13 @@ async function importFreshConfig() {
 describe("shell felt config", () => {
   it("wires modern experimental env vars into build-time defines", async () => {
     const config = await withEnv({
+      EXPERIMENTAL_MODERN_CELL_REP: "true",
       EXPERIMENTAL_MODERN_DATA_MODEL: "true",
       EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE: "true",
     }, importFreshConfig);
 
     expect(config.esbuild?.define).toMatchObject({
+      $EXPERIMENTAL_MODERN_CELL_REP: "true",
       $EXPERIMENTAL_MODERN_DATA_MODEL: "true",
       $EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE: "true",
     });

--- a/packages/shell/test/runtime-navigation.test.ts
+++ b/packages/shell/test/runtime-navigation.test.ts
@@ -89,6 +89,7 @@ describe("RuntimeInternals navigation", () => {
       $ENVIRONMENT?: string;
       $COMMIT_SHA?: string;
       $MEMORY_VERSION?: string;
+      $EXPERIMENTAL_MODERN_CELL_REP?: string;
       $EXPERIMENTAL_MODERN_DATA_MODEL?: string;
       $COMPILATION_CACHE_CLIENT?: string;
     };
@@ -97,6 +98,7 @@ describe("RuntimeInternals navigation", () => {
       $ENVIRONMENT: env.$ENVIRONMENT,
       $COMMIT_SHA: env.$COMMIT_SHA,
       $MEMORY_VERSION: env.$MEMORY_VERSION,
+      $EXPERIMENTAL_MODERN_CELL_REP: env.$EXPERIMENTAL_MODERN_CELL_REP,
       $EXPERIMENTAL_MODERN_DATA_MODEL: env.$EXPERIMENTAL_MODERN_DATA_MODEL,
       $COMPILATION_CACHE_CLIENT: env.$COMPILATION_CACHE_CLIENT,
     };
@@ -104,6 +106,7 @@ describe("RuntimeInternals navigation", () => {
     env.$ENVIRONMENT = "development";
     env.$COMMIT_SHA = undefined;
     env.$MEMORY_VERSION = undefined;
+    env.$EXPERIMENTAL_MODERN_CELL_REP = undefined;
     env.$EXPERIMENTAL_MODERN_DATA_MODEL = undefined;
     env.$COMPILATION_CACHE_CLIENT = undefined;
 
@@ -164,6 +167,8 @@ describe("RuntimeInternals navigation", () => {
       env.$ENVIRONMENT = originalEnv.$ENVIRONMENT;
       env.$COMMIT_SHA = originalEnv.$COMMIT_SHA;
       env.$MEMORY_VERSION = originalEnv.$MEMORY_VERSION;
+      env.$EXPERIMENTAL_MODERN_CELL_REP =
+        originalEnv.$EXPERIMENTAL_MODERN_CELL_REP;
       env.$EXPERIMENTAL_MODERN_DATA_MODEL =
         originalEnv.$EXPERIMENTAL_MODERN_DATA_MODEL;
       env.$COMPILATION_CACHE_CLIENT = originalEnv.$COMPILATION_CACHE_CLIENT;
@@ -177,6 +182,7 @@ describe("RuntimeInternals navigation", () => {
       $ENVIRONMENT?: string;
       $COMMIT_SHA?: string;
       $MEMORY_VERSION?: string;
+      $EXPERIMENTAL_MODERN_CELL_REP?: string;
       $EXPERIMENTAL_MODERN_DATA_MODEL?: string;
       $COMPILATION_CACHE_CLIENT?: string;
     };
@@ -185,6 +191,7 @@ describe("RuntimeInternals navigation", () => {
       $ENVIRONMENT: env.$ENVIRONMENT,
       $COMMIT_SHA: env.$COMMIT_SHA,
       $MEMORY_VERSION: env.$MEMORY_VERSION,
+      $EXPERIMENTAL_MODERN_CELL_REP: env.$EXPERIMENTAL_MODERN_CELL_REP,
       $EXPERIMENTAL_MODERN_DATA_MODEL: env.$EXPERIMENTAL_MODERN_DATA_MODEL,
       $COMPILATION_CACHE_CLIENT: env.$COMPILATION_CACHE_CLIENT,
     };
@@ -192,6 +199,7 @@ describe("RuntimeInternals navigation", () => {
     env.$ENVIRONMENT = "development";
     env.$COMMIT_SHA = undefined;
     env.$MEMORY_VERSION = undefined;
+    env.$EXPERIMENTAL_MODERN_CELL_REP = undefined;
     env.$EXPERIMENTAL_MODERN_DATA_MODEL = undefined;
     env.$COMPILATION_CACHE_CLIENT = undefined;
 
@@ -237,6 +245,8 @@ describe("RuntimeInternals navigation", () => {
       env.$ENVIRONMENT = originalEnv.$ENVIRONMENT;
       env.$COMMIT_SHA = originalEnv.$COMMIT_SHA;
       env.$MEMORY_VERSION = originalEnv.$MEMORY_VERSION;
+      env.$EXPERIMENTAL_MODERN_CELL_REP =
+        originalEnv.$EXPERIMENTAL_MODERN_CELL_REP;
       env.$EXPERIMENTAL_MODERN_DATA_MODEL =
         originalEnv.$EXPERIMENTAL_MODERN_DATA_MODEL;
       env.$COMPILATION_CACHE_CLIENT = originalEnv.$COMPILATION_CACHE_CLIENT;

--- a/packages/toolshed/env.ts
+++ b/packages/toolshed/env.ts
@@ -205,6 +205,7 @@ const EnvSchema = z.object({
   // env var to "false" would incorrectly enable the flag. The other boolean
   // env vars in this file have the same latent bug.
   // ===========================================================================
+  EXPERIMENTAL_MODERN_CELL_REP: flagValue(),
   EXPERIMENTAL_MODERN_DATA_MODEL: flagValue(),
   EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE: flagValue(),
 

--- a/packages/toolshed/index.ts
+++ b/packages/toolshed/index.ts
@@ -55,6 +55,7 @@ const initializeRuntime = async () => {
         as: identity,
       }),
       experimental: {
+        modernCellRep: env.EXPERIMENTAL_MODERN_CELL_REP,
         modernDataModel: env.EXPERIMENTAL_MODERN_DATA_MODEL,
         persistentSchedulerState: env.EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE,
       },


### PR DESCRIPTION
This PR does all the plumbing work to define a new "modern cell representation" experiment flag, without hooking it up to anything yet. Future PRs will define functionality behind this flag.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `modernCellRep` experiment flag and wires it through runtime, env/build config, CLI/toolshed, and the memory v2 protocol. No behavior change yet; this only sets and carries the flag and updates protocol parsing/compat to include it.

- **New Features**
  - Introduced `modernCellRep` flag with env var `EXPERIMENTAL_MODERN_CELL_REP`.
  - Added `@commonfabric/data-model/cell-rep` with `setModernCellRepConfig()`, `getModernCellRepConfig()`, `resetModernCellRepConfig()`.
  - Extended `Runtime.experimental` to include `modernCellRep`; sets on construct and resets on dispose.
  - Wired shell defines (`felt`), `EXPERIMENTAL` reads, CLI, toolshed, and background charm service to pass the flag.
  - Memory v2: added `modernCellRep` to `MemoryProtocolFlags`, included in wire encoding, and required by `compatibleMemoryProtocolFlags`.
  - `parseMemoryProtocolFlags` now accepts `modernCellRep` and empty flag objects, defaulting `modernDataModel` to `false` when omitted.
  - Updated docs and tests to cover the new flag and parsing/compat behavior.

<sup>Written for commit 87f113bf77e4b34e06e93c1ae239e18e6d651b50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

