### PR TITLE
Fix up `experimental-options.test.ts`.

### DIFF
--- a/packages/runner/test/experimental-options.test.ts
+++ b/packages/runner/test/experimental-options.test.ts
@@ -4,15 +4,6 @@ import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
 import {
-  fabricFromNativeValue,
-  getDataModelConfig,
-  isFabricValue,
-  resetDataModelConfig,
-  setDataModelConfig,
-  shallowFabricFromNativeValue,
-} from "@commonfabric/data-model/fabric-value";
-import { FabricError } from "@commonfabric/data-model/fabric-instances";
-import {
   getModernCellRepConfig,
   resetModernCellRepConfig,
 } from "@commonfabric/data-model/cell-rep";
@@ -25,14 +16,12 @@ const signer = await Identity.fromPassphrase("test experimental");
 
 /**
  * Tests for the `ExperimentalOptions` feature-flag system: verifies that
- * Runtime construction/disposal correctly propagates flags to the ambient
- * fabric-value config, and that `shallowFabricFromNativeValue`/`fabricFromNativeValue`
- * respect the `modernDataModel` gate.
+ * `Runtime` construction/disposal correctly propagates flags to all the ambient
+ * configs.
  */
 describe("ExperimentalOptions", () => {
   afterEach(() => {
     resetModernCellRepConfig();
-    resetDataModelConfig();
     resetPersistentSchedulerStateConfig();
   });
 
@@ -110,200 +99,6 @@ describe("ExperimentalOptions", () => {
       expect(runtime.experimental.schedulerHistoricalMightWrite).toBe(true);
       await runtime.dispose();
       await sm.close();
-    });
-  });
-
-  describe("shallowFabricFromNativeValue with modernDataModel flag", () => {
-    it("works normally when flag is OFF", () => {
-      setDataModelConfig(false);
-      expect(shallowFabricFromNativeValue("hello")).toBe("hello");
-      expect(shallowFabricFromNativeValue(42)).toBe(42);
-      expect(shallowFabricFromNativeValue(null)).toBe(null);
-      expect(shallowFabricFromNativeValue(true)).toBe(true);
-      expect(shallowFabricFromNativeValue({ a: 1 })).toEqual({ a: 1 });
-    });
-
-    it("converts Error to @Error object when flag is OFF", () => {
-      setDataModelConfig(false);
-      const err = new Error("test error");
-      const result = shallowFabricFromNativeValue(err);
-      expect(result).toEqual({
-        "@Error": {
-          name: "Error",
-          message: "test error",
-          stack: err.stack,
-          cause: undefined,
-        },
-      });
-    });
-
-    it("converts undefined in arrays to null when flag is OFF", () => {
-      setDataModelConfig(false);
-      const result = shallowFabricFromNativeValue([1, undefined, 3]);
-      expect(result).toEqual([1, null, 3]);
-    });
-
-    it("wraps Error in FabricError when flag is ON", () => {
-      setDataModelConfig(true);
-      const err = new Error("test error");
-      const result = shallowFabricFromNativeValue(err);
-      expect(result).toBeInstanceOf(FabricError);
-      expect((result as FabricError).message).toBe("test error");
-    });
-
-    it("preserves undefined in arrays when flag is ON", () => {
-      setDataModelConfig(true);
-      const arr = [1, undefined, 3];
-      const result = shallowFabricFromNativeValue(arr);
-      expect(result).toEqual(arr);
-      expect((result as unknown[])[1]).toBe(undefined);
-    });
-
-    it("reset restores the default behavior", () => {
-      const initial = getDataModelConfig();
-      // Toggle to the opposite of the default, then reset.
-      setDataModelConfig(!initial);
-      resetDataModelConfig();
-      expect(getDataModelConfig()).toBe(initial);
-    });
-  });
-
-  describe("fabricFromNativeValue with modernDataModel flag", () => {
-    it("works normally when flag is OFF", () => {
-      setDataModelConfig(false);
-      expect(fabricFromNativeValue({ a: { b: 1 } })).toEqual({ a: { b: 1 } });
-      expect(fabricFromNativeValue([1, 2, 3])).toEqual([1, 2, 3]);
-    });
-
-    it("converts nested Error to @Error object when flag is OFF", () => {
-      setDataModelConfig(false);
-      const err = new Error("nested");
-      const result = fabricFromNativeValue({ data: err });
-      expect(result).toEqual({
-        data: {
-          "@Error": {
-            name: "Error",
-            message: "nested",
-            stack: err.stack,
-            cause: undefined,
-          },
-        },
-      });
-    });
-
-    it("omits undefined-valued object properties when flag is OFF", () => {
-      setDataModelConfig(false);
-      const result = fabricFromNativeValue({ a: 1, b: undefined, c: 3 });
-      expect(result).toEqual({ a: 1, c: 3 });
-    });
-
-    it("wraps nested Error in FabricError when flag is ON", () => {
-      setDataModelConfig(true);
-      const err = new Error("nested");
-      const result = fabricFromNativeValue({ data: err }) as Record<
-        string,
-        unknown
-      >;
-      expect(result.data).toBeInstanceOf(FabricError);
-      expect((result.data as FabricError).message).toBe("nested");
-    });
-
-    it("preserves undefined-valued object properties when flag is ON", () => {
-      setDataModelConfig(true);
-      const result = fabricFromNativeValue({ a: 1, b: undefined, c: 3 });
-      expect(result).toEqual({ a: 1, b: undefined, c: 3 });
-      expect(Object.hasOwn(result as object, "b")).toBe(true);
-    });
-
-    it("wraps Error in array in FabricError when flag is ON", () => {
-      setDataModelConfig(true);
-      const err = new Error("in array");
-      const result = fabricFromNativeValue([1, err, 3]) as unknown[];
-      expect(result[1]).toBeInstanceOf(FabricError);
-      expect((result[1] as FabricError).message).toBe("in array");
-    });
-
-    it("preserves sparse array holes when flag is ON", () => {
-      setDataModelConfig(true);
-      // deno-lint-ignore no-sparse-arrays
-      const sparse = [1, , 3];
-      const result = fabricFromNativeValue(sparse) as unknown[];
-      expect(result.length).toBe(3);
-      expect(0 in result).toBe(true);
-      expect(1 in result).toBe(false); // hole preserved
-      expect(2 in result).toBe(true);
-    });
-
-    it("reset restores the default behavior", () => {
-      const initial = getDataModelConfig();
-      setDataModelConfig(!initial);
-      resetDataModelConfig();
-      expect(getDataModelConfig()).toBe(initial);
-    });
-
-    it("caches correctly when toJSON() returns undefined (no false cache miss)", () => {
-      setDataModelConfig(true);
-      // An object whose toJSON() returns undefined. In the rich path, undefined
-      // is a valid FabricValue, so this gets stored in the converted map as
-      // `undefined`. The bug (before the has() fix) would treat a subsequent
-      // lookup as a cache miss because `converted.get(obj) === undefined` can't
-      // distinguish "stored undefined" from "key not found".
-      const undef = { toJSON: () => undefined };
-      const result = fabricFromNativeValue({ a: undef, b: undef }) as Record<
-        string,
-        unknown
-      >;
-      // Both slots should be undefined (the converted value).
-      expect(result.a).toBe(undefined);
-      expect(result.b).toBe(undefined);
-      expect(Object.hasOwn(result, "a")).toBe(true);
-      expect(Object.hasOwn(result, "b")).toBe(true);
-      // No error thrown -- without the fix, the second encounter would re-mark
-      // the object as PROCESSING and then attempt to re-convert it, which could
-      // produce incorrect results or throw on circular reference detection.
-    });
-  });
-
-  describe("isFabricValue with modernDataModel flag", () => {
-    it("rejects Error when flag is OFF", () => {
-      setDataModelConfig(false);
-      expect(isFabricValue(new Error("test"))).toBe(false);
-    });
-
-    it("rejects [undefined] when flag is OFF", () => {
-      setDataModelConfig(false);
-      expect(isFabricValue([undefined])).toBe(false);
-    });
-
-    it("rejects Error even when flag is ON (needs conversion to FabricError)", () => {
-      setDataModelConfig(true);
-      expect(isFabricValue(new Error("test"))).toBe(false);
-    });
-
-    it("accepts [undefined] when flag is ON", () => {
-      setDataModelConfig(true);
-      expect(isFabricValue([undefined])).toBe(true);
-    });
-
-    it("accepts sparse arrays when flag is ON", () => {
-      setDataModelConfig(true);
-      // deno-lint-ignore no-sparse-arrays
-      const sparse = [1, , 3];
-      expect(isFabricValue(sparse)).toBe(true);
-    });
-
-    it("accepts sparse arrays when flag is OFF", () => {
-      setDataModelConfig(false);
-      // deno-lint-ignore no-sparse-arrays
-      const sparse = [1, , 3];
-      expect(isFabricValue(sparse)).toBe(true);
-    });
-
-    it("reset restores the default behavior", () => {
-      const initial = getDataModelConfig();
-      setDataModelConfig(!initial);
-      resetDataModelConfig();
-      expect(getDataModelConfig()).toBe(initial);
     });
   });
 


### PR DESCRIPTION
This PR cleans up `experimental-options.test.ts`. It had what amounted to a `data-model` test — which had become defunct — and had an out-of-date comment at the top of the file.

## Performance Baseline

This PR just removes a test, so the following accounts for a spurious perf check failure:

NEW_PERF_BASELINE: job: CLI Integration Tests (fuse) = 125s

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up `experimental-options.test.ts` by removing defunct, redundant data-model tests and updating the file header comment for accuracy. The suite now focuses on `Runtime` correctly propagating experimental flags to ambient configs and on reset behavior.

<sup>Written for commit 3efdcc8e2a1eba9b09826b14a3f6cf1d5401c00b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

