### PR TITLE
docs: add skill-authoring guide (maps, not procedures)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,11 @@ If you are developing patterns, use the repo-local `pattern-dev` skill at
 discovers the repo-local skill mirror through `.agents/skills/`, and Claude
 compatibility continues to use `.claude/skills/`.
 
+When authoring or reviewing a skill itself, read
+`docs/development/skill-authoring.md` — what belongs in a skill (non-derivable
+map & values) versus what just constrains the agent (procedure a capable model
+already does).
+
 ### Useful Pattern documentation
 
 **Start here:**

--- a/docs/development/skill-authoring.md
+++ b/docs/development/skill-authoring.md
@@ -1,0 +1,100 @@
+# Skill Authoring: Maps, Not Procedures
+
+> Guidance for writing and reviewing repo-local skills (`skills/**/SKILL.md`).
+> The bar is not "thorough" — it's "ages well." A good skill makes a capable
+> agent better today and an even more capable agent better tomorrow.
+
+## Why this exists
+
+We keep adding skills, and a skill is loaded into an agent's context on every
+invocation: it competes with the actual task for attention, and it shapes how
+the agent thinks before it has looked at anything. That is real leverage and a
+real failure mode. A skill can **augment** an agent (supply what it cannot know)
+or **constrain** it (channel it down paths someone hard-coded). As the
+underlying models get better at the work, the augmenting parts grow more
+valuable and the constraining parts turn into drag. This doc is the line we draw
+between the two.
+
+## The core distinction
+
+Every line in a skill is one of two things, and they have opposite trajectories.
+
+- **Map & values** — non-derivable local knowledge. Where the canonical hash
+  lives. That the tree already carries three forked SHA-256s. That pattern
+  source is two abstraction levels above what runs. How harsh our reviews should
+  be; that we ship many PRs and don't demand pristine. A frontier model with
+  perfect judgment _still won't know these_ — they are facts about our repo, our
+  history, and our preferences. This content **appreciates**: a smarter agent
+  does more with a good map.
+- **Procedure** — "order findings by impact," "label verified vs. suspected,"
+  the report template, the step-by-step. A capable model already does this. This
+  content **depreciates**: first it is redundant, then it actively fights a
+  better instinct.
+
+> Write the map. Minimize the procedure.
+
+The over-constraint we (rightly) worry about lives almost entirely in the
+procedure half. The fix is not "less detail" — a detailed map is the best thing
+a skill can be — it is "less _procedure_."
+
+## Principles over enumerations
+
+The specific thing that caps an agent is a **closed list presented as
+complete.** Give an agent "check for A, B, C, D" and it pattern-matches those
+four and stops looking; the cost is the fifth thing it never considers, because
+the list implied the space was covered.
+
+Prefer a **generative principle** that produces the right behavior on cases
+nobody enumerated:
+
+- ✅ "A searcher who lands on a doc must not be misled." (generates coverage)
+- ⚠️ "Check try/catch, singletons, async-in-handlers, `cf-disable-transform`."
+  (caps at what was known when written)
+
+Concrete tells _are_ useful — so when you enumerate, mark the list as seed, not
+boundary: "tells include, e.g., …". Same words, higher ceiling.
+
+## Floor, not ceiling
+
+A skill trades a little ceiling for a lot of floor. It slightly caps the
+best-case run (anchoring) in exchange for sharply raising the worst-case one — a
+tired invocation, a cheaper model, an agent having an off moment. For anything
+run often across varied contexts, that trade wins, because a _confidently wrong_
+run costs far more than a merely mediocre one. Prescribe in proportion to
+**frequency × variance × cost-of-a-bad-run.** A one-off you supervise needs
+almost none; a review skill run by many agents on every PR earns its map.
+
+## Values don't depreciate
+
+Much of what reads as "constraint" is really a _parameter the model can't
+infer_: how aggressive to be, what we tolerate, what counts as done. Better
+models do not converge on your team's taste on their own — it has to be told.
+Supplying that is not capping capability; it is configuration. Keep it.
+
+## Facts rot — so make them testable
+
+The cruel part: the highest-value content (the map of canonical homes, exact
+symbol names, file paths) is also the highest-rot. The moment the tree moves, an
+authoritative-looking fact starts actively misleading — the exact failure most
+skills exist to prevent. Two defenses:
+
+1. **Point, don't copy.** Reference the canonical doc or symbol; don't restate
+   its contents where they will drift out of sync.
+2. **Make load-bearing facts testable.** If a skill asserts "`@commonfabric/x`
+   exports `y`," a one-line CI grep checking those mentions against real exports
+   converts a rot-prone asset into a durable one.
+
+## The editing test
+
+For each line of a skill — writing one, or reviewing one — ask:
+
+> Would a frontier model with no repo context but excellent judgment already do
+> this?
+
+- **Yes** → it's procedure. Cut it, or compress to a one-line reminder.
+- **No, because it's a fact about our repo / history / values** → keep it. That's
+  the map.
+
+A good skill reads as a **map and a statement of values, not a recipe.** If you
+can delete a section and a competent agent's output barely changes, that section
+was spending context and ceiling for nothing.

--- a/docs/development/skill-authoring.md
+++ b/docs/development/skill-authoring.md
@@ -6,7 +6,7 @@
 
 ## Why this exists
 
-We keep adding skills, and a skill is loaded into an agent's context on every
+When we add a skill, that skill is loaded into an agent's context on every
 invocation: it competes with the actual task for attention, and it shapes how
 the agent thinks before it has looked at anything. That is real leverage and a
 real failure mode. A skill can **augment** an agent (supply what it cannot know)


### PR DESCRIPTION
## Why

When we add repo-local skills (`skills/**/SKILL.md`), each is loaded into an agent's context on *every* invocation — it shapes how the agent thinks before it has read anything, for better or worse. A skill can **augment** an agent (supply non-derivable local knowledge) or **constrain** it (hard-code procedure a capable model already does, then increasingly fights as models improve). We've had no shared bar for that trade-off, so each skill reinvents it and the constraining kind quietly accumulates — which is a real concern as agentic capability keeps rising and over-prescription turns into drag.

This guide draws the line: prefer **map & values** (non-derivable knowledge — canonical homes, repo history, how harsh to be; *appreciates* as models improve) over **procedure** (ordering, templates, step-by-step; *depreciates* and anchors), and make load-bearing facts testable so the highest-value content doesn't rot into active misinformation.

## What Changed

- New `docs/development/skill-authoring.md`. Sections: maps-vs-procedure (the core distinction), principles over enumerations, floor-not-ceiling, values-don't-depreciate, facts-rot-so-make-them-testable, and a one-line editing test ("would a frontier model with no repo context already do this?").

## Test plan

- Docs-only; no code paths touched. `deno fmt` / `deno lint` don't target standalone markdown, so there's nothing to run beyond prose review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `docs/development/skill-authoring.md` for repo-local `SKILL.md`: prefer maps/values, minimize procedure, make facts testable. Linked from `AGENTS.md` and tightened the opening line to reduce over-constraint and keep skills accurate.

<sup>Written for commit 2043714d0775f2a70c43f90d6b4319c5e37a8f1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



