### PR TITLE
fix(runner): stable implementationRef across source-based & by-identity loads (CT-1623)

### DIFF
--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -578,8 +578,15 @@ export class Engine extends EventTarget implements Harness {
   ): EvaluateResult {
     const prefix = `/${id}`;
     // Register module hashes up front so the canonical `cf:module/<hash>/<path>`
-    // sources are available for the verified set below.
-    this.registerModuleHashes(id, files);
+    // sources are available for the verified set below. Derive them from the
+    // graph's RESOLVED per-module identities (the same content-addressed
+    // `cf:module/<identity>` the cache + source-free reload use), NOT by
+    // re-hashing the raw `files` — those disagree (the resolved set folds the
+    // injected modules into each module's Merkle hash), which would make a
+    // function's `fn.src` (hence its implementationRef) differ between this
+    // source-based compile and a source-free by-identity reload, breaking
+    // `getExecutableFunction` for resumed callables (CT-1623).
+    this.registerModuleHashesFromGraph(id, graph);
     const verifiedSources = new Set<string>();
     const addVerifiedSource = (value: string | undefined) => {
       if (typeof value !== "string" || value.length === 0) return;
@@ -1069,6 +1076,41 @@ export class Engine extends EventTarget implements Harness {
       this.canonicalSourceByPrefixed.set(
         `/${id}${path}`,
         `cf:module/${hash}${path}`,
+      );
+    }
+  }
+
+  /**
+   * Like {@link registerModuleHashes}, but takes the RESOLVED per-module
+   * identities straight from the compiled graph (`cf:module/<identity>` in
+   * `graph.specifierByPath`) instead of re-hashing the raw program files.
+   *
+   * The two must agree: the cache key, the record-graph specifiers, and the
+   * source-free by-identity reload (`evaluateCachedModules`) all use the
+   * resolved identity (which folds the injected/resolved modules into each
+   * module's Merkle hash). Re-hashing the raw `program.files` here would yield a
+   * DIFFERENT hash for the same module, so a function's `fn.src` — and thus its
+   * minted `implementationRef` — would differ between this source-based compile
+   * and a source-free reload, and `getExecutableFunction` would miss when a
+   * resumed piece invokes a callable (CT-1623). Keying matches the source map's
+   * bundle paths (`/<id>/<authoredPath>`, plus injected modules under their own
+   * specifier path), and the canonical value matches the source-free form.
+   */
+  private registerModuleHashesFromGraph(
+    id: string,
+    graph: CompiledModuleGraph,
+  ): void {
+    const prefix = `/${id}`;
+    for (const [name, specifier] of graph.specifierByPath) {
+      if (!specifier.startsWith("cf:module/")) continue;
+      const identity = specifier.slice("cf:module/".length);
+      const authoredPath = name.startsWith(`${prefix}/`)
+        ? name.slice(prefix.length)
+        : name;
+      this.moduleHashByPrefixedSource.set(name, identity);
+      this.canonicalSourceByPrefixed.set(
+        name,
+        `cf:module/${identity}${authoredPath}`,
       );
     }
   }

--- a/packages/runner/test/by-identity-handler-exec.test.ts
+++ b/packages/runner/test/by-identity-handler-exec.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+const signer = await Identity.fromPassphrase("by-identity-handler-exec");
+const space = signer.did();
+
+// CT-1623: a piece RESUMED from storage in a fresh runtime under the ESM loader
+// loads its pattern source-free BY IDENTITY and must still resolve + execute its
+// callable functions. The FUSE integration (cf exec <handler>) exposed a gap:
+// "JavaScript module is missing an executable implementation" (runner.ts
+// getFallbackJavaScriptImplementation). This uses the REAL fuse-exec fixture
+// (non-default export, schema handlers with asCell state, a patternTool) and
+// drives: create + run the piece → persist → resume in a fresh runtime → invoke
+// the `recordMessage` handler.
+const FIXTURE_SRC = Deno.readTextFileSync(
+  new URL(
+    "../../cli/integration/pattern/fuse-exec.tsx",
+    import.meta.url,
+  ),
+);
+
+const RESULT_CAUSE = "by-identity fuse-exec resume";
+
+const PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  mainExport: "customPatternExport",
+  files: [{ name: "/main.tsx", contents: FIXTURE_SRC }],
+};
+
+describe("resume the fuse-exec piece by identity and invoke its handler", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+
+  const newRuntime = () =>
+    new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      experimental: { esmModuleLoader: true },
+    });
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+  });
+  afterEach(async () => {
+    await storageManager?.close();
+  });
+
+  it("invokes recordMessage after resuming the piece from storage", async () => {
+    const rt1 = newRuntime();
+    const rt2 = newRuntime();
+    try {
+      // Session 1: compile + run the piece, invoke once (control), persist.
+      const tx1 = rt1.edit();
+      const pm1 = rt1.patternManager;
+      const cold = await pm1.compilePattern(PROGRAM, { space, tx: tx1 });
+      expect(pm1.getPatternEntryRef(cold)?.symbol).toBe("customPatternExport");
+      const resultCell1 = rt1.getCell<Record<string, unknown>>(
+        space,
+        RESULT_CAUSE,
+        undefined,
+        tx1,
+      );
+      const r1 = rt1.run(tx1, cold, {}, resultCell1);
+      await tx1.commit();
+      await r1.pull();
+      // CONTROL: full-source handler executes in the originating runtime.
+      r1.key("recordMessage").send({ message: "hello" });
+      const ctrl = await r1.pull() as { messageCount: number };
+      expect(ctrl.messageCount).toBe(1);
+
+      await pm1.flushCompileCacheWrites();
+      await rt1.storageManager.synced();
+
+      // Session 2: fresh runtime resumes the SAME piece from storage (source-free
+      // by identity), then invokes the handler — the path `cf exec` takes.
+      const pm2 = rt2.patternManager;
+      const tx2 = rt2.edit();
+      const resultCell2 = rt2.getCell<Record<string, unknown>>(
+        space,
+        RESULT_CAUSE,
+        undefined,
+        tx2,
+      );
+      await tx2.commit();
+      // Force the storage-rehydration path (as cf exec hits it): the resumed
+      // piece's nodes come from the PERSISTED graph (module.implementation is a
+      // ref, not a live function), so resolution relies solely on
+      // getExecutableFunction — the path that fails under source-free by-identity.
+      await resultCell2.sync();
+      const started = await rt2.start(resultCell2);
+      expect(started).toBe(true);
+      expect(pm2.getCompileCacheStats().byIdentityHits).toBe(1);
+
+      await resultCell2.pull();
+      const before =
+        (resultCell2.getAsQueryResult() as { messageCount: number })
+          .messageCount;
+      resultCell2.key("recordMessage").send({ message: "world" });
+      await resultCell2.pull();
+      const after = (resultCell2.getAsQueryResult() as { messageCount: number })
+        .messageCount;
+      expect(after).toBe(before + 1);
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## What

Fixes the bug the flag-flip canary (#3782) exposed: under the **ESM module loader**, invoking a callable (handler/tool) on a piece **resumed from storage** throws **"JavaScript module is missing an executable implementation"**. Reproduced reliably by the FUSE `cf exec` integration (`fuse-exec.sh`); also affects any resumed piece whose node graph is rehydrated (where `module.implementation` is a ref, not a live function, so resolution relies solely on `getExecutableFunction(implementationRef, patternId)`).

## Root cause

A verified function's `implementationRef` embeds its `fn.src` (`cf:module/<hash>/path:line:col`), and the engine derived that module hash **two disagreeing ways**:

- **Record/cache identity** — `computeModuleIdentities` over the **resolved** module set (which folds injected modules like `cfc.ts` into each module's Merkle hash). Used by the content-addressed cache and the source-free `evaluateCachedModules` reload.
- **Cold-path `fn.src` hash** — `evaluateRecordGraph` → `registerModuleHashes`, which re-hashed the **raw `program.files`** via `computeModuleHashes`.

For the *same* module these yield different `cf:module/<hash>` values. So a function minted during the source-based compile (and persisted in the node graph) gets a **different** `implementationRef` than the same function re-evaluated on a source-free **by-identity** reload → `getExecutableFunction` misses → throw.

(Confirmed by instrumentation: across the two paths, `line:col`, `fn.toString()`, and the mint `ordinal` were all identical — only the `cf:module/<hash>` differed: `B-gthRb5…` vs `tfeFvTaU…`.)

## Fix

`evaluateRecordGraph` now canonicalizes `fn.src` from the graph's **resolved** per-module identities (`registerModuleHashesFromGraph`, reading `graph.specifierByPath`'s `cf:module/<identity>`) instead of re-hashing `program.files`. This is the same identity the cache and the source-free reload use, so `fn.src` — and therefore `implementationRef` — is now **identical across both compile paths**, and resumed callables resolve.

`fn.src` debug locations, CFC verified sources (`canonicalVerifiedSources`/`isVerifiedSourceInLoad`), and the scheduler fingerprint all derive from the same canonical-source map, so they track the corrected identity automatically.

## Validation

- **FUSE `cf exec` integration (`fuse-exec.sh`)**: red→green under the ESM loader, validated locally (FUSE-T). All callable invocations (handlers + tools, with/without verbs, stdin JSON, legacy write-through) pass.
- Full **runner** suite: 526 passed, 0 failed.
- `esm-source-location`, `cfc-implementation-identity`, `engine`, `esm-cell-cache-integration`, `load-by-identity`, `resume-by-identity` suites green.
- Adds `by-identity-handler-exec.test.ts` (resume a handler piece by identity + invoke).

## Notes

- No back-compat for previously-persisted (unstable) refs — intentional: the ESM loader isn't the default yet (#3782 unmerged), so there are no production pieces carrying the old refs.
- Follow-up (separate): the broader cleanup to derive `implementationRef` directly from `(moduleIdentity, bindingPath)` and retire the `ordinal`/`toString` mint now sits on a stable foundation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes callable invocation on pieces resumed from storage under the ESM loader by stabilizing `implementationRef` across source-based and by-identity loads (CT-1623). The FUSE `cf exec` path no longer throws “JavaScript module is missing an executable implementation”.

- **Bug Fixes**
  - Canonicalize `fn.src` from the compiled graph’s resolved `cf:module/<identity>` values instead of re-hashing raw files. This keeps module hashes identical across both compile paths and lets `getExecutableFunction` resolve resumed callables.
  - Add `by-identity-handler-exec.test.ts` to verify a resumed `fuse-exec` handler executes after a by-identity load.

<sup>Written for commit c64dad26096608c03ae87fa79055e245291b36ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

