### PR TITLE
docs: retire reactive `derive` references → computed()/lift-applied (CT-1643)

### DIFF
--- a/docs/development/debugging/cli-debugging.md
+++ b/docs/development/debugging/cli-debugging.md
@@ -46,7 +46,7 @@ This is the fastest way to inspect how `ts-transformers` rewrote:
 
 - JSX expressions
 - reactive array-method chains like `.map()` / `.filter()`
-- `computed()` / `derive()` wrapping
+- `computed()` wrapping
 - downstream schema/capability lowering effects
 
 It also works on fixture inputs while debugging the compiler itself:

--- a/docs/development/debugging/gotchas/closure-capture-in-nested-map.md
+++ b/docs/development/debugging/gotchas/closure-capture-in-nested-map.md
@@ -23,7 +23,7 @@
 fails fast) with one of these strings:
 
 > Reactive reference from outer scope cannot be accessed via closure. Wrap the
-> access in a derive that passes the variable through, or use computed() which
+> access in a computed() that passes the variable through, which
 > handles this automatically.
 
 > Cannot access cell via closure - reactive dependencies must be explicit

--- a/docs/development/scoped-cells-field-notes.md
+++ b/docs/development/scoped-cells-field-notes.md
@@ -23,8 +23,8 @@ Established what works, what doesn't, and what looks broken in the runtime.
   leak to another. Concretely observable: CLI `inspect` running as
   `claude.key` shows `myName: ""` while the browser session shows `"Alex"` —
   same cell id, different scope key.
-- **Derived scope checks.** `isJoined = derive(myName, …)` and `isAdmin =
-  derive({myName, adminName}, …)` flip correctly when their dependencies
+- **Derived scope checks.** `isJoined = computed(() => …)` and `isAdmin =
+  computed(() => …)` flip correctly when their dependencies
   update.
 - **First-writer-wins admin claim.** The handler that does `if
   (adminName.get() === "") { adminName.set(me); }` works correctly. The
@@ -52,7 +52,7 @@ These are the things that bit during the build. Each is also captured in
 
 2. **`.length` on a top-level `PerSpace<Array>` doesn't lift reactively.**
    `users.length` snapshots once. Have to write
-   `derive(users, u => u.length)`. Nested access through an object cell
+   `computed(() => users.length)`. Nested access through an object cell
    (`conversation.rooms.length`) works fine, but a top-level array does not.
    First version of the test reported `undefined` for `userCount`.
 
@@ -113,7 +113,7 @@ that locks this case in.
 #### B2. ~~`array.length` on a top-level scoped array doesn't lift reactively~~ — NOT A BUG
 
 **Status:** Investigated and closed. Per `--show-transformed` analysis,
-both `items.length` and `derive(items, i => i.length)` lower to the same
+both `items.length` and `computed(() => items.length)` lower to the same
 underlying reads. The behavioral diff observed in the first cozy-poll test
 was likely an artifact of how the test asserted (see B3) or a misread.
 

--- a/docs/specs/module-loading-verifier-and-engine-design.md
+++ b/docs/specs/module-loading-verifier-and-engine-design.md
@@ -56,7 +56,7 @@ execution) via `CompiledBundleValidator.verify()`. It has two distinct layers:
    - top-level `const` only — `let`/`var` rejected (no mutable module state);
    - each `const` initializer must be one of: a **direct function**
      (function/arrow with brace body), a **trusted-builder call**
-     (`pattern`/`lift`/`handler`/`action`/`computed`/`derive`) whose callback
+     (`pattern`/`lift`/`handler`/`action`/`computed`) whose callback
      argument is a *direct* callback at the builder-specific arg index
      (`callbackIndexesForBuilder`), a **trusted data-helper call**
      (`__cf_data`/`schema`/`safeDateNow`/`nonPrivateRandom` with exact arity), or

--- a/docs/specs/persistent-scheduler-state.md
+++ b/docs/specs/persistent-scheduler-state.md
@@ -726,7 +726,7 @@ all possible downstream readers when an input changes, because that recreates
 the broad fanout that pull mode is trying to avoid.
 
 Materializer identity is explicit scheduler metadata. For generated
-`computed()`/`derive()` callbacks, the transformer emits
+`computed()` callbacks, the transformer emits
 `materializerWriteInputPaths` only when capability analysis observes actual
 writes through captured cell inputs; the runner resolves those input paths to
 `materializerWriteEnvelopes` for the concrete action instance. A generated

