### PR TITLE
feat(cli): read id derive/from-mnemonic secrets from a file or stdin

### DIFF
--- a/docs/common/conventions/HOME_SPACE.md
+++ b/docs/common/conventions/HOME_SPACE.md
@@ -140,21 +140,19 @@ To share identity between browser and CLI:
 
 ```bash
 # 1. Create a mnemonic in the browser (login/register screen)
-# 2. Export a CLI key using fromMnemonic (not fromPassphrase):
-deno eval '
-import { Identity } from "./packages/identity/src/identity.ts";
-const mnemonic = "your 24-word mnemonic here";
-const id = await Identity.fromMnemonic(mnemonic, { implementation: "noble" });
-await Deno.writeFile("./browser.key", id.toPkcs8());
-'
+# 2. Export a matching CLI key with `cf id from-mnemonic`, reading the phrase
+#    from a file (`-- <file>`; or `-` for stdin) so it stays out of shell
+#    history and the process list:
+deno run -A packages/cli/mod.ts id from-mnemonic -- phrase.txt > ./browser.key
 
 # 3. Use that key with cf
 cf piece set-home -i ./browser.key -a http://localhost:8000 ./my-home.tsx
 ```
 
 Note: `cf id derive <passphrase>` will NOT produce the same identity as the
-browser. You must use `fromMnemonic` with `implementation: "noble"` to get a
-PKCS8 key that matches the browser's identity.
+browser — it uses `Identity.fromPassphrase()`, whereas browser mnemonic login
+and `cf id from-mnemonic` use `Identity.fromMnemonic()`. Use `from-mnemonic` to
+get a PKCS8 key that matches the browser's identity.
 
 ## Default App URL
 

--- a/docs/development/SHARED_IDENTITY.md
+++ b/docs/development/SHARED_IDENTITY.md
@@ -32,16 +32,26 @@ act as the same DID.
 ## Existing Browser Mnemonic To CLI
 
 If the browser identity already exists and you need a matching CLI key, derive a
-PKCS8 key from the browser recovery phrase with `cf id from-mnemonic`. Quote the
-whole phrase as a single argument:
+PKCS8 key from the browser recovery phrase with `cf id from-mnemonic`. Give it
+the phrase as a file (`-- <file>`) or on stdin (`-`) so the recovery phrase
+never lands in your shell history or the process argument list:
 
 ```bash
-deno run -A packages/cli/mod.ts id from-mnemonic "your 24-word mnemonic here" \
-  > .cf/browser.key
+# Read the phrase from a file (the phrase never appears on the command line):
+deno run -A packages/cli/mod.ts id from-mnemonic -- phrase.txt > .cf/browser.key
+
+# Or read it from stdin — pipe it in, or type/paste it then press Ctrl-D:
+deno run -A packages/cli/mod.ts id from-mnemonic - > .cf/browser.key
 
 export CF_IDENTITY="$PWD/.cf/browser.key"
 deno run -A packages/cli/mod.ts id did "$CF_IDENTITY"
 ```
+
+A single trailing newline is stripped from file or stdin input, so a phrase
+saved with `echo` or a text editor works as-is. You can still pass the phrase as
+a quoted inline argument (`id from-mnemonic "word1 ... word24"`), but avoid it
+for real recovery phrases: arguments are visible in shell history and to other
+processes via `ps`.
 
 Do not use `cf id derive <mnemonic>` for this. `from-mnemonic` uses
 `Identity.fromMnemonic()` (the same path as browser mnemonic login), while
@@ -59,7 +69,9 @@ If the CLI key already exists, import it directly in the browser with
 
 ```bash
 deno run -A packages/cli/mod.ts id new > .cf/shared-dev.key
-deno run -A packages/cli/mod.ts id derive "some passphrase" > .cf/shared-dev.key
+# `id derive` also reads the passphrase from a file (`-- <file>`) or stdin
+# (`-`), keeping it out of shell history (recommended for anything sensitive):
+deno run -A packages/cli/mod.ts id derive -- passphrase.txt > .cf/shared-dev.key
 ```
 
 The file must be a PKCS8/PEM private key. `*.key` and `.cf/` are gitignored in

--- a/packages/cli/commands/identity.ts
+++ b/packages/cli/commands/identity.ts
@@ -27,26 +27,64 @@ export const identity = new Command()
   )
   .action(getDid)
   /* id derive */
