### PR TITLE
fix(api): stop Default<[]> from collapsing array element type to never (CT-1640)

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -2146,6 +2146,17 @@ type IsEmptyTuple<T> = T extends readonly unknown[]
 // still present for RequireDefaults<> detection. (The lone `Default<[]>` form —
 // no sibling array — is not used in practice; the docs always pair it as
 // `T[] | Default<[]>`.)
+//
+// Why ONLY the empty tuple, and not all tuples: a non-empty literal-tuple default
+// in a union (e.g. `string[] | Default<["seed"]>`) also narrows parameter-position
+// methods — but to the literal element type, which is a legible error, not the
+// confusing `never`. More importantly, the empty tuple is the unique tuple that
+// can never be a legitimate *standalone* field type, so dropping its plain arm is
+// unconditionally safe. Generalizing to all tuples would collapse a standalone
+// tuple default like `Default<[string, number], ["a", 0]>` to `never` (the lone
+// branded arm strips away), breaking that contract. Authors who want an array
+// field with an empty-ish/seed default and a precise element type should use the
+// two-arg form `Default<string[], []>` (T = the array, not the tuple).
 export type Default<T, V extends T = T> = IsEmptyTuple<T> extends true
   ? T & DefaultMarker<T>
   :

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -2120,16 +2120,38 @@ export declare const DEFAULT_MARKER: unique symbol;
 
 type DefaultMarker<T> = { readonly [DEFAULT_MARKER]: T };
 
+// True only for the empty tuple `[]` (a length-0 tuple), false for general
+// arrays like `string[]` (whose `length` is the wide `number`) and non-empty
+// tuples. Used by Default<> to special-case `Default<[]>` (see below).
+type IsEmptyTuple<T> = T extends readonly unknown[]
+  ? number extends T["length"] ? false
+  : T["length"] extends 0 ? true
+  : false
+  : false;
+
 // Default type for specifying default values in type definitions.
 // The DEFAULT_MARKER brand enables RequireDefaults<T> to detect which fields
 // have runtime-provided defaults and make them non-optional in pattern bodies.
 // Detection uses conditional type inference (not keyof) for performance.
 // Nullish-only defaults need a standalone marker because `null & Brand` and
 // `undefined & Brand` collapse to `never`.
