### PR TITLE
fix(runner): reset container on array→object transition in normalizeAndDiff (CT-1663)

### DIFF
--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -1,4 +1,4 @@
-import { isRecord } from "@commonfabric/utils/types";
+import { isObject, isRecord } from "@commonfabric/utils/types";
 import {
   fabricFromNativeValue,
   FabricInstance,
@@ -898,17 +898,15 @@ export function normalizeAndDiff(
       "diff",
       () => `[BRANCH_OBJECT] Processing object at path=${pathStr}`,
     );
-    // If the current value is not a (regular) object, set it to an empty object
+    // If the current value is not a (regular) object, set it to an empty object.
     // Note that the alias case is handled above.
-    // `isRecord` is true for arrays (`typeof [] === "object"`), so we must
-    // reset explicitly on an array→object transition; otherwise per-key writes
-    // land in a slot whose stored parent is still an array and storage rejects
-    // them with a TypeMismatchError. This mirrors the array branch above, which
-    // resets a mismatched container via `value: []`.
-    if (
-      !isRecord(currentValue) || Array.isArray(currentValue) ||
-      isPrimitiveCellLink(currentValue)
-    ) {
+    // We use `isObject` (not `isRecord`) here deliberately: `isRecord` is true
+    // for arrays (`typeof [] === "object"`), whereas `isObject` excludes them.
+    // Resetting on an array→object transition is required; otherwise per-key
+    // writes land in a slot whose stored parent is still an array and storage
+    // rejects them with a TypeMismatchError. This mirrors the array branch
+    // above, which resets a mismatched container via `value: []`.
+    if (!isObject(currentValue) || isPrimitiveCellLink(currentValue)) {
       diffLogger.debug(
         "diff",
         () =>

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -899,8 +899,16 @@ export function normalizeAndDiff(
       () => `[BRANCH_OBJECT] Processing object at path=${pathStr}`,
     );
     // If the current value is not a (regular) object, set it to an empty object
-    // Note that the alias case is handled above
-    if (!isRecord(currentValue) || isPrimitiveCellLink(currentValue)) {
+    // Note that the alias case is handled above.
+    // `isRecord` is true for arrays (`typeof [] === "object"`), so we must
+    // reset explicitly on an array→object transition; otherwise per-key writes
+    // land in a slot whose stored parent is still an array and storage rejects
+    // them with a TypeMismatchError. This mirrors the array branch above, which
+    // resets a mismatched container via `value: []`.
+    if (
+      !isRecord(currentValue) || Array.isArray(currentValue) ||
+      isPrimitiveCellLink(currentValue)
+    ) {
       diffLogger.debug(
         "diff",
         () =>

--- a/packages/runner/test/data-updating.test.ts
+++ b/packages/runner/test/data-updating.test.ts
@@ -195,6 +195,25 @@ describe("data-updating", () => {
       expect(testCell.get().a).toHaveLength(3);
       expect(testCell.getAsQueryResult().a).toEqual([1, 2, 3]);
     });
+
+    it("should overwrite an array with an object", () => {
+      const testCell = runtime.getCell<{ a: any }>(
+        space,
+        "should overwrite an array with an object 1",
+        undefined,
+        tx,
+      );
+      testCell.set({ a: [{ type: "x" }] });
+      const success = diffAndUpdate(
+        runtime,
+        tx,
+        testCell.key("a").getAsNormalizedFullLink(),
+        { type: "cf-text" },
+      );
+      expect(success).toBeTruthy();
+      expect(testCell.get()).toHaveProperty("a");
+      expect(testCell.getAsQueryResult().a).toEqual({ type: "cf-text" });
+    });
   });
 
   describe("normalizeAndDiff", () => {


### PR DESCRIPTION
## Summary

Fixes [CT-1663](https://linear.app/common-tools/issue/CT-1663). The reactive differ throws `TypeMismatchError` when a value at a location changes from an **array** to a plain **object** in place.

The most common author-facing trigger is a `computed()` JSX child that returns an array of nodes OR a single node depending on state (e.g. an empty-list fallback):

```tsx
{computed(() =>
  items.length === 0
    ? <cf-text>No items</cf-text>      // single node (object)
    : items.map((it) => <row/>)        // array of nodes
)}
```

It renders fine while non-empty; deleting the last item (array → single node) throws and the section dies.

## Root cause

In `packages/runner/src/data-updating.ts`, the **object branch** of `normalizeAndDiff` reset a mismatched container only when:

```ts
!isRecord(currentValue) || isPrimitiveCellLink(currentValue)
```

But `isRecord` (`packages/utils/src/types.ts`) is `typeof value === "object" && value !== null` — which is **`true` for arrays**. So on an array→object transition the reset never fired, and the code fell through to per-key writes (`…__#0.type`, `.name`, …) into a slot whose stored parent is still an array. Storage rejects those at `applyChangeSet → writeValuesOrThrow`:

```
TypeMismatchError: Cannot write property at path [value, __#0, type] - expected object but found array
```

The **array branch** already resets a mismatched container via `changes.push({ location: link, value: [] })`. The object branch was simply missing the symmetric guard — the reverse (object→array) direction is handled and tested; array→object was unguarded and untested.

This is not an intentional shape-stability guard (the type system allows both — `RenderNode` includes `VNode` and `VNode[]`); it's an incidental differ asymmetry.

## Fix

Add `Array.isArray(currentValue)` to the object branch's reset condition so an array→object transition resets the container to `{}` before per-key writes, mirroring the array branch's `value: []` reset.

## Tests

- Added `should overwrite an array with an object` — the exact mirror of the existing `should overwrite an object with an array` test. It reproduces the `TypeMismatchError` before the fix and passes after.
- Full runner suite: **526 passed (2788 steps), 0 failed** — no regressions.

## Out of scope (deferred, see issue)

The secondary DX items from CT-1663 (register `TypeMismatchError` in the runtime-errors doc; make the runtime message name the cause) are intentionally not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CT-1663 by resetting the container on array→object transitions in `normalizeAndDiff` to prevent `TypeMismatchError` when `computed()` children flip between arrays and single nodes.

- **Bug Fixes**
  - In the object branch, now uses `isObject` (from `@commonfabric/utils/types`) in the reset guard so arrays are excluded and the container resets to `{}` before per-key writes; keeps the `isPrimitiveCellLink` check and mirrors the array branch.
  - Added a test (“should overwrite an array with an object”) that failed before and passes now; full runner suite green.

<sup>Written for commit bb51077c6a9eb81a804503fed969171a33a241b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

