### PR TITLE
fix(sqlite): SqliteDb brand survives capability shrinking; drop .get() from the type (#20)

### DIFF
--- a/docs/specs/sqlite-builtin/08-open-questions.md
+++ b/docs/specs/sqlite-builtin/08-open-questions.md
@@ -206,15 +206,21 @@ during design are marked **[resolved]** with the decision.
     one handler trip the limit only at commit time. A client-side assertion in the
     write seam (`recordSqliteWrite`) could surface this earlier with a clearer
     message. Nicety, not a correctness issue.
-20. **Two schema paths disagree on the `SqliteDb` brand.** The schema-generator's
-    object-formatter stamps `asCell: ["sqlite"]` for a `SqliteDb` field, but the
-    ts-transformer's capability analysis (used for handler-state schemas) infers
-    `asCell: ["readonly"]` from SqliteDb's read-only method surface — it does not
-    recognize the "sqlite" brand. This is **benign today**: `db.exec` reaches the
-    transaction via the materialized handle regardless of the wrapper brand
-    (proven e2e), and `db.query` is build-time only. But the inconsistency is a
-    latent trap; the capability analysis should learn the "sqlite" brand so both
-    paths agree.
+20. **[resolved] Two schema paths disagree on the `SqliteDb` brand.** The
+    schema-generator's object-formatter stamped `asCell: ["sqlite"]` for a
+    `SqliteDb` field, but the ts-transformer's capability analysis (handler-state
+    schemas) inferred `asCell: ["readonly"]` from SqliteDb's read-only method
+    surface. **Resolved** by teaching the transformer that the explicit `"sqlite"`
+    cell brand is authoritative and must survive capability shrinking — the same
+    mechanism that preserves `Stream` (`preservedWrapperFor` in
+    `type-shrinking.ts`); the schema generator now also recognizes the
+    `SqliteDb` wrapper name (`type-utils.ts`/`wrapperKindForName`). Both paths now
+    emit `["sqlite"]`. Making the brands agree surfaced two latent issues that are
+    also fixed: (a) the public `SqliteDb` type no longer extends `IReadable`, so
+    `db.get()`/`db.sample()` (meaningless on an opaque handle) no longer
+    type-check; (b) the runtime's `db.exec` reads the handle via `getRaw()` rather
+    than the schema-shaped `get()` (which, under the real `SqliteDatabase` schema,
+    shaped the handle down to `{}` and dropped `id`/`tables`).
 
 ## Code-review follow-ups (deferred hardening)
 

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -2106,13 +2106,17 @@ export interface ISqliteQueryable {
 }
 
 /**
- * SqliteDb is a cell variant (kind `"sqlite"`) — a DB handle cell exposing the
- * SQLite method surface (`.exec`/`.query`) instead of the general value-cell
- * mutators. It reads back the handle ref and carries the `toCell` back-pointer,
- * but is NOT writable (you can't `.set()` a DB handle).
+ * SqliteDb is a cell variant (kind `"sqlite"`) — a DB handle cell exposing ONLY
+ * the SQLite method surface (`.exec`/`.query`), not the general value-cell
+ * read/write API. In particular it deliberately does **not** extend
+ * `IReadable<T>`: `.get()`/`.sample()` are meaningless on an opaque DB handle
+ * (the handle ref is an internal detail; pattern code reads rows via `.query`),
+ * so omitting them keeps `db.get()` from type-checking. The handle is also not
+ * writable (you can't `.set()` a DB handle). The runtime still reads the raw
+ * handle internally via `getRaw()` to fold writes onto the transaction.
  */
 export interface ISqliteDb<T = SqliteDatabase>
-  extends IAnyCell<T>, IReadable<T>, ISqliteExecutable, ISqliteQueryable {}
+  extends IAnyCell<T>, ISqliteExecutable, ISqliteQueryable {}
 
 export interface SqliteDb<T = SqliteDatabase>
   extends BrandedCell<T, "sqlite">, ISqliteDb<T> {}

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -967,8 +967,10 @@ export class CellImpl<T extends FabricValue>
     // kind onto the delivered cell. Read the handle with `getRaw()` (NOT `get()`):
     // the delivered cell's schema is the `SqliteDatabase` shape (no declared
     // properties), so `get()` would shape the handle down to `{}` and drop the
