### PR TITLE
ci: capture the FUSE daemon log from its real path on failure

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -363,7 +363,21 @@ jobs:
 
       - name: 📋 FUSE daemon log (on failure)
         if: ${{ failure() && matrix.suite_name == 'fuse' }}
-        run: cat ~/.cf/fuse/fuse-daemon.log 2>/dev/null || echo "No daemon log found"
+        # `cf fuse mount --background` writes its log to /tmp/cf-fuse-<mountpoint>.log
+        # (see packages/cli/commands/fuse.ts), not ~/.cf/fuse — the old path always
+        # printed "No daemon log found", hiding the real daemon error. The mountpoint
+        # is an mktemp dir, so glob all fuse daemon logs.
+        run: |
+          shopt -s nullglob
+          logs=(/tmp/cf-fuse-*.log)
+          if [ ${#logs[@]} -eq 0 ]; then
+            echo "No FUSE daemon log found at /tmp/cf-fuse-*.log"
+          else
+            for f in "${logs[@]}"; do
+              echo "===== ${f} ====="
+              cat "${f}"
+            done
+          fi
 
       - name: 📤 Upload CLI integration timing data
         if: ${{ always() && startsWith(matrix.suite_name, 'core-') }}

--- a/deno.lock
+++ b/deno.lock
@@ -61,6 +61,7 @@
     "jsr:@std/streams@^1.0.16": "1.0.16",
     "jsr:@std/testing@1": "1.0.16",
     "jsr:@std/text@~1.0.7": "1.0.16",
+    "jsr:@std/yaml@*": "1.0.12",
     "jsr:@zip-js/zip-js@^2.7.52": "2.8.4",
     "npm:@ai-sdk/anthropic@^2.0.9": "2.0.44_zod@3.25.76",
     "npm:@ai-sdk/google-vertex@^3.0.16": "3.0.62_zod@3.25.76",
@@ -339,6 +340,9 @@
     },
     "@std/text@1.0.16": {
       "integrity": "ddb9853b75119a2473857d691cf1ec02ad90793a2e8b4a4ac49d7354281a0cf8"
+    },
+    "@std/yaml@1.0.12": {
+      "integrity": "7deabca4545bcedd07c5f69ea53acea71b8b4c67562f224e17b90d75944cb20c"
     },
     "@zip-js/zip-js@2.8.4": {
       "integrity": "d95019eeab46519a241125c3d7e367f5be5eb81c66747e01dbbb11ea464c5826"


### PR DESCRIPTION
## What

The `📋 FUSE daemon log (on failure)` step in `deno.yml` reads `~/.cf/fuse/fuse-daemon.log` — a path that never exists. `cf fuse mount --background` actually writes its log to `/tmp/cf-fuse-<mountpoint>.log` (`packages/cli/commands/fuse.ts:447`). So every FUSE integration failure prints **"No daemon log found"**, hiding the real daemon-side error.

This globs and prints all `/tmp/cf-fuse-*.log` files instead (the mountpoint is an `mktemp -d` dir, so the exact filename varies per run).

## Why now

The flag-flip canary (#3782) exposed a **FUSE-specific** `cf piece setsrc` hang under the ESM module loader (plain non-FUSE `setsrc` passes — only the FUSE job hangs). Diagnosing it has been blocked because the daemon log was never captured. This is a prerequisite CI fix: with the real log surfaced, the next failed FUSE run will show the actual daemon stack, and the hang can be fixed from ground truth instead of inference.

Standalone CI improvement — independent of the runtime bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix CI FUSE daemon log capture by reading from the actual `/tmp/cf-fuse-*.log` files on failure instead of the nonexistent `~/.cf/fuse/fuse-daemon.log`. This surfaces real daemon errors in failed FUSE runs, unblocking debugging of hangs like `cf piece setsrc` under the ESM loader.

<sup>Written for commit 5378bdeb39b820ebfe1aae8c30379bf8ed8f9721. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

