### PR TITLE
feat(ts-transformers): hoist handler calls to module scope (CT-1655, handler step)

### DIFF
--- a/packages/runner/test/compiled-module-verifier.test.ts
+++ b/packages/runner/test/compiled-module-verifier.test.ts
@@ -83,6 +83,30 @@ describe("verifyCompiledBundleModuleFactories()", () => {
     expect(() => verifyCompiledBundleModuleFactories(bundle)).not.toThrow();
   });
 
+  it("accepts a hoisted handler(...) call at module scope", () => {
+    // CT-1655: extends CT-1644's whole-call hoisting to `handler`. A reactive
+    // handler (or an `action` lowered to one) is hoisted to a module-scope
+    // const `__cfHandler_N = handler(eventSchema, stateSchema, cb)`, with the
+    // captures applied at the original site. The 3-arg form puts the callback
+    // at index 2; the verifier must accept this trusted-builder call at module
+    // scope and verify the callback there (previously the handler call only
+    // appeared inline inside a pattern/JSX body, unverified at module scope).
+    const bundle = `
+((runtimeDeps = {}) => {
+  define("main", ["require", "exports", "commonfabric"], function (require, exports, commonfabric_1) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    const __cfHandler_1 = (0, commonfabric_1.handler)(false, false, (_event, { count }) => count.set(count.get() + 1));
+    exports.default = (0, commonfabric_1.pattern)((__cf_pattern_input) => ({
+      inc: __cfHandler_1({ count: __cf_pattern_input.key("count") }),
+    }));
+  });
+});
+`;
+
+    expect(() => verifyCompiledBundleModuleFactories(bundle)).not.toThrow();
+  });
+
   it("accepts a previously parsed compiled bundle", () => {
     const bundle = `
 ((runtimeDeps = {}) => {

--- a/packages/ts-transformers/docs/derive-to-lift-design.md
+++ b/packages/ts-transformers/docs/derive-to-lift-design.md
@@ -12,7 +12,11 @@ of the `lift(...)({})` stopgap). **Phase 2 complete in CT-1644**
 (`LiftHoistingTransformer` hoists every lift call to a module-scope
 `const __cfLift_N = __cfHelpers.lift(...)`, after SchemaInjection; subsumes lift
 from the CT-1585 callback hoister). `derive` has since been fully retired from
-both the transformer (CT-1643) and the runtime export (CT-1624). **Phase 3
+both the transformer (CT-1643) and the runtime export (CT-1624). **CT-1655
+extends Phase 2's whole-call hoisting to the other builders**: `handler` shipped
+(hoisted to `const __cfHandler_N`, subsuming handler from the CT-1585 callback
+hoister); `pattern`/`patternTool` remain (different `mapWithPattern`-arg
+mechanic). See the follow-up section after the phase table. **Phase 3
 (`selfcontained` marker) is now the active phase** — its design below is current
 and its open questions are mostly resolved (see the Phase 3 section and
 tracker)._
@@ -37,8 +41,45 @@ one is merged.
 
 After all three phases land for `lift`, the same pattern extends to `handler`
 (which `action` lowers into) and to `pattern` (including transformer-synthesized
-pattern callbacks for `mapWithPattern` and friends). Those are out of scope for
-this doc but the architecture should make them tractable as follow-ups.
+pattern callbacks for `mapWithPattern` and friends). These are tracked under
+CT-1655, which converges the CT-1585 callback hoister and
+`LiftHoistingTransformer` into one unified module-scope hoisting phase.
+
+**Handler shipped in CT-1655.** `handler` is emitted in the same
+single-application shape as lift —
+`__cfHelpers.handler(eventSchema, stateSchema, cb)(captures)` (an `action` is
+lowered to this `handler` shape upstream, so it gets the same treatment) — so
+the hoist is mechanically identical to lift: the inner `handler(...)` call is
+hoisted to `const __cfHandler_N = __cfHelpers.handler(...)` and the original
+site becomes `__cfHandler_N(captures)`, with the `.for(...)` tail left anchored
+on the outer call. Implementation notes:
+
+- A new `HANDLER_BUILDER` `HoistableBuilderSpec` (prefix `__cfHandler`)
+  registers in `lift-hoisting.ts`'s `HOISTABLE_BUILDERS` alongside
+  `LIFT_BUILDER`.
+- Recognition uses a dedicated `isHandlerAppliedCall` predicate (not the
+  `lift-applied` CallKind): a handler-applied call keeps classifying as
+  `{ kind: "builder", builderName: "handler" }`, so every handler-specific
+  downstream dispatcher (ReactiveVariableFor's stream cause, capture-schema
+  injection, write-authorization, etc.) is unaffected.
+- `handler` is removed from CT-1585's `HOISTABLE_BUILDER_NAMES` in the same
+  change to avoid the double-hoist TDZ (the two consts would reference each
+  other out of declaration order). `BuilderCallbackHoistingTransformer` now owns
+  only `pattern`/`patternTool`.
+- The hoist-prefix original-node fallback in `resolveBuilderExpressionKind` is
+  generalized to `__cfHandler` so the synthetic `__cfHandler_N(captures)` site
+  still classifies as `handler` for the stages that run after hoisting.
+
+**Pattern / patternTool are the remaining piece of CT-1655.** Their hoist is a
+_different_ mechanic: `pattern` is not applied — it appears as
+`expr.mapWithPattern(__cfHelpers.pattern(cb, …), { extraParams })`, so the bare
+`pattern(...)` call (argument 0 of `mapWithPattern`) is hoisted and the call is
+rewritten to thread the hoisted name, while per-instance captures continue to
+flow through `mapWithPattern`'s second argument. The top-level
+`export default pattern(...)` is already module-scope and must NOT be hoisted.
+When pattern/patternTool land here too, `HOISTABLE_BUILDER_NAMES` empties and
+`BuilderCallbackHoistingTransformer` can be deleted — the "one unified hoisting
+phase" end-state.
 
 ## Relationship to prior work
 

--- a/packages/ts-transformers/src/ast/call-kind.ts
+++ b/packages/ts-transformers/src/ast/call-kind.ts
@@ -93,6 +93,18 @@ export const FUNCTION_HARDENING_HELPER_PREFIX = "__cfHardenFn";
  */
 export const SYNTHETIC_LIFT_HOIST_PREFIX = "__cfLift";
 
+/**
+ * Prefix for the module-scope const a hoisted `handler(...)` call is bound to
+ * (CT-1655, extending CT-1644's whole-call hoisting to handler). The handler is
+ * emitted in the lift-applied shape `__cfHelpers.handler(eventSchema,
+ * stateSchema, cb)(captures)`; the inner `handler(...)` call is hoisted to
+ * `const __cfHandler_N = __cfHelpers.handler(...)` and the original site becomes
+ * `__cfHandler_N(captures)`. Mechanically identical to lift hoisting, but the
+ * applied call keeps classifying as `{ kind: "builder", builderName: "handler" }`
+ * (NOT `lift-applied`) so existing handler-specific dispatchers are unaffected.
+ */
+export const SYNTHETIC_HANDLER_HOIST_PREFIX = "__cfHandler";
+
 export type ArrayMethodFamilyName = "map" | "filter" | "flatMap";
 
 export interface ArrayMethodAccessKind {
@@ -363,6 +375,52 @@ export function getCapabilitySummaryCallbackArgument(
  * wrapper additions handled consistently across the pipeline.
  */
 export function getLiftAppliedInnerCall(
+  call: ts.CallExpression,
+): ts.CallExpression | undefined {
+  const stripped = stripWrappers(call.expression);
+  return ts.isCallExpression(stripped) ? stripped : undefined;
+}
+
+/**
+ * True iff `call` is a handler in its applied shape
+ * `__cfHelpers.handler(eventSchema, stateSchema, cb)(captures)` — an outer
+ * application whose callee is itself the inner `handler(...)` call.
+ *
+ * Structurally this is the same single-application shape as lift-applied, but
+ * we deliberately keep it OUT of the `lift-applied` CallKind (CT-1655): a
+ * handler-applied call continues to classify as `{ kind: "builder",
+ * builderName: "handler" }` so handler-specific dispatchers (stream causes in
+ * ReactiveVariableFor, capture-schema injection, write-authorization, etc.) are
+ * unaffected. This predicate exists solely so the hoisting stage can recognise
+ * the unit to relocate without minting a new kind or widening the lift-applied
+ * gate.
+ *
+ * Guards against multi-application chains (`handler(cb)(x)(y)`) the same way
+ * lift-applied recognition does — only the single-application form is the
+ * canonical lowered handler shape.
+ */
+export function isHandlerAppliedCall(
+  call: ts.CallExpression,
+  checker: ts.TypeChecker,
+): boolean {
+  const target = stripWrappers(call.expression);
+  if (!ts.isCallExpression(target) || isMultiApplicationChain(call)) {
+    return false;
+  }
+  const builderKind = resolveBuilderExpressionKind(target, checker, new Set(), {
+    followFactoryResults: true,
+  });
+  return builderKind?.builderName === "handler";
+}
+
+/**
+ * For a handler-applied call (`__cfHelpers.handler(...)(captures)`), return the
+ * inner `handler(...)` CallExpression — the unit the hoisting stage relocates
+ * to a module-scope const. Returns undefined if `call` is not the applied
+ * shape. Mirrors {@link getLiftAppliedInnerCall}; routes through `stripWrappers`
+ * for the same forward-compatibility reasons.
+ */
+export function getHandlerAppliedInnerCall(
   call: ts.CallExpression,
 ): ts.CallExpression | undefined {
   const stripped = stripWrappers(call.expression);
@@ -1517,19 +1575,24 @@ function resolveBuilderExpressionKind(
     }
   }
 
-  // Hoisted-lift fallback (CT-1644): a `lift(...)` call hoisted to a
-  // module-scope const leaves a synthetic `__cfLift_N(captures)` site whose
-  // callee identifier the checker can't resolve to its const initializer
-  // (synthetic nodes have no symbol). `LiftHoistingTransformer` records the
-  // hoisted inner `lift(...)` call as the identifier's original node; resolve
-  // the builder kind through it so the application still reads as lift-applied.
-  // Gated on `followFactoryResults` (matches the applied-call recognition path)
-  // and on the `__cfLift` prefix (so only our hoisted sites take this path),
-  // and only consulted after symbol/name resolution has failed.
+  // Hoisted-builder fallback (CT-1644 lift; CT-1655 handler): a `lift(...)` or
+  // `handler(...)` call hoisted to a module-scope const leaves a synthetic
+  // `__cfLift_N(captures)` / `__cfHandler_N(captures)` site whose callee
+  // identifier the checker can't resolve to its const initializer (synthetic
+  // nodes have no symbol). The hoisting stage records the hoisted inner call as
+  // the identifier's original node; resolve the builder kind through it so the
+  // application still classifies as the right builder (lift-applied for lift,
+  // `builderName: "handler"` for handler) for downstream stages — notably
+  // ReactiveVariableFor's `.for(...)` / stream-cause attachment, which runs
+  // after hoisting and sees only the synthetic site. Gated on
+  // `followFactoryResults` (matches the applied-call recognition path) and on
+  // the hoist prefixes (so only our hoisted sites take this path), and only
+  // consulted after symbol/name resolution has failed.
   if (
     options.followFactoryResults &&
     ts.isIdentifier(target) &&
-    target.text.startsWith(SYNTHETIC_LIFT_HOIST_PREFIX)
+    (target.text.startsWith(SYNTHETIC_LIFT_HOIST_PREFIX) ||
+      target.text.startsWith(SYNTHETIC_HANDLER_HOIST_PREFIX))
   ) {
     const original = ts.getOriginalNode(target);
     if (original !== target && ts.isCallExpression(original)) {

--- a/packages/ts-transformers/src/closures/module-scope-callback-hoisting.ts
+++ b/packages/ts-transformers/src/closures/module-scope-callback-hoisting.ts
@@ -1,6 +1,7 @@
 import ts from "typescript";
 import { FUNCTION_HARDENING_HELPER_NAME } from "@commonfabric/utils/sandbox-contract";
 import {
+  SYNTHETIC_HANDLER_HOIST_PREFIX,
   SYNTHETIC_LIFT_HOIST_PREFIX,
   SYNTHETIC_MODULE_CALLBACK_PREFIX,
 } from "../ast/call-kind.ts";
@@ -12,16 +13,16 @@ import { CF_HELPERS_IDENTIFIER } from "../core/cf-helpers.ts";
 import { unwrapExpression } from "../utils/expression.ts";
 import type { TransformationContext } from "../core/mod.ts";
 
-// `lift` is intentionally absent. As of CT-1644 (Phase 2 of
+// `lift` and `handler` are intentionally absent. As of CT-1644 (Phase 2 of
 // derive→lift→selfcontained) `LiftHoistingTransformer` hoists the entire
-// `lift(...)` call to a module-scope const and owns lift hoisting outright.
-// Hoisting the lift *callback* here too would double-hoist: the two consts
-// reference each other out of declaration order, a TDZ ReferenceError at
-// module load. This hoister keeps the builders whose whole-call hoist hasn't
-// landed yet (`handler`/`pattern`/`patternTool`); when they get the same
-// treatment they move to LiftHoistingTransformer and this set empties out.
+// `lift(...)` call to a module-scope const; CT-1655 extends that to the
+// `handler(...)` call. Hoisting the *callback* here too would double-hoist:
+// the two consts reference each other out of declaration order, a TDZ
+// ReferenceError at module load. This hoister keeps the builders whose
+// whole-call hoist hasn't landed yet (`pattern`/`patternTool`); when they get
+// the same treatment they move to LiftHoistingTransformer and this set empties
+// out, at which point this hoister can be deleted.
 const HOISTABLE_BUILDER_NAMES = new Set([
-  "handler",
   "pattern",
   "patternTool",
 ]);
@@ -51,18 +52,24 @@ const HOISTABLE_BUILDER_NAMES = new Set([
  *     count as "uses module-scoped references" and incorrectly promote
  *     the outer callback to hoistable. The exclusion keeps the inner
  *     and outer hoist decisions independent.
- *   - `__cfLift` (prefix): `LiftHoistingTransformer`'s output (CT-1644).
- *     A hoisted `lift(...)` call leaves a `__cfLift_N(captures)` reference
- *     at its original site. When that site sits inside a callback this
- *     hoister later analyzes (e.g. a pattern callback), the `__cfLift_N`
- *     reference must not count as a user-authored module-scoped reference
- *     — same independence rationale as `__cfModuleCallback` above.
+ *   - `__cfLift` / `__cfHandler` (prefixes): the whole-call hoisting stage's
+ *     output (`LiftHoistingTransformer`, CT-1644 lift / CT-1655 handler). A
+ *     hoisted `lift(...)` / `handler(...)` call leaves a `__cfLift_N(captures)`
+ *     / `__cfHandler_N(captures)` reference at its original site. If that site
+ *     sits inside a callback this hoister analyzes (e.g. a pattern callback),
+ *     the reference must not count as a user-authored module-scoped reference
+ *     — same independence rationale as `__cfModuleCallback` above. (Today the
+ *     hoisting stage runs *after* this one, so these references don't yet exist
+ *     when this hoister analyzes; the exclusion is kept symmetric with the hoist
+ *     prefixes so it stays correct as the unified phase converges and is robust
+ *     to any future re-ordering.)
  */
 function isTransformerInjectedIdentifier(text: string): boolean {
   return text === CF_HELPERS_IDENTIFIER ||
     text.startsWith(FUNCTION_HARDENING_HELPER_NAME) ||
     text.startsWith(SYNTHETIC_MODULE_CALLBACK_PREFIX) ||
-    text.startsWith(SYNTHETIC_LIFT_HOIST_PREFIX);
+    text.startsWith(SYNTHETIC_LIFT_HOIST_PREFIX) ||
+    text.startsWith(SYNTHETIC_HANDLER_HOIST_PREFIX);
 }
 
 export function hoistModuleScopedBuilderCallbacks(

--- a/packages/ts-transformers/src/transformers/lift-hoisting.ts
+++ b/packages/ts-transformers/src/transformers/lift-hoisting.ts
@@ -1,7 +1,10 @@
 import ts from "typescript";
 import {
   detectCallKind,
+  getHandlerAppliedInnerCall,
   getLiftAppliedInnerCall,
+  isHandlerAppliedCall,
+  SYNTHETIC_HANDLER_HOIST_PREFIX,
   SYNTHETIC_LIFT_HOIST_PREFIX,
 } from "../ast/call-kind.ts";
 import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
@@ -49,19 +52,20 @@ import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
  *
  * CT-1585's `BuilderCallbackHoistingTransformer` hoists builder *callbacks*
  * (the function argument), not the whole call, and only when the callback
- * closes solely over module-level symbols. For `lift` that mechanic is now
- * redundant and actively harmful: hoisting the call here AND the callback
- * there produces a double hoist whose two consts reference each other out of
- * declaration order (TDZ `ReferenceError` at module load). So `lift` is
- * removed from CT-1585's hoistable set; this stage is its sole owner. CT-1585
- * still owns `pattern`/`handler`/`patternTool`.
+ * closes solely over module-level symbols. For `lift` (CT-1644) and `handler`
+ * (CT-1655) that mechanic is now redundant and actively harmful: hoisting the
+ * call here AND the callback there produces a double hoist whose two consts
+ * reference each other out of declaration order (TDZ `ReferenceError` at module
+ * load). So `lift` and `handler` are removed from CT-1585's hoistable set; this
+ * stage is their sole owner. CT-1585 still owns `pattern`/`patternTool`.
  *
  * ## Generality
  *
  * The hoist mechanic is builder-agnostic: only "which call expression is the
  * hoistable unit" and "what name prefix to bind it to" are builder-specific.
- * Those live in {@link HOISTABLE_BUILDERS}. Today only `lift` is registered;
- * when `pattern`/`handler` get the same addressed/selfcontained treatment they
+ * Those live in {@link HOISTABLE_BUILDERS}. Today `lift` and `handler` are
+ * registered (both the single-application `builder(...)(captures)` shape); when
+ * `pattern`/`patternTool` get the same addressed/selfcontained treatment they
  * register here too, converging CT-1585 and this stage into one hoisting phase
  * without restructuring.
  */
@@ -103,7 +107,29 @@ const LIFT_BUILDER: HoistableBuilderSpec = {
   },
 };
 
-const HOISTABLE_BUILDERS: readonly HoistableBuilderSpec[] = [LIFT_BUILDER];
+const HANDLER_BUILDER: HoistableBuilderSpec = {
+  prefix: SYNTHETIC_HANDLER_HOIST_PREFIX,
+  resolveHoistable: (call, context) => {
+    // The handler-applied shape is
+    // `__cfHelpers.handler(eventSchema, stateSchema, cb)(captures)` —
+    // structurally the same single-application unit as lift, so the same hoist
+    // mechanic applies: relocate the inner `handler(...)` call, leave
+    // `__cfHandler_N(captures)` at the site (the `.for(...)` tail stays
+    // anchored on the outer call). Unlike lift this is NOT a `lift-applied`
+    // CallKind — `isHandlerAppliedCall` recognises it while keeping the applied
+    // call classifying as `{ kind: "builder", builderName: "handler" }`, so
+    // handler-specific downstream dispatchers are untouched (CT-1655).
+    if (!isHandlerAppliedCall(call, context.checker)) {
+      return undefined;
+    }
+    return getHandlerAppliedInnerCall(call);
+  },
+};
+
+const HOISTABLE_BUILDERS: readonly HoistableBuilderSpec[] = [
+  LIFT_BUILDER,
+  HANDLER_BUILDER,
+];
 
 function hoistBuilderCalls(
   sourceFile: ts.SourceFile,

--- a/packages/ts-transformers/test/fixtures/closures/action-basic.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-basic.expected.jsx
@@ -11,6 +11,16 @@ import { Cell, pattern, action } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        count: {
+            type: "number",
+            asCell: ["cell"]
+        }
+    },
+    required: ["count"]
+} as const satisfies __cfHelpers.JSONSchema, (_, { count }) => count.set(count.get() + 1));
 interface State {
     count: Cell<number>;
 }
@@ -20,16 +30,7 @@ interface State {
 export default pattern((__cf_pattern_input) => {
     const count = __cf_pattern_input.key("count");
     return {
-        inc: __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
-            type: "object",
-            properties: {
-                count: {
-                    type: "number",
-                    asCell: ["cell"]
-                }
-            },
-            required: ["count"]
-        } as const satisfies __cfHelpers.JSONSchema, (_, { count }) => count.set(count.get() + 1))({
+        inc: __cfHandler_1({
             count: count
         }).for({ stream: ["__patternResult", "inc"] }, true)
     };

--- a/packages/ts-transformers/test/fixtures/closures/action-generic-event.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-generic-event.expected.jsx
@@ -11,6 +11,24 @@ import { Cell, pattern, action } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const __cfHandler_1 = __cfHelpers.handler({
+    type: "object",
+    properties: {
+        data: {
+            type: "string"
+        }
+    },
+    required: ["data"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        value: {
+            type: "string",
+            asCell: ["writeonly"]
+        }
+    },
+    required: ["value"]
+} as const satisfies __cfHelpers.JSONSchema, (e, { value }) => value.set(e.data));
 interface MyEvent {
     data: string;
 }
@@ -25,24 +43,7 @@ export default pattern((__cf_pattern_input) => {
     const value = __cf_pattern_input.key("value");
     return {
         // Test action<MyEvent>((e) => ...) variant (type parameter instead of inline annotation)
-        update: __cfHelpers.handler({
-            type: "object",
-            properties: {
-                data: {
-                    type: "string"
-                }
-            },
-            required: ["data"]
-        } as const satisfies __cfHelpers.JSONSchema, {
-            type: "object",
-            properties: {
-                value: {
-                    type: "string",
-                    asCell: ["writeonly"]
-                }
-            },
-            required: ["value"]
-        } as const satisfies __cfHelpers.JSONSchema, (e, { value }) => value.set(e.data))({
+        update: __cfHandler_1({
             value: value
         }).for({ stream: ["__patternResult", "update"] }, true)
     };

--- a/packages/ts-transformers/test/fixtures/closures/action-in-ternary-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-in-ternary-branch.expected.jsx
@@ -18,6 +18,18 @@ import { action, Cell, computed, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        isEditing: {
+            type: "boolean",
+            asCell: ["writeonly"]
+        }
+    },
+    required: ["isEditing"]
+} as const satisfies __cfHelpers.JSONSchema, (_, { isEditing }) => {
+    isEditing.set(true);
+});
 const __cfLift_1 = __cfHelpers.lift<{
     card: {
         description: string;
@@ -60,18 +72,7 @@ export default pattern((__cf_pattern_input) => {
     const isEditing = new Cell(false, {
         type: "boolean"
     } as const satisfies __cfHelpers.JSONSchema).for("isEditing", true);
-    const startEditing = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
-        type: "object",
-        properties: {
-            isEditing: {
-                type: "boolean",
-                asCell: ["writeonly"]
-            }
-        },
-        required: ["isEditing"]
-    } as const satisfies __cfHelpers.JSONSchema, (_, { isEditing }) => {
-        isEditing.set(true);
-    })({
+    const startEditing = __cfHandler_1({
         isEditing: isEditing
     }).for({ stream: "startEditing" }, true);
     const hasDescription = __cfLift_1({ card: {

--- a/packages/ts-transformers/test/fixtures/closures/action-in-ternary-with-explicit-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-in-ternary-with-explicit-computed.expected.jsx
@@ -18,6 +18,18 @@ import { action, Cell, computed, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        isEditing: {
+            type: "boolean",
+            asCell: ["writeonly"]
+        }
+    },
+    required: ["isEditing"]
+} as const satisfies __cfHelpers.JSONSchema, (_, { isEditing }) => {
+    isEditing.set(true);
+});
 const __cfLift_1 = __cfHelpers.lift<{
     card: {
         description: string;
@@ -81,18 +93,7 @@ export default pattern((__cf_pattern_input) => {
     const isEditing = new Cell(false, {
         type: "boolean"
     } as const satisfies __cfHelpers.JSONSchema).for("isEditing", true);
-    const startEditing = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
-        type: "object",
-        properties: {
-            isEditing: {
-                type: "boolean",
-                asCell: ["writeonly"]
-            }
-        },
-        required: ["isEditing"]
-    } as const satisfies __cfHelpers.JSONSchema, (_, { isEditing }) => {
-        isEditing.set(true);
-    })({
+    const startEditing = __cfHandler_1({
         isEditing: isEditing
     }).for({ stream: "startEditing" }, true);
     return {

--- a/packages/ts-transformers/test/fixtures/closures/action-partial.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-partial.expected.jsx
@@ -11,6 +11,32 @@ import { Cell, pattern, action } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        a: {
+            anyOf: [{
+                    type: "string"
+                }, {
+                    type: "undefined"
+                }],
+            asCell: ["readonly"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, (_, { a }) => console.log(a));
+const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        b: {
+            anyOf: [{
+                    type: "number"
+                }, {
+                    type: "undefined"
+                }],
+            asCell: ["readonly"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, (_, { b }) => console.log(b));
 interface BaseState {
     a: Cell<string>;
     b: Cell<number>;
@@ -25,34 +51,10 @@ export default pattern((__cf_pattern_input) => {
     const a = __cf_pattern_input.key("a");
     const b = __cf_pattern_input.key("b");
     return {
-        readA: __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
-            type: "object",
-            properties: {
-                a: {
-                    anyOf: [{
-                            type: "string"
-                        }, {
-                            type: "undefined"
-                        }],
-                    asCell: ["readonly"]
-                }
-            }
-        } as const satisfies __cfHelpers.JSONSchema, (_, { a }) => console.log(a))({
+        readA: __cfHandler_1({
             a: a
         }).for({ stream: ["__patternResult", "readA"] }, true),
-        readB: __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
-            type: "object",
-            properties: {
-                b: {
-                    anyOf: [{
-                            type: "number"
-                        }, {
-                            type: "undefined"
-                        }],
-                    asCell: ["readonly"]
-                }
-            }
-        } as const satisfies __cfHelpers.JSONSchema, (_, { b }) => console.log(b))({
+        readB: __cfHandler_2({
             b: b
         }).for({ stream: ["__patternResult", "readB"] }, true)
     };

--- a/packages/ts-transformers/test/fixtures/closures/action-required-partial.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-required-partial.expected.jsx
@@ -11,6 +11,26 @@ import { Cell, pattern, action } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        a: {
+            type: "string",
+            asCell: ["writeonly"]
+        }
+    },
+    required: ["a"]
+} as const satisfies __cfHelpers.JSONSchema, (_, { a }) => a.set("hello"));
+const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        b: {
+            type: "number",
+            asCell: ["writeonly"]
+        }
+    },
+    required: ["b"]
+} as const satisfies __cfHelpers.JSONSchema, (_, { b }) => b.set(42));
 interface BaseState {
     a?: Cell<string>;
     b: Cell<number>;
@@ -25,28 +45,10 @@ export default pattern((__cf_pattern_input) => {
     const a = __cf_pattern_input.key("a");
     const b = __cf_pattern_input.key("b");
     return {
-        setA: __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
-            type: "object",
-            properties: {
-                a: {
-                    type: "string",
-                    asCell: ["writeonly"]
-                }
-            },
-            required: ["a"]
-        } as const satisfies __cfHelpers.JSONSchema, (_, { a }) => a.set("hello"))({
+        setA: __cfHandler_1({
             a: a
         }).for({ stream: ["__patternResult", "setA"] }, true),
-        setB: __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
-            type: "object",
-            properties: {
-                b: {
-                    type: "number",
-                    asCell: ["writeonly"]
-                }
-            },
-            required: ["b"]
-        } as const satisfies __cfHelpers.JSONSchema, (_, { b }) => b.set(42))({
+        setB: __cfHandler_2({
             b: b
         }).for({ stream: ["__patternResult", "setB"] }, true)
     };

--- a/packages/ts-transformers/test/fixtures/closures/action-result-not-opaque.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-result-not-opaque.expected.jsx
@@ -16,6 +16,30 @@ import { action, pattern, UI, Writable } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        count: {
+            type: "number",
+            asCell: ["cell"]
+        }
+    },
+    required: ["count"]
+} as const satisfies __cfHelpers.JSONSchema, (_, { count }) => {
+    count.set(count.get() + 1);
+});
+const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        count: {
+            type: "number",
+            asCell: ["cell"]
+        }
+    },
+    required: ["count"]
+} as const satisfies __cfHelpers.JSONSchema, (_, { count }) => {
+    count.set(count.get() - 1);
+});
 interface State {
     label: string;
 }
@@ -28,32 +52,10 @@ export default pattern((__cf_pattern_input) => {
     const count = new Writable(0, {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("count", true);
-    const increment = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
-        type: "object",
-        properties: {
-            count: {
-                type: "number",
-                asCell: ["cell"]
-            }
-        },
-        required: ["count"]
-    } as const satisfies __cfHelpers.JSONSchema, (_, { count }) => {
-        count.set(count.get() + 1);
-    })({
+    const increment = __cfHandler_1({
         count: count
     }).for({ stream: "increment" }, true);
-    const decrement = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
-        type: "object",
-        properties: {
-            count: {
-                type: "number",
-                asCell: ["cell"]
-            }
-        },
-        required: ["count"]
-    } as const satisfies __cfHelpers.JSONSchema, (_, { count }) => {
-        count.set(count.get() - 1);
-    })({
+    const decrement = __cfHandler_2({
         count: count
     }).for({ stream: "decrement" }, true);
     return {

--- a/packages/ts-transformers/test/fixtures/closures/action-self-closure.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-self-closure.expected.jsx
@@ -15,6 +15,67 @@ import { action, type Default, NAME, pattern, SELF, UI, type VNode, Writable } f
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const __cfHandler_1 = __cfHelpers.handler({
+    type: "object",
+    properties: {},
+    additionalProperties: false
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        self: {
+            type: "object",
+            properties: {
+                title: {
+                    type: "string"
+                }
+            },
+            required: ["title"]
+        }
+    },
+    required: ["self"]
+} as const satisfies __cfHelpers.JSONSchema, (_, { self }) => {
+    console.log("self.title:", self.title);
+});
+const __cfHandler_2 = __cfHelpers.handler({
+    type: "object",
+    properties: {},
+    additionalProperties: false
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        self: {
+            $ref: "#/$defs/TestOutput"
+        },
+        count: {
+            type: "number",
+            asCell: ["cell"]
+        }
+    },
+    required: ["self", "count"],
+    $defs: {
+        TestOutput: {
+            type: "object",
+            properties: {
+                title: {
+                    type: "string"
+                },
+                count: {
+                    type: "number"
+                },
+                $NAME: {
+                    type: "string"
+                },
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["title", "count", "$NAME", "$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, (_, { self, count }) => {
+    console.log("self:", self);
+    count.set(count.get() + 1);
+});
 interface TestOutput {
     [NAME]: string;
     [UI]: VNode;
@@ -33,72 +94,13 @@ export default pattern((__cf_pattern_input) => {
         type: "number"
     } as const satisfies __cfHelpers.JSONSchema).for("count", true);
     // Action closing over `self` — works because all inputs use Default<>
-    const showSelf = __cfHelpers.handler({
-        type: "object",
-        properties: {},
-        additionalProperties: false
-    } as const satisfies __cfHelpers.JSONSchema, {
-        type: "object",
-        properties: {
-            self: {
-                type: "object",
-                properties: {
-                    title: {
-                        type: "string"
-                    }
-                },
-                required: ["title"]
-            }
-        },
-        required: ["self"]
-    } as const satisfies __cfHelpers.JSONSchema, (_, { self }) => {
-        console.log("self.title:", self.title);
-    })({
+    const showSelf = __cfHandler_1({
         self: {
             title: self.key("title")
         }
     }).for({ stream: "showSelf" }, true);
     // Action closing over both `self` and `count`
-    const incrementWithSelf = __cfHelpers.handler({
-        type: "object",
-        properties: {},
-        additionalProperties: false
-    } as const satisfies __cfHelpers.JSONSchema, {
-        type: "object",
-        properties: {
-            self: {
-                $ref: "#/$defs/TestOutput"
-            },
-            count: {
-                type: "number",
-                asCell: ["cell"]
-            }
-        },
-        required: ["self", "count"],
-        $defs: {
-            TestOutput: {
-                type: "object",
-                properties: {
-                    title: {
-                        type: "string"
-                    },
-                    count: {
-                        type: "number"
-                    },
-                    $NAME: {
-                        type: "string"
-                    },
-                    $UI: {
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }
-                },
-                required: ["title", "count", "$NAME", "$UI"]
-            }
-        }
-    } as const satisfies __cfHelpers.JSONSchema, (_, { self, count }) => {
-        console.log("self:", self);
-        count.set(count.get() + 1);
-    })({
+    const incrementWithSelf = __cfHandler_2({
         self: self,
         count: count
     }).for({ stream: "incrementWithSelf" }, true);

--- a/packages/ts-transformers/test/fixtures/closures/action-with-event.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-with-event.expected.jsx
@@ -11,6 +11,24 @@ import { Cell, pattern, action } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const __cfHandler_1 = __cfHelpers.handler({
+    type: "object",
+    properties: {
+        data: {
+            type: "string"
+        }
+    },
+    required: ["data"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        value: {
+            type: "string",
+            asCell: ["writeonly"]
+        }
+    },
+    required: ["value"]
+} as const satisfies __cfHelpers.JSONSchema, (e, { value }) => value.set(e.data));
 interface MyEvent {
     data: string;
 }
@@ -24,24 +42,7 @@ interface State {
 export default pattern((__cf_pattern_input) => {
     const value = __cf_pattern_input.key("value");
     return {
-        update: __cfHelpers.handler({
-            type: "object",
-            properties: {
-                data: {
-                    type: "string"
-                }
-            },
-            required: ["data"]
-        } as const satisfies __cfHelpers.JSONSchema, {
-            type: "object",
-            properties: {
-                value: {
-                    type: "string",
-                    asCell: ["writeonly"]
-                }
-            },
-            required: ["value"]
-        } as const satisfies __cfHelpers.JSONSchema, (e, { value }) => value.set(e.data))({
+        update: __cfHandler_1({
             value: value
         }).for({ stream: ["__patternResult", "update"] }, true)
     };

--- a/packages/ts-transformers/test/fixtures/closures/handler-basic.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-basic.expected.jsx
@@ -11,6 +11,22 @@ import { Cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        state: {
+            type: "object",
+            properties: {
+                counter: {
+                    type: "number",
+                    asCell: ["cell"]
+                }
+            },
+            required: ["counter"]
+        }
+    },
+    required: ["state"]
+} as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, { state }) => state.counter.set(state.counter.get() + 1));
 interface State {
     counter: Cell<number>;
 }
@@ -19,22 +35,7 @@ interface State {
 //   onClick={() => state.counter.set(...)} → onClick={handler(false, { state: { counter: asCell } }, (_, { state }) => ...)({ state: { counter } })}
 export default pattern((state) => {
     return {
-        [UI]: (<button type="button" onClick={__cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
-            type: "object",
-            properties: {
-                state: {
-                    type: "object",
-                    properties: {
-                        counter: {
-                            type: "number",
-                            asCell: ["cell"]
-                        }
-                    },
-                    required: ["counter"]
-                }
-            },
-            required: ["state"]
-        } as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, { state }) => state.counter.set(state.counter.get() + 1))({
+        [UI]: (<button type="button" onClick={__cfHandler_1({
             state: {
                 counter: state.key("counter")
             }

--- a/packages/ts-transformers/test/fixtures/closures/handler-computed-key.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-computed-key.expected.jsx
@@ -11,7 +11,20 @@ import { Cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfModuleCallback_1 = __cfHardenFn((__cf_handler_event, { recordMap }) => recordMap[nextKey()]!.set(counter));
+const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        recordMap: {
+            type: "object",
+            properties: {},
+            additionalProperties: {
+                type: "number",
+                asCell: ["cell"]
+            }
+        }
+    },
+    required: ["recordMap"]
+} as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, { recordMap }) => recordMap[nextKey()]!.set(counter));
 interface State {
     records: Record<string, Cell<number>>;
 }
@@ -28,20 +41,7 @@ __cfHardenFn(nextKey);
 export default pattern((state) => {
     const recordMap = state.key("records");
     return {
-        [UI]: (<button type="button" onClick={__cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
-            type: "object",
-            properties: {
-                recordMap: {
-                    type: "object",
-                    properties: {},
-                    additionalProperties: {
-                        type: "number",
-                        asCell: ["cell"]
-                    }
-                }
-            },
-            required: ["recordMap"]
-        } as const satisfies __cfHelpers.JSONSchema, __cfModuleCallback_1)({
+        [UI]: (<button type="button" onClick={__cfHandler_1({
             recordMap: recordMap
         })}>
         Step

--- a/packages/ts-transformers/test/fixtures/closures/handler-destructured-params.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-destructured-params.expected.jsx
@@ -11,6 +11,54 @@ import { Cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const __cfHandler_1 = __cfHelpers.handler({
+    type: "object",
+    properties: {
+        detail: {
+            type: "object",
+            properties: {
+                value: true,
+                items: {
+                    type: "array",
+                    items: {
+                        type: "object",
+                        properties: {
+                            label: {
+                                type: "string"
+                            },
+                            value: true
+                        },
+                        required: ["label", "value"]
+                    }
+                }
+            },
+            required: ["value", "items"]
+        }
+    },
+    required: ["detail"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        state: {
+            type: "object",
+            properties: {
+                selectedValue: {
+                    type: "string",
+                    asCell: ["writeonly"]
+                },
+                lastItems: {
+                    type: "string",
+                    asCell: ["writeonly"]
+                }
+            },
+            required: ["selectedValue", "lastItems"]
+        }
+    },
+    required: ["state"]
+} as const satisfies __cfHelpers.JSONSchema, ({ detail: { value, items } }, { state }) => {
+    state.selectedValue.set(value);
+    state.lastItems.set(items.map(i => i.label).join(", "));
+});
 interface State {
     selectedValue: Cell<string>;
     lastItems: Cell<string>;
@@ -24,54 +72,7 @@ export default pattern((state) => {
         [UI]: (<cf-select $value={state.key("selectedValue")} items={[
                 { label: "Option A", value: "a" },
                 { label: "Option B", value: "b" },
-            ]} oncf-change={__cfHelpers.handler({
-            type: "object",
-            properties: {
-                detail: {
-                    type: "object",
-                    properties: {
-                        value: true,
-                        items: {
-                            type: "array",
-                            items: {
-                                type: "object",
-                                properties: {
-                                    label: {
-                                        type: "string"
-                                    },
-                                    value: true
-                                },
-                                required: ["label", "value"]
-                            }
-                        }
-                    },
-                    required: ["value", "items"]
-                }
-            },
-            required: ["detail"]
-        } as const satisfies __cfHelpers.JSONSchema, {
-            type: "object",
-            properties: {
-                state: {
-                    type: "object",
-                    properties: {
-                        selectedValue: {
-                            type: "string",
-                            asCell: ["writeonly"]
-                        },
-                        lastItems: {
-                            type: "string",
-                            asCell: ["writeonly"]
-                        }
-                    },
-                    required: ["selectedValue", "lastItems"]
-                }
-            },
-            required: ["state"]
-        } as const satisfies __cfHelpers.JSONSchema, ({ detail: { value, items } }, { state }) => {
-            state.selectedValue.set(value);
-            state.lastItems.set(items.map(i => i.label).join(", "));
-        })({
+            ]} oncf-change={__cfHandler_1({
             state: {
                 selectedValue: state.key("selectedValue"),
                 lastItems: state.key("lastItems")

--- a/packages/ts-transformers/test/fixtures/closures/handler-event-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-event-param.expected.jsx
@@ -11,6 +11,41 @@ import { Cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const __cfHandler_1 = __cfHelpers.handler({
+    type: "object",
+    properties: {
+        detail: {
+            type: "object",
+            properties: {
+                value: true
+            },
+            required: ["value"]
+        }
+    },
+    required: ["detail"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        state: {
+            type: "object",
+            properties: {
+                changeCount: {
+                    type: "number",
+                    asCell: ["cell"]
+                },
+                selectedValue: {
+                    type: "string",
+                    asCell: ["writeonly"]
+                }
+            },
+            required: ["changeCount", "selectedValue"]
+        }
+    },
+    required: ["state"]
+} as const satisfies __cfHelpers.JSONSchema, (event, { state }) => {
+    state.selectedValue.set(event.detail.value);
+    state.changeCount.set(state.changeCount.get() + 1);
+});
 interface State {
     selectedValue: Cell<string>;
     changeCount: Cell<number>;
@@ -24,41 +59,7 @@ export default pattern((state) => {
         [UI]: (<cf-select $value={state.key("selectedValue")} items={[
                 { label: "Option A", value: "a" },
                 { label: "Option B", value: "b" },
-            ]} oncf-change={__cfHelpers.handler({
-            type: "object",
-            properties: {
-                detail: {
-                    type: "object",
-                    properties: {
-                        value: true
-                    },
-                    required: ["value"]
-                }
-            },
-            required: ["detail"]
-        } as const satisfies __cfHelpers.JSONSchema, {
-            type: "object",
-            properties: {
-                state: {
-                    type: "object",
-                    properties: {
-                        changeCount: {
-                            type: "number",
-                            asCell: ["cell"]
-                        },
-                        selectedValue: {
-                            type: "string",
-                            asCell: ["writeonly"]
-                        }
-                    },
-                    required: ["changeCount", "selectedValue"]
-                }
-            },
-            required: ["state"]
-        } as const satisfies __cfHelpers.JSONSchema, (event, { state }) => {
-            state.selectedValue.set(event.detail.value);
-            state.changeCount.set(state.changeCount.get() + 1);
-        })({
+            ]} oncf-change={__cfHandler_1({
             state: {
                 selectedValue: state.key("selectedValue"),
                 changeCount: state.key("changeCount")

--- a/packages/ts-transformers/test/fixtures/closures/handler-nested-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-nested-map.expected.jsx
@@ -11,6 +11,36 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        state: {
+            type: "object",
+            properties: {
+                items: {
+                    type: "array",
+                    items: {
+                        type: "object",
+                        properties: {
+                            value: {
+                                type: "number"
+                            }
+                        },
+                        required: ["value"]
+                    }
+                },
+                multiplier: {
+                    type: "number"
+                }
+            },
+            required: ["items", "multiplier"]
+        }
+    },
+    required: ["state"]
+} as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, { state }) => {
+    const scaled = state.items.map((item) => item.value * state.multiplier);
+    console.log(scaled);
+});
 interface State {
     items: Array<{
         value: number;
@@ -23,36 +53,7 @@ interface State {
 // Context: .map() on a plain array inside a handler remains a normal JS .map(), not a reactive transform
 export default pattern((state) => {
     return {
-        [UI]: (<button type="button" onClick={__cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
-            type: "object",
-            properties: {
-                state: {
-                    type: "object",
-                    properties: {
-                        items: {
-                            type: "array",
-                            items: {
-                                type: "object",
-                                properties: {
-                                    value: {
-                                        type: "number"
-                                    }
-                                },
-                                required: ["value"]
-                            }
-                        },
-                        multiplier: {
-                            type: "number"
-                        }
-                    },
-                    required: ["items", "multiplier"]
-                }
-            },
-            required: ["state"]
-        } as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, { state }) => {
-            const scaled = state.items.map((item) => item.value * state.multiplier);
-            console.log(scaled);
-        })({
+        [UI]: (<button type="button" onClick={__cfHandler_1({
             state: {
                 items: state.key("items"),
                 multiplier: state.key("multiplier")

--- a/packages/ts-transformers/test/fixtures/closures/handler-no-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-no-captures.expected.jsx
@@ -11,6 +11,10 @@ import { Cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {}
+} as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, __cf_handler_params) => console.log("hi"));
 interface State {
     counter: Cell<number>;
 }
@@ -20,10 +24,7 @@ interface State {
 // Context: No closed-over state; capture object is empty
 export default pattern((_state) => {
     return {
-        [UI]: (<button type="button" onClick={__cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
-            type: "object",
-            properties: {}
-        } as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, __cf_handler_params) => console.log("hi"))({})}>
+        [UI]: (<button type="button" onClick={__cfHandler_1({})}>
         Log
       </button>),
     };

--- a/packages/ts-transformers/test/fixtures/closures/handler-reserved-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-reserved-capture.expected.jsx
@@ -11,6 +11,15 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        __cf_handler_event: {
+            type: "string"
+        }
+    },
+    required: ["__cf_handler_event"]
+} as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event_1, { __cf_handler_event }) => __cf_handler_event);
 interface State {
     label: string;
 }
@@ -21,15 +30,7 @@ interface State {
 export default pattern((state) => {
     const __cf_handler_event = state.key("label");
     return {
-        [UI]: (<button type="button" onClick={__cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
-            type: "object",
-            properties: {
-                __cf_handler_event: {
-                    type: "string"
-                }
-            },
-            required: ["__cf_handler_event"]
-        } as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event_1, { __cf_handler_event }) => __cf_handler_event)({
+        [UI]: (<button type="button" onClick={__cfHandler_1({
             __cf_handler_event: __cf_handler_event
         })}>
         Echo

--- a/packages/ts-transformers/test/fixtures/closures/handler-unused-event.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-unused-event.expected.jsx
@@ -11,6 +11,24 @@ import { Cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const __cfHandler_1 = __cfHelpers.handler({
+    type: "unknown"
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        state: {
+            type: "object",
+            properties: {
+                counter: {
+                    type: "number",
+                    asCell: ["cell"]
+                }
+            },
+            required: ["counter"]
+        }
+    },
+    required: ["state"]
+} as const satisfies __cfHelpers.JSONSchema, (_, { state }) => state.counter.set(state.counter.get() + 1));
 interface State {
     counter: Cell<number>;
 }
@@ -20,24 +38,7 @@ interface State {
 // Context: Event param is named _ (unused); transformer emits a generic event schema placeholder
 export default pattern((state) => {
     return {
-        [UI]: (<button type="button" onClick={__cfHelpers.handler({
-            type: "unknown"
-        } as const satisfies __cfHelpers.JSONSchema, {
-            type: "object",
-            properties: {
-                state: {
-                    type: "object",
-                    properties: {
-                        counter: {
-                            type: "number",
-                            asCell: ["cell"]
-                        }
-                    },
-                    required: ["counter"]
-                }
-            },
-            required: ["state"]
-        } as const satisfies __cfHelpers.JSONSchema, (_, { state }) => state.counter.set(state.counter.get() + 1))({
+        [UI]: (<button type="button" onClick={__cfHandler_1({
             state: {
                 counter: state.key("counter")
             }

--- a/packages/ts-transformers/test/fixtures/closures/helper-owned-handler-nested-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/helper-owned-handler-nested-captures.expected.jsx
@@ -25,6 +25,55 @@ import { action, Default, pattern, Stream, Writable } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        timer: {
+            anyOf: [{
+                    type: "number"
+                }, {
+                    type: "null"
+                }],
+            asCell: ["cell"]
+        },
+        fileId: {
+            type: "string",
+            "default": "",
+            asCell: ["readonly"]
+        },
+        content: {
+            type: "string",
+            "default": "",
+            asCell: ["readonly"]
+        },
+        savedContent: {
+            type: "string",
+            "default": "",
+            asCell: ["readonly"]
+        },
+        onSaveFile: {
+            type: "object",
+            properties: {
+                fileId: {
+                    type: "string"
+                },
+                content: {
+                    type: "string"
+                }
+            },
+            required: ["fileId", "content"],
+            asCell: ["stream"]
+        }
+    },
+    required: ["timer", "fileId", "content", "savedContent", "onSaveFile"]
+} as const satisfies __cfHelpers.JSONSchema, (_, { timer, fileId, content, savedContent, onSaveFile }) => {
+    const prev = timer.get();
+    if (prev !== null)
+        clearTimeout(prev);
+    timer.set(setTimeout(() => {
+        flushLater(fileId, content, savedContent, onSaveFile);
+    }, 10));
+});
 function flushLater(fileId: Writable<Default<string, "">>, content: Writable<Default<string, "">>, savedContent: Writable<Default<string, "">>, onSaveFile: Stream<{
     fileId: string;
     content: string;
@@ -61,55 +110,7 @@ export default pattern((__cf_pattern_input) => {
                 type: "null"
             }]
     } as const satisfies __cfHelpers.JSONSchema).for("timer", true);
-    const trigger = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
-        type: "object",
-        properties: {
-            timer: {
-                anyOf: [{
-                        type: "number"
-                    }, {
-                        type: "null"
-                    }],
-                asCell: ["cell"]
-            },
-            fileId: {
-                type: "string",
-                "default": "",
-                asCell: ["readonly"]
-            },
-            content: {
-                type: "string",
-                "default": "",
-                asCell: ["readonly"]
-            },
-            savedContent: {
-                type: "string",
-                "default": "",
-                asCell: ["readonly"]
-            },
-            onSaveFile: {
-                type: "object",
-                properties: {
-                    fileId: {
-                        type: "string"
-                    },
-                    content: {
-                        type: "string"
-                    }
-                },
-                required: ["fileId", "content"],
-                asCell: ["stream"]
-            }
-        },
-        required: ["timer", "fileId", "content", "savedContent", "onSaveFile"]
-    } as const satisfies __cfHelpers.JSONSchema, (_, { timer, fileId, content, savedContent, onSaveFile }) => {
-        const prev = timer.get();
-        if (prev !== null)
-            clearTimeout(prev);
-        timer.set(setTimeout(() => {
-            flushLater(fileId, content, savedContent, onSaveFile);
-        }, 10));
-    })({
+    const trigger = __cfHandler_1({
         timer: timer,
         fileId: fileId,
         content: content,

--- a/packages/ts-transformers/test/fixtures/closures/hoisted-handler-preserves-capture-schemas.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/hoisted-handler-preserves-capture-schemas.expected.jsx
@@ -11,7 +11,36 @@ import { action, NAME, pattern, SELF, UI, type VNode, Writable, } from "commonfa
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfModuleCallback_1 = __cfHardenFn((_, { items }) => {
+const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        items: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Item"
+            },
+            asCell: ["readonly"]
+        }
+    },
+    required: ["items"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "number"
+                },
+                label: {
+                    type: "string"
+                },
+                $NAME: {
+                    type: "string"
+                }
+            },
+            required: ["id", "label", "$NAME"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, (_, { items }) => {
     const pieces = items.get() ?? [];
     const existing = pieces.find((p) => {
         const n = p?.[NAME];
@@ -21,7 +50,61 @@ const __cfModuleCallback_1 = __cfHardenFn((_, { items }) => {
         return navigateTo(existing);
     }
 });
-const __cfModuleCallback_2 = __cfHardenFn(({ label }, { self, items }) => {
+const __cfHandler_2 = __cfHelpers.handler({
+    type: "object",
+    properties: {
+        label: {
+            type: "string"
+        }
+    },
+    required: ["label"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        self: {
+            $ref: "#/$defs/ListOutput"
+        },
+        items: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Item"
+            },
+            asCell: ["writeonly"]
+        }
+    },
+    required: ["self", "items"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "number"
+                },
+                label: {
+                    type: "string"
+                },
+                $NAME: {
+                    type: "string"
+                }
+            },
+            required: ["id", "label", "$NAME"]
+        },
+        ListOutput: {
+            type: "object",
+            properties: {
+                read: true,
+                write: true,
+                $NAME: {
+                    type: "string"
+                },
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["read", "write", "$NAME", "$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, ({ label }, { self, items }) => {
     const newItem = Item({ id: 0, label, parent: self } as any);
     items.push(newItem as any);
     return newItem;
@@ -83,96 +166,13 @@ export default pattern((__cf_pattern_input) => {
     // `goToAllNotesAction` — reads `items.get()`, filters, conditionally
     // navigates. Triggers `items` to be classified `readonly` in this
     // action's captures schema.
-    const read = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
-        type: "object",
-        properties: {
-            items: {
-                type: "array",
-                items: {
-                    $ref: "#/$defs/Item"
-                },
-                asCell: ["readonly"]
-            }
-        },
-        required: ["items"],
-        $defs: {
-            Item: {
-                type: "object",
-                properties: {
-                    id: {
-                        type: "number"
-                    },
-                    label: {
-                        type: "string"
-                    },
-                    $NAME: {
-                        type: "string"
-                    }
-                },
-                required: ["id", "label", "$NAME"]
-            }
-        }
-    } as const satisfies __cfHelpers.JSONSchema, __cfModuleCallback_1)({
+    const read = __cfHandler_1({
         items: items
     }).for({ stream: "read" }, true);
     // `write` action: matches the shape of notebook.tsx's
     // `createNoteStreamAction` — pushes a new item, returns it. Should
     // get a schema with `items` classified `writeonly` (plus `self`).
-    const write = __cfHelpers.handler({
-        type: "object",
-        properties: {
-            label: {
-                type: "string"
-            }
-        },
-        required: ["label"]
-    } as const satisfies __cfHelpers.JSONSchema, {
-        type: "object",
-        properties: {
-            self: {
-                $ref: "#/$defs/ListOutput"
-            },
-            items: {
-                type: "array",
-                items: {
-                    $ref: "#/$defs/Item"
-                },
-                asCell: ["writeonly"]
-            }
-        },
-        required: ["self", "items"],
-        $defs: {
-            Item: {
-                type: "object",
-                properties: {
-                    id: {
-                        type: "number"
-                    },
-                    label: {
-                        type: "string"
-                    },
-                    $NAME: {
-                        type: "string"
-                    }
-                },
-                required: ["id", "label", "$NAME"]
-            },
-            ListOutput: {
-                type: "object",
-                properties: {
-                    read: true,
-                    write: true,
-                    $NAME: {
-                        type: "string"
-                    },
-                    $UI: {
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }
-                },
-                required: ["read", "write", "$NAME", "$UI"]
-            }
-        }
-    } as const satisfies __cfHelpers.JSONSchema, __cfModuleCallback_2)({
+    const write = __cfHandler_2({
         self: self,
         items: items
     }).for({ stream: "write" }, true);

--- a/packages/ts-transformers/test/fixtures/closures/inline-action-in-ternary-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/inline-action-in-ternary-branch.expected.jsx
@@ -19,6 +19,22 @@ import { Cell, computed, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        state: {
+            type: "object",
+            properties: {
+                isEditing: {
+                    type: "boolean",
+                    asCell: ["writeonly"]
+                }
+            },
+            required: ["isEditing"]
+        }
+    },
+    required: ["state"]
+} as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, { state }) => state.isEditing.set(true));
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         isEditing: __cfHelpers.ReadonlyCell<boolean>;
@@ -58,22 +74,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => (<cf-button onClick={__cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
-    type: "object",
-    properties: {
-        state: {
-            type: "object",
-            properties: {
-                isEditing: {
-                    type: "boolean",
-                    asCell: ["writeonly"]
-                }
-            },
-            required: ["isEditing"]
-        }
-    },
-    required: ["state"]
-} as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, { state }) => state.isEditing.set(true))({
+} as const satisfies __cfHelpers.JSONSchema, ({ state }) => (<cf-button onClick={__cfHandler_1({
     state: {
         isEditing: state.isEditing
     }

--- a/packages/ts-transformers/test/fixtures/closures/map-and-handler.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-and-handler.expected.jsx
@@ -44,6 +44,25 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ item, state }) => item.price * state.discount);
+const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        index: {
+            type: "number"
+        },
+        state: {
+            type: "object",
+            properties: {
+                selectedIndex: {
+                    type: "number",
+                    asCell: ["writeonly"]
+                }
+            },
+            required: ["selectedIndex"]
+        }
+    },
+    required: ["index", "state"]
+} as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, { state, index }) => state.selectedIndex.set(index));
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         items: { price: number; }[];
@@ -146,25 +165,7 @@ export default pattern((state) => {
                         discount: state.key("discount")
                     }
                 })}</span>
-            <button type="button" onClick={__cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
-                    type: "object",
-                    properties: {
-                        index: {
-                            type: "number"
-                        },
-                        state: {
-                            type: "object",
-                            properties: {
-                                selectedIndex: {
-                                    type: "number",
-                                    asCell: ["writeonly"]
-                                }
-                            },
-                            required: ["selectedIndex"]
-                        }
-                    },
-                    required: ["index", "state"]
-                } as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, { state, index }) => state.selectedIndex.set(index))({
+            <button type="button" onClick={__cfHandler_1({
                     state: {
                         selectedIndex: state.key("selectedIndex")
                     },

--- a/packages/ts-transformers/test/fixtures/closures/map-conditional-inline-handler-send.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-conditional-inline-handler-send.expected.jsx
@@ -66,6 +66,28 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema, ({ castVote, state }) => castVote({ votes: state.votes }).for({ stream: "boundCastVote" }));
+const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        boundCastVote: {
+            type: "unknown",
+            asCell: ["stream"]
+        },
+        item: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                }
+            },
+            required: ["id"]
+        }
+    },
+    required: ["boundCastVote", "item"]
+} as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, { boundCastVote, item }) => boundCastVote.send({
+    id: item.id,
+    step: "single",
+}));
 interface Item {
     id: string;
     label: string;
@@ -148,28 +170,7 @@ export default pattern((state) => {
                             type: "object",
                             properties: {}
                         }]
-                } as const satisfies __cfHelpers.JSONSchema, state.key("canVote"), <button type="button" onClick={__cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
-                    type: "object",
-                    properties: {
-                        boundCastVote: {
-                            type: "unknown",
-                            asCell: ["stream"]
-                        },
-                        item: {
-                            type: "object",
-                            properties: {
-                                id: {
-                                    type: "string"
-                                }
-                            },
-                            required: ["id"]
-                        }
-                    },
-                    required: ["boundCastVote", "item"]
-                } as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, { boundCastVote, item }) => boundCastVote.send({
-                    id: item.id,
-                    step: "single",
-                }))({
+                } as const satisfies __cfHelpers.JSONSchema, state.key("canVote"), <button type="button" onClick={__cfHandler_1({
                     boundCastVote: boundCastVote,
                     item: {
                         id: item.key("id")

--- a/packages/ts-transformers/test/fixtures/closures/nested-map-fallback-receiver.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/nested-map-fallback-receiver.expected.jsx
@@ -11,6 +11,27 @@ import { action, Default, pattern, UI, Writable } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const __cfHandler_1 = __cfHelpers.handler({
+    type: "object",
+    properties: {
+        name: {
+            type: "string"
+        }
+    },
+    required: ["name"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        assignName: {
+            type: "string",
+            asCell: [{
+                    kind: "cell",
+                    scope: "space"
+                }]
+        }
+    },
+    required: ["assignName"]
+} as const satisfies __cfHelpers.JSONSchema, (p, { assignName }) => assignName.set(p.name));
 const __cfLift_1 = __cfHelpers.lift<{
     people: __cfHelpers.PerSpace<__cfHelpers.Cell<Person[]>>;
 }, readonly Person[]>({
@@ -56,6 +77,31 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, ({ people }) => people.get());
+const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        setAssign: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"],
+            asCell: ["stream"]
+        },
+        p: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        }
+    },
+    required: ["setAssign", "p"]
+} as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, { setAssign, p }) => setAssign.send({ name: p.name }));
 interface Person {
     name: string;
 }
@@ -104,27 +150,7 @@ export default pattern((__cf_pattern_input) => {
         type: "string",
         scope: "space"
     } as const satisfies __cfHelpers.JSONSchema).for("assignName", true);
-    const setAssign = __cfHelpers.handler({
-        type: "object",
-        properties: {
-            name: {
-                type: "string"
-            }
-        },
-        required: ["name"]
-    } as const satisfies __cfHelpers.JSONSchema, {
-        type: "object",
-        properties: {
-            assignName: {
-                type: "string",
-                asCell: [{
-                        kind: "cell",
-                        scope: "space"
-                    }]
-            }
-        },
-        required: ["assignName"]
-    } as const satisfies __cfHelpers.JSONSchema, (p, { assignName }) => assignName.set(p.name))({
+    const setAssign = __cfHandler_1({
         assignName: assignName
     }).for({ stream: "setAssign" }, true);
     return {
@@ -138,31 +164,7 @@ export default pattern((__cf_pattern_input) => {
             {(__cfLift_1({ people: people }) ?? []).mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
                         const p = __cf_pattern_input.key("element");
                         const setAssign = __cf_pattern_input.key("params", "setAssign");
-                        return (<button type="button" onClick={__cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
-                            type: "object",
-                            properties: {
-                                setAssign: {
-                                    type: "object",
-                                    properties: {
-                                        name: {
-                                            type: "string"
-                                        }
-                                    },
-                                    required: ["name"],
-                                    asCell: ["stream"]
-                                },
-                                p: {
-                                    type: "object",
-                                    properties: {
-                                        name: {
-                                            type: "string"
-                                        }
-                                    },
-                                    required: ["name"]
-                                }
-                            },
-                            required: ["setAssign", "p"]
-                        } as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, { setAssign, p }) => setAssign.send({ name: p.name }))({
+                        return (<button type="button" onClick={__cfHandler_2({
                             setAssign: setAssign,
                             p: {
                                 name: p.key("name")

--- a/packages/ts-transformers/test/fixtures/closures/writable-of-terminal-methods.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/writable-of-terminal-methods.expected.jsx
@@ -17,6 +17,23 @@ import { action, pattern, UI, Writable } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        counter: {
+            type: "number",
+            asCell: ["writeonly"]
+        },
+        label: {
+            type: "string",
+            asCell: ["writeonly"]
+        }
+    },
+    required: ["counter", "label"]
+} as const satisfies __cfHelpers.JSONSchema, (_, { counter, label }) => {
+    counter.set(0);
+    label.set("Count");
+});
 interface State {
     title: string;
 }
@@ -36,23 +53,7 @@ export default pattern((__cf_pattern_input) => {
     const label = new Writable("Count", {
         type: "string"
     } as const satisfies __cfHelpers.JSONSchema).for("label", true);
-    const reset = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
-        type: "object",
-        properties: {
-            counter: {
-                type: "number",
-                asCell: ["writeonly"]
-            },
-            label: {
-                type: "string",
-                asCell: ["writeonly"]
-            }
-        },
-        required: ["counter", "label"]
-    } as const satisfies __cfHelpers.JSONSchema, (_, { counter, label }) => {
-        counter.set(0);
-        label.set("Count");
-    })({
+    const reset = __cfHandler_1({
         counter: counter,
         label: label
     }).for({ stream: "reset" }, true);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-captures.expected.jsx
@@ -19,6 +19,29 @@ import { action, Default, pattern, UI, VNode, Writable, } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const __cfHandler_1 = __cfHelpers.handler({
+    type: "object",
+    properties: {
+        name: {
+            type: "string"
+        }
+    },
+    required: ["name"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        path: {
+            type: "array",
+            items: {
+                type: "string"
+            },
+            asCell: ["writeonly"]
+        }
+    },
+    required: ["path"]
+} as const satisfies __cfHelpers.JSONSchema, ({ name }, { path }) => {
+    path.push(name);
+});
 const __cfLift_1 = __cfHelpers.lift<{
     path: __cfHelpers.Cell<string[]>;
 }, readonly string[]>({
@@ -110,6 +133,31 @@ const __cfLift_3 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, ({ entries, p }) => visibleEntries(entries, p[0] || ""));
+const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        pushPath: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"],
+            asCell: ["stream"]
+        },
+        entry: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        }
+    },
+    required: ["pushPath", "entry"]
+} as const satisfies __cfHelpers.JSONSchema, (_, { pushPath, entry }) => pushPath.send({ name: entry.name }));
 interface Entry {
     name: string;
 }
@@ -134,29 +182,7 @@ export default pattern((__cf_pattern_input) => {
             type: "string"
         }
     } as const satisfies __cfHelpers.JSONSchema).for("path", true);
-    const pushPath = __cfHelpers.handler({
-        type: "object",
-        properties: {
-            name: {
-                type: "string"
-            }
-        },
-        required: ["name"]
-    } as const satisfies __cfHelpers.JSONSchema, {
-        type: "object",
-        properties: {
-            path: {
-                type: "array",
-                items: {
-                    type: "string"
-                },
-                asCell: ["writeonly"]
-            }
-        },
-        required: ["path"]
-    } as const satisfies __cfHelpers.JSONSchema, ({ name }, { path }) => {
-        path.push(name);
-    })({
+    const pushPath = __cfHandler_1({
         path: path
     }).for({ stream: "pushPath" }, true);
     return {
@@ -202,31 +228,7 @@ export default pattern((__cf_pattern_input) => {
                 return visible.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
                     const entry = __cf_pattern_input.key("element");
                     const pushPath = __cf_pattern_input.key("params", "pushPath");
-                    return (<button type="button" onClick={__cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
-                        type: "object",
-                        properties: {
-                            pushPath: {
-                                type: "object",
-                                properties: {
-                                    name: {
-                                        type: "string"
-                                    }
-                                },
-                                required: ["name"],
-                                asCell: ["stream"]
-                            },
-                            entry: {
-                                type: "object",
-                                properties: {
-                                    name: {
-                                        type: "string"
-                                    }
-                                },
-                                required: ["name"]
-                            }
-                        },
-                        required: ["pushPath", "entry"]
-                    } as const satisfies __cfHelpers.JSONSchema, (_, { pushPath, entry }) => pushPath.send({ name: entry.name }))({
+                    return (<button type="button" onClick={__cfHandler_2({
                         pushPath: pushPath,
                         entry: {
                             name: entry.key("name")

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-default-input-local-chain-map-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-default-input-local-chain-map-capture.expected.jsx
@@ -18,6 +18,69 @@ import { action, Default, pattern, UI, VNode, Writable, } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const __cfHandler_1 = __cfHelpers.handler({
+    type: "object",
+    properties: {
+        name: {
+            type: "string"
+        }
+    },
+    required: ["name"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        path: {
+            type: "array",
+            items: {
+                type: "string"
+            },
+            asCell: ["writeonly"]
+        }
+    },
+    required: ["path"]
+} as const satisfies __cfHelpers.JSONSchema, ({ name }, { path }) => {
+    path.push(name);
+});
+const __cfHandler_2 = __cfHelpers.handler({
+    type: "object",
+    properties: {
+        item: {
+            $ref: "#/$defs/Entry"
+        }
+    },
+    required: ["item"],
+    $defs: {
+        Entry: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                },
+                name: {
+                    type: "string"
+                },
+                type: {
+                    "enum": ["file", "folder"]
+                },
+                children: {
+                    type: "array",
+                    items: {
+                        $ref: "#/$defs/Entry"
+                    }
+                },
+                contentType: {
+                    type: "string"
+                }
+            },
+            required: ["id", "name", "type"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {}
+} as const satisfies __cfHelpers.JSONSchema, ({ item }, __cf_action_params) => {
+    void item;
+});
 const __cfLift_1 = __cfHelpers.lift<{
     path: __cfHelpers.Cell<string[]>;
 }, readonly string[]>({
@@ -113,6 +176,81 @@ const __cfLift_2 = __cfHelpers.lift<{
         return 0;
     return a.type === "file" ? -1 : 1;
 }));
+const __cfHandler_3 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        handleNavigateInto: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"],
+            asCell: ["stream"]
+        },
+        item: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        }
+    },
+    required: ["handleNavigateInto", "item"]
+} as const satisfies __cfHelpers.JSONSchema, (_, { handleNavigateInto, item }) => handleNavigateInto.send({
+    name: item.name,
+}));
+const __cfHandler_4 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        handleOpenFile: {
+            type: "object",
+            properties: {
+                item: {
+                    $ref: "#/$defs/Entry"
+                }
+            },
+            required: ["item"],
+            asCell: ["stream"]
+        },
+        item: {
+            $ref: "#/$defs/Entry"
+        }
+    },
+    required: ["handleOpenFile", "item"],
+    $defs: {
+        Entry: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                },
+                name: {
+                    type: "string"
+                },
+                type: {
+                    "enum": ["file", "folder"]
+                },
+                children: {
+                    $ref: "#/$defs/AnonymousType_1"
+                },
+                contentType: {
+                    type: "string"
+                }
+            },
+            required: ["id", "name", "type"]
+        },
+        AnonymousType_1: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Entry"
+            }
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, (_, { handleOpenFile, item }) => handleOpenFile.send({ item }));
 interface Entry {
     id: string;
     name: string;
@@ -146,74 +284,10 @@ export default pattern((__cf_pattern_input) => {
             type: "string"
         }
     } as const satisfies __cfHelpers.JSONSchema).for("path", true);
-    const handleNavigateInto = __cfHelpers.handler({
-        type: "object",
-        properties: {
-            name: {
-                type: "string"
-            }
-        },
-        required: ["name"]
-    } as const satisfies __cfHelpers.JSONSchema, {
-        type: "object",
-        properties: {
-            path: {
-                type: "array",
-                items: {
-                    type: "string"
-                },
-                asCell: ["writeonly"]
-            }
-        },
-        required: ["path"]
-    } as const satisfies __cfHelpers.JSONSchema, ({ name }, { path }) => {
-        path.push(name);
-    })({
+    const handleNavigateInto = __cfHandler_1({
         path: path
     }).for({ stream: "handleNavigateInto" }, true);
-    const handleOpenFile = __cfHelpers.handler({
-        type: "object",
-        properties: {
-            item: {
-                $ref: "#/$defs/Entry"
-            }
-        },
-        required: ["item"],
-        $defs: {
-            Entry: {
-                type: "object",
-                properties: {
-                    id: {
-                        type: "string"
-                    },
-                    name: {
-                        type: "string"
-                    },
-                    type: {
-                        "enum": ["file", "folder"]
-                    },
-                    children: {
-                        $ref: "#/$defs/AnonymousType_1"
-                    },
-                    contentType: {
-                        type: "string"
-                    }
-                },
-                required: ["id", "name", "type"]
-            },
-            AnonymousType_1: {
-                type: "array",
-                items: {
-                    $ref: "#/$defs/Entry"
-                }
-            }
-        }
-    } as const satisfies __cfHelpers.JSONSchema, {
-        type: "object",
-        properties: {}
-    } as const satisfies __cfHelpers.JSONSchema, ({ item }, __cf_action_params) => {
-        void item;
-    })({}).for({ stream: "handleOpenFile" }, true);
+    const handleOpenFile = __cfHandler_2({}).for({ stream: "handleOpenFile" }, true);
     return {
         [UI]: (<div>
         {(() => {
@@ -313,86 +387,13 @@ export default pattern((__cf_pattern_input) => {
                     } as const satisfies __cfHelpers.JSONSchema, !isFolder &&
                         !!item.key("contentType"), item.key("contentType") !== "binary").for("isOpenable", true);
                     return (<button type="button" onClick={isFolder
-                            ? __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
-                                type: "object",
-                                properties: {
-                                    handleNavigateInto: {
-                                        type: "object",
-                                        properties: {
-                                            name: {
-                                                type: "string"
-                                            }
-                                        },
-                                        required: ["name"],
-                                        asCell: ["stream"]
-                                    },
-                                    item: {
-                                        type: "object",
-                                        properties: {
-                                            name: {
-                                                type: "string"
-                                            }
-                                        },
-                                        required: ["name"]
-                                    }
-                                },
-                                required: ["handleNavigateInto", "item"]
-                            } as const satisfies __cfHelpers.JSONSchema, (_, { handleNavigateInto, item }) => handleNavigateInto.send({
-                                name: item.name,
-                            }))({
+                            ? __cfHandler_3({
                                 handleNavigateInto: handleNavigateInto,
                                 item: {
                                     name: item.key("name")
                                 }
                             }) : isOpenable
-                            ? __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
-                                type: "object",
-                                properties: {
-                                    handleOpenFile: {
-                                        type: "object",
-                                        properties: {
-                                            item: {
-                                                $ref: "#/$defs/Entry"
-                                            }
-                                        },
-                                        required: ["item"],
-                                        asCell: ["stream"]
-                                    },
-                                    item: {
-                                        $ref: "#/$defs/Entry"
-                                    }
-                                },
-                                required: ["handleOpenFile", "item"],
-                                $defs: {
-                                    Entry: {
-                                        type: "object",
-                                        properties: {
-                                            id: {
-                                                type: "string"
-                                            },
-                                            name: {
-                                                type: "string"
-                                            },
-                                            type: {
-                                                "enum": ["file", "folder"]
-                                            },
-                                            children: {
-                                                $ref: "#/$defs/AnonymousType_1"
-                                            },
-                                            contentType: {
-                                                type: "string"
-                                            }
-                                        },
-                                        required: ["id", "name", "type"]
-                                    },
-                                    AnonymousType_1: {
-                                        type: "array",
-                                        items: {
-                                            $ref: "#/$defs/Entry"
-                                        }
-                                    }
-                                }
-                            } as const satisfies __cfHelpers.JSONSchema, (_, { handleOpenFile, item }) => handleOpenFile.send({ item }))({
+                            ? __cfHandler_4({
                                 handleOpenFile: handleOpenFile,
                                 item: item
                             }) : undefined}>

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-local-initializer-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-local-initializer-captures.expected.jsx
@@ -19,6 +19,29 @@ import { action, Default, pattern, UI, VNode, Writable, } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const __cfHandler_1 = __cfHelpers.handler({
+    type: "object",
+    properties: {
+        name: {
+            type: "string"
+        }
+    },
+    required: ["name"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        path: {
+            type: "array",
+            items: {
+                type: "string"
+            },
+            asCell: ["writeonly"]
+        }
+    },
+    required: ["path"]
+} as const satisfies __cfHelpers.JSONSchema, ({ name }, { path }) => {
+    path.push(name);
+});
 const __cfLift_1 = __cfHelpers.lift<{
     path: __cfHelpers.Cell<string[]>;
 }, readonly string[]>({
@@ -177,6 +200,31 @@ const __cfLift_3 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, ({ unsorted }) => [...unsorted].sort((a: Entry, b: Entry) => a.name.localeCompare(b.name)));
+const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        pushPath: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"],
+            asCell: ["stream"]
+        },
+        item: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        }
+    },
+    required: ["pushPath", "item"]
+} as const satisfies __cfHelpers.JSONSchema, (_, { pushPath, item }) => pushPath.send({ name: item.name }));
 interface Entry {
     id: string;
     name: string;
@@ -209,29 +257,7 @@ export default pattern((__cf_pattern_input) => {
             type: "string"
         }
     } as const satisfies __cfHelpers.JSONSchema).for("path", true);
-    const pushPath = __cfHelpers.handler({
-        type: "object",
-        properties: {
-            name: {
-                type: "string"
-            }
-        },
-        required: ["name"]
-    } as const satisfies __cfHelpers.JSONSchema, {
-        type: "object",
-        properties: {
-            path: {
-                type: "array",
-                items: {
-                    type: "string"
-                },
-                asCell: ["writeonly"]
-            }
-        },
-        required: ["path"]
-    } as const satisfies __cfHelpers.JSONSchema, ({ name }, { path }) => {
-        path.push(name);
-    })({
+    const pushPath = __cfHandler_1({
         path: path
     }).for({ stream: "pushPath" }, true);
     return {
@@ -260,31 +286,7 @@ export default pattern((__cf_pattern_input) => {
                 return items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
                     const item = __cf_pattern_input.key("element");
                     const pushPath = __cf_pattern_input.key("params", "pushPath");
-                    return (<button type="button" onClick={__cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
-                        type: "object",
-                        properties: {
-                            pushPath: {
-                                type: "object",
-                                properties: {
-                                    name: {
-                                        type: "string"
-                                    }
-                                },
-                                required: ["name"],
-                                asCell: ["stream"]
-                            },
-                            item: {
-                                type: "object",
-                                properties: {
-                                    name: {
-                                        type: "string"
-                                    }
-                                },
-                                required: ["name"]
-                            }
-                        },
-                        required: ["pushPath", "item"]
-                    } as const satisfies __cfHelpers.JSONSchema, (_, { pushPath, item }) => pushPath.send({ name: item.name }))({
+                    return (<button type="button" onClick={__cfHandler_2({
                         pushPath: pushPath,
                         item: {
                             name: item.key("name")

--- a/packages/ts-transformers/test/fixtures/schema-injection/builder-input-path-shrink.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/builder-input-path-shrink.expected.jsx
@@ -12,6 +12,22 @@ const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift(false, () => deriveInput.key("foo").get());
+const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        input: {
+            type: "object",
+            properties: {
+                foo: {
+                    type: "string"
+                }
+            },
+            required: ["foo"],
+            asCell: ["readonly"]
+        }
+    },
+    required: ["input"]
+} as const satisfies __cfHelpers.JSONSchema, (_, { input }) => input.key("foo").get());
 // FIXTURE: builder-input-path-shrink
 // Verifies: builder input schemas shrink to observed paths when reads/writes are specific,
 // including explicit type arguments and interprocedural helper calls.
@@ -131,22 +147,7 @@ const actionPattern = pattern((input: Writable<{
     foo: string;
     bar: string;
 }>) => {
-    const a = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
-        type: "object",
-        properties: {
-            input: {
-                type: "object",
-                properties: {
-                    foo: {
-                        type: "string"
-                    }
-                },
-                required: ["foo"],
-                asCell: ["readonly"]
-            }
-        },
-        required: ["input"]
-    } as const satisfies __cfHelpers.JSONSchema, (_, { input }) => input.key("foo").get())({
+    const a = __cfHandler_1({
         input: input
     }).for({ stream: "a" }, true);
     return a;


### PR DESCRIPTION
## What

Extend CT-1644's whole-call **lift** hoisting to **`handler`** — the first step of CT-1655, which converges CT-1585's callback hoister and `LiftHoistingTransformer` into one unified module-scope hoisting phase.

A reactive handler is emitted in the same single-application shape as lift — `__cfHelpers.handler(eventSchema, stateSchema, cb)(captures)` (an `action` is lowered to this `handler` shape upstream, so it gets the same treatment). The inner `handler(...)` call is hoisted to a module-scope const and the call site applies the captures:

```ts
// module scope:
const __cfHandler_1 = __cfHelpers.handler(eventSchema, stateSchema, (_, { state }) => …);
// original site:
__cfHandler_1({ state: { … } }).for({ stream: "…" }, true)
```

## Stacked on #3813 (CT-1644, lift)

> [!IMPORTANT]
> **Base is the CT-1644 branch, not `main`.** This builds directly on the lift-hoisting seam (`lift-hoisting.ts`, `HoistableBuilderSpec`, the `__cfLift` prefix + fallback) introduced in #3813, which is not yet merged. The diff here is the handler delta only. **Merge #3813 first**, then this retargets to `main`.

## How

- **`call-kind.ts`** — add `SYNTHETIC_HANDLER_HOIST_PREFIX`, a dedicated `isHandlerAppliedCall` predicate + `getHandlerAppliedInnerCall`, and generalize the hoist-prefix original-node fallback in `resolveBuilderExpressionKind` to `__cfHandler`. A handler-applied call **keeps** classifying as `{ kind: "builder", builderName: "handler" }` (deliberately *not* a new `lift-applied` kind), so every handler-specific downstream dispatcher — ReactiveVariableFor's stream cause, capture-schema injection, write-authorization, etc. — is untouched.
- **`lift-hoisting.ts`** — register a `HANDLER_BUILDER` `HoistableBuilderSpec` alongside `LIFT_BUILDER`.
- **`module-scope-callback-hoisting.ts`** — remove `handler` from `HOISTABLE_BUILDER_NAMES` **in the same change** to avoid the double-hoist TDZ (the two consts would reference each other out of declaration order). `BuilderCallbackHoistingTransformer` now owns only `pattern`/`patternTool`.

## Verification

- `deno task test` (ts-transformers): **292 passed / 603 steps / 0 failed**.
- **28 fixture goldens** regenerated and audited — every diff is exactly the hoist. The CT-1585 regression fixture `hoisted-handler-preserves-capture-schemas` flips from `__cfModuleCallback_N` callback-hoists to `__cfHandler_N` whole-call hoists (the convergence end-state); a TDZ scan across all 28 confirms no hoisted const initializer eagerly invokes another.
- **SES verifier** green; added a test asserting a hoisted `handler(...)` call passes module-scope verification (mirrors CT-1644's lift cases). Runner verifier/security suites green.
- **schema-generator** green (24 / 226).
- Pipeline stage-order regression unchanged + passing (handler hoisting registered *within* the existing `LiftHoistingTransformer` stage).
- Design doc (`derive-to-lift-design.md`) updated: status header + a follow-up section recording what shipped for handler and what remains for `pattern`/`patternTool`.

## Not in this PR

`pattern` / `patternTool` — a *different* mechanic (the bare `pattern(...)` is `mapWithPattern`'s arg[0], not an applied callee), plus a top-level-`export default pattern(...)` guard. Lands as the next step of CT-1655, after which `HOISTABLE_BUILDER_NAMES` empties and `BuilderCallbackHoistingTransformer` can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hoists `handler(...)` calls to module scope in `ts-transformers`, aligning with `lift` and progressing CT-1655 toward a single hoisting phase. This removes `handler` from the callback hoister to avoid TDZ and keeps downstream behavior unchanged.

- **New Features**
  - Hoist inner `handler(eventSchema, stateSchema, cb)` to `const __cfHandler_N = __cfHelpers.handler(...)`, and rewrite sites to `__cfHandler_N(captures).for(...)`; `action` (lowered to `handler`) is treated the same.
  - `runner` verifier accepts hoisted `handler(...)` at module scope; added a test to lock this.

- **Refactors**
  - Add `SYNTHETIC_HANDLER_HOIST_PREFIX`, `isHandlerAppliedCall`, and `getHandlerAppliedInnerCall`; extend the hoist-prefix fallback so `__cfHandler_N(captures)` still classifies as `{ kind: "builder", builderName: "handler" }`.
  - Register a `HANDLER_BUILDER` in `lift-hoisting.ts`; remove `handler` from `module-scope-callback-hoisting` (now only `pattern`/`patternTool`) to prevent double-hoist TDZ.
  - Ignore `__cfHandler`/`__cfLift` synthetic identifiers when detecting module-scoped refs in the callback hoister to keep hoist decisions independent.
  - Update the design doc with the shipped CT-1655 `handler` step and the remaining `pattern`/`patternTool` work.

<sup>Written for commit 895c1ea195bd7deb0edace59e8f461a6ee39d17c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

