### PR TITLE
[codex] Allow host skill scripts and larger subagent budgets

### DIFF
--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -63,7 +63,10 @@ import {
   parseAllowedSkillScriptSpec,
   uniqueAllowedSkillScripts,
 } from "./skills/scripts.ts";
-import type { HarnessAllowedSkillScript } from "./contracts/skill.ts";
+import type {
+  HarnessAllowedSkillScript,
+  HarnessSkillScriptExecutionTarget,
+} from "./contracts/skill.ts";
 import {
   digestJsonValue,
   parseStructuredResultJson,
@@ -94,6 +97,7 @@ const CLI_STRING_FLAGS = [
   "model",
   "skills-root",
   "skill",
+  "skill-script-execution-target",
   "gateway-base-url",
   "gateway-auth-mode",
   "artifact-root",
@@ -147,6 +151,7 @@ export interface CfHarnessCliConfig {
   skillsRootSandboxPath?: string;
   skillNames: readonly string[];
   allowedSkillScripts: readonly HarnessAllowedSkillScript[];
+  skillScriptExecutionTarget: HarnessSkillScriptExecutionTarget;
   skillCatalogEnabled: boolean;
   model?: string;
   gatewayBaseUrl: string;
@@ -303,6 +308,8 @@ Options:
   --system-prompt <text>        Optional system prompt
   --skills-root <path>          Skill root containing <name>/SKILL.md
   --skill <name>                Preload a skill for this run (repeatable)
+  --skill-script-execution-target <target>
+                                Execute skill scripts in sandbox or host (default: sandbox)
   --no-skill-catalog            Disable automatic skill catalog disclosure
   --model <name>                Model name (default: ${DEFAULT_MODEL})
   --gateway-base-url <url>      OpenAI-compatible gateway URL
@@ -458,6 +465,20 @@ const parseAllowedSkillScripts = (
       }`,
     );
   }
+};
+
+const parseSkillScriptExecutionTarget = (
+  input: string | undefined,
+): HarnessSkillScriptExecutionTarget => {
+  if (input === undefined || input === "") {
+    return "sandbox";
+  }
+  if (input === "sandbox" || input === "host") {
+    return input;
+  }
+  throw new Error(
+    "skill script execution target must be one of sandbox, host",
+  );
 };
 
 const parseSubagentProfile = (
@@ -814,6 +835,11 @@ export const parseCfHarnessCliArgs = async (
   if (allowedSkillScripts.length > 0 && skillsRoot === undefined) {
     throw new Error("--allow-skill-script requires --skills-root");
   }
+  const skillScriptExecutionTarget = parseSkillScriptExecutionTarget(
+    typeof args["skill-script-execution-target"] === "string"
+      ? args["skill-script-execution-target"]
+      : undefined,
+  );
   const allowedToolIds = parseBuiltinToolIds(
     args["allow-tool"] as string | readonly string[] | undefined,
   );
@@ -976,6 +1002,7 @@ export const parseCfHarnessCliArgs = async (
     ...(skillsRootSandboxPath !== undefined ? { skillsRootSandboxPath } : {}),
     skillNames,
     allowedSkillScripts,
+    skillScriptExecutionTarget,
     skillCatalogEnabled: args["no-skill-catalog"] !== true,
     ...(typeof args.model === "string"
       ? { model: args.model }
@@ -1572,6 +1599,7 @@ export const runCfHarnessCli = async (
         ...(parsed.allowedSkillScripts.length > 0
           ? { allowedSkillScripts: parsed.allowedSkillScripts }
           : {}),
+        skillScriptExecutionTarget: parsed.skillScriptExecutionTarget,
         ...(parsed.browserAccess !== undefined
           ? { browserAccess: parsed.browserAccess }
           : {}),
@@ -1604,6 +1632,7 @@ export const runCfHarnessCli = async (
         ...(parsed.allowedSkillScripts.length > 0
           ? { allowedSkillScripts: parsed.allowedSkillScripts }
           : {}),
+        skillScriptExecutionTarget: parsed.skillScriptExecutionTarget,
         ...(parsed.browserAccess !== undefined
           ? { browserAccess: parsed.browserAccess }
           : {}),
@@ -1650,6 +1679,7 @@ export const runCfHarnessCli = async (
         ...(parsed.allowedSkillScripts.length > 0
           ? { allowedSkillScripts: parsed.allowedSkillScripts }
           : {}),
+        skillScriptExecutionTarget: parsed.skillScriptExecutionTarget,
         ...(parsed.browserAccess !== undefined
           ? { browserAccess: parsed.browserAccess }
           : {}),
@@ -1682,6 +1712,7 @@ export const runCfHarnessCli = async (
         ...(parsed.allowedSkillScripts.length > 0
           ? { allowedSkillScripts: parsed.allowedSkillScripts }
           : {}),
+        skillScriptExecutionTarget: parsed.skillScriptExecutionTarget,
         apiKey: parsed.apiKey,
         apiKeySource: parsed.apiKeySource,
         cfcEnforcementModeOverride: parsed.cfcEnforcementModeOverride,

--- a/packages/cf-harness/src/contracts/subagent.ts
+++ b/packages/cf-harness/src/contracts/subagent.ts
@@ -17,7 +17,7 @@ export const WEB_FETCH_SUBAGENT_PROFILE = "web_fetch" as const;
 export const WEB_SEARCH_SUBAGENT_PROFILE = "web_search" as const;
 export const WEB_SEARCH_SUBAGENT_MODEL = "gemini-3.5-flash" as const;
 export const DEFAULT_SUBAGENT_MAX_MODEL_TURNS = 8;
-export const MAX_SUBAGENT_MAX_MODEL_TURNS = 16;
+export const MAX_SUBAGENT_MAX_MODEL_TURNS = 64;
 export const DEFAULT_SUBAGENT_RETURN_CHANNEL =
   "summary-and-sanitized-state" as const;
 export const DEFAULT_SUBAGENT_ALLOWED_TOOL_IDS = [

--- a/packages/cf-harness/src/tools/delegate-task.ts
+++ b/packages/cf-harness/src/tools/delegate-task.ts
@@ -43,7 +43,7 @@ export const delegateTaskTool: HarnessToolDefinition<
         maxModelTurns: {
           type: "integer",
           minimum: 1,
-          maximum: 16,
+          maximum: 64,
           description:
             "Optional child model-turn cap. Defaults to the harness subagent cap.",
         },

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -525,6 +525,8 @@ Deno.test({
           "deno-memory-profiler:scripts/memory.ts",
           "--allow-skill-script",
           "deno-memory-profiler:scripts/memory.ts",
+          "--skill-script-execution-target",
+          "host",
         ],
         {
           cwd: root,
@@ -540,10 +542,28 @@ Deno.test({
         skill: "deno-memory-profiler",
         path: "scripts/memory.ts",
       }]);
+      assertEquals(parsed.skillScriptExecutionTarget, "host");
     } finally {
       await Deno.remove(root, { recursive: true });
     }
   },
+});
+
+Deno.test("parseCfHarnessCliArgs rejects invalid skill script execution targets", async () => {
+  await assertRejects(
+    () =>
+      parseCfHarnessCliArgs(
+        [
+          "--prompt",
+          "hi",
+          "--skill-script-execution-target",
+          "remote",
+        ],
+        { cwd: "/tmp/project", env: {} },
+      ),
+    Error,
+    "skill script execution target must be one of sandbox, host",
+  );
 });
 
 Deno.test("parseCfHarnessCliArgs rejects skill script allowlists without a skills root", async () => {

--- a/packages/cf-harness/test/prompt-loop.test.ts
+++ b/packages/cf-harness/test/prompt-loop.test.ts
@@ -2897,8 +2897,8 @@ Deno.test("CfHarnessPromptLoop rejects invalid delegate_task inputs before creat
     },
     {
       name: "too many turns",
-      arguments: { goal: "Inspect", maxModelTurns: 17 },
-      message: "delegate_task maxModelTurns must be an integer from 1 to 16",
+      arguments: { goal: "Inspect", maxModelTurns: 65 },
+      message: "delegate_task maxModelTurns must be an integer from 1 to 64",
     },
     {
       name: "unknown profile",


### PR DESCRIPTION
## Summary
- Raise explicit `delegate_task.maxModelTurns` from 16 to 64 while keeping the default subagent cap at 8.
- Expose `--skill-script-execution-target sandbox|host` for exact allowlisted `run_skill_script` execution.
- Add CLI/parser coverage and update the invalid subagent-turn test for the new bound.

## Verification
- `deno fmt --check packages/cf-harness/src/cli.ts packages/cf-harness/src/contracts/subagent.ts packages/cf-harness/src/tools/delegate-task.ts packages/cf-harness/test/cli.test.ts packages/cf-harness/test/prompt-loop.test.ts`
- `deno test -A packages/cf-harness/test/cli.test.ts packages/cf-harness/test/prompt-loop.test.ts packages/cf-harness/test/tools-execution.test.ts` (197 passed)
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow running allowlisted skill scripts on the host and increase delegated subagent budgets. Adds a new CLI flag to choose the execution target and raises the max turn limit for `delegate_task`.

- **New Features**
  - Raise `delegate_task.maxModelTurns` limit from 16 to 64; default subagent cap remains 8.
  - Add `--skill-script-execution-target` with `sandbox|host` (default: `sandbox`), with input validation.
  - Wire `skillScriptExecutionTarget` through `parseCfHarnessCliArgs` and `runCfHarnessCli`.
  - Update tests for the new turn bound and invalid execution targets.

<sup>Written for commit 8ee362c626dcdeecd71b14c5006c214d9fc17837. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

