### PR TITLE
Reject arrays with enumerable named properties (fix #3837 TODO)

### DIFF
--- a/packages/data-model/src/deep-freeze.ts
+++ b/packages/data-model/src/deep-freeze.ts
@@ -6,6 +6,7 @@ import {
   IS_DEEP_FROZEN,
 } from "./interface.ts";
 import { isPlainObject } from "@commonfabric/utils/types";
+import { isArrayWithOnlyIndexProperties } from "@commonfabric/utils/arrays";
 
 /**
  * Cache of confirmed deep-frozen objects.
@@ -295,6 +296,8 @@ export function isDeepFrozenFabricValue(value: unknown): value is FabricValue {
       // instance is guaranteed to implement it.
       return item[IS_DEEP_FROZEN]((v) => checkValue(v));
     } else if (Array.isArray(item)) {
+      // Arrays with enumerable named properties have no fabric representation.
+      if (!isArrayWithOnlyIndexProperties(item)) return false;
       for (let i = 0; i <= item.length; i++) {
         if (i in item && !checkValue(item[i])) return false;
       }

--- a/packages/data-model/src/fabric-value-modern.ts
+++ b/packages/data-model/src/fabric-value-modern.ts
@@ -102,9 +102,27 @@ export function shallowFabricFromNativeValueModern(
       return new FabricBytes(value as Uint8Array);
     }
 
-    case NATIVE_TAGS.Array:
+    case NATIVE_TAGS.Array: {
+      // Arrays may only carry numeric index properties. An enumerable named
+      // property has no fabric representation, so reject it outright rather
+      // than silently dropping it ("death before confusion").
+      if (!isArrayWithOnlyIndexProperties(value as unknown[])) {
+        throw new Error(
+          "Cannot store array with enumerable named properties",
+        );
+      }
+      // Delegate frozenness handling to `cloneHelper()`.
+      return cloneHelper(
+        value as FabricValue,
+        freeze,
+        false,
+        false,
+        null,
+      ) as FabricValueLayer;
+    }
+
     case NATIVE_TAGS.Object:
-      // Arrays and plain objects: delegate frozenness handling to `cloneHelper()`.
+      // Plain objects: delegate frozenness handling to `cloneHelper()`.
       return cloneHelper(
         value as FabricValue,
         freeze,

--- a/packages/data-model/test/deep-freeze.test.ts
+++ b/packages/data-model/test/deep-freeze.test.ts
@@ -332,6 +332,32 @@ describe("deep-freeze", () => {
     });
   });
 
+  describe("`isDeepFrozenFabricValue()` array structure validity", () => {
+    it("returns `false` for a frozen array with enumerable named properties", () => {
+      // An array carrying a named property has no fabric representation, so it
+      // is not a valid `FabricValue` even when fully frozen.
+      const arr = [1, 2, 3] as unknown[] & { foo?: string };
+      arr.foo = "bar";
+      Object.freeze(arr);
+      expect(isDeepFrozenFabricValue(arr)).toBe(false);
+    });
+
+    it("returns `false` for a frozen array with named properties nested in a tree", () => {
+      const arr = [1, 2] as unknown[] & { extra?: number };
+      arr.extra = 42;
+      const tree = Object.freeze({ data: Object.freeze(arr) });
+      expect(isDeepFrozenFabricValue(tree)).toBe(false);
+    });
+
+    it("returns `true` for a frozen sparse array (holes are not named properties)", () => {
+      const sparse: unknown[] = [];
+      sparse[0] = 1;
+      sparse[2] = 3; // hole at index 1
+      Object.freeze(sparse);
+      expect(isDeepFrozenFabricValue(sparse)).toBe(true);
+    });
+  });
+
   // Cycle coverage for `deepFreeze()`'s arms (per the function's doc-comment
   // 4-arm dispatch) and the analogous arms of `checkValue` inside
   // `isDeepFrozenFabricValue`. Arm 1 (necessarily-or-known-deep-frozen) and

--- a/packages/data-model/test/fabric-value.test.ts
+++ b/packages/data-model/test/fabric-value.test.ts
@@ -1129,6 +1129,17 @@ describe("fabric-value", () => {
           "Cannot store array with enumerable named properties",
         );
       });
+
+      it("throws even for an already-frozen array with named properties", () => {
+        // Such an array is not a valid `FabricValue`, so it must not slip
+        // through the deep-frozen identity short-circuit.
+        const arr = [1, 2, 3] as unknown[] & { foo?: string };
+        arr.foo = "bar";
+        Object.freeze(arr);
+        expect(() => fabricFromNativeValue(arr)).toThrow(
+          "Cannot store array with enumerable named properties",
+        );
+      });
     });
 
     // `-0`, `NaN`, `+Infinity`, and `-Infinity` are valid `FabricValue`

--- a/packages/data-model/test/fabric-value.test.ts
+++ b/packages/data-model/test/fabric-value.test.ts
@@ -235,19 +235,12 @@ describe("fabric-value", () => {
         expect((result as unknown[])[1]).toBe(undefined);
       });
 
-      it("drops enumerable named properties on arrays", () => {
-        // TODO(danfuzz): This is a bug. Arrays with enumerable named
-        // properties should be rejected (thrown on), but `cloneHelper()`
-        // silently drops the named property instead. This test pins the
-        // current (buggy) behavior; fix the impl and flip this to expect a
-        // throw.
+      it("throws for arrays with enumerable named properties", () => {
         const arr = [1, 2, 3] as unknown[] & { foo?: string };
         arr.foo = "bar";
-        const result = shallowFabricFromNativeValue(arr) as unknown[] & {
-          foo?: string;
-        };
-        expect(result).toEqual([1, 2, 3]);
-        expect("foo" in result).toBe(false);
+        expect(() => shallowFabricFromNativeValue(arr)).toThrow(
+          "Cannot store array with enumerable named properties",
+        );
       });
     });
 
@@ -1110,43 +1103,31 @@ describe("fabric-value", () => {
       });
     });
 
-    // TODO(danfuzz): This whole block pins buggy behavior. Arrays with
-    // enumerable named properties should be rejected (thrown on), but
-    // `cloneHelper()` silently drops the named property instead. Fix the impl
-    // and flip these to expect a throw.
-    describe("drops enumerable named properties on arrays", () => {
-      it("drops named properties on a top-level array", () => {
+    describe("throws for arrays with enumerable named properties", () => {
+      it("throws for a top-level array with named properties", () => {
         const arr = [1, 2, 3] as unknown[] & { foo?: string };
         arr.foo = "bar";
-        const result = fabricFromNativeValue(arr) as unknown[] & {
-          foo?: string;
-        };
-        expect(result).toEqual([1, 2, 3]);
-        expect("foo" in result).toBe(false);
+        expect(() => fabricFromNativeValue(arr)).toThrow(
+          "Cannot store array with enumerable named properties",
+        );
       });
 
-      it("drops named properties on a nested array", () => {
+      it("throws for a nested array with named properties", () => {
         const arr = [1, 2] as unknown[] & { extra?: number };
         arr.extra = 42;
-        const result = fabricFromNativeValue({ data: arr }) as {
-          data: unknown[] & { extra?: number };
-        };
-        expect(result.data).toEqual([1, 2]);
-        expect("extra" in result.data).toBe(false);
+        expect(() => fabricFromNativeValue({ data: arr })).toThrow(
+          "Cannot store array with enumerable named properties",
+        );
       });
 
-      it("drops named properties on a sparse array", () => {
+      it("throws for a sparse array with named properties", () => {
         const sparse = [] as unknown[] & { name?: string };
         sparse[0] = 1;
         sparse[2] = 3;
         sparse.name = "test";
-        const result = fabricFromNativeValue(sparse) as unknown[] & {
-          name?: string;
-        };
-        expect(result[0]).toBe(1);
-        expect(1 in result).toBe(false);
-        expect(result[2]).toBe(3);
-        expect("name" in result).toBe(false);
+        expect(() => fabricFromNativeValue(sparse)).toThrow(
+          "Cannot store array with enumerable named properties",
+        );
       });
     });
 

--- a/packages/utils/src/arrays.ts
+++ b/packages/utils/src/arrays.ts
@@ -88,8 +88,8 @@ export function isArrayWithOnlyIndexProperties(array: unknown[]): boolean {
     return false;
   }
 
-  // Every key must be a syntactically valid array index. `Number(k)` would
-  // wrongly accept named keys whose numeric coercion lands in range -- e.g.
-  // `"01"`, `" 1"`, `"1.0"`, `"1e1"`, `"-0"`, and `""` (which coerces to `0`).
+  // Every key must be a syntactically valid array index. We use
+  // `isArrayIndexPropertyName()` to validate, in order to match the exact
+  // syntax for the string form of an array key.
   return keys.every(isArrayIndexPropertyName);
 }

--- a/packages/utils/src/arrays.ts
+++ b/packages/utils/src/arrays.ts
@@ -82,14 +82,14 @@ export function isArrayWithOnlyIndexProperties(array: unknown[]): boolean {
   const len = array.length;
   const keys = Object.keys(array);
 
-  // Quick check: more keys than length means there must be named properties.
+  // Quick check: more keys than length means there must be named properties
+  // (canonical index keys are a subset of `0..len-1`).
   if (keys.length > len) {
     return false;
   }
 
-  // Verify all keys are valid indices (non-negative integers < length).
-  return !keys.some((k) => {
-    const n = Number(k);
-    return !Number.isInteger(n) || n < 0 || n >= len;
-  });
+  // Every key must be a syntactically valid array index. `Number(k)` would
+  // wrongly accept named keys whose numeric coercion lands in range -- e.g.
+  // `"01"`, `" 1"`, `"1.0"`, `"1e1"`, `"-0"`, and `""` (which coerces to `0`).
+  return keys.every(isArrayIndexPropertyName);
 }

--- a/packages/utils/src/arrays.ts
+++ b/packages/utils/src/arrays.ts
@@ -79,17 +79,14 @@ export function isArrayIndexPropertyName(name: string): boolean {
  * @returns `true` if the array has only numeric properties, `false` otherwise.
  */
 export function isArrayWithOnlyIndexProperties(array: unknown[]): boolean {
-  const len = array.length;
   const keys = Object.keys(array);
 
-  // Quick check: more keys than length means there must be named properties
-  // (canonical index keys are a subset of `0..len-1`).
-  if (keys.length > len) {
-    return false;
-  }
-
-  // Every key must be a syntactically valid array index. We use
-  // `isArrayIndexPropertyName()` to validate, in order to match the exact
-  // syntax for the string form of an array key.
-  return keys.every(isArrayIndexPropertyName);
+  // `Object.keys()` on an (ordinary) array yields all array-index keys first,
+  // followed by any non-index keys. So if an array has _any_ non-index keys,
+  // then _one_ of them is always the final key. This means the array is
+  // index-only exactly when it has no keys or its last key is an index. (This
+  // relies on ordinary-array key ordering; the input is always a real array,
+  // never a `Proxy` with a reordering `ownKeys` trap.)
+  return keys.length === 0 ||
+    isArrayIndexPropertyName(keys[keys.length - 1]);
 }

--- a/packages/utils/test/arrays.test.ts
+++ b/packages/utils/test/arrays.test.ts
@@ -127,6 +127,17 @@ describe("arrays", () => {
       expect(isArrayWithOnlyIndexProperties(sparse)).toBe(false);
     });
 
+    it("returns `false` when a named property was added before any indices", () => {
+      // `Object.keys()` still orders indices first, so the named key is last:
+      // `["0", "1", "foo"]`. Pins the last-key optimization's reliance on that
+      // ordering rather than on insertion order.
+      const arr = [] as unknown[] & { foo?: string };
+      arr.foo = "bar";
+      arr[0] = 1;
+      arr[1] = 2;
+      expect(isArrayWithOnlyIndexProperties(arr)).toBe(false);
+    });
+
     describe("returns `false` for non-canonical index-shaped named keys", () => {
       // These keys are named properties, not array indices, but each has a
       // `Number(key)` that is an in-range non-negative integer -- so a naive

--- a/packages/utils/test/arrays.test.ts
+++ b/packages/utils/test/arrays.test.ts
@@ -126,5 +126,21 @@ describe("arrays", () => {
       sparse.foo = "bar";
       expect(isArrayWithOnlyIndexProperties(sparse)).toBe(false);
     });
+
+    describe("returns `false` for non-canonical index-shaped named keys", () => {
+      // These keys are named properties, not array indices, but each has a
+      // `Number(key)` that is an in-range non-negative integer -- so a naive
+      // numeric coercion would misclassify the array as index-only.
+      for (const key of ["01", " 1", "1.0", "1e1", "-0", ""]) {
+        it(`rejects the named key ${JSON.stringify(key)}`, () => {
+          // A roomy all-holes array, so the named key sits below `length` and
+          // doesn't trip the `keys.length > length` quick check.
+          const arr: unknown[] = [];
+          arr.length = 1000;
+          (arr as unknown as Record<string, unknown>)[key] = "x";
+          expect(isArrayWithOnlyIndexProperties(arr)).toBe(false);
+        });
+      }
+    });
   });
 });


