### PR TITLE
Fix CFC label flow through FUSE writeback

### DIFF
--- a/packages/cf-harness/integration/engine.integration.test.ts
+++ b/packages/cf-harness/integration/engine.integration.test.ts
@@ -205,6 +205,158 @@ const warmFabricParents = async (
   assertEquals(result.output.exitCode, 0);
 };
 
+const fabricHostPathForSandboxPath = (
+  fabricHostPath: string,
+  sandboxPath: string,
+): string =>
+  join(fabricHostPath, ...sandboxPath.slice("/fabric/".length).split("/"));
+
+type BoundedCommandStatus =
+  | { kind: "completed"; status: Deno.CommandStatus }
+  | { kind: "timed-out"; killError?: string };
+
+const commandStatusWithTimeout = async (
+  command: Deno.Command,
+  timeoutMs: number,
+): Promise<BoundedCommandStatus> => {
+  const child = command.spawn();
+  const statusPromise = child.status;
+  let timeoutId: number | undefined;
+  const timeoutPromise = new Promise<"timed-out">((resolve) => {
+    timeoutId = setTimeout(() => resolve("timed-out"), timeoutMs);
+  });
+  const result = await Promise.race([statusPromise, timeoutPromise]);
+  if (timeoutId !== undefined) clearTimeout(timeoutId);
+  if (result !== "timed-out") return { kind: "completed", status: result };
+
+  const describeError = (error: unknown): string =>
+    error instanceof Error ? error.message : String(error);
+  const appendError = (
+    existing: string | undefined,
+    label: string,
+    error: unknown,
+  ): string => {
+    const message = `${label}: ${describeError(error)}`;
+    return existing === undefined ? message : `${existing}; ${message}`;
+  };
+
+  let killError: string | undefined;
+  try {
+    child.kill("SIGKILL");
+  } catch (error) {
+    killError = appendError(killError, "SIGKILL failed", error);
+  }
+
+  let cleanupTimeoutId: number | undefined;
+  const cleanupTimeoutPromise = new Promise<"cleanup-timed-out">((resolve) => {
+    cleanupTimeoutId = setTimeout(() => resolve("cleanup-timed-out"), 1_000);
+  });
+  const cleanupResult = await Promise.race([
+    statusPromise.then(() => "closed" as const).catch((error) => ({
+      kind: "status-error" as const,
+      message: describeError(error),
+    })),
+    cleanupTimeoutPromise,
+  ]);
+  if (cleanupTimeoutId !== undefined) clearTimeout(cleanupTimeoutId);
+
+  if (cleanupResult === "cleanup-timed-out") {
+    child.unref();
+  } else if (cleanupResult !== "closed") {
+    killError = killError === undefined
+      ? `child status failed after timeout: ${cleanupResult.message}`
+      : `${killError}; child status failed after timeout: ${cleanupResult.message}`;
+  }
+
+  return killError === undefined
+    ? { kind: "timed-out" }
+    : { kind: "timed-out", killError };
+};
+
+const waitForFabricHostCfcSubject = async (
+  fabricHostPath: string,
+  sandboxPath: string,
+  subject: string,
+): Promise<void> => {
+  const hostPath = fabricHostPathForSandboxPath(fabricHostPath, sandboxPath);
+  const lastValuePath = await Deno.makeTempFile({
+    prefix: "cf-harness-cfc-xattr-",
+    suffix: ".txt",
+  });
+  const script = [
+    "import os, sys, time",
+    "path, subject, last_value_path = sys.argv[1:4]",
+    "last = ''",
+    "def record(value):",
+    "    with open(last_value_path, 'w', encoding='utf-8') as out:",
+    "        out.write(value)",
+    "for _ in range(50):",
+    "    try:",
+    "        last = os.getxattr(path, 'user.commonfabric.cfc.contentLabel').decode()",
+    "    except OSError as exc:",
+    "        last = f'{type(exc).__name__}: {exc}'",
+    "    if subject in last:",
+    "        record(last)",
+    "        raise SystemExit(0)",
+    "    time.sleep(0.1)",
+    "record(last)",
+    "raise SystemExit(1)",
+  ].join("\n");
+  try {
+    const result = await commandStatusWithTimeout(
+      new Deno.Command("python3", {
+        args: ["-c", script, hostPath, subject, lastValuePath],
+        stdout: "null",
+        stderr: "null",
+      }),
+      10_000,
+    );
+    if (result.kind === "timed-out") {
+      throw new Error(
+        `timed out waiting for host CFC xattr subprocess for ${hostPath}; ` +
+          `getxattr may be blocked by the live FUSE mount${
+            result.killError === undefined ? "" : `; ${result.killError}`
+          }`,
+      );
+    }
+    if (!result.status.success) {
+      let lastValue = "";
+      try {
+        lastValue = (await Deno.readTextFile(lastValuePath)).trim();
+      } catch (error) {
+        lastValue = error instanceof Error ? error.message : String(error);
+      }
+      throw new Error(
+        `timed out waiting for ${subject} in CFC xattr for ${hostPath}: ${lastValue}`,
+      );
+    }
+  } finally {
+    await Deno.remove(lastValuePath).catch((error) => {
+      if (!(error instanceof Deno.errors.NotFound)) throw error;
+    });
+  }
+};
+
+Deno.test({
+  name:
+    "cf-harness integration helper: command timeout returns before child exits",
+  permissions: { run: true },
+  async fn() {
+    const result = await commandStatusWithTimeout(
+      new Deno.Command(
+        Deno.execPath(),
+        {
+          args: ["eval", "await new Promise(() => {})"],
+          stdout: "null",
+          stderr: "null",
+        },
+      ),
+      20,
+    );
+    assertEquals(result.kind, "timed-out");
+  },
+});
+
 const invocationInputLabels = (): CfcLabelView => ({
   version: 1,
   entries: [{
@@ -983,9 +1135,7 @@ Deno.test({
         const result = await engine.invokeBuiltinTool("bash", {
           command: [
             "set -eu",
-            `IFS= read -r payload < ${
-              singleQuoteShell(fabricReadPath)
-            } || [ -n "$payload" ]`,
+            `cat ${singleQuoteShell(fabricReadPath)} >/dev/null`,
             `printf ${
               singleQuoteShell(hostPayload)
             } > /workspace/fuse-read-host.txt`,
@@ -1033,9 +1183,10 @@ Deno.test({
     );
     await withFabricHarness(
       "integration-input-label-fabric-write",
-      async (engine) => {
+      async (engine, _workspaceHostPath, fabricHostPath) => {
         const fabricPayload =
           "from invocation label through FUSE: integration-input-label-fabric-write\n";
+        const normalizedFabricPayload = fabricPayload.trimEnd();
         await warmFabricParents(engine, fabricWritePath);
         const writeResult = await engine.invokeBuiltinTool("bash", {
           command: [
@@ -1056,6 +1207,11 @@ Deno.test({
           INVOCATION_TAINT_SUBJECT,
         );
 
+        await waitForFabricHostCfcSubject(
+          fabricHostPath,
+          fabricWritePath,
+          INVOCATION_TAINT_SUBJECT,
+        );
         await warmFabricParents(engine, fabricWritePath);
         const readBack = await engine.invokeBuiltinTool("bash", {
           command: [
@@ -1064,7 +1220,7 @@ Deno.test({
           ].join("\n"),
         });
         assertEquals(readBack.output.exitCode, 0);
-        assertStringIncludes(readBack.output.stdout, fabricPayload);
+        assertStringIncludes(readBack.output.stdout, normalizedFabricPayload);
         assert(readBack.output.cfcResult !== undefined);
         assertEquals(readBack.output.cfcResult.stdout.policy, "opaque");
         assertLabelIncludesSubject(
@@ -1093,9 +1249,10 @@ Deno.test({
     );
     await withFabricHarness(
       "integration-input-label-fabric-join-write",
-      async (engine) => {
+      async (engine, _workspaceHostPath, fabricHostPath) => {
         const joinedPayload =
           "joined invocation and fabric labels: integration-input-label-fabric-join-write\n";
+        const normalizedJoinedPayload = joinedPayload.trimEnd();
         await warmFabricParents(engine, fabricReadPath);
         await warmFabricParents(engine, fabricWritePath);
         const joinedWrite = await engine.invokeBuiltinTool("bash", {
@@ -1122,6 +1279,11 @@ Deno.test({
           FABRIC_CFC_LABEL_SUBJECT,
         );
 
+        await waitForFabricHostCfcSubject(
+          fabricHostPath,
+          fabricWritePath,
+          INVOCATION_TAINT_SUBJECT,
+        );
         await warmFabricParents(engine, fabricWritePath);
         const readBack = await engine.invokeBuiltinTool("bash", {
           command: [
@@ -1130,7 +1292,7 @@ Deno.test({
           ].join("\n"),
         });
         assertEquals(readBack.output.exitCode, 0);
-        assertStringIncludes(readBack.output.stdout, joinedPayload);
+        assertStringIncludes(readBack.output.stdout, normalizedJoinedPayload);
         assert(readBack.output.cfcResult !== undefined);
         assertEquals(readBack.output.cfcResult.stdout.policy, "opaque");
         assertLabelIncludesSubject(

--- a/packages/fuse/cfc-writeback.test.ts
+++ b/packages/fuse/cfc-writeback.test.ts
@@ -23,6 +23,7 @@ import {
   normalizeCfcWritebackXattrName,
   parseCfcMode,
   resolveCfcMode,
+  safeReconcileCfcWritebacks,
   shouldEnableCfcAnnotations,
 } from "./cfc-writeback.ts";
 import {
@@ -141,6 +142,41 @@ Deno.test("CFC mode parsing and annotation defaults match runner modes", () => {
     }),
     true,
   );
+});
+
+Deno.test("safe writeback reconciliation records diagnostics without throwing", () => {
+  const diagnostics: string[] = [];
+  const ok = safeReconcileCfcWritebacks({
+    context: "unit test",
+    reconcile: () => {
+      throw new Error("storage unavailable");
+    },
+    recordDiagnostics: (messages) => diagnostics.push(...messages),
+  });
+
+  assertEquals(ok, false);
+  assertEquals(diagnostics, [
+    "unit test reconciliation failed: storage unavailable",
+  ]);
+});
+
+Deno.test("safe writeback reconciliation preserves normal diagnostics", () => {
+  const diagnostics: string[] = [];
+  const ok = safeReconcileCfcWritebacks({
+    context: "unit test",
+    reconcile: () => ({
+      inspected: 1,
+      rebound: 0,
+      reapplied: 0,
+      finalized: 0,
+      stale: 0,
+      diagnostics: ["existing diagnostic"],
+    }),
+    recordDiagnostics: (messages) => diagnostics.push(...messages),
+  });
+
+  assertEquals(ok, true);
+  assertEquals(diagnostics, ["existing diagnostic"]);
 });
 
 Deno.test("FUSE setattr flag constants and metadata field mapping match low-level ABI", () => {

--- a/packages/fuse/cfc-writeback.ts
+++ b/packages/fuse/cfc-writeback.ts
@@ -185,6 +185,24 @@ export type CfcWritebackReconciliationResult = {
   diagnostics: string[];
 };
 
+export function safeReconcileCfcWritebacks(options: {
+  context: string;
+  reconcile: () => CfcWritebackReconciliationResult;
+  recordDiagnostics: (messages: string[]) => void;
+}): boolean {
+  try {
+    const result = options.reconcile();
+    options.recordDiagnostics(result.diagnostics);
+    return true;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    options.recordDiagnostics([
+      `${options.context} reconciliation failed: ${message}`,
+    ]);
+    return false;
+  }
+}
+
 const CFC_MODES = [
   "disabled",
   "observe",

--- a/packages/fuse/handles.test.ts
+++ b/packages/fuse/handles.test.ts
@@ -40,6 +40,27 @@ Deno.test("HandleMap clears pending truncates when content arrives", () => {
   assertEquals(handleHasPendingChanges(handle), true);
 });
 
+Deno.test("HandleMap clears sibling pending truncates when content arrives", () => {
+  const handles = new HandleMap();
+  const writer = handles.open(1n, O_RDWR, encoder.encode("hello"));
+  const duplicate = handles.open(1n, O_RDWR, encoder.encode("hello"));
+
+  handles.truncateByIno(1n, 0, { pendingFh: writer });
+  handles.truncateByIno(1n, 0, { pendingFh: duplicate });
+  handles.write(writer, encoder.encode("fresh"), 0);
+
+  const writerHandle = handles.get(writer);
+  assertEquals(new TextDecoder().decode(writerHandle?.buffer), "fresh");
+  assertEquals(writerHandle?.dirty, true);
+  assertEquals(writerHandle?.truncatePending, false);
+  assertEquals(handleHasPendingChanges(writerHandle), true);
+
+  const duplicateHandle = handles.get(duplicate);
+  assertEquals(duplicateHandle?.dirty, false);
+  assertEquals(duplicateHandle?.truncatePending, false);
+  assertEquals(handleHasPendingChanges(duplicateHandle), false);
+});
+
 Deno.test("HandleMap truncates every open handle for an inode", () => {
   const handles = new HandleMap();
   const first = handles.open(1n, O_RDWR, encoder.encode("first"));

--- a/packages/fuse/handles.ts
+++ b/packages/fuse/handles.ts
@@ -138,6 +138,13 @@ export class HandleMap {
     state.dirty = true;
     state.truncatePending = false;
     state.version++;
+
+    for (const [otherFh, otherState] of this.handles) {
+      if (otherFh !== fh && otherState.ino === state.ino) {
+        otherState.truncatePending = false;
+      }
+    }
+
     return true;
   }
 

--- a/packages/fuse/mod.ts
+++ b/packages/fuse/mod.ts
@@ -43,6 +43,7 @@ import {
   normalizeCfcWritebackXattrName,
   parseCfcMode,
   resolveCfcMode,
+  safeReconcileCfcWritebacks,
   shouldEnableCfcAnnotations,
 } from "./cfc-writeback.ts";
 import {
@@ -597,9 +598,12 @@ export async function main(argv: string[] = Deno.args) {
     }
   }
 
-  function reconcileCfcWritebacks(): void {
-    const result = cfcWritebacks.reconcileTree(tree);
-    recordCfcDiagnostics(result.diagnostics);
+  function reconcileCfcWritebacks(context = "CFC writeback"): boolean {
+    return safeReconcileCfcWritebacks({
+      context,
+      reconcile: () => cfcWritebacks.reconcileTree(tree),
+      recordDiagnostics: recordCfcDiagnostics,
+    });
   }
 
   function authorizeExistingCfcWrite(
@@ -1566,6 +1570,7 @@ export async function main(argv: string[] = Deno.args) {
           }
           markExistingReady();
           await bridge.finalizeSourceWritePath(writeTarget.target);
+          reconcileCfcWritebacks("source flush post-finalize");
           markExistingFinalized();
           if (handle.version === flushVersion) {
             handle.dirty = false;
@@ -1612,6 +1617,7 @@ export async function main(argv: string[] = Deno.args) {
         if (!ok) return EINVAL;
         markExistingReady();
         await bridge.finalizeWritePath(writePath);
+        reconcileCfcWritebacks("fs projection flush post-finalize");
         markExistingFinalized();
         if (handle.version === flushVersion) {
           handle.dirty = false;
@@ -1667,6 +1673,7 @@ export async function main(argv: string[] = Deno.args) {
       await bridge.writeValue(writePath, value);
       markExistingReady();
       await bridge.finalizeWritePath(writePath);
+      reconcileCfcWritebacks("value flush post-finalize");
       markExistingFinalized();
       if (handle.version === flushVersion) {
         handle.dirty = false;
@@ -2163,6 +2170,7 @@ export async function main(argv: string[] = Deno.args) {
         }
       }
       if (!attrValue) {
+        reconcileCfcWritebacks("getxattr");
         attrValue = getCfcXattrValue(tree, ino, attrName, {
           enabled: cfcAnnotationsEnabled,
           namespace: cfcXattrNamespace,
@@ -2216,6 +2224,9 @@ export async function main(argv: string[] = Deno.args) {
         xattrNames.push("user.json.type");
       }
 
+      if (cfcAnnotationsEnabled) {
+        reconcileCfcWritebacks("listxattr");
+      }
       xattrNames.push(
         ...listCfcXattrNames(tree, inode, {
           enabled: cfcAnnotationsEnabled,


### PR DESCRIPTION
## Summary
- clear sibling pending truncates when a real write arrives on another open handle for the same inode
- reconcile prepared CFC writebacks after successful FUSE write finalization and before CFC xattr reads/listing
- make cf-harness Fabric readback wait for the host CFC content label before the follow-up sandbox read, with a bounded helper so a wedged FUSE getxattr fails fast instead of hanging the suite

## Spec-driven decisions
- `docs/specs/fuse-filesystem/10-cfc-filesystem-api-semantics.md` says ordinary programs should see normal POSIX-like success/error behavior; the harness test therefore proves behavior with ordinary sandbox `cat`/redirects instead of a custom probe.
- `docs/specs/fuse-filesystem/10-cfc-filesystem-api-semantics.md` and `docs/specs/fuse-filesystem/9-cfc-annotations.md` define `trusted.cfc.*` as protected enforcement metadata and `user.commonfabric.cfc.*` as compatibility/debug transport; this keeps writeback reconciliation in FUSE while exposing compat xattrs to the harness.
- `docs/specs/fuse-filesystem/9-cfc-annotations.md` requires missing/stale metadata to fail closed; the reconciliation path avoids lowering labels while pending writes rebuild exact annotations.
- `docs/specs/fuse-filesystem/4-read-write.md` defines scalar writes as flush/commit-boundary operations with immediate CFC/writeback denials, so duplicate pending-truncate state must be cleared once real content arrives.

## Verification
- LSP diagnostics: clean for `packages/fuse/handles.ts`, `packages/fuse/handles.test.ts`, `packages/fuse/mod.ts`, and `packages/cf-harness/integration/engine.integration.test.ts`
- `deno test -A packages/cf-harness/integration/engine.integration.test.ts --filter "command timeout"`
- `deno test -A packages/fuse/handles.test.ts packages/fuse/cfc-writeback.test.ts` (`43 passed`)
- Live remount validation: `deno task test:integration --filter Fabric` with CFC flow + durable host-label mode on `/tmp/cf-cfc-fresh-harness-rerun` (`5 passed`, `0 failed`, current reused fixture label subject `did:web:commonfabric.org#runtime`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CFC label flow through FUSE writeback so label reads reflect finalized writes, prevents harness hangs by bounding host-label waits, and clears duplicate pending truncates across open handles. Adds a safe reconciliation wrapper that records diagnostics on failure.

- **Bug Fixes**
  - `packages/fuse/mod.ts`: reconcile CFC writebacks after finalize paths and before CFC xattr reads/listing; wrap with `safeReconcileCfcWritebacks` to record errors as diagnostics.
  - `packages/fuse/cfc-writeback.ts` (+ tests): introduce `safeReconcileCfcWritebacks(...)` to avoid crashes and preserve reconciliation diagnostics.
  - `packages/fuse/handles.ts` (+ tests): when content is written on one handle, clear `truncatePending` on all sibling handles for the same inode.
  - `packages/cf-harness/integration/engine.integration.test.ts`: wait for host `user.commonfabric.cfc.contentLabel` via a bounded `commandStatusWithTimeout` and a polling script; simplify readback (`cat >/dev/null`, trim newline) to reduce flakiness.

<sup>Written for commit d620d28cf261b180df362f3018e3334edb9e6991. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

