### PR TITLE
Add cf-harness explicit host mounts

### DIFF
--- a/packages/cf-harness/src/cli.ts
+++ b/packages/cf-harness/src/cli.ts
@@ -1,5 +1,16 @@
 import { parseArgs } from "@std/cli/parse-args";
-import { dirname, isAbsolute, join, relative, resolve } from "@std/path";
+import {
+  basename,
+  dirname,
+  isAbsolute,
+  join,
+  relative,
+  resolve,
+} from "@std/path";
+import {
+  isAbsolute as isAbsoluteSandboxPath,
+  normalize as normalizeSandboxPath,
+} from "@std/path/posix";
 import type { JSONSchema } from "@commonfabric/api";
 import { type CfcEnforcementMode } from "@commonfabric/runner/cfc";
 import {
@@ -10,7 +21,6 @@ import {
 } from "./config.ts";
 import {
   createHarnessImageAttachment,
-  isRelativePathWithinWorkspace,
   parseImageAttachmentPaths,
 } from "./image-attachments.ts";
 import type { HarnessImageAttachment } from "./contracts/image.ts";
@@ -49,6 +59,7 @@ import {
   DEFAULT_DOCKER_RUNSC_IMAGE,
   DEFAULT_FABRIC_MOUNT_PATH,
 } from "./sandbox/docker-runsc.ts";
+import type { DockerRunscAdditionalMountConfig } from "./sandbox/types.ts";
 import {
   CfHarnessPromptLoop,
   type CreateHarnessPromptLoopOptions,
@@ -56,7 +67,6 @@ import {
 } from "./prompt-loop.ts";
 import {
   discoverHarnessSkills,
-  isHarnessSkillRootWithinWorkspace,
   loadHarnessSkillContext,
 } from "./skills/registry.ts";
 import {
@@ -110,6 +120,7 @@ const CLI_STRING_FLAGS = [
   "sandbox-image",
   "max-model-turns",
   "fabric-mount",
+  "host-mount",
   "browser-access-lease-id",
   "browser-access-cdp-url",
   "browser-access-owner",
@@ -130,6 +141,7 @@ const CLI_COLLECT_FLAGS = [
   "allow-subagent-profile",
   "skill",
   "image",
+  "host-mount",
 ] as const;
 
 export type CfHarnessCliOutputMode = (typeof CLI_OUTPUT_MODES)[number];
@@ -168,6 +180,16 @@ export interface CfHarnessCliConfig {
   apiKeySource?: "CF_HARNESS_API_KEY" | "OPENAI_API_KEY";
   sandboxImage?: string;
   fabricMount?: string;
+  hostMounts: readonly CfHarnessHostMountConfig[];
+}
+
+export type CfHarnessHostMountMode = "readonly" | "writable";
+
+export interface CfHarnessHostMountConfig {
+  name: string;
+  hostPath: string;
+  sandboxPath: string;
+  mode: CfHarnessHostMountMode;
 }
 
 export interface CfHarnessStructuredResultConfig {
@@ -192,6 +214,7 @@ export interface CfHarnessCliCapabilities {
     skillScripts: true;
     runManifest: true;
     fabricMount: true;
+    hostMounts: true;
     resumeRun: true;
   };
 }
@@ -329,6 +352,7 @@ Options:
   --cfc-enforcement-mode <mode> disabled | observe | enforce-explicit | enforce-strict
   --sandbox-image <image>       Docker image for the runsc-cfc sandbox (default: ${DEFAULT_DOCKER_RUNSC_IMAGE})
   --fabric-mount <path>         Host path for a Fabric FUSE mount (mounted at /fabric in the sandbox)
+  --host-mount <spec>           Extra host bind mount (repeatable: name=<id>,source=<host>,target=<sandbox>,mode=readonly|writable)
   --max-model-turns <n>         Maximum model turns before aborting
   --print-transcript            Print the final transcript JSON after the response
   --describe-capabilities       Print machine-readable capability JSON and exit
@@ -398,6 +422,7 @@ export const createCfHarnessCliCapabilities = (): CfHarnessCliCapabilities => ({
     skillScripts: true,
     runManifest: true,
     fabricMount: true,
+    hostMounts: true,
     resumeRun: true,
   },
 });
@@ -618,20 +643,242 @@ const parseSkillNames = (
   ];
 };
 
-const assertSkillsRootRealPathWithinWorkspace = async (
-  workspace: string,
-  skillsRoot: string,
-): Promise<void> => {
-  let workspaceRealPath: string;
+interface CfHarnessAllowedHostRoot {
+  hostPath: string;
+  sandboxPath: string;
+  readOnly: boolean;
+  name?: string;
+}
+
+const HOST_MOUNT_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+const normalizeSandboxMountPath = (path: string, label: string): string => {
+  const normalized = normalizeSandboxPath(path);
+  if (!isAbsoluteSandboxPath(normalized) || normalized === "/") {
+    throw new Error(`${label} must be an absolute non-root sandbox path`);
+  }
+  return normalized.length > 1 && normalized.endsWith("/")
+    ? normalized.slice(0, -1)
+    : normalized;
+};
+
+const parseHostMountSpecParts = (
+  spec: string,
+): Record<string, string> => {
+  const parts: Record<string, string> = {};
+  for (const segment of spec.split(",")) {
+    const trimmed = segment.trim();
+    if (trimmed.length === 0) {
+      continue;
+    }
+    const index = trimmed.indexOf("=");
+    if (index <= 0) {
+      throw new Error(
+        "--host-mount entries must use key=value comma-separated fields",
+      );
+    }
+    const key = trimmed.slice(0, index).trim();
+    const value = trimmed.slice(index + 1).trim();
+    if (key.length === 0 || value.length === 0) {
+      throw new Error("--host-mount fields require non-empty keys and values");
+    }
+    if (parts[key] !== undefined) {
+      throw new Error(`--host-mount field repeated: ${key}`);
+    }
+    parts[key] = value;
+  }
+  return parts;
+};
+
+const realPathIfDirectory = async (
+  path: string,
+  label: string,
+): Promise<string> => {
+  let realPath: string;
   try {
-    workspaceRealPath = await Deno.realPath(workspace);
+    realPath = await Deno.realPath(path);
   } catch (error) {
     if (error instanceof Deno.errors.NotFound) {
-      throw new Error(`workspace must exist: ${workspace}`);
+      throw new Error(`${label} must exist: ${path}`);
     }
     throw error;
   }
+  const stat = await Deno.stat(realPath);
+  if (!stat.isDirectory) {
+    throw new Error(`${label} must be a directory: ${path}`);
+  }
+  if (realPath === dirname(realPath)) {
+    throw new Error(`${label} must not be the filesystem root`);
+  }
+  return realPath;
+};
 
+const parseHostMountSpec = async (
+  spec: string,
+  cwd: string,
+): Promise<CfHarnessHostMountConfig> => {
+  if (spec.trim().length === 0) {
+    throw new Error("--host-mount requires a non-empty spec");
+  }
+  const parts = parseHostMountSpecParts(spec);
+  const name = parts.name;
+  const source = parts.source;
+  const target = parts.target;
+  const mode = parts.mode ?? "readonly";
+  if (name === undefined || source === undefined || target === undefined) {
+    throw new Error(
+      "--host-mount requires name, source, and target fields",
+    );
+  }
+  if (!HOST_MOUNT_NAME_PATTERN.test(name)) {
+    throw new Error(
+      "--host-mount name must start with an alphanumeric character and contain only alphanumerics, dot, underscore, or dash",
+    );
+  }
+  if (mode !== "readonly" && mode !== "writable") {
+    throw new Error("--host-mount mode must be readonly or writable");
+  }
+  return {
+    name,
+    hostPath: await realPathIfDirectory(
+      isAbsolute(source) ? resolve(source) : resolve(cwd, source),
+      "--host-mount source",
+    ),
+    sandboxPath: normalizeSandboxMountPath(target, "--host-mount target"),
+    mode,
+  };
+};
+
+const parseHostMountSpecs = async (
+  input: string | readonly string[] | undefined,
+  cwd: string,
+): Promise<readonly CfHarnessHostMountConfig[]> => {
+  const specs = input === undefined
+    ? []
+    : Array.isArray(input)
+    ? input
+    : [input];
+  const mounts = await Promise.all(
+    specs.map((spec) => parseHostMountSpec(spec, cwd)),
+  );
+  const names = new Set<string>();
+  for (const mount of mounts) {
+    if (names.has(mount.name)) {
+      throw new Error(`--host-mount name repeated: ${mount.name}`);
+    }
+    names.add(mount.name);
+  }
+  return mounts;
+};
+
+const resolveHostPathThroughNearestRealParent = (hostPath: string): string => {
+  const suffix: string[] = [];
+  let candidate = hostPath;
+  while (true) {
+    try {
+      const realCandidate = Deno.realPathSync(candidate);
+      return suffix.length === 0
+        ? realCandidate
+        : join(realCandidate, ...suffix);
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) {
+        throw error;
+      }
+    }
+    const parent = dirname(candidate);
+    if (parent === candidate) {
+      return hostPath;
+    }
+    suffix.unshift(basename(candidate));
+    candidate = parent;
+  }
+};
+
+const createAllowedHostRoots = (
+  workspace: string,
+  hostMounts: readonly CfHarnessHostMountConfig[],
+): readonly CfHarnessAllowedHostRoot[] => [
+  {
+    hostPath: resolveHostPathThroughNearestRealParent(workspace),
+    sandboxPath: "/workspace",
+    readOnly: false,
+  },
+  ...hostMounts.map((mount) => ({
+    hostPath: mount.hostPath,
+    sandboxPath: mount.sandboxPath,
+    readOnly: mount.mode === "readonly",
+    name: mount.name,
+  })),
+];
+
+const isHostPathWithinRoot = (root: string, path: string): boolean => {
+  const relativePath = relative(root, path);
+  return relativePath === "" ||
+    (!relativePath.startsWith("..") && !isAbsolute(relativePath));
+};
+
+const findAllowedHostRoot = (
+  roots: readonly CfHarnessAllowedHostRoot[],
+  hostPath: string,
+): CfHarnessAllowedHostRoot | undefined =>
+  roots
+    .filter((root) => isHostPathWithinRoot(root.hostPath, hostPath))
+    .sort((left, right) => right.hostPath.length - left.hostPath.length)[0];
+
+const resolveCliHostPath = (
+  workspace: string,
+  input: string,
+): string => isAbsolute(input) ? resolve(input) : resolve(workspace, input);
+
+const toSandboxPathForAllowedHostPath = (
+  root: CfHarnessAllowedHostRoot,
+  hostPath: string,
+): string => {
+  const relativePath = relative(root.hostPath, hostPath);
+  if (relativePath === "") {
+    return root.sandboxPath;
+  }
+  return normalizeSandboxPath(
+    `${root.sandboxPath}/${relativePath.replaceAll("\\", "/")}`,
+  );
+};
+
+const resolvePathWithinAllowedHostRoots = (
+  roots: readonly CfHarnessAllowedHostRoot[],
+  workspace: string,
+  input: string,
+  flagName: string,
+  options: { requireWritable?: boolean } = {},
+): {
+  hostPath: string;
+  sandboxPath: string;
+  root: CfHarnessAllowedHostRoot;
+} => {
+  const requestedHostPath = resolveCliHostPath(workspace, input);
+  const realHostPath = resolveHostPathThroughNearestRealParent(
+    requestedHostPath,
+  );
+  const hostPath = realHostPath;
+  const root = findAllowedHostRoot(roots, realHostPath);
+  if (root === undefined) {
+    throw new Error(
+      `${flagName} must stay within the workspace or a host mount`,
+    );
+  }
+  if (options.requireWritable && root.readOnly) {
+    throw new Error(`${flagName} must be inside a writable host mount`);
+  }
+  return {
+    hostPath,
+    sandboxPath: toSandboxPathForAllowedHostPath(root, hostPath),
+    root,
+  };
+};
+
+const assertSkillsRootRealPathWithinAllowedHostRoots = async (
+  roots: readonly CfHarnessAllowedHostRoot[],
+  skillsRoot: string,
+): Promise<void> => {
   let skillsRootRealPath: string;
   try {
     skillsRootRealPath = await Deno.realPath(skillsRoot);
@@ -641,11 +888,10 @@ const assertSkillsRootRealPathWithinWorkspace = async (
     }
     throw error;
   }
-
-  if (
-    !isHarnessSkillRootWithinWorkspace(workspaceRealPath, skillsRootRealPath)
-  ) {
-    throw new Error("--skills-root must stay within the workspace");
+  if (findAllowedHostRoot(roots, skillsRootRealPath) === undefined) {
+    throw new Error(
+      "--skills-root must stay within the workspace or a host mount",
+    );
   }
 };
 
@@ -694,36 +940,26 @@ const resolvePrompt = async (
   return positionalPrompt!;
 };
 
-const resolvePathWithinWorkspace = (
-  workspace: string,
-  input: string,
-  flagName: string,
-): string => {
-  const hostPath = isAbsolute(input)
-    ? resolve(input)
-    : resolve(workspace, input);
-  if (!isRelativePathWithinWorkspace(relative(workspace, hostPath))) {
-    throw new Error(`${flagName} must stay within the workspace`);
-  }
-  return hostPath;
-};
-
 const parseStructuredResultConfig = async (
   args: ReturnType<typeof parseArgs>,
   options: {
     cwd: string;
     workspace: string;
+    allowedHostRoots: readonly CfHarnessAllowedHostRoot[];
     readTextFile: (path: string) => Promise<string>;
   },
 ): Promise<CfHarnessStructuredResultConfig | undefined> => {
-  const structuredResultPath =
+  const structuredResultPathResolution =
     typeof args["structured-result-path"] === "string"
-      ? resolvePathWithinWorkspace(
+      ? resolvePathWithinAllowedHostRoots(
+        options.allowedHostRoots,
         options.workspace,
         args["structured-result-path"],
         "--structured-result-path",
+        { requireWritable: true },
       )
       : undefined;
+  const structuredResultPath = structuredResultPathResolution?.hostPath;
   const inlineSchema = typeof args["structured-result-schema"] === "string"
     ? args["structured-result-schema"]
     : undefined;
@@ -762,14 +998,7 @@ const parseStructuredResultConfig = async (
   }
   return {
     path: structuredResultPath,
-    sandboxPath: toWorkspaceSandboxPath(
-      options.workspace,
-      structuredResultPath,
-      {
-        strict: true,
-        errorPrefix: "--structured-result-path",
-      },
-    ),
+    sandboxPath: structuredResultPathResolution!.sandboxPath,
     schema: parsed.schema,
   };
 };
@@ -799,30 +1028,38 @@ export const parseCfHarnessCliArgs = async (
   const workspace = resolve(
     typeof args.workspace === "string" ? args.workspace : cwd,
   );
+  const hostMounts = await parseHostMountSpecs(
+    args["host-mount"] as string | readonly string[] | undefined,
+    cwd,
+  );
+  const allowedHostRoots = createAllowedHostRoots(workspace, hostMounts);
   const initialCwd = typeof args.cwd === "string"
-    ? toWorkspaceSandboxPath(workspace, resolve(workspace, args.cwd), {
-      strict: true,
-      errorPrefix: "--cwd",
-    })
+    ? resolvePathWithinAllowedHostRoots(
+      allowedHostRoots,
+      workspace,
+      args.cwd,
+      "--cwd",
+    ).sandboxPath
     : undefined;
   const focusRoot = typeof args["focus-root"] === "string"
     ? resolve(workspace, args["focus-root"])
     : undefined;
   const skillsRoot = typeof args["skills-root"] === "string"
-    ? resolve(workspace, args["skills-root"])
+    ? resolvePathWithinAllowedHostRoots(
+      allowedHostRoots,
+      workspace,
+      args["skills-root"],
+      "--skills-root",
+    ).hostPath
     : undefined;
   const skillsRootSandboxPath = skillsRoot !== undefined
-    ? toWorkspaceSandboxPath(workspace, skillsRoot, {
-      strict: true,
-      errorPrefix: "--skills-root",
-    })
+    ? resolvePathWithinAllowedHostRoots(
+      allowedHostRoots,
+      workspace,
+      skillsRoot,
+      "--skills-root",
+    ).sandboxPath
     : undefined;
-  if (
-    skillsRoot !== undefined &&
-    !isHarnessSkillRootWithinWorkspace(workspace, skillsRoot)
-  ) {
-    throw new Error("--skills-root must stay within the workspace");
-  }
   const skillNames = parseSkillNames(
     args.skill as string | readonly string[] | undefined,
   );
@@ -888,7 +1125,10 @@ export const parseCfHarnessCliArgs = async (
     throw new Error("--image is not supported with --resume-run");
   }
   if (skillsRoot !== undefined) {
-    await assertSkillsRootRealPathWithinWorkspace(workspace, skillsRoot);
+    await assertSkillsRootRealPathWithinAllowedHostRoots(
+      allowedHostRoots,
+      skillsRoot,
+    );
   }
   const artifactRoot = resolve(
     typeof args["artifact-root"] === "string"
@@ -922,17 +1162,24 @@ export const parseCfHarnessCliArgs = async (
   const structuredResult = await parseStructuredResultConfig(args, {
     cwd,
     workspace,
+    allowedHostRoots,
     readTextFile,
   });
   const prompt = await resolvePrompt(args, cwd, readTextFile);
   const imageAttachments = await Promise.all(
-    imagePaths.map((path) =>
-      createHarnessImageAttachment({
-        workspaceHostPath: workspace,
-        cwd: workspace,
+    imagePaths.map((path) => {
+      const resolved = resolvePathWithinAllowedHostRoots(
+        allowedHostRoots,
+        workspace,
         path,
-      })
-    ),
+        "--image",
+      );
+      return createHarnessImageAttachment({
+        workspaceHostPath: resolved.root.hostPath,
+        cwd: resolved.root.hostPath,
+        path: resolved.hostPath,
+      });
+    }),
   );
   const env = deps.env ??
     {
@@ -1030,6 +1277,7 @@ export const parseCfHarnessCliArgs = async (
     ...(apiKeySource !== undefined ? { apiKeySource } : {}),
     ...(sandboxImage !== undefined ? { sandboxImage } : {}),
     ...(fabricMount !== undefined ? { fabricMount } : {}),
+    hostMounts,
   };
 };
 
@@ -1040,6 +1288,24 @@ const readRunManifest = async (
   path === undefined
     ? undefined
     : parseLoomRunManifestJson(await readTextFile(path));
+
+const createAdditionalMountConfigs = (
+  config: Pick<CfHarnessCliConfig, "fabricMount" | "hostMounts">,
+): readonly DockerRunscAdditionalMountConfig[] => [
+  ...(config.fabricMount !== undefined
+    ? [{
+      kind: "fabric-fuse" as const,
+      hostPath: config.fabricMount,
+    }]
+    : []),
+  ...config.hostMounts.map((mount) => ({
+    kind: "host-bind" as const,
+    name: mount.name,
+    hostPath: mount.hostPath,
+    sandboxPath: mount.sandboxPath,
+    readOnly: mount.mode === "readonly",
+  })),
+];
 
 export const formatCfHarnessCliUsage = (): string => usage;
 
@@ -1103,14 +1369,40 @@ const appendStructuredResultInstructions = (
   );
 };
 
+const appendHostMountInstructions = (
+  lines: string[],
+  config: {
+    hostMounts?: readonly CfHarnessHostMountConfig[];
+    fabricMountPath?: string;
+  },
+): void => {
+  if (config.fabricMountPath !== undefined) {
+    lines.push(
+      `- A Common Fabric space is mounted at ${config.fabricMountPath}. You may browse its contents for context.`,
+    );
+  }
+  const hostMounts = config.hostMounts ?? [];
+  if (hostMounts.length === 0) {
+    return;
+  }
+  lines.push("- Additional host mounts are available in the sandbox:");
+  for (const mount of hostMounts) {
+    lines.push(`  - ${mount.sandboxPath}: ${mount.mode} (${mount.name})`);
+  }
+};
+
 export const buildCfHarnessOperatorSystemPrompt = (
   config:
     & Pick<
       CfHarnessCliConfig,
-      "workspace" | "focusRoot" | "systemPrompt" | "structuredResult"
+      | "workspace"
+      | "focusRoot"
+      | "systemPrompt"
+      | "structuredResult"
     >
     & {
       fabricMountPath?: string;
+      hostMounts?: readonly CfHarnessHostMountConfig[];
     },
 ): string => {
   const focusRoot = toWorkspaceSandboxPath(config.workspace, config.focusRoot);
@@ -1124,11 +1416,7 @@ export const buildCfHarnessOperatorSystemPrompt = (
     "- Read source files only when needed to answer the prompt accurately.",
     "- Stop once you have enough evidence to answer.",
   ];
-  if (config.fabricMountPath !== undefined) {
-    lines.push(
-      `- A Common Fabric space is mounted at ${config.fabricMountPath}. You may browse its contents for context.`,
-    );
-  }
+  appendHostMountInstructions(lines, config);
   appendStructuredResultInstructions(lines, config.structuredResult);
   appendAdditionalInstructions(lines, config.systemPrompt);
   return lines.join("\n");
@@ -1139,14 +1427,16 @@ export const buildCfHarnessBatchSystemPrompt = (
     & Pick<CfHarnessCliConfig, "systemPrompt" | "structuredResult">
     & {
       fabricMountPath?: string;
+      hostMounts?: readonly CfHarnessHostMountConfig[];
     },
 ): string => {
   const lines = [buildCfHarnessBaseSystemPrompt()];
-  if (config.fabricMountPath !== undefined) {
-    lines.push(
-      "",
-      `A Common Fabric space is mounted at ${config.fabricMountPath}. You may browse its contents for context.`,
-    );
+  if (
+    config.fabricMountPath !== undefined ||
+    (config.hostMounts ?? []).length > 0
+  ) {
+    lines.push("");
+    appendHostMountInstructions(lines, config);
   }
   appendStructuredResultInstructions(lines, config.structuredResult);
   appendAdditionalInstructions(lines, config.systemPrompt);
@@ -1165,6 +1455,7 @@ export const resolveCfHarnessCliSystemPrompt = (
     >
     & {
       fabricMountPath?: string;
+      hostMounts?: readonly CfHarnessHostMountConfig[];
       skillCatalogEnabled?: boolean;
       skillNames?: readonly string[];
     },
@@ -1555,6 +1846,7 @@ export const runCfHarnessCli = async (
         }
       }
       : undefined;
+    const additionalMounts = createAdditionalMountConfigs(parsed);
     const prepareSkillContextMessages = async (
       engine: CfHarnessEngine,
     ): Promise<string[]> => {
@@ -1608,14 +1900,7 @@ export const runCfHarnessCli = async (
         ...(parsed.runManifestPath !== undefined
           ? { runManifestPath: parsed.runManifestPath }
           : {}),
-        ...(parsed.fabricMount !== undefined
-          ? {
-            additionalMounts: [{
-              kind: "fabric-fuse" as const,
-              hostPath: parsed.fabricMount,
-            }],
-          }
-          : {}),
+        ...(additionalMounts.length > 0 ? { additionalMounts } : {}),
       });
       activateEngine(engine);
       const loop = createPromptLoop({
@@ -1688,14 +1973,7 @@ export const runCfHarnessCli = async (
         ...(parsed.runManifestPath !== undefined
           ? { runManifestPath: parsed.runManifestPath }
           : {}),
-        ...(parsed.fabricMount !== undefined
-          ? {
-            additionalMounts: [{
-              kind: "fabric-fuse" as const,
-              hostPath: parsed.fabricMount,
-            }],
-          }
-          : {}),
+        ...(additionalMounts.length > 0 ? { additionalMounts } : {}),
       });
       activateEngine(engine);
       const loop = createPromptLoop({

--- a/packages/cf-harness/src/diagnostics.ts
+++ b/packages/cf-harness/src/diagnostics.ts
@@ -85,8 +85,11 @@ export interface HarnessFabricWriteGovernanceSnapshot {
 export interface HarnessCfcMountSnapshot {
   kind: SandboxRuntimeMountKind;
   status: HarnessCfcMountStatus;
+  name?: string;
+  hostPath?: string;
   sandboxPath: string;
   readOnly?: boolean;
+  mode?: "readonly" | "writable";
   writeGovernance?: HarnessFabricWriteGovernanceSnapshot;
 }
 
@@ -103,6 +106,7 @@ export interface HarnessCfcCapabilitySnapshot {
   mounts: {
     workspace: HarnessCfcMountSnapshot;
     fabric: HarnessCfcMountSnapshot;
+    hostBinds: readonly HarnessCfcMountSnapshot[];
   };
   protectedXattrs: {
     expectedSandboxVisible: false;
@@ -305,6 +309,12 @@ const findMountDescription = (
 ): SandboxRuntimeMountDescription | undefined =>
   mounts?.find((mount) => mount.kind === kind);
 
+const findMountDescriptions = (
+  mounts: readonly SandboxRuntimeMountDescription[] | undefined,
+  kind: SandboxRuntimeMountKind,
+): readonly SandboxRuntimeMountDescription[] =>
+  mounts?.filter((mount) => mount.kind === kind) ?? [];
+
 const createCfcMountSnapshots = (
   sandboxDescription: SandboxRuntimeDescription,
   mode: CfcEnforcementMode,
@@ -321,6 +331,9 @@ const createCfcMountSnapshots = (
     workspace: {
       kind: "workspace",
       status: "configured",
+      ...(workspaceMount?.hostPath !== undefined
+        ? { hostPath: workspaceMount.hostPath }
+        : {}),
       sandboxPath: workspaceMount?.sandboxPath ??
         sandboxDescription.cfc?.workspaceMountPath ??
         sandboxDescription.defaultWorkingDirectory,
@@ -330,6 +343,9 @@ const createCfcMountSnapshots = (
       ? {
         kind: "fabric-fuse",
         status: "configured",
+        ...(fabricMount.hostPath !== undefined
+          ? { hostPath: fabricMount.hostPath }
+          : {}),
         sandboxPath: fabricMount.sandboxPath,
         readOnly: fabricMount.readOnly,
         writeGovernance: createFabricWriteGovernance({
@@ -348,6 +364,18 @@ const createCfcMountSnapshots = (
           delegatedToCfc: false,
         },
       },
+    hostBinds: findMountDescriptions(
+      sandboxDescription.cfc?.mounts,
+      "host-bind",
+    ).map((mount) => ({
+      kind: "host-bind" as const,
+      status: "configured" as const,
+      ...(mount.name !== undefined ? { name: mount.name } : {}),
+      ...(mount.hostPath !== undefined ? { hostPath: mount.hostPath } : {}),
+      sandboxPath: mount.sandboxPath,
+      readOnly: mount.readOnly,
+      mode: mount.readOnly ? "readonly" as const : "writable" as const,
+    })),
   };
 };
 

--- a/packages/cf-harness/src/engine.ts
+++ b/packages/cf-harness/src/engine.ts
@@ -265,8 +265,10 @@ const isSandboxPathWithinRoot = (root: string, path: string): boolean => {
 
 type HostSandboxMount = {
   kind: string;
+  name?: string;
   hostPath: string;
   sandboxPath: string;
+  readOnly?: boolean;
 };
 
 export class CfHarnessEngine {
@@ -310,11 +312,14 @@ export class CfHarnessEngine {
           kind: "workspace",
           hostPath: sandboxConfig.workspaceHostPath,
           sandboxPath: sandboxConfig.workspaceMountPath,
+          readOnly: false,
         },
         ...sandboxConfig.additionalMounts.map((mount) => ({
           kind: mount.kind,
+          ...(mount.kind === "host-bind" ? { name: mount.name } : {}),
           hostPath: mount.hostPath,
           sandboxPath: mount.sandboxPath,
+          readOnly: mount.readOnly,
         })),
       ]
       : this.workspaceHostPath !== undefined
@@ -322,6 +327,7 @@ export class CfHarnessEngine {
         kind: "workspace",
         hostPath: this.workspaceHostPath,
         sandboxPath: this.workspaceMountPath,
+        readOnly: false,
       }]
       : [];
     this.artifactStore = options.artifactStore ??
@@ -835,7 +841,10 @@ export class CfHarnessEngine {
     };
   }
 
-  #resolveHostPath(path: string): string {
+  #resolveHostMount(path: string): {
+    hostPath: string;
+    mount: HostSandboxMount;
+  } {
     if (this.#hostMounts.length === 0) {
       throw new Error(
         "bash-no-sandbox requires a host mount path to map sandbox paths",
@@ -853,14 +862,25 @@ export class CfHarnessEngine {
     }
     const sandboxRoot = normalizeSandboxRoot(mount.sandboxPath);
     if (sandboxPath === sandboxRoot) {
-      return normalizeHostPath(mount.hostPath);
+      return { hostPath: normalizeHostPath(mount.hostPath), mount };
     }
-    return normalizeHostPath(
-      joinHostPath(
-        mount.hostPath,
-        sandboxPath.slice(sandboxRoot.length + 1),
+    return {
+      hostPath: normalizeHostPath(
+        joinHostPath(
+          mount.hostPath,
+          sandboxPath.slice(sandboxRoot.length + 1),
+        ),
       ),
-    );
+      mount,
+    };
+  }
+
+  #resolveHostPath(path: string): string {
+    return this.#resolveHostMount(path).hostPath;
+  }
+
+  #resolveHostRootPath(path: string): string {
+    return normalizeHostPath(this.#resolveHostMount(path).mount.hostPath);
   }
 
   #hostPathToWorkspacePath(path: string): string | undefined {
@@ -1100,6 +1120,7 @@ export class CfHarnessEngine {
       resolvePath: (path: string) =>
         this.sandbox.resolvePath(path, this.#runState.currentDir),
       resolveHostPath: (path: string) => this.#resolveHostPath(path),
+      resolveHostRootPath: (path: string) => this.#resolveHostRootPath(path),
       hostPathToWorkspacePath: (path: string) =>
         this.#hostPathToWorkspacePath(path),
       isHostPathWithinWorkspace: (

--- a/packages/cf-harness/src/sandbox/docker-runsc.ts
+++ b/packages/cf-harness/src/sandbox/docker-runsc.ts
@@ -168,12 +168,27 @@ const normalizeAdditionalMount = (
   if (mount.hostPath.trim() === "") {
     throw new Error(`${mount.kind} hostPath must not be empty`);
   }
+  if (mount.kind === "host-bind" && mount.name.trim() === "") {
+    throw new Error("host-bind name must not be empty");
+  }
+  if (mount.kind === "host-bind") {
+    return {
+      kind: "host-bind",
+      name: mount.name,
+      hostPath: mount.hostPath,
+      sandboxPath: validateSandboxRoot(
+        mount.sandboxPath,
+        "host-bind sandboxPath",
+      ),
+      readOnly: mount.readOnly ?? true,
+    };
+  }
   return {
-    kind: mount.kind,
+    kind: "fabric-fuse",
     hostPath: mount.hostPath,
     sandboxPath: validateSandboxRoot(
       mount.sandboxPath ?? DEFAULT_FABRIC_MOUNT_PATH,
-      `${mount.kind} sandboxPath`,
+      "fabric-fuse sandboxPath",
     ),
     readOnly: mount.readOnly ?? false,
   };
@@ -496,6 +511,7 @@ export class DockerRunscSandboxRuntime implements SandboxRuntime {
 
   #mounts(): Array<{
     kind: SandboxRuntimeMountDescription["kind"];
+    name?: string;
     hostPath: string;
     sandboxPath: string;
     readOnly: boolean;
@@ -512,10 +528,15 @@ export class DockerRunscSandboxRuntime implements SandboxRuntime {
   }
 
   #mountDescriptions(): SandboxRuntimeMountDescription[] {
-    return this.#mounts().map(({ kind, sandboxPath, readOnly }) => ({
-      kind,
-      sandboxPath,
-      readOnly,
+    return this.#mounts().map((mount) => ({
+      kind: mount.kind,
+      ...(mount.kind === "host-bind" ? { name: mount.name } : {}),
+      hostPath: mount.hostPath,
+      sandboxPath: mount.sandboxPath,
+      readOnly: mount.readOnly,
+      ...(mount.kind === "host-bind"
+        ? { mode: mount.readOnly ? "readonly" as const : "writable" as const }
+        : {}),
     }));
   }
 

--- a/packages/cf-harness/src/sandbox/types.ts
+++ b/packages/cf-harness/src/sandbox/types.ts
@@ -5,27 +5,59 @@ export type HarnessSandboxKind = "docker-runsc-cfc";
 
 export type DockerNetworkMode = "none" | "bridge" | "host";
 
-export type SandboxRuntimeMountKind = "workspace" | "fabric-fuse";
+export type SandboxRuntimeMountKind =
+  | "workspace"
+  | "fabric-fuse"
+  | "host-bind";
+
+export type SandboxHostMountMode = "readonly" | "writable";
 
 export interface SandboxRuntimeMountDescription {
   kind: SandboxRuntimeMountKind;
+  name?: string;
+  hostPath?: string;
   sandboxPath: string;
   readOnly: boolean;
+  mode?: SandboxHostMountMode;
 }
 
-export interface DockerRunscAdditionalMountConfig {
+export interface DockerRunscFabricAdditionalMountConfig {
   kind: "fabric-fuse";
   hostPath: string;
   sandboxPath?: string;
   readOnly?: boolean;
 }
 
-export interface DockerRunscAdditionalMount {
+export interface DockerRunscHostBindAdditionalMountConfig {
+  kind: "host-bind";
+  name: string;
+  hostPath: string;
+  sandboxPath: string;
+  readOnly?: boolean;
+}
+
+export type DockerRunscAdditionalMountConfig =
+  | DockerRunscFabricAdditionalMountConfig
+  | DockerRunscHostBindAdditionalMountConfig;
+
+export interface DockerRunscFabricAdditionalMount {
   kind: "fabric-fuse";
   hostPath: string;
   sandboxPath: string;
   readOnly: boolean;
 }
+
+export interface DockerRunscHostBindAdditionalMount {
+  kind: "host-bind";
+  name: string;
+  hostPath: string;
+  sandboxPath: string;
+  readOnly: boolean;
+}
+
+export type DockerRunscAdditionalMount =
+  | DockerRunscFabricAdditionalMount
+  | DockerRunscHostBindAdditionalMount;
 
 export interface DockerRunscCfcInvocationContextSidecarTransport {
   kind: "sidecar";

--- a/packages/cf-harness/src/tools/types.ts
+++ b/packages/cf-harness/src/tools/types.ts
@@ -35,6 +35,7 @@ export interface HarnessToolContext {
   workspaceHostPath?: string;
   resolvePath(path: string): string;
   resolveHostPath(path: string): string;
+  resolveHostRootPath(path: string): string;
   hostPathToWorkspacePath(path: string): string | undefined;
   isHostPathWithinWorkspace(
     path: string,

--- a/packages/cf-harness/src/tools/view-image.ts
+++ b/packages/cf-harness/src/tools/view-image.ts
@@ -125,16 +125,11 @@ export const viewImageTool: HarnessToolDefinition<
         detail: RESERVED_ARTIFACT_PATH_DETAIL,
       });
     }
-    if (context.workspaceHostPath === undefined) {
-      return createStructuredFileToolErrorOutput(context, "view_image", {
-        path: resolvedPath,
-        code: "unknown",
-        detail: "workspace host path is not configured",
-      });
-    }
     let hostPath: string;
+    let hostRootPath: string;
     try {
       hostPath = context.resolveHostPath(resolvedPath);
+      hostRootPath = context.resolveHostRootPath(resolvedPath);
     } catch (error) {
       return createStructuredFileToolErrorOutput(context, "view_image", {
         path: resolvedPath,
@@ -144,8 +139,8 @@ export const viewImageTool: HarnessToolDefinition<
     }
     try {
       const imageAttachment = await createHarnessImageAttachment({
-        workspaceHostPath: context.workspaceHostPath,
-        cwd: context.workspaceHostPath,
+        workspaceHostPath: hostRootPath,
+        cwd: hostRootPath,
         path: hostPath,
       });
       return {

--- a/packages/cf-harness/test/artifacts.test.ts
+++ b/packages/cf-harness/test/artifacts.test.ts
@@ -273,6 +273,7 @@ Deno.test({
                   delegatedToCfc: false,
                 },
               },
+              hostBinds: [],
             },
             protectedXattrs: {
               expectedSandboxVisible: false,

--- a/packages/cf-harness/test/cli.test.ts
+++ b/packages/cf-harness/test/cli.test.ts
@@ -29,6 +29,9 @@ const ONE_PIXEL_PNG = decodeBase64(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p94AAAAASUVORK5CYII=",
 );
 
+const syntheticTmpProjectPath = (...segments: string[]): string =>
+  join(Deno.realPathSync("/tmp"), "project", ...segments);
+
 const createIoBuffers = (): {
   io: CfHarnessCliIO;
   stdout: string[];
@@ -134,8 +137,49 @@ Deno.test("parseCfHarnessCliArgs rejects image attachments outside the workspace
         },
       ),
     Error,
-    "--image paths must stay within the workspace",
+    "--image must stay within the workspace or a host mount",
   );
+});
+
+Deno.test("parseCfHarnessCliArgs accepts image attachments from a host mount", async () => {
+  const workspace = await Deno.makeTempDir();
+  const mounted = await Deno.makeTempDir();
+  const launcherCwd = await Deno.makeTempDir();
+  const imagePath = join(mounted, "capture.png");
+  await Deno.writeFile(imagePath, ONE_PIXEL_PNG);
+
+  const parsed = await parseCfHarnessCliArgs(
+    [
+      "--workspace",
+      workspace,
+      "--host-mount",
+      `name=file-cabinet,source=${mounted},target=/file-cabinet,mode=readonly`,
+      "--image",
+      imagePath,
+      "--prompt",
+      "Describe the image",
+    ],
+    {
+      cwd: launcherCwd,
+      env: {},
+    },
+  );
+
+  if ("help" in parsed) {
+    throw new Error("expected config result");
+  }
+  assertEquals(parsed.hostMounts, [{
+    name: "file-cabinet",
+    hostPath: await Deno.realPath(mounted),
+    sandboxPath: "/file-cabinet",
+    mode: "readonly",
+  }]);
+  assertEquals(parsed.imageAttachments.length, 1);
+  assertEquals(
+    parsed.imageAttachments[0].hostPath,
+    await Deno.realPath(imagePath),
+  );
+  assertEquals(parsed.imageAttachments[0].mediaType, "image/png");
 });
 
 Deno.test("parseCfHarnessCliArgs rejects image symlinks that resolve outside the workspace", async () => {
@@ -163,7 +207,7 @@ Deno.test("parseCfHarnessCliArgs rejects image symlinks that resolve outside the
         },
       ),
     Error,
-    "--image paths must stay within the workspace",
+    "--image must stay within the workspace or a host mount",
   );
 });
 
@@ -348,7 +392,10 @@ Deno.test({
       if ("help" in parsed) {
         throw new Error("expected config result");
       }
-      assertEquals(parsed.skillsRoot, join(workspace, "labs", "skills"));
+      assertEquals(
+        parsed.skillsRoot,
+        await Deno.realPath(join(workspace, "labs", "skills")),
+      );
       assertEquals(parsed.skillsRootSandboxPath, "/workspace/labs/skills");
       assertEquals(parsed.skillNames, ["pattern-dev", "cf"]);
       assertEquals(parsed.skillCatalogEnabled, false);
@@ -617,7 +664,7 @@ Deno.test("parseCfHarnessCliArgs supports structured result validation flags", a
   }
   assertEquals(
     parsed.structuredResult?.path,
-    "/tmp/project/results/capture.results.json",
+    syntheticTmpProjectPath("results", "capture.results.json"),
   );
   assertEquals(
     parsed.structuredResult?.sandboxPath,
@@ -2260,7 +2307,7 @@ Deno.test("runCfHarnessCli validates a top-level structured result sidecar", asy
       io,
       env: {},
       readTextFile: (path) => {
-        assertEquals(path, "/tmp/project/capture.results.json");
+        assertEquals(path, syntheticTmpProjectPath("capture.results.json"));
         return Promise.resolve(JSON.stringify({ ok: true, status: "done" }));
       },
       writeTextFile: (path, text) => {
@@ -2319,7 +2366,7 @@ Deno.test("runCfHarnessCli validates a top-level structured result sidecar", asy
   assertEquals(batchResult.structured_result.status, "valid");
   assertEquals(
     batchResult.structured_result.result_path,
-    "/tmp/project/capture.results.json",
+    syntheticTmpProjectPath("capture.results.json"),
   );
   assertEquals(
     batchResult.structured_result.schema_digest.startsWith("sha256:"),
@@ -2403,7 +2450,7 @@ Deno.test("runCfHarnessCli exits nonzero when top-level structured result is inv
     type: "cf-harness.structured-result-validation",
     status: "invalid",
     schema_digest: batchResult.structured_result.schema_digest,
-    result_path: "/tmp/project/capture.results.json",
+    result_path: syntheticTmpProjectPath("capture.results.json"),
     validation_error: "structured result did not match the schema",
   });
   assertEquals(
@@ -3002,6 +3049,171 @@ Deno.test("parseCfHarnessCliArgs rejects empty fabric-mount value", async () => 
   );
 });
 
+Deno.test("parseCfHarnessCliArgs parses explicit host mounts", async () => {
+  const workspace = await Deno.makeTempDir();
+  const mountRoot = await Deno.makeTempDir();
+
+  const parsed = await parseCfHarnessCliArgs(
+    [
+      "--workspace",
+      workspace,
+      "--host-mount",
+      `name=file-cabinet,source=${mountRoot},target=/file-cabinet,mode=writable`,
+      "--cwd",
+      mountRoot,
+      "--prompt",
+      "hi",
+    ],
+    { cwd: workspace, env: {} },
+  );
+
+  if ("help" in parsed) throw new Error("expected config result");
+  assertEquals(parsed.hostMounts, [{
+    name: "file-cabinet",
+    hostPath: await Deno.realPath(mountRoot),
+    sandboxPath: "/file-cabinet",
+    mode: "writable",
+  }]);
+  assertEquals(parsed.cwd, "/file-cabinet");
+});
+
+Deno.test("parseCfHarnessCliArgs rejects structured result paths in readonly host mounts", async () => {
+  const workspace = await Deno.makeTempDir();
+  const mountRoot = await Deno.makeTempDir();
+
+  await assertRejects(
+    () =>
+      parseCfHarnessCliArgs(
+        [
+          "--workspace",
+          workspace,
+          "--host-mount",
+          `name=docs,source=${mountRoot},target=/docs,mode=readonly`,
+          "--structured-result-path",
+          join(mountRoot, "result.json"),
+          "--structured-result-schema",
+          '{"type":"object"}',
+          "--prompt",
+          "hi",
+        ],
+        { cwd: workspace, env: {} },
+      ),
+    Error,
+    "--structured-result-path must be inside a writable host mount",
+  );
+});
+
+Deno.test("parseCfHarnessCliArgs allows structured result paths in writable host mounts", async () => {
+  const workspace = await Deno.makeTempDir();
+  const mountRoot = await Deno.makeTempDir();
+
+  const parsed = await parseCfHarnessCliArgs(
+    [
+      "--workspace",
+      workspace,
+      "--host-mount",
+      `name=file-cabinet,source=${mountRoot},target=/file-cabinet,mode=writable`,
+      "--structured-result-path",
+      join(mountRoot, "result.json"),
+      "--structured-result-schema",
+      '{"type":"object"}',
+      "--prompt",
+      "hi",
+    ],
+    { cwd: workspace, env: {} },
+  );
+
+  if ("help" in parsed) throw new Error("expected config result");
+  assertEquals(
+    parsed.structuredResult?.path,
+    join(await Deno.realPath(mountRoot), "result.json"),
+  );
+  assertEquals(
+    parsed.structuredResult?.sandboxPath,
+    "/file-cabinet/result.json",
+  );
+});
+
+Deno.test("parseCfHarnessCliArgs uses the most specific overlapping host mount", async () => {
+  const workspace = await Deno.makeTempDir();
+  const mountRoot = await Deno.makeTempDir();
+  const nestedRoot = join(mountRoot, "nested");
+  await Deno.mkdir(nestedRoot);
+
+  const parsed = await parseCfHarnessCliArgs(
+    [
+      "--workspace",
+      workspace,
+      "--host-mount",
+      `name=outer,source=${mountRoot},target=/outer,mode=readonly`,
+      "--host-mount",
+      `name=inner,source=${nestedRoot},target=/inner,mode=writable`,
+      "--structured-result-path",
+      join(nestedRoot, "result.json"),
+      "--structured-result-schema",
+      '{"type":"object"}',
+      "--prompt",
+      "hi",
+    ],
+    { cwd: workspace, env: {} },
+  );
+
+  if ("help" in parsed) throw new Error("expected config result");
+  assertEquals(
+    parsed.structuredResult?.path,
+    join(await Deno.realPath(nestedRoot), "result.json"),
+  );
+  assertEquals(parsed.structuredResult?.sandboxPath, "/inner/result.json");
+});
+
+Deno.test("parseCfHarnessCliArgs rejects missing paths under symlink parents outside allowed roots", async () => {
+  const workspace = await Deno.makeTempDir();
+  const outside = await Deno.makeTempDir();
+  const linkedOutside = join(workspace, "linked-outside");
+  await Deno.symlink(outside, linkedOutside, { type: "dir" });
+
+  await assertRejects(
+    () =>
+      parseCfHarnessCliArgs(
+        [
+          "--workspace",
+          workspace,
+          "--structured-result-path",
+          join(linkedOutside, "missing-result.json"),
+          "--structured-result-schema",
+          '{"type":"object"}',
+          "--prompt",
+          "hi",
+        ],
+        { cwd: workspace, env: {} },
+      ),
+    Error,
+    "--structured-result-path must stay within the workspace or a host mount",
+  );
+});
+
+Deno.test("parseCfHarnessCliArgs rejects invalid host mount specs", async () => {
+  const workspace = await Deno.makeTempDir();
+  const mountRoot = await Deno.makeTempDir();
+
+  await assertRejects(
+    () =>
+      parseCfHarnessCliArgs(
+        [
+          "--workspace",
+          workspace,
+          "--host-mount",
+          `name=bad name,source=${mountRoot},target=/data`,
+          "--prompt",
+          "hi",
+        ],
+        { cwd: workspace, env: {} },
+      ),
+    Error,
+    "--host-mount name must start",
+  );
+});
+
 Deno.test("buildCfHarnessOperatorSystemPrompt includes fabric mount guidance", () => {
   const prompt = buildCfHarnessOperatorSystemPrompt({
     workspace: "/tmp/project",
@@ -3022,6 +3234,24 @@ Deno.test("buildCfHarnessOperatorSystemPrompt omits fabric guidance without moun
     systemPrompt: undefined,
   });
   assertEquals(prompt.includes("mounted at"), false);
+});
+
+Deno.test("buildCfHarnessOperatorSystemPrompt includes host mount guidance", () => {
+  const prompt = buildCfHarnessOperatorSystemPrompt({
+    workspace: "/tmp/project",
+    systemPrompt: undefined,
+    hostMounts: [{
+      name: "file-cabinet",
+      hostPath: "/host/File Cabinet",
+      sandboxPath: "/file-cabinet",
+      mode: "writable",
+    }],
+  });
+
+  assertEquals(
+    prompt.includes("/file-cabinet: writable (file-cabinet)"),
+    true,
+  );
 });
 
 Deno.test("runCfHarnessCli threads fabric-mount into engine additionalMounts", async () => {
@@ -3086,6 +3316,80 @@ Deno.test("runCfHarnessCli threads fabric-mount into engine additionalMounts", a
   assertEquals(
     runPromptOptions?.systemPrompt?.includes(
       "A Common Fabric space is mounted at /fabric",
+    ),
+    true,
+  );
+});
+
+Deno.test("runCfHarnessCli threads host-mount into engine additionalMounts", async () => {
+  const workspace = await Deno.makeTempDir();
+  const mountRoot = await Deno.makeTempDir();
+  const { io, stderr } = createIoBuffers();
+  let createdOptions: Record<string, unknown> | undefined;
+  let runPromptOptions: RunHarnessPromptOptions | undefined;
+  const exitCode = await runCfHarnessCli(
+    [
+      "--workspace",
+      workspace,
+      "--prompt",
+      "Browse mounted files",
+      "--host-mount",
+      `name=file-cabinet,source=${mountRoot},target=/file-cabinet,mode=writable`,
+      "--gateway-auth-mode",
+      "none",
+    ],
+    {
+      io,
+      env: {},
+      createPromptLoop: (options) => {
+        createdOptions = options as Record<string, unknown>;
+        return {
+          runPrompt: (options) => {
+            runPromptOptions = options;
+            return Promise.resolve(
+              ({
+                model: "gpt-5.4",
+                finalAssistantText: "Done.",
+                transcript: [
+                  { role: "user", content: "Browse mounted files" },
+                  { role: "assistant", content: "Done." },
+                ],
+                modelTurns: 1,
+                runState: {
+                  runId: "run-host-mount",
+                  status: "completed",
+                  createdAt: "2026-04-30T00:00:00.000Z",
+                  updatedAt: "2026-04-30T00:00:01.000Z",
+                  cfcEnforcementMode: "disabled",
+                  currentDir: "/workspace",
+                  policyEvents: [],
+                  toolOutputs: [],
+                },
+              }) satisfies HarnessPromptLoopResult,
+            );
+          },
+          runTranscript: () =>
+            Promise.reject(new Error("unexpected resume path")),
+        };
+      },
+    },
+  );
+
+  assertEquals(exitCode, 0);
+  assertEquals(stderr, []);
+  const engine = createdOptions?.engine as CfHarnessEngine | undefined;
+  const mounts = engine?.sandbox.describe?.()?.cfc?.mounts;
+  assertEquals(mounts?.[1], {
+    kind: "host-bind",
+    name: "file-cabinet",
+    hostPath: await Deno.realPath(mountRoot),
+    sandboxPath: "/file-cabinet",
+    readOnly: false,
+    mode: "writable",
+  });
+  assertEquals(
+    runPromptOptions?.systemPrompt?.includes(
+      "/file-cabinet: writable (file-cabinet)",
     ),
     true,
   );

--- a/packages/cf-harness/test/diagnostics.test.ts
+++ b/packages/cf-harness/test/diagnostics.test.ts
@@ -139,6 +139,7 @@ Deno.test("collectHarnessCapabilitySnapshot captures fixed sandbox capabilities"
             delegatedToCfc: false,
           },
         },
+        hostBinds: [],
       },
       protectedXattrs: {
         expectedSandboxVisible: false,
@@ -202,7 +203,75 @@ Deno.test("collectHarnessCapabilitySnapshot reports configured Fabric mounts", a
         delegatedToCfc: false,
       },
     },
+    hostBinds: [],
   });
+});
+
+class FakeHostBindSandboxRuntime extends FakeSandboxRuntime {
+  describe(): SandboxRuntimeDescription {
+    return {
+      kind: "docker-runsc-cfc",
+      defaultWorkingDirectory: "/workspace",
+      cfc: {
+        runtimeRequested: true,
+        runtimeName: "runsc-cfc",
+        workspaceMountPath: "/workspace",
+        mounts: [
+          {
+            kind: "workspace",
+            hostPath: "/host/workspace",
+            sandboxPath: "/workspace",
+            readOnly: false,
+          },
+          {
+            kind: "host-bind",
+            name: "file-cabinet",
+            hostPath: "/host/File Cabinet",
+            sandboxPath: "/file-cabinet",
+            readOnly: false,
+            mode: "writable",
+          },
+          {
+            kind: "host-bind",
+            name: "loom-ops",
+            hostPath: "/host/loom/.ops",
+            sandboxPath: "/loom/ops",
+            readOnly: true,
+            mode: "readonly",
+          },
+        ],
+      },
+    };
+  }
+}
+
+Deno.test("collectHarnessCapabilitySnapshot reports configured host bind mounts", async () => {
+  const snapshot = await collectHarnessCapabilitySnapshot(
+    new FakeHostBindSandboxRuntime(),
+    "/workspace",
+    "2026-06-02T23:00:00.000Z",
+  );
+
+  assertEquals(snapshot.cfc.mounts.hostBinds, [
+    {
+      kind: "host-bind",
+      status: "configured",
+      name: "file-cabinet",
+      hostPath: "/host/File Cabinet",
+      sandboxPath: "/file-cabinet",
+      readOnly: false,
+      mode: "writable",
+    },
+    {
+      kind: "host-bind",
+      status: "configured",
+      name: "loom-ops",
+      hostPath: "/host/loom/.ops",
+      sandboxPath: "/loom/ops",
+      readOnly: true,
+      mode: "readonly",
+    },
+  ]);
 });
 
 Deno.test("collectHarnessCapabilitySnapshot records strict CFC attestation for writable Fabric mounts", async () => {

--- a/packages/cf-harness/test/docker-runsc-sandbox.test.ts
+++ b/packages/cf-harness/test/docker-runsc-sandbox.test.ts
@@ -198,6 +198,43 @@ Deno.test("resolveDockerRunscSandboxConfig normalizes a Fabric FUSE mount", () =
   }]);
 });
 
+Deno.test("resolveDockerRunscSandboxConfig normalizes host bind mounts", () => {
+  const config = resolveDockerRunscSandboxConfig({
+    workspaceHostPath: "/host/project",
+    additionalMounts: [{
+      kind: "host-bind",
+      name: "file-cabinet",
+      hostPath: "/host/File Cabinet",
+      sandboxPath: "/file-cabinet/",
+    }],
+  });
+
+  assertEquals(config.additionalMounts, [{
+    kind: "host-bind",
+    name: "file-cabinet",
+    hostPath: "/host/File Cabinet",
+    sandboxPath: "/file-cabinet",
+    readOnly: true,
+  }]);
+});
+
+Deno.test("resolveDockerRunscSandboxConfig rejects empty host bind names", () => {
+  assertThrows(
+    () =>
+      resolveDockerRunscSandboxConfig({
+        workspaceHostPath: "/host/project",
+        additionalMounts: [{
+          kind: "host-bind",
+          name: "",
+          hostPath: "/host/data",
+          sandboxPath: "/data",
+        }],
+      }),
+    Error,
+    "host-bind name must not be empty",
+  );
+});
+
 Deno.test("resolveDockerRunscSandboxConfig rejects overlapping sandbox roots", () => {
   assertThrows(
     () =>
@@ -581,8 +618,18 @@ Deno.test("DockerRunscSandboxRuntime mounts Fabric separately and accepts Fabric
 
   const description = runtime.describe();
   assertEquals(description.cfc?.mounts, [
-    { kind: "workspace", sandboxPath: "/workspace", readOnly: false },
-    { kind: "fabric-fuse", sandboxPath: "/fabric", readOnly: true },
+    {
+      kind: "workspace",
+      hostPath: "/host/project",
+      sandboxPath: "/workspace",
+      readOnly: false,
+    },
+    {
+      kind: "fabric-fuse",
+      hostPath: "/tmp/cf-fuse",
+      sandboxPath: "/fabric",
+      readOnly: true,
+    },
   ]);
 
   await runtime.run({
@@ -605,6 +652,59 @@ Deno.test("DockerRunscSandboxRuntime mounts Fabric separately and accepts Fabric
     "type=bind,src=/tmp/cf-fuse,dst=/fabric,readonly",
     "-w",
     "/fabric/home",
+    "sandbox:latest",
+    "/bin/pwd",
+  ]);
+});
+
+Deno.test("DockerRunscSandboxRuntime mounts host bind roots with read/write modes", async () => {
+  const runner = new FakeProcessRunner(dockerLifecycleResults({ stdout: "" }));
+  const runtime = new DockerRunscSandboxRuntime(
+    resolveDockerRunscSandboxConfig({
+      workspaceHostPath: "/host/project",
+      image: "sandbox:latest",
+      additionalMounts: [{
+        kind: "host-bind",
+        name: "file-cabinet",
+        hostPath: "/host/File Cabinet",
+        sandboxPath: "/file-cabinet",
+        readOnly: false,
+      }],
+    }),
+    runner,
+  );
+
+  assertEquals(runtime.isPathWithinWorkspace("/file-cabinet/Inbox"), false);
+  assertEquals(runtime.isPathWithinAllowedRoots("/file-cabinet/Inbox"), true);
+  assertEquals(runtime.describe().cfc?.mounts?.[1], {
+    kind: "host-bind",
+    name: "file-cabinet",
+    hostPath: "/host/File Cabinet",
+    sandboxPath: "/file-cabinet",
+    readOnly: false,
+    mode: "writable",
+  });
+
+  await runtime.run({
+    argv: ["/bin/pwd"],
+    cwd: "/file-cabinet",
+  });
+
+  assertEquals(runner.requests[0]?.args, [
+    "create",
+    "--runtime",
+    "runsc-cfc",
+    "--network",
+    "bridge",
+    ...(runtime.config.containerUser !== undefined
+      ? ["--user", runtime.config.containerUser]
+      : []),
+    "--mount",
+    "type=bind,src=/host/project,dst=/workspace",
+    "--mount",
+    "type=bind,src=/host/File Cabinet,dst=/file-cabinet",
+    "-w",
+    "/file-cabinet",
     "sandbox:latest",
     "/bin/pwd",
   ]);

--- a/packages/cf-harness/test/tools-execution.test.ts
+++ b/packages/cf-harness/test/tools-execution.test.ts
@@ -228,6 +228,9 @@ const createContext = (
         ? workspaceHostPath
         : `${workspaceHostPath}${sandboxPath.slice("/workspace".length)}`;
     },
+    resolveHostRootPath(_path: string) {
+      return workspaceHostPath;
+    },
     isHostPathWithinWorkspace(path: string) {
       return Promise.resolve(
         path === workspaceHostPath ||


### PR DESCRIPTION
## Summary

Adds explicit host bind mount support to `packages/cf-harness` so callers can expose narrow host directories to the gVisor sandbox without broadening the main workspace root.

Key changes:
- add repeated `--host-mount name=<id>,source=<host>,target=<sandbox>,mode=readonly|writable`
- thread host mounts through Docker/runsc sandbox config and runtime mount descriptions
- record host bind mount metadata in CFC capability diagnostics
- make cf-harness CLI path resolution understand the workspace plus explicit host roots for `--cwd`, `--image`, `--skills-root`, and structured result paths
- let `view_image` attach images from any authorized host-backed mount while preserving host root containment

## Policy shape

This first slice supports direct read-only or direct writable bind mounts. That lets Loom stop using a broad `commonpath` workspace immediately.

The intended next hardening step is directory-backed, reviewable overlays for writable user-data mounts. In that future posture, the sandbox can write through its merged view while Loom inspects and promotes accepted changes back to File Cabinet/GTD explicitly.

## Validation

- `deno fmt` on touched cf-harness files
- `deno check` on touched cf-harness source files
- `deno test -A packages/cf-harness/test/docker-runsc-sandbox.test.ts packages/cf-harness/test/diagnostics.test.ts packages/cf-harness/test/tools-execution.test.ts` (101 passed)
- `deno test -A packages/cf-harness/test/cli.test.ts` (85 passed)
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds explicit host bind mounts to `packages/cf-harness`, so you can map narrow host directories into the gVisor sandbox without widening the workspace. Includes a repeatable `--host-mount` flag with end-to-end support across CLI path resolution, Docker/runsc runtime, prompts, tools, diagnostics, and tests.

- **New Features**
  - CLI: `--host-mount name=<id>,source=<host>,target=<sandbox>,mode=readonly|writable` (repeatable). Validates names (pattern), unique names, existing directories (not root), absolute non-root sandbox targets, and mode (defaults to readonly).
  - Path resolution: `--cwd`, `--image`, `--skills-root`, and `--structured-result-path` resolve within the workspace or any host mount, picking the most specific mount when overlaps exist. Structured results require a writable mount.
  - Runtime and diagnostics: Host binds flow into Docker/runsc with normalization (non-empty name, default readonly). `describe()` now includes `name/hostPath/sandboxPath/readOnly/mode`. Capability snapshots add `hostBinds` and record `hostPath` for workspace and Fabric.
  - Prompts, tools, tests: System prompts list available mounts with mode and name. `view_image` can attach images from authorized host-backed mounts while preserving root containment via `resolveHostRootPath`. Added tests for parsing, path resolution across mounts, runtime mounting, diagnostics, and tool execution.

<sup>Written for commit af44bc235bcec5617d4499b572ab82028729bf8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

