### PR TITLE
fix(runner): accept `var x = require(...)` import preamble in ESM verifier (CT-1661)

### DIFF
--- a/packages/runner/src/sandbox/module-record-verifier.ts
+++ b/packages/runner/src/sandbox/module-record-verifier.ts
@@ -44,18 +44,24 @@ const EMPTY_BINDING_SET: ReadonlySet<string> = new Set<string>();
 //   const cf_1 = __importDefault(require("commonfabric"));
 //   const ns_1 = __importStar(require("./ns.ts"));
 //   var sibling_ts_1 = require("./sibling.ts");
-// Captures the local binding name and the imported specifier. Both `const` and
-// `var` are accepted: TypeScript's CommonJS emit declares the module reference
-// for a *re-export* (`export { x } from "./m"`) with `var` (hoisted ahead of the
-// live `Object.defineProperty(exports, …, { get })` getter) while plain imports
-// use `const`. The AMD verifier accepts the re-export form (imports arrive as
-// `define` factory params), so accepting `var` here keeps the ESM verdict in
-// parity — barrel re-exports load instead of failing SES at runtime (CT-1661).
-// A `var` binding is no less safe than `const`: any later reassignment is a bare
-// top-level assignment statement, which `classifyModuleItems` rejects as
-// unsupported executable code.
+// Captures (1) the declaration kind, (2) the local binding name, and (3) the
+// imported specifier. Both `const` and `var` are matched: TypeScript's CommonJS
+// emit declares the module reference for a *re-export* (`export { x } from
+// "./m"`) with `var` (hoisted ahead of the live `Object.defineProperty(exports,
+// …, { get })` getter) while plain imports use `const`. The AMD verifier accepts
+// the re-export form (imports arrive as `define` factory params), so accepting
+// `var` here keeps the ESM verdict in parity — barrel re-exports load instead of
+// failing SES at runtime (CT-1661).
+//
+// The `var` form is gated on a *non-runtime* (local) specifier at the call site:
+// a `const` runtime binding is immutable (reassigning a `const` throws at
+// runtime), but a `var` one is not, and the verifier does not inspect trusted
+// builder-callback bodies — so a `var` runtime binding could be reassigned to
+// attacker code from inside a callback and still pass trusted-builder
+// classification. TS only emits `var` for re-export module references, which are
+// always local, so runtime imports stay `const`-only.
 const REQUIRE_IMPORT = new RegExp(
-  "^(?:const|var)\\s+([A-Za-z_$][\\w$]*)\\s*=\\s*" +
+  "^(const|var)\\s+([A-Za-z_$][\\w$]*)\\s*=\\s*" +
     "(?:__importDefault|__importStar)?\\s*\\(?\\s*" +
     "require\\(\\s*[\"']([^\"']+)[\"']\\s*\\)\\s*\\)?\\s*;?$",
 );
