### PR TITLE
Scrub stale modern/legacy/rich data-model terminology repo-wide

### DIFF
--- a/docs/specs/memory-v2/01-data-model.md
+++ b/docs/specs/memory-v2/01-data-model.md
@@ -11,10 +11,10 @@ TypeScript type definition.
 
 Unless a subsection is explicitly talking about pure JSON schema/query syntax,
 runtime payloads in the current implementation should be read as
-`FabricValue`, not plain `JSONValue`. `FabricValue` is the shared rich-value
-surface from the data-model layer: it includes ordinary JSON values and also
-runtime-supported richer leaves such as `bigint`, `undefined`, and the escaped
-single-slash object forms used by the boundary codec.
+`FabricValue`, not plain `JSONValue`. `FabricValue` is the shared value
+surface from the data-model layer: it includes ordinary JSON values plus the
+extra leaves the runtime supports, such as `bigint`, `undefined`, and the
+escaped single-slash object forms used by the boundary codec.
 
 ---
 
@@ -565,8 +565,9 @@ snapshot_v10 → apply(patch_v11) → apply(patch_v12) → ... → current_state
 A `PatchWrite` fact stores its patch operations directly. The fact's content
 hash covers the full patch operation list, ensuring integrity.
 
-In the storage layer, patch operations are serialized with the shared rich-value
-boundary codec and stored inline on the seq-addressed `revision.data` column.
+In the storage layer, patch operations are serialized with the shared
+FabricValue boundary codec and stored inline on the seq-addressed
+`revision.data` column.
 See §02 Storage for details.
 
 ---
@@ -748,9 +749,8 @@ type JSONValue =
 
 /**
  * Any runtime value accepted by the shared memory-v2 boundary codec.
- * This strictly contains JSONValue and additionally supports richer leaves
- * such as bigint/undefined plus escaped slash-key objects when the active
- * runtime experimental flags enable them.
+ * This strictly contains JSONValue and additionally supports extra leaves
+ * such as bigint/undefined plus escaped slash-key objects.
  */
 type FabricValue = unknown;
 

--- a/docs/specs/memory-v2/02-storage.md
+++ b/docs/specs/memory-v2/02-storage.md
@@ -82,7 +82,7 @@ Notes:
   them through `["value", ...path]`.
 - `data`, `original`, `resolution`, `invocation`, `authorization`, and
   `snapshot.value` are serialized at the persistence boundary with the shared
-  rich-value JSON codec, not with ad hoc `JSON.stringify` calls in the middle of
+  FabricValue JSON codec, not with ad hoc `JSON.stringify` calls in the middle of
   replica/transaction logic.
 
 ### 3.2 `head` — Current State Pointer

--- a/docs/specs/memory-v2/03-commit-model.md
+++ b/docs/specs/memory-v2/03-commit-model.md
@@ -39,8 +39,8 @@ type Operation = SetOperation | PatchWriteOperation | DeleteOperation;
 Operations do not include parent hashes or other version identifiers. The server
 validates the read set, assigns a canonical `seq`, and records one or more
 sequenced revisions. `set` carries a logical `EntityDocument`; `patch` carries
