### PR TITLE
fix(runner): surface blocked narrower-scope link follows at warn level (CT-1642)

### DIFF
--- a/packages/runner/src/link-resolution.ts
+++ b/packages/runner/src/link-resolution.ts
@@ -254,12 +254,22 @@ export function resolveLink(
 
     if (nextHop !== undefined) {
       if (!canFollowLinkHop(link, nextHop.link)) {
-        logger.info("scope: blocked narrower link follow", () => [{
-          schemaScope: schemaScopeForLink(link),
-          linkScope: nextHop.link.scope,
-          source: cfcAddressFromLink(link),
-          target: cfcAddressFromLink(nextHop.link),
-        }]);
+        // Blocked narrower-scope follow during link resolution — resolves to
+        // undefined silently. Warn (not info) so the drop is observable; see
+        // the matching site in traverse.ts followPointer (CT-1642).
+        const schemaScope = schemaScopeForLink(link);
+        logger.warn("scope: blocked narrower link follow", () => [
+          `a "${schemaScope}"-scoped read cannot follow a ` +
+          `"${nextHop.link.scope}"-scoped link, so it resolves to undefined. ` +
+          `If this is inside a .map()/lift, resolve the narrower-scoped value ` +
+          `at the top level and pass the value down.`,
+          {
+            schemaScope,
+            linkScope: nextHop.link.scope,
+            source: cfcAddressFromLink(link),
+            target: cfcAddressFromLink(nextHop.link),
+          },
+        ]);
         link = undefinedDataLink(link);
         break;
       }

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -1344,8 +1344,17 @@ function followPointer(
   };
   const schemaScope = schemaScopeForSelector(selector);
   if (!canFollowScopedLink(schemaScope, link.scope)) {
-    logger.info("traverse", () => [
-      "blocked narrower-scope link follow",
+    // A broader-scoped read context cannot follow a link into a narrower scope
+    // (e.g. a space-scoped .map()/lift row reaching a perSession/perUser cell).
+    // The rule is intentional, but the follow resolves to undefined silently —
+    // a frequent cause of "my PerUser/PerSession value is undefined inside a
+    // map" authoring bugs (CT-1642). Warn (not info) so it actually surfaces:
+    // the traverse logger runs at "warn", which previously swallowed this.
+    logger.warn("traverse", () => [
+      `blocked narrower-scope link follow: a "${schemaScope}"-scoped read ` +
+      `cannot follow a "${link.scope}"-scoped link, so it resolves to ` +
+      `undefined. If this is inside a .map()/lift, resolve the ` +
+      `narrower-scoped value at the top level and pass the value down.`,
       {
         schemaScope,
         linkScope: link.scope,

--- a/packages/runner/test/schema-links.test.ts
+++ b/packages/runner/test/schema-links.test.ts
@@ -94,6 +94,71 @@ describe("Schema - Link Resolution", () => {
       });
     });
 
+    it("warns (not silently) when a narrower-scope link follow is blocked (CT-1642)", () => {
+      // Same setup as above: a session-scoped cell read through a user-scoped
+      // schema. The follow is correctly blocked (-> undefined); CT-1642 is that
+      // it used to log only at logger.info, which the traverse logger (level
+      // "warn") swallowed. Assert the drop now surfaces at warn level.
+      const traverseLogger = (globalThis as {
+        commonfabric?: {
+          logger?: Record<string, {
+            counts: { warn: number; info: number };
+          }>;
+        };
+      }).commonfabric?.logger?.["traverse"];
+      expect(traverseLogger).toBeDefined();
+
+      const sessionCell = createCell<string>(
+        runtime,
+        {
+          ...runtime.getCell(
+            space,
+            "ct1642-session-target",
+            { type: "string" },
+            tx,
+          ).getAsNormalizedFullLink(),
+          schema: { type: "string" },
+          scope: "session",
+        },
+        tx,
+      );
+      sessionCell.set("session private");
+
+      const source = runtime.getCell<{ current?: string }>(
+        space,
+        "ct1642-source",
+        {
+          type: "object",
+          properties: { current: { type: "string" } },
+        } as const satisfies JSONSchema,
+        tx,
+      );
+      source.set({ current: sessionCell as any });
+
+      const cappedSchema = {
+        type: "object",
+        properties: { current: { type: "string", scope: "user" } },
+      } as const satisfies JSONSchema;
+      const unrestrictedSchema = {
+        type: "object",
+        properties: { current: { type: "string", scope: "any" } },
+      } as const satisfies JSONSchema;
+
+      // Unrestricted read: follow succeeds, no blocked-follow warning.
+      const warnBeforeAllowed = traverseLogger!.counts.warn;
+      expect(source.asSchema(unrestrictedSchema).get()).toEqual({
+        current: "session private",
+      });
+      expect(traverseLogger!.counts.warn).toBe(warnBeforeAllowed);
+
+      // Capped read: follow is blocked -> undefined AND a warning is emitted.
+      const warnBeforeBlocked = traverseLogger!.counts.warn;
+      expect(source.asSchema(cappedSchema).get()).toEqual({
+        current: undefined,
+      });
+      expect(traverseLogger!.counts.warn).toBeGreaterThan(warnBeforeBlocked);
+    });
+
     it("should resolve array element links to the actual nested documents", () => {
       const schema = {
         type: "object",


### PR DESCRIPTION
## Summary

A broader-scoped read context (e.g. a space-scoped `.map()`/lift row) cannot follow a link into a narrower scope (`perUser`/`perSession`). **The scope rule is working as intended** (`scope.ts:61-69` `canFollowScopedLink`) — the problem is purely observability.

The blocked follow resolved to `undefined` while logging only at `logger.info`, and the traverse logger runs at `level: "warn"` (`traverse.ts:80`) — so the drop was **swallowed entirely**. This is a frequent silent cause of "my PerUser/PerSession value is `undefined` inside a map" authoring bugs (see the in-the-wild `cozy-poll` war-story comment referenced in CT-1642).

This promotes both blocked-follow sites — `traverse.ts` `followPointer` and `link-resolution.ts` `resolveLink` — from `logger.info` to `logger.warn`, with an author-actionable message naming the blocked scopes and the remedy:

> blocked narrower-scope link follow: a "user"-scoped read cannot follow a "session"-scoped link, so it resolves to undefined. If this is inside a .map()/lift, resolve the narrower-scoped value at the top level and pass the value down.

The scope rule itself is unchanged — this only raises the visibility of an already-correct block.

## Scope of change

- `packages/runner/src/traverse.ts` — `info` → `warn` (this is the fully-silent site; traverse logger is `level:"warn"`).
- `packages/runner/src/link-resolution.ts` — `info` → `warn` for consistency (its logger defaults to `info`, so this was less silent but still not author-facing).

## Test plan

- New `schema-links.test.ts` step asserts the `traverse` logger's `warn` count increments for a blocked (capped-scope) read and stays flat for an unrestricted read.
- Targeted runner suites (schema-links, traverse, link-resolution, pattern-scope, profile-owner-cfc) green: 62 passed (188 steps), 0 failed.

## Follow-up (not in this PR)

Alex's stronger suggestion — a build-time warning from `closure-capture-diagnostic.ts` when a narrower-scoped ref is captured into a `.map()`/lift body — is a good next step but out of scope here. This PR is the cheap, high-value runtime-observability half.

Closes CT-1642.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaced blocked narrower-scope link follows at warn level so authors can see why values resolve to undefined, especially inside .map()/lift. Scope rules are unchanged; addresses CT-1642.

- Bug Fixes
  - Raised log level from info to warn in `packages/runner/src/traverse.ts` (followPointer) and `packages/runner/src/link-resolution.ts` (resolveLink), with an actionable message naming the blocked scopes and the resolve-at-top-level-and-pass-down remedy.
  - Added `packages/runner/test/schema-links.test.ts` to assert a warn is emitted for capped-scope reads and not for unrestricted reads.

<sup>Written for commit 3a774b25001974a87fb4a34e3029c315373044cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

