### PR TITLE
`data-model` getters: `.shouldDeepFreeze` and `.wireTypeTag`

### DIFF
--- a/packages/data-model/src/BaseReconstructionContext.ts
+++ b/packages/data-model/src/BaseReconstructionContext.ts
@@ -10,17 +10,12 @@ import type { FabricInstance, ReconstructionContext } from "./interface.ts";
  * Abstract base that supplies the `shouldDeepFreeze` getter from a
  * constructor argument. Subclasses implement `getCell()` for their own
  * boundary semantics; they inherit `shouldDeepFreeze` for free.
- *
- * The `shouldDeepFreeze` argument defaults to `true`, mirroring
- * `cloneIfNecessary()`'s `frozen` option (see `value-clone.ts`): the
- * deep-frozen result is the safe default, and `shouldDeepFreeze === true`
- * corresponds to `cloneIfNecessary(value, { frozen: true })`.
  */
 export abstract class BaseReconstructionContext
   implements ReconstructionContext {
   readonly #shouldDeepFreeze: boolean;
 
-  constructor(shouldDeepFreeze: boolean = true) {
+  constructor(shouldDeepFreeze: boolean) {
     this.#shouldDeepFreeze = shouldDeepFreeze;
   }
 

--- a/packages/data-model/src/EmptyReconstructionContext.ts
+++ b/packages/data-model/src/EmptyReconstructionContext.ts
@@ -11,19 +11,18 @@ import { BaseReconstructionContext } from "./BaseReconstructionContext.ts";
 /**
  * `ReconstructionContext` whose `getCell()` always throws. `shouldDeepFreeze`
  * is inherited from `BaseReconstructionContext` (defaults to `true`).
- *
- * Both constructor arguments are optional and default so that
- * `new EmptyReconstructionContext()` is byte-identical to the historical
- * singleton: `shouldDeepFreeze` defaults to `true` (via the base class) and
- * the `getCell()` throw message defaults to the original literal. Callers
- * that need a different frozenness intent (e.g. a clone path that owns its
- * own freeze decision) or a situation-appropriate throw message pass them
- * explicitly.
  */
 export class EmptyReconstructionContext extends BaseReconstructionContext {
   readonly #getCellMessage: string;
 
-  constructor(shouldDeepFreeze?: boolean, getCellMessage?: string) {
+  /**
+   * Constructs an instance.
+   *
+   * @param shouldDeepFreeze - Should the result be deep-frozen?
+   * @param getCellMessage - Message to use in `getCell()` throw. Defaults to a
+   * generic message.
+   */
+  constructor(shouldDeepFreeze: boolean, getCellMessage?: string) {
     super(shouldDeepFreeze);
     this.#getCellMessage = getCellMessage ?? "no runtime context provided.";
   }
@@ -38,10 +37,11 @@ export class EmptyReconstructionContext extends BaseReconstructionContext {
 }
 
 /**
- * Shared `ReconstructionContext` instance whose `getCell()` always throws.
- * Pass this when a decoder wants a context object but isn't expected to need
- * cell reconstruction; if a cell ref does turn up, the throw makes the
- * unexpected reconstruction obvious instead of silent.
+ * Shared `EmptyReconstructionContext` instance whith `.shouldDeepFreeze ===
+ * true` and whose `getCell()` always throws. Pass this when a decoder wants a
+ * context object but isn't expected to need cell reconstruction; if a cell ref
+ * does turn up, the throw makes the unexpected reconstruction obvious instead
+ * of silent.
  */
 export const EMPTY_RECONSTRUCTION_CONTEXT: ReconstructionContext = Object
-  .freeze(new EmptyReconstructionContext());
+  .freeze(new EmptyReconstructionContext(true));

--- a/packages/data-model/src/EmptyReconstructionContext.ts
+++ b/packages/data-model/src/EmptyReconstructionContext.ts
@@ -37,7 +37,7 @@ export class EmptyReconstructionContext extends BaseReconstructionContext {
 }
 
 /**
- * Shared `EmptyReconstructionContext` instance whith `.shouldDeepFreeze ===
+ * Shared `EmptyReconstructionContext` instance with `.shouldDeepFreeze ===
  * true` and whose `getCell()` always throws. Pass this when a decoder wants a
  * context object but isn't expected to need cell reconstruction; if a cell ref
  * does turn up, the throw makes the unexpected reconstruction obvious instead

--- a/packages/data-model/src/fabric-instances/BaseFabricInstance.ts
+++ b/packages/data-model/src/fabric-instances/BaseFabricInstance.ts
@@ -13,6 +13,10 @@ import { FabricInstance } from "../interface.ts";
  * point individual subclasses stop implementing `deepClone()` directly.
  */
 export abstract class BaseFabricInstance extends FabricInstance {
+  //
+  // Instance members
+  //
+
   /**
    * The type tag to use for this instance to identify it in wire protocols.
    */
@@ -38,5 +42,29 @@ export abstract class BaseFabricInstance extends FabricInstance {
     // Cast needed: `Object.freeze()` returns `Readonly<T>`, which TS considers
     // incompatible with abstract class types due to protected members.
     return frozen ? Object.freeze(copy) as FabricInstance : copy;
+  }
+
+  //
+  // Static members
+  //
+
+  /**
+   * Gets the `.wireTypeTag` from a value which is _supposed_ to be an instance
+   * of this class but is only statically known / assumed to be an instance of
+   * the fully abstract `FabricInstance`. Throws a "shouldn't happen" error if
+   * there's trouble.
+   */
+  static wireTypeTagOf(value: FabricInstance): string {
+    if (!(value instanceof BaseFabricInstance)) {
+      throw new Error("Shouldn't happen: Encountered a `FabricInstance` which is not a `BaseFabricInstance`.");
+    }
+
+    const result = value.wireTypeTag;
+
+    if (typeof result !== "string") {
+      throw new Error("Shouldn't happen: Encountered a `BaseFabricInstance` with a non-string `wireTypeTag`.");
+    }
+
+    return result;
   }
 }

--- a/packages/data-model/src/fabric-instances/BaseFabricInstance.ts
+++ b/packages/data-model/src/fabric-instances/BaseFabricInstance.ts
@@ -14,6 +14,11 @@ import { FabricInstance } from "../interface.ts";
  */
 export abstract class BaseFabricInstance extends FabricInstance {
   /**
+   * The type tag to use for this instance to identify it in wire protocols.
+   */
+  abstract get wireTypeTag(): string;
+
+   /**
    * Returns a new unfrozen copy of this instance with the same data. Called
    * by `shallowClone()` when a new instance is needed.
    */

--- a/packages/data-model/src/fabric-instances/BaseFabricInstance.ts
+++ b/packages/data-model/src/fabric-instances/BaseFabricInstance.ts
@@ -22,7 +22,7 @@ export abstract class BaseFabricInstance extends FabricInstance {
    */
   abstract get wireTypeTag(): string;
 
-   /**
+  /**
    * Returns a new unfrozen copy of this instance with the same data. Called
    * by `shallowClone()` when a new instance is needed.
    */
@@ -56,13 +56,17 @@ export abstract class BaseFabricInstance extends FabricInstance {
    */
   static wireTypeTagOf(value: FabricInstance): string {
     if (!(value instanceof BaseFabricInstance)) {
-      throw new Error("Shouldn't happen: Encountered a `FabricInstance` which is not a `BaseFabricInstance`.");
+      throw new Error(
+        "Shouldn't happen: Encountered a `FabricInstance` which is not a `BaseFabricInstance`.",
+      );
     }
 
     const result = value.wireTypeTag;
 
     if (typeof result !== "string") {
-      throw new Error("Shouldn't happen: Encountered a `BaseFabricInstance` with a non-string `wireTypeTag`.");
+      throw new Error(
+        "Shouldn't happen: Encountered a `BaseFabricInstance` with a non-string `wireTypeTag`.",
+      );
     }
 
     return result;

--- a/packages/data-model/src/fabric-instances/ExplicitTagValue.ts
+++ b/packages/data-model/src/fabric-instances/ExplicitTagValue.ts
@@ -13,12 +13,31 @@ import { BaseFabricInstance } from "./BaseFabricInstance.ts";
  * See Section 3.2 of the formal spec.
  */
 export abstract class ExplicitTagValue extends BaseFabricInstance {
+  /** The value of {@link #wireTypeTag}. */
+  readonly #wireTypeTag;
+
+  /** The value of {@link #state}. */
+  readonly #state;
+
   constructor(
-    /** The original type tag, e.g. `"FutureType@2"`. */
-    readonly typeTag: string,
-    /** The raw state, already recursively processed by the deserializer. */
-    readonly state: FabricValue,
+    /** The original wire type tag, e.g. `"FutureType@2"`. */
+    wireTypeTag: string,
+    /** The raw state. */
+    state: FabricValue,
   ) {
     super();
+
+    this.#wireTypeTag = wireTypeTag;
+    this.#state = state; // TODO(danfuzz): Should be guaranteed deep-frozen.
+  }
+
+  /** Arbitrary raw instance state. */
+  get state(): FabricValue {
+    return this.#state;
+  }
+
+  /** @inheritDoc */
+  get wireTypeTag(): string {
+    return this.#wireTypeTag;
   }
 }

--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -135,6 +135,11 @@ export class FabricError extends FabricNativeWrapper<Error> {
     }
   }
 
+  /** @inheritDoc */
+  get wireTypeTag(): string {
+    return TAGS.Error;
+  }
+
   /**
    * Shallow conversion from a native `Error`. Used by the shallow conversion
    * layer (`shallowFabricFromNativeValueModern`). The error's `.cause` and

--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -80,9 +80,6 @@ export type FabricErrorState = {
  * spec.
  */
 export class FabricError extends FabricNativeWrapper<Error> {
-  /** @inheritDoc */
-  readonly typeTag = TAGS.Error;
-
   /** Constructor name of the originating native `Error` (e.g. `"TypeError"`). */
   type: string;
   /** The `.name` property (always a concrete string). */

--- a/packages/data-model/src/fabric-instances/FabricMap.ts
+++ b/packages/data-model/src/fabric-instances/FabricMap.ts
@@ -17,8 +17,6 @@ import { FabricNativeWrapper } from "./FabricNativeWrapper.ts";
  */
 export class FabricMap
   extends FabricNativeWrapper<Map<FabricValue, FabricValue>> {
-  /** @inheritDoc */
-  readonly typeTag = TAGS.Map;
   constructor(readonly map: Map<FabricValue, FabricValue>) {
     super();
   }

--- a/packages/data-model/src/fabric-instances/FabricMap.ts
+++ b/packages/data-model/src/fabric-instances/FabricMap.ts
@@ -23,6 +23,11 @@ export class FabricMap
     super();
   }
 
+  /** @inheritDoc */
+  get wireTypeTag(): string {
+    return TAGS.Map;
+  }
+
   [DECONSTRUCT](): FabricValue {
     throw new Error("FabricMap: not yet implemented");
   }

--- a/packages/data-model/src/fabric-instances/FabricNativeWrapper.ts
+++ b/packages/data-model/src/fabric-instances/FabricNativeWrapper.ts
@@ -10,9 +10,6 @@ import { BaseFabricInstance } from "./BaseFabricInstance.ts";
  */
 export abstract class FabricNativeWrapper<T extends object>
   extends BaseFabricInstance {
-  /** The wire format tag for this wrapper's type (e.g. `TAGS.Error`). */
-  abstract readonly typeTag: string;
-
   /** The wrapped native value, used by `toNativeValue` for freeze-state checks. */
   protected abstract get wrappedValue(): T;
 

--- a/packages/data-model/src/fabric-instances/FabricSet.ts
+++ b/packages/data-model/src/fabric-instances/FabricSet.ts
@@ -16,8 +16,6 @@ import { FabricNativeWrapper } from "./FabricNativeWrapper.ts";
  * wrapped collection are not supported on non-`Error` wrappers.
  */
 export class FabricSet extends FabricNativeWrapper<Set<FabricValue>> {
-  /** @inheritDoc */
-  readonly typeTag = TAGS.Set;
   constructor(readonly set: Set<FabricValue>) {
     super();
   }

--- a/packages/data-model/src/fabric-instances/FabricSet.ts
+++ b/packages/data-model/src/fabric-instances/FabricSet.ts
@@ -22,6 +22,11 @@ export class FabricSet extends FabricNativeWrapper<Set<FabricValue>> {
     super();
   }
 
+  /** @inheritDoc */
+  get wireTypeTag(): string {
+    return TAGS.Set;
+  }
+
   [DECONSTRUCT](): FabricValue {
     throw new Error("FabricSet: not yet implemented");
   }

--- a/packages/data-model/src/fabric-instances/ProblematicValue.ts
+++ b/packages/data-model/src/fabric-instances/ProblematicValue.ts
@@ -16,23 +16,31 @@ import { deepFreeze } from "../deep-freeze.ts";
  * failures. See Section 3.5 of the formal spec.
  */
 export class ProblematicValue extends ExplicitTagValue {
+  /** Value for {@link #error}. */
+  readonly #error;
+
   constructor(
     typeTag: string,
     state: FabricValue,
     /** Description of what went wrong. */
-    readonly error: string,
+    error: string,
   ) {
     super(typeTag, state);
+
+    this.#error = error;
+  }
+
+  /** Description of what went wrong. */
+  get error(): string {
+    return this.#error;
   }
 
   [DECONSTRUCT](): FabricValue {
-    return { type: this.typeTag, state: this.state, error: this.error };
+    return { type: this.wireTypeTag, state: this.state, error: this.error };
   }
 
   /**
-   * Deep-freezes in place. `typeTag` and `error` are immutable strings; the
-   * only `FabricValue`-typed slot is `state`, which is recursed via
-   * `subFreeze` before the wrapper itself is frozen.
+   * Deep-freezes in place.
    */
   [DEEP_FREEZE](
     subFreeze: (value: FabricValue) => FabricValue,
@@ -57,7 +65,7 @@ export class ProblematicValue extends ExplicitTagValue {
   }
 
   protected shallowUnfrozenClone(): ProblematicValue {
-    return new ProblematicValue(this.typeTag, this.state, this.error);
+    return new ProblematicValue(this.wireTypeTag, this.state, this.error);
   }
 
   static [RECONSTRUCT](

--- a/packages/data-model/src/fabric-instances/ProblematicValue.ts
+++ b/packages/data-model/src/fabric-instances/ProblematicValue.ts
@@ -20,12 +20,12 @@ export class ProblematicValue extends ExplicitTagValue {
   readonly #error;
 
   constructor(
-    typeTag: string,
+    wireTypeTag: string,
     state: FabricValue,
     /** Description of what went wrong. */
     error: string,
   ) {
-    super(typeTag, state);
+    super(wireTypeTag, state);
 
     this.#error = error;
   }

--- a/packages/data-model/src/fabric-instances/UnknownValue.ts
+++ b/packages/data-model/src/fabric-instances/UnknownValue.ts
@@ -17,18 +17,16 @@ import { deepFreeze } from "../deep-freeze.ts";
  * formal spec.
  */
 export class UnknownValue extends ExplicitTagValue {
-  constructor(typeTag: string, state: FabricValue) {
-    super(typeTag, state);
+  constructor(wireTypeTag: string, state: FabricValue) {
+    super(wireTypeTag, state);
   }
 
   [DECONSTRUCT](): FabricValue {
-    return { type: this.typeTag, state: this.state };
+    return { type: this.wireTypeTag, state: this.state };
   }
 
   /**
-   * Deep-freezes in place. `typeTag` is an immutable string; the only
-   * `FabricValue`-typed slot is `state`, which is recursed via `subFreeze`
-   * before the wrapper itself is frozen.
+   * Deep-freezes in place.
    */
   [DEEP_FREEZE](
     subFreeze: (value: FabricValue) => FabricValue,
@@ -53,7 +51,7 @@ export class UnknownValue extends ExplicitTagValue {
   }
 
   protected shallowUnfrozenClone(): UnknownValue {
-    return new UnknownValue(this.typeTag, this.state);
+    return new UnknownValue(this.wireTypeTag, this.state);
   }
 
   static [RECONSTRUCT](

--- a/packages/data-model/src/fabric-instances/UnknownValue.ts
+++ b/packages/data-model/src/fabric-instances/UnknownValue.ts
@@ -10,11 +10,10 @@ import { ExplicitTagValue } from "./ExplicitTagValue.ts";
 import { deepFreeze } from "../deep-freeze.ts";
 
 /**
- * Container for an unrecognized type's data, used for round-tripping. When
- * the serialization system encounters an unknown tag during deserialization,
- * it wraps the tag and state here; on re-serialization, it uses the preserved
- * `typeTag` to produce the original wire format. See Section 3.3 of the
- * formal spec.
+ * Container for an unrecognized type's data, used for round-tripping. When the
+ * serialization system encounters an unknown tag during deserialization, it
+ * wraps the tag and state here; on re-serialization, it uses the preserved data
+ * to produce the original wire format. See Section 3.3 of the formal spec.
  */
 export class UnknownValue extends ExplicitTagValue {
   constructor(wireTypeTag: string, state: FabricValue) {

--- a/packages/data-model/src/interface.ts
+++ b/packages/data-model/src/interface.ts
@@ -342,7 +342,7 @@ export interface ReconstructionContext {
    * sufficient for correctness regardless: each impl freezes its own output
    * when asked.
    */
-  readonly shouldDeepFreeze: boolean;
+  get shouldDeepFreeze(): boolean;
 }
 
 /**

--- a/packages/data-model/src/json-wire/FabricInstanceHandler.ts
+++ b/packages/data-model/src/json-wire/FabricInstanceHandler.ts
@@ -36,11 +36,11 @@ export const FabricInstanceHandler: TypeHandler = {
   ): JsonWireValue {
     const inst = value as FabricInstance;
 
-    // `ExplicitTagValue` (`UnknownValue`, `ProblematicValue`): use
-    // preserved `.typeTag` and re-serialize their stored state.
+    // For `ExplicitTagValue`, use the preserved original `wireTypeTag` and
+    // `state`.
     if (inst instanceof ExplicitTagValue) {
       const serializedState = recurse(inst.state);
-      return codec.wrapTag(inst.typeTag, serializedState);
+      return codec.wrapTag(inst.wireTypeTag, serializedState);
     }
 
     // General `FabricInstance`: use `[DECONSTRUCT]` and codec for tag.

--- a/packages/data-model/src/json-wire/JsonEncodingContext.ts
+++ b/packages/data-model/src/json-wire/JsonEncodingContext.ts
@@ -6,7 +6,6 @@ import {
   type ReconstructionContext,
   type SerializationContext,
 } from "../interface.ts";
-import { ExplicitTagValue } from "../fabric-instances/ExplicitTagValue.ts";
 import { deepFreeze } from "../deep-freeze.ts";
 import { UnknownValue } from "../fabric-instances/UnknownValue.ts";
 import { ProblematicValue } from "../fabric-instances/ProblematicValue.ts";

--- a/packages/data-model/src/json-wire/JsonEncodingContext.ts
+++ b/packages/data-model/src/json-wire/JsonEncodingContext.ts
@@ -119,7 +119,7 @@ export class JsonEncodingContext implements SerializationContext<string> {
     // Create a codec view that delegates to our private methods.
     this.codec = {
       wrapTag: (tag: string, state: JsonWireValue) => this.wrapTag(tag, state),
-      getTagFor: (value: FabricInstance) => this.getTagFor(value),
+      getTagFor: (value: FabricInstance) => BaseFabricInstance.wireTypeTagOf(value),
     };
 
     // Register native wrapper classes for deserialization. Each wrapper's
@@ -197,15 +197,6 @@ export class JsonEncodingContext implements SerializationContext<string> {
   //
   // Tag wrapping/unwrapping (private)
   //
-
-  /** Returns the wire format tag for a fabric instance's type. */
-  private getTagFor(value: FabricInstance): string {
-    if (value instanceof BaseFabricInstance) {
-      return value.wireTypeTag;
-    } else {
-      throw new Error("Shouldn't happen: Encountered a `FabricInstance` which is not a `BaseFabricInstance`.");
-    }
-  }
 
   /** Returns the class that can reconstruct instances for a given tag. */
   private getClassFor(

--- a/packages/data-model/src/json-wire/JsonEncodingContext.ts
+++ b/packages/data-model/src/json-wire/JsonEncodingContext.ts
@@ -119,7 +119,8 @@ export class JsonEncodingContext implements SerializationContext<string> {
     // Create a codec view that delegates to our private methods.
     this.codec = {
       wrapTag: (tag: string, state: JsonWireValue) => this.wrapTag(tag, state),
-      getTagFor: (value: FabricInstance) => BaseFabricInstance.wireTypeTagOf(value),
+      getTagFor: (value: FabricInstance) =>
+        BaseFabricInstance.wireTypeTagOf(value),
     };
 
     // Register native wrapper classes for deserialization. Each wrapper's

--- a/packages/data-model/src/json-wire/JsonEncodingContext.ts
+++ b/packages/data-model/src/json-wire/JsonEncodingContext.ts
@@ -13,9 +13,12 @@ import { ProblematicValue } from "../fabric-instances/ProblematicValue.ts";
 import { createDefaultRegistry } from "./createDefaultRegistry.ts";
 import type { JsonWireValue, TypeHandlerCodec } from "./interface.ts";
 import type { TypeHandlerRegistry } from "./TypeHandlerRegistry.ts";
-import { FabricError } from "../fabric-instances/FabricError.ts";
-import { FabricMap } from "../fabric-instances/FabricMap.ts";
-import { FabricSet } from "../fabric-instances/FabricSet.ts";
+import {
+  BaseFabricInstance,
+  FabricError,
+  FabricMap,
+  FabricSet,
+} from "../fabric-instances/index.ts";
 import { TAGS } from "../fabric-type-tags.ts";
 import { utf8SortedKeysOf } from "@commonfabric/utils/utf8";
 
@@ -197,16 +200,11 @@ export class JsonEncodingContext implements SerializationContext<string> {
 
   /** Returns the wire format tag for a fabric instance's type. */
   private getTagFor(value: FabricInstance): string {
-    if (value instanceof ExplicitTagValue) {
-      return value.typeTag;
+    if (value instanceof BaseFabricInstance) {
+      return value.wireTypeTag;
+    } else {
+      throw new Error("Shouldn't happen: Encountered a `FabricInstance` which is not a `BaseFabricInstance`.");
     }
-    const typeTag = (value as { typeTag?: unknown }).typeTag;
-    if (typeof typeTag === "string") {
-      return typeTag;
-    }
-    throw new Error(
-      `JsonEncodingContext: no tag registered for value: ${value}`,
-    );
   }
 
   /** Returns the class that can reconstruct instances for a given tag. */

--- a/packages/data-model/src/value-hash.ts
+++ b/packages/data-model/src/value-hash.ts
@@ -16,6 +16,7 @@ import { isDeepFrozen } from "./deep-freeze.ts";
 import { FabricHash } from "./fabric-primitives/FabricHash.ts";
 import { FabricBytes } from "./fabric-primitives/FabricBytes.ts";
 import { FabricRegExp } from "./fabric-primitives/FabricRegExp.ts";
+import { BaseFabricInstance } from "./fabric-instances/BaseFabricInstance.ts";
 import { DECONSTRUCT, type FabricInstance } from "./interface.ts";
 import { shallowFabricFromNativeValue } from "./native-conversion.ts";
 import { NATIVE_TAGS, tagFromNativeValue } from "./native-type-tags.ts";
@@ -300,16 +301,11 @@ function feedObjectValue(
     }
 
     case NATIVE_TAGS.FabricInstance: {
-      // Generic `FabricInstance` (protocol path via `[DECONSTRUCT]`).
+      const fabInst = value as FabricInstance;
       hasher.update(TAG_INSTANCE_BYTES);
-      const typeTag = (value as { typeTag?: unknown }).typeTag;
-      if (typeof typeTag !== "string") {
-        throw new Error(
-          `hashOf: FabricInstance missing typeTag property`,
-        );
-      }
-      hasher.update(getStringRep(typeTag));
-      const state = (value as FabricInstance)[DECONSTRUCT]();
+      const wireTypeTag = BaseFabricInstance.wireTypeTagOf(fabInst);
+      hasher.update(getStringRep(wireTypeTag));
+      const state = fabInst[DECONSTRUCT]();
       feedValue(hasher, state);
       return;
     }

--- a/packages/data-model/test/EmptyReconstructionContext.test.ts
+++ b/packages/data-model/test/EmptyReconstructionContext.test.ts
@@ -43,9 +43,8 @@ describe("EmptyReconstructionContext", () => {
   });
 
   describe("`EmptyReconstructionContext` (exported class)", () => {
-    it("reports `shouldDeepFreeze` as `true` with the historical verbatim throw message (default ctor)", () => {
-      const ctx = new EmptyReconstructionContext();
-      expect(ctx.shouldDeepFreeze).toBe(true);
+    it("throws the expected default message (default ctor)", () => {
+      const ctx = new EmptyReconstructionContext(true);
       expect(() =>
         ctx.getCell({ id: "of:bafyDEFAULT", path: [], space: "did:key:z1" })
       ).toThrow(

--- a/packages/data-model/test/fabric-instances/BaseFabricInstance.test.ts
+++ b/packages/data-model/test/fabric-instances/BaseFabricInstance.test.ts
@@ -16,15 +16,23 @@ import { BaseFabricInstance } from "../../src/fabric-instances/BaseFabricInstanc
  * counter (kept off the instance so freezing doesn't block bookkeeping).
  */
 class Probe extends BaseFabricInstance {
+  readonly #tag;
+
   constructor(
-    readonly tag: string,
+    tag: string,
     readonly counter: { calls: number } = { calls: 0 },
   ) {
     super();
+
+    this.#tag = tag;
+  }
+
+  get wireTypeTag(): string {
+    return this.#tag;
   }
 
   [DECONSTRUCT](): FabricValue {
-    return this.tag;
+    return this.#tag;
   }
 
   [DEEP_FREEZE](
@@ -46,7 +54,7 @@ class Probe extends BaseFabricInstance {
 
   protected shallowUnfrozenClone(): Probe {
     this.counter.calls += 1;
-    return new Probe(this.tag, this.counter);
+    return new Probe(this.#tag, this.counter);
   }
 }
 
@@ -78,7 +86,7 @@ describe("BaseFabricInstance", () => {
 
         expect(result).not.toBe(probe);
         expect(result instanceof Probe).toBe(true);
-        expect((result as Probe).tag).toBe("t");
+        expect((result as Probe).wireTypeTag).toBe("t");
         expect(Object.isFrozen(result)).toBe(true);
         // Original is left unfrozen.
         expect(Object.isFrozen(probe)).toBe(false);
@@ -95,7 +103,7 @@ describe("BaseFabricInstance", () => {
 
         expect(result).not.toBe(probe);
         expect(result instanceof Probe).toBe(true);
-        expect((result as Probe).tag).toBe("t");
+        expect((result as Probe).wireTypeTag).toBe("t");
         expect(Object.isFrozen(result)).toBe(false);
         // The identity-when-frozen optimization is `frozen===true` only;
         // a `frozen===false` call always allocates.

--- a/packages/data-model/test/fabric-instances/ExplicitTagValue.test.ts
+++ b/packages/data-model/test/fabric-instances/ExplicitTagValue.test.ts
@@ -6,7 +6,7 @@ import { ExplicitTagValue } from "../../src/fabric-instances/ExplicitTagValue.ts
 
 describe("ExplicitTagValue", () => {
   describe("instance members", () => {
-    describe("`.typeTag` / `.state`", () => {
+    describe("`.wireTypeTag` / `.state`", () => {
       it("provide access to the concrete subclass's tag and state", () => {
         const us: ExplicitTagValue = new UnknownValue("Tag@2", 42);
         expect(us.wireTypeTag).toBe("Tag@2");

--- a/packages/data-model/test/fabric-instances/ExplicitTagValue.test.ts
+++ b/packages/data-model/test/fabric-instances/ExplicitTagValue.test.ts
@@ -9,7 +9,7 @@ describe("ExplicitTagValue", () => {
     describe("`.typeTag` / `.state`", () => {
       it("provide access to the concrete subclass's tag and state", () => {
         const us: ExplicitTagValue = new UnknownValue("Tag@2", 42);
-        expect(us.typeTag).toBe("Tag@2");
+        expect(us.wireTypeTag).toBe("Tag@2");
         expect(us.state).toBe(42);
 
         const ps: ExplicitTagValue = new ProblematicValue(
@@ -17,7 +17,7 @@ describe("ExplicitTagValue", () => {
           "data",
           "err",
         );
-        expect(ps.typeTag).toBe("Bad@1");
+        expect(ps.wireTypeTag).toBe("Bad@1");
         expect(ps.state).toBe("data");
       });
     });

--- a/packages/data-model/test/fabric-instances/FabricError.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricError.test.ts
@@ -26,9 +26,9 @@ describe("FabricError", () => {
     expect(se instanceof FabricInstance).toBe(true);
   });
 
-  it("has typeTag `Error@1`", () => {
+  it("has the expected `.wireTypeTag`", () => {
     const se = FabricError.fromNativeError(new Error("test"));
-    expect(se.typeTag).toBe("Error@1");
+    expect(se.wireTypeTag).toBe("Error@1");
   });
 
   it("is an instance of `FabricNativeWrapper`", () => {

--- a/packages/data-model/test/fabric-instances/FabricMap.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricMap.test.ts
@@ -17,10 +17,10 @@ import { dummyContext, subFreeze, subIsDeepFrozen } from "./fixtures.ts";
 describe("FabricMap", () => {
   // Pure type-identity / supertype checks: cross-cutting carve-out per the
   // rule (they don't fit a single member, aren't construction mechanics).
-  it("implements `FabricInstance` with tag `Map@1`", () => {
+  it("implements `FabricInstance` with expected `.wireTypeTag`", () => {
     const sm = new FabricMap(new Map());
     expect(sm instanceof FabricInstance).toBe(true);
-    expect(sm.typeTag).toBe("Map@1");
+    expect(sm.wireTypeTag).toBe("Map@1");
   });
 
   it("is an instance of `FabricNativeWrapper`", () => {

--- a/packages/data-model/test/fabric-instances/FabricSet.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricSet.test.ts
@@ -15,10 +15,10 @@ import { subFreeze, subIsDeepFrozen } from "./fixtures.ts";
 describe("FabricSet", () => {
   // Pure type-identity / supertype check: cross-cutting carve-out per the
   // rule (doesn't fit a single member, isn't construction mechanics).
-  it("implements `FabricInstance` with tag `Set@1`", () => {
+  it("implements `FabricInstance` with the expected `.wireTypeTag`", () => {
     const ss = new FabricSet(new Set());
     expect(ss instanceof FabricInstance).toBe(true);
-    expect(ss.typeTag).toBe("Set@1");
+    expect(ss.wireTypeTag).toBe("Set@1");
   });
 
   describe("instance members", () => {

--- a/packages/data-model/test/fabric-instances/ProblematicValue.test.ts
+++ b/packages/data-model/test/fabric-instances/ProblematicValue.test.ts
@@ -20,9 +20,9 @@ describe("ProblematicValue", () => {
   });
 
   describe("constructor()", () => {
-    it("preserves `typeTag`, `state`, and `error`", () => {
+    it("preserves `wireTypeTag`, `state`, and `error`", () => {
       const ps = new ProblematicValue("BadType@1", { x: 1 }, "boom");
-      expect(ps.typeTag).toBe("BadType@1");
+      expect(ps.wireTypeTag).toBe("BadType@1");
       expect(ps.state).toEqual({ x: 1 });
       expect(ps.error).toBe("boom");
     });

--- a/packages/data-model/test/fabric-instances/UnknownValue.test.ts
+++ b/packages/data-model/test/fabric-instances/UnknownValue.test.ts
@@ -20,9 +20,9 @@ describe("UnknownValue", () => {
   });
 
   describe("constructor()", () => {
-    it("preserves `typeTag` and `state`", () => {
+    it("preserves `wireTypeTag` and `state`", () => {
       const us = new UnknownValue("FancyType@3", { data: [1, 2, 3] });
-      expect(us.typeTag).toBe("FancyType@3");
+      expect(us.wireTypeTag).toBe("FancyType@3");
       expect(us.state).toEqual({ data: [1, 2, 3] });
     });
   });

--- a/packages/data-model/test/fabric-instances/fixtures.ts
+++ b/packages/data-model/test/fabric-instances/fixtures.ts
@@ -9,7 +9,7 @@ export class DummyReconstructionContext extends BaseReconstructionContext {
   }
 }
 
-export const dummyContext = new DummyReconstructionContext();
+export const dummyContext = new DummyReconstructionContext(true);
 
 /**
  * Recursion-callback helpers for exercising the `[DEEP_FREEZE]` /

--- a/packages/data-model/test/json-wire/JsonEncodingContext.test.ts
+++ b/packages/data-model/test/json-wire/JsonEncodingContext.test.ts
@@ -371,7 +371,7 @@ describe("JsonEncodingContext", () => {
       const result = fromWireFormat(data);
       expect(result).toBeInstanceOf(ProblematicValue);
       const prob = result as unknown as ProblematicValue;
-      expect(prob.typeTag).toBe("BigInt@1");
+      expect(prob.wireTypeTag).toBe("BigInt@1");
       expect(prob.state).toBe(42);
     });
 
@@ -392,7 +392,7 @@ describe("JsonEncodingContext", () => {
       const result = fromWireFormat(data);
       expect(result).toBeInstanceOf(ProblematicValue);
       const prob = result as unknown as ProblematicValue;
-      expect(prob.typeTag).toBe("BigInt@1");
+      expect(prob.wireTypeTag).toBe("BigInt@1");
     });
   });
 
@@ -481,7 +481,7 @@ describe("JsonEncodingContext", () => {
         JSON.stringify({ "/SpecialNumber@1": 0 });
       const result = ctx.decode(encoded, runtime);
       expect(result).toBeInstanceOf(ProblematicValue);
-      expect((result as unknown as ProblematicValue).typeTag).toBe(
+      expect((result as unknown as ProblematicValue).wireTypeTag).toBe(
         "SpecialNumber@1",
       );
     });
@@ -493,7 +493,7 @@ describe("JsonEncodingContext", () => {
         JSON.stringify({ "/SpecialNumber@1": "Infinity" }); // missing leading +
       const result = ctx.decode(encoded, runtime);
       expect(result).toBeInstanceOf(ProblematicValue);
-      expect((result as unknown as ProblematicValue).typeTag).toBe(
+      expect((result as unknown as ProblematicValue).wireTypeTag).toBe(
         "SpecialNumber@1",
       );
     });
@@ -567,7 +567,7 @@ describe("JsonEncodingContext", () => {
         JSON.stringify({ "/Symbol@1": 42 });
       const result = ctx.decode(encodedJson, runtime);
       expect(result).toBeInstanceOf(ProblematicValue);
-      expect((result as unknown as ProblematicValue).typeTag).toBe(
+      expect((result as unknown as ProblematicValue).wireTypeTag).toBe(
         "Symbol@1",
       );
     });
@@ -863,9 +863,9 @@ describe("JsonEncodingContext", () => {
       expect(result.toNativeValue(true).constructor.name).toBe("Error");
     });
 
-    it("has `.typeTag` property", () => {
+    it("has `.wireTypeTag` property", () => {
       const se = FabricError.fromNativeError(new Error("test"));
-      expect(se.typeTag).toBe("Error@1");
+      expect(se.wireTypeTag).toBe("Error@1");
     });
 
     it("round-trips `FabricError` with pre-converted cause (raw `Error`)", () => {
@@ -1294,7 +1294,7 @@ describe("JsonEncodingContext", () => {
         const data = { "/Future@7": { id: "x" } } as JsonWireValue;
         const result = fromWireFormat(data);
         expect(result).toBeInstanceOf(UnknownValue);
-        expect((result as unknown as UnknownValue).typeTag).toBe("Future@7");
+        expect((result as unknown as UnknownValue).wireTypeTag).toBe("Future@7");
       });
 
       it("decoder strips exactly one `/quote` layer — inner `/quote` is preserved literally", () => {
@@ -1369,7 +1369,7 @@ describe("JsonEncodingContext", () => {
       const result = fromWireFormat(data);
       expect(result).toBeInstanceOf(UnknownValue);
       const unknown = result as unknown as UnknownValue;
-      expect(unknown.typeTag).toBe("FutureType@2");
+      expect(unknown.wireTypeTag).toBe("FutureType@2");
       expect(unknown.state).toEqual({ some: "data" });
     });
 
@@ -1387,7 +1387,7 @@ describe("JsonEncodingContext", () => {
       const result = roundTrip(us as FabricValue);
       expect(result).toBeInstanceOf(UnknownValue);
       const unknown = result as unknown as UnknownValue;
-      expect(unknown.typeTag).toBe("FutureType@2");
+      expect(unknown.wireTypeTag).toBe("FutureType@2");
       expect(unknown.state).toEqual({ some: "data" });
     });
 
@@ -1396,7 +1396,7 @@ describe("JsonEncodingContext", () => {
       const result = fromWireFormat(data);
       expect(result).toBeInstanceOf(UnknownValue);
       const unknown = result as unknown as UnknownValue;
-      expect(unknown.typeTag).toBe("hole");
+      expect(unknown.wireTypeTag).toBe("hole");
       expect(unknown.state).toBe(5);
     });
   });
@@ -1433,12 +1433,11 @@ describe("JsonEncodingContext", () => {
 
     it("throws on `FabricInstance` whose state references itself", () => {
       const { context } = makeTestContext();
-      // Create an UnknownValue whose state transitively references itself.
-      const us = new UnknownValue("Test@1", null);
-      // Mutate state to create a cycle: us -> [us] -> us.
-      (us as unknown as { state: FabricValue }).state = [
-        us,
-      ] as unknown as FabricValue;
+      // Create an instance with a circular reference in its state.
+      const state = { eek: [] as unknown[] };
+      state.eek.push(state);
+
+      const us = new UnknownValue("Test@1", state);
       expect(() => context.encode(us as FabricValue))
         .toThrow(
           "Circular reference",
@@ -1478,7 +1477,7 @@ describe("JsonEncodingContext", () => {
       );
       expect(result).toBeInstanceOf(ProblematicValue);
       const prob = result as unknown as ProblematicValue;
-      expect(prob.typeTag).toBe("BigInt@1");
+      expect(prob.wireTypeTag).toBe("BigInt@1");
     });
 
     it("lenient mode wraps failed class-registry reconstruction", () => {
@@ -1496,7 +1495,7 @@ describe("JsonEncodingContext", () => {
       );
       expect(result).toBeInstanceOf(ProblematicValue);
       const prob = result as unknown as ProblematicValue;
-      expect(prob.typeTag).toBe("Map@1");
+      expect(prob.wireTypeTag).toBe("Map@1");
     });
   });
 

--- a/packages/data-model/test/json-wire/JsonEncodingContext.test.ts
+++ b/packages/data-model/test/json-wire/JsonEncodingContext.test.ts
@@ -1294,7 +1294,9 @@ describe("JsonEncodingContext", () => {
         const data = { "/Future@7": { id: "x" } } as JsonWireValue;
         const result = fromWireFormat(data);
         expect(result).toBeInstanceOf(UnknownValue);
-        expect((result as unknown as UnknownValue).wireTypeTag).toBe("Future@7");
+        expect((result as unknown as UnknownValue).wireTypeTag).toBe(
+          "Future@7",
+        );
       });
 
       it("decoder strips exactly one `/quote` layer — inner `/quote` is preserved literally", () => {

--- a/packages/data-model/test/json-wire/JsonEncodingContext.test.ts
+++ b/packages/data-model/test/json-wire/JsonEncodingContext.test.ts
@@ -18,6 +18,10 @@ import { shallowFabricFromNativeValue } from "../../src/fabric-value.ts";
  * `BaseReconstructionContext` (defaults to `true`).
  */
 class TestReconstructionContext extends BaseReconstructionContext {
+  constructor() {
+    super(true);
+  }
+
   override getCell(): never {
     throw new Error("getCell not implemented in test runtime");
   }

--- a/packages/data-model/test/json-wire/json-encoding.test.ts
+++ b/packages/data-model/test/json-wire/json-encoding.test.ts
@@ -12,6 +12,10 @@ import { BaseReconstructionContext } from "../../src/BaseReconstructionContext.t
 
 /** Mock runtime for deserialization calls. */
 class MockRuntime extends BaseReconstructionContext {
+  constructor() {
+    super(true);
+  }
+
   override getCell(): never {
     throw new Error("getCell not implemented in test runtime");
   }

--- a/packages/data-model/test/native-conversion.test.ts
+++ b/packages/data-model/test/native-conversion.test.ts
@@ -343,6 +343,10 @@ describe("native-conversion", () => {
 
     it("returns `true` for custom `FabricInstance` subclass", () => {
       class CustomFabInst extends BaseFabricInstance {
+        get wireTypeTag(): string {
+          return "Custom@914";
+        }
+
         [DECONSTRUCT](): FabricValue {
           return { value: 42 };
         }

--- a/packages/runner/test/cell-core.test.ts
+++ b/packages/runner/test/cell-core.test.ts
@@ -99,15 +99,13 @@ describe("Cell", () => {
     // Error is stored as a `FabricError`-shaped value. `c.get()` returns a
     // proxy view of the stored wrapper — its observable fields (`type`,
     // `name`, `message`, `stack`, etc.) are exposed directly on the
-    // projection, and its `typeTag` is `"Error@1"` (`FabricError`'s tag).
+    // projection, and its `wireTypeTag` is `"Error@1"` (`FabricError`'s tag).
     const result = c.get() as {
       message: string;
       stack: string;
-      typeTag: string;
-      "@Error"?: unknown;
+      wireTypeTag: string;
     };
-    expect(result["@Error"]).toBeUndefined();
-    expect(result.typeTag).toBe("Error@1");
+    expect(result.wireTypeTag).toBe("Error@1");
     expect(result.message).toBe("something went wrong");
     expect(typeof result.stack).toBe("string");
     await localTx.commit();
@@ -138,11 +136,9 @@ describe("Cell", () => {
     const result = c.get() as {
       message: string;
       cause: { message: string; stack: string };
-      typeTag: string;
-      "@Error"?: unknown;
+      wireTypeTag: string;
     };
-    expect(result["@Error"]).toBeUndefined();
-    expect(result.typeTag).toBe("Error@1");
+    expect(result.wireTypeTag).toBe("Error@1");
     expect(result.message).toBe("wrapper error");
     expect(result.cause.message).toBe("root cause");
     expect(typeof result.cause.stack).toBe("string");
@@ -191,9 +187,9 @@ describe("Cell", () => {
 
     const targetResult = target.get() as {
       message: string;
-      typeTag: string;
+      wireTypeTag: string;
     };
-    expect(targetResult.typeTag).toBe("Error@1");
+    expect(targetResult.wireTypeTag).toBe("Error@1");
     expect(targetResult.message).toBe("through nested redirect");
 
     await localTx.commit();

--- a/packages/runner/test/fetch-data-mutex.test.ts
+++ b/packages/runner/test/fetch-data-mutex.test.ts
@@ -498,14 +498,13 @@ describe("fetch-data mutex mechanism", () => {
     // class-stripping bug, which made errors round-trip back as `{ ... }`
     // with message/stack lost.
     expect(data.error).toBeDefined();
-    expect((data.error as { "@Error"?: unknown })["@Error"]).toBeUndefined();
     const fe = data.error as {
-      typeTag: string;
+      wireTypeTag: string;
       name: string;
       message: string;
       stack: string;
     };
-    expect(fe.typeTag).toBe("Error@1");
+    expect(fe.wireTypeTag).toBe("Error@1");
     expect(fe.name).toBe("Error");
     expect(fe.message).toMatch(/HTTP 404/);
     expect(typeof fe.stack).toBe("string");


### PR DESCRIPTION
This PR makes two refinements to some `data-model` protocols, one small and one big.

The small change is changing the declaration of `.shouldDeepFreeze` to be a getter method instead of a regular exposed property. It was _already_ defined as a getter method in all concrete classes. In addition, this PR makes constructor arguments for `shouldDeepFreeze` be required; in practice they were explicitly passed in most cases already.

The big change is reworking how `FabricInstance` wire-format type tags are named and found. The status quo was that a regular property `typeTag` was defined on all `FabricInstance`s, though `FabricInstance` did not actually declared it. The code to find a type tag bounced through an `as unknown as { typeTag: string }`, which was… less than ideal. As of this PR, `BaseFabricInstance` — the intermediate abstract class focused on implementors (not clients) of `FabricInstance` classes — properly declares an abstract getter for `.wireTypeTag`, which is (a) properly defined on all classes that need it, and (b) gotten in a straightforward, safe, and unsurprising way.

## Performance Baseline

This PR makes basically no changes to the effective code, and the little that it _does_ do makes things arguably ever so slightly more efficient. As such, the following accounts for spurious perf check failures:

NEW_PERF_BASELINE: job: Pattern Integration Tests (4/4) = 189s
NEW_PERF_BASELINE: job: CLI Integration Tests (core-piece-links) = 121s


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes wire-format tags via a `.wireTypeTag` getter on `BaseFabricInstance` (plus `BaseFabricInstance.wireTypeTagOf(value)`), and makes `ReconstructionContext.shouldDeepFreeze` a getter with a required constructor argument. JSON encoding and value hashing now read tags through the new API, removing unsafe `typeTag` access.

- **Refactors**
  - Add abstract `get wireTypeTag()` and `static wireTypeTagOf(value)` to `BaseFabricInstance`.
  - Implement `.wireTypeTag` in `ExplicitTagValue`, `UnknownValue`, `ProblematicValue`, `FabricError`, `FabricMap`, `FabricSet`.
  - Switch JSON encoding and value hashing to `wireTypeTag`; remove legacy `.typeTag` (including `FabricNativeWrapper`’s abstract `typeTag`) and ad-hoc casts.
  - Minor doc/typo cleanups; remove an unused import.

- **Migration**
  - `FabricInstance` implementations must define `get wireTypeTag(): string` and stop exposing `.typeTag`.
  - Replace `value.typeTag` reads with `value.wireTypeTag` or `BaseFabricInstance.wireTypeTagOf(value)`.
  - `ReconstructionContext.shouldDeepFreeze` is now a getter; `BaseReconstructionContext` and `EmptyReconstructionContext` require an explicit `shouldDeepFreeze` constructor argument.

<sup>Written for commit 6f3f060931278e5ae49ea80aba889af0e63ab078. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



