### PR TITLE
chore(runner): Dedup sqlite cf_link codec + sqliteQuery factory (#24)

### DIFF
--- a/docs/specs/sqlite-builtin/08-open-questions.md
+++ b/docs/specs/sqlite-builtin/08-open-questions.md
@@ -239,15 +239,22 @@ during design are marked **[resolved]** with the decision.
     the attachment with `.has()` (no dead `alias` binding) and documents that the
     unqualified statement relies on the ≤1-cell-db invariant + core-table guard,
     not on alias qualification.
-24. **Codec / factory duplication (partly open).** The `toCell` divergence is
-    **fixed**: `encodeSqliteParams` now recovers a bound cell from a `toCell`
-    back-pointer too, matching the read side. Still open: `encodeSqliteParams`
-    inlines the cell→sigil encoding `encodeCfLinkValue` owns, `decodeCfLinkValue`
-    re-implements `parseCfLinkToSigil`'s prologue, and `cell.ts` rebuilds the
-    `sqliteQuery` node factory `builder/built-in.ts` exports. Consolidating these
-    is blocked by the cell.ts ↔ cf-link.ts import cycle (both need `isCell`);
-    resolve via a cycle-free helper module. The write/read codecs MUST stay
-    byte-identical until then.
+24. **[resolved] Codec / factory duplication.** All three are consolidated, with
+    the cell.ts ↔ cf-link.ts cycle broken via a cycle-free leaf module
+    (`builtins/sqlite/cf-link-codec.ts`, which depends only on `link-utils` +
+    types — no runtime `cell.ts` import).
+    - **Cell→sigil encode:** `encodeSqliteParams` (cell.ts) and `encodeCfLinkValue`
+      (cf-link.ts) both call the codec's `encodeCellToSigilString`, so write- and
+      read-path sigils are byte-identical by construction (no inlining).
+    - **Parse prologue:** `parseCfLinkToSigil` lives in the codec; `decodeCfLinkValue`
+      delegates to it (one prologue, not two). cf-link.ts re-exports it so importers
+      are unchanged.
+    - **Bound-cell recovery:** a single exported `asBoundCell` in cell.ts (where
+      `isCell`/`CellImpl` live), imported by cf-link.ts (the direction it already
+      imported `isCell`).
+    - **Factory:** the single `sqliteQuery` node factory lives in
+      `builtins/sqlite/query-node.ts`, imported by both `db.query` (cell.ts) and the
+      `sqliteQuery` builder export (built-in.ts).
 25. **[resolved]** `decodeRowLinkColumns` now copies a result row lazily — only
     when a link column actually decodes to a different value — so rows with no
     link columns (or null values) are returned as-is on the reactive read path,

--- a/packages/runner/src/builder/built-in.ts
+++ b/packages/runner/src/builder/built-in.ts
@@ -29,6 +29,7 @@ import type {
 } from "commonfabric";
 import { isRecord } from "@commonfabric/utils/types";
 import { isCell } from "../cell.ts";
+import { sqliteQueryNodeFactory } from "../builtins/sqlite/query-node.ts";
 import { LLMDialogResultSchema } from "../builtins/llm-schemas.ts";
 
 const WISH_ARGUMENT_SCHEMA = internSchema({
@@ -171,10 +172,10 @@ export const sqliteDatabase = createNodeFactory({
   implementation: "sqliteDatabase",
 }) as SqliteDatabaseFunction;
 
-export const sqliteQuery = createNodeFactory({
-  type: "ref",
-  implementation: "sqliteQuery",
-}) as SqliteQueryFunction;
+// Shares the single `sqliteQuery` node factory with `db.query` (cell.ts) — see
+// builtins/sqlite/query-node.ts — so both construct the same node.
+export const sqliteQuery =
+  sqliteQueryNodeFactory as unknown as SqliteQueryFunction;
 
 // ifElse with optional schema arguments (backward compatible)
 // See SIGNATURE_ARGS documentation above for why we use arguments.length

--- a/packages/runner/src/builtins/sqlite/cf-link-codec.ts
+++ b/packages/runner/src/builtins/sqlite/cf-link-codec.ts
@@ -1,0 +1,55 @@
+// Pure `_cf_link` codec — the cell↔sigil-string encode and the sigil
+// parse/validate prologue — shared by BOTH the write path (`encodeSqliteParams`
+// / `db.exec` in cell.ts) and the read/write helpers in cf-link.ts, so they
+// produce and parse BYTE-IDENTICAL sigil strings.
+//
+// This module depends only on `link-utils` + types — it has NO runtime import
+// of cell.ts (the `Cell` import below is type-only, erased at build) — so cell.ts
+// can import it without the cell.ts ↔ cf-link.ts cycle (08-open-questions #24).
+
+import type { Cell } from "../../cell.ts";
+import type { NormalizedFullLink } from "../../link-types.ts";
+import {
+  type CellLink,
+  createSigilLinkFromParsedLink,
+  isCellLink,
+} from "../../link-utils.ts";
+
+/**
+ * Encode a bound Cell to the stored `_cf_link` sigil-link JSON string: an
+ * ABSOLUTE link (id + space + scope, no `base`/`baseSpace`) with `schema`/
+ * `asCell` stripped (`includeSchema: false`), so the row resolves independent of
+ * any base document and stores no schema flags.
+ */
+export function encodeCellToSigilString(cell: Cell<unknown>): string {
+  const link: NormalizedFullLink = cell.getAsNormalizedFullLink();
+  const sigil = createSigilLinkFromParsedLink(link, { includeSchema: false });
+  return JSON.stringify(sigil);
+}
+
+/**
+ * Parse + validate a stored `_cf_link` value to its sigil-link OBJECT (or `null`
+ * for SQL NULL). This is the shared prologue of both `decodeCfLinkValue` (which
+ * then hydrates the sigil to a live Cell via the runtime) and the `asCell`
+ * query-result read path (which stores the sigil for deferred rehydration).
+ * Throws on a non-null/non-string value, malformed JSON, or JSON that is not a
+ * single sigil link.
+ */
+export function parseCfLinkToSigil(value: unknown): CellLink | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== "string") {
+    throw new TypeError(
+      `_cf_link columns hold a sigil-link string or NULL; got ${typeof value}`,
+    );
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    throw new TypeError("_cf_link value is not valid JSON");
+  }
+  if (!isCellLink(parsed)) {
+    throw new TypeError("_cf_link value is not a sigil link");
+  }
+  return parsed;
+}

--- a/packages/runner/src/builtins/sqlite/cf-link.ts
+++ b/packages/runner/src/builtins/sqlite/cf-link.ts
@@ -9,11 +9,12 @@
 import type { JSONSchema } from "../../builder/types.ts";
 import type { Runtime } from "../../runtime.ts";
 import type { Cell } from "../../cell.ts";
-import { isCell } from "../../cell.ts";
-import { toCell } from "../../back-to-cell.ts";
+import { asBoundCell } from "../../cell.ts";
 import type { IExtendedStorageTransaction } from "../../storage/interface.ts";
-import { createSigilLinkFromParsedLink, isCellLink } from "../../link-utils.ts";
-import type { NormalizedFullLink } from "../../link-types.ts";
+import {
+  encodeCellToSigilString,
+  parseCfLinkToSigil,
+} from "./cf-link-codec.ts";
 
 // Pure column-name helpers live in the memory package (server-authoritative,
 // lower pace-layer) and are re-exported here for client-side use.
@@ -22,17 +23,9 @@ export {
   isCfLinkColumn,
 } from "@commonfabric/memory/sqlite/columns";
 
-/** Recover a Cell from a value that is a cell or carries a `toCell` back-pointer. */
-function asCellOrUndefined(value: unknown): Cell<unknown> | undefined {
-  if (isCell(value)) return value as Cell<unknown>;
-  if (
-    value !== null && typeof value === "object" &&
-    typeof (value as { [toCell]?: unknown })[toCell] === "function"
-  ) {
-    return (value as { [toCell]: () => Cell<unknown> })[toCell]();
-  }
-  return undefined;
-}
+// The pure sigil parse/validate prologue lives in the cycle-free codec; re-export
+// it so existing importers (e.g. sqlite-builtins.ts) keep their import path.
+export { parseCfLinkToSigil } from "./cf-link-codec.ts";
 
 /**
  * Encode a cell reference to an absolute sigil-link JSON string for storage.
@@ -40,17 +33,13 @@ function asCellOrUndefined(value: unknown): Cell<unknown> | undefined {
  * independent of any base document or space. Throws if `value` is not a cell.
  */
 export function encodeCfLinkValue(value: unknown): string {
-  const cell = asCellOrUndefined(value);
+  const cell = asBoundCell(value);
   if (!cell) {
     throw new TypeError(
       "_cf_link columns store cell references only; got a non-cell value",
     );
   }
-  const link: NormalizedFullLink = cell.getAsNormalizedFullLink();
-  // No `base`/`baseSpace` => absolute link (id + space + scope included).
-  // `includeSchema: false` => strip schema/asCell flags from the stored sigil.
-  const sigil = createSigilLinkFromParsedLink(link, { includeSchema: false });
-  return JSON.stringify(sigil);
+  return encodeCellToSigilString(cell);
 }
 
 /**
@@ -64,45 +53,7 @@ export function decodeCfLinkValue(
   schema?: JSONSchema,
   tx?: IExtendedStorageTransaction,
 ): Cell<unknown> | null {
-  if (value === null || value === undefined) return null;
-  if (typeof value !== "string") {
-    throw new TypeError(
-      `_cf_link columns hold a sigil-link string or NULL; got ${typeof value}`,
-    );
-  }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(value);
-  } catch {
-    throw new TypeError("_cf_link value is not valid JSON");
-  }
-  if (!isCellLink(parsed)) {
-    throw new TypeError("_cf_link value is not a sigil link");
-  }
-  return runtime.getCellFromLink(parsed, schema, tx);
-}
-
-/**
- * Parse a stored `_cf_link` value to the sigil-link OBJECT (not a Cell), for
- * storing in a query result under an `asCell` schema so reads rehydrate to live
- * Cells. `null`/`undefined` → null. Throws like `decodeCfLinkValue` on a
- * non-string or non-sigil value.
- */
-export function parseCfLinkToSigil(value: unknown): unknown | null {
-  if (value === null || value === undefined) return null;
-  if (typeof value !== "string") {
-    throw new TypeError(
-      `_cf_link columns hold a sigil-link string or NULL; got ${typeof value}`,
-    );
-  }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(value);
-  } catch {
-    throw new TypeError("_cf_link value is not valid JSON");
-  }
-  if (!isCellLink(parsed)) {
-    throw new TypeError("_cf_link value is not a sigil link");
-  }
-  return parsed;
+  const sigil = parseCfLinkToSigil(value);
+  if (sigil === null) return null;
+  return runtime.getCellFromLink(sigil, schema, tx);
 }

