### PR TITLE
fix(patterns): give each cfc-group-chat user a per-user profile cell

### DIFF
--- a/packages/patterns/cfc-group-chat-demo/trusted.tsx
+++ b/packages/patterns/cfc-group-chat-demo/trusted.tsx
@@ -407,11 +407,24 @@ export const applyTrustedProfileSave = (
   }
 
   const existingProfile = currentProfileSnapshot(myProfile);
+  const nextSnapshot = makeProfileSnapshot(
+    trimmedName,
+    existingProfile,
+  ) as TrustedProfile;
+  // Each user's profile must be its OWN cell. The previous
+  // `Writable.for("profile")` used a constant cause, so every user sharing the
+  // space derived the *same* underlying entity: all message `authorProfile`
+  // links redirected to one shared profile cell holding whoever saved last.
+  // Authorship verification then compared each message's signature against that
+  // single (current-user) profile, so genuine messages from other users read
+  // as unverified while imported "fake" messages read as verified — a
+  // nondeterministic outcome that made the integration test flaky. A
+  // per-user-scoped cell is isolated by active DID (see
+  // docs/common/patterns/multi-user-patterns.md), giving each user a distinct
+  // profile entity.
   const profile = currentProfileCell(myProfile) ??
-    Writable.for<TrustedProfile>("profile");
-  profile.set(
-    makeProfileSnapshot(trimmedName, existingProfile) as TrustedProfile,
-  );
+    Writable.perUser.of<TrustedProfile>(nextSnapshot);
+  profile.set(nextSnapshot);
   myProfile.set({ profile });
   registerProfile(profiles, profile);
   return { trimmedName, profile };


### PR DESCRIPTION
## Summary

The `cfc-group-chat-demo` integration test was flaky (~1/3 pass locally; otherwise spinning `waitForInvalidAuthorshipState` to its 60s timeout). The cause was **not** slowness — it was a **per-user profile-cell collision**.

`applyTrustedProfileSave` created each user's profile with `Writable.for<TrustedProfile>("profile")` — a non-scoped cell with a **constant cause**. Every user sharing the piece's space derived the *same* underlying entity, so all message `authorProfile` links redirected to **one shared profile cell** holding whoever saved last. Authorship verification (`authorshipStateForLabel`) then compared every message's signature against that single (current-user) profile:

- genuine messages from other users → `unverified`
- imported "fake" messages (signed by + claiming the current user) → `verified`

…nondeterministically, depending on resolution timing.

## How it was diagnosed

A per-row probe capturing `author.ref()` vs `author.resolveAsCell().ref()` showed four **distinct** stored `authorRef`s that **all resolve to the same** profile entity (`of:fid1:REwk2B…`). An earlier fix that constrained the fake-message author pool to non-signers changed nothing (6/6 fail), ruling out author selection and confirming the shared-cell collision.

## The fix

Use the per-user-scoped constructor `Writable.perUser.of()` (isolated by active DID, per `docs/common/patterns/multi-user-patterns.md`) so each user gets a distinct profile entity. One call site in `applyTrustedProfileSave`.

## Validation

| | before | after |
|---|---|---|
| pass rate (local) | 1/3 → 0/6 | **5/5** |
| `waitForInvalidAuthorshipState` | 60 000ms (timeout → fail) | **5–17ms** |

`cf check packages/patterns/cfc-group-chat-demo/main.tsx` passes. The integration test is unchanged; the existing 60s timeout headroom is now moot but left in place to keep this PR focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make profile cells per user in `cfc-group-chat-demo` to stop profile collisions that broke authorship checks and made the integration test flaky.

- Bug Fixes
  - Replace `Writable.for("profile")` with per-user `Writable.perUser.of<TrustedProfile>` so each DID gets its own profile entity.
  - Fixes incorrect verification (other users’ messages marked unverified; fake messages marked verified).
  - Stabilizes the test: 5/5 local passes; invalid-authorship check now resolves in 5–17 ms (was 60s timeout).

<sup>Written for commit 112d87601df59640ecfc6dedf5c0e93982bf0418. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

