### PR TITLE
fix(schema-generator): collapse expanded Default<[]> array unions (CT-1639 pt 1)

### DIFF
--- a/packages/schema-generator/src/formatters/union-formatter.ts
+++ b/packages/schema-generator/src/formatters/union-formatter.ts
@@ -332,12 +332,20 @@ export class UnionFormatter implements TypeFormatter {
     const checker = context.typeChecker;
 
     let realArrayIndex = -1;
-    let sawDegenerateEmpty = false;
+    // Only the BRANDED empty member (`[] & DefaultMarker<[]>`) proves this is an
+    // expanded `Default<[]>`. A bare `[]` / `never[]` is the *unbranded* arm of
+    // that same Default union — but it also appears in ordinary unions like
+    // `string[] | []` that have nothing to do with defaults. So we require at
+    // least one branded empty member before collapsing + attaching `default:[]`;
+    // a bare empty member alone is left to normal union handling. (CT-1639)
+    let sawBrandedEmpty = false;
 
     for (let i = 0; i < members.length; i++) {
       const member = members[i]!;
       if (this.isDegenerateEmptyArrayMember(member, checker)) {
-        sawDegenerateEmpty = true;
+        if (this.hasDefaultBrand(member, checker)) {
+          sawBrandedEmpty = true;
+        }
         continue;
       }
       if (!checker.isArrayType(member) && !checker.isTupleType(member)) {
@@ -353,7 +361,7 @@ export class UnionFormatter implements TypeFormatter {
       }
     }
 
-    if (realArrayIndex === -1 || !sawDegenerateEmpty) {
+    if (realArrayIndex === -1 || !sawBrandedEmpty) {
       return undefined;
     }
 
@@ -400,6 +408,18 @@ export class UnionFormatter implements TypeFormatter {
       return !!elementType && (elementType.flags & ts.TypeFlags.Never) !== 0;
     }
     return false;
+  }
+
+  /**
+   * True if `member` carries the Default brand — i.e. it is an intersection with
+   * a brand-only marker constituent (`X & DefaultMarker<V>`). This is what
+   * distinguishes the unbranded `[]` arm of an *expanded* `Default<[]>` union
+   * from a bare `[]` in an ordinary union like `string[] | []`.
+   */
+  private hasDefaultBrand(member: ts.Type, checker: ts.TypeChecker): boolean {
+    if ((member.flags & ts.TypeFlags.Intersection) === 0) return false;
+    const parts = (member as ts.IntersectionType).types ?? [];
+    return parts.some((p) => this.isBrandOnlyMarker(p, checker));
   }
 
   /**

--- a/packages/schema-generator/src/formatters/union-formatter.ts
+++ b/packages/schema-generator/src/formatters/union-formatter.ts
@@ -112,6 +112,23 @@ export class UnionFormatter implements TypeFormatter {
       return defaultUnionSchema;
     }
 
+    // CT-1639: when Default<[]> reaches us already EXPANDED by the checker (no
+    // intact `Default<>` alias node — e.g. via a synthesized handler/map context
+    // schema), the union looks like `RealArray | ([] & DefaultMarker<[]>) | []`.
+    // tryFormatDefaultUnion can't recognize it (no Default node), so it would
+    // fall through to a multi-branch anyOf that splits the real array from the
+    // empty-array branch — dropping per-element capabilities like
+    // asCell:["comparable"] from the consumer's view. Collapse the degenerate
+    // empty-array members into the real array member and carry an empty default.
+    const expandedEmptyDefault = this.tryFormatExpandedEmptyArrayDefault(
+      members,
+      orderedMemberNodes,
+      context,
+    );
+    if (expandedEmptyDefault !== undefined) {
+      return expandedEmptyDefault;
+    }
+
     // Detect presence of null
     const hasNull = members.some((m) => (m.flags & ts.TypeFlags.Null) !== 0);
     // nonNull excludes only null; undefined members are kept because undefined is
@@ -289,6 +306,115 @@ export class UnionFormatter implements TypeFormatter {
     return this.applySchemaDefault(
       this.combineUnionSchemas(schemas, context),
       defaultEntry.entry.defaultValue,
+    );
+  }
+
+  /**
+   * CT-1639: collapse an EXPANDED `Default<[]>` array union.
+   *
+   * When `Default<[]>` is expanded by the checker (the intact alias node is
+   * gone), the union is `RealArray | ([] & DefaultMarker<[]>) | []` — one real
+   * (possibly element-capability-bearing) array member plus one or more
+   * degenerate empty-array members (the empty tuple `[]`/`never[]`, optionally
+   * intersected with the Default brand). Emitting these as separate `anyOf`
+   * branches loses the real array's per-element annotations from a consumer's
+   * view. Instead, format only the real array member and attach `default: []`.
+   *
+   * Returns undefined when the pattern doesn't apply (so the caller proceeds
+   * with its normal union handling) — notably when there is more than one real
+   * array member, or a non-array member is present.
+   */
+  private tryFormatExpandedEmptyArrayDefault(
+    members: readonly ts.Type[],
+    orderedMemberNodes: ReadonlyArray<ts.TypeNode | undefined> | undefined,
+    context: GenerationContext,
+  ): JSONSchemaMutable | undefined {
+    const checker = context.typeChecker;
+
+    let realArrayIndex = -1;
+    let sawDegenerateEmpty = false;
+
+    for (let i = 0; i < members.length; i++) {
+      const member = members[i]!;
+      if (this.isDegenerateEmptyArrayMember(member, checker)) {
+        sawDegenerateEmpty = true;
+        continue;
+      }
+      if (!checker.isArrayType(member) && !checker.isTupleType(member)) {
+        // A non-array, non-degenerate member means this isn't the
+        // `RealArray | Default<[]>` shape we collapse here.
+        return undefined;
+      }
+      if (realArrayIndex === -1) {
+        realArrayIndex = i;
+      } else {
+        // More than one real array member — not the Default<[]> collapse shape.
+        return undefined;
+      }
+    }
+
+    if (realArrayIndex === -1 || !sawDegenerateEmpty) {
+      return undefined;
+    }
+
+    const realArraySchema = this.schemaGenerator.formatChildType(
+      members[realArrayIndex]!,
+      context,
+      orderedMemberNodes?.[realArrayIndex],
+    );
+    return this.applySchemaDefault(realArraySchema, []);
+  }
+
+  /**
+   * True for a member that contributes only an empty array to the union: the
+   * empty tuple `[]` / `never[]`, optionally intersected with the Default brand
+   * (`[] & DefaultMarker<[]>`). For the intersection form we strip the brand
+   * constituents and check that the substantive remainder is an empty array.
+   */
+  private isDegenerateEmptyArrayMember(
+    member: ts.Type,
+    checker: ts.TypeChecker,
+  ): boolean {
+    if ((member.flags & ts.TypeFlags.Intersection) !== 0) {
+      const parts = (member as ts.IntersectionType).types ?? [];
+      const substantive = parts.filter(
+        (p) => !this.isBrandOnlyMarker(p, checker),
+      );
+      // Brand intersected with exactly one empty-array part (e.g.
+      // `[] & DefaultMarker<[]>`).
+      return substantive.length === 1 &&
+        this.isEmptyArrayType(substantive[0]!, checker);
+    }
+    return this.isEmptyArrayType(member, checker);
+  }
+
+  /** Empty tuple `[]`, or `never[]`. */
+  private isEmptyArrayType(type: ts.Type, checker: ts.TypeChecker): boolean {
+    if (checker.isTupleType(type)) {
+      return checker.getTypeArguments(type as ts.TypeReference).length === 0;
+    }
+    if (checker.isArrayType(type)) {
+      const elementType = checker.getTypeArguments(
+        type as ts.TypeReference,
+      )[0];
+      return !!elementType && (elementType.flags & ts.TypeFlags.Never) !== 0;
+    }
+    return false;
+  }
+
+  /**
+   * True for a "brand-only" object type that carries only symbol-keyed markers
+   * (e.g. `{ readonly [DEFAULT_MARKER]: T }`) — no string-keyed data properties.
+   * TypeScript encodes unique-symbol property names as "__@..." internally; a
+   * type with only such properties is a brand, not data. (Mirrors the same
+   * convention used by IntersectionFormatter.isBrandOnlyOrEmpty.)
+   */
+  private isBrandOnlyMarker(type: ts.Type, checker: ts.TypeChecker): boolean {
+    if ((type.flags & ts.TypeFlags.Object) === 0) return false;
+    const props = checker.getPropertiesOfType(type);
+    if (props.length === 0) return true; // empty object `{}`
+    return props.every((prop) =>
+      String(prop.escapedName as string).startsWith("__@")
     );
   }
 

--- a/packages/schema-generator/test/schema/default-union.test.ts
+++ b/packages/schema-generator/test/schema/default-union.test.ts
@@ -166,6 +166,19 @@ describe("Schema: Default in unions", () => {
     }
   });
 
+  it("does NOT fabricate a default for an ordinary array | empty-tuple union (no Default brand) (CT-1639)", async () => {
+    // A plain `string[] | []` has a bare empty-tuple member but NO Default brand.
+    // The expanded-Default collapse must not fire here — it would invent a
+    // `default: []` the author never asked for. (Regression for a cubic review
+    // finding on the CT-1639 pt-1 PR.)
+    const code = `type T = string[] | [];`;
+    const { type, checker, typeNode } = await getTypeFromCode(code, "T");
+    const result = asObjectSchema(
+      createSchemaTransformerV2().generateSchema(type, checker, typeNode),
+    );
+    expect((result as any).default).toBeUndefined();
+  });
+
   it("applies array defaults from T[] | Default<[...]>", async () => {
     const code = `
       interface Default<T, V extends T = T> {}

--- a/packages/schema-generator/test/schema/default-union.test.ts
+++ b/packages/schema-generator/test/schema/default-union.test.ts
@@ -131,6 +131,41 @@ describe("Schema: Default in unions", () => {
     expect(result.default).toBe(null);
   });
 
+  it("collapses an EXPANDED Default<[]> array union, preserving comparable items (CT-1639)", async () => {
+    // The transformer hands schema-gen a node where Default<[]> has already been
+    // EXPANDED by the checker into its raw branded form — there is no `Default<>`
+    // alias node left. We model that directly: `[] & DefaultMarker<[]>` plus the
+    // bare `[]` empty-array member, unioned with the real comparable array. The
+    // degenerate empty members must collapse so the comparable array survives
+    // (single array schema, asCell:["comparable"] kept, default: []).
+    const code = `
+      declare const DEFAULT_MARKER: unique symbol;
+      type DefaultMarker<T> = { readonly [DEFAULT_MARKER]: T };
+      interface Item { label: string }
+      type T = Array<ComparableCell<Item>> | ([] & DefaultMarker<[]>) | [];
+    `;
+    const { type, checker, typeNode } = await getTypeFromCode(code, "T");
+    const result = asObjectSchema(
+      createSchemaTransformerV2().generateSchema(type, checker, typeNode),
+    );
+
+    // Comparable items must be preserved on the (sole) array schema.
+    const arraySchema = result.anyOf
+      ? (result.anyOf as any[]).find((s) =>
+        s?.type === "array" && s?.items?.asCell
+      )
+      : result;
+    expect((arraySchema?.items as any)?.asCell).toEqual(["comparable"]);
+    // And the empty-only degenerate branch must not survive as a sibling that
+    // dilutes consumers: no `{ type: "array", items: false }` branch.
+    if (result.anyOf) {
+      const hasEmptyOnly = (result.anyOf as any[]).some((s) =>
+        s?.type === "array" && s?.items === false
+      );
+      expect(hasEmptyOnly).toBe(false);
+    }
+  });
+
   it("applies array defaults from T[] | Default<[...]>", async () => {
     const code = `
       interface Default<T, V extends T = T> {}


### PR DESCRIPTION
## Summary

Part 1 of CT-1639 (the silent `equals()`-based list-removal no-op under `Default<[]>`). This is the **schema-generator** half, fixed in a way that's correct for **any** consumer — not just the transformer.

When `Default<[]>` reaches the schema generator **already expanded** by the checker (no intact `Default<>` alias node — which is what the transformer hands it for a synthesized handler/map-context schema), the union is:

```
RealArray | ([] & DefaultMarker<[]>) | []
```

`UnionFormatter.tryFormatDefaultUnion` only recognizes an **intact** `Default<>` TypeReference node, so it returned `undefined` here and the code fell through to the generic multi-branch `anyOf` path. That split the real array from the empty-array branch (`{type:"array", items:false}`), diluting the real array member and dropping per-element annotations like `asCell:["comparable"]` from a consumer's view.

## Fix

Add `UnionFormatter.tryFormatExpandedEmptyArrayDefault`, run right after `tryFormatDefaultUnion`:
- Detect the **degenerate empty-array** members: bare `[]` / `never[]`, or `[] & DefaultMarker<[]>` (intersection — brand stripped via the `__@`-symbol convention already used by `IntersectionFormatter`).
- When exactly **one real array member** remains alongside ≥1 degenerate empty member, format only the real member and attach `default: []`.
- Returns `undefined` (falls back to normal union handling) for anything else — more than one real array member, or any non-array member.

This preserves the real array's element schema (including `comparable`) and applies the empty-array default, matching what `tryFormatDefaultUnion` does for the intact-alias form.

## Scope / follow-up

This is the schema-generator half. There is a **separate ts-transformers gap** (tracked as CT-1639 pt 2): in the real handler-param pipeline the array element handed to schema-gen is not always `comparable`-wrapped, because type-shrinking wraps the element **node** but doesn't re-register the wrapped **semantic type** that schema-gen reads. With pt 1 alone, the empty-array branch now collapses correctly (`default:[]` lands) but the `comparable` annotation can still be absent until pt 2. Pt 1 is a correct, independently-valuable improvement.

## Test plan

- New `default-union` test: an **expanded** `Default<[]>` array union keeps `asCell:["comparable"]` on a single array schema, with no empty-only sibling branch. (Fails before, passes after.)
- Full schema-generator suite green: **24 passed (227 steps)**.
- ts-transformers suite green (292); runner `patterns-default-array-materialization` + `patterns-findindex` green.

Part of CT-1639.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CT-1639 pt 1 by collapsing expanded `Default<[]>` array unions in `schema-generator` so a single array schema keeps item annotations and gets `default: []` instead of `anyOf`. Adds a brand check so collapse only happens when a `[] & DefaultMarker<[]>` member is present, avoiding fabricated defaults.

- **Bug Fixes**
  - Detect unions like `RealArray | ([] & DefaultMarker<[]>) | []` and emit the real array with `default: []`, preserving item schema (e.g., `asCell: ["comparable"]`); skip if multiple real arrays or any non-array member exists.
  - Require a branded empty member before collapsing; plain unions like `string[] | []` are left untouched.
  - Tests: cases for the branded expanded form and the no-brand union; `schema-generator` and `ts-transformers` suites pass.

<sup>Written for commit 9f8a3f1df2f2191f6cffbdfc173bd3cedba04e37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

