### PR TITLE
Collapse the last two modernDataModel branches to the modern path

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -9,7 +9,6 @@ import {
   DECONSTRUCT,
   FabricInstance,
   type FabricValue,
-  getDataModelConfig,
   shallowFabricFromNativeValue,
 } from "@commonfabric/data-model/fabric-value";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
@@ -2461,10 +2460,6 @@ export function recursivelyAddIDIfNeeded<T>(
   // Can't add IDs without frame.
   if (!frame) return value;
 
-  // Snapshot the modern-data-model flag once; used below at the freshly-
-  // built-container freeze points.
-  const modern = getDataModelConfig();
-
   // Already seen, return previously annotated result. Check this before
   // shallowFabricFromNativeValue() to handle circular references properly.
   if (seen.has(value)) return seen.get(value) as T;
@@ -2524,12 +2519,9 @@ export function recursivelyAddIDIfNeeded<T>(
 
   // From here `converted` is an array or record. The result container is
   // pre-registered in `seen` against the original `value` BEFORE descending
-  // into entries, so circular back-references to `value` resolve correctly
-  // even under modern, where shallow conversion allocates a fresh frozen
-  // clone whose own properties still point at the original (unfrozen)
-  // input. Without this, a cycle would re-enter
-  // `shallowFabricFromNativeValue(value)` on every pass and recurse
-  // forever.
+  // into entries, so circular back-references to `value` resolve correctly.
+  // Without this, a cycle would re-enter `shallowFabricFromNativeValue(value)`
+  // on every pass and recurse forever.
   const convertedDiffers = converted !== value;
 
   if (Array.isArray(converted)) {
@@ -2551,9 +2543,9 @@ export function recursivelyAddIDIfNeeded<T>(
       ) {
         changed = true;
         const withId = { [ID]: frame.generatedIdCounter++, ...v };
-        // Under modern, the ID-wrapped object is a freshly-built
-        // container that must also be deep-frozen.
-        if (modern) Object.freeze(withId);
+        // The ID-wrapped object is a freshly-built container that must also be
+        // deep-frozen.
+        Object.freeze(withId);
         result[i] = withId;
       } else {
         if (!Object.is(v, el)) {
@@ -2568,12 +2560,11 @@ export function recursivelyAddIDIfNeeded<T>(
       return value;
     }
 
-    // Under the modern data model, the value enters a write-boundary that
-    // expects deep-frozen `FabricValue` trees. Children are already frozen
-    // by `shallowFabricFromNativeValue()` above; freeze the freshly-built
-    // top-level container so the returned tree is deep-frozen as a whole.
-    if (modern) Object.freeze(result);
-    return result as T;
+    // The value enters a write-boundary that expects deep-frozen `FabricValue`
+    // trees. Children are already frozen by `shallowFabricFromNativeValue()`
+    // above; freeze the freshly-built top-level container so the returned tree
+    // is deep-frozen as a whole.
+    return Object.freeze(result) as T;
   } else {
     const sourceRecord = converted as Record<string, unknown>;
     const result: Record<string, unknown> = {};
@@ -2608,9 +2599,7 @@ export function recursivelyAddIDIfNeeded<T>(
       return value;
     }
 
-    // See array-branch comment above re: modern freeze.
-    if (modern) Object.freeze(result);
-    return result as T;
+    return Object.freeze(result) as T;
   }
 }
 

--- a/packages/runner/src/storage/v2-transaction.ts
+++ b/packages/runner/src/storage/v2-transaction.ts
@@ -1,7 +1,4 @@
-import {
-  cloneIfNecessary,
-  getDataModelConfig,
-} from "@commonfabric/data-model/fabric-value";
+import { cloneIfNecessary } from "@commonfabric/data-model/fabric-value";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { unclaimed } from "@commonfabric/memory/fact";
 import type { PatchOp, SqliteOperation } from "@commonfabric/memory/v2";
@@ -49,9 +46,7 @@ import { createReadOnlyTransactionError } from "./interface.ts";
 import {
   claim,
   load as loadInline,
-  NotFound,
   read as readAttestation,
-  TypeMismatchError,
 } from "./transaction/attestation.ts";
 import {
   applyMutablePathWrite,
@@ -990,37 +985,6 @@ export class V2StorageTransaction implements IStorageTransaction {
         doc.validated = true;
       }
       return { ok: { address, value: undefined } };
-    }
-    if (!getDataModelConfig()) {
-      const inspected = inspectPath(current.value, memoryAddress.path);
-      if (
-        !address.id.startsWith("data:") &&
-        !doc.validated
-      ) {
-        doc.validated = true;
-      }
-      if (inspected.kind === "notFound") {
-        return {
-          error: NotFound(current, memoryAddress, inspected.path).from(
-            address.space,
-          ),
-        };
-      }
-      if (inspected.kind === "typeMismatch") {
-        return {
-          error: TypeMismatchError(
-            { ...memoryAddress, path: inspected.path },
-            inspected.actualType,
-            "read",
-          ).from(address.space),
-        };
-      }
-      return {
-        ok: {
-          address: memoryAddress,
-          value: inspected.value,
-        },
-      };
     }
 
     if (isMutableTransactionReadAllowed(readMeta)) {


### PR DESCRIPTION
Source-only follow-up to #3850: collapses the last two runtime sites that branched on the (now-removed-by-default) `modernDataModel` flag to their modern behavior. After this, the only remaining `*DataModelConfig` references are the definition site and `fabric-value-legacy.ts` itself — both of which go away in the final legacy-strip PR.

## Changes

**`runner/src/cell.ts`** (`recursivelyAddIDIfNeeded`) — dropped the `const modern = getDataModelConfig()` snapshot; the three `if (modern) Object.freeze(…)` points become unconditional freezes (modern was always the live path). Behavior-preserving under modern; comments de-flagged.

**`runner/src/storage/v2-transaction.ts`** — removed the dead `if (!getDataModelConfig()) { … }` legacy read-path block (it only ran with the flag off), plus the now-unused `NotFound` / `TypeMismatchError` imports.

## Heads-up, @seefeldb

The deleted v2-transaction block is the legacy-only read path: with the flag off it ran `inspectPath(current.value, memoryAddress.path)` and returned `NotFound` / `TypeMismatchError` (or the inspected value). It never executed under modern, so removing it is behavior-preserving today — but in case it was read-path validation you meant to wire into the modern path, just flagging that it's coming out here. No action needed; it's recoverable from git history if you want to revive it later.

## Verification

`deno check` + `deno lint` clean on both files. Full `runner` suite: 525 passed / 2776 steps / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapsed the remaining `modernDataModel` branches to always use the modern path, removing legacy-only logic and unused imports. Behavior is unchanged under modern and this cleans up the runtime.

- **Refactors**
  - `packages/runner/src/cell.ts`: Removed `getDataModelConfig()` flow and made freezes unconditional on freshly built containers and top-level results.
  - `packages/runner/src/storage/v2-transaction.ts`: Deleted the dead legacy read-path block and the unused `NotFound`/`TypeMismatchError` imports from `@commonfabric/memory`.

<sup>Written for commit 3c19b131440432ac80af1a3200ab4ba97eac559b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

