### PR TITLE
feat(runner): load pattern by module identity — resolve-free warm load + cold recovery (CT-1623)

### DIFF
--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -37,6 +37,8 @@ import {
   resolveModuleImports,
 } from "./module-identity.ts";
 import {
+  buildRecordsFromCompiled,
+  type CachedCompiledModule,
   type CompiledModuleGraph,
   compileSourcesToRecords,
   computeModuleIdentities,
@@ -458,6 +460,83 @@ export class Engine extends EventTarget implements Harness {
   }
 
   /**
+   * Cold-recovery path: recompile cacheable modules from the
+   * inject-helper-transformed module set already stored in the content-addressed
+   * **source set** (`pattern:<identity>` cells), loaded by identity — i.e.
+   * recreate the pattern from its stored TypeScript alone. Skips **pretransform**
+   * (the source already carries the helper import and prefix-free normalized
+   * paths, so re-injecting/re-prefixing would corrupt it and shift identities)
+   * but still **resolves** to supply the runtime `.d.ts` type environment the CF
+   * transformer needs for schema generation (those types are TCB, from the
+   * static cache, not stored per pattern). Used when the compiled set misses
+   * (e.g. a runtimeVersion bump invalidates `compileCache:<rtver>/...`).
+   *
+   * Per-module identities recompute to the same content-addressed values (the
+   * module bodies + names are unchanged), so the rebuilt compiled set is
+   * addressable — and writable-back — under the new runtimeVersion. Returns the
+   * `CacheableModule[]` (feed to {@link evaluateCachedModules}) + entry identity.
+   * `entryFilename` is the entry module's normalized path.
+   */
+  async compileResolvedToRecordGraph(
+    resolvedFiles: Source[],
+    entryFilename: string,
+  ): Promise<{ modules: CacheableModule[]; entryIdentity: string }> {
+    const { compiler } = await this.getCompilerInternals();
+    // Resolve to add the runtime `.d.ts` type environment, WITHOUT pretransform
+    // (no re-inject/re-prefix — the stored source is already transformed).
+    const resolver = new EngineProgramResolver(
+      { main: entryFilename, files: resolvedFiles },
+      this.ctRuntime.staticCache,
+    );
+    const resolvedProgram = await this.resolve(resolver);
+    const moduleFiles = resolvedProgram.files.filter((f) =>
+      !f.name.endsWith(".d.ts")
+    );
+    // Identities recompute prefix-free over the (already-normalized) closure —
+    // they match the stored identities the source docs were keyed by.
+    const identityByPath = computeModuleIdentities(moduleFiles);
+
+    const emitted = compiler.compileToModules(resolvedProgram, {
+      runtimeModules: Engine.runtimeModuleNames(),
+      beforeTransformers: (program) => {
+        const pipeline = new CommonFabricTransformerPipeline();
+        return {
+          factories: pipeline.toFactories(program),
+          getDiagnostics: () => pipeline.getDiagnostics(),
+        };
+      },
+    });
+    for (const file of moduleFiles) {
+      if (!emitted.has(file.name)) {
+        throw new Error(
+          `Recompile from source produced no body for '${file.name}'`,
+        );
+      }
+    }
+
+    const importEdges = resolveModuleImports({ main: "", files: moduleFiles });
+    const modules: CacheableModule[] = moduleFiles.map((file) => {
+      const out = emitted.get(file.name)!;
+      const imports = (importEdges.get(file.name)?.internalDeps ?? []).map((
+        dep,
+      ) => ({
+        specifier: dep.specifier,
+        targetIdentity: identityByPath.get(dep.target)!,
+      }));
+      return {
+        identity: identityByPath.get(file.name)!,
+        filename: file.name,
+        source: file.contents,
+        js: out.js,
+        ...(out.sourceMap === undefined ? {} : { sourceMap: out.sourceMap }),
+        imports,
+      };
+    });
+    const entryIdentity = identityByPath.get(entryFilename)!;
+    return { modules, entryIdentity };
+  }
+
+  /**
    * Compile + evaluate a program through the ESM module-record path (the
    * `esmModuleLoader` route). Returns the same `{ main, exportMap, loadId }`
    * shape as {@link evaluate}, so callers can branch on the flag and treat the
@@ -486,7 +565,10 @@ export class Engine extends EventTarget implements Harness {
    */
   /**
    * Evaluate a verified ESM record graph (public so the PatternManager can run
-   * compile → cache write-back → evaluate as discrete steps).
+   * compile → cache write-back → evaluate as discrete steps). Thin wrapper over
+   * {@link evaluateGraph} with the source-compile registration strategy: module
+   * identities are recomputed from `files`, paths carry the `/<id>` prefix, and
+   * `files` flow into the export map for sub-pattern re-instantiation.
    */
   evaluateRecordGraph(
     id: string,
@@ -494,15 +576,67 @@ export class Engine extends EventTarget implements Harness {
     mainSpecifier: string,
     files: Source[],
   ): EvaluateResult {
+    const prefix = `/${id}`;
+    // Register module hashes up front so the canonical `cf:module/<hash>/<path>`
+    // sources are available for the verified set below.
+    this.registerModuleHashes(id, files);
+    const verifiedSources = new Set<string>();
+    const addVerifiedSource = (value: string | undefined) => {
+      if (typeof value !== "string" || value.length === 0) return;
+      verifiedSources.add(normalizeVerifiedSource(value));
+      if (value.startsWith(`${prefix}/`)) {
+        verifiedSources.add(
+          normalizeVerifiedSource(value.slice(id.length + 1)),
+        );
+      }
+    };
+    for (const file of files) addVerifiedSource(file.name);
+    for (const path of graph.specifierByPath.keys()) addVerifiedSource(path);
+    // Canonical `cf:module/<hash>/<path>` forms — functions carry these as their
+    // `fn.src`, so CFC's isVerifiedSourceInLoad must recognize them too.
+    for (const canonical of this.canonicalVerifiedSources(id, files)) {
+      addVerifiedSource(canonical);
+    }
+
+    return this.evaluateGraph(graph, mainSpecifier, {
+      loadIdPrefix: id,
+      // Already registered above (idempotent); keep as a no-op so evaluateGraph
+      // doesn't recompute the hashes a second time.
+      registerHashes: () => {},
+      verifiedSources,
+      fileNameForPath: (path) =>
+        path.startsWith(prefix) ? path.slice(prefix.length) : path,
+      filesForExports: files,
+    });
+  }
+
+  /**
+   * Evaluate a record graph. Shared core for both the source-compile path
+   * ({@link evaluateRecordGraph}) and the resolve-free cached-load path
+   * ({@link evaluateCachedModules}); `ctx` supplies the path/identity handling
+   * that differs between them (prefixed authored paths vs prefix-free cached
+   * identities). The graph is assumed already security-verified.
+   */
+  private evaluateGraph(
+    graph: CompiledModuleGraph,
+    mainSpecifier: string,
+    ctx: {
+      loadIdPrefix: string;
+      registerHashes(): void;
+      verifiedSources: Set<string>;
+      fileNameForPath(path: string): string;
+      filesForExports: Source[];
+    },
+  ): EvaluateResult {
     logger.timeStart("evaluateRecordGraph");
     try {
-      const loadId = `${id}:esm:${this.nextLoadId++}`;
+      const loadId = `${ctx.loadIdPrefix}:esm:${this.nextLoadId++}`;
       this.executableRegistry.beginVerifiedLoad(loadId);
       // Register per-module content hashes for parity with the AMD evaluate
       // path. This wires the scheduler's content-addressed implementation hash;
       // it becomes effective once source-location resolution under the ESM
       // loader is wired (see the sourceURL note in module-record-compiler.ts).
-      this.registerModuleHashes(id, files);
+      ctx.registerHashes();
 
       const globals = createModuleCompartmentGlobals({
         console: this.consoleShim,
@@ -557,29 +691,14 @@ export class Engine extends EventTarget implements Harness {
         );
         if (moduleMap) this.getSESRuntime().loadSourceMap(sourceUrl, moduleMap);
       }
-      // Verified-load sources: the original file names plus the prefixed module
-      // paths (both normalized), so CFC's isVerifiedSourceInLoad recognizes the
-      // source locations of functions defined by this load.
-      const verifiedSources = new Set<string>();
-      const addVerifiedSource = (value: string | undefined) => {
-        if (typeof value !== "string" || value.length === 0) return;
-        verifiedSources.add(normalizeVerifiedSource(value));
-        const prefixed = `/${id}/`;
-        if (value.startsWith(prefixed)) {
-          verifiedSources.add(
-            normalizeVerifiedSource(value.slice(id.length + 1)),
-          );
-        }
-      };
-      for (const file of files) addVerifiedSource(file.name);
-      for (const path of graph.specifierByPath.keys()) addVerifiedSource(path);
-      // Lockstep with canonical `fn.src`: functions now carry
-      // `cf:module/<hash>/<path>` source locations, so the verified set must
-      // recognize them too (else CFC identity fails closed).
-      for (const canonical of this.canonicalVerifiedSources(id, files)) {
-        addVerifiedSource(canonical);
-      }
-      this.executableRegistry.setVerifiedLoadSources(loadId, verifiedSources);
+      // Verified-load sources (the function source locations CFC's
+      // isVerifiedSourceInLoad recognizes) are computed by the caller, since the
+      // path/prefix convention — and the canonical `cf:module/<hash>/<path>`
+      // form — differs between the source-compile and cached load paths.
+      this.executableRegistry.setVerifiedLoadSources(
+        loadId,
+        ctx.verifiedSources,
+      );
 
       // Register functions defined during this load as verified, mirroring the
       // AMD path's verified-execution model.
@@ -611,17 +730,14 @@ export class Engine extends EventTarget implements Harness {
       const main = loaded.namespace as Exports;
       this.executableRegistry.captureVerifiedValue(loadId, main);
 
-      // Build the per-module export map (keyed by original source path, prefix
-      // stripped) from the SAME load, and map each exported value back to its
-      // RuntimeProgram for sub-pattern resolution.
-      const prefix = `/${id}`;
+      // Build the per-module export map (keyed by normalized source path) from
+      // the SAME load, and map each exported value back to its RuntimeProgram
+      // for sub-pattern resolution.
       const exportMap: Record<string, Exports> = {};
       const exportsByValue = new Map<unknown, RuntimeProgram>();
       for (const [path, specifier] of graph.specifierByPath) {
         const namespace = loaded.importNow(specifier) as Exports;
-        const fileName = path.startsWith(prefix)
-          ? path.slice(prefix.length)
-          : path;
+        const fileName = ctx.fileNameForPath(path);
         exportMap[fileName] = namespace;
         for (const [exportName, value] of Object.entries(namespace)) {
           // Only object/function exports are sub-pattern candidates. Skip the
@@ -635,7 +751,7 @@ export class Engine extends EventTarget implements Harness {
           exportsByValue.set(value, {
             main: fileName,
             mainExport: exportName,
-            files,
+            files: ctx.filesForExports,
           });
         }
       }
@@ -648,6 +764,99 @@ export class Engine extends EventTarget implements Harness {
     } finally {
       logger.timeEnd("evaluateRecordGraph");
     }
+  }
+
+  /**
+   * Warm load path: build a record graph **directly from cached compiled
+   * modules** (no TS source, no `resolve`, no recompile — see
+   * {@link buildRecordsFromCompiled}), register runtime records, security-verify
+   * (still re-verified while the integrity label is client-asserted), and
+   * evaluate. `entryIdentity` is the content identity of the entry module
+   * (`cf:module/<entryIdentity>`). Optional `sourceFiles` (the cached source
+   * closure) flow into the export map so sub-pattern re-instantiation keeps a
+   * program to recompile from; omit them and sub-patterns fall back to identity.
+   */
+  async evaluateCachedModules(
+    modules: readonly CachedCompiledModule[],
+    entryIdentity: string,
+    options: { sourceFiles?: Source[] } = {},
+  ): Promise<EvaluateResult> {
+    await this.getRuntimeInternals();
+    const { runtimeExports } = await this.getRuntimeInternals();
+    const runtimeNames = Engine.runtimeModuleNames().filter((name) =>
+      runtimeExports?.[name]
+    );
+    const runtimeModulesOption = Object.fromEntries(
+      runtimeNames.map((name) => [
+        name,
+        Object.keys(runtimeExports?.[name] ?? {}),
+      ]),
+    );
+
+    const graph = buildRecordsFromCompiled(modules, {
+      runtimeModules: runtimeModulesOption,
+    });
+
+    // Register runtime-module records so cf:runtime/* imports resolve.
+    const runtimeRecordExports: Record<string, Record<string, unknown>> = {};
+    for (const name of runtimeNames) {
+      runtimeRecordExports[name] = runtimeExports?.[name] as Record<
+        string,
+        unknown
+      >;
+    }
+    for (const [spec, record] of runtimeModuleRecords(runtimeRecordExports)) {
+      graph.records.set(spec, record as VirtualModuleRecord);
+    }
+
+    // Security-verify every cached body + the whole graph before executing —
+    // the cache's integrity label is still only client-asserted, so cached
+    // bytes are not trusted unverified (mirrors the compile path).
+    for (const [specifier, body] of graph.compiledBodies) {
+      verifyCompiledModuleBody(body, specifier);
+    }
+    const mainSpecifier = `cf:module/${entryIdentity}`;
+    if (!graph.records.has(mainSpecifier)) {
+      throw new Error(
+        `Cached closure is missing the entry module ${mainSpecifier}`,
+      );
+    }
+    verifyModuleGraph(graph.records, mainSpecifier);
+
+    // Verified-load sources: normalized module paths (no `/<id>` prefix — the
+    // cached records use prefix-free filenames as their sourceURLs) plus the
+    // canonical `cf:module/<identity><filename>` forms that functions carry as
+    // their `fn.src` (so CFC's isVerifiedSourceInLoad recognizes them).
+    const verifiedSources = new Set<string>();
+    for (const m of modules) {
+      verifiedSources.add(normalizeVerifiedSource(m.filename));
+      verifiedSources.add(
+        normalizeVerifiedSource(`cf:module/${m.identity}${m.filename}`),
+      );
+    }
+    for (const path of graph.specifierByPath.keys()) {
+      verifiedSources.add(normalizeVerifiedSource(path));
+    }
+
+    return this.evaluateGraph(graph, mainSpecifier, {
+      loadIdPrefix: entryIdentity,
+      // Register the KNOWN identities (keyed by normalized filename = the record
+      // sourceURL) instead of recomputing from source — we have no source here,
+      // and the identities are authoritative. Also populate the canonical
+      // source map so `fn.src` resolves to `cf:module/<identity>/<path>`.
+      registerHashes: () => {
+        for (const m of modules) {
+          this.moduleHashByPrefixedSource.set(m.filename, m.identity);
+          this.canonicalSourceByPrefixed.set(
+            m.filename,
+            `cf:module/${m.identity}${m.filename}`,
+          );
+        }
+      },
+      verifiedSources,
+      fileNameForPath: (path) => path, // already normalized
+      filesForExports: options.sourceFiles ?? [],
+    });
   }
 
   // Evaluate pre-compiled JS, returning exports.

--- a/packages/runner/src/harness/types.ts
+++ b/packages/runner/src/harness/types.ts
@@ -4,7 +4,10 @@ import type {
   ProgramResolver,
   Source,
 } from "@commonfabric/js-compiler";
-import type { CompiledModuleGraph } from "../sandbox/module-record-compiler.ts";
+import type {
+  CachedCompiledModule,
+  CompiledModuleGraph,
+} from "../sandbox/module-record-compiler.ts";
 import type { UnsafeHostTrustOptions } from "../unsafe-host-trust.ts";
 
 export type HarnessedFunction = (input: any) => void;
@@ -148,6 +151,21 @@ export interface Harness extends EventTarget {
     mainSpecifier: string,
     files: Source[],
   ): EvaluateResult;
+
+  // Warm load: build + verify + evaluate a pattern directly from cached compiled
+  // modules (by content identity) — no TS source, no resolve, no recompile.
+  evaluateCachedModules?(
+    modules: readonly CachedCompiledModule[],
+    entryIdentity: string,
+    options?: { sourceFiles?: Source[] },
+  ): Promise<EvaluateResult>;
+
+  // Cold recovery: recompile cacheable modules from the stored (already-resolved,
+  // inject-transformed) source set — e.g. after a runtimeVersion bump.
+  compileResolvedToRecordGraph?(
+    resolvedFiles: Source[],
+    entryFilename: string,
+  ): Promise<{ modules: CacheableModule[]; entryIdentity: string }>;
 
   // Resolves a `ProgramResolver` into a `Program` using the engine's
   // configuration.

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -24,10 +24,12 @@ import type {
   EvaluateResult,
 } from "./harness/types.ts";
 import { RuntimeProgram } from "./harness/types.ts";
+import type { CachedCompiledModule } from "./sandbox/module-record-compiler.ts";
 import type { IExtendedStorageTransaction } from "./storage/interface.ts";
 import {
   COMPILE_CACHE_RUNTIME_VERSION,
   loadCompiledClosure,
+  ROOT_LINK_SPECIFIER,
   writeCompiledDocs,
   writeSourceDocs,
 } from "./compilation-cache/cell-cache.ts";
@@ -89,15 +91,26 @@ export class PatternManager {
   // Pending metadata set before the meta cell exists (e.g., spec, parents)
   private pendingMetaById = new Map<URI, Partial<PatternMeta>>();
   // ESM content-addressed compile-cache instrumentation.
-  private esmCacheStats = { hits: 0, misses: 0 };
+  private esmCacheStats = { hits: 0, misses: 0, byIdentityHits: 0 };
   // In-flight compiled-cache write-backs (fire-and-forget); awaited by
   // flushCompileCacheWrites() for graceful shutdown / deterministic tests.
   private compileCacheWrites = new Set<Promise<unknown>>();
 
   constructor(readonly runtime: Runtime) {}
 
-  /** Hit/miss counts for the ESM content-addressed compile cache. */
-  getCompileCacheStats(): { hits: number; misses: number } {
+  /**
+   * Counters for the ESM content-addressed compile cache:
+   * - `byIdentityHits`: warm loads served directly by entry identity (no
+   *   resolve, no compile — the fast path);
+   * - `hits`: warm loads that still resolved but reused cached bodies (skipped
+   *   only the TS compile);
+   * - `misses`: cold compiles (also written back).
+   */
+  getCompileCacheStats(): {
+    hits: number;
+    misses: number;
+    byIdentityHits: number;
+  } {
     return { ...this.esmCacheStats };
   }
 
@@ -469,7 +482,14 @@ export class PatternManager {
 
   async compilePattern(
     input: string | RuntimeProgram,
-    cacheCtx?: { space: MemorySpace; tx?: IExtendedStorageTransaction },
+    cacheCtx?: {
+      space: MemorySpace;
+      tx?: IExtendedStorageTransaction;
+      // When the entry module's content identity is already known (e.g. stored
+      // in pattern metadata from a prior compile), the ESM cache path loads the
+      // compiled closure by identity and skips resolve + compile entirely.
+      knownEntryIdentity?: string;
+    },
   ): Promise<Pattern> {
     let program: RuntimeProgram;
     if (typeof input === "string") {
@@ -537,7 +557,11 @@ export class PatternManager {
    */
   private async compileViaCellCache(
     program: RuntimeProgram,
-    cacheCtx: { space: MemorySpace; tx?: IExtendedStorageTransaction },
+    cacheCtx: {
+      space: MemorySpace;
+      tx?: IExtendedStorageTransaction;
+      knownEntryIdentity?: string;
+    },
   ): Promise<Pattern> {
     const harness = this.runtime.harness;
     const { space } = cacheCtx;
@@ -546,6 +570,26 @@ export class PatternManager {
       runtimeVersion: COMPILE_CACHE_RUNTIME_VERSION,
       compilerDid,
     };
+
+    // Fast path — warm load BY IDENTITY: if the entry's content identity is
+    // already known (stored from a prior compile), load the compiled closure
+    // directly and build+evaluate from it, skipping `resolve` and `compile`
+    // entirely. Falls through to the compile path on any miss/incompleteness
+    // (evaluateCachedModules re-verifies the graph, so an incomplete closure
+    // throws and we recompile).
+    if (cacheCtx.knownEntryIdentity) {
+      const byIdentity = await this.tryWarmLoadByIdentity(
+        cacheCtx.knownEntryIdentity,
+        space,
+        cacheOpts,
+        program,
+      );
+      if (byIdentity) {
+        this.esmCacheStats.byIdentityHits++;
+        return byIdentity;
+      }
+    }
+
     // Read the cache on a dedicated, owned transaction (used read-only — the
     // load path only reads, and it is aborted below, never committed) so
     // cache-cell reads never enter the caller's transaction (whose commit must
@@ -622,6 +666,69 @@ export class PatternManager {
     }
 
     return this.patternFromEvaluation(result, program);
+  }
+
+  /**
+   * Resolve-free warm load: fetch the integrity-valid compiled closure for
+   * `entryIdentity` and build + evaluate the pattern directly from those cached
+   * bodies (no `resolve`, no `compile`). Returns the pattern, or `undefined`
+   * if the closure is absent/incomplete/invalid (caller then recompiles).
+   */
+  private async tryWarmLoadByIdentity(
+    entryIdentity: string,
+    space: MemorySpace,
+    cacheOpts: { runtimeVersion: string; compilerDid: string },
+    program: RuntimeProgram,
+  ): Promise<Pattern | undefined> {
+    const harness = this.runtime.harness;
+    const readTx = this.runtime.edit();
+    let closure;
+    try {
+      const readStart = performance.now();
+      closure = await loadCompiledClosure(
+        this.runtime,
+        space,
+        entryIdentity,
+        cacheOpts,
+        readTx,
+      );
+      logger.time(readStart, "compile-cache", "read-by-identity");
+    } finally {
+      readTx.abort?.("compile-cache by-identity read complete");
+    }
+    if (!closure.has(entryIdentity)) return undefined;
+
+    const cachedModules: CachedCompiledModule[] = [...closure].map(
+      ([identity, doc]) => ({
+        identity,
+        filename: doc.filename,
+        code: doc.code,
+        ...(doc.sourceMap !== undefined
+          ? { sourceMap: doc.sourceMap as never }
+          : {}),
+        // Drop the synthetic entry→root links (cfc.ts etc.); only real
+        // require/export-* edges resolve module records.
+        imports: doc.imports
+          .filter((i) => !i.specifier.startsWith(ROOT_LINK_SPECIFIER))
+          .map((i) => ({ specifier: i.specifier, targetIdentity: i.identity })),
+      }),
+    );
+
+    try {
+      const result = await harness.evaluateCachedModules!(
+        cachedModules,
+        entryIdentity,
+        { sourceFiles: program.files },
+      );
+      return this.patternFromEvaluation(result, program);
+    } catch (error) {
+      // Incomplete/invalid cached closure — fall back to recompile.
+      logger.warn("compile-cache-by-identity-miss", () => [
+        `entry=${entryIdentity}`,
+        String(error),
+      ]);
+      return undefined;
+    }
   }
 
   /**

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -460,6 +460,206 @@ export function compileSourcesToRecords(
   return { records, specifierByPath, compiledBodies, moduleSourceMaps };
 }
 
+/** A compiled module loaded from the content-addressed cache (no TS source). */
+export interface CachedCompiledModule {
+  /** Prefix-free content identity (the `cf:module/<hash>` hash, no scheme). */
+  identity: string;
+  /** Normalized authored path (e.g. `/main.tsx`); used for the eval sourceURL. */
+  filename: string;
+  /** Compiled CommonJS body. */
+  code: string;
+  /** Internal import edges: require specifier → dependency module identity. */
+  imports: { specifier: string; targetIdentity: string }[];
+  /** Per-module source map, if cached. */
+  sourceMap?: SourceMap;
+}
+
+/**
+ * Build a verified-able record graph **directly from cached compiled modules** —
+ * no TypeScript source, no `resolve`, no recompile. This is the warm load path:
+ * the content-addressed cache already holds each module's compiled body + its
+ * internal import edges (specifier → dependency identity), and the export
+ * **names** are recovered from the compiled body itself (see
+ * {@link extractCompiledExports}; `export *` is unioned transitively through the
+ * cached edges). Runtime (`cf:runtime/*`) records are registered by the caller.
+ *
+ * Returns the same {@link CompiledModuleGraph} shape as
+ * {@link compileSourcesToRecords}, keyed in identity space: `specifierByPath` is
+ * keyed by each module's normalized `filename`.
+ */
+export function buildRecordsFromCompiled(
+  modules: readonly CachedCompiledModule[],
+  options: { runtimeModules?: Record<string, string[]> } = {},
+): CompiledModuleGraph {
+  const runtimeModules = options.runtimeModules ?? {};
+  const specifierOf = (identity: string) => `cf:module/${identity}`;
+  const byIdentity = new Map(modules.map((m) => [m.identity, m]));
+
+  // Direct export names + `export *` edges (as dependency identities) per module.
+  const direct = new Map<
+    string,
+    { names: Set<string>; starTargets: string[] }
+  >();
+  for (const m of modules) {
+    const { names, starTargetSpecs } = extractCompiledExports(m.code);
+    const starTargets: string[] = [];
+    for (const spec of starTargetSpecs) {
+      const edge = m.imports.find((i) => i.specifier === spec);
+      if (edge) starTargets.push(edge.targetIdentity);
+      else {for (const n of runtimeModules[spec] ?? []) {
+          if (n !== "default") names.add(n);
+        }}
+    }
+    direct.set(m.identity, { names, starTargets });
+  }
+
+  // Full export set: own names ∪ transitively re-exported names (minus default).
+  const fullExportsMemo = new Map<string, string[]>();
+  const resolveFullExports = (identity: string): string[] => {
+    const memo = fullExportsMemo.get(identity);
+    if (memo) return memo;
+    const names = new Set<string>(direct.get(identity)?.names ?? []);
+    const walked = new Set<string>();
+    const stack = [...(direct.get(identity)?.starTargets ?? [])];
+    while (stack.length > 0) {
+      const cur = stack.pop()!;
+      if (walked.has(cur)) continue;
+      walked.add(cur);
+      for (const n of direct.get(cur)?.names ?? []) {
+        if (n !== "default") names.add(n);
+      }
+      stack.push(...(direct.get(cur)?.starTargets ?? []));
+    }
+    const result = [...names];
+    fullExportsMemo.set(identity, result);
+    return result;
+  };
+
+  const records = new Map<string, VirtualModuleRecord>();
+  const compiledBodies = new Map<string, string>();
+  const moduleSourceMaps = new Map<string, SourceMap>();
+  const specifierByPath = new Map<string, string>();
+
+  for (const m of modules) {
+    const specifier = specifierOf(m.identity);
+    specifierByPath.set(m.filename, specifier);
+    compiledBodies.set(specifier, m.code);
+    if (m.sourceMap) moduleSourceMaps.set(specifier, m.sourceMap);
+
+    const importSpecs = extractRuntimeImports(m.code);
+    const resolutions: Record<string, string> = {};
+    for (const spec of importSpecs) {
+      const edge = m.imports.find((i) => i.specifier === spec);
+      if (edge !== undefined) {
+        resolutions[spec] = specifierOf(edge.targetIdentity);
+      } else if (spec in runtimeModules) {
+        resolutions[spec] = `cf:runtime/${spec}`;
+      } else {
+        resolutions[spec] = spec;
+      }
+    }
+
+    const exportNames = resolveFullExports(m.identity);
+    const namespaceExports = [...exportNames, "__esModule"];
+    const sourceUrl = m.filename.replace(/[\r\n\u2028\u2029]/g, "_");
+    const compiled = m.code;
+    records.set(specifier, {
+      imports: importSpecs,
+      exports: namespaceExports,
+      resolutions,
+      execute: (moduleExports, compartment, resolvedImports) => {
+        const factory = compartment.evaluate(
+          `(function (exports, require, module) {\n${compiled}\n})\n//# sourceURL=${sourceUrl}`,
+        ) as (
+          exports: Record<string, unknown>,
+          require: (specifier: string) => Record<string, unknown>,
+          module: { exports: Record<string, unknown> },
+        ) => void;
+        const requireShim = (spec: string) =>
+          compartment.importNow(resolvedImports[spec] ?? spec);
+        populateModuleExports(moduleExports, exportNames, factory, requireShim);
+      },
+    });
+  }
+  // Silence unused in the rare all-internal case.
+  void byIdentity;
+
+  return { records, specifierByPath, compiledBodies, moduleSourceMaps };
+}
+
+/**
+ * Recover a compiled module's export surface by scanning its compiled CommonJS
+ * body (no TS source): `exports.<name> = …`, `Object.defineProperty(exports,
+ * "<name>", …)` (named re-exports), and `__exportStar(require("<spec>"), …)` for
+ * `export *`. Returns the directly-declared names (minus `__esModule`) plus the
+ * `export *` source specifiers (resolved to dependency identities by the caller).
+ */
+export function extractCompiledExports(
+  compiled: string,
+): { names: Set<string>; starTargetSpecs: string[] } {
+  const sourceFile = ts.createSourceFile(
+    "compiled.js",
+    compiled,
+    TARGET,
+    true,
+    ts.ScriptKind.JS,
+  );
+  const names = new Set<string>();
+  const starTargetSpecs = new Set<string>();
+
+  const isExportsRef = (node: ts.Expression): boolean =>
+    ts.isIdentifier(node) && node.text === "exports";
+
+  const requireArg = (node: ts.Expression): string | undefined => {
+    if (
+      ts.isCallExpression(node) && ts.isIdentifier(node.expression) &&
+      node.expression.text === "require" && node.arguments.length === 1 &&
+      ts.isStringLiteralLike(node.arguments[0])
+    ) {
+      return (node.arguments[0] as ts.StringLiteralLike).text;
+    }
+    return undefined;
+  };
+
+  function visit(node: ts.Node): void {
+    // exports.<name> = …
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isPropertyAccessExpression(node.left) &&
+      isExportsRef(node.left.expression)
+    ) {
+      const name = node.left.name.text;
+      if (name !== "__esModule") names.add(name);
+    }
+    if (ts.isCallExpression(node)) {
+      const callee = node.expression;
+      const calleeName = ts.isIdentifier(callee)
+        ? callee.text
+        : ts.isPropertyAccessExpression(callee)
+        ? callee.name.text
+        : undefined;
+      // Object.defineProperty(exports, "<name>", …) — named re-export / getter.
+      if (
+        calleeName === "defineProperty" && node.arguments.length >= 2 &&
+        isExportsRef(node.arguments[0]) &&
+        ts.isStringLiteralLike(node.arguments[1])
+      ) {
+        const name = (node.arguments[1] as ts.StringLiteralLike).text;
+        if (name !== "__esModule") names.add(name);
+      }
+      // __exportStar(require("<spec>"), exports) — `export *`.
+      if (calleeName === "__exportStar" && node.arguments.length >= 1) {
+        const spec = requireArg(node.arguments[0]);
+        if (spec !== undefined) starTargetSpecs.add(spec);
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(sourceFile);
+  return { names, starTargetSpecs: [...starTargetSpecs] };
+}
+
 /**
  * Extract the runtime import specifiers actually emitted as `require()` calls
  * in the compiled CommonJS body. This is the precise runtime dependency set;

--- a/packages/runner/test/build-from-compiled.test.ts
+++ b/packages/runner/test/build-from-compiled.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import { Engine } from "../src/harness/engine.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+import {
+  buildRecordsFromCompiled,
+  type CachedCompiledModule,
+  extractCompiledExports,
+} from "../src/sandbox/module-record-compiler.ts";
+
+const signer = await Identity.fromPassphrase("build-from-compiled");
+
+// The warm load path builds records directly from cached compiled bodies — no
+// TS source, no resolve, no recompile. The export NAMES are recovered from the
+// compiled JS (export * unioned transitively). These tests prove that the
+// resolve-free build produces records equivalent to the source-derived ones.
+
+describe("extractCompiledExports", () => {
+  it("recovers exports.X assignments and Object.defineProperty re-exports", () => {
+    const compiled = [
+      `Object.defineProperty(exports, "__esModule", { value: true });`,
+      `exports.b = exports.a = void 0;`,
+      `exports.a = 1;`,
+      `exports.b = 2;`,
+      `Object.defineProperty(exports, "c", { enumerable: true, get: function () { return x.c; } });`,
+    ].join("\n");
+    const { names, starTargetSpecs } = extractCompiledExports(compiled);
+    expect(new Set(names)).toEqual(new Set(["a", "b", "c"]));
+    expect(names.has("__esModule")).toBe(false);
+    expect(starTargetSpecs).toEqual([]);
+  });
+
+  it("recovers export-star require specifiers", () => {
+    const compiled = [
+      `var tslib_1 = require("tslib");`,
+      `__exportStar(require("./util.ts"), exports);`,
+      `exports.z = 9;`,
+    ].join("\n");
+    const { names, starTargetSpecs } = extractCompiledExports(compiled);
+    expect(new Set(names)).toEqual(new Set(["z"]));
+    expect(starTargetSpecs).toEqual(["./util.ts"]);
+  });
+});
+
+describe("buildRecordsFromCompiled (resolve-free, source-free)", () => {
+  let runtime: Runtime;
+  let engine: Engine;
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({ apiUrl: new URL(import.meta.url), storageManager });
+    engine = runtime.harness as Engine;
+  });
+  afterEach(async () => {
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  const PROGRAM: RuntimeProgram = {
+    main: "/main.tsx",
+    files: [
+      {
+        name: "/util.ts",
+        contents: "export const a = 1;\nexport const b = 2;",
+      },
+      {
+        name: "/reexport.ts",
+        contents: `export * from "./util.ts";\nexport const c = 3;`,
+      },
+      {
+        name: "/main.tsx",
+        contents: [
+          `import { pattern } from 'commonfabric';`,
+          `export * from "./reexport.ts";`,
+          `export const z = 9;`,
+          `export default pattern<{ v: number }>(({ v }) => ({ out: v }));`,
+        ].join("\n"),
+      },
+    ],
+  };
+
+  it("builds records whose exports + resolutions match the source-compiled graph", async () => {
+    const { graph, modules } = await engine.compileToRecordGraph(PROGRAM);
+
+    const cached: CachedCompiledModule[] = modules.map((m) => ({
+      identity: m.identity,
+      filename: m.filename,
+      code: m.js,
+      imports: m.imports,
+      ...(m.sourceMap !== undefined ? { sourceMap: m.sourceMap as never } : {}),
+    }));
+    const built = buildRecordsFromCompiled(cached, {
+      // Runtime export names so an `export *` from a runtime module (none here)
+      // would resolve; harmless to pass for parity with the engine.
+      runtimeModules: { commonfabric: [] },
+    });
+
+    // Map specifier → engine's normalized filename so we can identify authored
+    // modules (path starts with "/") vs the injected `cfc.ts` ambient helper.
+    const filenameBySpec = new Map(
+      modules.map((m) => [`cf:module/${m.identity}`, m.filename]),
+    );
+
+    // Every cf:module record is reproduced from cached bodies alone.
+    for (const [specifier, srcRecord] of graph.records) {
+      if (!specifier.startsWith("cf:module/")) continue; // skip cf:runtime/*
+      const builtRecord = built.records.get(specifier);
+      expect(builtRecord, `missing built record for ${specifier}`)
+        .toBeDefined();
+
+      const filename = filenameBySpec.get(specifier);
+      // Authored modules: JS-derived export names match source-derived exactly.
+      // The injected `cfc.ts` helper is the one exception — its source declares
+      // ambient exports (`export declare const …`) that the compiler ERASES, so
+      // source-analysis over-declares names with no runtime value while the
+      // compiled body assigns none. That module's namespace is unused (real
+      // values come from cf:runtime/commonfabric), so the difference is benign.
+      if (filename?.startsWith("/")) {
+        expect(new Set(builtRecord!.exports)).toEqual(
+          new Set(srcRecord.exports),
+        );
+      }
+
+      // Internal (cf:module/*) resolutions must match exactly for every module.
+      const internalRes = (r: Record<string, string> | undefined) =>
+        Object.fromEntries(
+          Object.entries(r ?? {}).filter(([, v]) => v.startsWith("cf:module/")),
+        );
+      expect(internalRes(builtRecord!.resolutions)).toEqual(
+        internalRes(srcRecord.resolutions),
+      );
+    }
+
+    // The entry's derived exports include the transitive export-* names.
+    const entrySpec = built.specifierByPath.get("/main.tsx")!;
+    expect(new Set(built.records.get(entrySpec)!.exports)).toEqual(
+      new Set(["z", "default", "a", "b", "c", "__esModule"]),
+    );
+  });
+});

--- a/packages/runner/test/esm-cell-cache-integration.test.ts
+++ b/packages/runner/test/esm-cell-cache-integration.test.ts
@@ -83,15 +83,43 @@ describe("ESM compile via content-addressed cell cache", () => {
     // Cold compile (miss): evaluates correctly and triggers write-back.
     const cold = await pm.compilePattern(PROGRAM, { space, tx });
     expect(await run(cold, 3)).toEqual({ result: 6 });
-    expect(pm.getCompileCacheStats()).toEqual({ hits: 0, misses: 1 });
+    expect(pm.getCompileCacheStats()).toEqual({
+      hits: 0,
+      misses: 1,
+      byIdentityHits: 0,
+    });
 
     // Wait for the fire-and-forget write-back to commit.
     await pm.flushCompileCacheWrites();
 
     // Warm compile (hit): served from the cache, still evaluates correctly.
     const warm = await pm.compilePattern(PROGRAM, { space, tx });
-    expect(pm.getCompileCacheStats()).toEqual({ hits: 1, misses: 1 });
+    expect(pm.getCompileCacheStats()).toEqual({
+      hits: 1,
+      misses: 1,
+      byIdentityHits: 0,
+    });
     expect(await run(warm, 5)).toEqual({ result: 10 });
+  });
+
+  it("warm load BY IDENTITY skips resolve+compile entirely", async () => {
+    const pm = runtime.patternManager;
+    // Cold compile to populate the cache + learn the entry identity.
+    await pm.compilePattern(PROGRAM, { space, tx });
+    await pm.flushCompileCacheWrites();
+    const { entryIdentity } = await (runtime.harness as Engine)
+      .compileToRecordGraph(PROGRAM);
+
+    // Load again WITH the known entry identity → resolve-free fast path.
+    const warm = await pm.compilePattern(PROGRAM, {
+      space,
+      tx,
+      knownEntryIdentity: entryIdentity,
+    });
+    const stats = pm.getCompileCacheStats();
+    expect(stats.byIdentityHits).toBe(1);
+    expect(stats.misses).toBe(1); // only the initial cold compile
+    expect(await run(warm, 6)).toEqual({ result: 12 });
   });
 
   it("warm hit reuses the cached body across a fresh runtime (cross-session)", async () => {
@@ -108,7 +136,11 @@ describe("ESM compile via content-addressed cell cache", () => {
     try {
       const pm2 = runtime2.patternManager;
       const warm = await pm2.compilePattern(PROGRAM, { space, tx: tx2 });
-      expect(pm2.getCompileCacheStats()).toEqual({ hits: 1, misses: 0 });
+      expect(pm2.getCompileCacheStats()).toEqual({
+        hits: 1,
+        misses: 0,
+        byIdentityHits: 0,
+      });
       // The cache-served pattern is a real, frozen pattern.
       expect(typeof warm).toBe("function");
     } finally {
@@ -130,7 +162,11 @@ describe("ESM compile via content-addressed cell cache", () => {
       const compiled = await pm.compilePattern(PROGRAM, { space, tx: dtx });
       await pm.flushCompileCacheWrites();
       // Cache path is skipped entirely → no hit/miss bookkeeping.
-      expect(pm.getCompileCacheStats()).toEqual({ hits: 0, misses: 0 });
+      expect(pm.getCompileCacheStats()).toEqual({
+        hits: 0,
+        misses: 0,
+        byIdentityHits: 0,
+      });
       expect(typeof compiled).toBe("function");
     } finally {
       await dtx.commit();
@@ -266,6 +302,7 @@ describe("ESM compile cache — Pattern.inSpace A → B routing", () => {
       expect(rt2.patternManager.getCompileCacheStats()).toEqual({
         hits: 1,
         misses: 0,
+        byIdentityHits: 0,
       });
       await tx2.commit();
     } finally {

--- a/packages/runner/test/esm-verifier.bench.ts
+++ b/packages/runner/test/esm-verifier.bench.ts
@@ -1,0 +1,371 @@
+/**
+ * ESM verifier body-vs-graph split benchmark (CT-1623).
+ *
+ * Isolates the per-module body scan (`verifyCompiledModuleBody` summed over all
+ * authored bodies) from the whole-graph structural check (`verifyModuleGraph`)
+ * and compares both against the AMD bundle verifier path, for a small synthetic
+ * program and the real parking-coordinator pattern.
+ *
+ * Pre-compile / pre-parse everything OUTSIDE the timed regions so the bench
+ * measures only the security-verify step, not the TypeScript compile.
+ *
+ * Run:
+ *   deno bench --allow-read --allow-write --allow-net --allow-ffi --allow-env \
+ *     --no-check packages/runner/test/esm-verifier.bench.ts
+ */
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Engine } from "../src/harness/engine.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+import { Runtime } from "../src/runtime.ts";
+import {
+  verifyCompiledModuleBody,
+  verifyModuleGraph,
+} from "../src/sandbox/module-record-verifier.ts";
+import { parseCompiledBundleSource } from "../src/sandbox/compiled-js-parser.ts";
+import { verifyParsedCompiledBundleModuleFactoriesWithParser } from "../src/sandbox/compiled-bundle-verifier.ts";
+import {
+  type BindingInfo,
+  classifyModuleItems,
+} from "../src/sandbox/compiled-bundle-verifier.ts";
+import { parseFunctionText } from "../src/sandbox/compiled-js-parser.ts";
+import {
+  isAllowedAuthoredImportSpecifier,
+  isRuntimeModuleIdentifier,
+} from "../src/sandbox/runtime-module-policy.ts";
+import {
+  isAllowedTsLibHelperDeclaration,
+  normalizeExact,
+} from "../src/sandbox/bundle-preflight.ts";
+
+// ---------------------------------------------------------------------------
+// Pre-shadow-detection baseline: the single-pass verifyCompiledModuleBody from
+// Phase D2.1 (commit 4e3f69d05), before the helper-shadow bypass fix landed in
+// 3517a3433 / a0213d532 added a second full statement scan.
+// This is used ONLY in the regression-delta bench group to quantify the cost of
+// the shadow-detection pass. Product code is untouched.
+// ---------------------------------------------------------------------------
+
+const EMPTY_BINDING_SET: ReadonlySet<string> = new Set<string>();
+
+const REQUIRE_IMPORT_LEGACY = new RegExp(
+  "^const\\s+([A-Za-z_$][\\w$]*)\\s*=\\s*" +
+    "(?:__importDefault|__importStar)?\\s*\\(?\\s*" +
+    "require\\(\\s*[\"']([^\"']+)[\"']\\s*\\)\\s*\\)?\\s*;?$",
+);
+
+/**
+ * Single-pass body verifier (pre-shadow-detection, Phase D2.1).
+ * Omits the shadow-name scan over all statements; used only to measure
+ * the overhead that the shadow-detection pass adds.
+ */
+function verifyCompiledModuleBodyLegacy(
+  compiled: string,
+  filename = "<module>",
+): void {
+  const wrapped = `function () {\n${compiled}\n}`;
+  const parsed = parseFunctionText(wrapped, 0, wrapped.length);
+
+  const env = new Map<string, BindingInfo>();
+  const classifiable: typeof parsed.body.statements = [];
+  for (const statement of parsed.body.statements) {
+    const text = wrapped.slice(statement.start, statement.end).trim();
+    // Inline tslib helper declarations: skip (not present in Phase D2.1 but
+    // cheap to add here so the diff is strictly the shadow-scan cost).
+    if (isAllowedTsLibHelperDeclaration(normalizeExact(text))) continue;
+    const match = REQUIRE_IMPORT_LEGACY.exec(text);
+    if (match && isAllowedAuthoredImportSpecifier(match[2])) {
+      const [, binding, specifier] = match;
+      env.set(binding, {
+        kind: "import",
+        dependencySpecifier: specifier,
+        namespaceImport: true,
+        trustedRuntimeName: isRuntimeModuleIdentifier(specifier)
+          ? specifier
+          : undefined,
+      });
+      continue;
+    }
+    classifiable.push(statement);
+  }
+
+  classifyModuleItems(wrapped, filename, classifiable, env, {
+    requiredGuards: EMPTY_BINDING_SET,
+    reservedBindings: EMPTY_BINDING_SET,
+    missingGuardsErrorAt: 0,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Setup helpers
+// ---------------------------------------------------------------------------
+
+const signer = await Identity.fromPassphrase("bench esm verifier");
+
+function createBenchEngine() {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const engine = runtime.harness as Engine;
+  return { engine, runtime, storageManager };
+}
+
+async function compileToGraph(program: RuntimeProgram) {
+  const { engine, runtime, storageManager } = createBenchEngine();
+  try {
+    // compileToRecordGraph runs the full pipeline (TS → records → verify).
+    // We keep the result for the pre-parsed bodies + record map. The verify
+    // step running here does NOT affect the bench timings below — those each
+    // call the verifier functions afresh on the pre-built inputs.
+    return await engine.compileToRecordGraph(program);
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+}
+
+async function compileToBundle(program: RuntimeProgram) {
+  const { engine, runtime, storageManager } = createBenchEngine();
+  try {
+    return await engine.compile(program);
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Programs
+// ---------------------------------------------------------------------------
+
+/** Small: 2 authored modules, minimal bodies. */
+const smallProgram: RuntimeProgram = {
+  main: "/main.ts",
+  files: [
+    {
+      name: "/labels.ts",
+      contents: [
+        "const defaultLabel = 'Open';",
+        "export default defaultLabel;",
+      ].join("\n"),
+    },
+    {
+      name: "/main.ts",
+      contents: [
+        'import { pattern } from "commonfabric";',
+        "import defaultLabel from './labels.ts';",
+        "export default pattern(() => ({",
+        "  label: defaultLabel,",
+        "}));",
+      ].join("\n"),
+    },
+  ],
+};
+
+async function loadParkingCoordinatorProgram(): Promise<RuntimeProgram> {
+  const [contents, adminContents, vehiclesContents] = await Promise.all([
+    Deno.readTextFile(
+      new URL(
+        "../../patterns/factory-outputs/parking-coordinator/main.tsx",
+        import.meta.url,
+      ),
+    ),
+    Deno.readTextFile(
+      new URL("../../patterns/cfc/admin/mod.ts", import.meta.url),
+    ),
+    Deno.readTextFile(new URL("../../patterns/vehicles.ts", import.meta.url)),
+  ]);
+  return {
+    main: "/factory-outputs/parking-coordinator/main.tsx",
+    files: [
+      { name: "/factory-outputs/parking-coordinator/main.tsx", contents },
+      { name: "/cfc/admin/mod.ts", contents: adminContents },
+      { name: "/vehicles.ts", contents: vehiclesContents },
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pre-compile everything (outside bench timing)
+// ---------------------------------------------------------------------------
+
+const parkingCoordinatorProgram = await loadParkingCoordinatorProgram();
+
+const [
+  smallGraph,
+  parkingGraph,
+  smallBundle,
+  parkingBundle,
+] = await Promise.all([
+  compileToGraph(smallProgram),
+  compileToGraph(parkingCoordinatorProgram),
+  compileToBundle(smallProgram),
+  compileToBundle(parkingCoordinatorProgram),
+]);
+
+// Pre-parse AMD bundles (outside bench timing)
+const smallParsedBundle = parseCompiledBundleSource(smallBundle.jsScript.js);
+const parkingParsedBundle = parseCompiledBundleSource(
+  parkingBundle.jsScript.js,
+);
+
+// Snapshot compiled bodies as plain arrays so the bench loop is allocation-free
+const smallBodies = [...smallGraph.graph.compiledBodies.entries()];
+const parkingBodies = [...parkingGraph.graph.compiledBodies.entries()];
+
+// Snapshot record maps + main specifiers for graph verify
+const smallRecords = smallGraph.graph.records;
+const smallMainSpec = smallGraph.mainSpecifier;
+const parkingRecords = parkingGraph.graph.records;
+const parkingMainSpec = parkingGraph.mainSpecifier;
+
+// Log program sizes for reference
+console.log(
+  `small: ${smallBodies.length} authored bodies, ` +
+    `total body bytes: ${smallBodies.reduce((s, [, b]) => s + b.length, 0)}, ` +
+    `AMD bundle: ${smallBundle.jsScript.js.length} chars`,
+);
+console.log(
+  `parking-coordinator: ${parkingBodies.length} authored bodies, ` +
+    `total body bytes: ${
+      parkingBodies.reduce((s, [, b]) => s + b.length, 0)
+    }, ` +
+    `AMD bundle: ${parkingBundle.jsScript.js.length} chars`,
+);
+
+// ---------------------------------------------------------------------------
+// Benchmarks: small program
+// ---------------------------------------------------------------------------
+
+Deno.bench(
+  `ESM body verify (all bodies summed): small [${smallBodies.length} modules]`,
+  { group: "esm-verifier-small", baseline: true },
+  () => {
+    for (const [specifier, body] of smallBodies) {
+      verifyCompiledModuleBody(body, specifier);
+    }
+  },
+);
+
+Deno.bench(
+  `ESM graph verify: small [${smallRecords.size} records]`,
+  { group: "esm-verifier-small" },
+  () => {
+    verifyModuleGraph(smallRecords, smallMainSpec);
+  },
+);
+
+Deno.bench(
+  `AMD bundle verify: small [${smallBundle.jsScript.js.length} chars]`,
+  { group: "esm-verifier-small" },
+  () => {
+    verifyParsedCompiledBundleModuleFactoriesWithParser(
+      smallBundle.jsScript.js,
+      smallParsedBundle,
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Benchmarks: parking-coordinator (large)
+// ---------------------------------------------------------------------------
+
+Deno.bench(
+  `ESM body verify (all bodies summed): parking-coordinator [${parkingBodies.length} modules]`,
+  { group: "esm-verifier-parking", baseline: true },
+  () => {
+    for (const [specifier, body] of parkingBodies) {
+      verifyCompiledModuleBody(body, specifier);
+    }
+  },
+);
+
+Deno.bench(
+  `ESM graph verify: parking-coordinator [${parkingRecords.size} records]`,
+  { group: "esm-verifier-parking" },
+  () => {
+    verifyModuleGraph(parkingRecords, parkingMainSpec);
+  },
+);
+
+Deno.bench(
+  `AMD bundle verify: parking-coordinator [${parkingBundle.jsScript.js.length} chars]`,
+  { group: "esm-verifier-parking" },
+  () => {
+    verifyParsedCompiledBundleModuleFactoriesWithParser(
+      parkingBundle.jsScript.js,
+      parkingParsedBundle,
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Per-module body verify: one bench per authored module (parking only, to
+// show per-module cost distribution — body size varies widely in a real
+// pattern, the per-module numbers help pinpoint which module dominates).
+// ---------------------------------------------------------------------------
+
+for (const [specifier, body] of parkingBodies) {
+  // Trim specifier to a readable label (last 12 hex chars of the hash)
+  const label = specifier.replace("cf:module/", "").slice(-12);
+  Deno.bench(
+    `ESM body verify: module …${label} [${body.length} bytes]`,
+    { group: "esm-verifier-per-module" },
+    () => {
+      verifyCompiledModuleBody(body, specifier);
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Regression delta: shadow-detection pass overhead
+//
+// Compare current `verifyCompiledModuleBody` (two passes: shadow-scan + classify)
+// against the pre-shadow-detection single-pass version from Phase D2.1.
+// The delta is the overhead introduced by commits 3517a3433 + a0213d532.
+// ---------------------------------------------------------------------------
+
+// Use only the dominant large module (first parking body by size) for the
+// per-module regression delta, so the signal is not diluted by tiny modules.
+const [dominantSpec, dominantBody] = parkingBodies.reduce((max, cur) =>
+  cur[1].length > max[1].length ? cur : max
+);
+
+Deno.bench(
+  `ESM body verify (current, two-pass): dominant module [${dominantBody.length} bytes]`,
+  { group: "esm-verifier-regression-delta", baseline: true },
+  () => {
+    verifyCompiledModuleBody(dominantBody, dominantSpec);
+  },
+);
+
+Deno.bench(
+  `ESM body verify (legacy single-pass, pre-shadow-detection): dominant module [${dominantBody.length} bytes]`,
+  { group: "esm-verifier-regression-delta" },
+  () => {
+    verifyCompiledModuleBodyLegacy(dominantBody, dominantSpec);
+  },
+);
+
+// Also run the regression delta over all parking bodies summed
+Deno.bench(
+  `ESM body verify (current, two-pass): parking all bodies [${parkingBodies.length} modules]`,
+  { group: "esm-verifier-regression-all", baseline: true },
+  () => {
+    for (const [specifier, body] of parkingBodies) {
+      verifyCompiledModuleBody(body, specifier);
+    }
+  },
+);
+
+Deno.bench(
+  `ESM body verify (legacy single-pass): parking all bodies [${parkingBodies.length} modules]`,
+  { group: "esm-verifier-regression-all" },
+  () => {
+    for (const [specifier, body] of parkingBodies) {
+      verifyCompiledModuleBodyLegacy(body, specifier);
+    }
+  },
+);

--- a/packages/runner/test/load-by-identity.test.ts
+++ b/packages/runner/test/load-by-identity.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import { Engine } from "../src/harness/engine.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+import type { Source } from "@commonfabric/js-compiler";
+import type { CachedCompiledModule } from "../src/sandbox/module-record-compiler.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+const signer = await Identity.fromPassphrase("load-by-identity");
+const space = signer.did();
+
+// The load-by-identity warm path: build + evaluate a pattern directly from
+// cached compiled modules (no TS source, no resolve, no recompile), and the
+// cold-recovery path: recreate the pattern from the stored TypeScript alone
+// (content-addressed source set) when the compiled set is unavailable — the
+// runtime-version-bump scenario.
+describe("load by module identity (warm + version-bump recovery)", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let engine: Engine;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      experimental: { esmModuleLoader: true },
+    });
+    engine = runtime.harness as Engine;
+    tx = runtime.edit();
+  });
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  const PROGRAM: RuntimeProgram = {
+    main: "/main.tsx",
+    files: [
+      { name: "/util.ts", contents: "export const double = (x:number)=>x*2;" },
+      {
+        name: "/main.tsx",
+        contents: [
+          "import { pattern, lift } from 'commonfabric';",
+          "import { double } from './util.ts';",
+          "const dbl = lift((x:number)=>double(x));",
+          "export default pattern<{ value: number }>(({ value }) => {",
+          "  return { result: dbl(value) };",
+          "});",
+        ].join("\n"),
+      },
+    ],
+  };
+
+  const runPattern = async (
+    main: Record<string, unknown> | undefined,
+    value: number,
+    cause: string,
+  ): Promise<unknown> => {
+    const pattern = (main as { default?: unknown })?.default;
+    const resultCell = runtime.getCell<{ result: number }>(
+      space,
+      cause,
+      undefined,
+      tx,
+    );
+    // deno-lint-ignore no-explicit-any
+    const result = runtime.run(tx, pattern as any, { value }, resultCell);
+    await tx.commit();
+    tx = runtime.edit();
+    await result.pull();
+    return result.getAsQueryResult();
+  };
+
+  const toCached = (
+    modules: {
+      identity: string;
+      filename: string;
+      js: string;
+      imports: unknown;
+    }[],
+  ): CachedCompiledModule[] =>
+    modules.map((m) => ({
+      identity: m.identity,
+      filename: m.filename,
+      code: m.js,
+      // deno-lint-ignore no-explicit-any
+      imports: m.imports as any,
+    }));
+
+  it("evaluates a pattern from cached compiled modules (no resolve/compile)", async () => {
+    const { modules, entryIdentity } = await engine.compileToRecordGraph(
+      PROGRAM,
+    );
+
+    // Warm path: build records + evaluate straight from the cached bodies.
+    const result = await engine.evaluateCachedModules(
+      toCached(modules),
+      entryIdentity,
+      { sourceFiles: PROGRAM.files },
+    );
+    expect(result.main).toBeDefined();
+    expect(await runPattern(result.main, 4, "warm cached run")).toEqual({
+      result: 8,
+    });
+  });
+
+  it("recreates the pattern from the stored TypeScript alone (runtime-version bump)", async () => {
+    // First compile — capture the content-addressed source set (what
+    // `pattern:<identity>` cells store: each module's resolved TS + identity).
+    const first = await engine.compileToRecordGraph(PROGRAM);
+    const storedSource: Source[] = first.modules.map((m) => ({
+      name: m.filename,
+      contents: m.source,
+    }));
+    const entryFilename =
+      first.modules.find((m) => m.identity === first.entryIdentity)!.filename;
+
+    // Simulate a runtime-version bump: the compiled set (keyed by
+    // runtimeVersion) is now a miss, so recover from the stored source alone —
+    // no in-hand program, no compiled cache. Recompiling is identity-stable.
+    const recovered = await engine.compileResolvedToRecordGraph(
+      storedSource,
+      entryFilename,
+    );
+
+    // Content-addressed: recompiling the stored source reproduces the SAME
+    // per-module identities (so the rebuilt compiled set is addressable, and
+    // writable-back under the new runtimeVersion).
+    expect(recovered.entryIdentity).toBe(first.entryIdentity);
+    expect(new Set(recovered.modules.map((m) => m.identity))).toEqual(
+      new Set(first.modules.map((m) => m.identity)),
+    );
+
+    // And the recreated pattern runs correctly.
+    const result = await engine.evaluateCachedModules(
+      toCached(recovered.modules),
+      recovered.entryIdentity,
+      { sourceFiles: storedSource },
+    );
+    expect(await runPattern(result.main, 5, "recovered run")).toEqual({
+      result: 10,
+    });
+  });
+});


### PR DESCRIPTION
## CT-1623 — load a pattern by module identity (resolve-free warm load + cold recovery)

The machinery to load a pattern **directly from its content-addressed compiled
cache by entry identity**, skipping TypeScript resolve *and* compile — and to
recreate it from the stored source set alone when the compiled set is
unavailable. Behind `CF_ESM_MODULE_LOADER` (default off); the source-compile path
is unchanged.

### What's here
- **`buildRecordsFromCompiled` + `extractCompiledExports`** (`module-record-compiler.ts`): assemble a verified record graph from cached compiled bodies, **deriving export names from the compiled JS** (`exports.X=`, `Object.defineProperty`, `__exportStar` unioned transitively) rather than storing them. Validated to match the source-derived records for authored modules.
- **`Engine.evaluateCachedModules`**: warm load — build + verify + evaluate straight from cached bodies. No source, no resolve, no compile.
- **`Engine.compileResolvedToRecordGraph`**: cold recovery — recreate from the stored source set's TS alone (skips pretransform; still resolves for the runtime `.d.ts` type env the CF transformer needs). Identities recompute identically, so the rebuilt compiled set is addressable + writable-back under a new `runtimeVersion`.
- **Shared `evaluateGraph` core**: `evaluateRecordGraph` refactored to delegate, so the source path and the cached path reuse the same security-sensitive eval (verified-load, source maps, canonical `fn.src`). Reconciled with `main`'s canonical-source work — both paths register `cf:module/<hash>/<path>` verified sources.
- **`PatternManager.tryWarmLoadByIdentity`**: when an entry identity is known (via `compilePattern`'s `cacheCtx.knownEntryIdentity`), take the resolve-free fast path; falls through to recompile on any miss/incompleteness. New `byIdentityHits` stat.
- **`esm-verifier.bench.ts`**: body-vs-graph verify split benchmark.

### Why
The content-addressed cache already stores everything a load needs (compiled bodies + import edges + source set). This is the foundation for a pattern reference becoming `(moduleIdentity, symbol)` so the browser never fetches/compiles TS for a cached pattern.

### Tests
Keystone record-equivalence (incl. transitive `export *`), warm load runs correctly, **runtime-version-bump recovery from stored source alone** (identities recompute identically, pattern runs). All ESM / cache / source-location / verifier-parity / pattern-manager suites green.

### Follow-ups (tracked)
- Wire the entry identity to the load decision in production: store it in pattern metadata and/or the `{identity, symbol}` result-cell reference (`runner.ts`) — `knownEntryIdentity` is plumbed but only set in tests today.
- Precompile pipeline so the browser loads compiled-by-identity.
- **CT-1659**: cache verify verdicts by content hash → skip re-verify on warm loads (the warm path currently re-verifies; the bench shows that's the largest ESM-specific per-load cost).

Refs CT-1623.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds resolve-free warm loading by module identity and cold recovery from stored source when compiled cache is missing. Improves load performance on cache hits while keeping the source-compile path unchanged. Behind `CF_ESM_MODULE_LOADER`.

- **New Features**
  - Build records directly from cached compiled modules with `extractCompiledExports` to derive export names from JS, unioning `export *` transitively; security verify before eval.
  - `Engine.evaluateCachedModules(modules, entryIdentity, { sourceFiles? })` for warm loads; registers runtime records and evaluates without TS resolve/compile.
  - `Engine.compileResolvedToRecordGraph(resolvedFiles, entryFilename)` for runtime-version-bump recovery; identities recompute identically for write-back under the new runtime version.
  - `PatternManager.tryWarmLoadByIdentity` fast path using `cacheCtx.knownEntryIdentity`, with a new `byIdentityHits` stat; falls back to recompile on any miss.

- **Refactors**
  - Shared `evaluateGraph` core used by both source and cached paths; consistent verified source handling including canonical `cf:module/<hash>/<path>` forms.

Addresses Linear CT-1623.

<sup>Written for commit bf915c19440076b09a97f241f62f3b3c0b5115be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

