### PR TITLE
fix(piece): sync loaded pieces before start

### DIFF
--- a/packages/piece/src/manager.ts
+++ b/packages/piece/src/manager.ts
@@ -310,8 +310,11 @@ export class PieceManager {
       );
 
     if (runIt) {
-      // start() handles sync, pattern loading, and running
-      // It's idempotent - no effect if already running
+      // Load persisted result/metadata before start() decides whether this is a
+      // resumed piece that needs dependency sync before scheduler wiring.
+      await timePiecePhase("get.piece.sync", () => piece.sync());
+      // start() handles pattern loading and running. It's idempotent - no
+      // effect if already running.
       await timePiecePhase(
         "get.runtime.start",
         () => this.runtime.start(piece),

--- a/packages/piece/test/test.ts
+++ b/packages/piece/test/test.ts
@@ -1,4 +1,40 @@
-import { describe } from "@std/testing/bdd";
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { PieceManager } from "../src/manager.ts";
 
 describe("noop", () => {
+});
+
+describe("PieceManager.get", () => {
+  it("syncs a loaded piece before starting it", async () => {
+    let pieceSynced = false;
+    let startSawSyncedPiece = false;
+
+    const piece = {
+      sync: () => {
+        pieceSynced = true;
+        return Promise.resolve();
+      },
+      asSchema: () => piece,
+    };
+    const runtime = {
+      userIdentityDID: "did:key:home",
+      getSpaceCell: () => ({
+        sync: () => Promise.resolve(),
+      }),
+      getCellFromEntityId: () => piece,
+      start: () => {
+        startSawSyncedPiece = pieceSynced;
+        return Promise.resolve(true);
+      },
+    };
+    const manager = new PieceManager({
+      as: {} as never,
+      space: "did:key:test-space" as never,
+    }, runtime as never);
+
+    await manager.get("piece-id", true, { type: "object" });
+
+    expect(startSawSyncedPiece).toBe(true);
+  });
 });


### PR DESCRIPTION
## What

Restores `003f58da5` (from the stuck `codex/sync-piece-before-run` branch): in `PieceManager.get()`, `await piece.sync()` **before** `runtime.start(piece)`, so persisted result/metadata is loaded before the scheduler is wired.

## Why

Without this, a piece can begin executing before its persisted data is loaded — a small data-loading race on the entry piece. Loading it first makes startup deterministic.

## Scope note

The companion commit `67d3ed696` (*sync rendered pieces with view schema*, threading `nameAndUiSchema` through the render path) was **dropped**: it caused a real regression — the `default-app` flow test ("create a note → see it in the space list") times out (reproduced locally; bisected to that commit; the sync-before-start commit alone passes). Starting/returning the narrow `NAME`+`UI` schema view loses data the render path needs; getting it right needs more work than this hygiene change warrants, so it's left for a separate effort.

This PR is just the small, safe sync-before-start change. (It is **not** the CT-1623 reload fix — that shipped in #3847.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)