### PR TITLE
feat(profiles): show cf-profile-badge in home Profile tab

### DIFF
--- a/packages/patterns/system/home.tsx
+++ b/packages/patterns/system/home.tsx
@@ -129,9 +129,12 @@ export default pattern<Record<string, never>, HomeOutput>((_) => {
   const learned = new Writable<LearnedSection>(EMPTY_LEARNED).for("learned");
   const spaces = new Writable<SpaceEntry[]>([]).for("spaces");
   const defaultAppUrl = new Writable("").for("defaultAppUrl");
-  // NOTE(CT-1628): the `as any` casts around `profile` below are required
-  // because the CFC wrapper types (TrustedProfileLink) don't yet compose with
-  // Writable/the pattern factory output type. Tracked for a proper type fix.
+  // NOTE(CT-1628): the `as any` casts on `profile` passed to
+  // `submitProfileCreation` / `ProfileCreate` below are required because the CFC
+  // wrapper type (TrustedProfileLink = Cfc<…>) doesn't compose with those
+  // handlers' `Writable<ProfileHomeOutput>` input. Tracked for a proper type
+  // fix. (The `$profile` / `$cell` view bindings need no cast — those props
+  // accept a `CellLike`.)
   const profile = new Writable<TrustedProfileLink>(undefined).for("profile");
   const profileName = new Writable("").for("profileName");
   const createProfileStream = submitProfileCreation({
@@ -204,10 +207,10 @@ export default pattern<Record<string, never>, HomeOutput>((_) => {
                         shadow DOM; integration tests assert on this text).
                       */
                       }
-                      <cf-profile-badge $profile={profile as any} />
+                      <cf-profile-badge $profile={profile} />
                       <strong>{profileName}</strong>
                     </cf-hstack>
-                    <cf-render $cell={profile as any} />
+                    <cf-render $cell={profile} />
                   </cf-vstack>
                 ),
                 profileCreate,

--- a/packages/patterns/system/home.tsx
+++ b/packages/patterns/system/home.tsx
@@ -197,12 +197,14 @@ export default pattern<Record<string, never>, HomeOutput>((_) => {
                     <cf-hstack id="home-profile-summary" gap="2" align="center">
                       {
                         /*
-                        Show the home-space `profileName` mirror here rather than
-                        `profile.key("name")`: the latter reads cross-space (into
-                        the profile space) and renders empty inline. The live,
-                        editable name is shown by the `cf-render` below.
+                        The trusted <cf-profile-badge> resolves the cross-space
+                        profile cell and renders its avatar + name as official
+                        system chrome. The `profileName` mirror is kept alongside
+                        it as a light-DOM label (the badge renders its name in
+                        shadow DOM; integration tests assert on this text).
                       */
                       }
+                      <cf-profile-badge $profile={profile as any} />
                       <strong>{profileName}</strong>
                     </cf-hstack>
                     <cf-render $cell={profile as any} />


### PR DESCRIPTION
Wires the trusted `<cf-profile-badge>` (added in #3879) into the home space's Profile tab. Once a profile exists, the tab renders the profile's avatar + name as official system chrome, with the home-space `profileName` mirror kept alongside as a light-DOM label that the `home-profile` integration test asserts on.

**Stacked on #3879** (needs the `cf-profile-badge` component). One-file change (`packages/patterns/system/home.tsx`, +6/−4).

### Why this is a separate PR
Extracted from #3880, which is being **closed/parked**. While verifying #3880 end-to-end (real headless-browser drive of the "Add profile card" flow), I found the owner-protected `elements` write is **silently rejected by a runtime CFC gap** — the click reaches the handler, but the write's transaction aborts with no surfaced error, so no element ever persists. This is the same class of runtime issue as **CT-1665** (the `writeAuthorizedBy` "trusted verified binding identity" gap that already blocks `avatar` saves), and is not cleanly fixable in pattern code. The unit tests in #3880 pass only because they hand-model the write in a way that bypasses the real lowering path (as cf-review suspected).

This badge wiring is **independent** of that element-link work and functions today, so it's worth landing on its own.

### Coordination
Touches the same `home.tsx` Profile-tab block as Berni's in-flight #3830 (multi-profile picker) — his picker is expected to supersede this block, so coordinate on merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the trusted `cf-profile-badge` in the Home Profile tab so profiles render avatar + name as system chrome. Keep the `profileName` mirror for tests, drop unnecessary `as any` casts on `$profile`/`$cell` bindings (note tightened to scope CT-1628 to creation inputs), and support CT-1645 by surfacing verified identity in Home.

<sup>Written for commit 829ea6d52ee57d0488fb83aefd4e485407979290. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