-    // `id`/`tables` fields. The raw fabric value carries the real handle ref.
-    const handle = this.getRaw() as
+    // `id`/`tables` fields. Use `lastNode: "value"` so the FINAL link is still
+    // resolved (a handler-delivered handle may sit behind a link at its target) —
+    // getRaw's default `"top"` would stop at the link object and miss `id`.
+    const handle = this.getRaw({ lastNode: "value" }) as
       | { id?: unknown; tables?: unknown }
       | undefined;
     if (!handle || typeof handle.id !== "string") {

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -964,8 +964,11 @@ export class CellImpl<T extends FabricValue>
     // `"sqlite"` is a type-level kind (the public `SqliteDb` type restricts who
     // can call `.exec`); at runtime we validate the actual handle value rather
     // than `_kind`, since handler-input materialization doesn't always stamp the
-    // kind onto the delivered cell.
-    const handle = this.get() as
+    // kind onto the delivered cell. Read the handle with `getRaw()` (NOT `get()`):
+    // the delivered cell's schema is the `SqliteDatabase` shape (no declared
+    // properties), so `get()` would shape the handle down to `{}` and drop the
+    // `id`/`tables` fields. The raw fabric value carries the real handle ref.
+    const handle = this.getRaw() as
       | { id?: unknown; tables?: unknown }
       | undefined;
     if (!handle || typeof handle.id !== "string") {

--- a/packages/runner/test/sqlite-db-exec.test.ts
+++ b/packages/runner/test/sqlite-db-exec.test.ts
@@ -90,6 +90,40 @@ describe("SqliteDb .exec (commit-folded write)", () => {
     await tx2.commit();
   });
 
+  it("reads the handle via getRaw even when the cell schema shapes it to {}", async () => {
+    // Real handler-input materialization delivers the handle cell with the
+    // `SqliteDatabase` schema (an object type with NO declared properties). A
+    // schema-shaped `get()` would project the handle down to `{}` and drop
+    // `id`/`tables`; `.exec` must read the raw handle (getRaw, lastNode:"value")
+    // and still fold the write. Regression guard for the get()->getRaw() fix.
+    const dbRef: SqliteDbRef = {
+      id: `of:exec-shaped-${crypto.randomUUID()}`,
+      tables: { notes: table({ id: "integer primary key", body: "text" }) },
+    };
+    const tx = runtime.edit();
+    const handle = runtime.getCell(space, "db-shaped", undefined, tx);
+    handle.set(dbRef);
+    const db = createCell(
+      runtime,
+      {
+        ...handle.getAsNormalizedFullLink(),
+        schema: { type: "object", properties: {} },
+      },
+      tx,
+      false,
+      "sqlite",
+    ) as unknown as SqliteDbCell;
+    // Sanity: a schema-shaped read drops the handle fields...
+    expect(db.get()).toEqual({});
+    // ...but exec still records the write from the raw handle.
+    db.exec("INSERT INTO notes (body) VALUES (?)", ["hi"]);
+    const res = await tx.commit();
+    expect(res.error).toBeUndefined();
+    const provider = storageManager.open(space);
+    const r = await provider.sqliteQuery!(dbRef, "SELECT body FROM notes");
+    expect(r.rows).toEqual([{ body: "hi" }]);
+  });
+
   it("throws on an undefined param, allows null", async () => {
     const dbRef: SqliteDbRef = {
       id: `of:exec-undef-${crypto.randomUUID()}`,

--- a/packages/schema-generator/src/formatters/common-fabric-formatter.ts
+++ b/packages/schema-generator/src/formatters/common-fabric-formatter.ts
@@ -311,6 +311,7 @@ export class CommonFabricFormatter implements TypeFormatter {
       "OpaqueCell",
       "Cell",
       "Stream",
+      "SqliteDb",
       "ReadonlyCell",
       "WriteonlyCell",
       "ComparableCell",

--- a/packages/schema-generator/src/type-utils.ts
+++ b/packages/schema-generator/src/type-utils.ts
@@ -34,6 +34,7 @@ function wrapperKindForName(name: string): NodeWrapperKind | undefined {
     case "WriteonlyCell":
     case "ComparableCell":
     case "Stream":
+    case "SqliteDb":
     case "OpaqueCell":
       return name;
     default:
@@ -385,7 +386,8 @@ export function getNamedTypeKey(
     const nodeTypeName = getEntityNameText(typeNode.typeName);
     if (
       nodeTypeName === "Default" || CELL_LIKE_WRAPPER_NAMES.has(nodeTypeName) ||
-      nodeTypeName === "Stream" || OPAQUE_WRAPPER_NAMES.has(nodeTypeName)
+      nodeTypeName === "Stream" || nodeTypeName === "SqliteDb" ||
+      OPAQUE_WRAPPER_NAMES.has(nodeTypeName)
     ) {
       return undefined;
     }
@@ -395,7 +397,8 @@ export function getNamedTypeKey(
   const aliasName = (type as TypeWithInternals).aliasSymbol?.name;
   if (
     aliasName === "Default" || CELL_LIKE_WRAPPER_NAMES.has(aliasName ?? "") ||
-    aliasName === "Stream" || aliasName === "OpaqueRef"
+    aliasName === "Stream" || aliasName === "SqliteDb" ||
+    aliasName === "OpaqueRef"
   ) {
     return undefined;
   }
@@ -457,7 +460,7 @@ export function getNamedTypeKey(
   if (name === "Array" || name === "ReadonlyArray") return undefined;
   if (
     CELL_LIKE_WRAPPER_NAMES.has(name ?? "") || name === "Stream" ||
-    name === "Default"
+    name === "SqliteDb" || name === "Default"
   ) {
     return undefined;
   }

--- a/packages/ts-transformers/src/transformers/schema-injection.ts
+++ b/packages/ts-transformers/src/transformers/schema-injection.ts
@@ -43,11 +43,10 @@ import {
   type CapabilitySummaryApplicationMode,
   containsAnyOrUnknownTypeNode,
   isCellLikeTypeNode,
-  isStreamTypeNode,
+  preservedWrapperFor,
   printTypeNode,
 } from "./type-shrinking.ts";
 import { isPatternFactoryCalleeExpression } from "./structural-reactive-factory.ts";
-import { getCellKind } from "./opaque-ref/opaque-ref.ts";
 
 type UiContractHint = NonNullable<SchemaHint["cfcUiContract"]>;
 type CellScope = "space" | "user" | "session";
@@ -138,13 +137,6 @@ function extractCellLikeInnerTypeNode(
   if (!ts.isTypeReferenceNode(node)) return undefined;
   if (!node.typeArguments || node.typeArguments.length === 0) return undefined;
   return node.typeArguments[0];
-}
-
-function isStreamCellType(
-  type: ts.Type | undefined,
-  checker: ts.TypeChecker,
-): boolean {
-  return !!type && getCellKind(type, checker) === "stream";
 }
 
 function parameterUsesCellLikeMethods(
@@ -266,8 +258,9 @@ function applyCapabilitySummaryToArgument(
       sourceFile,
     );
   const shouldWrap = !!innerTypeNode;
-  const preserveStreamWrapper = shouldWrap &&
-    (isStreamTypeNode(argumentNode) || isStreamCellType(argumentType, checker));
+  const preservedWrapper = shouldWrap
+    ? preservedWrapperFor(argumentNode, argumentType, checker)
+    : undefined;
   const baseTypeNode = innerTypeNode ?? argumentNode;
   let baseType = shouldWrap && argumentType
     ? (unwrapCellLikeType(argumentType, checker) ?? argumentType)
@@ -293,7 +286,7 @@ function applyCapabilitySummaryToArgument(
     mode === "defaults_only" ? "opaque" : paramSummary.capability,
     context,
     fnNode ?? fn,
-    preserveStreamWrapper,
+    preservedWrapper,
   );
 }
 
@@ -325,9 +318,9 @@ function applyCapabilitySummaryToParameter(
 
   const innerTypeNode = extractCellLikeInnerTypeNode(parameterNode);
   const shouldWrap = !!innerTypeNode;
-  const preserveStreamWrapper = shouldWrap &&
-    (isStreamTypeNode(parameterNode) ||
-      isStreamCellType(parameterType, checker));
+  const preservedWrapper = shouldWrap
+    ? preservedWrapperFor(parameterNode, parameterType, checker)
+    : undefined;
   const baseTypeNode = innerTypeNode ?? parameterNode;
   let baseType = shouldWrap && parameterType
     ? (unwrapCellLikeType(parameterType, checker) ?? parameterType)
@@ -353,7 +346,7 @@ function applyCapabilitySummaryToParameter(
     paramSummary.capability,
     context,
     fnNode ?? fn,
-    preserveStreamWrapper,
+    preservedWrapper,
   );
 }
 

--- a/packages/ts-transformers/src/transformers/type-shrinking.ts
+++ b/packages/ts-transformers/src/transformers/type-shrinking.ts
@@ -723,6 +723,23 @@ function isStreamCellType(
   return !!type && getCellKind(type, checker) === "stream";
 }
 
+export function isSqliteTypeNode(node: ts.TypeNode): boolean {
+  return ts.isTypeReferenceNode(node) &&
+    getTypeReferenceNodeName(node) === "SqliteDb";
+}
+
+/** A `SqliteDb` handle carries an explicit "sqlite" cell brand. Like `Stream`,
+ *  that brand is authoritative and must survive capability shrinking — the
+ *  reactive read/write inference would otherwise collapse its read-only method
+ *  surface to an `asCell: ["readonly"]` wrapper, disagreeing with the schema
+ *  generator's object-formatter path (which stamps `["sqlite"]`). */
+function isSqliteCellType(
+  type: ts.Type | undefined,
+  checker: ts.TypeChecker,
+): boolean {
+  return !!type && getCellKind(type, checker) === "sqlite";
+}
+
 export function printTypeNode(
   node: ts.TypeNode,
   sourceFile: ts.SourceFile,
@@ -1929,14 +1946,36 @@ export function wrapTypeNodeWithCapability(
   return createHelperWrapperTypeNode(node, wrapperName, factory);
 }
 
+/** Cell wrappers whose explicit brand is authoritative and must survive
+ *  capability shrinking instead of being replaced by an inferred read/write
+ *  capability wrapper. `Stream` (a callable interface) and `SqliteDb` (a handle
+ *  with a read-only method surface that would otherwise collapse to `readonly`)
+ *  both fall here; the emitted `__cfHelpers.<name>` node is recognized by the
+ *  schema generator and lowered to the matching `asCell` brand. */
+export type PreservedWrapper = "Stream" | "SqliteDb";
+
+export function preservedWrapperFor(
+  node: ts.TypeNode,
+  type: ts.Type | undefined,
+  checker: ts.TypeChecker,
+): PreservedWrapper | undefined {
+  if (isStreamTypeNode(node) || isStreamCellType(type, checker)) {
+    return "Stream";
+  }
+  if (isSqliteTypeNode(node) || isSqliteCellType(type, checker)) {
+    return "SqliteDb";
+  }
+  return undefined;
+}
+
 function wrapTypeNodeWithCapabilityOrStream(
   node: ts.TypeNode,
   capability: ReactiveCapability,
   factory: ts.NodeFactory,
-  preserveStream: boolean,
+  preservedWrapper: PreservedWrapper | undefined,
 ): ts.TypeNode {
-  return preserveStream
-    ? createHelperWrapperTypeNode(node, "Stream", factory)
+  return preservedWrapper
+    ? createHelperWrapperTypeNode(node, preservedWrapper, factory)
     : wrapTypeNodeWithCapability(node, capability, factory);
 }
 
@@ -2161,8 +2200,7 @@ function applyCellCapabilityPathsToTypeNode(
           inner,
           capability,
           factory,
-          isStreamTypeNode(updated) ||
-            isStreamCellType(memberSemanticType, checker),
+          preservedWrapperFor(updated, memberSemanticType, checker),
         );
         if (typeRegistry && isCellLikeType(memberSemanticType, checker)) {
           typeRegistry.set(updated, memberSemanticType);
@@ -2225,7 +2263,7 @@ function createIdentityOnlyReplacementTypeNode(
       unknownNode,
       forceComparable ? "comparable" : "opaque",
       factory,
-      isStreamTypeNode(node) || isStreamCellType(resolvedType, checker),
+      preservedWrapperFor(node, resolvedType, checker),
     );
     const wrappedType = resolveIdentitySemanticType(
       wrappedNode,
@@ -2980,7 +3018,7 @@ export function applyShrinkAndWrap(
   wrapCapability: ReactiveCapability = paramSummary.capability,
   context?: TransformationContext,
   fnNode?: ts.Node,
-  preserveStreamWrapper = false,
+  preservedWrapper: PreservedWrapper | undefined = undefined,
 ): ts.TypeNode {
   const shrinkPlan = deriveCapabilityShrinkPlan(paramSummary);
   const {
@@ -3048,7 +3086,7 @@ export function applyShrinkAndWrap(
       next,
       wrapCapability,
       factory,
-      preserveStreamWrapper,
+      preservedWrapper,
     );
   }
 
@@ -3211,7 +3249,7 @@ export function applyShrinkAndWrap(
     next,
     wrapCapability,
     factory,
-    preserveStreamWrapper,
+    preservedWrapper,
   );
   return wrapped;
 }

--- a/packages/ts-transformers/test/fixtures/handler-schema/sqlite-db-handler-state.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/sqlite-db-handler-state.expected.jsx
@@ -15,26 +15,30 @@ interface DbState {
     db: SqliteDb;
 }
 // FIXTURE: sqlite-db-handler-state
-// Verifies: a SqliteDb-typed handler-state field lowers to an asCell wrapper, so
-// the handler receives the live handle cell and `db.exec(...)` is valid.
-// NOTE on the brand: the ts-transformer's capability analysis infers
-// `asCell: ["readonly"]` here, from SqliteDb's read-only method surface — it does
-// NOT stamp the "sqlite" brand on the handler-state field (that brand comes from
-// the schema-generator's object-formatter path). `["readonly"]` is benign for the
-// handler case: `db.exec` reaches the transaction via the materialized handle
-// regardless of the wrapper brand (proven end to end in
-// runner/integration/sqlite-db-query-decode.test.tsx). The two-path brand
-// inconsistency is tracked in 08-open-questions.
+// Verifies: a SqliteDb-typed handler-state field lowers to an `asCell: ["sqlite"]`
+// wrapper, so the handler receives the live handle cell and `db.exec(...)` is valid.
+// The "sqlite" cell brand is authoritative and survives capability shrinking (like
+// Stream): the read/write inference would otherwise collapse SqliteDb's read-only
+// method surface to `asCell: ["readonly"]`, disagreeing with the schema generator's
+// object-formatter path (which stamps "sqlite"). Both paths now agree — this closed
+// the two-path brand inconsistency (#20 in 08-open-questions).
 const writeNote = handler({
     type: "unknown"
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
         db: {
-            asCell: ["readonly"]
+            $ref: "#/$defs/SqliteDatabase",
+            asCell: ["sqlite"]
         }
     },
-    required: ["db"]
+    required: ["db"],
+    $defs: {
+        SqliteDatabase: {
+            type: "object",
+            properties: {}
+        }
+    }
 } as const satisfies __cfHelpers.JSONSchema, (_, { db }) => {
     db.exec("INSERT INTO notes (body) VALUES (?)", ["hi"]);
 });

--- a/packages/ts-transformers/test/fixtures/handler-schema/sqlite-db-handler-state.input.tsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/sqlite-db-handler-state.input.tsx
@@ -5,16 +5,13 @@ interface DbState {
 }
 
 // FIXTURE: sqlite-db-handler-state
-// Verifies: a SqliteDb-typed handler-state field lowers to an asCell wrapper, so
-// the handler receives the live handle cell and `db.exec(...)` is valid.
-// NOTE on the brand: the ts-transformer's capability analysis infers
-// `asCell: ["readonly"]` here, from SqliteDb's read-only method surface — it does
-// NOT stamp the "sqlite" brand on the handler-state field (that brand comes from
-// the schema-generator's object-formatter path). `["readonly"]` is benign for the
-// handler case: `db.exec` reaches the transaction via the materialized handle
-// regardless of the wrapper brand (proven end to end in
-// runner/integration/sqlite-db-query-decode.test.tsx). The two-path brand
-// inconsistency is tracked in 08-open-questions.
+// Verifies: a SqliteDb-typed handler-state field lowers to an `asCell: ["sqlite"]`
+// wrapper, so the handler receives the live handle cell and `db.exec(...)` is valid.
+// The "sqlite" cell brand is authoritative and survives capability shrinking (like
+// Stream): the read/write inference would otherwise collapse SqliteDb's read-only
+// method surface to `asCell: ["readonly"]`, disagreeing with the schema generator's
+// object-formatter path (which stamps "sqlite"). Both paths now agree — this closed
+// the two-path brand inconsistency (#20 in 08-open-questions).
 const writeNote = handler<unknown, DbState>((_, { db }) => {
   db.exec("INSERT INTO notes (body) VALUES (?)", ["hi"]);
 });


### PR DESCRIPTION
Resolves 08-open-questions **#20** (the two-path `SqliteDb` brand disagreement), a follow-up to the SQLite-for-patterns feature.

## Problem
The schema generator's object-formatter stamped `asCell: ["sqlite"]` for a `SqliteDb` field, but the ts-transformer's capability analysis (used for **handler-state** schemas) inferred `asCell: ["readonly"]` from SqliteDb's read-only method surface. The two schema paths disagreed for the same field.

## Fix
- **Transformer** — the explicit `"sqlite"` cell brand is now authoritative and survives capability shrinking, reusing the exact mechanism that already preserves `Stream`. `preserveStream`/`isStreamCellType` is generalized into `preservedWrapperFor` (`Stream | SqliteDb`) in `type-shrinking.ts`, threaded through `schema-injection.ts`.
- **Schema generator** — recognizes the `SqliteDb` wrapper name (`type-utils.ts` `wrapperKindForName` + the hoist-exclusion guards), so a preserved `__cfHelpers.SqliteDb<…>` node lowers to `asCell: ["sqlite"]`.

Both paths now emit `["sqlite"]`.

## Two latent issues this surfaced (also fixed)
1. **`db.get()` should not exist at the pattern level.** The public `SqliteDb` type no longer extends `IReadable`, so `db.get()` / `db.sample()` — meaningless on an opaque handle (read rows via `db.query`) — no longer type-check.
2. **`db.exec` read the handle via the schema-shaped `get()`.** Under the real `SqliteDatabase` schema (no declared properties), `get()` shaped the handle down to `{}` and dropped `id`/`tables`, breaking the folded write. `CellImpl.exec` now reads via `getRaw()` (the true handle ref). The runtime still has `get()` internally; only the type surface drops it.

## Tests
- `handler-schema/sqlite-db-handler-state` fixture now expects `asCell: ["sqlite"]` (comment updated).
- Green: ts-transformers (292), schema-generator (24), runner sqlite unit (10) + e2e decode, memory sqlite (17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the `SqliteDb` brand during capability shrinking so both schema paths emit `asCell: ["sqlite"]`, drops `.get()`/`.sample()` from the public `SqliteDb` type, and fixes `.exec` to read the raw handle while resolving a final link. Resolves #20.

- **Bug Fixes**
  - Transformer: generalizes preserved wrappers to include `SqliteDb` (alongside `Stream`) so the explicit `"sqlite"` brand survives shrinking; both paths now emit `["sqlite"]`.
  - Schema generator: recognizes the `SqliteDb` wrapper name and unwraps it in `recursivelyUnwrapOpaqueRef`, preserving the brand even under `Opaque`/`OpaqueRef`, and lowers it to `asCell: ["sqlite"]`.
  - Runner: `CellImpl.exec` reads the handle via `getRaw({ lastNode: "value" })` to resolve a final link and avoid schema shaping to `{}`; this keeps `id`/`tables` intact and folds writes correctly.

- **Migration**
  - `SqliteDb` no longer extends `IReadable`; remove `db.get()`/`db.sample()` and use `db.query(...)` for reads.

<sup>Written for commit f36643a3d001c953034b411dfdbfb5f21045ccfc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