-export type Default<T, V extends T = T> =
-  | ([T] extends [null | undefined] ? DefaultMarker<T>
-    : T & DefaultMarker<T>)
-  | T;
+//
+// Empty-tuple special case (CT-1640): for `Default<[]>` we keep ONLY the branded
+// arm and drop the bare `| T` arm. Without this, `Default<[]>` would contribute a
+// bare `[]` (i.e. `never[]`) member; in the documented `T[] | Default<[]>` shape
+// that bare member survives `.get()`'s brand-stripping, leaving `T[] | never[]`,
+// and TypeScript intersects parameter-position element types across the union so
+// `.includes(x)`/`.indexOf(x)` collapse their parameter to `never`. Dropping the
+// bare arm lets the sibling `T[]` member supply the value type while the brand is
+// still present for RequireDefaults<> detection. (The lone `Default<[]>` form —
+// no sibling array — is not used in practice; the docs always pair it as
+// `T[] | Default<[]>`.)
+export type Default<T, V extends T = T> = IsEmptyTuple<T> extends true
+  ? T & DefaultMarker<T>
+  :
+    | ([T] extends [null | undefined] ? DefaultMarker<T>
+      : T & DefaultMarker<T>)
+    | T;
 
 /**
  * Marker for partial, recursive object defaults in `T | DeepDefault<V>` schema

--- a/packages/runner/test/require-defaults.test.ts
+++ b/packages/runner/test/require-defaults.test.ts
@@ -306,6 +306,38 @@ const _stripDefaultTuple: MustBeTrue<
   >
 > = true;
 
+// CT-1640: the documented `T[] | Default<[]>` shape strips to exactly `T[]`,
+// NOT `T[] | never[]`. `Default<[]>` keeps only its branded arm, so the bare
+// empty-tuple member never enters the union and the sibling `T[]` supplies the
+// value type.
+const _stripArrayUnionEmptyDefault: MustBeTrue<
+  AssertEqual<StripDefaultBrand<string[] | Default<[]>>, string[]>
+> = true;
+
+// Consequence: parameter-position array methods keep the element type (not
+// `never`). This is the actual CT-1640 symptom. The body is type-checked but
+// never executed (these are static assertions; the `declare`d binding has no
+// runtime value).
+function _ct1640ParamPositionMethods(
+  ids: StripDefaultBrand<string[] | Default<[]>>,
+): void {
+  const _includes: boolean = ids.includes("a");
+  const _indexOf: number = ids.indexOf("a");
+  void _includes;
+  void _indexOf;
+}
+void _ct1640ParamPositionMethods;
+
+// The Default<[]> brand must still be detectable, so RequireDefaults<> makes
+// the field required (this is why we keep the branded arm rather than dropping
+// Default<[]> entirely).
+const _emptyArrayUnionDefaultRequired: MustBeTrue<
+  AssertEqual<
+    Simplify<RequireDefaults<{ items?: string[] | Default<[]> }>>,
+    { items: string[] }
+  >
+> = true;
+
 // ============================================================================
 // StripDefaultBrand<T> — Default<T & U, V> intersection
 // ============================================================================


### PR DESCRIPTION
## Summary

`Writable<T[] | Default<[]>>.get()` returned an element type that collapsed to `never` in **parameter position**, so `.includes(x)` / `.indexOf(x)` / `.lastIndexOf(x)` failed to type-check:

> Argument of type 'string' is not assignable to parameter of type 'never'.

This bit the exact mutable-array shape the docs recommend (`docs/common/concepts/types-and-schemas/default.md`: `Writable<Column[] | Default<[]>>`).

## Root cause

`Default<[]>` expands to `([] & Brand) | []`. The bare empty-tuple `[]` (i.e. `never[]`) survives `.get()`'s brand-stripping, leaving `T[] | never[]` in the documented union shape. TypeScript intersects parameter-position element types across a union, so the `.includes`/`.indexOf` parameter becomes `string & never = never`.

## Fix

Special-case the empty tuple at the **`Default<>` definition** (not at `.get()`). A new `IsEmptyTuple<T>` detects the length-0 tuple; for it, `Default<>` keeps **only** the branded arm and drops the bare `| T` arm. So no bare `[]` enters the union — the sibling `T[]` supplies the value type, and the brand is still present for `RequireDefaults<>` detection.

```ts
export type Default<T, V extends T = T> = IsEmptyTuple<T> extends true
  ? T & DefaultMarker<T>                               // empty tuple: branded arm only
  : ([T] extends [null | undefined] ? DefaultMarker<T> : T & DefaultMarker<T>) | T;
```

### Why this, not a `.get()`-side dedup

The natural-looking alternative — apply the existing `RemoveRedundantUnionMembers` dedup at `.get()`/`sample()` — **breaks `Cell<T>`'s declared variance** (12× `TS2636 ... as implied by variance annotation`). `StripDefaultBrand<T>` is intentionally shallow because it sits in variance-sensitive cell positions (see the comment at `api/index.ts`). Fixing `Default<>` instead leaves `.get()` / `StripDefaultBrand` / cell variance completely untouched.

## Tradeoff

A **lone** `Writable<Default<[]>>` (no sibling array member) now strips to `never` rather than `never[]`. This form is **unused** in `packages/patterns` — every real usage is `T[] | Default<[]>`, which the docs always pair — and `never` is a louder signal than the silent `never[]` footgun.

## Relationship to CT-1639

Same root family (`Default<>` degrading array element-level inference). CT-1639 is the `comparable`-items facet (silent runtime removal no-op) and is a separate, transformer-side fix — tracked separately.

## Test plan

- New `require-defaults` type-level assertions: `string[] | Default<[]>` strips to exactly `string[]`; `.includes`/`.indexOf` keep the element type; the brand is still detected so `RequireDefaults<>` makes the field required.
- CT-1640 repro now type-checks clean.
- Real `Default<[]>` patterns (`render-test`, `shopping-list`, `bookmarks`) type-check via `cf check`.
- Full runner suite green: **514 passed (2793 steps), 0 failed.** api package tests green.

Closes CT-1640.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CT-1640: arrays using the documented `T[] | Default<[]>` shape no longer collapse element types to `never` in parameter position, so `.includes`/`.indexOf` type-check correctly. Docs clarify why only the empty tuple is special-cased and how to set empty defaults.

- **Bug Fixes**
  - Added `IsEmptyTuple` and updated `Default<T>` so `Default<[]>` keeps only the branded arm. This removes the bare `[]` from unions, fixes parameter types, and keeps `RequireDefaults<>` working.
  - Added type-level tests: `StripDefaultBrand<string[] | Default<[]>>` is `string[]`, and `.includes`/`.indexOf` accept `string`. Full suite passes.
  - Minor tradeoff: a lone `Default<[]>` now strips to `never` (unused in practice).

- **Docs**
  - Explained why the fix is empty-tuple-only: non-empty tuple defaults intentionally narrow parameter methods, and generalizing would break standalone tuple defaults. Recommend `Default<string[], []>` for an array field with an empty default.

<sup>Written for commit 5a3d9540e9e1ae540e9c8ff8474ec7a28aecd050. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

