### PR TITLE
fix(ts-transformers): point body-level writes to module-scope handler<> (CT-1641)

### DIFF
--- a/packages/ts-transformers/src/transformers/pattern-body-reactive-root-lowering.ts
+++ b/packages/ts-transformers/src/transformers/pattern-body-reactive-root-lowering.ts
@@ -55,6 +55,51 @@ const KNOWN_PATH_TERMINAL_METHODS = new Set([
   "flatMapWithPattern",
 ]);
 
+// Mutating methods on cells / reactive arrays. A write of any of these in the
+// pattern body is not lowerable, and the remedy is a module-scope handler<> —
+// NOT computed(), which is read-only (CT-1641).
+const WRITE_METHODS = new Set([
+  // Cell write API
+  "set",
+  "update",
+  "push",
+  "remove",
+  "removeAll",
+  // Array mutators (in case the author reaches for them on a reactive array)
+  "pop",
+  "shift",
+  "unshift",
+  "splice",
+  "sort",
+  "reverse",
+  "fill",
+  "copyWithin",
+]);
+
+// The remedy half of the "method calls are not lowerable" diagnostics. Writes
+// belong in a module-scope handler<>; reads should move into computed()/lift().
+function notLowerableMethodRemedy(methodName: string | undefined): string {
+  if (methodName && WRITE_METHODS.has(methodName)) {
+    return "Writes to pattern inputs must go through a module-scope handler<> " +
+      "(typed Writable<T>), not the pattern body. computed() is read-only.";
+  }
+  return "Move this call into computed().";
+}
+
+// Best-effort extraction of the invoked method name from a call expression
+// whose callee is a property access (e.g. `items.push(...)` -> "push").
+function calleeMethodName(call: ts.CallExpression): string | undefined {
+  const callee = call.expression;
+  if (ts.isPropertyAccessExpression(callee)) return callee.name.text;
+  if (
+    ts.isElementAccessExpression(callee) &&
+    ts.isStringLiteralLike(callee.argumentExpression)
+  ) {
+    return callee.argumentExpression.text;
+  }
+  return undefined;
+}
+
 function isSelfPathSegment(
   segment: PathSegment,
   context: TransformationContext,
@@ -817,7 +862,8 @@ function rewriteTrackedOpaquePatternBody(
           reportOnce(
             visited,
             "computation",
-            "Method calls on opaque pattern values are not lowerable. Move this call into computed().",
+            "Method calls on opaque pattern values are not lowerable. " +
+              notLowerableMethodRemedy(visited.name.text),
           );
           return visited;
         }
@@ -851,6 +897,9 @@ function rewriteTrackedOpaquePatternBody(
       );
       if (unsupportedCallRoot === "unsupported-receiver-method") {
         const reactiveContext = context.getReactiveContext(visited);
+        const methodName = calleeMethodName(visited);
+        const isWrite = methodName !== undefined &&
+          WRITE_METHODS.has(methodName);
         if (
           reactiveContext.kind === "pattern" &&
           (reactiveContext.owner === "pattern" ||
@@ -860,13 +909,17 @@ function rewriteTrackedOpaquePatternBody(
           reportOnce(
             visited,
             "receiver-method",
-            "Method calls on reactive values are not yet supported directly in non-JSX pattern bodies. Move this call into computed(() => ...), module-scope lift(), or another safe wrapper.",
+            isWrite
+              ? "Writes to pattern inputs are not supported directly in pattern bodies. " +
+                notLowerableMethodRemedy(methodName)
+              : "Method calls on reactive values are not yet supported directly in non-JSX pattern bodies. Move this call into computed(() => ...), module-scope lift(), or another safe wrapper.",
           );
         } else {
           reportOnce(
             visited,
             "receiver-method",
-            "Method calls on opaque pattern values are not lowerable. Move this call into computed().",
+            "Method calls on opaque pattern values are not lowerable. " +
+              notLowerableMethodRemedy(methodName),
           );
         }
       }

--- a/packages/ts-transformers/src/transformers/pattern-body-reactive-root-lowering.ts
+++ b/packages/ts-transformers/src/transformers/pattern-body-reactive-root-lowering.ts
@@ -76,12 +76,18 @@ const WRITE_METHODS = new Set([
   "copyWithin",
 ]);
 
-// The remedy half of the "method calls are not lowerable" diagnostics. Writes
-// belong in a module-scope handler<>; reads should move into computed()/lift().
+// The remedy half of the "method calls are not lowerable" diagnostics. The
+// pattern body runs once at construction, so an event-driven write there has no
+// triggering event and isn't lowerable; route it through a module-scope
+// handler<>. (Wrapping the write in computed() is not the fix either: a write in
+// a computed() re-triggers the computation and must be idempotent — see
+// docs/common/concepts/computed/side-effects.md.) Non-write unsupported calls
+// still belong in computed()/lift().
 function notLowerableMethodRemedy(methodName: string | undefined): string {
   if (methodName && WRITE_METHODS.has(methodName)) {
     return "Writes to pattern inputs must go through a module-scope handler<> " +
-      "(typed Writable<T>), not the pattern body. computed() is read-only.";
+      "(typed Writable<T>), not the pattern body, which runs once at " +
+      "construction.";
   }
   return "Move this call into computed().";
 }

--- a/packages/ts-transformers/test/validation.test.ts
+++ b/packages/ts-transformers/test/validation.test.ts
@@ -1286,6 +1286,74 @@ Deno.test("Pattern Context Validation - Receiver Method Calls", async (t) => {
       assertHasErrorType(errors, "pattern-context:optional-chaining");
     },
   );
+
+  await t.step(
+    "points body-level writes to a module-scope handler<>, not computed() (CT-1641)",
+    async () => {
+      const source =
+        `      import { pattern, UI, Writable } from "commonfabric";
+
+      interface Item { id: string; }
+      interface State { items: Writable<Item[]>; }
+
+      export default pattern<State>(({ items }) => {
+        items.push({ id: "x" });
+        return { [UI]: <div />, items };
+      });
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      assertGreater(errors.length, 0, "Expected a not-lowerable error");
+      const writeError = errors.find((e) =>
+        e.message.includes("not lowerable")
+      );
+      assertEquals(
+        writeError !== undefined,
+        true,
+        "Expected the not-lowerable diagnostic for the body-level push",
+      );
+      assertStringIncludes(writeError!.message, "module-scope handler<>");
+      // The misleading remedy must NOT appear for a write.
+      assertEquals(
+        writeError!.message.includes("Move this call into computed()"),
+        false,
+        "Writes should not be told to move into computed()",
+      );
+    },
+  );
+
+  await t.step(
+    "still suggests computed() for a non-write non-lowerable method call",
+    async () => {
+      const source = `      import { pattern, UI } from "commonfabric";
+
+      interface Item { label: string; }
+      interface State { items: Item[]; }
+
+      export default pattern<State>(({ items }) => {
+        const s = items.toLocaleString();
+        return { [UI]: <div>{s}</div>, items };
+      });
+    `;
+      const { diagnostics } = await validateSource(source, {
+        types: COMMONFABRIC_TYPES,
+      });
+      const errors = getErrors(diagnostics);
+      const methodError = errors.find((e) =>
+        e.message.includes("not lowerable")
+      );
+      if (methodError) {
+        assertStringIncludes(methodError.message, "computed()");
+        assertEquals(
+          methodError.message.includes("module-scope handler<>"),
+          false,
+          "Non-write methods should not be pointed at handler<>",
+        );
+      }
+    },
+  );
 });
 
 Deno.test("Pattern Context Validation - Safe Wrappers", async (t) => {


### PR DESCRIPTION
## Summary

Writing to a pattern input in the pattern body (e.g. `items.push(...)`) produced:

> Method calls on opaque pattern values are not lowerable. **Move this call into computed().**

That remedy is unhelpful for a **write**. Wrapping a body-level mutation in `computed()` is not the fix: writes inside `computed()` are allowed but must be **idempotent** (a non-idempotent write re-triggers the computation — see `docs/common/concepts/computed/side-effects.md`), and more to the point the pattern body runs **once at construction**, so an event-driven mutation has no triggering event there. The correct home is a **module-scope `handler<>`** (typed `Writable<T>`), per the CT-1641 ticket.

> ⚠️ An earlier revision of this PR justified the remedy with "computed() is read-only" — that claim is **false** and has been corrected (commit `7f72eb9`). Writes are permitted in `computed()`; they just must be idempotent. The remedy (route writes through a module-scope `handler<>`) is unchanged; only the rationale was wrong.

This branches the not-lowerable-method diagnostics on a `WRITE_METHODS` set: for mutating methods (`set`/`update`/`push`/`remove`/`removeAll` + array mutators), point the author at a module-scope `handler<>`; reads keep the existing `computed()`/`lift()` guidance.

Covers all three emission sites in `rewriteTrackedOpaquePatternBody` (the `parentCall` property-access path and both receiver-method call paths).

## Before / after

```
# before — any non-lowerable method call:
error: Method calls on opaque pattern values are not lowerable. Move this call into computed().

# after — for a write (items.push(...)):
error: Method calls on opaque pattern values are not lowerable. Writes to pattern inputs
       must go through a module-scope handler<> (typed Writable<T>), not the pattern body,
       which runs once at construction.

# after — for a non-write method: unchanged ("...Move this call into computed().")
```

## Notes

- `.set()` on a `Writable<T>` input in the body is still **accepted and lowered** (the argument's read gets wrapped in a `lift(...)` — confirmed via `--show-transformed`). The misleading error only fires for non-lowerable mutating method calls on **opaque** values (e.g. `.push()` on a reactive input array). So the write-method branch fires on the opaque/non-lowerable path specifically, not on every `.set()`.
- Reproduced and root-caused on fresh `main`; see the CT-1641 ticket comment for the `cf check` repro.

## Test plan

- New validation steps: a body-level write points to `handler<>` and never says "Move this call into computed()"; a non-write non-lowerable method still suggests `computed()`.
- Full `ts-transformers` suite green: 292 passed (603 steps), 0 failed.

Closes CT-1641.

🤖 Generated with [Claude Code](https://claude.com/claude-code)