### PR TITLE
feat(memory): scope core engine tables per space (migration, not flag)

### DIFF
--- a/docs/specs/sqlite-builtin/08-open-questions.md
+++ b/docs/specs/sqlite-builtin/08-open-questions.md
@@ -87,17 +87,23 @@ during design are marked **[resolved]** with the decision.
      await. The old LRU attach/detach *read* cache is removed; the limit is
      effectively never approached. A one-time startup **probe only logs** the
      real limit (no dependency on headroom).
-   - **Core-table shadowing:** V1 ships **without** the core-table rename. Cheap
-     mitigations now: the statement guard rejects schema-qualified references,
-     `ATTACH`/`DETACH`/`PRAGMA`, and multiple statements; patterns may **not
-     declare** a table whose name collides with the core set, and the guard
-     **rejects statements that reference a core-table identifier**. Residual,
-     documented pre-production gap: tokenizer-level reference checking has minor
-     false positives/negatives (e.g. a column literally named `commit`).
-     *Deferred (production hardening, behind a flag):* rename the engine's core
-     tables to include the space DID (e.g. `commit__<did>`), which removes
-     shadowing structurally and drops the name-based guarding. Kept out of the
-     feature's critical path because it's an invasive core-store migration.
+   - **Core-table shadowing → [resolved: per-space core-table scoping].** The
+     structural fix shipped: the engine scopes its core tables per space —
+     `commit` → `"commit__<token>"`, etc., where `<token>` is a stable hash of
+     the space DID (`engine.ts` `scopeToken`/`coreTableNames`). An attached
+     pattern cell-db's unqualified `commit` therefore can no longer resolve to a
+     core table (none exists by that bare name on the engine connection), so
+     shadowing is removed structurally rather than by the name denylist. It is a
+     **migration, not a flag**: `migrateCoreTablesToSpaceScoped` renames legacy
+     bare tables in place on first scoped open (idempotent; `ALTER TABLE RENAME`
+     auto-rewrites FK references), running before the scoped `INIT`/migrations.
+     Opening without a space keeps the legacy bare names (back-compat for
+     tools/tests that don't supply a DID). The guard's core-table-name rejection
+     is retained as a **belt-and-suspenders backstop** during the soak and can be
+     dropped once all live dbs are scoped. **Bonus:** because each space's core
+     tables are now globally unique, two spaces' dbs can be attached to one
+     connection without name collision — the precondition for **cross-space
+     transactions** (pinned by `v2-core-table-scoping-test.ts`).
 9. **[resolved — V1 cut] DDL ownership + migration scope → additive-only.** The
    database owns DDL via `sqliteDatabase({ tables })` (Section
    [01](./01-api.md#schema-ownership--the-database-owns-its-tables)); patterns do

--- a/packages/memory/test/v2-core-table-scoping-test.ts
+++ b/packages/memory/test/v2-core-table-scoping-test.ts
@@ -5,7 +5,7 @@
 // without a `space` keeps the legacy bare names (back-compat). A legacy bare-named
 // db is migrated in place on first scoped open.
 
-import { assertEquals, assertExists } from "@std/assert";
+import { assertEquals, assertExists, assertRejects } from "@std/assert";
 import { toFileUrl } from "@std/path";
 import { Database } from "@db/sqlite";
 import { applyCommit, close, type Engine, open, read } from "../v2/engine.ts";
@@ -161,6 +161,23 @@ Deno.test("re-scopes in place if the token derivation changes (no orphaning)", a
     close(reopened);
     await Deno.remove(path);
   }
+});
+
+Deno.test("refuses to open if multiple prior-token core sets coexist", async () => {
+  // Two different `commit__<token>` families in one file is an inconsistent
+  // state (one file = one space = one token). Re-scoping an arbitrary one would
+  // orphan the other, so open() must fail loudly rather than guess.
+  const path = await Deno.makeTempFile({ suffix: ".sqlite" });
+  const raw = new Database(path);
+  raw.exec(`CREATE TABLE "commit__aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" (seq)`);
+  raw.exec(`CREATE TABLE "commit__bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" (seq)`);
+  raw.close();
+  await assertRejects(
+    () => open({ url: toFileUrl(path), space: SPACE_A }),
+    Error,
+    "ambiguous core-table scoping",
+  );
+  await Deno.remove(path);
 });
 
 Deno.test("two spaces' core tables are disjoint (cross-space attach ready)", async () => {

--- a/packages/memory/test/v2-core-table-scoping-test.ts
+++ b/packages/memory/test/v2-core-table-scoping-test.ts
@@ -7,6 +7,7 @@
 
 import { assertEquals, assertExists } from "@std/assert";
 import { toFileUrl } from "@std/path";
+import { Database } from "@db/sqlite";
 import { applyCommit, close, type Engine, open, read } from "../v2/engine.ts";
 import type { EntityDocument } from "../v2.ts";
 
@@ -120,6 +121,45 @@ Deno.test("DIDs that collided under the old 32-bit token now get disjoint names"
     close(y);
     await Deno.remove(pathX);
     await Deno.remove(pathY);
+  }
+});
+
+Deno.test("re-scopes in place if the token derivation changes (no orphaning)", async () => {
+  const path = await Deno.makeTempFile({ suffix: ".sqlite" });
+
+  // 1. Scoped db with data under the current token.
+  const first = await open({ url: toFileUrl(path), space: SPACE_A });
+  writeEntity(first, "entity:keep", { n: 7 });
+  const curToken = tableNames(first).find((n) => /^commit__/.test(n))!
+    .slice("commit__".length);
+  close(first);
+
+  // 2. Simulate a CHANGED token derivation: rename the whole core family from
+  //    the current token to a fake "old" token, behind the engine's back.
+  const raw = new Database(path);
+  raw.exec("PRAGMA legacy_alter_table = OFF;");
+  const fakeOld = "0123456789abcdef0123456789abcdef";
+  for (
+    const r of raw.prepare(
+      `SELECT name FROM sqlite_master WHERE type='table' AND name LIKE '%\\_\\_' || ? ESCAPE '\\'`,
+    ).all(curToken) as Array<{ name: string }>
+  ) {
+    const base = r.name.slice(0, -(curToken.length + 2));
+    raw.exec(`ALTER TABLE "${r.name}" RENAME TO "${base}__${fakeOld}";`);
+  }
+  raw.close();
+
+  // 3. Reopen with the same space: the migration sees the prior-token tables and
+  //    re-scopes them to the current token; the data survives, no orphans.
+  const reopened = await open({ url: toFileUrl(path), space: SPACE_A });
+  try {
+    const names = tableNames(reopened);
+    assertExists(names.find((n) => n === `commit__${curToken}`));
+    assertEquals(names.some((n) => n.endsWith(`__${fakeOld}`)), false);
+    assertEquals(read(reopened, { id: "entity:keep" }), { value: { n: 7 } });
+  } finally {
+    close(reopened);
+    await Deno.remove(path);
   }
 });
 

--- a/packages/memory/test/v2-core-table-scoping-test.ts
+++ b/packages/memory/test/v2-core-table-scoping-test.ts
@@ -1,0 +1,136 @@
+// Core engine tables are scoped per-space (`commit__<token>` etc.) when `open()`
+// is given a `space`, so an attached pattern cell-db can't shadow a core table
+// on the write path, and two spaces' core tables never collide when attached to
+// one connection (the precondition for cross-space transactions). Opening
+// without a `space` keeps the legacy bare names (back-compat). A legacy bare-named
+// db is migrated in place on first scoped open.
+
+import { assertEquals, assertExists } from "@std/assert";
+import { toFileUrl } from "@std/path";
+import { applyCommit, close, type Engine, open, read } from "../v2/engine.ts";
+import type { EntityDocument } from "../v2.ts";
+
+const SPACE_A = "did:key:z6Mk-core-scope-a";
+const SPACE_B = "did:key:z6Mk-core-scope-b";
+
+const doc = (value: unknown): EntityDocument =>
+  ({ value }) as unknown as EntityDocument;
+
+const writeEntity = (engine: Engine, id: string, value: unknown): void => {
+  applyCommit(engine, {
+    sessionId: "session:test",
+    principal: "did:key:alice",
+    commit: {
+      localSeq: 1,
+      reads: { confirmed: [], pending: [] },
+      operations: [{ op: "set", id, value: doc(value) }],
+    },
+  });
+};
+
+const tableNames = (engine: Engine): string[] =>
+  (engine.database
+    .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+    .all() as Array<{ name: string }>)
+    .map((r) => r.name);
+
+Deno.test("open(space) scopes core tables; bare names are absent", async () => {
+  const path = await Deno.makeTempFile({ suffix: ".sqlite" });
+  const engine = await open({ url: toFileUrl(path), space: SPACE_A });
+  try {
+    const names = tableNames(engine);
+    // Core tables carry the per-space suffix; the bare names are gone.
+    assertExists(names.find((n) => /^commit__/.test(n)));
+    assertExists(names.find((n) => /^revision__/.test(n)));
+    assertEquals(names.includes("commit"), false);
+    assertEquals(names.includes("revision"), false);
+
+    // The scoped schema is fully functional end to end.
+    writeEntity(engine, "entity:a", { hello: "world" });
+    assertEquals(read(engine, { id: "entity:a" }), {
+      value: { hello: "world" },
+    });
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("open() without a space keeps legacy bare names", async () => {
+  const path = await Deno.makeTempFile({ suffix: ".sqlite" });
+  const engine = await open({ url: toFileUrl(path) });
+  try {
+    const names = tableNames(engine);
+    assertEquals(names.includes("commit"), true);
+    assertEquals(names.includes("revision"), true);
+    assertEquals(names.some((n) => /__/.test(n)), false);
+  } finally {
+    close(engine);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("legacy bare db is migrated to scoped names in place, data intact", async () => {
+  const path = await Deno.makeTempFile({ suffix: ".sqlite" });
+
+  // 1. Create a legacy (bare-named) db and write data through it.
+  const legacy = await open({ url: toFileUrl(path) });
+  writeEntity(legacy, "entity:keep", { n: 42 });
+  assertEquals(tableNames(legacy).includes("commit"), true);
+  close(legacy);
+
+  // 2. Reopen the SAME file WITH a space: the on-open migration renames the
+  //    core tables to scoped names and the previously-written data survives.
+  const scoped = await open({ url: toFileUrl(path), space: SPACE_A });
+  try {
+    const names = tableNames(scoped);
+    assertExists(names.find((n) => /^commit__/.test(n)));
+    assertEquals(names.includes("commit"), false);
+    assertEquals(read(scoped, { id: "entity:keep" }), { value: { n: 42 } });
+  } finally {
+    close(scoped);
+  }
+
+  // 3. Reopening again is idempotent (no double-rename) and still reads.
+  const reopened = await open({ url: toFileUrl(path), space: SPACE_A });
+  try {
+    assertEquals(read(reopened, { id: "entity:keep" }), { value: { n: 42 } });
+  } finally {
+    close(reopened);
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("two spaces' core tables are disjoint (cross-space attach ready)", async () => {
+  const pathA = await Deno.makeTempFile({ suffix: ".sqlite" });
+  const pathB = await Deno.makeTempFile({ suffix: ".sqlite" });
+  const engineA = await open({ url: toFileUrl(pathA), space: SPACE_A });
+  const engineB = await open({ url: toFileUrl(pathB), space: SPACE_B });
+  try {
+    const a = new Set(tableNames(engineA));
+    const b = new Set(tableNames(engineB));
+    // Different spaces => different token => no shared core-table name.
+    const shared = [...a].filter((n) => b.has(n) && /__/.test(n));
+    assertEquals(shared, []);
+
+    // Concretely: attach B's file into A's connection. Because the names are
+    // disjoint, both spaces' core tables coexist under one connection with no
+    // collision and no ambiguity for an unqualified reference.
+    engineA.database.exec(`ATTACH DATABASE ? AS other`, pathB);
+    try {
+      const aCommit = [...a].find((n) => /^commit__/.test(n))!;
+      const bCommit = [...b].find((n) => /^commit__/.test(n))!;
+      assertEquals(aCommit === bCommit, false);
+      // Both resolve, unqualified, on the same connection.
+      engineA.database.prepare(`SELECT count(*) AS c FROM "${aCommit}"`).get();
+      engineA.database.prepare(`SELECT count(*) AS c FROM "${bCommit}"`).get();
+    } finally {
+      engineA.database.exec(`DETACH DATABASE other`);
+    }
+  } finally {
+    close(engineA);
+    close(engineB);
+    await Deno.remove(pathA);
+    await Deno.remove(pathB);
+  }
+});

--- a/packages/memory/test/v2-core-table-scoping-test.ts
+++ b/packages/memory/test/v2-core-table-scoping-test.ts
@@ -101,6 +101,28 @@ Deno.test("legacy bare db is migrated to scoped names in place, data intact", as
   }
 });
 
+Deno.test("DIDs that collided under the old 32-bit token now get disjoint names", async () => {
+  // These two same-length DIDs produced an identical FNV-1a-32 token (reported
+  // in review); the SHA-256 token must keep their core tables disjoint so their
+  // data can never alias when sharing a connection.
+  const didX = "did:key:ziU9nCvUN8Zwo2uhnJUkWeqMA5CFhUwVpxUzdpYQFrppg";
+  const didY = "did:key:zDpzMFyyrHYN9M1RoWKS6zKqz1y3Sf2kRrovdqpJfrVyv";
+  const pathX = await Deno.makeTempFile({ suffix: ".sqlite" });
+  const pathY = await Deno.makeTempFile({ suffix: ".sqlite" });
+  const x = await open({ url: toFileUrl(pathX), space: didX });
+  const y = await open({ url: toFileUrl(pathY), space: didY });
+  try {
+    const xCommit = tableNames(x).find((n) => /^commit__/.test(n))!;
+    const yCommit = tableNames(y).find((n) => /^commit__/.test(n))!;
+    assertEquals(xCommit === yCommit, false);
+  } finally {
+    close(x);
+    close(y);
+    await Deno.remove(pathX);
+    await Deno.remove(pathY);
+  }
+});
+
 Deno.test("two spaces' core tables are disjoint (cross-space attach ready)", async () => {
   const pathA = await Deno.makeTempFile({ suffix: ".sqlite" });
   const pathB = await Deno.makeTempFile({ suffix: ".sqlite" });

--- a/packages/memory/test/v2-scheduler-state-test.ts
+++ b/packages/memory/test/v2-scheduler-state-test.ts
@@ -928,6 +928,7 @@ Deno.test("memory v2 server mirrors scheduler read indexes into read spaces", as
 
     const readEngine = await openEngine({
       url: resolveSpaceStoreUrl(store, readSpace),
+      space: readSpace,
     });
     try {
       const readers = findSchedulerReadersForWrite(readEngine, {
@@ -1102,6 +1103,7 @@ Deno.test("memory v2 server skips scheduler mirrors for unmounted read spaces", 
 
     const readEngine = await openEngine({
       url: resolveSpaceStoreUrl(store, readSpace),
+      space: readSpace,
     });
     try {
       const readers = findSchedulerReadersForWrite(readEngine, {

--- a/packages/memory/test/v2-sqlite-guard-test.ts
+++ b/packages/memory/test/v2-sqlite-guard-test.ts
@@ -106,6 +106,30 @@ describe("assertReadOnly", () => {
     expect(() => assertReadOnly("SELECT * FROM commit")).toThrow(GuardError);
     expect(() => assertReadOnly("SELECT * FROM revision")).toThrow(GuardError);
   });
+
+  it("rejects the SPACE-SCOPED core-table forms (commit__<token>)", () => {
+    // Core tables are renamed to `commit__<token>`; the token is a hash of the
+    // space's own public DID, so a pattern can derive it. Both the read and the
+    // folded-write guard must reject the scoped form, not just the bare name.
+    expect(() => assertReadOnly('SELECT * FROM "commit__deadbeefcafe"'))
+      .toThrow(
+        GuardError,
+      );
+    expect(() =>
+      assertWriteSafe('INSERT INTO "commit__deadbeefcafe" (seq) VALUES (1)')
+    ).toThrow(GuardError);
+    expect(() =>
+      assertReadOnly('SELECT * FROM "scheduler_observation__abc123"')
+    ).toThrow(GuardError);
+  });
+
+  it("does not false-reject pattern tables that merely start with a core name", () => {
+    // `commit__<token>` is reserved, but `commitments` / `commit_log` (no `__`)
+    // are ordinary pattern table names and must pass.
+    assertReadOnly("SELECT * FROM commitments");
+    assertReadOnly("SELECT * FROM commit_log");
+    assertWriteSafe("INSERT INTO commitments (a) VALUES (?)");
+  });
 });
 
 describe("assertWriteSafe", () => {

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -83,6 +83,88 @@ const declaredScopeFromScopeKey = (scopeKey: string): CellScope => {
   return "space";
 };
 
+// Identifier-safe, stable-per-space token for scoping core table names (FNV-1a
+// 32-bit + length, hex). Empty space => "" (legacy bare names, back-compat).
+const scopeToken = (space: string | undefined): string => {
+  if (!space) return "";
+  let h = 0x811c9dc5;
+  for (let i = 0; i < space.length; i++) {
+    h ^= space.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return `${(h >>> 0).toString(16).padStart(8, "0")}${
+    space.length.toString(16)
+  }`;
+};
+
+/** The 14 core engine tables, scoped per-space so they never collide with an
+ *  attached pattern cell-db on the write path. */
+interface CoreTableNames {
+  authorization: string;
+  invocation: string;
+  commit: string;
+  revision: string;
+  head: string;
+  snapshot: string;
+  branch: string;
+  blob_store: string;
+  scheduler_observation: string;
+  scheduler_action_snapshot: string;
+  scheduler_observation_replay: string;
+  scheduler_read_index: string;
+  scheduler_write_index: string;
+  scheduler_action_state: string;
+}
+
+const CORE_TABLE_KEYS: readonly (keyof CoreTableNames)[] = [
+  "authorization",
+  "invocation",
+  "commit",
+  "revision",
+  "head",
+  "snapshot",
+  "branch",
+  "blob_store",
+  "scheduler_observation",
+  "scheduler_action_snapshot",
+  "scheduler_observation_replay",
+  "scheduler_read_index",
+  "scheduler_write_index",
+  "scheduler_action_state",
+];
+
+/**
+ * Maps each core table to the SQL identifier to emit. With an empty token the
+ * names are byte-identical to the legacy schema: `commit` is a reserved word so
+ * it stays `"commit"` (quoted), the rest are bare. With a non-empty token every
+ * table becomes the quoted scoped identifier `"<table>__<token>"`.
+ */
+const coreTableNames = (token: string): CoreTableNames => {
+  if (token === "") {
+    return {
+      authorization: "authorization",
+      invocation: "invocation",
+      commit: `"commit"`,
+      revision: "revision",
+      head: "head",
+      snapshot: "snapshot",
+      branch: "branch",
+      blob_store: "blob_store",
+      scheduler_observation: "scheduler_observation",
+      scheduler_action_snapshot: "scheduler_action_snapshot",
+      scheduler_observation_replay: "scheduler_observation_replay",
+      scheduler_read_index: "scheduler_read_index",
+      scheduler_write_index: "scheduler_write_index",
+      scheduler_action_state: "scheduler_action_state",
+    };
+  }
+  const scoped = {} as CoreTableNames;
+  for (const key of CORE_TABLE_KEYS) {
+    scoped[key] = `"${key}__${token}"`;
+  }
+  return scoped;
+};
+
 const PRAGMAS = `
   PRAGMA journal_mode = WAL;
   PRAGMA synchronous = NORMAL;
@@ -97,16 +179,16 @@ const NEW_DB_PRAGMAS = `
   PRAGMA page_size = 32768;
 `;
 
-const INIT = `
+const buildInit = (T: CoreTableNames): string => `
 BEGIN TRANSACTION;
 
-CREATE TABLE IF NOT EXISTS authorization (
+CREATE TABLE IF NOT EXISTS ${T.authorization} (
   ref            TEXT    NOT NULL PRIMARY KEY,
   authorization  JSON    NOT NULL,
   created_at     TEXT    NOT NULL DEFAULT (datetime('now'))
 );
 
-CREATE TABLE IF NOT EXISTS invocation (
+CREATE TABLE IF NOT EXISTS ${T.invocation} (
   ref         TEXT    NOT NULL PRIMARY KEY,
   iss         TEXT    NOT NULL,
   aud         TEXT,
@@ -115,11 +197,11 @@ CREATE TABLE IF NOT EXISTS invocation (
   invocation  JSON    NOT NULL,
   created_at  TEXT    NOT NULL DEFAULT (datetime('now'))
 );
-CREATE INDEX IF NOT EXISTS idx_invocation_sub ON invocation (sub);
-CREATE INDEX IF NOT EXISTS idx_invocation_cmd ON invocation (cmd);
-CREATE INDEX IF NOT EXISTS idx_invocation_iss ON invocation (iss);
+CREATE INDEX IF NOT EXISTS idx_invocation_sub ON ${T.invocation} (sub);
+CREATE INDEX IF NOT EXISTS idx_invocation_cmd ON ${T.invocation} (cmd);
+CREATE INDEX IF NOT EXISTS idx_invocation_iss ON ${T.invocation} (iss);
 
-CREATE TABLE IF NOT EXISTS "commit" (
+CREATE TABLE IF NOT EXISTS ${T.commit} (
   seq                INTEGER NOT NULL PRIMARY KEY,
   branch             TEXT    NOT NULL DEFAULT '',
   session_id         TEXT    NOT NULL,
@@ -129,16 +211,16 @@ CREATE TABLE IF NOT EXISTS "commit" (
   original           JSON    NOT NULL,
   resolution         JSON    NOT NULL,
   created_at         TEXT    NOT NULL DEFAULT (datetime('now')),
-  FOREIGN KEY (invocation_ref) REFERENCES invocation(ref),
-  FOREIGN KEY (authorization_ref) REFERENCES authorization(ref)
+  FOREIGN KEY (invocation_ref) REFERENCES ${T.invocation}(ref),
+  FOREIGN KEY (authorization_ref) REFERENCES ${T.authorization}(ref)
 );
-CREATE INDEX IF NOT EXISTS idx_commit_branch ON "commit" (branch);
+CREATE INDEX IF NOT EXISTS idx_commit_branch ON ${T.commit} (branch);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_commit_session_local_seq
-  ON "commit" (session_id, local_seq);
+  ON ${T.commit} (session_id, local_seq);
 CREATE INDEX IF NOT EXISTS idx_commit_invocation_ref
-  ON "commit" (invocation_ref);
+  ON ${T.commit} (invocation_ref);
 
-CREATE TABLE IF NOT EXISTS revision (
+CREATE TABLE IF NOT EXISTS ${T.revision} (
   branch      TEXT    NOT NULL DEFAULT '',
   id          TEXT    NOT NULL,
   scope_key   TEXT    NOT NULL DEFAULT 'space',
@@ -148,16 +230,16 @@ CREATE TABLE IF NOT EXISTS revision (
   data        JSON,
   commit_seq  INTEGER NOT NULL,
   PRIMARY KEY (branch, id, scope_key, seq, op_index),
-  FOREIGN KEY (commit_seq) REFERENCES "commit"(seq)
+  FOREIGN KEY (commit_seq) REFERENCES ${T.commit}(seq)
 );
 CREATE INDEX IF NOT EXISTS idx_revision_branch_id_seq
-  ON revision (branch, id, scope_key, seq, op_index);
+  ON ${T.revision} (branch, id, scope_key, seq, op_index);
 CREATE INDEX IF NOT EXISTS idx_revision_commit
-  ON revision (commit_seq);
+  ON ${T.revision} (commit_seq);
 CREATE INDEX IF NOT EXISTS idx_revision_branch
-  ON revision (branch, seq);
+  ON ${T.revision} (branch, seq);
 
-CREATE TABLE IF NOT EXISTS head (
+CREATE TABLE IF NOT EXISTS ${T.head} (
   branch    TEXT    NOT NULL,
   id        TEXT    NOT NULL,
   scope_key TEXT    NOT NULL DEFAULT 'space',
@@ -165,9 +247,9 @@ CREATE TABLE IF NOT EXISTS head (
   op_index  INTEGER NOT NULL,
   PRIMARY KEY (branch, id, scope_key)
 );
-CREATE INDEX IF NOT EXISTS idx_head_branch ON head (branch);
+CREATE INDEX IF NOT EXISTS idx_head_branch ON ${T.head} (branch);
 
-CREATE TABLE IF NOT EXISTS snapshot (
+CREATE TABLE IF NOT EXISTS ${T.snapshot} (
   branch  TEXT    NOT NULL DEFAULT '',
   id      TEXT    NOT NULL,
   scope_key TEXT  NOT NULL DEFAULT 'space',
@@ -175,9 +257,9 @@ CREATE TABLE IF NOT EXISTS snapshot (
   value   JSON    NOT NULL,
   PRIMARY KEY (branch, id, scope_key, seq)
 );
-CREATE INDEX IF NOT EXISTS idx_snapshot_lookup ON snapshot (branch, id, scope_key, seq);
+CREATE INDEX IF NOT EXISTS idx_snapshot_lookup ON ${T.snapshot} (branch, id, scope_key, seq);
 
-CREATE TABLE IF NOT EXISTS branch (
+CREATE TABLE IF NOT EXISTS ${T.branch} (
   name           TEXT    NOT NULL PRIMARY KEY,
   parent_branch  TEXT,
   fork_seq       INTEGER,
@@ -186,19 +268,19 @@ CREATE TABLE IF NOT EXISTS branch (
   status         TEXT    NOT NULL DEFAULT 'active',
   created_at     TEXT    NOT NULL DEFAULT (datetime('now')),
   deleted_at     TEXT,
-  FOREIGN KEY (parent_branch) REFERENCES branch(name)
+  FOREIGN KEY (parent_branch) REFERENCES ${T.branch}(name)
 );
-INSERT OR IGNORE INTO branch (name, created_seq, head_seq, status)
+INSERT OR IGNORE INTO ${T.branch} (name, created_seq, head_seq, status)
 VALUES ('', 0, 0, 'active');
 
-CREATE TABLE IF NOT EXISTS blob_store (
+CREATE TABLE IF NOT EXISTS ${T.blob_store} (
   hash          TEXT    NOT NULL PRIMARY KEY,
   data          BLOB    NOT NULL,
   content_type  TEXT    NOT NULL,
   size          INTEGER NOT NULL
 );
 
-CREATE TABLE IF NOT EXISTS scheduler_observation (
+CREATE TABLE IF NOT EXISTS ${T.scheduler_observation} (
   observation_id      INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
   branch              TEXT    NOT NULL DEFAULT '',
   commit_seq          INTEGER,
@@ -210,10 +292,10 @@ CREATE TABLE IF NOT EXISTS scheduler_observation (
   process_generation  INTEGER NOT NULL,
   payload             JSON    NOT NULL,
   created_at          TEXT    NOT NULL DEFAULT (datetime('now')),
-  FOREIGN KEY (commit_seq) REFERENCES "commit"(seq)
+  FOREIGN KEY (commit_seq) REFERENCES ${T.commit}(seq)
 );
 CREATE INDEX IF NOT EXISTS idx_scheduler_observation_action
-  ON scheduler_observation (
+  ON ${T.scheduler_observation} (
     branch,
     piece_id,
     process_generation,
@@ -221,10 +303,10 @@ CREATE INDEX IF NOT EXISTS idx_scheduler_observation_action
     observation_id
   );
 CREATE UNIQUE INDEX IF NOT EXISTS idx_scheduler_observation_session_local
-  ON scheduler_observation (branch, session_id, local_seq)
+  ON ${T.scheduler_observation} (branch, session_id, local_seq)
   WHERE session_id IS NOT NULL AND local_seq IS NOT NULL;
 
-CREATE TABLE IF NOT EXISTS scheduler_action_snapshot (
+CREATE TABLE IF NOT EXISTS ${T.scheduler_action_snapshot} (
   branch              TEXT    NOT NULL DEFAULT '',
   owner_space         TEXT    NOT NULL DEFAULT '',
   piece_id            TEXT    NOT NULL,
@@ -242,10 +324,10 @@ CREATE TABLE IF NOT EXISTS scheduler_action_snapshot (
     action_id
   ),
   FOREIGN KEY (observation_id)
-    REFERENCES scheduler_observation(observation_id)
+    REFERENCES ${T.scheduler_observation}(observation_id)
 );
 
-CREATE TABLE IF NOT EXISTS scheduler_observation_replay (
+CREATE TABLE IF NOT EXISTS ${T.scheduler_observation_replay} (
   branch              TEXT    NOT NULL DEFAULT '',
   session_id          TEXT    NOT NULL,
   local_seq           INTEGER NOT NULL,
@@ -257,10 +339,10 @@ CREATE TABLE IF NOT EXISTS scheduler_observation_replay (
   created_at          TEXT    NOT NULL DEFAULT (datetime('now')),
   PRIMARY KEY (branch, session_id, local_seq),
   FOREIGN KEY (observation_id)
-    REFERENCES scheduler_observation(observation_id)
+    REFERENCES ${T.scheduler_observation}(observation_id)
 );
 
-CREATE TABLE IF NOT EXISTS scheduler_read_index (
+CREATE TABLE IF NOT EXISTS ${T.scheduler_read_index} (
   branch              TEXT    NOT NULL DEFAULT '',
   owner_space         TEXT,
   read_space          TEXT    NOT NULL,
@@ -273,19 +355,19 @@ CREATE TABLE IF NOT EXISTS scheduler_read_index (
   action_id           TEXT    NOT NULL,
   observation_id      INTEGER NOT NULL,
   FOREIGN KEY (observation_id)
-    REFERENCES scheduler_observation(observation_id)
+    REFERENCES ${T.scheduler_observation}(observation_id)
 );
 CREATE INDEX IF NOT EXISTS idx_scheduler_read_index_lookup
-  ON scheduler_read_index (branch, read_space, read_id, read_scope);
+  ON ${T.scheduler_read_index} (branch, read_space, read_id, read_scope);
 CREATE INDEX IF NOT EXISTS idx_scheduler_read_index_action
-  ON scheduler_read_index (
+  ON ${T.scheduler_read_index} (
     branch,
     piece_id,
     process_generation,
     action_id
   );
 
-CREATE TABLE IF NOT EXISTS scheduler_write_index (
+CREATE TABLE IF NOT EXISTS ${T.scheduler_write_index} (
   branch              TEXT    NOT NULL DEFAULT '',
   owner_space         TEXT    NOT NULL DEFAULT '',
   write_space         TEXT    NOT NULL,
@@ -298,17 +380,17 @@ CREATE TABLE IF NOT EXISTS scheduler_write_index (
   action_id           TEXT    NOT NULL,
   observation_id      INTEGER NOT NULL,
   FOREIGN KEY (observation_id)
-    REFERENCES scheduler_observation(observation_id)
+    REFERENCES ${T.scheduler_observation}(observation_id)
 );
 CREATE INDEX IF NOT EXISTS idx_scheduler_write_index_action
-  ON scheduler_write_index (
+  ON ${T.scheduler_write_index} (
     branch,
     piece_id,
     process_generation,
     action_id
   );
 
-CREATE TABLE IF NOT EXISTS scheduler_action_state (
+CREATE TABLE IF NOT EXISTS ${T.scheduler_action_state} (
   branch                 TEXT    NOT NULL DEFAULT '',
   owner_space            TEXT    NOT NULL DEFAULT '',
   piece_id               TEXT    NOT NULL,
@@ -326,24 +408,56 @@ CREATE TABLE IF NOT EXISTS scheduler_action_state (
     action_id
   ),
   FOREIGN KEY (latest_observation_id)
-    REFERENCES scheduler_observation(observation_id)
+    REFERENCES ${T.scheduler_observation}(observation_id)
 );
 
 COMMIT;
 `;
 
-const INSERT_AUTHORIZATION = `
-INSERT OR IGNORE INTO authorization (ref, authorization)
+interface StatementSql {
+  insertAuthorization: string;
+  insertInvocation: string;
+  insertCommit: string;
+  insertRevision: string;
+  upsertHead: string;
+  insertSnapshot: string;
+  deleteOldSnapshots: string;
+  updateBranchHead: string;
+  selectHead: string;
+  selectCurrentLocal: string;
+  selectAtSeqLocal: string;
+  selectLatestBase: string;
+  selectLatestSnapshot: string;
+  selectPatches: string;
+  selectPatchCount: string;
+  selectNextSeq: string;
+  selectServerSeq: string;
+  selectExistingCommit: string;
+  selectSetDeleteConflict: string;
+  selectPatchConflicts: string;
+  selectPendingResolution: string;
+  selectCommitRevisions: string;
+  selectBranch: string;
+  selectBranchStatus: string;
+  selectBranchHeadSeq: string;
+  selectBranches: string;
+  insertBranch: string;
+  deleteBranch: string;
+  insertBlob: string;
+  selectBlob: string;
+}
+
+const buildStatements = (T: CoreTableNames): StatementSql => ({
+  insertAuthorization: `
+INSERT OR IGNORE INTO ${T.authorization} (ref, authorization)
 VALUES (:ref, :authorization)
-`;
-
-const INSERT_INVOCATION = `
-INSERT OR IGNORE INTO invocation (ref, iss, aud, cmd, sub, invocation)
+`,
+  insertInvocation: `
+INSERT OR IGNORE INTO ${T.invocation} (ref, iss, aud, cmd, sub, invocation)
 VALUES (:ref, :iss, :aud, :cmd, :sub, :invocation)
-`;
-
-const INSERT_COMMIT = `
-INSERT INTO "commit" (
+`,
+  insertCommit: `
+INSERT INTO ${T.commit} (
   seq,
   branch,
   session_id,
@@ -363,10 +477,9 @@ VALUES (
   :original,
   :resolution
 )
-`;
-
-const INSERT_REVISION = `
-INSERT INTO revision (
+`,
+  insertRevision: `
+INSERT INTO ${T.revision} (
   branch,
   id,
   scope_key,
@@ -386,77 +499,69 @@ VALUES (
   :data,
   :commit_seq
 )
-`;
-
-const UPSERT_HEAD = `
-INSERT INTO head (branch, id, scope_key, seq, op_index)
+`,
+  upsertHead: `
+INSERT INTO ${T.head} (branch, id, scope_key, seq, op_index)
 VALUES (:branch, :id, :scope_key, :seq, :op_index)
 ON CONFLICT (branch, id, scope_key) DO UPDATE
 SET seq = :seq, op_index = :op_index
-`;
-
-const INSERT_SNAPSHOT = `
-INSERT OR REPLACE INTO snapshot (branch, id, scope_key, seq, value)
+`,
+  insertSnapshot: `
+INSERT OR REPLACE INTO ${T.snapshot} (branch, id, scope_key, seq, value)
 VALUES (:branch, :id, :scope_key, :seq, :value)
-`;
-
-const DELETE_OLD_SNAPSHOTS = `
-DELETE FROM snapshot
+`,
+  deleteOldSnapshots: `
+DELETE FROM ${T.snapshot}
 WHERE branch = :branch
   AND id = :id
   AND scope_key = :scope_key
   AND seq NOT IN (
     SELECT seq
-    FROM snapshot
+    FROM ${T.snapshot}
     WHERE branch = :branch
       AND id = :id
       AND scope_key = :scope_key
     ORDER BY seq DESC
     LIMIT :retention
   )
-`;
-
-const UPDATE_BRANCH_HEAD = `
-UPDATE branch
+`,
+  updateBranchHead: `
+UPDATE ${T.branch}
 SET head_seq = CASE
   WHEN head_seq < :seq THEN :seq
   ELSE head_seq
 END
 WHERE name = :branch
-`;
-
-const SELECT_HEAD = `
+`,
+  selectHead: `
 SELECT seq, op_index
-FROM head
+FROM ${T.head}
 WHERE branch = :branch AND id = :id AND scope_key = :scope_key
-`;
-
-const SELECT_CURRENT_LOCAL = `
+`,
+  selectCurrentLocal: `
 SELECT r.seq, r.op_index, r.op, r.data
-FROM head h
-JOIN revision r
+FROM ${T.head} h
+JOIN ${T.revision} r
  ON r.branch = h.branch
  AND r.id = h.id
  AND r.scope_key = h.scope_key
  AND r.seq = h.seq
  AND r.op_index = h.op_index
 WHERE h.branch = :branch AND h.id = :id AND h.scope_key = :scope_key
-`;
-
-const SELECT_AT_SEQ_LOCAL = `
+`,
+  selectAtSeqLocal: `
 SELECT seq, op_index, op, data
-FROM revision
+FROM ${T.revision}
 WHERE branch = :branch
   AND id = :id
   AND scope_key = :scope_key
   AND seq <= :seq
 ORDER BY seq DESC, op_index DESC
 LIMIT 1
-`;
-
-const SELECT_LATEST_BASE = `
+`,
+  selectLatestBase: `
 SELECT seq, op_index, op, data
-FROM revision
+FROM ${T.revision}
 WHERE branch = :branch
   AND id = :id
   AND scope_key = :scope_key
@@ -467,22 +572,20 @@ WHERE branch = :branch
   )
 ORDER BY seq DESC, op_index DESC
 LIMIT 1
-`;
-
-const SELECT_LATEST_SNAPSHOT = `
+`,
+  selectLatestSnapshot: `
 SELECT seq, value
-FROM snapshot
+FROM ${T.snapshot}
 WHERE branch = :branch
   AND id = :id
   AND scope_key = :scope_key
   AND seq <= :seq
 ORDER BY seq DESC
 LIMIT 1
-`;
-
-const SELECT_PATCHES = `
+`,
+  selectPatches: `
 SELECT seq, op_index, data
-FROM revision
+FROM ${T.revision}
 WHERE branch = :branch
   AND id = :id
   AND scope_key = :scope_key
@@ -496,39 +599,34 @@ WHERE branch = :branch
     (seq = :seq AND op_index <= :op_index)
   )
 ORDER BY seq ASC, op_index ASC
-`;
-
-const SELECT_PATCH_COUNT = `
+`,
+  selectPatchCount: `
 SELECT COUNT(*) AS count
-FROM revision
+FROM ${T.revision}
 WHERE branch = :branch
   AND id = :id
   AND scope_key = :scope_key
   AND op = 'patch'
   AND seq > :after_seq
   AND seq <= :seq
-`;
-
-const SELECT_NEXT_SEQ = `
+`,
+  selectNextSeq: `
 SELECT COALESCE(MAX(seq), 0) + 1 AS seq
-FROM "commit"
-`;
-
-const SELECT_SERVER_SEQ = `
+FROM ${T.commit}
+`,
+  selectServerSeq: `
 SELECT COALESCE(MAX(seq), 0) AS seq
-FROM "commit"
-`;
-
-const SELECT_EXISTING_COMMIT = `
+FROM ${T.commit}
+`,
+  selectExistingCommit: `
 SELECT seq, branch, original, resolution
-FROM "commit"
+FROM ${T.commit}
 WHERE session_id = :session_id
   AND local_seq = :local_seq
-`;
-
-const SELECT_SET_DELETE_CONFLICT = `
+`,
+  selectSetDeleteConflict: `
 SELECT seq
-FROM revision
+FROM ${T.revision}
 WHERE branch = :branch
   AND id = :id
   AND scope_key = :scope_key
@@ -536,59 +634,51 @@ WHERE branch = :branch
   AND op IN ('set', 'delete')
 ORDER BY seq DESC, op_index DESC
 LIMIT 1
-`;
-
-const SELECT_PATCH_CONFLICTS = `
+`,
+  selectPatchConflicts: `
 SELECT seq, op_index, data
-FROM revision
+FROM ${T.revision}
 WHERE branch = :branch
   AND id = :id
   AND scope_key = :scope_key
   AND seq > :after_seq
   AND op = 'patch'
 ORDER BY seq DESC, op_index DESC
-`;
-
-const SELECT_PENDING_RESOLUTION = `
+`,
+  selectPendingResolution: `
 SELECT seq
-FROM "commit"
+FROM ${T.commit}
 WHERE session_id = :session_id
   AND local_seq = :local_seq
-`;
-
-const SELECT_COMMIT_REVISIONS = `
+`,
+  selectCommitRevisions: `
 SELECT branch, id, scope_key, seq, op_index, op, data, commit_seq
-FROM revision
+FROM ${T.revision}
 WHERE commit_seq = :commit_seq
 ORDER BY op_index ASC
-`;
-
-const SELECT_BRANCH = `
+`,
+  selectBranch: `
 SELECT name, parent_branch, fork_seq, created_seq, head_seq, status
-FROM branch
+FROM ${T.branch}
 WHERE name = :branch
-`;
-
-const SELECT_BRANCH_STATUS = `
+`,
+  selectBranchStatus: `
 SELECT status
-FROM branch
+FROM ${T.branch}
 WHERE name = :branch
-`;
-
-const SELECT_BRANCH_HEAD_SEQ = `
+`,
+  selectBranchHeadSeq: `
 SELECT head_seq
-FROM branch
+FROM ${T.branch}
 WHERE name = :branch
-`;
-
-const SELECT_BRANCHES = `
+`,
+  selectBranches: `
 SELECT name, parent_branch, fork_seq, created_seq, head_seq, status
-FROM branch
+FROM ${T.branch}
 ORDER BY name ASC
-`;
-
-const INSERT_BRANCH = `
-INSERT INTO branch (
+`,
+  insertBranch: `
+INSERT INTO ${T.branch} (
   name,
   parent_branch,
   fork_seq,
@@ -604,26 +694,24 @@ VALUES (
   :head_seq,
   'active'
 )
-`;
-
-const DELETE_BRANCH = `
-UPDATE branch
+`,
+  deleteBranch: `
+UPDATE ${T.branch}
 SET status = 'deleted',
     deleted_at = datetime('now')
 WHERE name = :branch
   AND name <> ''
-`;
-
-const INSERT_BLOB = `
-INSERT OR IGNORE INTO blob_store (hash, data, content_type, size)
+`,
+  insertBlob: `
+INSERT OR IGNORE INTO ${T.blob_store} (hash, data, content_type, size)
 VALUES (:hash, :data, :content_type, :size)
-`;
-
-const SELECT_BLOB = `
+`,
+  selectBlob: `
 SELECT data, content_type, size
-FROM blob_store
+FROM ${T.blob_store}
 WHERE hash = :hash
-`;
+`,
+});
 
 type PreparedStatement = ReturnType<Database["prepare"]>;
 
@@ -666,6 +754,9 @@ export interface Engine {
   snapshotInterval: number;
   snapshotRetention: number;
   legacyCommitMetadataRefsRequired: boolean;
+  /** Per-space scoped names for the 14 core tables; consumed by the inline SQL
+   *  helpers that don't go through prepared statements. */
+  tableNames: CoreTableNames;
   statements: PreparedStatements;
 }
 
@@ -685,6 +776,9 @@ export class ProtocolError extends Error {
 
 export interface OpenOptions {
   url: URL;
+  /** Space DID; scopes the core table names so they are globally unique and
+   *  can't be shadowed by an attached pattern cell-db on the write path. */
+  space?: string;
   snapshotInterval?: number;
   snapshotRetention?: number;
 }
@@ -922,52 +1016,60 @@ type BranchRow = {
 export const DEFAULT_SNAPSHOT_INTERVAL = 10;
 export const DEFAULT_SNAPSHOT_RETENTION = 2;
 
-const prepareStatements = (database: Database): PreparedStatements => ({
-  insertAuthorization: database.prepare(INSERT_AUTHORIZATION),
-  insertBlob: database.prepare(INSERT_BLOB),
-  insertBranch: database.prepare(INSERT_BRANCH),
-  insertCommit: database.prepare(INSERT_COMMIT),
-  insertInvocation: database.prepare(INSERT_INVOCATION),
-  insertRevision: database.prepare(INSERT_REVISION),
-  insertSnapshot: database.prepare(INSERT_SNAPSHOT),
-  selectAtSeqLocal: database.prepare(SELECT_AT_SEQ_LOCAL),
-  selectBlob: database.prepare(SELECT_BLOB),
-  selectBranch: database.prepare(SELECT_BRANCH),
-  selectBranches: database.prepare(SELECT_BRANCHES),
-  selectBranchHeadSeq: database.prepare(SELECT_BRANCH_HEAD_SEQ),
-  selectBranchStatus: database.prepare(SELECT_BRANCH_STATUS),
-  selectCommitRevisions: database.prepare(SELECT_COMMIT_REVISIONS),
-  selectCurrentLocal: database.prepare(SELECT_CURRENT_LOCAL),
-  selectExistingCommit: database.prepare(SELECT_EXISTING_COMMIT),
-  selectHead: database.prepare(SELECT_HEAD),
-  selectLatestBase: database.prepare(SELECT_LATEST_BASE),
-  selectLatestSnapshot: database.prepare(SELECT_LATEST_SNAPSHOT),
-  selectNextSeq: database.prepare(SELECT_NEXT_SEQ),
-  selectPatchConflicts: database.prepare(SELECT_PATCH_CONFLICTS),
-  selectPatchCount: database.prepare(SELECT_PATCH_COUNT),
-  selectPatches: database.prepare(SELECT_PATCHES),
-  selectPendingResolution: database.prepare(SELECT_PENDING_RESOLUTION),
-  selectServerSeq: database.prepare(SELECT_SERVER_SEQ),
-  selectSetDeleteConflict: database.prepare(SELECT_SET_DELETE_CONFLICT),
-  upsertHead: database.prepare(UPSERT_HEAD),
-  updateBranchHead: database.prepare(UPDATE_BRANCH_HEAD),
-  deleteBranch: database.prepare(DELETE_BRANCH),
-  deleteOldSnapshots: database.prepare(DELETE_OLD_SNAPSHOTS),
-});
+const prepareStatements = (
+  database: Database,
+  token: string,
+): PreparedStatements => {
+  const sql = buildStatements(coreTableNames(token));
+  return {
+    insertAuthorization: database.prepare(sql.insertAuthorization),
+    insertBlob: database.prepare(sql.insertBlob),
+    insertBranch: database.prepare(sql.insertBranch),
+    insertCommit: database.prepare(sql.insertCommit),
+    insertInvocation: database.prepare(sql.insertInvocation),
+    insertRevision: database.prepare(sql.insertRevision),
+    insertSnapshot: database.prepare(sql.insertSnapshot),
+    selectAtSeqLocal: database.prepare(sql.selectAtSeqLocal),
+    selectBlob: database.prepare(sql.selectBlob),
+    selectBranch: database.prepare(sql.selectBranch),
+    selectBranches: database.prepare(sql.selectBranches),
+    selectBranchHeadSeq: database.prepare(sql.selectBranchHeadSeq),
+    selectBranchStatus: database.prepare(sql.selectBranchStatus),
+    selectCommitRevisions: database.prepare(sql.selectCommitRevisions),
+    selectCurrentLocal: database.prepare(sql.selectCurrentLocal),
+    selectExistingCommit: database.prepare(sql.selectExistingCommit),
+    selectHead: database.prepare(sql.selectHead),
+    selectLatestBase: database.prepare(sql.selectLatestBase),
+    selectLatestSnapshot: database.prepare(sql.selectLatestSnapshot),
+    selectNextSeq: database.prepare(sql.selectNextSeq),
+    selectPatchConflicts: database.prepare(sql.selectPatchConflicts),
+    selectPatchCount: database.prepare(sql.selectPatchCount),
+    selectPatches: database.prepare(sql.selectPatches),
+    selectPendingResolution: database.prepare(sql.selectPendingResolution),
+    selectServerSeq: database.prepare(sql.selectServerSeq),
+    selectSetDeleteConflict: database.prepare(sql.selectSetDeleteConflict),
+    upsertHead: database.prepare(sql.upsertHead),
+    updateBranchHead: database.prepare(sql.updateBranchHead),
+    deleteBranch: database.prepare(sql.deleteBranch),
+    deleteOldSnapshots: database.prepare(sql.deleteOldSnapshots),
+  };
+};
 
+// `table` is an already-quoted core-table identifier (e.g. `"commit"` or
+// `"revision__<token>"`); PRAGMA table_info accepts a quoted name directly.
 const hasColumn = (
   database: Database,
   table: string,
   column: string,
 ): boolean => {
-  const rows = database.prepare(`PRAGMA table_info("${table}")`).all() as Array<
+  const rows = database.prepare(`PRAGMA table_info(${table})`).all() as Array<
     { name: string }
   >;
   return rows.some((row) => row.name === column);
 };
 
 const primaryKeyColumns = (database: Database, table: string): string[] => {
-  const rows = database.prepare(`PRAGMA table_info("${table}")`).all() as Array<
+  const rows = database.prepare(`PRAGMA table_info(${table})`).all() as Array<
     { name: string; pk: number }
   >;
   return rows
@@ -985,8 +1087,11 @@ const indexColumns = (database: Database, index: string): string[] => {
     .map((row) => row.name);
 };
 
-const migrateScopedEntityTables = (database: Database): void => {
-  if (hasColumn(database, "revision", "scope_key")) {
+const migrateScopedEntityTables = (
+  database: Database,
+  T: CoreTableNames,
+): void => {
+  if (hasColumn(database, T.revision, "scope_key")) {
     return;
   }
 
@@ -999,11 +1104,11 @@ DROP INDEX IF EXISTS idx_revision_branch;
 DROP INDEX IF EXISTS idx_head_branch;
 DROP INDEX IF EXISTS idx_snapshot_lookup;
 
-ALTER TABLE revision RENAME TO revision_unscoped_migration;
-ALTER TABLE head RENAME TO head_unscoped_migration;
-ALTER TABLE snapshot RENAME TO snapshot_unscoped_migration;
+ALTER TABLE ${T.revision} RENAME TO revision_unscoped_migration;
+ALTER TABLE ${T.head} RENAME TO head_unscoped_migration;
+ALTER TABLE ${T.snapshot} RENAME TO snapshot_unscoped_migration;
 
-CREATE TABLE revision (
+CREATE TABLE ${T.revision} (
   branch      TEXT    NOT NULL DEFAULT '',
   id          TEXT    NOT NULL,
   scope_key   TEXT    NOT NULL DEFAULT 'space',
@@ -1013,16 +1118,16 @@ CREATE TABLE revision (
   data        JSON,
   commit_seq  INTEGER NOT NULL,
   PRIMARY KEY (branch, id, scope_key, seq, op_index),
-  FOREIGN KEY (commit_seq) REFERENCES "commit"(seq)
+  FOREIGN KEY (commit_seq) REFERENCES ${T.commit}(seq)
 );
 CREATE INDEX idx_revision_branch_id_seq
-  ON revision (branch, id, scope_key, seq, op_index);
+  ON ${T.revision} (branch, id, scope_key, seq, op_index);
 CREATE INDEX idx_revision_commit
-  ON revision (commit_seq);
+  ON ${T.revision} (commit_seq);
 CREATE INDEX idx_revision_branch
-  ON revision (branch, seq);
+  ON ${T.revision} (branch, seq);
 
-CREATE TABLE head (
+CREATE TABLE ${T.head} (
   branch    TEXT    NOT NULL,
   id        TEXT    NOT NULL,
   scope_key TEXT    NOT NULL DEFAULT 'space',
@@ -1030,9 +1135,9 @@ CREATE TABLE head (
   op_index  INTEGER NOT NULL,
   PRIMARY KEY (branch, id, scope_key)
 );
-CREATE INDEX idx_head_branch ON head (branch);
+CREATE INDEX idx_head_branch ON ${T.head} (branch);
 
-CREATE TABLE snapshot (
+CREATE TABLE ${T.snapshot} (
   branch    TEXT    NOT NULL DEFAULT '',
   id        TEXT    NOT NULL,
   scope_key TEXT    NOT NULL DEFAULT 'space',
@@ -1041,17 +1146,17 @@ CREATE TABLE snapshot (
   PRIMARY KEY (branch, id, scope_key, seq)
 );
 CREATE INDEX idx_snapshot_lookup
-  ON snapshot (branch, id, scope_key, seq);
+  ON ${T.snapshot} (branch, id, scope_key, seq);
 
-INSERT INTO revision (branch, id, scope_key, seq, op_index, op, data, commit_seq)
+INSERT INTO ${T.revision} (branch, id, scope_key, seq, op_index, op, data, commit_seq)
 SELECT branch, id, 'space', seq, op_index, op, data, commit_seq
 FROM revision_unscoped_migration;
 
-INSERT INTO head (branch, id, scope_key, seq, op_index)
+INSERT INTO ${T.head} (branch, id, scope_key, seq, op_index)
 SELECT branch, id, 'space', seq, op_index
 FROM head_unscoped_migration;
 
-INSERT INTO snapshot (branch, id, scope_key, seq, value)
+INSERT INTO ${T.snapshot} (branch, id, scope_key, seq, value)
 SELECT branch, id, 'space', seq, value
 FROM snapshot_unscoped_migration;
 
@@ -1063,38 +1168,47 @@ COMMIT;
 `);
 };
 
-const migrateSchedulerReadIndexOwnerSpace = (database: Database): void => {
-  if (hasColumn(database, "scheduler_read_index", "owner_space")) {
+const migrateSchedulerReadIndexOwnerSpace = (
+  database: Database,
+  T: CoreTableNames,
+): void => {
+  if (hasColumn(database, T.scheduler_read_index, "owner_space")) {
     return;
   }
 
   database.exec(`
-ALTER TABLE scheduler_read_index
+ALTER TABLE ${T.scheduler_read_index}
 ADD COLUMN owner_space TEXT;
 `);
 };
 
-const migrateSchedulerWriteIndexOwnerSpace = (database: Database): void => {
-  if (hasColumn(database, "scheduler_write_index", "owner_space")) {
+const migrateSchedulerWriteIndexOwnerSpace = (
+  database: Database,
+  T: CoreTableNames,
+): void => {
+  if (hasColumn(database, T.scheduler_write_index, "owner_space")) {
     return;
   }
 
   database.exec(`
-ALTER TABLE scheduler_write_index
+ALTER TABLE ${T.scheduler_write_index}
 ADD COLUMN owner_space TEXT NOT NULL DEFAULT '';
 `);
 };
 
-const migrateSchedulerActionSnapshotMetadata = (database: Database): void => {
-  if (!hasColumn(database, "scheduler_action_snapshot", "commit_seq")) {
+const migrateSchedulerActionSnapshotMetadata = (
+  database: Database,
+  T: CoreTableNames,
+): void => {
+  if (!hasColumn(database, T.scheduler_action_snapshot, "commit_seq")) {
     database.exec(`
-ALTER TABLE scheduler_action_snapshot
+ALTER TABLE ${T.scheduler_action_snapshot}
 ADD COLUMN commit_seq INTEGER;
 `);
   }
-  if (!hasColumn(database, "scheduler_action_snapshot", "observed_at_seq")) {
+  if (!hasColumn(database, T.scheduler_action_snapshot, "observed_at_seq")) {
     database.exec(`
-ALTER TABLE scheduler_action_snapshot
+ALTER TABLE ${T.scheduler_action_snapshot}
 ADD COLUMN observed_at_seq INTEGER NOT NULL DEFAULT 0;
 `);
   }
@@ -1102,9 +1216,10 @@ ADD COLUMN observed_at_seq INTEGER NOT NULL DEFAULT 0;
 
 const migrateSchedulerActionSnapshotOwnerSpaceKey = (
   database: Database,
+  T: CoreTableNames,
 ): void => {
   if (
-    primaryKeyColumns(database, "scheduler_action_snapshot").includes(
+    primaryKeyColumns(database, T.scheduler_action_snapshot).includes(
       "owner_space",
     )
   ) {
@@ -1113,7 +1228,7 @@ const migrateSchedulerActionSnapshotOwnerSpaceKey = (
 
   const ownerSpaceSelect = hasColumn(
       database,
-      "scheduler_action_snapshot",
+      T.scheduler_action_snapshot,
       "owner_space",
     )
     ? "COALESCE(owner_space, '')"
@@ -1122,10 +1237,10 @@ const migrateSchedulerActionSnapshotOwnerSpaceKey = (
   database.exec(`
 BEGIN TRANSACTION;
 
-ALTER TABLE scheduler_action_snapshot
+ALTER TABLE ${T.scheduler_action_snapshot}
 RENAME TO scheduler_action_snapshot_owner_space_migration;
 
-CREATE TABLE scheduler_action_snapshot (
+CREATE TABLE ${T.scheduler_action_snapshot} (
   branch              TEXT    NOT NULL DEFAULT '',
   owner_space         TEXT    NOT NULL DEFAULT '',
   piece_id            TEXT    NOT NULL,
@@ -1143,10 +1258,10 @@ CREATE TABLE scheduler_action_snapshot (
     action_id
   ),
   FOREIGN KEY (observation_id)
-    REFERENCES scheduler_observation(observation_id)
+    REFERENCES ${T.scheduler_observation}(observation_id)
 );
 
-INSERT OR REPLACE INTO scheduler_action_snapshot (
+INSERT OR REPLACE INTO ${T.scheduler_action_snapshot} (
   branch,
   owner_space,
   piece_id,
@@ -1177,9 +1292,10 @@ COMMIT;
 
 const migrateSchedulerActionStateOwnerSpaceKey = (
   database: Database,
+  T: CoreTableNames,
 ): void => {
   if (
-    primaryKeyColumns(database, "scheduler_action_state").includes(
+    primaryKeyColumns(database, T.scheduler_action_state).includes(
       "owner_space",
     )
   ) {
@@ -1188,7 +1304,7 @@ const migrateSchedulerActionStateOwnerSpaceKey = (
 
   const ownerSpaceSelect = hasColumn(
       database,
-      "scheduler_action_state",
+      T.scheduler_action_state,
       "owner_space",
     )
     ? "COALESCE(owner_space, '')"
@@ -1197,10 +1313,10 @@ const migrateSchedulerActionStateOwnerSpaceKey = (
   database.exec(`
 BEGIN TRANSACTION;
 
-ALTER TABLE scheduler_action_state
+ALTER TABLE ${T.scheduler_action_state}
 RENAME TO scheduler_action_state_owner_space_migration;
 
-CREATE TABLE scheduler_action_state (
+CREATE TABLE ${T.scheduler_action_state} (
   branch                 TEXT    NOT NULL DEFAULT '',
   owner_space            TEXT    NOT NULL DEFAULT '',
   piece_id               TEXT    NOT NULL,
@@ -1218,10 +1334,10 @@ CREATE TABLE scheduler_action_state (
     action_id
   ),
   FOREIGN KEY (latest_observation_id)
-    REFERENCES scheduler_observation(observation_id)
+    REFERENCES ${T.scheduler_observation}(observation_id)
 );
 
-INSERT OR REPLACE INTO scheduler_action_state (
+INSERT OR REPLACE INTO ${T.scheduler_action_state} (
   branch,
   owner_space,
   piece_id,
@@ -1250,7 +1366,10 @@ COMMIT;
 `);
 };
 
-const migrateSchedulerActionIndexes = (database: Database): void => {
+const migrateSchedulerActionIndexes = (
+  database: Database,
+  T: CoreTableNames,
+): void => {
   const readIndexHasOwnerSpace = indexColumns(
     database,
     "idx_scheduler_read_index_action",
@@ -1266,7 +1385,7 @@ const migrateSchedulerActionIndexes = (database: Database): void => {
   database.exec(`
 DROP INDEX IF EXISTS idx_scheduler_read_index_action;
 CREATE INDEX idx_scheduler_read_index_action
-  ON scheduler_read_index (
+  ON ${T.scheduler_read_index} (
     branch,
     owner_space,
     piece_id,
@@ -1276,7 +1395,7 @@ CREATE INDEX idx_scheduler_read_index_action
 
 DROP INDEX IF EXISTS idx_scheduler_write_index_action;
 CREATE INDEX idx_scheduler_write_index_action
-  ON scheduler_write_index (
+  ON ${T.scheduler_write_index} (
     branch,
     owner_space,
     piece_id,
@@ -1286,18 +1405,21 @@ CREATE INDEX idx_scheduler_write_index_action
 `);
 };
 
-const migrateSchedulerObservationReplayStatus = (database: Database): void => {
-  if (hasColumn(database, "scheduler_observation_replay", "status")) {
+const migrateSchedulerObservationReplayStatus = (
+  database: Database,
+  T: CoreTableNames,
+): void => {
+  if (hasColumn(database, T.scheduler_observation_replay, "status")) {
     return;
   }
 
   database.exec(`
 BEGIN TRANSACTION;
 
-ALTER TABLE scheduler_observation_replay
+ALTER TABLE ${T.scheduler_observation_replay}
 RENAME TO scheduler_observation_replay_legacy;
 
-CREATE TABLE scheduler_observation_replay (
+CREATE TABLE ${T.scheduler_observation_replay} (
   branch              TEXT    NOT NULL DEFAULT '',
   session_id          TEXT    NOT NULL,
   local_seq           INTEGER NOT NULL,
@@ -1309,10 +1431,10 @@ CREATE TABLE scheduler_observation_replay (
   created_at          TEXT    NOT NULL DEFAULT (datetime('now')),
   PRIMARY KEY (branch, session_id, local_seq),
   FOREIGN KEY (observation_id)
-    REFERENCES scheduler_observation(observation_id)
+    REFERENCES ${T.scheduler_observation}(observation_id)
 );
 
-INSERT INTO scheduler_observation_replay (
+INSERT INTO ${T.scheduler_observation_replay} (
   branch,
   session_id,
   local_seq,
@@ -1339,32 +1461,78 @@ COMMIT;
 `);
 };
 
+/**
+ * Bring a legacy (bare-named) core-table database up to space-scoped names. For
+ * each of the 14 core tables: when a non-empty token is in effect, if the bare
+ * table exists and the scoped one does not, rename it. SQLite auto-rewrites FK
+ * references on RENAME (legacy_alter_table=off), so pure renames suffice.
+ * Idempotent — already-scoped or absent tables are skipped.
+ */
+const migrateCoreTablesToSpaceScoped = (
+  database: Database,
+  token: string,
+): void => {
+  if (token === "") {
+    return;
+  }
+  const tableExists = (name: string): boolean =>
+    (database.prepare(`PRAGMA table_info("${name}")`).all() as unknown[])
+      .length > 0;
+
+  database.exec("BEGIN TRANSACTION;");
+  try {
+    for (const key of CORE_TABLE_KEYS) {
+      const bare = key; // bare identifier (e.g. `commit`, `revision`)
+      const scoped = `${key}__${token}`;
+      if (tableExists(bare) && !tableExists(scoped)) {
+        database.exec(
+          `ALTER TABLE "${bare}" RENAME TO "${scoped}";`,
+        );
+      }
+    }
+    database.exec("COMMIT;");
+  } catch (error) {
+    database.exec("ROLLBACK;");
+    throw error;
+  }
+};
+
 export const open = async (
   {
     url,
+    space,
     snapshotInterval = DEFAULT_SNAPSHOT_INTERVAL,
     snapshotRetention = DEFAULT_SNAPSHOT_RETENTION,
   }: OpenOptions,
 ): Promise<Engine> => {
+  const token = scopeToken(space);
+  const tableNames = coreTableNames(token);
   const database = await new Database(toDatabaseAddress(url), { create: true });
   database.exec(NEW_DB_PRAGMAS);
   database.exec(PRAGMAS);
-  database.exec(INIT);
-  migrateScopedEntityTables(database);
-  migrateSchedulerReadIndexOwnerSpace(database);
-  migrateSchedulerWriteIndexOwnerSpace(database);
-  migrateSchedulerActionSnapshotMetadata(database);
-  migrateSchedulerActionSnapshotOwnerSpaceKey(database);
-  migrateSchedulerActionStateOwnerSpaceKey(database);
-  migrateSchedulerActionIndexes(database);
-  migrateSchedulerObservationReplayStatus(database);
+  // Bring legacy bare-named core tables to scoped names FIRST, so the scoped
+  // schema bootstrap and migrations below see the renamed tables.
+  migrateCoreTablesToSpaceScoped(database, token);
+  database.exec(buildInit(tableNames));
+  migrateScopedEntityTables(database, tableNames);
+  migrateSchedulerReadIndexOwnerSpace(database, tableNames);
+  migrateSchedulerWriteIndexOwnerSpace(database, tableNames);
+  migrateSchedulerActionSnapshotMetadata(database, tableNames);
+  migrateSchedulerActionSnapshotOwnerSpaceKey(database, tableNames);
+  migrateSchedulerActionStateOwnerSpaceKey(database, tableNames);
+  migrateSchedulerActionIndexes(database, tableNames);
+  migrateSchedulerObservationReplayStatus(database, tableNames);
   return {
     url,
     database,
     snapshotInterval,
     snapshotRetention,
-    legacyCommitMetadataRefsRequired: commitMetadataRefsRequired(database),
-    statements: prepareStatements(database),
+    tableNames,
+    legacyCommitMetadataRefsRequired: commitMetadataRefsRequired(
+      database,
+      tableNames,
+    ),
+    statements: prepareStatements(database, token),
   };
 };
 
@@ -1651,8 +1819,8 @@ export const getLatestSchedulerActionSnapshot = (
       COALESCE(s.commit_seq, o.commit_seq) AS commit_seq,
       s.observed_at_seq AS observed_at_seq,
       s.payload
-    FROM scheduler_action_snapshot s
-    JOIN scheduler_observation o
+    FROM ${engine.tableNames.scheduler_action_snapshot} s
+    JOIN ${engine.tableNames.scheduler_observation} o
       ON o.observation_id = s.observation_id
     WHERE s.branch = :branch
       AND s.owner_space = :owner_space
@@ -1713,10 +1881,10 @@ export const listSchedulerActionSnapshots = (
       a.direct_dirty_seq,
       a.stale_seq,
       a.unknown_reason
-    FROM scheduler_action_snapshot s
-    JOIN scheduler_observation o
+    FROM ${engine.tableNames.scheduler_action_snapshot} s
+    JOIN ${engine.tableNames.scheduler_observation} o
       ON o.observation_id = s.observation_id
-    LEFT JOIN scheduler_action_state a
+    LEFT JOIN ${engine.tableNames.scheduler_action_state} a
       ON a.branch = s.branch
       AND a.owner_space = s.owner_space
       AND a.piece_id = s.piece_id
@@ -1837,7 +2005,7 @@ export const findSchedulerReadersForWrite = (
       process_generation,
       action_id,
       observation_id
-    FROM scheduler_read_index
+    FROM ${engine.tableNames.scheduler_read_index}
     WHERE branch = :branch
       AND read_space = :read_space
       AND read_id = :read_id
@@ -1957,7 +2125,7 @@ export const getSchedulerActionState = (
       direct_dirty_seq,
       stale_seq,
       unknown_reason
-    FROM scheduler_action_state
+    FROM ${engine.tableNames.scheduler_action_state}
     WHERE branch = :branch
       AND owner_space = :owner_space
       AND piece_id = :piece_id
@@ -2007,7 +2175,7 @@ function markSchedulerActionDirectDirty(
   dirtySeq: number,
 ): void {
   engine.database.prepare(`
-    INSERT INTO scheduler_action_state (
+    INSERT INTO ${engine.tableNames.scheduler_action_state} (
       branch,
       owner_space,
       piece_id,
@@ -2052,7 +2220,7 @@ function markSchedulerActionStale(
   staleSeq: number,
 ): void {
   engine.database.prepare(`
-    INSERT INTO scheduler_action_state (
+    INSERT INTO ${engine.tableNames.scheduler_action_state} (
       branch,
       owner_space,
       piece_id,
@@ -2139,7 +2307,7 @@ function schedulerWritesForAction(
       write_id,
       write_scope,
       write_path
-    FROM scheduler_write_index
+    FROM ${engine.tableNames.scheduler_write_index}
     WHERE branch = :branch
       AND owner_space = :owner_space
       AND piece_id = :piece_id
@@ -2333,8 +2501,8 @@ function selectSchedulerSnapshotRow(
       COALESCE(s.commit_seq, o.commit_seq) AS commit_seq,
       s.observed_at_seq AS observed_at_seq,
       s.payload
-    FROM scheduler_action_snapshot s
-    JOIN scheduler_observation o
+    FROM ${engine.tableNames.scheduler_action_snapshot} s
+    JOIN ${engine.tableNames.scheduler_observation} o
       ON o.observation_id = s.observation_id
     WHERE s.branch = :branch
       AND s.owner_space = :owner_space
@@ -2383,7 +2551,7 @@ function insertSchedulerObservationRow(
 ): number {
   runSchedulerObservationStatement("insert observation row", () => {
     engine.database.prepare(`
-      INSERT INTO scheduler_observation (
+      INSERT INTO ${engine.tableNames.scheduler_observation} (
         branch,
         commit_seq,
         observed_at_seq,
@@ -2434,7 +2602,7 @@ function updateSchedulerObservationRow(
 ): void {
   runSchedulerObservationStatement("update observation row", () => {
     engine.database.prepare(`
-      UPDATE scheduler_observation
+      UPDATE ${engine.tableNames.scheduler_observation}
       SET
         commit_seq = :commit_seq,
         observed_at_seq = :observed_at_seq,
@@ -2470,7 +2638,7 @@ function recordSchedulerObservationReplay(
 ): void {
   runSchedulerObservationStatement("record observation replay", () => {
     engine.database.prepare(`
-      INSERT INTO scheduler_observation_replay (
+      INSERT INTO ${engine.tableNames.scheduler_observation_replay} (
         branch,
         session_id,
         local_seq,
@@ -2526,7 +2694,7 @@ function getSchedulerObservationReplay(
 } | undefined {
   return engine.database.prepare(`
     SELECT status, reason, observation_id, observed_at_seq, payload
-    FROM scheduler_observation_replay
+    FROM ${engine.tableNames.scheduler_observation_replay}
     WHERE branch = :branch
       AND session_id = :session_id
       AND local_seq = :local_seq
@@ -2555,7 +2723,7 @@ function upsertSchedulerSnapshot(
   },
 ): void {
   engine.database.prepare(`
-    INSERT INTO scheduler_action_snapshot (
+    INSERT INTO ${engine.tableNames.scheduler_action_snapshot} (
       branch,
       owner_space,
       piece_id,
@@ -2702,7 +2870,7 @@ function reconcileSchedulerReadRows(
       process_generation,
       action_id,
       observation_id
-    FROM scheduler_read_index
+    FROM ${engine.tableNames.scheduler_read_index}
     WHERE branch = :branch
       AND COALESCE(owner_space, '') = :owner_space
       AND piece_id = :piece_id
@@ -2716,7 +2884,7 @@ function reconcileSchedulerReadRows(
   );
 
   const deleteReadRow = engine.database.prepare(`
-    DELETE FROM scheduler_read_index
+    DELETE FROM ${engine.tableNames.scheduler_read_index}
     WHERE branch = :branch
       AND owner_space IS :owner_space
       AND read_space = :read_space
@@ -2730,7 +2898,7 @@ function reconcileSchedulerReadRows(
   `);
 
   const insertReadRow = engine.database.prepare(`
-    INSERT INTO scheduler_read_index (
+    INSERT INTO ${engine.tableNames.scheduler_read_index} (
       branch,
       owner_space,
       read_space,
@@ -2763,7 +2931,7 @@ function reconcileSchedulerReadRows(
     keyForRow: schedulerReadIndexKey,
     deleteAllRows: () => {
       engine.database.prepare(`
-        DELETE FROM scheduler_read_index
+        DELETE FROM ${engine.tableNames.scheduler_read_index}
         WHERE branch = :branch
           AND COALESCE(owner_space, '') = :owner_space
           AND piece_id = :piece_id
@@ -2868,7 +3036,7 @@ function reconcileSchedulerWriteRows(
       process_generation,
       action_id,
       observation_id
-    FROM scheduler_write_index
+    FROM ${engine.tableNames.scheduler_write_index}
     WHERE branch = :branch
       AND owner_space = :owner_space
       AND piece_id = :piece_id
@@ -2882,7 +3050,7 @@ function reconcileSchedulerWriteRows(
   );
 
   const deleteWriteRow = engine.database.prepare(`
-    DELETE FROM scheduler_write_index
+    DELETE FROM ${engine.tableNames.scheduler_write_index}
     WHERE branch = :branch
       AND owner_space = :owner_space
       AND write_space = :write_space
@@ -2896,7 +3064,7 @@ function reconcileSchedulerWriteRows(
   `);
 
   const insertWriteRow = engine.database.prepare(`
-    INSERT INTO scheduler_write_index (
+    INSERT INTO ${engine.tableNames.scheduler_write_index} (
       branch,
       owner_space,
       write_space,
@@ -2929,7 +3097,7 @@ function reconcileSchedulerWriteRows(
     keyForRow: schedulerWriteIndexKey,
     deleteAllRows: () => {
       engine.database.prepare(`
-        DELETE FROM scheduler_write_index
+        DELETE FROM ${engine.tableNames.scheduler_write_index}
         WHERE branch = :branch
           AND owner_space = :owner_space
           AND piece_id = :piece_id
@@ -2979,7 +3147,7 @@ function upsertSchedulerActionState(
   },
 ): void {
   engine.database.prepare(`
-    INSERT INTO scheduler_action_state (
+    INSERT INTO ${engine.tableNames.scheduler_action_state} (
       branch,
       owner_space,
       piece_id,
@@ -4169,11 +4337,17 @@ const LEGACY_EMPTY_INVOCATION: InvocationRecord = {
 };
 const LEGACY_EMPTY_AUTHORIZATION: AuthorizationRecord = {};
 
-const commitMetadataRefsRequired = (database: Database): boolean => {
-  const rows = database.prepare(`PRAGMA table_info("commit")`).all() as Array<{
-    name: string;
-    notnull: number;
-  }>;
+const commitMetadataRefsRequired = (
+  database: Database,
+  T: CoreTableNames,
+): boolean => {
+  // `T.commit` is already a quoted identifier (`"commit"` or `"commit__<tok>"`);
+  // PRAGMA table_info accepts a quoted table name directly.
+  const rows = database.prepare(`PRAGMA table_info(${T.commit})`)
+    .all() as Array<{
+      name: string;
+      notnull: number;
+    }>;
   const byName = new Map(rows.map((row) => [row.name, row.notnull] as const));
   return byName.get("invocation_ref") === 1 ||
     byName.get("authorization_ref") === 1;

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -1476,20 +1476,39 @@ const migrateCoreTablesToSpaceScoped = (
     return;
   }
 
+  // Detect a core set scoped under a DIFFERENT token (a prior `commit__<old>`).
+  // This makes the rename SELF-HEALING: if the token derivation ever changes,
+  // we re-scope the existing tables to the current token in place instead of
+  // orphaning the data behind stale `<core>__<old>` names (the engine recomputes
+  // the token from the DID each open and stores no marker). `_` is a LIKE
+  // wildcard, so escape the literal `__`.
+  const priorToken = ((): string | undefined => {
+    const row = database.prepare(
+      `SELECT name FROM sqlite_master WHERE type = 'table' ` +
+        `AND name LIKE 'commit\\_\\_%' ESCAPE '\\' LIMIT 1`,
+    ).get() as { name?: string } | undefined;
+    const old = row?.name?.slice("commit__".length);
+    return old && old !== token ? old : undefined;
+  })();
+
   // `ALTER TABLE … RENAME TO` only auto-rewrites FK references in OTHER tables
   // when legacy_alter_table is OFF (the default). Pin it so a renamed parent
   // (e.g. `commit`) doesn't leave child FK clauses (`revision`, `scheduler_*`)
-  // pointing at the vanished bare name.
+  // pointing at the vanished source name.
   database.exec("PRAGMA legacy_alter_table = OFF;");
   database.exec("BEGIN TRANSACTION;");
   try {
     for (const key of CORE_TABLE_KEYS) {
-      const bare = key; // bare identifier (e.g. `commit`, `revision`)
       const scoped = `${key}__${token}`;
-      if (tableExists(bare) && !tableExists(scoped)) {
-        database.exec(
-          `ALTER TABLE "${bare}" RENAME TO "${scoped}";`,
-        );
+      if (tableExists(scoped)) continue;
+      // Rename from the legacy bare name, else from the prior-token name.
+      const source = tableExists(key)
+        ? key
+        : (priorToken && tableExists(`${key}__${priorToken}`))
+        ? `${key}__${priorToken}`
+        : undefined;
+      if (source !== undefined) {
+        database.exec(`ALTER TABLE "${source}" RENAME TO "${scoped}";`);
       }
     }
     database.exec("COMMIT;");

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -1483,12 +1483,25 @@ const migrateCoreTablesToSpaceScoped = (
   // the token from the DID each open and stores no marker). `_` is a LIKE
   // wildcard, so escape the literal `__`.
   const priorToken = ((): string | undefined => {
-    const row = database.prepare(
+    const rows = database.prepare(
       `SELECT name FROM sqlite_master WHERE type = 'table' ` +
-        `AND name LIKE 'commit\\_\\_%' ESCAPE '\\' LIMIT 1`,
-    ).get() as { name?: string } | undefined;
-    const old = row?.name?.slice("commit__".length);
-    return old && old !== token ? old : undefined;
+        `AND name LIKE 'commit\\_\\_%' ESCAPE '\\'`,
+    ).all() as Array<{ name: string }>;
+    const tokens = [
+      ...new Set(rows.map((r) => r.name.slice("commit__".length))),
+    ].filter((t) => t.length > 0 && t !== token);
+    if (tokens.length > 1) {
+      // More than one prior token in a single db means an inconsistent/
+      // unexpected state (one file is one space → one token). Re-scoping an
+      // arbitrary one would leave the others orphaned, so fail loudly rather
+      // than guess.
+      throw new Error(
+        `ambiguous core-table scoping: multiple prior tokens [${
+          tokens.join(", ")
+        }] in one database`,
+      );
+    }
+    return tokens[0];
   })();
 
   // `ALTER TABLE … RENAME TO` only auto-rewrites FK references in OTHER tables

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -1,4 +1,5 @@
 import { Database } from "@db/sqlite";
+import { encodeHex } from "@std/encoding/hex";
 import type { FabricValue } from "../interface.ts";
 import { runWrite } from "./sqlite/exec.ts";
 import { applyPatch } from "./patch.ts";
@@ -96,9 +97,7 @@ const scopeToken = async (space: string | undefined): Promise<string> => {
     "SHA-256",
     new TextEncoder().encode(space),
   );
-  return Array.from(new Uint8Array(digest).subarray(0, 16))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("");
+  return encodeHex(new Uint8Array(digest).subarray(0, 16));
 };
 
 /** The 14 core engine tables, scoped per-space so they never collide with an
@@ -144,29 +143,16 @@ const CORE_TABLE_KEYS: readonly (keyof CoreTableNames)[] = [
  * table becomes the quoted scoped identifier `"<table>__<token>"`.
  */
 const coreTableNames = (token: string): CoreTableNames => {
-  if (token === "") {
-    return {
-      authorization: "authorization",
-      invocation: "invocation",
-      commit: `"commit"`,
-      revision: "revision",
-      head: "head",
-      snapshot: "snapshot",
-      branch: "branch",
-      blob_store: "blob_store",
-      scheduler_observation: "scheduler_observation",
-      scheduler_action_snapshot: "scheduler_action_snapshot",
-      scheduler_observation_replay: "scheduler_observation_replay",
-      scheduler_read_index: "scheduler_read_index",
-      scheduler_write_index: "scheduler_write_index",
-      scheduler_action_state: "scheduler_action_state",
-    };
-  }
-  const scoped = {} as CoreTableNames;
+  const names = {} as CoreTableNames;
   for (const key of CORE_TABLE_KEYS) {
-    scoped[key] = `"${key}__${token}"`;
+    // Empty token => byte-identical legacy names: `commit` is the only reserved
+    // word, so it stays quoted; the rest were bare. Non-empty => all quoted and
+    // scoped.
+    names[key] = token === ""
+      ? (key === "commit" ? `"commit"` : key)
+      : `"${key}__${token}"`;
   }
-  return scoped;
+  return names;
 };
 
 const PRAGMAS = `
@@ -1483,6 +1469,18 @@ const migrateCoreTablesToSpaceScoped = (
     (database.prepare(`PRAGMA table_info("${name}")`).all() as unknown[])
       .length > 0;
 
+  // Fast path: already scoped (the common case — every reopen). `commit` is
+  // always present once the schema is bootstrapped, so its scoped form is a
+  // reliable marker; skip the probes + write transaction entirely.
+  if (tableExists(`commit__${token}`)) {
+    return;
+  }
+
+  // `ALTER TABLE … RENAME TO` only auto-rewrites FK references in OTHER tables
+  // when legacy_alter_table is OFF (the default). Pin it so a renamed parent
+  // (e.g. `commit`) doesn't leave child FK clauses (`revision`, `scheduler_*`)
+  // pointing at the vanished bare name.
+  database.exec("PRAGMA legacy_alter_table = OFF;");
   database.exec("BEGIN TRANSACTION;");
   try {
     for (const key of CORE_TABLE_KEYS) {

--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -83,18 +83,22 @@ const declaredScopeFromScopeKey = (scopeKey: string): CellScope => {
   return "space";
 };
 
-// Identifier-safe, stable-per-space token for scoping core table names (FNV-1a
-// 32-bit + length, hex). Empty space => "" (legacy bare names, back-compat).
-const scopeToken = (space: string | undefined): string => {
+// Identifier-safe, stable-per-space token for scoping core table names. Empty
+// space => "" (legacy bare names, back-compat).
+const scopeToken = async (space: string | undefined): Promise<string> => {
   if (!space) return "";
-  let h = 0x811c9dc5;
-  for (let i = 0; i < space.length; i++) {
-    h ^= space.charCodeAt(i);
-    h = Math.imul(h, 0x01000193);
-  }
-  return `${(h >>> 0).toString(16).padStart(8, "0")}${
-    space.length.toString(16)
-  }`;
+  // Core table names must be GLOBALLY disjoint across spaces (two spaces' tables
+  // may share one connection for cross-space transactions), so a token collision
+  // would silently alias data. Use 128 bits of SHA-256 — collision-resistant
+  // even for adversarially-chosen space DIDs (a 32-bit hash is birthday-bounded
+  // at ~65k spaces and trivially collidable).
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(space),
+  );
+  return Array.from(new Uint8Array(digest).subarray(0, 16))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
 };
 
 /** The 14 core engine tables, scoped per-space so they never collide with an
@@ -1505,7 +1509,7 @@ export const open = async (
     snapshotRetention = DEFAULT_SNAPSHOT_RETENTION,
   }: OpenOptions,
 ): Promise<Engine> => {
-  const token = scopeToken(space);
+  const token = await scopeToken(space);
   const tableNames = coreTableNames(token);
   const database = await new Database(toDatabaseAddress(url), { create: true });
   database.exec(NEW_DB_PRAGMAS);

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -2058,7 +2058,7 @@ export class Server {
       if (url.protocol === "file:") {
         await FS.ensureDir(Path.toFileUrl(Path.dirname(Path.fromFileUrl(url))));
       }
-      return await Engine.open({ url });
+      return await Engine.open({ url, space });
     })();
     opened.catch(() => {
       if (this.#engines.get(space) === opened) {

--- a/packages/memory/v2/sqlite/guard.ts
+++ b/packages/memory/v2/sqlite/guard.ts
@@ -160,10 +160,19 @@ const TABLE_POS_QUALIFIED_RE =
 
 // Core tables, sqlite_* / pragma_* introspection (sqlite_master, sqlite_schema,
 // pragma_table_info table-valued functions, etc.).
+//
+// Core engine tables are scoped per-space (`commit__<token>` — see engine.ts
+// `coreTableNames`), and that token is a hash of the space's own (public) DID,
+// so a pattern can derive it. We must reject the scoped form too — `commit`
+// AND `commit__<anything>` — otherwise a folded write to `"commit__<token>"`
+// would reach the real core table on the engine connection (`\b…\b` alone does
+// NOT match `commit__…`, since `_` is a word char). The optional `__\w+` only
+// applies to the core-table set, never to a plain `commit_log`/`commitments`
+// (no `__`), so it adds no false positives.
 const CORE_REF_RE = new RegExp(
-  `\\b(?:${
+  `\\b(?:(?:${
     CORE_TABLE_NAMES.join("|")
-  }|sqlite_[A-Za-z0-9_]*|pragma_[A-Za-z0-9_]*)\\b`,
+  })(?:__\\w+)?|sqlite_[A-Za-z0-9_]*|pragma_[A-Za-z0-9_]*)\\b`,
   "i",
 );
 

--- a/packages/memory/v2/sqlite/guard.ts
+++ b/packages/memory/v2/sqlite/guard.ts
@@ -8,9 +8,12 @@
 // engine table names.
 //
 // This is intentionally conservative — it can have minor false positives (e.g.
-// a column literally named `commit`). That residual is documented in
-// docs/specs/sqlite-builtin/08-open-questions.md (Q8a). The full structural fix
-// is the space-DID core-table rename, deferred behind a flag.
+// a column literally named `commit`). The structural fix is now in place: core
+// engine tables are scoped per-space (`commit__<token>` etc. — see
+// engine.ts `coreTableNames`), so an attached cell-db's unqualified `commit`
+// can no longer resolve to a core table. This core-table-name rejection is kept
+// as a belt-and-suspenders backstop during the migration soak and can be
+// dropped once all live dbs are scoped (docs/specs/sqlite-builtin/08-open-questions.md Q8a).
 
 /** Core engine table names a pattern statement must never reference. */
 export const CORE_TABLE_NAMES: readonly string[] = [


### PR DESCRIPTION
Resolves the **core-table shadowing** item (08-open-questions Q8a) and lays the groundwork for **cross-space transactions**.

## Problem
On the folded-write path a pattern cell-db is ATTACHed to the per-space engine connection. An unqualified `INSERT INTO commit …` could resolve to the **core** `commit` table instead of the pattern's own. The mitigation was a tokenizer-guard denylist of core-table names (with a documented false-positive: a pattern could never legitimately name a table `commit`).

## Fix — scope core tables per space (structural, not a guard)
Core engine tables are renamed to `"<table>__<token>"`, where `<token>` is a stable hash of the space DID (`engine.ts` `scopeToken` / `coreTableNames`). With no bare `commit` on the engine connection, an attached cell-db's unqualified `commit` can't shadow anything.

- **Migration, not a flag.** `migrateCoreTablesToSpaceScoped` renames legacy bare tables **in place** on first scoped open — idempotent, and `ALTER TABLE … RENAME TO` (default `legacy_alter_table=off`) auto-rewrites FK references, so it's pure renames (no recreate-and-copy). It runs **first** in the open sequence so the scoped `INIT` and the 8 existing migrations all see scoped names.
- **DID plumbed in.** `open({ url, space })`; `Server.openEngine(space)` supplies the DID. Opening **without** a space keeps byte-identical legacy bare names (back-compat for tools/tests with no DID — you can't scope without a DID).
- **Cross-space groundwork.** Each space's core tables are now globally unique, so two spaces' dbs can be attached to one connection with no name collision — the precondition for cross-space transactions.
- **Guard kept as backstop.** The guard's core-table-name rejection stays as belt-and-suspenders during the migration soak; it can be dropped in a follow-up once all live dbs are scoped.

## Scope
All core-table SQL lives in `engine.ts` (33 consts + `INIT` + 8 migrations) — converted to build from a per-token name map. `server.ts` passes `space`. Index names and column names are left bare (only table-position identifiers are scoped).

## Tests
New `v2-core-table-scoping-test.ts`: scoped-fresh; bare back-compat; **legacy→scoped migration round-trip with data intact + idempotent reopen**; two-space disjoint names + attach-into-one-connection. Full memory suite **164/0**; runner sqlite + e2e **11/0**; check + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes core engine tables per space to remove core-table shadowing and prep cross-space transactions. Uses a collision-resistant 128-bit SHA-256 token; migration runs on open with back-compat when `space` is omitted.

- **Bug Fixes**
  - Guard now rejects scoped core-table forms (`commit__<token>`), closing a bypass that could hit real core tables on folded writes.
  - Hardened migration: pin `PRAGMA legacy_alter_table = OFF`; minor cleanup using `@std/encoding/hex`.

- **Migration**
  - `migrateCoreTablesToSpaceScoped` renames legacy bare tables in place on first scoped open; idempotent, and `ALTER TABLE … RENAME TO` auto-rewrites FKs. Runs before scoped `INIT` and existing migrations.
  - Self-healing: if prior-token tables exist (e.g. `commit__<old>`), re-scopes the full core set to the current token to avoid orphaned data.
  - Refuses to open when multiple prior-token core families coexist to avoid arbitrary re-scoping.
  - Early-out when already scoped; opening without `space` keeps legacy bare names.

<sup>Written for commit 01909053b959112d1d573575c415f566cf2a8dc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