-  .command("derive", "Derives a keyfile from the provided passphrase.")
+  .command(
+    "derive",
+    "Derive a keyfile from a passphrase. Prefer `-- <file>` or `-` (stdin) " +
+      "over an inline argument to keep the secret out of shell history.",
+  )
+  .example(
+    cliText("cf id derive -- passphrase.txt > ./my.key"),
+    "Read the passphrase from the file passphrase.txt (recommended; keeps it " +
+      "out of shell history and the process list) and store a keyfile at " +
+      "./my.key.",
+  )
+  .example(
+    cliText("cf id derive - > ./my.key"),
+    "Read the passphrase from stdin (pipe it in, or type it and press Ctrl-D).",
+  )
   .example(
     cliText('cf id derive "common user" > ./my.key'),
-    'Create and store a keyfile at ./my.key derived from the string "common user".',
+    'Create a keyfile derived from the inline string "common user". Note: an ' +
+      "argument passed this way is visible in shell history and to other " +
+      "processes via `ps`; prefer a file or stdin for secrets.",
   )
-  .arguments("<passphrase:string>")
-  .action(deriveIdentity)
+  .arguments("[passphrase:string]")
+  .action(async function (_: void, passphrase?: string) {
+    const pkcs8Material = await pkcs8FromPassphrase(
+      await resolveSecret(passphrase, this.getLiteralArgs(), "passphrase"),
+    );
+    render(pkcs8Material);
+  })
   /* id from-mnemonic */
   .command(
     "from-mnemonic",
-    "Derives a keyfile from a BIP-39 mnemonic phrase, matching browser " +
-      "mnemonic login.",
+    "Derive a keyfile from a BIP-39 mnemonic phrase, matching browser " +
+      "mnemonic login. Prefer `-- <file>` or `-` (stdin) over an inline " +
+      "argument to keep the phrase out of shell history.",
+  )
+  .example(
+    cliText("cf id from-mnemonic -- phrase.txt > ./my.key"),
+    "Read the recovery phrase from the file phrase.txt (recommended; keeps it " +
+      "out of shell history and the process list) and create a keyfile whose " +
+      "DID matches the browser identity registered with that phrase.",
+  )
+  .example(
+    cliText("cf id from-mnemonic - > ./my.key"),
+    "Read the recovery phrase from stdin (pipe it in, or type it and press " +
+      "Ctrl-D).",
   )
   .example(
     cliText('cf id from-mnemonic "word1 word2 ... word24" > ./my.key'),
-    "Create a keyfile whose DID matches a browser identity registered with " +
-      "the given recovery phrase. Quote the whole phrase as one argument.",
+    "Pass the phrase as a single quoted inline argument. Note: this leaks the " +
+      "phrase into shell history and the process list; prefer a file or stdin.",
   )