--- a/docs/specs/pull-based-scheduler/README.md
+++ b/docs/specs/pull-based-scheduler/README.md
@@ -32,7 +32,7 @@ An **action** is a function `(tx: Transaction) => any` that the scheduler manage
 |-------------------|---------------------|-------------|
 | `sink(cell, callback)` | Effect | Runs callback when cell changes |
 | `lift(fn, ...inputs)` | Computation | Transforms inputs, writes to output cell |
-| `derive(input, fn)` | Computation | Derives new value from input |
+| `computed(() => ...)` | Computation | Derives a new reactive value |
 | Event handlers | Queued event action | Responds to user events |
 
 The scheduler doesn't know about patterns - it only sees actions with read/write dependencies.
@@ -98,7 +98,7 @@ writable-input targets are represented as `materializerWriteEnvelopes`, a
 separate pull-mode index.
 
 Materializer membership normally comes from explicit module/action metadata.
-For generated `computed()`/`derive()` callbacks, the transformer emits
+For generated `computed()` callbacks, the transformer emits
 `materializerWriteInputPaths` only when capability analysis observes actual
 writes through captured cell inputs. A Writable input in an output-producing
 generated action schema is not enough evidence: pure computations commonly

--- a/docs/specs/sandboxing/SES_SANDBOXING_SPEC.md
+++ b/docs/specs/sandboxing/SES_SANDBOXING_SPEC.md
@@ -123,7 +123,7 @@ Pattern Source (.tsx)
     ↓
 [1] ts-transformers (enhanced)
     - Hoist lift/handler to module scope (when external references exist)
-    - Rewrite inline derive → lift call
+    - Lower `computed(...)` to the lift-applied form `lift(...)(input)`
     - Emit optional verification hints for top-level items
     ↓
 [2] js-compiler (existing)
@@ -194,9 +194,8 @@ The `ts-transformers` package requires the following enhancements:
 
 | Transformation | Current Behavior | New Behavior |
 |----------------|------------------|--------------|
-| `computed(() => ...)` | → `derive({}, () => ...)` | → hoist `lift(...)` when the post-transform callback still depends on imports or module scope |
+| `computed(() => ...)` | → `lift(() => ...)({})` (lift-applied) | → hoist `lift(...)` when the post-transform callback still depends on imports or module scope |
 | `action(() => ...)` | → `handler((_, {}) => ...)({})` | → hoist `handler(...)` when the post-transform callback still depends on imports or module scope |
-| inline `derive(input, fn)` | kept inline | → hoist `lift(...)` when the post-transform callback still depends on imports or module scope |
 | `lift(...)` | allowed inline | **ERROR** if not at module scope |
 | `handler(...)` | allowed inline | **ERROR** if not at module scope |
 | module-scope calls | minimal validation | strict allowlist enforcement |
@@ -506,7 +505,8 @@ raw authored callback.
 
 By the time this hoisting pass runs:
 
-- `computed(...)` has already been rewritten to `derive(...)`
+- `computed(...)` has already been rewritten to the lift-applied form
+  `lift(...)(input)`
 - `action(...)` has already been rewritten to `handler(...)(params)`
 - closure lowering has already converted local closed-over values into explicit
   callback parameters / params objects where possible
@@ -531,13 +531,13 @@ This is the default behavior, not merely an optimization.
 
 ```typescript
 // This stays inline (self-contained after normalization)
-const doubled = derive(props.value, x => x * 2);
+const doubled = lift(({ value }) => value * 2)({ value: props.value });
 
 // This MUST be hoisted (still references module scope after normalization)
-const doubled = derive(props.value, x => x * multiplier);
+const doubled = lift(({ value }) => value * multiplier)({ value: props.value });
 ```
 
