### PR TITLE
feat(runner): identify map/flatmap/filter result containers by reserved output spot (CT-1623)

### DIFF
--- a/packages/patterns/integration/reload/default-app-notebook.test.ts
+++ b/packages/patterns/integration/reload/default-app-notebook.test.ts
@@ -25,15 +25,14 @@ describe("default-app notebook reload integration test", () => {
   const shell = new ShellIntegration();
   shell.bindLifecycle();
 
-  // TEMPORARILY DISABLED: content-addressed canonical `fn.src` (#3828) makes
-  // scheduler action identity stable across the default-app-bundle vs.
-  // Notebook-entry compilation split, so more persisted snapshots now match on
-  // reload. That surfaces legitimately dirty-at-shutdown actions that the broken
-  // identity previously hid, pushing the total reload action count above this
-  // shard's regression budget (~167 vs the 150 limit). The increase is correct
-  // behavior, not a regression; reducing it is separate follow-up work on
-  // dirty-at-shutdown settling. Re-enable once that lands.
-  it.skip("reloads every rapidly created notebook note in a separate shard", async () => {
+  // Re-enabled (CT-1623): map/flatmap/filter result containers (and nested
+  // pattern result cells) are now identified by the reserved output spot — a
+  // stable, position-derived identity — instead of the serialized `op` / inputs
+  // cell, which dragged in the session-varying `program` and forced per-row
+  // cell ids to churn across reloads. Persisted scheduler state now rehydrates,
+  // dropping reload action runs well under this shard's budget (was ~167 > 150;
+  // now ~80-95).
+  it("reloads every rapidly created notebook note in a separate shard", async () => {
     const identity = await Identity.generate({ implementation: "noble" });
     const notebookSpaceName = globalThis.crypto.randomUUID();
     const page = shell.page();

--- a/packages/runner/src/builtins/filter.ts
+++ b/packages/runner/src/builtins/filter.ts
@@ -81,13 +81,18 @@ export function filter(
         tx.getCfcState().implementationIdentity,
         "filter",
       );
+      // CT-1623: identify the result container by the reserved output spot
+      // (stable, program-independent). See map.ts for rationale.
+      const outputSpot = (cause as { outputSpot?: unknown } | undefined)
+        ?.outputSpot;
+      if (!outputSpot) {
+        throw new Error(
+          "filter: result container requires a write-redirect output binding",
+        );
+      }
       const baseResult = runtime.getCell<any[]>(
         parentCell.space,
-        {
-          filter: parentCell.entityId,
-          op: inputsCell.getAsQueryResult([], tx)?.op,
-          cause,
-        },
+        { filter: parentCell.entityId, outputSpot },
         resultSchema,
         tx,
       );

--- a/packages/runner/src/builtins/flatmap.ts
+++ b/packages/runner/src/builtins/flatmap.ts
@@ -83,13 +83,18 @@ export function flatMap(
         tx.getCfcState().implementationIdentity,
         "flatMap",
       );
+      // CT-1623: identify the result container by the reserved output spot
+      // (stable, program-independent). See map.ts for rationale.
+      const outputSpot = (cause as { outputSpot?: unknown } | undefined)
+        ?.outputSpot;
+      if (!outputSpot) {
+        throw new Error(
+          "flatMap: result container requires a write-redirect output binding",
+        );
+      }
       const baseResult = runtime.getCell<any[]>(
         parentCell.space,
-        {
-          flatMap: parentCell.entityId,
-          op: inputsCell.getAsQueryResult([], tx)?.op,
-          cause,
-        },
+        { flatMap: parentCell.entityId, outputSpot },
         resultSchema,
         tx,
       );

--- a/packages/runner/src/builtins/map.ts
+++ b/packages/runner/src/builtins/map.ts
@@ -106,13 +106,23 @@ export function map(
         "map",
         opPattern.resultSchema,
       );
+      // CT-1623: identify the result container by the reserved output spot —
+      // the fully-resolved write-redirect target the runner supplies in `cause`.
+      // It is a stable, position-derived, program-independent identity, unlike
+      // the serialized `op` / `cause.inputs`, both of which drag in the
+      // session-varying `program` and force the container id (and every per-row
+      // id derived from it) to churn across reloads. A `map` node always writes
+      // through a write redirect, so the absence of an output spot is a bug.
+      const outputSpot = (cause as { outputSpot?: unknown } | undefined)
+        ?.outputSpot;
+      if (!outputSpot) {
+        throw new Error(
+          "map: result container requires a write-redirect output binding",
+        );
+      }
       const baseResult = runtime.getCell<any[]>(
         parentCell.space,
-        {
-          map: parentCell.entityId,
-          op: inputsCell.getAsQueryResult([], tx)?.op,
-          cause,
-        },
+        { map: parentCell.entityId, outputSpot },
         resultSchema,
         tx,
       );

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -3834,12 +3834,16 @@ export class Runner {
       // DISTINCT concrete cells. Resolving the raw bindings would let pseudo
       // cells at the same path (e.g. `internal.x` vs `result.x`) collapse onto
       // the base result cell and collide on one shared child cell.
+      // `bindPatterns: false` — output bindings never carry sub-patterns to
+      // instantiate, so skip that work; we only need the pseudo-cell aliases
+      // resolved to their concrete links.
       const mappedOutputBindings = unwrapOneLevelAndBindtoDoc(
         this.runtime.cfc,
         outputBindings,
         argumentCellLink,
         internalCellLink,
         resultCellLink,
+        { bindPatterns: false },
       );
       const outputRedirect = firstResolvedOutputRedirect(
         this.runtime,

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -3828,10 +3828,23 @@ export class Runner {
       // below); we only borrow the resolved output link's coordinates as the
       // cause. A pattern node always writes through a write redirect, so the
       // absence of one is a bug (the legacy non-redirect variants are removed).
+      //
+      // Bind the output bindings first (as `instantiateRawNode` does), so the
+      // `argument`/`internal`/`result` pseudo-cell aliases resolve to their
+      // DISTINCT concrete cells. Resolving the raw bindings would let pseudo
+      // cells at the same path (e.g. `internal.x` vs `result.x`) collapse onto
+      // the base result cell and collide on one shared child cell.
+      const mappedOutputBindings = unwrapOneLevelAndBindtoDoc(
+        this.runtime.cfc,
+        outputBindings,
+        argumentCellLink,
+        internalCellLink,
+        resultCellLink,
+      );
       const outputRedirect = firstResolvedOutputRedirect(
         this.runtime,
         tx,
-        outputBindings,
+        mappedOutputBindings,
         resultCell,
       );
       if (!outputRedirect) {

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -356,6 +356,45 @@ const recordRawBuiltinResultSchemaPolicyInput = (
   );
 };
 
+/**
+ * Find the first write-redirect link within an output binding and return its
+ * FULLY RESOLVED normalized link (`id` and `space` populated). The output spot
+ * a pattern node writes through is reserved for that node, so its resolved
+ * coordinates form a stable, position-derived, program-independent identity —
+ * suitable as the cause for the node's result cell instead of hashing the
+ * pattern object (which drags in the session-varying `program`). Returns
+ * undefined if the binding contains no write redirect.
+ */
+function firstResolvedOutputRedirect(
+  runtime: Runtime,
+  tx: IExtendedStorageTransaction,
+  binding: unknown,
+  baseCell: Cell<any>,
+): NormalizedFullLink | undefined {
+  if (isWriteRedirectLink(binding)) {
+    return resolveLink(
+      runtime,
+      tx,
+      parseLink(binding, baseCell),
+      "writeRedirect",
+    );
+  }
+  if (Array.isArray(binding)) {
+    for (const child of binding) {
+      const found = firstResolvedOutputRedirect(runtime, tx, child, baseCell);
+      if (found) return found;
+    }
+    return undefined;
+  }
+  if (isRecord(binding) && !isCellLink(binding)) {
+    for (const child of Object.values(binding)) {
+      const found = firstResolvedOutputRedirect(runtime, tx, child, baseCell);
+      if (found) return found;
+    }
+  }
+  return undefined;
+}
+
 const recordSetupProjectionPolicyInputs = (
   tx: IExtendedStorageTransaction,
   runtime: Runtime,
@@ -3501,6 +3540,18 @@ export class Runner {
       tx,
     );
 
+    // CT-1623: the output spot this node writes through is reserved for this
+    // node, so its fully-resolved coordinates are a stable, position-derived,
+    // program-independent identity. Builtins that mint a result container
+    // (map/flatmap/filter) key it on this instead of the serialized op /
+    // inputs cell (both of which drag in the session-varying `program`).
+    const resolvedOutputSpot = firstResolvedOutputRedirect(
+      this.runtime,
+      tx,
+      mappedOutputBindings,
+      processCell,
+    );
+
     const builtinFrame = builtinIdentity
       ? pushFrameFromCause(undefined, {
         runtime: this.runtime,
@@ -3544,7 +3595,19 @@ export class Runner {
           );
         },
         addCancel,
-        { inputs: inputsCell, parents: processCell.entityId },
+        {
+          inputs: inputsCell,
+          parents: processCell.entityId,
+          ...(resolvedOutputSpot
+            ? {
+              outputSpot: {
+                space: resolvedOutputSpot.space,
+                id: resolvedOutputSpot.id,
+                path: [...resolvedOutputSpot.path],
+              },
+            }
+            : {}),
+        },
         processCell,
         this.runtime,
       );
@@ -3757,13 +3820,34 @@ export class Runner {
       const resultScope = patternDefaultScope(patternImpl) ??
         module.defaultScope;
       const targetSpace = module.targetSpace ?? resultCell.space;
+      // CT-1623: identify the result cell by the (fully resolved) output spot
+      // reserved for this node — a stable, position-derived, program-independent
+      // identity — rather than hashing the pattern object (which drags in the
+      // session-varying `program` and forces `materializeRuntimeProgram`). We
+      // still mint a NEW cell and point the binding at it (`sendToBindings`
+      // below); we only borrow the resolved output link's coordinates as the
+      // cause. A pattern node always writes through a write redirect, so the
+      // absence of one is a bug (the legacy non-redirect variants are removed).
+      const outputRedirect = firstResolvedOutputRedirect(
+        this.runtime,
+        tx,
+        outputBindings,
+        resultCell,
+      );
+      if (!outputRedirect) {
+        throw new Error(
+          "instantiatePatternNode: result cell requires a write-redirect " +
+            "output binding to anchor a reload-stable identity",
+        );
+      }
       const baseResultCell = this.runtime.getCell(
         targetSpace,
         {
-          pattern: module.implementation,
-          parent: resultCell.entityId,
-          inputBindings,
-          outputBindings,
+          resultFor: {
+            space: outputRedirect.space,
+            id: outputRedirect.id,
+            path: [...outputRedirect.path],
+          },
         },
         patternImpl.resultSchema,
         tx,


### PR DESCRIPTION
## Problem

On reload, the default-app notebook re-ran ~167 actions (over the 150 budget), so persisted scheduler state could not be reused. Root cause: per-row `map` cell ids churned across reloads.

The `map`/`flatmap`/`filter` **result container** was keyed on the serialized `op` *and* the immutable `inputs` cell — both of which serialize the pattern via `patternToJSON`, which includes `program`. The cell store turns `program` into a session-specific link, so the container id (and every per-row id derived from it via `{ map: container, elementKey }`) changed every session. Persisted observations/dirty state keyed on the old ids never matched → everything re-ran.

This is also why neither a content-addressed `op.src` nor stabilizing the pattern id alone fixed it — the container churned via **both** `op` and `cause.inputs`.

## Fix

Identify the result container by its **reserved output spot** — the fully-resolved write-redirect target the node writes through. That output slot is reserved for exactly this node, so its coordinates are a stable, position-derived, **program-independent** identity. The container id (and all per-row ids) are then stable across reloads.

- **`firstResolvedOutputRedirect()`** — finds the first write redirect in an output binding and returns its *fully resolved* normalized link (`id` + `space` populated). Full resolution is the crux: `findAllWriteRedirectCells` only does `parseLink`, so a missing-`id` link degenerates into the processCell (the collision that broke earlier naive attempts).
- Plumb the resolved output spot through the raw-builtin cause; `map`/`flatmap`/`filter` key their container on it, **throwing** if absent (every such node writes through a write redirect).
- Anchor nested-pattern result cells (`instantiatePatternNode`) on the same resolved output spot, replacing the pattern-object hash.
- Re-enable the default-app notebook reload integration test (was skipped at ~167 > 150).

No `materializeRuntimeProgram` / source-in-identity needed — the program dependence is removed at the source.

## Validation

- **517/517 runner unit tests pass** (incl. pattern-scope, nested/dynamic/derive-returning-pattern, esm).
- **Reload integration test passes with headroom**: action runs dropped from ~167 (baseline / over budget) to **~80–95** across runs (budget 150), with `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE` on.

## Notes

- Non-redirect / non-link output variants now **throw** (per design — those variants are being removed). No unit or integration path hit the throw.
- One-time id migration: existing persisted spaces get new container ids on first load after this lands (same as a `materialize`-style fix would).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Anchored `map`/`flatMap`/`filter` result containers and nested pattern result cells to their reserved output spot to stop id churn across sessions. Satisfies CT-1623, lets persisted scheduler state rehydrate, re-enables the default-app reload test (~80–95 actions), and skips unnecessary pattern binding when resolving output pseudo-cells to reduce overhead.

- **Bug Fixes**
  - Added `firstResolvedOutputRedirect()` to return a fully-resolved normalized link and pass it as `outputSpot`.
  - Keyed result containers on `outputSpot` in `map`/`flatMap`/`filter`; throw if the node lacks a write-redirect output.
  - Anchored nested-pattern result cells on the same `outputSpot`; bind output pseudo-cells (`argument`/`internal`/`result`) before resolving to avoid alias collisions, and set `bindPatterns: false` to skip unneeded sub-pattern work.
  - Re-enabled the default-app notebook reload integration test; all runner unit tests pass.

- **Migration**
  - One-time identity change: existing persisted spaces get new container ids on first load. No manual steps required.

<sup>Written for commit c1fe2fa20c0dedd05afe4cc73e1636e0a91710e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

