### PR TITLE
[VALIDATION-DO-NOT-MERGE] flip + setsrc fix (#3843)

### DIFF
--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -545,7 +545,10 @@ export class PatternManager {
         mainSpecifier,
         program.files,
       );
-      return this.patternFromEvaluation(result, program);
+      // Associate the entry identity even on the non-cache ESM branch so the
+      // pattern's {identity, symbol} ref is always consistent (correct export
+      // symbol), regardless of whether the compiled cache was written.
+      return this.patternFromEvaluation(result, program, entryIdentity);
     }
 
     const { cachedCompiler } = this.runtime;

--- a/packages/runner/src/piece-helpers.ts
+++ b/packages/runner/src/piece-helpers.ts
@@ -100,7 +100,16 @@ export async function compileAndSavePattern(
       files: [{ name: "/main.tsx", contents: patternSrc }],
     };
   }
-  const pattern = await runtime.patternManager.compilePattern(patternSrc);
+  // Compile with the target space so the ESM path participates fully in the
+  // content-addressed cell cache: it learns the entry identity, associates the
+  // pattern's {identity, symbol} ref (with the real export name), and writes the
+  // compiled + source docs into `space`. Without this the save path and the
+  // (cache-backed) load path disagree about the content identity — a non-default
+  // `mainExport` would reload under the wrong symbol and the watcher would never
+  // converge (cf piece setsrc hang under the ESM loader).
+  const pattern = await runtime.patternManager.compilePattern(patternSrc, {
+    space: options.space,
+  });
   if (!pattern) {
     throw new Error("No default pattern found in the compiled exports.");
   }

--- a/packages/runner/src/sandbox/esm-loader-config.ts
+++ b/packages/runner/src/sandbox/esm-loader-config.ts
@@ -4,11 +4,11 @@
  * persistent-scheduler-state ambient flags: the `Runtime` constructor
  * propagates the explicit option here and reads the effective value back.
  *