-#### 4.3.1 Computed / Derive Hoisting Rule
+#### 4.3.1 Computed Hoisting Rule
 
 **Before (current):**
 ```typescript
@@ -550,25 +550,25 @@ export const MyPattern = pattern<Input, Output>((props) => {
 **After transformation (current):**
 ```typescript
 export const MyPattern = pattern<Input, Output>((props) => {
-  const doubled = derive({}, () => props.value * 2);
+  const doubled = lift(({ value }) => value * 2)({ value: props.value });
   return { doubled };
 });
 ```
 
-If the post-transform derive callback is self-contained, it stays inline.
+If the post-transform lift-applied callback is self-contained, it stays inline.
 
-If the post-transform derive callback still references imports or module scope,
-the transformer must hoist the builder factory, not the fully applied call.
-This applies equally to nested builder callbacks introduced by helpers such as
+If the post-transform callback still references imports or module scope, the
+transformer must hoist the builder factory, not the fully applied call. This
+applies equally to nested builder callbacks introduced by helpers such as
 `map(...)`, `mapWithPattern(...)`, or inline sub-`pattern(...)` creation. If
 the post-transform callback still sees module-scoped bindings, it must be
 lifted to module scope so verified evaluation can mint and register a stable
 `implementationRef` for the real executable body.
 
-Concretely:
+Concretely, the lift-applied shape splits into a factory and an application:
 
-- starting point: `derive(inputSchema, outputSchema, params, fn)`
-- hoist target: `lift(inputSchema, outputSchema, fn)`
+- starting point: `lift(inputSchema, outputSchema, fn)(params)`
+- hoist target: `lift(inputSchema, outputSchema, fn)` (the factory)
 - original-site replacement: `hoistedLift(params)`
 
 **After transformation (new, when hoisting is required):**
@@ -583,12 +583,6 @@ export const MyPattern = pattern<Input, Output>((props) => {
   return { doubled };
 });
 ```
-
-The same rule applies to explicit `derive(...)` calls:
-
-- if the post-transform callback is self-contained, keep `derive(...)` inline
-- if it still depends on imports or module scope, hoist `lift(...)` and leave
-  the application with `(params)` at the original location
 
 #### 4.3.2 Action / Handler Hoisting Rule
 
@@ -643,7 +637,7 @@ explicitly and are not the target of the module-hoisting rule above.
 **Before:**
 ```typescript
 export const MyPattern = pattern<Input, Output>((props) => {
-  const total = derive(props.items, items => items.reduce((a, b) => a + b, 0));
+  const total = computed(() => props.items.reduce((a, b) => a + b, 0));
   return { total };
 });
 ```
@@ -865,7 +859,7 @@ not currently exposed to authored SES modules through `runtimeDeps`.
 These runtime modules may export:
 
 - module-scope trusted builder entrypoints: `pattern`, `lift`, `handler`,
-  `action`, `derive`, `computed`
+  `action`, `computed`
 - callback-scope helper entrypoints such as `patternTool(...)`, which remain
   valid inside verified pattern callbacks but are not part of the module-scope
   trusted-builder allowlist
@@ -1756,7 +1750,7 @@ module even if the hints are wrong or missing.
 - `packages/ts-transformers/src/hoisting/*`
 - compiler pipeline entrypoints that preserve the hints into emitted JS
 
-#### 1.2 Hoist computed/action/derive when useful (Priority: High)
+#### 1.2 Hoist computed/action when useful (Priority: High)
 
 Continue to hoist only when the post-transform builder callback still depends on
 imports or module scope. Earlier closure-lowering passes already internalize
@@ -1765,8 +1759,9 @@ references after normalization.
 
 The hoist target must be the builder factory:
 
-- `derive(inputSchema, outputSchema, params, fn)` hoists as
-  `lift(inputSchema, outputSchema, fn)` and leaves the `(params)` call in place
+- `lift(inputSchema, outputSchema, fn)(params)` (the lift-applied form, e.g.
+  from `computed(...)`) hoists as `lift(inputSchema, outputSchema, fn)` and
+  leaves the `(params)` call in place
 - `handler(eventSchema, stateSchema, fn)(params)` hoists as
   `handler(eventSchema, stateSchema, fn)` and leaves the `(params)` call in
   place

--- a/docs/specs/scoped-cell-instances.md
+++ b/docs/specs/scoped-cell-instances.md
@@ -425,7 +425,7 @@ computation rules below.
 
 ## Computation Rules
 
-For ordinary compute nodes, including `derive`, `computed`, and `lift`, the
+For ordinary compute nodes, including `computed` and `lift`, the
 logical output schema has the narrowest scope of the input schemas.
 
 If a computation whose output location is broader reads data from a narrower

--- a/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_current_behavior_spec.md
@@ -100,7 +100,6 @@ Current mode-sensitive behavior:
 `detectCallKind()` drives multiple transformers. It recognizes:
 
 - builders: `pattern`, `handler`, `action`, `lift`, `computed`, `render`
