### PR TITLE
feat(ts-transformers): hoist pattern calls to module scope (CT-1655, pattern step)

### DIFF
--- a/packages/runner/test/compiled-module-verifier.test.ts
+++ b/packages/runner/test/compiled-module-verifier.test.ts
@@ -107,6 +107,33 @@ describe("verifyCompiledBundleModuleFactories()", () => {
     expect(() => verifyCompiledBundleModuleFactories(bundle)).not.toThrow();
   });
 
+  it("accepts a hoisted pattern(...) call at module scope", () => {
+    // CT-1655: extends whole-call hoisting to `pattern`. A reactive map lowers
+    // to `receiver.mapWithPattern(pattern(cb, inSchema, outSchema), { params })`;
+    // the bare `pattern(...)` (the first mapWithPattern argument) is hoisted to a
+    // module-scope const `__cfPattern_N = pattern(...)` with the callback inline,
+    // and the call site reads `mapWithPattern(__cfPattern_N, { params })`. The
+    // verifier must accept this trusted-builder call at module scope and verify
+    // its callback (index 0) there.
+    const bundle = `
+((runtimeDeps = {}) => {
+  define("main", ["require", "exports", "commonfabric"], function (require, exports, commonfabric_1) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    const __cfPattern_1 = (0, commonfabric_1.pattern)((__cf_pattern_input) => {
+      const item = __cf_pattern_input.key("element");
+      return item.key("name");
+    }, false, false);
+    exports.default = (0, commonfabric_1.pattern)((__cf_pattern_input) => ({
+      names: __cf_pattern_input.key("items").mapWithPattern(__cfPattern_1, {}),
+    }));
+  });
+});
+`;
+
+    expect(() => verifyCompiledBundleModuleFactories(bundle)).not.toThrow();
+  });
+
   it("accepts a previously parsed compiled bundle", () => {
     const bundle = `
 ((runtimeDeps = {}) => {

--- a/packages/ts-transformers/docs/derive-to-lift-design.md
+++ b/packages/ts-transformers/docs/derive-to-lift-design.md
@@ -13,13 +13,16 @@ of the `lift(...)({})` stopgap). **Phase 2 complete in CT-1644**
 `const __cfLift_N = __cfHelpers.lift(...)`, after SchemaInjection; subsumes lift
 from the CT-1585 callback hoister). `derive` has since been fully retired from
 both the transformer (CT-1643) and the runtime export (CT-1624). **CT-1655
-extends Phase 2's whole-call hoisting to the other builders**: `handler` shipped
-(hoisted to `const __cfHandler_N`, subsuming handler from the CT-1585 callback
-hoister); `pattern`/`patternTool` remain (different `mapWithPattern`-arg
-mechanic). See the follow-up section after the phase table. **Phase 3
-(`selfcontained` marker) is now the active phase** — its design below is current
-and its open questions are mostly resolved (see the Phase 3 section and
-tracker)._
+extends Phase 2's whole-call hoisting to the other builders**: `handler`
+(hoisted to `const __cfHandler_N`) and `pattern` (hoisted to
+`const __cfPattern_N` out of `mapWithPattern`'s first argument) shipped, both
+subsuming their builder from the CT-1585 callback hoister; the hoisting stage
+was renamed `LiftHoistingTransformer` → `BuilderCallHoistingTransformer`
+accordingly. Only `patternTool` remains (its captures thread through the call's
+own argument, so whole-call hoisting needs a safety investigation first). See
+the follow-up section after the phase table. **Phase 3 (`selfcontained` marker)
+is now the active phase** — its design below is current and its open questions
+are mostly resolved (see the Phase 3 section and tracker)._
 
 ## Motivation
 
@@ -64,22 +67,62 @@ on the outer call. Implementation notes:
   injection, write-authorization, etc.) is unaffected.
 - `handler` is removed from CT-1585's `HOISTABLE_BUILDER_NAMES` in the same
   change to avoid the double-hoist TDZ (the two consts would reference each
-  other out of declaration order). `BuilderCallbackHoistingTransformer` now owns
-  only `pattern`/`patternTool`.
+  other out of declaration order).
 - The hoist-prefix original-node fallback in `resolveBuilderExpressionKind` is
   generalized to `__cfHandler` so the synthetic `__cfHandler_N(captures)` site
   still classifies as `handler` for the stages that run after hoisting.
 
-**Pattern / patternTool are the remaining piece of CT-1655.** Their hoist is a
-_different_ mechanic: `pattern` is not applied — it appears as
-`expr.mapWithPattern(__cfHelpers.pattern(cb, …), { extraParams })`, so the bare
-`pattern(...)` call (argument 0 of `mapWithPattern`) is hoisted and the call is
-rewritten to thread the hoisted name, while per-instance captures continue to
-flow through `mapWithPattern`'s second argument. The top-level
-`export default pattern(...)` is already module-scope and must NOT be hoisted.
-When pattern/patternTool land here too, `HOISTABLE_BUILDER_NAMES` empties and
-`BuilderCallbackHoistingTransformer` can be deleted — the "one unified hoisting
-phase" end-state.
+**Pattern shipped in CT-1655 (next).** `pattern`'s hoist is a _different_
+mechanic: pattern is not applied — a reactive map lowers to
+`expr.mapWithPattern(__cfHelpers.pattern(cb, inSchema, outSchema), { params })`,
+so the bare `pattern(...)` call (argument 0 of `mapWithPattern`) is the
+hoistable unit, with per-instance captures flowing through `mapWithPattern`'s
+_second_ argument. The bare pattern call is therefore capture-free and safe to
+evaluate once at module scope. Implementation notes:
+
+- The hoisting stage was renamed `LiftHoistingTransformer` →
+  `BuilderCallHoistingTransformer` (`lift-hoisting.ts` →
+  `builder-call-hoisting.ts`): it now owns lift + handler + pattern, the
+  "Call"-vs-"Callback" contrast distinguishing it from the
+  `BuilderCallbackHoistingTransformer` it is subsuming.
+- `HoistableBuilderSpec` gains an optional `rewriteSite` hook. Applied builders
+  (lift/handler) keep the default callee-swap; pattern provides `rewriteSite` to
+  replace just `mapWithPattern`'s first argument with the hoisted name, leaving
+  the callee and the params argument intact.
+- Recognition is positional via `getMapWithPatternHoistablePatternCall`: a
+  `*WithPattern` call whose first argument is a `pattern(...)` builder call. The
+  top-level `export default pattern(...)` is a _direct_ call (not a
+  `*WithPattern` argument), so it is naturally excluded — no special guard
+  needed.
+- `pattern` is removed from CT-1585's `HOISTABLE_BUILDER_NAMES` in the same
+  change (same double-hoist-TDZ rationale; observed directly without it).
+- Pattern's hoisted reference sits in `mapWithPattern` argument position, not an
+  applied reactive-origin site, so it does _not_ need the
+  `resolveBuilderExpressionKind` original-node fallback (confirmed: full suite
+  green without it).
+- **Insertion ordering (eager-callback hazard).** `pattern(...)` _invokes_ its
+  callback eagerly at construction (`runner/src/builder/pattern.ts`,
+  `const outputs = fn(...)`) to capture the reactive graph — unlike `lift`/
+  `handler`, whose callbacks are stored and run lazily. So a hoisted
+  `const __cfPattern_N = pattern(cb)` placed naïvely after the imports throws a
+  module-load TDZ `ReferenceError` if `cb` reads a module-scoped binding
+  declared later (e.g. `const onRemoveFavorite = handler(...)` used inside a
+  mapped JSX — see `patterns/system/favorites-manager.tsx`). The stage therefore
+  no longer pools all hoists into one after-imports block; it flushes each
+  statement's hoists immediately _before_ that top-level statement. That keeps
+  every hoist after the module-scoped bindings its (eagerly-run) callback
+  references, since the original use site necessarily followed those
+  declarations. The transformer's golden tests only check emitted text, so this
+  was caught by the runner's pattern-execution tests, not the fixture suite.
+
+**`patternTool` is deferred.** Unlike `pattern`,
+`patternTool(fn, { extraParams })` is a direct call whose per-instance captures
+thread through its _own_ second argument — so whole-call hoisting would relocate
+those captures to module scope, which is only safe if `extraParams` can never
+carry per-instance reactive state. That needs investigation, so `patternTool`
+stays in `BuilderCallbackHoistingTransformer` for now. When it is resolved,
+`HOISTABLE_BUILDER_NAMES` empties and `BuilderCallbackHoistingTransformer` can
+be deleted — the "one unified hoisting phase" end-state.
 
 ## Relationship to prior work
 

--- a/packages/ts-transformers/src/ast/call-kind.ts
+++ b/packages/ts-transformers/src/ast/call-kind.ts
@@ -108,6 +108,20 @@ export const SYNTHETIC_LIFT_HOIST_PREFIX = "__cfLift";
  */
 export const SYNTHETIC_HANDLER_HOIST_PREFIX = "__cfHandler";
 
+/**
+ * Prefix for the module-scope const a hoisted `pattern(...)` call is bound to
+ * (CT-1655). Pattern's hoist differs from lift/handler: the bare
+ * `__cfHelpers.pattern(cb, inputSchema, outputSchema)` call sits in the FIRST
+ * argument of an enclosing `receiver.mapWithPattern(pattern(...), { params })`
+ * call (per-instance captures flow through the params object, the second
+ * argument). The bare pattern call is hoisted to
+ * `const __cfPattern_N = __cfHelpers.pattern(...)` and the `*WithPattern` call's
+ * first argument is rewritten to `__cfPattern_N`. The top-level
+ * `export default pattern(...)` is a direct call (not a `*WithPattern`
+ * argument) and is NOT hoisted.
+ */
+export const SYNTHETIC_PATTERN_HOIST_PREFIX = "__cfPattern";
+
 export type ArrayMethodFamilyName = "map" | "filter" | "flatMap";
 
 export interface ArrayMethodAccessKind {
@@ -330,6 +344,50 @@ export function getPatternToolCallbackArgument(
   return callbackArg
     ? resolveCallbackFunctionExpression(callbackArg, checker)
     : undefined;
+}
+
+/**
+ * If `call` is a lowered reactive array-method call in the `*WithPattern`
+ * family — `mapWithPattern` / `filterWithPattern` / `flatMapWithPattern`, and
+ * any future lowered array method registered with `lowered: true` — whose FIRST
+ * argument is a bare `pattern(...)` builder call, return that inner pattern call
+ * (the hoistable unit). Otherwise return undefined. Recognition keys on the
+ * array-method family's `lowered` flag, not a hardcoded method name, so new
+ * `*WithPattern` lowerings are picked up automatically. The canonical shape is
+ * `receiver.mapWithPattern(pattern(...), { params })`.
+ *
+ * This is how the hoisting stage finds the pattern call to relocate (CT-1655):
+ * unlike lift/handler, the pattern call is not *applied* — it sits in the first
+ * argument position of the enclosing `*WithPattern` call, with per-instance
+ * captures threaded through that call's SECOND argument (the params object).
+ * So the bare `pattern(...)` is capture-free and safe to evaluate once at
+ * module scope. The top-level `export default pattern(...)` is a direct call,
+ * not a `*WithPattern` argument, so it is naturally excluded.
+ */
+export function getWithPatternHoistablePatternCall(
+  call: ts.CallExpression,
+  checker: ts.TypeChecker,
+): ts.CallExpression | undefined {
+  const callee = stripWrappers(call.expression);
+  if (!ts.isPropertyAccessExpression(callee)) {
+    return undefined;
+  }
+  const accessKind = getArrayMethodAccessKindByName(callee.name.text);
+  if (!accessKind?.lowered) {
+    return undefined;
+  }
+  const firstArg = call.arguments[0];
+  if (!firstArg) {
+    return undefined;
+  }
+  const patternCall = stripWrappers(firstArg);
+  if (
+    !ts.isCallExpression(patternCall) ||
+    !isPatternBuilderCall(patternCall, checker)
+  ) {
+    return undefined;
+  }
+  return patternCall;
 }
 
 export function getCapabilitySummaryCallbackArgument(

--- a/packages/ts-transformers/src/cf-pipeline.ts
+++ b/packages/ts-transformers/src/cf-pipeline.ts
@@ -1,10 +1,10 @@
 import {
   BuilderCallbackHoistingTransformer,
+  BuilderCallHoistingTransformer,
   CastValidationTransformer,
   EmptyArrayOfValidationTransformer,
   HelperOwnedExpressionSiteLoweringTransformer,
   JsxExpressionSiteRouterTransformer,
-  LiftHoistingTransformer,
   ModuleScopeCfDataTransformer,
   ModuleScopeFunctionHardeningTransformer,
   ModuleScopeShadowingTransformer,
@@ -88,8 +88,8 @@ const CFC_TRANSFORMER_STAGE_SPECS: readonly TransformerStageSpec[] = [
     create: (options) => new SchemaInjectionTransformer(options),
   },
   {
-    name: "LiftHoistingTransformer",
-    create: (options) => new LiftHoistingTransformer(options),
+    name: "BuilderCallHoistingTransformer",
+    create: (options) => new BuilderCallHoistingTransformer(options),
   },
   {
     name: "SchemaGeneratorTransformer",

--- a/packages/ts-transformers/src/closures/module-scope-callback-hoisting.ts
+++ b/packages/ts-transformers/src/closures/module-scope-callback-hoisting.ts
@@ -4,6 +4,7 @@ import {
   SYNTHETIC_HANDLER_HOIST_PREFIX,
   SYNTHETIC_LIFT_HOIST_PREFIX,
   SYNTHETIC_MODULE_CALLBACK_PREFIX,
+  SYNTHETIC_PATTERN_HOIST_PREFIX,
 } from "../ast/call-kind.ts";
 import {
   isDeclaredWithinFunction,
@@ -13,17 +14,19 @@ import { CF_HELPERS_IDENTIFIER } from "../core/cf-helpers.ts";
 import { unwrapExpression } from "../utils/expression.ts";
 import type { TransformationContext } from "../core/mod.ts";
 
-// `lift` and `handler` are intentionally absent. As of CT-1644 (Phase 2 of
-// derive→lift→selfcontained) `LiftHoistingTransformer` hoists the entire
-// `lift(...)` call to a module-scope const; CT-1655 extends that to the
-// `handler(...)` call. Hoisting the *callback* here too would double-hoist:
-// the two consts reference each other out of declaration order, a TDZ
-// ReferenceError at module load. This hoister keeps the builders whose
-// whole-call hoist hasn't landed yet (`pattern`/`patternTool`); when they get
-// the same treatment they move to LiftHoistingTransformer and this set empties
-// out, at which point this hoister can be deleted.
+// `lift`, `handler`, and `pattern` are intentionally absent. The whole-call
+// hoisting stage (`BuilderCallHoistingTransformer`) hoists the entire builder call to
+// a module-scope const: `lift` (CT-1644), then `handler` and `pattern`
+// (CT-1655). Hoisting the *callback* here too would double-hoist — the two
+// consts reference each other out of declaration order, a TDZ ReferenceError at
+// module load (observed directly: `const __cfPattern_1 = pattern(__cfModuleCallback_1, …)`
+// declared before `const __cfModuleCallback_1 = …`). Only `patternTool` remains:
+// its whole-call hoist is deferred because its per-instance captures thread
+// through the call's own second argument (unlike `pattern`, whose captures live
+// in the enclosing `mapWithPattern` params), so relocating the whole call to
+// module scope is not obviously capture-safe. When `patternTool` is resolved
+// this set empties and this hoister can be deleted.
 const HOISTABLE_BUILDER_NAMES = new Set([
-  "pattern",
   "patternTool",
 ]);
 
@@ -52,24 +55,26 @@ const HOISTABLE_BUILDER_NAMES = new Set([
  *     count as "uses module-scoped references" and incorrectly promote
  *     the outer callback to hoistable. The exclusion keeps the inner
  *     and outer hoist decisions independent.
- *   - `__cfLift` / `__cfHandler` (prefixes): the whole-call hoisting stage's
- *     output (`LiftHoistingTransformer`, CT-1644 lift / CT-1655 handler). A
- *     hoisted `lift(...)` / `handler(...)` call leaves a `__cfLift_N(captures)`
- *     / `__cfHandler_N(captures)` reference at its original site. If that site
- *     sits inside a callback this hoister analyzes (e.g. a pattern callback),
- *     the reference must not count as a user-authored module-scoped reference
- *     — same independence rationale as `__cfModuleCallback` above. (Today the
- *     hoisting stage runs *after* this one, so these references don't yet exist
- *     when this hoister analyzes; the exclusion is kept symmetric with the hoist
- *     prefixes so it stays correct as the unified phase converges and is robust
- *     to any future re-ordering.)
+ *   - `__cfLift` / `__cfHandler` / `__cfPattern` (prefixes): the whole-call
+ *     hoisting stage's output (`BuilderCallHoistingTransformer`, CT-1644 lift /
+ *     CT-1655 handler + pattern). A hoisted `lift(...)` / `handler(...)` /
+ *     `pattern(...)` call leaves a `__cfLift_N(captures)` /
+ *     `__cfHandler_N(captures)` / `__cfPattern_N` reference at its original
+ *     site. If that site sits inside a callback this hoister analyzes (e.g. a
+ *     patternTool callback), the reference must not count as a user-authored
+ *     module-scoped reference — same independence rationale as
+ *     `__cfModuleCallback` above. (Today the hoisting stage runs *after* this
+ *     one, so these references don't yet exist when this hoister analyzes; the
+ *     exclusion is kept symmetric with the hoist prefixes so it stays correct
+ *     as the unified phase converges and is robust to any future re-ordering.)
  */
 function isTransformerInjectedIdentifier(text: string): boolean {
   return text === CF_HELPERS_IDENTIFIER ||
     text.startsWith(FUNCTION_HARDENING_HELPER_NAME) ||
     text.startsWith(SYNTHETIC_MODULE_CALLBACK_PREFIX) ||
     text.startsWith(SYNTHETIC_LIFT_HOIST_PREFIX) ||
-    text.startsWith(SYNTHETIC_HANDLER_HOIST_PREFIX);
+    text.startsWith(SYNTHETIC_HANDLER_HOIST_PREFIX) ||
+    text.startsWith(SYNTHETIC_PATTERN_HOIST_PREFIX);
 }
 
 export function hoistModuleScopedBuilderCallbacks(
@@ -263,7 +268,7 @@ function resolveHoistTarget(
 
   // Lift-applied shape (`__cfHelpers.lift(...)(input)`): the outer call's
   // callee is itself a call expression. As of CT-1644 this hoister no longer
-  // touches lift — `LiftHoistingTransformer` (which runs after SchemaInjection)
+  // touches lift — `BuilderCallHoistingTransformer` (which runs after SchemaInjection)
   // hoists the WHOLE lift call to module scope, callback inline. Hoisting the
   // callback here as well would double-hoist into a TDZ at module load. Refuse
   // all applied-call shapes.

--- a/packages/ts-transformers/src/transformers/builder-call-hoisting.ts
+++ b/packages/ts-transformers/src/transformers/builder-call-hoisting.ts
@@ -3,18 +3,25 @@ import {
   detectCallKind,
   getHandlerAppliedInnerCall,
   getLiftAppliedInnerCall,
+  getWithPatternHoistablePatternCall,
   isHandlerAppliedCall,
   SYNTHETIC_HANDLER_HOIST_PREFIX,
   SYNTHETIC_LIFT_HOIST_PREFIX,
+  SYNTHETIC_PATTERN_HOIST_PREFIX,
 } from "../ast/call-kind.ts";
 import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
 
 /**
- * Phase 2 of derive→lift→selfcontained (CT-1644): hoist every reactive
- * `lift(...)` call to module scope.
+ * Hoist every reactive *builder call* to module scope: `lift` (CT-1644, Phase 2
+ * of derive→lift→selfcontained), then `handler` and `pattern` (CT-1655). Each
+ * becomes a named, addressable, eventually-selfcontainable module-scope const —
+ * the substrate Phase 3 wraps with `selfcontained(...)`. (Formerly named
+ * `LiftHoistingTransformer` / `lift-hoisting.ts`, when it only owned lift.)
  *
- * After Phase 1 (CT-1615) and SchemaInjection, every reactive lift-style
- * computation in lowered output is the schema-injected *lift-applied* shape:
+ * The hoist mechanic differs by builder shape; see {@link HOISTABLE_BUILDERS}.
+ * For the original lift case: after Phase 1 (CT-1615) and SchemaInjection, every
+ * reactive lift-style computation in lowered output is the schema-injected
+ * *lift-applied* shape:
  *
  * ```ts
  *   __cfHelpers.lift(argSchema, resSchema, callback)(captures).for("result", true)
@@ -69,7 +76,7 @@ import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
  * register here too, converging CT-1585 and this stage into one hoisting phase
  * without restructuring.
  */
-export class LiftHoistingTransformer extends HelpersOnlyTransformer {
+export class BuilderCallHoistingTransformer extends HelpersOnlyTransformer {
   override transform(context: TransformationContext): ts.SourceFile {
     return hoistBuilderCalls(context.sourceFile, context);
   }
@@ -80,10 +87,19 @@ export class LiftHoistingTransformer extends HelpersOnlyTransformer {
  * this builder's hoistable unit and, if so, return the inner call to relocate
  * to module scope plus the name prefix to bind it under.
  *
- * `innerCall` is the expression bound to `const <prefix>_N`. The original
- * outer call is rewritten to `<prefix>_N(...outer arguments)`, preserving any
- * surrounding member chain (e.g. the `.for(...)` tail) since that hangs off the
- * outer call node, which keeps its position.
+ * `innerCall` is the expression bound to `const <prefix>_N`. How the original
+ * site is rewritten to reference that name depends on the builder shape:
+ *
+ *   - **Applied builders** (`lift`/`handler`): the visited call IS the inner
+ *     call applied to captures — `inner(captures)`. The default rewrite swaps
+ *     the callee for the hoisted name, leaving the captures arguments and any
+ *     surrounding member chain (e.g. the `.for(...)` tail) anchored in place.
+ *   - **Argument-position builders** (`pattern`/`patternTool`): the visited
+ *     call is the *enclosing* `mapWithPattern` call and the inner pattern call
+ *     sits in one of its arguments. The default callee-swap is wrong here — the
+ *     callee (`.mapWithPattern`) and the other arguments must survive untouched.
+ *     Such builders provide {@link rewriteSite} to replace just the argument
+ *     that held the inner call with the hoisted name.
  */
 interface HoistableBuilderSpec {
   readonly prefix: string;
@@ -91,6 +107,18 @@ interface HoistableBuilderSpec {
     call: ts.CallExpression,
     context: TransformationContext,
   ) => ts.CallExpression | undefined;
+  /**
+   * Optional: produce the replacement for the visited site once the inner call
+   * has been hoisted to `hoistedName`. Omit for applied builders, which take
+   * the default callee-swap. Provide it when the inner call sits in an argument
+   * position (the visited call is an enclosing call whose callee must survive).
+   */
+  readonly rewriteSite?: (
+    visited: ts.CallExpression,
+    hoistedName: ts.Identifier,
+    innerCall: ts.CallExpression,
+    factory: ts.NodeFactory,
+  ) => ts.Expression;
 }
 
 const LIFT_BUILDER: HoistableBuilderSpec = {
@@ -126,9 +154,35 @@ const HANDLER_BUILDER: HoistableBuilderSpec = {
   },
 };
 
+const PATTERN_BUILDER: HoistableBuilderSpec = {
+  prefix: SYNTHETIC_PATTERN_HOIST_PREFIX,
+  resolveHoistable: (call, context) => {
+    // Pattern is NOT applied: the bare `__cfHelpers.pattern(cb, inSchema,
+    // outSchema)` call sits in the FIRST argument of an enclosing
+    // `receiver.mapWithPattern(pattern(...), { params })` call (per-instance
+    // captures flow through the params object, the second argument). The
+    // visited node here is the `*WithPattern` call; the hoistable unit is its
+    // first argument. Because captures live in the params object, the bare
+    // pattern call is capture-free and safe to relocate to module scope.
+    return getWithPatternHoistablePatternCall(call, context.checker);
+  },
+  rewriteSite: (visited, hoistedName, _innerCall, factory) => {
+    // Replace ONLY the first argument (the pattern call) with the hoisted name,
+    // keeping the `.mapWithPattern` callee and the trailing params argument(s)
+    // intact. (Applied builders take the default callee-swap instead.)
+    return factory.updateCallExpression(
+      visited,
+      visited.expression,
+      visited.typeArguments,
+      [hoistedName, ...visited.arguments.slice(1)],
+    );
+  },
+};
+
 const HOISTABLE_BUILDERS: readonly HoistableBuilderSpec[] = [
   LIFT_BUILDER,
   HANDLER_BUILDER,
+  PATTERN_BUILDER,
 ];
 
 function hoistBuilderCalls(
@@ -136,7 +190,21 @@ function hoistBuilderCalls(
   context: TransformationContext,
 ): ts.SourceFile {
   const factory = context.factory;
-  const hoisted: ts.Statement[] = [];
+
+  // Hoisted consts produced while visiting the CURRENT top-level statement.
+  // They are flushed immediately before that statement (see below), not pooled
+  // into a single after-imports block. This keeps each hoisted const *after*
+  // every module-scoped binding declared in an earlier top-level statement —
+  // which the original use site necessarily followed, since you cannot
+  // reference a binding before its declaration in valid source. That ordering
+  // matters because `pattern(...)` INVOKES its callback eagerly at construction
+  // (unlike `lift`/`handler`, whose callbacks are stored and run lazily): a
+  // hoisted `const __cfPattern_N = pattern(cb)` whose `cb` reads a later
+  // module-scoped `const onRemoveFavorite = handler(...)` would otherwise throw
+  // a module-load TDZ `ReferenceError`. (Verified against
+  // patterns/system/favorites-manager.tsx; the after-imports placement that is
+  // safe for lift/handler is NOT safe for pattern.)
+  let pendingHoists: ts.Statement[] = [];
 
   // Per-file counters keyed by builder prefix. Explicit counters + literal
   // suffixes (NOT `factory.createUniqueName`, whose `.text` carries only the
@@ -171,7 +239,7 @@ function hoistBuilderCalls(
       ts.setOriginalNode(name, innerCall);
 
       // const <prefix>_N = <inner lift(...) call>;
-      hoisted.push(
+      pendingHoists.push(
         factory.createVariableStatement(
           undefined,
           factory.createVariableDeclarationList(
@@ -188,11 +256,16 @@ function hoistBuilderCalls(
         ),
       );
 
-      // Rewrite the site to apply the captures to the hoisted name. We reuse
-      // the visited outer call's own node identity (updateCallExpression) so
-      // any surrounding member chain — notably the `.for(...)` tail that
-      // ReactiveVariableForTransformer later expects on the result — stays
-      // anchored to the same position.
+      // Rewrite the site to reference the hoisted name. Applied builders take
+      // the default callee-swap: reuse the visited outer call's own node
+      // identity (updateCallExpression) so any surrounding member chain —
+      // notably the `.for(...)` tail that ReactiveVariableForTransformer later
+      // expects on the result — stays anchored to the same position.
+      // Argument-position builders (pattern/patternTool) override via
+      // `rewriteSite` to replace just the argument that held the inner call.
+      if (builder.rewriteSite) {
+        return builder.rewriteSite(visited, name, innerCall, factory);
+      }
       return factory.updateCallExpression(
         visited,
         name,
@@ -204,36 +277,20 @@ function hoistBuilderCalls(
     return visited;
   };
 
-  const transformed = ts.visitNode(sourceFile, visit) as ts.SourceFile;
-  if (hoisted.length === 0) {
-    return transformed;
+  // Visit each top-level statement, flushing the hoists it produced immediately
+  // BEFORE it. A statement's hoisted consts are placed after every preceding
+  // top-level statement — and therefore after every module-scoped binding the
+  // hoisted (eagerly-run) pattern callbacks reference, since those bindings had
+  // to precede the original use site. Among hoists from the same statement,
+  // post-order traversal already pushed inner/earlier calls first, so a hoist
+  // that references another hoist (e.g. `__cfPattern` whose callback calls
+  // `__cfLift`) sees it declared above.
+  const resultStatements: ts.Statement[] = [];
+  for (const statement of sourceFile.statements) {
+    pendingHoists = [];
+    const visitedStatement = ts.visitNode(statement, visit) as ts.Statement;
+    resultStatements.push(...pendingHoists, visitedStatement);
   }
 
-  const insertAt = findHoistInsertionIndex(transformed.statements);
-  return factory.updateSourceFile(transformed, [
-    ...transformed.statements.slice(0, insertAt),
-    ...hoisted,
-    ...transformed.statements.slice(insertAt),
-  ]);
-}
-
-/**
- * Insert hoisted consts immediately after the leading import declarations.
- * The hoisted lift const's initializer eagerly evaluates only self-contained
- * schema literals and constructs (does not invoke) its inline callback, so it
- * has no eager module-level identifier dependency that placement after imports
- * could leave undefined. (Verified by spike: a lift closing over a later
- * module-level `const` runs clean, because the reference lives in the
- * lazily-invoked callback body.)
- */
-function findHoistInsertionIndex(
-  statements: readonly ts.Statement[],
-): number {
-  let index = 0;
-  while (
-    index < statements.length && ts.isImportDeclaration(statements[index])
-  ) {
-    index += 1;
-  }
-  return index;
+  return factory.updateSourceFile(sourceFile, resultStatements);
 }

--- a/packages/ts-transformers/src/transformers/builder-callback-hoisting.ts
+++ b/packages/ts-transformers/src/transformers/builder-callback-hoisting.ts
@@ -3,15 +3,22 @@ import { HelpersOnlyTransformer, TransformationContext } from "../core/mod.ts";
 import { hoistModuleScopedBuilderCallbacks } from "../closures/module-scope-callback-hoisting.ts";
 
 /**
- * Hoist builder callbacks (handler/pattern/patternTool) whose body closes
- * only over module-level symbols. The hoisted form becomes
- * `const __cfModuleCallback_N = ...` at module scope, replacing the inline
- * callback at the call site with a reference to the new name.
+ * Hoist builder callbacks whose body closes only over module-level symbols.
+ * The hoisted form becomes `const __cfModuleCallback_N = ...` at module scope,
+ * replacing the inline callback at the call site with a reference to the new
+ * name.
  *
- * `lift` is NOT handled here: as of CT-1644 `LiftHoistingTransformer` (which
- * runs after SchemaInjection) hoists the whole `lift(...)` call to module scope
- * with its callback inline. When `handler` and `pattern` get the same
- * whole-call treatment, this stage folds into that one unified hoisting phase.
+ * Only `patternTool` is handled here now. `lift` (CT-1644), `handler`, and
+ * `pattern` (CT-1655) get their WHOLE call hoisted by
+ * `BuilderCallHoistingTransformer` (which runs after SchemaInjection) with the
+ * callback inline; hoisting the callback here too would double-hoist into a
+ * module-load TDZ, so they are removed from this stage's set. `patternTool`
+ * remains because its per-instance captures thread through the call's own
+ * second argument (unlike `pattern`, whose captures live in the enclosing
+ * `mapWithPattern` params), so relocating its whole call is not obviously
+ * capture-safe — pending follow-up. When `patternTool` is resolved this stage
+ * empties and can be deleted, leaving `BuilderCallHoistingTransformer` as the
+ * sole module-scope hoisting phase.
  *
  * This stage runs after `PatternCallbackLoweringTransformer` so that
  * pattern callbacks have their in-place lowerings (the

--- a/packages/ts-transformers/src/transformers/mod.ts
+++ b/packages/ts-transformers/src/transformers/mod.ts
@@ -1,10 +1,10 @@
+export { BuilderCallHoistingTransformer } from "./builder-call-hoisting.ts";
 export { BuilderCallbackHoistingTransformer } from "./builder-callback-hoisting.ts";
 export { CastValidationTransformer } from "./cast-validation.ts";
 export { PatternCallbackLoweringTransformer } from "./pattern-callback-lowering.ts";
 export { EmptyArrayOfValidationTransformer } from "./empty-array-of-validation.ts";
 export { HelperOwnedExpressionSiteLoweringTransformer } from "./helper-owned-expression-site-lowering.ts";
 export { JsxExpressionSiteRouterTransformer } from "./jsx-expression-site-router.ts";
-export { LiftHoistingTransformer } from "./lift-hoisting.ts";
 export { ModuleScopeCfDataTransformer } from "./module-scope-cf-data.ts";
 export { ModuleScopeFunctionHardeningTransformer } from "./module-scope-function-hardening.ts";
 export { ModuleScopeShadowingTransformer } from "./module-scope-shadowing.ts";

--- a/packages/ts-transformers/test/closures/module-scope-helper-hoisting.test.ts
+++ b/packages/ts-transformers/test/closures/module-scope-helper-hoisting.test.ts
@@ -83,20 +83,23 @@ Deno.test("Closure Transformer does not hoist nested handler callbacks that also
   );
 });
 
-Deno.test("CT-1585: Closure Transformer hoists synthesized mapWithPattern callback that closes only over module-level symbols", async () => {
+Deno.test("CT-1655: whole synthesized mapWithPattern pattern() call is hoisted to module scope", async () => {
   // Source shape: a .map() callback whose body invokes a module-level
   // pattern factory (`EntryRow`) and reads a module-level constant
   // (`UI`). After the closure transformer rewrites .map() to
-  // .mapWithPattern(__cfHelpers.pattern(...)), the synthesized pattern
-  // callback closes only over module-scoped references — there are no
-  // per-call-site captures. The `hoistModuleScopedBuilderCallbacks` tail
-  // step should therefore hoist the synthesized callback to module scope
-  // and replace it at the call site with a reference to the hoisted name.
+  // `.mapWithPattern(__cfHelpers.pattern(cb, inSchema, outSchema), { params })`,
+  // the synthesized pattern callback closes only over module-scoped references —
+  // there are no per-call-site captures (the params object is empty).
   //
-  // Currently failing: the hoister does not fire on the synthesized
-  // pattern callback. The inline `__cfHelpers.pattern((_input) => { ... })`
-  // remains at the call site instead of being replaced by a hoisted
-  // reference. See CT-1585.
+  // CT-1585 originally hoisted just the *callback* to `__cfModuleCallback_N`.
+  // CT-1655 instead hoists the WHOLE `pattern(...)` call (the first argument of
+  // mapWithPattern) to a module-scope `const __cfPattern_N = __cfHelpers
+  // .pattern(...)`, with the callback inline, and rewrites the mapWithPattern
+  // first argument to reference the hoisted name. (Hoisting the callback here
+  // too — the CT-1585 mechanic — would double-hoist into a module-load TDZ, so
+  // `pattern` is removed from that hoister's set.) The property this test
+  // guards is unchanged: a module-scope-only pattern becomes a named,
+  // module-scope, self-contained unit.
   const source = `    import { pattern, UI } from "commonfabric";
 
     interface Entry { piece: string }
@@ -122,28 +125,30 @@ Deno.test("CT-1585: Closure Transformer hoists synthesized mapWithPattern callba
   const output = await transformSource(source, options);
   const normalized = output.replace(/\s+/g, " ");
 
-  // The synthesized pattern callback should be hoisted to module scope.
-  // Hoisting runs *after* PatternCallbackLowering (see CT-1585), so the
-  // hoisted callback has the fully-lowered shape:
-  //   `__cf_pattern_input => { const entry = __cf_pattern_input.key("element"); ... }`
-  // (rather than the destructured form `({ element, params }) => ...`
-  // which exists transiently between stages 7 and 11). The exact name
-  // is generated; capture it for the call-site assertion.
+  // The whole pattern() call is hoisted to module scope with its callback
+  // inline. Hoisting runs *after* PatternCallbackLowering, so the inline
+  // callback has the fully-lowered shape
+  // `__cf_pattern_input => { const entry = __cf_pattern_input.key("element"); ... }`.
+  // The exact const name is generated; capture it for the call-site assertion.
   const hoistedMatch = normalized.match(
-    /const (__cfModuleCallback_?\d+) = (?:__cfHardenFn\()?\(?__cf_pattern_input\b/,
+    /const (__cfPattern_\d+) = __cfHelpers\.pattern\(\s*__cf_pattern_input\b/,
   );
   assert(
     hoistedMatch,
-    `expected synthesized pattern callback to be hoisted to module scope. Output was:\n${output}`,
+    `expected whole pattern() call hoisted to module scope. Output was:\n${output}`,
   );
 
   const hoistedName = hoistedMatch[1]!;
-  // The mapWithPattern call site should reference the hoisted name
-  // rather than carry the callback inline.
+  // The mapWithPattern call site references the hoisted name as its first
+  // argument (callback no longer inline at the site).
   assertMatch(
     normalized,
-    new RegExp(
-      `mapWithPattern\\(\\s*__cfHelpers\\.pattern\\(\\s*${hoistedName}\\b`,
-    ),
+    new RegExp(`mapWithPattern\\(\\s*${hoistedName}\\b`),
+  );
+  // And the CT-1585 callback-hoist no longer fires for pattern (no separate
+  // hardened `__cfModuleCallback_N` wrapper for this callback).
+  assertNotMatch(
+    normalized,
+    /const __cfModuleCallback_\d+ = __cfHardenFn\(\(?__cf_pattern_input\b/,
   );
 });

--- a/packages/ts-transformers/test/fixtures/ast-transform/authored-ifelse-reactive-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/authored-ifelse-reactive-roots.expected.jsx
@@ -11,6 +11,7 @@ import { ifElse, pattern, Writable } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const identity = __cfHardenFn(<T,>(value: T) => value);
 const __cfLift_1 = __cfHelpers.lift<{
     name: string;
 }, string>({
@@ -77,7 +78,6 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, ({ name }) => name.trim());
-const identity = __cfHardenFn(<T,>(value: T) => value);
 // FIXTURE: authored-ifelse-reactive-roots
 // Verifies: authored ifElse outside JSX and top-level receiver-method roots lower reactively
 //   ifElse(show, count + 1, 0)         → compute-wrapped branch

--- a/packages/ts-transformers/test/fixtures/ast-transform/builder-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/builder-conditional.expected.jsx
@@ -11,6 +11,10 @@ import { Default, NAME, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface PatternState {
+    count: Default<number, 0>;
+    label: Default<string, "">;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         count: number;
@@ -32,10 +36,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.count > 0);
-interface PatternState {
-    count: Default<number, 0>;
-    label: Default<string, "">;
-}
 // FIXTURE: builder-conditional
 // Verifies: ternary in JSX is transformed to ifElse() with a lift-applied condition
 //   state.count > 0 ? <p>A</p> : <p>B</p> → __cfHelpers.ifElse(...schemas, lift(...)({...}), <p>A</p>, <p>B</p>)

--- a/packages/ts-transformers/test/fixtures/ast-transform/computed-alias-const-rewrite.expected.js
+++ b/packages/ts-transformers/test/fixtures/ast-transform/computed-alias-const-rewrite.expected.js
@@ -11,10 +11,10 @@ import { computed } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift(false, () => 1);
 // FIXTURE: computed-alias-const-rewrite
 // Verifies: stable const aliases to `computed()` still lower to `derive()`.
 const alias = computed;
+const __cfLift_1 = __cfHelpers.lift(false, () => 1);
 export default __cfLift_1();
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }

--- a/packages/ts-transformers/test/fixtures/ast-transform/computed-object-literal-input.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/computed-object-literal-input.expected.jsx
@@ -11,28 +11,6 @@ import { cell, computed, lift } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = lift({
-    type: "string"
-} as const satisfies __cfHelpers.JSONSchema, {
-    type: "string"
-} as const satisfies __cfHelpers.JSONSchema, (value: string) => value);
-const __cfLift_2 = lift({
-    type: "number"
-} as const satisfies __cfHelpers.JSONSchema, {
-    type: "number"
-} as const satisfies __cfHelpers.JSONSchema, (count: number) => count);
-const __cfLift_3 = lift({
-    type: "number"
-} as const satisfies __cfHelpers.JSONSchema, {
-    type: "number"
-} as const satisfies __cfHelpers.JSONSchema, (count: number) => count);
-const __cfLift_4 = lift({
-    type: "number"
-} as const satisfies __cfHelpers.JSONSchema, {
-    type: "number"
-} as const satisfies __cfHelpers.JSONSchema, (count: number) => count);
-const __cfLift_5 = __cfHelpers.lift(false, () => `stage:${normalizedStage} attempts:${attempts}` +
-    ` accepted:${accepted} rejected:${rejected}`);
 const stage = __cfHelpers.__cf_data(cell<string>("initial", {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema).for("stage", true));
@@ -45,6 +23,11 @@ const acceptedCount = __cfHelpers.__cf_data(cell<number>(0, {
 const rejectedCount = __cfHelpers.__cf_data(cell<number>(0, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema).for("rejectedCount", true));
+const __cfLift_1 = lift({
+    type: "string"
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "string"
+} as const satisfies __cfHelpers.JSONSchema, (value: string) => value);
 // FIXTURE: computed-object-literal-input
 // Verifies: cell(), lift(), and computed() all get schemas injected from type annotations
 //   cell<string>("initial")             → cell<string>("initial", { type: "string" })
@@ -52,9 +35,26 @@ const rejectedCount = __cfHelpers.__cf_data(cell<number>(0, {
 //   computed(() => `...`)               → captures lift outputs into lift(inputSchema, outputSchema, { ... }, fn)
 // Context: No export default; first export-relevant statement is the cells/lifts/computed at top level
 const normalizedStage = __cfHelpers.__cf_data(__cfLift_1(stage).for("normalizedStage", true));
+const __cfLift_2 = lift({
+    type: "number"
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "number"
+} as const satisfies __cfHelpers.JSONSchema, (count: number) => count);
 const attempts = __cfHelpers.__cf_data(__cfLift_2(attemptCount).for("attempts", true));
+const __cfLift_3 = lift({
+    type: "number"
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "number"
+} as const satisfies __cfHelpers.JSONSchema, (count: number) => count);
 const accepted = __cfHelpers.__cf_data(__cfLift_3(acceptedCount).for("accepted", true));
+const __cfLift_4 = lift({
+    type: "number"
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "number"
+} as const satisfies __cfHelpers.JSONSchema, (count: number) => count);
 const rejected = __cfHelpers.__cf_data(__cfLift_4(rejectedCount).for("rejected", true));
+const __cfLift_5 = __cfHelpers.lift(false, () => `stage:${normalizedStage} attempts:${attempts}` +
+    ` accepted:${accepted} rejected:${rejected}`);
 const _summary = __cfHelpers.__cf_data(__cfLift_5().for("_summary", true));
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }

--- a/packages/ts-transformers/test/fixtures/ast-transform/counter-pattern-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/counter-pattern-no-name.expected.jsx
@@ -11,27 +11,6 @@ import { Cell, Default, handler, NAME, pattern, str, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
-    state: {
-        value: number;
-    };
-}, number>({
-    type: "object",
-    properties: {
-        state: {
-            type: "object",
-            properties: {
-                value: {
-                    type: "number"
-                }
-            },
-            required: ["value"]
-        }
-    },
-    required: ["state"]
-} as const satisfies __cfHelpers.JSONSchema, {
-    type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.value + 1);
 interface CounterState {
     value: Cell<number>;
 }
@@ -66,6 +45,27 @@ const decrement = handler(false as const satisfies __cfHelpers.JSONSchema, {
 }) => {
     state.value.set(state.value.get() - 1);
 });
+const __cfLift_1 = __cfHelpers.lift<{
+    state: {
+        value: number;
+    };
+}, number>({
+    type: "object",
+    properties: {
+        state: {
+            type: "object",
+            properties: {
+                value: {
+                    type: "number"
+                }
+            },
+            required: ["value"]
+        }
+    },
+    required: ["state"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "number"
+} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.value + 1);
 // FIXTURE: counter-pattern-no-name
 // Verifies: same transforms as counter-pattern apply even when the file has no unique name
 //   handler<unknown, CounterState>(fn) → handler(true, stateSchema, fn)

--- a/packages/ts-transformers/test/fixtures/ast-transform/counter-pattern.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/counter-pattern.expected.jsx
@@ -11,27 +11,6 @@ import { Cell, Default, handler, NAME, pattern, str, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
-    state: {
-        value: number;
-    };
-}, number>({
-    type: "object",
-    properties: {
-        state: {
-            type: "object",
-            properties: {
-                value: {
-                    type: "number"
-                }
-            },
-            required: ["value"]
-        }
-    },
-    required: ["state"]
-} as const satisfies __cfHelpers.JSONSchema, {
-    type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.value + 1);
 interface CounterState {
     value: Cell<number>;
 }
@@ -66,6 +45,27 @@ const decrement = handler(false as const satisfies __cfHelpers.JSONSchema, {
 }) => {
     state.value.set(state.value.get() - 1);
 });
+const __cfLift_1 = __cfHelpers.lift<{
+    state: {
+        value: number;
+    };
+}, number>({
+    type: "object",
+    properties: {
+        state: {
+            type: "object",
+            properties: {
+                value: {
+                    type: "number"
+                }
+            },
+            required: ["value"]
+        }
+    },
+    required: ["state"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "number"
+} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.value + 1);
 // FIXTURE: counter-pattern
 // Verifies: full pattern with handlers, ternary, str template, and schema generation
 //   handler<unknown, CounterState>(fn) → handler(true, stateSchema, fn)

--- a/packages/ts-transformers/test/fixtures/ast-transform/event-handler-no-compute-wrap.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/event-handler-no-compute-wrap.expected.jsx
@@ -11,20 +11,6 @@ import { Cell, Default, handler, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
-    count: Default<number, 0>;
-}, number>({
-    type: "object",
-    properties: {
-        count: {
-            type: "number",
-            "default": 0
-        }
-    },
-    required: ["count"]
-} as const satisfies __cfHelpers.JSONSchema, {
-    type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ count }) => count + 1);
 declare global {
     namespace JSX {
         interface IntrinsicElements {
@@ -46,6 +32,20 @@ const handleClick = handler({
 } as const satisfies __cfHelpers.JSONSchema, (_, { count }) => {
     count.set(count.get() + 1);
 });
+const __cfLift_1 = __cfHelpers.lift<{
+    count: Default<number, 0>;
+}, number>({
+    type: "object",
+    properties: {
+        count: {
+            type: "number",
+            "default": 0
+        }
+    },
+    required: ["count"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "number"
+} as const satisfies __cfHelpers.JSONSchema, ({ count }) => count + 1);
 // FIXTURE: event-handler-no-compute-wrap
 // Verifies: handler invocations in JSX are NOT wrapped in a reactive compute
 // wrapper (formerly derive, now lift-applied post-CT-1615), while

--- a/packages/ts-transformers/test/fixtures/ast-transform/non-jsx-wildcard-traversal-call-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/non-jsx-wildcard-traversal-call-roots.expected.jsx
@@ -11,6 +11,18 @@ import { pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    wishes: [
+        {
+            id: string;
+            status: string;
+        },
+        {
+            id: string;
+            status: string;
+        }
+    ];
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         wishes: [{ id: string; status: string; }, { id: string; status: string; }];
@@ -155,18 +167,6 @@ const __cfLift_4 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, ({ state }) => Object.entries(state.wishes[1]));
-interface State {
-    wishes: [
-        {
-            id: string;
-            status: string;
-        },
-        {
-            id: string;
-            status: string;
-        }
-    ];
-}
 // FIXTURE: non-jsx-wildcard-traversal-call-roots
 // Verifies: wildcard traversal calls lower as whole call roots outside JSX
 export default pattern((state) => ({

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-array-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-array-map.expected.jsx
@@ -11,6 +11,23 @@ import { Cell, computed, handler, NAME, pattern, str, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const adder = handler(false as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        values: {
+            type: "array",
+            items: {
+                type: "string"
+            },
+            asCell: ["writeonly"]
+        }
+    },
+    required: ["values"]
+} as const satisfies __cfHelpers.JSONSchema, (_, state: {
+    values: Cell<string[]>;
+}) => {
+    state.values.push(Math.random().toString(36).substring(2, 15));
+});
 const __cfLift_1 = __cfHelpers.lift<{
     values: unknown[];
 }, void>({
@@ -29,23 +46,44 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, ({ values }) => {
     console.log("values#", values?.length);
 });
-const adder = handler(false as const satisfies __cfHelpers.JSONSchema, {
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const value = __cf_pattern_input.key("element");
+    const index = __cf_pattern_input.key("index");
+    return (<div>
+                {index}: {value}
+              </div>);
+}, {
     type: "object",
     properties: {
-        values: {
-            type: "array",
-            items: {
-                type: "string"
-            },
-            asCell: ["writeonly"]
+        element: {
+            type: "string"
+        },
+        index: {
+            type: "number"
         }
     },
-    required: ["values"]
-} as const satisfies __cfHelpers.JSONSchema, (_, state: {
-    values: Cell<string[]>;
-}) => {
-    state.values.push(Math.random().toString(36).substring(2, 15));
-});
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: pattern-array-map
 // Verifies: .map() on a reactive array is transformed to .mapWithPattern()
 //   values.map((value, index) => JSX)  → values.mapWithPattern(pattern(fn, elementSchema, outputSchema), {})
@@ -61,44 +99,7 @@ export default pattern((__cf_pattern_input) => {
         [UI]: (<div>
           <button type="button" onClick={adder({ values })}>Add Value</button>
           <div>
-            {values.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const value = __cf_pattern_input.key("element");
-                const index = __cf_pattern_input.key("index");
-                return (<div>
-                {index}: {value}
-              </div>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "string"
-                    },
-                    index: {
-                        type: "number"
-                    }
-                },
-                required: ["element"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+            {values.mapWithPattern(__cfPattern_1, {})}
           </div>
         </div>),
         values,

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-call-arg-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-call-arg-conditional.expected.jsx
@@ -11,6 +11,7 @@ import { pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const identity = __cfHardenFn(<T,>(value: T) => value);
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         done: boolean;
@@ -32,7 +33,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     "enum": ["Done", "Pending"]
 } as const satisfies __cfHelpers.JSONSchema, ({ state }) => identity(state.done ? "Done" : "Pending"));
-const identity = __cfHardenFn(<T,>(value: T) => value);
 // FIXTURE: pattern-call-arg-conditional
 // Verifies: top-level ordinary helper calls with reactive arguments are lifted
 //   as whole calls rather than lowering only the inner argument expression.

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-call-root-containers.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-call-root-containers.expected.jsx
@@ -11,6 +11,7 @@ import { pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const identity = __cfHardenFn(<T,>(value: T) => value);
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         done: boolean;
@@ -53,28 +54,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     "enum": ["Done", "Pending"]
 } as const satisfies __cfHelpers.JSONSchema, ({ state }) => identity(state.done ? "Done" : "Pending"));
-const __cfLift_3 = __cfHelpers.lift<{
-    state: {
-        done: boolean;
-    };
-}, "Done" | "Pending">({
-    type: "object",
-    properties: {
-        state: {
-            type: "object",
-            properties: {
-                done: {
-                    type: "boolean"
-                }
-            },
-            required: ["done"]
-        }
-    },
-    required: ["state"]
-} as const satisfies __cfHelpers.JSONSchema, {
-    "enum": ["Done", "Pending"]
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => identity(state.done ? "Done" : "Pending"));
-const identity = __cfHardenFn(<T,>(value: T) => value);
 // FIXTURE: pattern-call-root-containers
 // Verifies: top-level ordinary call roots whole-wrap consistently across
 //   non-JSX container kinds instead of lowering only their nested conditional
@@ -118,6 +97,27 @@ export const objectAndArray = pattern((state) => {
     },
     required: ["value", "list"]
 } as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_3 = __cfHelpers.lift<{
+    state: {
+        done: boolean;
+    };
+}, "Done" | "Pending">({
+    type: "object",
+    properties: {
+        state: {
+            type: "object",
+            properties: {
+                done: {
+                    type: "boolean"
+                }
+            },
+            required: ["done"]
+        }
+    },
+    required: ["state"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    "enum": ["Done", "Pending"]
+} as const satisfies __cfHelpers.JSONSchema, ({ state }) => identity(state.done ? "Done" : "Pending"));
 export default pattern((state) => __cfLift_3({ state: {
         done: state.key("done")
     } }).for("__patternResult", true), {

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-local-helper-call-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-local-helper-call-roots.expected.jsx
@@ -11,6 +11,7 @@ import { pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const double = __cfHardenFn((x: number) => x * 2);
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         count: number;
@@ -32,7 +33,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ state }) => double(state.count + 1));
-const double = __cfHardenFn((x: number) => x * 2);
 // FIXTURE: pattern-local-helper-call-roots
 // Verifies: top-level ordinary local helper calls with reactive inputs are
 //   lifted as whole calls, while plain inputs stay plain.

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-top-level-root-lowering.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-top-level-root-lowering.expected.jsx
@@ -11,6 +11,7 @@ import { pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const identity = __cfHardenFn(<T,>(value: T) => value);
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         user: {
@@ -132,7 +133,6 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.label ?? "Pending");
-const identity = __cfHardenFn(<T,>(value: T) => value);
 // FIXTURE: pattern-top-level-root-lowering
 // Verifies: top-level non-JSX ordinary helper calls with reactive inputs are
 //   lifted as whole calls instead of lowering only inner argument expressions.

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-two-schemas.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-two-schemas.expected.jsx
@@ -12,6 +12,13 @@ import "commonfabric/schema";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+// Test that pattern with both schemas already present is not transformed
+interface Input {
+    count: number;
+}
+interface Result {
+    doubled: number;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     count: number;
 }, number>({
@@ -25,13 +32,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ count }) => count * 2);
-// Test that pattern with both schemas already present is not transformed
-interface Input {
-    count: number;
-}
-interface Result {
-    doubled: number;
-}
 // FIXTURE: pattern-two-schemas
 // Verifies: pattern with both input and output schemas already present preserves them
 //   pattern<Input, Result>(fn, inputSchema, outputSchema) → pattern(fn, inputSchema, outputSchema) (schemas kept)

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-with-name-and-type.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-with-name-and-type.expected.jsx
@@ -11,6 +11,9 @@ import { computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface MyInput {
+    value: number;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     input: {
         value: number;
@@ -32,9 +35,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ input }) => input.value * 2);
-interface MyInput {
-    value: number;
-}
 // FIXTURE: pattern-with-name-and-type
 // Verifies: pattern with inline typed parameter generates input and output schemas
 //   pattern((input: MyInput) => ...)   → pattern((input) => ..., inputSchema, outputSchema)

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-with-type.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-with-type.expected.jsx
@@ -11,6 +11,9 @@ import { computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface MyInput {
+    value: number;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     input: {
         value: number;
@@ -32,9 +35,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ input }) => input.value * 2);
-interface MyInput {
-    value: number;
-}
 // FIXTURE: pattern-with-type
 // Verifies: pattern with inline typed parameter generates input and output schemas
 //   pattern((input: MyInput) => ...)   → pattern((input) => ..., inputSchema, outputSchema)

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-builders.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-builders.expected.jsx
@@ -40,6 +40,42 @@ const addTodo = handler({
 } as const satisfies __cfHelpers.JSONSchema, (event, state) => {
     state.items.push(event.add);
 });
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const index = __cf_pattern_input.key("index");
+    return <li key={index}>{item}</li>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "string"
+        },
+        index: {
+            type: "number"
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: schema-generation-builders
 // Verifies: handler with generic type args generates event+state schemas; .map() becomes .mapWithPattern()
 //   handler<TodoEvent, { items: Cell<string[]> }>(fn) → handler(eventSchema, stateSchema, fn)
@@ -52,42 +88,7 @@ export default pattern((state) => {
           Add
         </button>
         <ul>
-          {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-            const item = __cf_pattern_input.key("element");
-            const index = __cf_pattern_input.key("index");
-            return <li key={index}>{item}</li>;
-        }, {
-            type: "object",
-            properties: {
-                element: {
-                    type: "string"
-                },
-                index: {
-                    type: "number"
-                }
-            },
-            required: ["element"]
-        } as const satisfies __cfHelpers.JSONSchema, {
-            anyOf: [{
-                    $ref: "https://commonfabric.org/schemas/vnode.json"
-                }, {
-                    $ref: "#/$defs/UIRenderable"
-                }, {
-                    type: "object",
-                    properties: {}
-                }],
-            $defs: {
-                UIRenderable: {
-                    type: "object",
-                    properties: {
-                        $UI: {
-                            $ref: "https://commonfabric.org/schemas/vnode.json"
-                        }
-                    },
-                    required: ["$UI"]
-                }
-            }
-        } as const satisfies __cfHelpers.JSONSchema), {})}
+          {state.key("items").mapWithPattern(__cfPattern_1, {})}
         </ul>
       </div>),
     };

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-alias.expected.jsx
@@ -11,9 +11,6 @@ import { computed as computedAlias } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift(false, (): AliasResult => ({
-    length: state.text.length,
-}));
 type AliasInput = {
     text: string;
 };
@@ -21,6 +18,9 @@ type AliasResult = {
     length: number;
 };
 declare const state: AliasInput;
+const __cfLift_1 = __cfHelpers.lift(false, (): AliasResult => ({
+    length: state.text.length,
+}));
 // FIXTURE: schema-generation-computed-alias
 // Verifies: a reactive builder imported under an alias still gets schema injection
 //   computedAlias((): AliasResult => ...) → captures `state` and lowers to lift(inputSchema, outputSchema, ...)

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-inside-jsx.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-inside-jsx.expected.jsx
@@ -11,8 +11,8 @@ import { computed } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift(false, () => value * 2);
 declare const value: number;
+const __cfLift_1 = __cfHelpers.lift(false, () => value * 2);
 // FIXTURE: schema-generation-computed-inside-jsx
 // Verifies: a reactive builder inside a JSX expression still gets schemas injected
 //   computed(() => value * 2) → captures `value` and lowers to lift(inputSchema, outputSchema, ...)

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-multiple-returns.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-multiple-returns.expected.jsx
@@ -11,13 +11,13 @@ import { computed } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+declare const flag: boolean;
 const __cfLift_1 = __cfHelpers.lift(false, () => {
     if (flag) {
         return "hello";
     }
     return 42;
 });
-declare const flag: boolean;
 // FIXTURE: schema-generation-computed-multiple-returns
 // Verifies: a reactive builder with multiple return paths infers a union output schema
 //   computed(() => { ... }) → output schema is an enum union of the returned literals

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-untyped.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-untyped.expected.jsx
@@ -11,8 +11,8 @@ import { computed } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift(false, () => total * 2);
 declare const total: number;
+const __cfLift_1 = __cfHelpers.lift(false, () => total * 2);
 // FIXTURE: schema-generation-computed-untyped
 // Verifies: a reactive builder with no generic type args infers schemas from captured values
 //   computed(() => total * 2) → captures `total` ({ type: "number" }) and infers output from the body

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed.expected.jsx
@@ -11,9 +11,6 @@ import { computed } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift(false, (): DeriveResult => ({
-    doubled: source.count * 2,
-}));
 type DeriveInput = {
     count: number;
 };
@@ -21,6 +18,9 @@ type DeriveResult = {
     doubled: number;
 };
 declare const source: DeriveInput;
+const __cfLift_1 = __cfHelpers.lift(false, (): DeriveResult => ({
+    doubled: source.count * 2,
+}));
 // FIXTURE: schema-generation-computed
 // Verifies: computed() closure-extracts a captured value into a lift() with input
 // (capture) and output schemas generated from type info

--- a/packages/ts-transformers/test/fixtures/ast-transform/str-template-call-interpolation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/str-template-call-interpolation.expected.jsx
@@ -11,6 +11,13 @@ import { NAME, pattern, str } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface PatternState {
+    value: number;
+}
+function format(n: number): string {
+    return `#${n}`;
+}
+__cfHardenFn(format);
 const __cfLift_1 = __cfHelpers.lift<{
     cell: {
         value: number;
@@ -53,13 +60,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ cell }) => cell.value + 1);
-interface PatternState {
-    value: number;
-}
-function format(n: number): string {
-    return `#${n}`;
-}
-__cfHardenFn(format);
 // FIXTURE: str-template-call-interpolation
 // Verifies: reactive lowering of expressions interpolated into a str`` tagged template.
 //   The str runtime lifts its interpolation over the values it receives, so any value

--- a/packages/ts-transformers/test/fixtures/ast-transform/ternary_computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/ternary_computed.expected.jsx
@@ -11,6 +11,9 @@ import { Default, NAME, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface PatternState {
+    value: Default<number, 0>;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         value: number;
@@ -53,9 +56,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.value + 2);
-interface PatternState {
-    value: Default<number, 0>;
-}
 // FIXTURE: ternary_computed
 // Verifies: ternary with expressions on both sides produces ifElse() with a lift-applied computation for each branch
 //   state.value + 1 ? state.value + 2 : "undefined" → ifElse(...schemas, lift(...)({...}), lift(...)({...}), "undefined")

--- a/packages/ts-transformers/test/fixtures/closures/action-basic.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-basic.expected.jsx
@@ -11,6 +11,9 @@ import { Cell, pattern, action } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    count: Cell<number>;
+}
 const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -21,9 +24,6 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     },
     required: ["count"]
 } as const satisfies __cfHelpers.JSONSchema, (_, { count }) => count.set(count.get() + 1));
-interface State {
-    count: Cell<number>;
-}
 // FIXTURE: action-basic
 // Verifies: action() callback is extracted into a handler with captured state
 //   action(() => count.set(...)) → handler(eventSchema, captureSchema, (_, { count }) => count.set(...))({ count })

--- a/packages/ts-transformers/test/fixtures/closures/action-generic-event.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-generic-event.expected.jsx
@@ -11,6 +11,12 @@ import { Cell, pattern, action } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface MyEvent {
+    data: string;
+}
+interface State {
+    value: Cell<string>;
+}
 const __cfHandler_1 = __cfHelpers.handler({
     type: "object",
     properties: {
@@ -29,12 +35,6 @@ const __cfHandler_1 = __cfHelpers.handler({
     },
     required: ["value"]
 } as const satisfies __cfHelpers.JSONSchema, (e, { value }) => value.set(e.data));
-interface MyEvent {
-    data: string;
-}
-interface State {
-    value: Cell<string>;
-}
 // FIXTURE: action-generic-event
 // Verifies: action<MyEvent>(fn) with a type parameter generates a typed event schema
 //   action<MyEvent>((e) => ...) → handler(MyEvent schema, captureSchema, (e, { value }) => ...)({ value })

--- a/packages/ts-transformers/test/fixtures/closures/action-in-ternary-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-in-ternary-branch.expected.jsx
@@ -18,6 +18,13 @@ import { action, Cell, computed, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Card {
+    title: string;
+    description: string;
+}
+interface Input {
+    card: Card;
+}
 const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -54,13 +61,6 @@ const __cfLift_1 = __cfHelpers.lift<{
     const desc = card.description;
     return desc && desc.length > 0;
 });
-interface Card {
-    title: string;
-    description: string;
-}
-interface Input {
-    card: Card;
-}
 // FIXTURE: action-in-ternary-branch
 // Verifies: action() result used in a ternary branch alongside computed() keeps
 //   local JSX rewrites instead of forcing a whole-branch lift-applied computation

--- a/packages/ts-transformers/test/fixtures/closures/action-in-ternary-with-explicit-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-in-ternary-with-explicit-computed.expected.jsx
@@ -18,6 +18,13 @@ import { action, Cell, computed, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Card {
+    title: string;
+    description: string;
+}
+interface Input {
+    card: Card;
+}
 const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -76,13 +83,6 @@ const __cfLift_1 = __cfHelpers.lift<{
                 <span>{card.description}</span>
                 <cf-button onClick={startEditing}>Edit</cf-button>
               </div>));
-interface Card {
-    title: string;
-    description: string;
-}
-interface Input {
-    card: Card;
-}
 // FIXTURE: action-in-ternary-with-explicit-computed
 // Verifies: action() referenced inside an explicit computed() in JSX is captured in the lift-applied wrapper
 //   action(() => ...) → handler(...)({ isEditing })

--- a/packages/ts-transformers/test/fixtures/closures/action-partial.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-partial.expected.jsx
@@ -11,6 +11,12 @@ import { Cell, pattern, action } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface BaseState {
+    a: Cell<string>;
+    b: Cell<number>;
+}
+// Partial<BaseState> should make both 'a' and 'b' optional in the schema
+type PartState = Partial<BaseState>;
 const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -37,12 +43,6 @@ const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, (_, { b }) => console.log(b));
-interface BaseState {
-    a: Cell<string>;
-    b: Cell<number>;
-}
-// Partial<BaseState> should make both 'a' and 'b' optional in the schema
-type PartState = Partial<BaseState>;
 // FIXTURE: action-partial
 // Verifies: Partial<BaseState> produces optional (anyOf undefined|type) capture schemas in handlers
 //   action(() => console.log(a)) → handler(false, { a: { anyOf: [undefined, string] } }, ...)({ a })

--- a/packages/ts-transformers/test/fixtures/closures/action-required-partial.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-required-partial.expected.jsx
@@ -11,6 +11,12 @@ import { Cell, pattern, action } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface BaseState {
+    a?: Cell<string>;
+    b: Cell<number>;
+}
+// Required<BaseState> should make 'a' required in the schema
+type ReqState = Required<BaseState>;
 const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -31,12 +37,6 @@ const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     },
     required: ["b"]
 } as const satisfies __cfHelpers.JSONSchema, (_, { b }) => b.set(42));
-interface BaseState {
-    a?: Cell<string>;
-    b: Cell<number>;
-}
-// Required<BaseState> should make 'a' required in the schema
-type ReqState = Required<BaseState>;
 // FIXTURE: action-required-partial
 // Verifies: Required<BaseState> makes originally-optional properties required in capture schemas
 //   action(() => a.set("hello")) → handler(false, { a: { type: "string", asCell, required } }, ...)({ a })

--- a/packages/ts-transformers/test/fixtures/closures/action-result-not-opaque.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-result-not-opaque.expected.jsx
@@ -16,6 +16,9 @@ import { action, pattern, UI, Writable } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    label: string;
+}
 const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -40,9 +43,6 @@ const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
 } as const satisfies __cfHelpers.JSONSchema, (_, { count }) => {
     count.set(count.get() - 1);
 });
-interface State {
-    label: string;
-}
 // FIXTURE: action-result-not-opaque
 // Verifies: action() results used as JSX event handlers are not marked asOpaque in the output
 //   action(() => count.set(...)) → handler(false, { count: { asCell } }, (_, { count }) => ...)({ count })

--- a/packages/ts-transformers/test/fixtures/closures/action-self-closure.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-self-closure.expected.jsx
@@ -15,6 +15,12 @@ import { action, type Default, NAME, pattern, SELF, UI, type VNode, Writable } f
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface TestOutput {
+    [NAME]: string;
+    [UI]: VNode;
+    title: string;
+    count: number;
+}
 const __cfHandler_1 = __cfHelpers.handler({
     type: "object",
     properties: {},
@@ -76,12 +82,6 @@ const __cfHandler_2 = __cfHelpers.handler({
     console.log("self:", self);
     count.set(count.get() + 1);
 });
-interface TestOutput {
-    [NAME]: string;
-    [UI]: VNode;
-    title: string;
-    count: number;
-}
 // FIXTURE: action-self-closure
 // Verifies: action() closing over SELF captures self properties in the handler
 //   action(() => console.log(self.title)) → handler(eventSchema, { self: { title } }, (_, { self }) => ...)({ self: { title: self.key("title") } })

--- a/packages/ts-transformers/test/fixtures/closures/action-with-event.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-with-event.expected.jsx
@@ -11,6 +11,12 @@ import { Cell, pattern, action } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface MyEvent {
+    data: string;
+}
+interface State {
+    value: Cell<string>;
+}
 const __cfHandler_1 = __cfHelpers.handler({
     type: "object",
     properties: {
@@ -29,12 +35,6 @@ const __cfHandler_1 = __cfHelpers.handler({
     },
     required: ["value"]
 } as const satisfies __cfHelpers.JSONSchema, (e, { value }) => value.set(e.data));
-interface MyEvent {
-    data: string;
-}
-interface State {
-    value: Cell<string>;
-}
 // FIXTURE: action-with-event
 // Verifies: action() with an inline-annotated event parameter generates a typed event schema
 //   action((e: MyEvent) => value.set(e.data)) → handler(MyEvent schema, captureSchema, (e, { value }) => ...)({ value })

--- a/packages/ts-transformers/test/fixtures/closures/cell-map-with-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/cell-map-with-captures.expected.jsx
@@ -11,6 +11,10 @@ import { Cell, cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    values: number[];
+    multiplier: number;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     value: number;
     state: {
@@ -36,10 +40,59 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ value, state }) => value * state.multiplier);
-interface State {
-    values: number[];
-    multiplier: number;
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const value = __cf_pattern_input.key("element");
+    const state = __cf_pattern_input.key("params", "state");
+    return (<span>{__cfLift_1({
+        value: value,
+        state: {
+            multiplier: state.key("multiplier")
+        }
+    })}</span>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "number"
+        },
+        params: {
+            type: "object",
+            properties: {
+                state: {
+                    type: "object",
+                    properties: {
+                        multiplier: {
+                            type: "number"
+                        }
+                    },
+                    required: ["multiplier"]
+                }
+            },
+            required: ["state"]
+        }
+    },
+    required: ["element", "params"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: cell-map-with-captures
 // Verifies: Cell.map() with outer-scope captures is transformed to mapWithPattern with params
 //   typedValues.map((value) => <span>{value * state.multiplier}</span>)
@@ -57,59 +110,7 @@ export default pattern((state) => {
     } as const satisfies __cfHelpers.JSONSchema).for("typedValues", true);
     return {
         [UI]: (<div>
-        {typedValues.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const value = __cf_pattern_input.key("element");
-                const state = __cf_pattern_input.key("params", "state");
-                return (<span>{__cfLift_1({
-                    value: value,
-                    state: {
-                        multiplier: state.key("multiplier")
-                    }
-                })}</span>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "number"
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            state: {
-                                type: "object",
-                                properties: {
-                                    multiplier: {
-                                        type: "number"
-                                    }
-                                },
-                                required: ["multiplier"]
-                            }
-                        },
-                        required: ["state"]
-                    }
-                },
-                required: ["element", "params"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        {typedValues.mapWithPattern(__cfPattern_1, {
                 state: {
                     multiplier: state.key("multiplier")
                 }

--- a/packages/ts-transformers/test/fixtures/closures/computed-array-length.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-array-length.expected.jsx
@@ -21,6 +21,10 @@ import { computed, NAME, pattern, UI, wish } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Charm {
+    id: string;
+    name: string;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     allCharms: {
         length: number;
@@ -63,10 +67,52 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ allCharms }) => allCharms.length);
-interface Charm {
-    id: string;
-    name: string;
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const charm = __cf_pattern_input.key("element");
+    return (<li>{charm.key("name")}</li>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Charm"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Charm: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                },
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["id", "name"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-array-length
 // Verifies: computed(() => expr) with .length access on an OpaqueRef<T[]> is closure-extracted
 //   computed(() => allCharms.length) → lift(({ allCharms }) => allCharms.length)({ allCharms: { length: allCharms.length } })
@@ -111,52 +157,7 @@ export default pattern(() => {
                 length: allCharms.key("length")
             } })}</span>
         <ul>
-          {allCharms.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const charm = __cf_pattern_input.key("element");
-                return (<li>{charm.key("name")}</li>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Charm"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    Charm: {
-                        type: "object",
-                        properties: {
-                            id: {
-                                type: "string"
-                            },
-                            name: {
-                                type: "string"
-                            }
-                        },
-                        required: ["id", "name"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+          {allCharms.mapWithPattern(__cfPattern_1, {})}
         </ul>
       </div>),
     };

--- a/packages/ts-transformers/test/fixtures/closures/computed-destructured-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-destructured-map.expected.jsx
@@ -18,6 +18,10 @@ import { computed, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Item {
+    name: string;
+    done: boolean;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     items: {
         done: boolean;
@@ -137,10 +141,6 @@ const __cfLift_2 = __cfHelpers.lift<{
     const { tasks } = result;
     return tasks.map((task) => <li>{task.name}</li>);
 });
-interface Item {
-    name: string;
-    done: boolean;
-}
 // FIXTURE: computed-destructured-map
 // Verifies: .map() on a destructured property of a computed result inside another computed() is NOT transformed to .mapWithPattern()
 //   computed(() => { const { tasks } = result; return tasks.map(fn) }) → lift(({ result }) => { const { tasks } = result; return tasks.map(fn) })(...)

--- a/packages/ts-transformers/test/fixtures/closures/computed-destructured-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-destructured-param.expected.jsx
@@ -11,6 +11,10 @@ import { Writable, computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Point {
+    x: number;
+    y: number;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     point: __cfHelpers.ReadonlyCell<Point>;
     multiplier: __cfHelpers.ReadonlyCell<number>;
@@ -47,10 +51,6 @@ const __cfLift_1 = __cfHelpers.lift<{
     const { x, y } = point.get();
     return (x + y) * multiplier.get();
 });
-interface Point {
-    x: number;
-    y: number;
-}
 // FIXTURE: computed-destructured-param
 // Verifies: a captured cell works alongside destructuring inside the computed body
 //   computed(() => { const { x, y } = point.get(); ... }) → lift(...)({ point, multiplier })

--- a/packages/ts-transformers/test/fixtures/closures/computed-filter-map-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-filter-map-chain.expected.jsx
@@ -11,6 +11,10 @@ import { computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Preference {
+    ingredient: string;
+    preference: "liked" | "disliked";
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         preferences: {
@@ -54,10 +58,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         .filter((p) => p.preference === "liked")
         .map((p) => p.ingredient);
 });
-interface Preference {
-    ingredient: string;
-    preference: "liked" | "disliked";
-}
 // FIXTURE: computed-filter-map-chain
 // Verifies: .filter() and .map() inside computed() are NOT transformed
 // Context: Inside computed(), OpaqueRef auto-unwraps to plain array, so

--- a/packages/ts-transformers/test/fixtures/closures/computed-in-computed-scoped-no-false-rewrite.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-in-computed-scoped-no-false-rewrite.expected.jsx
@@ -11,6 +11,7 @@ import { computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const config = __cfHelpers.__cf_data({ bar: "module-level" });
 const __cfLift_1 = __cfHelpers.lift(false, () => ({ bar: 1 }));
 const __cfLift_2 = __cfHelpers.lift(false, () => {
     const condition = 1 > 0;
@@ -20,7 +21,6 @@ const __cfLift_2 = __cfHelpers.lift(false, () => {
     }
     return config.bar;
 });
-const config = __cfHelpers.__cf_data({ bar: "module-level" });
 // FIXTURE: computed-in-computed-scoped-no-false-rewrite
 // Verifies: a block-scoped computed() result named `config` does NOT cause
 //   the module-level `config.bar` to be rewritten to `config.key("bar")`.

--- a/packages/ts-transformers/test/fixtures/closures/computed-inside-map-with-method-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-inside-map-with-method-chain.expected.jsx
@@ -11,6 +11,19 @@ import { computed, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface SubItem {
+    id: number;
+    name: string;
+    active: boolean;
+}
+interface Item {
+    id: number;
+    title: string;
+    subItems: SubItem[];
+}
+interface State {
+    items: Item[];
+}
 const __cfLift_1 = __cfHelpers.lift<{
     item: {
         subItems: SubItem[];
@@ -55,19 +68,81 @@ const __cfLift_1 = __cfHelpers.lift<{
     .filter((s) => s.active)
     .map((s) => s.name)
     .join(", "));
-interface SubItem {
-    id: number;
-    name: string;
-    active: boolean;
-}
-interface Item {
-    id: number;
-    title: string;
-    subItems: SubItem[];
-}
-interface State {
-    items: Item[];
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return (<div>
+            <h2>{item.key("title")}</h2>
+            <p>
+              Active items:{" "}
+              {__cfLift_1({ item: {
+                subItems: item.key("subItems")
+            } })}
+            </p>
+          </div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "number"
+                },
+                title: {
+                    type: "string"
+                },
+                subItems: {
+                    type: "array",
+                    items: {
+                        $ref: "#/$defs/SubItem"
+                    }
+                }
+            },
+            required: ["id", "title", "subItems"]
+        },
+        SubItem: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "number"
+                },
+                name: {
+                    type: "string"
+                },
+                active: {
+                    type: "boolean"
+                }
+            },
+            required: ["id", "name", "active"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-inside-map-with-method-chain
 // Verifies: a computed nested inside .map() correctly transforms outer .map() but leaves inner chains alone
 //   state.items.map(fn) → state.items.mapWithPattern(pattern(...))
@@ -81,81 +156,7 @@ export default pattern((state) => {
                 - inside the computed, item.subItems unwraps to a plain JS array
                 - .filter() returns a plain JS array
                 - Plain arrays don't have .mapWithPattern() */}
-        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                return (<div>
-            <h2>{item.key("title")}</h2>
-            <p>
-              Active items:{" "}
-              {__cfLift_1({ item: {
-                            subItems: item.key("subItems")
-                        } })}
-            </p>
-          </div>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Item"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            id: {
-                                type: "number"
-                            },
-                            title: {
-                                type: "string"
-                            },
-                            subItems: {
-                                type: "array",
-                                items: {
-                                    $ref: "#/$defs/SubItem"
-                                }
-                            }
-                        },
-                        required: ["id", "title", "subItems"]
-                    },
-                    SubItem: {
-                        type: "object",
-                        properties: {
-                            id: {
-                                type: "number"
-                            },
-                            name: {
-                                type: "string"
-                            },
-                            active: {
-                                type: "boolean"
-                            }
-                        },
-                        required: ["id", "name", "active"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+        {state.key("items").mapWithPattern(__cfPattern_1, {})}
       </div>),
     };
 }, {

--- a/packages/ts-transformers/test/fixtures/closures/computed-local-var-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-local-var-map.expected.jsx
@@ -18,6 +18,10 @@ import { computed, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Item {
+    name: string;
+    price: number;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     items: {
         price: number;
@@ -110,10 +114,6 @@ const __cfLift_2 = __cfHelpers.lift<{
     const localVar = filtered;
     return localVar.map((item) => <li>{item.name}</li>);
 });
-interface Item {
-    name: string;
-    price: number;
-}
 // FIXTURE: computed-local-var-map
 // Verifies: .map() on a local variable assigned from a computed result inside another computed() is NOT transformed to .mapWithPattern()
 //   computed(() => { const localVar = filtered; return localVar.map(fn) }) → lift(({ filtered }) => { const localVar = filtered; return localVar.map(fn) })(...)

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-conditional.expected.jsx
@@ -11,6 +11,13 @@ import { computed, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const identity = __cfHardenFn((x: string) => x);
+interface Item {
+    done: boolean;
+}
+interface State {
+    items: Item[];
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         items: Item[];
@@ -81,13 +88,52 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, ({ row }) => identity(row.done ? "Done" : "Pending"));
-const identity = __cfHardenFn((x: string) => x);
-interface Item {
-    done: boolean;
-}
-interface State {
-    items: Item[];
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const row = __cf_pattern_input.key("element");
+    const label = __cfLift_2({ row: {
+            done: row.key("done")
+        } }).for("label", true);
+    return <span>{label}</span>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                done: {
+                    type: "boolean"
+                }
+            },
+            required: ["done"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-map-call-arg-conditional
 // Verifies: callback-local ordinary call roots within a computed-array .map()
 //   callback whole-wrap as callback-local lift-applied computations rather than
@@ -100,53 +146,8 @@ export default pattern((state) => {
         } }).for("rows", true);
     return {
         [UI]: (<div>
-        {rows.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const row = __cf_pattern_input.key("element");
-                const label = __cfLift_2({ row: {
-                        done: row.key("done")
-                    } }).for("label", true);
-                return <span>{label}</span>;
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Item"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            done: {
-                                type: "boolean"
-                            }
-                        },
-                        required: ["done"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>)
+        {rows.mapWithPattern(__cfPattern_1, {})}
+      </div>),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-logical-and.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-logical-and.expected.jsx
@@ -11,6 +11,13 @@ import { computed, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const identity = __cfHardenFn((x: unknown) => x);
+interface Item {
+    done: boolean;
+}
+interface State {
+    items: Item[];
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         items: Item[];
@@ -81,13 +88,52 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "unknown"
 } as const satisfies __cfHelpers.JSONSchema, ({ row }) => identity(row.done && "Done"));
-const identity = __cfHardenFn((x: unknown) => x);
-interface Item {
-    done: boolean;
-}
-interface State {
-    items: Item[];
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const row = __cf_pattern_input.key("element");
+    const label = __cfLift_2({ row: {
+            done: row.key("done")
+        } }).for("label", true);
+    return <span>{label}</span>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                done: {
+                    type: "boolean"
+                }
+            },
+            required: ["done"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-map-call-arg-logical-and
 // Verifies: callback-local ordinary call roots within a computed-array .map()
 //   callback whole-wrap as callback-local lift-applied computations rather than
@@ -100,53 +146,8 @@ export default pattern((state) => {
         } }).for("rows", true);
     return {
         [UI]: (<div>
-        {rows.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const row = __cf_pattern_input.key("element");
-                const label = __cfLift_2({ row: {
-                        done: row.key("done")
-                    } }).for("label", true);
-                return <span>{label}</span>;
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Item"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            done: {
-                                type: "boolean"
-                            }
-                        },
-                        required: ["done"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>)
+        {rows.mapWithPattern(__cfPattern_1, {})}
+      </div>),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-call-root-containers.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-call-root-containers.expected.jsx
@@ -11,6 +11,13 @@ import { computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const identity = __cfHardenFn((value: string) => value);
+interface Item {
+    done: boolean;
+}
+interface State {
+    items: Item[];
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         items: Item[];
@@ -102,6 +109,50 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, ({ row }) => identity(row.done ? "Done" : "Pending"));
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const row = __cf_pattern_input.key("element");
+    return ({
+        value: __cfLift_2({ row: {
+                done: row.key("done")
+            } }).for(["__patternResult", "value"], true),
+        list: [__cfLift_3({ row: {
+                    done: row.key("done")
+                } }).for(["__patternResult", "list", 0], true)]
+    });
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                done: {
+                    type: "boolean"
+                }
+            },
+            required: ["done"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        value: {
+            type: "string"
+        },
+        list: {
+            type: "array",
+            items: {
+                type: "string"
+            }
+        }
+    },
+    required: ["value", "list"]
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_4 = __cfHelpers.lift<{
     row: {
         done: boolean;
@@ -123,13 +174,33 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, ({ row }) => identity(row.done ? "Done" : "Pending"));
-const identity = __cfHardenFn((value: string) => value);
-interface Item {
-    done: boolean;
-}
-interface State {
-    items: Item[];
-}
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const row = __cf_pattern_input.key("element");
+    return __cfLift_4({ row: {
+            done: row.key("done")
+        } }).for("__patternResult", true);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                done: {
+                    type: "boolean"
+                }
+            },
+            required: ["done"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "string"
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-map-call-root-containers
 // Verifies: inside a computed-array .map() callback, callback-local ordinary
 //   call roots whole-wrap as callback-local lift-applied computations across
@@ -144,77 +215,8 @@ export default pattern((state) => {
     const rows = __cfLift_1({ state: {
             items: state.key("items")
         } }).for("rows", true);
-    const views = rows.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-        const row = __cf_pattern_input.key("element");
-        return ({
-            value: __cfLift_2({ row: {
-                    done: row.key("done")
-                } }),
-            list: [__cfLift_3({ row: {
-                        done: row.key("done")
-                    } })],
-        });
-    }, {
-        type: "object",
-        properties: {
-            element: {
-                $ref: "#/$defs/Item"
-            }
-        },
-        required: ["element"],
-        $defs: {
-            Item: {
-                type: "object",
-                properties: {
-                    done: {
-                        type: "boolean"
-                    }
-                },
-                required: ["done"]
-            }
-        }
-    } as const satisfies __cfHelpers.JSONSchema, {
-        type: "object",
-        properties: {
-            value: {
-                type: "string"
-            },
-            list: {
-                type: "array",
-                items: {
-                    type: "string"
-                }
-            }
-        },
-        required: ["value", "list"]
-    } as const satisfies __cfHelpers.JSONSchema), {}).for("views", true);
-    const labels = rows.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-        const row = __cf_pattern_input.key("element");
-        return __cfLift_4({ row: {
-                done: row.key("done")
-            } });
-    }, {
-        type: "object",
-        properties: {
-            element: {
-                $ref: "#/$defs/Item"
-            }
-        },
-        required: ["element"],
-        $defs: {
-            Item: {
-                type: "object",
-                properties: {
-                    done: {
-                        type: "boolean"
-                    }
-                },
-                required: ["done"]
-            }
-        }
-    } as const satisfies __cfHelpers.JSONSchema, {
-        type: "string"
-    } as const satisfies __cfHelpers.JSONSchema), {}).for("labels", true);
+    const views = rows.mapWithPattern(__cfPattern_1, {}).for("views", true);
+    const labels = rows.mapWithPattern(__cfPattern_2, {}).for("labels", true);
     return { views, labels };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-direct-return-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-direct-return-conditional.expected.jsx
@@ -11,6 +11,12 @@ import { computed, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Item {
+    done: boolean;
+}
+interface State {
+    items: Item[];
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         items: Item[];
@@ -60,12 +66,39 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items);
-interface Item {
-    done: boolean;
-}
-interface State {
-    items: Item[];
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const row = __cf_pattern_input.key("element");
+    return __cfHelpers.ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        "enum": ["Done", "Pending"]
+    } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Done", "Pending").for("__patternResult", true);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                done: {
+                    type: "boolean"
+                }
+            },
+            required: ["done"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    "enum": ["Done", "Pending"]
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-map-direct-return-conditional
 // Verifies: direct callback-return ternary on a computed array is lowered to ifElse()
 //   rows.map((row) => row.done ? "Done" : "Pending")
@@ -78,40 +111,8 @@ export default pattern((state) => {
         } }).for("rows", true);
     return {
         [UI]: (<div>
-        {rows.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-            const row = __cf_pattern_input.key("element");
-            return __cfHelpers.ifElse({
-                type: "boolean"
-            } as const satisfies __cfHelpers.JSONSchema, {
-                type: "string"
-            } as const satisfies __cfHelpers.JSONSchema, {
-                type: "string"
-            } as const satisfies __cfHelpers.JSONSchema, {
-                "enum": ["Done", "Pending"]
-            } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Done", "Pending").for("__patternResult", true);
-        }, {
-            type: "object",
-            properties: {
-                element: {
-                    $ref: "#/$defs/Item"
-                }
-            },
-            required: ["element"],
-            $defs: {
-                Item: {
-                    type: "object",
-                    properties: {
-                        done: {
-                            type: "boolean"
-                        }
-                    },
-                    required: ["done"]
-                }
-            }
-        } as const satisfies __cfHelpers.JSONSchema, {
-            "enum": ["Done", "Pending"]
-        } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>)
+        {rows.mapWithPattern(__cfPattern_1, {})}
+      </div>),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-in-derived-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-in-derived-branch.expected.jsx
@@ -11,6 +11,14 @@ import { Cell, computed, Default, pattern, UI, Writable } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Person {
+    name: string;
+    rank: number;
+}
+interface PatternInput {
+    people?: Cell<Default<Person[], [
+    ]>>;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     people: __cfHelpers.ReadonlyCell<Person[]>;
 }, { name: string; rank: number; isFirst: boolean; }[]>({
@@ -76,14 +84,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ people }) => people.get().length);
-interface Person {
-    name: string;
-    rank: number;
-}
-interface PatternInput {
-    people?: Cell<Default<Person[], [
-    ]>>;
-}
 // FIXTURE: computed-map-in-derived-branch
 // Verifies: moving a reactive computation out of a JSX slot forces the whole
 //   branch into derive(), so nested maps run in compute context and stay plain

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-in-ternary-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-in-ternary-branch.expected.jsx
@@ -11,6 +11,14 @@ import { Cell, computed, Default, pattern, UI, Writable } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Person {
+    name: string;
+    rank: number;
+}
+interface PatternInput {
+    people?: Cell<Default<Person[], [
+    ]>>;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     people: __cfHelpers.ReadonlyCell<Person[]>;
 }, { name: string; rank: number; isFirst: boolean; }[]>({
@@ -76,6 +84,52 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ people }) => people.get().length);
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const person = __cf_pattern_input.key("element");
+    return (<span>{person.key("name")}</span>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Person"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Person: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                rank: {
+                    type: "number"
+                }
+            },
+            required: ["name", "rank"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     count: number;
 }, string>({
@@ -89,14 +143,61 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, ({ count }) => count + " people");
-interface Person {
-    name: string;
-    rank: number;
-}
-interface PatternInput {
-    people?: Cell<Default<Person[], [
-    ]>>;
-}
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const entry = __cf_pattern_input.key("element");
+    return (<li>
+                    {__cfHelpers.ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        "enum": ["", "\u2605 "]
+    } as const satisfies __cfHelpers.JSONSchema, entry.key("isFirst"), "★ ", "")}
+                    {entry.key("name")}
+                  </li>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                rank: {
+                    type: "number"
+                },
+                isFirst: {
+                    type: "boolean"
+                }
+            },
+            required: ["name", "rank", "isFirst"]
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-map-in-ternary-branch
 // Verifies: a computed array used inside a ternary JSX branch stays pattern-lowered
 //   const adminData = computed(() => [...people.get()].sort(...).map(...))
@@ -114,52 +215,7 @@ export default pattern((__cf_pattern_input) => {
     const count = __cfLift_2({ people: people }).for("count", true);
     return {
         [UI]: (<div>
-        {people.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const person = __cf_pattern_input.key("element");
-                return (<span>{person.key("name")}</span>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Person"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    Person: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            },
-                            rank: {
-                                type: "number"
-                            }
-                        },
-                        required: ["name", "rank"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+        {people.mapWithPattern(__cfPattern_1, {})}
         {__cfHelpers.ifElse({
             type: "boolean",
             asCell: ["cell"]
@@ -180,61 +236,7 @@ export default pattern((__cf_pattern_input) => {
         } as const satisfies __cfHelpers.JSONSchema, showAdmin, <div>
               <span>{__cfLift_3({ count: count })}</span>
               <ul>
-                {adminData.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const entry = __cf_pattern_input.key("element");
-                return (<li>
-                    {__cfHelpers.ifElse({
-                    type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    "enum": ["", "\u2605 "]
-                } as const satisfies __cfHelpers.JSONSchema, entry.key("isFirst"), "★ ", "")}
-                    {entry.key("name")}
-                  </li>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            },
-                            rank: {
-                                type: "number"
-                            },
-                            isFirst: {
-                                type: "boolean"
-                            }
-                        },
-                        required: ["name", "rank", "isFirst"]
-                    }
-                },
-                required: ["element"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+                {adminData.mapWithPattern(__cfPattern_2, {})}
               </ul>
             </div>, null)}
       </div>),

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-input-no-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-input-no-captures.expected.jsx
@@ -20,6 +20,10 @@ import { Cell, computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Item {
+    id: number;
+    value: string;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     items: __cfHelpers.ReadonlyCell<Item[]>;
 }, number>({
@@ -51,10 +55,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ items }) => items.get().map((item) => item.value).length);
-interface Item {
-    id: number;
-    value: string;
-}
 // FIXTURE: computed-map-input-no-captures
 // Verifies: a computed over a captured cell array uses a plain .map() (not .mapWithPattern)
 //   computed(() => items.get().map(...).length) → lift(...)({ items })

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-local-array-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-local-array-conditional.expected.jsx
@@ -11,6 +11,12 @@ import { computed, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Item {
+    done: boolean;
+}
+interface State {
+    items: Item[];
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         items: Item[];
@@ -76,12 +82,58 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema, ({ view }) => view[0]);
-interface Item {
-    done: boolean;
-}
-interface State {
-    items: Item[];
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const row = __cf_pattern_input.key("element");
+    const view = [__cfHelpers.ifElse({
+            type: "boolean"
+        } as const satisfies __cfHelpers.JSONSchema, {
+            type: "string"
+        } as const satisfies __cfHelpers.JSONSchema, {
+            type: "string"
+        } as const satisfies __cfHelpers.JSONSchema, {
+            "enum": ["Done", "Pending"]
+        } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Done", "Pending").for(["view", 0], true)];
+    return <span>{__cfLift_2({ view: view })}</span>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                done: {
+                    type: "boolean"
+                }
+            },
+            required: ["done"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-map-local-array-conditional
 // Verifies: nested ternary inside a callback-local array initializer within a
 //   computed-array .map() callback is lowered at the array element site.
@@ -93,59 +145,8 @@ export default pattern((state) => {
         } }).for("rows", true);
     return {
         [UI]: (<div>
-        {rows.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const row = __cf_pattern_input.key("element");
-                const view = [__cfHelpers.ifElse({
-                        type: "boolean"
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        type: "string"
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        type: "string"
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        "enum": ["Done", "Pending"]
-                    } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Done", "Pending").for(["view", 0], true)];
-                return <span>{__cfLift_2({ view: view })}</span>;
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Item"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            done: {
-                                type: "boolean"
-                            }
-                        },
-                        required: ["done"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>)
+        {rows.mapWithPattern(__cfPattern_1, {})}
+      </div>),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-local-call-root.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-local-call-root.expected.jsx
@@ -11,6 +11,13 @@ import { computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const identity = __cfHardenFn((value: string) => value);
+interface Item {
+    done: boolean;
+}
+interface State {
+    items: Item[];
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         items: Item[];
@@ -81,13 +88,34 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, ({ row }) => identity(row.done ? "Done" : "Pending"));
-const identity = __cfHardenFn((value: string) => value);
-interface Item {
-    done: boolean;
-}
-interface State {
-    items: Item[];
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const row = __cf_pattern_input.key("element");
+    const label = __cfLift_2({ row: {
+            done: row.key("done")
+        } }).for("label", true);
+    return label;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                done: {
+                    type: "boolean"
+                }
+            },
+            required: ["done"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "string"
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-map-local-call-root
 // Verifies: callback-local ordinary call roots in a computed-array .map()
 //   callback whole-wrap as callback-local lift-applied computations even when
@@ -98,34 +126,7 @@ export default pattern((state) => {
     const rows = __cfLift_1({ state: {
             items: state.key("items")
         } }).for("rows", true);
-    const labels = rows.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-        const row = __cf_pattern_input.key("element");
-        const label = __cfLift_2({ row: {
-                done: row.key("done")
-            } }).for("label", true);
-        return label;
-    }, {
-        type: "object",
-        properties: {
-            element: {
-                $ref: "#/$defs/Item"
-            }
-        },
-        required: ["element"],
-        $defs: {
-            Item: {
-                type: "object",
-                properties: {
-                    done: {
-                        type: "boolean"
-                    }
-                },
-                required: ["done"]
-            }
-        }
-    } as const satisfies __cfHelpers.JSONSchema, {
-        type: "string"
-    } as const satisfies __cfHelpers.JSONSchema), {}).for("labels", true);
+    const labels = rows.mapWithPattern(__cfPattern_1, {}).for("labels", true);
     return { labels };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-conditional.expected.jsx
@@ -11,6 +11,12 @@ import { computed, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Item {
+    done: boolean;
+}
+interface State {
+    items: Item[];
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         items: Item[];
@@ -60,12 +66,58 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items);
-interface Item {
-    done: boolean;
-}
-interface State {
-    items: Item[];
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const row = __cf_pattern_input.key("element");
+    const view = { status: __cfHelpers.ifElse({
+            type: "boolean"
+        } as const satisfies __cfHelpers.JSONSchema, {
+            type: "string"
+        } as const satisfies __cfHelpers.JSONSchema, {
+            type: "string"
+        } as const satisfies __cfHelpers.JSONSchema, {
+            "enum": ["Done", "Pending"]
+        } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Done", "Pending").for(["view", "status"], true) };
+    return <span>{view.status}</span>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                done: {
+                    type: "boolean"
+                }
+            },
+            required: ["done"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-map-local-object-conditional
 // Verifies: nested ternary inside a callback-local object initializer within a
 //   computed-array .map() callback is lowered to ifElse().
@@ -77,59 +129,8 @@ export default pattern((state) => {
         } }).for("rows", true);
     return {
         [UI]: (<div>
-        {rows.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const row = __cf_pattern_input.key("element");
-                const view = { status: __cfHelpers.ifElse({
-                        type: "boolean"
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        type: "string"
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        type: "string"
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        "enum": ["Done", "Pending"]
-                    } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Done", "Pending").for(["view", "status"], true) };
-                return <span>{view.status}</span>;
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Item"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            done: {
-                                type: "boolean"
-                            }
-                        },
-                        required: ["done"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>)
+        {rows.mapWithPattern(__cfPattern_1, {})}
+      </div>),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-logical-or.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-logical-or.expected.jsx
@@ -11,6 +11,12 @@ import { computed, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Item {
+    done: boolean;
+}
+interface State {
+    items: Item[];
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         items: Item[];
@@ -60,12 +66,56 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items);
-interface Item {
-    done: boolean;
-}
-interface State {
-    items: Item[];
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const row = __cf_pattern_input.key("element");
+    const view = { status: __cfHelpers.unless({
+            type: "boolean"
+        } as const satisfies __cfHelpers.JSONSchema, {
+            type: "string"
+        } as const satisfies __cfHelpers.JSONSchema, {
+            "enum": [true, "Pending"]
+        } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Pending").for(["view", "status"], true) };
+    return <span>{view.status}</span>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                done: {
+                    type: "boolean"
+                }
+            },
+            required: ["done"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-map-local-object-logical-or
 // Verifies: nested || inside a callback-local object initializer within a
 //   computed-array .map() callback is lowered to unless().
@@ -77,57 +127,8 @@ export default pattern((state) => {
         } }).for("rows", true);
     return {
         [UI]: (<div>
-        {rows.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const row = __cf_pattern_input.key("element");
-                const view = { status: __cfHelpers.unless({
-                        type: "boolean"
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        type: "string"
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        "enum": [true, "Pending"]
-                    } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Pending").for(["view", "status"], true) };
-                return <span>{view.status}</span>;
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Item"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            done: {
-                                type: "boolean"
-                            }
-                        },
-                        required: ["done"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>)
+        {rows.mapWithPattern(__cfPattern_1, {})}
+      </div>),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-pre-resolved-return-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-pre-resolved-return-conditional.expected.jsx
@@ -11,6 +11,12 @@ import { computed, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Item {
+    done: boolean;
+}
+interface State {
+    items: Item[];
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         items: {
@@ -52,12 +58,34 @@ const __cfLift_1 = __cfHelpers.lift<{
         required: ["done"]
     }
 } as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items.map((item) => ({ done: item.done })));
-interface Item {
-    done: boolean;
-}
-interface State {
-    items: Item[];
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const row = __cf_pattern_input.key("element");
+    return __cfHelpers.ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        "enum": ["Done", "Pending"]
+    } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Done", "Pending").for("__patternResult", true);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                done: {
+                    type: "boolean"
+                }
+            },
+            required: ["done"]
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    "enum": ["Done", "Pending"]
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-map-pre-resolved-return-conditional
 // Verifies: pre-resolving a boolean inside the source computed does not avoid
 //   the need to lower the later direct callback-return ternary.
@@ -70,35 +98,8 @@ export default pattern((state) => {
         } }).for("rows", true);
     return {
         [UI]: (<div>
-        {rows.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-            const row = __cf_pattern_input.key("element");
-            return __cfHelpers.ifElse({
-                type: "boolean"
-            } as const satisfies __cfHelpers.JSONSchema, {
-                type: "string"
-            } as const satisfies __cfHelpers.JSONSchema, {
-                type: "string"
-            } as const satisfies __cfHelpers.JSONSchema, {
-                "enum": ["Done", "Pending"]
-            } as const satisfies __cfHelpers.JSONSchema, row.key("done"), "Done", "Pending").for("__patternResult", true);
-        }, {
-            type: "object",
-            properties: {
-                element: {
-                    type: "object",
-                    properties: {
-                        done: {
-                            type: "boolean"
-                        }
-                    },
-                    required: ["done"]
-                }
-            },
-            required: ["element"]
-        } as const satisfies __cfHelpers.JSONSchema, {
-            "enum": ["Done", "Pending"]
-        } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>)
+        {rows.mapWithPattern(__cfPattern_1, {})}
+      </div>),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-union-return.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-union-return.expected.jsx
@@ -11,6 +11,18 @@ import { computed, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface ContentPart {
+    type: "text" | "image";
+    text?: string;
+    image?: string;
+}
+interface Message {
+    role: "user" | "assistant";
+    content: string | ContentPart[];
+}
+interface State {
+    messages: Message[];
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         messages: Message[];
@@ -94,18 +106,6 @@ const __cfLift_1 = __cfHelpers.lift<{
     }
     return null;
 });
-interface ContentPart {
-    type: "text" | "image";
-    text?: string;
-    image?: string;
-}
-interface Message {
-    role: "user" | "assistant";
-    content: string | ContentPart[];
-}
-interface State {
-    messages: Message[];
-}
 // FIXTURE: computed-map-union-return
 // Verifies: a computed returning a union type (string | null) with a nested .map() infers the correct output schema
 //   computed(() => { ...; return content }) → lift(schema, anyOf[string, null])({ messages })

--- a/packages/ts-transformers/test/fixtures/closures/computed-method-call-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-method-call-capture.expected.jsx
@@ -11,6 +11,11 @@ import { Writable, computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    counter: {
+        value: number;
+    };
+}
 const __cfLift_1 = __cfHelpers.lift<{
     value: __cfHelpers.ReadonlyCell<number>;
     state: {
@@ -45,11 +50,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ value, state }) => value.get() + state.counter.value);
-interface State {
-    counter: {
-        value: number;
-    };
-}
 // FIXTURE: computed-method-call-capture
 // Verifies: a deep property access on a captured object is restructured into a nested capture object
 //   computed(() => value.get() + state.counter.value) → lift(...)({ value, state: { counter: { value } } })

--- a/packages/ts-transformers/test/fixtures/closures/computed-nullable-optional-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-nullable-optional-chain.expected.jsx
@@ -11,6 +11,12 @@ import { computed, pattern, UI, NAME } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+// Represents a question that may or may not exist
+type Question = {
+    question: string;
+    category: string;
+    priority: number;
+};
 const __cfLift_1 = __cfHelpers.lift(false, (): Question | null => {
     // In real code this would filter and return first match, or null
     return null;
@@ -133,12 +139,6 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, ({ topQuestion }) => topQuestion === null ? "" : topQuestion.category);
-// Represents a question that may or may not exist
-type Question = {
-    question: string;
-    category: string;
-    priority: number;
-};
 // FIXTURE: computed-nullable-optional-chain
 // Verifies: computed() capturing a nullable computed result preserves anyOf [type, null] in schema
 //   computed(() => topQuestion?.question || "") → lift(({ topQuestion }) => topQuestion?.question || "")({ topQuestion })

--- a/packages/ts-transformers/test/fixtures/closures/computed-property-access-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-property-access-map.expected.jsx
@@ -18,6 +18,10 @@ import { computed, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Item {
+    name: string;
+    done: boolean;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     items: {
         done: boolean;
@@ -129,10 +133,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, ({ result }) => {
     return result.tasks.map((task) => <li>{task.name}</li>);
 });
-interface Item {
-    name: string;
-    done: boolean;
-}
 // FIXTURE: computed-property-access-map
 // Verifies: .map() on a property access of a computed result inside another computed() is NOT transformed to .mapWithPattern()
 //   computed(() => result.tasks.map(fn)) → lift(({ result }) => result.tasks.map(fn))({ result: { tasks: result.key("tasks") } })

--- a/packages/ts-transformers/test/fixtures/closures/computed-result-in-derive-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-result-in-derive-captures.expected.jsx
@@ -16,6 +16,12 @@ import { computed, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    items: Array<{
+        name: string;
+        done: boolean;
+    }>;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         items: {
@@ -85,12 +91,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, ({ stats }) => `${stats.count} of ${stats.total} done`);
-interface State {
-    items: Array<{
-        name: string;
-        done: boolean;
-    }>;
-}
 // FIXTURE: computed-result-in-derive-captures
 // Verifies: computed() result properties captured in a subsequent lift-applied computation use .key() access
 //   computed(() => `${stats.count} of ${stats.total} done`) → lift(({ stats }) => ...)({ stats: { count: stats.key("count"), total: stats.key("total") } })

--- a/packages/ts-transformers/test/fixtures/closures/computed-result-property-in-return.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-result-property-in-return.expected.jsx
@@ -17,6 +17,9 @@ import { computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    items: string[];
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         items: string[];
@@ -62,9 +65,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ summary }) => summary.length);
-interface State {
-    items: string[];
-}
 // FIXTURE: computed-result-property-in-return
 // Verifies: .length on a computed() string result is captured via .key("length") in a subsequent lift-applied computation
 //   computed(() => summary.length) → lift(({ summary }) => summary.length)({ summary: { length: summary.key("length") } })

--- a/packages/ts-transformers/test/fixtures/closures/computed-union-undefined.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-union-undefined.expected.jsx
@@ -11,6 +11,10 @@ import { Writable, computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Config {
+    required: number;
+    unionUndefined: number | undefined;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     value: __cfHelpers.ReadonlyCell<number>;
     config: {
@@ -41,10 +45,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ value, config }) => value.get() + config.required + (config.unionUndefined ?? 0));
-interface Config {
-    required: number;
-    unionUndefined: number | undefined;
-}
 // FIXTURE: computed-union-undefined
 // Verifies: captured properties with `number | undefined` union types produce correct schemas
 //   computed(() => ...) → lift(...)({ value, config: { required, unionUndefined } })

--- a/packages/ts-transformers/test/fixtures/closures/computed-with-closed-over-cell-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-with-closed-over-cell-map.expected.jsx
@@ -11,6 +11,31 @@ import { Writable, computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const n = __cf_pattern_input.key("element");
+    const multiplier = __cf_pattern_input.key("params", "multiplier");
+    return n * multiplier.get();
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "number"
+        },
+        params: {
+            type: "object",
+            properties: {
+                multiplier: {
+                    type: "number",
+                    asCell: ["readonly"]
+                }
+            },
+            required: ["multiplier"]
+        }
+    },
+    required: ["element", "params"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "number"
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_1 = __cfHelpers.lift<{
     numbers: __cfHelpers.ReadonlyCell<number[]>;
     multiplier: __cfHelpers.ReadonlyCell<number>;
@@ -35,31 +60,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     items: {
         type: "number"
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ numbers, multiplier }) => numbers.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-    const n = __cf_pattern_input.key("element");
-    const multiplier = __cf_pattern_input.key("params", "multiplier");
-    return n * multiplier.get();
-}, {
-    type: "object",
-    properties: {
-        element: {
-            type: "number"
-        },
-        params: {
-            type: "object",
-            properties: {
-                multiplier: {
-                    type: "number",
-                    asCell: ["readonly"]
-                }
-            },
-            required: ["multiplier"]
-        }
-    },
-    required: ["element", "params"]
-} as const satisfies __cfHelpers.JSONSchema, {
-    type: "number"
-} as const satisfies __cfHelpers.JSONSchema), {
+} as const satisfies __cfHelpers.JSONSchema, ({ numbers, multiplier }) => numbers.mapWithPattern(__cfPattern_1, {
     multiplier: multiplier
 }));
 // FIXTURE: computed-with-closed-over-cell-map

--- a/packages/ts-transformers/test/fixtures/closures/fetch-data-result-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/fetch-data-result-map.expected.jsx
@@ -14,55 +14,56 @@ const __cfAmdHooks = undefined;
 interface Item {
     name: string;
 }
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return <span>{item.key("name")}</span>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 export default pattern(() => {
     const __cf_destructure_1 = fetchData<Item[]>({
         url: "https://example.com",
         result: [],
     }), items = __cf_destructure_1.key("result").for("items", true);
     return {
-        [UI]: <div>{items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-            const item = __cf_pattern_input.key("element");
-            return <span>{item.key("name")}</span>;
-        }, {
-            type: "object",
-            properties: {
-                element: {
-                    $ref: "#/$defs/Item"
-                }
-            },
-            required: ["element"],
-            $defs: {
-                Item: {
-                    type: "object",
-                    properties: {
-                        name: {
-                            type: "string"
-                        }
-                    },
-                    required: ["name"]
-                }
-            }
-        } as const satisfies __cfHelpers.JSONSchema, {
-            anyOf: [{
-                    $ref: "https://commonfabric.org/schemas/vnode.json"
-                }, {
-                    $ref: "#/$defs/UIRenderable"
-                }, {
-                    type: "object",
-                    properties: {}
-                }],
-            $defs: {
-                UIRenderable: {
-                    type: "object",
-                    properties: {
-                        $UI: {
-                            $ref: "https://commonfabric.org/schemas/vnode.json"
-                        }
-                    },
-                    required: ["$UI"]
-                }
-            }
-        } as const satisfies __cfHelpers.JSONSchema), {})}</div>,
+        [UI]: <div>{items.mapWithPattern(__cfPattern_1, {})}</div>,
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/filter-basic.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/filter-basic.expected.jsx
@@ -19,6 +19,86 @@ interface Item {
 interface State {
     items: Item[];
 }
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return item.key("active");
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "number"
+                },
+                name: {
+                    type: "string"
+                },
+                active: {
+                    type: "boolean"
+                }
+            },
+            required: ["id", "name", "active"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return (<div>Item #{item.key("id")}: {item.key("name")}</div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "number"
+                },
+                name: {
+                    type: "string"
+                },
+                active: {
+                    type: "boolean"
+                }
+            },
+            required: ["id", "name", "active"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: filter-basic
 // Verifies: .filter() + .map() chain on reactive arrays are both transformed
 //   .filter(fn) → .filterWithPattern(pattern(...), {})
@@ -28,85 +108,7 @@ interface State {
 export default pattern((state) => {
     return {
         [UI]: (<div>
-        {state.key("items").filterWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                return item.key("active");
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Item"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            id: {
-                                type: "number"
-                            },
-                            name: {
-                                type: "string"
-                            },
-                            active: {
-                                type: "boolean"
-                            }
-                        },
-                        required: ["id", "name", "active"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                type: "boolean"
-            } as const satisfies __cfHelpers.JSONSchema), {}).mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                return (<div>Item #{item.key("id")}: {item.key("name")}</div>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Item"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            id: {
-                                type: "number"
-                            },
-                            name: {
-                                type: "string"
-                            },
-                            active: {
-                                type: "boolean"
-                            }
-                        },
-                        required: ["id", "name", "active"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+        {state.key("items").filterWithPattern(__cfPattern_1, {}).mapWithPattern(__cfPattern_2, {})}
       </div>),
     };
 }, {

--- a/packages/ts-transformers/test/fixtures/closures/filter-flatmap-fallback-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/filter-flatmap-fallback-chain.expected.jsx
@@ -15,6 +15,103 @@ interface Item {
     id: string;
     tags?: string[];
 }
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return item.key("id");
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                },
+                tags: {
+                    type: "array",
+                    items: {
+                        type: "string"
+                    }
+                }
+            },
+            required: ["id"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "string"
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return item.key("tags") ?? [];
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                },
+                tags: {
+                    type: "array",
+                    items: {
+                        type: "string"
+                    }
+                }
+            },
+            required: ["id"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "array",
+    items: {
+        type: "string"
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
+    const tag = __cf_pattern_input.key("element");
+    return <span>{tag}</span>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "string"
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: filter-flatmap-fallback-chain
 // Verifies: fallback receiver chains keep structural array-method lowering
 //   (items ?? []).filter(fn).flatMap(fn).map(fn)
@@ -24,101 +121,7 @@ export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     return {
         [UI]: (<div>
-        {(items ?? []).filterWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                return item.key("id");
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Item"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            id: {
-                                type: "string"
-                            },
-                            tags: {
-                                type: "array",
-                                items: {
-                                    type: "string"
-                                }
-                            }
-                        },
-                        required: ["id"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                type: "string"
-            } as const satisfies __cfHelpers.JSONSchema), {}).flatMapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                return item.key("tags") ?? [];
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Item"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            id: {
-                                type: "string"
-                            },
-                            tags: {
-                                type: "array",
-                                items: {
-                                    type: "string"
-                                }
-                            }
-                        },
-                        required: ["id"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                type: "array",
-                items: {
-                    type: "string"
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {}).mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const tag = __cf_pattern_input.key("element");
-                return <span>{tag}</span>;
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "string"
-                    }
-                },
-                required: ["element"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+        {(items ?? []).filterWithPattern(__cfPattern_1, {}).flatMapWithPattern(__cfPattern_2, {}).mapWithPattern(__cfPattern_3, {})}
       </div>),
     };
 }, {

--- a/packages/ts-transformers/test/fixtures/closures/filter-flatmap-plain-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/filter-flatmap-plain-captures.expected.jsx
@@ -36,6 +36,47 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, ({ item, suffix }) => item.label.endsWith(suffix));
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const suffix = __cf_pattern_input.params.suffix;
+    return __cfLift_1({
+        item: {
+            label: item.key("label")
+        },
+        suffix: suffix
+    }).for("__patternResult", true);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                label: {
+                    type: "string"
+                },
+                tags: {
+                    type: "array",
+                    items: {
+                        type: "string"
+                    }
+                }
+            },
+            required: ["label", "tags"]
+        },
+        params: {
+            type: "object",
+            properties: {
+                suffix: {
+                    type: "string"
+                }
+            },
+            required: ["suffix"]
+        }
+    },
+    required: ["element", "params"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     item: {
         tags: string[];
@@ -67,6 +108,65 @@ const __cfLift_2 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema, ({ item, prefix }) => [prefix + item.tags[0]]);
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const prefix = __cf_pattern_input.params.prefix;
+    return __cfHelpers.ifElse({
+        type: "number"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "array",
+        items: {
+            type: "string"
+        }
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "array",
+        items: false
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "array",
+        items: {
+            type: "string"
+        }
+    } as const satisfies __cfHelpers.JSONSchema, item.key("tags", "length"), __cfLift_2({
+        item: {
+            tags: item.key("tags")
+        },
+        prefix: prefix
+    }), []).for("__patternResult", true);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                label: {
+                    type: "string"
+                },
+                tags: {
+                    type: "array",
+                    items: {
+                        type: "string"
+                    }
+                }
+            },
+            required: ["label", "tags"]
+        },
+        params: {
+            type: "object",
+            properties: {
+                prefix: {
+                    type: "string"
+                }
+            },
+            required: ["prefix"]
+        }
+    },
+    required: ["element", "params"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "array",
+    items: {
+        type: "string"
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: filter-flatmap-plain-captures
 // Verifies: plain lexical captures in reactive filter/flatMap chains become
 // params values, not reactive key(...) lookups
@@ -79,107 +179,9 @@ export default pattern((__cf_pattern_input) => {
     const suffix = "!";
     const prefix = "#";
     return {
-        labels: items.filterWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-            const item = __cf_pattern_input.key("element");
-            const suffix = __cf_pattern_input.params.suffix;
-            return __cfLift_1({
-                item: {
-                    label: item.key("label")
-                },
-                suffix: suffix
-            });
-        }, {
-            type: "object",
-            properties: {
-                element: {
-                    type: "object",
-                    properties: {
-                        label: {
-                            type: "string"
-                        },
-                        tags: {
-                            type: "array",
-                            items: {
-                                type: "string"
-                            }
-                        }
-                    },
-                    required: ["label", "tags"]
-                },
-                params: {
-                    type: "object",
-                    properties: {
-                        suffix: {
-                            type: "string"
-                        }
-                    },
-                    required: ["suffix"]
-                }
-            },
-            required: ["element", "params"]
-        } as const satisfies __cfHelpers.JSONSchema, {
-            type: "boolean"
-        } as const satisfies __cfHelpers.JSONSchema), {
+        labels: items.filterWithPattern(__cfPattern_1, {
             suffix: suffix
-        }).flatMapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-            const item = __cf_pattern_input.key("element");
-            const prefix = __cf_pattern_input.params.prefix;
-            return __cfHelpers.ifElse({
-                type: "number"
-            } as const satisfies __cfHelpers.JSONSchema, {
-                type: "array",
-                items: {
-                    type: "string"
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                type: "array",
-                items: false
-            } as const satisfies __cfHelpers.JSONSchema, {
-                type: "array",
-                items: {
-                    type: "string"
-                }
-            } as const satisfies __cfHelpers.JSONSchema, item.key("tags", "length"), __cfLift_2({
-                item: {
-                    tags: item.key("tags")
-                },
-                prefix: prefix
-            }), []);
-        }, {
-            type: "object",
-            properties: {
-                element: {
-                    type: "object",
-                    properties: {
-                        label: {
-                            type: "string"
-                        },
-                        tags: {
-                            type: "array",
-                            items: {
-                                type: "string"
-                            }
-                        }
-                    },
-                    required: ["label", "tags"]
-                },
-                params: {
-                    type: "object",
-                    properties: {
-                        prefix: {
-                            type: "string"
-                        }
-                    },
-                    required: ["prefix"]
-                }
-            },
-            required: ["element", "params"]
-        } as const satisfies __cfHelpers.JSONSchema, {
-            type: "array",
-            items: {
-                type: "string"
-            }
-        } as const satisfies __cfHelpers.JSONSchema), {
+        }).flatMapWithPattern(__cfPattern_2, {
             prefix: prefix
         }).for(["__patternResult", "labels"], true)
     };

--- a/packages/ts-transformers/test/fixtures/closures/filter-map-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/filter-map-chain.expected.jsx
@@ -11,6 +11,46 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Item {
+    id: number;
+    price: number;
+    active: boolean;
+}
+interface State {
+    items: Item[];
+    taxRate: number;
+}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return item.key("active");
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "number"
+                },
+                price: {
+                    type: "number"
+                },
+                active: {
+                    type: "boolean"
+                }
+            },
+            required: ["id", "price", "active"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_1 = __cfHelpers.lift<{
     item: {
         price: number;
@@ -44,15 +84,80 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ item, state }) => item.price * (1 + state.taxRate));
-interface Item {
-    id: number;
-    price: number;
-    active: boolean;
-}
-interface State {
-    items: Item[];
-    taxRate: number;
-}
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const state = __cf_pattern_input.key("params", "state");
+    return (<div>
+              Total: {__cfLift_1({
+        item: {
+            price: item.key("price")
+        },
+        state: {
+            taxRate: state.key("taxRate")
+        }
+    })}
+            </div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        },
+        params: {
+            type: "object",
+            properties: {
+                state: {
+                    type: "object",
+                    properties: {
+                        taxRate: {
+                            type: "number"
+                        }
+                    },
+                    required: ["taxRate"]
+                }
+            },
+            required: ["state"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "number"
+                },
+                price: {
+                    type: "number"
+                },
+                active: {
+                    type: "boolean"
+                }
+            },
+            required: ["id", "price", "active"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: filter-map-chain
 // Verifies: filter+map chain with captured outer variables
 //   .filter(fn) → .filterWithPattern(pattern(...), {})  — no captures
@@ -63,110 +168,7 @@ interface State {
 export default pattern((state) => {
     return {
         [UI]: (<div>
-        {state.key("items").filterWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                return item.key("active");
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Item"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            id: {
-                                type: "number"
-                            },
-                            price: {
-                                type: "number"
-                            },
-                            active: {
-                                type: "boolean"
-                            }
-                        },
-                        required: ["id", "price", "active"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                type: "boolean"
-            } as const satisfies __cfHelpers.JSONSchema), {}).mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                const state = __cf_pattern_input.key("params", "state");
-                return (<div>
-              Total: {__cfLift_1({
-                    item: {
-                        price: item.key("price")
-                    },
-                    state: {
-                        taxRate: state.key("taxRate")
-                    }
-                })}
-            </div>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Item"
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            state: {
-                                type: "object",
-                                properties: {
-                                    taxRate: {
-                                        type: "number"
-                                    }
-                                },
-                                required: ["taxRate"]
-                            }
-                        },
-                        required: ["state"]
-                    }
-                },
-                required: ["element", "params"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            id: {
-                                type: "number"
-                            },
-                            price: {
-                                type: "number"
-                            },
-                            active: {
-                                type: "boolean"
-                            }
-                        },
-                        required: ["id", "price", "active"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        {state.key("items").filterWithPattern(__cfPattern_1, {}).mapWithPattern(__cfPattern_2, {
                 state: {
                     taxRate: state.key("taxRate")
                 }

--- a/packages/ts-transformers/test/fixtures/closures/flatmap-basic.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/flatmap-basic.expected.jsx
@@ -18,6 +18,55 @@ interface Item {
 interface State {
     items: Item[];
 }
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return (<div>Item #{item.key("id")}</div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "number"
+                },
+                tags: {
+                    type: "array",
+                    items: {
+                        type: "string"
+                    }
+                }
+            },
+            required: ["id", "tags"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: flatmap-basic
 // Verifies: .flatMap() on a reactive array is transformed
 //   .flatMap(fn) → .flatMapWithPattern(pattern(...), {})
@@ -25,55 +74,7 @@ interface State {
 export default pattern((state) => {
     return {
         [UI]: (<div>
-        {state.key("items").flatMapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                return (<div>Item #{item.key("id")}</div>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Item"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            id: {
-                                type: "number"
-                            },
-                            tags: {
-                                type: "array",
-                                items: {
-                                    type: "string"
-                                }
-                            }
-                        },
-                        required: ["id", "tags"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+        {state.key("items").flatMapWithPattern(__cfPattern_1, {})}
       </div>),
     };
 }, {

--- a/packages/ts-transformers/test/fixtures/closures/handler-basic.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-basic.expected.jsx
@@ -11,6 +11,9 @@ import { Cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    counter: Cell<number>;
+}
 const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -27,9 +30,6 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     },
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, { state }) => state.counter.set(state.counter.get() + 1));
-interface State {
-    counter: Cell<number>;
-}
 // FIXTURE: handler-basic
 // Verifies: inline arrow function in JSX onClick is extracted into a handler with captures
 //   onClick={() => state.counter.set(...)} → onClick={handler(false, { state: { counter: asCell } }, (_, { state }) => ...)({ state: { counter } })}

--- a/packages/ts-transformers/test/fixtures/closures/handler-computed-key.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-computed-key.expected.jsx
@@ -11,6 +11,15 @@ import { Cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    records: Record<string, Cell<number>>;
+}
+let counter = 0;
+function nextKey(): string {
+    counter += 1;
+    return `key-${counter}`;
+}
+__cfHardenFn(nextKey);
 const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -25,15 +34,6 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     },
     required: ["recordMap"]
 } as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, { recordMap }) => recordMap[nextKey()]!.set(counter));
-interface State {
-    records: Record<string, Cell<number>>;
-}
-let counter = 0;
-function nextKey(): string {
-    counter += 1;
-    return `key-${counter}`;
-}
-__cfHardenFn(nextKey);
 // FIXTURE: handler-computed-key
 // Verifies: handler capturing a Record with computed (dynamic) key access is transformed correctly
 //   onClick={() => recordMap[nextKey()]!.set(counter)) → handler(false, { recordMap: { additionalProperties, asOpaque } }, ...)({ recordMap })

--- a/packages/ts-transformers/test/fixtures/closures/handler-destructured-params.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-destructured-params.expected.jsx
@@ -11,6 +11,10 @@ import { Cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    selectedValue: Cell<string>;
+    lastItems: Cell<string>;
+}
 const __cfHandler_1 = __cfHelpers.handler({
     type: "object",
     properties: {
@@ -59,10 +63,6 @@ const __cfHandler_1 = __cfHelpers.handler({
     state.selectedValue.set(value);
     state.lastItems.set(items.map(i => i.label).join(", "));
 });
-interface State {
-    selectedValue: Cell<string>;
-    lastItems: Cell<string>;
-}
 // FIXTURE: handler-destructured-params
 // Verifies: destructured event parameter in inline handler is preserved and schema-typed
 //   onct-change={({ detail: { value, items } }) => ...} → handler(event schema with detail.value + detail.items, capture schema, ({ detail: { value, items } }, { state }) => ...)({ state })

--- a/packages/ts-transformers/test/fixtures/closures/handler-event-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-event-param.expected.jsx
@@ -11,6 +11,10 @@ import { Cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    selectedValue: Cell<string>;
+    changeCount: Cell<number>;
+}
 const __cfHandler_1 = __cfHelpers.handler({
     type: "object",
     properties: {
@@ -46,10 +50,6 @@ const __cfHandler_1 = __cfHelpers.handler({
     state.selectedValue.set(event.detail.value);
     state.changeCount.set(state.changeCount.get() + 1);
 });
-interface State {
-    selectedValue: Cell<string>;
-    changeCount: Cell<number>;
-}
 // FIXTURE: handler-event-param
 // Verifies: inline handler with a named event parameter generates event + capture schemas
 //   onct-change={(event) => ...} → handler(event schema with detail.value, capture schema, (event, { state }) => ...)({ state })

--- a/packages/ts-transformers/test/fixtures/closures/handler-nested-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-nested-map.expected.jsx
@@ -11,6 +11,12 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    items: Array<{
+        value: number;
+    }>;
+    multiplier: number;
+}
 const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -41,12 +47,6 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     const scaled = state.items.map((item) => item.value * state.multiplier);
     console.log(scaled);
 });
-interface State {
-    items: Array<{
-        value: number;
-    }>;
-    multiplier: number;
-}
 // FIXTURE: handler-nested-map
 // Verifies: .map() inside a handler body is NOT transformed to .mapWithPattern()
 //   onClick={() => { state.items.map(...) }) → handler(..., (_, { state }) => { state.items.map(...) })

--- a/packages/ts-transformers/test/fixtures/closures/handler-no-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-no-captures.expected.jsx
@@ -11,13 +11,13 @@ import { Cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    counter: Cell<number>;
+}
 const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {}
 } as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, __cf_handler_params) => console.log("hi"));
-interface State {
-    counter: Cell<number>;
-}
 // FIXTURE: handler-no-captures
 // Verifies: inline handler with no captured outer variables still gets wrapped with empty captures
 //   onClick={() => console.log("hi")) → handler(false, { properties: {} }, (_, __cf_handler_params) => ...)({})

--- a/packages/ts-transformers/test/fixtures/closures/handler-reserved-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-reserved-capture.expected.jsx
@@ -11,6 +11,9 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    label: string;
+}
 const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -20,9 +23,6 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     },
     required: ["__cf_handler_event"]
 } as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event_1, { __cf_handler_event }) => __cf_handler_event);
-interface State {
-    label: string;
-}
 // FIXTURE: handler-reserved-capture
 // Verifies: captured variable named __cf_handler_event is renamed to avoid collision with the synthetic event param
 //   onClick={() => __cf_handler_event) → handler(false, { __cf_handler_event: ... }, (__cf_handler_event_1, { __cf_handler_event }) => ...)

--- a/packages/ts-transformers/test/fixtures/closures/handler-unused-event.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-unused-event.expected.jsx
@@ -11,6 +11,9 @@ import { Cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    counter: Cell<number>;
+}
 const __cfHandler_1 = __cfHelpers.handler({
     type: "unknown"
 } as const satisfies __cfHelpers.JSONSchema, {
@@ -29,9 +32,6 @@ const __cfHandler_1 = __cfHelpers.handler({
     },
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, (_, { state }) => state.counter.set(state.counter.get() + 1));
-interface State {
-    counter: Cell<number>;
-}
 // FIXTURE: handler-unused-event
 // Verifies: inline handler with an unused event param (_) still generates an event schema placeholder
 //   onClick={(_: unknown) => state.counter.set(...)) → handler(event schema, capture schema, (_, { state }) => ...)({ state })

--- a/packages/ts-transformers/test/fixtures/closures/helper-owned-handler-nested-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/helper-owned-handler-nested-captures.expected.jsx
@@ -25,6 +25,30 @@ import { action, Default, pattern, Stream, Writable } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+function flushLater(fileId: Writable<Default<string, "">>, content: Writable<Default<string, "">>, savedContent: Writable<Default<string, "">>, onSaveFile: Stream<{
+    fileId: string;
+    content: string;
+}>): void {
+    const nextContent = content.get();
+    const lastSaved = savedContent.get();
+    const targetFileId = fileId.get().trim();
+    if (!targetFileId || nextContent === lastSaved)
+        return;
+    onSaveFile.send({ fileId: targetFileId, content: nextContent });
+}
+__cfHardenFn(flushLater);
+interface Input {
+    fileId: Writable<Default<string, "">>;
+    content: Writable<Default<string, "">>;
+    savedContent: Writable<Default<string, "">>;
+    onSaveFile: Stream<{
+        fileId: string;
+        content: string;
+    }>;
+}
+interface Output {
+    trigger: Stream<void>;
+}
 const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -74,30 +98,6 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
         flushLater(fileId, content, savedContent, onSaveFile);
     }, 10));
 });
-function flushLater(fileId: Writable<Default<string, "">>, content: Writable<Default<string, "">>, savedContent: Writable<Default<string, "">>, onSaveFile: Stream<{
-    fileId: string;
-    content: string;
-}>): void {
-    const nextContent = content.get();
-    const lastSaved = savedContent.get();
-    const targetFileId = fileId.get().trim();
-    if (!targetFileId || nextContent === lastSaved)
-        return;
-    onSaveFile.send({ fileId: targetFileId, content: nextContent });
-}
-__cfHardenFn(flushLater);
-interface Input {
-    fileId: Writable<Default<string, "">>;
-    content: Writable<Default<string, "">>;
-    savedContent: Writable<Default<string, "">>;
-    onSaveFile: Stream<{
-        fileId: string;
-        content: string;
-    }>;
-}
-interface Output {
-    trigger: Stream<void>;
-}
 export default pattern((__cf_pattern_input) => {
     const fileId = __cf_pattern_input.key("fileId");
     const content = __cf_pattern_input.key("content");

--- a/packages/ts-transformers/test/fixtures/closures/hoisted-handler-preserves-capture-schemas.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/hoisted-handler-preserves-capture-schemas.expected.jsx
@@ -11,6 +11,55 @@ import { action, NAME, pattern, SELF, UI, type VNode, Writable, } from "commonfa
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+// `navigateTo` is a CommonFabric built-in for SPA navigation; importing
+// it ensures it lives at module scope and the action bodies that
+// reference it (a) compile and (b) close over a module-level symbol.
+declare const navigateTo: (target: any) => any;
+interface Item {
+    id: number;
+    label: string;
+    [NAME]: string;
+}
+interface ListOutput {
+    [NAME]: string;
+    [UI]: VNode;
+    read: any;
+    write: any;
+}
+const Item = pattern((__cf_pattern_input) => {
+    const id = __cf_pattern_input.key("id");
+    const label = __cf_pattern_input.key("label");
+    return ({
+        id,
+        label,
+        [NAME]: label,
+    });
+}, {
+    type: "object",
+    properties: {
+        id: {
+            type: "number"
+        },
+        label: {
+            type: "string"
+        }
+    },
+    required: ["id", "label"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        id: {
+            type: "number"
+        },
+        label: {
+            type: "string"
+        },
+        $NAME: {
+            type: "string"
+        }
+    },
+    required: ["id", "label", "$NAME"]
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -109,55 +158,6 @@ const __cfHandler_2 = __cfHelpers.handler({
     items.push(newItem as any);
     return newItem;
 });
-// `navigateTo` is a CommonFabric built-in for SPA navigation; importing
-// it ensures it lives at module scope and the action bodies that
-// reference it (a) compile and (b) close over a module-level symbol.
-declare const navigateTo: (target: any) => any;
-interface Item {
-    id: number;
-    label: string;
-    [NAME]: string;
-}
-interface ListOutput {
-    [NAME]: string;
-    [UI]: VNode;
-    read: any;
-    write: any;
-}
-const Item = pattern((__cf_pattern_input) => {
-    const id = __cf_pattern_input.key("id");
-    const label = __cf_pattern_input.key("label");
-    return ({
-        id,
-        label,
-        [NAME]: label,
-    });
-}, {
-    type: "object",
-    properties: {
-        id: {
-            type: "number"
-        },
-        label: {
-            type: "string"
-        }
-    },
-    required: ["id", "label"]
-} as const satisfies __cfHelpers.JSONSchema, {
-    type: "object",
-    properties: {
-        id: {
-            type: "number"
-        },
-        label: {
-            type: "string"
-        },
-        $NAME: {
-            type: "string"
-        }
-    },
-    required: ["id", "label", "$NAME"]
-} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: hoisted-handler-preserves-capture-schemas (CT-1585 regression)
 export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");

--- a/packages/ts-transformers/test/fixtures/closures/ifelse-factory-boundaries.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/ifelse-factory-boundaries.expected.jsx
@@ -11,44 +11,6 @@ import { handler, ifElse, lift, pattern, UI, Writable } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
-    msg: {
-        type: string;
-    };
-}, boolean>({
-    type: "object",
-    properties: {
-        msg: {
-            type: "object",
-            properties: {
-                type: {
-                    type: "string"
-                }
-            },
-            required: ["type"]
-        }
-    },
-    required: ["msg"]
-} as const satisfies __cfHelpers.JSONSchema, {
-    type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ msg }) => msg.type === "system");
-const __cfModuleCallback_1 = __cfHardenFn(__cf_pattern_input => {
-    const entry = __cf_pattern_input.key("element");
-    return ifElse({
-        type: "boolean"
-    } as const satisfies __cfHelpers.JSONSchema, {
-        anyOf: [{}, {
-                type: "object",
-                properties: {}
-            }]
-    } as const satisfies __cfHelpers.JSONSchema, {
-        type: "null"
-    } as const satisfies __cfHelpers.JSONSchema, {
-        anyOf: [{
-                type: "null"
-            }, {}]
-    } as const satisfies __cfHelpers.JSONSchema, moduleHasSettings({ piece: entry.key("piece") }), <span>settings</span>, null);
-});
 const moduleHasSettings = lift({
     type: "object",
     properties: {
@@ -95,6 +57,157 @@ interface Message {
     id: string;
     type: "chat" | "system";
 }
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const entry = __cf_pattern_input.key("element");
+    return ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{}, {
+                type: "object",
+                properties: {}
+            }]
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "null"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{
+                type: "null"
+            }, {}]
+    } as const satisfies __cfHelpers.JSONSchema, moduleHasSettings({ piece: entry.key("piece") }), <span>settings</span>, null).for("__patternResult", true);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Entry"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Entry: {
+            type: "object",
+            properties: {
+                piece: {
+                    type: "object",
+                    properties: {
+                        settingsUI: {
+                            type: "string"
+                        }
+                    }
+                }
+            },
+            required: ["piece"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            type: "null"
+        }, {
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_1 = __cfHelpers.lift<{
+    msg: {
+        type: string;
+    };
+}, boolean>({
+    type: "object",
+    properties: {
+        msg: {
+            type: "object",
+            properties: {
+                type: {
+                    type: "string"
+                }
+            },
+            required: ["type"]
+        }
+    },
+    required: ["msg"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema, ({ msg }) => msg.type === "system");
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const msg = __cf_pattern_input.key("element");
+    const selectedId = __cf_pattern_input.key("params", "selectedId");
+    return ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{}, {
+                type: "object",
+                properties: {}
+            }]
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{}, {
+                type: "object",
+                properties: {}
+            }]
+    } as const satisfies __cfHelpers.JSONSchema, {} as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ msg: {
+            type: msg.key("type")
+        } }), <span>{msg.key("id")}</span>, <button type="button" onClick={selectMessage({ selectedId, msgId: msg.key("id") })}>
+                open
+              </button>).for("__patternResult", true);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Message"
+        },
+        params: {
+            type: "object",
+            properties: {
+                selectedId: {
+                    type: "string",
+                    asCell: ["readonly"]
+                }
+            },
+            required: ["selectedId"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Message: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                },
+                type: {
+                    "enum": ["chat", "system"]
+                }
+            },
+            required: ["id", "type"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: ifelse-factory-boundaries
 // Verifies: authored ifElse keeps captured property access inside factory boundaries
 //   moduleHasSettings({ piece: entry.piece }) → piece capture stays structural inside lift() call
@@ -107,123 +220,11 @@ export default pattern((__cf_pattern_input) => {
     } as const satisfies __cfHelpers.JSONSchema).for("selectedId", true);
     return {
         [UI]: (<div>
-          {entries.mapWithPattern(__cfHelpers.pattern(__cfModuleCallback_1, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Entry"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    Entry: {
-                        type: "object",
-                        properties: {
-                            piece: {
-                                type: "object",
-                                properties: {
-                                    settingsUI: {
-                                        type: "string"
-                                    }
-                                }
-                            }
-                        },
-                        required: ["piece"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        type: "null"
-                    }, {
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
-          {messages.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const msg = __cf_pattern_input.key("element");
-                const selectedId = __cf_pattern_input.key("params", "selectedId");
-                return ifElse({
-                    type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{}, {
-                            type: "object",
-                            properties: {}
-                        }]
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{}, {
-                            type: "object",
-                            properties: {}
-                        }]
-                } as const satisfies __cfHelpers.JSONSchema, {} as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ msg: {
-                        type: msg.key("type")
-                    } }), <span>{msg.key("id")}</span>, <button type="button" onClick={selectMessage({ selectedId, msgId: msg.key("id") })}>
-                open
-              </button>).for("__patternResult", true);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Message"
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            selectedId: {
-                                type: "string",
-                                asCell: ["readonly"]
-                            }
-                        },
-                        required: ["selectedId"]
-                    }
-                },
-                required: ["element", "params"],
-                $defs: {
-                    Message: {
-                        type: "object",
-                        properties: {
-                            id: {
-                                type: "string"
-                            },
-                            type: {
-                                "enum": ["chat", "system"]
-                            }
-                        },
-                        required: ["id", "type"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+          {entries.mapWithPattern(__cfPattern_1, {})}
+          {messages.mapWithPattern(__cfPattern_2, {
                 selectedId: selectedId
             })}
-        </div>)
+        </div>),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/inline-action-in-ternary-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/inline-action-in-ternary-branch.expected.jsx
@@ -19,6 +19,14 @@ import { Cell, computed, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Card {
+    title: string;
+    description: string;
+}
+interface State {
+    card: Card;
+    isEditing: Cell<boolean>;
+}
 const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -79,14 +87,6 @@ const __cfLift_1 = __cfHelpers.lift<{
         isEditing: state.isEditing
     }
 })}>Edit</cf-button>));
-interface Card {
-    title: string;
-    description: string;
-}
-interface State {
-    card: Card;
-    isEditing: Cell<boolean>;
-}
 // FIXTURE: inline-action-in-ternary-branch
 // Verifies: inline arrow handler inside explicit computed() in a ternary branch is extracted and captured in a lift-applied computation
 //   computed(() => <cf-button onClick={() => state.isEditing.set(true)} />) → lift(..., handler(...)(...))({ state: { isEditing: asCell } })

--- a/packages/ts-transformers/test/fixtures/closures/map-and-handler.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-and-handler.expected.jsx
@@ -11,6 +11,13 @@ import { Cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    items: Array<{
+        price: number;
+    }>;
+    discount: number;
+    selectedIndex: Cell<number>;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     item: {
         price: number;
@@ -63,6 +70,85 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     },
     required: ["index", "state"]
 } as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, { state, index }) => state.selectedIndex.set(index));
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const index = __cf_pattern_input.key("index");
+    const state = __cf_pattern_input.key("params", "state");
+    return (<div>
+            <span>{__cfLift_1({
+        item: {
+            price: item.key("price")
+        },
+        state: {
+            discount: state.key("discount")
+        }
+    })}</span>
+            <button type="button" onClick={__cfHandler_1({
+        state: {
+            selectedIndex: state.key("selectedIndex")
+        },
+        index: index
+    })}>
+              Select
+            </button>
+          </div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                price: {
+                    type: "number"
+                }
+            },
+            required: ["price"]
+        },
+        index: {
+            type: "number"
+        },
+        params: {
+            type: "object",
+            properties: {
+                state: {
+                    type: "object",
+                    properties: {
+                        discount: {
+                            type: "number"
+                        },
+                        selectedIndex: {
+                            type: "number",
+                            asCell: ["readonly"]
+                        }
+                    },
+                    required: ["discount", "selectedIndex"]
+                }
+            },
+            required: ["state"]
+        }
+    },
+    required: ["element", "params"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         items: { price: number; }[];
@@ -137,13 +223,6 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ state }) => (state.items[state.selectedIndex.get()]?.price ?? 0) * state.discount);
-interface State {
-    items: Array<{
-        price: number;
-    }>;
-    discount: number;
-    selectedIndex: Cell<number>;
-}
 // FIXTURE: map-and-handler
 // Verifies: .map() in JSX is transformed to .mapWithPattern() and inline handler inside map body is extracted
 //   state.items.map((item, index) => JSX) → state.key("items").mapWithPattern(pattern(...), { state: { discount, selectedIndex } })
@@ -152,85 +231,7 @@ interface State {
 export default pattern((state) => {
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                const index = __cf_pattern_input.key("index");
-                const state = __cf_pattern_input.key("params", "state");
-                return (<div>
-            <span>{__cfLift_1({
-                    item: {
-                        price: item.key("price")
-                    },
-                    state: {
-                        discount: state.key("discount")
-                    }
-                })}</span>
-            <button type="button" onClick={__cfHandler_1({
-                    state: {
-                        selectedIndex: state.key("selectedIndex")
-                    },
-                    index: index
-                })}>
-              Select
-            </button>
-          </div>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "object",
-                        properties: {
-                            price: {
-                                type: "number"
-                            }
-                        },
-                        required: ["price"]
-                    },
-                    index: {
-                        type: "number"
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            state: {
-                                type: "object",
-                                properties: {
-                                    discount: {
-                                        type: "number"
-                                    },
-                                    selectedIndex: {
-                                        type: "number",
-                                        asCell: ["readonly"]
-                                    }
-                                },
-                                required: ["discount", "selectedIndex"]
-                            }
-                        },
-                        required: ["state"]
-                    }
-                },
-                required: ["element", "params"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        {state.key("items").mapWithPattern(__cfPattern_1, {
                 state: {
                     discount: state.key("discount"),
                     selectedIndex: state.key("selectedIndex")

--- a/packages/ts-transformers/test/fixtures/closures/map-array-destructure-lowering.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-array-destructure-lowering.expected.jsx
@@ -18,6 +18,49 @@ type Row = [
 interface State {
     rows: Row[];
 }
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const left = __cf_pattern_input.key("element", "0");
+    const right = __cf_pattern_input.key("element", "1");
+    return (<span>
+            {left}:{right}
+          </span>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Row"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Row: {
+            type: "array",
+            items: {
+                type: "string"
+            }
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-array-destructure-lowering
 // Verifies: array destructuring in .map() callback is lowered to index-based key access
 //   .map(([left, right]) => ...) → .mapWithPattern(pattern(...), {})
@@ -25,49 +68,7 @@ interface State {
 export default pattern((state) => {
     return {
         [UI]: (<div>
-        {state.key("rows").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const left = __cf_pattern_input.key("element", "0");
-                const right = __cf_pattern_input.key("element", "1");
-                return (<span>
-            {left}:{right}
-          </span>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Row"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    Row: {
-                        type: "array",
-                        items: {
-                            type: "string"
-                        }
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+        {state.key("rows").mapWithPattern(__cfPattern_1, {})}
       </div>),
     };
 }, {

--- a/packages/ts-transformers/test/fixtures/closures/map-array-destructure-shorthand.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-array-destructure-shorthand.expected.jsx
@@ -18,6 +18,93 @@ type ItemTuple = [
 interface State {
     items: ItemTuple[];
 }
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element", "0");
+    return (<div data-item={item}>{item}</div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/ItemTuple"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        ItemTuple: {
+            type: "array",
+            items: {
+                type: ["number", "string"]
+            }
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element", "0");
+    const count = __cf_pattern_input.key("element", "1");
+    const index = __cf_pattern_input.key("index");
+    return (<div key={index}>
+            {item}: {count}
+          </div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/ItemTuple"
+        },
+        index: {
+            type: "number"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        ItemTuple: {
+            type: "array",
+            items: {
+                type: ["number", "string"]
+            }
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-array-destructure-shorthand
 // Verifies: array-destructured map params are not incorrectly captured as shorthand properties
 //   .map(([item]) => ...) → .mapWithPattern(pattern(...), {}) with key("element", "0")
@@ -29,95 +116,10 @@ export default pattern((__cf_pattern_input) => {
         [UI]: (<div>
         {/* Array destructured parameter - without fix, 'item' would be
                 incorrectly captured in params due to shorthand usage in JSX */}
-        {items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element", "0");
-                return (<div data-item={item}>{item}</div>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/ItemTuple"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    ItemTuple: {
-                        type: "array",
-                        items: {
-                            type: ["number", "string"]
-                        }
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+        {items.mapWithPattern(__cfPattern_1, {})}
 
         {/* Multiple array destructured params */}
-        {items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element", "0");
-                const count = __cf_pattern_input.key("element", "1");
-                const index = __cf_pattern_input.key("index");
-                return (<div key={index}>
-            {item}: {count}
-          </div>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/ItemTuple"
-                    },
-                    index: {
-                        type: "number"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    ItemTuple: {
-                        type: "array",
-                        items: {
-                            type: ["number", "string"]
-                        }
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+        {items.mapWithPattern(__cfPattern_2, {})}
       </div>),
     };
 }, {

--- a/packages/ts-transformers/test/fixtures/closures/map-array-destructured.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-array-destructured.expected.jsx
@@ -19,6 +19,108 @@ interface State {
     pizzas: PizzaEntry[];
     scale: number;
 }
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const date = __cf_pattern_input.key("element", "0");
+    const pizza = __cf_pattern_input.key("element", "1");
+    return (<div>
+            {date}: {pizza}
+          </div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/PizzaEntry"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        PizzaEntry: {
+            type: "array",
+            items: {
+                type: "string"
+            }
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const date = __cf_pattern_input.key("element", "0");
+    const pizza = __cf_pattern_input.key("element", "1");
+    const state = __cf_pattern_input.key("params", "state");
+    return (<div>
+            {date}: {pizza} (scale: {state.key("scale")})
+          </div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/PizzaEntry"
+        },
+        params: {
+            type: "object",
+            properties: {
+                state: {
+                    type: "object",
+                    properties: {
+                        scale: {
+                            type: "number"
+                        }
+                    },
+                    required: ["scale"]
+                }
+            },
+            required: ["state"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        PizzaEntry: {
+            type: "array",
+            items: {
+                type: "string"
+            }
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-array-destructured
 // Verifies: array destructuring in .map() is lowered, with and without captured outer state
 //   .map(([date, pizza]) => ...) → .mapWithPattern(pattern(...), {}) with index-based keys
@@ -28,110 +130,10 @@ export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Map with array destructured parameter */}
-        {state.key("pizzas").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const date = __cf_pattern_input.key("element", "0");
-                const pizza = __cf_pattern_input.key("element", "1");
-                return (<div>
-            {date}: {pizza}
-          </div>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/PizzaEntry"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    PizzaEntry: {
-                        type: "array",
-                        items: {
-                            type: "string"
-                        }
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+        {state.key("pizzas").mapWithPattern(__cfPattern_1, {})}
 
         {/* Map with array destructured parameter and capture */}
-        {state.key("pizzas").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const date = __cf_pattern_input.key("element", "0");
-                const pizza = __cf_pattern_input.key("element", "1");
-                const state = __cf_pattern_input.key("params", "state");
-                return (<div>
-            {date}: {pizza} (scale: {state.key("scale")})
-          </div>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/PizzaEntry"
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            state: {
-                                type: "object",
-                                properties: {
-                                    scale: {
-                                        type: "number"
-                                    }
-                                },
-                                required: ["scale"]
-                            }
-                        },
-                        required: ["state"]
-                    }
-                },
-                required: ["element", "params"],
-                $defs: {
-                    PizzaEntry: {
-                        type: "array",
-                        items: {
-                            type: "string"
-                        }
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        {state.key("pizzas").mapWithPattern(__cfPattern_2, {
                 state: {
                     scale: state.key("scale")
                 }

--- a/packages/ts-transformers/test/fixtures/closures/map-body-destructure-cases.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-body-destructure-cases.expected.jsx
@@ -11,6 +11,61 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Spot {
+    spotNumber: string;
+}
+interface Person {
+    name: string;
+    spotPreferences: string[];
+}
+interface State {
+    spots: Spot[];
+    people: Person[];
+}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const spot = __cf_pattern_input.key("element");
+    const sn = spot.key("spotNumber");
+    return <li>{sn}</li>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Spot"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Spot: {
+            type: "object",
+            properties: {
+                spotNumber: {
+                    type: "string"
+                }
+            },
+            required: ["spotNumber"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_1 = __cfHelpers.lift<{
     spotPreferences: string[];
 }, boolean>({
@@ -43,17 +98,75 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, ({ spotPreferences }) => spotPreferences.map((n) => "#" + n).join(", "));
-interface Spot {
-    spotNumber: string;
-}
-interface Person {
-    name: string;
-    spotPreferences: string[];
-}
-interface State {
-    spots: Spot[];
-    people: Person[];
-}
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const person = __cf_pattern_input.key("element");
+    const name = person.key("name"), spotPreferences = person.key("spotPreferences");
+    return (<li>
+                <span>{name}</span>
+                {__cfHelpers.ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{}, {
+                type: "object",
+                properties: {}
+            }]
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "null"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{
+                type: "null"
+            }, {}, {
+                type: "object",
+                properties: {}
+            }]
+    } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ spotPreferences: spotPreferences }), <span>{__cfLift_2({ spotPreferences: spotPreferences })}</span>, null)}
+              </li>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Person"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Person: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                spotPreferences: {
+                    type: "array",
+                    items: {
+                        type: "string"
+                    }
+                }
+            },
+            required: ["name", "spotPreferences"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-body-destructure-cases
 // Verifies: body-local destructuring inside reactive .map() callbacks lowers to key() access
 //   const { spotNumber: sn } = spot        -> sn bound from spot.key("spotNumber")
@@ -65,122 +178,11 @@ export default pattern((state) => {
     return {
         [UI]: (<section>
         <ul>
-          {state.key("spots").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const spot = __cf_pattern_input.key("element");
-                const sn = spot.key("spotNumber");
-                return <li>{sn}</li>;
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Spot"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    Spot: {
-                        type: "object",
-                        properties: {
-                            spotNumber: {
-                                type: "string"
-                            }
-                        },
-                        required: ["spotNumber"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+          {state.key("spots").mapWithPattern(__cfPattern_1, {})}
         </ul>
 
         <ul>
-          {state.key("people").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const person = __cf_pattern_input.key("element");
-                const name = person.key("name"), spotPreferences = person.key("spotPreferences");
-                return (<li>
-                <span>{name}</span>
-                {__cfHelpers.ifElse({
-                    type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{}, {
-                            type: "object",
-                            properties: {}
-                        }]
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "null"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{
-                            type: "null"
-                        }, {}, {
-                            type: "object",
-                            properties: {}
-                        }]
-                } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ spotPreferences: spotPreferences }), <span>{__cfLift_2({ spotPreferences: spotPreferences })}</span>, null)}
-              </li>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Person"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    Person: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            },
-                            spotPreferences: {
-                                type: "array",
-                                items: {
-                                    type: "string"
-                                }
-                            }
-                        },
-                        required: ["name", "spotPreferences"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+          {state.key("people").mapWithPattern(__cfPattern_2, {})}
         </ul>
       </section>),
     };

--- a/packages/ts-transformers/test/fixtures/closures/map-callback-schema-params.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-callback-schema-params.expected.jsx
@@ -11,6 +11,60 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Item {
+    id: string;
+    price: number;
+}
+interface State {
+    items: Item[];
+    discount: number;
+}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return <span>{item.key("id")}</span>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                },
+                price: {
+                    type: "number"
+                }
+            },
+            required: ["id", "price"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_1 = __cfHelpers.lift<{
     item: {
         price: number;
@@ -44,14 +98,75 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ item, state }) => item.price * state.discount);
-interface Item {
-    id: string;
-    price: number;
-}
-interface State {
-    items: Item[];
-    discount: number;
-}
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const state = __cf_pattern_input.key("params", "state");
+    return (<span>{__cfLift_1({
+        item: {
+            price: item.key("price")
+        },
+        state: {
+            discount: state.key("discount")
+        }
+    })}</span>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        },
+        params: {
+            type: "object",
+            properties: {
+                state: {
+                    type: "object",
+                    properties: {
+                        discount: {
+                            type: "number"
+                        }
+                    },
+                    required: ["discount"]
+                }
+            },
+            required: ["state"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                },
+                price: {
+                    type: "number"
+                }
+            },
+            required: ["id", "price"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-callback-schema-params
 // Verifies: mapWithPattern callback schemas omit params when captures are unused
 // and include params when captures are used
@@ -63,123 +178,10 @@ export default pattern((state) => {
     return {
         [UI]: (<div>
         <section data-kind="unused">
-          {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-            const item = __cf_pattern_input.key("element");
-            return <span>{item.key("id")}</span>;
-        }, {
-            type: "object",
-            properties: {
-                element: {
-                    $ref: "#/$defs/Item"
-                }
-            },
-            required: ["element"],
-            $defs: {
-                Item: {
-                    type: "object",
-                    properties: {
-                        id: {
-                            type: "string"
-                        },
-                        price: {
-                            type: "number"
-                        }
-                    },
-                    required: ["id", "price"]
-                }
-            }
-        } as const satisfies __cfHelpers.JSONSchema, {
-            anyOf: [{
-                    $ref: "https://commonfabric.org/schemas/vnode.json"
-                }, {
-                    $ref: "#/$defs/UIRenderable"
-                }, {
-                    type: "object",
-                    properties: {}
-                }],
-            $defs: {
-                UIRenderable: {
-                    type: "object",
-                    properties: {
-                        $UI: {
-                            $ref: "https://commonfabric.org/schemas/vnode.json"
-                        }
-                    },
-                    required: ["$UI"]
-                }
-            }
-        } as const satisfies __cfHelpers.JSONSchema), {})}
+          {state.key("items").mapWithPattern(__cfPattern_1, {})}
         </section>
         <section data-kind="used">
-          {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                const state = __cf_pattern_input.key("params", "state");
-                return (<span>{__cfLift_1({
-                    item: {
-                        price: item.key("price")
-                    },
-                    state: {
-                        discount: state.key("discount")
-                    }
-                })}</span>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Item"
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            state: {
-                                type: "object",
-                                properties: {
-                                    discount: {
-                                        type: "number"
-                                    }
-                                },
-                                required: ["discount"]
-                            }
-                        },
-                        required: ["state"]
-                    }
-                },
-                required: ["element", "params"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            id: {
-                                type: "string"
-                            },
-                            price: {
-                                type: "number"
-                            }
-                        },
-                        required: ["id", "price"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+          {state.key("items").mapWithPattern(__cfPattern_2, {
                 state: {
                     discount: state.key("discount")
                 }

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-cell-fn.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-cell-fn.expected.jsx
@@ -16,6 +16,55 @@ interface State {
         name: string;
     }>;
 }
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const count = __cf_pattern_input.key("params", "count");
+    return (<span>{item.key("name")} #{count}</span>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        },
+        params: {
+            type: "object",
+            properties: {
+                count: {
+                    type: "number",
+                    asCell: ["readonly"]
+                }
+            },
+            required: ["count"]
+        }
+    },
+    required: ["element", "params"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-capture-cell-fn
 // Verifies: cell() variable closed over in .map() is captured with asCell schema annotation
 //   .map(fn) → .mapWithPattern(pattern(...), { count: count })
@@ -26,55 +75,7 @@ export default pattern((state) => {
     } as const satisfies __cfHelpers.JSONSchema).for("count", true);
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                const count = __cf_pattern_input.key("params", "count");
-                return (<span>{item.key("name")} #{count}</span>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            }
-                        },
-                        required: ["name"]
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            count: {
-                                type: "number",
-                                asCell: ["readonly"]
-                            }
-                        },
-                        required: ["count"]
-                    }
-                },
-                required: ["element", "params"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        {state.key("items").mapWithPattern(__cfPattern_1, {
                 count: count
             })}
       </div>),

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-cell-of.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-cell-of.expected.jsx
@@ -16,6 +16,55 @@ interface State {
         name: string;
     }>;
 }
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const counter = __cf_pattern_input.key("params", "counter");
+    return (<span>{item.key("name")} #{counter}</span>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        },
+        params: {
+            type: "object",
+            properties: {
+                counter: {
+                    type: "number",
+                    asCell: ["readonly"]
+                }
+            },
+            required: ["counter"]
+        }
+    },
+    required: ["element", "params"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-capture-cell-of
 // Verifies: new Cell() variable closed over in .map() is captured with asCell schema annotation
 //   .map(fn) → .mapWithPattern(pattern(...), { counter: counter })
@@ -26,55 +75,7 @@ export default pattern((state) => {
     } as const satisfies __cfHelpers.JSONSchema).for("counter", true);
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                const counter = __cf_pattern_input.key("params", "counter");
-                return (<span>{item.key("name")} #{counter}</span>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            }
-                        },
-                        required: ["name"]
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            counter: {
-                                type: "number",
-                                asCell: ["readonly"]
-                            }
-                        },
-                        required: ["counter"]
-                    }
-                },
-                required: ["element", "params"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        {state.key("items").mapWithPattern(__cfPattern_1, {
                 counter: counter
             })}
       </div>),

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-cell-param-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-cell-param-no-name.expected.jsx
@@ -50,6 +50,71 @@ const removeItem = handler({
 } as const satisfies __cfHelpers.JSONSchema, (_, _2) => {
     // Not relevant for repro
 });
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const _ = __cf_pattern_input.key("element");
+    const index = __cf_pattern_input.key("index");
+    const items = __cf_pattern_input.key("params", "items");
+    return (<li key={index}>
+              <cf-button onClick={removeItem({ items, index })}>
+                Remove
+              </cf-button>
+            </li>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        },
+        index: {
+            type: "number"
+        },
+        params: {
+            type: "object",
+            properties: {
+                items: {
+                    type: "array",
+                    items: {
+                        $ref: "#/$defs/Item"
+                    }
+                }
+            },
+            required: ["items"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                text: {
+                    type: "string",
+                    "default": ""
+                }
+            },
+            required: ["text"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-capture-cell-param-no-name
 // Verifies: pattern without generic type param still captures destructured bindings correctly
 //   .map(fn) → .mapWithPattern(pattern(...), { items: items })
@@ -59,71 +124,7 @@ export default pattern((__cf_pattern_input: InputSchema) => {
     const items = __cf_pattern_input.key("items");
     return {
         [UI]: (<ul>
-          {items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const _ = __cf_pattern_input.key("element");
-                const index = __cf_pattern_input.key("index");
-                const items = __cf_pattern_input.key("params", "items");
-                return (<li key={index}>
-              <cf-button onClick={removeItem({ items, index })}>
-                Remove
-              </cf-button>
-            </li>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Item"
-                    },
-                    index: {
-                        type: "number"
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            items: {
-                                type: "array",
-                                items: {
-                                    $ref: "#/$defs/Item"
-                                }
-                            }
-                        },
-                        required: ["items"]
-                    }
-                },
-                required: ["element", "params"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            text: {
-                                type: "string",
-                                "default": ""
-                            }
-                        },
-                        required: ["text"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+          {items.mapWithPattern(__cfPattern_1, {
                 items: items
             })}
         </ul>),

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-cell-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-cell-param.expected.jsx
@@ -50,6 +50,71 @@ const removeItem = handler({
 } as const satisfies __cfHelpers.JSONSchema, (_, _2) => {
     // Not relevant for repro
 });
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const _ = __cf_pattern_input.key("element");
+    const index = __cf_pattern_input.key("index");
+    const items = __cf_pattern_input.key("params", "items");
+    return (<li key={index}>
+              <cf-button onClick={removeItem({ items, index })}>
+                Remove
+              </cf-button>
+            </li>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        },
+        index: {
+            type: "number"
+        },
+        params: {
+            type: "object",
+            properties: {
+                items: {
+                    type: "array",
+                    items: {
+                        $ref: "#/$defs/Item"
+                    }
+                }
+            },
+            required: ["items"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                text: {
+                    type: "string",
+                    "default": ""
+                }
+            },
+            required: ["text"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-capture-cell-param
 // Verifies: destructured pattern param closed over in .map() is captured as opaque
 //   .map(fn) → .mapWithPattern(pattern(...), { items: items })
@@ -59,71 +124,7 @@ export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     return {
         [UI]: (<ul>
-          {items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const _ = __cf_pattern_input.key("element");
-                const index = __cf_pattern_input.key("index");
-                const items = __cf_pattern_input.key("params", "items");
-                return (<li key={index}>
-              <cf-button onClick={removeItem({ items, index })}>
-                Remove
-              </cf-button>
-            </li>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Item"
-                    },
-                    index: {
-                        type: "number"
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            items: {
-                                type: "array",
-                                items: {
-                                    $ref: "#/$defs/Item"
-                                }
-                            }
-                        },
-                        required: ["items"]
-                    }
-                },
-                required: ["element", "params"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            text: {
-                                type: "string",
-                                "default": ""
-                            }
-                        },
-                        required: ["text"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+          {items.mapWithPattern(__cfPattern_1, {
                 items: items
             })}
         </ul>),

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-derived-from-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-derived-from-param.expected.jsx
@@ -11,6 +11,12 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    items: number[];
+    settings: {
+        multiplier: number;
+    };
+}
 const __cfLift_1 = __cfHelpers.lift<{
     item: number;
     settings: {
@@ -36,12 +42,59 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ item, settings }) => item * settings.multiplier);
-interface State {
-    items: number[];
-    settings: {
-        multiplier: number;
-    };
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const settings = __cf_pattern_input.key("params", "settings");
+    return (<span>{__cfLift_1({
+        item: item,
+        settings: {
+            multiplier: settings.key("multiplier")
+        }
+    })}</span>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "number"
+        },
+        params: {
+            type: "object",
+            properties: {
+                settings: {
+                    type: "object",
+                    properties: {
+                        multiplier: {
+                            type: "number"
+                        }
+                    },
+                    required: ["multiplier"]
+                }
+            },
+            required: ["settings"]
+        }
+    },
+    required: ["element", "params"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-capture-derived-from-param
 // Verifies: variable derived from state (const settings = state.settings) is captured correctly
 //   .map(fn) → .mapWithPattern(pattern(...), { settings: { multiplier: settings.key("multiplier") } })
@@ -50,59 +103,7 @@ export default pattern((state) => {
     const settings = state.key("settings");
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                const settings = __cf_pattern_input.key("params", "settings");
-                return (<span>{__cfLift_1({
-                    item: item,
-                    settings: {
-                        multiplier: settings.key("multiplier")
-                    }
-                })}</span>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "number"
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            settings: {
-                                type: "object",
-                                properties: {
-                                    multiplier: {
-                                        type: "number"
-                                    }
-                                },
-                                required: ["multiplier"]
-                            }
-                        },
-                        required: ["settings"]
-                    }
-                },
-                required: ["element", "params"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        {state.key("items").mapWithPattern(__cfPattern_1, {
                 settings: {
                     multiplier: settings.key("multiplier")
                 }

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-mixed-reactivity.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-mixed-reactivity.expected.jsx
@@ -17,6 +17,63 @@ interface State {
     }>;
     threshold: number;
 }
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const label = __cf_pattern_input.params.label;
+    const derived = __cf_pattern_input.key("params", "derived");
+    const limit = __cf_pattern_input.key("params", "limit");
+    return (<span>{label}: {item.key("value")} / {derived} / {limit}</span>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                value: {
+                    type: "number"
+                }
+            },
+            required: ["value"]
+        },
+        params: {
+            type: "object",
+            properties: {
+                label: {
+                    type: "string"
+                },
+                derived: {
+                    type: "number"
+                },
+                limit: {
+                    type: "number",
+                    asCell: ["cell"]
+                }
+            },
+            required: ["label", "derived", "limit"]
+        }
+    },
+    required: ["element", "params"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-capture-mixed-reactivity
 // Verifies: captures of different reactivity kinds are annotated distinctly in the schema
 //   label (plain string) → params.label (type: "string", accessed via .params)
@@ -31,63 +88,7 @@ export default pattern((state) => {
     const derived = state.key("threshold");
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                const label = __cf_pattern_input.params.label;
-                const derived = __cf_pattern_input.key("params", "derived");
-                const limit = __cf_pattern_input.key("params", "limit");
-                return (<span>{label}: {item.key("value")} / {derived} / {limit}</span>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "object",
-                        properties: {
-                            value: {
-                                type: "number"
-                            }
-                        },
-                        required: ["value"]
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            label: {
-                                type: "string"
-                            },
-                            derived: {
-                                type: "number"
-                            },
-                            limit: {
-                                type: "number",
-                                asCell: ["cell"]
-                            }
-                        },
-                        required: ["label", "derived", "limit"]
-                    }
-                },
-                required: ["element", "params"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        {state.key("items").mapWithPattern(__cfPattern_1, {
                 label: label,
                 derived: derived,
                 limit: limit

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-object-literal.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-object-literal.expected.jsx
@@ -16,6 +16,63 @@ interface State {
         name: string;
     }>;
 }
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const style = __cf_pattern_input.params.style;
+    return (<span style={style}>{item.key("name")}</span>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        },
+        params: {
+            type: "object",
+            properties: {
+                style: {
+                    type: "object",
+                    properties: {
+                        color: {
+                            type: "string"
+                        },
+                        fontSize: {
+                            type: "number"
+                        }
+                    },
+                    required: ["color", "fontSize"]
+                }
+            },
+            required: ["style"]
+        }
+    },
+    required: ["element", "params"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-capture-object-literal
 // Verifies: plain object literal closed over in .map() is captured as a non-reactive param
 //   .map(fn) → .mapWithPattern(pattern(...), { style: style })
@@ -24,63 +81,7 @@ export default pattern((state) => {
     const style = { color: "red", fontSize: 14 };
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                const style = __cf_pattern_input.params.style;
-                return (<span style={style}>{item.key("name")}</span>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            }
-                        },
-                        required: ["name"]
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            style: {
-                                type: "object",
-                                properties: {
-                                    color: {
-                                        type: "string"
-                                    },
-                                    fontSize: {
-                                        type: "number"
-                                    }
-                                },
-                                required: ["color", "fontSize"]
-                            }
-                        },
-                        required: ["style"]
-                    }
-                },
-                required: ["element", "params"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        {state.key("items").mapWithPattern(__cfPattern_1, {
                 style: style
             })}
       </div>),

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-writable-of.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-writable-of.expected.jsx
@@ -16,6 +16,59 @@ interface State {
         name: string;
     }>;
 }
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const selected = __cf_pattern_input.key("params", "selected");
+    return (<span>{item.key("name")} {selected}</span>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        },
+        params: {
+            type: "object",
+            properties: {
+                selected: {
+                    anyOf: [{
+                            type: "string"
+                        }, {
+                            type: "null"
+                        }],
+                    asCell: ["readonly"]
+                }
+            },
+            required: ["selected"]
+        }
+    },
+    required: ["element", "params"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-capture-writable-of
 // Verifies: new Writable() variable closed over in .map() is captured with asCell annotation
 //   .map(fn) → .mapWithPattern(pattern(...), { selected: selected })
@@ -30,59 +83,7 @@ export default pattern((state) => {
     } as const satisfies __cfHelpers.JSONSchema).for("selected", true);
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                const selected = __cf_pattern_input.key("params", "selected");
-                return (<span>{item.key("name")} {selected}</span>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            }
-                        },
-                        required: ["name"]
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            selected: {
-                                anyOf: [{
-                                        type: "string"
-                                    }, {
-                                        type: "null"
-                                    }],
-                                asCell: ["readonly"]
-                            }
-                        },
-                        required: ["selected"]
-                    }
-                },
-                required: ["element", "params"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        {state.key("items").mapWithPattern(__cfPattern_1, {
                 selected: selected
             })}
       </div>),

--- a/packages/ts-transformers/test/fixtures/closures/map-cell-receiver-in-lift.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-cell-receiver-in-lift.expected.jsx
@@ -21,12 +21,7 @@ const items = __cfHelpers.__cf_data(new Cell<string[]>([], {
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema).for("items", true));
-export const fn = lift(false as const satisfies __cfHelpers.JSONSchema, {
-    type: "array",
-    items: {
-        type: "string"
-    }
-} as const satisfies __cfHelpers.JSONSchema, () => items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return item;
 }, {
@@ -39,7 +34,13 @@ export const fn = lift(false as const satisfies __cfHelpers.JSONSchema, {
     required: ["element"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema), {}));
+} as const satisfies __cfHelpers.JSONSchema);
+export const fn = lift(false as const satisfies __cfHelpers.JSONSchema, {
+    type: "array",
+    items: {
+        type: "string"
+    }
+} as const satisfies __cfHelpers.JSONSchema, () => items.mapWithPattern(__cfPattern_1, {}));
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-computed-alias-side-effect.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-computed-alias-side-effect.expected.jsx
@@ -11,6 +11,14 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+let keyCounter = 0;
+function nextKey() {
+    return `value-${keyCounter++}`;
+}
+__cfHardenFn(nextKey);
+interface State {
+    items: Array<Record<string, number>>;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     element: any;
     __cf_amount_key: any;
@@ -24,7 +32,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema, ({ element, __cf_amount_key }) => element[__cf_amount_key]);
-const __cfModuleCallback_1 = __cfHardenFn(__cf_pattern_input => {
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const element = __cf_pattern_input.key("element");
     const __cf_amount_key = nextKey();
     const amount = __cfLift_1({
@@ -32,15 +40,39 @@ const __cfModuleCallback_1 = __cfHardenFn(__cf_pattern_input => {
         __cf_amount_key: __cf_amount_key
     }).for("amount", true);
     return (<span>{amount}</span>);
-});
-let keyCounter = 0;
-function nextKey() {
-    return `value-${keyCounter++}`;
-}
-__cfHardenFn(nextKey);
-interface State {
-    items: Array<Record<string, number>>;
-}
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {},
+            additionalProperties: {
+                type: "number"
+            }
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-computed-alias-side-effect
 // Verifies: computed property key with side effects is hoisted and used via a lift-applied computation
 //   { [nextKey()]: amount } → __cf_amount_key = nextKey(); lift(...)(...element[__cf_amount_key])
@@ -49,39 +81,7 @@ interface State {
 export default pattern((state) => {
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cfModuleCallback_1, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "object",
-                        properties: {},
-                        additionalProperties: {
-                            type: "number"
-                        }
-                    }
-                },
-                required: ["element"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+        {state.key("items").mapWithPattern(__cfPattern_1, {})}
       </div>),
     };
 }, {

--- a/packages/ts-transformers/test/fixtures/closures/map-computed-alias-with-plain-binding.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-computed-alias-with-plain-binding.expected.jsx
@@ -11,6 +11,17 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+function dynamicKey(): "value" {
+    return "value";
+}
+__cfHardenFn(dynamicKey);
+interface Item {
+    foo: number;
+    value: number;
+}
+interface State {
+    items: Item[];
+}
 const __cfLift_1 = __cfHelpers.lift<{
     element: any;
     __cf_val_key: any;
@@ -41,7 +52,7 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ foo, val }) => foo + val);
-const __cfModuleCallback_1 = __cfHardenFn(__cf_pattern_input => {
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const element = __cf_pattern_input.key("element");
     const __cf_val_key = dynamicKey();
     const foo = element.key("foo");
@@ -53,18 +64,49 @@ const __cfModuleCallback_1 = __cfHardenFn(__cf_pattern_input => {
         foo: foo,
         val: val
     })}</span>);
-});
-function dynamicKey(): "value" {
-    return "value";
-}
-__cfHardenFn(dynamicKey);
-interface Item {
-    foo: number;
-    value: number;
-}
-interface State {
-    items: Item[];
-}
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                foo: {
+                    type: "number"
+                },
+                value: {
+                    type: "number"
+                }
+            },
+            required: ["foo", "value"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-computed-alias-with-plain-binding
 // Verifies: computed property key mixed with a static destructured binding in the same pattern
 //   { foo, [dynamicKey()]: val } → key binding for foo, lift-applied computation for val
@@ -73,49 +115,7 @@ interface State {
 export default pattern((state) => {
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cfModuleCallback_1, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Item"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            foo: {
-                                type: "number"
-                            },
-                            value: {
-                                type: "number"
-                            }
-                        },
-                        required: ["foo", "value"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+        {state.key("items").mapWithPattern(__cfPattern_1, {})}
       </div>),
     };
 }, {

--- a/packages/ts-transformers/test/fixtures/closures/map-computed-fallback-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-computed-fallback-alias.expected.jsx
@@ -11,6 +11,16 @@ import { computed, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Reaction {
+    emoji: string;
+}
+interface Message {
+    id: string;
+    reactions?: Reaction[];
+}
+interface Input {
+    messages: Message[];
+}
 const __cfLift_1 = __cfHelpers.lift<{
     msg: {
         reactions?: Reaction[] | undefined;
@@ -59,16 +69,134 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, ({ msg }) => (msg.reactions ?? []) as Reaction[]);
-interface Reaction {
-    emoji: string;
-}
-interface Message {
-    id: string;
-    reactions?: Reaction[];
-}
-interface Input {
-    messages: Message[];
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const reaction = __cf_pattern_input.key("element");
+    const msg = __cf_pattern_input.key("params", "msg");
+    return (<button type="button" data-msg-id={msg.key("id")}>
+                  {reaction.key("emoji")}
+                </button>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Reaction"
+        },
+        params: {
+            type: "object",
+            properties: {
+                msg: {
+                    type: "object",
+                    properties: {
+                        id: {
+                            type: "string"
+                        }
+                    },
+                    required: ["id"]
+                }
+            },
+            required: ["msg"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Reaction: {
+            type: "object",
+            properties: {
+                emoji: {
+                    type: "string"
+                }
+            },
+            required: ["emoji"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const msg = __cf_pattern_input.key("element");
+    const messageReactions = __cfLift_1({ msg: {
+            reactions: msg.key("reactions")
+        } }).for("messageReactions", true);
+    return (<div>
+              {messageReactions.mapWithPattern(__cfPattern_1, {
+            msg: {
+                id: msg.key("id")
+            }
+        })}
+            </div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Message"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Message: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                },
+                reactions: {
+                    type: "array",
+                    items: {
+                        $ref: "#/$defs/Reaction"
+                    }
+                }
+            },
+            required: ["id"]
+        },
+        Reaction: {
+            type: "object",
+            properties: {
+                emoji: {
+                    type: "string"
+                }
+            },
+            required: ["emoji"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-computed-fallback-alias
 // Verifies: computed() inside a map callback creates a lift-applied computation and nested map is also transformed
 //   computed(() => (msg.reactions ?? [])) → lift(...)(...) with msg.reactions as input
@@ -78,134 +206,8 @@ export default pattern((__cf_pattern_input) => {
     const messages = __cf_pattern_input.key("messages");
     return {
         [UI]: (<div>
-        {messages.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const msg = __cf_pattern_input.key("element");
-                const messageReactions = __cfLift_1({ msg: {
-                        reactions: msg.key("reactions")
-                    } }).for("messageReactions", true);
-                return (<div>
-              {messageReactions.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                        const reaction = __cf_pattern_input.key("element");
-                        const msg = __cf_pattern_input.key("params", "msg");
-                        return (<button type="button" data-msg-id={msg.key("id")}>
-                  {reaction.key("emoji")}
-                </button>);
-                    }, {
-                        type: "object",
-                        properties: {
-                            element: {
-                                $ref: "#/$defs/Reaction"
-                            },
-                            params: {
-                                type: "object",
-                                properties: {
-                                    msg: {
-                                        type: "object",
-                                        properties: {
-                                            id: {
-                                                type: "string"
-                                            }
-                                        },
-                                        required: ["id"]
-                                    }
-                                },
-                                required: ["msg"]
-                            }
-                        },
-                        required: ["element", "params"],
-                        $defs: {
-                            Reaction: {
-                                type: "object",
-                                properties: {
-                                    emoji: {
-                                        type: "string"
-                                    }
-                                },
-                                required: ["emoji"]
-                            }
-                        }
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        anyOf: [{
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }, {
-                                $ref: "#/$defs/UIRenderable"
-                            }, {
-                                type: "object",
-                                properties: {}
-                            }],
-                        $defs: {
-                            UIRenderable: {
-                                type: "object",
-                                properties: {
-                                    $UI: {
-                                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                                    }
-                                },
-                                required: ["$UI"]
-                            }
-                        }
-                    } as const satisfies __cfHelpers.JSONSchema), {
-                        msg: {
-                            id: msg.key("id")
-                        }
-                    })}
-            </div>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Message"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    Message: {
-                        type: "object",
-                        properties: {
-                            id: {
-                                type: "string"
-                            },
-                            reactions: {
-                                type: "array",
-                                items: {
-                                    $ref: "#/$defs/Reaction"
-                                }
-                            }
-                        },
-                        required: ["id"]
-                    },
-                    Reaction: {
-                        type: "object",
-                        properties: {
-                            emoji: {
-                                type: "string"
-                            }
-                        },
-                        required: ["emoji"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>)
+        {messages.mapWithPattern(__cfPattern_2, {})}
+      </div>),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/map-conditional-expression.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-conditional-expression.expected.jsx
@@ -11,6 +11,15 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Item {
+    id: number;
+    price: number;
+}
+interface State {
+    items: Item[];
+    discount: number;
+    threshold: number;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     item: {
         price: number;
@@ -77,15 +86,95 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ item, state }) => item.price * (1 - state.discount));
-interface Item {
-    id: number;
-    price: number;
-}
-interface State {
-    items: Item[];
-    discount: number;
-    threshold: number;
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const state = __cf_pattern_input.key("params", "state");
+    return (<div>
+            Price: ${__cfHelpers.ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "number"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "number"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "number"
+    } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({
+        item: {
+            price: item.key("price")
+        },
+        state: {
+            threshold: state.key("threshold")
+        }
+    }), __cfLift_2({
+        item: {
+            price: item.key("price")
+        },
+        state: {
+            discount: state.key("discount")
+        }
+    }), item.key("price"))}
+          </div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        },
+        params: {
+            type: "object",
+            properties: {
+                state: {
+                    type: "object",
+                    properties: {
+                        threshold: {
+                            type: "number"
+                        },
+                        discount: {
+                            type: "number"
+                        }
+                    },
+                    required: ["threshold", "discount"]
+                }
+            },
+            required: ["state"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "number"
+                },
+                price: {
+                    type: "number"
+                }
+            },
+            required: ["id", "price"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-conditional-expression
 // Verifies: ternary expression in .map() callback is transformed to ifElse() with lift-applied branches
 //   item.price > state.threshold ? ... : ... → ifElse(lift(...)(condition), lift(...)(trueBranch), falseBranch)
@@ -95,95 +184,7 @@ export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Ternary with captures in map callback */}
-        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                const state = __cf_pattern_input.key("params", "state");
-                return (<div>
-            Price: ${__cfHelpers.ifElse({
-                    type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "number"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "number"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "number"
-                } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({
-                    item: {
-                        price: item.key("price")
-                    },
-                    state: {
-                        threshold: state.key("threshold")
-                    }
-                }), __cfLift_2({
-                    item: {
-                        price: item.key("price")
-                    },
-                    state: {
-                        discount: state.key("discount")
-                    }
-                }), item.key("price"))}
-          </div>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Item"
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            state: {
-                                type: "object",
-                                properties: {
-                                    threshold: {
-                                        type: "number"
-                                    },
-                                    discount: {
-                                        type: "number"
-                                    }
-                                },
-                                required: ["threshold", "discount"]
-                            }
-                        },
-                        required: ["state"]
-                    }
-                },
-                required: ["element", "params"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            id: {
-                                type: "number"
-                            },
-                            price: {
-                                type: "number"
-                            }
-                        },
-                        required: ["id", "price"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        {state.key("items").mapWithPattern(__cfPattern_1, {
                 state: {
                     threshold: state.key("threshold"),
                     discount: state.key("discount")

--- a/packages/ts-transformers/test/fixtures/closures/map-conditional-inline-handler-send.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-conditional-inline-handler-send.expected.jsx
@@ -11,6 +11,53 @@ import { Cell, handler, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Item {
+    id: string;
+    label: string;
+}
+interface VoteEvent {
+    id: string;
+    step: "single" | "double";
+}
+interface State {
+    items: Item[];
+    canVote: boolean;
+    votes: VoteEvent[];
+}
+const castVote = handler({
+    type: "unknown"
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        votes: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/VoteEvent"
+            },
+            asCell: ["cell"]
+        }
+    },
+    required: ["votes"],
+    $defs: {
+        VoteEvent: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                },
+                step: {
+                    "enum": ["single", "double"]
+                }
+            },
+            required: ["id", "step"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, (_event, { votes }) => {
+    votes.set([
+        ...votes.get(),
+        { id: "module", step: "single" },
+    ]);
+});
 const __cfLift_1 = __cfHelpers.lift<{
     castVote: __cfHelpers.HandlerFactory<{ votes: __cfHelpers.Cell<VoteEvent[]>; }, unknown>;
     state: {
@@ -88,53 +135,96 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     id: item.id,
     step: "single",
 }));
-interface Item {
-    id: string;
-    label: string;
-}
-interface VoteEvent {
-    id: string;
-    step: "single" | "double";
-}
-interface State {
-    items: Item[];
-    canVote: boolean;
-    votes: VoteEvent[];
-}
-const castVote = handler({
-    type: "unknown"
-} as const satisfies __cfHelpers.JSONSchema, {
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const state = __cf_pattern_input.key("params", "state");
+    const boundCastVote = __cf_pattern_input.key("params", "boundCastVote");
+    return (<div>
+              {__cfHelpers.when({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{}, {
+                type: "object",
+                properties: {}
+            }]
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{
+                type: "boolean"
+            }, {}, {
+                type: "object",
+                properties: {}
+            }]
+    } as const satisfies __cfHelpers.JSONSchema, state.key("canVote"), <button type="button" onClick={__cfHandler_1({
+        boundCastVote: boundCastVote,
+        item: {
+            id: item.key("id")
+        }
+    })}>
+                  {item.key("label")}
+                </button>)}
+            </div>);
+}, {
     type: "object",
     properties: {
-        votes: {
-            type: "array",
-            items: {
-                $ref: "#/$defs/VoteEvent"
+        element: {
+            $ref: "#/$defs/Item"
+        },
+        params: {
+            type: "object",
+            properties: {
+                state: {
+                    type: "object",
+                    properties: {
+                        canVote: {
+                            type: "boolean"
+                        }
+                    },
+                    required: ["canVote"]
+                },
+                boundCastVote: {
+                    type: "unknown",
+                    asCell: ["stream"]
+                }
             },
-            asCell: ["cell"]
+            required: ["state", "boundCastVote"]
         }
     },
-    required: ["votes"],
+    required: ["element", "params"],
     $defs: {
-        VoteEvent: {
+        Item: {
             type: "object",
             properties: {
                 id: {
                     type: "string"
                 },
-                step: {
-                    "enum": ["single", "double"]
+                label: {
+                    type: "string"
                 }
             },
-            required: ["id", "step"]
+            required: ["id", "label"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, (_event, { votes }) => {
-    votes.set([
-        ...votes.get(),
-        { id: "module", step: "single" },
-    ]);
-});
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-conditional-inline-handler-send
 // Verifies: inline onClick handlers inside conditional JSX branches retain
 // imperative handler semantics when nested in reactive map callbacks.
@@ -151,96 +241,7 @@ export default pattern((state) => {
     }).for({ stream: "boundCastVote" }, true);
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                const state = __cf_pattern_input.key("params", "state");
-                const boundCastVote = __cf_pattern_input.key("params", "boundCastVote");
-                return (<div>
-              {__cfHelpers.when({
-                    type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{}, {
-                            type: "object",
-                            properties: {}
-                        }]
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{
-                            type: "boolean"
-                        }, {}, {
-                            type: "object",
-                            properties: {}
-                        }]
-                } as const satisfies __cfHelpers.JSONSchema, state.key("canVote"), <button type="button" onClick={__cfHandler_1({
-                    boundCastVote: boundCastVote,
-                    item: {
-                        id: item.key("id")
-                    }
-                })}>
-                  {item.key("label")}
-                </button>)}
-            </div>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Item"
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            state: {
-                                type: "object",
-                                properties: {
-                                    canVote: {
-                                        type: "boolean"
-                                    }
-                                },
-                                required: ["canVote"]
-                            },
-                            boundCastVote: {
-                                type: "unknown",
-                                asCell: ["stream"]
-                            }
-                        },
-                        required: ["state", "boundCastVote"]
-                    }
-                },
-                required: ["element", "params"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            id: {
-                                type: "string"
-                            },
-                            label: {
-                                type: "string"
-                            }
-                        },
-                        required: ["id", "label"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        {state.key("items").mapWithPattern(__cfPattern_1, {
                 state: {
                     canVote: state.key("canVote")
                 },

--- a/packages/ts-transformers/test/fixtures/closures/map-destructure-alias-action-collision.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-destructure-alias-action-collision.expected.jsx
@@ -17,6 +17,50 @@ interface Spot {
 interface State {
     spots: Spot[];
 }
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const spot = __cf_pattern_input.key("element");
+    const sn = spot.key("spotNumber");
+    return <li>{sn}</li>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Spot"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Spot: {
+            type: "object",
+            properties: {
+                spotNumber: {
+                    type: "string"
+                }
+            },
+            required: ["spotNumber"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-destructure-alias-action-collision
 // Verifies: destructured alias inside map callback body is lowered to explicit key() access
 //   const { spotNumber: sn } = spot → const sn = spot.key("spotNumber")
@@ -25,50 +69,7 @@ interface State {
 export default pattern((state) => {
     return {
         [UI]: (<ul>
-        {state.key("spots").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const spot = __cf_pattern_input.key("element");
-                const sn = spot.key("spotNumber");
-                return <li>{sn}</li>;
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Spot"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    Spot: {
-                        type: "object",
-                        properties: {
-                            spotNumber: {
-                                type: "string"
-                            }
-                        },
-                        required: ["spotNumber"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+        {state.key("spots").mapWithPattern(__cfPattern_1, {})}
       </ul>),
     };
 }, {

--- a/packages/ts-transformers/test/fixtures/closures/map-destructured-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-destructured-alias.expected.jsx
@@ -11,6 +11,12 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    items: Array<{
+        price: number;
+    }>;
+    discount: number;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     cost: number;
     state: {
@@ -36,12 +42,65 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ cost, state }) => cost * state.discount);
-interface State {
-    items: Array<{
-        price: number;
-    }>;
-    discount: number;
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const cost = __cf_pattern_input.key("element", "price");
+    const state = __cf_pattern_input.key("params", "state");
+    return (<span>{__cfLift_1({
+        cost: cost,
+        state: {
+            discount: state.key("discount")
+        }
+    })}</span>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                price: {
+                    type: "number"
+                }
+            },
+            required: ["price"]
+        },
+        params: {
+            type: "object",
+            properties: {
+                state: {
+                    type: "object",
+                    properties: {
+                        discount: {
+                            type: "number"
+                        }
+                    },
+                    required: ["discount"]
+                }
+            },
+            required: ["state"]
+        }
+    },
+    required: ["element", "params"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-destructured-alias
 // Verifies: object destructuring with alias in .map() param is lowered to key() on the original name
 //   .map(({ price: cost }) => ...) → key("element", "price") assigned to cost
@@ -50,65 +109,7 @@ interface State {
 export default pattern((state) => {
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const cost = __cf_pattern_input.key("element", "price");
-                const state = __cf_pattern_input.key("params", "state");
-                return (<span>{__cfLift_1({
-                    cost: cost,
-                    state: {
-                        discount: state.key("discount")
-                    }
-                })}</span>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "object",
-                        properties: {
-                            price: {
-                                type: "number"
-                            }
-                        },
-                        required: ["price"]
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            state: {
-                                type: "object",
-                                properties: {
-                                    discount: {
-                                        type: "number"
-                                    }
-                                },
-                                required: ["discount"]
-                            }
-                        },
-                        required: ["state"]
-                    }
-                },
-                required: ["element", "params"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        {state.key("items").mapWithPattern(__cfPattern_1, {
                 state: {
                     discount: state.key("discount")
                 }

--- a/packages/ts-transformers/test/fixtures/closures/map-destructured-computed-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-destructured-computed-alias.expected.jsx
@@ -11,6 +11,14 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const dynamicKey = "value" as const;
+interface Item {
+    value: number;
+    other: number;
+}
+interface State {
+    items: Item[];
+}
 const __cfLift_1 = __cfHelpers.lift<{
     element: any;
     __cf_val_key: any;
@@ -24,7 +32,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ element, __cf_val_key }) => element[__cf_val_key]);
-const __cfModuleCallback_1 = __cfHardenFn(__cf_pattern_input => {
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const element = __cf_pattern_input.key("element");
     const __cf_val_key = dynamicKey;
     const val = __cfLift_1({
@@ -32,15 +40,49 @@ const __cfModuleCallback_1 = __cfHardenFn(__cf_pattern_input => {
         __cf_val_key: __cf_val_key
     }).for("val", true);
     return (<span>{val}</span>);
-});
-const dynamicKey = "value" as const;
-interface Item {
-    value: number;
-    other: number;
-}
-interface State {
-    items: Item[];
-}
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                value: {
+                    type: "number"
+                },
+                other: {
+                    type: "number"
+                }
+            },
+            required: ["value", "other"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-destructured-computed-alias
 // Verifies: computed property key with a const-asserted identifier is lowered to lift-applied
 //   { [dynamicKey]: val } → __cf_val_key = dynamicKey; lift(...)(...element[__cf_val_key])
@@ -49,49 +91,7 @@ interface State {
 export default pattern((state) => {
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cfModuleCallback_1, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Item"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            value: {
-                                type: "number"
-                            },
-                            other: {
-                                type: "number"
-                            }
-                        },
-                        required: ["value", "other"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+        {state.key("items").mapWithPattern(__cfPattern_1, {})}
       </div>),
     };
 }, {

--- a/packages/ts-transformers/test/fixtures/closures/map-destructured-numeric-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-destructured-numeric-alias.expected.jsx
@@ -16,6 +16,44 @@ interface State {
         0: number;
     }>;
 }
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const first = __cf_pattern_input.key("element", "0");
+    return (<span>{first}</span>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                "0": {
+                    type: "number"
+                }
+            },
+            required: ["0"]
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-destructured-numeric-alias
 // Verifies: numeric property key destructuring in .map() param is lowered to key() with string index
 //   .map(({ 0: first }) => ...) → key("element", "0") assigned to first
@@ -23,44 +61,7 @@ interface State {
 export default pattern((state) => {
     return {
         [UI]: (<div>
-        {state.key("entries").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const first = __cf_pattern_input.key("element", "0");
-                return (<span>{first}</span>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "object",
-                        properties: {
-                            "0": {
-                                type: "number"
-                            }
-                        },
-                        required: ["0"]
-                    }
-                },
-                required: ["element"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+        {state.key("entries").mapWithPattern(__cfPattern_1, {})}
       </div>),
     };
 }, {

--- a/packages/ts-transformers/test/fixtures/closures/map-destructured-opaque-local-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-destructured-opaque-local-capture.expected.jsx
@@ -21,133 +21,135 @@ interface State {
         }[];
     }[];
 }
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const tag = __cf_pattern_input.key("element");
+    const tasks = __cf_pattern_input.key("params", "tasks");
+    return (<span>
+                {tag.key("name")}:{tasks.key("length")}
+              </span>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        },
+        params: {
+            type: "object",
+            properties: {
+                tasks: {
+                    type: "object",
+                    properties: {
+                        length: {
+                            type: "number"
+                        }
+                    },
+                    required: ["length"]
+                }
+            },
+            required: ["tasks"]
+        }
+    },
+    required: ["element", "params"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const section = __cf_pattern_input.key("element");
+    const tasks = section.key("tasks");
+    return (<div>
+            {section.key("tags").mapWithPattern(__cfPattern_1, {
+            tasks: {
+                length: tasks.key("length")
+            }
+        })}
+          </div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                tasks: {
+                    type: "array",
+                    items: {
+                        type: "object",
+                        properties: {
+                            label: {
+                                type: "string"
+                            }
+                        },
+                        required: ["label"]
+                    }
+                },
+                tags: {
+                    type: "array",
+                    items: {
+                        type: "object",
+                        properties: {
+                            name: {
+                                type: "string"
+                            }
+                        },
+                        required: ["name"]
+                    }
+                }
+            },
+            required: ["tasks", "tags"]
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-destructured-opaque-local-capture
 // Verifies: destructured opaque locals captured by nested map callbacks stay reactive
 //   const { tasks } = section → const tasks = __cf_pattern_input.key("params", "tasks")
 //   nested tag callback reads tasks.length through key("length"), not plain params values
 export default pattern((state) => ({
     [UI]: (<div>
-      {state.key("sections").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-            const section = __cf_pattern_input.key("element");
-            const tasks = section.key("tasks");
-            return (<div>
-            {section.key("tags").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                    const tag = __cf_pattern_input.key("element");
-                    const tasks = __cf_pattern_input.key("params", "tasks");
-                    return (<span>
-                {tag.key("name")}:{tasks.key("length")}
-              </span>);
-                }, {
-                    type: "object",
-                    properties: {
-                        element: {
-                            type: "object",
-                            properties: {
-                                name: {
-                                    type: "string"
-                                }
-                            },
-                            required: ["name"]
-                        },
-                        params: {
-                            type: "object",
-                            properties: {
-                                tasks: {
-                                    type: "object",
-                                    properties: {
-                                        length: {
-                                            type: "number"
-                                        }
-                                    },
-                                    required: ["length"]
-                                }
-                            },
-                            required: ["tasks"]
-                        }
-                    },
-                    required: ["element", "params"]
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{
-                            $ref: "https://commonfabric.org/schemas/vnode.json"
-                        }, {
-                            $ref: "#/$defs/UIRenderable"
-                        }, {
-                            type: "object",
-                            properties: {}
-                        }],
-                    $defs: {
-                        UIRenderable: {
-                            type: "object",
-                            properties: {
-                                $UI: {
-                                    $ref: "https://commonfabric.org/schemas/vnode.json"
-                                }
-                            },
-                            required: ["$UI"]
-                        }
-                    }
-                } as const satisfies __cfHelpers.JSONSchema), {
-                    tasks: {
-                        length: tasks.key("length")
-                    }
-                })}
-          </div>);
-        }, {
-            type: "object",
-            properties: {
-                element: {
-                    type: "object",
-                    properties: {
-                        tasks: {
-                            type: "array",
-                            items: {
-                                type: "object",
-                                properties: {
-                                    label: {
-                                        type: "string"
-                                    }
-                                },
-                                required: ["label"]
-                            }
-                        },
-                        tags: {
-                            type: "array",
-                            items: {
-                                type: "object",
-                                properties: {
-                                    name: {
-                                        type: "string"
-                                    }
-                                },
-                                required: ["name"]
-                            }
-                        }
-                    },
-                    required: ["tasks", "tags"]
-                }
-            },
-            required: ["element"]
-        } as const satisfies __cfHelpers.JSONSchema, {
-            anyOf: [{
-                    $ref: "https://commonfabric.org/schemas/vnode.json"
-                }, {
-                    $ref: "#/$defs/UIRenderable"
-                }, {
-                    type: "object",
-                    properties: {}
-                }],
-            $defs: {
-                UIRenderable: {
-                    type: "object",
-                    properties: {
-                        $UI: {
-                            $ref: "https://commonfabric.org/schemas/vnode.json"
-                        }
-                    },
-                    required: ["$UI"]
-                }
-            }
-        } as const satisfies __cfHelpers.JSONSchema), {})}
+      {state.key("sections").mapWithPattern(__cfPattern_2, {})}
     </div>),
 }), {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/map-destructured-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-destructured-param.expected.jsx
@@ -11,6 +11,14 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Point {
+    x: number;
+    y: number;
+}
+interface State {
+    points: Point[];
+    scale: number;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     x: number;
     state: {
@@ -61,14 +69,76 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ y, state }) => y * state.scale);
-interface Point {
-    x: number;
-    y: number;
-}
-interface State {
-    points: Point[];
-    scale: number;
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const x = __cf_pattern_input.key("element", "x");
+    const y = __cf_pattern_input.key("element", "y");
+    const state = __cf_pattern_input.key("params", "state");
+    return (<div>
+            Point: ({__cfLift_1({
+        x: x,
+        state: {
+            scale: state.key("scale")
+        }
+    })}, {__cfLift_2({
+        y: y,
+        state: {
+            scale: state.key("scale")
+        }
+    })})
+          </div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                x: {
+                    type: "number"
+                },
+                y: {
+                    type: "number"
+                }
+            },
+            required: ["x", "y"]
+        },
+        params: {
+            type: "object",
+            properties: {
+                state: {
+                    type: "object",
+                    properties: {
+                        scale: {
+                            type: "number"
+                        }
+                    },
+                    required: ["scale"]
+                }
+            },
+            required: ["state"]
+        }
+    },
+    required: ["element", "params"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-destructured-param
 // Verifies: object destructuring in .map() param is lowered to key() calls on each property
 //   .map(({ x, y }) => ...) → key("element", "x"), key("element", "y")
@@ -78,76 +148,7 @@ export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Map with destructured parameter and capture */}
-        {state.key("points").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const x = __cf_pattern_input.key("element", "x");
-                const y = __cf_pattern_input.key("element", "y");
-                const state = __cf_pattern_input.key("params", "state");
-                return (<div>
-            Point: ({__cfLift_1({
-                    x: x,
-                    state: {
-                        scale: state.key("scale")
-                    }
-                })}, {__cfLift_2({
-                    y: y,
-                    state: {
-                        scale: state.key("scale")
-                    }
-                })})
-          </div>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "object",
-                        properties: {
-                            x: {
-                                type: "number"
-                            },
-                            y: {
-                                type: "number"
-                            }
-                        },
-                        required: ["x", "y"]
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            state: {
-                                type: "object",
-                                properties: {
-                                    scale: {
-                                        type: "number"
-                                    }
-                                },
-                                required: ["scale"]
-                            }
-                        },
-                        required: ["state"]
-                    }
-                },
-                required: ["element", "params"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        {state.key("points").mapWithPattern(__cfPattern_1, {
                 state: {
                     scale: state.key("scale")
                 }

--- a/packages/ts-transformers/test/fixtures/closures/map-destructured-string-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-destructured-string-alias.expected.jsx
@@ -16,6 +16,44 @@ interface State {
         couponCode: string;
     }>;
 }
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const code = __cf_pattern_input.key("element", "couponCode");
+    return (<span>{code}</span>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                couponCode: {
+                    type: "string"
+                }
+            },
+            required: ["couponCode"]
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-destructured-string-alias
 // Verifies: object destructuring with string-property alias in .map() param is lowered to key()
 //   .map(({ couponCode: code }) => ...) → key("element", "couponCode") assigned to code
@@ -23,44 +61,7 @@ interface State {
 export default pattern((state) => {
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const code = __cf_pattern_input.key("element", "couponCode");
-                return (<span>{code}</span>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "object",
-                        properties: {
-                            couponCode: {
-                                type: "string"
-                            }
-                        },
-                        required: ["couponCode"]
-                    }
-                },
-                required: ["element"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+        {state.key("items").mapWithPattern(__cfPattern_1, {})}
       </div>),
     };
 }, {

--- a/packages/ts-transformers/test/fixtures/closures/map-element-access-opaque.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-element-access-opaque.expected.jsx
@@ -11,6 +11,10 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    sortedTags: string[];
+    tagCounts: Record<string, number>;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         tagCounts: Record<string, number>;
@@ -40,10 +44,65 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema, ({ state, tag }) => state.tagCounts[tag]);
-interface State {
-    sortedTags: string[];
-    tagCounts: Record<string, number>;
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const tag = __cf_pattern_input.key("element");
+    const state = __cf_pattern_input.key("params", "state");
+    return (<span>
+            {tag}: {__cfLift_1({
+        state: {
+            tagCounts: state.key("tagCounts")
+        },
+        tag: tag
+    })}
+          </span>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "string"
+        },
+        params: {
+            type: "object",
+            properties: {
+                state: {
+                    type: "object",
+                    properties: {
+                        tagCounts: {
+                            type: "object",
+                            properties: {},
+                            additionalProperties: {
+                                type: "number"
+                            }
+                        }
+                    },
+                    required: ["tagCounts"]
+                }
+            },
+            required: ["state"]
+        }
+    },
+    required: ["element", "params"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-element-access-opaque
 // Verifies: .map() on reactive array is transformed when callback uses bracket access on a captured opaque object
 //   .map(fn) → .mapWithPattern(pattern(...), {state: {tagCounts: ...}})
@@ -52,65 +111,7 @@ interface State {
 export default pattern((state) => {
     return {
         [UI]: (<div>
-        {state.key("sortedTags").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const tag = __cf_pattern_input.key("element");
-                const state = __cf_pattern_input.key("params", "state");
-                return (<span>
-            {tag}: {__cfLift_1({
-                    state: {
-                        tagCounts: state.key("tagCounts")
-                    },
-                    tag: tag
-                })}
-          </span>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "string"
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            state: {
-                                type: "object",
-                                properties: {
-                                    tagCounts: {
-                                        type: "object",
-                                        properties: {},
-                                        additionalProperties: {
-                                            type: "number"
-                                        }
-                                    }
-                                },
-                                required: ["tagCounts"]
-                            }
-                        },
-                        required: ["state"]
-                    }
-                },
-                required: ["element", "params"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        {state.key("sortedTags").mapWithPattern(__cfPattern_1, {
                 state: {
                     tagCounts: state.key("tagCounts")
                 }

--- a/packages/ts-transformers/test/fixtures/closures/map-element-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-element-computed.expected.jsx
@@ -11,6 +11,14 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Item {
+    id: number;
+    name: string;
+}
+interface State {
+    items: Item[];
+    prefix: string;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     item: {
         name: string;
@@ -32,14 +40,52 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, ({ item }) => item.name.toUpperCase());
-interface Item {
-    id: number;
-    name: string;
-}
-interface State {
-    items: Item[];
-    prefix: string;
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const index = __cf_pattern_input.key("index");
+    return (<div>
+            Item #{index}: {__cfLift_1({ item: {
+            name: item.key("name")
+        } })}
+          </div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        },
+        index: {
+            type: "number"
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-element-computed
 // Verifies: .map() on reactive array is transformed with computed element property access
 //   .map(fn) → .mapWithPattern(pattern(...), {})
@@ -49,52 +95,7 @@ export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Performs computation on element property - should wrap in computed() */}
-        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                const index = __cf_pattern_input.key("index");
-                return (<div>
-            Item #{index}: {__cfLift_1({ item: {
-                        name: item.key("name")
-                    } })}
-          </div>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            }
-                        },
-                        required: ["name"]
-                    },
-                    index: {
-                        type: "number"
-                    }
-                },
-                required: ["element"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+        {state.key("items").mapWithPattern(__cfPattern_1, {})}
       </div>),
     };
 }, {

--- a/packages/ts-transformers/test/fixtures/closures/map-handler-reference-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-handler-reference-no-name.expected.jsx
@@ -41,6 +41,71 @@ interface State {
     items: Item[];
     count: Cell<number>;
 }
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const state = __cf_pattern_input.key("params", "state");
+    return (<cf-button onClick={handleClick({ count: state.key("count") })}>
+            {item.key("name")}
+          </cf-button>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        },
+        params: {
+            type: "object",
+            properties: {
+                state: {
+                    type: "object",
+                    properties: {
+                        count: {
+                            type: "number",
+                            asCell: ["readonly"]
+                        }
+                    },
+                    required: ["count"]
+                }
+            },
+            required: ["state"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "number"
+                },
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["id", "name"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-handler-reference-no-name
 // Verifies: .map() transform works when pattern has inline type annotation instead of type arg
 //   .map(fn) → .mapWithPattern(pattern(...), {state: {count: ...}})
@@ -49,71 +114,7 @@ export default pattern((state: State) => {
     return {
         [UI]: (<div>
         {/* Map callback references handler - should NOT capture it */}
-        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                const state = __cf_pattern_input.key("params", "state");
-                return (<cf-button onClick={handleClick({ count: state.key("count") })}>
-            {item.key("name")}
-          </cf-button>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Item"
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            state: {
-                                type: "object",
-                                properties: {
-                                    count: {
-                                        type: "number",
-                                        asCell: ["readonly"]
-                                    }
-                                },
-                                required: ["count"]
-                            }
-                        },
-                        required: ["state"]
-                    }
-                },
-                required: ["element", "params"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            id: {
-                                type: "number"
-                            },
-                            name: {
-                                type: "string"
-                            }
-                        },
-                        required: ["id", "name"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        {state.key("items").mapWithPattern(__cfPattern_1, {
                 state: {
                     count: state.key("count")
                 }

--- a/packages/ts-transformers/test/fixtures/closures/map-handler-reference-with-type-arg-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-handler-reference-with-type-arg-no-name.expected.jsx
@@ -41,6 +41,71 @@ interface State {
     items: Item[];
     count: Cell<number>;
 }
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const state = __cf_pattern_input.key("params", "state");
+    return (<cf-button onClick={handleClick({ count: state.key("count") })}>
+            {item.key("name")}
+          </cf-button>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        },
+        params: {
+            type: "object",
+            properties: {
+                state: {
+                    type: "object",
+                    properties: {
+                        count: {
+                            type: "number",
+                            asCell: ["readonly"]
+                        }
+                    },
+                    required: ["count"]
+                }
+            },
+            required: ["state"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "number"
+                },
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["id", "name"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-handler-reference-with-type-arg-no-name
 // Verifies: .map() transform works with type arg on pattern but no export name
 //   .map(fn) → .mapWithPattern(pattern(...), {state: {count: ...}})
@@ -49,71 +114,7 @@ export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Map callback references handler - should NOT capture it */}
-        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                const state = __cf_pattern_input.key("params", "state");
-                return (<cf-button onClick={handleClick({ count: state.key("count") })}>
-            {item.key("name")}
-          </cf-button>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Item"
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            state: {
-                                type: "object",
-                                properties: {
-                                    count: {
-                                        type: "number",
-                                        asCell: ["readonly"]
-                                    }
-                                },
-                                required: ["count"]
-                            }
-                        },
-                        required: ["state"]
-                    }
-                },
-                required: ["element", "params"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            id: {
-                                type: "number"
-                            },
-                            name: {
-                                type: "string"
-                            }
-                        },
-                        required: ["id", "name"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        {state.key("items").mapWithPattern(__cfPattern_1, {
                 state: {
                     count: state.key("count")
                 }

--- a/packages/ts-transformers/test/fixtures/closures/map-handler-reference.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-handler-reference.expected.jsx
@@ -41,6 +41,71 @@ interface State {
     items: Item[];
     count: Cell<number>;
 }
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const state = __cf_pattern_input.key("params", "state");
+    return (<cf-button onClick={handleClick({ count: state.key("count") })}>
+            {item.key("name")}
+          </cf-button>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        },
+        params: {
+            type: "object",
+            properties: {
+                state: {
+                    type: "object",
+                    properties: {
+                        count: {
+                            type: "number",
+                            asCell: ["readonly"]
+                        }
+                    },
+                    required: ["count"]
+                }
+            },
+            required: ["state"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "number"
+                },
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["id", "name"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-handler-reference
 // Verifies: .map() on reactive array is transformed when callback references a module-level handler
 //   .map(fn) → .mapWithPattern(pattern(...), {state: {count: ...}})
@@ -49,71 +114,7 @@ export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Map callback references handler - should NOT capture it */}
-        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                const state = __cf_pattern_input.key("params", "state");
-                return (<cf-button onClick={handleClick({ count: state.key("count") })}>
-            {item.key("name")}
-          </cf-button>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Item"
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            state: {
-                                type: "object",
-                                properties: {
-                                    count: {
-                                        type: "number",
-                                        asCell: ["readonly"]
-                                    }
-                                },
-                                required: ["count"]
-                            }
-                        },
-                        required: ["state"]
-                    }
-                },
-                required: ["element", "params"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            id: {
-                                type: "number"
-                            },
-                            name: {
-                                type: "string"
-                            }
-                        },
-                        required: ["id", "name"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        {state.key("items").mapWithPattern(__cfPattern_1, {
                 state: {
                     count: state.key("count")
                 }

--- a/packages/ts-transformers/test/fixtures/closures/map-import-reference.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-import-reference.expected.jsx
@@ -11,6 +11,20 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+// Module-level constant - should NOT be captured
+const TAX_RATE = 0.08;
+// Module-level function - should NOT be captured
+function formatPrice(price: number): string {
+    return `$${price.toFixed(2)}`;
+}
+__cfHardenFn(formatPrice);
+interface Item {
+    id: number;
+    price: number;
+}
+interface State {
+    items: Item[];
+}
 const __cfLift_1 = __cfHelpers.lift<{
     item: {
         price: number;
@@ -32,20 +46,56 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, ({ item }) => formatPrice(item.price * (1 + TAX_RATE)));
-// Module-level constant - should NOT be captured
-const TAX_RATE = 0.08;
-// Module-level function - should NOT be captured
-function formatPrice(price: number): string {
-    return `$${price.toFixed(2)}`;
-}
-__cfHardenFn(formatPrice);
-interface Item {
-    id: number;
-    price: number;
-}
-interface State {
-    items: Item[];
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return (<div>
+            Item: {__cfLift_1({ item: {
+            price: item.key("price")
+        } })}
+          </div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "number"
+                },
+                price: {
+                    type: "number"
+                }
+            },
+            required: ["id", "price"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-import-reference
 // Verifies: .map() on reactive array is transformed when callback references module-level constants and functions
 //   .map(fn) → .mapWithPattern(pattern(...), {})
@@ -55,56 +105,7 @@ export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Should NOT capture module-level constant or function */}
-        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                return (<div>
-            Item: {__cfLift_1({ item: {
-                        price: item.key("price")
-                    } })}
-          </div>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Item"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            id: {
-                                type: "number"
-                            },
-                            price: {
-                                type: "number"
-                            }
-                        },
-                        required: ["id", "price"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+        {state.key("items").mapWithPattern(__cfPattern_1, {})}
       </div>),
     };
 }, {

--- a/packages/ts-transformers/test/fixtures/closures/map-index-param-used.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-index-param-used.expected.jsx
@@ -11,6 +11,14 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Item {
+    id: number;
+    name: string;
+}
+interface State {
+    items: Item[];
+    offset: number;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     index: number;
     state: {
@@ -36,14 +44,71 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ index, state }) => index + state.offset);
-interface Item {
-    id: number;
-    name: string;
-}
-interface State {
-    items: Item[];
-    offset: number;
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const index = __cf_pattern_input.key("index");
+    const state = __cf_pattern_input.key("params", "state");
+    return (<div>
+            Item #{__cfLift_1({
+        index: index,
+        state: {
+            offset: state.key("offset")
+        }
+    })}: {item.key("name")}
+          </div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        },
+        index: {
+            type: "number"
+        },
+        params: {
+            type: "object",
+            properties: {
+                state: {
+                    type: "object",
+                    properties: {
+                        offset: {
+                            type: "number"
+                        }
+                    },
+                    required: ["offset"]
+                }
+            },
+            required: ["state"]
+        }
+    },
+    required: ["element", "params"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-index-param-used
 // Verifies: .map() on reactive array is transformed when index param is used with a capture
 //   .map(fn) → .mapWithPattern(pattern(...), {state: {offset: ...}})
@@ -53,71 +118,7 @@ export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Uses both index parameter and captures state.offset */}
-        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                const index = __cf_pattern_input.key("index");
-                const state = __cf_pattern_input.key("params", "state");
-                return (<div>
-            Item #{__cfLift_1({
-                    index: index,
-                    state: {
-                        offset: state.key("offset")
-                    }
-                })}: {item.key("name")}
-          </div>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            }
-                        },
-                        required: ["name"]
-                    },
-                    index: {
-                        type: "number"
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            state: {
-                                type: "object",
-                                properties: {
-                                    offset: {
-                                        type: "number"
-                                    }
-                                },
-                                required: ["offset"]
-                            }
-                        },
-                        required: ["state"]
-                    }
-                },
-                required: ["element", "params"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        {state.key("items").mapWithPattern(__cfPattern_1, {
                 state: {
                     offset: state.key("offset")
                 }

--- a/packages/ts-transformers/test/fixtures/closures/map-index-shorthand.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-index-shorthand.expected.jsx
@@ -18,6 +18,94 @@ interface Item {
 interface State {
     items: Item[];
 }
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const i = __cf_pattern_input.key("index");
+    return (<div key={i}>
+            Item #{i}: {item.key("name")}
+          </div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        },
+        index: {
+            type: "number"
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const idx = __cf_pattern_input.key("index");
+    return (<div key={idx}>
+            Position {idx}: {item.key("name")}
+          </div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        },
+        index: {
+            type: "number"
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-index-shorthand
 // Verifies: .map() on reactive array is transformed when index param uses shorthand names (i, idx)
 //   .map((item, i) => ...) → .mapWithPattern(pattern(...), {})
@@ -27,96 +115,10 @@ export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Map with common shorthand index parameter names */}
-        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                const i = __cf_pattern_input.key("index");
-                return (<div key={i}>
-            Item #{i}: {item.key("name")}
-          </div>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            }
-                        },
-                        required: ["name"]
-                    },
-                    index: {
-                        type: "number"
-                    }
-                },
-                required: ["element"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+        {state.key("items").mapWithPattern(__cfPattern_1, {})}
 
         {/* Map with idx as index parameter */}
-        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                const idx = __cf_pattern_input.key("index");
-                return (<div key={idx}>
-            Position {idx}: {item.key("name")}
-          </div>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            }
-                        },
-                        required: ["name"]
-                    },
-                    index: {
-                        type: "number"
-                    }
-                },
-                required: ["element"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+        {state.key("items").mapWithPattern(__cfPattern_2, {})}
       </div>),
     };
 }, {

--- a/packages/ts-transformers/test/fixtures/closures/map-inline-fallback-receivers.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-inline-fallback-receivers.expected.jsx
@@ -22,6 +22,207 @@ interface Message {
 interface Input {
     messages: Message[];
 }
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const reaction = __cf_pattern_input.key("element");
+    const msg = __cf_pattern_input.key("params", "msg");
+    return (<button type="button" data-msg-id={msg.key("id")}>
+                {reaction.key("emoji")}
+              </button>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Reaction"
+        },
+        params: {
+            type: "object",
+            properties: {
+                msg: {
+                    type: "object",
+                    properties: {
+                        id: {
+                            type: "string"
+                        }
+                    },
+                    required: ["id"]
+                }
+            },
+            required: ["msg"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Reaction: {
+            type: "object",
+            properties: {
+                emoji: {
+                    type: "string"
+                },
+                userNames: {
+                    type: "array",
+                    items: {
+                        type: "string"
+                    }
+                }
+            },
+            required: ["emoji", "userNames"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const reaction = __cf_pattern_input.key("element");
+    const msg = __cf_pattern_input.key("params", "msg");
+    return (<span>
+                {msg.key("id")}:{reaction.key("userNames", "length")}
+              </span>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                userNames: {
+                    type: "array",
+                    items: {
+                        type: "unknown"
+                    }
+                }
+            },
+            required: ["userNames"]
+        },
+        params: {
+            type: "object",
+            properties: {
+                msg: {
+                    type: "object",
+                    properties: {
+                        id: {
+                            type: "string"
+                        }
+                    },
+                    required: ["id"]
+                }
+            },
+            required: ["msg"]
+        }
+    },
+    required: ["element", "params"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
+    const msg = __cf_pattern_input.key("element");
+    return (<section>
+            {(msg.key("reactions") ?? []).mapWithPattern(__cfPattern_1, {
+            msg: {
+                id: msg.key("id")
+            }
+        })}
+            {(msg.key("reactions") || []).mapWithPattern(__cfPattern_2, {
+            msg: {
+                id: msg.key("id")
+            }
+        })}
+          </section>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Message"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Message: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                },
+                reactions: {
+                    type: "array",
+                    items: {
+                        $ref: "#/$defs/Reaction"
+                    }
+                }
+            },
+            required: ["id"]
+        },
+        Reaction: {
+            type: "object",
+            properties: {
+                emoji: {
+                    type: "string"
+                },
+                userNames: {
+                    type: "array",
+                    items: {
+                        type: "string"
+                    }
+                }
+            },
+            required: ["emoji", "userNames"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-inline-fallback-receivers
 // Verifies: inline fallback array-method receivers are transformed structurally
 //   (msg.reactions ?? []).map(fn) → lift(...)(...).mapWithPattern(pattern(...), { msg: { id: ... } })
@@ -31,205 +232,7 @@ export default pattern((__cf_pattern_input) => {
     const messages = __cf_pattern_input.key("messages");
     return {
         [UI]: (<div>
-        {messages.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const msg = __cf_pattern_input.key("element");
-                return (<section>
-            {(msg.key("reactions") ?? []).mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                        const reaction = __cf_pattern_input.key("element");
-                        const msg = __cf_pattern_input.key("params", "msg");
-                        return (<button type="button" data-msg-id={msg.key("id")}>
-                {reaction.key("emoji")}
-              </button>);
-                    }, {
-                        type: "object",
-                        properties: {
-                            element: {
-                                $ref: "#/$defs/Reaction"
-                            },
-                            params: {
-                                type: "object",
-                                properties: {
-                                    msg: {
-                                        type: "object",
-                                        properties: {
-                                            id: {
-                                                type: "string"
-                                            }
-                                        },
-                                        required: ["id"]
-                                    }
-                                },
-                                required: ["msg"]
-                            }
-                        },
-                        required: ["element", "params"],
-                        $defs: {
-                            Reaction: {
-                                type: "object",
-                                properties: {
-                                    emoji: {
-                                        type: "string"
-                                    },
-                                    userNames: {
-                                        type: "array",
-                                        items: {
-                                            type: "string"
-                                        }
-                                    }
-                                },
-                                required: ["emoji", "userNames"]
-                            }
-                        }
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        anyOf: [{
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }, {
-                                $ref: "#/$defs/UIRenderable"
-                            }, {
-                                type: "object",
-                                properties: {}
-                            }],
-                        $defs: {
-                            UIRenderable: {
-                                type: "object",
-                                properties: {
-                                    $UI: {
-                                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                                    }
-                                },
-                                required: ["$UI"]
-                            }
-                        }
-                    } as const satisfies __cfHelpers.JSONSchema), {
-                        msg: {
-                            id: msg.key("id")
-                        }
-                    })}
-            {(msg.key("reactions") || []).mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                        const reaction = __cf_pattern_input.key("element");
-                        const msg = __cf_pattern_input.key("params", "msg");
-                        return (<span>
-                {msg.key("id")}:{reaction.key("userNames", "length")}
-              </span>);
-                    }, {
-                        type: "object",
-                        properties: {
-                            element: {
-                                type: "object",
-                                properties: {
-                                    userNames: {
-                                        type: "array",
-                                        items: {
-                                            type: "unknown"
-                                        }
-                                    }
-                                },
-                                required: ["userNames"]
-                            },
-                            params: {
-                                type: "object",
-                                properties: {
-                                    msg: {
-                                        type: "object",
-                                        properties: {
-                                            id: {
-                                                type: "string"
-                                            }
-                                        },
-                                        required: ["id"]
-                                    }
-                                },
-                                required: ["msg"]
-                            }
-                        },
-                        required: ["element", "params"]
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        anyOf: [{
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }, {
-                                $ref: "#/$defs/UIRenderable"
-                            }, {
-                                type: "object",
-                                properties: {}
-                            }],
-                        $defs: {
-                            UIRenderable: {
-                                type: "object",
-                                properties: {
-                                    $UI: {
-                                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                                    }
-                                },
-                                required: ["$UI"]
-                            }
-                        }
-                    } as const satisfies __cfHelpers.JSONSchema), {
-                        msg: {
-                            id: msg.key("id")
-                        }
-                    })}
-          </section>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Message"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    Message: {
-                        type: "object",
-                        properties: {
-                            id: {
-                                type: "string"
-                            },
-                            reactions: {
-                                type: "array",
-                                items: {
-                                    $ref: "#/$defs/Reaction"
-                                }
-                            }
-                        },
-                        required: ["id"]
-                    },
-                    Reaction: {
-                        type: "object",
-                        properties: {
-                            emoji: {
-                                type: "string"
-                            },
-                            userNames: {
-                                type: "array",
-                                items: {
-                                    type: "string"
-                                }
-                            }
-                        },
-                        required: ["emoji", "userNames"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+        {messages.mapWithPattern(__cfPattern_3, {})}
       </div>),
     };
 }, {

--- a/packages/ts-transformers/test/fixtures/closures/map-inside-ifelse-with-handler.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-inside-ifelse-with-handler.expected.jsx
@@ -42,6 +42,68 @@ const removeItem = handler({
         items.set(currentItems.toSpliced(index, 1));
     }
 });
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const items = __cf_pattern_input.key("params", "items");
+    return (<div>
+                  <span>{item.key("name")}</span>
+                  <button type="button" onClick={removeItem({ items, item })}>Remove</button>
+                </div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        },
+        params: {
+            type: "object",
+            properties: {
+                items: {
+                    type: "array",
+                    items: {
+                        $ref: "#/$defs/Item"
+                    }
+                }
+            },
+            required: ["items"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "number"
+                },
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["id", "name"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-inside-ifelse-with-handler
 // Verifies: .map() inside an ifElse branch is still transformed to mapWithPattern
 //   .map(fn) → .mapWithPattern(pattern(...), {items: ...})
@@ -67,68 +129,7 @@ export default pattern((__cf_pattern_input) => {
                         properties: {}
                     }]
             } as const satisfies __cfHelpers.JSONSchema, {} as const satisfies __cfHelpers.JSONSchema, hasItems, <div>
-              {items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                    const item = __cf_pattern_input.key("element");
-                    const items = __cf_pattern_input.key("params", "items");
-                    return (<div>
-                  <span>{item.key("name")}</span>
-                  <button type="button" onClick={removeItem({ items, item })}>Remove</button>
-                </div>);
-                }, {
-                    type: "object",
-                    properties: {
-                        element: {
-                            $ref: "#/$defs/Item"
-                        },
-                        params: {
-                            type: "object",
-                            properties: {
-                                items: {
-                                    type: "array",
-                                    items: {
-                                        $ref: "#/$defs/Item"
-                                    }
-                                }
-                            },
-                            required: ["items"]
-                        }
-                    },
-                    required: ["element", "params"],
-                    $defs: {
-                        Item: {
-                            type: "object",
-                            properties: {
-                                id: {
-                                    type: "number"
-                                },
-                                name: {
-                                    type: "string"
-                                }
-                            },
-                            required: ["id", "name"]
-                        }
-                    }
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{
-                            $ref: "https://commonfabric.org/schemas/vnode.json"
-                        }, {
-                            $ref: "#/$defs/UIRenderable"
-                        }, {
-                            type: "object",
-                            properties: {}
-                        }],
-                    $defs: {
-                        UIRenderable: {
-                            type: "object",
-                            properties: {
-                                $UI: {
-                                    $ref: "https://commonfabric.org/schemas/vnode.json"
-                                }
-                            },
-                            required: ["$UI"]
-                        }
-                    }
-                } as const satisfies __cfHelpers.JSONSchema), {
+              {items.mapWithPattern(__cfPattern_1, {
                     items: items
                 })}
             </div>, <div>No items</div>)}

--- a/packages/ts-transformers/test/fixtures/closures/map-jsx-map-filter-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-jsx-map-filter-chain.expected.jsx
@@ -15,6 +15,110 @@ interface Item {
     name: string;
     active: boolean;
 }
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return ({
+        name: item.key("name"),
+        active: item.key("active"),
+    });
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                active: {
+                    type: "boolean"
+                }
+            },
+            required: ["name", "active"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        name: {
+            type: "string"
+        },
+        active: {
+            type: "boolean"
+        }
+    },
+    required: ["name", "active"]
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const entry = __cf_pattern_input.key("element");
+    return entry.key("active");
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                active: {
+                    type: "boolean"
+                }
+            },
+            required: ["name", "active"]
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
+    const entry = __cf_pattern_input.key("element");
+    return <span>{entry.key("name")}</span>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                active: {
+                    type: "boolean"
+                }
+            },
+            required: ["name", "active"]
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-jsx-map-filter-chain
 // Verifies: chained .map().filter().map() on reactive array all transform
 //   .map(fn)    → .mapWithPattern(pattern(...), {})
@@ -25,108 +129,7 @@ export default pattern((__cf_pattern_input) => {
     const list = __cf_pattern_input.key("list");
     return {
         [UI]: (<div>
-        {list.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                return ({
-                    name: item.key("name"),
-                    active: item.key("active"),
-                });
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Item"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            },
-                            active: {
-                                type: "boolean"
-                            }
-                        },
-                        required: ["name", "active"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                type: "object",
-                properties: {
-                    name: {
-                        type: "string"
-                    },
-                    active: {
-                        type: "boolean"
-                    }
-                },
-                required: ["name", "active"]
-            } as const satisfies __cfHelpers.JSONSchema), {}).filterWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const entry = __cf_pattern_input.key("element");
-                return entry.key("active");
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            },
-                            active: {
-                                type: "boolean"
-                            }
-                        },
-                        required: ["name", "active"]
-                    }
-                },
-                required: ["element"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                type: "boolean"
-            } as const satisfies __cfHelpers.JSONSchema), {}).mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const entry = __cf_pattern_input.key("element");
-                return <span>{entry.key("name")}</span>;
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            },
-                            active: {
-                                type: "boolean"
-                            }
-                        },
-                        required: ["name", "active"]
-                    }
-                },
-                required: ["element"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+        {list.mapWithPattern(__cfPattern_1, {}).filterWithPattern(__cfPattern_2, {}).mapWithPattern(__cfPattern_3, {})}
       </div>),
     };
 }, {

--- a/packages/ts-transformers/test/fixtures/closures/map-local-helper-call-root.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-local-helper-call-root.expected.jsx
@@ -11,6 +11,7 @@ import { pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const identity = __cfHardenFn(<T,>(value: T) => value);
 const __cfLift_1 = __cfHelpers.lift<{
     item: string;
 }, string>({
@@ -24,7 +25,20 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, ({ item }) => identity(item.toUpperCase()));
-const identity = __cfHardenFn(<T,>(value: T) => value);
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return __cfLift_1({ item: item }).for("__patternResult", true);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "string"
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "string"
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-local-helper-call-root
 // Verifies: non-JSX pattern-owned map callbacks lift ordinary local helper
 //   calls as whole callback-local lift-applied computations rather than lowering only the inner
@@ -33,20 +47,7 @@ const identity = __cfHardenFn(<T,>(value: T) => value);
 //   -> mapWithPattern(..., ({ item }) => lift(({ item }) => identity(item.toUpperCase()))(...))
 export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
-    return items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-        const item = __cf_pattern_input.key("element");
-        return __cfLift_1({ item: item });
-    }, {
-        type: "object",
-        properties: {
-            element: {
-                type: "string"
-            }
-        },
-        required: ["element"]
-    } as const satisfies __cfHelpers.JSONSchema, {
-        type: "string"
-    } as const satisfies __cfHelpers.JSONSchema), {}).for("__patternResult", true);
+    return items.mapWithPattern(__cfPattern_1, {}).for("__patternResult", true);
 }, {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/closures/map-multiple-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-multiple-captures.expected.jsx
@@ -11,6 +11,16 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Item {
+    price: number;
+    quantity: number;
+}
+interface State {
+    items: Item[];
+    discount: number;
+    taxRate: number;
+}
+const shippingCost = 5.99;
 const __cfLift_1 = __cfHelpers.lift<{
     item: {
         price: number;
@@ -56,16 +66,87 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ item, state, multiplier }) => item.price * item.quantity * state.discount * state.taxRate * multiplier + shippingCost);
-interface Item {
-    price: number;
-    quantity: number;
-}
-interface State {
-    items: Item[];
-    discount: number;
-    taxRate: number;
-}
-const shippingCost = 5.99;
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const state = __cf_pattern_input.key("params", "state");
+    const multiplier = __cf_pattern_input.params.multiplier;
+    return (<span>
+            Total: {__cfLift_1({
+        item: {
+            price: item.key("price"),
+            quantity: item.key("quantity")
+        },
+        state: {
+            discount: state.key("discount"),
+            taxRate: state.key("taxRate")
+        },
+        multiplier: multiplier
+    })}
+          </span>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        },
+        params: {
+            type: "object",
+            properties: {
+                state: {
+                    type: "object",
+                    properties: {
+                        discount: {
+                            type: "number"
+                        },
+                        taxRate: {
+                            type: "number"
+                        }
+                    },
+                    required: ["discount", "taxRate"]
+                },
+                multiplier: {
+                    type: "number"
+                }
+            },
+            required: ["state", "multiplier"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                price: {
+                    type: "number"
+                },
+                quantity: {
+                    type: "number"
+                }
+            },
+            required: ["price", "quantity"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-multiple-captures
 // Verifies: .map() on reactive array captures multiple outer variables (state + local)
 //   .map(fn) → .mapWithPattern(pattern(...), {state: {discount, taxRate}, multiplier})
@@ -80,87 +161,7 @@ export default pattern((state) => {
     const multiplier = 2;
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                const state = __cf_pattern_input.key("params", "state");
-                const multiplier = __cf_pattern_input.params.multiplier;
-                return (<span>
-            Total: {__cfLift_1({
-                    item: {
-                        price: item.key("price"),
-                        quantity: item.key("quantity")
-                    },
-                    state: {
-                        discount: state.key("discount"),
-                        taxRate: state.key("taxRate")
-                    },
-                    multiplier: multiplier
-                })}
-          </span>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Item"
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            state: {
-                                type: "object",
-                                properties: {
-                                    discount: {
-                                        type: "number"
-                                    },
-                                    taxRate: {
-                                        type: "number"
-                                    }
-                                },
-                                required: ["discount", "taxRate"]
-                            },
-                            multiplier: {
-                                type: "number"
-                            }
-                        },
-                        required: ["state", "multiplier"]
-                    }
-                },
-                required: ["element", "params"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            price: {
-                                type: "number"
-                            },
-                            quantity: {
-                                type: "number"
-                            }
-                        },
-                        required: ["price", "quantity"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        {state.key("items").mapWithPattern(__cfPattern_1, {
                 state: {
                     discount: state.key("discount"),
                     taxRate: state.key("taxRate")

--- a/packages/ts-transformers/test/fixtures/closures/map-multiple-similar-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-multiple-similar-captures.expected.jsx
@@ -11,6 +11,17 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    items: Array<{
+        price: number;
+    }>;
+    checkout: {
+        discount: number;
+    };
+    upsell: {
+        discount: number;
+    };
+}
 const __cfLift_1 = __cfHelpers.lift<{
     item: {
         price: number;
@@ -64,17 +75,89 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ item, state }) => item.price * state.checkout.discount * state.upsell.discount);
-interface State {
-    items: Array<{
-        price: number;
-    }>;
-    checkout: {
-        discount: number;
-    };
-    upsell: {
-        discount: number;
-    };
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const state = __cf_pattern_input.key("params", "state");
+    return (<span>
+            {__cfLift_1({
+        item: {
+            price: item.key("price")
+        },
+        state: {
+            checkout: {
+                discount: state.key("checkout", "discount")
+            },
+            upsell: {
+                discount: state.key("upsell", "discount")
+            }
+        }
+    })}
+          </span>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                price: {
+                    type: "number"
+                }
+            },
+            required: ["price"]
+        },
+        params: {
+            type: "object",
+            properties: {
+                state: {
+                    type: "object",
+                    properties: {
+                        checkout: {
+                            type: "object",
+                            properties: {
+                                discount: {
+                                    type: "number"
+                                }
+                            },
+                            required: ["discount"]
+                        },
+                        upsell: {
+                            type: "object",
+                            properties: {
+                                discount: {
+                                    type: "number"
+                                }
+                            },
+                            required: ["discount"]
+                        }
+                    },
+                    required: ["checkout", "upsell"]
+                }
+            },
+            required: ["state"]
+        }
+    },
+    required: ["element", "params"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-multiple-similar-captures
 // Verifies: .map() correctly captures multiple state properties with the same leaf name
 //   .map(fn) → .mapWithPattern(pattern(...), {state: {checkout: {discount}, upsell: {discount}}})
@@ -83,89 +166,7 @@ interface State {
 export default pattern((state) => {
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                const state = __cf_pattern_input.key("params", "state");
-                return (<span>
-            {__cfLift_1({
-                    item: {
-                        price: item.key("price")
-                    },
-                    state: {
-                        checkout: {
-                            discount: state.key("checkout", "discount")
-                        },
-                        upsell: {
-                            discount: state.key("upsell", "discount")
-                        }
-                    }
-                })}
-          </span>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "object",
-                        properties: {
-                            price: {
-                                type: "number"
-                            }
-                        },
-                        required: ["price"]
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            state: {
-                                type: "object",
-                                properties: {
-                                    checkout: {
-                                        type: "object",
-                                        properties: {
-                                            discount: {
-                                                type: "number"
-                                            }
-                                        },
-                                        required: ["discount"]
-                                    },
-                                    upsell: {
-                                        type: "object",
-                                        properties: {
-                                            discount: {
-                                                type: "number"
-                                            }
-                                        },
-                                        required: ["discount"]
-                                    }
-                                },
-                                required: ["checkout", "upsell"]
-                            }
-                        },
-                        required: ["state"]
-                    }
-                },
-                required: ["element", "params"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        {state.key("items").mapWithPattern(__cfPattern_1, {
                 state: {
                     checkout: {
                         discount: state.key("checkout", "discount")

--- a/packages/ts-transformers/test/fixtures/closures/map-nested-callback.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-nested-callback.expected.jsx
@@ -24,6 +24,157 @@ interface State {
     items: Item[];
     prefix: string;
 }
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const tag = __cf_pattern_input.key("element");
+    const item = __cf_pattern_input.key("params", "item");
+    return (<li>{item.key("name")} - {tag.key("name")}</li>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Tag"
+        },
+        params: {
+            type: "object",
+            properties: {
+                item: {
+                    type: "object",
+                    properties: {
+                        name: {
+                            type: "string"
+                        }
+                    },
+                    required: ["name"]
+                }
+            },
+            required: ["item"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Tag: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "number"
+                },
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["id", "name"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const state = __cf_pattern_input.key("params", "state");
+    return (<div>
+            {state.key("prefix")}: {item.key("name")}
+            <ul>
+              {item.key("tags").mapWithPattern(__cfPattern_1, {
+            item: {
+                name: item.key("name")
+            }
+        })}
+            </ul>
+          </div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        },
+        params: {
+            type: "object",
+            properties: {
+                state: {
+                    type: "object",
+                    properties: {
+                        prefix: {
+                            type: "string"
+                        }
+                    },
+                    required: ["prefix"]
+                }
+            },
+            required: ["state"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "number"
+                },
+                name: {
+                    type: "string"
+                },
+                tags: {
+                    type: "array",
+                    items: {
+                        $ref: "#/$defs/Tag"
+                    }
+                }
+            },
+            required: ["id", "name", "tags"]
+        },
+        Tag: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "number"
+                },
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["id", "name"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-nested-callback
 // Verifies: nested .map() calls on reactive arrays are each transformed independently
 //   outer .map(fn) → .mapWithPattern(pattern(...), {state: {prefix}})
@@ -33,156 +184,7 @@ export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Outer map captures state.prefix, inner map closes over item from outer callback */}
-        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                const state = __cf_pattern_input.key("params", "state");
-                return (<div>
-            {state.key("prefix")}: {item.key("name")}
-            <ul>
-              {item.key("tags").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                        const tag = __cf_pattern_input.key("element");
-                        const item = __cf_pattern_input.key("params", "item");
-                        return (<li>{item.key("name")} - {tag.key("name")}</li>);
-                    }, {
-                        type: "object",
-                        properties: {
-                            element: {
-                                $ref: "#/$defs/Tag"
-                            },
-                            params: {
-                                type: "object",
-                                properties: {
-                                    item: {
-                                        type: "object",
-                                        properties: {
-                                            name: {
-                                                type: "string"
-                                            }
-                                        },
-                                        required: ["name"]
-                                    }
-                                },
-                                required: ["item"]
-                            }
-                        },
-                        required: ["element", "params"],
-                        $defs: {
-                            Tag: {
-                                type: "object",
-                                properties: {
-                                    id: {
-                                        type: "number"
-                                    },
-                                    name: {
-                                        type: "string"
-                                    }
-                                },
-                                required: ["id", "name"]
-                            }
-                        }
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        anyOf: [{
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }, {
-                                $ref: "#/$defs/UIRenderable"
-                            }, {
-                                type: "object",
-                                properties: {}
-                            }],
-                        $defs: {
-                            UIRenderable: {
-                                type: "object",
-                                properties: {
-                                    $UI: {
-                                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                                    }
-                                },
-                                required: ["$UI"]
-                            }
-                        }
-                    } as const satisfies __cfHelpers.JSONSchema), {
-                        item: {
-                            name: item.key("name")
-                        }
-                    })}
-            </ul>
-          </div>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Item"
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            state: {
-                                type: "object",
-                                properties: {
-                                    prefix: {
-                                        type: "string"
-                                    }
-                                },
-                                required: ["prefix"]
-                            }
-                        },
-                        required: ["state"]
-                    }
-                },
-                required: ["element", "params"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            id: {
-                                type: "number"
-                            },
-                            name: {
-                                type: "string"
-                            },
-                            tags: {
-                                type: "array",
-                                items: {
-                                    $ref: "#/$defs/Tag"
-                                }
-                            }
-                        },
-                        required: ["id", "name", "tags"]
-                    },
-                    Tag: {
-                        type: "object",
-                        properties: {
-                            id: {
-                                type: "number"
-                            },
-                            name: {
-                                type: "string"
-                            }
-                        },
-                        required: ["id", "name"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        {state.key("items").mapWithPattern(__cfPattern_2, {
                 state: {
                     prefix: state.key("prefix")
                 }

--- a/packages/ts-transformers/test/fixtures/closures/map-nested-property.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-nested-property.expected.jsx
@@ -23,6 +23,79 @@ interface State {
     items: Item[];
     currentUser: User;
 }
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const state = __cf_pattern_input.key("params", "state");
+    return (<div>
+            {item.key("name")} - edited by {state.key("currentUser", "firstName")} {state.key("currentUser", "lastName")}
+          </div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        },
+        params: {
+            type: "object",
+            properties: {
+                state: {
+                    type: "object",
+                    properties: {
+                        currentUser: {
+                            type: "object",
+                            properties: {
+                                firstName: {
+                                    type: "string"
+                                },
+                                lastName: {
+                                    type: "string"
+                                }
+                            },
+                            required: ["firstName", "lastName"]
+                        }
+                    },
+                    required: ["currentUser"]
+                }
+            },
+            required: ["state"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "number"
+                },
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["id", "name"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-nested-property
 // Verifies: .map() on reactive array captures nested property access on state
 //   .map(fn) → .mapWithPattern(pattern(...), {state: {currentUser: {firstName, lastName}}})
@@ -30,79 +103,7 @@ interface State {
 export default pattern((state) => {
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                const state = __cf_pattern_input.key("params", "state");
-                return (<div>
-            {item.key("name")} - edited by {state.key("currentUser", "firstName")} {state.key("currentUser", "lastName")}
-          </div>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Item"
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            state: {
-                                type: "object",
-                                properties: {
-                                    currentUser: {
-                                        type: "object",
-                                        properties: {
-                                            firstName: {
-                                                type: "string"
-                                            },
-                                            lastName: {
-                                                type: "string"
-                                            }
-                                        },
-                                        required: ["firstName", "lastName"]
-                                    }
-                                },
-                                required: ["currentUser"]
-                            }
-                        },
-                        required: ["state"]
-                    }
-                },
-                required: ["element", "params"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            id: {
-                                type: "number"
-                            },
-                            name: {
-                                type: "string"
-                            }
-                        },
-                        required: ["id", "name"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        {state.key("items").mapWithPattern(__cfPattern_1, {
                 state: {
                     currentUser: {
                         firstName: state.key("currentUser", "firstName"),

--- a/packages/ts-transformers/test/fixtures/closures/map-no-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-no-captures.expected.jsx
@@ -18,6 +18,52 @@ interface Item {
 interface State {
     items: Item[];
 }
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return (<div>Item #{item.key("id")}: ${item.key("price")}</div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "number"
+                },
+                price: {
+                    type: "number"
+                }
+            },
+            required: ["id", "price"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-no-captures
 // Verifies: .map() on reactive array is transformed even with no captured outer variables
 //   .map(fn) → .mapWithPattern(pattern(...), {})
@@ -26,52 +72,7 @@ export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* No captures - just uses the callback parameter */}
-        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                return (<div>Item #{item.key("id")}: ${item.key("price")}</div>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Item"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            id: {
-                                type: "number"
-                            },
-                            price: {
-                                type: "number"
-                            }
-                        },
-                        required: ["id", "price"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+        {state.key("items").mapWithPattern(__cfPattern_1, {})}
       </div>),
     };
 }, {

--- a/packages/ts-transformers/test/fixtures/closures/map-outer-element.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-outer-element.expected.jsx
@@ -15,6 +15,52 @@ interface State {
     items: number[];
     highlight: string;
 }
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const _ = __cf_pattern_input.key("element");
+    const index = __cf_pattern_input.key("index");
+    const element = __cf_pattern_input.key("params", "element");
+    return (<span key={index}>{element}</span>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "number"
+        },
+        index: {
+            type: "number"
+        },
+        params: {
+            type: "object",
+            properties: {
+                element: {
+                    type: "string"
+                }
+            },
+            required: ["element"]
+        }
+    },
+    required: ["element", "params"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-outer-element
 // Verifies: .map() on reactive array captures a local variable aliased from state
 //   .map(fn) → .mapWithPattern(pattern(...), {element: ...})
@@ -23,52 +69,7 @@ export default pattern((state) => {
     const element = state.key("highlight");
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const _ = __cf_pattern_input.key("element");
-                const index = __cf_pattern_input.key("index");
-                const element = __cf_pattern_input.key("params", "element");
-                return (<span key={index}>{element}</span>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "number"
-                    },
-                    index: {
-                        type: "number"
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            element: {
-                                type: "string"
-                            }
-                        },
-                        required: ["element"]
-                    }
-                },
-                required: ["element", "params"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        {state.key("items").mapWithPattern(__cfPattern_1, {
                 element: element
             })}
       </div>),

--- a/packages/ts-transformers/test/fixtures/closures/map-parking-style-join.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-parking-style-join.expected.jsx
@@ -11,6 +11,27 @@ import { computed, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Spot {
+    active: boolean;
+    spotNumber: string;
+    label?: string;
+}
+interface Person {
+    name: string;
+    email: string;
+    commuteMode: string;
+    priorityRank: number;
+    defaultSpot?: string;
+    spotPreferences: string[];
+    isFirst: boolean;
+    isLast: boolean;
+}
+interface State {
+    people: Person[];
+    editingPersonName: string | null;
+    removePersonConfirmTarget: string | null;
+    spots: Spot[];
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         editingPersonName: string | null;
@@ -179,27 +200,265 @@ const __cfLift_6 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, ({ spotPreferences }) => spotPreferences.map((n) => "#" + n).join(", "));
-interface Spot {
-    active: boolean;
-    spotNumber: string;
-    label?: string;
-}
-interface Person {
-    name: string;
-    email: string;
-    commuteMode: string;
-    priorityRank: number;
-    defaultSpot?: string;
-    spotPreferences: string[];
-    isFirst: boolean;
-    isLast: boolean;
-}
-interface State {
-    people: Person[];
-    editingPersonName: string | null;
-    removePersonConfirmTarget: string | null;
-    spots: Spot[];
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const person = __cf_pattern_input.key("element");
+    const state = __cf_pattern_input.key("params", "state");
+    const personName = person.key("name"), email = person.key("email"), commuteMode = person.key("commuteMode"), priorityRank = person.key("priorityRank"), defaultSpot = person.key("defaultSpot"), spotPreferences = person.key("spotPreferences"), isFirst = person.key("isFirst"), isLast = person.key("isLast");
+    const isEditing = __cfLift_1({
+        state: {
+            editingPersonName: state.key("editingPersonName")
+        },
+        personName: personName
+    }).for("isEditing", true);
+    const isRemoveConfirm = __cfLift_2({
+        state: {
+            removePersonConfirmTarget: state.key("removePersonConfirmTarget")
+        },
+        personName: personName
+    }).for("isRemoveConfirm", true);
+    const activeSpotOpts = __cfLift_3({ state: {
+            spots: state.key("spots")
+        } }).for("activeSpotOpts", true);
+    return (<section>
+              <span>{personName}</span>
+              <span>{email}</span>
+              <span>{commuteMode}</span>
+              <span>{priorityRank}</span>
+              {__cfHelpers.ifElse({
+        type: ["string", "undefined"]
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{}, {
+                type: "object",
+                properties: {}
+            }]
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "null"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{
+                type: "null"
+            }, {}, {
+                type: "object",
+                properties: {}
+            }]
+    } as const satisfies __cfHelpers.JSONSchema, defaultSpot, <span>{defaultSpot}</span>, null)}
+              {__cfHelpers.ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{}, {
+                type: "object",
+                properties: {}
+            }]
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "null"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{
+                type: "null"
+            }, {}, {
+                type: "object",
+                properties: {}
+            }]
+    } as const satisfies __cfHelpers.JSONSchema, isFirst, <span>first</span>, null)}
+              {__cfHelpers.ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{}, {
+                type: "object",
+                properties: {}
+            }]
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "null"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{
+                type: "null"
+            }, {}, {
+                type: "object",
+                properties: {}
+            }]
+    } as const satisfies __cfHelpers.JSONSchema, isLast, <span>last</span>, null)}
+              {__cfHelpers.ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{}, {
+                type: "object",
+                properties: {}
+            }]
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "null"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{
+                type: "null"
+            }, {}, {
+                type: "object",
+                properties: {}
+            }]
+    } as const satisfies __cfHelpers.JSONSchema, isEditing, <span>editing</span>, null)}
+              {__cfHelpers.ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{}, {
+                type: "object",
+                properties: {}
+            }]
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "null"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{
+                type: "null"
+            }, {}, {
+                type: "object",
+                properties: {}
+            }]
+    } as const satisfies __cfHelpers.JSONSchema, isRemoveConfirm, <span>removing</span>, null)}
+              {__cfHelpers.ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{}, {
+                type: "object",
+                properties: {}
+            }]
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "null"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{
+                type: "null"
+            }, {}, {
+                type: "object",
+                properties: {}
+            }]
+    } as const satisfies __cfHelpers.JSONSchema, __cfLift_4({ activeSpotOpts: {
+            length: activeSpotOpts.key("length")
+        } }), <span>spots</span>, null)}
+              {__cfHelpers.ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{}, {
+                type: "object",
+                properties: {}
+            }]
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "null"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{
+                type: "null"
+            }, {}, {
+                type: "object",
+                properties: {}
+            }]
+    } as const satisfies __cfHelpers.JSONSchema, __cfLift_5({ spotPreferences: spotPreferences }), <span>
+                    Prefers: {__cfLift_6({ spotPreferences: spotPreferences })}
+                  </span>, null)}
+            </section>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Person"
+        },
+        params: {
+            type: "object",
+            properties: {
+                state: {
+                    type: "object",
+                    properties: {
+                        editingPersonName: {
+                            anyOf: [{
+                                    type: "string"
+                                }, {
+                                    type: "null"
+                                }]
+                        },
+                        removePersonConfirmTarget: {
+                            anyOf: [{
+                                    type: "string"
+                                }, {
+                                    type: "null"
+                                }]
+                        },
+                        spots: {
+                            type: "array",
+                            items: {
+                                $ref: "#/$defs/Spot"
+                            }
+                        }
+                    },
+                    required: ["editingPersonName", "removePersonConfirmTarget", "spots"]
+                }
+            },
+            required: ["state"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Spot: {
+            type: "object",
+            properties: {
+                active: {
+                    type: "boolean"
+                },
+                spotNumber: {
+                    type: "string"
+                },
+                label: {
+                    type: "string"
+                }
+            },
+            required: ["active", "spotNumber"]
+        },
+        Person: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                email: {
+                    type: "string"
+                },
+                commuteMode: {
+                    type: "string"
+                },
+                priorityRank: {
+                    type: "number"
+                },
+                defaultSpot: {
+                    type: "string"
+                },
+                spotPreferences: {
+                    type: "array",
+                    items: {
+                        type: "string"
+                    }
+                },
+                isFirst: {
+                    type: "boolean"
+                },
+                isLast: {
+                    type: "boolean"
+                }
+            },
+            required: ["name", "email", "commuteMode", "priorityRank", "spotPreferences", "isFirst", "isLast"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-parking-style-join
 // Verifies: nested plain-array joins inside a reactive map callback stay plain in complex branches
 //   state.people.map(fn)                    -> state.key("people").mapWithPattern(pattern(...), ...)
@@ -209,272 +468,14 @@ interface State {
 export default pattern((state) => {
     return {
         [UI]: (<div>
-        {state.key("people").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const person = __cf_pattern_input.key("element");
-                const state = __cf_pattern_input.key("params", "state");
-                const personName = person.key("name"), email = person.key("email"), commuteMode = person.key("commuteMode"), priorityRank = person.key("priorityRank"), defaultSpot = person.key("defaultSpot"), spotPreferences = person.key("spotPreferences"), isFirst = person.key("isFirst"), isLast = person.key("isLast");
-                const isEditing = __cfLift_1({
-                    state: {
-                        editingPersonName: state.key("editingPersonName")
-                    },
-                    personName: personName
-                }).for("isEditing", true);
-                const isRemoveConfirm = __cfLift_2({
-                    state: {
-                        removePersonConfirmTarget: state.key("removePersonConfirmTarget")
-                    },
-                    personName: personName
-                }).for("isRemoveConfirm", true);
-                const activeSpotOpts = __cfLift_3({ state: {
-                        spots: state.key("spots")
-                    } }).for("activeSpotOpts", true);
-                return (<section>
-              <span>{personName}</span>
-              <span>{email}</span>
-              <span>{commuteMode}</span>
-              <span>{priorityRank}</span>
-              {__cfHelpers.ifElse({
-                    type: ["string", "undefined"]
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{}, {
-                            type: "object",
-                            properties: {}
-                        }]
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "null"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{
-                            type: "null"
-                        }, {}, {
-                            type: "object",
-                            properties: {}
-                        }]
-                } as const satisfies __cfHelpers.JSONSchema, defaultSpot, <span>{defaultSpot}</span>, null)}
-              {__cfHelpers.ifElse({
-                    type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{}, {
-                            type: "object",
-                            properties: {}
-                        }]
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "null"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{
-                            type: "null"
-                        }, {}, {
-                            type: "object",
-                            properties: {}
-                        }]
-                } as const satisfies __cfHelpers.JSONSchema, isFirst, <span>first</span>, null)}
-              {__cfHelpers.ifElse({
-                    type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{}, {
-                            type: "object",
-                            properties: {}
-                        }]
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "null"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{
-                            type: "null"
-                        }, {}, {
-                            type: "object",
-                            properties: {}
-                        }]
-                } as const satisfies __cfHelpers.JSONSchema, isLast, <span>last</span>, null)}
-              {__cfHelpers.ifElse({
-                    type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{}, {
-                            type: "object",
-                            properties: {}
-                        }]
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "null"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{
-                            type: "null"
-                        }, {}, {
-                            type: "object",
-                            properties: {}
-                        }]
-                } as const satisfies __cfHelpers.JSONSchema, isEditing, <span>editing</span>, null)}
-              {__cfHelpers.ifElse({
-                    type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{}, {
-                            type: "object",
-                            properties: {}
-                        }]
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "null"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{
-                            type: "null"
-                        }, {}, {
-                            type: "object",
-                            properties: {}
-                        }]
-                } as const satisfies __cfHelpers.JSONSchema, isRemoveConfirm, <span>removing</span>, null)}
-              {__cfHelpers.ifElse({
-                    type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{}, {
-                            type: "object",
-                            properties: {}
-                        }]
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "null"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{
-                            type: "null"
-                        }, {}, {
-                            type: "object",
-                            properties: {}
-                        }]
-                } as const satisfies __cfHelpers.JSONSchema, __cfLift_4({ activeSpotOpts: {
-                        length: activeSpotOpts.key("length")
-                    } }), <span>spots</span>, null)}
-              {__cfHelpers.ifElse({
-                    type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{}, {
-                            type: "object",
-                            properties: {}
-                        }]
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "null"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{
-                            type: "null"
-                        }, {}, {
-                            type: "object",
-                            properties: {}
-                        }]
-                } as const satisfies __cfHelpers.JSONSchema, __cfLift_5({ spotPreferences: spotPreferences }), <span>
-                    Prefers: {__cfLift_6({ spotPreferences: spotPreferences })}
-                  </span>, null)}
-            </section>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Person"
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            state: {
-                                type: "object",
-                                properties: {
-                                    editingPersonName: {
-                                        anyOf: [{
-                                                type: "string"
-                                            }, {
-                                                type: "null"
-                                            }]
-                                    },
-                                    removePersonConfirmTarget: {
-                                        anyOf: [{
-                                                type: "string"
-                                            }, {
-                                                type: "null"
-                                            }]
-                                    },
-                                    spots: {
-                                        type: "array",
-                                        items: {
-                                            $ref: "#/$defs/Spot"
-                                        }
-                                    }
-                                },
-                                required: ["editingPersonName", "removePersonConfirmTarget", "spots"]
-                            }
-                        },
-                        required: ["state"]
-                    }
-                },
-                required: ["element", "params"],
-                $defs: {
-                    Spot: {
-                        type: "object",
-                        properties: {
-                            active: {
-                                type: "boolean"
-                            },
-                            spotNumber: {
-                                type: "string"
-                            },
-                            label: {
-                                type: "string"
-                            }
-                        },
-                        required: ["active", "spotNumber"]
-                    },
-                    Person: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            },
-                            email: {
-                                type: "string"
-                            },
-                            commuteMode: {
-                                type: "string"
-                            },
-                            priorityRank: {
-                                type: "number"
-                            },
-                            defaultSpot: {
-                                type: "string"
-                            },
-                            spotPreferences: {
-                                type: "array",
-                                items: {
-                                    type: "string"
-                                }
-                            },
-                            isFirst: {
-                                type: "boolean"
-                            },
-                            isLast: {
-                                type: "boolean"
-                            }
-                        },
-                        required: ["name", "email", "commuteMode", "priorityRank", "spotPreferences", "isFirst", "isLast"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        {state.key("people").mapWithPattern(__cfPattern_1, {
                 state: {
                     editingPersonName: state.key("editingPersonName"),
                     removePersonConfirmTarget: state.key("removePersonConfirmTarget"),
                     spots: state.key("spots")
                 }
             })}
-      </div>)
+      </div>),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/map-pattern-factory-result-key-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-pattern-factory-result-key-access.expected.jsx
@@ -11,18 +11,6 @@ import { NAME, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfModuleCallback_1 = __cfHardenFn(__cf_pattern_input => {
-    const entry = __cf_pattern_input.key("element");
-    const row = EntryRow({
-        piece: entry.key("piece"),
-        name: entry.key("name"),
-        backlinks: entry.key("backlinks"),
-    });
-    return {
-        ui: row.key(__cfHelpers.UI),
-        n: row.key(__cfHelpers.NAME),
-    };
-});
 interface Entry {
     piece: string;
     name: string;
@@ -77,6 +65,57 @@ const EntryRow = pattern((input) => ({
     },
     required: ["rendered", "$UI", "$NAME"]
 } as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const entry = __cf_pattern_input.key("element");
+    const row = EntryRow({
+        piece: entry.key("piece"),
+        name: entry.key("name"),
+        backlinks: entry.key("backlinks"),
+    });
+    return {
+        ui: row.key(__cfHelpers.UI),
+        n: row.key(__cfHelpers.NAME),
+    };
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Entry"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Entry: {
+            type: "object",
+            properties: {
+                piece: {
+                    type: "string"
+                },
+                name: {
+                    type: "string"
+                },
+                backlinks: {
+                    type: "array",
+                    items: {
+                        type: "string"
+                    }
+                }
+            },
+            required: ["piece", "name", "backlinks"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        ui: {
+            type: "string"
+        },
+        n: {
+            type: "string"
+        }
+    },
+    required: ["ui", "n"]
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-pattern-factory-result-key-access (CT-1586)
 // Verifies: `row[K]` where K is a well-known CF computed key (UI or NAME)
 // and row is a pattern-factory result inside a JSX-context map callback
@@ -91,46 +130,7 @@ export default pattern((__cf_pattern_input) => {
     const filtered = __cf_pattern_input.key("filtered");
     return ({
         [UI]: (<div>
-      {filtered.mapWithPattern(__cfHelpers.pattern(__cfModuleCallback_1, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Entry"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    Entry: {
-                        type: "object",
-                        properties: {
-                            piece: {
-                                type: "string"
-                            },
-                            name: {
-                                type: "string"
-                            },
-                            backlinks: {
-                                type: "array",
-                                items: {
-                                    type: "string"
-                                }
-                            }
-                        },
-                        required: ["piece", "name", "backlinks"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                type: "object",
-                properties: {
-                    ui: {
-                        type: "string"
-                    },
-                    n: {
-                        type: "string"
-                    }
-                },
-                required: ["ui", "n"]
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+      {filtered.mapWithPattern(__cfPattern_1, {})}
     </div>),
     });
 }, {

--- a/packages/ts-transformers/test/fixtures/closures/map-plain-array-no-transform.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-plain-array-no-transform.expected.jsx
@@ -11,6 +11,9 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    multiplier: number;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         multiplier: number;
@@ -36,9 +39,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ state, n }) => n * state.multiplier);
-interface State {
-    multiplier: number;
-}
 // FIXTURE: map-plain-array-no-transform
 // Verifies: .map() on a plain (non-reactive) array is NOT transformed to mapWithPattern
 //   plainArray.map(fn) → plainArray.map(fn) (unchanged)

--- a/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-alias-in-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-alias-in-computed.expected.jsx
@@ -11,6 +11,19 @@ import { Writable, computed, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Habit {
+    name: string;
+}
+interface HabitLog {
+    habitName: string;
+    date: string;
+    completed: boolean;
+}
+interface Input {
+    habits: Habit[];
+    logs: Writable<HabitLog[]>;
+    todayDate: string;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     logs: __cfHelpers.ReadonlyCell<HabitLog[]>;
     habit: {
@@ -66,19 +79,97 @@ const __cfLift_1 = __cfHelpers.lift<{
         log.date === todayDate &&
         log.completed);
 });
-interface Habit {
-    name: string;
-}
-interface HabitLog {
-    habitName: string;
-    date: string;
-    completed: boolean;
-}
-interface Input {
-    habits: Habit[];
-    logs: Writable<HabitLog[]>;
-    todayDate: string;
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const habit = __cf_pattern_input.key("element");
+    const logs = __cf_pattern_input.key("params", "logs");
+    const todayDate = __cf_pattern_input.key("params", "todayDate");
+    const doneToday = __cfLift_1({
+        logs: logs,
+        habit: {
+            name: habit.key("name")
+        },
+        todayDate: todayDate
+    }).for("doneToday", true);
+    return <span>{__cfHelpers.ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        "enum": ["yes", "no"]
+    } as const satisfies __cfHelpers.JSONSchema, doneToday, "yes", "no")}</span>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Habit"
+        },
+        params: {
+            type: "object",
+            properties: {
+                logs: {
+                    type: "array",
+                    items: {
+                        $ref: "#/$defs/HabitLog"
+                    },
+                    asCell: ["readonly"]
+                },
+                todayDate: {
+                    type: "string"
+                }
+            },
+            required: ["logs", "todayDate"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        HabitLog: {
+            type: "object",
+            properties: {
+                habitName: {
+                    type: "string"
+                },
+                date: {
+                    type: "string"
+                },
+                completed: {
+                    type: "boolean"
+                }
+            },
+            required: ["habitName", "date", "completed"]
+        },
+        Habit: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-plain-array-some-alias-in-computed
 // Verifies: aliasing the result of .get() inside computed() still keeps nested plain-array callbacks plain
 //   const logList = logs.get()
@@ -89,100 +180,10 @@ export default pattern((__cf_pattern_input) => {
     const logs = __cf_pattern_input.key("logs");
     const todayDate = __cf_pattern_input.key("todayDate");
     return {
-        [UI]: <div>{habits.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const habit = __cf_pattern_input.key("element");
-                const logs = __cf_pattern_input.key("params", "logs");
-                const todayDate = __cf_pattern_input.key("params", "todayDate");
-                const doneToday = __cfLift_1({
-                    logs: logs,
-                    habit: {
-                        name: habit.key("name")
-                    },
-                    todayDate: todayDate
-                }).for("doneToday", true);
-                return <span>{__cfHelpers.ifElse({
-                    type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    "enum": ["yes", "no"]
-                } as const satisfies __cfHelpers.JSONSchema, doneToday, "yes", "no")}</span>;
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Habit"
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            logs: {
-                                type: "array",
-                                items: {
-                                    $ref: "#/$defs/HabitLog"
-                                },
-                                asCell: ["readonly"]
-                            },
-                            todayDate: {
-                                type: "string"
-                            }
-                        },
-                        required: ["logs", "todayDate"]
-                    }
-                },
-                required: ["element", "params"],
-                $defs: {
-                    HabitLog: {
-                        type: "object",
-                        properties: {
-                            habitName: {
-                                type: "string"
-                            },
-                            date: {
-                                type: "string"
-                            },
-                            completed: {
-                                type: "boolean"
-                            }
-                        },
-                        required: ["habitName", "date", "completed"]
-                    },
-                    Habit: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            }
-                        },
-                        required: ["name"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        [UI]: <div>{habits.mapWithPattern(__cfPattern_1, {
                 logs: logs,
                 todayDate: todayDate
-            })}</div>
+            })}</div>,
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-in-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-in-computed.expected.jsx
@@ -11,6 +11,19 @@ import { Writable, computed, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Habit {
+    name: string;
+}
+interface HabitLog {
+    habitName: string;
+    date: string;
+    completed: boolean;
+}
+interface Input {
+    habits: Habit[];
+    logs: Writable<HabitLog[]>;
+    todayDate: string;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     logs: __cfHelpers.ReadonlyCell<HabitLog[]>;
     habit: {
@@ -63,19 +76,97 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, ({ logs, habit, todayDate }) => logs.get().some((log) => log.habitName === habit.name &&
     log.date === todayDate &&
     log.completed));
-interface Habit {
-    name: string;
-}
-interface HabitLog {
-    habitName: string;
-    date: string;
-    completed: boolean;
-}
-interface Input {
-    habits: Habit[];
-    logs: Writable<HabitLog[]>;
-    todayDate: string;
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const habit = __cf_pattern_input.key("element");
+    const logs = __cf_pattern_input.key("params", "logs");
+    const todayDate = __cf_pattern_input.key("params", "todayDate");
+    const doneToday = __cfLift_1({
+        logs: logs,
+        habit: {
+            name: habit.key("name")
+        },
+        todayDate: todayDate
+    }).for("doneToday", true);
+    return <span>{__cfHelpers.ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        "enum": ["yes", "no"]
+    } as const satisfies __cfHelpers.JSONSchema, doneToday, "yes", "no")}</span>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Habit"
+        },
+        params: {
+            type: "object",
+            properties: {
+                logs: {
+                    type: "array",
+                    items: {
+                        $ref: "#/$defs/HabitLog"
+                    },
+                    asCell: ["readonly"]
+                },
+                todayDate: {
+                    type: "string"
+                }
+            },
+            required: ["logs", "todayDate"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        HabitLog: {
+            type: "object",
+            properties: {
+                habitName: {
+                    type: "string"
+                },
+                date: {
+                    type: "string"
+                },
+                completed: {
+                    type: "boolean"
+                }
+            },
+            required: ["habitName", "date", "completed"]
+        },
+        Habit: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-plain-array-some-in-computed
 // Verifies: plain-array callbacks nested inside computed() remain plain even inside a reactive outer map callback
 //   habits.map(fn) -> habits.mapWithPattern(...)
@@ -86,100 +177,10 @@ export default pattern((__cf_pattern_input) => {
     const logs = __cf_pattern_input.key("logs");
     const todayDate = __cf_pattern_input.key("todayDate");
     return {
-        [UI]: <div>{habits.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const habit = __cf_pattern_input.key("element");
-                const logs = __cf_pattern_input.key("params", "logs");
-                const todayDate = __cf_pattern_input.key("params", "todayDate");
-                const doneToday = __cfLift_1({
-                    logs: logs,
-                    habit: {
-                        name: habit.key("name")
-                    },
-                    todayDate: todayDate
-                }).for("doneToday", true);
-                return <span>{__cfHelpers.ifElse({
-                    type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    "enum": ["yes", "no"]
-                } as const satisfies __cfHelpers.JSONSchema, doneToday, "yes", "no")}</span>;
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Habit"
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            logs: {
-                                type: "array",
-                                items: {
-                                    $ref: "#/$defs/HabitLog"
-                                },
-                                asCell: ["readonly"]
-                            },
-                            todayDate: {
-                                type: "string"
-                            }
-                        },
-                        required: ["logs", "todayDate"]
-                    }
-                },
-                required: ["element", "params"],
-                $defs: {
-                    HabitLog: {
-                        type: "object",
-                        properties: {
-                            habitName: {
-                                type: "string"
-                            },
-                            date: {
-                                type: "string"
-                            },
-                            completed: {
-                                type: "boolean"
-                            }
-                        },
-                        required: ["habitName", "date", "completed"]
-                    },
-                    Habit: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            }
-                        },
-                        required: ["name"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        [UI]: <div>{habits.mapWithPattern(__cfPattern_1, {
                 logs: logs,
                 todayDate: todayDate
-            })}</div>
+            })}</div>,
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/closures/map-receiver-key-lowering.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-receiver-key-lowering.expected.jsx
@@ -19,6 +19,63 @@ interface Item {
 interface Input {
     items: Item[];
 }
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const subItem = __cf_pattern_input.key("element");
+    return subItem.key("value");
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                value: {
+                    type: "string"
+                }
+            },
+            required: ["value"]
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "string"
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return item.key("subItems").mapWithPattern(__cfPattern_1, {}).for("__patternResult", true);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                subItems: {
+                    type: "array",
+                    items: {
+                        type: "object",
+                        properties: {
+                            value: {
+                                type: "string"
+                            }
+                        },
+                        required: ["value"]
+                    }
+                }
+            },
+            required: ["subItems"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "array",
+    items: {
+        type: "string"
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-receiver-key-lowering
 // Verifies: nested .map() calls are both transformed, with receiver lowered to .key()
 //   items.map(fn) → items.mapWithPattern(pattern(...), {})
@@ -26,62 +83,7 @@ interface Input {
 // Context: No captures; receiver expression item.subItems is lowered to item.key("subItems")
 const _p = pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
-    return items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-        const item = __cf_pattern_input.key("element");
-        return item.key("subItems").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-            const subItem = __cf_pattern_input.key("element");
-            return subItem.key("value");
-        }, {
-            type: "object",
-            properties: {
-                element: {
-                    type: "object",
-                    properties: {
-                        value: {
-                            type: "string"
-                        }
-                    },
-                    required: ["value"]
-                }
-            },
-            required: ["element"]
-        } as const satisfies __cfHelpers.JSONSchema, {
-            type: "string"
-        } as const satisfies __cfHelpers.JSONSchema), {}).for("__patternResult", true);
-    }, {
-        type: "object",
-        properties: {
-            element: {
-                $ref: "#/$defs/Item"
-            }
-        },
-        required: ["element"],
-        $defs: {
-            Item: {
-                type: "object",
-                properties: {
-                    subItems: {
-                        type: "array",
-                        items: {
-                            type: "object",
-                            properties: {
-                                value: {
-                                    type: "string"
-                                }
-                            },
-                            required: ["value"]
-                        }
-                    }
-                },
-                required: ["subItems"]
-            }
-        }
-    } as const satisfies __cfHelpers.JSONSchema, {
-        type: "array",
-        items: {
-            type: "string"
-        }
-    } as const satisfies __cfHelpers.JSONSchema), {});
+    return items.mapWithPattern(__cfPattern_2, {});
 }, {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/closures/map-receiver-method-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-receiver-method-roots.expected.jsx
@@ -11,6 +11,7 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const identity = __cfHardenFn(<T,>(value: T) => value);
 const __cfLift_1 = __cfHelpers.lift<{
     item: string;
 }, string>({
@@ -24,6 +25,38 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, ({ item }) => item.toUpperCase());
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return <span>{__cfLift_1({ item: item })}</span>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "string"
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     item: string;
 }, string>({
@@ -37,7 +70,38 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, ({ item }) => identity(item.toUpperCase()));
-const identity = __cfHardenFn(<T,>(value: T) => value);
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return <span>{__cfLift_2({ item: item })}</span>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "string"
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-receiver-method-roots
 // Verifies: receiver-method roots inside pattern-owned map callbacks lower reactively
 //   item.toUpperCase()            → callback-local lift-applied computation
@@ -46,70 +110,8 @@ export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     return ({
         [UI]: (<div>
-      {items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-            const item = __cf_pattern_input.key("element");
-            return <span>{__cfLift_1({ item: item })}</span>;
-        }, {
-            type: "object",
-            properties: {
-                element: {
-                    type: "string"
-                }
-            },
-            required: ["element"]
-        } as const satisfies __cfHelpers.JSONSchema, {
-            anyOf: [{
-                    $ref: "https://commonfabric.org/schemas/vnode.json"
-                }, {
-                    $ref: "#/$defs/UIRenderable"
-                }, {
-                    type: "object",
-                    properties: {}
-                }],
-            $defs: {
-                UIRenderable: {
-                    type: "object",
-                    properties: {
-                        $UI: {
-                            $ref: "https://commonfabric.org/schemas/vnode.json"
-                        }
-                    },
-                    required: ["$UI"]
-                }
-            }
-        } as const satisfies __cfHelpers.JSONSchema), {})}
-      {items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-            const item = __cf_pattern_input.key("element");
-            return <span>{__cfLift_2({ item: item })}</span>;
-        }, {
-            type: "object",
-            properties: {
-                element: {
-                    type: "string"
-                }
-            },
-            required: ["element"]
-        } as const satisfies __cfHelpers.JSONSchema, {
-            anyOf: [{
-                    $ref: "https://commonfabric.org/schemas/vnode.json"
-                }, {
-                    $ref: "#/$defs/UIRenderable"
-                }, {
-                    type: "object",
-                    properties: {}
-                }],
-            $defs: {
-                UIRenderable: {
-                    type: "object",
-                    properties: {
-                        $UI: {
-                            $ref: "https://commonfabric.org/schemas/vnode.json"
-                        }
-                    },
-                    required: ["$UI"]
-                }
-            }
-        } as const satisfies __cfHelpers.JSONSchema), {})}
+      {items.mapWithPattern(__cfPattern_1, {})}
+      {items.mapWithPattern(__cfPattern_2, {})}
     </div>),
     });
 }, {

--- a/packages/ts-transformers/test/fixtures/closures/map-regains-reactive-aliases.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-regains-reactive-aliases.expected.jsx
@@ -11,6 +11,17 @@ import { Default, computed, lift, pattern, wish } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const passthrough = lift({
+    type: "array",
+    items: {
+        type: "string"
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "array",
+    items: {
+        type: "string"
+    }
+} as const satisfies __cfHelpers.JSONSchema, (items: string[]) => items);
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         items: string[];
@@ -57,6 +68,20 @@ const __cfLift_2 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema, ({ inner }) => inner);
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return item + "!";
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "string"
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "string"
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     inner: string[];
 }, string[]>({
@@ -77,21 +102,22 @@ const __cfLift_3 = __cfHelpers.lift<{
     }
 } as const satisfies __cfHelpers.JSONSchema, ({ inner }) => {
     const foo = __cfLift_2({ inner: inner }).for("foo", true);
-    return foo.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-        const item = __cf_pattern_input.key("element");
-        return item + "!";
-    }, {
-        type: "object",
-        properties: {
-            element: {
-                type: "string"
-            }
-        },
-        required: ["element"]
-    } as const satisfies __cfHelpers.JSONSchema, {
-        type: "string"
-    } as const satisfies __cfHelpers.JSONSchema), {});
+    return foo.mapWithPattern(__cfPattern_1, {});
 });
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return item + "!";
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "string"
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "string"
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_4 = __cfHelpers.lift<{
     inner: string[];
 }, string[]>({
@@ -112,21 +138,22 @@ const __cfLift_4 = __cfHelpers.lift<{
     }
 } as const satisfies __cfHelpers.JSONSchema, ({ inner }) => {
     const foo = passthrough(inner).for("foo", true);
-    return foo.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-        const item = __cf_pattern_input.key("element");
-        return item + "!";
-    }, {
-        type: "object",
-        properties: {
-            element: {
-                type: "string"
-            }
-        },
-        required: ["element"]
-    } as const satisfies __cfHelpers.JSONSchema, {
-        type: "string"
-    } as const satisfies __cfHelpers.JSONSchema), {});
+    return foo.mapWithPattern(__cfPattern_2, {});
 });
+const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return item + "!";
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "string"
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "string"
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_5 = __cfHelpers.lift(false, () => {
     const foo = wish<Default<string[], [
     ]>>({ query: "#items" }, {
@@ -136,20 +163,7 @@ const __cfLift_5 = __cfHelpers.lift(false, () => {
         },
         "default": []
     } as const satisfies __cfHelpers.JSONSchema).result!;
-    return foo.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-        const item = __cf_pattern_input.key("element");
-        return item + "!";
-    }, {
-        type: "object",
-        properties: {
-            element: {
-                type: "string"
-            }
-        },
-        required: ["element"]
-    } as const satisfies __cfHelpers.JSONSchema, {
-        type: "string"
-    } as const satisfies __cfHelpers.JSONSchema), {});
+    return foo.mapWithPattern(__cfPattern_3, {});
 });
 const __cfLift_6 = __cfHelpers.lift<{
     inner: string[];
@@ -170,6 +184,34 @@ const __cfLift_6 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema, ({ inner }) => inner);
+const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return item.key("length") > 1;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "string"
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_5 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return item + "!";
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "string"
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "string"
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_7 = __cfHelpers.lift<{
     inner: string[];
 }, string[]>({
@@ -190,34 +232,8 @@ const __cfLift_7 = __cfHelpers.lift<{
     }
 } as const satisfies __cfHelpers.JSONSchema, ({ inner }) => {
     const foo = __cfLift_6({ inner: inner }).for("foo", true);
-    const filtered = foo.filterWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-        const item = __cf_pattern_input.key("element");
-        return item.key("length") > 1;
-    }, {
-        type: "object",
-        properties: {
-            element: {
-                type: "string"
-            }
-        },
-        required: ["element"]
-    } as const satisfies __cfHelpers.JSONSchema, {
-        type: "boolean"
-    } as const satisfies __cfHelpers.JSONSchema), {}).for("filtered", true);
-    return filtered.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-        const item = __cf_pattern_input.key("element");
-        return item + "!";
-    }, {
-        type: "object",
-        properties: {
-            element: {
-                type: "string"
-            }
-        },
-        required: ["element"]
-    } as const satisfies __cfHelpers.JSONSchema, {
-        type: "string"
-    } as const satisfies __cfHelpers.JSONSchema), {});
+    const filtered = foo.filterWithPattern(__cfPattern_4, {}).for("filtered", true);
+    return filtered.mapWithPattern(__cfPattern_5, {});
 });
 const __cfLift_8 = __cfHelpers.lift<{
     inner: string[];
@@ -238,6 +254,20 @@ const __cfLift_8 = __cfHelpers.lift<{
         type: "string"
     }
 } as const satisfies __cfHelpers.JSONSchema, ({ inner }) => inner);
+const __cfPattern_6 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return item.key("length") > 1;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "string"
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_9 = __cfHelpers.lift<{
     item: string;
 }, string>({
@@ -251,6 +281,20 @@ const __cfLift_9 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, ({ item }) => item.toUpperCase());
+const __cfPattern_7 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return __cfLift_9({ item: item }).for("__patternResult", true);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "string"
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "string"
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_10 = __cfHelpers.lift<{
     inner: string[];
 }, string[]>({
@@ -271,46 +315,9 @@ const __cfLift_10 = __cfHelpers.lift<{
     }
 } as const satisfies __cfHelpers.JSONSchema, ({ inner }) => {
     const foo = __cfLift_8({ inner: inner }).for("foo", true);
-    const filtered = foo.filterWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-        const item = __cf_pattern_input.key("element");
-        return item.key("length") > 1;
-    }, {
-        type: "object",
-        properties: {
-            element: {
-                type: "string"
-            }
-        },
-        required: ["element"]
-    } as const satisfies __cfHelpers.JSONSchema, {
-        type: "boolean"
-    } as const satisfies __cfHelpers.JSONSchema), {}).for("filtered", true);
-    return filtered.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-        const item = __cf_pattern_input.key("element");
-        return __cfLift_9({ item: item }).for("__patternResult", true);
-    }, {
-        type: "object",
-        properties: {
-            element: {
-                type: "string"
-            }
-        },
-        required: ["element"]
-    } as const satisfies __cfHelpers.JSONSchema, {
-        type: "string"
-    } as const satisfies __cfHelpers.JSONSchema), {});
+    const filtered = foo.filterWithPattern(__cfPattern_6, {}).for("filtered", true);
+    return filtered.mapWithPattern(__cfPattern_7, {});
 });
-const passthrough = lift({
-    type: "array",
-    items: {
-        type: "string"
-    }
-} as const satisfies __cfHelpers.JSONSchema, {
-    type: "array",
-    items: {
-        type: "string"
-    }
-} as const satisfies __cfHelpers.JSONSchema, (items: string[]) => items);
 // FIXTURE: map-regains-reactive-aliases
 // Verifies: compute-owned aliases that still resolve to reactive array roots
 // are rewritten back to mapWithPattern/filterWithPattern when used in pattern

--- a/packages/ts-transformers/test/fixtures/closures/map-root-fallback-wrappers.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-root-fallback-wrappers.expected.jsx
@@ -11,6 +11,9 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Item {
+    id: string;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     items?: Item[] | undefined;
 }, Item[]>({
@@ -51,6 +54,49 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, ({ items }) => items ?? []);
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return <span data-inline-id={item.key("id")}>{item.key("id")}</span>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                }
+            },
+            required: ["id"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     items?: Item[] | undefined;
 }, Item[]>({
@@ -91,6 +137,49 @@ const __cfLift_2 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, ({ items }) => (items as Item[] | undefined) ?? []);
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return (<span data-cast-id={item.key("id")}>{item.key("id")}</span>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                }
+            },
+            required: ["id"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     items?: Item[] | undefined;
 }, Item[]>({
@@ -131,9 +220,49 @@ const __cfLift_3 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, ({ items }) => (items satisfies Item[] | undefined) ?? []);
-interface Item {
-    id: string;
-}
+const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return (<span data-satisfies-id={item.key("id")}>{item.key("id")}</span>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                }
+            },
+            required: ["id"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-root-fallback-wrappers
 // Verifies: top-level fallback receiver roots keep structural array-method lowering across wrapper forms
 //   (items ?? []).map(fn)                             -> lift(...)(...).mapWithPattern(...)
@@ -144,135 +273,9 @@ export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     return {
         [UI]: (<div>
-        {(__cfLift_1({ items: items })).mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-            const item = __cf_pattern_input.key("element");
-            return <span data-inline-id={item.key("id")}>{item.key("id")}</span>;
-        }, {
-            type: "object",
-            properties: {
-                element: {
-                    $ref: "#/$defs/Item"
-                }
-            },
-            required: ["element"],
-            $defs: {
-                Item: {
-                    type: "object",
-                    properties: {
-                        id: {
-                            type: "string"
-                        }
-                    },
-                    required: ["id"]
-                }
-            }
-        } as const satisfies __cfHelpers.JSONSchema, {
-            anyOf: [{
-                    $ref: "https://commonfabric.org/schemas/vnode.json"
-                }, {
-                    $ref: "#/$defs/UIRenderable"
-                }, {
-                    type: "object",
-                    properties: {}
-                }],
-            $defs: {
-                UIRenderable: {
-                    type: "object",
-                    properties: {
-                        $UI: {
-                            $ref: "https://commonfabric.org/schemas/vnode.json"
-                        }
-                    },
-                    required: ["$UI"]
-                }
-            }
-        } as const satisfies __cfHelpers.JSONSchema), {})}
-        {(__cfLift_2({ items: items })).mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-            const item = __cf_pattern_input.key("element");
-            return (<span data-cast-id={item.key("id")}>{item.key("id")}</span>);
-        }, {
-            type: "object",
-            properties: {
-                element: {
-                    $ref: "#/$defs/Item"
-                }
-            },
-            required: ["element"],
-            $defs: {
-                Item: {
-                    type: "object",
-                    properties: {
-                        id: {
-                            type: "string"
-                        }
-                    },
-                    required: ["id"]
-                }
-            }
-        } as const satisfies __cfHelpers.JSONSchema, {
-            anyOf: [{
-                    $ref: "https://commonfabric.org/schemas/vnode.json"
-                }, {
-                    $ref: "#/$defs/UIRenderable"
-                }, {
-                    type: "object",
-                    properties: {}
-                }],
-            $defs: {
-                UIRenderable: {
-                    type: "object",
-                    properties: {
-                        $UI: {
-                            $ref: "https://commonfabric.org/schemas/vnode.json"
-                        }
-                    },
-                    required: ["$UI"]
-                }
-            }
-        } as const satisfies __cfHelpers.JSONSchema), {})}
-        {(__cfLift_3({ items: items })).mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-            const item = __cf_pattern_input.key("element");
-            return (<span data-satisfies-id={item.key("id")}>{item.key("id")}</span>);
-        }, {
-            type: "object",
-            properties: {
-                element: {
-                    $ref: "#/$defs/Item"
-                }
-            },
-            required: ["element"],
-            $defs: {
-                Item: {
-                    type: "object",
-                    properties: {
-                        id: {
-                            type: "string"
-                        }
-                    },
-                    required: ["id"]
-                }
-            }
-        } as const satisfies __cfHelpers.JSONSchema, {
-            anyOf: [{
-                    $ref: "https://commonfabric.org/schemas/vnode.json"
-                }, {
-                    $ref: "#/$defs/UIRenderable"
-                }, {
-                    type: "object",
-                    properties: {}
-                }],
-            $defs: {
-                UIRenderable: {
-                    type: "object",
-                    properties: {
-                        $UI: {
-                            $ref: "https://commonfabric.org/schemas/vnode.json"
-                        }
-                    },
-                    required: ["$UI"]
-                }
-            }
-        } as const satisfies __cfHelpers.JSONSchema), {})}
+        {(__cfLift_1({ items: items })).mapWithPattern(__cfPattern_1, {})}
+        {(__cfLift_2({ items: items })).mapWithPattern(__cfPattern_2, {})}
+        {(__cfLift_3({ items: items })).mapWithPattern(__cfPattern_3, {})}
       </div>),
     };
 }, {

--- a/packages/ts-transformers/test/fixtures/closures/map-single-capture-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-single-capture-no-name.expected.jsx
@@ -11,6 +11,12 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    items: Array<{
+        price: number;
+    }>;
+    discount: number;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     item: {
         price: number;
@@ -44,12 +50,67 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ item, state }) => item.price * state.discount);
-interface State {
-    items: Array<{
-        price: number;
-    }>;
-    discount: number;
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const state = __cf_pattern_input.key("params", "state");
+    return (<span>{__cfLift_1({
+        item: {
+            price: item.key("price")
+        },
+        state: {
+            discount: state.key("discount")
+        }
+    })}</span>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                price: {
+                    type: "number"
+                }
+            },
+            required: ["price"]
+        },
+        params: {
+            type: "object",
+            properties: {
+                state: {
+                    type: "object",
+                    properties: {
+                        discount: {
+                            type: "number"
+                        }
+                    },
+                    required: ["discount"]
+                }
+            },
+            required: ["state"]
+        }
+    },
+    required: ["element", "params"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-single-capture-no-name
 // Verifies: .map() transform with single capture works when pattern uses inline type annotation
 //   .map(fn) → .mapWithPattern(pattern(...), {state: {discount: ...}})
@@ -57,67 +118,7 @@ interface State {
 export default pattern((state: State) => {
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                const state = __cf_pattern_input.key("params", "state");
-                return (<span>{__cfLift_1({
-                    item: {
-                        price: item.key("price")
-                    },
-                    state: {
-                        discount: state.key("discount")
-                    }
-                })}</span>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "object",
-                        properties: {
-                            price: {
-                                type: "number"
-                            }
-                        },
-                        required: ["price"]
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            state: {
-                                type: "object",
-                                properties: {
-                                    discount: {
-                                        type: "number"
-                                    }
-                                },
-                                required: ["discount"]
-                            }
-                        },
-                        required: ["state"]
-                    }
-                },
-                required: ["element", "params"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        {state.key("items").mapWithPattern(__cfPattern_1, {
                 state: {
                     discount: state.key("discount")
                 }

--- a/packages/ts-transformers/test/fixtures/closures/map-single-capture-with-type-arg-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-single-capture-with-type-arg-no-name.expected.jsx
@@ -11,6 +11,12 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    items: Array<{
+        price: number;
+    }>;
+    discount: number;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     item: {
         price: number;
@@ -44,12 +50,67 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ item, state }) => item.price * state.discount);
-interface State {
-    items: Array<{
-        price: number;
-    }>;
-    discount: number;
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const state = __cf_pattern_input.key("params", "state");
+    return (<span>{__cfLift_1({
+        item: {
+            price: item.key("price")
+        },
+        state: {
+            discount: state.key("discount")
+        }
+    })}</span>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                price: {
+                    type: "number"
+                }
+            },
+            required: ["price"]
+        },
+        params: {
+            type: "object",
+            properties: {
+                state: {
+                    type: "object",
+                    properties: {
+                        discount: {
+                            type: "number"
+                        }
+                    },
+                    required: ["discount"]
+                }
+            },
+            required: ["state"]
+        }
+    },
+    required: ["element", "params"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-single-capture-with-type-arg-no-name
 // Verifies: .map() transform with single capture works with type arg on pattern
 //   .map(fn) → .mapWithPattern(pattern(...), {state: {discount: ...}})
@@ -57,67 +118,7 @@ interface State {
 export default pattern((state) => {
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                const state = __cf_pattern_input.key("params", "state");
-                return (<span>{__cfLift_1({
-                    item: {
-                        price: item.key("price")
-                    },
-                    state: {
-                        discount: state.key("discount")
-                    }
-                })}</span>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "object",
-                        properties: {
-                            price: {
-                                type: "number"
-                            }
-                        },
-                        required: ["price"]
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            state: {
-                                type: "object",
-                                properties: {
-                                    discount: {
-                                        type: "number"
-                                    }
-                                },
-                                required: ["discount"]
-                            }
-                        },
-                        required: ["state"]
-                    }
-                },
-                required: ["element", "params"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        {state.key("items").mapWithPattern(__cfPattern_1, {
                 state: {
                     discount: state.key("discount")
                 }

--- a/packages/ts-transformers/test/fixtures/closures/map-single-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-single-capture.expected.jsx
@@ -11,6 +11,12 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    items: Array<{
+        price: number;
+    }>;
+    discount: number;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     item: {
         price: number;
@@ -44,12 +50,67 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ item, state }) => item.price * state.discount);
-interface State {
-    items: Array<{
-        price: number;
-    }>;
-    discount: number;
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const state = __cf_pattern_input.key("params", "state");
+    return (<span>{__cfLift_1({
+        item: {
+            price: item.key("price")
+        },
+        state: {
+            discount: state.key("discount")
+        }
+    })}</span>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                price: {
+                    type: "number"
+                }
+            },
+            required: ["price"]
+        },
+        params: {
+            type: "object",
+            properties: {
+                state: {
+                    type: "object",
+                    properties: {
+                        discount: {
+                            type: "number"
+                        }
+                    },
+                    required: ["discount"]
+                }
+            },
+            required: ["state"]
+        }
+    },
+    required: ["element", "params"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-single-capture
 // Verifies: .map() on reactive array captures a single outer state property
 //   .map(fn) → .mapWithPattern(pattern(...), {state: {discount: ...}})
@@ -57,67 +118,7 @@ interface State {
 export default pattern((state) => {
     return {
         [UI]: (<div>
-        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                const state = __cf_pattern_input.key("params", "state");
-                return (<span>{__cfLift_1({
-                    item: {
-                        price: item.key("price")
-                    },
-                    state: {
-                        discount: state.key("discount")
-                    }
-                })}</span>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "object",
-                        properties: {
-                            price: {
-                                type: "number"
-                            }
-                        },
-                        required: ["price"]
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            state: {
-                                type: "object",
-                                properties: {
-                                    discount: {
-                                        type: "number"
-                                    }
-                                },
-                                required: ["discount"]
-                            }
-                        },
-                        required: ["state"]
-                    }
-                },
-                required: ["element", "params"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        {state.key("items").mapWithPattern(__cfPattern_1, {
                 state: {
                     discount: state.key("discount")
                 }

--- a/packages/ts-transformers/test/fixtures/closures/map-symbol-key-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-symbol-key-access.expected.jsx
@@ -18,6 +18,43 @@ interface Entry {
 interface Input {
     items: Entry[];
 }
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return ({ n: item.key(__cfHelpers.NAME), u: item.key(__cfHelpers.UI) });
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Entry"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Entry: {
+            type: "object",
+            properties: {
+                $NAME: {
+                    type: "string"
+                },
+                $UI: {
+                    type: "string"
+                }
+            },
+            required: ["$NAME", "$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        n: {
+            type: "string"
+        },
+        u: {
+            type: "string"
+        }
+    },
+    required: ["n", "u"]
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-symbol-key-access
 // Verifies: .map() on reactive array is transformed when callback uses symbol key access
 //   .map(fn) → .mapWithPattern(pattern(...), {})
@@ -25,43 +62,7 @@ interface Input {
 // Context: Symbol-keyed property access (NAME, UI) is lowered to .key() with helper references
 const _p = pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
-    return items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-        const item = __cf_pattern_input.key("element");
-        return ({ n: item.key(__cfHelpers.NAME), u: item.key(__cfHelpers.UI) });
-    }, {
-        type: "object",
-        properties: {
-            element: {
-                $ref: "#/$defs/Entry"
-            }
-        },
-        required: ["element"],
-        $defs: {
-            Entry: {
-                type: "object",
-                properties: {
-                    $NAME: {
-                        type: "string"
-                    },
-                    $UI: {
-                        type: "string"
-                    }
-                },
-                required: ["$NAME", "$UI"]
-            }
-        }
-    } as const satisfies __cfHelpers.JSONSchema, {
-        type: "object",
-        properties: {
-            n: {
-                type: "string"
-            },
-            u: {
-                type: "string"
-            }
-        },
-        required: ["n", "u"]
-    } as const satisfies __cfHelpers.JSONSchema), {});
+    return items.mapWithPattern(__cfPattern_1, {});
 }, {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/closures/map-template-literal.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-template-literal.expected.jsx
@@ -11,6 +11,15 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Item {
+    id: number;
+    name: string;
+}
+interface State {
+    items: Item[];
+    prefix: string;
+    suffix: string;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         prefix: string;
@@ -48,15 +57,79 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, ({ state, item }) => `${state.prefix} ${item.name} ${state.suffix}`);
-interface Item {
-    id: number;
-    name: string;
-}
-interface State {
-    items: Item[];
-    prefix: string;
-    suffix: string;
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const state = __cf_pattern_input.key("params", "state");
+    return (<div>{__cfLift_1({
+        state: {
+            prefix: state.key("prefix"),
+            suffix: state.key("suffix")
+        },
+        item: {
+            name: item.key("name")
+        }
+    })}</div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        },
+        params: {
+            type: "object",
+            properties: {
+                state: {
+                    type: "object",
+                    properties: {
+                        prefix: {
+                            type: "string"
+                        },
+                        suffix: {
+                            type: "string"
+                        }
+                    },
+                    required: ["prefix", "suffix"]
+                }
+            },
+            required: ["state"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "number"
+                },
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["id", "name"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-template-literal
 // Verifies: .map() on reactive array is transformed when callback uses a template literal with captures
 //   .map(fn) → .mapWithPattern(pattern(...), {state: {prefix, suffix}})
@@ -66,79 +139,7 @@ export default pattern((state) => {
     return {
         [UI]: (<div>
         {/* Template literal with captures */}
-        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                const state = __cf_pattern_input.key("params", "state");
-                return (<div>{__cfLift_1({
-                    state: {
-                        prefix: state.key("prefix"),
-                        suffix: state.key("suffix")
-                    },
-                    item: {
-                        name: item.key("name")
-                    }
-                })}</div>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Item"
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            state: {
-                                type: "object",
-                                properties: {
-                                    prefix: {
-                                        type: "string"
-                                    },
-                                    suffix: {
-                                        type: "string"
-                                    }
-                                },
-                                required: ["prefix", "suffix"]
-                            }
-                        },
-                        required: ["state"]
-                    }
-                },
-                required: ["element", "params"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            id: {
-                                type: "number"
-                            },
-                            name: {
-                                type: "string"
-                            }
-                        },
-                        required: ["id", "name"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        {state.key("items").mapWithPattern(__cfPattern_1, {
                 state: {
                     prefix: state.key("prefix"),
                     suffix: state.key("suffix")

--- a/packages/ts-transformers/test/fixtures/closures/map-ternary-inside-nested-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-ternary-inside-nested-map.expected.jsx
@@ -21,6 +21,19 @@ import { Cell, computed, Default, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Tag {
+    name: string;
+    active: boolean;
+}
+interface Item {
+    label: string;
+    tags: Tag[];
+}
+interface PatternInput {
+    items?: Cell<Default<Item[], [
+    ]>>;
+    showInactive?: Default<boolean, false>;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     items: __cfHelpers.ReadonlyCell<unknown[]>;
 }, boolean>({
@@ -67,19 +80,174 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, ({ item }) => item.tags.length > 0);
-interface Tag {
-    name: string;
-    active: boolean;
-}
-interface Item {
-    label: string;
-    tags: Tag[];
-}
-interface PatternInput {
-    items?: Cell<Default<Item[], [
-    ]>>;
-    showInactive?: Default<boolean, false>;
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const tag = __cf_pattern_input.key("element");
+    const showInactive = __cf_pattern_input.key("params", "showInactive");
+    return (<li>
+                    {/* This ternary should be transformed to ifElse */}
+                    {__cfHelpers.ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, tag.key("active"), tag.key("name"), __cfHelpers.ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, showInactive, `(${tag.key("name")})`, ""))}
+                  </li>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Tag"
+        },
+        params: {
+            type: "object",
+            properties: {
+                showInactive: {
+                    type: "boolean",
+                    "default": false
+                }
+            },
+            required: ["showInactive"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Tag: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                active: {
+                    type: "boolean"
+                }
+            },
+            required: ["name", "active"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const showInactive = __cf_pattern_input.key("params", "showInactive");
+    return (<div>
+              {/* Ternary in outer map, outside inner map - should also be ifElse */}
+              <strong>{__cfHelpers.ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, __cfLift_2({ item: {
+            tags: {
+                length: item.key("tags", "length")
+            }
+        } }), item.key("label"), "No tags")}</strong>
+              <ul>
+                {item.key("tags").mapWithPattern(__cfPattern_1, {
+            showInactive: showInactive
+        })}
+              </ul>
+            </div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        },
+        params: {
+            type: "object",
+            properties: {
+                showInactive: {
+                    type: "boolean",
+                    "default": false
+                }
+            },
+            required: ["showInactive"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                label: {
+                    type: "string"
+                },
+                tags: {
+                    type: "array",
+                    items: {
+                        $ref: "#/$defs/Tag"
+                    }
+                }
+            },
+            required: ["label", "tags"]
+        },
+        Tag: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                active: {
+                    type: "boolean"
+                }
+            },
+            required: ["name", "active"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-ternary-inside-nested-map
 // Verifies: ternaries inside nested .map() callbacks are transformed to ifElse
 //   outer ternary → ifElse(hasItems, items.mapWithPattern(...), <p>No items</p>)
@@ -111,173 +279,7 @@ export default pattern((__cf_pattern_input) => {
                     type: "object",
                     properties: {}
                 }]
-        } as const satisfies __cfHelpers.JSONSchema, hasItems, items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-            const item = __cf_pattern_input.key("element");
-            const showInactive = __cf_pattern_input.key("params", "showInactive");
-            return (<div>
-              {/* Ternary in outer map, outside inner map - should also be ifElse */}
-              <strong>{__cfHelpers.ifElse({
-                type: "boolean"
-            } as const satisfies __cfHelpers.JSONSchema, {
-                type: "string"
-            } as const satisfies __cfHelpers.JSONSchema, {
-                type: "string"
-            } as const satisfies __cfHelpers.JSONSchema, {
-                type: "string"
-            } as const satisfies __cfHelpers.JSONSchema, __cfLift_2({ item: {
-                    tags: {
-                        length: item.key("tags", "length")
-                    }
-                } }), item.key("label"), "No tags")}</strong>
-              <ul>
-                {item.key("tags").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                    const tag = __cf_pattern_input.key("element");
-                    const showInactive = __cf_pattern_input.key("params", "showInactive");
-                    return (<li>
-                    {/* This ternary should be transformed to ifElse */}
-                    {__cfHelpers.ifElse({
-                        type: "boolean"
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        type: "string"
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        type: "string"
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        type: "string"
-                    } as const satisfies __cfHelpers.JSONSchema, tag.key("active"), tag.key("name"), __cfHelpers.ifElse({
-                        type: "boolean"
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        type: "string"
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        type: "string"
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        type: "string"
-                    } as const satisfies __cfHelpers.JSONSchema, showInactive, `(${tag.key("name")})`, ""))}
-                  </li>);
-                }, {
-                    type: "object",
-                    properties: {
-                        element: {
-                            $ref: "#/$defs/Tag"
-                        },
-                        params: {
-                            type: "object",
-                            properties: {
-                                showInactive: {
-                                    type: "boolean",
-                                    "default": false
-                                }
-                            },
-                            required: ["showInactive"]
-                        }
-                    },
-                    required: ["element", "params"],
-                    $defs: {
-                        Tag: {
-                            type: "object",
-                            properties: {
-                                name: {
-                                    type: "string"
-                                },
-                                active: {
-                                    type: "boolean"
-                                }
-                            },
-                            required: ["name", "active"]
-                        }
-                    }
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{
-                            $ref: "https://commonfabric.org/schemas/vnode.json"
-                        }, {
-                            $ref: "#/$defs/UIRenderable"
-                        }, {
-                            type: "object",
-                            properties: {}
-                        }],
-                    $defs: {
-                        UIRenderable: {
-                            type: "object",
-                            properties: {
-                                $UI: {
-                                    $ref: "https://commonfabric.org/schemas/vnode.json"
-                                }
-                            },
-                            required: ["$UI"]
-                        }
-                    }
-                } as const satisfies __cfHelpers.JSONSchema), {
-                    showInactive: showInactive
-                })}
-              </ul>
-            </div>);
-        }, {
-            type: "object",
-            properties: {
-                element: {
-                    $ref: "#/$defs/Item"
-                },
-                params: {
-                    type: "object",
-                    properties: {
-                        showInactive: {
-                            type: "boolean",
-                            "default": false
-                        }
-                    },
-                    required: ["showInactive"]
-                }
-            },
-            required: ["element", "params"],
-            $defs: {
-                Item: {
-                    type: "object",
-                    properties: {
-                        label: {
-                            type: "string"
-                        },
-                        tags: {
-                            type: "array",
-                            items: {
-                                $ref: "#/$defs/Tag"
-                            }
-                        }
-                    },
-                    required: ["label", "tags"]
-                },
-                Tag: {
-                    type: "object",
-                    properties: {
-                        name: {
-                            type: "string"
-                        },
-                        active: {
-                            type: "boolean"
-                        }
-                    },
-                    required: ["name", "active"]
-                }
-            }
-        } as const satisfies __cfHelpers.JSONSchema, {
-            anyOf: [{
-                    $ref: "https://commonfabric.org/schemas/vnode.json"
-                }, {
-                    $ref: "#/$defs/UIRenderable"
-                }, {
-                    type: "object",
-                    properties: {}
-                }],
-            $defs: {
-                UIRenderable: {
-                    type: "object",
-                    properties: {
-                        $UI: {
-                            $ref: "https://commonfabric.org/schemas/vnode.json"
-                        }
-                    },
-                    required: ["$UI"]
-                }
-            }
-        } as const satisfies __cfHelpers.JSONSchema), {
+        } as const satisfies __cfHelpers.JSONSchema, hasItems, items.mapWithPattern(__cfPattern_2, {
             showInactive: showInactive
         }), <p>No items</p>)}
       </div>),

--- a/packages/ts-transformers/test/fixtures/closures/map-wish-default-handler-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-wish-default-handler-capture.expected.jsx
@@ -52,6 +52,70 @@ const removeItem = handler({
 } as const satisfies __cfHelpers.JSONSchema, (_, { items, item }) => {
     items.remove(item);
 });
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const items = __cf_pattern_input.key("params", "items");
+    return (<li>
+            {item.key("name")}
+            <button type="button" onClick={removeItem({ items, item })}>
+              Remove
+            </button>
+          </li>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        },
+        params: {
+            type: "object",
+            properties: {
+                items: {
+                    type: "array",
+                    items: {
+                        $ref: "#/$defs/Item"
+                    }
+                }
+            },
+            required: ["items"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                value: {
+                    type: "number"
+                }
+            },
+            required: ["name", "value"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-wish-default-handler-capture
 // Verifies: wish<Default<Array<T>, []>>().result maps still lower to mapWithPattern with handler captures
 //   wish<Default<Item[], []>>(...).result!.map(fn) -> mapWithPattern(pattern(...), { items: items })
@@ -83,70 +147,7 @@ export default pattern((_) => {
     return {
         [NAME]: "Test",
         [UI]: (<ul>
-        {items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                const items = __cf_pattern_input.key("params", "items");
-                return (<li>
-            {item.key("name")}
-            <button type="button" onClick={removeItem({ items, item })}>
-              Remove
-            </button>
-          </li>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Item"
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            items: {
-                                type: "array",
-                                items: {
-                                    $ref: "#/$defs/Item"
-                                }
-                            }
-                        },
-                        required: ["items"]
-                    }
-                },
-                required: ["element", "params"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            },
-                            value: {
-                                type: "number"
-                            }
-                        },
-                        required: ["name", "value"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        {items.mapWithPattern(__cfPattern_1, {
                 items: items
             })}
       </ul>),

--- a/packages/ts-transformers/test/fixtures/closures/map-with-array-param-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-with-array-param-no-name.expected.jsx
@@ -11,6 +11,51 @@ import { cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const index = __cf_pattern_input.key("index");
+    const array = __cf_pattern_input.key("array");
+    return (<div>
+            Item {item} at index {index} of {array.key("length")} total items
+          </div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "number"
+        },
+        index: {
+            type: "number"
+        },
+        array: {
+            type: "array",
+            items: {
+                type: "number"
+            }
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-with-array-param-no-name
 // Verifies: .map() with array param works when pattern uses inline type annotation
 //   .map((item, index, array) => ...) → .mapWithPattern(pattern(...), {})
@@ -25,51 +70,7 @@ export default pattern((_state: any) => {
     } as const satisfies __cfHelpers.JSONSchema).for("items", true);
     return {
         [UI]: (<div>
-        {items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                const index = __cf_pattern_input.key("index");
-                const array = __cf_pattern_input.key("array");
-                return (<div>
-            Item {item} at index {index} of {array.key("length")} total items
-          </div>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "number"
-                    },
-                    index: {
-                        type: "number"
-                    },
-                    array: {
-                        type: "array",
-                        items: {
-                            type: "number"
-                        }
-                    }
-                },
-                required: ["element"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+        {items.mapWithPattern(__cfPattern_1, {})}
       </div>),
     };
 }, false as const satisfies __cfHelpers.JSONSchema, {

--- a/packages/ts-transformers/test/fixtures/closures/map-with-array-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-with-array-param.expected.jsx
@@ -11,6 +11,51 @@ import { cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const index = __cf_pattern_input.key("index");
+    const array = __cf_pattern_input.key("array");
+    return (<div>
+            Item {item} at index {index} of {array.key("length")} total items
+          </div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "number"
+        },
+        index: {
+            type: "number"
+        },
+        array: {
+            type: "array",
+            items: {
+                type: "number"
+            }
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-with-array-param
 // Verifies: .map() on reactive array is transformed when the third parameter (array) is used
 //   .map((item, index, array) => ...) → .mapWithPattern(pattern(...), {})
@@ -25,51 +70,7 @@ export default pattern((_state) => {
     } as const satisfies __cfHelpers.JSONSchema).for("items", true);
     return {
         [UI]: (<div>
-        {items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                const index = __cf_pattern_input.key("index");
-                const array = __cf_pattern_input.key("array");
-                return (<div>
-            Item {item} at index {index} of {array.key("length")} total items
-          </div>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "number"
-                    },
-                    index: {
-                        type: "number"
-                    },
-                    array: {
-                        type: "array",
-                        items: {
-                            type: "number"
-                        }
-                    }
-                },
-                required: ["element"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+        {items.mapWithPattern(__cfPattern_1, {})}
       </div>),
     };
 }, false as const satisfies __cfHelpers.JSONSchema, {

--- a/packages/ts-transformers/test/fixtures/closures/nested-map-fallback-receiver.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/nested-map-fallback-receiver.expected.jsx
@@ -11,6 +11,16 @@ import { action, Default, pattern, UI, Writable } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Person {
+    name: string;
+}
+interface State {
+    rows: Default<Array<{
+        id: string;
+        label: string;
+    }>, [
+    ]>;
+}
 const __cfHandler_1 = __cfHelpers.handler({
     type: "object",
     properties: {
@@ -102,16 +112,158 @@ const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     },
     required: ["setAssign", "p"]
 } as const satisfies __cfHelpers.JSONSchema, (__cf_handler_event, { setAssign, p }) => setAssign.send({ name: p.name }));
-interface Person {
-    name: string;
-}
-interface State {
-    rows: Default<Array<{
-        id: string;
-        label: string;
-    }>, [
-    ]>;
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const p = __cf_pattern_input.key("element");
+    const setAssign = __cf_pattern_input.key("params", "setAssign");
+    return (<button type="button" onClick={__cfHandler_2({
+        setAssign: setAssign,
+        p: {
+            name: p.key("name")
+        }
+    })}>
+                {p.key("name")}
+              </button>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Person"
+        },
+        params: {
+            type: "object",
+            properties: {
+                setAssign: {
+                    type: "object",
+                    properties: {
+                        name: {
+                            type: "string"
+                        }
+                    },
+                    required: ["name"],
+                    asCell: ["stream"]
+                }
+            },
+            required: ["setAssign"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Person: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const row = __cf_pattern_input.key("element");
+    const people = __cf_pattern_input.key("params", "people");
+    const setAssign = __cf_pattern_input.key("params", "setAssign");
+    return (<div>
+            <span>{row.key("label")}</span>
+            {(__cfLift_1({ people: people }) ?? []).mapWithPattern(__cfPattern_1, {
+            setAssign: setAssign
+        })}
+          </div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                },
+                label: {
+                    type: "string"
+                }
+            },
+            required: ["id", "label"]
+        },
+        params: {
+            type: "object",
+            properties: {
+                people: {
+                    type: "array",
+                    items: {
+                        $ref: "#/$defs/Person"
+                    },
+                    asCell: [{
+                            kind: "cell",
+                            scope: "space"
+                        }]
+                },
+                setAssign: {
+                    type: "object",
+                    properties: {
+                        name: {
+                            type: "string"
+                        }
+                    },
+                    required: ["name"],
+                    asCell: ["stream"]
+                }
+            },
+            required: ["people", "setAssign"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Person: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: nested-map-fallback-receiver
 // Verifies: a fallback-receiver array method — (reactiveCall() ?? []).map(...) —
 //   nested INSIDE another .map() callback is lowered to mapWithPattern, so its
@@ -155,157 +307,7 @@ export default pattern((__cf_pattern_input) => {
     }).for({ stream: "setAssign" }, true);
     return {
         [UI]: (<div>
-        {rows.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const row = __cf_pattern_input.key("element");
-                const people = __cf_pattern_input.key("params", "people");
-                const setAssign = __cf_pattern_input.key("params", "setAssign");
-                return (<div>
-            <span>{row.key("label")}</span>
-            {(__cfLift_1({ people: people }) ?? []).mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                        const p = __cf_pattern_input.key("element");
-                        const setAssign = __cf_pattern_input.key("params", "setAssign");
-                        return (<button type="button" onClick={__cfHandler_2({
-                            setAssign: setAssign,
-                            p: {
-                                name: p.key("name")
-                            }
-                        })}>
-                {p.key("name")}
-              </button>);
-                    }, {
-                        type: "object",
-                        properties: {
-                            element: {
-                                $ref: "#/$defs/Person"
-                            },
-                            params: {
-                                type: "object",
-                                properties: {
-                                    setAssign: {
-                                        type: "object",
-                                        properties: {
-                                            name: {
-                                                type: "string"
-                                            }
-                                        },
-                                        required: ["name"],
-                                        asCell: ["stream"]
-                                    }
-                                },
-                                required: ["setAssign"]
-                            }
-                        },
-                        required: ["element", "params"],
-                        $defs: {
-                            Person: {
-                                type: "object",
-                                properties: {
-                                    name: {
-                                        type: "string"
-                                    }
-                                },
-                                required: ["name"]
-                            }
-                        }
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        anyOf: [{
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }, {
-                                $ref: "#/$defs/UIRenderable"
-                            }, {
-                                type: "object",
-                                properties: {}
-                            }],
-                        $defs: {
-                            UIRenderable: {
-                                type: "object",
-                                properties: {
-                                    $UI: {
-                                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                                    }
-                                },
-                                required: ["$UI"]
-                            }
-                        }
-                    } as const satisfies __cfHelpers.JSONSchema), {
-                        setAssign: setAssign
-                    })}
-          </div>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "object",
-                        properties: {
-                            id: {
-                                type: "string"
-                            },
-                            label: {
-                                type: "string"
-                            }
-                        },
-                        required: ["id", "label"]
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            people: {
-                                type: "array",
-                                items: {
-                                    $ref: "#/$defs/Person"
-                                },
-                                asCell: [{
-                                        kind: "cell",
-                                        scope: "space"
-                                    }]
-                            },
-                            setAssign: {
-                                type: "object",
-                                properties: {
-                                    name: {
-                                        type: "string"
-                                    }
-                                },
-                                required: ["name"],
-                                asCell: ["stream"]
-                            }
-                        },
-                        required: ["people", "setAssign"]
-                    }
-                },
-                required: ["element", "params"],
-                $defs: {
-                    Person: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            }
-                        },
-                        required: ["name"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        {rows.mapWithPattern(__cfPattern_2, {
                 people: people,
                 setAssign: setAssign
             })}

--- a/packages/ts-transformers/test/fixtures/closures/pattern-nested-jsx-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-nested-jsx-map.expected.jsx
@@ -22,6 +22,18 @@ import { Cell, computed, Default, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Tag {
+    name: string;
+}
+interface Item {
+    label: string;
+    tags: Tag[];
+    selectedIndex: number;
+}
+interface PatternInput {
+    items?: Cell<Default<Item[], [
+    ]>>;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     items: __cfHelpers.ReadonlyCell<unknown[]>;
 }, boolean>({
@@ -64,18 +76,155 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, ({ i, item }) => i === item.selectedIndex);
-interface Tag {
-    name: string;
-}
-interface Item {
-    label: string;
-    tags: Tag[];
-    selectedIndex: number;
-}
-interface PatternInput {
-    items?: Cell<Default<Item[], [
-    ]>>;
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const tag = __cf_pattern_input.key("element");
+    const i = __cf_pattern_input.key("index");
+    const item = __cf_pattern_input.key("params", "item");
+    return (<li>
+                    {__cfHelpers.ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        "enum": ["", "* "]
+    } as const satisfies __cfHelpers.JSONSchema, __cfLift_2({
+        i: i,
+        item: {
+            selectedIndex: item.key("selectedIndex")
+        }
+    }), "* ", "")}
+                    {tag.key("name")}
+                  </li>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Tag"
+        },
+        index: {
+            type: "number"
+        },
+        params: {
+            type: "object",
+            properties: {
+                item: {
+                    type: "object",
+                    properties: {
+                        selectedIndex: {
+                            type: "number"
+                        }
+                    },
+                    required: ["selectedIndex"]
+                }
+            },
+            required: ["item"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Tag: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return (<div>
+              <strong>{item.key("label")}</strong>
+              <ul>
+                {item.key("tags").mapWithPattern(__cfPattern_1, {
+            item: {
+                selectedIndex: item.key("selectedIndex")
+            }
+        })}
+              </ul>
+            </div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                label: {
+                    type: "string"
+                },
+                tags: {
+                    type: "array",
+                    items: {
+                        $ref: "#/$defs/Tag"
+                    }
+                },
+                selectedIndex: {
+                    type: "number"
+                }
+            },
+            required: ["label", "tags", "selectedIndex"]
+        },
+        Tag: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: pattern-nested-jsx-map
 // Verifies: nested .map() calls in JSX both become mapWithPattern, including inside ifElse
 //   items.map((item) => ...) → items.mapWithPattern(pattern(...))
@@ -108,154 +257,7 @@ export default pattern((__cf_pattern_input) => {
                     type: "object",
                     properties: {}
                 }]
-        } as const satisfies __cfHelpers.JSONSchema, hasItems, items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-            const item = __cf_pattern_input.key("element");
-            return (<div>
-              <strong>{item.key("label")}</strong>
-              <ul>
-                {item.key("tags").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                    const tag = __cf_pattern_input.key("element");
-                    const i = __cf_pattern_input.key("index");
-                    const item = __cf_pattern_input.key("params", "item");
-                    return (<li>
-                    {__cfHelpers.ifElse({
-                        type: "boolean"
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        type: "string"
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        type: "string"
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        "enum": ["", "* "]
-                    } as const satisfies __cfHelpers.JSONSchema, __cfLift_2({
-                        i: i,
-                        item: {
-                            selectedIndex: item.key("selectedIndex")
-                        }
-                    }), "* ", "")}
-                    {tag.key("name")}
-                  </li>);
-                }, {
-                    type: "object",
-                    properties: {
-                        element: {
-                            $ref: "#/$defs/Tag"
-                        },
-                        index: {
-                            type: "number"
-                        },
-                        params: {
-                            type: "object",
-                            properties: {
-                                item: {
-                                    type: "object",
-                                    properties: {
-                                        selectedIndex: {
-                                            type: "number"
-                                        }
-                                    },
-                                    required: ["selectedIndex"]
-                                }
-                            },
-                            required: ["item"]
-                        }
-                    },
-                    required: ["element", "params"],
-                    $defs: {
-                        Tag: {
-                            type: "object",
-                            properties: {
-                                name: {
-                                    type: "string"
-                                }
-                            },
-                            required: ["name"]
-                        }
-                    }
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{
-                            $ref: "https://commonfabric.org/schemas/vnode.json"
-                        }, {
-                            $ref: "#/$defs/UIRenderable"
-                        }, {
-                            type: "object",
-                            properties: {}
-                        }],
-                    $defs: {
-                        UIRenderable: {
-                            type: "object",
-                            properties: {
-                                $UI: {
-                                    $ref: "https://commonfabric.org/schemas/vnode.json"
-                                }
-                            },
-                            required: ["$UI"]
-                        }
-                    }
-                } as const satisfies __cfHelpers.JSONSchema), {
-                    item: {
-                        selectedIndex: item.key("selectedIndex")
-                    }
-                })}
-              </ul>
-            </div>);
-        }, {
-            type: "object",
-            properties: {
-                element: {
-                    $ref: "#/$defs/Item"
-                }
-            },
-            required: ["element"],
-            $defs: {
-                Item: {
-                    type: "object",
-                    properties: {
-                        label: {
-                            type: "string"
-                        },
-                        tags: {
-                            type: "array",
-                            items: {
-                                $ref: "#/$defs/Tag"
-                            }
-                        },
-                        selectedIndex: {
-                            type: "number"
-                        }
-                    },
-                    required: ["label", "tags", "selectedIndex"]
-                },
-                Tag: {
-                    type: "object",
-                    properties: {
-                        name: {
-                            type: "string"
-                        }
-                    },
-                    required: ["name"]
-                }
-            }
-        } as const satisfies __cfHelpers.JSONSchema, {
-            anyOf: [{
-                    $ref: "https://commonfabric.org/schemas/vnode.json"
-                }, {
-                    $ref: "#/$defs/UIRenderable"
-                }, {
-                    type: "object",
-                    properties: {}
-                }],
-            $defs: {
-                UIRenderable: {
-                    type: "object",
-                    properties: {
-                        $UI: {
-                            $ref: "https://commonfabric.org/schemas/vnode.json"
-                        }
-                    },
-                    required: ["$UI"]
-                }
-            }
-        } as const satisfies __cfHelpers.JSONSchema), {}), <p>No items</p>)}
+        } as const satisfies __cfHelpers.JSONSchema, hasItems, items.mapWithPattern(__cfPattern_2, {}), <p>No items</p>)}
       </div>),
     };
 }, {

--- a/packages/ts-transformers/test/fixtures/closures/pattern-preserve-opaque-input.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-preserve-opaque-input.expected.jsx
@@ -11,6 +11,10 @@ import { pattern, type Writable, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    foo: string;
+    bar: string;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     input: __cfHelpers.Writable<State>;
 }, string>({
@@ -39,10 +43,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, ({ input }) => input.key("foo").get());
-interface State {
-    foo: string;
-    bar: string;
-}
 // FIXTURE: pattern-preserve-opaque-input
 // Verifies: Writable<T> pattern input is preserved as an opaque ref, with JSX .get() wrapped in a lift-applied computation
 //   input.key("foo").get() in JSX → lift(({ input }) => input.key("foo").get())({ input })

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-basic-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-basic-capture.expected.jsx
@@ -11,6 +11,14 @@ import { cell, computed, pattern, patternTool, type PatternToolResult } from "co
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const content = __cfHelpers.__cf_data(cell("Hello world\nGoodbye world", {
+    type: "string"
+} as const satisfies __cfHelpers.JSONSchema).for("content", true));
+type Output = {
+    grepTool: PatternToolResult<{
+        content: string;
+    }>;
+};
 const __cfLift_1 = __cfHelpers.lift<{
     query: string;
     content: string;
@@ -33,14 +41,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, ({ content, query }) => {
     return content.split("\n").filter((c: string) => c.includes(query));
 });
-const content = __cfHelpers.__cf_data(cell("Hello world\nGoodbye world", {
-    type: "string"
-} as const satisfies __cfHelpers.JSONSchema).for("content", true));
-type Output = {
-    grepTool: PatternToolResult<{
-        content: string;
-    }>;
-};
 // FIXTURE: patternTool-basic-capture
 // Verifies: patternTool captures a module-scoped cell as an extraParam
 //   patternTool(fn, { content }) → patternTool(fn, { content }) (content passed through)

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-multiple-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-multiple-captures.expected.jsx
@@ -11,6 +11,15 @@ import { computed, pattern, patternTool, type PatternToolResult, Writable } from
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const multiplier = __cfHelpers.__cf_data(new Writable(2, {
+    type: "number"
+} as const satisfies __cfHelpers.JSONSchema).for("multiplier", true));
+const prefix = __cfHelpers.__cf_data(new Writable("Result: ", {
+    type: "string"
+} as const satisfies __cfHelpers.JSONSchema).for("prefix", true));
+type Output = {
+    tool: PatternToolResult<Record<string, never>>;
+};
 const __cfLift_1 = __cfHelpers.lift<{
     value: number;
 }, string>({
@@ -26,15 +35,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, ({ value }) => {
     return prefix.get() + String(value * multiplier.get());
 });
-const multiplier = __cfHelpers.__cf_data(new Writable(2, {
-    type: "number"
-} as const satisfies __cfHelpers.JSONSchema).for("multiplier", true));
-const prefix = __cfHelpers.__cf_data(new Writable("Result: ", {
-    type: "string"
-} as const satisfies __cfHelpers.JSONSchema).for("prefix", true));
-type Output = {
-    tool: PatternToolResult<Record<string, never>>;
-};
 // FIXTURE: patternTool-multiple-captures
 // Verifies: patternTool with no explicit extraParams auto-captures multiple module-scoped reactive vars
 //   patternTool(fn) → patternTool(fn, { prefix, multiplier })

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-no-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-no-captures.expected.jsx
@@ -11,6 +11,9 @@ import { computed, pattern, patternTool, type PatternToolResult } from "commonfa
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+type Output = {
+    tool: PatternToolResult<Record<string, never>>;
+};
 const __cfLift_1 = __cfHelpers.lift<{
     query: string;
     content: string;
@@ -33,9 +36,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, ({ content, query }) => {
     return content.split("\n").filter((c: string) => c.includes(query));
 });
-type Output = {
-    tool: PatternToolResult<Record<string, never>>;
-};
 // No external captures - should not be transformed by PatternToolStrategy
 // FIXTURE: patternTool-no-captures
 // Verifies: patternTool with no external captures leaves extraParams empty

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-with-existing-params.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-with-existing-params.expected.jsx
@@ -11,6 +11,17 @@ import { cell, computed, pattern, patternTool, type PatternToolResult } from "co
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const multiplier = __cfHelpers.__cf_data(cell(2, {
+    type: "number"
+} as const satisfies __cfHelpers.JSONSchema).for("multiplier", true));
+const offset = __cfHelpers.__cf_data(cell(10, {
+    type: "number"
+} as const satisfies __cfHelpers.JSONSchema).for("offset", true));
+type Output = {
+    tool: PatternToolResult<{
+        offset: number;
+    }>;
+};
 const __cfLift_1 = __cfHelpers.lift<{
     value: number;
     offset: number;
@@ -30,17 +41,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, ({ value, offset }) => {
     return value * multiplier.get() + offset;
 });
-const multiplier = __cfHelpers.__cf_data(cell(2, {
-    type: "number"
-} as const satisfies __cfHelpers.JSONSchema).for("multiplier", true));
-const offset = __cfHelpers.__cf_data(cell(10, {
-    type: "number"
-} as const satisfies __cfHelpers.JSONSchema).for("offset", true));
-type Output = {
-    tool: PatternToolResult<{
-        offset: number;
-    }>;
-};
 // Test: patternTool with an existing extraParam, and a new capture
 // The function has { value: number, offset: number } as input type
 // We provide offset via extraParams, and the transformer should capture multiplier

--- a/packages/ts-transformers/test/fixtures/closures/unless-with-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/unless-with-map.expected.jsx
@@ -26,6 +26,49 @@ interface PatternInput {
     items: Cell<Default<Item[], [
     ]>>;
 }
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return <li>{item.key("label")}</li>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                label: {
+                    type: "string"
+                }
+            },
+            required: ["label"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: unless-with-map
 // Verifies: || operator becomes unless() with reactive map as fallback
 //   customContent || items.map(...) → unless(customContent, items.mapWithPattern(...))
@@ -46,49 +89,7 @@ export default pattern((__cf_pattern_input) => {
             items: {}
         } as const satisfies __cfHelpers.JSONSchema, {
             asCell: ["cell"]
-        } as const satisfies __cfHelpers.JSONSchema, customContent, items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-            const item = __cf_pattern_input.key("element");
-            return <li>{item.key("label")}</li>;
-        }, {
-            type: "object",
-            properties: {
-                element: {
-                    $ref: "#/$defs/Item"
-                }
-            },
-            required: ["element"],
-            $defs: {
-                Item: {
-                    type: "object",
-                    properties: {
-                        label: {
-                            type: "string"
-                        }
-                    },
-                    required: ["label"]
-                }
-            }
-        } as const satisfies __cfHelpers.JSONSchema, {
-            anyOf: [{
-                    $ref: "https://commonfabric.org/schemas/vnode.json"
-                }, {
-                    $ref: "#/$defs/UIRenderable"
-                }, {
-                    type: "object",
-                    properties: {}
-                }],
-            $defs: {
-                UIRenderable: {
-                    type: "object",
-                    properties: {
-                        $UI: {
-                            $ref: "https://commonfabric.org/schemas/vnode.json"
-                        }
-                    },
-                    required: ["$UI"]
-                }
-            }
-        } as const satisfies __cfHelpers.JSONSchema), {}))}
+        } as const satisfies __cfHelpers.JSONSchema, customContent, items.mapWithPattern(__cfPattern_1, {}))}
       </div>),
     };
 }, {

--- a/packages/ts-transformers/test/fixtures/closures/when-with-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/when-with-map.expected.jsx
@@ -26,6 +26,49 @@ interface PatternInput {
     items: Cell<Default<Item[], [
     ]>>;
 }
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return <li>{item.key("label")}</li>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                label: {
+                    type: "string"
+                }
+            },
+            required: ["label"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: when-with-map
 // Verifies: && operator becomes when() with reactive map as the value
 //   showItems && items.map(...) → when(showItems, items.mapWithPattern(...))
@@ -51,49 +94,7 @@ export default pattern((__cf_pattern_input) => {
                     type: "array",
                     items: {}
                 }]
-        } as const satisfies __cfHelpers.JSONSchema, showItems, items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-            const item = __cf_pattern_input.key("element");
-            return <li>{item.key("label")}</li>;
-        }, {
-            type: "object",
-            properties: {
-                element: {
-                    $ref: "#/$defs/Item"
-                }
-            },
-            required: ["element"],
-            $defs: {
-                Item: {
-                    type: "object",
-                    properties: {
-                        label: {
-                            type: "string"
-                        }
-                    },
-                    required: ["label"]
-                }
-            }
-        } as const satisfies __cfHelpers.JSONSchema, {
-            anyOf: [{
-                    $ref: "https://commonfabric.org/schemas/vnode.json"
-                }, {
-                    $ref: "#/$defs/UIRenderable"
-                }, {
-                    type: "object",
-                    properties: {}
-                }],
-            $defs: {
-                UIRenderable: {
-                    type: "object",
-                    properties: {
-                        $UI: {
-                            $ref: "https://commonfabric.org/schemas/vnode.json"
-                        }
-                    },
-                    required: ["$UI"]
-                }
-            }
-        } as const satisfies __cfHelpers.JSONSchema), {}))}
+        } as const satisfies __cfHelpers.JSONSchema, showItems, items.mapWithPattern(__cfPattern_1, {}))}
       </div>),
     };
 }, {

--- a/packages/ts-transformers/test/fixtures/closures/writable-of-terminal-methods.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/writable-of-terminal-methods.expected.jsx
@@ -17,6 +17,9 @@ import { action, pattern, UI, Writable } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    title: string;
+}
 const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -34,9 +37,6 @@ const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     counter.set(0);
     label.set("Count");
 });
-interface State {
-    title: string;
-}
 // FIXTURE: writable-of-terminal-methods
 // Verifies: new Writable() gets schema annotation, and action() with .set() becomes handler()
 //   new Writable(0) → new Writable(0, { type: "number" })

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/authored-ifelse-jsx-branches.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/authored-ifelse-jsx-branches.expected.jsx
@@ -11,6 +11,9 @@ import { ifElse, pattern, UI, Writable } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Item {
+    name: string;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     limit: number;
 }, boolean>({
@@ -24,6 +27,49 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, ({ limit }) => limit > 0);
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return <span>{item.key("name")}</span>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     count: __cfHelpers.ReadonlyCell<number>;
 }, number>({
@@ -38,9 +84,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ count }) => count.get());
-interface Item {
-    name: string;
-}
 // FIXTURE: authored-ifelse-jsx-branches
 // Verifies: authored ifElse in JSX lowers both conditions and reactive branches correctly
 //   ifElse(limit > 0, items.map(...), <span>Hidden</span>) → derived condition + pattern-lowered map branch
@@ -87,49 +130,7 @@ export default pattern((__cf_pattern_input) => {
                         }]
                 }
             }
-        } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ limit: limit }), items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-            const item = __cf_pattern_input.key("element");
-            return <span>{item.key("name")}</span>;
-        }, {
-            type: "object",
-            properties: {
-                element: {
-                    $ref: "#/$defs/Item"
-                }
-            },
-            required: ["element"],
-            $defs: {
-                Item: {
-                    type: "object",
-                    properties: {
-                        name: {
-                            type: "string"
-                        }
-                    },
-                    required: ["name"]
-                }
-            }
-        } as const satisfies __cfHelpers.JSONSchema, {
-            anyOf: [{
-                    $ref: "https://commonfabric.org/schemas/vnode.json"
-                }, {
-                    $ref: "#/$defs/UIRenderable"
-                }, {
-                    type: "object",
-                    properties: {}
-                }],
-            $defs: {
-                UIRenderable: {
-                    type: "object",
-                    properties: {
-                        $UI: {
-                            $ref: "https://commonfabric.org/schemas/vnode.json"
-                        }
-                    },
-                    required: ["$UI"]
-                }
-            }
-        } as const satisfies __cfHelpers.JSONSchema), {}), <span>Hidden</span>)}
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ limit: limit }), items.mapWithPattern(__cfPattern_1, {}), <span>Hidden</span>)}
       <p>{ifElse({
             type: "boolean"
         } as const satisfies __cfHelpers.JSONSchema, {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/complex-expressions.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/complex-expressions.expected.jsx
@@ -11,6 +11,11 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Problem {
+    price: number;
+    discount: number;
+    tax: number;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     price: number;
     discount: number;
@@ -49,11 +54,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ price, discount, tax }) => (price - discount) * (1 + tax));
-interface Problem {
-    price: number;
-    discount: number;
-    tax: number;
-}
 // FIXTURE: complex-expressions
 // Verifies: multi-variable arithmetic in JSX is wrapped in a lift-applied computation with captured refs
 //   {price - discount}             → lift((...) => price - discount)({ price, discount })

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/computed-boundary-nested-ternaries.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/computed-boundary-nested-ternaries.expected.jsx
@@ -24,23 +24,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     "enum": ["B", "C"]
 } as const satisfies __cfHelpers.JSONSchema, ({ bar }) => bar ? "B" : "C");
-const __cfLift_2 = __cfHelpers.lift<{
-    foo: boolean;
-    bar: boolean;
-}, "A" | "B" | "C">({
-    type: "object",
-    properties: {
-        foo: {
-            type: "boolean"
-        },
-        bar: {
-            type: "boolean"
-        }
-    },
-    required: ["foo", "bar"]
-} as const satisfies __cfHelpers.JSONSchema, {
-    "enum": ["A", "B", "C"]
-} as const satisfies __cfHelpers.JSONSchema, ({ foo, bar }) => foo ? "A" : bar ? "B" : "C");
 // FIXTURE: computed-boundary-nested-ternaries
 // Verifies: outer branch lowering does not structurally lower nested ternaries inside computed callbacks
 //   show ? computed(() => bar ? "B" : "C") : "D" → outer branch lowers, inner ternary stays authored
@@ -89,6 +72,23 @@ export const OuterTernary = pattern((__cf_pattern_input) => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_2 = __cfHelpers.lift<{
+    foo: boolean;
+    bar: boolean;
+}, "A" | "B" | "C">({
+    type: "object",
+    properties: {
+        foo: {
+            type: "boolean"
+        },
+        bar: {
+            type: "boolean"
+        }
+    },
+    required: ["foo", "bar"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    "enum": ["A", "B", "C"]
+} as const satisfies __cfHelpers.JSONSchema, ({ foo, bar }) => foo ? "A" : bar ? "B" : "C");
 export const AuthoredIfElse = pattern((__cf_pattern_input) => {
     const show = __cf_pattern_input.key("show");
     const foo = __cf_pattern_input.key("foo");

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/derived-property-access-with-derived-key.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/derived-property-access-with-derived-key.expected.jsx
@@ -11,6 +11,14 @@ import { Cell, computed, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Item {
+    name: string;
+    done: Cell<boolean>;
+}
+interface Assignment {
+    aisle: string;
+    item: Item;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     items: Item[];
 }, { aisle: string; item: Item; }[]>({
@@ -290,14 +298,150 @@ const __cfLift_4 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, ({ groupedByAisle, aisleName }) => groupedByAisle[aisleName]);
-interface Item {
-    name: string;
-    done: Cell<boolean>;
-}
-interface Assignment {
-    aisle: string;
-    item: Item;
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const assignment = __cf_pattern_input.key("element");
+    return (<div>
+                  <span>{assignment.key("item", "name")}</span>
+                  <cf-checkbox $checked={assignment.key("item", "done")}/>
+                </div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Assignment"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Assignment: {
+            type: "object",
+            properties: {
+                aisle: {
+                    type: "string"
+                },
+                item: {
+                    $ref: "#/$defs/Item"
+                }
+            },
+            required: ["aisle", "item"]
+        },
+        Item: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                done: {
+                    type: "boolean",
+                    asCell: ["cell"]
+                }
+            },
+            required: ["name", "done"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const aisleName = __cf_pattern_input.key("element");
+    const groupedByAisle = __cf_pattern_input.key("params", "groupedByAisle");
+    return (<div>
+              <h3>{aisleName}</h3>
+              {__cfLift_4({
+            groupedByAisle: groupedByAisle,
+            aisleName: aisleName
+        })!.mapWithPattern(__cfPattern_1, {})}
+            </div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "string"
+        },
+        params: {
+            type: "object",
+            properties: {
+                groupedByAisle: {
+                    type: "object",
+                    properties: {},
+                    additionalProperties: {
+                        type: "array",
+                        items: {
+                            $ref: "#/$defs/Assignment"
+                        }
+                    }
+                }
+            },
+            required: ["groupedByAisle"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Assignment: {
+            type: "object",
+            properties: {
+                aisle: {
+                    type: "string"
+                },
+                item: {
+                    $ref: "#/$defs/Item"
+                }
+            },
+            required: ["aisle", "item"]
+        },
+        Item: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                done: {
+                    type: "boolean",
+                    asCell: ["cell"]
+                }
+            },
+            required: ["name", "done"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // CT-1036: Property access on derived grouped objects with derived keys
 // This pattern groups items by a property, then maps over the group keys
 // and accesses the grouped object with each key.
@@ -320,149 +464,7 @@ export default pattern((__cf_pattern_input) => {
     // - Map over the result
     return {
         [UI]: (<div>
-          {aisleNames.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const aisleName = __cf_pattern_input.key("element");
-                const groupedByAisle = __cf_pattern_input.key("params", "groupedByAisle");
-                return (<div>
-              <h3>{aisleName}</h3>
-              {__cfLift_4({
-                        groupedByAisle: groupedByAisle,
-                        aisleName: aisleName
-                    })!.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                        const assignment = __cf_pattern_input.key("element");
-                        return (<div>
-                  <span>{assignment.key("item", "name")}</span>
-                  <cf-checkbox $checked={assignment.key("item", "done")}/>
-                </div>);
-                    }, {
-                        type: "object",
-                        properties: {
-                            element: {
-                                $ref: "#/$defs/Assignment"
-                            }
-                        },
-                        required: ["element"],
-                        $defs: {
-                            Assignment: {
-                                type: "object",
-                                properties: {
-                                    aisle: {
-                                        type: "string"
-                                    },
-                                    item: {
-                                        $ref: "#/$defs/Item"
-                                    }
-                                },
-                                required: ["aisle", "item"]
-                            },
-                            Item: {
-                                type: "object",
-                                properties: {
-                                    name: {
-                                        type: "string"
-                                    },
-                                    done: {
-                                        type: "boolean",
-                                        asCell: ["cell"]
-                                    }
-                                },
-                                required: ["name", "done"]
-                            }
-                        }
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        anyOf: [{
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }, {
-                                $ref: "#/$defs/UIRenderable"
-                            }, {
-                                type: "object",
-                                properties: {}
-                            }],
-                        $defs: {
-                            UIRenderable: {
-                                type: "object",
-                                properties: {
-                                    $UI: {
-                                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                                    }
-                                },
-                                required: ["$UI"]
-                            }
-                        }
-                    } as const satisfies __cfHelpers.JSONSchema), {})}
-            </div>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "string"
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            groupedByAisle: {
-                                type: "object",
-                                properties: {},
-                                additionalProperties: {
-                                    type: "array",
-                                    items: {
-                                        $ref: "#/$defs/Assignment"
-                                    }
-                                }
-                            }
-                        },
-                        required: ["groupedByAisle"]
-                    }
-                },
-                required: ["element", "params"],
-                $defs: {
-                    Assignment: {
-                        type: "object",
-                        properties: {
-                            aisle: {
-                                type: "string"
-                            },
-                            item: {
-                                $ref: "#/$defs/Item"
-                            }
-                        },
-                        required: ["aisle", "item"]
-                    },
-                    Item: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            },
-                            done: {
-                                type: "boolean",
-                                asCell: ["cell"]
-                            }
-                        },
-                        required: ["name", "done"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+          {aisleNames.mapWithPattern(__cfPattern_2, {
                 groupedByAisle: groupedByAisle
             })}
         </div>),

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-complex.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-complex.expected.jsx
@@ -11,6 +11,26 @@ import { ifElse, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    matrix: number[][];
+    row: number;
+    col: number;
+    items: string[];
+    arr: number[];
+    a: number;
+    b: number;
+    indices: number[];
+    nested: {
+        arrays: string[][];
+        index: number;
+    };
+    users: Array<{
+        name: string;
+        scores: number[];
+    }>;
+    selectedUser: number;
+    selectedScore: number;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         matrix: number[][];
@@ -581,26 +601,6 @@ const __cfLift_18 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.arr[0]! + state.arr[1]! + state.arr[2]!);
-interface State {
-    matrix: number[][];
-    row: number;
-    col: number;
-    items: string[];
-    arr: number[];
-    a: number;
-    b: number;
-    indices: number[];
-    nested: {
-        arrays: string[][];
-        index: number;
-    };
-    users: Array<{
-        name: string;
-        scores: number[];
-    }>;
-    selectedUser: number;
-    selectedScore: number;
-}
 // FIXTURE: element-access-complex
 // Verifies: complex element-access patterns (nested, computed, chained, conditional) are wrapped in a lift-applied computation
 //   state.matrix[state.row]![state.col]         → lift(...)({ matrix, row, col })

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-simple.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-simple.expected.jsx
@@ -11,6 +11,13 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    items: string[];
+    index: number;
+    matrix: number[][];
+    row: number;
+    col: number;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         items: string[];
@@ -98,13 +105,6 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "undefined"]
 } as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.matrix[state.row]![state.col]);
-interface State {
-    items: string[];
-    index: number;
-    matrix: number[][];
-    row: number;
-    col: number;
-}
 // FIXTURE: element-access-simple
 // Verifies: dynamic element access on reactive arrays is wrapped in a lift-applied computation
 //   state.items[state.index]            → lift(({state}) => state.items[state.index])({ items, index })

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/filter-callback-local-consts.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/filter-callback-local-consts.expected.jsx
@@ -14,6 +14,16 @@ import { pattern, UI, VNode, } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface FileEntry {
+    name: string;
+    type: "file" | "folder";
+}
+interface Input {
+    files: FileEntry[];
+}
+interface Output {
+    [UI]: VNode;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     file: {
         type: string;
@@ -35,97 +45,89 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, ({ file }) => file.type === "folder");
-interface FileEntry {
-    name: string;
-    type: "file" | "folder";
-}
-interface Input {
-    files: FileEntry[];
-}
-interface Output {
-    [UI]: VNode;
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const file = __cf_pattern_input.key("element");
+    const isFolder = __cfLift_1({ file: {
+            type: file.key("type")
+        } }).for("isFolder", true);
+    return isFolder;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/FileEntry"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        FileEntry: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                type: {
+                    "enum": ["file", "folder"]
+                }
+            },
+            required: ["name", "type"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const file = __cf_pattern_input.key("element");
+    return <span>{file.key("name")}</span>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/FileEntry"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        FileEntry: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                type: {
+                    "enum": ["file", "folder"]
+                }
+            },
+            required: ["name", "type"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
-        {files.filterWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const file = __cf_pattern_input.key("element");
-                const isFolder = __cfLift_1({ file: {
-                        type: file.key("type")
-                    } }).for("isFolder", true);
-                return isFolder;
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/FileEntry"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    FileEntry: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            },
-                            type: {
-                                "enum": ["file", "folder"]
-                            }
-                        },
-                        required: ["name", "type"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                type: "boolean"
-            } as const satisfies __cfHelpers.JSONSchema), {}).mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const file = __cf_pattern_input.key("element");
-                return <span>{file.key("name")}</span>;
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/FileEntry"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    FileEntry: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            },
-                            type: {
-                                "enum": ["file", "folder"]
-                            }
-                        },
-                        required: ["name", "type"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>)
+        {files.filterWithPattern(__cfPattern_1, {}).mapWithPattern(__cfPattern_2, {})}
+      </div>),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/flatmap-callback-expression-statement.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/flatmap-callback-expression-statement.expected.jsx
@@ -14,6 +14,16 @@ import { pattern, UI, VNode, } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface FileEntry {
+    name: string;
+    type: "file" | "folder";
+}
+interface Input {
+    files: FileEntry[];
+}
+interface Output {
+    [UI]: VNode;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     file: {
         name: string;
@@ -39,76 +49,67 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     asCell: ["opaque"]
 } as const satisfies __cfHelpers.JSONSchema, ({ file }) => console.log("mapping", file.name, file.type));
-interface FileEntry {
-    name: string;
-    type: "file" | "folder";
-}
-interface Input {
-    files: FileEntry[];
-}
-interface Output {
-    [UI]: VNode;
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const file = __cf_pattern_input.key("element");
+    __cfLift_1({ file: {
+            name: file.key("name"),
+            type: file.key("type")
+        } });
+    return [<span>{file.key("name")}</span>];
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/FileEntry"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        FileEntry: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                type: {
+                    "enum": ["file", "folder"]
+                }
+            },
+            required: ["name", "type"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "array",
+    items: {
+        $ref: "#/$defs/JSXElement"
+    },
+    $defs: {
+        JSXElement: {
+            anyOf: [{
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }, {
+                    $ref: "#/$defs/UIRenderable"
+                }, {
+                    type: "object",
+                    properties: {}
+                }]
+        },
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
-        {files.flatMapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const file = __cf_pattern_input.key("element");
-                __cfLift_1({ file: {
-                        name: file.key("name"),
-                        type: file.key("type")
-                    } });
-                return [<span>{file.key("name")}</span>];
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/FileEntry"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    FileEntry: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            },
-                            type: {
-                                "enum": ["file", "folder"]
-                            }
-                        },
-                        required: ["name", "type"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                type: "array",
-                items: {
-                    $ref: "#/$defs/JSXElement"
-                },
-                $defs: {
-                    JSXElement: {
-                        anyOf: [{
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }, {
-                                $ref: "#/$defs/UIRenderable"
-                            }, {
-                                type: "object",
-                                properties: {}
-                            }]
-                    },
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+        {files.flatMapWithPattern(__cfPattern_1, {})}
       </div>),
     };
 }, {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-captures.expected.jsx
@@ -19,6 +19,22 @@ import { action, Default, pattern, UI, VNode, Writable, } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Entry {
+    name: string;
+}
+interface Input {
+    entries: Writable<Default<Entry[], [
+    ]>>;
+}
+interface Output {
+    [UI]: VNode;
+}
+function visibleEntries(entries: Writable<Default<Entry[], [
+]>>, prefix: string): Entry[] {
+    const list = entries.get();
+    return list.filter((entry) => prefix.length === 0 || entry.name.startsWith(prefix));
+}
+__cfHardenFn(visibleEntries);
 const __cfHandler_1 = __cfHelpers.handler({
     type: "object",
     properties: {
@@ -158,22 +174,73 @@ const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     },
     required: ["pushPath", "entry"]
 } as const satisfies __cfHelpers.JSONSchema, (_, { pushPath, entry }) => pushPath.send({ name: entry.name }));
-interface Entry {
-    name: string;
-}
-interface Input {
-    entries: Writable<Default<Entry[], [
-    ]>>;
-}
-interface Output {
-    [UI]: VNode;
-}
-function visibleEntries(entries: Writable<Default<Entry[], [
-]>>, prefix: string): Entry[] {
-    const list = entries.get();
-    return list.filter((entry) => prefix.length === 0 || entry.name.startsWith(prefix));
-}
-__cfHardenFn(visibleEntries);
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const entry = __cf_pattern_input.key("element");
+    const pushPath = __cf_pattern_input.key("params", "pushPath");
+    return (<button type="button" onClick={__cfHandler_2({
+        pushPath: pushPath,
+        entry: {
+            name: entry.key("name")
+        }
+    })}>
+              {entry.key("name")}
+            </button>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Entry"
+        },
+        params: {
+            type: "object",
+            properties: {
+                pushPath: {
+                    type: "object",
+                    properties: {
+                        name: {
+                            type: "string"
+                        }
+                    },
+                    required: ["name"],
+                    asCell: ["stream"]
+                }
+            },
+            required: ["pushPath"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Entry: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 export default pattern((__cf_pattern_input) => {
     const entries = __cf_pattern_input.key("entries");
     const path = new Writable<string[]>([], {
@@ -225,73 +292,7 @@ export default pattern((__cf_pattern_input) => {
                     entries: entries,
                     p: p
                 }).for("visible", true);
-                return visible.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                    const entry = __cf_pattern_input.key("element");
-                    const pushPath = __cf_pattern_input.key("params", "pushPath");
-                    return (<button type="button" onClick={__cfHandler_2({
-                        pushPath: pushPath,
-                        entry: {
-                            name: entry.key("name")
-                        }
-                    })}>
-              {entry.key("name")}
-            </button>);
-                }, {
-                    type: "object",
-                    properties: {
-                        element: {
-                            $ref: "#/$defs/Entry"
-                        },
-                        params: {
-                            type: "object",
-                            properties: {
-                                pushPath: {
-                                    type: "object",
-                                    properties: {
-                                        name: {
-                                            type: "string"
-                                        }
-                                    },
-                                    required: ["name"],
-                                    asCell: ["stream"]
-                                }
-                            },
-                            required: ["pushPath"]
-                        }
-                    },
-                    required: ["element", "params"],
-                    $defs: {
-                        Entry: {
-                            type: "object",
-                            properties: {
-                                name: {
-                                    type: "string"
-                                }
-                            },
-                            required: ["name"]
-                        }
-                    }
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{
-                            $ref: "https://commonfabric.org/schemas/vnode.json"
-                        }, {
-                            $ref: "#/$defs/UIRenderable"
-                        }, {
-                            type: "object",
-                            properties: {}
-                        }],
-                    $defs: {
-                        UIRenderable: {
-                            type: "object",
-                            properties: {
-                                $UI: {
-                                    $ref: "https://commonfabric.org/schemas/vnode.json"
-                                }
-                            },
-                            required: ["$UI"]
-                        }
-                    }
-                } as const satisfies __cfHelpers.JSONSchema), {
+                return visible.mapWithPattern(__cfPattern_1, {
                     pushPath: pushPath
                 });
             })()}

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-default-input-local-chain-map-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-default-input-local-chain-map-capture.expected.jsx
@@ -18,6 +18,31 @@ import { action, Default, pattern, UI, VNode, Writable, } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Entry {
+    id: string;
+    name: string;
+    type: "file" | "folder";
+    children?: Entry[];
+    contentType?: string;
+}
+function findChildren(tree: readonly Entry[], path: readonly string[]): readonly Entry[] {
+    let current: readonly Entry[] = tree;
+    for (const name of Array.isArray(path) ? path : []) {
+        const folder = current.find((entry: Entry) => entry.name === name && entry.type === "folder");
+        if (!folder || !folder.children)
+            return [];
+        current = folder.children;
+    }
+    return current;
+}
+__cfHardenFn(findChildren);
+interface Input {
+    entries: Default<Entry[], [
+    ]>;
+}
+interface Output {
+    [UI]: VNode;
+}
 const __cfHandler_1 = __cfHelpers.handler({
     type: "object",
     properties: {
@@ -251,31 +276,116 @@ const __cfHandler_4 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, (_, { handleOpenFile, item }) => handleOpenFile.send({ item }));
-interface Entry {
-    id: string;
-    name: string;
-    type: "file" | "folder";
-    children?: Entry[];
-    contentType?: string;
-}
-function findChildren(tree: readonly Entry[], path: readonly string[]): readonly Entry[] {
-    let current: readonly Entry[] = tree;
-    for (const name of Array.isArray(path) ? path : []) {
-        const folder = current.find((entry: Entry) => entry.name === name && entry.type === "folder");
-        if (!folder || !folder.children)
-            return [];
-        current = folder.children;
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const handleNavigateInto = __cf_pattern_input.key("params", "handleNavigateInto");
+    const handleOpenFile = __cf_pattern_input.key("params", "handleOpenFile");
+    const isFolder = item.key("type") === "folder";
+    const isOpenable = __cfHelpers.when({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, !isFolder &&
+        !!item.key("contentType"), item.key("contentType") !== "binary").for("isOpenable", true);
+    return (<button type="button" onClick={isFolder
+            ? __cfHandler_3({
+                handleNavigateInto: handleNavigateInto,
+                item: {
+                    name: item.key("name")
+                }
+            }) : isOpenable
+            ? __cfHandler_4({
+                handleOpenFile: handleOpenFile,
+                item: item
+            }) : undefined}>
+                {item.key("name")}
+              </button>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Entry"
+        },
+        params: {
+            type: "object",
+            properties: {
+                handleNavigateInto: {
+                    type: "object",
+                    properties: {
+                        name: {
+                            type: "string"
+                        }
+                    },
+                    required: ["name"],
+                    asCell: ["stream"]
+                },
+                handleOpenFile: {
+                    type: "object",
+                    properties: {
+                        item: {
+                            $ref: "#/$defs/Entry"
+                        }
+                    },
+                    required: ["item"],
+                    asCell: ["stream"]
+                }
+            },
+            required: ["handleNavigateInto", "handleOpenFile"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Entry: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                },
+                name: {
+                    type: "string"
+                },
+                type: {
+                    "enum": ["file", "folder"]
+                },
+                children: {
+                    $ref: "#/$defs/AnonymousType_1"
+                },
+                contentType: {
+                    type: "string"
+                }
+            },
+            required: ["id", "name", "type"]
+        },
+        AnonymousType_1: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Entry"
+            }
+        }
     }
-    return current;
-}
-__cfHardenFn(findChildren);
-interface Input {
-    entries: Default<Entry[], [
-    ]>;
-}
-interface Output {
-    [UI]: VNode;
-}
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 export default pattern((__cf_pattern_input) => {
     const entries = __cf_pattern_input.key("entries");
     const path = new Writable<string[]>([], {
@@ -373,116 +483,7 @@ export default pattern((__cf_pattern_input) => {
                 } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ path: path }), [])).for("p", true) as string[];
                 const unsorted = findChildren(tree, p) as Entry[];
                 const items = __cfLift_2({ unsorted: unsorted }).for("items", true);
-                return items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                    const item = __cf_pattern_input.key("element");
-                    const handleNavigateInto = __cf_pattern_input.key("params", "handleNavigateInto");
-                    const handleOpenFile = __cf_pattern_input.key("params", "handleOpenFile");
-                    const isFolder = item.key("type") === "folder";
-                    const isOpenable = __cfHelpers.when({
-                        type: "boolean"
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        type: "boolean"
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        type: "boolean"
-                    } as const satisfies __cfHelpers.JSONSchema, !isFolder &&
-                        !!item.key("contentType"), item.key("contentType") !== "binary").for("isOpenable", true);
-                    return (<button type="button" onClick={isFolder
-                            ? __cfHandler_3({
-                                handleNavigateInto: handleNavigateInto,
-                                item: {
-                                    name: item.key("name")
-                                }
-                            }) : isOpenable
-                            ? __cfHandler_4({
-                                handleOpenFile: handleOpenFile,
-                                item: item
-                            }) : undefined}>
-                {item.key("name")}
-              </button>);
-                }, {
-                    type: "object",
-                    properties: {
-                        element: {
-                            $ref: "#/$defs/Entry"
-                        },
-                        params: {
-                            type: "object",
-                            properties: {
-                                handleNavigateInto: {
-                                    type: "object",
-                                    properties: {
-                                        name: {
-                                            type: "string"
-                                        }
-                                    },
-                                    required: ["name"],
-                                    asCell: ["stream"]
-                                },
-                                handleOpenFile: {
-                                    type: "object",
-                                    properties: {
-                                        item: {
-                                            $ref: "#/$defs/Entry"
-                                        }
-                                    },
-                                    required: ["item"],
-                                    asCell: ["stream"]
-                                }
-                            },
-                            required: ["handleNavigateInto", "handleOpenFile"]
-                        }
-                    },
-                    required: ["element", "params"],
-                    $defs: {
-                        Entry: {
-                            type: "object",
-                            properties: {
-                                id: {
-                                    type: "string"
-                                },
-                                name: {
-                                    type: "string"
-                                },
-                                type: {
-                                    "enum": ["file", "folder"]
-                                },
-                                children: {
-                                    $ref: "#/$defs/AnonymousType_1"
-                                },
-                                contentType: {
-                                    type: "string"
-                                }
-                            },
-                            required: ["id", "name", "type"]
-                        },
-                        AnonymousType_1: {
-                            type: "array",
-                            items: {
-                                $ref: "#/$defs/Entry"
-                            }
-                        }
-                    }
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{
-                            $ref: "https://commonfabric.org/schemas/vnode.json"
-                        }, {
-                            $ref: "#/$defs/UIRenderable"
-                        }, {
-                            type: "object",
-                            properties: {}
-                        }],
-                    $defs: {
-                        UIRenderable: {
-                            type: "object",
-                            properties: {
-                                $UI: {
-                                    $ref: "https://commonfabric.org/schemas/vnode.json"
-                                }
-                            },
-                            required: ["$UI"]
-                        }
-                    }
-                } as const satisfies __cfHelpers.JSONSchema), {
+                return items.mapWithPattern(__cfPattern_1, {
                     handleNavigateInto: handleNavigateInto,
                     handleOpenFile: handleOpenFile
                 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-filter-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-filter-capture.expected.jsx
@@ -14,6 +14,22 @@ import { Default, pattern, UI, VNode, Writable, } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Entry {
+    name: string;
+}
+interface Input {
+    entries: Writable<Default<Entry[], [
+    ]>>;
+}
+interface Output {
+    [UI]: VNode;
+}
+function visibleEntries(entries: Writable<Default<Entry[], [
+]>>, prefix: string): Entry[] {
+    const list = entries.get();
+    return list.filter((entry) => prefix.length === 0 || entry.name.startsWith(prefix));
+}
+__cfHardenFn(visibleEntries);
 const __cfLift_1 = __cfHelpers.lift<{
     path: __cfHelpers.Cell<string[]>;
 }, readonly string[]>({
@@ -111,22 +127,90 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, ({ entry, labelPrefix }) => entry.name.startsWith(`${labelPrefix}`));
-interface Entry {
-    name: string;
-}
-interface Input {
-    entries: Writable<Default<Entry[], [
-    ]>>;
-}
-interface Output {
-    [UI]: VNode;
-}
-function visibleEntries(entries: Writable<Default<Entry[], [
-]>>, prefix: string): Entry[] {
-    const list = entries.get();
-    return list.filter((entry) => prefix.length === 0 || entry.name.startsWith(prefix));
-}
-__cfHardenFn(visibleEntries);
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const entry = __cf_pattern_input.key("element");
+    const labelPrefix = __cf_pattern_input.key("params", "labelPrefix");
+    return __cfLift_3({
+        entry: {
+            name: entry.key("name")
+        },
+        labelPrefix: labelPrefix
+    }).for("__patternResult", true);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Entry"
+        },
+        params: {
+            type: "object",
+            properties: {
+                labelPrefix: {
+                    type: "string",
+                    asCell: ["readonly"]
+                }
+            },
+            required: ["labelPrefix"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Entry: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const entry = __cf_pattern_input.key("element");
+    return <button type="button">{entry.key("name")}</button>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Entry"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Entry: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 export default pattern((__cf_pattern_input) => {
     const entries = __cf_pattern_input.key("entries");
     const path = new Writable<string[]>([], {
@@ -159,92 +243,10 @@ export default pattern((__cf_pattern_input) => {
                     entries: entries,
                     p: p
                 }).for("visible", true);
-                const filtered = visible.filterWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                    const entry = __cf_pattern_input.key("element");
-                    const labelPrefix = __cf_pattern_input.key("params", "labelPrefix");
-                    return __cfLift_3({
-                        entry: {
-                            name: entry.key("name")
-                        },
-                        labelPrefix: labelPrefix
-                    });
-                }, {
-                    type: "object",
-                    properties: {
-                        element: {
-                            $ref: "#/$defs/Entry"
-                        },
-                        params: {
-                            type: "object",
-                            properties: {
-                                labelPrefix: {
-                                    type: "string",
-                                    asCell: ["readonly"]
-                                }
-                            },
-                            required: ["labelPrefix"]
-                        }
-                    },
-                    required: ["element", "params"],
-                    $defs: {
-                        Entry: {
-                            type: "object",
-                            properties: {
-                                name: {
-                                    type: "string"
-                                }
-                            },
-                            required: ["name"]
-                        }
-                    }
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema), {
+                const filtered = visible.filterWithPattern(__cfPattern_1, {
                     labelPrefix: labelPrefix
                 }).for("filtered", true);
-                return filtered.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                    const entry = __cf_pattern_input.key("element");
-                    return <button type="button">{entry.key("name")}</button>;
-                }, {
-                    type: "object",
-                    properties: {
-                        element: {
-                            $ref: "#/$defs/Entry"
-                        }
-                    },
-                    required: ["element"],
-                    $defs: {
-                        Entry: {
-                            type: "object",
-                            properties: {
-                                name: {
-                                    type: "string"
-                                }
-                            },
-                            required: ["name"]
-                        }
-                    }
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{
-                            $ref: "https://commonfabric.org/schemas/vnode.json"
-                        }, {
-                            $ref: "#/$defs/UIRenderable"
-                        }, {
-                            type: "object",
-                            properties: {}
-                        }],
-                    $defs: {
-                        UIRenderable: {
-                            type: "object",
-                            properties: {
-                                $UI: {
-                                    $ref: "https://commonfabric.org/schemas/vnode.json"
-                                }
-                            },
-                            required: ["$UI"]
-                        }
-                    }
-                } as const satisfies __cfHelpers.JSONSchema), {});
+                return filtered.mapWithPattern(__cfPattern_2, {});
             })()}
       </div>)
     };

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-flatmap-fallback-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-flatmap-fallback-capture.expected.jsx
@@ -15,6 +15,18 @@ import { pattern, UI, VNode } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Entry {
+    name: string;
+}
+interface Input {
+    entries: Entry[];
+    prefix: string;
+    labelPrefix: string;
+}
+interface Output {
+    [UI]: VNode;
+}
+const visibleEntries = __cfHardenFn((entries: Entry[], prefix: string) => entries.filter((entry) => entry.name.startsWith(prefix)));
 const __cfLift_1 = __cfHelpers.lift<{
     entries: Entry[];
     prefix: string;
@@ -85,18 +97,96 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, ({ entry, labelPrefix }) => entry.name.startsWith(labelPrefix));
-interface Entry {
-    name: string;
-}
-interface Input {
-    entries: Entry[];
-    prefix: string;
-    labelPrefix: string;
-}
-interface Output {
-    [UI]: VNode;
-}
-const visibleEntries = __cfHardenFn((entries: Entry[], prefix: string) => entries.filter((entry) => entry.name.startsWith(prefix)));
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const entry = __cf_pattern_input.key("element");
+    const labelPrefix = __cf_pattern_input.key("params", "labelPrefix");
+    return __cfHelpers.ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "array",
+        items: {
+            type: "string"
+        }
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "array",
+        items: false
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "array",
+        items: {
+            type: "string"
+        }
+    } as const satisfies __cfHelpers.JSONSchema, __cfLift_2({
+        entry: {
+            name: entry.key("name")
+        },
+        labelPrefix: labelPrefix
+    }), [entry.key("name")], []).for("__patternResult", true);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Entry"
+        },
+        params: {
+            type: "object",
+            properties: {
+                labelPrefix: {
+                    type: "string"
+                }
+            },
+            required: ["labelPrefix"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Entry: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "array",
+    items: {
+        type: "string"
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const label = __cf_pattern_input.key("element");
+    return <button type="button">{label}</button>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "string"
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 export default pattern((__cf_pattern_input) => {
     const entries = __cf_pattern_input.key("entries");
     const prefix = __cf_pattern_input.key("prefix");
@@ -143,98 +233,10 @@ export default pattern((__cf_pattern_input) => {
                     entries: entries,
                     prefix: prefix
                 }).for(["visible", 3], true), []).for("visible", true);
-                const labels = visible.flatMapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                    const entry = __cf_pattern_input.key("element");
-                    const labelPrefix = __cf_pattern_input.key("params", "labelPrefix");
-                    return __cfHelpers.ifElse({
-                        type: "boolean"
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        type: "array",
-                        items: {
-                            type: "string"
-                        }
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        type: "array",
-                        items: false
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        type: "array",
-                        items: {
-                            type: "string"
-                        }
-                    } as const satisfies __cfHelpers.JSONSchema, __cfLift_2({
-                        entry: {
-                            name: entry.key("name")
-                        },
-                        labelPrefix: labelPrefix
-                    }), [entry.key("name")], []);
-                }, {
-                    type: "object",
-                    properties: {
-                        element: {
-                            $ref: "#/$defs/Entry"
-                        },
-                        params: {
-                            type: "object",
-                            properties: {
-                                labelPrefix: {
-                                    type: "string"
-                                }
-                            },
-                            required: ["labelPrefix"]
-                        }
-                    },
-                    required: ["element", "params"],
-                    $defs: {
-                        Entry: {
-                            type: "object",
-                            properties: {
-                                name: {
-                                    type: "string"
-                                }
-                            },
-                            required: ["name"]
-                        }
-                    }
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "array",
-                    items: {
-                        type: "string"
-                    }
-                } as const satisfies __cfHelpers.JSONSchema), {
+                const labels = visible.flatMapWithPattern(__cfPattern_1, {
                     labelPrefix: labelPrefix
                 }).for("labels", true);
-                return labels.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                    const label = __cf_pattern_input.key("element");
-                    return <button type="button">{label}</button>;
-                }, {
-                    type: "object",
-                    properties: {
-                        element: {
-                            type: "string"
-                        }
-                    },
-                    required: ["element"]
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{
-                            $ref: "https://commonfabric.org/schemas/vnode.json"
-                        }, {
-                            $ref: "#/$defs/UIRenderable"
-                        }, {
-                            type: "object",
-                            properties: {}
-                        }],
-                    $defs: {
-                        UIRenderable: {
-                            type: "object",
-                            properties: {
-                                $UI: {
-                                    $ref: "https://commonfabric.org/schemas/vnode.json"
-                                }
-                            },
-                            required: ["$UI"]
-                        }
-                    }
-                } as const satisfies __cfHelpers.JSONSchema), {});
+                return labels.mapWithPattern(__cfPattern_2, {});
             })()}
     </div>)
     });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-capture.expected.jsx
@@ -18,6 +18,22 @@ import { Default, pattern, UI, VNode, Writable, } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Entry {
+    name: string;
+}
+interface Input {
+    entries: Writable<Default<Entry[], [
+    ]>>;
+}
+interface Output {
+    [UI]: VNode;
+}
+function visibleEntries(entries: Writable<Default<Entry[], [
+]>>, prefix: string): Entry[] {
+    const list = entries.get();
+    return list.filter((entry) => prefix.length === 0 || entry.name.startsWith(prefix));
+}
+__cfHardenFn(visibleEntries);
 const __cfLift_1 = __cfHelpers.lift<{
     path: __cfHelpers.Cell<string[]>;
 }, readonly string[]>({
@@ -89,22 +105,62 @@ const __cfLift_2 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, ({ entries, p }) => visibleEntries(entries, p[0] || ""));
-interface Entry {
-    name: string;
-}
-interface Input {
-    entries: Writable<Default<Entry[], [
-    ]>>;
-}
-interface Output {
-    [UI]: VNode;
-}
-function visibleEntries(entries: Writable<Default<Entry[], [
-]>>, prefix: string): Entry[] {
-    const list = entries.get();
-    return list.filter((entry) => prefix.length === 0 || entry.name.startsWith(prefix));
-}
-__cfHardenFn(visibleEntries);
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const entry = __cf_pattern_input.key("element");
+    const labelPrefix = __cf_pattern_input.key("params", "labelPrefix");
+    return (<button type="button">
+              {labelPrefix}:{entry.key("name")}
+            </button>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Entry"
+        },
+        params: {
+            type: "object",
+            properties: {
+                labelPrefix: {
+                    type: "string",
+                    asCell: ["readonly"]
+                }
+            },
+            required: ["labelPrefix"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Entry: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 export default pattern((__cf_pattern_input) => {
     const entries = __cf_pattern_input.key("entries");
     const path = new Writable<string[]>([], {
@@ -137,62 +193,7 @@ export default pattern((__cf_pattern_input) => {
                     entries: entries,
                     p: p
                 }).for("visible", true);
-                return visible.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                    const entry = __cf_pattern_input.key("element");
-                    const labelPrefix = __cf_pattern_input.key("params", "labelPrefix");
-                    return (<button type="button">
-              {labelPrefix}:{entry.key("name")}
-            </button>);
-                }, {
-                    type: "object",
-                    properties: {
-                        element: {
-                            $ref: "#/$defs/Entry"
-                        },
-                        params: {
-                            type: "object",
-                            properties: {
-                                labelPrefix: {
-                                    type: "string",
-                                    asCell: ["readonly"]
-                                }
-                            },
-                            required: ["labelPrefix"]
-                        }
-                    },
-                    required: ["element", "params"],
-                    $defs: {
-                        Entry: {
-                            type: "object",
-                            properties: {
-                                name: {
-                                    type: "string"
-                                }
-                            },
-                            required: ["name"]
-                        }
-                    }
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{
-                            $ref: "https://commonfabric.org/schemas/vnode.json"
-                        }, {
-                            $ref: "#/$defs/UIRenderable"
-                        }, {
-                            type: "object",
-                            properties: {}
-                        }],
-                    $defs: {
-                        UIRenderable: {
-                            type: "object",
-                            properties: {
-                                $UI: {
-                                    $ref: "https://commonfabric.org/schemas/vnode.json"
-                                }
-                            },
-                            required: ["$UI"]
-                        }
-                    }
-                } as const satisfies __cfHelpers.JSONSchema), {
+                return visible.mapWithPattern(__cfPattern_1, {
                     labelPrefix: labelPrefix
                 });
             })()}

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-fallback-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-fallback-capture.expected.jsx
@@ -15,6 +15,18 @@ import { pattern, UI, VNode } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Entry {
+    name: string;
+}
+interface Input {
+    entries: Entry[];
+    prefix: string;
+    labelPrefix: string;
+}
+interface Output {
+    [UI]: VNode;
+}
+const visibleEntries = __cfHardenFn((entries: Entry[], prefix: string) => entries.filter((entry) => entry.name.startsWith(prefix)));
 const __cfLift_1 = __cfHelpers.lift<{
     entries: Entry[];
     prefix: string;
@@ -60,18 +72,61 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, ({ entries, prefix }) => visibleEntries(entries, prefix));
-interface Entry {
-    name: string;
-}
-interface Input {
-    entries: Entry[];
-    prefix: string;
-    labelPrefix: string;
-}
-interface Output {
-    [UI]: VNode;
-}
-const visibleEntries = __cfHardenFn((entries: Entry[], prefix: string) => entries.filter((entry) => entry.name.startsWith(prefix)));
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const entry = __cf_pattern_input.key("element");
+    const labelPrefix = __cf_pattern_input.key("params", "labelPrefix");
+    return (<button type="button">
+            {labelPrefix}:{entry.key("name")}
+          </button>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Entry"
+        },
+        params: {
+            type: "object",
+            properties: {
+                labelPrefix: {
+                    type: "string"
+                }
+            },
+            required: ["labelPrefix"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Entry: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 export default pattern((__cf_pattern_input) => {
     const entries = __cf_pattern_input.key("entries");
     const prefix = __cf_pattern_input.key("prefix");
@@ -118,61 +173,7 @@ export default pattern((__cf_pattern_input) => {
                     entries: entries,
                     prefix: prefix
                 }).for(["visible", 3], true), []).for("visible", true);
-                return visible.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                    const entry = __cf_pattern_input.key("element");
-                    const labelPrefix = __cf_pattern_input.key("params", "labelPrefix");
-                    return (<button type="button">
-            {labelPrefix}:{entry.key("name")}
-          </button>);
-                }, {
-                    type: "object",
-                    properties: {
-                        element: {
-                            $ref: "#/$defs/Entry"
-                        },
-                        params: {
-                            type: "object",
-                            properties: {
-                                labelPrefix: {
-                                    type: "string"
-                                }
-                            },
-                            required: ["labelPrefix"]
-                        }
-                    },
-                    required: ["element", "params"],
-                    $defs: {
-                        Entry: {
-                            type: "object",
-                            properties: {
-                                name: {
-                                    type: "string"
-                                }
-                            },
-                            required: ["name"]
-                        }
-                    }
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{
-                            $ref: "https://commonfabric.org/schemas/vnode.json"
-                        }, {
-                            $ref: "#/$defs/UIRenderable"
-                        }, {
-                            type: "object",
-                            properties: {}
-                        }],
-                    $defs: {
-                        UIRenderable: {
-                            type: "object",
-                            properties: {
-                                $UI: {
-                                    $ref: "https://commonfabric.org/schemas/vnode.json"
-                                }
-                            },
-                            required: ["$UI"]
-                        }
-                    }
-                } as const satisfies __cfHelpers.JSONSchema), {
+                return visible.mapWithPattern(__cfPattern_1, {
                     labelPrefix: labelPrefix
                 });
             })()}

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-local-initializer-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-local-initializer-captures.expected.jsx
@@ -19,6 +19,30 @@ import { action, Default, pattern, UI, VNode, Writable, } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Entry {
+    id: string;
+    name: string;
+    type: "file" | "folder";
+    children?: Entry[];
+}
+function findChildren(tree: Writable<Entry[]>, path: readonly string[]): readonly Entry[] {
+    let current = tree.get();
+    for (const name of path) {
+        const folder = current.find((entry: Entry) => entry.name === name && entry.type === "folder");
+        if (!folder || !folder.children)
+            return [];
+        current = folder.children;
+    }
+    return current;
+}
+__cfHardenFn(findChildren);
+interface Input {
+    entries: Writable<Default<Entry[], [
+    ]>>;
+}
+interface Output {
+    [UI]: VNode;
+}
 const __cfHandler_1 = __cfHelpers.handler({
     type: "object",
     properties: {
@@ -225,30 +249,88 @@ const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.J
     },
     required: ["pushPath", "item"]
 } as const satisfies __cfHelpers.JSONSchema, (_, { pushPath, item }) => pushPath.send({ name: item.name }));
-interface Entry {
-    id: string;
-    name: string;
-    type: "file" | "folder";
-    children?: Entry[];
-}
-function findChildren(tree: Writable<Entry[]>, path: readonly string[]): readonly Entry[] {
-    let current = tree.get();
-    for (const name of path) {
-        const folder = current.find((entry: Entry) => entry.name === name && entry.type === "folder");
-        if (!folder || !folder.children)
-            return [];
-        current = folder.children;
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const pushPath = __cf_pattern_input.key("params", "pushPath");
+    return (<button type="button" onClick={__cfHandler_2({
+        pushPath: pushPath,
+        item: {
+            name: item.key("name")
+        }
+    })}>
+                {item.key("name")}
+              </button>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Entry"
+        },
+        params: {
+            type: "object",
+            properties: {
+                pushPath: {
+                    type: "object",
+                    properties: {
+                        name: {
+                            type: "string"
+                        }
+                    },
+                    required: ["name"],
+                    asCell: ["stream"]
+                }
+            },
+            required: ["pushPath"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Entry: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                },
+                name: {
+                    type: "string"
+                },
+                type: {
+                    "enum": ["file", "folder"]
+                },
+                children: {
+                    $ref: "#/$defs/AnonymousType_1"
+                }
+            },
+            required: ["id", "name", "type"]
+        },
+        AnonymousType_1: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Entry"
+            }
+        }
     }
-    return current;
-}
-__cfHardenFn(findChildren);
-interface Input {
-    entries: Writable<Default<Entry[], [
-    ]>>;
-}
-interface Output {
-    [UI]: VNode;
-}
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 export default pattern((__cf_pattern_input) => {
     const entries = __cf_pattern_input.key("entries");
     const path = new Writable<string[]>([], {
@@ -283,88 +365,7 @@ export default pattern((__cf_pattern_input) => {
                     p: p
                 }).for("unsorted", true);
                 const items = __cfLift_3({ unsorted: unsorted }).for("items", true);
-                return items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                    const item = __cf_pattern_input.key("element");
-                    const pushPath = __cf_pattern_input.key("params", "pushPath");
-                    return (<button type="button" onClick={__cfHandler_2({
-                        pushPath: pushPath,
-                        item: {
-                            name: item.key("name")
-                        }
-                    })}>
-                {item.key("name")}
-              </button>);
-                }, {
-                    type: "object",
-                    properties: {
-                        element: {
-                            $ref: "#/$defs/Entry"
-                        },
-                        params: {
-                            type: "object",
-                            properties: {
-                                pushPath: {
-                                    type: "object",
-                                    properties: {
-                                        name: {
-                                            type: "string"
-                                        }
-                                    },
-                                    required: ["name"],
-                                    asCell: ["stream"]
-                                }
-                            },
-                            required: ["pushPath"]
-                        }
-                    },
-                    required: ["element", "params"],
-                    $defs: {
-                        Entry: {
-                            type: "object",
-                            properties: {
-                                id: {
-                                    type: "string"
-                                },
-                                name: {
-                                    type: "string"
-                                },
-                                type: {
-                                    "enum": ["file", "folder"]
-                                },
-                                children: {
-                                    $ref: "#/$defs/AnonymousType_1"
-                                }
-                            },
-                            required: ["id", "name", "type"]
-                        },
-                        AnonymousType_1: {
-                            type: "array",
-                            items: {
-                                $ref: "#/$defs/Entry"
-                            }
-                        }
-                    }
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{
-                            $ref: "https://commonfabric.org/schemas/vnode.json"
-                        }, {
-                            $ref: "#/$defs/UIRenderable"
-                        }, {
-                            type: "object",
-                            properties: {}
-                        }],
-                    $defs: {
-                        UIRenderable: {
-                            type: "object",
-                            properties: {
-                                $UI: {
-                                    $ref: "https://commonfabric.org/schemas/vnode.json"
-                                }
-                            },
-                            required: ["$UI"]
-                        }
-                    }
-                } as const satisfies __cfHelpers.JSONSchema), {
+                return items.mapWithPattern(__cfPattern_1, {
                     pushPath: pushPath
                 });
             })()}

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-arithmetic-operations.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-arithmetic-operations.expected.jsx
@@ -11,6 +11,12 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    count: number;
+    price: number;
+    discount: number;
+    quantity: number;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         count: number;
@@ -288,12 +294,6 @@ const __cfLift_12 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.price + 10);
-interface State {
-    count: number;
-    price: number;
-    discount: number;
-    quantity: number;
-}
 // FIXTURE: jsx-arithmetic-operations
 // Verifies: arithmetic expressions with reactive refs in JSX are wrapped in a lift-applied computation
 //   {state.count + 1}                      → lift(({state}) => state.count + 1)({ count })

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-array-method-sink-calls.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-array-method-sink-calls.expected.jsx
@@ -11,6 +11,11 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    items: number[];
+    threshold: number;
+    factor: number;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         items: number[];
@@ -128,11 +133,6 @@ const __cfLift_4 = __cfHelpers.lift<{
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items.filter((x) => x > state.threshold).join(", ").toUpperCase()
     .trim());
-interface State {
-    items: number[];
-    threshold: number;
-    factor: number;
-}
 // FIXTURE: jsx-array-method-sink-calls
 // Verifies: direct JSX sink receiver-methods over structural array-method chains can use the shared post-closure path
 //   state.items.filter(fn).join(", ")                        → shared post-closure lift-applied computation over the sink call

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-complex-mixed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-complex-mixed.expected.jsx
@@ -11,6 +11,18 @@ import { computed, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Item {
+    id: number;
+    name: string;
+    price: number;
+    active: boolean;
+}
+interface State {
+    items: Item[];
+    filter: string;
+    discount: number;
+    taxRate: number;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         items: {
@@ -118,6 +130,102 @@ const __cfLift_3 = __cfHelpers.lift<{
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, ({ item, state }) => (item.price * (1 - state.discount) * (1 + state.taxRate))
     .toFixed(2));
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const state = __cf_pattern_input.key("params", "state");
+    return (<li key={item.key("id")}>
+              <span>{item.key("name")}</span>
+              <span>- Original: ${item.key("price")}</span>
+              <span>
+                - Discounted: ${__cfLift_2({
+        item: {
+            price: item.key("price")
+        },
+        state: {
+            discount: state.key("discount")
+        }
+    })}
+              </span>
+              <span>
+                - With tax:
+                ${__cfLift_3({
+        item: {
+            price: item.key("price")
+        },
+        state: {
+            discount: state.key("discount"),
+            taxRate: state.key("taxRate")
+        }
+    })}
+              </span>
+            </li>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        },
+        params: {
+            type: "object",
+            properties: {
+                state: {
+                    type: "object",
+                    properties: {
+                        discount: {
+                            type: "number"
+                        },
+                        taxRate: {
+                            type: "number"
+                        }
+                    },
+                    required: ["discount", "taxRate"]
+                }
+            },
+            required: ["state"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "number"
+                },
+                name: {
+                    type: "string"
+                },
+                price: {
+                    type: "number"
+                },
+                active: {
+                    type: "boolean"
+                }
+            },
+            required: ["id", "name", "price", "active"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_4 = __cfHelpers.lift<{
     state: {
         items: Item[];
@@ -309,18 +417,6 @@ const __cfLift_10 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.filter.length > 0);
-interface Item {
-    id: number;
-    name: string;
-    price: number;
-    active: boolean;
-}
-interface State {
-    items: Item[];
-    filter: string;
-    discount: number;
-    taxRate: number;
-}
 // FIXTURE: jsx-complex-mixed
 // Verifies: mixed transforms -- map, filter, arithmetic, ternary/ifElse, attribute bindings in one pattern
 //   .filter(fn)              → .filterWithPattern(pattern(...), {captures})
@@ -343,102 +439,7 @@ export default pattern((state) => {
 
         <h3>Array with Complex Expressions</h3>
         <ul>
-          {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                const state = __cf_pattern_input.key("params", "state");
-                return (<li key={item.key("id")}>
-              <span>{item.key("name")}</span>
-              <span>- Original: ${item.key("price")}</span>
-              <span>
-                - Discounted: ${__cfLift_2({
-                    item: {
-                        price: item.key("price")
-                    },
-                    state: {
-                        discount: state.key("discount")
-                    }
-                })}
-              </span>
-              <span>
-                - With tax:
-                ${__cfLift_3({
-                    item: {
-                        price: item.key("price")
-                    },
-                    state: {
-                        discount: state.key("discount"),
-                        taxRate: state.key("taxRate")
-                    }
-                })}
-              </span>
-            </li>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Item"
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            state: {
-                                type: "object",
-                                properties: {
-                                    discount: {
-                                        type: "number"
-                                    },
-                                    taxRate: {
-                                        type: "number"
-                                    }
-                                },
-                                required: ["discount", "taxRate"]
-                            }
-                        },
-                        required: ["state"]
-                    }
-                },
-                required: ["element", "params"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            id: {
-                                type: "number"
-                            },
-                            name: {
-                                type: "string"
-                            },
-                            price: {
-                                type: "number"
-                            },
-                            active: {
-                                type: "boolean"
-                            }
-                        },
-                        required: ["id", "name", "price", "active"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+          {state.key("items").mapWithPattern(__cfPattern_1, {
                 state: {
                     discount: state.key("discount"),
                     taxRate: state.key("taxRate")

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-conditional-rendering-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-conditional-rendering-no-name.expected.jsx
@@ -11,6 +11,14 @@ import { ifElse, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    isActive: boolean;
+    count: number;
+    userType: string;
+    score: number;
+    hasPermission: boolean;
+    isPremium: boolean;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         count: number;
@@ -242,14 +250,6 @@ const __cfLift_11 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.count > 5);
-interface State {
-    isActive: boolean;
-    count: number;
-    userType: string;
-    score: number;
-    hasPermission: boolean;
-    isPremium: boolean;
-}
 // FIXTURE: jsx-conditional-rendering-no-name
 // Verifies: same conditional rendering transforms work when pattern has no NAME export
 //   cond ? a : b             → ifElse(schema..., cond, a, b)

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-conditional-rendering.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-conditional-rendering.expected.jsx
@@ -11,6 +11,14 @@ import { ifElse, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    isActive: boolean;
+    count: number;
+    userType: string;
+    score: number;
+    hasPermission: boolean;
+    isPremium: boolean;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         count: number;
@@ -242,14 +250,6 @@ const __cfLift_11 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.count > 5);
-interface State {
-    isActive: boolean;
-    count: number;
-    userType: string;
-    score: number;
-    hasPermission: boolean;
-    isPremium: boolean;
-}
 // FIXTURE: jsx-conditional-rendering
 // Verifies: ternary expressions and ifElse() calls in JSX are transformed to reactive ifElse()
 //   cond ? a : b             → ifElse(schema, schema, schema, schema, cond, a, b)

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-function-calls.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-function-calls.expected.jsx
@@ -11,6 +11,15 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    a: number;
+    b: number;
+    price: number;
+    text: string;
+    values: number[];
+    name: string;
+    float: string;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         a: number;
@@ -536,15 +545,6 @@ const __cfLift_24 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ state }) => Math.max(state.a + 1, state.b * 2));
-interface State {
-    a: number;
-    b: number;
-    price: number;
-    text: string;
-    values: number[];
-    name: string;
-    float: string;
-}
 // FIXTURE: jsx-function-calls
 // Verifies: function/method calls with reactive args in JSX are wrapped in a lift-applied computation
 //   Math.max(state.a, state.b)     → lift(({state}) => Math.max(state.a, state.b))({ a, b })

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-property-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-property-access.expected.jsx
@@ -11,6 +11,37 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface User {
+    name: string;
+    age: number;
+    active: boolean;
+    profile: {
+        bio: string;
+        location: string;
+        settings: {
+            theme: string;
+            notifications: boolean;
+        };
+    };
+}
+interface Config {
+    theme: {
+        primaryColor: string;
+        secondaryColor: string;
+        fontSize: number;
+    };
+    features: {
+        darkMode: boolean;
+        beta: boolean;
+    };
+}
+interface State {
+    user: User;
+    config: Config;
+    items: string[];
+    index: number;
+    numbers: number[];
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         user: {
@@ -301,37 +332,6 @@ const __cfLift_9 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.config.theme.fontSize + 2);
-interface User {
-    name: string;
-    age: number;
-    active: boolean;
-    profile: {
-        bio: string;
-        location: string;
-        settings: {
-            theme: string;
-            notifications: boolean;
-        };
-    };
-}
-interface Config {
-    theme: {
-        primaryColor: string;
-        secondaryColor: string;
-        fontSize: number;
-    };
-    features: {
-        darkMode: boolean;
-        beta: boolean;
-    };
-}
-interface State {
-    user: User;
-    config: Config;
-    items: string[];
-    index: number;
-    numbers: number[];
-}
 // FIXTURE: jsx-property-access
 // Verifies: nested property access chains in JSX are converted to .key() or wrapped in a lift-applied computation
 //   state.user.name                → state.key("user", "name")  (simple access, no lift)

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-string-operations.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-string-operations.expected.jsx
@@ -11,6 +11,13 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    firstName: string;
+    lastName: string;
+    title: string;
+    message: string;
+    count: number;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         title: string;
@@ -295,13 +302,6 @@ const __cfLift_12 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, ({ state }) => "Count: " + state.count);
-interface State {
-    firstName: string;
-    lastName: string;
-    title: string;
-    message: string;
-    count: number;
-}
 // FIXTURE: jsx-string-operations
 // Verifies: string concatenation, template literals, and string methods in JSX are wrapped in a lift-applied computation
 //   state.title + ": " + state.firstName → lift(...)({ title, firstName })

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-wildcard-traversal-call-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-wildcard-traversal-call-roots.expected.jsx
@@ -11,6 +11,18 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    wishes: [
+        {
+            id: string;
+            status: string;
+        },
+        {
+            id: string;
+            status: string;
+        }
+    ];
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         wishes: [{ id: string; status: string; }, { id: string; status: string; }];
@@ -155,18 +167,6 @@ const __cfLift_4 = __cfHelpers.lift<{
         }
     }
 } as const satisfies __cfHelpers.JSONSchema, ({ state }) => Object.entries(state.wishes[1]));
-interface State {
-    wishes: [
-        {
-            id: string;
-            status: string;
-        },
-        {
-            id: string;
-            status: string;
-        }
-    ];
-}
 // FIXTURE: jsx-wildcard-traversal-call-roots
 // Verifies: wildcard traversal calls lower as whole JSX call roots
 export default pattern((state) => ({

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-array-length-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-array-length-conditional.expected.jsx
@@ -28,6 +28,38 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, ({ list }) => list.get().length > 0);
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const name = __cf_pattern_input.key("element");
+    return (<span>{name}</span>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "string"
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-array-length-conditional
 // Verifies: length-guard && map pattern is transformed to when() wrapping mapWithPattern()
 //   list.get().length > 0 && (<div>{list.map(...)}</div>) → when(lift(...)(...length), <div>{list.mapWithPattern(...)}</div>)
@@ -55,38 +87,7 @@ export default pattern((_state) => {
                     properties: {}
                 }]
         } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ list: list }), <div>
-            {list.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const name = __cf_pattern_input.key("element");
-                return (<span>{name}</span>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "string"
-                    }
-                },
-                required: ["element"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+            {list.mapWithPattern(__cfPattern_1, {})}
           </div>)}
       </div>),
     };

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-aliased-const-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-aliased-const-computation.expected.jsx
@@ -17,6 +17,17 @@ import { Default, pattern, UI, VNode, Writable, } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface FileEntry {
+    name: string;
+    type: "file" | "folder";
+}
+interface Input {
+    files: Writable<Default<FileEntry[], [
+    ]>>;
+}
+interface Output {
+    [UI]: VNode;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     kind: string;
 }, boolean>({
@@ -30,78 +41,68 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, ({ kind }) => kind === "folder");
-interface FileEntry {
-    name: string;
-    type: "file" | "folder";
-}
-interface Input {
-    files: Writable<Default<FileEntry[], [
-    ]>>;
-}
-interface Output {
-    [UI]: VNode;
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const file = __cf_pattern_input.key("element");
+    const kind = file.key("type");
+    const isFolder = __cfLift_1({ kind: kind }).for("isFolder", true);
+    return <span>{__cfHelpers.ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, isFolder, file.key("name"), "locked")}</span>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/FileEntry"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        FileEntry: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                type: {
+                    "enum": ["file", "folder"]
+                }
+            },
+            required: ["name", "type"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
-        {files.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const file = __cf_pattern_input.key("element");
-                const kind = file.key("type");
-                const isFolder = __cfLift_1({ kind: kind }).for("isFolder", true);
-                return <span>{__cfHelpers.ifElse({
-                    type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, isFolder, file.key("name"), "locked")}</span>;
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/FileEntry"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    FileEntry: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            },
-                            type: {
-                                "enum": ["file", "folder"]
-                            }
-                        },
-                        required: ["name", "type"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>)
+        {files.mapWithPattern(__cfPattern_1, {})}
+      </div>),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-array-destructured-alias-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-array-destructured-alias-computation.expected.jsx
@@ -17,19 +17,6 @@ import { Default, pattern, UI, VNode, Writable, } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
-    kind: string;
-}, boolean>({
-    type: "object",
-    properties: {
-        kind: {
-            type: "string"
-        }
-    },
-    required: ["kind"]
-} as const satisfies __cfHelpers.JSONSchema, {
-    type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ kind }) => kind === "folder");
 interface FileEntry {
     name: string;
     tags: [
@@ -44,70 +31,84 @@ interface Input {
 interface Output {
     [UI]: VNode;
 }
+const __cfLift_1 = __cfHelpers.lift<{
+    kind: string;
+}, boolean>({
+    type: "object",
+    properties: {
+        kind: {
+            type: "string"
+        }
+    },
+    required: ["kind"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema, ({ kind }) => kind === "folder");
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const file = __cf_pattern_input.key("element");
+    const __cf_destructure_1 = file.key("tags"), kind = __cf_destructure_1.key("0");
+    const isFolder = __cfLift_1({ kind: kind }).for("isFolder", true);
+    return <span>{__cfHelpers.ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, isFolder, file.key("name"), "locked")}</span>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/FileEntry"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        FileEntry: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                tags: {
+                    type: "array",
+                    items: {
+                        type: "string"
+                    }
+                }
+            },
+            required: ["name", "tags"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
-        {files.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const file = __cf_pattern_input.key("element");
-                const __cf_destructure_1 = file.key("tags"), kind = __cf_destructure_1.key("0");
-                const isFolder = __cfLift_1({ kind: kind }).for("isFolder", true);
-                return <span>{__cfHelpers.ifElse({
-                    type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, isFolder, file.key("name"), "locked")}</span>;
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/FileEntry"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    FileEntry: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            },
-                            tags: {
-                                type: "array",
-                                items: {
-                                    type: "string"
-                                }
-                            }
-                        },
-                        required: ["name", "tags"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>)
+        {files.mapWithPattern(__cfPattern_1, {})}
+      </div>),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-direct-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-direct-alias.expected.jsx
@@ -29,57 +29,58 @@ interface Input {
 interface Output {
     [UI]: VNode;
 }
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const file = __cf_pattern_input.key("element");
+    const kind = file.key("type");
+    return <span>{kind}</span>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/FileEntry"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        FileEntry: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                type: {
+                    "enum": ["file", "folder"]
+                }
+            },
+            required: ["name", "type"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
-        {files.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const file = __cf_pattern_input.key("element");
-                const kind = file.key("type");
-                return <span>{kind}</span>;
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/FileEntry"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    FileEntry: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            },
-                            type: {
-                                "enum": ["file", "folder"]
-                            }
-                        },
-                        required: ["name", "type"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+        {files.mapWithPattern(__cfPattern_1, {})}
       </div>),
     };
 }, {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-element-property-helper-comparison.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-element-property-helper-comparison.expected.jsx
@@ -18,6 +18,23 @@ import { Default, pattern, UI, VNode, Writable, } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Message {
+    author: string;
+    body: string;
+}
+interface Input {
+    name: Writable<Default<string, "">>;
+    selectedRoom: Writable<Default<{
+        messages: Message[];
+    }, {
+        messages: [
+        ];
+    }>>;
+}
+interface Output {
+    [UI]: VNode;
+}
+const senderName = __cfHardenFn((name?: string) => name?.trim() || "Anonymous");
 const __cfLift_1 = __cfHelpers.lift<{
     selectedRoom: __cfHelpers.ReadonlyCell<Default<{
         messages: Message[];
@@ -128,117 +145,101 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, ({ message }) => message.author === "Alice");
-interface Message {
-    author: string;
-    body: string;
-}
-interface Input {
-    name: Writable<Default<string, "">>;
-    selectedRoom: Writable<Default<{
-        messages: Message[];
-    }, {
-        messages: [
-        ];
-    }>>;
-}
-interface Output {
-    [UI]: VNode;
-}
-const senderName = __cfHardenFn((name?: string) => name?.trim() || "Anonymous");
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const message = __cf_pattern_input.key("element");
+    const name = __cf_pattern_input.key("params", "name");
+    const isMine = __cfLift_2({
+        message: {
+            author: message.key("author")
+        },
+        name: name
+    }).for("isMine", true);
+    const isKnownAuthor = __cfLift_3({ message: {
+            author: message.key("author")
+        } }).for("isKnownAuthor", true);
+    return (<div data-author-kind={__cfHelpers.ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        "enum": ["known", "other"]
+    } as const satisfies __cfHelpers.JSONSchema, isKnownAuthor, "known", "other")} style={{ justifyContent: __cfHelpers.ifElse({
+            type: "boolean"
+        } as const satisfies __cfHelpers.JSONSchema, {
+            type: "string"
+        } as const satisfies __cfHelpers.JSONSchema, {
+            type: "string"
+        } as const satisfies __cfHelpers.JSONSchema, {
+            "enum": ["flex-end", "flex-start"]
+        } as const satisfies __cfHelpers.JSONSchema, isMine, "flex-end", "flex-start") }}>
+              {message.key("author")}
+              {message.key("body")}
+            </div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Message"
+        },
+        params: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string",
+                    "default": "",
+                    asCell: ["readonly"]
+                }
+            },
+            required: ["name"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Message: {
+            type: "object",
+            properties: {
+                author: {
+                    type: "string"
+                },
+                body: {
+                    type: "string"
+                }
+            },
+            required: ["author", "body"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 export default pattern((__cf_pattern_input) => {
     const name = __cf_pattern_input.key("name");
     const selectedRoom = __cf_pattern_input.key("selectedRoom");
     return {
         [UI]: (<div>
-        {__cfLift_1({ selectedRoom: selectedRoom }).mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-            const message = __cf_pattern_input.key("element");
-            const name = __cf_pattern_input.key("params", "name");
-            const isMine = __cfLift_2({
-                message: {
-                    author: message.key("author")
-                },
-                name: name
-            }).for("isMine", true);
-            const isKnownAuthor = __cfLift_3({ message: {
-                    author: message.key("author")
-                } }).for("isKnownAuthor", true);
-            return (<div data-author-kind={__cfHelpers.ifElse({
-                type: "boolean"
-            } as const satisfies __cfHelpers.JSONSchema, {
-                type: "string"
-            } as const satisfies __cfHelpers.JSONSchema, {
-                type: "string"
-            } as const satisfies __cfHelpers.JSONSchema, {
-                "enum": ["known", "other"]
-            } as const satisfies __cfHelpers.JSONSchema, isKnownAuthor, "known", "other")} style={{ justifyContent: __cfHelpers.ifElse({
-                    type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    "enum": ["flex-end", "flex-start"]
-                } as const satisfies __cfHelpers.JSONSchema, isMine, "flex-end", "flex-start") }}>
-              {message.key("author")}
-              {message.key("body")}
-            </div>);
-        }, {
-            type: "object",
-            properties: {
-                element: {
-                    $ref: "#/$defs/Message"
-                },
-                params: {
-                    type: "object",
-                    properties: {
-                        name: {
-                            type: "string",
-                            "default": "",
-                            asCell: ["readonly"]
-                        }
-                    },
-                    required: ["name"]
-                }
-            },
-            required: ["element", "params"],
-            $defs: {
-                Message: {
-                    type: "object",
-                    properties: {
-                        author: {
-                            type: "string"
-                        },
-                        body: {
-                            type: "string"
-                        }
-                    },
-                    required: ["author", "body"]
-                }
-            }
-        } as const satisfies __cfHelpers.JSONSchema, {
-            anyOf: [{
-                    $ref: "https://commonfabric.org/schemas/vnode.json"
-                }, {
-                    $ref: "#/$defs/UIRenderable"
-                }, {
-                    type: "object",
-                    properties: {}
-                }],
-            $defs: {
-                UIRenderable: {
-                    type: "object",
-                    properties: {
-                        $UI: {
-                            $ref: "https://commonfabric.org/schemas/vnode.json"
-                        }
-                    },
-                    required: ["$UI"]
-                }
-            }
-        } as const satisfies __cfHelpers.JSONSchema), {
+        {__cfLift_1({ selectedRoom: selectedRoom }).mapWithPattern(__cfPattern_1, {
             name: name
         })}
-      </div>)
+      </div>),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-expression-statement.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-expression-statement.expected.jsx
@@ -18,6 +18,17 @@ import { Default, pattern, UI, VNode, Writable, } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface FileEntry {
+    name: string;
+    type: "file" | "folder";
+}
+interface Input {
+    files: Writable<Default<FileEntry[], [
+    ]>>;
+}
+interface Output {
+    [UI]: VNode;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     file: {
         name: string;
@@ -43,71 +54,61 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     asCell: ["opaque"]
 } as const satisfies __cfHelpers.JSONSchema, ({ file }) => console.log("mapping", file.name, file.type));
-interface FileEntry {
-    name: string;
-    type: "file" | "folder";
-}
-interface Input {
-    files: Writable<Default<FileEntry[], [
-    ]>>;
-}
-interface Output {
-    [UI]: VNode;
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const file = __cf_pattern_input.key("element");
+    __cfLift_1({ file: {
+            name: file.key("name"),
+            type: file.key("type")
+        } });
+    return <span>{file.key("name")}</span>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/FileEntry"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        FileEntry: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                type: {
+                    "enum": ["file", "folder"]
+                }
+            },
+            required: ["name", "type"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
-        {files.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const file = __cf_pattern_input.key("element");
-                __cfLift_1({ file: {
-                        name: file.key("name"),
-                        type: file.key("type")
-                    } });
-                return <span>{file.key("name")}</span>;
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/FileEntry"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    FileEntry: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            },
-                            type: {
-                                "enum": ["file", "folder"]
-                            }
-                        },
-                        required: ["name", "type"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+        {files.mapWithPattern(__cfPattern_1, {})}
       </div>),
     };
 }, {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-helper-call-over-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-helper-call-over-alias.expected.jsx
@@ -17,6 +17,18 @@ import { Default, pattern, UI, VNode, Writable, } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface FileEntry {
+    name: string;
+    type: "file" | "folder";
+}
+interface Input {
+    files: Writable<Default<FileEntry[], [
+    ]>>;
+}
+interface Output {
+    [UI]: VNode;
+}
+const describeKind = __cfHardenFn((kind: "file" | "folder"): string => kind === "folder" ? "dir" : "doc");
 const __cfLift_1 = __cfHelpers.lift<{
     kind: string;
 }, string>({
@@ -30,71 +42,60 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, ({ kind }) => describeKind(kind));
-interface FileEntry {
-    name: string;
-    type: "file" | "folder";
-}
-interface Input {
-    files: Writable<Default<FileEntry[], [
-    ]>>;
-}
-interface Output {
-    [UI]: VNode;
-}
-const describeKind = __cfHardenFn((kind: "file" | "folder"): string => kind === "folder" ? "dir" : "doc");
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const file = __cf_pattern_input.key("element");
+    const kind = file.key("type");
+    const label = __cfLift_1({ kind: kind }).for("label", true);
+    return <span>{label}</span>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/FileEntry"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        FileEntry: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                type: {
+                    "enum": ["file", "folder"]
+                }
+            },
+            required: ["name", "type"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
-        {files.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const file = __cf_pattern_input.key("element");
-                const kind = file.key("type");
-                const label = __cfLift_1({ kind: kind }).for("label", true);
-                return <span>{label}</span>;
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/FileEntry"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    FileEntry: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            },
-                            type: {
-                                "enum": ["file", "folder"]
-                            }
-                        },
-                        required: ["name", "type"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>)
+        {files.mapWithPattern(__cfPattern_1, {})}
+      </div>),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-local-consts.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-local-consts.expected.jsx
@@ -17,6 +17,18 @@ import { Default, pattern, UI, VNode, Writable, } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface FileEntry {
+    name: string;
+    type: "file" | "folder";
+    contentType: "text" | "binary";
+}
+interface Input {
+    files: Writable<Default<FileEntry[], [
+    ]>>;
+}
+interface Output {
+    [UI]: VNode;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     file: {
         type: string;
@@ -59,92 +71,81 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, ({ file }) => file.contentType !== "binary");
-interface FileEntry {
-    name: string;
-    type: "file" | "folder";
-    contentType: "text" | "binary";
-}
-interface Input {
-    files: Writable<Default<FileEntry[], [
-    ]>>;
-}
-interface Output {
-    [UI]: VNode;
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const file = __cf_pattern_input.key("element");
+    const isFolder = __cfLift_1({ file: {
+            type: file.key("type")
+        } }).for("isFolder", true);
+    const isOpenable = __cfHelpers.unless({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, isFolder, __cfLift_2({ file: {
+            contentType: file.key("contentType")
+        } }).for(["isOpenable", 4], true)).for("isOpenable", true);
+    return <span>{__cfHelpers.ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, isOpenable, file.key("name"), "locked")}</span>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/FileEntry"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        FileEntry: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                type: {
+                    "enum": ["file", "folder"]
+                },
+                contentType: {
+                    "enum": ["text", "binary"]
+                }
+            },
+            required: ["name", "type", "contentType"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
-        {files.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const file = __cf_pattern_input.key("element");
-                const isFolder = __cfLift_1({ file: {
-                        type: file.key("type")
-                    } }).for("isFolder", true);
-                const isOpenable = __cfHelpers.unless({
-                    type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, isFolder, __cfLift_2({ file: {
-                        contentType: file.key("contentType")
-                    } }).for(["isOpenable", 4], true)).for("isOpenable", true);
-                return <span>{__cfHelpers.ifElse({
-                    type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, isOpenable, file.key("name"), "locked")}</span>;
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/FileEntry"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    FileEntry: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            },
-                            type: {
-                                "enum": ["file", "folder"]
-                            },
-                            contentType: {
-                                "enum": ["text", "binary"]
-                            }
-                        },
-                        required: ["name", "type", "contentType"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>)
+        {files.mapWithPattern(__cfPattern_1, {})}
+      </div>),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-aggregate-alias-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-aggregate-alias-computation.expected.jsx
@@ -17,6 +17,17 @@ import { Default, pattern, UI, VNode, Writable, } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface FileEntry {
+    name: string;
+    type: "file" | "folder";
+}
+interface Input {
+    files: Writable<Default<FileEntry[], [
+    ]>>;
+}
+interface Output {
+    [UI]: VNode;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     meta: {
         kind: string;
@@ -38,80 +49,70 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, ({ meta }) => meta.kind === "folder");
-interface FileEntry {
-    name: string;
-    type: "file" | "folder";
-}
-interface Input {
-    files: Writable<Default<FileEntry[], [
-    ]>>;
-}
-interface Output {
-    [UI]: VNode;
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const file = __cf_pattern_input.key("element");
+    const meta = { kind: file.key("type") };
+    const isFolder = __cfLift_1({ meta: {
+            kind: meta.kind
+        } }).for("isFolder", true);
+    return <span>{__cfHelpers.ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, isFolder, file.key("name"), "locked")}</span>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/FileEntry"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        FileEntry: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                type: {
+                    "enum": ["file", "folder"]
+                }
+            },
+            required: ["name", "type"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
-        {files.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const file = __cf_pattern_input.key("element");
-                const meta = { kind: file.key("type") };
-                const isFolder = __cfLift_1({ meta: {
-                        kind: meta.kind
-                    } }).for("isFolder", true);
-                return <span>{__cfHelpers.ifElse({
-                    type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, isFolder, file.key("name"), "locked")}</span>;
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/FileEntry"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    FileEntry: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            },
-                            type: {
-                                "enum": ["file", "folder"]
-                            }
-                        },
-                        required: ["name", "type"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>)
+        {files.mapWithPattern(__cfPattern_1, {})}
+      </div>),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-aggregate-plain-sibling-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-aggregate-plain-sibling-computation.expected.jsx
@@ -28,58 +28,59 @@ interface Input {
 interface Output {
     [UI]: VNode;
 }
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const file = __cf_pattern_input.key("element");
+    const meta = { kind: file.key("type"), label: "plain" };
+    const shout = meta.label + "!";
+    return <span>{shout}</span>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/FileEntry"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        FileEntry: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                type: {
+                    "enum": ["file", "folder"]
+                }
+            },
+            required: ["name", "type"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
-        {files.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const file = __cf_pattern_input.key("element");
-                const meta = { kind: file.key("type"), label: "plain" };
-                const shout = meta.label + "!";
-                return <span>{shout}</span>;
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/FileEntry"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    FileEntry: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            },
-                            type: {
-                                "enum": ["file", "folder"]
-                            }
-                        },
-                        required: ["name", "type"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+        {files.mapWithPattern(__cfPattern_1, {})}
       </div>),
     };
 }, {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-destructured-alias-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-destructured-alias-computation.expected.jsx
@@ -17,6 +17,17 @@ import { Default, pattern, UI, VNode, Writable, } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface FileEntry {
+    name: string;
+    type: "file" | "folder";
+}
+interface Input {
+    files: Writable<Default<FileEntry[], [
+    ]>>;
+}
+interface Output {
+    [UI]: VNode;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     kind: string;
 }, boolean>({
@@ -30,78 +41,68 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, ({ kind }) => kind === "folder");
-interface FileEntry {
-    name: string;
-    type: "file" | "folder";
-}
-interface Input {
-    files: Writable<Default<FileEntry[], [
-    ]>>;
-}
-interface Output {
-    [UI]: VNode;
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const file = __cf_pattern_input.key("element");
+    const kind = file.key("type");
+    const isFolder = __cfLift_1({ kind: kind }).for("isFolder", true);
+    return <span>{__cfHelpers.ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, isFolder, file.key("name"), "locked")}</span>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/FileEntry"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        FileEntry: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                type: {
+                    "enum": ["file", "folder"]
+                }
+            },
+            required: ["name", "type"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
-        {files.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const file = __cf_pattern_input.key("element");
-                const kind = file.key("type");
-                const isFolder = __cfLift_1({ kind: kind }).for("isFolder", true);
-                return <span>{__cfHelpers.ifElse({
-                    type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, isFolder, file.key("name"), "locked")}</span>;
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/FileEntry"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    FileEntry: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            },
-                            type: {
-                                "enum": ["file", "folder"]
-                            }
-                        },
-                        required: ["name", "type"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>)
+        {files.mapWithPattern(__cfPattern_1, {})}
+      </div>),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-tuple-aggregate-alias-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-tuple-aggregate-alias-computation.expected.jsx
@@ -17,6 +17,17 @@ import { Default, pattern, UI, VNode, Writable, } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface FileEntry {
+    name: string;
+    type: "file" | "folder";
+}
+interface Input {
+    files: Writable<Default<FileEntry[], [
+    ]>>;
+}
+interface Output {
+    [UI]: VNode;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     info: readonly ["file" | "folder", string];
 }, boolean>({
@@ -33,78 +44,68 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, ({ info }) => info[0] === "folder");
-interface FileEntry {
-    name: string;
-    type: "file" | "folder";
-}
-interface Input {
-    files: Writable<Default<FileEntry[], [
-    ]>>;
-}
-interface Output {
-    [UI]: VNode;
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const file = __cf_pattern_input.key("element");
+    const info = [file.key("type"), file.key("name")] as const;
+    const isFolder = __cfLift_1({ info: info }).for("isFolder", true);
+    return <span>{__cfHelpers.ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, isFolder, info[1], "locked")}</span>;
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/FileEntry"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        FileEntry: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                type: {
+                    "enum": ["file", "folder"]
+                }
+            },
+            required: ["name", "type"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 export default pattern((__cf_pattern_input) => {
     const files = __cf_pattern_input.key("files");
     return {
         [UI]: (<div>
-        {files.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const file = __cf_pattern_input.key("element");
-                const info = [file.key("type"), file.key("name")] as const;
-                const isFolder = __cfLift_1({ info: info }).for("isFolder", true);
-                return <span>{__cfHelpers.ifElse({
-                    type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, isFolder, info[1], "locked")}</span>;
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/FileEntry"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    FileEntry: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            },
-                            type: {
-                                "enum": ["file", "folder"]
-                            }
-                        },
-                        required: ["name", "type"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
-      </div>)
+        {files.mapWithPattern(__cfPattern_1, {})}
+      </div>),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-nested-conditional-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-nested-conditional-no-name.expected.jsx
@@ -11,6 +11,60 @@ import { cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return (<div>
+                {__cfHelpers.when({
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{}, {
+                type: "object",
+                properties: {}
+            }]
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{
+                type: "string"
+            }, {}, {
+                type: "object",
+                properties: {}
+            }]
+    } as const satisfies __cfHelpers.JSONSchema, item.key("name"), <span>{item.key("name")}</span>)}
+              </div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-nested-conditional-no-name
 // Verifies: same nested conditional map transforms work when pattern param is typed as any
 //   showList && <div>{items.map(...)}</div> → when(showList, <div>{items.mapWithPattern(...)}</div>)
@@ -47,60 +101,7 @@ export default pattern((_state: any) => {
                     properties: {}
                 }]
         } as const satisfies __cfHelpers.JSONSchema, showList, <div>
-            {items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                return (<div>
-                {__cfHelpers.when({
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{}, {
-                            type: "object",
-                            properties: {}
-                        }]
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{
-                            type: "string"
-                        }, {}, {
-                            type: "object",
-                            properties: {}
-                        }]
-                } as const satisfies __cfHelpers.JSONSchema, item.key("name"), <span>{item.key("name")}</span>)}
-              </div>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            }
-                        },
-                        required: ["name"]
-                    }
-                },
-                required: ["element"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+            {items.mapWithPattern(__cfPattern_1, {})}
           </div>)}
       </div>),
     };

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-nested-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-nested-conditional.expected.jsx
@@ -11,6 +11,60 @@ import { cell, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return (<div>
+                {__cfHelpers.when({
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{}, {
+                type: "object",
+                properties: {}
+            }]
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{
+                type: "string"
+            }, {}, {
+                type: "object",
+                properties: {}
+            }]
+    } as const satisfies __cfHelpers.JSONSchema, item.key("name"), <span>{item.key("name")}</span>)}
+              </div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-nested-conditional
 // Verifies: when() guard around mapWithPattern() with nested when() inside the map body
 //   showList && <div>{items.map(item => <div>{item.name && <span>}</div>)}</div>
@@ -47,60 +101,7 @@ export default pattern((_state) => {
                     properties: {}
                 }]
         } as const satisfies __cfHelpers.JSONSchema, showList, <div>
-            {items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                return (<div>
-                {__cfHelpers.when({
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{}, {
-                            type: "object",
-                            properties: {}
-                        }]
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{
-                            type: "string"
-                        }, {}, {
-                            type: "object",
-                            properties: {}
-                        }]
-                } as const satisfies __cfHelpers.JSONSchema, item.key("name"), <span>{item.key("name")}</span>)}
-              </div>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            }
-                        },
-                        required: ["name"]
-                    }
-                },
-                required: ["element"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+            {items.mapWithPattern(__cfPattern_1, {})}
           </div>)}
       </div>),
     };

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-single-capture-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-single-capture-no-name.expected.jsx
@@ -28,6 +28,48 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, ({ people }) => people.get().length > 0);
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const person = __cf_pattern_input.key("element");
+    const index = __cf_pattern_input.key("index");
+    return (<li key={index}>{person.key("name")}</li>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        },
+        index: {
+            type: "number"
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-single-capture-no-name
 // Verifies: same map + length guard transforms work with _state: any parameter
 //   people.get().length > 0 && <ul>{people.map(...)}</ul> → when(..., <ul>{mapWithPattern(...)}</ul>)
@@ -68,48 +110,7 @@ export default pattern((_state: any) => {
                     properties: {}
                 }]
         } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ people: people }), <ul>
-            {people.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const person = __cf_pattern_input.key("element");
-                const index = __cf_pattern_input.key("index");
-                return (<li key={index}>{person.key("name")}</li>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            }
-                        },
-                        required: ["name"]
-                    },
-                    index: {
-                        type: "number"
-                    }
-                },
-                required: ["element"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+            {people.mapWithPattern(__cfPattern_1, {})}
           </ul>)}
       </div>),
     };

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-single-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-single-capture.expected.jsx
@@ -28,6 +28,48 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, ({ people }) => people.get().length > 0);
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const person = __cf_pattern_input.key("element");
+    const index = __cf_pattern_input.key("index");
+    return (<li key={index}>{person.key("name")}</li>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        },
+        index: {
+            type: "number"
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-single-capture
 // Verifies: .map() with length guard is transformed to when() + mapWithPattern()
 //   people.get().length > 0 && <ul>{people.map((person, index) => <li>)}</ul>
@@ -68,48 +110,7 @@ export default pattern((_state) => {
                     properties: {}
                 }]
         } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ people: people }), <ul>
-            {people.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const person = __cf_pattern_input.key("element");
-                const index = __cf_pattern_input.key("index");
-                return (<li key={index}>{person.key("name")}</li>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            }
-                        },
-                        required: ["name"]
-                    },
-                    index: {
-                        type: "number"
-                    }
-                },
-                required: ["element"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+            {people.mapWithPattern(__cfPattern_1, {})}
           </ul>)}
       </div>),
     };

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/method-chains.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/method-chains.expected.jsx
@@ -11,6 +11,28 @@ import { computed, pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    text: string;
+    searchTerm: string;
+    items: number[];
+    start: number;
+    end: number;
+    threshold: number;
+    factor: number;
+    names: string[];
+    prefix: string;
+    prices: number[];
+    discount: number;
+    taxRate: number;
+    users: Array<{
+        name: string;
+        age: number;
+        active: boolean;
+    }>;
+    minAge: number;
+    words: string[];
+    separator: string;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         text: string;
@@ -106,6 +128,36 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items.filter((x) => x > state.threshold).length);
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const x = __cf_pattern_input.key("element");
+    const state = __cf_pattern_input.key("params", "state");
+    return x > state.key("threshold");
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "number"
+        },
+        params: {
+            type: "object",
+            properties: {
+                state: {
+                    type: "object",
+                    properties: {
+                        threshold: {
+                            type: "number"
+                        }
+                    },
+                    required: ["threshold"]
+                }
+            },
+            required: ["state"]
+        }
+    },
+    required: ["element", "params"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_5 = __cfHelpers.lift<{
     x: number;
     state: {
@@ -131,6 +183,59 @@ const __cfLift_5 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ x, state }) => x * state.factor);
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const x = __cf_pattern_input.key("element");
+    const state = __cf_pattern_input.key("params", "state");
+    return (<li>Value: {__cfLift_5({
+        x: x,
+        state: {
+            factor: state.key("factor")
+        }
+    })}</li>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "number"
+        },
+        params: {
+            type: "object",
+            properties: {
+                state: {
+                    type: "object",
+                    properties: {
+                        factor: {
+                            type: "number"
+                        }
+                    },
+                    required: ["factor"]
+                }
+            },
+            required: ["state"]
+        }
+    },
+    required: ["element", "params"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_6 = __cfHelpers.lift<{
     state: {
         items: number[];
@@ -264,6 +369,38 @@ const __cfLift_10 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, ({ name }) => name.trim().toLowerCase().replace(" ", "-"));
+const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
+    const name = __cf_pattern_input.key("element");
+    return (<li>{__cfLift_10({ name: name })}</li>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "string"
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_11 = __cfHelpers.lift<{
     state: {
         prices: number[];
@@ -479,6 +616,62 @@ const __cfLift_18 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, ({ u }) => u.name.toLowerCase());
+const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
+    const u = __cf_pattern_input.key("element");
+    return (<li>{__cfHelpers.ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, u.key("active"), __cfLift_17({ u: {
+            name: u.key("name")
+        } }), __cfLift_18({ u: {
+            name: u.key("name")
+        } }))}</li>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                },
+                age: {
+                    type: "number"
+                },
+                active: {
+                    type: "boolean"
+                }
+            },
+            required: ["name", "age", "active"]
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_19 = __cfHelpers.lift<{
     state: {
         users: { name: string; age: number; active: boolean; }[];
@@ -621,28 +814,6 @@ const __cfLift_23 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.words.join(state.separator).toUpperCase());
-interface State {
-    text: string;
-    searchTerm: string;
-    items: number[];
-    start: number;
-    end: number;
-    threshold: number;
-    factor: number;
-    names: string[];
-    prefix: string;
-    prices: number[];
-    discount: number;
-    taxRate: number;
-    users: Array<{
-        name: string;
-        age: number;
-        active: boolean;
-    }>;
-    minAge: number;
-    words: string[];
-    separator: string;
-}
 // FIXTURE: method-chains
 // Verifies: chained method calls and array method chains in JSX are wrapped in a lift-applied computation
 //   state.text.trim().toLowerCase()          → lift(...)({ text })
@@ -687,92 +858,11 @@ export default pattern((state) => {
 
         {/* Filter then map */}
         <ul>
-          {state.key("items").filterWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const x = __cf_pattern_input.key("element");
-                const state = __cf_pattern_input.key("params", "state");
-                return x > state.key("threshold");
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "number"
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            state: {
-                                type: "object",
-                                properties: {
-                                    threshold: {
-                                        type: "number"
-                                    }
-                                },
-                                required: ["threshold"]
-                            }
-                        },
-                        required: ["state"]
-                    }
-                },
-                required: ["element", "params"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                type: "boolean"
-            } as const satisfies __cfHelpers.JSONSchema), {
+          {state.key("items").filterWithPattern(__cfPattern_1, {
                 state: {
                     threshold: state.key("threshold")
                 }
-            }).mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const x = __cf_pattern_input.key("element");
-                const state = __cf_pattern_input.key("params", "state");
-                return (<li>Value: {__cfLift_5({
-                    x: x,
-                    state: {
-                        factor: state.key("factor")
-                    }
-                })}</li>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "number"
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            state: {
-                                type: "object",
-                                properties: {
-                                    factor: {
-                                        type: "number"
-                                    }
-                                },
-                                required: ["factor"]
-                            }
-                        },
-                        required: ["state"]
-                    }
-                },
-                required: ["element", "params"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+            }).mapWithPattern(__cfPattern_2, {
                 state: {
                     factor: state.key("factor")
                 }
@@ -819,38 +909,7 @@ export default pattern((state) => {
         <h3>Complex Method Combinations</h3>
         {/* Map with chained operations inside */}
         <ul>
-          {state.key("names").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const name = __cf_pattern_input.key("element");
-                return (<li>{__cfLift_10({ name: name })}</li>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "string"
-                    }
-                },
-                required: ["element"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+          {state.key("names").mapWithPattern(__cfPattern_3, {})}
         </ul>
 
         {/* Reduce with reactive accumulator */}
@@ -909,62 +968,7 @@ export default pattern((state) => {
 
         {/* Map with conditional logic */}
         <ul>
-          {state.key("users").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const u = __cf_pattern_input.key("element");
-                return (<li>{__cfHelpers.ifElse({
-                    type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, u.key("active"), __cfLift_17({ u: {
-                        name: u.key("name")
-                    } }), __cfLift_18({ u: {
-                        name: u.key("name")
-                    } }))}</li>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            },
-                            age: {
-                                type: "number"
-                            },
-                            active: {
-                                type: "boolean"
-                            }
-                        },
-                        required: ["name", "age", "active"]
-                    }
-                },
-                required: ["element"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+          {state.key("users").mapWithPattern(__cfPattern_4, {})}
         </ul>
 
         {/* Some/every with reactive predicates */}

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-cell-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-cell-map.expected.jsx
@@ -11,31 +11,6 @@ import { Cell, cell, handler, ifElse, lift, NAME, navigateTo, pattern, UI, } fro
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
-    cellRef: unknown[];
-}, boolean>({
-    type: "object",
-    properties: {
-        cellRef: {
-            type: "array",
-            items: {
-                type: "unknown"
-            }
-        }
-    },
-    required: ["cellRef"]
-} as const satisfies __cfHelpers.JSONSchema, {
-    type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ cellRef }) => !cellRef?.length);
-const __cfLift_2 = __cfHelpers.lift<{
-    charm: any;
-}, any>({
-    type: "object",
-    properties: {
-        charm: true
-    },
-    required: ["charm"]
-} as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema, ({ charm }) => charm[__cfHelpers.NAME]);
 // the simple charm (to which we'll store references within a cell)
 const SimplePattern = pattern(() => ({
     [NAME]: "Some Simple Pattern",
@@ -166,6 +141,72 @@ const goToCharm = handler({
     console.log("goToCharm clicked");
     return navigateTo(charm);
 });
+const __cfLift_1 = __cfHelpers.lift<{
+    cellRef: unknown[];
+}, boolean>({
+    type: "object",
+    properties: {
+        cellRef: {
+            type: "array",
+            items: {
+                type: "unknown"
+            }
+        }
+    },
+    required: ["cellRef"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "boolean"
+} as const satisfies __cfHelpers.JSONSchema, ({ cellRef }) => !cellRef?.length);
+const __cfLift_2 = __cfHelpers.lift<{
+    charm: any;
+}, any>({
+    type: "object",
+    properties: {
+        charm: true
+    },
+    required: ["charm"]
+} as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema, ({ charm }) => charm[__cfHelpers.NAME]);
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const charm = __cf_pattern_input.key("element");
+    const index = __cf_pattern_input.key("index");
+    return (<li>
+                <cf-button onClick={goToCharm({ charm })}>
+                  Go to Charm {index + 1}
+                </cf-button>
+                <span>Charm {index + 1}: {__cfHelpers.unless(true as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema, __cfLift_2({ charm: charm }), "Unnamed")}</span>
+              </li>);
+}, {
+    type: "object",
+    properties: {
+        element: true,
+        index: {
+            type: "number"
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: opaque-ref-cell-map
 // Verifies: a reactive factory result still rewrites JSX ifElse predicates after
 //           the forbidden OpaqueRef cast is removed
@@ -201,47 +242,7 @@ export default pattern(() => {
                     properties: {}
                 }]
         } as const satisfies __cfHelpers.JSONSchema, {} as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ cellRef: cellRef }), <div>No charms created yet</div>, <ul>
-            {cellRef.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const charm = __cf_pattern_input.key("element");
-                const index = __cf_pattern_input.key("index");
-                return (<li>
-                <cf-button onClick={goToCharm({ charm })}>
-                  Go to Charm {index + 1}
-                </cf-button>
-                <span>Charm {index + 1}: {__cfHelpers.unless(true as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema, __cfLift_2({ charm: charm }), "Unnamed")}</span>
-              </li>);
-            }, {
-                type: "object",
-                properties: {
-                    element: true,
-                    index: {
-                        type: "number"
-                    }
-                },
-                required: ["element"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+            {cellRef.mapWithPattern(__cfPattern_1, {})}
           </ul>)}
 
         <cf-button onClick={createSimplePattern({ cellRef })}>

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/optional-chain-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/optional-chain-captures.expected.jsx
@@ -11,6 +11,17 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Item {
+    maybe?: {
+        value: number;
+    };
+}
+interface State {
+    maybe?: {
+        value: number;
+    };
+    items: Item[];
+}
 const __cfLift_1 = __cfHelpers.lift<{
     item: {
         maybe?: { value: number; } | undefined;
@@ -37,17 +48,56 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ item }) => item.maybe?.value ?? 0);
-interface Item {
-    maybe?: {
-        value: number;
-    };
-}
-interface State {
-    maybe?: {
-        value: number;
-    };
-    items: Item[];
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return (<span>{__cfLift_1({ item: {
+            maybe: item.key("maybe")
+        } })}</span>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                maybe: {
+                    type: "object",
+                    properties: {
+                        value: {
+                            type: "number"
+                        }
+                    },
+                    required: ["value"]
+                }
+            }
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: optional-chain-captures
 // Verifies: optional chaining (?.) in JSX is resolved to .key() or wrapped in a lift-applied computation
 //   state.maybe?.value         → state.key("maybe", "value")
@@ -57,56 +107,7 @@ export default pattern((state) => {
     return {
         [UI]: (<div>
         <span>{state.key("maybe", "value")}</span>
-        {state.key("items").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                return (<span>{__cfLift_1({ item: {
-                        maybe: item.key("maybe")
-                    } })}</span>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Item"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            maybe: {
-                                type: "object",
-                                properties: {
-                                    value: {
-                                        type: "number"
-                                    }
-                                },
-                                required: ["value"]
-                            }
-                        }
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+        {state.key("items").mapWithPattern(__cfPattern_1, {})}
       </div>),
     };
 }, {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/parent-suppression-edge.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/parent-suppression-edge.expected.jsx
@@ -11,6 +11,81 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    user: {
+        name: string;
+        age: number;
+        email: string;
+        profile: {
+            bio: string;
+            location: string;
+            website: string;
+        };
+        settings: {
+            theme: string;
+            notifications: boolean;
+            privacy: string;
+        };
+    };
+    config: {
+        theme: {
+            colors: {
+                primary: string;
+                secondary: string;
+                background: string;
+            };
+            fonts: {
+                heading: string;
+                body: string;
+                mono: string;
+            };
+            spacing: {
+                small: number;
+                medium: number;
+                large: number;
+            };
+        };
+        features: {
+            darkMode: boolean;
+            animations: boolean;
+            betaFeatures: boolean;
+        };
+    };
+    data: {
+        items: Array<{
+            id: number;
+            name: string;
+            value: number;
+        }>;
+        totals: {
+            count: number;
+            sum: number;
+            average: number;
+        };
+    };
+    deeply: {
+        nested: {
+            structure: {
+                with: {
+                    many: {
+                        levels: {
+                            value: string;
+                            count: number;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    arrays: {
+        first: string[];
+        second: number[];
+        nested: Array<{
+            items: string[];
+            count: number;
+        }>;
+    };
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         user: {
@@ -299,81 +374,6 @@ const __cfLift_8 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.user.email.toLowerCase());
-interface State {
-    user: {
-        name: string;
-        age: number;
-        email: string;
-        profile: {
-            bio: string;
-            location: string;
-            website: string;
-        };
-        settings: {
-            theme: string;
-            notifications: boolean;
-            privacy: string;
-        };
-    };
-    config: {
-        theme: {
-            colors: {
-                primary: string;
-                secondary: string;
-                background: string;
-            };
-            fonts: {
-                heading: string;
-                body: string;
-                mono: string;
-            };
-            spacing: {
-                small: number;
-                medium: number;
-                large: number;
-            };
-        };
-        features: {
-            darkMode: boolean;
-            animations: boolean;
-            betaFeatures: boolean;
-        };
-    };
-    data: {
-        items: Array<{
-            id: number;
-            name: string;
-            value: number;
-        }>;
-        totals: {
-            count: number;
-            sum: number;
-            average: number;
-        };
-    };
-    deeply: {
-        nested: {
-            structure: {
-                with: {
-                    many: {
-                        levels: {
-                            value: string;
-                            count: number;
-                        };
-                    };
-                };
-            };
-        };
-    };
-    arrays: {
-        first: string[];
-        second: number[];
-        nested: Array<{
-            items: string[];
-            count: number;
-        }>;
-    };
-}
 // FIXTURE: parent-suppression-edge
 // Verifies: property access suppression -- sibling properties share a captured parent in a lift-applied computation
 //   {state.user.name} ... {state.user.age} → individual .key() or shared lift(...)({ user: {...} })

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-statements-vs-jsx.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-statements-vs-jsx.expected.jsx
@@ -11,6 +11,37 @@ import { Cell, handler, NAME, pattern, str, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface PatternState {
+    value: number;
+}
+const increment = handler(false as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        value: {
+            type: "number",
+            asCell: ["cell"]
+        }
+    },
+    required: ["value"]
+} as const satisfies __cfHelpers.JSONSchema, (_e, state: {
+    value: Cell<number>;
+}) => {
+    state.value.set(state.value.get() + 1);
+});
+const decrement = handler(false as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        value: {
+            type: "number",
+            asCell: ["cell"]
+        }
+    },
+    required: ["value"]
+} as const satisfies __cfHelpers.JSONSchema, (_e, state: {
+    value: Cell<number>;
+}) => {
+    state.value.set(state.value.get() - 1);
+});
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         value: number;
@@ -95,37 +126,6 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.value > 10);
-interface PatternState {
-    value: number;
-}
-const increment = handler(false as const satisfies __cfHelpers.JSONSchema, {
-    type: "object",
-    properties: {
-        value: {
-            type: "number",
-            asCell: ["cell"]
-        }
-    },
-    required: ["value"]
-} as const satisfies __cfHelpers.JSONSchema, (_e, state: {
-    value: Cell<number>;
-}) => {
-    state.value.set(state.value.get() + 1);
-});
-const decrement = handler(false as const satisfies __cfHelpers.JSONSchema, {
-    type: "object",
-    properties: {
-        value: {
-            type: "number",
-            asCell: ["cell"]
-        }
-    },
-    required: ["value"]
-} as const satisfies __cfHelpers.JSONSchema, (_e, state: {
-    value: Cell<number>;
-}) => {
-    state.value.set(state.value.get() - 1);
-});
 // FIXTURE: pattern-statements-vs-jsx
 // Verifies: only JSX-context expressions are transformed; statement-context expressions are left alone
 //   const next = state.value + 1    → NOT transformed (statement context)

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-vs-computed-logical-and.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-vs-computed-logical-and.expected.jsx
@@ -11,24 +11,6 @@ import { computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
-    bar: string;
-}, string | false>({
-    type: "object",
-    properties: {
-        bar: {
-            type: "string"
-        }
-    },
-    required: ["bar"]
-} as const satisfies __cfHelpers.JSONSchema, {
-    anyOf: [{
-            type: "string"
-        }, {
-            type: "boolean",
-            "enum": [false]
-        }]
-} as const satisfies __cfHelpers.JSONSchema, ({ foo, bar }) => foo && bar);
 // FIXTURE: pattern-vs-computed-logical-and
 // Verifies: top-level pattern JSX logical roots lower structurally, but computed-owned logical roots stay authored
 //   <div>{foo && name}</div> in a pattern body → __cfHelpers.when(...)
@@ -81,6 +63,24 @@ export const PatternLogicalAnd = pattern((__cf_pattern_input) => {
         }
     }
 } as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_1 = __cfHelpers.lift<{
+    bar: string;
+}, string | false>({
+    type: "object",
+    properties: {
+        bar: {
+            type: "string"
+        }
+    },
+    required: ["bar"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            type: "string"
+        }, {
+            type: "boolean",
+            "enum": [false]
+        }]
+} as const satisfies __cfHelpers.JSONSchema, ({ foo, bar }) => foo && bar);
 export const ComputedLogicalAnd = pattern((__cf_pattern_input) => {
     const foo = __cf_pattern_input.key("foo");
     const bar = __cf_pattern_input.key("bar");

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/safe-context-and-jsx.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/safe-context-and-jsx.expected.jsx
@@ -25,27 +25,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, ({ show }) => show);
-const __cfLift_2 = __cfHelpers.lift<{
-    value: string | null;
-}, string | null>({
-    type: "object",
-    properties: {
-        value: {
-            anyOf: [{
-                    type: "string"
-                }, {
-                    type: "null"
-                }]
-        }
-    },
-    required: ["value"]
-} as const satisfies __cfHelpers.JSONSchema, {
-    anyOf: [{
-            type: "string"
-        }, {
-            type: "null"
-        }]
-} as const satisfies __cfHelpers.JSONSchema, ({ value }) => value);
 // FIXTURE: safe-context-and-jsx
 // Verifies: && and || with JSX inside handler callbacks are transformed to when()/unless()
 //   computed(() => show) && <span> → when(computed(() => show), <span>)
@@ -141,6 +120,27 @@ const MyHandler = handler({
 } as const satisfies __cfHelpers.JSONSchema, (_event, { show }) => {
     return <div>{__cfLift_1({ show: show }) && <span>Content</span>}</div>;
 });
+const __cfLift_2 = __cfHelpers.lift<{
+    value: string | null;
+}, string | null>({
+    type: "object",
+    properties: {
+        value: {
+            anyOf: [{
+                    type: "string"
+                }, {
+                    type: "null"
+                }]
+        }
+    },
+    required: ["value"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            type: "string"
+        }, {
+            type: "null"
+        }]
+} as const satisfies __cfHelpers.JSONSchema, ({ value }) => value);
 // Test: || with JSX inside handler callback should transform to unless()
 const MyHandler2 = handler({
     type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-branch-ownership.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-branch-ownership.expected.jsx
@@ -11,6 +11,22 @@ import { computed, pattern, UI, Writable } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface TagEvent {
+    label: string;
+}
+interface Item {
+    name: string;
+    value: number;
+}
+type State = {
+    user: {
+        settings: {
+            notifications: boolean;
+        };
+    };
+    recentEvents: TagEvent[];
+    items: Item[];
+};
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         items: Item[];
@@ -106,22 +122,55 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.recentEvents.length === 0);
-interface TagEvent {
-    label: string;
-}
-interface Item {
-    name: string;
-    value: number;
-}
-type State = {
-    user: {
-        settings: {
-            notifications: boolean;
-        };
-    };
-    recentEvents: TagEvent[];
-    items: Item[];
-};
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const event = __cf_pattern_input.key("element");
+    const idx = __cf_pattern_input.key("index");
+    return (<cf-hstack key={idx} gap="2">
+                  <span>{event.key("label")}</span>
+                </cf-hstack>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/TagEvent"
+        },
+        index: {
+            type: "number"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        TagEvent: {
+            type: "object",
+            properties: {
+                label: {
+                    type: "string"
+                }
+            },
+            required: ["label"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: ternary-branch-ownership
 // Verifies: ternary branches preserve the right ownership mode for lowered work
 //   state.user.settings.notifications ? "enabled" : "disabled"
@@ -171,55 +220,7 @@ export default pattern((state) => {
                     properties: {}
                 }]
         } as const satisfies __cfHelpers.JSONSchema, __cfLift_3({ state: state }), <span>No events yet</span>, <div>
-              {state.key("recentEvents").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const event = __cf_pattern_input.key("element");
-                const idx = __cf_pattern_input.key("index");
-                return (<cf-hstack key={idx} gap="2">
-                  <span>{event.key("label")}</span>
-                </cf-hstack>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/TagEvent"
-                    },
-                    index: {
-                        type: "number"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    TagEvent: {
-                        type: "object",
-                        properties: {
-                            label: {
-                                type: "string"
-                            }
-                        },
-                        required: ["label"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+              {state.key("recentEvents").mapWithPattern(__cfPattern_1, {})}
             </div>)}
         {__cfHelpers.ifElse({
             type: "boolean",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-hoisted-compute-plain-map-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-hoisted-compute-plain-map-branch.expected.jsx
@@ -11,6 +11,10 @@ import { computed, pattern, UI, Writable } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Item {
+    name: string;
+    value: number;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         items: Item[];
@@ -95,10 +99,6 @@ const __cfLift_2 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items.length);
-interface Item {
-    name: string;
-    value: number;
-}
 // FIXTURE: ternary-hoisted-compute-plain-map-branch
 // Verifies: once a ternary JSX branch is wholly compute-wrapped, compute-owned
 // array maps inside that branch stay plain Array.map() calls.

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-pure-jsx-map-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-pure-jsx-map-branch.expected.jsx
@@ -11,6 +11,9 @@ import { pattern, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface TagEvent {
+    label: string;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     recentEvents: TagEvent[];
 }, boolean>({
@@ -27,9 +30,55 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, ({ recentEvents }) => recentEvents.length === 0);
-interface TagEvent {
-    label: string;
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const event = __cf_pattern_input.key("element");
+    const idx = __cf_pattern_input.key("index");
+    return (<cf-hstack key={idx} gap="2">
+                <span>{event.key("label")}</span>
+              </cf-hstack>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/TagEvent"
+        },
+        index: {
+            type: "number"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        TagEvent: {
+            type: "object",
+            properties: {
+                label: {
+                    type: "string"
+                }
+            },
+            required: ["label"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: ternary-pure-jsx-map-branch
 // Verifies: a plain reactive array map inside a ternary JSX branch stays
 // pattern-lowered without wrapping the whole branch in extra lift-applied noise.
@@ -59,55 +108,7 @@ export default pattern((__cf_pattern_input) => {
                     properties: {}
                 }]
         } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({ recentEvents: recentEvents }), <span>No events yet</span>, <div>
-            {recentEvents.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const event = __cf_pattern_input.key("element");
-                const idx = __cf_pattern_input.key("index");
-                return (<cf-hstack key={idx} gap="2">
-                <span>{event.key("label")}</span>
-              </cf-hstack>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/TagEvent"
-                    },
-                    index: {
-                        type: "number"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    TagEvent: {
-                        type: "object",
-                        properties: {
-                            label: {
-                                type: "string"
-                            }
-                        },
-                        required: ["label"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+            {recentEvents.mapWithPattern(__cfPattern_1, {})}
           </div>)}
     </div>),
     });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/wrapped-element-binding-reads.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/wrapped-element-binding-reads.expected.jsx
@@ -24,6 +24,16 @@ import { pattern, UI, type VNode } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+type Entry = {
+    name: string;
+};
+interface Input {
+    entries: Entry[];
+    prefix: string;
+}
+interface Output {
+    [UI]: VNode;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     entry: {
         name: string;
@@ -99,98 +109,89 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, ({ entry, prefix }) => (entry as Entry).name === prefix);
-type Entry = {
-    name: string;
-};
-interface Input {
-    entries: Entry[];
-    prefix: string;
-}
-interface Output {
-    [UI]: VNode;
-}
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const entry = __cf_pattern_input.key("element");
+    const prefix = __cf_pattern_input.key("params", "prefix");
+    // Parenthesized: (entry).name
+    const a = __cfLift_1({
+        entry: {
+            name: entry.key("name")
+        },
+        prefix: prefix
+    }).for("a", true);
+    // Non-null asserted: entry!.name
+    const b = __cfLift_2({
+        entry: {
+            name: entry.key("name")
+        },
+        prefix: prefix
+    }).for("b", true);
+    // 'as' asserted: (entry as Entry).name
+    const c = __cfLift_3({
+        entry: {
+            name: entry.key("name")
+        },
+        prefix: prefix
+    }).for("c", true);
+    return (<span data-a={a} data-b={b} data-c={c}>{entry.key("name")}</span>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Entry"
+        },
+        params: {
+            type: "object",
+            properties: {
+                prefix: {
+                    type: "string"
+                }
+            },
+            required: ["prefix"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Entry: {
+            type: "object",
+            properties: {
+                name: {
+                    type: "string"
+                }
+            },
+            required: ["name"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 export default pattern((__cf_pattern_input) => {
     const entries = __cf_pattern_input.key("entries");
     const prefix = __cf_pattern_input.key("prefix");
     return ({
         [UI]: (<div>
-      {entries.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const entry = __cf_pattern_input.key("element");
-                const prefix = __cf_pattern_input.key("params", "prefix");
-                // Parenthesized: (entry).name
-                const a = __cfLift_1({
-                    entry: {
-                        name: entry.key("name")
-                    },
-                    prefix: prefix
-                }).for("a", true);
-                // Non-null asserted: entry!.name
-                const b = __cfLift_2({
-                    entry: {
-                        name: entry.key("name")
-                    },
-                    prefix: prefix
-                }).for("b", true);
-                // 'as' asserted: (entry as Entry).name
-                const c = __cfLift_3({
-                    entry: {
-                        name: entry.key("name")
-                    },
-                    prefix: prefix
-                }).for("c", true);
-                return (<span data-a={a} data-b={b} data-c={c}>{entry.key("name")}</span>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Entry"
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            prefix: {
-                                type: "string"
-                            }
-                        },
-                        required: ["prefix"]
-                    }
-                },
-                required: ["element", "params"],
-                $defs: {
-                    Entry: {
-                        type: "object",
-                        properties: {
-                            name: {
-                                type: "string"
-                            }
-                        },
-                        required: ["name"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+      {entries.mapWithPattern(__cfPattern_1, {
                 prefix: prefix
             })}
-    </div>)
+    </div>),
     });
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/kitchensink/branch-lowered-capture-preservation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/branch-lowered-capture-preservation.expected.jsx
@@ -11,6 +11,92 @@ import { computed, handler, ifElse, pattern, UI, Writable } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+const openNoteEditor = handler({
+    type: "unknown"
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        subPieces: {
+            type: "array",
+            items: {
+                type: "string"
+            }
+        },
+        editingNoteIndex: {
+            type: ["number", "undefined"]
+        },
+        editingNoteText: {
+            type: "string"
+        },
+        index: {
+            type: "number"
+        }
+    },
+    required: ["subPieces", "editingNoteIndex", "editingNoteText", "index"]
+} as const satisfies __cfHelpers.JSONSchema, (_event, state) => state);
+const openSettings = handler({
+    type: "unknown"
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        settingsModuleIndex: {
+            type: ["number", "undefined"]
+        },
+        index: {
+            type: "number"
+        }
+    },
+    required: ["settingsModuleIndex", "index"]
+} as const satisfies __cfHelpers.JSONSchema, (_event, state) => state);
+const toggleExpanded = handler({
+    type: "unknown"
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        expandedIndex: {
+            type: ["number", "undefined"]
+        },
+        index: {
+            type: "number"
+        }
+    },
+    required: ["expandedIndex", "index"]
+} as const satisfies __cfHelpers.JSONSchema, (_event, state) => state);
+const trashSubPiece = handler({
+    type: "unknown"
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        subPieces: {
+            type: "array",
+            items: {
+                type: "string"
+            }
+        },
+        trashedSubPieces: {
+            type: "array",
+            items: {
+                type: "string"
+            }
+        },
+        expandedIndex: {
+            type: ["number", "undefined"]
+        },
+        settingsModuleIndex: {
+            type: ["number", "undefined"]
+        },
+        index: {
+            type: "number"
+        }
+    },
+    required: ["subPieces", "trashedSubPieces", "expandedIndex", "settingsModuleIndex", "index"]
+} as const satisfies __cfHelpers.JSONSchema, (_event, state) => state);
+interface Item {
+    note?: string;
+    collapsed?: boolean;
+    pinned?: boolean;
+    allowMultiple: boolean;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     items: Item[];
 }, { entry: Item; index: number; isExpanded: boolean; isPinned: boolean; allowMultiple: boolean; }[]>({
@@ -192,92 +278,228 @@ const __cfLift_6 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, ({ isExpanded }) => !isExpanded);
-const openNoteEditor = handler({
-    type: "unknown"
-} as const satisfies __cfHelpers.JSONSchema, {
-    type: "object",
-    properties: {
-        subPieces: {
-            type: "array",
-            items: {
-                type: "string"
-            }
-        },
-        editingNoteIndex: {
-            type: ["number", "undefined"]
-        },
-        editingNoteText: {
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const entry = __cf_pattern_input.key("element", "entry");
+    const index = __cf_pattern_input.key("element", "index");
+    const isExpanded = __cf_pattern_input.key("element", "isExpanded");
+    const isPinned = __cf_pattern_input.key("element", "isPinned");
+    const allowMultiple = __cf_pattern_input.key("element", "allowMultiple");
+    const subPieces = __cf_pattern_input.key("params", "subPieces");
+    const editingNoteIndex = __cf_pattern_input.key("params", "editingNoteIndex");
+    const editingNoteText = __cf_pattern_input.key("params", "editingNoteText");
+    const settingsModuleIndex = __cf_pattern_input.key("params", "settingsModuleIndex");
+    const expandedIndex = __cf_pattern_input.key("params", "expandedIndex");
+    const trashedSubPieces = __cf_pattern_input.key("params", "trashedSubPieces");
+    return ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{}, {
+                type: "object",
+                properties: {}
+            }]
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "null"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{
+                type: "null"
+            }, {}]
+    } as const satisfies __cfHelpers.JSONSchema, __cfLift_2({ entry: {
+            collapsed: entry.key("collapsed")
+        } }), <div>
+              {ifElse({
+            type: "boolean"
+        } as const satisfies __cfHelpers.JSONSchema, {
+            anyOf: [{}, {
+                    type: "object",
+                    properties: {}
+                }]
+        } as const satisfies __cfHelpers.JSONSchema, {
+            type: "null"
+        } as const satisfies __cfHelpers.JSONSchema, {
+            anyOf: [{
+                    type: "null"
+                }, {}]
+        } as const satisfies __cfHelpers.JSONSchema, allowMultiple, <button type="button" onClick={openNoteEditor({
+                subPieces,
+                editingNoteIndex,
+                editingNoteText,
+                index,
+            })} style={__cfLift_3({ entry: entry })} title={__cfLift_4({ entry: entry })}>
+                  note
+                </button>, null)}
+              {__cfHelpers.when({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{
+                type: "null"
+            }, {}]
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{
+                type: ["boolean", "null"]
+            }, {}]
+    } as const satisfies __cfHelpers.JSONSchema, __cfLift_5({ isExpanded: isExpanded }), ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{}, {
+                type: "object",
+                properties: {}
+            }]
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "null"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{
+                type: "null"
+            }, {}]
+    } as const satisfies __cfHelpers.JSONSchema, true, <button type="button" onClick={openSettings({ settingsModuleIndex, index })}>
+                  settings
+                </button>, null))}
+              <button type="button" onClick={toggleExpanded({ expandedIndex, index })} style={{ background: __cfHelpers.ifElse({
+            type: "boolean"
+        } as const satisfies __cfHelpers.JSONSchema, {
             type: "string"
-        },
-        index: {
-            type: "number"
-        }
-    },
-    required: ["subPieces", "editingNoteIndex", "editingNoteText", "index"]
-} as const satisfies __cfHelpers.JSONSchema, (_event, state) => state);
-const openSettings = handler({
-    type: "unknown"
-} as const satisfies __cfHelpers.JSONSchema, {
+        } as const satisfies __cfHelpers.JSONSchema, {
+            type: "string"
+        } as const satisfies __cfHelpers.JSONSchema, {
+            "enum": ["a", "b"]
+        } as const satisfies __cfHelpers.JSONSchema, isPinned, "a", "b") }}>
+                expand
+              </button>
+              {__cfHelpers.when({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{}, {
+                type: "object",
+                properties: {}
+            }]
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{
+                type: "boolean"
+            }, {}, {
+                type: "object",
+                properties: {}
+            }]
+    } as const satisfies __cfHelpers.JSONSchema, __cfLift_6({ isExpanded: isExpanded }), <button type="button" onClick={trashSubPiece({
+            subPieces,
+            trashedSubPieces,
+            expandedIndex,
+            settingsModuleIndex,
+            index,
+        })}>
+                  trash
+                </button>)}
+            </div>, null).for("__patternResult", true);
+}, {
     type: "object",
     properties: {
-        settingsModuleIndex: {
-            type: ["number", "undefined"]
+        element: {
+            type: "object",
+            properties: {
+                entry: {
+                    $ref: "#/$defs/Item"
+                },
+                index: {
+                    type: "number"
+                },
+                isExpanded: {
+                    type: "boolean"
+                },
+                isPinned: {
+                    type: "boolean"
+                },
+                allowMultiple: {
+                    type: "boolean"
+                }
+            },
+            required: ["entry", "index", "isExpanded", "isPinned", "allowMultiple"]
         },
-        index: {
-            type: "number"
+        params: {
+            type: "object",
+            properties: {
+                subPieces: {
+                    type: "array",
+                    items: {
+                        type: "string"
+                    }
+                },
+                editingNoteIndex: {
+                    anyOf: [{
+                            type: "number"
+                        }, {
+                            type: "undefined"
+                        }],
+                    asCell: ["readonly"]
+                },
+                editingNoteText: {
+                    type: "string",
+                    asCell: ["readonly"]
+                },
+                settingsModuleIndex: {
+                    anyOf: [{
+                            type: "number"
+                        }, {
+                            type: "undefined"
+                        }],
+                    asCell: ["readonly"]
+                },
+                expandedIndex: {
+                    anyOf: [{
+                            type: "number"
+                        }, {
+                            type: "undefined"
+                        }],
+                    asCell: ["readonly"]
+                },
+                trashedSubPieces: {
+                    type: "array",
+                    items: {
+                        type: "string"
+                    }
+                }
+            },
+            required: ["subPieces", "editingNoteIndex", "editingNoteText", "settingsModuleIndex", "expandedIndex", "trashedSubPieces"]
         }
     },
-    required: ["settingsModuleIndex", "index"]
-} as const satisfies __cfHelpers.JSONSchema, (_event, state) => state);
-const toggleExpanded = handler({
-    type: "unknown"
+    required: ["element", "params"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                note: {
+                    type: "string"
+                },
+                collapsed: {
+                    type: "boolean"
+                },
+                pinned: {
+                    type: "boolean"
+                },
+                allowMultiple: {
+                    type: "boolean"
+                }
+            },
+            required: ["allowMultiple"]
+        }
+    }
 } as const satisfies __cfHelpers.JSONSchema, {
-    type: "object",
-    properties: {
-        expandedIndex: {
-            type: ["number", "undefined"]
-        },
-        index: {
-            type: "number"
+    anyOf: [{
+            type: "null"
+        }, {
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
         }
-    },
-    required: ["expandedIndex", "index"]
-} as const satisfies __cfHelpers.JSONSchema, (_event, state) => state);
-const trashSubPiece = handler({
-    type: "unknown"
-} as const satisfies __cfHelpers.JSONSchema, {
-    type: "object",
-    properties: {
-        subPieces: {
-            type: "array",
-            items: {
-                type: "string"
-            }
-        },
-        trashedSubPieces: {
-            type: "array",
-            items: {
-                type: "string"
-            }
-        },
-        expandedIndex: {
-            type: ["number", "undefined"]
-        },
-        settingsModuleIndex: {
-            type: ["number", "undefined"]
-        },
-        index: {
-            type: "number"
-        }
-    },
-    required: ["subPieces", "trashedSubPieces", "expandedIndex", "settingsModuleIndex", "index"]
-} as const satisfies __cfHelpers.JSONSchema, (_event, state) => state);
-interface Item {
-    note?: string;
-    collapsed?: boolean;
-    pinned?: boolean;
-    allowMultiple: boolean;
-}
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: branch-lowered-capture-preservation
 // Verifies: branch-lowered UI chunks inside a computed-array map preserve captured
 // params needed by nested ifElse branches, inline computed() attributes, and handlers
@@ -306,228 +528,7 @@ export default pattern((__cf_pattern_input) => {
     const allEntries = __cfLift_1({ items: items }).for("allEntries", true);
     return {
         [UI]: (<div>
-        {allEntries.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const entry = __cf_pattern_input.key("element", "entry");
-                const index = __cf_pattern_input.key("element", "index");
-                const isExpanded = __cf_pattern_input.key("element", "isExpanded");
-                const isPinned = __cf_pattern_input.key("element", "isPinned");
-                const allowMultiple = __cf_pattern_input.key("element", "allowMultiple");
-                const subPieces = __cf_pattern_input.key("params", "subPieces");
-                const editingNoteIndex = __cf_pattern_input.key("params", "editingNoteIndex");
-                const editingNoteText = __cf_pattern_input.key("params", "editingNoteText");
-                const settingsModuleIndex = __cf_pattern_input.key("params", "settingsModuleIndex");
-                const expandedIndex = __cf_pattern_input.key("params", "expandedIndex");
-                const trashedSubPieces = __cf_pattern_input.key("params", "trashedSubPieces");
-                return ifElse({
-                    type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{}, {
-                            type: "object",
-                            properties: {}
-                        }]
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "null"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{
-                            type: "null"
-                        }, {}]
-                } as const satisfies __cfHelpers.JSONSchema, __cfLift_2({ entry: {
-                        collapsed: entry.key("collapsed")
-                    } }), <div>
-              {ifElse({
-                        type: "boolean"
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        anyOf: [{}, {
-                                type: "object",
-                                properties: {}
-                            }]
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        type: "null"
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        anyOf: [{
-                                type: "null"
-                            }, {}]
-                    } as const satisfies __cfHelpers.JSONSchema, allowMultiple, <button type="button" onClick={openNoteEditor({
-                            subPieces,
-                            editingNoteIndex,
-                            editingNoteText,
-                            index,
-                        })} style={__cfLift_3({ entry: entry })} title={__cfLift_4({ entry: entry })}>
-                  note
-                </button>, null)}
-              {__cfHelpers.when({
-                    type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{
-                            type: "null"
-                        }, {}]
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{
-                            type: ["boolean", "null"]
-                        }, {}]
-                } as const satisfies __cfHelpers.JSONSchema, __cfLift_5({ isExpanded: isExpanded }), ifElse({
-                    type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{}, {
-                            type: "object",
-                            properties: {}
-                        }]
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "null"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{
-                            type: "null"
-                        }, {}]
-                } as const satisfies __cfHelpers.JSONSchema, true, <button type="button" onClick={openSettings({ settingsModuleIndex, index })}>
-                  settings
-                </button>, null))}
-              <button type="button" onClick={toggleExpanded({ expandedIndex, index })} style={{ background: __cfHelpers.ifElse({
-                        type: "boolean"
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        type: "string"
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        type: "string"
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        "enum": ["a", "b"]
-                    } as const satisfies __cfHelpers.JSONSchema, isPinned, "a", "b") }}>
-                expand
-              </button>
-              {__cfHelpers.when({
-                    type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{}, {
-                            type: "object",
-                            properties: {}
-                        }]
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{
-                            type: "boolean"
-                        }, {}, {
-                            type: "object",
-                            properties: {}
-                        }]
-                } as const satisfies __cfHelpers.JSONSchema, __cfLift_6({ isExpanded: isExpanded }), <button type="button" onClick={trashSubPiece({
-                        subPieces,
-                        trashedSubPieces,
-                        expandedIndex,
-                        settingsModuleIndex,
-                        index,
-                    })}>
-                  trash
-                </button>)}
-            </div>, null).for("__patternResult", true);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "object",
-                        properties: {
-                            entry: {
-                                $ref: "#/$defs/Item"
-                            },
-                            index: {
-                                type: "number"
-                            },
-                            isExpanded: {
-                                type: "boolean"
-                            },
-                            isPinned: {
-                                type: "boolean"
-                            },
-                            allowMultiple: {
-                                type: "boolean"
-                            }
-                        },
-                        required: ["entry", "index", "isExpanded", "isPinned", "allowMultiple"]
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            subPieces: {
-                                type: "array",
-                                items: {
-                                    type: "string"
-                                }
-                            },
-                            editingNoteIndex: {
-                                anyOf: [{
-                                        type: "number"
-                                    }, {
-                                        type: "undefined"
-                                    }],
-                                asCell: ["readonly"]
-                            },
-                            editingNoteText: {
-                                type: "string",
-                                asCell: ["readonly"]
-                            },
-                            settingsModuleIndex: {
-                                anyOf: [{
-                                        type: "number"
-                                    }, {
-                                        type: "undefined"
-                                    }],
-                                asCell: ["readonly"]
-                            },
-                            expandedIndex: {
-                                anyOf: [{
-                                        type: "number"
-                                    }, {
-                                        type: "undefined"
-                                    }],
-                                asCell: ["readonly"]
-                            },
-                            trashedSubPieces: {
-                                type: "array",
-                                items: {
-                                    type: "string"
-                                }
-                            }
-                        },
-                        required: ["subPieces", "editingNoteIndex", "editingNoteText", "settingsModuleIndex", "expandedIndex", "trashedSubPieces"]
-                    }
-                },
-                required: ["element", "params"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            note: {
-                                type: "string"
-                            },
-                            collapsed: {
-                                type: "boolean"
-                            },
-                            pinned: {
-                                type: "boolean"
-                            },
-                            allowMultiple: {
-                                type: "boolean"
-                            }
-                        },
-                        required: ["allowMultiple"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        type: "null"
-                    }, {
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        {allEntries.mapWithPattern(__cfPattern_1, {
                 subPieces: subPieces,
                 editingNoteIndex: editingNoteIndex,
                 editingNoteText: editingNoteText,
@@ -535,7 +536,7 @@ export default pattern((__cf_pattern_input) => {
                 expandedIndex: expandedIndex,
                 trashedSubPieces: trashedSubPieces
             })}
-      </div>)
+      </div>),
     };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/kitchensink/helper-owned-compute-branches.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/helper-owned-compute-branches.expected.jsx
@@ -22,6 +22,17 @@ import { computed, ifElse, pattern, UI, Writable } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Badge {
+    text: string;
+    active: boolean;
+}
+interface Project {
+    id: string;
+    name: string;
+    archived: boolean;
+    members: string[];
+    badges: Badge[];
+}
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         showArchived: boolean;
@@ -142,6 +153,73 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, ({ project, member }) => `${project.name}-${member}`);
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const member = __cf_pattern_input.key("element");
+    const memberIndex = __cf_pattern_input.key("index");
+    const project = __cf_pattern_input.params.project;
+    return (<small>
+              {__cfHelpers.ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, __cfLift_2({ memberIndex: memberIndex }), __cfLift_3({
+        project: {
+            name: project.name
+        },
+        member: member
+    }), member)}
+            </small>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "string"
+        },
+        index: {
+            type: "number"
+        },
+        params: {
+            type: "object",
+            properties: {
+                project: {
+                    type: "object",
+                    properties: {
+                        name: {
+                            type: "string"
+                        }
+                    },
+                    required: ["name"]
+                }
+            },
+            required: ["project"]
+        }
+    },
+    required: ["element", "params"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_4 = __cfHelpers.lift<{
     visibleProjects: {
         name: string;
@@ -258,73 +336,7 @@ visibleProjects.map((project, projectIndex) => {
                     : ""}
             </span>))}
           {/* [TRANSFORM] .map() → mapWithPattern: fallbackMembers is a Writable (reactive Cell), lowered even inside computed */}
-          {fallbackMembers.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-            const member = __cf_pattern_input.key("element");
-            const memberIndex = __cf_pattern_input.key("index");
-            const project = __cf_pattern_input.params.project;
-            return (<small>
-              {__cfHelpers.ifElse({
-                type: "boolean"
-            } as const satisfies __cfHelpers.JSONSchema, {
-                type: "string"
-            } as const satisfies __cfHelpers.JSONSchema, {
-                type: "string"
-            } as const satisfies __cfHelpers.JSONSchema, {
-                type: "string"
-            } as const satisfies __cfHelpers.JSONSchema, __cfLift_2({ memberIndex: memberIndex }), __cfLift_3({
-                project: {
-                    name: project.name
-                },
-                member: member
-            }), member)}
-            </small>);
-        }, {
-            type: "object",
-            properties: {
-                element: {
-                    type: "string"
-                },
-                index: {
-                    type: "number"
-                },
-                params: {
-                    type: "object",
-                    properties: {
-                        project: {
-                            type: "object",
-                            properties: {
-                                name: {
-                                    type: "string"
-                                }
-                            },
-                            required: ["name"]
-                        }
-                    },
-                    required: ["project"]
-                }
-            },
-            required: ["element", "params"]
-        } as const satisfies __cfHelpers.JSONSchema, {
-            anyOf: [{
-                    $ref: "https://commonfabric.org/schemas/vnode.json"
-                }, {
-                    $ref: "#/$defs/UIRenderable"
-                }, {
-                    type: "object",
-                    properties: {}
-                }],
-            $defs: {
-                UIRenderable: {
-                    type: "object",
-                    properties: {
-                        $UI: {
-                            $ref: "https://commonfabric.org/schemas/vnode.json"
-                        }
-                    },
-                    required: ["$UI"]
-                }
-            }
-        } as const satisfies __cfHelpers.JSONSchema), {
+          {fallbackMembers.mapWithPattern(__cfPattern_1, {
             project: {
                 name: project.name
             }
@@ -340,17 +352,6 @@ visibleProjects.map((project, projectIndex) => {
             </span>))}
         </div>);
 }));
-interface Badge {
-    text: string;
-    active: boolean;
-}
-interface Project {
-    id: string;
-    name: string;
-    archived: boolean;
-    members: string[];
-    badges: Badge[];
-}
 // [TRANSFORM] pattern: type param stripped; input+output schemas appended after callback
 export default pattern((state) => {
     // [TRANSFORM] new Writable: schema arg injected

--- a/packages/ts-transformers/test/fixtures/kitchensink/nested-computed-output-maps.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/nested-computed-output-maps.expected.jsx
@@ -27,6 +27,57 @@ import { computed, handler, ifElse, lift, pattern, UI, Writable, } from "commonf
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Comment {
+    id: string;
+    text: string;
+    flagged: boolean;
+    reactions: string[];
+}
+interface Thread {
+    id: string;
+    title: string;
+    muted: boolean;
+    comments: Comment[];
+}
+// [TRANSFORM] handler: event schema (true=unknown) and state schema injected
+const jumpToComment = handler({
+    type: "unknown"
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        selectedCommentId: {
+            type: ["string", "undefined"]
+        },
+        threadId: {
+            type: "string"
+        },
+        commentId: {
+            type: "string"
+        },
+        lane: {
+            type: "string"
+        },
+        outerIndex: {
+            type: "number"
+        },
+        innerIndex: {
+            type: "number"
+        }
+    },
+    required: ["selectedCommentId", "threadId", "commentId", "lane", "outerIndex", "innerIndex"]
+} as const satisfies __cfHelpers.JSONSchema, (_event, state) => state);
+// [TRANSFORM] lift: input and output schemas injected
+const passthroughLabels = lift({
+    type: "array",
+    items: {
+        type: "string"
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "array",
+    items: {
+        type: "string"
+    }
+} as const satisfies __cfHelpers.JSONSchema, (labels: string[]) => labels);
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         threads: Thread[];
@@ -284,6 +335,91 @@ const __cfLift_4 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, ({ state, comment }) => `${state.lane}:${comment.id}`);
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const comment = __cf_pattern_input.key("element");
+    const reboundIndex = __cf_pattern_input.key("index");
+    const outerIndex = __cf_pattern_input.params.outerIndex;
+    const state = __cf_pattern_input.key("params", "state");
+    return (<aside>
+              {__cfHelpers.ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, __cfLift_3({
+        reboundIndex: reboundIndex,
+        outerIndex: outerIndex
+    }), __cfLift_4({
+        state: {
+            lane: state.key("lane")
+        },
+        comment: {
+            id: comment.key("id")
+        }
+    }), comment.key("text"))}
+            </aside>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                },
+                text: {
+                    type: "string"
+                }
+            },
+            required: ["id", "text"]
+        },
+        index: {
+            type: "number"
+        },
+        params: {
+            type: "object",
+            properties: {
+                outerIndex: {
+                    type: "number"
+                },
+                state: {
+                    type: "object",
+                    properties: {
+                        lane: {
+                            type: "string"
+                        }
+                    },
+                    required: ["lane"]
+                }
+            },
+            required: ["outerIndex", "state"]
+        }
+    },
+    required: ["element", "params"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_5 = __cfHelpers.lift<{
     edgeIndex: number;
     outerIndex: number;
@@ -326,6 +462,80 @@ const __cfLift_6 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, ({ state, edge }) => `${state.lane}:${edge}`);
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const edge = __cf_pattern_input.key("element");
+    const edgeIndex = __cf_pattern_input.key("index");
+    const outerIndex = __cf_pattern_input.params.outerIndex;
+    const state = __cf_pattern_input.key("params", "state");
+    return (<small>
+              {__cfHelpers.ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, __cfLift_5({
+        edgeIndex: edgeIndex,
+        outerIndex: outerIndex
+    }), __cfLift_6({
+        state: {
+            lane: state.key("lane")
+        },
+        edge: edge
+    }), edge)}
+            </small>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "string"
+        },
+        index: {
+            type: "number"
+        },
+        params: {
+            type: "object",
+            properties: {
+                outerIndex: {
+                    type: "number"
+                },
+                state: {
+                    type: "object",
+                    properties: {
+                        lane: {
+                            type: "string"
+                        }
+                    },
+                    required: ["lane"]
+                }
+            },
+            required: ["outerIndex", "state"]
+        }
+    },
+    required: ["element", "params"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_7 = __cfHelpers.lift<{
     visibleThreads: {
         thread: {
@@ -489,91 +699,7 @@ visibleThreads.map(({ thread, outerIndex, visibleComments }) => {
             </div>))}
           {/* [TRANSFORM] .map() → mapWithPattern: reboundComments is output of nested computed() — reactive even inside outer computed */}
           {/* [TRANSFORM] closure captures: outerIndex (via params opaque), state.lane (via params reactive .key()) */}
-          {reboundComments.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-            const comment = __cf_pattern_input.key("element");
-            const reboundIndex = __cf_pattern_input.key("index");
-            const outerIndex = __cf_pattern_input.params.outerIndex;
-            const state = __cf_pattern_input.key("params", "state");
-            return (<aside>
-              {__cfHelpers.ifElse({
-                type: "boolean"
-            } as const satisfies __cfHelpers.JSONSchema, {
-                type: "string"
-            } as const satisfies __cfHelpers.JSONSchema, {
-                type: "string"
-            } as const satisfies __cfHelpers.JSONSchema, {
-                type: "string"
-            } as const satisfies __cfHelpers.JSONSchema, __cfLift_3({
-                reboundIndex: reboundIndex,
-                outerIndex: outerIndex
-            }), __cfLift_4({
-                state: {
-                    lane: state.key("lane")
-                },
-                comment: {
-                    id: comment.key("id")
-                }
-            }), comment.key("text"))}
-            </aside>);
-        }, {
-            type: "object",
-            properties: {
-                element: {
-                    type: "object",
-                    properties: {
-                        id: {
-                            type: "string"
-                        },
-                        text: {
-                            type: "string"
-                        }
-                    },
-                    required: ["id", "text"]
-                },
-                index: {
-                    type: "number"
-                },
-                params: {
-                    type: "object",
-                    properties: {
-                        outerIndex: {
-                            type: "number"
-                        },
-                        state: {
-                            type: "object",
-                            properties: {
-                                lane: {
-                                    type: "string"
-                                }
-                            },
-                            required: ["lane"]
-                        }
-                    },
-                    required: ["outerIndex", "state"]
-                }
-            },
-            required: ["element", "params"]
-        } as const satisfies __cfHelpers.JSONSchema, {
-            anyOf: [{
-                    $ref: "https://commonfabric.org/schemas/vnode.json"
-                }, {
-                    $ref: "#/$defs/UIRenderable"
-                }, {
-                    type: "object",
-                    properties: {}
-                }],
-            $defs: {
-                UIRenderable: {
-                    type: "object",
-                    properties: {
-                        $UI: {
-                            $ref: "https://commonfabric.org/schemas/vnode.json"
-                        }
-                    },
-                    required: ["$UI"]
-                }
-            }
-        } as const satisfies __cfHelpers.JSONSchema), {
+          {reboundComments.mapWithPattern(__cfPattern_1, {
             outerIndex: outerIndex,
             state: {
                 lane: state.lane
@@ -581,80 +707,7 @@ visibleThreads.map(({ thread, outerIndex, visibleComments }) => {
         })}
           {/* [TRANSFORM] .map() → mapWithPattern: liftedSeparators is output of lift() — reactive even inside outer computed */}
           {/* [TRANSFORM] closure captures: outerIndex (via params opaque), state.lane (via params reactive .key()) */}
-          {liftedSeparators.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-            const edge = __cf_pattern_input.key("element");
-            const edgeIndex = __cf_pattern_input.key("index");
-            const outerIndex = __cf_pattern_input.params.outerIndex;
-            const state = __cf_pattern_input.key("params", "state");
-            return (<small>
-              {__cfHelpers.ifElse({
-                type: "boolean"
-            } as const satisfies __cfHelpers.JSONSchema, {
-                type: "string"
-            } as const satisfies __cfHelpers.JSONSchema, {
-                type: "string"
-            } as const satisfies __cfHelpers.JSONSchema, {
-                type: "string"
-            } as const satisfies __cfHelpers.JSONSchema, __cfLift_5({
-                edgeIndex: edgeIndex,
-                outerIndex: outerIndex
-            }), __cfLift_6({
-                state: {
-                    lane: state.key("lane")
-                },
-                edge: edge
-            }), edge)}
-            </small>);
-        }, {
-            type: "object",
-            properties: {
-                element: {
-                    type: "string"
-                },
-                index: {
-                    type: "number"
-                },
-                params: {
-                    type: "object",
-                    properties: {
-                        outerIndex: {
-                            type: "number"
-                        },
-                        state: {
-                            type: "object",
-                            properties: {
-                                lane: {
-                                    type: "string"
-                                }
-                            },
-                            required: ["lane"]
-                        }
-                    },
-                    required: ["outerIndex", "state"]
-                }
-            },
-            required: ["element", "params"]
-        } as const satisfies __cfHelpers.JSONSchema, {
-            anyOf: [{
-                    $ref: "https://commonfabric.org/schemas/vnode.json"
-                }, {
-                    $ref: "#/$defs/UIRenderable"
-                }, {
-                    type: "object",
-                    properties: {}
-                }],
-            $defs: {
-                UIRenderable: {
-                    type: "object",
-                    properties: {
-                        $UI: {
-                            $ref: "https://commonfabric.org/schemas/vnode.json"
-                        }
-                    },
-                    required: ["$UI"]
-                }
-            }
-        } as const satisfies __cfHelpers.JSONSchema), {
+          {liftedSeparators.mapWithPattern(__cfPattern_2, {
             outerIndex: outerIndex,
             state: {
                 lane: state.lane
@@ -702,57 +755,130 @@ const __cfLift_9 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, ({ state, label }) => `${state.lane}:${label}`);
-interface Comment {
-    id: string;
-    text: string;
-    flagged: boolean;
-    reactions: string[];
-}
-interface Thread {
-    id: string;
-    title: string;
-    muted: boolean;
-    comments: Comment[];
-}
-// [TRANSFORM] handler: event schema (true=unknown) and state schema injected
-const jumpToComment = handler({
-    type: "unknown"
-} as const satisfies __cfHelpers.JSONSchema, {
+const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
+    const label = __cf_pattern_input.key("element");
+    const labelIndex = __cf_pattern_input.key("index");
+    const state = __cf_pattern_input.key("params", "state");
+    return (<header data-lane-label={labelIndex}>
+            {__cfHelpers.ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        type: "string"
+    } as const satisfies __cfHelpers.JSONSchema, __cfLift_8({ labelIndex: labelIndex }), __cfLift_9({
+        state: {
+            lane: state.key("lane")
+        },
+        label: label
+    }), label)}
+          </header>);
+}, {
     type: "object",
     properties: {
-        selectedCommentId: {
-            type: ["string", "undefined"]
-        },
-        threadId: {
+        element: {
             type: "string"
         },
-        commentId: {
-            type: "string"
-        },
-        lane: {
-            type: "string"
-        },
-        outerIndex: {
+        index: {
             type: "number"
         },
-        innerIndex: {
+        params: {
+            type: "object",
+            properties: {
+                state: {
+                    type: "object",
+                    properties: {
+                        lane: {
+                            type: "string"
+                        }
+                    },
+                    required: ["lane"]
+                }
+            },
+            required: ["state"]
+        }
+    },
+    required: ["element", "params"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
+    const row = __cf_pattern_input.key("element");
+    const rowIndex = __cf_pattern_input.key("index");
+    return (<section data-row={rowIndex}>{row}</section>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/JSXElement"
+        },
+        index: {
             type: "number"
         }
     },
-    required: ["selectedCommentId", "threadId", "commentId", "lane", "outerIndex", "innerIndex"]
-} as const satisfies __cfHelpers.JSONSchema, (_event, state) => state);
-// [TRANSFORM] lift: input and output schemas injected
-const passthroughLabels = lift({
-    type: "array",
-    items: {
-        type: "string"
+    required: ["element"],
+    $defs: {
+        JSXElement: {
+            anyOf: [{
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }, {
+                    $ref: "#/$defs/UIRenderable"
+                }, {
+                    type: "object",
+                    properties: {}
+                }]
+        },
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
     }
 } as const satisfies __cfHelpers.JSONSchema, {
-    type: "array",
-    items: {
-        type: "string"
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
     }
-} as const satisfies __cfHelpers.JSONSchema, (labels: string[]) => labels);
+} as const satisfies __cfHelpers.JSONSchema);
 // [TRANSFORM] pattern: type param stripped; input+output schemas appended after callback
 export default pattern((state) => {
     // [TRANSFORM] new Writable: schema arg injected; undefined default added for optional type
@@ -777,135 +903,13 @@ export default pattern((state) => {
         [UI]: (<div>
         {/* [TRANSFORM] .map() → mapWithPattern: laneLabels is output of lift() in pattern context — reactive */}
         {/* [TRANSFORM] ternary lowered: labelIndex===0 ? `${state.lane}:${label}` : label → ifElse(lift(cond), lift(true-branch), label) */}
-        {laneLabels.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const label = __cf_pattern_input.key("element");
-                const labelIndex = __cf_pattern_input.key("index");
-                const state = __cf_pattern_input.key("params", "state");
-                return (<header data-lane-label={labelIndex}>
-            {__cfHelpers.ifElse({
-                    type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    type: "string"
-                } as const satisfies __cfHelpers.JSONSchema, __cfLift_8({ labelIndex: labelIndex }), __cfLift_9({
-                    state: {
-                        lane: state.key("lane")
-                    },
-                    label: label
-                }), label)}
-          </header>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        type: "string"
-                    },
-                    index: {
-                        type: "number"
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            state: {
-                                type: "object",
-                                properties: {
-                                    lane: {
-                                        type: "string"
-                                    }
-                                },
-                                required: ["lane"]
-                            }
-                        },
-                        required: ["state"]
-                    }
-                },
-                required: ["element", "params"]
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+        {laneLabels.mapWithPattern(__cfPattern_3, {
                 state: {
                     lane: state.key("lane")
                 }
             })}
         {/* [TRANSFORM] .map() → mapWithPattern: threadRows is output of computed() — reactive, back in pattern-owned UI */}
-        {threadRows.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const row = __cf_pattern_input.key("element");
-                const rowIndex = __cf_pattern_input.key("index");
-                return (<section data-row={rowIndex}>{row}</section>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/JSXElement"
-                    },
-                    index: {
-                        type: "number"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    JSXElement: {
-                        anyOf: [{
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }, {
-                                $ref: "#/$defs/UIRenderable"
-                            }, {
-                                type: "object",
-                                properties: {}
-                            }]
-                    },
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+        {threadRows.mapWithPattern(__cfPattern_4, {})}
       </div>),
     };
 }, {

--- a/packages/ts-transformers/test/fixtures/kitchensink/nested-writable-pattern-branches.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/nested-writable-pattern-branches.expected.jsx
@@ -22,6 +22,47 @@ import { computed, handler, ifElse, pattern, UI, Writable } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Task {
+    id: string;
+    label: string;
+    done: boolean;
+    tags: string[];
+    note?: string;
+}
+interface Section {
+    id: string;
+    title: string;
+    expanded: boolean;
+    accent?: string;
+    tasks: Task[];
+}
+// [TRANSFORM] handler: event schema (true=unknown) and state schema injected
+const selectTask = handler({
+    type: "unknown"
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        selectedTaskId: {
+            type: ["string", "undefined"]
+        },
+        hoveredSectionId: {
+            type: ["string", "undefined"]
+        },
+        sectionId: {
+            type: "string"
+        },
+        taskId: {
+            type: "string"
+        },
+        sectionIndex: {
+            type: "number"
+        },
+        taskIndex: {
+            type: "number"
+        }
+    },
+    required: ["selectedTaskId", "hoveredSectionId", "sectionId", "taskId", "sectionIndex", "taskIndex"]
+} as const satisfies __cfHelpers.JSONSchema, (_event, state) => state);
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         sections: __cfHelpers.ReadonlyCell<unknown[]>;
@@ -84,6 +125,273 @@ const __cfLift_3 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, ({ tagIndex, taskIndex }) => tagIndex === taskIndex);
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const tag = __cf_pattern_input.key("element");
+    const tagIndex = __cf_pattern_input.key("index");
+    const taskIndex = __cf_pattern_input.key("params", "taskIndex");
+    const section = __cf_pattern_input.key("params", "section");
+    const state = __cf_pattern_input.key("params", "state");
+    const task = __cf_pattern_input.key("params", "task");
+    return (<span>
+                            {__cfHelpers.ifElse({
+            type: "boolean"
+        } as const satisfies __cfHelpers.JSONSchema, {
+            type: "string"
+        } as const satisfies __cfHelpers.JSONSchema, {
+            type: "string"
+        } as const satisfies __cfHelpers.JSONSchema, {
+            type: "string"
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_3({
+            tagIndex: tagIndex,
+            taskIndex: taskIndex
+        }), `${section.key("title")}:${tag}`, __cfHelpers.ifElse({
+            type: "boolean"
+        } as const satisfies __cfHelpers.JSONSchema, {
+            type: "string"
+        } as const satisfies __cfHelpers.JSONSchema, {
+            type: "string"
+        } as const satisfies __cfHelpers.JSONSchema, {
+            type: "string"
+        } as const satisfies __cfHelpers.JSONSchema, __cfHelpers.unless({
+            type: "boolean"
+        } as const satisfies __cfHelpers.JSONSchema, {
+            type: "boolean"
+        } as const satisfies __cfHelpers.JSONSchema, {
+            type: "boolean"
+        } as const satisfies __cfHelpers.JSONSchema, state.key("showCompleted"), !task.key("done")), tag, ""))}
+                          </span>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "string"
+        },
+        index: {
+            type: "number"
+        },
+        params: {
+            type: "object",
+            properties: {
+                taskIndex: {
+                    type: "number"
+                },
+                section: {
+                    type: "object",
+                    properties: {
+                        title: {
+                            type: "string"
+                        }
+                    },
+                    required: ["title"]
+                },
+                state: {
+                    type: "object",
+                    properties: {
+                        showCompleted: {
+                            type: "boolean"
+                        }
+                    },
+                    required: ["showCompleted"]
+                },
+                task: {
+                    type: "object",
+                    properties: {
+                        done: {
+                            type: "boolean"
+                        }
+                    },
+                    required: ["done"]
+                }
+            },
+            required: ["taskIndex", "section", "state", "task"]
+        }
+    },
+    required: ["element", "params"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const task = __cf_pattern_input.key("element");
+    const taskIndex = __cf_pattern_input.key("index");
+    const selectedTaskId = __cf_pattern_input.key("params", "selectedTaskId");
+    const hoveredSectionId = __cf_pattern_input.key("params", "hoveredSectionId");
+    const section = __cf_pattern_input.key("params", "section");
+    const sectionIndex = __cf_pattern_input.key("params", "sectionIndex");
+    const state = __cf_pattern_input.key("params", "state");
+    return (<div>
+                        <button type="button" onClick={selectTask({
+            selectedTaskId,
+            hoveredSectionId,
+            sectionId: section.key("id"),
+            taskId: task.key("id"),
+            sectionIndex,
+            taskIndex,
+        })}>
+                          {/* [TRANSFORM] ternary lowered: task.done ? <span>...</span> : ifElse(...) → ifElse(task.done, ..., ...) */}
+                          {__cfHelpers.ifElse({
+            type: "boolean"
+        } as const satisfies __cfHelpers.JSONSchema, {
+            anyOf: [{}, {
+                    type: "object",
+                    properties: {}
+                }]
+        } as const satisfies __cfHelpers.JSONSchema, {} as const satisfies __cfHelpers.JSONSchema, {
+            anyOf: [{}, {
+                    type: "object",
+                    properties: {}
+                }]
+        } as const satisfies __cfHelpers.JSONSchema, task.key("done"), <span>{task.key("label")}</span>, ifElse({
+            type: "boolean"
+        } as const satisfies __cfHelpers.JSONSchema, {
+            anyOf: [{}, {
+                    type: "object",
+                    properties: {}
+                }]
+        } as const satisfies __cfHelpers.JSONSchema, {
+            anyOf: [{}, {
+                    type: "object",
+                    properties: {}
+                }]
+        } as const satisfies __cfHelpers.JSONSchema, {} as const satisfies __cfHelpers.JSONSchema, __cfHelpers.when({
+            type: "boolean"
+        } as const satisfies __cfHelpers.JSONSchema, {
+            type: "boolean"
+        } as const satisfies __cfHelpers.JSONSchema, {
+            type: "boolean"
+        } as const satisfies __cfHelpers.JSONSchema, __cfLift_2({ task: {
+                note: task.key("note")
+            } }), task.key("note") !== ""), <strong>{task.key("label")}</strong>, <em>{task.key("label")}</em>))}
+                        </button>
+                        {/* [TRANSFORM] .map() → mapWithPattern: task.tags is reactive pattern-owned data (nested inside sections map) */}
+                        {/* [TRANSFORM] closure captures: taskIndex, section, state, task (all via params) */}
+                        {/* [TRANSFORM] ternary lowered: tagIndex===taskIndex ? `${section.title}:${tag}` : (showCompleted||!task.done ? tag : "") */}
+                        {task.key("tags").mapWithPattern(__cfPattern_1, {
+            taskIndex: taskIndex,
+            section: {
+                title: section.key("title")
+            },
+            state: {
+                showCompleted: state.key("showCompleted")
+            },
+            task: {
+                done: task.key("done")
+            }
+        })}
+                      </div>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Task"
+        },
+        index: {
+            type: "number"
+        },
+        params: {
+            type: "object",
+            properties: {
+                selectedTaskId: {
+                    type: ["string", "undefined"],
+                    asCell: ["readonly"]
+                },
+                hoveredSectionId: {
+                    type: ["string", "undefined"],
+                    asCell: ["readonly"]
+                },
+                section: {
+                    type: "object",
+                    properties: {
+                        id: {
+                            type: "string"
+                        },
+                        title: {
+                            type: "string"
+                        }
+                    },
+                    required: ["id", "title"]
+                },
+                sectionIndex: {
+                    type: "number"
+                },
+                state: {
+                    type: "object",
+                    properties: {
+                        showCompleted: {
+                            type: "boolean"
+                        }
+                    },
+                    required: ["showCompleted"]
+                }
+            },
+            required: ["selectedTaskId", "hoveredSectionId", "section", "sectionIndex", "state"]
+        }
+    },
+    required: ["element", "params"],
+    $defs: {
+        Task: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                },
+                label: {
+                    type: "string"
+                },
+                done: {
+                    type: "boolean"
+                },
+                tags: {
+                    type: "array",
+                    items: {
+                        type: "string"
+                    }
+                },
+                note: {
+                    type: "string"
+                }
+            },
+            required: ["id", "label", "done", "tags"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_4 = __cfHelpers.lift<{
     section: {
         tasks: {
@@ -141,47 +449,170 @@ const __cfLift_4 = __cfHelpers.lift<{
 section.tasks.length > 0
     ? <small>{section.title} collapsed</small>
     : <small>empty</small>);
-interface Task {
-    id: string;
-    label: string;
-    done: boolean;
-    tags: string[];
-    note?: string;
-}
-interface Section {
-    id: string;
-    title: string;
-    expanded: boolean;
-    accent?: string;
-    tasks: Task[];
-}
-// [TRANSFORM] handler: event schema (true=unknown) and state schema injected
-const selectTask = handler({
-    type: "unknown"
-} as const satisfies __cfHelpers.JSONSchema, {
+const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
+    const section = __cf_pattern_input.key("element");
+    const sectionIndex = __cf_pattern_input.key("index");
+    const state = __cf_pattern_input.key("params", "state");
+    const selectedTaskId = __cf_pattern_input.key("params", "selectedTaskId");
+    const hoveredSectionId = __cf_pattern_input.key("params", "hoveredSectionId");
+    return (<section>
+                <h2 style={{
+        // [TRANSFORM] ternary lowered: section.accent ? section.accent : state.globalAccent → ifElse(...)
+        color: __cfHelpers.ifElse({
+            type: ["string", "undefined"]
+        } as const satisfies __cfHelpers.JSONSchema, {
+            type: "string"
+        } as const satisfies __cfHelpers.JSONSchema, {
+            type: "string"
+        } as const satisfies __cfHelpers.JSONSchema, {
+            type: "string"
+        } as const satisfies __cfHelpers.JSONSchema, section.key("accent"), section.key("accent"), state.key("globalAccent")),
+    }}>
+                  {section.key("title")}
+                </h2>
+                {/* [TRANSFORM] ifElse: schema-injected authored ifElse(section.expanded, ..., ...) */}
+                {ifElse({
+            type: "boolean"
+        } as const satisfies __cfHelpers.JSONSchema, {
+            anyOf: [{}, {
+                    type: "object",
+                    properties: {}
+                }]
+        } as const satisfies __cfHelpers.JSONSchema, {
+            anyOf: [{}, {
+                    type: "object",
+                    properties: {}
+                }]
+        } as const satisfies __cfHelpers.JSONSchema, {} as const satisfies __cfHelpers.JSONSchema, section.key("expanded"), <div>
+                    {/* [TRANSFORM] .map() → mapWithPattern: section.tasks is reactive pattern-owned data */}
+                    {/* [TRANSFORM] closure captures: selectedTaskId, hoveredSectionId, section, sectionIndex, state (all via params) */}
+                    {section.key("tasks").mapWithPattern(__cfPattern_2, {
+                selectedTaskId: selectedTaskId,
+                hoveredSectionId: hoveredSectionId,
+                section: {
+                    id: section.key("id"),
+                    title: section.key("title")
+                },
+                sectionIndex: sectionIndex,
+                state: {
+                    showCompleted: state.key("showCompleted")
+                }
+            })}
+                  </div>, __cfLift_4({ section: {
+                tasks: {
+                    length: section.key("tasks", "length")
+                },
+                title: section.key("title")
+            } }))}
+              </section>);
+}, {
     type: "object",
     properties: {
-        selectedTaskId: {
-            type: ["string", "undefined"]
+        element: {
+            $ref: "#/$defs/Section"
         },
-        hoveredSectionId: {
-            type: ["string", "undefined"]
-        },
-        sectionId: {
-            type: "string"
-        },
-        taskId: {
-            type: "string"
-        },
-        sectionIndex: {
+        index: {
             type: "number"
         },
-        taskIndex: {
-            type: "number"
+        params: {
+            type: "object",
+            properties: {
+                state: {
+                    type: "object",
+                    properties: {
+                        globalAccent: {
+                            type: "string"
+                        },
+                        showCompleted: {
+                            type: "boolean"
+                        }
+                    },
+                    required: ["globalAccent", "showCompleted"]
+                },
+                selectedTaskId: {
+                    type: ["string", "undefined"],
+                    asCell: ["readonly"]
+                },
+                hoveredSectionId: {
+                    type: ["string", "undefined"],
+                    asCell: ["readonly"]
+                }
+            },
+            required: ["state", "selectedTaskId", "hoveredSectionId"]
         }
     },
-    required: ["selectedTaskId", "hoveredSectionId", "sectionId", "taskId", "sectionIndex", "taskIndex"]
-} as const satisfies __cfHelpers.JSONSchema, (_event, state) => state);
+    required: ["element", "params"],
+    $defs: {
+        Section: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                },
+                title: {
+                    type: "string"
+                },
+                expanded: {
+                    type: "boolean"
+                },
+                accent: {
+                    type: "string"
+                },
+                tasks: {
+                    type: "array",
+                    items: {
+                        $ref: "#/$defs/Task"
+                    }
+                }
+            },
+            required: ["id", "title", "expanded", "tasks"]
+        },
+        Task: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                },
+                label: {
+                    type: "string"
+                },
+                done: {
+                    type: "boolean"
+                },
+                tags: {
+                    type: "array",
+                    items: {
+                        type: "string"
+                    }
+                },
+                note: {
+                    type: "string"
+                }
+            },
+            required: ["id", "label", "done", "tags"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // [TRANSFORM] pattern: type param stripped; input+output schemas appended after callback
 export default pattern((state) => {
     // [TRANSFORM] new Writable: schema arg injected; undefined default added for optional type
@@ -214,435 +645,7 @@ export default pattern((state) => {
         } as const satisfies __cfHelpers.JSONSchema, {} as const satisfies __cfHelpers.JSONSchema, hasSections, <div>
             {/* [TRANSFORM] .map() → mapWithPattern: state.sections is Writable<Section[]> — reactive, pattern context */}
             {/* [TRANSFORM] closure captures: state (reactive), selectedTaskId (Writable), hoveredSectionId (Writable) */}
-            {state.key("sections").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const section = __cf_pattern_input.key("element");
-                const sectionIndex = __cf_pattern_input.key("index");
-                const state = __cf_pattern_input.key("params", "state");
-                const selectedTaskId = __cf_pattern_input.key("params", "selectedTaskId");
-                const hoveredSectionId = __cf_pattern_input.key("params", "hoveredSectionId");
-                return (<section>
-                <h2 style={{
-                    // [TRANSFORM] ternary lowered: section.accent ? section.accent : state.globalAccent → ifElse(...)
-                    color: __cfHelpers.ifElse({
-                        type: ["string", "undefined"]
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        type: "string"
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        type: "string"
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        type: "string"
-                    } as const satisfies __cfHelpers.JSONSchema, section.key("accent"), section.key("accent"), state.key("globalAccent")),
-                }}>
-                  {section.key("title")}
-                </h2>
-                {/* [TRANSFORM] ifElse: schema-injected authored ifElse(section.expanded, ..., ...) */}
-                {ifElse({
-                        type: "boolean"
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        anyOf: [{}, {
-                                type: "object",
-                                properties: {}
-                            }]
-                    } as const satisfies __cfHelpers.JSONSchema, {
-                        anyOf: [{}, {
-                                type: "object",
-                                properties: {}
-                            }]
-                    } as const satisfies __cfHelpers.JSONSchema, {} as const satisfies __cfHelpers.JSONSchema, section.key("expanded"), <div>
-                    {/* [TRANSFORM] .map() → mapWithPattern: section.tasks is reactive pattern-owned data */}
-                    {/* [TRANSFORM] closure captures: selectedTaskId, hoveredSectionId, section, sectionIndex, state (all via params) */}
-                    {section.key("tasks").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                            const task = __cf_pattern_input.key("element");
-                            const taskIndex = __cf_pattern_input.key("index");
-                            const selectedTaskId = __cf_pattern_input.key("params", "selectedTaskId");
-                            const hoveredSectionId = __cf_pattern_input.key("params", "hoveredSectionId");
-                            const section = __cf_pattern_input.key("params", "section");
-                            const sectionIndex = __cf_pattern_input.key("params", "sectionIndex");
-                            const state = __cf_pattern_input.key("params", "state");
-                            return (<div>
-                        <button type="button" onClick={selectTask({
-                                    selectedTaskId,
-                                    hoveredSectionId,
-                                    sectionId: section.key("id"),
-                                    taskId: task.key("id"),
-                                    sectionIndex,
-                                    taskIndex,
-                                })}>
-                          {/* [TRANSFORM] ternary lowered: task.done ? <span>...</span> : ifElse(...) → ifElse(task.done, ..., ...) */}
-                          {__cfHelpers.ifElse({
-                                    type: "boolean"
-                                } as const satisfies __cfHelpers.JSONSchema, {
-                                    anyOf: [{}, {
-                                            type: "object",
-                                            properties: {}
-                                        }]
-                                } as const satisfies __cfHelpers.JSONSchema, {} as const satisfies __cfHelpers.JSONSchema, {
-                                    anyOf: [{}, {
-                                            type: "object",
-                                            properties: {}
-                                        }]
-                                } as const satisfies __cfHelpers.JSONSchema, task.key("done"), <span>{task.key("label")}</span>, ifElse({
-                                    type: "boolean"
-                                } as const satisfies __cfHelpers.JSONSchema, {
-                                    anyOf: [{}, {
-                                            type: "object",
-                                            properties: {}
-                                        }]
-                                } as const satisfies __cfHelpers.JSONSchema, {
-                                    anyOf: [{}, {
-                                            type: "object",
-                                            properties: {}
-                                        }]
-                                } as const satisfies __cfHelpers.JSONSchema, {} as const satisfies __cfHelpers.JSONSchema, __cfHelpers.when({
-                                    type: "boolean"
-                                } as const satisfies __cfHelpers.JSONSchema, {
-                                    type: "boolean"
-                                } as const satisfies __cfHelpers.JSONSchema, {
-                                    type: "boolean"
-                                } as const satisfies __cfHelpers.JSONSchema, __cfLift_2({ task: {
-                                        note: task.key("note")
-                                    } }), task.key("note") !== ""), <strong>{task.key("label")}</strong>, <em>{task.key("label")}</em>))}
-                        </button>
-                        {/* [TRANSFORM] .map() → mapWithPattern: task.tags is reactive pattern-owned data (nested inside sections map) */}
-                        {/* [TRANSFORM] closure captures: taskIndex, section, state, task (all via params) */}
-                        {/* [TRANSFORM] ternary lowered: tagIndex===taskIndex ? `${section.title}:${tag}` : (showCompleted||!task.done ? tag : "") */}
-                        {task.key("tags").mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                                    const tag = __cf_pattern_input.key("element");
-                                    const tagIndex = __cf_pattern_input.key("index");
-                                    const taskIndex = __cf_pattern_input.key("params", "taskIndex");
-                                    const section = __cf_pattern_input.key("params", "section");
-                                    const state = __cf_pattern_input.key("params", "state");
-                                    const task = __cf_pattern_input.key("params", "task");
-                                    return (<span>
-                            {__cfHelpers.ifElse({
-                                            type: "boolean"
-                                        } as const satisfies __cfHelpers.JSONSchema, {
-                                            type: "string"
-                                        } as const satisfies __cfHelpers.JSONSchema, {
-                                            type: "string"
-                                        } as const satisfies __cfHelpers.JSONSchema, {
-                                            type: "string"
-                                        } as const satisfies __cfHelpers.JSONSchema, __cfLift_3({
-                                            tagIndex: tagIndex,
-                                            taskIndex: taskIndex
-                                        }), `${section.key("title")}:${tag}`, __cfHelpers.ifElse({
-                                            type: "boolean"
-                                        } as const satisfies __cfHelpers.JSONSchema, {
-                                            type: "string"
-                                        } as const satisfies __cfHelpers.JSONSchema, {
-                                            type: "string"
-                                        } as const satisfies __cfHelpers.JSONSchema, {
-                                            type: "string"
-                                        } as const satisfies __cfHelpers.JSONSchema, __cfHelpers.unless({
-                                            type: "boolean"
-                                        } as const satisfies __cfHelpers.JSONSchema, {
-                                            type: "boolean"
-                                        } as const satisfies __cfHelpers.JSONSchema, {
-                                            type: "boolean"
-                                        } as const satisfies __cfHelpers.JSONSchema, state.key("showCompleted"), !task.key("done")), tag, ""))}
-                          </span>);
-                                }, {
-                                    type: "object",
-                                    properties: {
-                                        element: {
-                                            type: "string"
-                                        },
-                                        index: {
-                                            type: "number"
-                                        },
-                                        params: {
-                                            type: "object",
-                                            properties: {
-                                                taskIndex: {
-                                                    type: "number"
-                                                },
-                                                section: {
-                                                    type: "object",
-                                                    properties: {
-                                                        title: {
-                                                            type: "string"
-                                                        }
-                                                    },
-                                                    required: ["title"]
-                                                },
-                                                state: {
-                                                    type: "object",
-                                                    properties: {
-                                                        showCompleted: {
-                                                            type: "boolean"
-                                                        }
-                                                    },
-                                                    required: ["showCompleted"]
-                                                },
-                                                task: {
-                                                    type: "object",
-                                                    properties: {
-                                                        done: {
-                                                            type: "boolean"
-                                                        }
-                                                    },
-                                                    required: ["done"]
-                                                }
-                                            },
-                                            required: ["taskIndex", "section", "state", "task"]
-                                        }
-                                    },
-                                    required: ["element", "params"]
-                                } as const satisfies __cfHelpers.JSONSchema, {
-                                    anyOf: [{
-                                            $ref: "https://commonfabric.org/schemas/vnode.json"
-                                        }, {
-                                            $ref: "#/$defs/UIRenderable"
-                                        }, {
-                                            type: "object",
-                                            properties: {}
-                                        }],
-                                    $defs: {
-                                        UIRenderable: {
-                                            type: "object",
-                                            properties: {
-                                                $UI: {
-                                                    $ref: "https://commonfabric.org/schemas/vnode.json"
-                                                }
-                                            },
-                                            required: ["$UI"]
-                                        }
-                                    }
-                                } as const satisfies __cfHelpers.JSONSchema), {
-                                    taskIndex: taskIndex,
-                                    section: {
-                                        title: section.key("title")
-                                    },
-                                    state: {
-                                        showCompleted: state.key("showCompleted")
-                                    },
-                                    task: {
-                                        done: task.key("done")
-                                    }
-                                })}
-                      </div>);
-                        }, {
-                            type: "object",
-                            properties: {
-                                element: {
-                                    $ref: "#/$defs/Task"
-                                },
-                                index: {
-                                    type: "number"
-                                },
-                                params: {
-                                    type: "object",
-                                    properties: {
-                                        selectedTaskId: {
-                                            type: ["string", "undefined"],
-                                            asCell: ["readonly"]
-                                        },
-                                        hoveredSectionId: {
-                                            type: ["string", "undefined"],
-                                            asCell: ["readonly"]
-                                        },
-                                        section: {
-                                            type: "object",
-                                            properties: {
-                                                id: {
-                                                    type: "string"
-                                                },
-                                                title: {
-                                                    type: "string"
-                                                }
-                                            },
-                                            required: ["id", "title"]
-                                        },
-                                        sectionIndex: {
-                                            type: "number"
-                                        },
-                                        state: {
-                                            type: "object",
-                                            properties: {
-                                                showCompleted: {
-                                                    type: "boolean"
-                                                }
-                                            },
-                                            required: ["showCompleted"]
-                                        }
-                                    },
-                                    required: ["selectedTaskId", "hoveredSectionId", "section", "sectionIndex", "state"]
-                                }
-                            },
-                            required: ["element", "params"],
-                            $defs: {
-                                Task: {
-                                    type: "object",
-                                    properties: {
-                                        id: {
-                                            type: "string"
-                                        },
-                                        label: {
-                                            type: "string"
-                                        },
-                                        done: {
-                                            type: "boolean"
-                                        },
-                                        tags: {
-                                            type: "array",
-                                            items: {
-                                                type: "string"
-                                            }
-                                        },
-                                        note: {
-                                            type: "string"
-                                        }
-                                    },
-                                    required: ["id", "label", "done", "tags"]
-                                }
-                            }
-                        } as const satisfies __cfHelpers.JSONSchema, {
-                            anyOf: [{
-                                    $ref: "https://commonfabric.org/schemas/vnode.json"
-                                }, {
-                                    $ref: "#/$defs/UIRenderable"
-                                }, {
-                                    type: "object",
-                                    properties: {}
-                                }],
-                            $defs: {
-                                UIRenderable: {
-                                    type: "object",
-                                    properties: {
-                                        $UI: {
-                                            $ref: "https://commonfabric.org/schemas/vnode.json"
-                                        }
-                                    },
-                                    required: ["$UI"]
-                                }
-                            }
-                        } as const satisfies __cfHelpers.JSONSchema), {
-                            selectedTaskId: selectedTaskId,
-                            hoveredSectionId: hoveredSectionId,
-                            section: {
-                                id: section.key("id"),
-                                title: section.key("title")
-                            },
-                            sectionIndex: sectionIndex,
-                            state: {
-                                showCompleted: state.key("showCompleted")
-                            }
-                        })}
-                  </div>, __cfLift_4({ section: {
-                            tasks: {
-                                length: section.key("tasks", "length")
-                            },
-                            title: section.key("title")
-                        } }))}
-              </section>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Section"
-                    },
-                    index: {
-                        type: "number"
-                    },
-                    params: {
-                        type: "object",
-                        properties: {
-                            state: {
-                                type: "object",
-                                properties: {
-                                    globalAccent: {
-                                        type: "string"
-                                    },
-                                    showCompleted: {
-                                        type: "boolean"
-                                    }
-                                },
-                                required: ["globalAccent", "showCompleted"]
-                            },
-                            selectedTaskId: {
-                                type: ["string", "undefined"],
-                                asCell: ["readonly"]
-                            },
-                            hoveredSectionId: {
-                                type: ["string", "undefined"],
-                                asCell: ["readonly"]
-                            }
-                        },
-                        required: ["state", "selectedTaskId", "hoveredSectionId"]
-                    }
-                },
-                required: ["element", "params"],
-                $defs: {
-                    Section: {
-                        type: "object",
-                        properties: {
-                            id: {
-                                type: "string"
-                            },
-                            title: {
-                                type: "string"
-                            },
-                            expanded: {
-                                type: "boolean"
-                            },
-                            accent: {
-                                type: "string"
-                            },
-                            tasks: {
-                                type: "array",
-                                items: {
-                                    $ref: "#/$defs/Task"
-                                }
-                            }
-                        },
-                        required: ["id", "title", "expanded", "tasks"]
-                    },
-                    Task: {
-                        type: "object",
-                        properties: {
-                            id: {
-                                type: "string"
-                            },
-                            label: {
-                                type: "string"
-                            },
-                            done: {
-                                type: "boolean"
-                            },
-                            tags: {
-                                type: "array",
-                                items: {
-                                    type: "string"
-                                }
-                            },
-                            note: {
-                                type: "string"
-                            }
-                        },
-                        required: ["id", "label", "done", "tags"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {
+            {state.key("sections").mapWithPattern(__cfPattern_3, {
                 state: {
                     globalAccent: state.key("globalAccent"),
                     showCompleted: state.key("showCompleted")

--- a/packages/ts-transformers/test/fixtures/schema-injection/builder-input-path-shrink.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/builder-input-path-shrink.expected.jsx
@@ -11,23 +11,6 @@ import { action, computed, handler, lift, pattern, type Writable } from "commonf
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift(false, () => deriveInput.key("foo").get());
-const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
-    type: "object",
-    properties: {
-        input: {
-            type: "object",
-            properties: {
-                foo: {
-                    type: "string"
-                }
-            },
-            required: ["foo"],
-            asCell: ["readonly"]
-        }
-    },
-    required: ["input"]
-} as const satisfies __cfHelpers.JSONSchema, (_, { input }) => input.key("foo").get());
 // FIXTURE: builder-input-path-shrink
 // Verifies: builder input schemas shrink to observed paths when reads/writes are specific,
 // including explicit type arguments and interprocedural helper calls.
@@ -49,6 +32,7 @@ const deriveInput = __cfHelpers.__cf_data({} as Writable<{
     foo: string;
     bar: string;
 }>);
+const __cfLift_1 = __cfHelpers.lift(false, () => deriveInput.key("foo").get());
 const computedObserved = __cfHelpers.__cf_data(__cfLift_1().for("computedObserved", true));
 const handlerObserved = handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
@@ -143,6 +127,22 @@ const liftExplicit = lift({
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, (input) => input.key("foo").get());
+const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        input: {
+            type: "object",
+            properties: {
+                foo: {
+                    type: "string"
+                }
+            },
+            required: ["foo"],
+            asCell: ["readonly"]
+        }
+    },
+    required: ["input"]
+} as const satisfies __cfHelpers.JSONSchema, (_, { input }) => input.key("foo").get());
 const actionPattern = pattern((input: Writable<{
     foo: string;
     bar: string;

--- a/packages/ts-transformers/test/fixtures/schema-injection/capability-wrapper-narrowing.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/capability-wrapper-narrowing.expected.jsx
@@ -137,32 +137,7 @@ const comparable = lift({
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema, (input: Writable<State>) => input.equals(input));
-const opaqueMap = lift({
-    type: "array",
-    items: {
-        $ref: "#/$defs/Item"
-    },
-    asCell: ["opaque"],
-    $defs: {
-        Item: {
-            type: "object",
-            properties: {
-                id: {
-                    type: "string"
-                },
-                label: {
-                    type: "string"
-                }
-            },
-            required: ["id", "label"]
-        }
-    }
-} as const satisfies __cfHelpers.JSONSchema, {
-    type: "array",
-    items: {
-        type: "string"
-    }
-} as const satisfies __cfHelpers.JSONSchema, (input: Writable<Item[]>) => input.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return item.key("id");
 }, {
@@ -189,7 +164,33 @@ const opaqueMap = lift({
     }
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema), {}));
+} as const satisfies __cfHelpers.JSONSchema);
+const opaqueMap = lift({
+    type: "array",
+    items: {
+        $ref: "#/$defs/Item"
+    },
+    asCell: ["opaque"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                id: {
+                    type: "string"
+                },
+                label: {
+                    type: "string"
+                }
+            },
+            required: ["id", "label"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "array",
+    items: {
+        type: "string"
+    }
+} as const satisfies __cfHelpers.JSONSchema, (input: Writable<Item[]>) => input.mapWithPattern(__cfPattern_1, {}));
 export { comparable, opaqueMap, pushOnly, readOnly, readWrite, setOnly, updateOnly, };
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }

--- a/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection-shorthand.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection-shorthand.expected.jsx
@@ -11,23 +11,6 @@ import { Cell, computed, lift, pattern, Writable } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
-    summary: {
-        difference: any;
-    };
-}, any>({
-    type: "object",
-    properties: {
-        summary: {
-            type: "object",
-            properties: {
-                difference: true
-            },
-            required: ["difference"]
-        }
-    },
-    required: ["summary"]
-} as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema, ({ summary }) => summary.difference);
 const liftSummary = lift({
     type: "object",
     properties: {
@@ -64,6 +47,23 @@ const liftSummary = lift({
         difference: primaryValue - secondaryValue,
     };
 });
+const __cfLift_1 = __cfHelpers.lift<{
+    summary: {
+        difference: any;
+    };
+}, any>({
+    type: "object",
+    properties: {
+        summary: {
+            type: "object",
+            properties: {
+                difference: true
+            },
+            required: ["difference"]
+        }
+    },
+    required: ["summary"]
+} as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema, ({ summary }) => summary.difference);
 // FIXTURE: context-lift-result-property-projection-shorthand
 // Verifies: shorthand object returns preserve the projected computed() result type
 //   return { difference } → result schema difference: number

--- a/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection.expected.jsx
@@ -11,23 +11,6 @@ import { Cell, computed, lift, pattern, Writable } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift<{
-    summary: {
-        difference: any;
-    };
-}, any>({
-    type: "object",
-    properties: {
-        summary: {
-            type: "object",
-            properties: {
-                difference: true
-            },
-            required: ["difference"]
-        }
-    },
-    required: ["summary"]
-} as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema, ({ summary }) => summary.difference);
 const liftSummary = lift({
     type: "object",
     properties: {
@@ -64,6 +47,23 @@ const liftSummary = lift({
         difference: primaryValue - secondaryValue,
     };
 });
+const __cfLift_1 = __cfHelpers.lift<{
+    summary: {
+        difference: any;
+    };
+}, any>({
+    type: "object",
+    properties: {
+        summary: {
+            type: "object",
+            properties: {
+                difference: true
+            },
+            required: ["difference"]
+        }
+    },
+    required: ["summary"]
+} as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema, ({ summary }) => summary.difference);
 // FIXTURE: context-lift-result-property-projection
 // Verifies: a reactive builder preserves projected property schemas when the captured
 // input comes from a typed lift() result rather than falling back to unknown

--- a/packages/ts-transformers/test/fixtures/schema-transform/opaque-ref-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/opaque-ref-map.expected.jsx
@@ -15,6 +15,82 @@ interface TodoItem {
     title: string;
     done: boolean;
 }
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    return item.key("title");
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/TodoItem"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        TodoItem: {
+            type: "object",
+            properties: {
+                title: {
+                    type: "string"
+                },
+                done: {
+                    type: "boolean"
+                }
+            },
+            required: ["title", "done"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "string"
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const index = __cf_pattern_input.key("index");
+    return ({
+        title: item.key("title"),
+        done: item.key("done"),
+        position: index,
+    });
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/TodoItem"
+        },
+        index: {
+            type: "number"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        TodoItem: {
+            type: "object",
+            properties: {
+                title: {
+                    type: "string"
+                },
+                done: {
+                    type: "boolean"
+                }
+            },
+            required: ["title", "done"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        title: {
+            type: "string"
+        },
+        done: {
+            type: "boolean"
+        },
+        position: {
+            type: "number"
+        }
+    },
+    required: ["title", "done", "position"]
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: opaque-ref-map
 // Verifies: .map() on typed arrays is transformed to .mapWithPattern() with generated schemas
 //   items.map((item) => item.title) → items.mapWithPattern(pattern(...), {})
@@ -23,83 +99,9 @@ interface TodoItem {
 export default pattern((__cf_pattern_input) => {
     const items = __cf_pattern_input.key("items");
     // Map on opaque ref arrays should be transformed to mapWithPattern
-    const mapped = items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-        const item = __cf_pattern_input.key("element");
-        return item.key("title");
-    }, {
-        type: "object",
-        properties: {
-            element: {
-                $ref: "#/$defs/TodoItem"
-            }
-        },
-        required: ["element"],
-        $defs: {
-            TodoItem: {
-                type: "object",
-                properties: {
-                    title: {
-                        type: "string"
-                    },
-                    done: {
-                        type: "boolean"
-                    }
-                },
-                required: ["title", "done"]
-            }
-        }
-    } as const satisfies __cfHelpers.JSONSchema, {
-        type: "string"
-    } as const satisfies __cfHelpers.JSONSchema), {}).for("mapped", true);
+    const mapped = items.mapWithPattern(__cfPattern_1, {}).for("mapped", true);
     // This should also be transformed
-    const filtered = items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-        const item = __cf_pattern_input.key("element");
-        const index = __cf_pattern_input.key("index");
-        return ({
-            title: item.key("title"),
-            done: item.key("done"),
-            position: index,
-        });
-    }, {
-        type: "object",
-        properties: {
-            element: {
-                $ref: "#/$defs/TodoItem"
-            },
-            index: {
-                type: "number"
-            }
-        },
-        required: ["element"],
-        $defs: {
-            TodoItem: {
-                type: "object",
-                properties: {
-                    title: {
-                        type: "string"
-                    },
-                    done: {
-                        type: "boolean"
-                    }
-                },
-                required: ["title", "done"]
-            }
-        }
-    } as const satisfies __cfHelpers.JSONSchema, {
-        type: "object",
-        properties: {
-            title: {
-                type: "string"
-            },
-            done: {
-                type: "boolean"
-            },
-            position: {
-                type: "number"
-            }
-        },
-        required: ["title", "done", "position"]
-    } as const satisfies __cfHelpers.JSONSchema), {}).for("filtered", true);
+    const filtered = items.mapWithPattern(__cfPattern_2, {}).for("filtered", true);
     return { mapped, filtered };
 }, {
     type: "object",

--- a/packages/ts-transformers/test/fixtures/schema-transform/pattern-any-result-override.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/pattern-any-result-override.expected.jsx
@@ -11,6 +11,8 @@ import { computed, pattern, UI, VNode, } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+// Simulates `any` leaking through a generic function (like generateObject)
+declare function fetchAny(): any;
 const __cfLift_1 = __cfHelpers.lift<{
     result: any;
     prompt: string;
@@ -24,8 +26,6 @@ const __cfLift_1 = __cfHelpers.lift<{
     },
     required: ["result", "prompt"]
 } as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema, ({ result, prompt }) => result?.title || prompt || "Untitled");
-// Simulates `any` leaking through a generic function (like generateObject)
-declare function fetchAny(): any;
 // FIXTURE: pattern-any-result-override
 // Verifies: explicit Output type parameter overrides inferred `any` return type for schema generation
 //   pattern<Input, string>() → output schema { type: "string" } instead of inferred any

--- a/packages/ts-transformers/test/fixtures/schema-transform/pattern-explicit-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/pattern-explicit-types.expected.jsx
@@ -11,6 +11,12 @@ import { computed, pattern, } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface Input {
+    foo: string;
+}
+interface Output extends Input {
+    bar: number;
+}
 const __cfLift_1 = __cfHelpers.lift<{
     input: { foo: string; } & {} & { [SELF]: Output; };
 }, { bar: number; foo: string; [SELF]: Output; }>({
@@ -39,12 +45,6 @@ const __cfLift_1 = __cfHelpers.lift<{
     },
     required: ["bar", "foo"]
 } as const satisfies __cfHelpers.JSONSchema, ({ input }) => ({ ...input, bar: 123 }));
-interface Input {
-    foo: string;
-}
-interface Output extends Input {
-    bar: number;
-}
 // FIXTURE: pattern-explicit-types
 // Verifies: explicit Input and Output type parameters generate separate input/output schemas
 //   pattern<Input, Output>() → input schema from Input, output schema from Output (includes inherited fields)

--- a/packages/ts-transformers/test/fixtures/schema-transform/pattern-with-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/pattern-with-types.expected.jsx
@@ -134,6 +134,54 @@ const addItem = handler // <
 }) => {
     items.push({ text: event.detail.message });
 });
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const item = __cf_pattern_input.key("element");
+    const index = __cf_pattern_input.key("index");
+    return (<li key={index}>{item.key("text")}</li>);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            $ref: "#/$defs/Item"
+        },
+        index: {
+            type: "number"
+        }
+    },
+    required: ["element"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                text: {
+                    type: "string",
+                    "default": ""
+                }
+            },
+            required: ["text"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: pattern-with-types
 // Verifies: full pattern with toSchema, handler, JSX, and .map() all transform correctly together
 //   toSchema<T>() → inline JSON schema literal with Default<> mapped to "default" values
@@ -152,54 +200,7 @@ export default pattern((__cf_pattern_input) => {
         <p>Basic pattern</p>
         <p>Items count: {items_count}</p>
         <ul>
-          {items.mapWithPattern(__cfHelpers.pattern(__cf_pattern_input => {
-                const item = __cf_pattern_input.key("element");
-                const index = __cf_pattern_input.key("index");
-                return (<li key={index}>{item.key("text")}</li>);
-            }, {
-                type: "object",
-                properties: {
-                    element: {
-                        $ref: "#/$defs/Item"
-                    },
-                    index: {
-                        type: "number"
-                    }
-                },
-                required: ["element"],
-                $defs: {
-                    Item: {
-                        type: "object",
-                        properties: {
-                            text: {
-                                type: "string",
-                                "default": ""
-                            }
-                        },
-                        required: ["text"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema, {
-                anyOf: [{
-                        $ref: "https://commonfabric.org/schemas/vnode.json"
-                    }, {
-                        $ref: "#/$defs/UIRenderable"
-                    }, {
-                        type: "object",
-                        properties: {}
-                    }],
-                $defs: {
-                    UIRenderable: {
-                        type: "object",
-                        properties: {
-                            $UI: {
-                                $ref: "https://commonfabric.org/schemas/vnode.json"
-                            }
-                        },
-                        required: ["$UI"]
-                    }
-                }
-            } as const satisfies __cfHelpers.JSONSchema), {})}
+          {items.mapWithPattern(__cfPattern_1, {})}
         </ul>
         <cf-message-input name="Send" placeholder="Type a message..." appearance="rounded" oncf-send={addItem({ items })}/>
       </div>),

--- a/packages/ts-transformers/test/fixtures/schema-transform/with-opaque-ref.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/with-opaque-ref.expected.jsx
@@ -11,6 +11,22 @@ import { Cell, pattern, toSchema, UI } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
+interface State {
+    value: Cell<number>;
+}
+const model = __cfHelpers.__cf_data({
+    type: "object",
+    properties: {
+        value: {
+            type: "number",
+            asCell: ["cell"]
+        }
+    },
+    required: ["value"],
+    "default": {
+        value: 0
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_1 = __cfHelpers.lift<{
     cell: {
         value: __cfHelpers.Cell<number>;
@@ -33,22 +49,6 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, ({ cell }) => cell.value.get() * 2);
-interface State {
-    value: Cell<number>;
-}
-const model = __cfHelpers.__cf_data({
-    type: "object",
-    properties: {
-        value: {
-            type: "number",
-            asCell: ["cell"]
-        }
-    },
-    required: ["value"],
-    "default": {
-        value: 0
-    }
-} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: with-opaque-ref
 // Verifies: Cell<> fields generate asCell in schema and a reactive builder gets input/output schemas injected
 //   Cell<number> → { type: "number", asCell: true }

--- a/packages/ts-transformers/test/pipeline-regressions.test.ts
+++ b/packages/ts-transformers/test/pipeline-regressions.test.ts
@@ -108,7 +108,7 @@ Deno.test(
       "PatternCallbackLoweringTransformer",
       "BuilderCallbackHoistingTransformer",
       "SchemaInjectionTransformer",
-      "LiftHoistingTransformer",
+      "BuilderCallHoistingTransformer",
       "SchemaGeneratorTransformer",
       "ReactiveVariableForTransformer",
       "ModuleScopeShadowingTransformer",
@@ -449,23 +449,29 @@ Deno.test(
       types: COMMONFABRIC_TYPES,
     });
 
-    const mapStart = output.indexOf("{examples.mapWithPattern(");
     assert(
-      mapStart >= 0,
-      "expected transformed examples.mapWithPattern callback",
+      output.includes("{examples.mapWithPattern("),
+      "expected transformed examples.mapWithPattern call site",
     );
-    const mapWindow = output.slice(mapStart, mapStart + 5000);
 
+    // CT-1655: the whole `pattern(...)` call for this map is hoisted to a
+    // module-scope `const __cfPattern_N = __cfHelpers.pattern(...)`, so the
+    // callback (and its `__cf_pattern_input.key("params", …)` prologue) now
+    // lives at module scope, ABOVE the `examples.mapWithPattern(__cfPattern_N,
+    // …)` call site rather than inline at it. The property this test guards is
+    // unchanged: the examples capture's params-keyed prologue survives the
+    // pipeline. Assert against the whole output (the prologue lines are unique
+    // to this map's callback).
     assertStringIncludes(
-      mapWindow,
+      output,
       'const selectedExampleId = __cf_pattern_input.key("params", "selectedExampleId");',
     );
     assertStringIncludes(
-      mapWindow,
+      output,
       'const currentItem = __cf_pattern_input.key("params", "currentItem");',
     );
     assertStringIncludes(
-      mapWindow,
+      output,
       'const examples = __cf_pattern_input.key("params", "examples");',
     );
   },


### PR DESCRIPTION
## What

Extend CT-1655's whole-call hoisting to **`pattern`**, building on the merged `lift` (#3813) and `handler` (#3831) steps.

Unlike lift/handler (which are *applied* — `builder(...)(captures)`), a reactive map lowers to `expr.mapWithPattern(__cfHelpers.pattern(cb, inSchema, outSchema), { params })` — so the bare `pattern(...)` call sits in `mapWithPattern`'s **first argument**, with per-instance captures flowing through the **second**. The bare pattern call is therefore capture-free and safe to evaluate once at module scope:

```ts
// module scope:
const __cfPattern_1 = __cfHelpers.pattern(cb, inSchema, outSchema);
// call site:
receiver.mapWithPattern(__cfPattern_1, { params })
```

## How

- **Rename** the hoisting stage `LiftHoistingTransformer` → `BuilderCallHoistingTransformer` (`lift-hoisting.ts` → `builder-call-hoisting.ts`): it now owns lift + handler + pattern — the "**Call**"-vs-"**Callback**" contrast distinguishing it from the `BuilderCallbackHoistingTransformer` it is subsuming.
- **`HoistableBuilderSpec` gains an optional `rewriteSite` hook.** Applied builders (lift/handler) keep the default callee-swap; pattern provides `rewriteSite` to replace just `mapWithPattern`'s first argument with the hoisted name, leaving the callee and the params argument intact.
- **Positional recognition** via `getMapWithPatternHoistablePatternCall`: a `*WithPattern` call whose first argument is a `pattern(...)` builder call. The top-level `export default pattern(...)` is a *direct* call (not a `*WithPattern` argument), so it is **naturally excluded** — no special guard needed.
- **`pattern` removed from CT-1585's `HOISTABLE_BUILDER_NAMES`** in the same change (same double-hoist-TDZ rationale — observed directly without it). Pattern's hoisted reference sits in argument position, not an applied reactive-origin site, so it does **not** need the `resolveBuilderExpressionKind` original-node fallback (confirmed: full suite green without it).

## Verification

- `deno task test` (ts-transformers): **292 passed / 608 steps / 0 failed**.
- **130 fixture goldens** regenerated and audited via three structural checks: ✅ no top-level `export default pattern(...)` hoisted, ✅ no double-hoist TDZ, ✅ nested hoisted builders safe (post-order declaration + lazy callback bodies — e.g. a `__cfPattern_N` whose callback invokes `__cfLift_M`/`__cfHandler_M`).
- **SES verifier** green; added a test asserting a hoisted `pattern(...)` call passes module-scope verification (mirrors the lift/handler cases).
- **schema-generator** green (24 / 226). Pipeline stage-order regression updated + passing.
- Two assertion tests updated for the new shape; design doc updated; fmt/lint clean.

## Not in this PR

**`patternTool` is intentionally deferred.** Unlike `pattern`, `patternTool(fn, { extraParams })` is a *direct* call whose per-instance captures thread through its **own** second argument — so whole-call hoisting would relocate those captures to module scope, which is only safe if `extraParams` can never carry per-instance reactive state. That needs a dedicated investigation, so `patternTool` stays in `BuilderCallbackHoistingTransformer` for now. When it is resolved, `HOISTABLE_BUILDER_NAMES` empties and `BuilderCallbackHoistingTransformer` can be deleted — the "one unified hoisting phase" end-state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hoisted `pattern(...)` calls out of `mapWithPattern` to module scope and rewrote call sites to use `__cfPattern_N`, reducing duplicate work and preventing TDZ. For CT-1655, hoists now emit immediately before each top-level statement to handle `pattern`’s eager callback execution.

- New Features
  - Hoist `__cfHelpers.pattern(cb, inSchema, outSchema)` from the first `mapWithPattern` arg to `const __cfPattern_N`, then call `mapWithPattern(__cfPattern_N, { params })`.
  - Insert hoisted `__cfPattern_N` immediately before the owning top-level statement to avoid TDZ.
  - Add `SYNTHETIC_PATTERN_HOIST_PREFIX` and positional detection via `getWithPatternHoistablePatternCall` (excludes direct `export default pattern(...)`); add `rewriteSite` to `HoistableBuilderSpec` to swap only `mapWithPattern`’s first arg.

- Refactors
  - Rename transformer to `BuilderCallHoistingTransformer`; update pipeline/exports.
  - Remove `pattern` from CT-1585’s `HOISTABLE_BUILDER_NAMES`; keep `patternTool` in `BuilderCallbackHoistingTransformer`.
  - Add SES verifier coverage for a hoisted `pattern(...)` at module scope; docs updated; fixtures regenerated.

<sup>Written for commit 6d724f1f8540d627778ff25defbde3883f701bec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

