### PR TITLE
fix(runner): make piece save path content-identity-symmetric (CT-1623)

### DIFF
--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -545,7 +545,10 @@ export class PatternManager {
         mainSpecifier,
         program.files,
       );
-      return this.patternFromEvaluation(result, program);
+      // Associate the entry identity even on the non-cache ESM branch so the
+      // pattern's {identity, symbol} ref is always consistent (correct export
+      // symbol), regardless of whether the compiled cache was written.
+      return this.patternFromEvaluation(result, program, entryIdentity);
     }
 
     const { cachedCompiler } = this.runtime;

--- a/packages/runner/src/piece-helpers.ts
+++ b/packages/runner/src/piece-helpers.ts
@@ -100,7 +100,16 @@ export async function compileAndSavePattern(
       files: [{ name: "/main.tsx", contents: patternSrc }],
     };
   }
-  const pattern = await runtime.patternManager.compilePattern(patternSrc);
+  // Compile with the target space so the ESM path participates fully in the
+  // content-addressed cell cache: it learns the entry identity, associates the
+  // pattern's {identity, symbol} ref (with the real export name), and writes the
+  // compiled + source docs into `space`. Without this the save path and the
+  // (cache-backed) load path disagree about the content identity — a non-default
+  // `mainExport` would reload under the wrong symbol and the watcher would never
+  // converge (cf piece setsrc hang under the ESM loader).
+  const pattern = await runtime.patternManager.compilePattern(patternSrc, {
+    space: options.space,
+  });
   if (!pattern) {
     throw new Error("No default pattern found in the compiled exports.");
   }

--- a/packages/runner/test/compile-and-save-identity.test.ts
+++ b/packages/runner/test/compile-and-save-identity.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import { compileAndSavePattern } from "../src/piece-helpers.ts";
+import {
+  COMPILE_CACHE_RUNTIME_VERSION,
+  loadCompiledClosure,
+} from "../src/compilation-cache/cell-cache.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+const signer = await Identity.fromPassphrase("compile-and-save-identity");
+const space = signer.did();
+
+// Regression (CT-1623): the piece save path (compileAndSavePattern, used by
+// `cf piece new/setsrc`) must associate the pattern's content-addressed
+// {identity, symbol} ref — with the REAL export symbol — and write the compiled
+// cache into the target space. Previously it compiled with no cacheCtx, so the
+// save side never learned an entryIdentity while the (cache-backed) load side
+// did; with a non-default mainExport the reload used the wrong symbol and the
+// pattern-change watcher never converged (cf piece setsrc hung under the ESM
+// loader once flipped on by default).
+describe("compileAndSavePattern associates the content-addressed identity", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      experimental: { esmModuleLoader: true },
+    });
+  });
+  afterEach(async () => {
+    await runtime?.patternManager.flushCompileCacheWrites();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  // A pattern exported under a NON-default name — the case that broke.
+  const NAMED: RuntimeProgram = {
+    main: "/main.tsx",
+    mainExport: "customPatternExport",
+    files: [
+      {
+        name: "/main.tsx",
+        contents: [
+          "import { pattern, lift } from 'commonfabric';",
+          "const dbl = lift((x:number)=>x*2);",
+          "export const customPatternExport = pattern<{ value: number }>(",
+          "  ({ value }) => ({ result: dbl(value) }),",
+          ");",
+        ].join("\n"),
+      },
+    ],
+  };
+
+  it("records {identity, symbol} with the real export name (not 'default')", async () => {
+    const pattern = await compileAndSavePattern(runtime, NAMED, { space });
+
+    const ref = runtime.patternManager.getPatternEntryRef(pattern);
+    expect(ref).toBeDefined();
+    expect(ref!.symbol).toBe("customPatternExport");
+    expect(typeof ref!.identity).toBe("string");
+    expect(ref!.identity.length).toBeGreaterThan(0);
+  });
+
+  it("writes the compiled cache into the target space (cache-backed save)", async () => {
+    const pattern = await compileAndSavePattern(runtime, NAMED, { space });
+    const ref = runtime.patternManager.getPatternEntryRef(pattern)!;
+    await runtime.patternManager.flushCompileCacheWrites();
+
+    const readTx = runtime.edit();
+    const closure = await loadCompiledClosure(
+      runtime,
+      space,
+      ref.identity,
+      {
+        runtimeVersion: COMPILE_CACHE_RUNTIME_VERSION,
+        compilerDid: runtime.userIdentityDID,
+      },
+      readTx,
+    );
+    readTx.abort?.("read complete");
+    // The save path populated the compiled closure, so the daemon's reload can
+    // hit the by-identity fast path instead of churning.
+    expect(closure.has(ref.identity)).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Fixes a regression surfaced by the flag-flip canary (#3782): under the **ESM module loader**, `cf piece setsrc` on a pattern with a **non-default `mainExport`** hangs (scheduler never reaches idle → the CLI's `getResult().pull()` never resolves) or fails. The FUSE CLI integration test reproduces it reliably (it deploys with `--main-export customPatternExport`).

This was dormant on `main` (the ESM loader is still off by default), so #3833 merged green — the flip is the first time the content-addressed reload path runs live.

## Root cause — a save/load asymmetry

When result cells gained the content-addressed `{identity, symbol}` reference (#3833):

- The piece **save** path — `compileAndSavePattern` → `compilePattern(src)` with **no `cacheCtx`** — took the non-cache ESM branch, never associated an `entryIdentity`, and `patternFromEvaluation` was called without it. So `applySetupState` wrote **no/stale** `patternIdentity`.
- The daemon's **load** path *did* learn the `entryIdentity` and wrote `patternIdentity` with the real symbol.
- CLI and daemon share the space, so they disagreed about the content identity. With a non-default export, the by-identity reload used the wrong symbol (`"default"`), `loadPatternByIdentity` missed/threw, and the `sinkMeta("pattern")` watcher / `ensurePieceRunning` churned without converging.

## Fix

- **`compileAndSavePattern` compiles with `cacheCtx: { space }`** — the save path now participates fully in the content-addressed cache: learns the entry identity, associates the `{identity, symbol}` ref with the real export name, and writes the compiled + source docs into the target space (so the daemon's by-identity reload **hits** instead of churning).
- **The non-cache ESM branch of `compilePattern` passes `entryIdentity` to `patternFromEvaluation`** — so the ref is consistent even when the compiled cache isn't written (CFC disabled / other callers).

## Test

`compile-and-save-identity.test.ts`: a non-default-export pattern saved via `compileAndSavePattern` records `{identity, symbol: "customPatternExport"}` (not `"default"`) and populates the compiled closure in the target space.

Full `runner` suite (526) + `piece` suite green.

## Validation plan

After this lands on `main`, rebase the flag-flip PR (#3782) on top and confirm the FUSE CLI integration goes green (and the Performance Check runs again instead of being skipped behind the fuse failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a hang/failure in `cf piece setsrc` for patterns with a non-default `mainExport` under the ESM loader by making the save path content-identity symmetric with the load path. Addresses CT-1623.

- **Bug Fixes**
  - `compileAndSavePattern` now compiles with `cacheCtx: { space }` to learn the entry identity, set the `{identity, symbol}` with the real export name, and write compiled + source docs into the target space.
  - The non-cache ESM branch of `compilePattern` now passes `entryIdentity` to `patternFromEvaluation` so refs stay consistent even without cache writes.
  - Added `compile-and-save-identity.test.ts` to verify the `{identity, symbol: "customPatternExport"}` ref and that the compiled closure is stored in the target space.

<sup>Written for commit fd4f4956f73e1e7d7bc750acb53ee008e2a3425d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

