### PR TITLE
test(skills): make cf-review's load-bearing facts testable

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -43,6 +43,9 @@ jobs:
       - name: 🔎 Type check codebase
         run: deno task check
 
+      - name: 🧭 Check cf-review skill facts
+        run: deno task check-skill-facts
+
   test:
     name: "Test"
     runs-on:

--- a/deno.json
+++ b/deno.json
@@ -37,6 +37,7 @@
   ],
   "tasks": {
     "check": "./tasks/check.sh",
+    "check-skill-facts": "deno test --allow-read skills/cf-review/check-facts.ts",
     "cf": "deno run --allow-run --allow-env --allow-read ./packages/cli/launcher.ts",
     "test": "./tasks/test.ts",
     "test-all": "echo \"Use 'deno task test' instead.\" && exit 1",

--- a/docs/development/skill-audit.md
+++ b/docs/development/skill-audit.md
@@ -51,3 +51,10 @@ cited path may be skill-local rather than repo-root, a token may be illustrative
 (`cf-{name}.figma.ts`), and the worst case — "the home moved but both old and
 new names still exist" — is invisible to a grep. The tripwire stays narrow on
 purpose; the audit carries the judgment.
+
+One row it cannot cover by construction: the cf-review anti-dup table's
+cell↔link entry names a **bare internal symbol** (`convertCellsToLinks` in
+`packages/runner/src/cell.ts`) — an internal runner function with no package
+export, so there's nothing for the resolvability check to resolve. That symbol's
+accuracy is the audit's job, not the tripwire's. (Noted from @mpsalisbury's
+review of #3829.)

--- a/docs/development/skill-audit.md
+++ b/docs/development/skill-audit.md
@@ -1,0 +1,52 @@
+<!-- @reviewed 2026-06-04 -->
+
+# Skill Fact Audit
+
+A skill's map — canonical homes, exact symbols, file paths — is its
+highest-value and highest-rot content (see
+[`skill-authoring.md`](./skill-authoring.md), "facts rot — make them testable").
+Two mechanisms keep it honest, and they are complementary, not alternatives:
+
+- **Tripwire (deterministic floor).** `deno task check-skill-facts` — a cheap,
+  instant, zero-token CI gate that fails if a package or repo path a skill cites
+  stops existing. Runs on every PR (the `check` job). Catches _existence_ rot
+  only, and deliberately hardcodes nothing.
+- **Audit (LLM ceiling).** A periodic / on-change pass that reads a skill against
+  the current tree and judges the _semantic_ rot the tripwire cannot see: a
+  canonical home that moved or was renamed, advice that is now wrong, a new home
+  the skill should mention, framing that has drifted from how the system actually
+  works. This half **appreciates** as models improve — at the limit it is the
+  more useful of the two.
+
+The auditor is **cf-review itself** — do not build a parallel reviewer. cf-review
+already verifies a skill's facts against the tree (it did so unprompted when it
+reviewed its own PR). The audit is just cf-review pointed at a skill.
+
+## Triggers
+
+- **On change** — when a PR touches `skills/**`, give it a cf-review pass. (A
+  norm today; can become a CI job that runs cf-review on the skill diff once
+  agent-in-CI infra is settled.)
+- **Periodic** — on a schedule (e.g. monthly), run the prompt below over each
+  `skills/**/SKILL.md` and open an issue or fix-PR per drift found. Wire it
+  through the repo's scheduled-agent / routine capability.
+
+## Audit prompt
+
+> Read `<skill>/SKILL.md` and audit every load-bearing fact against the current
+> tree. For each canonical home, symbol, path, package export, and behavioral
+> claim it asserts: is it still true? Has a home moved, been renamed, or been
+> removed? Is any "do not" advice stale? Is there a _new_ canonical home or
+> footgun the skill should name but doesn't? Does the framing still match how the
+> system actually works, and is it still coherent with
+> `docs/development/skill-authoring.md`? Verify against the tree (read the code /
+> exports) — don't speculate. Report drift as: location · the claim · what is
+> actually true now · the one-line fix. If everything resolves, say so and stop.
+
+## Why this isn't all in the tripwire
+
+Deterministic extraction of "is this fact still _true_" from prose is brittle: a
+cited path may be skill-local rather than repo-root, a token may be illustrative
+(`cf-{name}.figma.ts`), and the worst case — "the home moved but both old and
+new names still exist" — is invisible to a grep. The tripwire stays narrow on
+purpose; the audit carries the judgment.

--- a/docs/development/skill-audit.md
+++ b/docs/development/skill-audit.md
@@ -8,9 +8,10 @@ highest-value and highest-rot content (see
 Two mechanisms keep it honest, and they are complementary, not alternatives:
 
 - **Tripwire (deterministic floor).** `deno task check-skill-facts` — a cheap,
-  instant, zero-token CI gate that fails if a package or repo path a skill cites
-  stops existing. Runs on every PR (the `check` job). Catches _existence_ rot
-  only, and deliberately hardcodes nothing.
+  instant, zero-token CI gate that fails if an import specifier or repo path a
+  skill cites stops _resolving_: a bare import of a package with no root export,
+  a missing subpath, or a vanished path. Runs on every PR (the `check` job).
+  Catches resolvability rot only, and deliberately hardcodes nothing.
 - **Audit (LLM ceiling).** A periodic / on-change pass that reads a skill against
   the current tree and judges the _semantic_ rot the tripwire cannot see: a
   canonical home that moved or was renamed, advice that is now wrong, a new home

--- a/skills/cf-review/check-facts.ts
+++ b/skills/cf-review/check-facts.ts
@@ -1,14 +1,21 @@
 #!/usr/bin/env -S deno run --allow-read
 /**
  * Deterministic "tripwire" for the cf-review skill: a cheap, instant, zero-token
- * CI gate that fails if a package or repo path the skill cites stops existing.
+ * CI gate that fails if an import specifier or repo path the skill cites does not
+ * resolve against the tree.
  *
- * Scope is deliberately narrow — existence only, and NO hardcoded fact list
- * (that would just re-introduce the rot it guards against). Semantic drift — a
- * canonical home that moved or was renamed, advice that is now wrong, something
- * missing — is the job of the LLM audit (`docs/development/skill-audit.md`), the
- * appreciating half of the pair. Together they implement the "make load-bearing
- * facts testable" guidance in `docs/development/skill-authoring.md`.
+ * It checks two things, and deliberately hardcodes no fact list (that would just
+ * re-introduce the rot it guards):
+ *   1. Every `@commonfabric/...` specifier resolves — a bare package reference
+ *      needs a root (".") export; a subpath needs that subpath in `exports`.
+ *      (A bare reference to a subpath-only package is the bug this caught.)
+ *   2. Every repo-root path cited in backticks exists.
+ *
+ * Semantic drift — a canonical home that moved or was renamed, advice that is now
+ * wrong, something missing — is the job of the LLM audit
+ * (`docs/development/skill-audit.md`), the appreciating half of the pair.
+ * Together they implement "make load-bearing facts testable" from
+ * `docs/development/skill-authoring.md`.
  *
  * Run:  deno task check-skill-facts
  *   or: deno test --allow-read skills/cf-review/check-facts.ts
@@ -27,30 +34,59 @@ const exists = (p: string): boolean => {
   }
 };
 
-/** Existence facts in the cf-review skill that must resolve against the tree. */
+/** Does `key` ("." or "./sub") resolve against a deno.json `exports` value? */
+function resolves(exp: unknown, key: string): boolean {
+  if (typeof exp === "string") return key === "."; // string = root export only
+  if (exp !== null && typeof exp === "object") {
+    return key in (exp as Record<string, unknown>);
+  }
+  return false;
+}
+
+/** Facts in the cf-review skill that must resolve against the tree. */
 export async function collectErrors(): Promise<string[]> {
   const errors: string[] = [];
   const skill = await read("skills/cf-review/SKILL.md");
 
-  // Every `@commonfabric/<pkg>` the skill names is a real workspace package.
+  // Build a name -> exports map for every workspace package.
   const root = JSON.parse(await read("deno.json")) as { workspace?: string[] };
-  const names = new Set<string>();
+  const exportsByName = new Map<string, unknown>();
   for (const member of root.workspace ?? []) {
     try {
       const pkg = JSON.parse(
         await read(`${member.replace(/^\.\//, "")}/deno.json`),
-      ) as { name?: string };
-      if (pkg.name) names.add(pkg.name);
+      ) as { name?: string; exports?: unknown };
+      if (pkg.name) exportsByName.set(pkg.name, pkg.exports);
     } catch {
       // workspace member without a readable deno.json — skip
     }
   }
-  for (const ref of new Set(skill.match(/@commonfabric\/[a-z0-9-]+/g) ?? [])) {
-    if (!names.has(ref)) errors.push(`package not in workspace: ${ref}`);
+
+  // Every `@commonfabric/...` specifier the skill names must resolve.
+  const specifiers = new Set(
+    skill.match(/@commonfabric\/[a-z0-9-]+(?:\/[a-z0-9-]+)*/g) ?? [],
+  );
+  for (const spec of specifiers) {
+    const m = spec.match(/^(@commonfabric\/[a-z0-9-]+)(?:\/(.+))?$/);
+    if (!m) continue;
+    const base = m[1];
+    const sub = m[2];
+    if (!exportsByName.has(base)) {
+      errors.push(`package not in workspace: ${base}`);
+      continue;
+    }
+    const key = sub ? `./${sub}` : ".";
+    if (!resolves(exportsByName.get(base), key)) {
+      errors.push(
+        sub
+          ? `${base} has no export "${key}" — specifier "${spec}" won't resolve`
+          : `${base} has no root export — bare "${spec}" won't resolve; cite a subpath`,
+      );
+    }
   }
 
-  // Every repo-root path the skill cites in backticks exists. Only tokens rooted
-  // at a known top-level dir count as paths; placeholders are skipped.
+  // Every repo-root path cited in backticks exists. Only tokens rooted at a known
+  // top-level dir count as paths; placeholders are skipped.
   const placeholder = /[<>{}*]|\.\.\.|path\/to/;
   const paths = new Set(
     [...skill.matchAll(/`([^`\n]+)`/g)]
@@ -75,7 +111,7 @@ if (import.meta.main) {
   console.log("cf-review skill facts OK");
 }
 
-Deno.test("cf-review skill: cited packages and paths resolve", async () => {
+Deno.test("cf-review skill: cited specifiers and paths resolve", async () => {
   const errors = await collectErrors();
   if (errors.length > 0) {
     throw new Error(`cf-review SKILL.md drift:\n  - ${errors.join("\n  - ")}`);

--- a/skills/cf-review/check-facts.ts
+++ b/skills/cf-review/check-facts.ts
@@ -1,25 +1,24 @@
 #!/usr/bin/env -S deno run --allow-read
 /**
- * Fact-check for the cf-review skill.
+ * Deterministic "tripwire" for the cf-review skill: a cheap, instant, zero-token
+ * CI gate that fails if a package or repo path the skill cites stops existing.
  *
- * The skill's anti-duplication map (the table of canonical homes) and its file
- * references are its highest-value *and* highest-rot content: the moment the
- * tree moves, an authoritative-looking line starts actively misleading — the
- * exact failure the skill exists to prevent. Per
- * `docs/development/skill-authoring.md` ("facts rot — make them testable"), this
- * turns those load-bearing facts into a test that fails loudly on drift.
+ * Scope is deliberately narrow — existence only, and NO hardcoded fact list
+ * (that would just re-introduce the rot it guards against). Semantic drift — a
+ * canonical home that moved or was renamed, advice that is now wrong, something
+ * missing — is the job of the LLM audit (`docs/development/skill-audit.md`), the
+ * appreciating half of the pair. Together they implement the "make load-bearing
+ * facts testable" guidance in `docs/development/skill-authoring.md`.
  *
  * Run:  deno task check-skill-facts
  *   or: deno test --allow-read skills/cf-review/check-facts.ts
- *   or: deno run  --allow-read skills/cf-review/check-facts.ts
  */
 
 const HERE = import.meta.dirname ?? Deno.cwd();
 const ROOT = `${HERE}/../..`;
 
 const read = (p: string): Promise<string> => Deno.readTextFile(`${ROOT}/${p}`);
-
-const pathExists = (p: string): boolean => {
+const exists = (p: string): boolean => {
   try {
     Deno.statSync(`${ROOT}/${p}`);
     return true;
@@ -28,35 +27,31 @@ const pathExists = (p: string): boolean => {
   }
 };
 
-/** Every fact in the skill that must resolve against the tree. */
+/** Existence facts in the cf-review skill that must resolve against the tree. */
 export async function collectErrors(): Promise<string[]> {
   const errors: string[] = [];
   const skill = await read("skills/cf-review/SKILL.md");
 
-  // 1. Every `@commonfabric/<pkg>` the skill names is a workspace package.
+  // Every `@commonfabric/<pkg>` the skill names is a real workspace package.
   const root = JSON.parse(await read("deno.json")) as { workspace?: string[] };
-  const workspaceNames = new Set<string>();
+  const names = new Set<string>();
   for (const member of root.workspace ?? []) {
-    const rel = member.replace(/^\.\//, "");
     try {
-      const pkg = JSON.parse(await read(`${rel}/deno.json`)) as {
-        name?: string;
-      };
-      if (pkg.name) workspaceNames.add(pkg.name);
+      const pkg = JSON.parse(
+        await read(`${member.replace(/^\.\//, "")}/deno.json`),
+      ) as { name?: string };
+      if (pkg.name) names.add(pkg.name);
     } catch {
       // workspace member without a readable deno.json — skip
     }
   }
   for (const ref of new Set(skill.match(/@commonfabric\/[a-z0-9-]+/g) ?? [])) {
-    if (!workspaceNames.has(ref)) {
-      errors.push(`package not in workspace: ${ref}`);
-    }
+    if (!names.has(ref)) errors.push(`package not in workspace: ${ref}`);
   }
 
-  // 2. Every repo-relative path cited in backticks exists. Only tokens rooted at
-  //    a known top-level dir count as paths; placeholders (<…>, *, path/to/…)
-  //    are skipped.
-  const placeholder = /[<>*]|path\/to/;
+  // Every repo-root path the skill cites in backticks exists. Only tokens rooted
+  // at a known top-level dir count as paths; placeholders are skipped.
+  const placeholder = /[<>{}*]|\.\.\.|path\/to/;
   const paths = new Set(
     [...skill.matchAll(/`([^`\n]+)`/g)]
       .map((m) => m[1].trim())
@@ -64,31 +59,7 @@ export async function collectErrors(): Promise<string[]> {
       .filter((t) => !placeholder.test(t)),
   );
   for (const p of paths) {
-    if (!pathExists(p)) errors.push(`path does not exist: ${p}`);
-  }
-
-  // 3. The data-model subpath exports the anti-dup table leans on.
-  const dataModel = JSON.parse(
-    await read("packages/data-model/deno.json"),
-  ) as { exports?: Record<string, string> };
-  const exportsMap = dataModel.exports ?? {};
-  for (const sub of ["value-hash", "schema-hash", "value-clone", "json-wire"]) {
-    if (!(`./${sub}` in exportsMap)) {
-      errors.push(`@commonfabric/data-model missing export ./${sub}`);
-    }
-  }
-
-  // 4. The one symbol the table names directly.
-  if (
-    !/export function convertCellsToLinks\b/.test(
-      await read(
-        "packages/runner/src/cell.ts",
-      ),
-    )
-  ) {
-    errors.push(
-      "convertCellsToLinks no longer exported from packages/runner/src/cell.ts",
-    );
+    if (!exists(p)) errors.push(`path does not exist: ${p}`);
   }
 
   return errors;
@@ -104,13 +75,9 @@ if (import.meta.main) {
   console.log("cf-review skill facts OK");
 }
 
-Deno.test("cf-review skill: cited facts resolve against the tree", async () => {
+Deno.test("cf-review skill: cited packages and paths resolve", async () => {
   const errors = await collectErrors();
   if (errors.length > 0) {
-    throw new Error(
-      `cf-review SKILL.md references that no longer resolve:\n  - ${
-        errors.join("\n  - ")
-      }`,
-    );
+    throw new Error(`cf-review SKILL.md drift:\n  - ${errors.join("\n  - ")}`);
   }
 });

--- a/skills/cf-review/check-facts.ts
+++ b/skills/cf-review/check-facts.ts
@@ -32,8 +32,9 @@ const exists = (p: string): boolean => {
   try {
     Deno.statSync(`${ROOT}/${p}`);
     return true;
-  } catch {
-    return false;
+  } catch (e) {
+    if (e instanceof Deno.errors.NotFound) return false;
+    throw e; // unexpected I/O error — surface it
   }
 };
 
@@ -57,14 +58,21 @@ export async function collectErrors(): Promise<string[]> {
   const root = JSON.parse(await read("deno.json")) as { workspace?: string[] };
   const exportsByName = new Map<string, unknown>();
   for (const member of root.workspace ?? []) {
+    const path = `${member.replace(/^\.\//, "")}/deno.json`;
+    let raw: string;
     try {
-      const pkg = JSON.parse(
-        await read(`${member.replace(/^\.\//, "")}/deno.json`),
-      ) as { name?: string; exports?: unknown };
-      if (pkg.name) exportsByName.set(pkg.name, pkg.exports);
-    } catch {
-      // workspace member without a readable deno.json — skip
+      raw = await read(path);
+    } catch (e) {
+      if (e instanceof Deno.errors.NotFound) continue; // member has no deno.json
+      throw e; // real I/O failure — surface it, don't hide config breakage
     }
+    let pkg: { name?: string; exports?: unknown };
+    try {
+      pkg = JSON.parse(raw);
+    } catch (e) {
+      throw new Error(`invalid JSON in ${path}: ${(e as Error).message}`);
+    }
+    if (pkg.name) exportsByName.set(pkg.name, pkg.exports);
   }
 
   // Every `@commonfabric/...` specifier the skill names must resolve. Subpath

--- a/skills/cf-review/check-facts.ts
+++ b/skills/cf-review/check-facts.ts
@@ -1,0 +1,116 @@
+#!/usr/bin/env -S deno run --allow-read
+/**
+ * Fact-check for the cf-review skill.
+ *
+ * The skill's anti-duplication map (the table of canonical homes) and its file
+ * references are its highest-value *and* highest-rot content: the moment the
+ * tree moves, an authoritative-looking line starts actively misleading — the
+ * exact failure the skill exists to prevent. Per
+ * `docs/development/skill-authoring.md` ("facts rot — make them testable"), this
+ * turns those load-bearing facts into a test that fails loudly on drift.
+ *
+ * Run:  deno task check-skill-facts
+ *   or: deno test --allow-read skills/cf-review/check-facts.ts
+ *   or: deno run  --allow-read skills/cf-review/check-facts.ts
+ */
+
+const HERE = import.meta.dirname ?? Deno.cwd();
+const ROOT = `${HERE}/../..`;
+
+const read = (p: string): Promise<string> => Deno.readTextFile(`${ROOT}/${p}`);
+
+const pathExists = (p: string): boolean => {
+  try {
+    Deno.statSync(`${ROOT}/${p}`);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/** Every fact in the skill that must resolve against the tree. */
+export async function collectErrors(): Promise<string[]> {
+  const errors: string[] = [];
+  const skill = await read("skills/cf-review/SKILL.md");
+
+  // 1. Every `@commonfabric/<pkg>` the skill names is a workspace package.
+  const root = JSON.parse(await read("deno.json")) as { workspace?: string[] };
+  const workspaceNames = new Set<string>();
+  for (const member of root.workspace ?? []) {
+    const rel = member.replace(/^\.\//, "");
+    try {
+      const pkg = JSON.parse(await read(`${rel}/deno.json`)) as {
+        name?: string;
+      };
+      if (pkg.name) workspaceNames.add(pkg.name);
+    } catch {
+      // workspace member without a readable deno.json — skip
+    }
+  }
+  for (const ref of new Set(skill.match(/@commonfabric\/[a-z0-9-]+/g) ?? [])) {
+    if (!workspaceNames.has(ref)) {
+      errors.push(`package not in workspace: ${ref}`);
+    }
+  }
+
+  // 2. Every repo-relative path cited in backticks exists. Only tokens rooted at
+  //    a known top-level dir count as paths; placeholders (<…>, *, path/to/…)
+  //    are skipped.
+  const placeholder = /[<>*]|path\/to/;
+  const paths = new Set(
+    [...skill.matchAll(/`([^`\n]+)`/g)]
+      .map((m) => m[1].trim())
+      .filter((t) => /^(packages|docs|tasks|scripts)\//.test(t))
+      .filter((t) => !placeholder.test(t)),
+  );
+  for (const p of paths) {
+    if (!pathExists(p)) errors.push(`path does not exist: ${p}`);
+  }
+
+  // 3. The data-model subpath exports the anti-dup table leans on.
+  const dataModel = JSON.parse(
+    await read("packages/data-model/deno.json"),
+  ) as { exports?: Record<string, string> };
+  const exportsMap = dataModel.exports ?? {};
+  for (const sub of ["value-hash", "schema-hash", "value-clone", "json-wire"]) {
+    if (!(`./${sub}` in exportsMap)) {
+      errors.push(`@commonfabric/data-model missing export ./${sub}`);
+    }
+  }
+
+  // 4. The one symbol the table names directly.
+  if (
+    !/export function convertCellsToLinks\b/.test(
+      await read(
+        "packages/runner/src/cell.ts",
+      ),
+    )
+  ) {
+    errors.push(
+      "convertCellsToLinks no longer exported from packages/runner/src/cell.ts",
+    );
+  }
+
+  return errors;
+}
+
+if (import.meta.main) {
+  const errors = await collectErrors();
+  if (errors.length > 0) {
+    console.error("cf-review skill facts FAILED:");
+    for (const e of errors) console.error(`  - ${e}`);
+    Deno.exit(1);
+  }
+  console.log("cf-review skill facts OK");
+}
+
+Deno.test("cf-review skill: cited facts resolve against the tree", async () => {
+  const errors = await collectErrors();
+  if (errors.length > 0) {
+    throw new Error(
+      `cf-review SKILL.md references that no longer resolve:\n  - ${
+        errors.join("\n  - ")
+      }`,
+    );
+  }
+});

--- a/skills/cf-review/check-facts.ts
+++ b/skills/cf-review/check-facts.ts
@@ -21,7 +21,10 @@
  *   or: deno test --allow-read skills/cf-review/check-facts.ts
  */
 
-const HERE = import.meta.dirname ?? Deno.cwd();
+const HERE = import.meta.dirname;
+if (HERE === undefined) {
+  throw new Error("check-facts.ts must be run from a file path");
+}
 const ROOT = `${HERE}/../..`;
 
 const read = (p: string): Promise<string> => Deno.readTextFile(`${ROOT}/${p}`);
@@ -46,6 +49,8 @@ function resolves(exp: unknown, key: string): boolean {
 /** Facts in the cf-review skill that must resolve against the tree. */
 export async function collectErrors(): Promise<string[]> {
   const errors: string[] = [];
+  // Scope: gates the cf-review skill only. ~15 other skills have a SKILL.md;
+  // generalizing to all of `skills/**` (glob this read) is future work.
   const skill = await read("skills/cf-review/SKILL.md");
 
   // Build a name -> exports map for every workspace package.
@@ -62,9 +67,10 @@ export async function collectErrors(): Promise<string[]> {
     }
   }
 
-  // Every `@commonfabric/...` specifier the skill names must resolve.
+  // Every `@commonfabric/...` specifier the skill names must resolve. Subpath
+  // segments allow PascalCase / dots (e.g. data-model/BaseReconstructionContext).
   const specifiers = new Set(
-    skill.match(/@commonfabric\/[a-z0-9-]+(?:\/[a-z0-9-]+)*/g) ?? [],
+    skill.match(/@commonfabric\/[a-z0-9-]+(?:\/[\w.-]+)*/g) ?? [],
   );
   for (const spec of specifiers) {
     const m = spec.match(/^(@commonfabric\/[a-z0-9-]+)(?:\/(.+))?$/);


### PR DESCRIPTION
Follow-up to #3829 (stacked). Implements @mpsalisbury's "make load-bearing facts testable" ask as a **hybrid** (per review discussion): a deterministic tripwire (floor) + an LLM audit (ceiling). A grep alone only catches existence/resolvability rot; the LLM audit is the more useful half at the limit.

## Tripwire — deterministic floor
`skills/cf-review/check-facts.ts` — `deno task check-skill-facts` (also a `Deno.test`). A cheap, instant, zero-token check that every `@commonfabric/...` specifier and repo path the cf-review skill cites **resolves** against the tree: a bare import needs a root (`.`) export, a subpath needs that subpath in `exports`, and cited paths must exist. **No hardcoded fact list. Wired into the CI `check` job.** Negative-tested — a bare reference to a subpath-only package (e.g. `@commonfabric/data-model`) or a vanished path makes it exit 1.

## Audit — LLM ceiling
`docs/development/skill-audit.md` — the periodic / on-change **semantic** pass that catches what a grep can't: a canonical home that moved or was renamed, stale advice, a missing home, framing drift. The auditor is **cf-review itself**, not a parallel reviewer. This half *appreciates* as models improve.

## Stacking
Based on `add-cf-review-skill` (#3829) because the tripwire reads `skills/cf-review/SKILL.md`. Retarget to `main` once #3829 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — on behalf of @bfollington