@@ -189,18 +195,22 @@ export function verifyCompiledModuleBody(
       const usesShadowedImportHelper =
         (importDefaultShadowed && /\b__importDefault\s*\(/.test(text)) ||
         (importStarShadowed && /\b__importStar\s*\(/.test(text));
+      // A `var` import binding is mutable at runtime, so only accept it for a
+      // non-runtime (local) specifier — never a trusted runtime module (see the
+      // REQUIRE_IMPORT comment). A `var` runtime require falls through and is
+      // rejected by classification as a top-level mutable binding.
+      const isRuntime = bound ? isRuntimeModuleIdentifier(bound[3]) : false;
+      const mutableRuntimeBinding = bound?.[1] === "var" && isRuntime;
       if (
-        bound && !usesShadowedImportHelper &&
-        isAllowedAuthoredImportSpecifier(bound[2])
+        bound && !usesShadowedImportHelper && !mutableRuntimeBinding &&
+        isAllowedAuthoredImportSpecifier(bound[3])
       ) {
-        const [, binding, specifier] = bound;
+        const [, , binding, specifier] = bound;
         env.set(binding, {
           kind: "import",
           dependencySpecifier: specifier,
           namespaceImport: true,
-          trustedRuntimeName: isRuntimeModuleIdentifier(specifier)
-            ? specifier
-            : undefined,
+          trustedRuntimeName: isRuntime ? specifier : undefined,
         });
         return;
       }

--- a/packages/runner/src/sandbox/module-record-verifier.ts
+++ b/packages/runner/src/sandbox/module-record-verifier.ts
@@ -43,9 +43,19 @@ const EMPTY_BINDING_SET: ReadonlySet<string> = new Set<string>();
 //   const util_ts_1 = require("./util.ts");
 //   const cf_1 = __importDefault(require("commonfabric"));
 //   const ns_1 = __importStar(require("./ns.ts"));
-// Captures the local binding name and the imported specifier.
+//   var sibling_ts_1 = require("./sibling.ts");
+// Captures the local binding name and the imported specifier. Both `const` and
+// `var` are accepted: TypeScript's CommonJS emit declares the module reference
+// for a *re-export* (`export { x } from "./m"`) with `var` (hoisted ahead of the
+// live `Object.defineProperty(exports, …, { get })` getter) while plain imports
+// use `const`. The AMD verifier accepts the re-export form (imports arrive as
+// `define` factory params), so accepting `var` here keeps the ESM verdict in
+// parity — barrel re-exports load instead of failing SES at runtime (CT-1661).
+// A `var` binding is no less safe than `const`: any later reassignment is a bare
+// top-level assignment statement, which `classifyModuleItems` rejects as
+// unsupported executable code.
 const REQUIRE_IMPORT = new RegExp(
-  "^const\\s+([A-Za-z_$][\\w$]*)\\s*=\\s*" +
+  "^(?:const|var)\\s+([A-Za-z_$][\\w$]*)\\s*=\\s*" +
     "(?:__importDefault|__importStar)?\\s*\\(?\\s*" +
     "require\\(\\s*[\"']([^\"']+)[\"']\\s*\\)\\s*\\)?\\s*;?$",
 );

--- a/packages/runner/test/esm-module-body-verifier.test.ts
+++ b/packages/runner/test/esm-module-body-verifier.test.ts
@@ -79,6 +79,21 @@ describe("verifyCompiledModuleBody", () => {
     );
   });
 
+  it("rejects a `var` require of a trusted runtime module", () => {
+    // CT-1661 follow-up (Codex P1): the `var` relaxation must not extend to
+    // trusted runtime bindings. A `var` binding is mutable at runtime (only a
+    // `const` throws on reassignment), and the verifier does not inspect trusted
+    // builder-callback bodies — so a `var cf = require("commonfabric")` could be
+    // reassigned to attacker code from inside a callback yet still pass
+    // trusted-builder classification. Runtime imports must stay `const`.
+    const body = `var cf = require("commonfabric");\n` +
+      `const v = (0, cf.pattern)((s) => { cf = globalThis; return s; });\n` +
+      `exports.v = v;`;
+    expect(() => verifyCompiledModuleBody(body, "/main.ts")).toThrow(
+      /mutable bindings/,
+    );
+  });
+
   it("rejects reassignment of a var import binding", () => {
     // Safety guard for the `var` relaxation: accepting `var x = require(...)`
     // relies on any later reassignment being independently rejected. A bare

--- a/packages/runner/test/esm-module-body-verifier.test.ts
+++ b/packages/runner/test/esm-module-body-verifier.test.ts
@@ -53,6 +53,42 @@ describe("verifyCompiledModuleBody", () => {
     expect(() => verifyCompiledModuleBody(body, "/main.ts")).not.toThrow();
   });
 
+  it("accepts a named re-export (`export { x } from` — var require preamble)", () => {
+    // CT-1661: TypeScript's CommonJS emit declares the module reference for a
+    // named re-export with `var` (hoisted ahead of the live getter), unlike the
+    // `const` of a plain import. The import-preamble fast-path must accept the
+    // `var` form so the re-export verifies — matching the AMD verdict, which
+    // already accepts re-exports (imports arrive as factory params).
+    const body = compiledBody({
+      "/sibling.ts": `export const thatConst = (): number => 42;`,
+      "/main.ts":
+        `export { thatConst } from "./sibling.ts";\nexport const own = (): number => 2;`,
+    }, "/main.ts");
+    expect(body).toMatch(/var \w+ = require\(/); // sanity: TS emits `var`
+    expect(body).toContain('Object.defineProperty(exports, "thatConst"'); // getter
+    expect(() => verifyCompiledModuleBody(body, "/main.ts")).not.toThrow();
+  });
+
+  it("still rejects a non-import top-level `var` binding", () => {
+    // The `var` relaxation is scoped to the `= require(...)` import preamble.
+    // A plain mutable top-level binding must remain a SES violation.
+    const body =
+      `Object.defineProperty(exports, "__esModule", { value: true });\nvar leaked = 7;`;
+    expect(() => verifyCompiledModuleBody(body, "/main.ts")).toThrow(
+      /mutable bindings/,
+    );
+  });
+
+  it("rejects reassignment of a var import binding", () => {
+    // Safety guard for the `var` relaxation: accepting `var x = require(...)`
+    // relies on any later reassignment being independently rejected. A bare
+    // top-level assignment is not a recognized item, so it must throw.
+    const body =
+      `Object.defineProperty(exports, "__esModule", { value: true });\n` +
+      `var m = require("./sibling.ts");\nm = globalThis;`;
+    expect(() => verifyCompiledModuleBody(body, "/main.ts")).toThrow();
+  });
+
   it("rejects export-star require of a disallowed specifier", () => {
     // Hand-built body: __exportStar from a non-local, non-runtime specifier.
     const body =

--- a/packages/runner/test/esm-pattern-run.test.ts
+++ b/packages/runner/test/esm-pattern-run.test.ts
@@ -77,6 +77,53 @@ describe("Pattern run via esmModuleLoader", () => {
     expect(result.getAsQueryResult()).toEqual({ result: 6 });
   });
 
+  it("runs a pattern through a named re-export barrel (`export { x } from`)", async () => {
+    // CT-1661: a barrel that re-exports a sibling's binding compiles to a `var
+    // ... = require(...)` preamble plus a live getter. Under the ESM loader this
+    // previously failed SES verification at runtime ("Top-level mutable bindings
+    // are not allowed") even though `cf check` (AMD path) passed. The re-export
+    // must now both verify AND resolve the live binding correctly end-to-end.
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [
+        {
+          name: "/sibling.ts",
+          contents: "export const factor = (x:number)=>x*3;",
+        },
+        {
+          name: "/barrel.ts",
+          contents: "export { factor } from './sibling.ts';",
+        },
+        {
+          name: "/main.tsx",
+          contents: [
+            "import { pattern, lift } from 'commonfabric';",
+            "import { factor } from './barrel.ts';",
+            "const tripled = lift((x:number)=>factor(x));",
+            "export default pattern<{ value: number }>(({ value }) => {",
+            "  return { result: tripled(value) };",
+            "});",
+          ].join("\n"),
+        },
+      ],
+    };
+
+    const compiled = await runtime.patternManager.compilePattern(program);
+    expect(Object.isFrozen(compiled)).toBe(true);
+
+    const resultCell = runtime.getCell<{ result: number }>(
+      space,
+      "esm re-export barrel run",
+      undefined,
+      tx,
+    );
+    const result = runtime.run(tx, compiled, { value: 5 }, resultCell);
+    await tx.commit();
+    tx = runtime.edit();
+    await result.pull();
+    expect(result.getAsQueryResult()).toEqual({ result: 15 });
+  });
+
   it("composes a frozen sub-pattern imported from another module", async () => {
     // The sub-pattern is exported from /sub.tsx (and hardened at the module
     // boundary), then imported and instantiated INSIDE the parent pattern. This

--- a/packages/runner/test/esm-verifier-parity.test.ts
+++ b/packages/runner/test/esm-verifier-parity.test.ts
@@ -136,6 +136,14 @@ const REJECT: Case[] = [
     reject: /.*/,
   },
   {
+    // CT-1661: the `var` re-export relaxation must not extend to trusted runtime
+    // bindings — `var` is mutable at runtime, so a runtime require must be
+    // `const`. Mirrors `const` accept "named reexport getter from a var require".
+    name: "var require of a trusted runtime module",
+    body: `var cf = require("commonfabric");\nexports.cf = cf;`,
+    reject: /mutable/i,
+  },
+  {
     name: "bare side-effect import of a disallowed specifier",
     body: `require("node:child_process");\nexports.x = 1;`,
     reject: /.*/,

--- a/packages/runner/test/esm-verifier-parity.test.ts
+++ b/packages/runner/test/esm-verifier-parity.test.ts
@@ -47,6 +47,15 @@ const ACCEPT: Case[] = [
       `const inner_1 = require("./inner.ts");\nObject.defineProperty(exports, "x", { enumerable: true, get: function () { return inner_1.x; } });`,
   },
   {
+    // CT-1661: `export { x } from "./m"` emits the module reference as `var`
+    // (hoisted ahead of the getter), not `const`. AMD accepts re-exports
+    // (imports are factory params); the ESM import-preamble must accept the
+    // `var` form too, or the same source diverges between the two verifiers.
+    name: "named reexport getter from a var require preamble",
+    body:
+      `var inner_1 = require("./inner.ts");\nObject.defineProperty(exports, "x", { enumerable: true, get: function () { return inner_1.x; } });`,
+  },
+  {
     name: "ambient safe global inside a builder callback",
     body: `${IMPORT}\nexports.v = (0, cf_1.pattern)((s) => fetch(s.url));`,
   },


### PR DESCRIPTION
## Summary

Fixes [CT-1661](https://linear.app/common-tools/issue/CT-1661). A pattern that re-exports from a sibling module — `export { x } from "./mod.ts"`, an ordinary barrel-file move — passed `cf check` clean, then failed at ESM-loader runtime with an opaque SES error:

```
ModuleVerificationError: cf:module/<hash>:18:1:
Top-level mutable bindings are not allowed in SES mode
```

## Root cause

TypeScript's per-module CommonJS emit declares the module reference for a **re-export** with `var` (hoisted ahead of the live `Object.defineProperty(exports, …, { get })` getter), whereas a plain import uses `const`:

```js
var sibling_ts_1 = require("./sibling.ts");                          // <-- var, not const
Object.defineProperty(exports, "thatConst", {
  enumerable: true, get: function () { return sibling_ts_1.thatConst; },
});
```

The ESM verifier's import-preamble fast-path (`REQUIRE_IMPORT` in `module-record-verifier.ts`) only matched `const`, so the `var` fell through to `verifyVariableStatement`, which rejects any non-`const` top-level binding. The getter itself is fine — it's the `var` require that trips SES.

The **AMD** verifier (used by `cf check`) accepts the same re-export because imports arrive as `define` factory params rather than `var x = require(...)`. So AMD accepts / ESM rejects — an AMD/ESM **parity violation**, and the source of the "green check, runtime explosion" gap. It grows in impact as `esmModuleLoader` becomes the default.

## Fix

Extend the import-preamble fast-path to accept both `const` and `var` for the `= require(...)` form. This restores AMD/ESM verdict parity, so barrel re-exports load instead of failing SES at runtime.

**Safety:** the relaxation is scoped to the `= require("<allowed>")` preamble. Any later reassignment of the binding is a bare top-level assignment statement, which `classifyModuleItems` already rejects as unsupported executable code (covered by a new adversarial test). A non-import top-level `var`/`let` remains a SES violation.

## Tests

- **esm-module-body-verifier**: accepts the `var` re-export; still rejects a non-import top-level `var`; rejects reassignment of a `var` import binding.
- **esm-pattern-run**: end-to-end — a barrel re-export both verifies *and* resolves the live binding correctly at runtime (5×3=15).
- **esm-verifier-parity**: the CT-1661 `var`-require + getter shape as an ACCEPT parity case.

All adjacent security/parity suites (adversarial, parity, module-record, compiled-module, source-location, engine, loader, cell-cache, compiler) pass with no failures; format and type-check clean.

## Note

The issue also asked, as a fallback, to (a) run the SES verifier during `cf check` and (b) map errors back to authored file:line. Those aren't needed for this specific form now that it just works, but remain valid hardening for *other* SES divergences — worth a separate follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts `var x = require(...)` in the ESM verifier for named re-exports, gated to non-runtime specifiers, to restore AMD/ESM parity and fix the SES “Top-level mutable bindings” error. Addresses CT-1661.

- **Bug Fixes**
  - Import preamble accepts `const` and `var` for local `= require(...)`; `var` requires of trusted runtime modules (e.g., `commonfabric`) are rejected.
  - Barrel re-exports (`export { x } from "./m"`) now verify and run under `esmModuleLoader`; added tests for verifier acceptance, runtime behavior, parity, and the runtime `var` exploit rejection.

<sup>Written for commit 65d569a47de8b4f1767730e64263be7fdd34fe85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

