### PR TITLE
perf(runner): single-sync cache reads, resilient write-back, phase timing (CT-1623)

### DIFF
--- a/packages/runner/src/compilation-cache/cell-cache.ts
+++ b/packages/runner/src/compilation-cache/cell-cache.ts
@@ -239,25 +239,36 @@ interface StoredSourceDoc {
   imports: { specifier: string; link: unknown }[];
 }
 
-/** Schema for a source-set document; `imports[].link` auto-loads as a cell. */
+/**
+ * Schema for a source-set document. **Recursive**: each `imports[].link` is an
+ * `asCell` reference back to a source document (`$ref: "#/$defs/sourceDoc"`), so
+ * syncing the entry cell under this schema transitively loads the *entire*
+ * import closure in one round-trip — the storage layer follows the sigil links
+ * and pulls every reachable document. No per-cell `sync()` is needed on load.
+ */
 export const SOURCE_DOC_SCHEMA = {
-  type: "object",
-  properties: {
-    kind: { type: "string" },
-    identity: { type: "string" },
-    code: { type: "string" },
-    filename: { type: "string" },
-    imports: {
-      type: "array",
-      items: {
-        type: "object",
-        properties: {
-          specifier: { type: "string" },
-          link: { asCell: ["cell"] },
+  $defs: {
+    sourceDoc: {
+      type: "object",
+      properties: {
+        kind: { type: "string" },
+        identity: { type: "string" },
+        code: { type: "string" },
+        filename: { type: "string" },
+        imports: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              specifier: { type: "string" },
+              link: { $ref: "#/$defs/sourceDoc", asCell: ["cell"] },
+            },
+          },
         },
       },
     },
   },
+  $ref: "#/$defs/sourceDoc",
 } as const satisfies JSONSchema;
 
 /**
@@ -275,10 +286,12 @@ export function writeSourceDocs(
 ): void {
   const docs = buildSourceDocs(modules, entryIdentity);
   for (const [identity, doc] of docs) {
-    const cell = runtime.getCell(
+    // Write with an untyped cell (the recursive read schema would over-constrain
+    // `set`); reads address the same entity via SOURCE_DOC_SCHEMA.
+    const cell = runtime.getCell<StoredSourceDoc>(
       space,
       sourceDocKey(identity),
-      SOURCE_DOC_SCHEMA,
+      undefined,
       tx,
     );
     cell.set({
@@ -297,10 +310,13 @@ export function writeSourceDocs(
 
 /**
  * Load the source-document closure reachable from `entryIdentity` in `space` by
- * following import links. Each cell is `sync()`d before reading so a closure
- * persisted in a prior session loads from storage. Returns the raw documents
- * keyed by their **stored** identity (verify with {@link verifySourceDocs}
- * before trusting). Resolves to `undefined` if the entry document is absent.
+ * following import links. A **single** `sync()` on the entry cell under the
+ * recursive {@link SOURCE_DOC_SCHEMA} transitively loads the whole closure (the
+ * storage layer follows the `asCell` sigil links), so the walk below reads the
+ * already-loaded linked cells synchronously — no per-cell `sync()`. Returns the
+ * raw documents keyed by their **stored** identity (verify with
+ * {@link verifySourceDocs} before trusting). Resolves to `undefined` if the
+ * entry document is absent.
  */
 export async function loadSourceClosure(
   runtime: Runtime,
@@ -314,23 +330,25 @@ export async function loadSourceClosure(
     SOURCE_DOC_SCHEMA,
     tx,
   );
+  // One sync pulls the entire link closure (recursive schema). No further syncs.
   await entry.sync();
   const root = entry.get() as StoredSourceDoc | undefined;
   if (!root || typeof root.identity !== "string") return undefined;
 
   const out = new Map<string, SourceDoc>();
-  const queue: { doc: StoredSourceDoc }[] = [{ doc: root }];
+  const queue: StoredSourceDoc[] = [root];
   while (queue.length > 0) {
-    const { doc } = queue.shift()!;
+    const doc = queue.shift()!;
     if (out.has(doc.identity)) continue;
     const imports: ModuleImportRef[] = [];
     const childDocs: StoredSourceDoc[] = [];
     for (const imp of doc.imports ?? []) {
+      // `link` is already a loaded Cell (the entry sync pulled it). View it
+      // under the recursive schema so its own links resolve as cells too.
       if (!isCell(imp.link)) continue;
-      const childCell = (imp.link as Cell<unknown>).asSchema(SOURCE_DOC_SCHEMA);
-      // A linked cell is not synced transitively by the parent — sync each.
-      await childCell.sync();
-      const child = childCell.get() as StoredSourceDoc | undefined;
+      const child = (imp.link as Cell<unknown>)
+        .asSchema(SOURCE_DOC_SCHEMA)
+        .get() as StoredSourceDoc | undefined;
       if (!child || typeof child.identity !== "string") continue;
       imports.push({ specifier: imp.specifier, identity: child.identity });
       childDocs.push(child);
@@ -342,7 +360,7 @@ export async function loadSourceClosure(
       imports,
     });
     for (const child of childDocs) {
-      if (!out.has(child.identity)) queue.push({ doc: child });
+      if (!out.has(child.identity)) queue.push(child);
     }
   }
   return out;
@@ -415,13 +433,42 @@ const compiledDocProperties = {
   },
 } as const;
 
-/** Read schema for a compiled document (`imports[].link` auto-loads). */
+/**
+ * Read schema for a compiled document. **Recursive**: each `imports[].link` is
+ * an `asCell` reference back to a compiled document, so a single `sync()` on the
+ * entry cell transitively loads the entire compiled closure (one round-trip),
+ * and the loader reads the linked cells synchronously — no per-cell `sync()`.
+ */
 export const COMPILED_DOC_SCHEMA = {
-  type: "object",
-  properties: compiledDocProperties,
+  $defs: {
+    compiledDoc: {
+      type: "object",
+      properties: {
+        kind: { type: "string" },
+        identity: { type: "string" },
+        code: { type: "string" },
+        filename: { type: "string" },
+        sourceMap: {},
+        imports: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              specifier: { type: "string" },
+              link: { $ref: "#/$defs/compiledDoc", asCell: ["cell"] },
+            },
+          },
+        },
+      },
+    },
+  },
+  $ref: "#/$defs/compiledDoc",
 } as const satisfies JSONSchema;
 
