### PR TITLE
feat(runner): load patterns by content identity in production — {identity, symbol} result cell (step 3)

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -295,6 +295,7 @@ export interface IReadable<T> {
  */
 export type MetaField =
   | "pattern"
+  | "patternIdentity" // content-addressed {identity, symbol} pattern reference
   | "argument"
   | "internal"
   | "schema"

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -94,6 +94,11 @@ export class PatternManager {
   private patternIdMap = new Map<URI, Pattern>();
   // Map from pattern object instance to patternId
   private patternToIdMap = new WeakMap<Pattern, URI>();
+  // Map from pattern object instance to the entry module's content identity
+  // (prefix-free `cf:module/<hash>` minus the scheme). Learned on the ESM cache
+  // path; lets a result cell reference a pattern by {identity, symbol} and load
+  // it straight from the compiled cache without the program/meta indirection.
+  private patternToEntryIdentity = new WeakMap<Pattern, string>();
   private patternToVerifiedLoadId = new WeakMap<Pattern, string>();
   // Pending metadata set before the meta cell exists (e.g., spec, parents)
   private pendingMetaById = new Map<URI, Partial<PatternMeta>>();
@@ -680,7 +685,7 @@ export class PatternManager {
       writeBack.finally(() => this.compileCacheWrites.delete(writeBack));
     }
 
-    return this.patternFromEvaluation(result, program);
+    return this.patternFromEvaluation(result, program, entryIdentity);
   }
 
   /**
@@ -735,7 +740,7 @@ export class PatternManager {
         entryIdentity,
         { sourceFiles: program.files },
       );
-      return this.patternFromEvaluation(result, program);
+      return this.patternFromEvaluation(result, program, entryIdentity);
     } catch (error) {
       // Incomplete/invalid cached closure — fall back to recompile.
       logger.warn("compile-cache-by-identity-miss", () => [
@@ -744,6 +749,112 @@ export class PatternManager {
       ]);
       return undefined;
     }
+  }
+
+  /**
+   * Load a pattern referenced purely by content identity — the
+   * `{identity, symbol}` result-cell reference — straight from the compiled
+   * cache, with NO TypeScript program in hand and NO meta-cell roundtrip. The
+   * pattern's TS source is never pulled on this path; it is only needed for cold
+   * recovery, which the caller handles by falling back to the patternId load.
+   *
+   * Returns the pattern, or `undefined` when the by-identity load is
+   * unavailable (ESM loader off / CFC not enforcing / closure absent or
+   * incomplete / invalid) so the caller can fall back to `loadPattern`.
+   */
+  async loadPatternByIdentity(
+    entryIdentity: string,
+    symbol: string,
+    space: MemorySpace,
+  ): Promise<Pattern | undefined> {
+    const harness = this.runtime.harness;
+    if (
+      this.runtime.experimental.esmModuleLoader !== true ||
+      !harness.evaluateCachedModules ||
+      this.runtime.cfcEnforcementMode === "disabled"
+    ) {
+      return undefined;
+    }
+    const cacheOpts = {
+      runtimeVersion: COMPILE_CACHE_RUNTIME_VERSION,
+      compilerDid: this.runtime.userIdentityDID,
+    };
+
+    const readTx = this.runtime.edit();
+    let closure;
+    try {
+      const readStart = performance.now();
+      closure = await loadCompiledClosure(
+        this.runtime,
+        space,
+        entryIdentity,
+        cacheOpts,
+        readTx,
+      );
+      logger.time(readStart, "compile-cache", "load-pattern-by-identity");
+    } finally {
+      readTx.abort?.("load-pattern-by-identity read complete");
+    }
+    if (!closure.has(entryIdentity)) return undefined;
+
+    const cachedModules: CachedCompiledModule[] = [...closure].map(
+      ([identity, doc]) => ({
+        identity,
+        filename: doc.filename,
+        code: doc.code,
+        ...(doc.sourceMap !== undefined
+          ? { sourceMap: doc.sourceMap as never }
+          : {}),
+        imports: doc.imports
+          .filter((i) => !i.specifier.startsWith(ROOT_LINK_SPECIFIER))
+          .map((i) => ({ specifier: i.specifier, targetIdentity: i.identity })),
+      }),
+    );
+
+    try {
+      // Source-free: no sourceFiles. Sub-patterns fall back to identity.
+      const result = await harness.evaluateCachedModules(
+        cachedModules,
+        entryIdentity,
+      );
+      const pattern = this.patternFromMain(result, symbol, entryIdentity);
+      this.esmCacheStats.byIdentityHits++;
+      return pattern;
+    } catch (error) {
+      logger.warn("load-pattern-by-identity-miss", () => [
+        `entry=${entryIdentity}`,
+        `symbol=${symbol}`,
+        String(error),
+      ]);
+      return undefined;
+    }
+  }
+
+  /**
+   * Build a pattern object from an evaluation result by export `symbol`, with
+   * NO program attached (the source-free by-identity path). Mirrors
+   * `patternFromEvaluation` minus `setPatternProgram` — recovery of the program
+   * happens by identity via the source closure, not from the pattern object.
+   */
+  private patternFromMain(
+    { main, loadId }: EvaluateResult,
+    symbol: string,
+    entryIdentity: string,
+  ): Pattern {
+    if (!main) {
+      throw new Error("Pattern compilation produced no exports.");
+    }
+    if (!(symbol in main)) {
+      throw new Error(`No "${symbol}" export found in compiled pattern.`);
+    }
+    const pattern = main[symbol] as Pattern;
+    if (isTrustedPattern(pattern)) {
+      this.patternToEntryIdentity.set(pattern, entryIdentity);
+      if (loadId) {
+        this.seedVerifiedLoadIds(pattern, loadId);
+      }
+    }
+    return pattern;
   }
 
   /**
@@ -792,6 +903,7 @@ export class PatternManager {
   private patternFromEvaluation(
     { main, loadId }: EvaluateResult,
     program: RuntimeProgram,
+    entryIdentity?: string,
   ): Pattern {
     if (!main) {
       throw new Error("Pattern compilation produced no exports.");
@@ -808,11 +920,26 @@ export class PatternManager {
     // cannot masquerade as a verified-loaded pattern in the side-tables.
     if (isTrustedPattern(pattern)) {
       setPatternProgram(pattern, program);
+      if (entryIdentity) {
+        this.patternToEntryIdentity.set(pattern, entryIdentity);
+      }
       if (loadId) {
         this.seedVerifiedLoadIds(pattern, loadId);
       }
     }
     return pattern;
+  }
+
+  /**
+   * The entry module's content identity for a pattern object, if known (it is
+   * learned on the ESM cache path). Lets callers persist a result cell's
+   * reference as {identity, symbol} so the pattern reloads straight from the
+   * compiled cache. Returns undefined for legacy/AMD patterns.
+   */
+  getPatternEntryIdentity(pattern: Pattern | Module): string | undefined {
+    return this.patternToEntryIdentity.get(
+      this.findOriginalPattern(pattern as Pattern),
+    );
   }
 
   /**

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -94,11 +94,18 @@ export class PatternManager {
   private patternIdMap = new Map<URI, Pattern>();
   // Map from pattern object instance to patternId
   private patternToIdMap = new WeakMap<Pattern, URI>();
-  // Map from pattern object instance to the entry module's content identity
-  // (prefix-free `cf:module/<hash>` minus the scheme). Learned on the ESM cache
-  // path; lets a result cell reference a pattern by {identity, symbol} and load
-  // it straight from the compiled cache without the program/meta indirection.
-  private patternToEntryIdentity = new WeakMap<Pattern, string>();
+  // Map from pattern object instance to its content-addressed {identity, symbol}
+  // reference — the entry module's identity (prefix-free `cf:module/<hash>`
+  // minus the scheme) and the export name this pattern was selected by. Learned
+  // on the ESM cache path; lets a result cell reference a pattern by
+  // {identity, symbol} and load it straight from the compiled cache without the
+  // program/meta indirection. The symbol is recorded from the authored program
+  // (cold) or the load symbol (warm) — never recomputed from a source-free
+  // pattern's stub program, which would lose a non-"default" export name.
+  private patternToEntryRef = new WeakMap<
+    Pattern,
+    { identity: string; symbol: string }
+  >();
   private patternToVerifiedLoadId = new WeakMap<Pattern, string>();
   // Pending metadata set before the meta cell exists (e.g., spec, parents)
   private pendingMetaById = new Map<URI, Partial<PatternMeta>>();
@@ -849,7 +856,7 @@ export class PatternManager {
     }
     const pattern = main[symbol] as Pattern;
     if (isTrustedPattern(pattern)) {
-      this.patternToEntryIdentity.set(pattern, entryIdentity);
+      this.patternToEntryRef.set(pattern, { identity: entryIdentity, symbol });
       if (loadId) {
         this.seedVerifiedLoadIds(pattern, loadId);
       }
@@ -921,7 +928,10 @@ export class PatternManager {
     if (isTrustedPattern(pattern)) {
       setPatternProgram(pattern, program);
       if (entryIdentity) {
-        this.patternToEntryIdentity.set(pattern, entryIdentity);
+        this.patternToEntryRef.set(pattern, {
+          identity: entryIdentity,
+          symbol: exportName,
+        });
       }
       if (loadId) {
         this.seedVerifiedLoadIds(pattern, loadId);
@@ -931,13 +941,15 @@ export class PatternManager {
   }
 
   /**
-   * The entry module's content identity for a pattern object, if known (it is
-   * learned on the ESM cache path). Lets callers persist a result cell's
-   * reference as {identity, symbol} so the pattern reloads straight from the
-   * compiled cache. Returns undefined for legacy/AMD patterns.
+   * The content-addressed {identity, symbol} reference for a pattern object, if
+   * known (learned on the ESM cache path). Lets callers persist a result cell's
+   * reference so the pattern reloads straight from the compiled cache. Returns
+   * undefined for legacy/AMD patterns.
    */
-  getPatternEntryIdentity(pattern: Pattern | Module): string | undefined {
-    return this.patternToEntryIdentity.get(
+  getPatternEntryRef(
+    pattern: Pattern | Module,
+  ): { identity: string; symbol: string } | undefined {
+    return this.patternToEntryRef.get(
       this.findOriginalPattern(pattern as Pattern),
     );
   }

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -55,6 +55,13 @@ export const patternMetaSchema = internSchema(
       spec: { type: "string" },
       parents: { type: "array", items: { type: "string" } },
       patternName: { type: "string" },
+      // Content identity of the entry module (the prefix-free `cf:module/<hash>`
+      // minus the scheme), learned on the first cold ESM compile. Persisting it
+      // here is what makes the resolve-free by-identity fast path fire on every
+      // later load: `compilePatternOnce` reads it back and passes it as
+      // `knownEntryIdentity`. Absent on legacy/AMD patterns (the load simply
+      // falls back to resolve + compile, then re-learns + stores it).
+      entryIdentity: { type: "string" },
       program: {
         type: "object",
         properties: {
@@ -489,6 +496,10 @@ export class PatternManager {
       // in pattern metadata from a prior compile), the ESM cache path loads the
       // compiled closure by identity and skips resolve + compile entirely.
       knownEntryIdentity?: string;
+      // Invoked once the entry module's content identity is known for this
+      // compile (warm-by-identity or cold). Lets the caller persist it (e.g.
+      // into pattern metadata) so subsequent loads can take the fast path.
+      onEntryIdentity?: (entryIdentity: string) => void;
     },
   ): Promise<Pattern> {
     let program: RuntimeProgram;
@@ -513,8 +524,9 @@ export class PatternManager {
       if (cacheCtx && this.runtime.cfcEnforcementMode !== "disabled") {
         return await this.compileViaCellCache(program, cacheCtx);
       }
-      const { id, graph, mainSpecifier } = await this.runtime.harness
-        .compileToRecordGraph(program);
+      const { id, graph, mainSpecifier, entryIdentity } = await this.runtime
+        .harness.compileToRecordGraph(program);
+      cacheCtx?.onEntryIdentity?.(entryIdentity);
       const result = this.runtime.harness.evaluateRecordGraph(
         id,
         graph,
@@ -561,6 +573,7 @@ export class PatternManager {
       space: MemorySpace;
       tx?: IExtendedStorageTransaction;
       knownEntryIdentity?: string;
+      onEntryIdentity?: (entryIdentity: string) => void;
     },
   ): Promise<Pattern> {
     const harness = this.runtime.harness;
@@ -586,6 +599,7 @@ export class PatternManager {
       );
       if (byIdentity) {
         this.esmCacheStats.byIdentityHits++;
+        cacheCtx.onEntryIdentity?.(cacheCtx.knownEntryIdentity);
         return byIdentity;
       }
     }
@@ -638,6 +652,7 @@ export class PatternManager {
       readTx.abort?.("compile-cache read complete");
     }
     const { id, graph, mainSpecifier, entryIdentity, modules } = compiled;
+    cacheCtx.onEntryIdentity?.(entryIdentity);
 
     const evalStart = performance.now();
     const result = harness.evaluateRecordGraph!(
@@ -891,13 +906,34 @@ export class PatternManager {
     }
 
     const source = patternMeta.program!;
+    // A previously-stored entry identity (set on the first cold ESM compile)
+    // lets the cache path skip resolve + compile and load by identity.
+    const knownEntryIdentity = patternMeta.entryIdentity;
+    let learnedEntryIdentity: string | undefined;
     // Pass the target space so the ESM path can use the per-space cell cache.
-    const pattern = await this.compilePattern(source, { space, tx });
+    const pattern = await this.compilePattern(source, {
+      space,
+      tx,
+      knownEntryIdentity,
+      onEntryIdentity: (id) => {
+        learnedEntryIdentity = id;
+      },
+    });
     this.patternIdMap.set(patternId, pattern);
     this.patternToIdMap.set(pattern, patternId);
     this.patternMetaCellById.set(patternId, metaCell.withTx());
     this.associateVerifiedFunctions(patternId, pattern);
     this.evictIfNeeded();
+    // Persist the entry identity once learned (cold compile) so the next load
+    // takes the by-identity fast path. Fire-and-forget — never blocks the load,
+    // but tracked alongside the cache writes so shutdown / tests can flush it.
+    if (learnedEntryIdentity && learnedEntryIdentity !== knownEntryIdentity) {
+      const metaWrite = this.setPatternMetaFields(patternId, {
+        entryIdentity: learnedEntryIdentity,
+      });
+      this.compileCacheWrites.add(metaWrite);
+      metaWrite.finally(() => this.compileCacheWrites.delete(metaWrite));
+    }
     return pattern;
   }
 

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -1090,6 +1090,37 @@ export class PatternManager {
   }
 
   /**
+   * Load a pattern by its content-addressed {identity, symbol} reference and
+   * register it under `patternId` so `patternById(patternId)` resolves it (the
+   * reload path keys on patternId everywhere). The source-free fast path: no TS
+   * program, no meta-cell sync. Returns undefined when the by-identity load is
+   * unavailable, so the caller falls back to `loadPattern(patternId)`.
+   */
+  async loadPatternByIdentityAs(
+    patternId: URI,
+    entryIdentity: string,
+    symbol: string,
+    space: MemorySpace,
+  ): Promise<Pattern | undefined> {
+    const existing = this.patternIdMap.get(patternId);
+    if (existing) {
+      this.touchPattern(patternId);
+      return existing;
+    }
+    const pattern = await this.loadPatternByIdentity(
+      entryIdentity,
+      symbol,
+      space,
+    );
+    if (!pattern) return undefined;
+    this.patternIdMap.set(patternId, pattern);
+    this.patternToIdMap.set(pattern, patternId);
+    this.associateVerifiedFunctions(patternId, pattern);
+    this.evictIfNeeded();
+    return pattern;
+  }
+
+  /**
    * Set or update metadata fields for a pattern before or after saving.
    * If the metadata cell already exists, it updates it in-place.
    * Otherwise, it stores the fields to be applied on the next save.

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -29,7 +29,6 @@ import {
   popFrame,
   pushFrameFromCause,
 } from "./builder/pattern.ts";
-import { getPatternProgram } from "./builder/pattern-metadata.ts";
 import { type Cell, createCell, isCell } from "./cell.ts";
 import { type Action } from "./scheduler.ts";
 import { RetryImmediately } from "./scheduler/retry-immediately.ts";
@@ -855,14 +854,15 @@ export class Runner {
     // the runtime load straight from the compiled cache by identity — no TS
     // source pulled, no meta-cell roundtrip — falling back to the patternId
     // load when the by-identity load is unavailable. See loadPatternByIdentity.
-    const entryIdentity = this.runtime.patternManager.getPatternEntryIdentity(
-      pattern,
-    );
-    if (entryIdentity) {
-      const symbol = getPatternProgram(pattern)?.mainExport ?? "default";
+    // The ref carries the authoritative export symbol (recorded at compile/load
+    // time); we never recompute it from `pattern`'s program here, since a
+    // source-free reloaded pattern only has a stub program (mainExport
+    // "default"), which would clobber a non-"default" export name.
+    const entryRef = this.runtime.patternManager.getPatternEntryRef(pattern);
+    if (entryRef) {
       resultCell.withTx(tx).setMetaRaw("patternIdentity", {
-        identity: entryIdentity,
-        symbol,
+        identity: entryRef.identity,
+        symbol: entryRef.symbol,
       });
     }
 

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -29,6 +29,7 @@ import {
   popFrame,
   pushFrameFromCause,
 } from "./builder/pattern.ts";
+import { getPatternProgram } from "./builder/pattern-metadata.ts";
 import { type Cell, createCell, isCell } from "./cell.ts";
 import { type Action } from "./scheduler.ts";
 import { RetryImmediately } from "./scheduler/retry-immediately.ts";
@@ -849,6 +850,22 @@ export class Runner {
     // Set the pattern in the resultCell as well
     resultCell.withTx(tx).setMetaRaw("pattern", getSigilLink(patternId));
 
+    // Also record the content-addressed {identity, symbol} reference when the
+    // pattern's entry identity is known (ESM cache path). On reload this lets
+    // the runtime load straight from the compiled cache by identity — no TS
+    // source pulled, no meta-cell roundtrip — falling back to the patternId
+    // load when the by-identity load is unavailable. See loadPatternByIdentity.
+    const entryIdentity = this.runtime.patternManager.getPatternEntryIdentity(
+      pattern,
+    );
+    if (entryIdentity) {
+      const symbol = getPatternProgram(pattern)?.mainExport ?? "default";
+      resultCell.withTx(tx).setMetaRaw("patternIdentity", {
+        identity: entryIdentity,
+        symbol,
+      });
+    }
+
     this.updateResultProjection(tx, pattern, resultCell.withTx(tx), {
       preserveName: previousPatternId === patternId,
     });
@@ -1234,10 +1251,21 @@ export class Runner {
   ): Promise<boolean> {
     const pattern = this.runtime.patternManager.patternById(patternId);
     if (!pattern) {
-      return this.runtime.patternManager.loadPattern(
-        patternId,
-        rootCell.space,
-      )
+      // Prefer the content-addressed {identity, symbol} reference when present:
+      // it loads straight from the compiled cache (no TS source, no meta-cell
+      // roundtrip). Fall back to the patternId load (which handles cold
+      // recovery from the stored source) when by-identity is unavailable.
+      const identityRef = getPatternIdentityRef(rootCell);
+      const pm = this.runtime.patternManager;
+      const loadPromise = identityRef
+        ? pm.loadPatternByIdentityAs(
+          patternId,
+          identityRef.identity,
+          identityRef.symbol,
+          rootCell.space,
+        ).then((byId) => byId ?? pm.loadPattern(patternId, rootCell.space))
+        : pm.loadPattern(patternId, rootCell.space);
+      return loadPromise
         .then((loaded) => {
           if (loaded) {
             return this.doStart(rootCell, seenCells);
@@ -3804,4 +3832,25 @@ function getTxDebugActionId(
  */
 function getPatternId(resultCell: Cell<unknown>): URI | undefined {
   return getMetaLink(resultCell, "pattern")?.id;
+}
+
+/**
+ * Read the content-addressed {identity, symbol} pattern reference from a result
+ * cell, if one was recorded at setup (ESM cache path). Lets the reload path
+ * load the pattern straight from the compiled cache by identity. Returns
+ * undefined for legacy result cells that only carry the patternId link.
+ */
+function getPatternIdentityRef(
+  resultCell: Cell<unknown>,
+): { identity: string; symbol: string } | undefined {
+  const raw = resultCell.getMetaRaw("patternIdentity", {
+    meta: ignoreReadForScheduling,
+  });
+  if (
+    isRecord(raw) && typeof raw.identity === "string" &&
+    typeof raw.symbol === "string"
+  ) {
+    return { identity: raw.identity, symbol: raw.symbol };
+  }
+  return undefined;
 }

--- a/packages/runner/test/load-by-identity-meta-bridge.test.ts
+++ b/packages/runner/test/load-by-identity-meta-bridge.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+const signer = await Identity.fromPassphrase("load-by-identity-meta-bridge");
+const space = signer.did();
+
+// Step 3 — the production trigger: the entry module's content identity is
+// learned on the first cold ESM compile and persisted into the pattern's
+// metadata (`entryIdentity`). A later `loadPattern` reads it back and passes it
+// as `knownEntryIdentity`, so the resolve-free by-identity fast path fires
+// instead of resolve + compile. This proves the bridge survives the
+// persistence boundary (a fresh runtime on the same storage).
+describe("load by identity — pattern-metadata bridge", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+
+  const PROGRAM: RuntimeProgram = {
+    main: "/main.tsx",
+    files: [
+      { name: "/util.ts", contents: "export const double = (x:number)=>x*2;" },
+      {
+        name: "/main.tsx",
+        contents: [
+          "import { pattern, lift } from 'commonfabric';",
+          "import { double } from './util.ts';",
+          "const dbl = lift((x:number)=>double(x));",
+          "export default pattern<{ value: number }>(({ value }) => {",
+          "  return { result: dbl(value) };",
+          "});",
+        ].join("\n"),
+      },
+    ],
+  };
+
+  const newRuntime = () =>
+    new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      experimental: { esmModuleLoader: true },
+    });
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+  });
+  afterEach(async () => {
+    await storageManager?.close();
+  });
+
+  it("learns entryIdentity on cold load, then fast-paths a later load", async () => {
+    // Sessions share one emulated store (the persistence boundary). Earlier
+    // runtimes stay alive so their in-flight writes reach the shared store
+    // before a later session reads them; everything is disposed at the end.
+    const rt1 = newRuntime();
+    const rt2 = newRuntime();
+    const rt3 = newRuntime();
+    try {
+      // Session 1: register + persist the pattern's program (no entryIdentity).
+      const tx1 = rt1.edit();
+      const pm1 = rt1.patternManager;
+      const cold = await pm1.compilePattern(PROGRAM, { space, tx: tx1 });
+      const patternId = pm1.registerPattern(cold, PROGRAM);
+      await tx1.commit();
+      await pm1.saveAndSyncPattern({ patternId, space });
+      await pm1.flushCompileCacheWrites();
+      await rt1.storageManager.synced();
+      // The freshly authored meta has no entry identity stored yet.
+      expect(pm1.getPatternMeta({ patternId }).entryIdentity).toBeUndefined();
+
+      // Session 2: a fresh runtime loads the pattern from storage. No stored
+      // entryIdentity → no by-identity fast path. It compiles (content-warm hit
+      // off session 1's compiled cache) and, crucially, learns the entry
+      // identity and writes it back into the metadata.
+      const pm2 = rt2.patternManager;
+      await pm2.loadPattern(patternId, space);
+      expect(pm2.getCompileCacheStats().byIdentityHits).toBe(0);
+      // Flush the fire-and-forget compiled + metadata write-backs.
+      await pm2.flushCompileCacheWrites();
+      await rt2.storageManager.synced();
+      const learned = pm2.getPatternMeta({ patternId }).entryIdentity;
+      expect(typeof learned).toBe("string");
+      expect(learned!.length).toBeGreaterThan(0);
+
+      // Session 3: another fresh runtime loads the pattern. The metadata now
+      // carries entryIdentity → the by-identity fast path fires (no resolve, no
+      // compile): a byIdentity hit.
+      const pm3 = rt3.patternManager;
+      const loaded = await pm3.loadPattern(patternId, space);
+      const stats = pm3.getCompileCacheStats();
+      expect(stats.byIdentityHits).toBe(1);
+      expect(stats.misses).toBe(0);
+      expect(typeof loaded).toBe("function");
+    } finally {
+      await rt3.dispose();
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+});

--- a/packages/runner/test/load-by-identity-meta-bridge.test.ts
+++ b/packages/runner/test/load-by-identity-meta-bridge.test.ts
@@ -109,7 +109,7 @@ describe("load by identity — pattern-metadata bridge", () => {
       const tx1 = rt1.edit();
       const pm1 = rt1.patternManager;
       const cold = await pm1.compilePattern(PROGRAM, { space, tx: tx1 });
-      const entryIdentity = pm1.getPatternEntryIdentity(cold);
+      const entryIdentity = pm1.getPatternEntryRef(cold)?.identity;
       expect(typeof entryIdentity).toBe("string");
       await tx1.commit();
       await pm1.flushCompileCacheWrites();
@@ -140,6 +140,72 @@ describe("load by identity — pattern-metadata bridge", () => {
       await tx2.commit();
       await result.pull();
       expect(result.getAsQueryResult()).toEqual({ result: 14 });
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+
+  it("preserves a non-default export symbol across a source-free reload", async () => {
+    // A pattern exported under a NON-default name. The {identity, symbol}
+    // reference must keep that symbol — a source-free reload has only a stub
+    // program (mainExport "default"), so the symbol must come from the pattern's
+    // recorded entry ref, never be recomputed from the program.
+    const NAMED: RuntimeProgram = {
+      main: "/main.tsx",
+      mainExport: "myPattern",
+      files: [
+        {
+          name: "/main.tsx",
+          contents: [
+            "import { pattern, lift } from 'commonfabric';",
+            "const dbl = lift((x:number)=>x*2);",
+            "export const myPattern = pattern<{ value: number }>(",
+            "  ({ value }) => ({ result: dbl(value) }),",
+            ");",
+          ].join("\n"),
+        },
+      ],
+    };
+
+    const rt1 = newRuntime();
+    const rt2 = newRuntime();
+    try {
+      const tx1 = rt1.edit();
+      const pm1 = rt1.patternManager;
+      const cold = await pm1.compilePattern(NAMED, { space, tx: tx1 });
+      // The authored compile records the real export symbol.
+      expect(pm1.getPatternEntryRef(cold)?.symbol).toBe("myPattern");
+      const entryIdentity = pm1.getPatternEntryRef(cold)!.identity;
+      await tx1.commit();
+      await pm1.flushCompileCacheWrites();
+      await rt1.storageManager.synced();
+
+      // Reload by identity with the non-default symbol → still runs, and the
+      // reloaded pattern carries the SAME {identity, symbol} ref (not "default").
+      const pm2 = rt2.patternManager;
+      const reloaded = await pm2.loadPatternByIdentity(
+        entryIdentity,
+        "myPattern",
+        space,
+      );
+      expect(typeof reloaded).toBe("function");
+      expect(pm2.getPatternEntryRef(reloaded!)).toEqual({
+        identity: entryIdentity,
+        symbol: "myPattern",
+      });
+
+      const tx2 = rt2.edit();
+      const resultCell = rt2.getCell<{ result: number }>(
+        space,
+        "named-export by-identity run",
+        undefined,
+        tx2,
+      );
+      const result = rt2.run(tx2, reloaded!, { value: 9 }, resultCell);
+      await tx2.commit();
+      await result.pull();
+      expect(result.getAsQueryResult()).toEqual({ result: 18 });
     } finally {
       await rt2.dispose();
       await rt1.dispose();

--- a/packages/runner/test/load-by-identity-meta-bridge.test.ts
+++ b/packages/runner/test/load-by-identity-meta-bridge.test.ts
@@ -5,6 +5,7 @@ import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
+import { getPatternProgram } from "../src/builder/pattern-metadata.ts";
 
 const signer = await Identity.fromPassphrase("load-by-identity-meta-bridge");
 const space = signer.did();
@@ -95,6 +96,51 @@ describe("load by identity — pattern-metadata bridge", () => {
       expect(typeof loaded).toBe("function");
     } finally {
       await rt3.dispose();
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+
+  it("loadPatternByIdentity runs source-free, with no program attached", async () => {
+    const rt1 = newRuntime();
+    const rt2 = newRuntime();
+    try {
+      // Populate the compiled cache + learn the entry identity.
+      const tx1 = rt1.edit();
+      const pm1 = rt1.patternManager;
+      const cold = await pm1.compilePattern(PROGRAM, { space, tx: tx1 });
+      const entryIdentity = pm1.getPatternEntryIdentity(cold);
+      expect(typeof entryIdentity).toBe("string");
+      await tx1.commit();
+      await pm1.flushCompileCacheWrites();
+      await rt1.storageManager.synced();
+
+      // Fresh runtime loads the pattern by {identity, symbol} alone — no
+      // program, no meta cell. It still runs correctly.
+      const pm2 = rt2.patternManager;
+      const loaded = await pm2.loadPatternByIdentity(
+        entryIdentity!,
+        "default",
+        space,
+      );
+      expect(typeof loaded).toBe("function");
+      expect(pm2.getCompileCacheStats().byIdentityHits).toBe(1);
+      // No TypeScript source was pulled: the builder stamps a program stub, but
+      // its `files` are empty on the source-free path (vs. the authored set).
+      expect(getPatternProgram(loaded!)?.files ?? []).toEqual([]);
+
+      const tx2 = rt2.edit();
+      const resultCell = rt2.getCell<{ result: number }>(
+        space,
+        "by-identity source-free run",
+        undefined,
+        tx2,
+      );
+      const result = rt2.run(tx2, loaded!, { value: 7 }, resultCell);
+      await tx2.commit();
+      await result.pull();
+      expect(result.getAsQueryResult()).toEqual({ result: 14 });
+    } finally {
       await rt2.dispose();
       await rt1.dispose();
     }

--- a/packages/runner/test/resume-by-identity.test.ts
+++ b/packages/runner/test/resume-by-identity.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+const signer = await Identity.fromPassphrase("resume-by-identity");
+const space = signer.did();
+
+// End-to-end step 3: a result cell records the content-addressed
+// {identity, symbol} pattern reference at setup; a fresh runtime resuming that
+// result cell from storage loads the pattern straight from the compiled cache
+// BY IDENTITY (no TS source pulled, no meta-cell roundtrip), and re-runs it.
+describe("resume a result cell by {identity, symbol}", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+
+  const RESULT_CAUSE = "resume-by-identity result cell";
+
+  const PROGRAM: RuntimeProgram = {
+    main: "/main.tsx",
+    files: [
+      { name: "/util.ts", contents: "export const double = (x:number)=>x*2;" },
+      {
+        name: "/main.tsx",
+        contents: [
+          "import { pattern, lift } from 'commonfabric';",
+          "import { double } from './util.ts';",
+          "const dbl = lift((x:number)=>double(x));",
+          "export default pattern<{ value: number }>(({ value }) => {",
+          "  return { result: dbl(value) };",
+          "});",
+        ].join("\n"),
+      },
+    ],
+  };
+
+  const newRuntime = () =>
+    new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      experimental: { esmModuleLoader: true },
+    });
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+  });
+  afterEach(async () => {
+    await storageManager?.close();
+  });
+
+  it("resumes from the compiled cache by identity, source-free", async () => {
+    const rt1 = newRuntime();
+    const rt2 = newRuntime();
+    try {
+      // Session 1: set up + run the pattern. applySetupState records both the
+      // patternId link and the {identity, symbol} reference on the result cell.
+      const tx1 = rt1.edit();
+      const pm1 = rt1.patternManager;
+      const compiled = await pm1.compilePattern(PROGRAM, { space, tx: tx1 });
+      // The cold ESM compile learned the entry identity.
+      expect(pm1.getPatternEntryIdentity(compiled)).toBeTruthy();
+
+      const resultCell1 = rt1.getCell<{ result: number }>(
+        space,
+        RESULT_CAUSE,
+        undefined,
+        tx1,
+      );
+      const r1 = rt1.run(tx1, compiled, { value: 3 }, resultCell1);
+      await tx1.commit();
+      await r1.pull();
+      expect(r1.getAsQueryResult()).toEqual({ result: 6 });
+
+      await pm1.flushCompileCacheWrites();
+      await rt1.storageManager.synced();
+
+      // Session 2: a fresh runtime resumes the SAME result cell from storage.
+      // No pattern in memory → the reload reads the {identity, symbol}
+      // reference and loads straight from the compiled cache by identity.
+      const pm2 = rt2.patternManager;
+      const tx2 = rt2.edit();
+      const resultCell2 = rt2.getCell<{ result: number }>(
+        space,
+        RESULT_CAUSE,
+        undefined,
+        tx2,
+      );
+      await tx2.commit();
+
+      const started = await rt2.start(resultCell2);
+      expect(started).toBe(true);
+      // Loaded BY IDENTITY — the resolve-free, source-free fast path.
+      expect(pm2.getCompileCacheStats().byIdentityHits).toBe(1);
+
+      const tx3 = rt2.edit();
+      const readCell = rt2.getCell<{ result: number }>(
+        space,
+        RESULT_CAUSE,
+        undefined,
+        tx3,
+      );
+      await readCell.sync();
+      expect(readCell.getAsQueryResult()).toEqual({ result: 6 });
+      tx3.abort?.("read complete");
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+});

--- a/packages/runner/test/resume-by-identity.test.ts
+++ b/packages/runner/test/resume-by-identity.test.ts
@@ -60,7 +60,7 @@ describe("resume a result cell by {identity, symbol}", () => {
       const pm1 = rt1.patternManager;
       const compiled = await pm1.compilePattern(PROGRAM, { space, tx: tx1 });
       // The cold ESM compile learned the entry identity.
-      expect(pm1.getPatternEntryIdentity(compiled)).toBeTruthy();
+      expect(pm1.getPatternEntryRef(compiled)?.identity).toBeTruthy();
 
       const resultCell1 = rt1.getCell<{ result: number }>(
         space,


### PR DESCRIPTION
## What

Part of **CT-1623** (ESM module loader). **Step 3**: make the content-addressed **by-identity** load path fire in production, and realize the `{identity, symbol}` result-cell reference design.

#3832 landed the machinery to load a pattern directly from its cached compiled modules (no resolve, no TS compile, no SES re-verify) but it was **dormant** — nothing supplied `knownEntryIdentity` outside tests. This PR wires it on, in three layers:

### 1. Metadata bridge — activate the fast path
- `entryIdentity` added to `patternMetaSchema`
- `compilePattern` reports the learned entry identity via an `onEntryIdentity` callback
- `compilePatternOnce` reads a stored `entryIdentity` → passes it as `knownEntryIdentity` (resolve-free fast path), and writes it back on the first cold compile (tracked by `flushCompileCacheWrites`)

So the first load learns + persists the entry identity; every later `loadPattern` skips resolve + compile.

### 2. Source-free `loadPatternByIdentity`
- `patternToEntryIdentity` WeakMap + `getPatternEntryIdentity()` — associates the entry identity with the pattern object wherever it is learned
- `loadPatternByIdentity(entryIdentity, symbol, space)` — loads a pattern straight from the compiled cache with **no TypeScript program in hand and no meta-cell roundtrip**; the source is never pulled. Gated on ESM loader + CFC enforcement + closure completeness.
- `patternFromMain()` builds the pattern by export symbol without attaching a program.

### 3. `{identity, symbol}` result-cell reference (the user's design)
- at setup, `applySetupState` records a `patternIdentity` meta of `{identity, symbol}` on the result cell (alongside the existing `pattern → sigilLink(patternId)` link)
- on reload, `startAvailablePattern` reads it and loads via `loadPatternByIdentityAs` (loads by identity + registers under the existing `patternId`, so the rest of the reload path is unchanged), **falling back** to `loadPattern(patternId)` when by-identity is unavailable (legacy patterns, CFC disabled, or a cold/incomplete closure needing source recovery)
- `patternIdentity` added to the `MetaField` union

Net: a result cell created via `cf` carries the module identity + symbol, and a fresh runtime resuming it loads straight from the compiled cache — **the TypeScript is never pulled on the hot path**. Behavior is a strict superset of before (patternId fallback preserved).

## Tests

- `load-by-identity-meta-bridge.test.ts` — the metadata bridge survives the persistence boundary; source-free `loadPatternByIdentity` runs with an empty program file set.
- `resume-by-identity.test.ts` — **end-to-end**: a fresh runtime resumes a result cell from storage purely by `{identity, symbol}` (`byIdentityHits: 1`) and re-runs it correctly.
- Full `runner` package suite green (519 passed, 0 failed).

## Not in this PR (follow-ups)

- **Step 4: precompile pipeline** — compile system patterns server/build-side and serve compiled-by-identity so the browser never fetches + compiles raw `.tsx`.
- Pattern-change watcher (`sinkMeta("pattern")`) still uses the patternId path; changes are rare, so left for a follow-up.
- CT-1659 (verify verdict cache), CT-1653 (resolve-skip pointer doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)