### PR TITLE
chore: configure Cubic to review with the cf-review skill guidance

### DIFF
--- a/cubic.yaml
+++ b/cubic.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://cubic.dev/schema/cubic-repository-config.schema.json
+#
+# Cubic config — make the AI reviewer use the same guidance as the repo-local
+# `/cf-review` skill and human reviewers. See https://docs.cubic.dev/configure/cubic-yaml
+#
+# Single source of truth: the review guidance lives in skills/cf-review/SKILL.md.
+# Edit the skill, not this file. (Cubic reads at most ~10k chars per custom
+# agent and the skill is larger, so the durable, principle-level lenses are
+# restated in `description` — concatenated first, so always kept — while
+# `file_paths` carries the full detail. The rot-prone specifics, e.g. exact
+# canonical-home module names, live only in the skill.)
+
+version: 1
+
+reviews:
+  # Posture mirrors the skill's bandwidth discipline: flag real bugs and
+  # regressions loudly, keep nits minimal, don't demand a pristine first pass.
+  sensitivity: medium
+
+  custom_rules:
+    - name: cf-review (Common Fabric review guidance)
+      description: >-
+        Apply Common Fabric's code-review guidance (full text follows, sourced
+        from skills/cf-review/SKILL.md). Repo-specific lenses to apply even if
+        the text below is truncated: (1) Anti-duplication — never re-fork
+        hashing, serialization, cloning, or identity; reuse the canonical
+        @commonfabric modules instead of hand-rolling. (2) Framework-fit — flag
+        code fighting the TS-transformer / reactive-graph model
+        (error-swallowing try/catch, singletons, async/await in handlers,
+        transformer escape hatches). (3) Coherence — a change to runtime
+        semantics must update the docs, comments, and examples it makes stale,
+        so someone searching later is not misled. (4) Test rigor — each touched
+        test should guard a nameable principle. (5) Bandwidth — separate
+        blocking bugs from non-blocking improvements and optional nits.
+      file_paths:
+        - skills/cf-review/SKILL.md

--- a/cubic.yaml
+++ b/cubic.yaml
@@ -24,10 +24,10 @@ reviews:
         from skills/cf-review/SKILL.md). Repo-specific lenses to apply even if
         the text below is truncated: (1) Anti-duplication — never re-fork
         hashing, serialization, cloning, or identity; reuse the canonical
-        @commonfabric modules instead of hand-rolling. (2) Framework-fit — flag
-        code fighting the TS-transformer / reactive-graph model
-        (error-swallowing try/catch, singletons, async/await in handlers,
-        transformer escape hatches). (3) Coherence — a change to runtime
+        @commonfabric modules instead of hand-rolling. (2) Framework-fit — in
+        patterns and the runtime that serves them, flag code fighting the
+        transformer pipeline / reactive-graph model (error-swallowing try/catch,
+        singletons, async/await in handlers, transformer escape hatches). (3) Coherence — a change to runtime
         semantics must update the docs, comments, and examples it makes stale,
         so someone searching later is not misled. (4) Test rigor — each touched
         test should guard a nameable principle. (5) Bandwidth — separate


### PR DESCRIPTION
Wires the Cubic AI reviewer to the **same guidance** as the repo-local `/cf-review` skill and human reviewers — so the three stay coherent. Stacked on #3829 (the `file_paths` reference needs `skills/cf-review/SKILL.md`).

## How

A file-backed custom review agent ([cubic.yaml docs](https://docs.cubic.dev/configure/cubic-yaml)):

```yaml
reviews:
  custom_rules:
    - name: cf-review (Common Fabric review guidance)
      description: >- …durable principle-level lenses…
      file_paths:
        - skills/cf-review/SKILL.md
```

**Single source of truth** — edit the skill, not this file.

## The one wrinkle: Cubic's 10k/agent cap

The skill is ~15.6k chars; Cubic uses the first ~10k per agent (`description` + file, concatenated in that order). So:

- The **durable, principle-level lenses** (anti-duplication, framework-fit, coherence, test-rigor, bandwidth) go in `description` — concatenated **first**, so always retained even when the body is truncated. These are the "map & values" that don't rot.
- `file_paths` carries the **full** skill detail (values → north-star → why-this-repo → Step 1 → Dimensions 1–3 land within the first 10k; the rot-prone specifics like exact canonical-home module names stay single-sourced there).
- `sensitivity: medium` mirrors the skill's "loud on real bugs/regressions, quiet on nits" posture.

## Notes

- Validated: `deno fmt --check` clean; parses; `file_paths` target resolves.
- Takes effect once on `main`. Retarget to `main` after #3829 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — on behalf of @bfollington

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Configure the Cubic reviewer to follow the repo’s `/cf-review` skill so reviews stay consistent and use a single source of truth.

- **New Features**
  - Added `cubic.yaml` with a custom rule sourcing `skills/cf-review/SKILL.md`.
  - Restated durable principles in `description` to survive Cubic’s ~10k cap; full detail stays in the skill.
  - Set `sensitivity: medium` to be loud on bugs, quiet on nits.

- **Refactors**
  - Aligned wording with the skill: say "the transformer pipeline"; framework-fit covers patterns and the runtime.

<sup>Written for commit e2bba45fa50d6ab32202c8aa732516fe32ac5785. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