-/** Write schema: stamps the compiler integrity atom on the stored value. */
+/**
+ * Write schema: stamps the compiler integrity atom on the stored value. Flat
+ * (no recursive `$ref`) — writing a single document does not transitively load.
+ */
 export function compiledDocWriteSchema(compilerDid: string): JSONSchema {
   return {
     type: "object",
@@ -509,17 +556,19 @@ export function writeCompiledDocs(
 
 /**
  * Load the integrity-valid compiled documents reachable from `entryIdentity` by
- * following import links. Each cell is `sync()`d before reading so a closure
- * persisted in a prior session loads from storage.
+ * following import links. A **single** `sync()` on the entry cell under the
+ * recursive {@link COMPILED_DOC_SCHEMA} transitively loads the whole closure
+ * (the storage layer follows the `asCell` sigil links), so the walk reads the
+ * already-loaded linked cells synchronously — no per-cell `sync()`.
  *
- * Fail-closed and link-faithful: the BFS walks the *actual linked cells* (never
- * re-deriving a cell from a stored `identity` field), and a cell is read only
- * after its own persisted CFC label is confirmed to carry the compiler
- * integrity atom. So every document in the result — and every import edge — came
- * from an integrity-stamped cell that the parent's sigil link actually points
- * at; an unstamped/tampered child is dropped along with the edge to it (treated
- * as a cache miss, so the caller recompiles). The entry is the one cell looked
- * up by key, from the caller's trusted `entryIdentity`.
+ * Fail-closed and link-faithful: the walk follows the *actual linked cells*
+ * (never re-deriving a cell from a stored `identity` field), and a cell's stored
+ * doc is used only after its own persisted CFC label is confirmed to carry the
+ * compiler integrity atom. So every document in the result — and every import
+ * edge — came from an integrity-stamped cell that the parent's sigil link
+ * actually points at; an unstamped/tampered child is dropped along with the edge
+ * to it (treated as a cache miss, so the caller recompiles). The entry is the
+ * one cell looked up by key, from the caller's trusted `entryIdentity`.
  *
  * Resolves to the valid documents keyed by their stored identity (empty map if
  * the entry itself is missing/unstamped).
@@ -535,12 +584,12 @@ export async function loadCompiledClosure(
   const out = new Map<string, CompiledDoc>();
   const visited = new Set<string>();
 
-  // Integrity-check a cell, returning its stored doc only if the cell carries
-  // the compiler atom (fail-closed). The cell is synced first.
-  const readVerified = async (
+  // Integrity-gated read (fail-closed): the cell's stored doc only if its
+  // persisted CFC label carries the compiler atom. No sync here — the entry's
+  // single sync (below) has already transitively loaded the whole closure.
+  const verifiedDoc = (
     cell: Cell<unknown>,
-  ): Promise<StoredCompiledDoc | undefined> => {
-    await cell.sync();
+  ): StoredCompiledDoc | undefined => {
     if (!cellCarriesIntegrity(cell, atom, tx)) return undefined;
     const doc = cell.get() as StoredCompiledDoc | undefined;
     return doc && typeof doc.identity === "string" ? doc : undefined;
@@ -552,7 +601,9 @@ export async function loadCompiledClosure(
     COMPILED_DOC_SCHEMA,
     tx,
   );
-  const entryDoc = await readVerified(entryCell);
+  // One sync pulls the entire link closure (recursive schema). No further syncs.
+  await entryCell.sync();
+  const entryDoc = verifiedDoc(entryCell);
   if (entryDoc === undefined) return out;
 
   const queue: { doc: StoredCompiledDoc }[] = [{ doc: entryDoc }];
@@ -564,12 +615,12 @@ export async function loadCompiledClosure(
     const imports: ModuleImportRef[] = [];
     for (const imp of doc.imports ?? []) {
       if (!isCell(imp.link)) continue;
-      // Follow the actual linked cell and integrity-check IT before trusting
-      // either the edge or the child's content (no re-lookup by stored id).
-      const childCell = (imp.link as Cell<unknown>).asSchema(
-        COMPILED_DOC_SCHEMA,
+      // `link` is an already-loaded Cell (the entry sync pulled it). View it
+      // under the recursive schema so its own links resolve as cells too, then
+      // integrity-check + read synchronously — no re-lookup by id, no sync.
+      const child = verifiedDoc(
+        (imp.link as Cell<unknown>).asSchema(COMPILED_DOC_SCHEMA),
       );
-      const child = await readVerified(childCell);
       if (child === undefined) continue;
       imports.push({ specifier: imp.specifier, identity: child.identity });
       if (!visited.has(child.identity)) queue.push({ doc: child });

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -335,7 +335,9 @@ export class Engine extends EventTarget implements Harness {
         }
       } else {
         const { compiler } = await this.getCompilerInternals();
-        logger.timeStart("compileToRecordGraph", "ts-compile");
+        // Concurrency-safe timing: explicit start (a shared timer key would be
+        // clobbered by parallel compiles). Same for `records`/`verify` below.
+        const tsCompileStart = performance.now();
         const modules = compiler.compileToModules(resolvedProgram, {
           noCheck: options.noCheck,
           runtimeModules: Engine.runtimeModuleNames(),
@@ -347,7 +349,7 @@ export class Engine extends EventTarget implements Harness {
             };
           },
         });
-        logger.timeEnd("compileToRecordGraph", "ts-compile");
+        logger.time(tsCompileStart, "compileToRecordGraph", "ts-compile");
 
         // Every authored source must have an emitted body; a missing one would
         // otherwise be silently dropped and only fail later at import.
@@ -373,7 +375,7 @@ export class Engine extends EventTarget implements Harness {
           Object.keys(runtimeExports?.[name] ?? {}),
         ]),
       );
-      logger.timeStart("compileToRecordGraph", "records");
+      const recordsStart = performance.now();
       const graph = compileSourcesToRecords(moduleFiles, {
         precompiledBodies,
         precompiledSourceMaps,
@@ -386,7 +388,7 @@ export class Engine extends EventTarget implements Harness {
         // a second hashing/import-resolution pass over the module set.
         identityByPath,
       });
-      logger.timeEnd("compileToRecordGraph", "records");
+      logger.time(recordsStart, "compileToRecordGraph", "records");
 
       // Register runtime-module records so cf:runtime/* imports resolve.
       const runtimeRecordExports: Record<string, Record<string, unknown>> = {};
@@ -405,14 +407,13 @@ export class Engine extends EventTarget implements Harness {
       // Security-verify every authored module body before it can execute.
       // (Runs even on a warm cache hit — the integrity label is still only
       // client-asserted, so we do not yet trust cached bytes unverified.)
-      logger.timeStart("compileToRecordGraph", "verify");
+      const verifyStart = performance.now();
       for (const [specifier, body] of graph.compiledBodies) {
         verifyCompiledModuleBody(body, specifier);
       }
 
       const mainSpecifier = graph.specifierByPath.get(mappedProgram.main);
       if (mainSpecifier === undefined) {
-        logger.timeEnd("compileToRecordGraph", "verify");
         throw new Error(
           "ESM compile produced no record for the program entry",
         );
@@ -424,7 +425,7 @@ export class Engine extends EventTarget implements Harness {
       // invoked with `verify: false` in evaluateRecordGraph — graph
       // verification happens once, at compile time, before any module executes.
       verifyModuleGraph(graph.records, mainSpecifier);
-      logger.timeEnd("compileToRecordGraph", "verify");
+      logger.time(verifyStart, "compileToRecordGraph", "verify");
 
       // Serializable per-module descriptors for write-back to the cache, in
       // identity space (the engine's `/<id>` path prefix never leaks out). Each

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -335,6 +335,7 @@ export class Engine extends EventTarget implements Harness {
         }
       } else {
         const { compiler } = await this.getCompilerInternals();
+        logger.timeStart("compileToRecordGraph", "ts-compile");
         const modules = compiler.compileToModules(resolvedProgram, {
           noCheck: options.noCheck,
           runtimeModules: Engine.runtimeModuleNames(),
@@ -346,6 +347,7 @@ export class Engine extends EventTarget implements Harness {
             };
           },
         });
+        logger.timeEnd("compileToRecordGraph", "ts-compile");
 
         // Every authored source must have an emitted body; a missing one would
         // otherwise be silently dropped and only fail later at import.
@@ -371,6 +373,7 @@ export class Engine extends EventTarget implements Harness {
           Object.keys(runtimeExports?.[name] ?? {}),
         ]),
       );
+      logger.timeStart("compileToRecordGraph", "records");
       const graph = compileSourcesToRecords(moduleFiles, {
         precompiledBodies,
         precompiledSourceMaps,
@@ -383,6 +386,7 @@ export class Engine extends EventTarget implements Harness {
         // a second hashing/import-resolution pass over the module set.
         identityByPath,
       });
+      logger.timeEnd("compileToRecordGraph", "records");
 
       // Register runtime-module records so cf:runtime/* imports resolve.
       const runtimeRecordExports: Record<string, Record<string, unknown>> = {};
@@ -399,12 +403,16 @@ export class Engine extends EventTarget implements Harness {
       }
 
       // Security-verify every authored module body before it can execute.
+      // (Runs even on a warm cache hit — the integrity label is still only
+      // client-asserted, so we do not yet trust cached bytes unverified.)
+      logger.timeStart("compileToRecordGraph", "verify");
       for (const [specifier, body] of graph.compiledBodies) {
         verifyCompiledModuleBody(body, specifier);
       }
 
       const mainSpecifier = graph.specifierByPath.get(mappedProgram.main);
       if (mainSpecifier === undefined) {
+        logger.timeEnd("compileToRecordGraph", "verify");
         throw new Error(
           "ESM compile produced no record for the program entry",
         );
@@ -416,6 +424,7 @@ export class Engine extends EventTarget implements Harness {
       // invoked with `verify: false` in evaluateRecordGraph — graph
       // verification happens once, at compile time, before any module executes.
       verifyModuleGraph(graph.records, mainSpecifier);
+      logger.timeEnd("compileToRecordGraph", "verify");
 
       // Serializable per-module descriptors for write-back to the cache, in
       // identity space (the engine's `/<id>` path prefix never leaks out). Each

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -558,7 +558,9 @@ export class PatternManager {
     try {
       compiled = await harness.compileToRecordGraph!(program, {
         precompiledModulesFor: async ({ entryIdentity, identities }) => {
-          logger.timeStart("compile-cache", "read");
+          // Concurrency-safe timing: explicit start (no shared timer key, which
+          // parallel compiles would clobber). Same for the others below.
+          const readStart = performance.now();
           const closure = await loadCompiledClosure(
             this.runtime,
             space,
@@ -566,7 +568,7 @@ export class PatternManager {
             cacheOpts,
             readTx,
           );
-          logger.timeEnd("compile-cache", "read");
+          logger.time(readStart, "compile-cache", "read");
           // Full hit only: every emitted module must be present (and
           // integrity-valid). A partial set cannot be trusted (transitively
           // sensitive identities), so fall back to a full recompile.
@@ -593,14 +595,14 @@ export class PatternManager {
     }
     const { id, graph, mainSpecifier, entryIdentity, modules } = compiled;
 
-    logger.timeStart("compile-cache", "evaluate");
+    const evalStart = performance.now();
     const result = harness.evaluateRecordGraph!(
       id,
       graph,
       mainSpecifier,
       program.files,
     );
-    logger.timeEnd("compile-cache", "evaluate");
+    logger.time(evalStart, "compile-cache", "evaluate");
 
     if (warmHit) {
       this.esmCacheStats.hits++;
@@ -636,12 +638,12 @@ export class PatternManager {
     entryIdentity: string,
     opts: { runtimeVersion: string; compilerDid: string },
   ): Promise<void> {
-    logger.timeStart("compile-cache", "writeback");
+    const writebackStart = performance.now();
     const { error } = await this.runtime.editWithRetry((tx) => {
       writeSourceDocs(this.runtime, space, modules, entryIdentity, tx);
       writeCompiledDocs(this.runtime, space, modules, entryIdentity, opts, tx);
     });
-    logger.timeEnd("compile-cache", "writeback");
+    logger.time(writebackStart, "compile-cache", "writeback");
     if (error) {
       logger.error("compile-cache-writeback-failed", () => [
         `entry=${entryIdentity}`,

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -558,6 +558,7 @@ export class PatternManager {
     try {
       compiled = await harness.compileToRecordGraph!(program, {
         precompiledModulesFor: async ({ entryIdentity, identities }) => {
+          logger.timeStart("compile-cache", "read");
           const closure = await loadCompiledClosure(
             this.runtime,
             space,
@@ -565,6 +566,7 @@ export class PatternManager {
             cacheOpts,
             readTx,
           );
+          logger.timeEnd("compile-cache", "read");
           // Full hit only: every emitted module must be present (and
           // integrity-valid). A partial set cannot be trusted (transitively
           // sensitive identities), so fall back to a full recompile.
@@ -591,27 +593,28 @@ export class PatternManager {
     }
     const { id, graph, mainSpecifier, entryIdentity, modules } = compiled;
 
+    logger.timeStart("compile-cache", "evaluate");
     const result = harness.evaluateRecordGraph!(
       id,
       graph,
       mainSpecifier,
       program.files,
     );
+    logger.timeEnd("compile-cache", "evaluate");
 
     if (warmHit) {
       this.esmCacheStats.hits++;
     } else {
       this.esmCacheStats.misses++;
-      // Cold/partial: persist the freshly compiled module set for next time,
-      // fire-and-forget on its own transaction (tracked for flush/shutdown).
+      // Cold/partial: persist the freshly compiled module set for next time.
+      // Fire-and-forget — the pattern is already returned below, so cache
+      // persistence never blocks the load. Tracked for flush/shutdown.
       const writeBack = this.writeBackCompileCache(
         space,
         modules,
         entryIdentity,
         cacheOpts,
-      ).catch((error) => {
-        logger.warn("compile-cache-writeback-failed", () => [String(error)]);
-      });
+      );
       this.compileCacheWrites.add(writeBack);
       writeBack.finally(() => this.compileCacheWrites.delete(writeBack));
     }
@@ -621,8 +624,11 @@ export class PatternManager {
 
   /**
    * Write the source + compiled document sets for an emitted module set into
-   * `space` on a fresh transaction and commit it (CFC-prepared so the compiled
-   * docs' integrity label persists). Independent of the caller's transaction.
+   * `space`, on its own transaction, independent of the caller's. Uses
+   * `editWithRetry` so a commit conflict (e.g. the cache write racing the
+   * pattern's own space writes) retries rather than silently dropping the
+   * entry; a final failure is logged (not thrown) since the cache is an
+   * optimization, never on the correctness path.
    */
   private async writeBackCompileCache(
     space: MemorySpace,
@@ -630,11 +636,18 @@ export class PatternManager {
     entryIdentity: string,
     opts: { runtimeVersion: string; compilerDid: string },
   ): Promise<void> {
-    const tx = this.runtime.edit();
-    writeSourceDocs(this.runtime, space, modules, entryIdentity, tx);
-    writeCompiledDocs(this.runtime, space, modules, entryIdentity, opts, tx);
-    this.runtime.prepareTxForCommit(tx);
-    await tx.commit();
+    logger.timeStart("compile-cache", "writeback");
+    const { error } = await this.runtime.editWithRetry((tx) => {
+      writeSourceDocs(this.runtime, space, modules, entryIdentity, tx);
+      writeCompiledDocs(this.runtime, space, modules, entryIdentity, opts, tx);
+    });
+    logger.timeEnd("compile-cache", "writeback");
+    if (error) {
+      logger.error("compile-cache-writeback-failed", () => [
+        `entry=${entryIdentity}`,
+        error.message,
+      ]);
+    }
   }
 
   private async evaluateToPattern(


### PR DESCRIPTION
## Summary

Three improvements to the Phase 4 ESM compilation cell cache (#3810), surfaced by a perf dig into the flag-on pattern-integration slowdown. All behind `CF_ESM_MODULE_LOADER` (default off); no behavior change with the flag off.

### 1. Single-`sync()` closure load
The cache doc schemas (source + compiled) are now **recursive** (`$defs` + self-`$ref` + `asCell` on `imports[].link`), so one `sync()` on the entry cell transitively loads the *entire* import closure in a single round-trip. `loadSourceClosure` / `loadCompiledClosure` drop their per-cell `await sync()` (which was **K serial round-trips** against real storage) and walk the already-loaded linked cells synchronously. Fail-closed CFC integrity checks and link-faithful traversal are unchanged.

### 2. Resilient, non-blocking write-back
`writeBackCompileCache` now uses `editWithRetry` instead of a bare `tx.commit()`: a commit conflict (the cache write racing the pattern's own space writes) **retries** rather than silently dropping the entry; a final failure is `logger.error`'d, never thrown. Still fire-and-forget — the pattern is returned before the write-back resolves, so cache persistence never blocks the load.

### 3. Phase timing (`logger`)
`logger.timeStart/timeEnd` around the compile phases (`compileToRecordGraph/{ts-compile,records,verify}`) and the cache path (`compile-cache/{read,evaluate,writeback}`). Enable with `CF_LOG_TIMING=engine,pattern-manager CF_LOG_TIMING_CONSOLE=1`.

Measured split (emulated storage): cold compile is dominated by **ts-compile (~130ms)**; **verification is cheap (~4ms)** — so the warm-hit re-verify costs almost nothing and is kept; warm reload is ~27ms (no ts-compile).

## Follow-up (filed)
The timing also showed warm hits still pay `resolve` (~12ms) — a fixed cost the AMD cache avoids (it keys by a cheap input hash). Tracked as **CT-1653** (programHash→entryIdentity pointer doc), not in this PR.

## Tests
All cache / ESM / pattern-manager / verifier-parity / integration suites green (incl. cross-session warm hit, `Pattern.inSpace` A→B, CFC fail-closed). Refs CT-1623.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the ESM compile cache by loading import closures with a single sync, adding retrying write-back, and adding concurrency‑safe phase timing. Gated behind `CF_ESM_MODULE_LOADER` (off by default); addresses CT-1623.

- **Performance**
  - Single-sync cache reads: recursive schemas load the full import graph with one `sync()`. Drops per‑cell syncs and walks links synchronously.
  - Phase timing: concurrency-safe `logger.time(start, ...)` around `compileToRecordGraph/{ts-compile,records,verify}` and `compile-cache/{read,evaluate,writeback}`. Enable with `CF_LOG_TIMING=engine,pattern-manager` and `CF_LOG_TIMING_CONSOLE=1`.

- **Reliability**
  - Non-blocking write-back with `editWithRetry` to retry commit conflicts; final failure is logged (not thrown) so cache persistence never blocks the pattern load.

<sup>Written for commit f4dab9401e9b8ee04196f45ac858540159456eb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