-path-targeted edits whose leaf values use the shared rich-value surface rather
-than a JSON-only subset.
+path-targeted edits whose leaf values use the shared FabricValue surface, not
+just a JSON subset.
 
 ## 3.2 Transaction Structure
 

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -269,8 +269,7 @@ export interface IAnyCell<T> {}
 export interface IReadable<T> {
   /**
    * Read the cell's current value as a Proxy view. See the
-   * {@link IReadable} interface docs for the modern-mode frozenness
-   * contract.
+   * {@link IReadable} interface docs for the frozenness contract.
    */
   get(options?: { traverseCells?: boolean }): Readonly<StripDefaultBrand<T>>;
   /**
@@ -318,7 +317,7 @@ export interface IMetaCell {
 export interface IWritable<T, C extends AnyBrandedCell<any>> {
   /**
    * Set the cell's value. See the {@link IWritable} interface docs for
-   * the modern-mode frozenness contract on the input.
+   * the frozenness contract on the input.
    */
   set(value: T | AnyCellWrapping<T>): C;
   /**
@@ -332,8 +331,8 @@ export interface IWritable<T, C extends AnyBrandedCell<any>> {
   ): C;
   /**
    * Append one or more values to an array cell. See the
-   * {@link IWritable} interface docs for the modern-mode frozenness
-   * contract on the inputs.
+   * {@link IWritable} interface docs for the frozenness contract on the
+   * inputs.
    */
   push(
     this: IsThisArray,

--- a/packages/data-model/src/interface.ts
+++ b/packages/data-model/src/interface.ts
@@ -203,7 +203,7 @@ export abstract class FabricPrimitive extends FabricSpecialObject {
  * portable across realms and processes via their registry key. Unique
  * symbols (`Symbol(desc)`) are not portable and are rejected at the fabric
  * boundary. TypeScript's `symbol` type cannot distinguish the two, so the
- * gate is a runtime one. Note also that the modern fabric-value path
+ * gate is a runtime one. Note also that the fabric-value path
  * separately rejects all symbols at the entrance (relaxation deferred to a
  * follow-up); the type union admits `symbol` so the lower layers (hashing,
  * JSON encoding) can be written and tested ahead of that gate change.
@@ -258,8 +258,9 @@ export type FabricValueLayer =
  * inside `FabricValue`.
  *
  * The `{ toJSON(): unknown }` arm covers objects (and functions) that are
- * convertible to fabric form via their `toJSON()` method. This is a legacy
- * conversion path but is included here so the `isFabricCompatible()` type predicate
+ * convertible to fabric form via their `toJSON()` method. This is a
+ * `toJSON()`-based conversion path, included here so the
+ * `isFabricCompatible()` type predicate
  * (`value is FabricValue | FabricNativeObject`) remains sound.
  *
  * Note: `bigint` is NOT included here -- it is a primitive (like `undefined`)

--- a/packages/data-model/src/json-wire/JsonEncodingContext.ts
+++ b/packages/data-model/src/json-wire/JsonEncodingContext.ts
@@ -132,7 +132,7 @@ export class JsonEncodingContext implements SerializationContext<string> {
   //
 
   /**
-   * Encodes a fabric value to a JSON string. Serializes modern types into
+   * Encodes a fabric value to a JSON string. Serializes fabric types into
    * the `/<Type>@<Version>` tagged wire format, then stringifies.
    */
   encode(value: FabricValue): string {
@@ -141,7 +141,7 @@ export class JsonEncodingContext implements SerializationContext<string> {
 
   /**
    * Decodes a JSON string back into a fabric value. Parses the string,
-   * then deserializes tagged forms back into modern runtime types.
+   * then deserializes tagged forms back into runtime types.
    */
   decode(data: string, runtime: ReconstructionContext): FabricValue {
     if (!JsonEncodingContext.seemsLikeEncoded(data)) {
@@ -385,7 +385,7 @@ export class JsonEncodingContext implements SerializationContext<string> {
   //
 
   /**
-   * Deserializes a wire-format value back into modern runtime types.
+   * Deserializes a wire-format value back into runtime types.
    * See Section 4.5 of the formal spec.
    *
    * Frozen-ness contract: values returned via the type-handler dispatch arm

--- a/packages/data-model/src/schema-utils.ts
+++ b/packages/data-model/src/schema-utils.ts
@@ -121,8 +121,7 @@ export function toDeepFrozenSchema<T extends JSONSchema>(
  *   mutate nested properties.
  *
  * Note: do not use this on proxy-wrapped schemas from the runtime — those
- * sites should continue using `JSON.parse(JSON.stringify(...))` until the
- * modern data-model flag graduates.
+ * sites continue using `JSON.parse(JSON.stringify(...))`.
  */
 export function cloneSchemaMutable(
   schema: JSONSchema | undefined,

--- a/packages/data-model/src/schema-utils.ts
+++ b/packages/data-model/src/schema-utils.ts
@@ -121,7 +121,12 @@ export function toDeepFrozenSchema<T extends JSONSchema>(
  *   mutate nested properties.
  *
  * Note: do not use this on proxy-wrapped schemas from the runtime — those
- * sites continue using `JSON.parse(JSON.stringify(...))`.
+ * sites currently use `JSON.parse(JSON.stringify(...))` instead.
+ *
+ * TODO(danfuzz): Get those runtime sites off the
+ * `JSON.parse(JSON.stringify(...))` round-trip — e.g. by teaching this
+ * function to handle proxy-wrapped schemas — so nothing relies on a
+ * stringify/parse round-trip to normalize a schema.
  */
 export function cloneSchemaMutable(
   schema: JSONSchema | undefined,

--- a/packages/data-model/test/json-wire/json-encoding.test.ts
+++ b/packages/data-model/test/json-wire/json-encoding.test.ts
@@ -160,7 +160,7 @@ describe("json-encoding", () => {
       });
     });
 
-    it("mixed value with modern types and slash-keys round-trips", () => {
+    it("mixed value with fabric types and slash-keys round-trips", () => {
       const value = {
         count: 42n,
         ref: { "/": { "link@1": { id: "of:bafyabc", path: [] } } },
@@ -206,8 +206,8 @@ describe("json-encoding", () => {
     });
 
     it("rejects plain JSON without the prefix", () => {
-      // These are all things the legacy heuristic accepts; under the modern
-      // dispatch they must be rejected, since they don't carry the prefix.
+      // These are plain JSON without the prefix, so the dispatch must reject
+      // them.
       expect(seemsLikeJsonEncodedFabricValue("true")).toBe(false);
       expect(seemsLikeJsonEncodedFabricValue("false")).toBe(false);
       expect(seemsLikeJsonEncodedFabricValue("null")).toBe(false);

--- a/packages/data-model/test/native-type-tags.test.ts
+++ b/packages/data-model/test/native-type-tags.test.ts
@@ -97,7 +97,7 @@ describe("native-type-tags", () => {
 
     // Functions are non-objects and return Primitive from tagFromNativeValue.
     // In practice, functions with toJSON() are handled separately in
-    // the modern conversion path, not via tagFromNativeValue.
+    // the conversion path, not via tagFromNativeValue.
     it("returns `Primitive` for functions (even with `toJSON`)", () => {
       const fn = () => {};
       (fn as unknown as { toJSON: () => string }).toJSON = () => "converted";

--- a/packages/memory/test/v2-engine-test.ts
+++ b/packages/memory/test/v2-engine-test.ts
@@ -1594,7 +1594,7 @@ Deno.test("memory v2 engine rejects branch reads before createdSeq", async () =>
   }
 });
 
-Deno.test("memory v2 engine persists rich patch values at the storage boundary", async () => {
+Deno.test("memory v2 engine persists fabric patch values at the storage boundary", async () => {
   const { engine, path } = await createEngine();
 
   try {

--- a/packages/runner/src/builder/json-utils.ts
+++ b/packages/runner/src/builder/json-utils.ts
@@ -351,10 +351,8 @@ export function moduleToJSON(module: Module) {
   const frame = getTopFrame();
   // Destructure-and-drop the runtime-only methods that handler modules
   // attach for the in-builder ergonomics (`mod.with(...)`/`mod.bind(...)`).
-  // They are not part of the serialized contract — under the legacy
-  // data-model layer they were silently omitted by `JSON.stringify`-style
-  // semantics; under modern they would surface as
-  // `Cannot store function per se`.
+  // They are not part of the serialized contract; left in, they would surface
+  // as `Cannot store function per se`, so they are destructured out here.
   const {
     implementation: _implementation,
     toJSON: _toJSON,

--- a/packages/runner/src/builtins/fetch-utils.ts
+++ b/packages/runner/src/builtins/fetch-utils.ts
@@ -36,11 +36,9 @@ export const internalSchema = internSchema(
  *     construction (e.g. `{ url, mode, options }`, or one level deeper
  *     `{ method, body }`), and the resulting hash needs to be the same
  *     regardless of whether an absent field is omitted entirely or
- *     present-but-`undefined`. This matches the JSON-style normalization
- *     that the legacy fabric-value layer applied implicitly; under the
- *     modern layer `undefined` properties are preserved, so this
- *     function must do the normalization itself to stay
- *     data-model-flag-agnostic.
+ *     present-but-`undefined`. The fabric-value layer preserves
+ *     `undefined`-valued properties, so this function must do the
+ *     JSON-style normalization itself.
  *
  * `hashStringOf()` itself is happy to hash `undefined` values; no
  * normalization for hashability per se is needed.

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -2102,7 +2102,7 @@ function handleSchema(
 ): { type: string; value: any } {
   const schema = getCellSchema(resolved.cellRef) ?? {};
   // TODO(danfuzz): Replace JSON.parse(JSON.stringify(...)) with
-  // cloneSchemaMutable() before turning on modern data-model.
+  // cloneSchemaMutable() here.
   const value = JSON.parse(JSON.stringify(schema));
   return { type: "json", value };
 }
@@ -2872,7 +2872,7 @@ async function startRequest(
       description:
         "Call this tool to present a structured result. This stores the result for the caller.",
       // TODO(danfuzz): Replace JSON.parse(JSON.stringify(...)) with
-      // cloneSchemaMutable() before turning on modern data-model.
+      // cloneSchemaMutable() here.
       inputSchema: prepareSchemaForLLM(
         JSON.parse(JSON.stringify(userResultSchema)),
       ),

--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -1083,7 +1083,7 @@ export function generateObject<T extends Record<string, unknown>>(
             description:
               "Call this tool with the final structured result matching the required schema. This should be your last action.",
             // TODO(danfuzz): Replace JSON.parse(JSON.stringify(...)) with
-            // cloneSchemaMutable() before turning on modern data-model.
+            // cloneSchemaMutable() here.
             inputSchema: llmToolExecutionHelpers.prepareSchemaForLLM(
               JSON.parse(JSON.stringify(schema)),
             ),
@@ -1401,7 +1401,7 @@ export function generateObject<T extends Record<string, unknown>>(
         messages: requestMessages,
         maxTokens: maxTokens ?? 8192,
         // TODO(danfuzz): Replace JSON.parse(JSON.stringify(...)) with
-        // cloneSchemaMutable() before turning on modern data-model.
+        // cloneSchemaMutable() here.
         schema: llmToolExecutionHelpers.prepareSchemaForLLM(
           JSON.parse(JSON.stringify(schema)),
         ) as Record<string, unknown>,

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -2491,10 +2491,11 @@ export function recursivelyAddIDIfNeeded<T>(
   }
 
   // Convert value to fabric form. This handles:
-  // - Primitives (e.g., -0 → 0, reject NaN/Infinity/Symbol/BigInt)
-  // - Instances (e.g., Error → @Error wrapper)
+  // - Primitives (e.g., pass -0/NaN/Infinity/bigint through, reject unique
+  //   symbols)
+  // - Instances (e.g., Error → FabricError, Date → FabricEpochNsec)
   // - Objects/arrays with toJSON() methods
-  // - Sparse arrays (densified with null in holes)
+  // - Sparse arrays (holes preserved)
   const converted = shallowFabricFromNativeValue(value);
 
   // `FabricInstance` returned by the conversion step (e.g. `FabricError`

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -2512,7 +2512,8 @@ export function recursivelyAddIDIfNeeded<T>(
   }
 
   // Primitives need no further processing. Cache the conversion when it
-  // changed the value (e.g. `-0 → 0`) so callers see consistent results.
+  // produced a different value (e.g. an object whose `toJSON()` returns a
+  // primitive) so callers see consistent results.
   if (!isRecord(converted)) {
     if (converted !== value) seen.set(value, converted);
     return converted as T;

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -2659,8 +2659,8 @@ export function convertCellsToLinks(
 
   seen.set(value, path); // ...which needs to be tracked for circularity.
 
-  // Convert the (top level of) the value to something JSON-encodable if not
-  // already JSON-encodable, or throw if it's neither already valid nor
+  // Convert the (top level of) the value to fabric form (a valid `FabricValue`)
+  // if it isn't already, or throw if it's neither already valid nor
   // convertible.
   value = shallowFabricFromNativeValue(value);
 

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -750,8 +750,8 @@ export function normalizeAndDiff(
     ];
   }
 
-  // Convert the (top level of) the value to something JSON-encodable if not
-  // already JSON-encodable, or throw if it's neither already valid nor
+  // Convert the (top level of) the value to fabric form (a valid `FabricValue`)
+  // if it isn't already, or throw if it's neither already valid nor
   // convertible.
   const fabricValue = shallowFabricFromNativeValue(newValue);
   if (fabricValue !== newValue) {

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -819,11 +819,11 @@ export class Runner {
       meta: ignoreReadForScheduling,
     });
     // `fabricFromNativeValue()` below rebuilds a fresh tree from `internal`
-    // without mutating its inputs (true on both the modern and legacy paths),
-    // and `internal` isn't used after that. So the operands can be merged by
-    // reference: no defensive deep copy of `defaults` / `pattern.initial`, and
-    // no mutable (`frozen: false`) read of `previousInternal`, is needed --
-    // `Object.assign` only reads their top-level keys.
+    // without mutating its inputs, and `internal` isn't used after that. So the
+    // operands can be merged by reference: no defensive deep copy of `defaults`
+    // / `pattern.initial`, and no mutable (`frozen: false`) read of
+    // `previousInternal`, is needed -- `Object.assign` only reads their
+    // top-level keys.
     const internal = Object.assign(
       {},
       (defaults as unknown as { internal?: FabricValue })?.internal,

--- a/packages/runner/src/sandbox/esm-loader-config.ts
+++ b/packages/runner/src/sandbox/esm-loader-config.ts
@@ -1,10 +1,10 @@
 /**
  * Ambient runtime flag for the experimental ESM module-record loader (the
- * `esmModuleLoader` experimental option). Mirrors the modern-data-model and
- * persistent-scheduler-state ambient flags: the `Runtime` constructor
+ * `esmModuleLoader` experimental option). Mirrors the
+ * persistent-scheduler-state ambient flag: the `Runtime` constructor
  * propagates the explicit option here and reads the effective value back.
  *
- * Unlike those two, the default is seeded from the `CF_ESM_MODULE_LOADER`
+ * Unlike that one, the default is seeded from the `CF_ESM_MODULE_LOADER`
  * environment variable, so the ESM loader can be exercised suite-wide (e.g. a
  * regression cross-check) without threading the option through every `Runtime`
  * construction. The production default stays OFF (the env var is unset), so this

--- a/packages/runner/src/sandbox/plain-data.ts
+++ b/packages/runner/src/sandbox/plain-data.ts
@@ -99,7 +99,7 @@ function validateModuleSafeValue(
 
   // TODO(danfuzz): This part of the code will probably have to gain the
   // ability to reason specifically about `FabricSpecialObject`s in order
-  // to fully support the modern data model.
+  // to fully support the data model.
   try {
     if (Array.isArray(objectValue)) {
       validateOwnProperties(objectValue, path, visited, { skipLength: true });

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -838,7 +838,7 @@ function annotateWithBackToCellSymbols(
     // back-to-cell symbol. See function header comment for details.
     // `shallowMutableClone` deep-freezes the bound children as
     // inexpensive defense-in-depth; in practice the only trigger here is a
-    // non-extensible (hence, under the modern data model, deep-frozen) value,
+    // non-extensible (hence deep-frozen) value,
     // so the children are already deep-frozen and pass through by identity.
     value = shallowMutableClone(value as FabricValue);
   }

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -2803,10 +2803,13 @@ export class SchemaObjectTraverser<V extends FabricValue>
         schema: itemSchema,
       };
       this.tx.read(curDoc.address, READ_NON_RECURSIVE_FOR_SCHEDULING);
-      // Sparse array holes are densified to `null` at the storage boundary.
-      // When the item schema expects cells/streams, or the
-      // schema rejects both `null` and `undefined`, treat that committed `null`
-      // as a missing slot so array consumers still see hole semantics.
+      // TODO(danfuzz): Sparse array holes should be preserved by the data
+      // model, but they currently come back as `null` from the storage
+      // boundary — that's a bug. As a stopgap, when the item schema expects
+      // cells/streams, or the schema rejects both `null` and `undefined`, treat
+      // that committed `null` as a missing slot so array consumers still see
+      // hole semantics. Fix the hole densification at its source and remove
+      // this.
       if (
         item === null &&
         this.shouldTreatNullArrayEntryAsHole(curSelector.schema)

--- a/packages/runner/src/traverse.ts
+++ b/packages/runner/src/traverse.ts
@@ -2803,8 +2803,8 @@ export class SchemaObjectTraverser<V extends FabricValue>
         schema: itemSchema,
       };
       this.tx.read(curDoc.address, READ_NON_RECURSIVE_FOR_SCHEDULING);
-      // Sparse array holes are densified to `null` at the storage boundary in
-      // legacy JSON mode. When the item schema expects cells/streams, or the
+      // Sparse array holes are densified to `null` at the storage boundary.
+      // When the item schema expects cells/streams, or the
       // schema rejects both `null` and `undefined`, treat that committed `null`
       // as a missing slot so array consumers still see hole semantics.
       if (

--- a/packages/runner/test/cell-core.test.ts
+++ b/packages/runner/test/cell-core.test.ts
@@ -33,8 +33,8 @@ import { trustPattern } from "./support/trusted-builder.ts";
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
 
-const richSigner = await Identity.fromPassphrase("test rich raw");
-const richSpace = richSigner.did();
+const rawSigner = await Identity.fromPassphrase("test raw");
+const rawSpace = rawSigner.did();
 
 describe("Cell", () => {
   let runtime: Runtime;
@@ -89,18 +89,17 @@ describe("Cell", () => {
     const localTx = rt.edit();
     const c = rt.getCell<unknown>(
       space,
-      "should wrap Error instances in FabricError on set (modern)",
+      "should wrap Error instances in FabricError on set",
       undefined,
       localTx,
     );
     const error = new TypeError("something went wrong");
     c.set(error);
 
-    // Modern path: error is stored as a `FabricError`-shaped value rather
-    // than the legacy `@Error` wrapper. `c.get()` returns a proxy view of
-    // the stored wrapper — its observable fields (`type`, `name`,
-    // `message`, `stack`, etc.) are exposed directly on the projection,
-    // and its `typeTag` is `"Error@1"` (`FabricError`'s tag).
+    // Error is stored as a `FabricError`-shaped value. `c.get()` returns a
+    // proxy view of the stored wrapper — its observable fields (`type`,
+    // `name`, `message`, `stack`, etc.) are exposed directly on the
+    // projection, and its `typeTag` is `"Error@1"` (`FabricError`'s tag).
     const result = c.get() as {
       message: string;
       stack: string;
@@ -125,7 +124,7 @@ describe("Cell", () => {
     const localTx = rt.edit();
     const c = rt.getCell<unknown>(
       space,
-      "should preserve Error cause property on set (modern)",
+      "should preserve Error cause property on set",
       undefined,
       localTx,
     );
@@ -133,10 +132,9 @@ describe("Cell", () => {
     const error = new Error("wrapper error", { cause });
     c.set(error);
 
-    // Modern path: outer error is a `FabricError`-shaped value; its cause
-    // is also `FabricError`-shaped (recursively wrapped at conversion
-    // time), not a legacy `@Error` wrapper. The proxy view exposes the
-    // wrapper's observable fields directly.
+    // Outer error is a `FabricError`-shaped value; its cause is also
+    // `FabricError`-shaped (recursively wrapped at conversion time). The
+    // proxy view exposes the wrapper's observable fields directly.
     const result = c.get() as {
       message: string;
       cause: { message: string; stack: string };
@@ -163,7 +161,7 @@ describe("Cell", () => {
 
     const target = rt.getCell<unknown>(
       space,
-      "nested redirect target (modern Error)",
+      "nested redirect target",
       undefined,
       localTx,
     );
@@ -176,7 +174,7 @@ describe("Cell", () => {
     // per-key recursion in the `isRecord(newValue)` branch.
     const parent = rt.getCell<{ slot: unknown }>(
       space,
-      "nested redirect parent (modern Error)",
+      "nested redirect parent",
       undefined,
       localTx,
     );
@@ -252,7 +250,7 @@ describe("Cell", () => {
     const localTx = rt.edit();
     const c = rt.getCell<unknown>(
       space,
-      "sparse sharing modern",
+      "sparse sharing",
       undefined,
       localTx,
     );
@@ -291,10 +289,9 @@ describe("Cell", () => {
 
     const result = recursivelyAddIDIfNeeded(value, frame);
 
-    // Modern: the legacy "preserve identity when nothing to do"
-    // optimization doesn't apply for unfrozen inputs. Instead the
-    // function returns a structurally equivalent, deep-frozen tree
-    // (top-level included).
+    // The "preserve identity when nothing to do" optimization doesn't
+    // apply for unfrozen inputs; the function returns a structurally
+    // equivalent, deep-frozen tree (top-level included).
     expect(result).not.toBe(value);
     expect(result).toEqual(value);
     expect(Object.isFrozen(result)).toBe(true);
@@ -307,7 +304,7 @@ describe("Cell", () => {
       generatedIdCounter: 0,
       opaqueRefs: new Set(),
     };
-    // Deep-freeze before passing in. Under modern, an already-frozen
+    // Deep-freeze before passing in. An already-frozen
     // plain Object/Array is a valid `FabricValue` and shallow fabric
     // conversion returns it as-is, so reference identity survives all
     // the way out.
@@ -340,7 +337,7 @@ describe("Cell", () => {
 
     const result = recursivelyAddIDIfNeeded(value, frame) as typeof value;
 
-    // Modern: shallow fabric conversion clones at each level, so no
+    // Shallow fabric conversion clones at each level, so no
     // sub-branch is reference-preserved. The core invariants that
     // remain: ID assignment for objects-in-arrays still fires, and
     // primitive list elements still pass through unchanged. The
@@ -1035,7 +1032,7 @@ describe("Cell raw methods: frozen-or-not", () => {
   let tx: IExtendedStorageTransaction;
 
   beforeEach(() => {
-    storageManager = StorageManager.emulate({ as: richSigner });
+    storageManager = StorageManager.emulate({ as: rawSigner });
     runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
@@ -1051,7 +1048,7 @@ describe("Cell raw methods: frozen-or-not", () => {
 
   it("getRaw returns a frozen object", () => {
     const cell = runtime.getCell<{ a: number; b: number[] }>(
-      richSpace,
+      rawSpace,
       "getRaw frozen",
       undefined,
       tx,
@@ -1065,7 +1062,7 @@ describe("Cell raw methods: frozen-or-not", () => {
 
   it("getRawUntyped returns a frozen object", () => {
     const cell = runtime.getCell<{ x: number[] }>(
-      richSpace,
+      rawSpace,
       "getRawUntyped frozen",
       undefined,
       tx,
@@ -1079,7 +1076,7 @@ describe("Cell raw methods: frozen-or-not", () => {
 
   it("getRawUntyped({ frozen: false }) returns a mutable deep copy", () => {
     const cell = runtime.getCell<{ items: number[] }>(
-      richSpace,
+      rawSpace,
       "getRawUntyped frozen false mutable",
       undefined,
       tx,
@@ -1103,7 +1100,7 @@ describe("Cell raw methods: frozen-or-not", () => {
 
   it("getRaw and getRawUntyped agree, both frozen", () => {
     const cell = runtime.getCell<{ v: string }>(
-      richSpace,
+      rawSpace,
       "raw agreement frozen",
       undefined,
       tx,
@@ -1116,10 +1113,10 @@ describe("Cell raw methods: frozen-or-not", () => {
     expect(Object.isFrozen(untyped)).toBe(true);
   });
 
-  it("setRawUntyped stores arrays correctly (rich path)", () => {
+  it("setRawUntyped stores arrays correctly", () => {
     const cell = runtime.getCell<number[]>(
-      richSpace,
-      "setRawUntyped array rich",
+      rawSpace,
+      "setRawUntyped array",
       undefined,
       tx,
     );
@@ -1129,10 +1126,10 @@ describe("Cell raw methods: frozen-or-not", () => {
     expect(Object.isFrozen(raw)).toBe(true);
   });
 
-  it("setRawUntyped stores nested objects correctly (rich path)", () => {
+  it("setRawUntyped stores nested objects correctly", () => {
     const cell = runtime.getCell<{ a: { b: number[] } }>(
-      richSpace,
-      "setRawUntyped nested rich",
+      rawSpace,
+      "setRawUntyped nested",
       undefined,
       tx,
     );
@@ -1144,10 +1141,10 @@ describe("Cell raw methods: frozen-or-not", () => {
     expect(Object.isFrozen(raw.a.b)).toBe(true);
   });
 
-  it("setRawUntyped stores null (rich path)", () => {
+  it("setRawUntyped stores null", () => {
     const cell = runtime.getCell<number | null>(
-      richSpace,
-      "setRawUntyped null rich",
+      rawSpace,
+      "setRawUntyped null",
       undefined,
       tx,
     );
@@ -1158,7 +1155,7 @@ describe("Cell raw methods: frozen-or-not", () => {
 
   it("getRawUntyped({ frozen: false }) returns mutable array copy", () => {
     const cell = runtime.getCell<number[]>(
-      richSpace,
+      rawSpace,
       "getRawUntyped frozen false array",
       undefined,
       tx,
@@ -1172,7 +1169,7 @@ describe("Cell raw methods: frozen-or-not", () => {
 
   it("getRawUntyped({ frozen: false }) returns mutable deeply nested copy", () => {
     const cell = runtime.getCell<{ a: { b: { c: number[] } } }>(
-      richSpace,
+      rawSpace,
       "getRawUntyped frozen false deep nested",
       undefined,
       tx,
@@ -1192,7 +1189,7 @@ describe("Cell raw methods: frozen-or-not", () => {
 
   it("getRawUntyped({ frozen: false }) with empty array", () => {
     const cell = runtime.getCell<unknown[]>(
-      richSpace,
+      rawSpace,
       "getRawUntyped frozen false empty array",
       undefined,
       tx,
@@ -1205,7 +1202,7 @@ describe("Cell raw methods: frozen-or-not", () => {
 
   it("getRawUntyped({ frozen: false }) successive calls return independent copies", () => {
     const cell = runtime.getCell<{ val: number }>(
-      richSpace,
+      rawSpace,
       "getRawUntyped frozen false independence",
       undefined,
       tx,
@@ -1219,7 +1216,7 @@ describe("Cell raw methods: frozen-or-not", () => {
 
   it("getRawUntyped({ frozen: true }) returns frozen (same as default)", () => {
     const cell = runtime.getCell<{ x: number }>(
-      richSpace,
+      rawSpace,
       "getRawUntyped frozen true",
       undefined,
       tx,
@@ -1232,7 +1229,7 @@ describe("Cell raw methods: frozen-or-not", () => {
 
   it("getRawUntyped({ frozen: false }) with deeply nested structure", () => {
     const cell = runtime.getCell<{ a: { b: { c: number[] } } }>(
-      richSpace,
+      rawSpace,
       "getRawUntyped frozen false deep",
       undefined,
       tx,
@@ -1249,7 +1246,7 @@ describe("Cell raw methods: frozen-or-not", () => {
 
   it("getRawUntyped({ frozen: false }) successive calls are independent", () => {
     const cell = runtime.getCell<{ val: number }>(
-      richSpace,
+      rawSpace,
       "getRawUntyped frozen false independence",
       undefined,
       tx,
@@ -1276,13 +1273,11 @@ describe("Cell raw methods: frozen-or-not", () => {
 // originally added (PRs #1472, #1562) to handle string-form values
 // returned from a previous shape of the storage layer. PR #2971 in
 // March 2026 wired `valueFromJson` into the storage-boundary read path
-// (`memory/space.ts`), unconditionally decoding the `is` column to an
-// object before reaching either defensive parse: under flag-OFF
-// `valueFromJsonLegacy` is literally `JSON.parse(json)`, and under flag-ON
-// `valueFromJsonModern` strips the `fvj1:` prefix and decodes. From that
-// point on, neither guard could fire through the standard public API, and
-// the defensive parses became orphaned — which is what motivated their
-// deletion.
+// (`memory/space.ts`): `valueFromJson` unconditionally decodes the `is`
+// column to an object (stripping the `fvj1:` prefix) before reaching
+// either defensive parse. From that point on, neither guard could fire
+// through the standard public API, and the defensive parses became
+// orphaned — which is what motivated their deletion.
 //
 // The tests below pin the round-trip behavior that, post-deletion, is the
 // observable contract. They serve as a passive regression net for any future
@@ -1420,7 +1415,7 @@ describe(
     it("preserves the sign of -0 on set", () => {
       const c = runtime.getCell<unknown>(
         space,
-        "modern: preserve -0",
+        "preserve -0",
         undefined,
         tx,
       );
@@ -1433,7 +1428,7 @@ describe(
     it("stores NaN", () => {
       const c = runtime.getCell<unknown>(
         space,
-        "modern: store NaN",
+        "store NaN",
         undefined,
         tx,
       );
@@ -1445,7 +1440,7 @@ describe(
     it("stores +Infinity and -Infinity", () => {
       const c = runtime.getCell<unknown>(
         space,
-        "modern: store infinities",
+        "store infinities",
         undefined,
         tx,
       );
@@ -1484,7 +1479,7 @@ describe(
     it("round-trips an interned symbol with stable identity", () => {
       const c = runtime.getCell<unknown>(
         space,
-        "modern: interned symbol round-trip",
+        "interned symbol round-trip",
         undefined,
         tx,
       );
@@ -1499,7 +1494,7 @@ describe(
     it("round-trips an interned symbol with an empty key", () => {
       const c = runtime.getCell<unknown>(
         space,
-        "modern: interned empty-key symbol",
+        "interned empty-key symbol",
         undefined,
         tx,
       );
@@ -1511,7 +1506,7 @@ describe(
     it("throws on a unique (uninterned) symbol", () => {
       const c = runtime.getCell<unknown>(
         space,
-        "modern: throw on unique symbol",
+        "throw on unique symbol",
         undefined,
         tx,
       );

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -2009,7 +2009,7 @@ Deno.test("memory v2 stacked commits: dropping an earlier pending write invalida
   }
 });
 
-Deno.test("memory v2 stacked commits: pending visibility preserves rich fabric values", async () => {
+Deno.test("memory v2 stacked commits: pending visibility preserves fabric values", async () => {
   const harness = await createHarness();
   let commitPromise: Promise<any> | undefined;
   try {

--- a/packages/toolshed/routes/blobs/blobs.test.ts
+++ b/packages/toolshed/routes/blobs/blobs.test.ts
@@ -59,7 +59,7 @@ describe("Blob Routes", () => {
     expect(new Uint8Array(await get.arrayBuffer())).toEqual(bytes);
   });
 
-  it("accepts blob upload encoding without ambient data model flags", async () => {
+  it("accepts blob upload encoding with an explicit codec", async () => {
     const identity = await Identity.fromPassphrase(
       "toolshed-blob-route-explicit-codec",
     );

--- a/packages/toolshed/routes/blobs/blobs.test.ts
+++ b/packages/toolshed/routes/blobs/blobs.test.ts
@@ -59,7 +59,7 @@ describe("Blob Routes", () => {
     expect(new Uint8Array(await get.arrayBuffer())).toEqual(bytes);
   });
 
-  it("accepts blob upload encoding with an explicit codec", async () => {
+  it("accepts blob upload encoding from an explicit codec, without ambient data-model flags", async () => {
     const identity = await Identity.fromPassphrase(
       "toolshed-blob-route-explicit-codec",
     );

--- a/packages/utils/src/strip-undefined-props.ts
+++ b/packages/utils/src/strip-undefined-props.ts
@@ -8,11 +8,9 @@ import { isPlainObject } from "./types.ts";
  *
  * Intended use is to canonicalize an object shape for stable comparison
  * (e.g. content-hashing), where a property that's present-but-`undefined`
- * should be treated the same as an omitted property. This matches the
- * JSON-style normalization that the legacy fabric-value layer applied
- * implicitly; under the modern layer, `undefined`-valued properties are
- * preserved, so callers that need this normalization must apply it
- * directly.
+ * should be treated the same as an omitted property. The fabric-value layer
+ * preserves `undefined`-valued properties, so callers that need this
+ * normalization must apply it directly.
  */
 export function stripUndefinedProps(
   value: Record<string, unknown>,


### PR DESCRIPTION
Cleanup unlocked by retiring the legacy data model. Now that there's just *the* data model (no flag, no modern-vs-legacy split), this scrubs defunct references to the "modern"/"legacy" data model, data-model flags, and the old "rich"/"rich-value" branding, and reworks them to read forward-looking about the single data model.

**Comment/doc/test-name only — no behavior change.**

## 1. Keyword terminology sweep (23 files)

Driven by a repo-wide grep for `modern`/`legacy`/`rich`/flag references (two cataloguer passes → categorize → four parallel editors):

- **Code comments** — dropped "under the modern data model" / modern-vs-legacy contrasts (`schema.ts`, `sandbox/plain-data.ts`, `runner.ts`, `builtins/fetch-utils.ts`, `builder/json-utils.ts`, `utils/strip-undefined-props.ts`, `traverse.ts`, `data-model/interface.ts`, `json-wire/JsonEncodingContext.ts`, `api/index.ts`); retired the defunct "before turning on modern data-model" TODOs (`builtins/llm.ts`/`llm-dialog.ts`); removed the now-gone data-model ambient flag from `esm-loader-config`'s comparison.
- **Test names** — dropped `(rich path)` / `(modern)` / `modern:` / `rich` qualifiers (`cell-core`, `json-encoding`, `native-type-tags`, `v2-engine`, `memory-v2-stacked-commit`); renamed `rich*` helpers → `raw*`.
- **Docs** — dropped "rich-value" branding + a defunct experimental-flag clause in the `memory-v2` specs.

The `blobs` "without ambient data-model flags" test keeps that wording (clarified): it's not defunct — `modernCellRep` is still an ambient data-model flag, so the explicit-codec path really is asserted to work without one.

## 2. Behavioral comments the keyword sweep can't see

Some comments describe the *old behavior factually* with no `modern`/`legacy` keyword, so a grep can't catch them; a behavioral-signature probe (`@Error`, `-0 → 0`, `densif`, `JSON-encodable`, NaN-coercion, …) turned these up:

- `cell.ts` — a conversion comment describing `shallowFabricFromNativeValue()` in legacy terms (`-0 → 0`, reject `NaN`/`bigint`, `Error → @Error`, holes densified) → corrected to current behavior; and a stale `-0 → 0` example → a real value-changing case (`toJSON()`→primitive).
- `cell.ts` + `data-updating.ts` — "convert to something JSON-encodable" → "convert to fabric form (a valid `FabricValue`)".

## 3. Two `TODO(danfuzz)`s surfaced along the way

- **A real bug**: `traverse.ts` — sparse array holes should be preserved by the data model, but they come back as `null` from the storage boundary (and a `shouldTreatNullArrayEntryAsHole` workaround papers over it). Recast the comment as a `TODO` to fix the densification at its source.
- **A cleanup**: `schema-utils.ts` — recast the "proxy-wrapped schemas continue using `JSON.parse(JSON.stringify(...))`" note as a `TODO` to retire that round-trip.

## Scope / carve-outs

Excludes the `docs/specs/space-model*` carve-out; leaves alone genuinely historical docs (dated work-logs), the still-live `modernCellRep` flag, the hash-format `legacy`/`modern` distinction (a separate, intentionally-surviving lineage), and the `LegacyAlias` link API.

## Verification

`deno fmt`/`lint`/`check` clean; touched suites green (`data-model` 30/1587/0, `runner` cell-core + memory-v2-stacked-commit 54/0, `memory` v2-engine 19/0, `toolshed` blobs 1/0). Repo-wide re-grep: 0 remaining stale terminology hits outside the carve-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