-  .arguments("<mnemonic:string>")
-  .action(identityFromMnemonic);
+  .arguments("[mnemonic:string]")
+  .action(async function (_: void, mnemonic?: string) {
+    const pkcs8Material = await pkcs8FromMnemonic(
+      await resolveSecret(mnemonic, this.getLiteralArgs(), "mnemonic"),
+    );
+    render(pkcs8Material);
+  });
 
 async function createIdentity() {
   const pkcs8Material = await pkcs8FromEntropy();
@@ -58,12 +96,54 @@ async function getDid(_: void, keypath: string) {
   render(did);
 }
 
-async function deriveIdentity(_: void, passphrase: string) {
-  const pkcs8Material = await pkcs8FromPassphrase(passphrase);
-  render(pkcs8Material);
+// Resolves a secret (passphrase or mnemonic) from, in order of precedence:
+//   * a `-- <file>` argument: read the secret from that file;
+//   * a `-` argument, or no argument at all: read the secret from stdin;
+//   * otherwise: the inline argument value (used verbatim, for backwards
+//     compatibility).
+// Reading from a file or stdin keeps the secret out of shell history and the
+// process argument list (which is visible to other local processes via `ps`).
+// File and stdin input have a single trailing newline stripped so that an
+// editor- or `echo`-produced value matches the equivalent inline argument.
+async function resolveSecret(
+  arg: string | undefined,
+  literalArgs: string[],
+  label: string,
+): Promise<string> {
+  if (literalArgs.length > 0) {
+    if (arg !== undefined) {
+      throw new Error(
+        `Provide the ${label} inline or as a -- <file>, not both.`,
+      );
+    }
+    if (literalArgs.length > 1) {
+      throw new Error(`Expected a single ${label} file after \`--\`.`);
+    }
+    const path = literalArgs[0];
+    return requireNonEmpty(
+      stripTrailingNewline(await Deno.readTextFile(path)),
+      label,
+      path,
+    );
+  }
+  if (arg !== undefined && arg !== "-") return arg;
+  if (Deno.stdin.isTerminal()) {
+    console.error(`Reading ${label} from stdin; type it and press Ctrl-D...`);
+  }
+  return requireNonEmpty(
+    stripTrailingNewline(await new Response(Deno.stdin.readable).text()),
+    label,
+    "stdin",
+  );
 }
 
-async function identityFromMnemonic(_: void, mnemonic: string) {
-  const pkcs8Material = await pkcs8FromMnemonic(mnemonic);
-  render(pkcs8Material);
+function stripTrailingNewline(text: string): string {
+  return text.replace(/\r?\n$/, "");
+}
+
+function requireNonEmpty(value: string, label: string, source: string): string {
+  if (value.length === 0) {
+    throw new Error(`No ${label} provided from ${source}.`);
+  }
+  return value;
 }

--- a/packages/cli/test/id.test.ts
+++ b/packages/cli/test/id.test.ts
@@ -72,4 +72,71 @@ describe("cli id", () => {
     expect(code).toBe(0);
     checkStderr(stderr);
   });
+
+  it("Derives a passphrase key from stdin via '-'", async () => {
+    // Trailing newline (as `echo`/files produce) must be stripped so the
+    // result matches the equivalent argv invocation.
+    const { code, stdout, stderr } = await cf("id derive -", "common user\n");
+    const keyBuffer = encode(stdout.join("\n"));
+    const identity = await Identity.fromPkcs8(keyBuffer);
+    expect(identity.did()).toBe(COMMON_USER_DID);
+    expect(code).toBe(0);
+    checkStderr(stderr);
+  });
+
+  it("Derives a passphrase key from stdin when the argument is omitted", async () => {
+    const { code, stdout, stderr } = await cf("id derive", "common user");
+    const keyBuffer = encode(stdout.join("\n"));
+    const identity = await Identity.fromPkcs8(keyBuffer);
+    expect(identity.did()).toBe(COMMON_USER_DID);
+    expect(code).toBe(0);
+    checkStderr(stderr);
+  });
+
+  it("Derives a mnemonic key from stdin via '-'", async () => {
+    const { code, stdout, stderr } = await cf(
+      "id from-mnemonic -",
+      `${TEST_MNEMONIC}\n`,
+    );
+    const keyBuffer = encode(stdout.join("\n"));
+    const identity = await Identity.fromPkcs8(keyBuffer);
+    expect(identity.did()).toBe(TEST_MNEMONIC_DID);
+    expect(code).toBe(0);
+    checkStderr(stderr);
+  });
+
+  it("Errors when no secret is provided on stdin", async () => {
+    const { code, stdout } = await cf("id from-mnemonic -", "");
+    expect(code).not.toBe(0);
+    expect(stdout.length).toBe(0);
+  });
+
+  it("Derives a passphrase key from a file via '-- <file>'", async () => {
+    const file = await Deno.makeTempFile();
+    // Trailing newline (as editors/`echo` produce) must be stripped.
+    await Deno.writeTextFile(file, "common user\n");
+    const { code, stdout, stderr } = await cf(`id derive -- ${file}`);
+    const identity = await Identity.fromPkcs8(encode(stdout.join("\n")));
+    expect(identity.did()).toBe(COMMON_USER_DID);
+    expect(code).toBe(0);
+    checkStderr(stderr);
+  });
+
+  it("Derives a mnemonic key from a file via '-- <file>'", async () => {
+    const file = await Deno.makeTempFile();
+    await Deno.writeTextFile(file, `${TEST_MNEMONIC}\n`);
+    const { code, stdout, stderr } = await cf(`id from-mnemonic -- ${file}`);
+    const identity = await Identity.fromPkcs8(encode(stdout.join("\n")));
+    expect(identity.did()).toBe(TEST_MNEMONIC_DID);
+    expect(code).toBe(0);
+    checkStderr(stderr);
+  });
+
+  it("Errors when both an inline value and a -- <file> are given", async () => {
+    const file = await Deno.makeTempFile();
+    await Deno.writeTextFile(file, "common user");
+    const { code, stdout } = await cf(`id derive inline -- ${file}`);
+    expect(code).not.toBe(0);
+    expect(stdout.length).toBe(0);
+  });
 });

--- a/packages/cli/test/utils.ts
+++ b/packages/cli/test/utils.ts
@@ -1,4 +1,4 @@
-import { decode } from "@commonfabric/utils/encoding";
+import { decode, encode } from "@commonfabric/utils/encoding";
 import { join } from "@std/path";
 import { expect } from "@std/expect/expect";
 
@@ -39,6 +39,7 @@ export function checkStderr(stderr: string[]) {
 async function runCliTask(
   task: "cli-no-pwd-override",
   command: string,
+  stdin?: string,
 ): Promise<{ code: number; stdout: string[]; stderr: string[] }> {
   // Use a regex to split up spaces outside of quotes.
   const match = command.match(/(?:[^\s"]+|"[^"]*")+/g);
@@ -48,7 +49,7 @@ async function runCliTask(
   // Filter out quotes that are in strings
   const args = match.map((arg) => arg.replace(/"/g, ""));
 
-  const { code, stdout, stderr } = await new Deno.Command(Deno.execPath(), {
+  const child = new Deno.Command(Deno.execPath(), {
     cwd: join(import.meta.dirname!, ".."),
     args: [
       "task",
@@ -60,7 +61,20 @@ async function runCliTask(
       task,
       ...args,
     ],
-  }).output();
+    // `.output()` requires stdout/stderr to be piped; `.spawn()` would
+    // otherwise default them to "inherit".
+    stdout: "piped",
+    stderr: "piped",
+    stdin: stdin === undefined ? "null" : "piped",
+  }).spawn();
+
+  if (stdin !== undefined) {
+    const writer = child.stdin.getWriter();
+    await writer.write(encode(stdin));
+    await writer.close();
+  }
+
+  const { code, stdout, stderr } = await child.output();
   return {
     code,
     stdout: bytesToLines(stdout),
@@ -70,10 +84,12 @@ async function runCliTask(
 
 // Executes the `cf` command via CLI
 // `const { stdout, stderr, code } = cf("dev --no-run ./pattern.tsx")`
+// Pass `stdin` to feed the command's standard input.
 export async function cf(
   command: string,
+  stdin?: string,
 ): Promise<{ code: number; stdout: string[]; stderr: string[] }> {
-  return await runCliTask("cli-no-pwd-override", command);
+  return await runCliTask("cli-no-pwd-override", command, stdin);
 }
 
 export async function withEnv(

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -32,8 +32,15 @@ deno run -A packages/cli/mod.ts id derive "implicit trust" > cf.key
 deno run -A packages/cli/mod.ts id new > cf.key
 
 # To match a browser identity registered with a recovery phrase:
-deno run -A packages/cli/mod.ts id from-mnemonic "word1 word2 ... word24" > cf.key
+deno run -A packages/cli/mod.ts id from-mnemonic -- phrase.txt > cf.key
 ```
+
+Both `id derive` and `id from-mnemonic` accept the secret three ways: as a file
+(`-- <file>`), on stdin (`-`, or no argument), or as an inline positional
+argument. Prefer a file or stdin for real secrets — an inline argument is
+visible in shell history and to other processes via `ps`. A single trailing
+newline is stripped from file/stdin input, so `echo`/editor input matches the
+equivalent inline value.
 
 Note: `id derive` (passphrase) and `id from-mnemonic` (BIP-39 phrase) use
 different derivations and produce different DIDs from the same text. Use


### PR DESCRIPTION
Passing a passphrase or recovery phrase as an argv positional leaks it into shell history and the process argument list (visible via `ps`). Both `id derive` and `id from-mnemonic` now accept the secret without putting it on the command line.

Resolution precedence for the passphrase/mnemonic:
  * `-- <file>`  -> read the secret from that file (cliffy routes post-`--` tokens to getLiteralArgs(), so this stays unambiguous);
  * `-`, or no argument at all -> read the secret from stdin;
  * otherwise -> the inline argument, used verbatim (backwards compatible).

File and stdin input have a single trailing newline stripped so an editor- or `echo`-produced value matches the equivalent inline argument. Empty input, a missing file, more than one file after `--`, or mixing an inline value with `-- <file>` all error cleanly with nothing written to stdout.

Docs updated to recommend the file/stdin forms (SHARED_IDENTITY.md, HOME_SPACE.md, and the cf skill, replacing the old `deno eval` fromMnemonic workaround). Adds a `stdin` option to the cli test harness and covers the file, stdin, and conflict cases.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add secure input for `cf id derive` and `cf id from-mnemonic` so passphrases and recovery phrases can be read from a file or stdin instead of argv, avoiding leaks to shell history and `ps`. Backwards compatible, with updated help text, docs, and tests.

- New Features
  - Input precedence: `-- <file>`; `-` or no arg -> stdin; else inline arg (kept for compatibility).
  - Strip a single trailing newline from file/stdin input to match inline values.
  - Clear errors for empty input, missing file, multiple files after `--`, or mixing inline with `-- <file>`.
  - Updated examples in command help and docs; added stdin support to the CLI test harness and tests for file/stdin/conflict cases.

<sup>Written for commit 560f01b067504b3ca4858c359d00aebd8bd0da74. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

