### PR TITLE
Remove the runtime `modernDataModel` option.

### DIFF
--- a/docs/specs/persistent-scheduler-state.md
+++ b/docs/specs/persistent-scheduler-state.md
@@ -893,7 +893,7 @@ attach scheduler observations to transactions, memory clients do not request
 scheduler snapshots, and the memory server does not write scheduler observation
 rows, dirty rows, or cross-space mirrors. Snapshot-list requests intentionally
 return an empty result while the flag is off, even if a previous flagged run
-left scheduler rows in the SQLite database. Unlike `modernDataModel`, this flag
+left scheduler rows in the SQLite database. Unlike `modernCellRep`, this flag
 is not a required memory protocol compatibility flag: mismatched peers may still
 connect, and the server-side flag determines whether scheduler observation rows
 are accepted and served.

--- a/docs/specs/sparse-array-preservation.md
+++ b/docs/specs/sparse-array-preservation.md
@@ -248,8 +248,6 @@ Test coverage verifies sparse preservation at each layer:
 - **`packages/runner/test/data-updating.test.ts`** — All four hole transition
   cases (hole-to-hole, value-to-hole, hole-to-value, value-to-value); `hasPath`
   returns false through holes.
-- **`packages/runner/test/experimental-options.test.ts`** — `isFabricValue`
-  accepts sparse arrays regardless of the `modernDataModel` flag.
 - **`packages/runner/test/patterns-core.test.ts`** — End-to-end test: maps over
   `[10, <hole>, 30]` and verifies output is `[20, <hole>, 60]` with holes
   preserved through the full pipeline.

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -254,15 +254,12 @@ export interface IAnyCell<T> {}
 /**
  * Readable cells provide a view onto stored data.
  *
- * **Frozenness contract (modern data model only):** `get()` and `sample()`
+ * **Frozenness contract:** `get()` and `sample()`
  * return a JS Proxy over the stored value. Writes through the proxy are
- * rejected with a "read-only" runtime error under both flag states (this
- * is independent of the data-model flag — the proxy itself enforces
- * non-mutation). Under `modernDataModel: true`, the underlying stored
+ * rejected with a "read-only" runtime error. The underlying stored
  * data is additionally a deep-frozen `FabricValue` tree, so callers that
  * escape the proxy (e.g. via `getRaw()`) see frozen data without an
- * extra clone. Under `modernDataModel: false` (legacy), only the proxy
- * trap protects against mutation; the underlying data may be unfrozen.
+ * extra clone.
  *
  * Note: `Object.isFrozen(proxy)` reports `false` regardless of the
  * underlying state — that's a property of how JS Proxy reports
@@ -310,14 +307,11 @@ export interface IMetaCell {
 /**
  * Writable cells can update their value.
  *
- * **Frozenness contract (modern data model only):** Values passed into
- * `set()`, `update()`, and `push()` flow through a write-boundary
- * normalization step that — under `modernDataModel: true` — shallowly
- * freezes any plain unfrozen Object/Array levels it visits. Inputs that
- * are already deep-frozen valid `FabricValue` trees are accepted
- * identity-preservingly with no further cloning. Under
- * `modernDataModel: false` (legacy), no freezing happens at the write
- * boundary; storage handles its own frozenness invariants on commit.
+ * **Frozenness contract:** Values passed into `set()`, `update()`, and `push()`
+ * flow through a write-boundary normalization step that shallowly freezes any
+ * plain unfrozen Object/Array levels it visits. Inputs that are already
+ * deep-frozen valid `FabricValue` trees are accepted identity-preservingly with
+ * no further cloning.
  */
 export interface IWritable<T, C extends AnyBrandedCell<any>> {
   /**

--- a/packages/background-charm-service/src/worker-controller.ts
+++ b/packages/background-charm-service/src/worker-controller.ts
@@ -26,7 +26,6 @@ export interface WorkerOptions {
   timeoutMs?: number;
   experimental?: {
     modernCellRep?: boolean;
-    modernDataModel?: boolean;
     persistentSchedulerState?: boolean;
   };
 }

--- a/packages/background-charm-service/src/worker-ipc.ts
+++ b/packages/background-charm-service/src/worker-ipc.ts
@@ -13,7 +13,6 @@ export type InitializationData = {
   rawIdentity: KeyPairRaw;
   experimental?: {
     modernCellRep?: boolean;
-    modernDataModel?: boolean;
     persistentSchedulerState?: boolean;
   };
 };

--- a/packages/data-model/src/interface.ts
+++ b/packages/data-model/src/interface.ts
@@ -196,9 +196,7 @@ export abstract class FabricPrimitive extends FabricSpecialObject {
  * members of the union instead, not routed through that arm. Some native types
  * are converted to fabric primitives during conversion.
  *
- * `undefined` is preserved when the `modernDataModel` flag is ON. When the
- * flag is OFF, `undefined` in arrays is converted to `null` and `undefined`
- * object properties are omitted -- matching legacy behavior.
+ * `undefined` is preserved.
  *
  * `symbol` values are restricted at runtime to **registry-interned** symbols
  * -- those for which `Symbol.keyFor(s)` returns a string. These are

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -1428,14 +1428,11 @@ export class CellImpl<T extends FabricValue>
    * Proxy wrapping). By default returns a deep-frozen `FabricValue`
    * snapshot; pass `{ frozen: false }` for a mutable deep copy.
    *
-   * **Frozenness contract:** Defaults to `{ frozen: true }` regardless
-   * of the data-model flag, returning a deep-frozen `FabricValue`
-   * snapshot via `cloneIfNecessary()`. Under `modernDataModel: true`
-   * the underlying storage already holds a deep-frozen tree, so the
-   * clone is typically a no-op. Under `modernDataModel: false` (legacy)
-   * the snapshot is freshly frozen at read time. The `{ frozen: false }`
-   * variant returns a fresh mutable deep copy and never aliases storage
-   * state.
+   * **Frozenness contract:** Defaults to `{ frozen: true }`, returning a
+   * deep-frozen `FabricValue` snapshot via `cloneIfNecessary()`. The underlying
+   * storage already holds a deep-frozen tree, so the clone is typically a
+   * no-op. The `{ frozen: false }` variant returns a fresh mutable deep copy
+   * and never aliases storage state.
    */
   getRaw(options?: RawCellReadOptions): Immutable<T> | undefined {
     return this.getRawUntyped(options) as Immutable<T> | undefined;
@@ -2240,17 +2237,13 @@ function validateStaticData(value: unknown): void {
  * This ensures that mutable arrays only consist of links to documents, at least
  * when written to only via .set, .update and .push above.
  *
- * **Frozenness contract (modern data model only):** This function sits at
- * the write boundary into runner/memory storage. Under
- * `modernDataModel: true`, the returned tree is always a valid
- * deep-frozen `FabricValue`: the shallow fabric conversion freezes the
- * sub-trees it visits, and the function freezes the freshly-built
- * top-level container before returning. If the input is already a
- * deep-frozen valid `FabricValue`, the shallow conversion returns it
- * as-is and reference identity is preserved end-to-end. Under
- * `modernDataModel: false` (legacy), no freezing happens here at all
- * and the legacy "preserve identity when there's nothing to do"
- * optimization applies regardless of input frozenness.
+ * **Frozenness contract:** This function sits at the write boundary into
+ * runner/memory storage. The returned tree is always a valid deep-frozen
+ * `FabricValue`: the shallow fabric conversion freezes the sub-trees it visits,
+ * and the function freezes the freshly-built top-level container before
+ * returning. If the input is already a deep-frozen valid `FabricValue`, the
+ * shallow conversion returns it as-is and reference identity is preserved
+ * end-to-end.
  *
  * TODO(seefeld): When an array has default entries and is rewritten as [...old,
  * new], this will still break, because the previous entries will point back to

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -170,12 +170,11 @@ export function createQueryResultProxy<T>(
 
   if (!isRecord(value)) return value;
 
-  // When modernDataModel is enabled, stored objects are deep-frozen during
-  // storage normalization (fabricFromNativeValueModern). A frozen proxy target
-  // would force every property access through the invariant guard (ECMAScript
-  // 10.5.8: a [[Get]] trap on a non-configurable, non-writable data property
-  // must return the target's own value), bypassing the get trap's link
-  // resolution entirely.
+  // Stored objects are deep-frozen during storage normalization
+  // (fabricFromNativeValueModern). A frozen proxy target would force every
+  // property access through the invariant guard (ECMAScript 10.5.8: a [[Get]]
+  // trap on a non-configurable, non-writable data property must return the
+  // target's own value), bypassing the get trap's link resolution entirely.
   //
   // Fix: use an unfrozen empty stub as the proxy target. The stub's contents
   // are irrelevant -- the get trap always reads live data from the transaction,

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -127,10 +127,9 @@ const arrayMethods: { [key: string]: ArrayMethodType } = {
  * as `Cell.set()` / `Cell.push()`.
  *
  * **Frozenness contract:** Values handed to the write-side array mutators flow
- * through `recursivelyAddIDIfNeeded()` and so inherit its modern-mode contract:
- * plain unfrozen Object/Array inputs get shallowly frozen at each visited
- * level; already-deep- frozen valid `FabricValue` inputs are accepted
- * identity-preservingly.
+ * through `recursivelyAddIDIfNeeded()` and so plain unfrozen Object/Array
+ * inputs get shallowly frozen at each visited level; already-deep- frozen valid
+ * `FabricValue` inputs are accepted identity-preservingly.
  */
 export function createQueryResultProxy<T>(
   runtime: Runtime,

--- a/packages/runner/src/query-result-proxy.ts
+++ b/packages/runner/src/query-result-proxy.ts
@@ -126,13 +126,11 @@ const arrayMethods: { [key: string]: ArrayMethodType } = {
  * `unshift`, etc.) route through the same write-boundary normalization
  * as `Cell.set()` / `Cell.push()`.
  *
- * **Frozenness contract (modern data model only):** Values handed to
- * the write-side array mutators flow through `recursivelyAddIDIfNeeded`
- * and so inherit its modern-mode contract: plain unfrozen Object/Array
- * inputs get shallowly frozen at each visited level; already-deep-
- * frozen valid `FabricValue` inputs are accepted identity-preservingly.
- * Under `modernDataModel: false` (legacy), no freezing happens at the
- * write boundary.
+ * **Frozenness contract:** Values handed to the write-side array mutators flow
+ * through `recursivelyAddIDIfNeeded()` and so inherit its modern-mode contract:
+ * plain unfrozen Object/Array inputs get shallowly frozen at each visited
+ * level; already-deep- frozen valid `FabricValue` inputs are accepted
+ * identity-preservingly.
  */
 export function createQueryResultProxy<T>(
   runtime: Runtime,

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -15,11 +15,6 @@ import type {
 } from "./builder/types.ts";
 import { ContextualFlowControl } from "./cfc.ts";
 import {
-  getDataModelConfig,
-  resetDataModelConfig,
-  setDataModelConfig,
-} from "@commonfabric/data-model/fabric-value";
-import {
   getModernCellRepConfig,
   resetModernCellRepConfig,
   setModernCellRepConfig,
@@ -182,8 +177,6 @@ export type PieceCreatedCallback = (piece: Cell<any>) => void;
 export interface ExperimentalOptions {
   /** Enable the modern "cell representation" classes. */
   modernCellRep?: boolean | undefined;
-  /** Enable the new fabric value type system (bigint, Map, Set, Uint8Array, Date, FabricInstance). */
-  modernDataModel?: boolean | undefined;
   /** Persist scheduler observations and use them for scheduler rehydration. */
   persistentSchedulerState?: boolean | undefined;
   /** Preserve cumulative scheduler write history instead of using current-known writes. */
@@ -337,7 +330,6 @@ export class Runtime {
   constructor(options: RuntimeOptions) {
     this.experimental = {
       modernCellRep: undefined,
-      modernDataModel: undefined,
       persistentSchedulerState: undefined,
       schedulerHistoricalMightWrite: undefined,
       esmModuleLoader: undefined,
@@ -354,16 +346,13 @@ export class Runtime {
       );
     }
 
-    // Propagate experimental flags to their ambient control points, then
-    // read back the effective state so `experimental.modernDataModel` reflects
-    // what is actually in effect (matters when the caller didn't pass an
-    // explicit value — without this, consumers like `createQueryResultProxy`
-    // see `undefined` and treat the runtime as legacy even when the global
-    // default is modern).
+    // Propagate experimental flags to their ambient control points, then read
+    // back the effective state so `experimental.*` reflects what is actually in
+    // effect (matters when the caller didn't pass an explicit value and the
+    // default happens to be `true`; without this, consumers would see
+    // `undefined` and probably get very confused).
     setModernCellRepConfig(this.experimental.modernCellRep);
     this.experimental.modernCellRep = getModernCellRepConfig();
-    setDataModelConfig(this.experimental.modernDataModel);
-    this.experimental.modernDataModel = getDataModelConfig();
     setPersistentSchedulerStateConfig(
       this.experimental.persistentSchedulerState,
     );
@@ -549,7 +538,6 @@ export class Runtime {
 
     // Reset experimental config to defaults.
     resetModernCellRepConfig();
-    resetDataModelConfig();
     resetPersistentSchedulerStateConfig();
     resetEsmModuleLoaderConfig();
 

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -458,12 +458,12 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
             `Value at path ${address.path.join("/")} is not an object`,
           );
         }
-        // When modernDataModel is ON, stored objects are deep-frozen by
-        // fabricFromNativeValueModern(). Clone before mutation to avoid
-        // TypeError on frozen objects: this always copies (the value may be the
-        // transaction's working copy, which must not be mutated in place), and
-        // it deep-freezes the bound children as inexpensive defense-in-depth
-        // against accidental deeper mutation of the shared input.
+        // Stored objects are deep-frozen by `fabricFromNativeValueModern()`.
+        // Clone before mutation to avoid `TypeError` on frozen objects: this
+        // always copies (the value may be the transaction's working copy, which
+        // must not be mutated in place), and it deep-freezes the bound children
+        // as inexpensive defense-in-depth against accidental deeper mutation of
+        // the shared input.
         valueObj = shallowMutableClone(
           currentValue as FabricValue,
         ) as FabricObject;

--- a/packages/runner/test/cell-core.test.ts
+++ b/packages/runner/test/cell-core.test.ts
@@ -956,6 +956,21 @@ describe("Cell utility functions", () => {
       expect(cell.getRawUntyped({ frozen: false })).toEqual(cell.getRaw());
     });
 
+    it("getRawUntyped({ frozen: false }) _does_ clone", () => {
+      const cell = runtime.getCell<{ items: number[] }>(
+        space,
+        "getRawUntyped frozen false clone off",
+        undefined,
+        tx,
+      );
+      const orig = { items: [1, 2] };
+      cell.set(orig);
+      const result = cell.getRawUntyped({ frozen: false });
+      expect(result).toEqual(orig);
+      expect(result).not.toBe(orig);
+      expect(Object.isFrozen(result)).toBe(false);
+    });
+
     it("setRawUntyped accepts an array", () => {
       const cell = runtime.getCell<number[]>(
         space,
@@ -1010,21 +1025,6 @@ describe("Cell utility functions", () => {
       expect(() => cell.setRawUntyped(42 as FabricValue)).toThrow(
         "Transaction required",
       );
-    });
-
-    it("getRawUntyped({ frozen: false }) _does_ clone (flag OFF)", () => {
-      // Even with `modernDataModel === false`, `cloneIfNecessary()` _will_
-      // make a clone of a frozen value to get a mutable result.
-      const cell = runtime.getCell<{ items: number[] }>(
-        space,
-        "getRawUntyped frozen false clone off",
-        undefined,
-        tx,
-      );
-      cell.set({ items: [1, 2] });
-      const result = cell.getRawUntyped({ frozen: false });
-      expect(result).toEqual({ items: [1, 2] });
-      expect(Object.isFrozen(result)).toBe(false);
     });
   });
 });

--- a/packages/runner/test/cell-core.test.ts
+++ b/packages/runner/test/cell-core.test.ts
@@ -9,7 +9,6 @@ import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import type { FabricValue } from "@commonfabric/memory/interface";
 import {
-  getDataModelConfig,
   resetDataModelConfig,
   setDataModelConfig,
 } from "@commonfabric/data-model/fabric-value";
@@ -85,40 +84,11 @@ describe("Cell", () => {
     expect(c.get()).toBe(20);
   });
 
-  it("should convert Error instances to @Error wrapper on set (legacy)", async () => {
+  it("should wrap Error instances in FabricError on set", async () => {
     const sm = StorageManager.emulate({ as: signer });
     const rt = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: sm,
-      experimental: { modernDataModel: false },
-    });
-    const localTx = rt.edit();
-    const c = rt.getCell<unknown>(
-      space,
-      "should convert Error instances to @Error wrapper on set (legacy)",
-      undefined,
-      localTx,
-    );
-    const error = new TypeError("something went wrong");
-    c.set(error);
-
-    // Legacy path: error should be converted to the `@Error` wrapper.
-    const result = c.get() as { "@Error": Record<string, unknown> } | undefined;
-    expect(result).toHaveProperty("@Error");
-    expect(result!["@Error"].name).toBe("TypeError");
-    expect(result!["@Error"].message).toBe("something went wrong");
-    expect(typeof result!["@Error"].stack).toBe("string");
-    await localTx.commit();
-    await rt.dispose();
-    await sm.close();
-  });
-
-  it("should wrap Error instances in FabricError on set (modern)", async () => {
-    const sm = StorageManager.emulate({ as: signer });
-    const rt = new Runtime({
-      apiUrl: new URL(import.meta.url),
-      storageManager: sm,
-      experimental: { modernDataModel: true },
     });
     const localTx = rt.edit();
     const c = rt.getCell<unknown>(
@@ -150,44 +120,11 @@ describe("Cell", () => {
     await sm.close();
   });
 
-  it("should preserve Error cause property on set (legacy)", async () => {
+  it("should preserve Error cause property on set", async () => {
     const sm = StorageManager.emulate({ as: signer });
     const rt = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: sm,
-      experimental: { modernDataModel: false },
-    });
-    const localTx = rt.edit();
-    const c = rt.getCell<unknown>(
-      space,
-      "should preserve Error cause property on set (legacy)",
-      undefined,
-      localTx,
-    );
-    const cause = new Error("root cause");
-    const error = new Error("wrapper error", { cause });
-    c.set(error);
-
-    // Legacy path: error cause is recursively converted to `@Error` wrapper.
-    const result = c.get() as { "@Error": Record<string, unknown> } | undefined;
-    expect(result).toHaveProperty("@Error");
-    expect(result!["@Error"].message).toBe("wrapper error");
-    const causeWrapper = result!["@Error"].cause as {
-      "@Error": Record<string, unknown>;
-    };
-    expect(causeWrapper).toHaveProperty("@Error");
-    expect(causeWrapper["@Error"].message).toBe("root cause");
-    await localTx.commit();
-    await rt.dispose();
-    await sm.close();
-  });
-
-  it("should preserve Error cause property on set (modern)", async () => {
-    const sm = StorageManager.emulate({ as: signer });
-    const rt = new Runtime({
-      apiUrl: new URL(import.meta.url),
-      storageManager: sm,
-      experimental: { modernDataModel: true },
     });
     const localTx = rt.edit();
     const c = rt.getCell<unknown>(
@@ -220,12 +157,11 @@ describe("Cell", () => {
     await sm.close();
   });
 
-  it("Error set through a nested write-redirect lands on the target (modern)", async () => {
+  it("Error set through a nested write-redirect lands on the target", async () => {
     const sm = StorageManager.emulate({ as: signer });
     const rt = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: sm,
-      experimental: { modernDataModel: true },
     });
     const localTx = rt.edit();
 
@@ -311,46 +247,11 @@ describe("Cell", () => {
     expect(result?.arr.length).toBe(3);
   });
 
-  it("should preserve shared sparse arrays and preserve sharing (legacy)", async () => {
+  it("should preserve shared sparse arrays with structural equality", async () => {
     const sm = StorageManager.emulate({ as: signer });
     const rt = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: sm,
-      experimental: { modernDataModel: false },
-    });
-    const localTx = rt.edit();
-    const c = rt.getCell<unknown>(
-      space,
-      "sparse sharing legacy",
-      undefined,
-      localTx,
-    );
-    const sparse: unknown[] = [];
-    sparse[0] = 1;
-    sparse[3] = 2; // holes at indices 1 and 2
-    // Same sparse array referenced twice
-    c.set([sparse, sparse]);
-
-    const result = c.get() as unknown[][] | undefined;
-    // Both should preserve holes
-    expect(result?.[0][0]).toBe(1);
-    expect(1 in (result?.[0] ?? [])).toBe(false);
-    expect(2 in (result?.[0] ?? [])).toBe(false);
-    expect(result?.[0][3]).toBe(2);
-    expect(result?.[0].length).toBe(4);
-    // With modernDataModel OFF, both should reference the same array
-    expect(result?.[0]).toBe(result?.[1]);
-    await localTx.commit();
-    await rt.dispose();
-    await sm.close();
-  });
-
-  it("should preserve shared sparse arrays with structural equality (modern)", async () => {
-    const sm = StorageManager.emulate({ as: signer });
-    const rt = new Runtime({
-      apiUrl: new URL(import.meta.url),
-      storageManager: sm,
-      experimental: { modernDataModel: true },
     });
     const localTx = rt.edit();
     const c = rt.getCell<unknown>(
@@ -379,168 +280,83 @@ describe("Cell", () => {
     await sm.close();
   });
 
-  // `recursivelyAddIDIfNeeded()` has a legacy "preserve reference identity
-  // when there's nothing to do" optimization. Under the modern data model
-  // (`modernDataModel: true`), the function instead guarantees a
-  // deep-frozen `FabricValue` result for unfrozen inputs: shallow fabric
-  // conversion freezes the visited sub-trees and the function freezes
-  // the freshly-built top-level container. However, when the input is
-  // *already* deep-frozen (a valid `FabricValue`), the shallow
-  // conversion returns it as-is, so identity *is* preserved end-to-end.
-  // The pairs below pin the legacy invariant explicitly and assert the
-  // modern shape (both sides: unfrozen vs. already-frozen) separately.
-  // (Direct unit tests of `recursivelyAddIDIfNeeded` don't go through a
-  // `Runtime`, so flag control happens via `setDataModelConfig()`
-  // rather than runtime construction.)
+  it("returns a deep-frozen structural copy when recursivelyAddIDIfNeeded has nothing to do (unfrozen input)", () => {
+    const frame: Frame = {
+      generatedIdCounter: 0,
+      opaqueRefs: new Set(),
+    };
+    const interests = ["coding", "reading"];
+    const value = {
+      firstName: "Ada",
+      lastName: "Lovelace",
+      interests,
+      stable: { nested: true },
+    };
 
-  it("preserves identity when recursivelyAddIDIfNeeded has nothing to do (legacy)", () => {
-    const savedFlag = getDataModelConfig();
-    setDataModelConfig(false);
-    try {
-      const frame: Frame = {
-        generatedIdCounter: 0,
-        opaqueRefs: new Set(),
-      };
-      const interests = ["coding", "reading"];
-      const value = {
-        firstName: "Ada",
-        lastName: "Lovelace",
-        interests,
-        stable: { nested: true },
-      };
+    const result = recursivelyAddIDIfNeeded(value, frame);
 
-      const result = recursivelyAddIDIfNeeded(value, frame);
-
-      expect(result).toBe(value);
-      expect(result.interests).toBe(interests);
-      expect(result.stable).toBe(value.stable);
-    } finally {
-      setDataModelConfig(savedFlag);
-    }
+    // Modern: the legacy "preserve identity when nothing to do"
+    // optimization doesn't apply for unfrozen inputs. Instead the
+    // function returns a structurally equivalent, deep-frozen tree
+    // (top-level included).
+    expect(result).not.toBe(value);
+    expect(result).toEqual(value);
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(Object.isFrozen(result.interests)).toBe(true);
+    expect(Object.isFrozen(result.stable)).toBe(true);
   });
 
-  it("returns a deep-frozen structural copy when recursivelyAddIDIfNeeded has nothing to do (modern, unfrozen input)", () => {
-    const savedFlag = getDataModelConfig();
-    setDataModelConfig(true);
-    try {
-      const frame: Frame = {
-        generatedIdCounter: 0,
-        opaqueRefs: new Set(),
-      };
-      const interests = ["coding", "reading"];
-      const value = {
-        firstName: "Ada",
-        lastName: "Lovelace",
-        interests,
-        stable: { nested: true },
-      };
+  it("preserves identity when input is already deep-frozen", () => {
+    const frame: Frame = {
+      generatedIdCounter: 0,
+      opaqueRefs: new Set(),
+    };
+    // Deep-freeze before passing in. Under modern, an already-frozen
+    // plain Object/Array is a valid `FabricValue` and shallow fabric
+    // conversion returns it as-is, so reference identity survives all
+    // the way out.
+    const interests = Object.freeze(["coding", "reading"]);
+    const stable = Object.freeze({ nested: true });
+    const value = Object.freeze({
+      firstName: "Ada",
+      lastName: "Lovelace",
+      interests,
+      stable,
+    });
 
-      const result = recursivelyAddIDIfNeeded(value, frame);
+    const result = recursivelyAddIDIfNeeded(value, frame);
 
-      // Modern: the legacy "preserve identity when nothing to do"
-      // optimization doesn't apply for unfrozen inputs. Instead the
-      // function returns a structurally equivalent, deep-frozen tree
-      // (top-level included).
-      expect(result).not.toBe(value);
-      expect(result).toEqual(value);
-      expect(Object.isFrozen(result)).toBe(true);
-      expect(Object.isFrozen(result.interests)).toBe(true);
-      expect(Object.isFrozen(result.stable)).toBe(true);
-    } finally {
-      setDataModelConfig(savedFlag);
-    }
+    expect(result).toBe(value);
+    expect(result.interests).toBe(interests);
+    expect(result.stable).toBe(stable);
   });
 
-  it("preserves identity when input is already deep-frozen (modern)", () => {
-    const savedFlag = getDataModelConfig();
-    setDataModelConfig(true);
-    try {
-      const frame: Frame = {
-        generatedIdCounter: 0,
-        opaqueRefs: new Set(),
-      };
-      // Deep-freeze before passing in. Under modern, an already-frozen
-      // plain Object/Array is a valid `FabricValue` and shallow fabric
-      // conversion returns it as-is, so reference identity survives all
-      // the way out.
-      const interests = Object.freeze(["coding", "reading"]);
-      const stable = Object.freeze({ nested: true });
-      const value = Object.freeze({
-        firstName: "Ada",
-        lastName: "Lovelace",
-        interests,
-        stable,
-      });
+  it("adds generated IDs to objects in arrays regardless of clone depth", () => {
+    const frame: Frame = {
+      generatedIdCounter: 0,
+      opaqueRefs: new Set(),
+    };
+    const stable = { nested: true };
+    const value = {
+      stable,
+      list: [{ name: "Ada" }, "plain"],
+    };
 
-      const result = recursivelyAddIDIfNeeded(value, frame);
+    const result = recursivelyAddIDIfNeeded(value, frame) as typeof value;
 
-      expect(result).toBe(value);
-      expect(result.interests).toBe(interests);
-      expect(result.stable).toBe(stable);
-    } finally {
-      setDataModelConfig(savedFlag);
-    }
-  });
-
-  it("only clones branches that need generated IDs (legacy)", () => {
-    const savedFlag = getDataModelConfig();
-    setDataModelConfig(false);
-    try {
-      const frame: Frame = {
-        generatedIdCounter: 0,
-        opaqueRefs: new Set(),
-      };
-      const stable = { nested: true };
-      const value = {
-        stable,
-        list: [{ name: "Ada" }, "plain"],
-      };
-
-      const result = recursivelyAddIDIfNeeded(value, frame) as typeof value;
-
-      expect(result).not.toBe(value);
-      expect(result.stable).toBe(stable);
-      expect(result.list).not.toBe(value.list);
-      expect(result.list[0]).not.toBe(value.list[0]);
-      expect((result.list[0] as Record<PropertyKey, unknown>)[ID]).toBe(0);
-      expect(result.list[1]).toBe(value.list[1]);
-    } finally {
-      setDataModelConfig(savedFlag);
-    }
-  });
-
-  it("adds generated IDs to objects in arrays regardless of clone depth (modern)", () => {
-    const savedFlag = getDataModelConfig();
-    setDataModelConfig(true);
-    try {
-      const frame: Frame = {
-        generatedIdCounter: 0,
-        opaqueRefs: new Set(),
-      };
-      const stable = { nested: true };
-      const value = {
-        stable,
-        list: [{ name: "Ada" }, "plain"],
-      };
-
-      const result = recursivelyAddIDIfNeeded(value, frame) as typeof value;
-
-      // Modern: shallow fabric conversion clones at each level, so no
-      // sub-branch is reference-preserved. The core invariants that
-      // remain: ID assignment for objects-in-arrays still fires, and
-      // primitive list elements still pass through unchanged. The
-      // returned tree is deep-frozen as a whole (top-level + sub-trees).
-      expect(result).not.toBe(value);
-      expect(result.stable).not.toBe(stable);
-      expect(result.stable).toEqual(stable);
-      expect((result.list[0] as Record<PropertyKey, unknown>)[ID]).toBe(0);
-      expect(result.list[1]).toBe("plain");
-      expect(Object.isFrozen(result)).toBe(true);
-      expect(Object.isFrozen(result.list)).toBe(true);
-      expect(Object.isFrozen(result.list[0])).toBe(true);
-    } finally {
-      setDataModelConfig(savedFlag);
-    }
+    // Modern: shallow fabric conversion clones at each level, so no
+    // sub-branch is reference-preserved. The core invariants that
+    // remain: ID assignment for objects-in-arrays still fires, and
+    // primitive list elements still pass through unchanged. The
+    // returned tree is deep-frozen as a whole (top-level + sub-trees).
+    expect(result).not.toBe(value);
+    expect(result.stable).not.toBe(stable);
+    expect(result.stable).toEqual(stable);
+    expect((result.list[0] as Record<PropertyKey, unknown>)[ID]).toBe(0);
+    expect(result.list[1]).toBe("plain");
+    expect(Object.isFrozen(result)).toBe(true);
+    expect(Object.isFrozen(result.list)).toBe(true);
+    expect(Object.isFrozen(result.list[0])).toBe(true);
   });
 
   it("should preserve holes and add IDs to objects in sparse arrays", () => {
@@ -585,30 +401,6 @@ describe("Cell", () => {
     // toJSON() should have been called
     expect(result?.arr).toBe("custom-array-value");
   });
-
-  it("should throw when setting BigInt with modernDataModel OFF", async () => {
-    const sm = StorageManager.emulate({ as: signer });
-    const rt = new Runtime({
-      apiUrl: new URL(import.meta.url),
-      storageManager: sm,
-      experimental: { modernDataModel: false },
-    });
-    const localTx = rt.edit();
-    const c = rt.getCell<unknown>(
-      space,
-      "should throw when setting BigInt legacy",
-      undefined,
-      localTx,
-    );
-    expect(() => c.set({ value: BigInt(123) })).toThrow("Cannot store bigint");
-    await localTx.commit();
-    await rt.dispose();
-    await sm.close();
-  });
-
-  // Note: A complementary test for BigInt with modernDataModel ON is deferred.
-  // The cell layer accepts BigInt, but the storage layer's JSON.stringify
-  // cannot serialize it yet, causing an uncaught async error.
 
   it("should create a proxy for the cell", () => {
     const c = runtime.getCell<{ x: number; y: number }>(
@@ -1258,8 +1050,7 @@ describe("Cell utility functions", () => {
   });
 });
 
-// Separate top-level describe with modernDataModel enabled for frozen-ness.
-describe("Cell raw methods: frozen-or-not (modernDataModel ON)", () => {
+describe("Cell raw methods: frozen-or-not", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
   let tx: IExtendedStorageTransaction;
@@ -1269,9 +1060,6 @@ describe("Cell raw methods: frozen-or-not (modernDataModel ON)", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      experimental: {
-        modernDataModel: true,
-      },
     });
     tx = runtime.edit();
   });
@@ -1628,226 +1416,129 @@ describe(`Cell result-meta round-trip`, () => {
   );
 });
 
-// Cell-storage behavior for the four "weird" numeric values: `-0`, `NaN`,
-// `+Infinity`, `-Infinity`. The two data-model paths diverge sharply here:
-//
-// * Legacy (`modernDataModel = false`): `-0` is normalized to `0` on set, and
-//   any non-finite number throws `"Cannot store non-finite number"` at the
-//   fabric-value boundary inside `cell.set()`.
-// * Modern  (`modernDataModel = true`): all four values flow through end-to-end
-//   (PRs #3492/#3493/#3495). `-0` keeps its sign; `NaN` and `±Infinity` are
-//   stored faithfully and read back as themselves.
-//
-// These tests pin both behaviors so a future flag-default change can't quietly
-// regress either path.
-for (const modernDataModel of [false, true]) {
-  describe(
-    `Cell special-number storage with \`modernDataModel = ${modernDataModel}\``,
-    () => {
-      let runtime: Runtime;
-      let storageManager: ReturnType<typeof StorageManager.emulate>;
-      let tx: IExtendedStorageTransaction;
+describe(
+  `Cell special-number storage`,
+  () => {
+    let runtime: Runtime;
+    let storageManager: ReturnType<typeof StorageManager.emulate>;
+    let tx: IExtendedStorageTransaction;
 
-      beforeEach(() => {
-        storageManager = StorageManager.emulate({ as: signer });
-        runtime = new Runtime({
-          apiUrl: new URL(import.meta.url),
-          storageManager,
-          experimental: { modernDataModel },
-        });
-        tx = runtime.edit();
+    beforeEach(() => {
+      storageManager = StorageManager.emulate({ as: signer });
+      runtime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager,
       });
+      tx = runtime.edit();
+    });
 
-      afterEach(async () => {
-        await tx.commit();
-        await runtime?.dispose();
-        await storageManager?.close();
+    afterEach(async () => {
+      await tx.commit();
+      await runtime?.dispose();
+      await storageManager?.close();
+    });
+
+    it("preserves the sign of -0 on set", () => {
+      const c = runtime.getCell<unknown>(
+        space,
+        "modern: preserve -0",
+        undefined,
+        tx,
+      );
+      c.set({ value: -0 });
+      const result = c.get() as { value: number } | undefined;
+      expect(Object.is(result?.value, -0)).toBe(true);
+      expect(Object.is(result?.value, 0)).toBe(false);
+    });
+
+    it("stores NaN", () => {
+      const c = runtime.getCell<unknown>(
+        space,
+        "modern: store NaN",
+        undefined,
+        tx,
+      );
+      c.set({ value: NaN });
+      const result = c.get() as { value: number } | undefined;
+      expect(Number.isNaN(result?.value)).toBe(true);
+    });
+
+    it("stores +Infinity and -Infinity", () => {
+      const c = runtime.getCell<unknown>(
+        space,
+        "modern: store infinities",
+        undefined,
+        tx,
+      );
+      c.set({ pos: Infinity, neg: -Infinity });
+      const result = c.get() as
+        | { pos: number; neg: number }
+        | undefined;
+      expect(result?.pos).toBe(Infinity);
+      expect(result?.neg).toBe(-Infinity);
+    });
+  },
+);
+
+describe(
+  "Cell symbol storage",
+  () => {
+    let runtime: Runtime;
+    let storageManager: ReturnType<typeof StorageManager.emulate>;
+    let tx: IExtendedStorageTransaction;
+
+    beforeEach(() => {
+      storageManager = StorageManager.emulate({ as: signer });
+      runtime = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager,
       });
+      tx = runtime.edit();
+    });
 
-      if (modernDataModel) {
-        it("preserves the sign of -0 on set", () => {
-          const c = runtime.getCell<unknown>(
-            space,
-            "modern: preserve -0",
-            undefined,
-            tx,
-          );
-          c.set({ value: -0 });
-          const result = c.get() as { value: number } | undefined;
-          expect(Object.is(result?.value, -0)).toBe(true);
-          expect(Object.is(result?.value, 0)).toBe(false);
-        });
+    afterEach(async () => {
+      await tx.commit();
+      await runtime?.dispose();
+      await storageManager?.close();
+    });
 
-        it("stores NaN", () => {
-          const c = runtime.getCell<unknown>(
-            space,
-            "modern: store NaN",
-            undefined,
-            tx,
-          );
-          c.set({ value: NaN });
-          const result = c.get() as { value: number } | undefined;
-          expect(Number.isNaN(result?.value)).toBe(true);
-        });
+    it("round-trips an interned symbol with stable identity", () => {
+      const c = runtime.getCell<unknown>(
+        space,
+        "modern: interned symbol round-trip",
+        undefined,
+        tx,
+      );
+      c.set({ tag: Symbol.for("status") });
+      const result = c.get() as { tag: symbol } | undefined;
+      // Same registry key in the same realm yields the same symbol
+      // instance, so the round-tripped value is `Object.is` to the
+      // constructed sentinel.
+      expect(Object.is(result?.tag, Symbol.for("status"))).toBe(true);
+    });
 
-        it("stores +Infinity and -Infinity", () => {
-          const c = runtime.getCell<unknown>(
-            space,
-            "modern: store infinities",
-            undefined,
-            tx,
-          );
-          c.set({ pos: Infinity, neg: -Infinity });
-          const result = c.get() as
-            | { pos: number; neg: number }
-            | undefined;
-          expect(result?.pos).toBe(Infinity);
-          expect(result?.neg).toBe(-Infinity);
-        });
-      } else {
-        it("converts -0 to 0 on set", () => {
-          const c = runtime.getCell<unknown>(
-            space,
-            "legacy: -0 to 0",
-            undefined,
-            tx,
-          );
-          c.set({ value: -0 });
-          const result = c.get() as { value: number } | undefined;
-          expect(result?.value).toBe(0);
-          expect(Object.is(result?.value, 0)).toBe(true);
-          expect(Object.is(result?.value, -0)).toBe(false);
-        });
+    it("round-trips an interned symbol with an empty key", () => {
+      const c = runtime.getCell<unknown>(
+        space,
+        "modern: interned empty-key symbol",
+        undefined,
+        tx,
+      );
+      c.set({ tag: Symbol.for("") });
+      const result = c.get() as { tag: symbol } | undefined;
+      expect(Object.is(result?.tag, Symbol.for(""))).toBe(true);
+    });
 
-        it("throws when setting NaN", () => {
-          const c = runtime.getCell<unknown>(
-            space,
-            "legacy: throw on NaN",
-            undefined,
-            tx,
-          );
-          expect(() => c.set({ value: NaN })).toThrow(
-            "Cannot store non-finite number",
-          );
-        });
-
-        it("throws when setting +Infinity or -Infinity", () => {
-          const c = runtime.getCell<unknown>(
-            space,
-            "legacy: throw on infinities",
-            undefined,
-            tx,
-          );
-          expect(() => c.set({ value: Infinity })).toThrow(
-            "Cannot store non-finite number",
-          );
-          expect(() => c.set({ value: -Infinity })).toThrow(
-            "Cannot store non-finite number",
-          );
-        });
-      }
-    },
-  );
-}
-
-// Cell-storage behavior for symbols. The two data-model paths diverge:
-//
-// * Legacy (`modernDataModel = false`): any symbol -- registry-interned or
-//   unique -- throws `"Cannot store symbol"` at the fabric-value boundary
-//   inside `cell.set()`.
-// * Modern  (`modernDataModel = true`): registry-interned symbols
-//   (`Symbol.for(key)`) round-trip end-to-end, with `Object.is` identity
-//   preserved against any same-key `Symbol.for` in the same realm. Unique
-//   symbols (`Symbol(desc)`) throw the more specific `"Cannot store unique
-//   (uninterned) symbol"` (PRs #3503/#3510).
-for (const modernDataModel of [false, true]) {
-  describe(
-    `Cell symbol storage with \`modernDataModel = ${modernDataModel}\``,
-    () => {
-      let runtime: Runtime;
-      let storageManager: ReturnType<typeof StorageManager.emulate>;
-      let tx: IExtendedStorageTransaction;
-
-      beforeEach(() => {
-        storageManager = StorageManager.emulate({ as: signer });
-        runtime = new Runtime({
-          apiUrl: new URL(import.meta.url),
-          storageManager,
-          experimental: { modernDataModel },
-        });
-        tx = runtime.edit();
-      });
-
-      afterEach(async () => {
-        await tx.commit();
-        await runtime?.dispose();
-        await storageManager?.close();
-      });
-
-      if (modernDataModel) {
-        it("round-trips an interned symbol with stable identity", () => {
-          const c = runtime.getCell<unknown>(
-            space,
-            "modern: interned symbol round-trip",
-            undefined,
-            tx,
-          );
-          c.set({ tag: Symbol.for("status") });
-          const result = c.get() as { tag: symbol } | undefined;
-          // Same registry key in the same realm yields the same symbol
-          // instance, so the round-tripped value is `Object.is` to the
-          // constructed sentinel.
-          expect(Object.is(result?.tag, Symbol.for("status"))).toBe(true);
-        });
-
-        it("round-trips an interned symbol with an empty key", () => {
-          const c = runtime.getCell<unknown>(
-            space,
-            "modern: interned empty-key symbol",
-            undefined,
-            tx,
-          );
-          c.set({ tag: Symbol.for("") });
-          const result = c.get() as { tag: symbol } | undefined;
-          expect(Object.is(result?.tag, Symbol.for(""))).toBe(true);
-        });
-
-        it("throws on a unique (uninterned) symbol", () => {
-          const c = runtime.getCell<unknown>(
-            space,
-            "modern: throw on unique symbol",
-            undefined,
-            tx,
-          );
-          expect(() => c.set({ value: Symbol("nope") })).toThrow(
-            "Cannot store unique (uninterned) symbol",
-          );
-        });
-      } else {
-        it("throws on an interned symbol", () => {
-          const c = runtime.getCell<unknown>(
-            space,
-            "legacy: throw on interned symbol",
-            undefined,
-            tx,
-          );
-          expect(() => c.set({ tag: Symbol.for("status") })).toThrow(
-            "Cannot store symbol",
-          );
-        });
-
-        it("throws on a unique (uninterned) symbol", () => {
-          const c = runtime.getCell<unknown>(
-            space,
-            "legacy: throw on unique symbol",
-            undefined,
-            tx,
-          );
-          expect(() => c.set({ value: Symbol("nope") })).toThrow(
-            "Cannot store symbol",
-          );
-        });
-      }
-    },
-  );
-}
+    it("throws on a unique (uninterned) symbol", () => {
+      const c = runtime.getCell<unknown>(
+        space,
+        "modern: throw on unique symbol",
+        undefined,
+        tx,
+      );
+      expect(() => c.set({ value: Symbol("nope") })).toThrow(
+        "Cannot store unique (uninterned) symbol",
+      );
+    });
+  },
+);

--- a/packages/runner/test/cell-core.test.ts
+++ b/packages/runner/test/cell-core.test.ts
@@ -273,7 +273,7 @@ describe("Cell", () => {
     expect(2 in (result?.[0] ?? [])).toBe(false);
     expect(result?.[0][3]).toBe(2);
     expect(result?.[0].length).toBe(4);
-    // With modernDataModel ON, both should be structurally equal
+    // Both should be structurally equal
     expect(result?.[0]).toEqual(result?.[1]);
     await localTx.commit();
     await rt.dispose();
@@ -727,9 +727,6 @@ describe("Cell", () => {
       argumentLink?.scope,
     );
   });
-
-  // Cycle-resolution tests live in a separate `describe` below so they can be
-  // pinned to both `modernDataModel` flag states explicitly.
 });
 
 // Cycle-resolution behavior should hold under both `modernDataModel` flag

--- a/packages/runner/test/cell-core.test.ts
+++ b/packages/runner/test/cell-core.test.ts
@@ -8,10 +8,6 @@ import "@commonfabric/utils/equal-ignoring-symbols";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import type { FabricValue } from "@commonfabric/memory/interface";
-import {
-  resetDataModelConfig,
-  setDataModelConfig,
-} from "@commonfabric/data-model/fabric-value";
 import { isCell, recursivelyAddIDIfNeeded } from "../src/cell.ts";
 import { LINK_V1_TAG } from "../src/sigil-types.ts";
 import { isCellResult } from "../src/query-result-proxy.ts";
@@ -729,117 +725,103 @@ describe("Cell", () => {
   });
 });
 
-// Cycle-resolution behavior should hold under both `modernDataModel` flag
-// states, so these tests are run twice, once per state. Modeled on
-// `packages/data-model/test/clone-if-necessary.test.ts`. The flag is set in
-// `beforeEach` BEFORE constructing the `Runtime`, so the runtime captures
-// the correct value (the `Runtime` constructor snapshots
-// `getDataModelConfig()` at construction time).
 describe("Cell circular references", () => {
-  for (const modernMode of [false, true]) {
-    const label = modernMode ? "modern" : "legacy";
+  let runtime: Runtime;
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let tx: IExtendedStorageTransaction;
 
-    describe(`(${label})`, () => {
-      let runtime: Runtime;
-      let storageManager: ReturnType<typeof StorageManager.emulate>;
-      let tx: IExtendedStorageTransaction;
-
-      beforeEach(() => {
-        setDataModelConfig(modernMode);
-        storageManager = StorageManager.emulate({ as: signer });
-        runtime = new Runtime({
-          apiUrl: new URL(import.meta.url),
-          storageManager,
-        });
-        tx = runtime.edit();
-      });
-
-      afterEach(async () => {
-        await tx.commit();
-        await runtime?.dispose();
-        await storageManager?.close();
-        resetDataModelConfig();
-      });
-
-      it("should translate circular references into links", () => {
-        const schema = {
-          $ref: "#/$defs/Root",
-          $defs: {
-            Root: {
-              type: "object",
-              properties: {
-                x: { type: "number" },
-                y: { type: "number" },
-                z: { $ref: "#/$defs/Root" },
-              },
-              required: ["x", "y", "z"],
-            },
-          },
-        } as const satisfies JSONSchema;
-        const c = runtime.getCell(
-          space,
-          "should translate circular references into links",
-          schema,
-          tx,
-        );
-        const data: any = { x: 1, y: 2 };
-        data.z = data;
-        c.set(data);
-
-        const proxy = c.getAsQueryResult();
-        expect(proxy.z).toBe(proxy);
-
-        const value = c.get();
-        expect(value.z.z.z).toBe(value.z.z);
-
-        const raw = c.getRaw();
-        expect(raw?.z).toMatchObject({ "/": { [LINK_V1_TAG]: { path: [] } } });
-      });
-
-      it("should translate circular references into links across cells", () => {
-        const schema = {
-          $ref: "#/$defs/Root",
-          $defs: {
-            Root: {
-              type: "object",
-              properties: {
-                list: {
-                  type: "array",
-                  items: {
-                    type: "object",
-                    properties: { parent: { $ref: "#/$defs/Root" } },
-                    asCell: ["cell"],
-                    required: ["parent"],
-                  },
-                },
-              },
-              required: ["list"],
-            },
-          },
-        } as const satisfies JSONSchema;
-        const c = runtime.getCell(
-          space,
-          "should translate circular references into links",
-          schema,
-          tx,
-        );
-        const inner: any = { [ID]: 1 }; // ID will turn this into a separate cell
-        const outer: any = { list: [inner] };
-        inner.parent = outer;
-        c.set(outer);
-
-        const proxy = c.getAsQueryResult();
-        expect(proxy.list[0].parent).toBe(proxy);
-
-        const { id } = c.getAsNormalizedFullLink();
-        const innerCell = c.get().list[0];
-        const raw = innerCell.getRaw();
-        expect(raw).toMatchObject({
-          parent: { "/": { [LINK_V1_TAG]: { id } } },
-        });
-      });
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
     });
-  }
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("should translate circular references into links", () => {
+    const schema = {
+      $ref: "#/$defs/Root",
+      $defs: {
+        Root: {
+          type: "object",
+          properties: {
+            x: { type: "number" },
+            y: { type: "number" },
+            z: { $ref: "#/$defs/Root" },
+          },
+          required: ["x", "y", "z"],
+        },
+      },
+    } as const satisfies JSONSchema;
+    const c = runtime.getCell(
+      space,
+      "should translate circular references into links",
+      schema,
+      tx,
+    );
+    const data: any = { x: 1, y: 2 };
+    data.z = data;
+    c.set(data);
+
+    const proxy = c.getAsQueryResult();
+    expect(proxy.z).toBe(proxy);
+
+    const value = c.get();
+    expect(value.z.z.z).toBe(value.z.z);
+
+    const raw = c.getRaw();
+    expect(raw?.z).toMatchObject({ "/": { [LINK_V1_TAG]: { path: [] } } });
+  });
+
+  it("should translate circular references into links across cells", () => {
+    const schema = {
+      $ref: "#/$defs/Root",
+      $defs: {
+        Root: {
+          type: "object",
+          properties: {
+            list: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: { parent: { $ref: "#/$defs/Root" } },
+                asCell: ["cell"],
+                required: ["parent"],
+              },
+            },
+          },
+          required: ["list"],
+        },
+      },
+    } as const satisfies JSONSchema;
+    const c = runtime.getCell(
+      space,
+      "should translate circular references into links",
+      schema,
+      tx,
+    );
+    const inner: any = { [ID]: 1 }; // ID will turn this into a separate cell
+    const outer: any = { list: [inner] };
+    inner.parent = outer;
+    c.set(outer);
+
+    const proxy = c.getAsQueryResult();
+    expect(proxy.list[0].parent).toBe(proxy);
+
+    const { id } = c.getAsNormalizedFullLink();
+    const innerCell = c.get().list[0];
+    const raw = innerCell.getRaw();
+    expect(raw).toMatchObject({
+      parent: { "/": { [LINK_V1_TAG]: { id } } },
+    });
+  });
 });
 
 describe("Cell utility functions", () => {

--- a/packages/runner/test/cell-hooks.test.ts
+++ b/packages/runner/test/cell-hooks.test.ts
@@ -7,10 +7,6 @@ import "@commonfabric/utils/equal-ignoring-symbols";
 
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import {
-  resetDataModelConfig,
-  setDataModelConfig,
-} from "@commonfabric/data-model/fabric-value";
 import { isCell } from "../src/cell.ts";
 import { isCellResult } from "../src/query-result-proxy.ts";
 import { toCell } from "../src/back-to-cell.ts";
@@ -708,77 +704,61 @@ describe("toCell and toOpaqueRef hooks", () => {
       expect(isCell(deepCell)).toBe(true);
       expect(deepCell.get().value).toBe(42);
     });
-
-    // Cycle-handling test moved to a separate parameterized `describe`
-    // below so it can be pinned to both `modernDataModel` flag states.
   });
 });
 
-// Run cycle-handling under both `modernDataModel` flag states explicitly.
-// Modeled on `packages/data-model/test/clone-if-necessary.test.ts`. The flag
-// is set in `beforeEach` BEFORE constructing the `Runtime`, so the runtime
-// captures the correct value (the `Runtime` constructor snapshots
-// `getDataModelConfig()` at construction time).
 describe("toCell and toOpaqueRef hooks: circular references", () => {
-  for (const modernMode of [false, true]) {
-    const label = modernMode ? "modern" : "legacy";
+  let runtime: Runtime;
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let tx: IExtendedStorageTransaction;
 
-    describe(`(${label})`, () => {
-      let runtime: Runtime;
-      let storageManager: ReturnType<typeof StorageManager.emulate>;
-      let tx: IExtendedStorageTransaction;
-
-      beforeEach(() => {
-        setDataModelConfig(modernMode);
-        storageManager = StorageManager.emulate({ as: signer });
-        runtime = new Runtime({
-          apiUrl: new URL(import.meta.url),
-          storageManager,
-        });
-        tx = runtime.edit();
-      });
-
-      afterEach(async () => {
-        await tx.commit();
-        await runtime?.dispose();
-        await storageManager?.close();
-        resetDataModelConfig();
-      });
-
-      it("should handle circular references gracefully", () => {
-        const schema = {
-          $ref: "#/$defs/Root",
-          $defs: {
-            Root: {
-              type: "object",
-              properties: {
-                name: { type: "string" },
-                self: { $ref: "#/$defs/Root" },
-              },
-            },
-          },
-        } as const satisfies JSONSchema;
-
-        const c = runtime.getCell<any>(
-          space,
-          "hook-edge-circular",
-          schema,
-          tx,
-        );
-
-        const data: any = { name: "circular" };
-        data.self = data;
-        c.set(data);
-
-        const result = c.get();
-        expect(toCell in result).toBe(true);
-        expect(result.name).toBe("circular");
-        // With circular references, the self reference points back to the
-        // same data.
-        expect(result.self.name).toBe("circular");
-        // Can navigate infinitely.
-        expect(result.self.self.name).toBe("circular");
-      });
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
     });
-  }
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("should handle circular references gracefully", () => {
+    const schema = {
+      $ref: "#/$defs/Root",
+      $defs: {
+        Root: {
+          type: "object",
+          properties: {
+            name: { type: "string" },
+            self: { $ref: "#/$defs/Root" },
+          },
+        },
+      },
+    } as const satisfies JSONSchema;
+
+    const c = runtime.getCell<any>(
+      space,
+      "hook-edge-circular",
+      schema,
+      tx,
+    );
+
+    const data: any = { name: "circular" };
+    data.self = data;
+    c.set(data);
+
+    const result = c.get();
+    expect(toCell in result).toBe(true);
+    expect(result.name).toBe("circular");
+    // With circular references, the self reference points back to the
+    // same data.
+    expect(result.self.name).toBe("circular");
+    // Can navigate infinitely.
+    expect(result.self.self.name).toBe("circular");
+  });
 });

--- a/packages/runner/test/experimental-options.test.ts
+++ b/packages/runner/test/experimental-options.test.ts
@@ -12,7 +12,10 @@ import {
   shallowFabricFromNativeValue,
 } from "@commonfabric/data-model/fabric-value";
 import { FabricError } from "@commonfabric/data-model/fabric-instances";
-import { getModernCellRepConfig } from "@commonfabric/data-model/cell-rep";
+import {
+  getModernCellRepConfig,
+  resetModernCellRepConfig,
+} from "@commonfabric/data-model/cell-rep";
 import {
   getPersistentSchedulerStateConfig,
   resetPersistentSchedulerStateConfig,
@@ -28,6 +31,7 @@ const signer = await Identity.fromPassphrase("test experimental");
  */
 describe("ExperimentalOptions", () => {
   afterEach(() => {
+    resetModernCellRepConfig();
     resetDataModelConfig();
     resetPersistentSchedulerStateConfig();
   });

--- a/packages/runner/test/experimental-options.test.ts
+++ b/packages/runner/test/experimental-options.test.ts
@@ -12,6 +12,7 @@ import {
   shallowFabricFromNativeValue,
 } from "@commonfabric/data-model/fabric-value";
 import { FabricError } from "@commonfabric/data-model/fabric-instances";
+import { getModernCellRepConfig } from "@commonfabric/data-model/cell-rep";
 import {
   getPersistentSchedulerStateConfig,
   resetPersistentSchedulerStateConfig,
@@ -39,7 +40,6 @@ describe("ExperimentalOptions", () => {
         storageManager: sm,
         experimental: {
           modernCellRep: false,
-          modernDataModel: false,
           // Explicit so the assertion is deterministic regardless of the
           // CF_ESM_MODULE_LOADER env (e.g. during the flag-on cross-check).
           esmModuleLoader: false,
@@ -47,7 +47,6 @@ describe("ExperimentalOptions", () => {
       });
       expect(runtime.experimental).toEqual({
         modernCellRep: false,
-        modernDataModel: false,
         persistentSchedulerState: false,
         schedulerHistoricalMightWrite: undefined,
         esmModuleLoader: false,
@@ -63,13 +62,11 @@ describe("ExperimentalOptions", () => {
         storageManager: sm,
         experimental: {
           modernCellRep: true,
-          modernDataModel: true,
           esmModuleLoader: false, // explicit: deterministic regardless of env
         },
       });
       expect(runtime.experimental).toEqual({
         modernCellRep: true,
-        modernDataModel: true,
         persistentSchedulerState: false,
         schedulerHistoricalMightWrite: undefined,
         esmModuleLoader: false,
@@ -84,13 +81,11 @@ describe("ExperimentalOptions", () => {
         apiUrl: new URL(import.meta.url),
         storageManager: sm,
         experimental: {
-          modernDataModel: true,
           esmModuleLoader: false, // explicit: deterministic regardless of env
         },
       });
       expect(runtime.experimental).toEqual({
         modernCellRep: false,
-        modernDataModel: true,
         persistentSchedulerState: false,
         schedulerHistoricalMightWrite: undefined,
         esmModuleLoader: false,
@@ -309,18 +304,18 @@ describe("ExperimentalOptions", () => {
   });
 
   describe("Runtime sets and resets global config", () => {
-    it("constructing Runtime with modernDataModel sets global config", async () => {
+    it("constructing Runtime with modernCellRep sets global config", async () => {
       const sm = StorageManager.emulate({ as: signer });
       const runtime = new Runtime({
         apiUrl: new URL(import.meta.url),
         storageManager: sm,
         experimental: {
-          modernDataModel: true,
+          modernCellRep: true,
           esmModuleLoader: false, // explicit: deterministic regardless of env
         },
       });
 
-      expect(getDataModelConfig()).toBe(true);
+      expect(getModernCellRepConfig()).toBe(true);
 
       await runtime.dispose();
       await sm.close();
@@ -347,10 +342,10 @@ describe("ExperimentalOptions", () => {
       const runtime = new Runtime({
         apiUrl: new URL(import.meta.url),
         storageManager: sm,
-        experimental: { modernDataModel: false },
+        experimental: { modernCellRep: false },
       });
 
-      expect(getDataModelConfig()).toBe(false);
+      expect(getModernCellRepConfig()).toBe(false);
 
       await runtime.dispose();
       await sm.close();
@@ -361,32 +356,32 @@ describe("ExperimentalOptions", () => {
       const runtime = new Runtime({
         apiUrl: new URL(import.meta.url),
         storageManager: sm,
-        experimental: { modernDataModel: true },
+        experimental: { modernCellRep: true },
       });
 
-      expect(getDataModelConfig()).toBe(true);
+      expect(getModernCellRepConfig()).toBe(true);
 
       await runtime.dispose();
       await sm.close();
     });
 
     it("disposing Runtime resets global config to the default", async () => {
-      const initial = getDataModelConfig();
+      const initial = getModernCellRepConfig();
       const sm = StorageManager.emulate({ as: signer });
       const runtime = new Runtime({
         apiUrl: new URL(import.meta.url),
         storageManager: sm,
         experimental: {
-          modernDataModel: !initial,
+          modernCellRep: !initial,
         },
       });
 
-      expect(getDataModelConfig()).toBe(!initial);
+      expect(getModernCellRepConfig()).toBe(!initial);
 
       await runtime.dispose();
       await sm.close();
 
-      expect(getDataModelConfig()).toBe(initial);
+      expect(getModernCellRepConfig()).toBe(initial);
       expect(getPersistentSchedulerStateConfig()).toBe(false);
     });
   });

--- a/packages/runner/test/fetch-data-mutex.test.ts
+++ b/packages/runner/test/fetch-data-mutex.test.ts
@@ -451,13 +451,6 @@ describe("fetch-data mutex mechanism", () => {
     globalThis.fetch = slowFetch;
   });
 
-  // Bifurcated by data model: the legacy fabric-value layer converts a
-  // thrown `Error` to the `{ "@Error": { name, message, stack } }` wrapper;
-  // the modern layer wraps it as a `FabricError`-shaped value (`typeTag`
-  // "Error@1", observable fields under `.error`). Each variant pins its
-  // own `Runtime` with an explicit `experimental.modernDataModel` (the
-  // constructor snapshots the flag at construction time), per the
-  // `cell-core.test.ts` Error-bifurcation pattern.
   const error404Fetch = () => {
     globalThis.fetch = async () => {
       await new Promise((resolve) => setTimeout(resolve, 10));
@@ -501,9 +494,6 @@ describe("fetch-data mutex mechanism", () => {
       pending?: boolean;
     };
 
-    // Modern path: error is a `FabricError`-shaped value (`typeTag`
-    // "Error@1"), not the legacy `@Error` wrapper; its observable fields
-    // (`name`, `message`, `stack`) are exposed directly on the wrapper.
     // Regression guard for the `memory/v2/patch.ts` `structuredClone()`
     // class-stripping bug, which made errors round-trip back as `{ ... }`
     // with message/stack lost.

--- a/packages/runner/test/fetch-data-mutex.test.ts
+++ b/packages/runner/test/fetch-data-mutex.test.ts
@@ -465,64 +465,12 @@ describe("fetch-data mutex mechanism", () => {
     };
   };
 
-  it("should handle fetch errors gracefully (legacy)", async () => {
+  it("should handle fetch errors gracefully", async () => {
     error404Fetch();
     const sm = StorageManager.emulate({ as: signer });
     const rt = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: sm,
-      experimental: { modernDataModel: false },
-    });
-    const localTx = rt.edit();
-    const { commonfabric } = createTrustedBuilder(rt);
-    const fetchData = commonfabric.byRef("fetchData");
-    const testPattern = commonfabric.pattern<{ url: string }>(
-      ({ url }) => fetchData({ url, mode: "json" }),
-    );
-
-    const resultCell = rt.getCell(
-      space,
-      "error-test-legacy",
-      undefined,
-      localTx,
-    );
-    const result = rt.run(
-      localTx,
-      testPattern,
-      { url: "/api/error" },
-      resultCell,
-    );
-    localTx.commit();
-
-    await result.pull();
-    await new Promise((resolve) => setTimeout(resolve, 200));
-
-    const data = (await result.pull()) as {
-      error?: unknown;
-      pending?: boolean;
-    };
-
-    // Legacy path: error is the `@Error` wrapper.
-    expect(data.error).toBeDefined();
-    expect(data.error).toHaveProperty("@Error");
-    const errorInfo =
-      (data.error as { "@Error": Record<string, unknown> })["@Error"];
-    expect(errorInfo.name).toBe("Error");
-    expect(errorInfo.message).toMatch(/HTTP 404/);
-    expect(data.pending).toBe(false);
-
-    await localTx.commit();
-    await rt.dispose();
-    await sm.close();
-  });
-
-  it("should handle fetch errors gracefully (modern)", async () => {
-    error404Fetch();
-    const sm = StorageManager.emulate({ as: signer });
-    const rt = new Runtime({
-      apiUrl: new URL(import.meta.url),
-      storageManager: sm,
-      experimental: { modernDataModel: true },
     });
     const localTx = rt.edit();
     const { commonfabric } = createTrustedBuilder(rt);

--- a/packages/runner/test/frozen-mutation.test.ts
+++ b/packages/runner/test/frozen-mutation.test.ts
@@ -1,9 +1,9 @@
 /**
  * Contract tests for frozen-object safety.
  *
- * When `modernDataModel` is ON, `fabricFromNativeValueModern()` deep-freezes all
- * stored objects at commit time. Code paths that read these frozen objects from
- * storage must clone before mutating.
+ * `fabricFromNativeValueModern()` deep-freezes all stored objects at commit
+ * time. Code paths that read these frozen objects from storage must clone
+ * before mutating.
  *
  * The writeOrThrow tests use a two-transaction pattern to exercise the real
  * freeze:

--- a/packages/runner/test/frozen-mutation.test.ts
+++ b/packages/runner/test/frozen-mutation.test.ts
@@ -40,9 +40,6 @@ describe("frozen-object safety contracts", () => {
       runtime = new Runtime({
         apiUrl: new URL(import.meta.url),
         storageManager,
-        experimental: {
-          modernDataModel: true,
-        },
       });
     });
 

--- a/packages/runner/test/frozen-proxy-target.test.ts
+++ b/packages/runner/test/frozen-proxy-target.test.ts
@@ -62,9 +62,6 @@ describe("frozen proxy target: link resolution through frozen objects", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      experimental: {
-        modernDataModel: true,
-      },
     });
     tx = runtime.edit();
   });
@@ -132,9 +129,6 @@ describe("frozen proxy target: proxy wrapping and trap behavior", () => {
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      experimental: {
-        modernDataModel: true,
-      },
     });
     tx = runtime.edit();
   });
@@ -446,7 +440,7 @@ describe("frozen proxy target: proxy wrapping and trap behavior", () => {
   });
 });
 
-describe("frozen proxy target: v2 committed reads with modernDataModel ON", () => {
+describe("frozen proxy target: v2 committed reads", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
   let tx: IExtendedStorageTransaction;
@@ -458,9 +452,6 @@ describe("frozen proxy target: v2 committed reads with modernDataModel ON", () =
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      experimental: {
-        modernDataModel: true,
-      },
     });
     tx = runtime.edit();
   });
@@ -471,7 +462,7 @@ describe("frozen proxy target: v2 committed reads with modernDataModel ON", () =
     await storageManager?.close();
   });
 
-  it("resolves sigil links and freezes raw tx reads in rich mode", async () => {
+  it("resolves sigil links and freezes raw tx reads", async () => {
     const targetCell = runtime.getCell<{ answer: number }>(
       space,
       "v2-rich-link-target",
@@ -521,7 +512,7 @@ describe("frozen proxy target: v2 committed reads with modernDataModel ON", () =
   });
 });
 
-describe("frozen proxy target: committed reads with modernDataModel OFF (legacy)", () => {
+describe("frozen proxy target: committed reads", () => {
   let storageManager: ReturnType<typeof StorageManager.emulate>;
   let runtime: Runtime;
   let tx: IExtendedStorageTransaction;
@@ -533,57 +524,6 @@ describe("frozen proxy target: committed reads with modernDataModel OFF (legacy)
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
-      experimental: {
-        modernDataModel: false,
-      },
-    });
-    tx = runtime.edit();
-  });
-
-  afterEach(async () => {
-    await tx.commit();
-    await runtime?.dispose();
-    await storageManager?.close();
-  });
-
-  it("returns frozen committed objects when modernDataModel is OFF (legacy)", async () => {
-    const link = writeCell(runtime, tx, "legacy-frozen-raw", {
-      a: 1,
-      b: 2,
-    });
-
-    tx = await commitAndReopen(runtime, tx);
-    const rawValue = tx.readValueOrThrow(link);
-    expect(Object.isFrozen(rawValue)).toBe(true);
-
-    const result = createQueryResultProxy<{ a: number; b: number }>(
-      runtime,
-      tx,
-      link,
-      0,
-      false,
-    );
-
-    expect(Number(result.a)).toBe(1);
-    expect(Number(result.b)).toBe(2);
-  });
-});
-
-describe("frozen proxy target: committed reads under modernDataModel", () => {
-  let storageManager: ReturnType<typeof StorageManager.emulate>;
-  let runtime: Runtime;
-  let tx: IExtendedStorageTransaction;
-
-  beforeEach(() => {
-    storageManager = StorageManager.emulate({
-      as: signer,
-    });
-    runtime = new Runtime({
-      apiUrl: new URL(import.meta.url),
-      storageManager,
-      experimental: {
-        modernDataModel: true,
-      },
     });
     tx = runtime.edit();
   });
@@ -614,101 +554,5 @@ describe("frozen proxy target: committed reads under modernDataModel", () => {
 
     expect(Number(result.a)).toBe(1);
     expect(Number(result.b)).toBe(2);
-  });
-});
-
-describe("frozen proxy target: wrap fires under modernDataModel=OFF", () => {
-  let storageManager: ReturnType<typeof StorageManager.emulate>;
-  let runtime: Runtime;
-  let tx: IExtendedStorageTransaction;
-
-  beforeEach(() => {
-    storageManager = StorageManager.emulate({
-      as: signer,
-    });
-    // Construct the runtime under `modernDataModel: true` so the storage
-    // layer produces a deep-frozen committed value, then flip the flag to
-    // `false` post-write to simulate the post-PR-C state where a frozen
-    // value reaches `createQueryResultProxy` while `modernDataModel` is
-    // falsy. Prior to PR-B, this case hit a now-removed short-circuit at
-    // `query-result-proxy.ts:162-168` that returned the raw frozen value
-    // instead of wrapping it -- defeating link resolution and breaking
-    // user-code mutation through the proxy.
-    runtime = new Runtime({
-      apiUrl: new URL(import.meta.url),
-      storageManager,
-      experimental: {
-        modernDataModel: true,
-      },
-    });
-    tx = runtime.edit();
-  });
-
-  afterEach(async () => {
-    await tx.commit();
-    await runtime?.dispose();
-    await storageManager?.close();
-  });
-
-  it("wraps a frozen object input even when modernDataModel is OFF", async () => {
-    const link = writeCell(runtime, tx, "pr-b-wrap-frozen-object", {
-      a: 1,
-      b: 2,
-    });
-
-    tx = await commitAndReopen(runtime, tx);
-
-    // Precondition: the committed read returns a deep-frozen object.
-    const rawValue = tx.readValueOrThrow(link);
-    expect(Object.isFrozen(rawValue)).toBe(true);
-
-    // Simulate the post-PR-C state: frozen value reaches the proxy with
-    // `modernDataModel` falsy.
-    runtime.experimental.modernDataModel = false;
-
-    const proxy = createQueryResultProxy<{ a: number; b: number }>(
-      runtime,
-      tx,
-      link,
-      0,
-      false,
-    );
-
-    // Post-PR-B, the proxy must wrap the frozen value (not return it raw),
-    // so property access goes through the get trap.
-    expect(proxy).not.toBe(rawValue);
-    expect(Number(proxy.a)).toBe(1);
-    expect(Number(proxy.b)).toBe(2);
-  });
-
-  it("wraps a frozen array input even when modernDataModel is OFF", async () => {
-    const link = writeCell(runtime, tx, "pr-b-wrap-frozen-array", [
-      10,
-      20,
-      30,
-    ]);
-
-    tx = await commitAndReopen(runtime, tx);
-
-    const rawValue = tx.readValueOrThrow(link);
-    expect(Object.isFrozen(rawValue)).toBe(true);
-    expect(Array.isArray(rawValue)).toBe(true);
-
-    runtime.experimental.modernDataModel = false;
-
-    const proxy = createQueryResultProxy<number[]>(
-      runtime,
-      tx,
-      link,
-      0,
-      false,
-    );
-
-    // The proxy must wrap so array-method dispatch at `:266-321` can fire
-    // for write-mutation methods. Spot-check via a read-only iterator that
-    // routes through the proxy's get-trap rather than the raw target.
-    expect(proxy).not.toBe(rawValue);
-    expect(Array.isArray(proxy)).toBe(true);
-    expect([...proxy].map(Number)).toEqual([10, 20, 30]);
   });
 });

--- a/packages/runner/test/frozen-proxy-target.test.ts
+++ b/packages/runner/test/frozen-proxy-target.test.ts
@@ -1,11 +1,10 @@
 /**
  * Tests for the frozen proxy target fix in `query-result-proxy.ts`.
  *
- * When `modernDataModel` is enabled, stored objects are deep-frozen at
- * commit time. After commit, reads in a new transaction return direct
- * references to these frozen objects. The proxy creation function must still
- * wrap them (using an unfrozen stub as the proxy target) so that link
- * resolution and all proxy traps work correctly.
+ * Stored objects are deep-frozen at commit time. After commit, reads in a new
+ * transaction return direct references to these frozen objects. The proxy
+ * creation function must still wrap them (using an unfrozen stub as the proxy
+ * target) so that link resolution and all proxy traps work correctly.
  *
  * These tests now go through a real commit/reopen cycle. The v2 transaction
  * core isolates caller-owned values on write, so pre-freezing inputs is no
@@ -83,7 +82,7 @@ describe("frozen proxy target: link resolution through frozen objects", () => {
     targetCell.set({ answer: 42 });
 
     // Set up a cell whose value contains a sigil link to the target.
-    // Write it deep-frozen to simulate post-commit state with modernDataModel.
+    // Write it deep-frozen to simulate post-commit state.
     const sourceLink = writeCell(
       runtime,
       tx,
@@ -534,7 +533,7 @@ describe("frozen proxy target: committed reads", () => {
     await storageManager?.close();
   });
 
-  it("returns frozen committed objects under modernDataModel", async () => {
+  it("returns frozen committed objects", async () => {
     const link = writeCell(runtime, tx, "modern-frozen-raw", {
       a: 1,
       b: 2,

--- a/packages/runner/test/runner.test.ts
+++ b/packages/runner/test/runner.test.ts
@@ -845,111 +845,13 @@ describe("runPattern", () => {
     expect(cellValue?.counter).toEqual(2);
   });
 
-  it("should create separate copies of initial values for each pattern instance", async () => {
-    // Use a local runtime with modernDataModel OFF and mutable raw copies
-    // to verify legacy-mode initial values are independent.
-    const sm = StorageManager.emulate({ as: signer });
-    const localRuntime = new Runtime({
-      apiUrl: new URL(import.meta.url),
-      storageManager: sm,
-      experimental: { modernDataModel: false },
-    });
-
-    const pattern: Pattern = {
-      argumentSchema: {
-        type: "object",
-        properties: {
-          input: { type: "number" },
-        },
-      },
-      initial: {
-        internal: {
-          counter: 10,
-          nested: { value: "initial" },
-        },
-      },
-      resultSchema: {},
-      result: {
-        counter: { $alias: { cell: "internal", path: ["counter"] } },
-        nested: { $alias: { cell: "internal", path: ["nested"] } },
-      },
-      nodes: [
-        {
-          module: {
-            type: "javascript",
-            implementation: (args: { input: number }) => {
-              return {
-                counter: args.input,
-              };
-            },
-          },
-          inputs: { $alias: { cell: "argument", path: ["input"] } },
-          outputs: { $alias: { cell: "internal", path: ["counter"] } },
-        },
-      ],
-    };
-
-    // Create first instance
-    const result1Cell = localRuntime.getCell(
-      space,
-      "should create separate copies of initial values 1",
-    );
-    const result1 = runTrusted(
-      localRuntime,
-      undefined,
-      pattern,
-      { input: 5 },
-      result1Cell,
-    );
-    await result1.pull();
-
-    // Create second instance
-    const result2Cell = localRuntime.getCell(
-      space,
-      "should create separate copies of initial values 2",
-    );
-    const result2 = runTrusted(
-      localRuntime,
-      undefined,
-      pattern,
-      { input: 10 },
-      result2Cell,
-    );
-    await result2.pull();
-
-    // Use getRawUntyped({ frozen: false }) for mutable copies
-    const internal1 = localRuntime.getCellFromLink(
-      getMetaLink(result1, "internal")!,
-    ).getRawUntyped({ frozen: false }) as any;
-    const internal2 = localRuntime.getCellFromLink(
-      getMetaLink(result2, "internal")!,
-    ).getRawUntyped({ frozen: false }) as any;
-
-    // Verify they are different objects
-    expect(internal1).not.toBe(internal2);
-    expect(internal1.nested).not.toBe(internal2.nested);
-
-    // Modify nested object in first instance
-    internal1.nested.value = "modified";
-
-    // Verify second instance is unaffected
-    expect(internal2.nested.value).toBe("initial");
-    const result2Value = await result2.pull() as any;
-    expect(result2Value.nested.value).toBe("initial");
-
-    await localRuntime.storageManager.synced();
-    await localRuntime.dispose();
-    await sm.close();
-  });
-
-  it("should create separate copies of initial values (modern, frozen)", async () => {
+  it("should create separate copies of initial values (frozen)", async () => {
     // `getRaw()` returns frozen objects; verify independence via
     // `getRawUntyped({ frozen: false })` for mutable access.
     const sm = StorageManager.emulate({ as: signer });
     const localRuntime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager: sm,
-      experimental: { modernDataModel: true },
     });
 
     const pattern: Pattern = {

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -131,7 +131,7 @@ export interface InitializationData {
   timeoutMs?: number;
   // Experimental space-model feature flags.
   experimental?: {
-    modernDataModel?: boolean;
+    modernCellRep?: boolean;
     persistentSchedulerState?: boolean;
     esmModuleLoader?: boolean;
   };

--- a/packages/toolshed/routes/blobs/blobs.test.ts
+++ b/packages/toolshed/routes/blobs/blobs.test.ts
@@ -150,9 +150,6 @@ describe("Blob Routes", () => {
           as: identity,
           address: new URL("/api/storage/memory", base),
         }),
-        experimental: {
-          modernDataModel: true,
-        },
       });
 
       try {


### PR DESCRIPTION
This PR removes the `modernDataModel` option from the runtime bag of experimental options, and then follows through addressing every site that depended on it existing. I also cleaned up some related comments, and I fixed/removed other tests that were testing the legacy data model in files that I was already touching because of the "main quest."

## Performance Baseline

This PR removes a wee bit of regular code and a lot of tests, and nothing else. So the following accounts for a spurious perf check failure:

NEW_PERF_BASELINE: subtest: pattern-unit-1/pattern-unit-tests > packages/patterns/cfc-render-policy-demo/main.test.tsx = 9s

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the `modernDataModel` runtime option and fully adopt the modern data model. This simplifies the API, removes legacy code paths and tests, and updates docs/comments to reflect a single behavior.

- **Refactors**
  - Removed `experimental.modernDataModel` from `Runtime`, background worker IPC, and `runtime-client` protocol types; protocol/worker init now use `modernCellRep`.
  - Simplified docs/comments to a single model; updated spec references (e.g., scheduler state) and test comments.
  - Ensured proxies always wrap values; deep-frozen `FabricValue` is the default everywhere.
  - Added/propagated missing `modernCellRep` option and reset it on dispose; `runtime.experimental` reflects effective values.
  - Consolidated tests to modern-only semantics; removed legacy-mode assertions and dual-mode parameterizations; adjusted cycle/error/symbol/special-number tests accordingly.

- **Migration**
  - Delete any use of `experimental.modernDataModel`:
    - `new Runtime({ experimental: { modernDataModel: ... } })`
    - Background worker `WorkerOptions.experimental.modernDataModel`
    - Initialization payloads `experimental.modernDataModel` (use `modernCellRep` where applicable)
  - Rely on modern semantics: stored values are deep-frozen, read views are always proxied, interned symbols and special numbers round-trip. Use `getRaw({ frozen: false })` for mutable copies.
  - If you toggled globals in tests, switch to `modernCellRep` helpers (e.g., `getModernCellRepConfig`/`resetModernCellRepConfig`).

<sup>Written for commit 9e25176fb4f9ccf67e489a7d9185786a22d323a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