-- `derive`
 - `ifElse`, `when`, `unless`
 - reactive array calls (`map`, `mapWithPattern`, `filter`, `filterWithPattern`,
   `flatMap`, `flatMapWithPattern`)
@@ -175,7 +174,6 @@ On call `receiver.get()` (no args):
   - structurally traces back to a reactive-origin call result/alias/binding
     initialized from one of:
     - builders (`pattern`, `computed`, `lift`, `handler`, `action`, `render`)
-    - `derive`
     - `ifElse`, `when`, `unless`
     - cell factories / `Cell.for`
     - `wish`
@@ -205,7 +203,7 @@ access chain. This means `as any` single casts do not hide property accesses
 from capability analysis.
 
 When interprocedural analysis is enabled (compute-context builders like `lift`,
-`derive`, `handler`), read paths discovered in helper function bodies propagate
+`handler`), read paths discovered in helper function bodies propagate
 back to the caller's parameter summary, but the current MVP intentionally only
 does this for resolved helper bodies in the same source file. Cross-file or
 otherwise unsupported helper calls fall back to the conservative wildcard path
@@ -277,7 +275,7 @@ Restricted contexts are callbacks of:
 
 Compute wrappers override restrictions:
 
-- `computed`, `action`, `derive`, `lift`, `handler` callbacks
+- `computed`, `action`, `lift`, `handler` callbacks
 - inline JSX `on*` handlers
 - standalone function definitions
 - JSX expressions (handled by opaque-ref JSX transformer)
@@ -294,19 +292,19 @@ Diagnostics emitted in all modes:
   - special message for immediate `lift(fn)(args)` suggesting `computed()`
 - **Error** `standalone-function:reactive-operation`
   - in standalone functions (except inline first arg to `patternTool`):
-    `computed(...)`, `derive(...)`, or reactive collection methods on reactive
+    `computed(...)`, `lift(...)`, or reactive collection methods on reactive
     receivers
   - collection-method diagnostics currently use `.map(...)`-style guidance and
     suggest eager `<cell>.get().map(...)` when explicit eager mapping is
     acceptable
 - **Error** `compute-context:local-reactive-use`
-  - inside a `computed(...)`/`derive(...)` callback, a reactive value created in
+  - inside a `computed(...)`/`lift(...)` callback, a reactive value created in
     that same callback is consumed as a plain value in control-flow or another
     non-lowered computation site
-  - typical culprits are local `computed(...)`, `derive(...)`, `lift(...)`,
+  - typical culprits are local `computed(...)`, `lift(...)`,
     `wish(...)`, or reactive collection aliases and their property accesses
   - message instructs the author to move the use into a nested
-    `computed(() => ...)` or `derive(() => ...)`
+    `computed(() => ...)` or module-scope `lift()`
 - **Error** `pattern-context:optional-chaining`
   - optional calls in restricted reactive context (outside JSX)
   - optional property / element access that appears outside a supported
@@ -388,7 +386,7 @@ For each `JsxExpression`:
 - if no rewrite required and no logical binary operators (`&&`, `||`), skip
 - in compute context:
   - only semantic logical rewrites (`&&`/`||`) are considered
-  - derive/computed wrapping is skipped
+  - computed wrapping is skipped
 - compute-context JSX does not lower `&&` / `||`
 - pattern-context JSX lowers `&&` / `||` deterministically
 - in `mode: "error"`:
@@ -417,9 +415,9 @@ Key rewrite rules:
   - becomes `ifElse(cond, x, y)` with branch/predicate processing
 - non-compute contexts:
   - complex reactive expressions are wrapped via `computed(() => expr)` (later
-    lowered to `derive`)
+    lowered to the lift-applied form)
 - compute contexts:
-  - no derive/computed wrappers; only child rewrites and logical conversions
+  - no computed wrappers; only child rewrites and logical conversions
 
 Helper-owned compute branches introduced by ternary / conditional-helper
 rewriting are re-analyzed with synthetic compute ownership. This preserves
@@ -588,7 +586,7 @@ Current-main behavior distinguishes three buckets for non-JSX authored sites:
      `variable-initializer`, `object-property`, `array-element`, and
      `return-expression`
 2. **explicit compute callbacks**
