### PR TITLE
Stop testing the legacy data model (prep for legacy-path removal)

### DIFF
--- a/docs/development/EXPERIMENTAL_OPTIONS.md
+++ b/docs/development/EXPERIMENTAL_OPTIONS.md
@@ -121,9 +121,8 @@ Key points:
 2. The **shell build** bakes the flags into the JS bundle via esbuild defines.
 3. The **IPC protocol** carries the flags from the main thread to the Web Worker
    via `InitializationData`.
-4. The **Runtime constructor** calls `setDataModelConfig()`, which
-   sets the module-level ambient config used by `fabricFromNativeValue()` and related
-   functions.
+4. The **Runtime constructor** calls experiment configuration functions, which
+   collectively set up the ambient config for the system.
 
 ## Background Charm Service
 

--- a/packages/data-model/test/cloneForMutation.test.ts
+++ b/packages/data-model/test/cloneForMutation.test.ts
@@ -3,660 +3,643 @@ import { expect } from "@std/expect";
 import {
   cloneForMutation,
   CloneForMutationError,
-  resetDataModelConfig,
-  setDataModelConfig,
 } from "../src/fabric-value.ts";
 import type { FabricValue } from "../src/fabric-value.ts";
 import { deepFreeze, isDeepFrozen } from "../src/deep-freeze.ts";
 import { FabricEpochNsec } from "../src/fabric-primitives/FabricEpochNsec.ts";
 import { FabricError } from "../src/fabric-instances/FabricError.ts";
 