### PR DESCRIPTION
Fixes the array-named-property bug flagged (and pinned with `TODO(danfuzz)`) in #3837: the modern data model **silently dropped** enumerable named properties on arrays instead of rejecting them, where the legacy path threw. Also fixes (and then speeds up) the underlying `isArrayWithOnlyIndexProperties()` predicate.

## The fix

**1. Conversion boundary** — `shallowFabricFromNativeValueModern()`'s `Array` case now rejects arrays with enumerable named properties (`isArrayWithOnlyIndexProperties`) instead of letting `cloneHelper()`'s index-only copy quietly drop them. The deep `fabricFromNativeValue()` routes through the shallow converter, so this one guard covers both. Message: `Cannot store array with enumerable named properties`.

**2. `isDeepFrozenFabricValue()`** — its array arm walked indices only, so it classified a frozen named-prop array as a valid `FabricValue`. That let such an array slip past the new guard via `fabricFromNativeValue()`'s `freeze && isDeepFrozenFabricValue` identity short-circuit. Added the same index-only check to the array arm, closing the bypass.

**3. `isArrayWithOnlyIndexProperties()`** — the predicate backing both guards used a `Number(k)` heuristic that wrongly accepts non-canonical named keys whose numeric coercion lands in range: `"01"`, `" 1"`, `"1.0"`, `"1e1"`, `"-0"`, and `""` (→ `0`). Switched to the canonical `isArrayIndexPropertyName()` validator. Then sped it up: since `Object.keys()` on an ordinary array returns integer-index keys first and any non-index keys last, a named property (if present) is always the final key — so checking just the last key is sufficient (O(1) validation), dropping the per-key scan.

`cloneHelper()` itself is left untouched — it stays a general utility for already-valid `FabricValue`s, mirroring how legacy put the check in the *converter*, not the *cloner*.

## Tests

- Flipped the previously-pinned `TODO(danfuzz)` tests in `fabric-value.test.ts` from "drops" to "throws" (shallow + deep top-level/nested/sparse), plus a case for the already-frozen-array bypass.
- New `deep-freeze.test.ts` block for the predicate directly, with a sparse-array control.
- New `arrays.test.ts` coverage: the six deceptive non-canonical keys, plus a named-property-added-before-indices case pinning the last-key optimization's ordering reliance.
- **Red→green verified** for each fix (and the optimization), with controls (sparse arrays, in-range canonical indices) staying green throughout.

## Verification

Full `data-model` suite: 28 files / 1814 steps, 0 failed. Full `utils` suite: green. Runner write-boundary tests green. `deno fmt`/`lint`/`check` clean.

**Perf note:** `isArrayWithOnlyIndexProperties()` is now O(1)-validation, but it still allocates via `Object.keys()` per call, and it's invoked per array node by the `isDeepFrozenFabricValue` arm — which gates `cloneIfNecessary`'s deep identity optimization. A mild allocation add on a hot path; worth a perf-check glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
