### PR TITLE
test(reload): browser render metrics + scheduler rehydration-health summary

### DIFF
--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -436,6 +436,16 @@ export async function waitForRuntimeSynced(
 }
 
 export type SchedulerLoadSummary = {
+  /** Scheduler-state rehydration health on (re)load. */
+  rehydration: {
+    ok: number;
+    missNoSnapshot: number;
+    missActionId: number;
+    missFingerprint: number;
+    skipShouldNotApply: number;
+    fallbackRunNoMatch: number;
+    fallbackRunTimeout: number;
+  };
   graph: {
     nodes: number;
     edges: number;
@@ -480,6 +490,10 @@ export async function collectSchedulerLoadSummary(
         rt?: {
           getLoggerCounts?: () => Promise<{
             timing: Record<string, Record<string, TimingRow>>;
+            counts?: Record<
+              string,
+              Record<string, { debug?: number } | number>
+            >;
           }>;
           getGraphSnapshot?: () => Promise<{
             nodes: GraphNode[];
@@ -494,9 +508,26 @@ export async function collectSchedulerLoadSummary(
     }
     await rt.idle();
 
-    const { timing } = await rt.getLoggerCounts();
+    const { timing, counts } = await rt.getLoggerCounts();
     const graph = await rt.getGraphSnapshot();
     const schedulerTiming = timing["scheduler"] ?? {};
+
+    // Scheduler-state rehydration health on (re)load: how many actions restored
+    // from a persisted observation vs re-ran, and why the misses missed.
+    const schedulerCounts = counts?.["scheduler"] ?? {};
+    const countKey = (key: string): number => {
+      const v = schedulerCounts[key] as { debug?: number } | number | undefined;
+      return typeof v === "number" ? v : (v?.debug ?? 0);
+    };
+    const rehydration = {
+      ok: countKey("rehydrate/ok"),
+      missNoSnapshot: countKey("rehydrate/miss/no-snapshot"),
+      missActionId: countKey("rehydrate/miss/action-id"),
+      missFingerprint: countKey("rehydrate/miss/fingerprint"),
+      skipShouldNotApply: countKey("rehydrate/skip/should-not-apply"),
+      fallbackRunNoMatch: countKey("rehydrate/fallback-run/no-match"),
+      fallbackRunTimeout: countKey("rehydrate/fallback-run/timeout"),
+    };
     const schedulerRunCount = schedulerTiming["scheduler/run"]?.count ?? 0;
     const schedulerRunActionCount =
       schedulerTiming["scheduler/run/action"]?.count ?? 0;
@@ -537,6 +568,7 @@ export async function collectSchedulerLoadSummary(
     const round = (value: number) => Number(value.toFixed(3));
 
     return {
+      rehydration,
       graph: {
         nodes: graph.nodes.length,
         edges: graph.edges.length,

--- a/packages/patterns/integration/reload/default-app-notebook.test.ts
+++ b/packages/patterns/integration/reload/default-app-notebook.test.ts
@@ -100,6 +100,7 @@ describe("default-app notebook reload integration test", () => {
     const reloadRenderState = await collectNotebookRenderState(page);
     assertEquals(reloadRenderState.noteCount, noteCreates);
     assertEquals(reloadRenderState.renderedNoteChips, noteCreates);
+    const browserMetrics = await collectBrowserLoadMetrics(page);
 
     const schedulerSummary = await collectSchedulerLoadSummary(page);
     assert(
@@ -108,6 +109,7 @@ describe("default-app notebook reload integration test", () => {
     );
     const reloadSummary = {
       reloadToRenderedMs: Number((performance.now() - startedAt).toFixed(3)),
+      browser: browserMetrics,
       ...schedulerSummary,
     };
     console.log(
@@ -129,6 +131,91 @@ describe("default-app notebook reload integration test", () => {
     );
   });
 });
+
+// Captures real, user-perceived reload render timing — paint metrics
+// (FCP/LCP = "time to pixel rendered"), long-task pressure, and a DOM
+// quiet-period settle time — so reload perf is observable independently of
+// scheduler action counts.
+async function collectBrowserLoadMetrics(page: Page): Promise<{
+  domContentLoadedEventEndMs?: number;
+  loadEventEndMs?: number;
+  firstPaintMs?: number;
+  firstContentfulPaintMs?: number;
+  largestContentfulPaintMs?: number;
+  longTaskCount?: number;
+  longTaskTotalMs?: number;
+  postRenderStableMs: number;
+}> {
+  return await page.evaluate(async () => {
+    const round = (value: number | undefined) =>
+      value === undefined ? undefined : Number(value.toFixed(3));
+    const supported = PerformanceObserver.supportedEntryTypes ?? [];
+    const observeBuffered = async (type: string) => {
+      if (!supported.includes(type)) return [] as PerformanceEntry[];
+      const entries: PerformanceEntry[] = [];
+      const observer = new PerformanceObserver((list) => {
+        entries.push(...list.getEntries());
+      });
+      observer.observe({ type, buffered: true });
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      observer.disconnect();
+      return entries;
+    };
+
+    const navigation = performance.getEntriesByType("navigation")
+      .at(-1) as PerformanceNavigationTiming | undefined;
+    const paint = performance.getEntriesByType("paint");
+    const firstPaint = paint.find((entry) => entry.name === "first-paint");
+    const firstContentfulPaint = paint.find((entry) =>
+      entry.name === "first-contentful-paint"
+    );
+    const largestContentfulPaint = (await observeBuffered(
+      "largest-contentful-paint",
+    )).at(-1);
+    const longTasks = await observeBuffered("longtask");
+
+    const postRenderStableMs = await new Promise<number>((resolve) => {
+      let settled = false;
+      let quietTimer: number | undefined;
+      const done = () => {
+        if (settled) return;
+        settled = true;
+        if (quietTimer !== undefined) clearTimeout(quietTimer);
+        clearTimeout(maxTimer);
+        observer.disconnect();
+        requestAnimationFrame(() =>
+          requestAnimationFrame(() => resolve(performance.now()))
+        );
+      };
+      const resetQuietTimer = () => {
+        if (quietTimer !== undefined) clearTimeout(quietTimer);
+        quietTimer = setTimeout(done, 100);
+      };
+      const observer = new MutationObserver(resetQuietTimer);
+      observer.observe(document.documentElement, {
+        attributes: true,
+        childList: true,
+        characterData: true,
+        subtree: true,
+      });
+      resetQuietTimer();
+      const maxTimer = setTimeout(done, 1_000);
+    });
+
+    return {
+      domContentLoadedEventEndMs: round(navigation?.domContentLoadedEventEnd),
+      loadEventEndMs: round(navigation?.loadEventEnd),
+      firstPaintMs: round(firstPaint?.startTime),
+      firstContentfulPaintMs: round(firstContentfulPaint?.startTime),
+      largestContentfulPaintMs: round(largestContentfulPaint?.startTime),
+      longTaskCount: longTasks.length,
+      longTaskTotalMs: round(
+        longTasks.reduce((sum, entry) => sum + entry.duration, 0),
+      ),
+      postRenderStableMs: round(postRenderStableMs)!,
+    };
+  });
+}
 
 async function setSchedulerPullMode(
   page: Page,

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -663,15 +663,21 @@ export class Scheduler {
     });
     const snapshot = result.snapshots[0];
     if (!snapshot || !isSchedulerActionObservation(snapshot.observation)) {
+      // Health counter: no persisted snapshot matched this action's id. On
+      // reload this is the common reason an action re-runs instead of
+      // rehydrating. Counts surface in getLoggerCounts().counts.scheduler.
+      logger.debug("rehydrate/miss/no-snapshot", () => []);
       return false;
     }
     if (!this.observationMatchesCurrentAction(action, snapshot.observation)) {
       return false;
     }
     if (options.shouldApply && !options.shouldApply()) {
+      logger.debug("rehydrate/skip/should-not-apply", () => []);
       return false;
     }
 
+    logger.debug("rehydrate/ok", () => []);
     return this.rehydrateActionFromObservation(action, {
       observation: snapshot.observation,
       ...(snapshot.directDirtySeq !== undefined
@@ -692,14 +698,17 @@ export class Scheduler {
   ): boolean {
     const actionId = this.getActionId(action);
     if (observation.actionId !== actionId) {
+      logger.debug("rehydrate/miss/action-id", () => []);
       return false;
     }
 
     const telemetry = getSchedulerActionTelemetryInfo(action);
-    return observation.implementationFingerprint ===
+    const matches = observation.implementationFingerprint ===
         schedulerImplementationFingerprint(action, actionId, telemetry) &&
       observation.runtimeFingerprint ===
         schedulerRuntimeFingerprint(this.pullMode ? "pull" : "push");
+    if (!matches) logger.debug("rehydrate/miss/fingerprint", () => []);
+    return matches;
   }
 
   private setActionObservationIdentity(
@@ -736,6 +745,7 @@ export class Scheduler {
             options.timeoutMs ?? DEFAULT_INITIAL_REHYDRATION_TIMEOUT_MS,
           ]);
           this.initialRehydrationTokens.delete(action);
+          logger.debug("rehydrate/fallback-run/timeout", () => []);
           this.scheduleInitialActionRun(action);
         }
         return;
@@ -744,6 +754,7 @@ export class Scheduler {
         return;
       }
       if (!rehydrated) {
+        logger.debug("rehydrate/fallback-run/no-match", () => []);
         this.scheduleInitialActionRun(action);
       }
     })().catch((error) => {


### PR DESCRIPTION
## What

Two permanent, low-risk observability additions for the default-app reload path — no behavior change.

### 1. Browser render metrics (restored from codex `e72dbba2d`)
`collectBrowserLoadMetrics` in the reload test captures real, user-perceived reload timing:
- **`firstContentfulPaintMs` / `largestContentfulPaintMs`** — time-to-pixel-rendered
- `firstPaintMs`, `domContentLoadedEventEndMs`, `loadEventEndMs`
- `longTaskCount` / `longTaskTotalMs` — main-thread pressure
- `postRenderStableMs` — DOM mutation-observer quiet-period settle time

Surfaced under `reloadSummary.browser`. This makes reload perf observable independent of scheduler action counts.

### 2. Scheduler-state rehydration health
Named, **zero-overhead** counters (the logger increments counts even when filtered) at the rehydration decision points in `scheduler.ts`:
- `rehydrate/ok` — restored from a persisted observation
- `rehydrate/miss/no-snapshot`, `/miss/action-id`, `/miss/fingerprint`
- `rehydrate/skip/should-not-apply`
- `rehydrate/fallback-run/no-match`, `/fallback-run/timeout`

Surfaced as a `rehydration` field on `collectSchedulerLoadSummary`. Answers "how well did persisted scheduler state rehydrate on reload, and why did the misses miss?" — a useful regression signal for CT-1623 follow-ups.

## Sample output (notebook reload)
```
"browser": { "firstContentfulPaintMs": 174.8, "largestContentfulPaintMs": 174.8, "longTaskCount": 0, "postRenderStableMs": ... },
"rehydration": { "ok": 59, "missNoSnapshot": 81, "missActionId": 0, "missFingerprint": 0, "skipShouldNotApply": 4, "fallbackRunNoMatch": 47, "fallbackRunTimeout": 0 }
```

The `missNoSnapshot`/`fallbackRun` counts are exactly the residual home-view churn under investigation — now first-class and trendable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add browser render metrics to the default-app reload test and add scheduler rehydration-health counters to make reload performance and state restore observable. No runtime behavior changes; supports CT-1623 by surfacing rehydration misses.

- **New Features**
  - Browser metrics: collect FCP/LCP, FP, DCL, load, long-task count/total, and a post-render settle time; emitted under reloadSummary.browser.
  - Scheduler rehydration health: named counters at decision points (`rehydrate/ok`, `rehydrate/miss/*`, `rehydrate/skip/should-not-apply`, `rehydrate/fallback-run/*`); exposed via getLoggerCounts().counts.scheduler and returned as rehydration in collectSchedulerLoadSummary.

<sup>Written for commit 69272a5d382224c04f7c61b28f9a773056611635. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3874?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