--- a/packages/runner/src/builtins/sqlite/query-node.ts
+++ b/packages/runner/src/builtins/sqlite/query-node.ts
@@ -1,0 +1,13 @@
+// The single `sqliteQuery` node factory, shared by the `db.query` method
+// (cell.ts) and the public `sqliteQuery` builder export (builder/built-in.ts) so
+// both construct the SAME reactive node instead of each calling
+// `createNodeFactory` for the same implementation. Lives in its own module
+// (depends only on builder/module.ts, which does not import cell.ts) so cell.ts
+// can import it without a cycle (08-open-questions #24).
+
+import { createNodeFactory } from "../../builder/module.ts";
+// deno-lint-ignore no-explicit-any
+export const sqliteQueryNodeFactory = createNodeFactory<any, any>({
+  type: "ref",
+  implementation: "sqliteQuery",
+});

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -458,7 +458,8 @@ function parseSqliteInsertColumns(sql: string): string[] | undefined {
  * (`:col`) to bind a Cell in those statements.
  */
 /**
- * Recover a Cell from a value that is a Cell or carries a `toCell` back-pointer.
+ * Recover a Cell from a value that is a Cell or carries a `toCell` back-pointer
+ * (delegating the back-pointer case to query-result-proxy's `getCellOrThrow`).
  * Shared by the write path (`encodeSqliteParams`) and `cf-link.ts`'s
  * `encodeCfLinkValue` so `db.exec` and the `sqliteQuery` builtin agree on what
  * counts as a bound cell. (Lives here because it needs `isCell` /
@@ -466,12 +467,7 @@ function parseSqliteInsertColumns(sql: string): string[] | undefined {
  */
 export function asBoundCell(value: unknown): Cell<unknown> | undefined {
   if (isCell(value)) return value as Cell<unknown>;
-  if (value !== null && typeof value === "object") {
-    const fn = (value as { [toCell]?: unknown })[toCell];
-    if (typeof fn === "function") {
-      return (value as { [toCell]: () => Cell<unknown> })[toCell]();
-    }
-  }
+  if (isCellResultForDereferencing(value)) return getCellOrThrow(value);
   return undefined;
 }
 

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -16,6 +16,8 @@ import { internSchema } from "@commonfabric/data-model/schema-hash";
 import type { MemorySpace } from "@commonfabric/memory/interface";
 import type { SqliteParamsWire } from "@commonfabric/memory/v2";
 import { isCfLinkColumn } from "@commonfabric/memory/sqlite/columns";
+import { encodeCellToSigilString } from "./builtins/sqlite/cf-link-codec.ts";
+import { sqliteQueryNodeFactory } from "./builtins/sqlite/query-node.ts";
 import { getTopFrame, pattern } from "./builder/pattern.ts";
 import { createNodeFactory, lift } from "./builder/module.ts";
 import {
@@ -146,7 +148,6 @@ export type RawCellReadOptions = IReadOptions & {
 let mapFactory: NodeFactory<any, any> | undefined;
 let filterFactory: NodeFactory<any, any> | undefined;
 let flatMapFactory: NodeFactory<any, any> | undefined;
-let sqliteQueryFactory: NodeFactory<any, any> | undefined;
 
 // WeakMap to store connected nodes for each cell instance
 const cellNodes = new WeakMap<OpaqueCell<unknown>, Set<NodeRef>>();
@@ -456,6 +457,24 @@ function parseSqliteInsertColumns(sql: string): string[] | undefined {
  * would corrupt a non-link column). Use an explicit column list or named params
  * (`:col`) to bind a Cell in those statements.
  */
+/**
+ * Recover a Cell from a value that is a Cell or carries a `toCell` back-pointer.
+ * Shared by the write path (`encodeSqliteParams`) and `cf-link.ts`'s
+ * `encodeCfLinkValue` so `db.exec` and the `sqliteQuery` builtin agree on what
+ * counts as a bound cell. (Lives here because it needs `isCell` /
+ * `instanceof CellImpl`; cf-link.ts already imports from cell.ts.)
+ */
+export function asBoundCell(value: unknown): Cell<unknown> | undefined {
+  if (isCell(value)) return value as Cell<unknown>;
+  if (value !== null && typeof value === "object") {
+    const fn = (value as { [toCell]?: unknown })[toCell];
+    if (typeof fn === "function") {
+      return (value as { [toCell]: () => Cell<unknown> })[toCell]();
+    }
+  }
+  return undefined;
+}
+
 export function encodeSqliteParams(
   sql: string,
   params?: ReadonlyArray<unknown> | Record<string, unknown>,
@@ -469,31 +488,14 @@ export function encodeSqliteParams(
       );
     }
   };
-  // Recover a Cell from a value that is a Cell or carries a `toCell`
-  // back-pointer (matches encodeCfLinkValue/asCellOrUndefined on the read side,
-  // so db.exec and the sqliteQuery builtin agree on what counts as a bound cell).
-  const boundCell = (value: unknown): Cell<unknown> | undefined => {
-    if (isCell(value)) return value as Cell<unknown>;
-    if (value !== null && typeof value === "object") {
-      const fn = (value as { [toCell]?: unknown })[toCell];
-      if (typeof fn === "function") {
-        return (value as { [toCell]: () => Cell<unknown> })[toCell]();
-      }
-    }
-    return undefined;
-  };
   const encodeOne = (value: unknown, isLinkCol: boolean): unknown => {
     assertDefined(value);
-    const cell = boundCell(value);
+    const cell = asBoundCell(value);
     if (cell) {
       if (!isLinkCol) {
         throw new TypeError("cells may only be bound to _cf_link columns");
       }
-      return JSON.stringify(
-        createSigilLinkFromParsedLink(cell.getAsNormalizedFullLink(), {
-          includeSchema: false,
-        }),
-      );
+      return encodeCellToSigilString(cell);
     }
     return value;
   };
@@ -505,7 +507,7 @@ export function encodeSqliteParams(
         return encodeOne(v, isCfLinkColumn(cols[i % cols.length] ?? ""));
       }
       assertDefined(v);
-      if (boundCell(v)) {
+      if (asBoundCell(v)) {
         throw new TypeError(
           "sqlite: a Cell parameter must bind to a _cf_link column, but the " +
             "target column can't be determined from this statement. Use an " +
@@ -1869,13 +1871,7 @@ export class CellImpl<T extends FabricValue>
       reactOn?: unknown;
     },
   ): OpaqueRef<{ pending: boolean; result?: Row[]; error?: unknown }> {
-    if (!sqliteQueryFactory) {
-      sqliteQueryFactory = createNodeFactory({
-        type: "ref",
-        implementation: "sqliteQuery",
-      });
-    }
-    return sqliteQueryFactory({
+    return sqliteQueryNodeFactory({
       db: this,
       sql,
       params: options?.params,


### PR DESCRIPTION
Resolves 08-open-questions **#24** (codec / factory duplication) — a cleanup follow-up to the SQLite-for-patterns feature. No behavior change.

## What was duplicated
1. **Cell→sigil encoding** inlined in `encodeSqliteParams` (cell.ts) *and* owned by `encodeCfLinkValue` (cf-link.ts) — two copies of `createSigilLinkFromParsedLink(...) + JSON.stringify`, which MUST stay byte-identical.
2. **Sigil parse/validate prologue** copy-pasted between `decodeCfLinkValue` and `parseCfLinkToSigil`.
3. **`sqliteQuery` node factory** built twice — lazily in `cell.ts` (`db.query`) and eagerly in `builder/built-in.ts` (the `sqliteQuery` export).

Consolidation was blocked by the **cell.ts ↔ cf-link.ts import cycle** (`isCell` lives in cell.ts as `instanceof CellImpl`).

## How the cycle is broken
- **NEW `builtins/sqlite/cf-link-codec.ts`** — the pure codec (`encodeCellToSigilString`, `parseCfLinkToSigil`). Depends only on `link-utils` + types; its only `cell.ts` touch is a **type-only** `Cell` import (erased at runtime), so cell.ts can import it with no cycle.
- **Bound-cell recovery** (`isCell` ‖ `toCell` back-pointer) → one exported `asBoundCell` in cell.ts; cf-link.ts imports it (the direction it already imported `isCell`).
- **NEW `builtins/sqlite/query-node.ts`** — the single `sqliteQuery` node factory, imported by both `cell.ts` and `built-in.ts`. It imports only `builder/module.ts` (verified leaf — no `cell.ts` import), so no `cell.ts ↔ built-in.ts` cycle.

## Result
`encodeSqliteParams`/`encodeCfLinkValue` produce byte-identical sigils by construction; one parse prologue; one factory instance. **Net −52 lines.**

## Tests
Runner sqlite unit + `_cf_link` round-trip/decode/rowschema + the real-server e2e (`sqlite-db-query-decode`) all green (11/0); cell-core/as-cell green (module-init/cycle check); typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates the SQLite `_cf_link` codec and the `sqliteQuery` node factory to remove copy‑paste and break the `cell.ts` ↔ `cf-link.ts` cycle. Resolves 08-open-questions #24 with no behavior change; write/read sigils remain byte‑identical.

- **Refactors**
  - Added `builtins/sqlite/cf-link-codec.ts` with `encodeCellToSigilString` and `parseCfLinkToSigil`; used by `encodeSqliteParams` and `encodeCfLinkValue` (re-exported from `cf-link.ts`).
  - Introduced `asBoundCell` in `cell.ts` for consistent bound-cell recovery; now delegates to `isCellResult`/`getCellOrThrow`; used on write and read paths.
  - Added `builtins/sqlite/query-node.ts` as the single `sqliteQuery` factory; shared by `db.query` and the builder export (`built-in.ts`).

<sup>Written for commit 8787be6efa24010d78bb0194285349ca0faeb9ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