-// Both legacy and modern flag states use modern clone semantics. Test cases are
-// parameterized across both modes to ensure the contract is durable under
-// either flag setting.
 describe("cloneForMutation", () => {
-  afterEach(() => {
-    resetDataModelConfig();
+  describe("empty path", () => {
+    it("returns the root as mutable, plus identical `pathValue`", () => {
+      const root = Object.freeze({ a: 1, b: 2 }) as FabricValue;
+      const { value, pathValue } = cloneForMutation(root, []);
+
+      expect(value).not.toBe(root);
+      expect(Object.isFrozen(value)).toBe(false);
+      expect(pathValue).toBe(value);
+      expect(value).toEqual({ a: 1, b: 2 });
+    });
+
+    it("returns input identity when already mutable + `force=false`", () => {
+      const root = { a: 1 } as FabricValue;
+      const { value, pathValue } = cloneForMutation(root, [], {
+        force: false,
+      });
+      expect(value).toBe(root);
+      expect(pathValue).toBe(root);
+    });
+
+    it("does not touch the input on default options (`force` defaults to `true`)", () => {
+      // Default `force` is true, matching `cloneIfNecessary`'s default
+      // when `frozen: false`. Even with mutable input, the result is a
+      // fresh copy.
+      const root = { a: 1 } as FabricValue;
+      const { value, pathValue } = cloneForMutation(root, []);
+      expect(value).not.toBe(root);
+      expect(pathValue).toBe(value);
+      expect(value).toEqual({ a: 1 });
+      expect(Object.isFrozen(value)).toBe(false);
+    });
+
+    it("always shallow-clones the root when `force=true`", () => {
+      const root = { a: 1 } as FabricValue;
+      const { value, pathValue } = cloneForMutation(root, [], {
+        force: true,
+      });
+      expect(value).not.toBe(root);
+      expect(pathValue).toBe(value);
+      expect(value).toEqual({ a: 1 });
+      expect(Object.isFrozen(value)).toBe(false);
+    });
+
+    it("handles an empty-path `FabricInstance` via `shallowClone(false)`", () => {
+      const err = FabricError.fromNativeError(new Error("test"));
+      Object.freeze(err);
+      const { value, pathValue } = cloneForMutation(
+        err as unknown as FabricValue,
+        [],
+      );
+      expect(value).not.toBe(err);
+      expect(value).toBeInstanceOf(FabricError);
+      expect(Object.isFrozen(value)).toBe(false);
+      expect(pathValue).toBe(value);
+      // `shallowUnfrozenClone` preserves the FabricValue-shaped state.
+      const cloned = value as unknown as FabricError;
+      expect(cloned.type).toBe(err.type);
+      expect(cloned.name).toBe(err.name);
+      expect(cloned.message).toBe(err.message);
+    });
   });
 
-  for (const modernMode of [false, true]) {
-    const label = modernMode ? "modern" : "legacy";
-
-    describe(`(${label} path)`, () => {
-      beforeEach(() => setDataModelConfig(modernMode));
-
-      describe("empty path", () => {
-        it("returns the root as mutable, plus identical `pathValue`", () => {
-          const root = Object.freeze({ a: 1, b: 2 }) as FabricValue;
-          const { value, pathValue } = cloneForMutation(root, []);
-
-          expect(value).not.toBe(root);
-          expect(Object.isFrozen(value)).toBe(false);
-          expect(pathValue).toBe(value);
-          expect(value).toEqual({ a: 1, b: 2 });
-        });
-
-        it("returns input identity when already mutable + `force=false`", () => {
-          const root = { a: 1 } as FabricValue;
-          const { value, pathValue } = cloneForMutation(root, [], {
-            force: false,
-          });
-          expect(value).toBe(root);
-          expect(pathValue).toBe(root);
-        });
-
-        it("does not touch the input on default options (`force` defaults to `true`)", () => {
-          // Default `force` is true, matching `cloneIfNecessary`'s default
-          // when `frozen: false`. Even with mutable input, the result is a
-          // fresh copy.
-          const root = { a: 1 } as FabricValue;
-          const { value, pathValue } = cloneForMutation(root, []);
-          expect(value).not.toBe(root);
-          expect(pathValue).toBe(value);
-          expect(value).toEqual({ a: 1 });
-          expect(Object.isFrozen(value)).toBe(false);
-        });
-
-        it("always shallow-clones the root when `force=true`", () => {
-          const root = { a: 1 } as FabricValue;
-          const { value, pathValue } = cloneForMutation(root, [], {
-            force: true,
-          });
-          expect(value).not.toBe(root);
-          expect(pathValue).toBe(value);
-          expect(value).toEqual({ a: 1 });
-          expect(Object.isFrozen(value)).toBe(false);
-        });
-
-        it("handles an empty-path `FabricInstance` via `shallowClone(false)`", () => {
-          const err = FabricError.fromNativeError(new Error("test"));
-          Object.freeze(err);
-          const { value, pathValue } = cloneForMutation(
-            err as unknown as FabricValue,
-            [],
-          );
-          expect(value).not.toBe(err);
-          expect(value).toBeInstanceOf(FabricError);
-          expect(Object.isFrozen(value)).toBe(false);
-          expect(pathValue).toBe(value);
-          // `shallowUnfrozenClone` preserves the FabricValue-shaped state.
-          const cloned = value as unknown as FabricError;
-          expect(cloned.type).toBe(err.type);
-          expect(cloned.name).toBe(err.name);
-          expect(cloned.message).toBe(err.message);
-        });
-      });
-
-      describe("single-step path", () => {
-        it("clones only the spine and exposes the leaf container", () => {
-          const inner = Object.freeze({ x: 1 });
-          const sibling = Object.freeze({ y: 2 });
-          const root = Object.freeze({
-            a: inner,
-            b: sibling,
-          }) as FabricValue;
-
-          const { value, pathValue } = cloneForMutation(root, ["a"]);
-
-          expect(value).not.toBe(root);
-          expect(pathValue).toBe(
-            (value as unknown as Record<string, unknown>).a,
-          );
-          expect(pathValue).not.toBe(inner); // had to thaw it
-          expect(Object.isFrozen(value)).toBe(false);
-          expect(Object.isFrozen(pathValue)).toBe(false);
-
-          // Critical: the sibling subtree is preserved by identity.
-          expect((value as unknown as Record<string, unknown>).b).toBe(sibling);
-        });
-
-        it("descends into a single-element array", () => {
-          const noteA = Object.freeze({ title: "first" });
-          const noteB = Object.freeze({ title: "second" });
-          const root = Object.freeze({
-            notes: Object.freeze([noteA, noteB]),
-          }) as FabricValue;
-
-          const { value, pathValue } = cloneForMutation(root, ["notes"]);
-
-          expect(Array.isArray(pathValue)).toBe(true);
-          expect((pathValue as unknown as unknown[]).length).toBe(2);
-
-          // The note objects inside the freshly-thawed array are still the
-          // original frozen instances -- shallow-thaw shares references.
-          expect((pathValue as unknown as unknown[])[0]).toBe(noteA);
-          expect((pathValue as unknown as unknown[])[1]).toBe(noteB);
-
-          // The spliced-in array lives inside the new root.
-          expect((value as unknown as Record<string, unknown>).notes).toBe(
-            pathValue,
-          );
-        });
-
-        it("returns input root identity when already mutable + `force=false`", () => {
-          const inner = { x: 1 };
-          const root = { a: inner } as FabricValue;
-
-          const { value, pathValue } = cloneForMutation(root, ["a"], {
-            force: false,
-          });
-
-          // Already-mutable root reused by identity.
-          expect(value).toBe(root);
-          // Inner was already mutable too -- reused.
-          expect(pathValue).toBe(inner);
-        });
-
-        it("does not touch a mutable input on default options", () => {
-          // Default `force` is true: input is left alone even when mutable.
-          const inner = { x: 1 };
-          const root = { a: inner } as FabricValue;
-
-          const { value, pathValue } = cloneForMutation(root, ["a"]);
-
-          expect(value).not.toBe(root);
-          expect(pathValue).not.toBe(inner);
-          // Sibling identity still preserved (would be `b` if present).
-        });
-
-        it("always copies the root and leaf when `force=true`", () => {
-          const inner = { x: 1 };
-          const root = { a: inner } as FabricValue;
-
-          const { value, pathValue } = cloneForMutation(root, ["a"], {
-            force: true,
-          });
-
-          expect(value).not.toBe(root);
-          expect(pathValue).not.toBe(inner);
-          // ...but the leaf's children stay shared.
-          expect(pathValue).toEqual({ x: 1 });
-        });
-      });
-
-      describe("deep paths", () => {
-        it("clones every spine container, preserves off-spine identity", () => {
-          // Tree shape:
-          //   root
-          //     ├ a (frozen, on spine)
-          //     │   ├ b (frozen, on spine)
-          //     │   │   └ c (frozen, on spine -- the target)
-          //     │   └ b2 (frozen, OFF spine)
-          //     └ a2 (frozen, OFF spine)
-          const c = Object.freeze({ leaf: true });
-          const b2 = Object.freeze({ off: "spine-b" });
-          const b = Object.freeze({ c, b2 });
-          const a2 = Object.freeze({ off: "spine-a" });
-          const a = Object.freeze({ b, a2 });
-          const root = Object.freeze({ a, a2 }) as FabricValue;
-
-          const { value, pathValue } = cloneForMutation(root, ["a", "b", "c"]);
-
-          // Every spine container is freshly cloned (or at minimum,
-          // distinct from the input's frozen original).
-          expect(value).not.toBe(root);
-          const newA = (value as unknown as Record<string, unknown>)
-            .a as Record<
-              string,
-              unknown
-            >;
-          expect(newA).not.toBe(a);
-          const newB = newA.b as Record<string, unknown>;
-          expect(newB).not.toBe(b);
-          const newC = newB.c;
-          expect(newC).toBe(pathValue);
-          expect(newC).not.toBe(c);
-
-          // Off-spine subtrees retained by identity:
-          //   - root.a2 (sibling of `a`)
-          //   - a.b is now newA.b (= newB); but a.a2 (= a2) -- wait, a2 is on
-          //     root, not on a. The off-spine peer at depth `a` is `root.a2`.
-          //   - The off-spine peer at depth `b` is `a.a2`... no, `a` only has
-          //     children `b` and `a2`. So `a2` is off-spine relative to the
-          //     descent into `b`.
-          expect((value as unknown as Record<string, unknown>).a2).toBe(a2);
-          expect(newA.a2).toBe(a2);
-          expect(newB.b2).toBe(b2);
-
-          // Spine is mutable, off-spine retains frozenness:
-          expect(Object.isFrozen(value)).toBe(false);
-          expect(Object.isFrozen(newA)).toBe(false);
-          expect(Object.isFrozen(newB)).toBe(false);
-          expect(Object.isFrozen(newC)).toBe(false);
-          expect(Object.isFrozen(a2)).toBe(true);
-          expect(Object.isFrozen(b2)).toBe(true);
-        });
-
-        it("descends through arrays as well as objects", () => {
-          const target = Object.freeze({ leaf: true });
-          const otherNote = Object.freeze({ leaf: false });
-          const notes = Object.freeze([otherNote, target]);
-          const root = Object.freeze({ notes }) as FabricValue;
-
-          const { value, pathValue } = cloneForMutation(
-            root,
-            ["notes", "1"],
-          );
-
-          const newNotes = (value as unknown as Record<string, unknown>).notes;
-          expect(Array.isArray(newNotes)).toBe(true);
-          expect(newNotes).not.toBe(notes);
-          // Other (off-spine) element preserved by identity.
-          expect((newNotes as unknown[])[0]).toBe(otherNote);
-          // Target is the freshly-thawed pathValue.
-          expect((newNotes as unknown[])[1]).toBe(pathValue);
-          expect(pathValue).not.toBe(target);
-        });
-      });
-
-      describe("deep-frozen cache preservation", () => {
-        it("preserves off-spine deep-frozen subtrees in the cache", () => {
-          // A deeply-nested off-spine subtree:
-          const sibling = deepFreeze({ deep: { nested: [1, 2, 3] } });
-          // (Sanity: deepFreeze has cached it.)
-          expect(isDeepFrozen(sibling)).toBe(true);
-
-          const target = Object.freeze({ leaf: true });
-          const root = deepFreeze({ a: target, b: sibling }) as FabricValue;
-
-          const { value } = cloneForMutation(root, ["a"]);
-
-          // The sibling subtree is preserved by identity AND retains its
-          // place in the deep-frozen cache (so future `isDeepFrozen` checks
-          // and `cloneIfNecessary` short-circuits stay O(1)).
-          expect((value as unknown as Record<string, unknown>).b).toBe(sibling);
-          expect(isDeepFrozen(sibling)).toBe(true);
-        });
-      });
-
-      describe("`FabricInstance` at leaf", () => {
-        it("clones via `shallowClone(false)`, not as a plain object", () => {
-          const err = FabricError.fromNativeError(new Error("boom"));
-          Object.freeze(err);
-          const root = Object.freeze({ payload: err }) as FabricValue;
-
-          const { value, pathValue } = cloneForMutation(root, ["payload"]);
-
-          expect(pathValue).toBeInstanceOf(FabricError);
-          expect(pathValue).not.toBe(err);
-          expect(Object.isFrozen(pathValue)).toBe(false);
-          // The FabricValue-shaped state is preserved (shallowClone).
-          const cloned = pathValue as unknown as FabricError;
-          expect(cloned.type).toBe(err.type);
-          expect(cloned.message).toBe(err.message);
-          // And spliced into the new spine.
-          expect((value as unknown as Record<string, unknown>).payload).toBe(
-            pathValue,
-          );
-        });
-      });
-
-      describe("mutation through pathValue", () => {
-        it("supports array push without touching the input", () => {
-          const notes = Object.freeze([{ id: 1 }, { id: 2 }]);
-          const root = Object.freeze({ notes }) as FabricValue;
-
-          const { value, pathValue } = cloneForMutation(root, ["notes"]);
-
-          (pathValue as unknown as Array<Record<string, unknown>>).push({
-            id: 3,
-          });
-
-          expect((value as unknown as Record<string, unknown>).notes).toBe(
-            pathValue,
-          );
-          expect((pathValue as unknown as unknown[]).length).toBe(3);
-          // Input is untouched.
-          expect(notes.length).toBe(2);
-        });
-
-        it("supports object property delete without touching the input", () => {
-          const root = Object.freeze({
-            keep: 1,
-            drop: 2,
-          }) as FabricValue;
-
-          const { value, pathValue } = cloneForMutation(root, []);
-
-          delete (pathValue as unknown as Record<string, unknown>).drop;
-
-          expect(value).toEqual({ keep: 1 });
-          expect((root as unknown as Record<string, unknown>).drop).toBe(2);
-        });
-
-        it("does not touch the input on `force=true` even with mutable input", () => {
-          const inner = { x: 1, y: 2 };
-          const root = { inner };
-
-          const { value, pathValue } = cloneForMutation(
-            root as unknown as FabricValue,
-            ["inner"],
-            { force: true },
-          );
-
-          (pathValue as unknown as Record<string, unknown>).x = 999;
-
-          expect((value as unknown as Record<string, unknown>).inner).toBe(
-            pathValue,
-          );
-          // Input untouched.
-          expect(inner.x).toBe(1);
-          expect(root.inner).toBe(inner);
-        });
-      });
-
-      describe("createMissing", () => {
-        it("creates a missing intermediate object", () => {
-          const root = Object.freeze({ a: { existing: 1 } }) as FabricValue;
-          const { value, pathValue } = cloneForMutation(
-            root,
-            ["a", "new"],
-            { createMissing: true, nextKeyAfterPath: "key" },
-          );
-          const newA = (value as unknown as Record<string, unknown>)
-            .a as Record<
-              string,
-              unknown
-            >;
-          // The original `a.existing` is preserved by identity (off-spine).
-          expect(newA.existing).toBe(1);
-          // `a.new` is freshly created and is what `pathValue` points at.
-          expect(newA.new).toBe(pathValue);
-          // `nextKeyAfterPath: "key"` selects an object.
-          expect(pathValue).toEqual({});
-          expect(Array.isArray(pathValue)).toBe(false);
-        });
-
-        it("creates a missing intermediate array (numeric next key)", () => {
-          const root = Object.freeze({ a: {} }) as FabricValue;
-          const { value, pathValue } = cloneForMutation(
-            root,
-            ["a", "items"],
-            { createMissing: true, nextKeyAfterPath: "0" },
-          );
-          const newA = (value as unknown as Record<string, unknown>)
-            .a as Record<
-              string,
-              unknown
-            >;
-          expect(newA.items).toBe(pathValue);
-          expect(Array.isArray(pathValue)).toBe(true);
-          expect(pathValue).toEqual([]);
-        });
-
-        it("treats `-` as the JSON-Pointer array append marker", () => {
-          const root = Object.freeze({}) as FabricValue;
-          const { value: _v, pathValue } = cloneForMutation(
-            root,
-            ["items"],
-            { createMissing: true, nextKeyAfterPath: "-" },
-          );
-          expect(Array.isArray(pathValue)).toBe(true);
-        });
-
-        it("defaults to an object when `nextKeyAfterPath` is omitted", () => {
-          const root = Object.freeze({}) as FabricValue;
-          const { pathValue } = cloneForMutation(
-            root,
-            ["new"],
-            { createMissing: true },
-          );
-          expect(Array.isArray(pathValue)).toBe(false);
-          expect(pathValue).toEqual({});
-        });
-
-        it("chains multiple missing intermediates with correct shapes", () => {
-          // path: ["a", "0", "items", "0", "name"]
-          //   a -> object (next segment is "0" -- wait, this is the
-          //   array-index test below; for THIS test let's mix object
-          //   and array).
-          //
-          // Try: root.notes[0].title where notes doesn't exist.
-          // - path[0]="notes" -> needs container at root.notes. Next is
-          //   "0" -> array.
-          // - path[1]="0" -> needs container at root.notes[0]. Next is
-          //   "title" -> object.
-          // - path[2]="title" -> the leaf, nextKeyAfterPath="" -> object
-          //   if missing.
-          const root = Object.freeze({}) as FabricValue;
-          const { value, pathValue } = cloneForMutation(
-            root,
-            ["notes", "0", "title"],
-            { createMissing: true },
-          );
-          const newRoot = value as unknown as Record<string, unknown>;
-          expect(Array.isArray(newRoot.notes)).toBe(true);
-          const notes = newRoot.notes as unknown[];
-          expect(notes.length).toBe(1);
-          expect(typeof notes[0]).toBe("object");
-          expect(Array.isArray(notes[0])).toBe(false);
-          // The leaf was created with default `nextKeyAfterPath: ""` -> object.
-          expect(pathValue).toBe(
-            (notes[0] as Record<string, unknown>).title,
-          );
-          expect(pathValue).toEqual({});
-        });
-
-        it("preserves existing intermediates while creating missing ones", () => {
-          const existingNotes = Object.freeze([{ kept: 1 }]);
-          const root = Object.freeze({
-            notes: existingNotes,
-          }) as FabricValue;
-          const { value, pathValue } = cloneForMutation(
-            root,
-            ["notes", "0", "newKey"],
-            { createMissing: true, nextKeyAfterPath: "leaf" },
-          );
-          const newRoot = value as unknown as Record<string, unknown>;
-          const newNotes = newRoot.notes as unknown[];
-          // The existing element was thawed (spine touches it) but the
-          // sibling identity of `existingNotes[0].kept` is preserved.
-          const note0 = newNotes[0] as Record<string, unknown>;
-          expect(note0.kept).toBe(1);
-          // The newly-created leaf-parent slot.
-          expect(note0.newKey).toBe(pathValue);
-          expect(pathValue).toEqual({});
-        });
-
-        it("does not interfere with normal (non-missing) descent", () => {
-          // If everything exists, `createMissing: true` should behave the
-          // same as the default.
-          const root = Object.freeze({
-            a: Object.freeze({ b: Object.freeze({ c: 42 }) }),
-          }) as FabricValue;
-          const { pathValue } = cloneForMutation(
-            root,
-            ["a", "b"],
-            { createMissing: true },
-          );
-          expect(pathValue).toEqual({ c: 42 });
-        });
-
-        it("interacts correctly with `force=false` (identity on existing path)", () => {
-          // If `createMissing: true` but every step exists AND `force:
-          // false` AND input is already mutable, identity is preserved.
-          const inner = { existing: 1 };
-          const root = { a: inner } as FabricValue;
-          const { value, pathValue } = cloneForMutation(
-            root,
-            ["a"],
-            { createMissing: true, force: false },
-          );
-          expect(value).toBe(root);
-          expect(pathValue).toBe(inner);
-        });
-
-        it("respects `force=true` on the spine-thaw even when creating", () => {
-          // When force=true (default), already-mutable spine containers
-          // are still copied. `createMissing` doesn't change that.
-          const root = { existing: 1 } as FabricValue;
-          const { value, pathValue } = cloneForMutation(
-            root,
-            ["new"],
-            { createMissing: true },
-          );
-          expect(value).not.toBe(root); // root was force-copied
-          expect((value as unknown as Record<string, unknown>).existing).toBe(
-            1,
-          );
-          expect((value as unknown as Record<string, unknown>).new).toBe(
-            pathValue,
-          );
-        });
-      });
-
-      describe("CloneForMutationError", () => {
-        it("uses kind `missing-segment` for a missing intermediate", () => {
-          const root = Object.freeze({ a: { b: 1 } }) as FabricValue;
-          try {
-            cloneForMutation(root, ["a", "nonesuch", "more"]);
-            throw new Error("expected throw");
-          } catch (e) {
-            expect(e).toBeInstanceOf(CloneForMutationError);
-            const err = e as CloneForMutationError;
-            expect(err.kind).toBe("missing-segment");
-            expect(err.pathIndex).toBe(1);
-            expect(err.valueKind).toBe("undefined");
-          }
-        });
-
-        it("uses kind `non-container-descent` for primitive in path", () => {
-          const root = Object.freeze({ x: 42 }) as FabricValue;
-          try {
-            cloneForMutation(root, ["x", "anything"]);
-            throw new Error("expected throw");
-          } catch (e) {
-            expect(e).toBeInstanceOf(CloneForMutationError);
-            const err = e as CloneForMutationError;
-            expect(err.kind).toBe("non-container-descent");
-            expect(err.pathIndex).toBe(0);
-            expect(err.valueKind).toBe("number");
-          }
-        });
-
-        it("uses kind `non-mutable-leaf` for a primitive leaf", () => {
-          const root = Object.freeze({ x: 42 }) as FabricValue;
-          try {
-            cloneForMutation(root, ["x"]);
-            throw new Error("expected throw");
-          } catch (e) {
-            expect(e).toBeInstanceOf(CloneForMutationError);
-            const err = e as CloneForMutationError;
-            expect(err.kind).toBe("non-mutable-leaf");
-            expect(err.pathIndex).toBe(0);
-            expect(err.valueKind).toBe("number");
-          }
-        });
-
-        it("uses kind `non-mutable-root` for empty path with bad root", () => {
-          try {
-            cloneForMutation(42 as FabricValue, []);
-            throw new Error("expected throw");
-          } catch (e) {
-            expect(e).toBeInstanceOf(CloneForMutationError);
-            const err = e as CloneForMutationError;
-            expect(err.kind).toBe("non-mutable-root");
-            expect(err.pathIndex).toBe(-1);
-            expect(err.valueKind).toBe("number");
-          }
-        });
-
-        it("uses kind `non-container-root` for non-empty path with bad root", () => {
-          try {
-            cloneForMutation(42 as FabricValue, ["x"]);
-            throw new Error("expected throw");
-          } catch (e) {
-            expect(e).toBeInstanceOf(CloneForMutationError);
-            const err = e as CloneForMutationError;
-            expect(err.kind).toBe("non-container-root");
-            expect(err.pathIndex).toBe(-1);
-            expect(err.valueKind).toBe("number");
-          }
-        });
-
-        it("sets `error.name` to `CloneForMutationError`", () => {
-          try {
-            cloneForMutation(42 as FabricValue, []);
-            throw new Error("expected throw");
-          } catch (e) {
-            expect((e as Error).name).toBe("CloneForMutationError");
-          }
-        });
-      });
-
-      describe("errors", () => {
-        it("throws on a missing path segment", () => {
-          const root = Object.freeze({ a: { b: 1 } }) as FabricValue;
-          expect(() => cloneForMutation(root, ["a", "nonesuch"]))
-            .toThrow("missing path segment");
-        });
-
-        it("throws on a missing array index", () => {
-          const root = Object.freeze({
-            notes: Object.freeze([1, 2, 3]),
-          }) as FabricValue;
-          expect(() => cloneForMutation(root, ["notes", "10"]))
-            .toThrow("missing path segment");
-        });
-
-        it("throws when descending through a primitive", () => {
-          const root = Object.freeze({ x: 42 }) as FabricValue;
-          expect(() => cloneForMutation(root, ["x", "anything"]))
-            .toThrow("cannot descend into");
-        });
-
-        it("throws when descending through a `FabricInstance`", () => {
-          const err = FabricError.fromNativeError(new Error("inside"));
-          const root = Object.freeze({ err }) as FabricValue;
-          // `path = ["err", "something"]` tries to descend INTO the
-          // FabricInstance, which isn't supported.
-          expect(() => cloneForMutation(root, ["err", "message"])).toThrow(
-            "cannot descend into",
-          );
-        });
-
-        it("throws when descending through a `FabricPrimitive`", () => {
-          const epoch = new FabricEpochNsec(123n);
-          const root = Object.freeze({
-            epoch: epoch as unknown as FabricValue,
-          }) as FabricValue;
-          expect(() => cloneForMutation(root, ["epoch", "anything"]))
-            .toThrow("cannot descend into");
-        });
-
-        it("throws when the leaf is a primitive (not mutable)", () => {
-          const root = Object.freeze({ x: 42 }) as FabricValue;
-          expect(() => cloneForMutation(root, ["x"]))
-            .toThrow("cannot mutate");
-        });
-
-        it("throws when the leaf is a `FabricPrimitive` (not mutable)", () => {
-          const epoch = new FabricEpochNsec(123n);
-          const root = Object.freeze({
-            epoch: epoch as unknown as FabricValue,
-          }) as FabricValue;
-          expect(() => cloneForMutation(root, ["epoch"]))
-            .toThrow("cannot mutate");
-        });
-
-        it("throws on empty-path against a non-mutable root", () => {
-          expect(() => cloneForMutation(42 as FabricValue, []))
-            .toThrow("cannot mutate");
-        });
-
-        it("throws on non-empty path against a non-container root", () => {
-          expect(() => cloneForMutation(42 as FabricValue, ["x"]))
-            .toThrow("cannot descend into");
-        });
-
-        it("throws on non-empty path against a `FabricInstance` root", () => {
-          // A FabricInstance is OK at the leaf but not as the root of a
-          // non-empty path (we don't descend into FabricInstance internals).
-          const err = FabricError.fromNativeError(new Error("test"));
-          expect(() => cloneForMutation(err as unknown as FabricValue, ["x"]))
-            .toThrow("cannot descend into");
-        });
-      });
+  describe("single-step path", () => {
+    it("clones only the spine and exposes the leaf container", () => {
+      const inner = Object.freeze({ x: 1 });
+      const sibling = Object.freeze({ y: 2 });
+      const root = Object.freeze({
+        a: inner,
+        b: sibling,
+      }) as FabricValue;
+
+      const { value, pathValue } = cloneForMutation(root, ["a"]);
+
+      expect(value).not.toBe(root);
+      expect(pathValue).toBe(
+        (value as unknown as Record<string, unknown>).a,
+      );
+      expect(pathValue).not.toBe(inner); // had to thaw it
+      expect(Object.isFrozen(value)).toBe(false);
+      expect(Object.isFrozen(pathValue)).toBe(false);
+
+      // Critical: the sibling subtree is preserved by identity.
+      expect((value as unknown as Record<string, unknown>).b).toBe(sibling);
     });
-  }
+
+    it("descends into a single-element array", () => {
+      const noteA = Object.freeze({ title: "first" });
+      const noteB = Object.freeze({ title: "second" });
+      const root = Object.freeze({
+        notes: Object.freeze([noteA, noteB]),
+      }) as FabricValue;
+
+      const { value, pathValue } = cloneForMutation(root, ["notes"]);
+
+      expect(Array.isArray(pathValue)).toBe(true);
+      expect((pathValue as unknown as unknown[]).length).toBe(2);
+
+      // The note objects inside the freshly-thawed array are still the
+      // original frozen instances -- shallow-thaw shares references.
+      expect((pathValue as unknown as unknown[])[0]).toBe(noteA);
+      expect((pathValue as unknown as unknown[])[1]).toBe(noteB);
+
+      // The spliced-in array lives inside the new root.
+      expect((value as unknown as Record<string, unknown>).notes).toBe(
+        pathValue,
+      );
+    });
+
+    it("returns input root identity when already mutable + `force=false`", () => {
+      const inner = { x: 1 };
+      const root = { a: inner } as FabricValue;
+
+      const { value, pathValue } = cloneForMutation(root, ["a"], {
+        force: false,
+      });
+
+      // Already-mutable root reused by identity.
+      expect(value).toBe(root);
+      // Inner was already mutable too -- reused.
+      expect(pathValue).toBe(inner);
+    });
+
+    it("does not touch a mutable input on default options", () => {
+      // Default `force` is true: input is left alone even when mutable.
+      const inner = { x: 1 };
+      const root = { a: inner } as FabricValue;
+
+      const { value, pathValue } = cloneForMutation(root, ["a"]);
+
+      expect(value).not.toBe(root);
+      expect(pathValue).not.toBe(inner);
+      // Sibling identity still preserved (would be `b` if present).
+    });
+
+    it("always copies the root and leaf when `force=true`", () => {
+      const inner = { x: 1 };
+      const root = { a: inner } as FabricValue;
+
+      const { value, pathValue } = cloneForMutation(root, ["a"], {
+        force: true,
+      });
+
+      expect(value).not.toBe(root);
+      expect(pathValue).not.toBe(inner);
+      // ...but the leaf's children stay shared.
+      expect(pathValue).toEqual({ x: 1 });
+    });
+  });
+
+  describe("deep paths", () => {
+    it("clones every spine container, preserves off-spine identity", () => {
+      // Tree shape:
+      //   root
+      //     ├ a (frozen, on spine)
+      //     │   ├ b (frozen, on spine)
+      //     │   │   └ c (frozen, on spine -- the target)
+      //     │   └ b2 (frozen, OFF spine)
+      //     └ a2 (frozen, OFF spine)
+      const c = Object.freeze({ leaf: true });
+      const b2 = Object.freeze({ off: "spine-b" });
+      const b = Object.freeze({ c, b2 });
+      const a2 = Object.freeze({ off: "spine-a" });
+      const a = Object.freeze({ b, a2 });
+      const root = Object.freeze({ a, a2 }) as FabricValue;
+
+      const { value, pathValue } = cloneForMutation(root, ["a", "b", "c"]);
+
+      // Every spine container is freshly cloned (or at minimum,
+      // distinct from the input's frozen original).
+      expect(value).not.toBe(root);
+      const newA = (value as unknown as Record<string, unknown>)
+        .a as Record<
+          string,
+          unknown
+        >;
+      expect(newA).not.toBe(a);
+      const newB = newA.b as Record<string, unknown>;
+      expect(newB).not.toBe(b);
+      const newC = newB.c;
+      expect(newC).toBe(pathValue);
+      expect(newC).not.toBe(c);
+
+      // Off-spine subtrees retained by identity:
+      //   - root.a2 (sibling of `a`)
+      //   - a.b is now newA.b (= newB); but a.a2 (= a2) -- wait, a2 is on
+      //     root, not on a. The off-spine peer at depth `a` is `root.a2`.
+      //   - The off-spine peer at depth `b` is `a.a2`... no, `a` only has
+      //     children `b` and `a2`. So `a2` is off-spine relative to the
+      //     descent into `b`.
+      expect((value as unknown as Record<string, unknown>).a2).toBe(a2);
+      expect(newA.a2).toBe(a2);
+      expect(newB.b2).toBe(b2);
+
+      // Spine is mutable, off-spine retains frozenness:
+      expect(Object.isFrozen(value)).toBe(false);
+      expect(Object.isFrozen(newA)).toBe(false);
+      expect(Object.isFrozen(newB)).toBe(false);
+      expect(Object.isFrozen(newC)).toBe(false);
+      expect(Object.isFrozen(a2)).toBe(true);
+      expect(Object.isFrozen(b2)).toBe(true);
+    });
+
+    it("descends through arrays as well as objects", () => {
+      const target = Object.freeze({ leaf: true });
+      const otherNote = Object.freeze({ leaf: false });
+      const notes = Object.freeze([otherNote, target]);
+      const root = Object.freeze({ notes }) as FabricValue;
+
+      const { value, pathValue } = cloneForMutation(
+        root,
+        ["notes", "1"],
+      );
+
+      const newNotes = (value as unknown as Record<string, unknown>).notes;
+      expect(Array.isArray(newNotes)).toBe(true);
+      expect(newNotes).not.toBe(notes);
+      // Other (off-spine) element preserved by identity.
+      expect((newNotes as unknown[])[0]).toBe(otherNote);
+      // Target is the freshly-thawed pathValue.
+      expect((newNotes as unknown[])[1]).toBe(pathValue);
+      expect(pathValue).not.toBe(target);
+    });
+  });
+
+  describe("deep-frozen cache preservation", () => {
+    it("preserves off-spine deep-frozen subtrees in the cache", () => {
+      // A deeply-nested off-spine subtree:
+      const sibling = deepFreeze({ deep: { nested: [1, 2, 3] } });
+      // (Sanity: deepFreeze has cached it.)
+      expect(isDeepFrozen(sibling)).toBe(true);
+
+      const target = Object.freeze({ leaf: true });
+      const root = deepFreeze({ a: target, b: sibling }) as FabricValue;
+
+      const { value } = cloneForMutation(root, ["a"]);
+
+      // The sibling subtree is preserved by identity AND retains its
+      // place in the deep-frozen cache (so future `isDeepFrozen` checks
+      // and `cloneIfNecessary` short-circuits stay O(1)).
+      expect((value as unknown as Record<string, unknown>).b).toBe(sibling);
+      expect(isDeepFrozen(sibling)).toBe(true);
+    });
+  });
+
+  describe("`FabricInstance` at leaf", () => {
+    it("clones via `shallowClone(false)`, not as a plain object", () => {
+      const err = FabricError.fromNativeError(new Error("boom"));
+      Object.freeze(err);
+      const root = Object.freeze({ payload: err }) as FabricValue;
+
+      const { value, pathValue } = cloneForMutation(root, ["payload"]);
+
+      expect(pathValue).toBeInstanceOf(FabricError);
+      expect(pathValue).not.toBe(err);
+      expect(Object.isFrozen(pathValue)).toBe(false);
+      // The FabricValue-shaped state is preserved (shallowClone).
+      const cloned = pathValue as unknown as FabricError;
+      expect(cloned.type).toBe(err.type);
+      expect(cloned.message).toBe(err.message);
+      // And spliced into the new spine.
+      expect((value as unknown as Record<string, unknown>).payload).toBe(
+        pathValue,
+      );
+    });
+  });
+
+  describe("mutation through pathValue", () => {
+    it("supports array push without touching the input", () => {
+      const notes = Object.freeze([{ id: 1 }, { id: 2 }]);
+      const root = Object.freeze({ notes }) as FabricValue;
+
+      const { value, pathValue } = cloneForMutation(root, ["notes"]);
+
+      (pathValue as unknown as Array<Record<string, unknown>>).push({
+        id: 3,
+      });
+
+      expect((value as unknown as Record<string, unknown>).notes).toBe(
+        pathValue,
+      );
+      expect((pathValue as unknown as unknown[]).length).toBe(3);
+      // Input is untouched.
+      expect(notes.length).toBe(2);
+    });
+
+    it("supports object property delete without touching the input", () => {
+      const root = Object.freeze({
+        keep: 1,
+        drop: 2,
+      }) as FabricValue;
+
+      const { value, pathValue } = cloneForMutation(root, []);
+
+      delete (pathValue as unknown as Record<string, unknown>).drop;
+
+      expect(value).toEqual({ keep: 1 });
+      expect((root as unknown as Record<string, unknown>).drop).toBe(2);
+    });
+
+    it("does not touch the input on `force=true` even with mutable input", () => {
+      const inner = { x: 1, y: 2 };
+      const root = { inner };
+
+      const { value, pathValue } = cloneForMutation(
+        root as unknown as FabricValue,
+        ["inner"],
+        { force: true },
+      );
+
+      (pathValue as unknown as Record<string, unknown>).x = 999;
+
+      expect((value as unknown as Record<string, unknown>).inner).toBe(
+        pathValue,
+      );
+      // Input untouched.
+      expect(inner.x).toBe(1);
+      expect(root.inner).toBe(inner);
+    });
+  });
+
+  describe("createMissing", () => {
+    it("creates a missing intermediate object", () => {
+      const root = Object.freeze({ a: { existing: 1 } }) as FabricValue;
+      const { value, pathValue } = cloneForMutation(
+        root,
+        ["a", "new"],
+        { createMissing: true, nextKeyAfterPath: "key" },
+      );
+      const newA = (value as unknown as Record<string, unknown>)
+        .a as Record<
+          string,
+          unknown
+        >;
+      // The original `a.existing` is preserved by identity (off-spine).
+      expect(newA.existing).toBe(1);
+      // `a.new` is freshly created and is what `pathValue` points at.
+      expect(newA.new).toBe(pathValue);
+      // `nextKeyAfterPath: "key"` selects an object.
+      expect(pathValue).toEqual({});
+      expect(Array.isArray(pathValue)).toBe(false);
+    });
+
+    it("creates a missing intermediate array (numeric next key)", () => {
+      const root = Object.freeze({ a: {} }) as FabricValue;
+      const { value, pathValue } = cloneForMutation(
+        root,
+        ["a", "items"],
+        { createMissing: true, nextKeyAfterPath: "0" },
+      );
+      const newA = (value as unknown as Record<string, unknown>)
+        .a as Record<
+          string,
+          unknown
+        >;
+      expect(newA.items).toBe(pathValue);
+      expect(Array.isArray(pathValue)).toBe(true);
+      expect(pathValue).toEqual([]);
+    });
+
+    it("treats `-` as the JSON-Pointer array append marker", () => {
+      const root = Object.freeze({}) as FabricValue;
+      const { value: _v, pathValue } = cloneForMutation(
+        root,
+        ["items"],
+        { createMissing: true, nextKeyAfterPath: "-" },
+      );
+      expect(Array.isArray(pathValue)).toBe(true);
+    });
+
+    it("defaults to an object when `nextKeyAfterPath` is omitted", () => {
+      const root = Object.freeze({}) as FabricValue;
+      const { pathValue } = cloneForMutation(
+        root,
+        ["new"],
+        { createMissing: true },
+      );
+      expect(Array.isArray(pathValue)).toBe(false);
+      expect(pathValue).toEqual({});
+    });
+
+    it("chains multiple missing intermediates with correct shapes", () => {
+      // path: ["a", "0", "items", "0", "name"]
+      //   a -> object (next segment is "0" -- wait, this is the
+      //   array-index test below; for THIS test let's mix object
+      //   and array).
+      //
+      // Try: root.notes[0].title where notes doesn't exist.
+      // - path[0]="notes" -> needs container at root.notes. Next is
+      //   "0" -> array.
+      // - path[1]="0" -> needs container at root.notes[0]. Next is
+      //   "title" -> object.
+      // - path[2]="title" -> the leaf, nextKeyAfterPath="" -> object
+      //   if missing.
+      const root = Object.freeze({}) as FabricValue;
+      const { value, pathValue } = cloneForMutation(
+        root,
+        ["notes", "0", "title"],
+        { createMissing: true },
+      );
+      const newRoot = value as unknown as Record<string, unknown>;
+      expect(Array.isArray(newRoot.notes)).toBe(true);
+      const notes = newRoot.notes as unknown[];
+      expect(notes.length).toBe(1);
+      expect(typeof notes[0]).toBe("object");
+      expect(Array.isArray(notes[0])).toBe(false);
+      // The leaf was created with default `nextKeyAfterPath: ""` -> object.
+      expect(pathValue).toBe(
+        (notes[0] as Record<string, unknown>).title,
+      );
+      expect(pathValue).toEqual({});
+    });
+
+    it("preserves existing intermediates while creating missing ones", () => {
+      const existingNotes = Object.freeze([{ kept: 1 }]);
+      const root = Object.freeze({
+        notes: existingNotes,
+      }) as FabricValue;
+      const { value, pathValue } = cloneForMutation(
+        root,
+        ["notes", "0", "newKey"],
+        { createMissing: true, nextKeyAfterPath: "leaf" },
+      );
+      const newRoot = value as unknown as Record<string, unknown>;
+      const newNotes = newRoot.notes as unknown[];
+      // The existing element was thawed (spine touches it) but the
+      // sibling identity of `existingNotes[0].kept` is preserved.
+      const note0 = newNotes[0] as Record<string, unknown>;
+      expect(note0.kept).toBe(1);
+      // The newly-created leaf-parent slot.
+      expect(note0.newKey).toBe(pathValue);
+      expect(pathValue).toEqual({});
+    });
+
+    it("does not interfere with normal (non-missing) descent", () => {
+      // If everything exists, `createMissing: true` should behave the
+      // same as the default.
+      const root = Object.freeze({
+        a: Object.freeze({ b: Object.freeze({ c: 42 }) }),
+      }) as FabricValue;
+      const { pathValue } = cloneForMutation(
+        root,
+        ["a", "b"],
+        { createMissing: true },
+      );
+      expect(pathValue).toEqual({ c: 42 });
+    });
+
+    it("interacts correctly with `force=false` (identity on existing path)", () => {
+      // If `createMissing: true` but every step exists AND `force:
+      // false` AND input is already mutable, identity is preserved.
+      const inner = { existing: 1 };
+      const root = { a: inner } as FabricValue;
+      const { value, pathValue } = cloneForMutation(
+        root,
+        ["a"],
+        { createMissing: true, force: false },
+      );
+      expect(value).toBe(root);
+      expect(pathValue).toBe(inner);
+    });
+
+    it("respects `force=true` on the spine-thaw even when creating", () => {
+      // When force=true (default), already-mutable spine containers
+      // are still copied. `createMissing` doesn't change that.
+      const root = { existing: 1 } as FabricValue;
+      const { value, pathValue } = cloneForMutation(
+        root,
+        ["new"],
+        { createMissing: true },
+      );
+      expect(value).not.toBe(root); // root was force-copied
+      expect((value as unknown as Record<string, unknown>).existing).toBe(
+        1,
+      );
+      expect((value as unknown as Record<string, unknown>).new).toBe(
+        pathValue,
+      );
+    });
+  });
+
+  describe("CloneForMutationError", () => {
+    it("uses kind `missing-segment` for a missing intermediate", () => {
+      const root = Object.freeze({ a: { b: 1 } }) as FabricValue;
+      try {
+        cloneForMutation(root, ["a", "nonesuch", "more"]);
+        throw new Error("expected throw");
+      } catch (e) {
+        expect(e).toBeInstanceOf(CloneForMutationError);
+        const err = e as CloneForMutationError;
+        expect(err.kind).toBe("missing-segment");
+        expect(err.pathIndex).toBe(1);
+        expect(err.valueKind).toBe("undefined");
+      }
+    });
+
+    it("uses kind `non-container-descent` for primitive in path", () => {
+      const root = Object.freeze({ x: 42 }) as FabricValue;
+      try {
+        cloneForMutation(root, ["x", "anything"]);
+        throw new Error("expected throw");
+      } catch (e) {
+        expect(e).toBeInstanceOf(CloneForMutationError);
+        const err = e as CloneForMutationError;
+        expect(err.kind).toBe("non-container-descent");
+        expect(err.pathIndex).toBe(0);
+        expect(err.valueKind).toBe("number");
+      }
+    });
+
+    it("uses kind `non-mutable-leaf` for a primitive leaf", () => {
+      const root = Object.freeze({ x: 42 }) as FabricValue;
+      try {
+        cloneForMutation(root, ["x"]);
+        throw new Error("expected throw");
+      } catch (e) {
+        expect(e).toBeInstanceOf(CloneForMutationError);
+        const err = e as CloneForMutationError;
+        expect(err.kind).toBe("non-mutable-leaf");
+        expect(err.pathIndex).toBe(0);
+        expect(err.valueKind).toBe("number");
+      }
+    });
+
+    it("uses kind `non-mutable-root` for empty path with bad root", () => {
+      try {
+        cloneForMutation(42 as FabricValue, []);
+        throw new Error("expected throw");
+      } catch (e) {
+        expect(e).toBeInstanceOf(CloneForMutationError);
+        const err = e as CloneForMutationError;
+        expect(err.kind).toBe("non-mutable-root");
+        expect(err.pathIndex).toBe(-1);
+        expect(err.valueKind).toBe("number");
+      }
+    });
+
+    it("uses kind `non-container-root` for non-empty path with bad root", () => {
+      try {
+        cloneForMutation(42 as FabricValue, ["x"]);
+        throw new Error("expected throw");
+      } catch (e) {
+        expect(e).toBeInstanceOf(CloneForMutationError);
+        const err = e as CloneForMutationError;
+        expect(err.kind).toBe("non-container-root");
+        expect(err.pathIndex).toBe(-1);
+        expect(err.valueKind).toBe("number");
+      }
+    });
+
+    it("sets `error.name` to `CloneForMutationError`", () => {
+      try {
+        cloneForMutation(42 as FabricValue, []);
+        throw new Error("expected throw");
+      } catch (e) {
+        expect((e as Error).name).toBe("CloneForMutationError");
+      }
+    });
+  });
+
+  describe("errors", () => {
+    it("throws on a missing path segment", () => {
+      const root = Object.freeze({ a: { b: 1 } }) as FabricValue;
+      expect(() => cloneForMutation(root, ["a", "nonesuch"]))
+        .toThrow("missing path segment");
+    });
+
+    it("throws on a missing array index", () => {
+      const root = Object.freeze({
+        notes: Object.freeze([1, 2, 3]),
+      }) as FabricValue;
+      expect(() => cloneForMutation(root, ["notes", "10"]))
+        .toThrow("missing path segment");
+    });
+
+    it("throws when descending through a primitive", () => {
+      const root = Object.freeze({ x: 42 }) as FabricValue;
+      expect(() => cloneForMutation(root, ["x", "anything"]))
+        .toThrow("cannot descend into");
+    });
+
+    it("throws when descending through a `FabricInstance`", () => {
+      const err = FabricError.fromNativeError(new Error("inside"));
+      const root = Object.freeze({ err }) as FabricValue;
+      // `path = ["err", "something"]` tries to descend INTO the
+      // FabricInstance, which isn't supported.
+      expect(() => cloneForMutation(root, ["err", "message"])).toThrow(
+        "cannot descend into",
+      );
+    });
+
+    it("throws when descending through a `FabricPrimitive`", () => {
+      const epoch = new FabricEpochNsec(123n);
+      const root = Object.freeze({
+        epoch: epoch as unknown as FabricValue,
+      }) as FabricValue;
+      expect(() => cloneForMutation(root, ["epoch", "anything"]))
+        .toThrow("cannot descend into");
+    });
+
+    it("throws when the leaf is a primitive (not mutable)", () => {
+      const root = Object.freeze({ x: 42 }) as FabricValue;
+      expect(() => cloneForMutation(root, ["x"]))
+        .toThrow("cannot mutate");
+    });
+
+    it("throws when the leaf is a `FabricPrimitive` (not mutable)", () => {
+      const epoch = new FabricEpochNsec(123n);
+      const root = Object.freeze({
+        epoch: epoch as unknown as FabricValue,
+      }) as FabricValue;
+      expect(() => cloneForMutation(root, ["epoch"]))
+        .toThrow("cannot mutate");
+    });
+
+    it("throws on empty-path against a non-mutable root", () => {
+      expect(() => cloneForMutation(42 as FabricValue, []))
+        .toThrow("cannot mutate");
+    });
+
+    it("throws on non-empty path against a non-container root", () => {
+      expect(() => cloneForMutation(42 as FabricValue, ["x"]))
+        .toThrow("cannot descend into");
+    });
+
+    it("throws on non-empty path against a `FabricInstance` root", () => {
+      // A FabricInstance is OK at the leaf but not as the root of a
+      // non-empty path (we don't descend into FabricInstance internals).
+      const err = FabricError.fromNativeError(new Error("test"));
+      expect(() => cloneForMutation(err as unknown as FabricValue, ["x"]))
+        .toThrow("cannot descend into");
+    });
+  });
 });

--- a/packages/data-model/test/cloneForMutation.test.ts
+++ b/packages/data-model/test/cloneForMutation.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
   cloneForMutation,

--- a/packages/data-model/test/cloneIfNecessary.test.ts
+++ b/packages/data-model/test/cloneIfNecessary.test.ts
@@ -1,11 +1,6 @@
 import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import {
-  cloneIfNecessary,
-  type CloneOptions,
-  resetDataModelConfig,
-  setDataModelConfig,
-} from "../src/fabric-value.ts";
+import { cloneIfNecessary, type CloneOptions } from "../src/fabric-value.ts";
 import type { FabricValue } from "../src/fabric-value.ts";
 import { isDeepFrozen, isDeepFrozenFabricValue } from "../src/deep-freeze.ts";
 import { FabricBytes } from "../src/fabric-primitives/FabricBytes.ts";
@@ -20,456 +15,408 @@ import { ProblematicValue } from "../src/fabric-instances/ProblematicValue.ts";
 import { UnknownValue } from "../src/fabric-instances/UnknownValue.ts";
 import { FabricPrimitive, FabricSpecialObject } from "../src/interface.ts";
 
-// Both legacy and modern flag states use modern clone semantics. Test cases are
-// parameterized across both modes to ensure the contract is durable under
-// either flag setting.
 describe("cloneIfNecessary", () => {
-  // Always reset after each test to avoid leaking flag state.
-  afterEach(() => {
-    resetDataModelConfig();
+  describe(`error cases`, () => {
+    it("throws for `frozen=true`, `force=true`", () => {
+      const value = { a: 1 } as FabricValue;
+      expect(() => cloneIfNecessary(value, { frozen: true, force: true }))
+        .toThrow("frozen: true, force: true");
+    });
+
+    it("throws for `frozen=false`, `force=false`, `deep=true`", () => {
+      const value = { a: 1 } as FabricValue;
+      expect(() => cloneIfNecessary(value, { frozen: false, force: false }))
+        .toThrow("frozen: false, force: false, deep: true");
+    });
   });
 
-  for (const modernMode of [false, true]) {
-    const label = modernMode ? "modern" : "legacy";
-
-    describe(`error cases (${label} path)`, () => {
-      beforeEach(() => setDataModelConfig(modernMode));
-
-      it("throws for `frozen=true`, `force=true`", () => {
-        const value = { a: 1 } as FabricValue;
-        expect(() => cloneIfNecessary(value, { frozen: true, force: true }))
-          .toThrow("frozen: true, force: true");
-      });
-
-      it("throws for `frozen=false`, `force=false`, `deep=true`", () => {
-        const value = { a: 1 } as FabricValue;
-        expect(() => cloneIfNecessary(value, { frozen: false, force: false }))
-          .toThrow("frozen: false, force: false, deep: true");
-      });
+  describe(`default options`, () => {
+    it("passes through primitives unchanged", () => {
+      expect(cloneIfNecessary(42 as FabricValue)).toBe(42);
+      expect(cloneIfNecessary("hello" as FabricValue)).toBe("hello");
+      expect(cloneIfNecessary(null)).toBe(null);
+      expect(cloneIfNecessary(true as FabricValue)).toBe(true);
+      expect(cloneIfNecessary(undefined)).toBe(undefined);
     });
 
-    describe(`default options (${label} path)`, () => {
-      beforeEach(() => setDataModelConfig(modernMode));
-
-      it("passes through primitives unchanged", () => {
-        expect(cloneIfNecessary(42 as FabricValue)).toBe(42);
-        expect(cloneIfNecessary("hello" as FabricValue)).toBe("hello");
-        expect(cloneIfNecessary(null)).toBe(null);
-        expect(cloneIfNecessary(true as FabricValue)).toBe(true);
-        expect(cloneIfNecessary(undefined)).toBe(undefined);
-      });
-
-      it("passes through bigint unchanged", () => {
-        expect(cloneIfNecessary(42n as FabricValue)).toBe(42n);
-      });
-
-      it("returns a frozen copy of an unfrozen object", () => {
-        const value = { a: 1, b: "two" } as FabricValue;
-        const result = cloneIfNecessary(value);
-        expect(result).toEqual({ a: 1, b: "two" });
-        expect(result).not.toBe(value);
-        expect(Object.isFrozen(result)).toBe(true);
-      });
-
-      it("returns a frozen copy of an unfrozen array", () => {
-        const value = [1, 2, 3] as FabricValue;
-        const result = cloneIfNecessary(value);
-        expect(result).toEqual([1, 2, 3]);
-        expect(result).not.toBe(value);
-        expect(Object.isFrozen(result)).toBe(true);
-      });
-
-      it("deep-freezes nested structures", () => {
-        const value = { a: { b: [1, 2] } } as FabricValue;
-        const result = cloneIfNecessary(value) as Record<string, unknown>;
-        expect(Object.isFrozen(result)).toBe(true);
-        expect(Object.isFrozen(result.a)).toBe(true);
-        const inner = (result.a as Record<string, unknown>).b;
-        expect(Object.isFrozen(inner)).toBe(true);
-      });
-
-      it("returns already-deep-frozen value as-is (identity optimization)", () => {
-        const inner = Object.freeze([1, 2]);
-        const value = Object.freeze({ a: inner }) as FabricValue;
-        const result = cloneIfNecessary(value);
-        expect(result).toBe(value); // identity -- no clone needed
-      });
-
-      it("preserves deep-frozen subtrees as-is within unfrozen parent", () => {
-        // `frozenChild` is a deep-frozen subtree.
-        const frozenChild = Object.freeze({ x: Object.freeze([1, 2]) });
-        // `value` is NOT frozen (unfrozen parent), so it must be cloned.
-        const value = { a: frozenChild, b: "mutable" } as FabricValue;
-        const result = cloneIfNecessary(value) as Record<string, unknown>;
-        // The outer object is a new frozen clone.
-        expect(result).not.toBe(value);
-        expect(Object.isFrozen(result)).toBe(true);
-        // The deep-frozen subtree is preserved by identity -- not re-cloned.
-        expect(result.a).toBe(frozenChild);
-        expect(result.b).toBe("mutable");
-      });
+    it("passes through bigint unchanged", () => {
+      expect(cloneIfNecessary(42n as FabricValue)).toBe(42n);
     });
 
-    describe(`\`frozen=false\`, deep clone (${label} path)`, () => {
-      beforeEach(() => setDataModelConfig(modernMode));
-
-      it("returns a mutable copy of a frozen object", () => {
-        const value = Object.freeze({ a: 1, b: "two" }) as FabricValue;
-        const result = cloneIfNecessary(value, { frozen: false });
-        expect(result).toEqual({ a: 1, b: "two" });
-        expect(result).not.toBe(value);
-        expect(Object.isFrozen(result)).toBe(false);
-      });
-
-      it("returns a mutable array copy", () => {
-        const value = Object.freeze([1, 2, 3]) as FabricValue;
-        const result = cloneIfNecessary(value, { frozen: false });
-        expect(result).toEqual([1, 2, 3]);
-        expect(result).not.toBe(value);
-        expect(Object.isFrozen(result)).toBe(false);
-      });
-
-      it("clones already-mutable values (`force=true` default)", () => {
-        const inner = { x: 1 };
-        const value = { a: inner, b: [2, 3] } as FabricValue;
-        const result = cloneIfNecessary(value, { frozen: false }) as Record<
-          string,
-          unknown
-        >;
-        // Must be a different reference, even though input is already mutable.
-        expect(result).not.toBe(value);
-        expect(result).toEqual({ a: { x: 1 }, b: [2, 3] });
-        expect(Object.isFrozen(result)).toBe(false);
-        // Nested values are also cloned.
-        expect(result.a).not.toBe(inner);
-        expect(result.b).not.toBe((value as Record<string, unknown>).b);
-      });
-
-      it("deep-unfreezes nested structures", () => {
-        const inner = Object.freeze([1, 2]);
-        const value = Object.freeze({
-          a: Object.freeze({ b: inner }),
-        }) as FabricValue;
-        const result = cloneIfNecessary(value, { frozen: false }) as Record<
-          string,
-          unknown
-        >;
-        expect(Object.isFrozen(result)).toBe(false);
-        expect(Object.isFrozen(result.a)).toBe(false);
-        const innerResult = (result.a as Record<string, unknown>).b;
-        expect(Object.isFrozen(innerResult)).toBe(false);
-      });
+    it("returns a frozen copy of an unfrozen object", () => {
+      const value = { a: 1, b: "two" } as FabricValue;
+      const result = cloneIfNecessary(value);
+      expect(result).toEqual({ a: 1, b: "two" });
+      expect(result).not.toBe(value);
+      expect(Object.isFrozen(result)).toBe(true);
     });
 
-    describe(`shallow clone (${label} path)`, () => {
-      beforeEach(() => setDataModelConfig(modernMode));
-
-      it("shallow-clones an unfrozen object to frozen", () => {
-        const inner = { x: 1 };
-        const value = { a: inner } as FabricValue;
-        const result = cloneIfNecessary(value, { deep: false }) as Record<
-          string,
-          unknown
-        >;
-        expect(result).not.toBe(value);
-        expect(Object.isFrozen(result)).toBe(true);
-        // Shallow: inner reference is preserved (not deep-cloned).
-        expect(result.a).toBe(inner);
-      });
-
-      it("returns already-frozen object as-is (shallow, `force=false`)", () => {
-        const value = Object.freeze({ a: 1 }) as FabricValue;
-        const result = cloneIfNecessary(value, { deep: false });
-        expect(result).toBe(value);
-      });
-
-      it("shallow-clones frozen object to mutable (`deep=false`, `frozen=false`)", () => {
-        const value = Object.freeze({ a: 1, b: "two" }) as FabricValue;
-        const result = cloneIfNecessary(value, {
-          deep: false,
-          frozen: false,
-        }) as Record<string, unknown>;
-        expect(result).not.toBe(value);
-        expect(Object.isFrozen(result)).toBe(false);
-        expect(result.a).toBe(1);
-      });
-
-      it("force-copies mutable object (shallow, `frozen=false`, `force=true`)", () => {
-        const value = { a: 1 } as FabricValue;
-        const result = cloneIfNecessary(value, {
-          deep: false,
-          frozen: false,
-        }); // force defaults to true for frozen=false
-        expect(result).not.toBe(value);
-        expect(result).toEqual({ a: 1 });
-        expect(Object.isFrozen(result)).toBe(false);
-      });
-
-      it("returns mutable as-is (shallow, `frozen=false`, `force=false`)", () => {
-        const value = { a: 1 } as FabricValue;
-        const result = cloneIfNecessary(value, {
-          deep: false,
-          frozen: false,
-          force: false,
-        });
-        expect(result).toBe(value);
-      });
-
-      it("thaws frozen value (shallow, `frozen=false`, `force=false`)", () => {
-        const value = Object.freeze({ a: 1 }) as FabricValue;
-        const result = cloneIfNecessary(value, {
-          deep: false,
-          frozen: false,
-          force: false,
-        });
-        expect(result).not.toBe(value);
-        expect(result).toEqual({ a: 1 });
-        expect(Object.isFrozen(result)).toBe(false);
-      });
+    it("returns a frozen copy of an unfrozen array", () => {
+      const value = [1, 2, 3] as FabricValue;
+      const result = cloneIfNecessary(value);
+      expect(result).toEqual([1, 2, 3]);
+      expect(result).not.toBe(value);
+      expect(Object.isFrozen(result)).toBe(true);
     });
 
-    describe(`\`FabricInstance\` (${label} path)`, () => {
-      beforeEach(() => setDataModelConfig(modernMode));
-
-      it("identity-returns an already-deep-frozen `FabricError`", () => {
-        // A `FabricError` with no `cause` or extras is deep-frozen as soon
-        // as the wrapper is `Object.freeze`'d (the wrapper itself is the
-        // canonical state). `cloneIfNecessary` therefore returns identity.
-        const error = FabricError.fromNativeError(new Error("test"));
-        Object.freeze(error);
-        const result = cloneIfNecessary(error);
-        expect(result).toBe(error);
-        expect((result as FabricError).message).toBe("test");
-      });
-
-      it("deep-clones a `FabricError` with a mutable cause", () => {
-        // Wrapper frozen but `cause` not -> not deep-frozen -> clone.
-        const error = FabricError.fromNativeError(
-          new Error("test", { cause: { mutable: true } }),
-        );
-        Object.freeze(error);
-        const result = cloneIfNecessary(error);
-        expect(result).toBeInstanceOf(FabricError);
-        expect(result).not.toBe(error);
-        expect(Object.isFrozen(result)).toBe(true);
-        expect((result as FabricError).message).toBe("test");
-      });
-
-      it("produces a mutable `FabricError` clone (deep, `frozen=false`)", () => {
-        // Deep clone with `frozen: false` yields a fresh *mutable*
-        // `FabricError`.
-        const error = FabricError.fromNativeError(new Error("test"));
-        Object.freeze(error);
-        const result = cloneIfNecessary(
-          error as unknown as FabricValue,
-          { frozen: false },
-        );
-        expect(result).toBeInstanceOf(FabricError);
-        expect(result).not.toBe(error);
-        expect(Object.isFrozen(result)).toBe(false);
-        expect((result as FabricError).message).toBe("test");
-      });
-
-      it("preserves a nested already-deep-frozen `FabricError` by identity", () => {
-        // Container is rebuilt (mutable input -> frozen output) but the
-        // nested deep-frozen FabricError is returned by identity.
-        const error = FabricError.fromNativeError(new Error("nested"));
-        Object.freeze(error);
-        const value = { err: error, x: 42 } as FabricValue;
-        const result = cloneIfNecessary(value) as Record<string, unknown>;
-        expect(result).not.toBe(value);
-        expect(Object.isFrozen(result)).toBe(true);
-        expect(result.err).toBeInstanceOf(FabricError);
-        expect(result.err).toBe(error);
-        expect((result.err as FabricError).message).toBe("nested");
-        expect(result.x).toBe(42);
-      });
-
-      it("shallow-clones an object containing a `FabricError` (`deep=false`)", () => {
-        // Shallow clone of a container shares the nested instance by
-        // reference -- it is never traversed or rebuilt.
-        const error = FabricError.fromNativeError(new Error("nested"));
-        const value = { err: error, x: 42 } as FabricValue;
-        const result = cloneIfNecessary(value, { deep: false }) as Record<
-          string,
-          unknown
-        >;
-        expect(result).not.toBe(value);
-        expect(Object.isFrozen(result)).toBe(true);
-        expect(result.err).toBe(error);
-        expect(result.x).toBe(42);
-      });
+    it("deep-freezes nested structures", () => {
+      const value = { a: { b: [1, 2] } } as FabricValue;
+      const result = cloneIfNecessary(value) as Record<string, unknown>;
+      expect(Object.isFrozen(result)).toBe(true);
+      expect(Object.isFrozen(result.a)).toBe(true);
+      const inner = (result.a as Record<string, unknown>).b;
+      expect(Object.isFrozen(inner)).toBe(true);
     });
 
-    describe(`\`undefined\` preservation (${label} path)`, () => {
-      beforeEach(() => setDataModelConfig(modernMode));
-
-      it("preserves `undefined` in objects", () => {
-        const value = { a: 1, b: undefined } as FabricValue;
-        const result = cloneIfNecessary(value) as Record<string, unknown>;
-        expect(result.b).toBe(undefined);
-        expect("b" in result).toBe(true);
-        expect(Object.isFrozen(result)).toBe(true);
-      });
-
-      it("preserves `undefined` in arrays", () => {
-        const value = [1, undefined, 3] as FabricValue;
-        const result = cloneIfNecessary(value) as unknown[];
-        expect(result[1]).toBe(undefined);
-        expect(1 in result).toBe(true);
-        expect(Object.isFrozen(result)).toBe(true);
-      });
-
-      it("passes through `undefined` as top-level value", () => {
-        expect(cloneIfNecessary(undefined, { frozen: false })).toBe(
-          undefined,
-        );
-      });
-
-      it("passes through `undefined` with default options", () => {
-        expect(cloneIfNecessary(undefined)).toBe(undefined);
-      });
+    it("returns already-deep-frozen value as-is (identity optimization)", () => {
+      const inner = Object.freeze([1, 2]);
+      const value = Object.freeze({ a: inner }) as FabricValue;
+      const result = cloneIfNecessary(value);
+      expect(result).toBe(value); // identity -- no clone needed
     });
 
-    describe(`\`null\` prototype preservation (${label} path)`, () => {
-      beforeEach(() => setDataModelConfig(modernMode));
+    it("preserves deep-frozen subtrees as-is within unfrozen parent", () => {
+      // `frozenChild` is a deep-frozen subtree.
+      const frozenChild = Object.freeze({ x: Object.freeze([1, 2]) });
+      // `value` is NOT frozen (unfrozen parent), so it must be cloned.
+      const value = { a: frozenChild, b: "mutable" } as FabricValue;
+      const result = cloneIfNecessary(value) as Record<string, unknown>;
+      // The outer object is a new frozen clone.
+      expect(result).not.toBe(value);
+      expect(Object.isFrozen(result)).toBe(true);
+      // The deep-frozen subtree is preserved by identity -- not re-cloned.
+      expect(result.a).toBe(frozenChild);
+      expect(result.b).toBe("mutable");
+    });
+  });
 
-      it("preserves `null` prototype on objects", () => {
-        const value = Object.create(null) as Record<string, unknown>;
-        value.a = 1;
-        value.b = "two";
-        const result = cloneIfNecessary(
-          value as FabricValue,
-        ) as Record<string, unknown>;
-        expect(Object.getPrototypeOf(result)).toBe(null);
-        expect(result.a).toBe(1);
-        expect(result.b).toBe("two");
-        expect(Object.isFrozen(result)).toBe(true);
-      });
-
-      it("preserves `null` prototype when `frozen=false`", () => {
-        const value = Object.create(null) as Record<string, unknown>;
-        value.x = 42;
-        const result = cloneIfNecessary(
-          value as FabricValue,
-          { frozen: false },
-        ) as Record<string, unknown>;
-        expect(Object.getPrototypeOf(result)).toBe(null);
-        expect(result.x).toBe(42);
-        expect(Object.isFrozen(result)).toBe(false);
-      });
-
-      it("preserves `null` prototype on shallow clone", () => {
-        const value = Object.create(null) as Record<string, unknown>;
-        value.a = 1;
-        const result = cloneIfNecessary(
-          value as FabricValue,
-          { deep: false },
-        ) as Record<string, unknown>;
-        expect(Object.getPrototypeOf(result)).toBe(null);
-        expect(result.a).toBe(1);
-        expect(Object.isFrozen(result)).toBe(true);
-      });
-
-      it("preserves `null` prototype on shallow clone when `frozen=false`", () => {
-        const value = Object.create(null) as Record<string, unknown>;
-        value.b = 2;
-        const result = cloneIfNecessary(
-          value as FabricValue,
-          { frozen: false, deep: false },
-        ) as Record<string, unknown>;
-        expect(Object.getPrototypeOf(result)).toBe(null);
-        expect(result.b).toBe(2);
-        expect(Object.isFrozen(result)).toBe(false);
-      });
+  describe(`\`frozen=false\`, deep clone`, () => {
+    it("returns a mutable copy of a frozen object", () => {
+      const value = Object.freeze({ a: 1, b: "two" }) as FabricValue;
+      const result = cloneIfNecessary(value, { frozen: false });
+      expect(result).toEqual({ a: 1, b: "two" });
+      expect(result).not.toBe(value);
+      expect(Object.isFrozen(result)).toBe(false);
     });
 
-    describe(`\`FabricPrimitive\` (${label} path)`, () => {
-      beforeEach(() => setDataModelConfig(modernMode));
-
-      it("passes through `FabricEpochNsec` unchanged", () => {
-        const epoch = new FabricEpochNsec(1234567890n);
-        Object.freeze(epoch);
-        const result = cloneIfNecessary(epoch as unknown as FabricValue);
-        expect(result).toBe(epoch); // identity -- special primitives are immutable
-      });
-
-      it("passes through `FabricEpochNsec` when `frozen=false`", () => {
-        const epoch = new FabricEpochNsec(42n);
-        Object.freeze(epoch);
-        // frozen parameter is irrelevant for special primitives
-        const result = cloneIfNecessary(
-          epoch as unknown as FabricValue,
-          { frozen: false },
-        );
-        expect(result).toBe(epoch); // identity -- special primitives are immutable
-      });
-
-      it("passes through `FabricEpochNsec` nested in an object", () => {
-        const epoch = new FabricEpochNsec(999n);
-        Object.freeze(epoch);
-        const value = { time: epoch, label: "test" } as FabricValue;
-        const result = cloneIfNecessary(value) as Record<string, unknown>;
-        expect(Object.isFrozen(result)).toBe(true);
-        expect(result.time).toBe(epoch); // same instance -- not cloned
-        expect(result.label).toBe("test");
-      });
+    it("returns a mutable array copy", () => {
+      const value = Object.freeze([1, 2, 3]) as FabricValue;
+      const result = cloneIfNecessary(value, { frozen: false });
+      expect(result).toEqual([1, 2, 3]);
+      expect(result).not.toBe(value);
+      expect(Object.isFrozen(result)).toBe(false);
     });
 
-    describe(`circular reference detection (${label} path)`, () => {
-      beforeEach(() => setDataModelConfig(modernMode));
-
-      it("throws on direct circular object reference", () => {
-        const obj = {} as Record<string, unknown>;
-        obj.self = obj;
-        expect(() => cloneIfNecessary(obj as FabricValue)).toThrow(
-          "Cannot deep-clone circular reference",
-        );
-      });
-
-      it("throws on circular array reference", () => {
-        const arr: unknown[] = [1, 2];
-        arr.push(arr);
-        expect(() => cloneIfNecessary(arr as FabricValue)).toThrow(
-          "Cannot deep-clone circular reference",
-        );
-      });
-
-      it("throws on indirect circular reference", () => {
-        const a = {} as Record<string, unknown>;
-        const b = { parent: a } as Record<string, unknown>;
-        a.child = b;
-        expect(() => cloneIfNecessary(a as FabricValue)).toThrow(
-          "Cannot deep-clone circular reference",
-        );
-      });
-
-      it("handles shared (diamond) references without throwing", () => {
-        const shared = { x: 1 };
-        const value = { a: shared, b: shared } as FabricValue;
-        // Shared (non-circular) references should not throw.
-        const result = cloneIfNecessary(value) as Record<string, unknown>;
-        expect(result).toEqual({ a: { x: 1 }, b: { x: 1 } });
-        expect(Object.isFrozen(result)).toBe(true);
-      });
+    it("clones already-mutable values (`force=true` default)", () => {
+      const inner = { x: 1 };
+      const value = { a: inner, b: [2, 3] } as FabricValue;
+      const result = cloneIfNecessary(value, { frozen: false }) as Record<
+        string,
+        unknown
+      >;
+      // Must be a different reference, even though input is already mutable.
+      expect(result).not.toBe(value);
+      expect(result).toEqual({ a: { x: 1 }, b: [2, 3] });
+      expect(Object.isFrozen(result)).toBe(false);
+      // Nested values are also cloned.
+      expect(result.a).not.toBe(inner);
+      expect(result.b).not.toBe((value as Record<string, unknown>).b);
     });
-  }
 
-  describe("config lifecycle", () => {
-    it("preserves clone semantics across mode switches", () => {
+    it("deep-unfreezes nested structures", () => {
+      const inner = Object.freeze([1, 2]);
+      const value = Object.freeze({
+        a: Object.freeze({ b: inner }),
+      }) as FabricValue;
+      const result = cloneIfNecessary(value, { frozen: false }) as Record<
+        string,
+        unknown
+      >;
+      expect(Object.isFrozen(result)).toBe(false);
+      expect(Object.isFrozen(result.a)).toBe(false);
+      const innerResult = (result.a as Record<string, unknown>).b;
+      expect(Object.isFrozen(innerResult)).toBe(false);
+    });
+  });
+
+  describe(`shallow clone`, () => {
+    it("shallow-clones an unfrozen object to frozen", () => {
+      const inner = { x: 1 };
+      const value = { a: inner } as FabricValue;
+      const result = cloneIfNecessary(value, { deep: false }) as Record<
+        string,
+        unknown
+      >;
+      expect(result).not.toBe(value);
+      expect(Object.isFrozen(result)).toBe(true);
+      // Shallow: inner reference is preserved (not deep-cloned).
+      expect(result.a).toBe(inner);
+    });
+
+    it("returns already-frozen object as-is (shallow, `force=false`)", () => {
+      const value = Object.freeze({ a: 1 }) as FabricValue;
+      const result = cloneIfNecessary(value, { deep: false });
+      expect(result).toBe(value);
+    });
+
+    it("shallow-clones frozen object to mutable (`deep=false`, `frozen=false`)", () => {
+      const value = Object.freeze({ a: 1, b: "two" }) as FabricValue;
+      const result = cloneIfNecessary(value, {
+        deep: false,
+        frozen: false,
+      }) as Record<string, unknown>;
+      expect(result).not.toBe(value);
+      expect(Object.isFrozen(result)).toBe(false);
+      expect(result.a).toBe(1);
+    });
+
+    it("force-copies mutable object (shallow, `frozen=false`, `force=true`)", () => {
       const value = { a: 1 } as FabricValue;
+      const result = cloneIfNecessary(value, {
+        deep: false,
+        frozen: false,
+      }); // force defaults to true for frozen=false
+      expect(result).not.toBe(value);
+      expect(result).toEqual({ a: 1 });
+      expect(Object.isFrozen(result)).toBe(false);
+    });
 
-      setDataModelConfig(true);
-      const modernResult = cloneIfNecessary(value);
-      expect(modernResult).not.toBe(value);
-      expect(Object.isFrozen(modernResult)).toBe(true);
-      expect(modernResult).toEqual({ a: 1 });
+    it("returns mutable as-is (shallow, `frozen=false`, `force=false`)", () => {
+      const value = { a: 1 } as FabricValue;
+      const result = cloneIfNecessary(value, {
+        deep: false,
+        frozen: false,
+        force: false,
+      });
+      expect(result).toBe(value);
+    });
 
-      resetDataModelConfig();
-      const legacyResult = cloneIfNecessary(value);
-      expect(legacyResult).not.toBe(value);
-      expect(Object.isFrozen(legacyResult)).toBe(true);
-      expect(legacyResult).toEqual({ a: 1 });
+    it("thaws frozen value (shallow, `frozen=false`, `force=false`)", () => {
+      const value = Object.freeze({ a: 1 }) as FabricValue;
+      const result = cloneIfNecessary(value, {
+        deep: false,
+        frozen: false,
+        force: false,
+      });
+      expect(result).not.toBe(value);
+      expect(result).toEqual({ a: 1 });
+      expect(Object.isFrozen(result)).toBe(false);
+    });
+  });
+
+  describe(`\`FabricInstance\``, () => {
+    it("identity-returns an already-deep-frozen `FabricError`", () => {
+      // A `FabricError` with no `cause` or extras is deep-frozen as soon
+      // as the wrapper is `Object.freeze`'d (the wrapper itself is the
+      // canonical state). `cloneIfNecessary` therefore returns identity.
+      const error = FabricError.fromNativeError(new Error("test"));
+      Object.freeze(error);
+      const result = cloneIfNecessary(error);
+      expect(result).toBe(error);
+      expect((result as FabricError).message).toBe("test");
+    });
+
+    it("deep-clones a `FabricError` with a mutable cause", () => {
+      // Wrapper frozen but `cause` not -> not deep-frozen -> clone.
+      const error = FabricError.fromNativeError(
+        new Error("test", { cause: { mutable: true } }),
+      );
+      Object.freeze(error);
+      const result = cloneIfNecessary(error);
+      expect(result).toBeInstanceOf(FabricError);
+      expect(result).not.toBe(error);
+      expect(Object.isFrozen(result)).toBe(true);
+      expect((result as FabricError).message).toBe("test");
+    });
+
+    it("produces a mutable `FabricError` clone (deep, `frozen=false`)", () => {
+      // Deep clone with `frozen: false` yields a fresh *mutable*
+      // `FabricError`.
+      const error = FabricError.fromNativeError(new Error("test"));
+      Object.freeze(error);
+      const result = cloneIfNecessary(
+        error as unknown as FabricValue,
+        { frozen: false },
+      );
+      expect(result).toBeInstanceOf(FabricError);
+      expect(result).not.toBe(error);
+      expect(Object.isFrozen(result)).toBe(false);
+      expect((result as FabricError).message).toBe("test");
+    });
+
+    it("preserves a nested already-deep-frozen `FabricError` by identity", () => {
+      // Container is rebuilt (mutable input -> frozen output) but the
+      // nested deep-frozen FabricError is returned by identity.
+      const error = FabricError.fromNativeError(new Error("nested"));
+      Object.freeze(error);
+      const value = { err: error, x: 42 } as FabricValue;
+      const result = cloneIfNecessary(value) as Record<string, unknown>;
+      expect(result).not.toBe(value);
+      expect(Object.isFrozen(result)).toBe(true);
+      expect(result.err).toBeInstanceOf(FabricError);
+      expect(result.err).toBe(error);
+      expect((result.err as FabricError).message).toBe("nested");
+      expect(result.x).toBe(42);
+    });
+
+    it("shallow-clones an object containing a `FabricError` (`deep=false`)", () => {
+      // Shallow clone of a container shares the nested instance by
+      // reference -- it is never traversed or rebuilt.
+      const error = FabricError.fromNativeError(new Error("nested"));
+      const value = { err: error, x: 42 } as FabricValue;
+      const result = cloneIfNecessary(value, { deep: false }) as Record<
+        string,
+        unknown
+      >;
+      expect(result).not.toBe(value);
+      expect(Object.isFrozen(result)).toBe(true);
+      expect(result.err).toBe(error);
+      expect(result.x).toBe(42);
+    });
+  });
+
+  describe(`\`undefined\` preservation`, () => {
+    it("preserves `undefined` in objects", () => {
+      const value = { a: 1, b: undefined } as FabricValue;
+      const result = cloneIfNecessary(value) as Record<string, unknown>;
+      expect(result.b).toBe(undefined);
+      expect("b" in result).toBe(true);
+      expect(Object.isFrozen(result)).toBe(true);
+    });
+
+    it("preserves `undefined` in arrays", () => {
+      const value = [1, undefined, 3] as FabricValue;
+      const result = cloneIfNecessary(value) as unknown[];
+      expect(result[1]).toBe(undefined);
+      expect(1 in result).toBe(true);
+      expect(Object.isFrozen(result)).toBe(true);
+    });
+
+    it("passes through `undefined` as top-level value", () => {
+      expect(cloneIfNecessary(undefined, { frozen: false })).toBe(
+        undefined,
+      );
+    });
+
+    it("passes through `undefined` with default options", () => {
+      expect(cloneIfNecessary(undefined)).toBe(undefined);
+    });
+  });
+
+  describe(`\`null\` prototype preservation`, () => {
+    it("preserves `null` prototype on objects", () => {
+      const value = Object.create(null) as Record<string, unknown>;
+      value.a = 1;
+      value.b = "two";
+      const result = cloneIfNecessary(
+        value as FabricValue,
+      ) as Record<string, unknown>;
+      expect(Object.getPrototypeOf(result)).toBe(null);
+      expect(result.a).toBe(1);
+      expect(result.b).toBe("two");
+      expect(Object.isFrozen(result)).toBe(true);
+    });
+
+    it("preserves `null` prototype when `frozen=false`", () => {
+      const value = Object.create(null) as Record<string, unknown>;
+      value.x = 42;
+      const result = cloneIfNecessary(
+        value as FabricValue,
+        { frozen: false },
+      ) as Record<string, unknown>;
+      expect(Object.getPrototypeOf(result)).toBe(null);
+      expect(result.x).toBe(42);
+      expect(Object.isFrozen(result)).toBe(false);
+    });
+
+    it("preserves `null` prototype on shallow clone", () => {
+      const value = Object.create(null) as Record<string, unknown>;
+      value.a = 1;
+      const result = cloneIfNecessary(
+        value as FabricValue,
+        { deep: false },
+      ) as Record<string, unknown>;
+      expect(Object.getPrototypeOf(result)).toBe(null);
+      expect(result.a).toBe(1);
+      expect(Object.isFrozen(result)).toBe(true);
+    });
+
+    it("preserves `null` prototype on shallow clone when `frozen=false`", () => {
+      const value = Object.create(null) as Record<string, unknown>;
+      value.b = 2;
+      const result = cloneIfNecessary(
+        value as FabricValue,
+        { frozen: false, deep: false },
+      ) as Record<string, unknown>;
+      expect(Object.getPrototypeOf(result)).toBe(null);
+      expect(result.b).toBe(2);
+      expect(Object.isFrozen(result)).toBe(false);
+    });
+  });
+
+  describe(`\`FabricPrimitive\``, () => {
+    it("passes through `FabricEpochNsec` unchanged", () => {
+      const epoch = new FabricEpochNsec(1234567890n);
+      Object.freeze(epoch);
+      const result = cloneIfNecessary(epoch as unknown as FabricValue);
+      expect(result).toBe(epoch); // identity -- special primitives are immutable
+    });
+
+    it("passes through `FabricEpochNsec` when `frozen=false`", () => {
+      const epoch = new FabricEpochNsec(42n);
+      Object.freeze(epoch);
+      // frozen parameter is irrelevant for special primitives
+      const result = cloneIfNecessary(
+        epoch as unknown as FabricValue,
+        { frozen: false },
+      );
+      expect(result).toBe(epoch); // identity -- special primitives are immutable
+    });
+
+    it("passes through `FabricEpochNsec` nested in an object", () => {
+      const epoch = new FabricEpochNsec(999n);
+      Object.freeze(epoch);
+      const value = { time: epoch, label: "test" } as FabricValue;
+      const result = cloneIfNecessary(value) as Record<string, unknown>;
+      expect(Object.isFrozen(result)).toBe(true);
+      expect(result.time).toBe(epoch); // same instance -- not cloned
+      expect(result.label).toBe("test");
+    });
+  });
+
+  describe(`circular reference detection`, () => {
+    it("throws on direct circular object reference", () => {
+      const obj = {} as Record<string, unknown>;
+      obj.self = obj;
+      expect(() => cloneIfNecessary(obj as FabricValue)).toThrow(
+        "Cannot deep-clone circular reference",
+      );
+    });
+
+    it("throws on circular array reference", () => {
+      const arr: unknown[] = [1, 2];
+      arr.push(arr);
+      expect(() => cloneIfNecessary(arr as FabricValue)).toThrow(
+        "Cannot deep-clone circular reference",
+      );
+    });
+
+    it("throws on indirect circular reference", () => {
+      const a = {} as Record<string, unknown>;
+      const b = { parent: a } as Record<string, unknown>;
+      a.child = b;
+      expect(() => cloneIfNecessary(a as FabricValue)).toThrow(
+        "Cannot deep-clone circular reference",
+      );
+    });
+
+    it("handles shared (diamond) references without throwing", () => {
+      const shared = { x: 1 };
+      const value = { a: shared, b: shared } as FabricValue;
+      // Shared (non-circular) references should not throw.
+      const result = cloneIfNecessary(value) as Record<string, unknown>;
+      expect(result).toEqual({ a: { x: 1 }, b: { x: 1 } });
+      expect(Object.isFrozen(result)).toBe(true);
     });
   });
 
@@ -682,98 +629,86 @@ describe("cloneIfNecessary", () => {
   ];
 
   describe("`cloneIfNecessary()`: subclass coverage matrix", () => {
-    afterEach(() => {
-      resetDataModelConfig();
-    });
+    beforeEach(() => setDataModelConfig(modernMode));
 
-    for (const modernMode of [false, true]) {
-      const modeLabel = modernMode ? "modern" : "legacy";
+    for (const c of subclassCases) {
+      describe(c.name, () => {
+        for (const inputFrozen of [false, true]) {
+          const frozenLabel = inputFrozen ? "frozen input" : "mutable input";
 
-      describe(`(${modeLabel} path)`, () => {
-        beforeEach(() => setDataModelConfig(modernMode));
+          describe(frozenLabel, () => {
+            for (const vec of optionVectors) {
+              it(vec.label, () => {
+                const value = c.factory();
+                if (inputFrozen) Object.freeze(value);
+                const ctor = value.constructor as new (
+                  ...args: never[]
+                ) => FabricSpecialObject;
+                const wasFrozen = Object.isFrozen(value);
 
-        for (const c of subclassCases) {
-          describe(c.name, () => {
-            for (const inputFrozen of [false, true]) {
-              const frozenLabel = inputFrozen
-                ? "frozen input"
-                : "mutable input";
+                const expected = expectedOutcome(
+                  c,
+                  value as unknown as FabricValue,
+                  vec.opts,
+                );
 
-              describe(frozenLabel, () => {
-                for (const vec of optionVectors) {
-                  it(vec.label, () => {
-                    const value = c.factory();
-                    if (inputFrozen) Object.freeze(value);
-                    const ctor = value.constructor as new (
-                      ...args: never[]
-                    ) => FabricSpecialObject;
-                    const wasFrozen = Object.isFrozen(value);
-
-                    const expected = expectedOutcome(
-                      c,
+                if (expected.kind === "throws") {
+                  expect(() =>
+                    cloneIfNecessary(
                       value as unknown as FabricValue,
                       vec.opts,
+                    )
+                  ).toThrow();
+                  return;
+                }
+
+                // Determine whether `cloneIfNecessary` should short-circuit
+                // via `canReturnAsIs` -- which we mirror in the test for
+                // identity assertions. This is the same logic as
+                // `expectedOutcome`'s `canReturnAsIs` arm, restated here in
+                // a form that doesn't presume an "ok" outcome.
+                let identityExpected: boolean;
+                if (vec.opts.force) {
+                  identityExpected = false;
+                } else if (vec.opts.deep) {
+                  identityExpected = vec.opts.frozen &&
+                    isDeepFrozenFabricValue(
+                      value as unknown as FabricValue,
                     );
+                } else {
+                  identityExpected = wasFrozen === vec.opts.frozen;
+                }
 
-                    if (expected.kind === "throws") {
-                      expect(() =>
-                        cloneIfNecessary(
-                          value as unknown as FabricValue,
-                          vec.opts,
-                        )
-                      ).toThrow();
-                      return;
-                    }
+                const result = cloneIfNecessary(
+                  value as unknown as FabricValue,
+                  vec.opts,
+                ) as FabricSpecialObject;
 
-                    // Determine whether `cloneIfNecessary` should short-circuit
-                    // via `canReturnAsIs` -- which we mirror in the test for
-                    // identity assertions. This is the same logic as
-                    // `expectedOutcome`'s `canReturnAsIs` arm, restated here in
-                    // a form that doesn't presume an "ok" outcome.
-                    let identityExpected: boolean;
-                    if (vec.opts.force) {
-                      identityExpected = false;
-                    } else if (vec.opts.deep) {
-                      identityExpected = vec.opts.frozen &&
-                        isDeepFrozenFabricValue(
-                          value as unknown as FabricValue,
-                        );
-                    } else {
-                      identityExpected = wasFrozen === vec.opts.frozen;
-                    }
+                // (1) Class identity is preserved.
+                expect(result).toBeInstanceOf(ctor);
 
-                    const result = cloneIfNecessary(
-                      value as unknown as FabricValue,
-                      vec.opts,
-                    ) as FabricSpecialObject;
+                // (2) `FabricPrimitive`: always returns the source by
+                // identity; result is always frozen (constructor invariant).
+                if (value instanceof FabricPrimitive) {
+                  expect(result).toBe(value);
+                  expect(Object.isFrozen(result)).toBe(true);
+                  return;
+                }
 
-                    // (1) Class identity is preserved.
-                    expect(result).toBeInstanceOf(ctor);
+                // (3) Frozenness matches the requested `frozen` option.
+                expect(Object.isFrozen(result)).toBe(vec.opts.frozen);
 
-                    // (2) `FabricPrimitive`: always returns the source by
-                    // identity; result is always frozen (constructor invariant).
-                    if (value instanceof FabricPrimitive) {
-                      expect(result).toBe(value);
-                      expect(Object.isFrozen(result)).toBe(true);
-                      return;
-                    }
+                // (4) Identity preservation matches the canReturnAsIs
+                // prediction.
+                if (identityExpected) {
+                  expect(result).toBe(value);
+                } else {
+                  expect(result).not.toBe(value);
+                }
 
-                    // (3) Frozenness matches the requested `frozen` option.
-                    expect(Object.isFrozen(result)).toBe(vec.opts.frozen);
-
-                    // (4) Identity preservation matches the canReturnAsIs
-                    // prediction.
-                    if (identityExpected) {
-                      expect(result).toBe(value);
-                    } else {
-                      expect(result).not.toBe(value);
-                    }
-
-                    // (5) `isDeepFrozen` agrees on deep-frozen requests.
-                    if (vec.opts.deep && vec.opts.frozen) {
-                      expect(isDeepFrozen(result as unknown)).toBe(true);
-                    }
-                  });
+                // (5) `isDeepFrozen` agrees on deep-frozen requests.
+                if (vec.opts.deep && vec.opts.frozen) {
+                  expect(isDeepFrozen(result as unknown)).toBe(true);
                 }
               });
             }

--- a/packages/data-model/test/cloneIfNecessary.test.ts
+++ b/packages/data-model/test/cloneIfNecessary.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { cloneIfNecessary, type CloneOptions } from "../src/fabric-value.ts";
 import type { FabricValue } from "../src/fabric-value.ts";

--- a/packages/data-model/test/cloneIfNecessary.test.ts
+++ b/packages/data-model/test/cloneIfNecessary.test.ts
@@ -629,8 +629,6 @@ describe("cloneIfNecessary", () => {
   ];
 
   describe("`cloneIfNecessary()`: subclass coverage matrix", () => {
-    beforeEach(() => setDataModelConfig(modernMode));
-
     for (const c of subclassCases) {
       describe(c.name, () => {
         for (const inputFrozen of [false, true]) {

--- a/packages/data-model/test/fabric-primitives/FabricEpochDays.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochDays.test.ts
@@ -2,11 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { FabricEpochDays } from "../../src/fabric-primitives/FabricEpochDays.ts";
 import { FabricInstance, FabricPrimitive } from "../../src/interface.ts";
-import {
-  resetDataModelConfig,
-  setDataModelConfig,
-  shallowFabricFromNativeValue,
-} from "../../src/fabric-value.ts";
+import { shallowFabricFromNativeValue } from "../../src/fabric-value.ts";
 
 describe("FabricEpochDays", () => {
   // Pure type-identity / supertype checks: cross-cutting carve-out per the
@@ -51,14 +47,9 @@ describe("FabricEpochDays", () => {
   // of the class, so it lives directly under the class `describe()`.
   describe("shallowFabricFromNativeValue() integration", () => {
     it("passes through unchanged even with `freeze=false`", () => {
-      setDataModelConfig(true);
-      try {
-        const days = new FabricEpochDays(456n);
-        // freeze=false should still return the same instance (not a copy).
-        expect(shallowFabricFromNativeValue(days, false)).toBe(days);
-      } finally {
-        resetDataModelConfig();
-      }
+      const days = new FabricEpochDays(456n);
+      // freeze=false should still return the same instance (not a copy).
+      expect(shallowFabricFromNativeValue(days, false)).toBe(days);
     });
   });
 });

--- a/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
@@ -2,11 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { FabricEpochNsec } from "../../src/fabric-primitives/FabricEpochNsec.ts";
 import { FabricInstance, FabricPrimitive } from "../../src/interface.ts";
-import {
-  resetDataModelConfig,
-  setDataModelConfig,
-  shallowFabricFromNativeValue,
-} from "../../src/fabric-value.ts";
+import { shallowFabricFromNativeValue } from "../../src/fabric-value.ts";
 
 describe("FabricEpochNsec", () => {
   // Pure type-identity / supertype checks: cross-cutting carve-out per the
@@ -57,14 +53,9 @@ describe("FabricEpochNsec", () => {
   // of the class, so it lives directly under the class `describe()`.
   describe("shallowFabricFromNativeValue() integration", () => {
     it("passes through unchanged even with `freeze=false`", () => {
-      setDataModelConfig(true);
-      try {
-        const nsec = new FabricEpochNsec(123n);
-        // freeze=false should still return the same instance (not a copy).
-        expect(shallowFabricFromNativeValue(nsec, false)).toBe(nsec);
-      } finally {
-        resetDataModelConfig();
-      }
+      const nsec = new FabricEpochNsec(123n);
+      // freeze=false should still return the same instance (not a copy).
+      expect(shallowFabricFromNativeValue(nsec, false)).toBe(nsec);
     });
   });
 });

--- a/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { FabricInstance, FabricPrimitive } from "../../src/interface.ts";
 import { FabricRegExp } from "../../src/fabric-primitives/FabricRegExp.ts";

--- a/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
@@ -5,8 +5,6 @@ import { FabricRegExp } from "../../src/fabric-primitives/FabricRegExp.ts";
 import { isConvertibleNativeInstance } from "../../src/native-instance-utils.ts";
 import {
   isFabricCompatible,
-  resetDataModelConfig,
-  setDataModelConfig,
   shallowFabricFromNativeValue,
 } from "../../src/fabric-value.ts";
 import {
@@ -152,30 +150,20 @@ describe("FabricRegExp", () => {
     });
   });
 
-  describe("shallowFabricFromNativeValue() (modern path)", () => {
+  describe("shallowFabricFromNativeValue()", () => {
     it("converts a `RegExp` to a `FabricRegExp`", () => {
-      setDataModelConfig(true);
-      try {
-        const result = shallowFabricFromNativeValue(/abc/gi);
-        expect(result).toBeInstanceOf(FabricRegExp);
-        expect((result as FabricRegExp).source).toBe("abc");
-        expect((result as FabricRegExp).flags).toBe("gi");
-      } finally {
-        resetDataModelConfig();
-      }
+      const result = shallowFabricFromNativeValue(/abc/gi);
+      expect(result).toBeInstanceOf(FabricRegExp);
+      expect((result as FabricRegExp).source).toBe("abc");
+      expect((result as FabricRegExp).flags).toBe("gi");
     });
 
     it("rejects a `RegExp` with extra enumerable properties", () => {
-      setDataModelConfig(true);
-      try {
-        const re = /abc/;
-        (re as unknown as Record<string, unknown>).custom = 1;
-        expect(() => shallowFabricFromNativeValue(re)).toThrow(
-          "Cannot store RegExp with extra enumerable properties",
-        );
-      } finally {
-        resetDataModelConfig();
-      }
+      const re = /abc/;
+      (re as unknown as Record<string, unknown>).custom = 1;
+      expect(() => shallowFabricFromNativeValue(re)).toThrow(
+        "Cannot store RegExp with extra enumerable properties",
+      );
     });
   });
 
@@ -195,13 +183,6 @@ describe("FabricRegExp", () => {
   });
 
   describe("isFabricCompatible()", () => {
-    beforeEach(() => {
-      setDataModelConfig(true);
-    });
-    afterEach(() => {
-      resetDataModelConfig();
-    });
-
     it("returns `true` for a plain `RegExp`", () => {
       expect(isFabricCompatible(/abc/gi)).toBe(true);
     });

--- a/packages/data-model/test/json-wire/JsonEncodingContext.test.ts
+++ b/packages/data-model/test/json-wire/JsonEncodingContext.test.ts
@@ -10,11 +10,7 @@ import { FabricEpochNsec } from "../../src/fabric-primitives/FabricEpochNsec.ts"
 import { FabricError } from "../../src/fabric-instances/FabricError.ts";
 import { isDeepFrozen } from "../../src/deep-freeze.ts";
 import { BaseReconstructionContext } from "../../src/BaseReconstructionContext.ts";
-import {
-  resetDataModelConfig,
-  setDataModelConfig,
-  shallowFabricFromNativeValue,
-} from "../../src/fabric-value.ts";
+import { shallowFabricFromNativeValue } from "../../src/fabric-value.ts";
 
 /**
  * Shared test `ReconstructionContext`: `getCell()` always throws (no test
@@ -694,46 +690,31 @@ describe("JsonEncodingContext", () => {
 
   describe("`Date` -> `FabricEpochNsec` conversion", () => {
     it("converts `Date(0)` to `FabricEpochNsec(0n)`", () => {
-      setDataModelConfig(true);
-      try {
-        const date = new Date(0);
-        const result = shallowFabricFromNativeValue(
-          date,
-        ) as unknown as FabricEpochNsec;
-        expect(result).toBeInstanceOf(FabricEpochNsec);
-        expect(result.value).toBe(0n);
-      } finally {
-        resetDataModelConfig();
-      }
+      const date = new Date(0);
+      const result = shallowFabricFromNativeValue(
+        date,
+      ) as unknown as FabricEpochNsec;
+      expect(result).toBeInstanceOf(FabricEpochNsec);
+      expect(result.value).toBe(0n);
     });
 
     it("converts `Date` to nanoseconds (`msec * 1_000_000`)", () => {
-      setDataModelConfig(true);
-      try {
-        const date = new Date("2024-01-01T00:00:00.000Z");
-        const result = shallowFabricFromNativeValue(
-          date,
-        ) as unknown as FabricEpochNsec;
-        expect(result).toBeInstanceOf(FabricEpochNsec);
-        const expectedNsec = BigInt(date.getTime()) * 1_000_000n;
-        expect(result.value).toBe(expectedNsec);
-      } finally {
-        resetDataModelConfig();
-      }
+      const date = new Date("2024-01-01T00:00:00.000Z");
+      const result = shallowFabricFromNativeValue(
+        date,
+      ) as unknown as FabricEpochNsec;
+      expect(result).toBeInstanceOf(FabricEpochNsec);
+      const expectedNsec = BigInt(date.getTime()) * 1_000_000n;
+      expect(result.value).toBe(expectedNsec);
     });
 
     it("converts negative `Date` to negative nanoseconds", () => {
-      setDataModelConfig(true);
-      try {
-        const date = new Date(-86400000); // -1 day
-        const result = shallowFabricFromNativeValue(
-          date,
-        ) as unknown as FabricEpochNsec;
-        expect(result).toBeInstanceOf(FabricEpochNsec);
-        expect(result.value).toBe(-86400000000000n);
-      } finally {
-        resetDataModelConfig();
-      }
+      const date = new Date(-86400000); // -1 day
+      const result = shallowFabricFromNativeValue(
+        date,
+      ) as unknown as FabricEpochNsec;
+      expect(result).toBeInstanceOf(FabricEpochNsec);
+      expect(result.value).toBe(-86400000000000n);
     });
   });
 

--- a/packages/memory/test/v2-engine-test.ts
+++ b/packages/memory/test/v2-engine-test.ts
@@ -2,10 +2,6 @@ import { assertEquals, assertExists, assertThrows } from "@std/assert";
 import { toFileUrl } from "@std/path";
 import { Database } from "@db/sqlite";
 import {
-  resetDataModelConfig,
-  setDataModelConfig,
-} from "@commonfabric/data-model/fabric-value";
-import {
   applyCommit,
   close,
   createBranch,
@@ -1599,65 +1595,60 @@ Deno.test("memory v2 engine rejects branch reads before createdSeq", async () =>
 });
 
 Deno.test("memory v2 engine persists rich patch values at the storage boundary", async () => {
-  setDataModelConfig(true);
+  const { engine, path } = await createEngine();
+
   try {
-    const { engine, path } = await createEngine();
+    applyCommit(engine, {
+      sessionId: "session:rich-patch",
+      invocation: invocationFor(1),
+      authorization,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: "entity:rich-patch",
+          value: toEntityDocument({ counter: 1n }),
+        }],
+      },
+    });
 
-    try {
-      applyCommit(engine, {
-        sessionId: "session:rich-patch",
-        invocation: invocationFor(1),
-        authorization,
-        commit: {
-          localSeq: 1,
-          reads: { confirmed: [], pending: [] },
-          operations: [{
-            op: "set",
-            id: "entity:rich-patch",
-            value: toEntityDocument({ counter: 1n }),
+    applyCommit(engine, {
+      sessionId: "session:rich-patch",
+      invocation: invocationFor(2),
+      authorization,
+      commit: {
+        localSeq: 2,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "patch",
+          id: "entity:rich-patch",
+          patches: [{
+            op: "replace",
+            path: "/value/counter",
+            value: 2n,
           }],
-        },
-      });
+        }],
+      },
+    });
 
-      applyCommit(engine, {
-        sessionId: "session:rich-patch",
-        invocation: invocationFor(2),
-        authorization,
-        commit: {
-          localSeq: 2,
-          reads: { confirmed: [], pending: [] },
-          operations: [{
-            op: "patch",
-            id: "entity:rich-patch",
-            patches: [{
-              op: "replace",
-              path: "/value/counter",
-              value: 2n,
-            }],
-          }],
-        },
-      });
+    assertEquals(
+      read(engine, { id: "entity:rich-patch" }),
+      toEntityDocument({ counter: 2n }),
+    );
 
-      assertEquals(
-        read(engine, { id: "entity:rich-patch" }),
-        toEntityDocument({ counter: 2n }),
-      );
-
-      const patchRow = engine.database.prepare(
-        `SELECT data
+    const patchRow = engine.database.prepare(
+      `SELECT data
          FROM revision
          WHERE id = 'entity:rich-patch' AND seq = 2`,
-      ).get() as { data: string } | undefined;
-      assertEquals(decodeStored(patchRow?.data), [{
-        op: "replace",
-        path: "/value/counter",
-        value: 2n,
-      }]);
-    } finally {
-      close(engine);
-      await Deno.remove(path);
-    }
+    ).get() as { data: string } | undefined;
+    assertEquals(decodeStored(patchRow?.data), [{
+      op: "replace",
+      path: "/value/counter",
+      value: 2n,
+    }]);
   } finally {
-    resetDataModelConfig();
+    close(engine);
+    await Deno.remove(path);
   }
 });

--- a/packages/memory/test/v2-server-test.ts
+++ b/packages/memory/test/v2-server-test.ts
@@ -1,11 +1,6 @@
 import { assertEquals, assertExists } from "@std/assert";
 import { FakeTime } from "@std/testing/time";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
-import {
-  getDataModelConfig,
-  resetDataModelConfig,
-  setDataModelConfig,
-} from "@commonfabric/data-model/fabric-value";
 import { parseClientMessage, Server, SessionRegistry } from "../v2/server.ts";
 import {
   encodeMemoryBoundary,
@@ -33,22 +28,6 @@ const HELLO_OK = {
 
 const tick = async () => {
   await new Promise((resolve) => setTimeout(resolve, 0));
-};
-
-const withModernDataModel = async <T>(
-  fn: () => Promise<T> | T,
-): Promise<T> => {
-  const previousDataModel = getDataModelConfig();
-  setDataModelConfig(true);
-  try {
-    return await fn();
-  } finally {
-    if (previousDataModel) {
-      setDataModelConfig(true);
-    } else {
-      resetDataModelConfig();
-    }
-  }
 };
 
 const shiftMessage = (messages: ServerMessage[]): ServerMessage => {
@@ -233,17 +212,15 @@ Deno.test("memory v2 server direct document helpers round-trip values", async ()
   };
 
   try {
-    await withModernDataModel(async () => {
-      await server.writeDocument(space, id, contents);
+    await server.writeDocument(space, id, contents);
 
-      assertEquals(await server.readDocument(space, id), {
-        value: contents,
-      });
-      assertEquals(
-        await server.readDocument(space, "cid:fid1:missing-document"),
-        null,
-      );
+    assertEquals(await server.readDocument(space, id), {
+      value: contents,
     });
+    assertEquals(
+      await server.readDocument(space, "cid:fid1:missing-document"),
+      null,
+    );
   } finally {
     await server.close();
   }

--- a/packages/memory/test/v2-test.ts
+++ b/packages/memory/test/v2-test.ts
@@ -1,10 +1,6 @@
 import { afterEach, describe, it } from "@std/testing/bdd";
 import { assert, assertEquals, assertFalse, assertThrows } from "@std/assert";
 import {
-  resetDataModelConfig,
-  setDataModelConfig,
-} from "@commonfabric/data-model/fabric-value";
-import {
   resetModernCellRepConfig,
   setModernCellRepConfig,
 } from "@commonfabric/data-model/cell-rep";
@@ -115,10 +111,8 @@ describe("memory v2 source links", () => {
 describe("memory v2 flags", () => {
   it("reflects the active runtime storage flags", () => {
     resetModernCellRepConfig();
-    resetDataModelConfig();
     resetPersistentSchedulerStateConfig();
     setModernCellRepConfig(false);
-    setDataModelConfig(false);
     setPersistentSchedulerStateConfig(false);
 
     assertEquals(getMemoryProtocolFlags(), {
@@ -127,7 +121,6 @@ describe("memory v2 flags", () => {
     });
 
     setModernCellRepConfig(true);
-    setDataModelConfig(true);
     setPersistentSchedulerStateConfig(true);
 
     assertEquals(getMemoryProtocolFlags(), {
@@ -136,7 +129,6 @@ describe("memory v2 flags", () => {
     });
 
     resetModernCellRepConfig();
-    resetDataModelConfig();
     resetPersistentSchedulerStateConfig();
   });
 
@@ -199,10 +191,6 @@ describe("parseMemoryProtocolFlags", () => {
 // ---------------------------------------------------------------------------
 
 describe("memory v2 boundary decode", () => {
-  afterEach(() => {
-    resetDataModelConfig();
-  });
-
   it("returns deeply-frozen plain JSON trees", () => {
     const decoded = decodeMemoryBoundary<{
       value: {

--- a/packages/memory/test/v2-test.ts
+++ b/packages/memory/test/v2-test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, it } from "@std/testing/bdd";
+import { describe, it } from "@std/testing/bdd";
 import { assert, assertEquals, assertFalse, assertThrows } from "@std/assert";
 import {
   resetModernCellRepConfig,

--- a/packages/runner/test/fetch-utils.test.ts
+++ b/packages/runner/test/fetch-utils.test.ts
@@ -1,95 +1,49 @@
-import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import {
-  resetDataModelConfig,
-  setDataModelConfig,
-} from "@commonfabric/data-model/fabric-value";
 import { computeInputHashFromValue } from "../src/builtins/fetch-utils.ts";
 
-// ============================================================================
-// Tests
-// ============================================================================
-//
-// `computeInputHashFromValue()` must produce a stable hash across legacy and
-// modern fabric-value-layer states. In particular, callers commonly build
-// snapshots via unconditional object construction, so omitted-key versus
-// present-but-`undefined` must hash identically -- a property the legacy
-// layer used to provide implicitly, and which the function now normalizes
-// directly.
-
 describe("computeInputHashFromValue", () => {
-  afterEach(() => {
-    resetDataModelConfig();
+  it("drops the top-level `result` type-hint field", () => {
+    const a = computeInputHashFromValue({ url: "x", mode: "json" });
+    const b = computeInputHashFromValue({
+      url: "x",
+      mode: "json",
+      result: "ignored type hint",
+    });
+    expect(a).toBe(b);
   });
 
-  for (const modernMode of [false, true]) {
-    const label = modernMode ? "modern" : "legacy";
-
-    describe(`(${label} path)`, () => {
-      beforeEach(() => setDataModelConfig(modernMode));
-
-      it("drops the top-level `result` type-hint field", () => {
-        const a = computeInputHashFromValue({ url: "x", mode: "json" });
-        const b = computeInputHashFromValue({
-          url: "x",
-          mode: "json",
-          result: "ignored type hint",
-        });
-        expect(a).toBe(b);
-      });
-
-      it("treats omitted vs `undefined` top-level properties identically", () => {
-        const a = computeInputHashFromValue({ url: "x", mode: "json" });
-        const b = computeInputHashFromValue({
-          url: "x",
-          mode: "json",
-          options: undefined,
-        });
-        expect(a).toBe(b);
-      });
-
-      it("treats omitted vs `undefined` nested properties identically", () => {
-        const a = computeInputHashFromValue({
-          url: "x",
-          options: { method: "GET" },
-        });
-        const b = computeInputHashFromValue({
-          url: "x",
-          options: { method: "GET", body: undefined },
-        });
-        expect(a).toBe(b);
-      });
-
-      it("distinguishes inputs that differ in non-`undefined` content", () => {
-        const a = computeInputHashFromValue({ url: "x", mode: "json" });
-        const b = computeInputHashFromValue({ url: "y", mode: "json" });
-        expect(a).not.toBe(b);
-      });
-
-      it("treats `undefined` inputs as the empty object", () => {
-        const a = computeInputHashFromValue(undefined);
-        const b = computeInputHashFromValue({});
-        expect(a).toBe(b);
-      });
+  it("treats omitted vs `undefined` top-level properties identically", () => {
+    const a = computeInputHashFromValue({ url: "x", mode: "json" });
+    const b = computeInputHashFromValue({
+      url: "x",
+      mode: "json",
+      options: undefined,
     });
-  }
+    expect(a).toBe(b);
+  });
 
-  describe("(flag-independent output)", () => {
-    afterEach(() => {
-      resetDataModelConfig();
+  it("treats omitted vs `undefined` nested properties identically", () => {
+    const a = computeInputHashFromValue({
+      url: "x",
+      options: { method: "GET" },
     });
+    const b = computeInputHashFromValue({
+      url: "x",
+      options: { method: "GET", body: undefined },
+    });
+    expect(a).toBe(b);
+  });
 
-    it("produces the same hash under legacy and modern for the same inputs", () => {
-      const inputs = {
-        url: "http://example/api",
-        mode: "json" as const,
-        options: { method: "GET", body: undefined },
-      };
-      setDataModelConfig(false);
-      const legacyHash = computeInputHashFromValue(inputs);
-      setDataModelConfig(true);
-      const modernHash = computeInputHashFromValue(inputs);
-      expect(modernHash).toBe(legacyHash);
-    });
+  it("distinguishes inputs that differ in non-`undefined` content", () => {
+    const a = computeInputHashFromValue({ url: "x", mode: "json" });
+    const b = computeInputHashFromValue({ url: "y", mode: "json" });
+    expect(a).not.toBe(b);
+  });
+
+  it("treats `undefined` inputs as the empty object", () => {
+    const a = computeInputHashFromValue(undefined);
+    const b = computeInputHashFromValue({});
+    expect(a).toBe(b);
   });
 });

--- a/packages/runner/test/frozen-mutation.test.ts
+++ b/packages/runner/test/frozen-mutation.test.ts
@@ -21,14 +21,9 @@ import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
 import { ExtendedStorageTransaction } from "../src/storage/extended-storage-transaction.ts";
-import { resetDataModelConfig } from "@commonfabric/data-model/fabric-value";
 
 const signer = await Identity.fromPassphrase("test frozen mutation");
 const space = signer.did();
-
-function resetAllConfigs() {
-  resetDataModelConfig();
-}
 
 describe("frozen-object safety contracts", () => {
   describe("writeOrThrow clones frozen parents before mutation", () => {
@@ -46,7 +41,6 @@ describe("frozen-object safety contracts", () => {
     afterEach(async () => {
       await runtime?.dispose();
       await storageManager?.close();
-      resetAllConfigs();
     });
 
     it("writes through a frozen parent when intermediate path is missing", async () => {

--- a/packages/runner/test/memory-v2-read-freeze.test.ts
+++ b/packages/runner/test/memory-v2-read-freeze.test.ts
@@ -1,8 +1,4 @@
 import {
-  resetDataModelConfig,
-  setDataModelConfig,
-} from "@commonfabric/data-model/fabric-value";
-import {
   assert,
   assertEquals,
   assertNotStrictEquals,
@@ -17,7 +13,6 @@ const space = signer.did();
 const type = "application/json" as const;
 
 Deno.test("memory v2 raw reads freeze the returned subtree without exposing mutable state", async () => {
-  setDataModelConfig(true);
   const storage = StorageManager.emulate({
     as: signer,
   });
@@ -67,12 +62,10 @@ Deno.test("memory v2 raw reads freeze the returned subtree without exposing muta
     assertEquals(full.stats.visits, 3);
   } finally {
     await storage.close();
-    resetDataModelConfig();
   }
 });
 
 Deno.test("memory v2 raw reads reuse frozen snapshots until the document changes", async () => {
-  setDataModelConfig(true);
   const storage = StorageManager.emulate({
     as: signer,
   });
@@ -147,12 +140,10 @@ Deno.test("memory v2 raw reads reuse frozen snapshots until the document changes
     assert(Object.isFrozen(afterWrite));
   } finally {
     await storage.close();
-    resetDataModelConfig();
   }
 });
 
 Deno.test("memory v2 read cache: sibling-path snapshot survives write, ancestor and written-subtree snapshots get rebuilt", async () => {
-  setDataModelConfig(true);
   const storage = StorageManager.emulate({ as: signer });
 
   try {
@@ -232,7 +223,6 @@ Deno.test("memory v2 read cache: sibling-path snapshot survives write, ancestor 
     assertNotStrictEquals(ancestorBefore, ancestorAfter);
   } finally {
     await storage.close();
-    resetDataModelConfig();
   }
 });
 
@@ -242,7 +232,6 @@ Deno.test("memory v2 read cache: array `.length` reads invalidate when an index 
   // `/items/length` pointer is not on the chain of `/items/1` by path-string
   // overlap, but it IS semantically dependent on the index write -- so the
   // cache invalidator must drop it.
-  setDataModelConfig(true);
   const storage = StorageManager.emulate({ as: signer });
 
   try {
@@ -276,12 +265,10 @@ Deno.test("memory v2 read cache: array `.length` reads invalidate when an index 
     assertEquals(lenAfter, 2);
   } finally {
     await storage.close();
-    resetDataModelConfig();
   }
 });
 
 Deno.test("memory v2 raw reads keep prior frozen snapshots stable after sibling writes", async () => {
-  setDataModelConfig(true);
   const storage = StorageManager.emulate({
     as: signer,
   });
@@ -340,6 +327,5 @@ Deno.test("memory v2 raw reads keep prior frozen snapshots stable after sibling 
     assert(Object.isFrozen(second.stats));
   } finally {
     await storage.close();
-    resetDataModelConfig();
   }
 });

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -5,10 +5,6 @@ import {
   assertStrictEquals,
 } from "@std/assert";
 import {
-  resetDataModelConfig,
-  setDataModelConfig,
-} from "@commonfabric/data-model/fabric-value";
-import {
   jsonFromValue,
   valueFromJson,
 } from "@commonfabric/data-model/json-wire";
@@ -2014,7 +2010,6 @@ Deno.test("memory v2 stacked commits: dropping an earlier pending write invalida
 });
 
 Deno.test("memory v2 stacked commits: pending visibility preserves rich fabric values", async () => {
-  setDataModelConfig(true);
   const harness = await createHarness();
   let commitPromise: Promise<any> | undefined;
   try {
@@ -2034,7 +2029,6 @@ Deno.test("memory v2 stacked commits: pending visibility preserves rich fabric v
   } finally {
     await commitPromise?.catch(() => {});
     await harness.close();
-    resetDataModelConfig();
   }
 });
 

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -17,25 +17,9 @@ import {
 import { decodeMemoryBoundary } from "@commonfabric/memory/v2";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { cellRefToSigilLink } from "./utils.ts";
-import {
-  getDataModelConfig,
-  setDataModelConfig,
-} from "@commonfabric/data-model/fabric-value";
 import { Runtime } from "@commonfabric/runner";
 import * as V2Storage from "../../runner/src/storage/v2.ts";
 import { parseLink } from "../../runner/src/link-utils.ts";
-
-const withModernDataModel = async <T>(
-  fn: () => Promise<T> | T,
-): Promise<T> => {
-  const previousDataModel = getDataModelConfig();
-  setDataModelConfig(true);
-  try {
-    return await fn();
-  } finally {
-    setDataModelConfig(previousDataModel);
-  }
-};
 
 const cfcSigner = await Identity.fromPassphrase(
   "runtime-processor-cfc-label-tests",
@@ -755,18 +739,16 @@ describe("RuntimeProcessor blob upload IPC", () => {
     } as unknown as RuntimeProcessor;
 
     try {
-      await withModernDataModel(async () => {
-        await expect(
-          RuntimeProcessor.prototype.handleUploadBlob.call(processor, {
-            type: RequestType.UploadBlob,
-            contentType: "image/png",
-            body: [1, 2, 3],
-            suffix: "png",
-          }),
-        ).resolves.toEqual({
-          id: "fid1:test",
-          url: "blobs/test.png",
-        });
+      await expect(
+        RuntimeProcessor.prototype.handleUploadBlob.call(processor, {
+          type: RequestType.UploadBlob,
+          contentType: "image/png",
+          body: [1, 2, 3],
+          suffix: "png",
+        }),
+      ).resolves.toEqual({
+        id: "fid1:test",
+        url: "blobs/test.png",
       });
     } finally {
       globalThis.fetch = originalFetch;

--- a/packages/toolshed/routes/blobs/blobs.test.ts
+++ b/packages/toolshed/routes/blobs/blobs.test.ts
@@ -12,12 +12,7 @@ import { JsonEncodingContext } from "@commonfabric/data-model/json-wire";
 import { encodeMemoryBoundary } from "@commonfabric/memory/v2";
 import { Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import {
-  type FabricValue,
-  getDataModelConfig,
-  resetDataModelConfig,
-  setDataModelConfig,
-} from "@commonfabric/data-model/fabric-value";
+import { type FabricValue } from "@commonfabric/data-model/fabric-value";
 
 if (env.ENV !== "test") {
   throw new Error("ENV must be 'test'");
@@ -26,22 +21,6 @@ if (env.ENV !== "test") {
 const app = createApp()
   .route("/", memory)
   .route("/", router);
-
-const withModernDataModel = async <T>(
-  fn: () => Promise<T> | T,
-): Promise<T> => {
-  const previousDataModel = getDataModelConfig();
-  setDataModelConfig(true);
-  try {
-    return await fn();
-  } finally {
-    if (previousDataModel) {
-      setDataModelConfig(true);
-    } else {
-      resetDataModelConfig();
-    }
-  }
-};
 
 const encodeBlobPayload = (payload: { type: string; body: FabricBytes }) =>
   encodeMemoryBoundary(payload);
@@ -63,23 +42,21 @@ describe("Blob Routes", () => {
     const id = hashOf(contents).toString();
     const hash = id.slice("fid1:".length);
 
-    await withModernDataModel(async () => {
-      const post = await app.request(`/${identity.did()}/blobs/image.gif`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: encodeBlobPayload(contents),
-      });
-      expect(post.status).toBe(201);
-      expect(await post.json()).toEqual({
-        id,
-        url: `blobs/${hash}.gif`,
-      });
-
-      const get = await app.request(`/${identity.did()}/blobs/${hash}.png`);
-      expect(get.status).toBe(200);
-      expect(get.headers.get("Content-Type")).toBe("image/gif");
-      expect(new Uint8Array(await get.arrayBuffer())).toEqual(bytes);
+    const post = await app.request(`/${identity.did()}/blobs/image.gif`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: encodeBlobPayload(contents),
     });
+    expect(post.status).toBe(201);
+    expect(await post.json()).toEqual({
+      id,
+      url: `blobs/${hash}.gif`,
+    });
+
+    const get = await app.request(`/${identity.did()}/blobs/${hash}.png`);
+    expect(get.status).toBe(200);
+    expect(get.headers.get("Content-Type")).toBe("image/gif");
+    expect(new Uint8Array(await get.arrayBuffer())).toEqual(bytes);
   });
 
   it("accepts blob upload encoding without ambient data model flags", async () => {
@@ -94,25 +71,20 @@ describe("Blob Routes", () => {
     const id = hashOf(contents).toString();
     const hash = id.slice("fid1:".length);
 
-    setDataModelConfig(false);
-    try {
-      const post = await app.request(`/${identity.did()}/blobs/image.gif`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: blobUploadEncoding.encode(contents as FabricValue),
-      });
-      expect(post.status).toBe(201);
-      expect(await post.json()).toEqual({
-        id,
-        url: `blobs/${hash}.gif`,
-      });
+    const post = await app.request(`/${identity.did()}/blobs/image.gif`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: blobUploadEncoding.encode(contents as FabricValue),
+    });
+    expect(post.status).toBe(201);
+    expect(await post.json()).toEqual({
+      id,
+      url: `blobs/${hash}.gif`,
+    });
 
-      const get = await app.request(`/${identity.did()}/blobs/${hash}.gif`);
-      expect(get.status).toBe(200);
-      expect(new Uint8Array(await get.arrayBuffer())).toEqual(bytes);
-    } finally {
-      resetDataModelConfig();
-    }
+    const get = await app.request(`/${identity.did()}/blobs/${hash}.gif`);
+    expect(get.status).toBe(200);
+    expect(new Uint8Array(await get.arrayBuffer())).toEqual(bytes);
   });
 
   it("stores blob contents as a cell document value", async () => {
@@ -126,61 +98,59 @@ describe("Blob Routes", () => {
     const cid = `cid:${id}` as const;
     const hash = id.slice("fid1:".length);
 
-    await withModernDataModel(async () => {
-      const post = await app.request(`/${identity.did()}/blobs/image.png`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: encodeBlobPayload(contents),
-      });
-      expect(post.status).toBe(201);
-
-      const document = await memoryServer.readDocument(
-        identity.did(),
-        cid,
-      );
-      expect(document?.value).toEqual(contents);
-
-      const server = Deno.serve({ port: 0 }, app.fetch);
-      const base = new URL(
-        `http://${server.addr.hostname}:${server.addr.port}`,
-      );
-      const runtime = new Runtime({
-        apiUrl: base,
-        storageManager: StorageManager.open({
-          as: identity,
-          address: new URL("/api/storage/memory", base),
-        }),
-      });
-
-      try {
-        const provider = runtime.storageManager.open(identity.did());
-        const sync = await provider.sync(cid, {
-          path: [],
-          schema: false,
-        });
-        expect(sync).toEqual({ ok: {} });
-
-        const cell = runtime.getCellFromLink<{
-          type: string;
-          body: FabricBytes;
-        }>({
-          id: cid,
-          path: [],
-          space: identity.did(),
-        });
-        await cell.sync();
-        await runtime.storageManager.synced();
-
-        const value = cell.get();
-        expect(value.type).toBe("image/png");
-        expect(value.body).toBeTruthy();
-        expect(value.body.constructor.name).toBe("FabricBytes");
-        expect((await post.json()).url).toBe(`blobs/${hash}.png`);
-      } finally {
-        await runtime.dispose();
-        await server.shutdown();
-      }
+    const post = await app.request(`/${identity.did()}/blobs/image.png`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: encodeBlobPayload(contents),
     });
+    expect(post.status).toBe(201);
+
+    const document = await memoryServer.readDocument(
+      identity.did(),
+      cid,
+    );
+    expect(document?.value).toEqual(contents);
+
+    const server = Deno.serve({ port: 0 }, app.fetch);
+    const base = new URL(
+      `http://${server.addr.hostname}:${server.addr.port}`,
+    );
+    const runtime = new Runtime({
+      apiUrl: base,
+      storageManager: StorageManager.open({
+        as: identity,
+        address: new URL("/api/storage/memory", base),
+      }),
+    });
+
+    try {
+      const provider = runtime.storageManager.open(identity.did());
+      const sync = await provider.sync(cid, {
+        path: [],
+        schema: false,
+      });
+      expect(sync).toEqual({ ok: {} });
+
+      const cell = runtime.getCellFromLink<{
+        type: string;
+        body: FabricBytes;
+      }>({
+        id: cid,
+        path: [],
+        space: identity.did(),
+      });
+      await cell.sync();
+      await runtime.storageManager.synced();
+
+      const value = cell.get();
+      expect(value.type).toBe("image/png");
+      expect(value.body).toBeTruthy();
+      expect(value.body.constructor.name).toBe("FabricBytes");
+      expect((await post.json()).url).toBe(`blobs/${hash}.png`);
+    } finally {
+      await runtime.dispose();
+      await server.shutdown();
+    }
   });
 
   it("returns 404 for an absent blob", async () => {
@@ -208,13 +178,11 @@ describe("Blob Routes", () => {
     const id = hashOf(contents).toString();
     const hash = id.slice("fid1:".length);
 
-    const post = await withModernDataModel(() =>
-      app.request(`/${identity.did()}/blobs/image.toolonggg`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: encodeBlobPayload(contents),
-      })
-    );
+    const post = await app.request(`/${identity.did()}/blobs/image.toolonggg`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: encodeBlobPayload(contents),
+    });
 
     expect(post.status).toBe(201);
     expect(await post.json()).toEqual({
@@ -252,19 +220,17 @@ describe("Blob Routes", () => {
     const id = hashOf(contents).toString();
     const hash = id.slice("fid1:".length);
 
-    await withModernDataModel(async () => {
-      const post = await app.request(`/${identity.did()}/blobs/page.html`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: encodeBlobPayload(contents),
-      });
-      expect(post.status).toBe(201);
-
-      const get = await app.request(`/${identity.did()}/blobs/${hash}.html`);
-      expect(get.status).toBe(200);
-      expect(get.headers.get("Content-Type")).toBe("application/octet-stream");
-      expect(new Uint8Array(await get.arrayBuffer())).toEqual(bytes);
+    const post = await app.request(`/${identity.did()}/blobs/page.html`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: encodeBlobPayload(contents),
     });
+    expect(post.status).toBe(201);
+
+    const get = await app.request(`/${identity.did()}/blobs/${hash}.html`);
+    expect(get.status).toBe(200);
+    expect(get.headers.get("Content-Type")).toBe("application/octet-stream");
+    expect(new Uint8Array(await get.arrayBuffer())).toEqual(bytes);
   });
 
   it("rejects invalid blob payloads", async () => {


### PR DESCRIPTION
Prep for retiring the legacy data model: gets every test off the `modernDataModel` flag, so the legacy code path can be removed in a follow-up as a clean source-only change. No source changes here (one doc tweak aside).

## What changed

De-flags the test suite — removes all `setDataModelConfig` / `getDataModelConfig` / `resetDataModelConfig` usage from tests:

- **Dropped** tests that only existed to exercise the legacy (flag-off) data model, where an equivalent modern test already covers the behavior.
- **De-parameterized** tests that ran a body across both flag states down to modern-only.
- **Unwound** the fancier harnesses — a couple of tests used a `withModernDataModel(fn)` save/restore-around-a-block wrapper (`const prev = getDataModelConfig(); … finally`), now removed in favor of running modern directly.

Touches tests in `data-model`, `memory`, `runner`, `runtime-client`, and `toolshed`, plus a small `EXPERIMENTAL_OPTIONS.md` doc update.

After this, the only remaining `*DataModelConfig` references are the two runtime **source** sites (`runner/src/cell.ts`, `runner/src/storage/v2-transaction.ts`) and the definition/legacy module — all of which go away in the legacy-strip PR.

## Verification

Ran every changed test file: `data-model` (6 files, 512 steps), `memory` (`v2-engine`, `v2-test`, `v2-server`), `runner` (`fetch-utils`, `frozen-mutation`, `memory-v2-read-freeze`, `memory-v2-stacked-commit`), `runtime-client` (`runtime-processor`, 44 steps), `toolshed` (`blobs`) — all green, type-checks clean (`deno test` type-checks by default; `deno task check` happy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Performance Baseline

This PR is test-only, so the following accounts for spurious perf check failures:

NEW_PERF_BASELINE: job: Build Binaries = 87s
NEW_PERF_BASELINE: job: Runner Tests (4/4) = 99s
NEW_PERF_BASELINE: job: Generated Patterns Integration Tests (3/4) = 97s
NEW_PERF_BASELINE: job: Generated Patterns Integration Tests = 97s

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops testing the legacy data model by removing all data model flag usage from tests. The suite now runs only the modern path, paving the way to delete the legacy code path in a follow-up.

- **Refactors**
  - Removed all `setDataModelConfig` / `getDataModelConfig` / `resetDataModelConfig` usage from tests and deleted `withModernDataModel(...)` helpers.
  - Dropped tests that only exercised legacy behavior when modern coverage exists.
  - De-parameterized dual-mode tests to modern-only.
  - Updated `EXPERIMENTAL_OPTIONS.md` to note the Runtime sets experiment config via constructor calls.

<sup>Written for commit 741bbd63916a6d66e80df8a3e65a44fb97535c4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