-   - `computed` / `derive` / `action` / `lift` / `handler` callbacks remain the
+   - `computed` / `action` / `lift` / `handler` callbacks remain the
      explicit reactive boundary
    - inside those callbacks, authored conditionals stay authored JS inside the
      callback body rather than being rewritten to helper control flow
@@ -787,9 +785,9 @@ pipeline. Current built-in behavior:
 
 ## 13. Current Known Limits (Observed)
 
-1. Generic helper functions with uninstantiated type-parameter derive result
-   types can degrade schema precision (type arguments may be intentionally
-   omitted).
+1. Generic helper functions with uninstantiated type-parameter lift-applied
+   result types can degrade schema precision (type arguments may be
+   intentionally omitted).
 2. Action and JSX inline handler callback extraction currently unwraps arrow
    functions only.
 3. Optional-call forms on opaque pattern roots are non-lowerable and report
@@ -827,7 +825,7 @@ Additional non-fixture unit suites cover:
 - event-handler detection heuristics
 - opaque-ref analysis/normalization/runtime-style APIs
 - pipeline regression and policy/capability-analysis behavior
-- derive call helper and identifier utilities
+- lift-applied call helper and identifier utilities
 
 ## 15. Stability Statement
 

--- a/docs/specs/ts-transformer/ts_transformers_design_deltas.md
+++ b/docs/specs/ts-transformer/ts_transformers_design_deltas.md
@@ -30,7 +30,7 @@ behavior and open follow-up work.
   - local reactive rewrap aliases in compute callbacks can re-enter collection
     rewrite eligibility
   - pattern callback canonicalization and `key(...)` lowering
-  - local opaque-root rewriting inside derive callbacks
+  - local opaque-root rewriting inside lift-applied callbacks
   - capability analysis with path/capability shrinking at schema boundaries
   - additive wrapper support for `ReadonlyCell` / `WriteonlyCell` / `OpaqueCell`
   - structural reactive-origin detection for `.get()` validation and opaque-root
@@ -50,7 +50,7 @@ behavior and open follow-up work.
   - schema shrink validation for declared `unknown`-typed properties
   - array item shrinking to `unknown` when only non-item properties (for
     example `.length`) are observed
-  - projected-result / object-literal schema recovery for derive/lift result
+  - projected-result / object-literal schema recovery for lift result
     inference
   - compute-context local reactive alias diagnostics
 - Partially landed:
@@ -67,7 +67,7 @@ behavior and open follow-up work.
 **Proposed terms:**
 
 - `compute context` for callbacks where values are being computed in a wrapped
-  compute form (`computed`, `derive`, `action`, `lift`, `handler`, etc.)
+  compute form (`computed`, `action`, `lift`, `handler`, etc.)
 - `pattern context` for top-level pattern/render-style author code where
   parameters are opaque by default and direct computation should trigger
   guidance/rewrite
@@ -122,7 +122,7 @@ behavior and open follow-up work.
   non-auto-unwrapped cell-like set (`Cell`, `Writable`, `Stream`, etc.).
 - In **compute context**, local aliases created inside the same callback may
   become reactive again when they re-wrap a reactive collection via
-  `computed(...)`, `derive(...)`, `lift(...)`, `action(...)`, `handler(...)`,
+  `computed(...)`, `lift(...)`, `action(...)`, `handler(...)`,
   `wish(...)`, or an already-lowered reactive collection call.
 - Never rewrite plain JS array operators.
 - The callback parameter of `.map` is treated as a **pattern callback
@@ -186,7 +186,7 @@ contract support).
   read/written, with conservative fallback to broader shape on unknown-dynamic
   operations.
 - Preserve broad pattern boundary shapes (including schema defaults) so links to
-  downstream `compute`/`handler`/`derive` code do not lose fields that are not
+  downstream `compute`/`handler` code do not lose fields that are not
   directly read in the outer pattern callback.
 - In pattern-style contexts, treat "lowerable to opaque/key semantics" as the
   primary legality criterion. Uses that cannot be lowered should produce
@@ -218,7 +218,7 @@ contract support).
 
 1. Rewrite decisions for collection and conditional operators can be explained
    from `{context, receiver capability summary}`, not `OpaqueRef` heuristics.