- * Unlike those two, the default is seeded from the `CF_ESM_MODULE_LOADER`
- * environment variable, so the ESM loader can be exercised suite-wide (e.g. a
+ * The default is ON: the ESM module-record loader is the production default.
+ * Set `CF_ESM_MODULE_LOADER=0` (or `false`) to opt back into the legacy AMD
+ * bundle loader. The env var also lets the loader be selected suite-wide (e.g. a
  * regression cross-check) without threading the option through every `Runtime`
- * construction. The production default stays OFF (the env var is unset), so this
- * is NOT the flag flip — it only makes the flag toggleable from the environment.
+ * construction.
  */
 
 function readEnvDefault(): boolean {
@@ -16,10 +16,12 @@ function readEnvDefault(): boolean {
     const value = (globalThis as {
       Deno?: { env?: { get(name: string): string | undefined } };
     }).Deno?.env?.get?.("CF_ESM_MODULE_LOADER");
-    return value === "1" || value === "true";
+    // Default ON: the ESM module-record loader is the default loader; opt out
+    // with CF_ESM_MODULE_LOADER=0 (or "false").
+    return value !== "0" && value !== "false";
   } catch {
-    // Env access may be denied (no --allow-env); treat as unset / off.
-    return false;
+    // Env access denied (no --allow-env): use the default (ON).
+    return true;
   }
 }
 

--- a/packages/runner/test/compile-and-save-identity.test.ts
+++ b/packages/runner/test/compile-and-save-identity.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import { compileAndSavePattern } from "../src/piece-helpers.ts";
+import {
+  COMPILE_CACHE_RUNTIME_VERSION,
+  loadCompiledClosure,
+} from "../src/compilation-cache/cell-cache.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+const signer = await Identity.fromPassphrase("compile-and-save-identity");
+const space = signer.did();
+
+// Regression (CT-1623): the piece save path (compileAndSavePattern, used by
+// `cf piece new/setsrc`) must associate the pattern's content-addressed
+// {identity, symbol} ref — with the REAL export symbol — and write the compiled
+// cache into the target space. Previously it compiled with no cacheCtx, so the
+// save side never learned an entryIdentity while the (cache-backed) load side
+// did; with a non-default mainExport the reload used the wrong symbol and the
+// pattern-change watcher never converged (cf piece setsrc hung under the ESM
+// loader once flipped on by default).
+describe("compileAndSavePattern associates the content-addressed identity", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      experimental: { esmModuleLoader: true },
+    });
+  });
+  afterEach(async () => {
+    await runtime?.patternManager.flushCompileCacheWrites();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  // A pattern exported under a NON-default name — the case that broke.
+  const NAMED: RuntimeProgram = {
+    main: "/main.tsx",
+    mainExport: "customPatternExport",
+    files: [
+      {
+        name: "/main.tsx",
+        contents: [
+          "import { pattern, lift } from 'commonfabric';",
+          "const dbl = lift((x:number)=>x*2);",
+          "export const customPatternExport = pattern<{ value: number }>(",
+          "  ({ value }) => ({ result: dbl(value) }),",
+          ");",
+        ].join("\n"),
+      },
+    ],
+  };
+
+  it("records {identity, symbol} with the real export name (not 'default')", async () => {
+    const pattern = await compileAndSavePattern(runtime, NAMED, { space });
+
+    const ref = runtime.patternManager.getPatternEntryRef(pattern);
+    expect(ref).toBeDefined();
+    expect(ref!.symbol).toBe("customPatternExport");
+    expect(typeof ref!.identity).toBe("string");
+    expect(ref!.identity.length).toBeGreaterThan(0);
+  });
+
+  it("writes the compiled cache into the target space (cache-backed save)", async () => {
+    const pattern = await compileAndSavePattern(runtime, NAMED, { space });
+    const ref = runtime.patternManager.getPatternEntryRef(pattern)!;
+    await runtime.patternManager.flushCompileCacheWrites();
+
+    const readTx = runtime.edit();
+    const closure = await loadCompiledClosure(
+      runtime,
+      space,
+      ref.identity,
+      {
+        runtimeVersion: COMPILE_CACHE_RUNTIME_VERSION,
+        compilerDid: runtime.userIdentityDID,
+      },
+      readTx,
+    );
+    readTx.abort?.("read complete");
+    // The save path populated the compiled closure, so the daemon's reload can
+    // hit the by-identity fast path instead of churning.
+    expect(closure.has(ref.identity)).toBe(true);
+  });
+});

--- a/packages/runner/test/esm-loader-config.test.ts
+++ b/packages/runner/test/esm-loader-config.test.ts
@@ -17,9 +17,10 @@ const envDefault: boolean = (() => {
     const v = (globalThis as {
       Deno?: { env?: { get(name: string): string | undefined } };
     }).Deno?.env?.get?.("CF_ESM_MODULE_LOADER");
-    return v === "1" || v === "true";
+    // Mirror readEnvDefault: ON by default unless explicitly "0"/"false".
+    return v !== "0" && v !== "false";
   } catch {
-    return false;
+    return true;
   }
 })();
 


### PR DESCRIPTION
Throwaway validation branch: PR #3843's fix + the flag flip (#3782) combined, to confirm the FUSE CLI integration passes under ESM-default-on. Will be closed once validated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flip ESM module loader ON by default and fix piece save/load identity mismatch so `cf piece setsrc` works with non‑default `mainExport` under ESM (CT-1623).

- **Bug Fixes**
  - `compileAndSavePattern` compiles with `{ space }` cache context to learn the entry identity, record the correct `{identity, symbol}`, and write compiled + source docs into the target space.
  - Non-cache ESM path now passes `entryIdentity` to `patternFromEvaluation` so the `{identity, symbol}` is consistent even when the compiled cache isn’t written.
  - Added a regression test to verify a named export records the right symbol and populates the compiled closure.

- **Migration**
  - ESM module-record loader is now the default. Set `CF_ESM_MODULE_LOADER=0` or `false` to use the legacy AMD loader.

<sup>Written for commit 2efd74bb94c785774c9e89474506170b8cebbb8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

