### PR TITLE
fix(schema-generator): preserve array-items comparable under Default<[]> unions (CT-1639 Gap B)

### DIFF
--- a/packages/schema-generator/src/formatters/common-fabric-formatter.ts
+++ b/packages/schema-generator/src/formatters/common-fabric-formatter.ts
@@ -547,9 +547,15 @@ export class CommonFabricFormatter implements TypeFormatter {
     if (context.schemaHints && context.typeNode) {
       const hint = context.schemaHints.get(context.typeNode);
       if (hint?.items === false) {
+        // Pass the inner node even when it isn't used to build the inner schema
+        // (shouldPassTypeNode=false): the override only reads the element's
+        // capability from it. For an expanded `Default<[]> | Item[]` union the
+        // element's `comparable` capability lives ONLY on the synthetic node
+        // (the resolved union type can't express it), so the node is required to
+        // recover it. (CT-1639 Gap B)
         const itemsOverride = this.createArrayItemsOverride(
           innerType,
-          shouldPassTypeNode ? innerTypeNode : undefined,
+          innerTypeNode,
           context,
         );
         childContext = { ...context, arrayItemsOverride: itemsOverride };
@@ -598,19 +604,73 @@ export class CommonFabricFormatter implements TypeFormatter {
       context.typeChecker,
       arrayTypeNode,
     );
-    if (!elementInfo) {
-      return base;
+
+    let resolvedElementWrapperKind: "Default" | WrapperKind | undefined;
+    if (elementInfo) {
+      resolvedElementWrapperKind = elementInfo.elementNode
+        ? resolveWrapperNode(elementInfo.elementNode, context.typeChecker)?.kind
+        : getCellWrapperInfo(elementInfo.elementType, context.typeChecker)
+          ?.kind;
+    } else {
+      // No element info — e.g. an expanded `Default<[]> | Item[]` union, whose
+      // type is not array-like so getArrayElementInfo can't reach the element.
+      // The real array member's element capability (e.g. `comparable`) lives on
+      // the synthetic NODE, not the resolved union type, so recover it from the
+      // node by descending to the real array member's element. (CT-1639 Gap B)
+      resolvedElementWrapperKind = this.elementWrapperFromUnionNode(
+        arrayTypeNode,
+        context.typeChecker,
+      );
     }
 
-    const resolvedElementWrapperKind = elementInfo.elementNode
-      ? resolveWrapperNode(elementInfo.elementNode, context.typeChecker)?.kind
-      : getCellWrapperInfo(elementInfo.elementType, context.typeChecker)?.kind;
     const elementWrapperKind = resolvedElementWrapperKind === "Default"
       ? undefined
       : resolvedElementWrapperKind;
     return elementWrapperKind
       ? this.applyWrapperSemantics(base, elementWrapperKind)
       : base;
+  }
+
+  /**
+   * For a synthetic union type node like `ComparableCell<unknown>[] | Default<[]>`
+   * (the expanded form of `Writable<Item[] | Default<[]>>`'s inner), find the
+   * single real-array member and return the wrapper kind of its element node.
+   * Empty-array / `Default<...>` members are skipped. Returns undefined when the
+   * node is not a union, has no real array member, or the element is unwrapped.
+   */
+  private elementWrapperFromUnionNode(
+    node: ts.TypeNode | undefined,
+    checker: ts.TypeChecker,
+  ): "Default" | WrapperKind | undefined {
+    if (!node || !ts.isUnionTypeNode(node)) return undefined;
+    let elementNode: ts.TypeNode | undefined;
+    for (const member of node.types) {
+      const arrayElement = this.arrayElementNode(member);
+      if (!arrayElement) continue; // non-array member (e.g. Default<[]>) — skip
+      // Skip degenerate empty-array members (`never[]`) — they're the unbranded
+      // arm of an expanded `Default<[]>` and carry no real element. (The branded
+      // `[] & DefaultMarker` arm and the empty tuple `[]` are not ArrayTypeNodes,
+      // so arrayElementNode already returned undefined for them.)
+      if (arrayElement.kind === ts.SyntaxKind.NeverKeyword) continue;
+      if (elementNode) return undefined; // more than one real array member
+      elementNode = arrayElement;
+    }
+    if (!elementNode) return undefined;
+    return resolveWrapperNode(elementNode, checker)?.kind;
+  }
+
+  /** The element TypeNode of `T[]` or `Array<T>`/`ReadonlyArray<T>`, else undefined. */
+  private arrayElementNode(node: ts.TypeNode): ts.TypeNode | undefined {
+    if (ts.isArrayTypeNode(node)) return node.elementType;
+    if (
+      ts.isTypeReferenceNode(node) && ts.isIdentifier(node.typeName) &&
+      (node.typeName.text === "Array" ||
+        node.typeName.text === "ReadonlyArray") &&
+      node.typeArguments && node.typeArguments.length > 0
+    ) {
+      return node.typeArguments[0];
+    }
+    return undefined;
   }
 
   private isUnusableInnerType(type: ts.Type): boolean {

--- a/packages/ts-transformers/test/fixtures/handler-schema/identity-only-handler-default-array.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/identity-only-handler-default-array.expected.jsx
@@ -1,0 +1,62 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { Default, equals, handler, Writable } from "commonfabric";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+type MentionablePiece = {
+    title?: string;
+    isHidden?: boolean;
+    mentioned?: MentionablePiece[];
+    backlinks?: MentionablePiece[];
+};
+// CT-1639 Gap B: the array carries a `Default<[]>` union member. The items must
+// still shrink to `{ type: "unknown", asCell: ["comparable"] }` — identical to
+// the non-Default `identity-only-handler-payload` fixture — so that the
+// equals()/findIndex removal idiom keeps matching live links. Before the fix the
+// expanded `Default<[]>` union dropped the items `comparable`, silently breaking
+// equals()-based removal.
+const removePiece = handler({
+    type: "object",
+    properties: {
+        piece: {
+            type: "unknown",
+            asCell: ["comparable"]
+        }
+    },
+    required: ["piece"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        allPieces: {
+            type: "array",
+            items: {
+                type: "unknown",
+                asCell: ["comparable"]
+            },
+            "default": [],
+            asCell: ["cell"]
+        }
+    },
+    required: ["allPieces"]
+} as const satisfies __cfHelpers.JSONSchema, ({ piece }, { allPieces }) => {
+    const current = allPieces.get();
+    const idx = current.findIndex((c) => equals(c, piece));
+    if (idx >= 0)
+        allPieces.set(current.toSpliced(idx, 1));
+});
+// FIXTURE: identity-only-handler-default-array
+// Verifies: a `Writable<T[] | Default<[]>>` array used only for identity removal
+// keeps `asCell: ["comparable"]` on its items (with `default: []` from the
+// Default<[]> collapse), matching the non-Default identity-only fixture. (CT-1639)
+export { removePiece };
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/handler-schema/identity-only-handler-default-array.input.tsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/identity-only-handler-default-array.input.tsx
@@ -1,0 +1,29 @@
+import { Default, equals, handler, Writable } from "commonfabric";
+
+type MentionablePiece = {
+  title?: string;
+  isHidden?: boolean;
+  mentioned?: MentionablePiece[];
+  backlinks?: MentionablePiece[];
+};
+
+// CT-1639 Gap B: the array carries a `Default<[]>` union member. The items must
+// still shrink to `{ type: "unknown", asCell: ["comparable"] }` — identical to
+// the non-Default `identity-only-handler-payload` fixture — so that the
+// equals()/findIndex removal idiom keeps matching live links. Before the fix the
+// expanded `Default<[]>` union dropped the items `comparable`, silently breaking
+// equals()-based removal.
+const removePiece = handler<
+  { piece: MentionablePiece },
+  { allPieces: Writable<MentionablePiece[] | Default<[]>> }
+>(({ piece }, { allPieces }) => {
+  const current = allPieces.get();
+  const idx = current.findIndex((c) => equals(c, piece));
+  if (idx >= 0) allPieces.set(current.toSpliced(idx, 1));
+});
+
+// FIXTURE: identity-only-handler-default-array
+// Verifies: a `Writable<T[] | Default<[]>>` array used only for identity removal
+// keeps `asCell: ["comparable"]` on its items (with `default: []` from the
+// Default<[]> collapse), matching the non-Default identity-only fixture. (CT-1639)
+export { removePiece };


### PR DESCRIPTION
**Stacked on #3841** (CT-1639 Gap A). Base this on the pr1 branch; the diff here is only the Gap B change. Rebase onto `main` once #3841 merges.

## What

Fixes **CT-1639 Gap B**: the array **items** lose `asCell: ["comparable"]` in the emitted handler/map context schema when the array type carries a `Default<[]>` union member — silently breaking `equals()`-based list removal (the × button "does nothing", no type or runtime error).

```js
// Writable<Item[] | Default<[]>> + equals()/findIndex removal handler
// BEFORE: items: { type: "unknown" }                       // no comparable → equals() always -1
// AFTER:  items: { type: "unknown", asCell: ["comparable"] } // matches the plain Writable<Item[]> control
```

## Root cause

The handler-context `items` field is a `Cell<…>` wrapper. Because the `equals()/findIndex` body marks the items identity-only (`items: false` hint), `CommonFabricFormatter.formatWrapperType` builds an `arrayItemsOverride` via `createArrayItemsOverride` and threads it into the child context; that override *is* the emitted items-element schema (consumed by `ArrayFormatter`, and by the Gap A `tryFormatExpandedEmptyArrayDefault` collapse which formats the surviving `Item[]` member with the override still in context).

For an expanded `Default<[]> | Item[]`, the array type is a **union** — `getArrayElementInfo` can't walk a union type to an element, so the override fell back to a bare `{ type: "unknown" }` with **no comparable**. The element `comparable` capability lives only on the synthetic *node*, never on the resolved union type (its members' element types are plain `Item`). The comparable-less override then clobbered the would-be-correct element schema downstream.

The plain `Writable<Item[]>` control already works: its inner resolves to `any` + a synthetic array node, so it goes node-based and reads the synthetic `ComparableCell` element node directly (the override is discarded on that path). This PR brings the `Default<[]>` variant to parity.

## Fix (`common-fabric-formatter.ts`)

1. Always pass the inner node to `createArrayItemsOverride` (it only *reads* element capability from the node, never builds a schema from it → strictly safe; can only recover more capability).
2. When `getArrayElementInfo` finds no element (the union case), descend the union **node** to the single real-array member and read its element node's wrapper kind (`elementWrapperFromUnionNode` / `arrayElementNode`). Skips non-array / `Default<…>` / empty-tuple / branded-marker / degenerate `never[]` members; bails if there's more than one real array member.

## Verification

- Trigger repro now emits `items: { type: "unknown", asCell: ["comparable"] }, default: []` — identical to the control plus Gap A's `default`.
- New golden fixture `handler-schema/identity-only-handler-default-array` (mirrors the existing non-Default `identity-only-handler-payload`). **Stash-verified to FAIL on the unpatched tree** and pass with the fix.
- `schema-generator` 24/229 ✓ · `ts-transformers` 292/609 ✓ (incl. the new fixture) · targeted runner tests (`schema-links`, `patterns-findindex`, `cell-as-cell`) ✓ · real `Default<[]>` patterns (`render-test`, `tags`, `record`) `cf check` clean · fmt + lint ✓.

## Note on the diagnosis

Corrects the earlier "3-layer schema-gen chain / type-shrinking discards comparable" theories on the ticket — both were artifacts of probe experiments that moved `items` off the live path. On the clean tree the loss is one function (`createArrayItemsOverride`), upstream of all of it. Full trace in session notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves array item comparability in handler schemas for `Writable<T[] | Default<[]>>`, restoring equals()/findIndex-based removals. Addresses Linear CT-1639 (Gap B).

- **Bug Fixes**
  - In `schema-generator`, always pass the inner type node to `createArrayItemsOverride` so element capability can be read from the synthetic node.
  - For `Default<[]>` unions, descend the union node to the single real array member to recover the element wrapper; skip non-arrays, `Default<…>`, and empty/never members; bail on multiple arrays.
  - Result: items keep `asCell: ["comparable"]` with `default: []`, matching the non-Default path. Added fixture `identity-only-handler-default-array`.

<sup>Written for commit 84836b8c13731c9fe02328992feaabd07cb67962. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