-2. Boundary schemas/types for compute-oriented boundaries (`derive`, `lift`,
+2. Boundary schemas/types for compute-oriented boundaries (`lift`,
    `handler`, compute-like callbacks) can be shrunk to used paths when no
    wildcard operations are present.
 3. Wildcard/dynamic operations (`...obj`, `Object.keys`, `for..in`, `for..of`,
@@ -369,7 +369,7 @@ Lowering is acceptable only when semantic equivalence is exact.
 ## P-005 Make Reactive Boundaries Explicit Where Opaque Values Dominate
 
 In pattern context, emitted forms should make reactive/opaque boundaries
-explicit (`when`, `unless`, `ifElse`, `derive`, schema boundaries), to reduce
+explicit (`when`, `unless`, `ifElse`, schema boundaries), to reduce
 implicit behavior and runtime ambiguity.
 
 ## P-006 Minimize Rewrite Surface In Compute Context
@@ -463,7 +463,7 @@ interface ReactiveContextInfo {
     | "render"
     | "array-map"
     | "computed"
-    | "derive"
+    | "lift-applied"
     | "action"
     | "lift"
     | "handler"
@@ -481,7 +481,7 @@ passes as authoritative context boundaries. Example target behavior:
 <div>{[0, 1].forEach(() => list.map(...))}</div>
 ```
 
-If JSX rewriting first introduces a compute wrapper (`computed`/`derive`) around
+If JSX rewriting first introduces a compute wrapper (`computed`) around
 this expression, the nested `list.map(...)` is in compute context for subsequent
 collection rewrite policy.
 
@@ -504,7 +504,7 @@ Emitters/strategies call policy functions instead of embedding local logic.
 **Current complexity:** `emitBinaryExpression` mixes:
 
 1. logical lowering (`&&`/`||`)
-2. derive/computed wrapping fallback
+2. computed wrapping fallback
 3. expensive-RHS heuristics
 
 **Recommendation:** structure as:
@@ -714,7 +714,7 @@ logic.
 **Status:** Landed (intraprocedural)
 
 1. Tag analysis origins from:
-   - pattern/lift/derive/handler/action callback parameters
+   - pattern/lift/handler/action callback parameters
    - results of `lift(...)` and `pattern(...)` invoked within pattern code
    - `.map` callback parameters only when that call site is selected for
      `mapWithPattern` rewrite

--- a/docs/specs/ts-transformer/ts_transformers_goals.md
+++ b/docs/specs/ts-transformer/ts_transformers_goals.md
@@ -44,7 +44,7 @@ Authors should be able to:
 
 The runtime should receive:
 
-1. explicit schemas for significant boundaries (`pattern`, `derive`, `lift`,
+1. explicit schemas for significant boundaries (`pattern`, `lift`,
    `handler`, `cell`, `wish`, `generateObject`, conditional helpers)
 2. explicit closure capture params instead of hidden lexical captures
 3. explicit control-flow helper calls where required by reactive semantics

--- a/docs/specs/ts-transformer/ts_transformers_lowering_contract.md
+++ b/docs/specs/ts-transformer/ts_transformers_lowering_contract.md
@@ -32,7 +32,7 @@ especially:
 - reactive control flow
 - reactive collection operators
 - property/element access over reactive values
-- wrapper introduction (`derive`, `computed`, helper control-flow forms)
+- wrapper introduction (`computed`, helper control-flow forms)
 - callback capture and ownership lowering
 
 ## 3. Semantic Invariants
@@ -71,7 +71,6 @@ An outer rewrite must not silently root-rewrite through a nested reactive
 context boundary such as:
 
 - `computed(...)`
-- `derive(...)`
 - `action(...)`
 - `handler(...)`
 - rewritten collection callbacks

--- a/docs/specs/ts-transformer/ts_transformers_review_guide.md
+++ b/docs/specs/ts-transformer/ts_transformers_review_guide.md
@@ -41,7 +41,7 @@ for this PR is:
 - **Supported**
   - local reactive value expressions in JSX
   - authored helper control flow (`ifElse`, `when`, `unless`)
-  - explicit computation callbacks (`computed`, `derive`, `action`, `lift`,
+  - explicit computation callbacks (`computed`, `action`, `lift`,
     `handler`)
   - supported reactive collection callbacks (`map` / `filter` / `flatMap`)
   - top-level pattern-body lowerable value-expression sites such as returned

--- a/docs/specs/ts-transformer/ts_transformers_target_pattern_language_spec.md
+++ b/docs/specs/ts-transformer/ts_transformers_target_pattern_language_spec.md
@@ -407,7 +407,7 @@ construct is only supportable by compatibility behavior such as:
 
 1. leaving the foreign container authored as plain JS
 2. or, in older/rarer cases, wrapping the whole foreign container as one
-   compute/derive island
+   compute island
 
 that is strong evidence it should be rejected from the target language rather
 than elevated into the core language.

--- a/skills/pattern-debug/SKILL.md
+++ b/skills/pattern-debug/SKILL.md
@@ -101,7 +101,7 @@ a function:**
 
 - Inside `computed()` body, ternaries are plain JS (Writable objects always
   truthy)
-- Cell bindings (`$value`, `$checked`) inside `derive()` may get positionally
+- Cell bindings (`$value`, `$checked`) inside `computed()` may get positionally
   mis-resolved
 - Fix: use bare JSX ternaries, hoist `computed()` for data only
 - See `docs/common/concepts/computed/computed.md`


### PR DESCRIPTION
Final docs/skills sweep for [CT-1643](https://linear.app/common-tools/issue/CT-1643), now that `derive` is fully removed from `ts-transformers/src` (#3809 renamed the internal label + diagnostics; #3817 removed the dead legacy-shape code). Docs only — no code changes.

The lowered form of a reactive lifted-function computation is the **lift-applied** shape (`lift(...)(input)`, produced from `computed()`); this PR updates spec/skill references that still named `derive` as a current authored or lowered form.

## Changes

- **ts-transformer specs** (`current_behavior_spec`, `design_deltas`, `lowering_contract`, `review_guide`, `goals`, `target_pattern_language_spec`): dropped `derive` from builder/compute-form lists; deleted it from the `detectCallKind` / reactive-origin lists (it is no longer a recognized call kind); "lowered to derive" → lift-applied. The doc copy of the reactive-context `owner` union now reads `"lift-applied"`, matching the source rename from #3809.
- **`SES_SANDBOXING_SPEC.md`** (Phase-3 sandboxable design): **rewrote the lowering narrative** from the pre-migration `computed → derive({})` model to the current `computed → lift(...)(input)` lift-applied model, keeping the worked hoisting examples internally consistent. (This doc predated CT-1621; we're now well-positioned to make it accurate.)
- **scheduler specs, debugging gotchas, scoped-cells-field-notes, pattern-debug skill**: `computed()/derive()` → `computed()`; `derive(...)` examples → `computed(() => ...)`.

## Deliberately left untouched (not the reactive builder)

- English-verb "derive" (derive a key / ids / schema / edges).
- The CLI `id derive` subcommand.
- The `.derive` `OpaqueRef` proxy method (`capability-wrappers.md`) — a real method, distinct from the removed `derive()` builder.
- The historical CT-1589 field note.

## Separately flagged

`PATTERN_TESTING_SPEC.md:419` links to a removed `test-reactivity-computed-derive-same/` fixture — a stale dead-link issue, not derive terminology. Left for a dead-link pass.

## Verification

Confirmed zero reactive-`derive` references remain in `docs/`/`skills/` (every remaining `derive` is an English verb, the `id derive` CLI, the `.derive` method, or a historical note). pre-commit `deno fmt`/`deno lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retires reactive `derive` from docs/specs and updates all references to `computed()` lowering to the lift‑applied form `lift(...)(input)`. Completes CT-1643 by aligning terminology with the removal from `ts-transformers/src`.

- **Refactors**
  - Updated `ts-transformers` specs: removed `derive` from builder lists, replaced “lowered to derive” with “lift-applied,” and set reactive-context owner to `"lift-applied"`.
  - Rewrote `SES_SANDBOXING_SPEC.md` lowering narrative to `computed → lift(...)(input)` with consistent hoisting examples.
  - Cleaned scheduler/debugging/field-notes/skills: `computed()/derive()` → `computed()`, and `derive(...)` examples → `computed(() => ...)`.
  - Intentionally left “derive” as an English verb, the CLI `id derive` subcommand, the `.derive` proxy method, and the historical note unchanged.
  - Flagged a stale dead link in `PATTERN_TESTING_SPEC.md` for a separate pass.

<sup>Written for commit 4aa63a60966ffa18b2bb460540ae2b5729ab2d34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

