### PR TITLE
feat(fair-share): identity via shared profiles (cf-avatar + cf-profile-badge + join)

### DIFF
--- a/packages/patterns/fair-share/main.tsx
+++ b/packages/patterns/fair-share/main.tsx
@@ -24,11 +24,13 @@ import {
   computed,
   Default,
   equals,
+  handler,
   NAME,
   pattern,
   type PerUser,
   safeDateNow,
   UI,
+  wish,
   Writable,
 } from "commonfabric";
 
@@ -36,6 +38,10 @@ import {
 
 interface Person {
   name: string;
+  // Optional avatar snapshot (image URL or emoji/glyph), sourced from the
+  // person's shared profile when they "join with your profile". Display-only —
+  // `name` stays the natural key, so the money/balance logic is unaffected.
+  avatar?: string;
 }
 
 interface Expense {
@@ -48,6 +54,7 @@ interface Expense {
 
 interface Balance {
   name: string;
+  avatar?: string;
   paid: number;
   share: number;
   net: number; // paid - share; positive => is owed, negative => owes
@@ -114,6 +121,34 @@ const computeSettlements = (balances: Balance[]): Settlement[] => {
   return result;
 };
 
+// Snapshot the current viewer's shared profile (name + avatar) into the shared
+// `people` ledger and select them as "you". This is the participant/roster
+// idiom: each viewer contributes their own #profile snapshot on join, rather
+// than the app querying everyone's private profile state (see
+// docs/specs/shared-profile-rosters.md). `name` stays the natural key.
+const joinWithProfile = handler<
+  unknown,
+  {
+    people: Writable<Person[]>;
+    myName: Writable<string>;
+    name: string;
+    avatar: string;
+  }
+>((_event, { people, myName, name, avatar }) => {
+  const n = (name ?? "").trim();
+  if (!n) return;
+  const av = (avatar ?? "").trim();
+  const cur = people.get();
+  const idx = cur.findIndex((p) => p.name === n);
+  if (idx < 0) {
+    people.push(av ? { name: n, avatar: av } : { name: n });
+  } else if (av && !cur[idx].avatar) {
+    // Backfill the avatar snapshot if this name was added by hand earlier.
+    people.set(cur.toSpliced(idx, 1, { ...cur[idx], avatar: av }));
+  }
+  myName.set(n);
+});
+
 // ============ PATTERN ============
 
 export default pattern<State>(({ people, expenses, myName }) => {
@@ -126,6 +161,21 @@ export default pattern<State>(({ people, expenses, myName }) => {
 
   // --- Identity (resolve per-user name once at top level) ---
   const me = (myName ?? "").trim();
+
+  // The current viewer's *shared profile* (resolved via wish). `#profile` is the
+  // live cell bound to <cf-profile-badge>; the field targets give the name/avatar
+  // we snapshot into the ledger on "join". Profile-count-agnostic: resolves the
+  // viewer's default profile.
+  const profileWish = wish({ query: "#profile" });
+  const profileNameWish = wish<string>({ query: "#profileName" });
+  const profileAvatarWish = wish<string>({ query: "#profileAvatar" });
+  const myProfileName = computed(() => (profileNameWish.result ?? "").trim());
+  const myProfileAvatar = computed(() =>
+    (profileAvatarWish.result ?? "").trim()
+  );
+  const hasProfile = computed(() =>
+    (profileNameWish.result ?? "").trim() !== ""
+  );
 
   // --- Derived data ---
   const peopleOptions = computed(() =>
@@ -165,7 +215,13 @@ export default pattern<State>(({ people, expenses, myName }) => {
     return ppl.map((p) => {
       const paid = (paidCents.get(p.name) ?? 0) / 100;
       const share = (shareCents.get(p.name) ?? 0) / 100;
-      return { name: p.name, paid, share, net: paid - share };
+      return {
+        name: p.name,
+        avatar: p.avatar ?? "",
+        paid,
+        share,
+        net: paid - share,
+      };
     });
   });
 
@@ -198,35 +254,59 @@ export default pattern<State>(({ people, expenses, myName }) => {
 
         {/* ===== You ===== */}
         <cf-card>
-          <cf-hstack gap="3" align="center" wrap>
-            <cf-label>You are</cf-label>
-            <cf-select
-              $value={myName}
-              items={peopleOptions}
-              style={{ minWidth: "160px" }}
-            />
-            {computed(() => {
-              const net = myNet;
-              if (net === null) {
+          <cf-vstack gap="3">
+            {
+              /* Identity via shared profile: the trusted badge shows who you are,
+                and "Join" snapshots your profile name+avatar into the ledger. */
+            }
+            <cf-hstack gap="3" align="center" wrap>
+              <cf-label>You are</cf-label>
+              <cf-profile-badge $profile={profileWish.result} size="sm" />
+              <cf-button
+                color="primary"
+                variant="solid"
+                disabled={computed(() => !hasProfile)}
+                onClick={joinWithProfile({
+                  people: people as any,
+                  myName: myName as any,
+                  name: myProfileName,
+                  avatar: myProfileAvatar,
+                })}
+              >
+                Join with your profile
+              </cf-button>
+            </cf-hstack>
+            {/* Fallback: pick yourself from the people added by hand. */}
+            <cf-hstack gap="3" align="center" wrap>
+              <cf-label>or pick</cf-label>
+              <cf-select
+                $value={myName}
+                items={peopleOptions}
+                style={{ minWidth: "160px" }}
+              />
+              {computed(() => {
+                const net = myNet;
+                if (net === null) {
+                  return (
+                    <cf-text tone="muted">
+                      Pick who you are to see your balance.
+                    </cf-text>
+                  );
+                }
                 return (
-                  <cf-text tone="muted">
-                    Pick who you are to see your balance.
-                  </cf-text>
+                  <cf-badge
+                    color={net > 0 ? "accent" : net < 0 ? "danger" : "neutral"}
+                  >
+                    {net > 0
+                      ? `You are owed ${money(net)}`
+                      : net < 0
+                      ? `You owe ${money(-net)}`
+                      : "You're settled up"}
+                  </cf-badge>
                 );
-              }
-              return (
-                <cf-badge
-                  color={net > 0 ? "accent" : net < 0 ? "danger" : "neutral"}
-                >
-                  {net > 0
-                    ? `You are owed ${money(net)}`
-                    : net < 0
-                    ? `You owe ${money(-net)}`
-                    : "You're settled up"}
-                </cf-badge>
-              );
-            })}
-          </cf-hstack>
+              })}
+            </cf-hstack>
+          </cf-vstack>
         </cf-card>
 
         {/* ===== People ===== */}
@@ -241,40 +321,47 @@ export default pattern<State>(({ people, expenses, myName }) => {
             }
             <cf-hstack gap="2" wrap>
               {people.map((person) => (
-                <cf-chip
-                  label={person.name}
-                  removable
-                  oncf-remove={() => {
-                    const cur = people.get();
-                    const idx = cur.findIndex((p) => equals(person, p));
-                    if (idx < 0) return;
-                    const name = { ...cur[idx] }.name;
-                    // Cascade-clean so balances stay zero-sum: drop expenses
-                    // they paid (money has no creditor now) and remove them
-                    // from every other split. Built with a plain for-loop and
-                    // explicit array spreads — chaining .filter()/.map() on the
-                    // reactive .get() array makes the transformer rewrite them
-                    // to .filterWithPattern()/.mapWithPattern(), which throw at
-                    // runtime here.
-                    const cleaned: Expense[] = [];
-                    for (const e of expenses.get()) {
-                      if (e.paidBy === name) continue;
-                      const had = [...(e.sharedBy ?? [])];
-                      // Empty sharedBy means "split among everyone" — it stays
-                      // implicit-everyone (now a smaller group), so keep it as-is.
-                      if (had.length === 0) {
-                        cleaned.push({ ...e });
-                        continue;
+                <cf-hstack gap="1" align="center">
+                  <cf-avatar
+                    src={person.avatar}
+                    name={person.name}
+                    size="xs"
+                  />
+                  <cf-chip
+                    label={person.name}
+                    removable
+                    oncf-remove={() => {
+                      const cur = people.get();
+                      const idx = cur.findIndex((p) => equals(person, p));
+                      if (idx < 0) return;
+                      const name = { ...cur[idx] }.name;
+                      // Cascade-clean so balances stay zero-sum: drop expenses
+                      // they paid (money has no creditor now) and remove them
+                      // from every other split. Built with a plain for-loop and
+                      // explicit array spreads — chaining .filter()/.map() on the
+                      // reactive .get() array makes the transformer rewrite them
+                      // to .filterWithPattern()/.mapWithPattern(), which throw at
+                      // runtime here.
+                      const cleaned: Expense[] = [];
+                      for (const e of expenses.get()) {
+                        if (e.paidBy === name) continue;
+                        const had = [...(e.sharedBy ?? [])];
+                        // Empty sharedBy means "split among everyone" — it stays
+                        // implicit-everyone (now a smaller group), so keep it as-is.
+                        if (had.length === 0) {
+                          cleaned.push({ ...e });
+                          continue;
+                        }
+                        const shared = had.filter((s) => s !== name);
+                        // An explicit split emptied by this removal is dropped.
+                        if (shared.length === 0) continue;
+                        cleaned.push({ ...e, sharedBy: shared });
                       }
-                      const shared = had.filter((s) => s !== name);
-                      // An explicit split emptied by this removal is dropped.
-                      if (shared.length === 0) continue;
-                      cleaned.push({ ...e, sharedBy: shared });
-                    }
-                    people.set(cur.toSpliced(idx, 1));
-                    expenses.set(cleaned);
-                  }}
-                />
+                      people.set(cur.toSpliced(idx, 1));
+                      expenses.set(cleaned);
+                    }}
+                  />
+                </cf-hstack>
               ))}
             </cf-hstack>
             {computed(() =>
@@ -476,7 +563,10 @@ export default pattern<State>(({ people, expenses, myName }) => {
                     fontWeight: b.name === me ? "700" : "400",
                   }}
                 >
-                  <span>{b.name === me ? `${b.name} (you)` : b.name}</span>
+                  <cf-hstack gap="2" align="center">
+                    <cf-avatar src={b.avatar} name={b.name} size="xs" />
+                    <span>{b.name === me ? `${b.name} (you)` : b.name}</span>
+                  </cf-hstack>
                   <cf-badge
                     color={b.net > 0
                       ? "accent"

--- a/packages/patterns/fair-share/main.tsx
+++ b/packages/patterns/fair-share/main.tsx
@@ -267,8 +267,8 @@ export default pattern<State>(({ people, expenses, myName }) => {
                 variant="solid"
                 disabled={computed(() => !hasProfile)}
                 onClick={joinWithProfile({
-                  people: people as any,
-                  myName: myName as any,
+                  people,
+                  myName,
                   name: myProfileName,
                   avatar: myProfileAvatar,
                 })}


### PR DESCRIPTION
## Summary

⚠️ **Stacked on #3879** (needs `cf-avatar`/`cf-profile-badge`). Builds on the merged Fair Share pattern (#3803).

Integrates shared-profile identity into `fair-share` — **additively**, so the penny-exact money / cascade-delete logic is untouched (`name` stays the natural key):

- **People** and **Balances** rows render **`<cf-avatar>`** (image / emoji-glyph / initials).
- The **"You"** card shows the trusted **`<cf-profile-badge>`** for the viewer's `#profile`, plus a **"Join with your profile"** action — the participant/roster idiom from `docs/specs/shared-profile-rosters.md`: resolve the viewer's `#profileName` / `#profileAvatar` and snapshot them into the shared `people` ledger, then select them as "you". The manual "you are" picker stays as a fallback for people added by hand.
- `Person` / `Balance` gain an optional `avatar` snapshot. The **bare People `.map()`** and `equals()`-based removal (with the pattern's documented transformer footguns) are preserved.

## Testing

- `deno task cf check` clean (typecheck + instantiation).
- Deployed locally + browser-verified: People + Balances show avatars (image/emoji/initials); the "You" badge resolves `#profile` (Unknown-profile fallback for the no-profile CLI identity); "Join" is disabled without a profile; the add-expense / balances / settle-up flow is unchanged; 0 console errors.

Relates to CT-1645 / CT-1649.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds shared-profile identity to Fair Share: shows your `cf-profile-badge`, adds “Join with your profile” (snapshots name/avatar into `people`), and renders avatars; money math and cascade-delete stay unchanged (`name` remains the key), and unnecessary `joinWithProfile` casts are removed. Aligns with CT-1645.

- New Features
  - People and Balances rows render `cf-avatar` (image/emoji/initials).
  - “You” card shows `cf-profile-badge` and a “Join with your profile” action.
  - Join snapshots `#profileName`/`#profileAvatar`, selects you, and backfills avatar for existing names; manual picker remains.

<sup>Written for commit c4a73485d974934233cc2b87afa9dba5fb7baf5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

