### PR TITLE
feat(ui): generative identity seal for verified cf-profile-badge

### DIFF
--- a/packages/patterns/catalog/stories/cf-profile-badge-story.tsx
+++ b/packages/patterns/catalog/stories/cf-profile-badge-story.tsx
@@ -87,8 +87,10 @@ export default pattern<ProfileBadgeStoryInput, ProfileBadgeStoryOutput>(() => {
           style={{ fontSize: "0.875rem", color: "#6b7280", maxWidth: "40ch" }}
         >
           The shield is the system seal. Avatar paths shown: image (Ada), emoji
-          (Grace), initials (Alan). Verification + the unspoofable seal effects
-          are a deferred pass — v1 renders the “presented” state.
+          (Grace), initials (Alan). The verified seal — a DID-derived aura —
+          only renders for a runtime-attested profile (a “represents-principal”
+          CFC label), which this story can’t mint, so these badges stay in the
+          plain “presented” state.
         </span>
       </div>
     ),

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.test.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.test.ts
@@ -166,6 +166,51 @@ describe("CFProfileBadge", () => {
       expect(el._state).toBe("presented");
       expect(el._seal).toBeUndefined();
     });
+
+    it("discards a label read superseded mid-flight (no stale seal write)", async () => {
+      const el = new CFProfileBadge() as any;
+      markConnected(el, true);
+
+      // A label read whose timing we control.
+      const gate = deferred<unknown>();
+      const verify = el._refreshVerification({
+        getCfcLabel: () => gate.promise,
+      });
+
+      // Simulate a re-bind / disconnect superseding this read: both `_resolve`
+      // and `disconnectedCallback` bump `_resolveGeneration`.
+      el._resolveGeneration++;
+
+      // The read now resolves with a valid attestation — but it is stale.
+      gate.resolve(representsPrincipalLabel(OWNER_DID));
+      await verify;
+
+      // The superseded read must NOT have flipped the badge to verified.
+      expect(el._state).toBe("presented");
+      expect(el._seal).toBeUndefined();
+    });
+
+    it("logs and stays presented when the label read fails", async () => {
+      const el = new CFProfileBadge() as any;
+      markConnected(el, true);
+
+      const originalError = console.error;
+      let logged = 0;
+      console.error = () => {
+        logged++;
+      };
+      try {
+        await el._refreshVerification({
+          getCfcLabel: () => Promise.reject(new Error("ipc boom")),
+        });
+      } finally {
+        console.error = originalError;
+      }
+
+      expect(logged).toBe(1);
+      expect(el._state).toBe("presented");
+      expect(el._seal).toBeUndefined();
+    });
   });
 
   describe("profileDisplayFromValue", () => {

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.test.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.test.ts
@@ -2,6 +2,24 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { NAME } from "@commonfabric/runtime-client";
 import { CFProfileBadge, profileDisplayFromValue } from "./cf-profile-badge.ts";
+import { identitySeal } from "./identity-seal.ts";
+
+const OWNER_DID = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+
+/** A resolved-cell stub that answers `getCfcLabel()` with the given label. */
+function labelCell(label: unknown) {
+  return { getCfcLabel: () => Promise.resolve(label) };
+}
+
+function representsPrincipalLabel(subject: string) {
+  return {
+    version: 1,
+    entries: [{
+      path: ["name"],
+      label: { integrity: [{ kind: "represents-principal", subject }] },
+    }],
+  };
+}
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -101,6 +119,52 @@ describe("CFProfileBadge", () => {
       el.disconnectedCallback();
       expect(unsubscribeCount).toBe(1);
       expect(el._unsubscribe).toBeUndefined();
+    });
+  });
+
+  describe("verification seal", () => {
+    it("enters the verified state and derives the seal from the owner DID", async () => {
+      const el = new CFProfileBadge() as any;
+      markConnected(el, true);
+
+      await el._refreshVerification(
+        labelCell(representsPrincipalLabel(OWNER_DID)),
+      );
+
+      expect(el._state).toBe("verified");
+      // The seal is the pure DID-derived fingerprint, identical everywhere.
+      expect(el._seal?.did).toBe(OWNER_DID);
+      expect(el._seal?.hue).toBe(identitySeal(OWNER_DID).hue);
+    });
+
+    it("stays presented (no seal) when the label has no represents-principal atom", async () => {
+      const el = new CFProfileBadge() as any;
+      markConnected(el, true);
+
+      await el._refreshVerification(labelCell({
+        version: 1,
+        entries: [{ path: [], label: { integrity: ["profile-link"] } }],
+      }));
+
+      expect(el._state).toBe("presented");
+      expect(el._seal).toBeUndefined();
+    });
+
+    it("clears a prior seal up-front on re-bind, before the new attestation resolves", () => {
+      const el = new CFProfileBadge() as any;
+      markConnected(el, true);
+      // Simulate an already-verified badge for some other identity.
+      el._state = "verified";
+      el._seal = identitySeal(OWNER_DID);
+
+      // Re-bind to a different, never-resolving profile. `_resolve` resets the
+      // verification synchronously before its first await, so the stale seal
+      // must be gone immediately — it never lingers during the async gap.
+      el.profile = { resolveAsCell: () => new Promise(() => {}) };
+      void el._resolve();
+
+      expect(el._state).toBe("presented");
+      expect(el._seal).toBeUndefined();
     });
   });
 

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
@@ -124,25 +124,69 @@ export class CFProfileBadge extends BaseElement {
         display: block;
       }
 
-      /* The generative aura ring. It is transparent until the badge is verified;
-        when verified, the per-identity conic gradient is supplied inline (it is
-        a pure function of the owner DID), so the ring is unique-but-stable for
-        each person. The thin surface-colored gap separates the ring from the
-        avatar so the colors read cleanly at any size. */
+      /* The generative aura ring. Transparent until the badge is verified; when
+        verified, a separate aura-ring layer carries the per-identity conic
+        gradient (a pure function of the owner DID) behind the avatar, so the ring
+        is unique-but-stable for each person. Keeping it on its own layer lets it
+        spin on hover without rotating the avatar. */
       .aura {
+        position: relative;
         display: inline-flex;
         flex: 0 0 auto;
         border-radius: var(--cf-border-radius-full, 9999px);
         padding: 0;
       }
 
+      .aura-ring {
+        position: absolute;
+        inset: 0;
+        border-radius: var(--cf-border-radius-full, 9999px);
+        z-index: 0;
+        transform-origin: center;
+      }
+
+      .aura cf-avatar {
+        position: relative;
+        z-index: 1;
+      }
+
       .badge[data-state="verified"] .aura {
-        padding: 2px;
+        padding: 3px;
       }
 
       .badge[data-state="verified"] .aura cf-avatar {
-        box-shadow: 0 0 0 1.5px var(--cf-theme-color-surface, hsl(0, 0%, 99%));
+        box-shadow: 0 0 0 2px var(--cf-theme-color-surface, hsl(0, 0%, 99%));
         border-radius: var(--cf-border-radius-full, 9999px);
+      }
+
+      /* Hovering a verified badge spins the aura and lifts the glow — a small,
+        deliberate "this is special" tell that user-space chrome doesn't get. */
+      .badge[data-state="verified"] .aura:hover .aura-ring {
+        animation: cf-aura-spin 5s linear infinite;
+      }
+
+      .badge[data-state="verified"] .aura:hover {
+        transform: scale(1.04);
+        transition: transform 160ms ease-out;
+      }
+
+      .badge[data-state="verified"] .aura {
+        transition: transform 200ms ease-out;
+      }
+
+      @keyframes cf-aura-spin {
+        to {
+          transform: rotate(1turn);
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .badge[data-state="verified"] .aura:hover .aura-ring {
+          animation: none;
+        }
+        .badge[data-state="verified"] .aura:hover {
+          transform: none;
+        }
       }
 
       /* When verified the seal mark is tinted with the identity's accent color
@@ -299,8 +343,13 @@ export class CFProfileBadge extends BaseElement {
 
   override render() {
     const verified = this._state === "verified" && this._seal !== undefined;
-    const auraStyle = verified
-      ? `background: ${this._seal!.ringGradient};`
+    // The aura ring layer carries the DID-derived conic gradient plus a soft glow
+    // in the identity's hue, so the fingerprint reads at badge scale.
+    const hue = this._seal?.hue ?? 0;
+    const ringStyle = verified
+      ? `background: ${
+        this._seal!.ringGradient
+      }; box-shadow: 0 0 0 1px hsl(${hue} 80% 58% / 0.3), 0 0 10px -1px hsl(${hue} 85% 60% / 0.7);`
       : "";
     const sealStyle = verified ? `color: ${this._seal!.accent};` : "";
     const sealTitle = verified
@@ -314,7 +363,12 @@ export class CFProfileBadge extends BaseElement {
         data-cf-profile-badge
         data-state="${this._state}"
       >
-        <span class="aura" part="aura" style="${auraStyle}">
+        <span class="aura" part="aura">
+          ${verified
+            ? html`
+              <span class="aura-ring" part="aura-ring" style="${ringStyle}"> </span>
+            `
+            : null}
           <cf-avatar
             part="avatar"
             exportparts="avatar"

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
@@ -11,6 +11,11 @@ import {
 } from "@commonfabric/runtime-client";
 import type { DID } from "@commonfabric/identity";
 import { runtimeContext, spaceContext } from "../../runtime-context.ts";
+import {
+  ownerPrincipalFromLabel,
+  readCfcLabelView,
+} from "../../core/cfc-label.ts";
+import { type IdentitySeal, identitySeal } from "./identity-seal.ts";
 
 /** Verification state of the presented identity. */
 export type ProfileBadgeState = "presented" | "verified" | "unverified";
@@ -56,18 +61,18 @@ export const profileDisplayFromValue = (val: unknown): ProfileBadgeDisplay => {
  *
  * You bind it a *cell* containing a profile (e.g. `$profile={profileCell}`) and
  * it renders the person's avatar + name as system chrome. It runs on the trusted
- * main thread (outside the iframe sandbox where patterns run), which makes it the
- * right home for an *unspoofable* identity treatment — but that property is
- * **deferred, not delivered by v1**: today the seal renders unconditionally and
- * `_state` is always "presented", so a pattern could compose a visually identical
- * badge. v1 just renders avatar + name from the cell.
+ * main thread (outside the iframe sandbox where patterns run), which is what lets
+ * it draw an identity treatment a pattern cannot forge.
  *
- * The deferred pass (see CT-1645 follow-ups) is what earns "unspoofable": read
- * the cell's CFC label via `getCfcLabel()` (the `represents-principal` atom →
- * owner DID), compare it to the authenticated identity, and draw the "seal"
- * effects **only when verified** (gate on `_state === "verified"`). The seam is
- * `_refreshVerification()` + the `_state` field; reuse `authorshipStateForLabel`
- * from `cf-cfc-authorship`.
+ * When the bound cell carries a runtime-attested `represents-principal` CFC label
+ * (read over trusted IPC via `getCfcLabel()`), the badge enters the **verified**
+ * state and draws a *generative identity seal* — a deterministic aura derived
+ * purely from the owner's principal DID (see `identity-seal.ts`). Because the
+ * aura is a pure function of the DID, it is the *same everywhere* that person's
+ * badge appears, so it reads as a recognizable fingerprint of their identity;
+ * and because it is gated on the attestation (which user-space cannot mint), a
+ * pattern can mimic the CSS but not earn the verified seal for a DID it doesn't
+ * control. Without that label the badge stays in the plain "presented" state.
  *
  * @element cf-profile-badge
  * @attr {string} size - avatar size: xs | sm | md | lg | xl (default md)
@@ -119,10 +124,29 @@ export class CFProfileBadge extends BaseElement {
         display: block;
       }
 
-      /* Reserved for the deferred trusted pass: when verification lands, a
-        "verified" badge gets the system seal treatment that user-space CSS
-        cannot reproduce (it depends on runtime-confirmed provenance, not just
-        these styles). */
+      /* The generative aura ring. It is transparent until the badge is verified;
+        when verified, the per-identity conic gradient is supplied inline (it is
+        a pure function of the owner DID), so the ring is unique-but-stable for
+        each person. The thin surface-colored gap separates the ring from the
+        avatar so the colors read cleanly at any size. */
+      .aura {
+        display: inline-flex;
+        flex: 0 0 auto;
+        border-radius: var(--cf-border-radius-full, 9999px);
+        padding: 0;
+      }
+
+      .badge[data-state="verified"] .aura {
+        padding: 2px;
+      }
+
+      .badge[data-state="verified"] .aura cf-avatar {
+        box-shadow: 0 0 0 1.5px var(--cf-theme-color-surface, hsl(0, 0%, 99%));
+        border-radius: var(--cf-border-radius-full, 9999px);
+      }
+
+      /* When verified the seal mark is tinted with the identity's accent color
+        (also DID-derived), supplied inline. */
       .badge[data-state="verified"] .seal {
         color: var(--cf-theme-color-primary, hsl(212, 100%, 47%));
       }
@@ -152,6 +176,10 @@ export class CFProfileBadge extends BaseElement {
 
   @state()
   private accessor _state: ProfileBadgeState = "presented";
+
+  /** Generative identity seal, derived from the owner DID once verified. */
+  @state()
+  private accessor _seal: IdentitySeal | undefined = undefined;
 
   private _unsubscribe?: () => void;
   private _resolveGeneration = 0;
@@ -192,6 +220,8 @@ export class CFProfileBadge extends BaseElement {
     const cell = this.profile;
     if (!cell) {
       this._applyValue(undefined);
+      this._state = "presented";
+      this._seal = undefined;
       return;
     }
 
@@ -234,24 +264,49 @@ export class CFProfileBadge extends BaseElement {
   }
 
   /**
-   * Trust seam — deferred. The unspoofable presentation will read the resolved
-   * cell's CFC label (`represents-principal` → owner DID, via `getCfcLabel()`),
-   * verify it against the authenticated identity, set `_state` accordingly, and
-   * only then draw the seal/effects that user-space cannot reproduce. v1
-   * intentionally renders the unverified "presented" state. Reuse
-   * `authorshipStateForLabel` / the label helpers from cf-cfc-authorship.
+   * Reads the resolved cell's runtime-attested CFC label and, if it carries a
+   * `represents-principal` atom, enters the verified state and derives the
+   * generative seal from the owner principal DID. The seal is a pure function of
+   * the DID, so it is identical wherever this person's badge renders. No
+   * attestation → the badge stays in the plain "presented" state (a pattern can
+   * mimic the chrome but cannot mint the label that unlocks the seal).
    *
-   * LIFECYCLE: this is synchronous today, so it is safe. When the deferred pass
-   * introduces an `await` (label read), it MUST re-check
-   * `generation === this._resolveGeneration && this.isConnected` AFTER the await
-   * before writing `_state`, otherwise it leaks state writes onto detached /
-   * superseded instances (same hazard guarded against in `_resolve`).
+   * LIFECYCLE: this awaits a label read, so after the await it MUST re-check
+   * `generation === this._resolveGeneration && this.isConnected` before writing
+   * `_state`/`_seal` — `disconnectedCallback` bumps the generation, so a badge
+   * detached (or re-bound) mid-read won't leak a state write onto a stale /
+   * detached instance (same hazard guarded in `_resolve`).
    */
-  private _refreshVerification(_cell: CellHandle): void {
-    this._state = "presented";
+  private async _refreshVerification(cell: CellHandle): Promise<void> {
+    const generation = this._resolveGeneration;
+    try {
+      const view = await readCfcLabelView(cell);
+      if (generation !== this._resolveGeneration || !this.isConnected) return;
+      const owner = ownerPrincipalFromLabel(view);
+      if (owner) {
+        this._seal = identitySeal(owner);
+        this._state = "verified";
+      } else {
+        this._seal = undefined;
+        this._state = "presented";
+      }
+    } catch {
+      if (generation !== this._resolveGeneration || !this.isConnected) return;
+      this._seal = undefined;
+      this._state = "presented";
+    }
   }
 
   override render() {
+    const verified = this._state === "verified" && this._seal !== undefined;
+    const auraStyle = verified
+      ? `background: ${this._seal!.ringGradient};`
+      : "";
+    const sealStyle = verified ? `color: ${this._seal!.accent};` : "";
+    const sealTitle = verified
+      ? "Identity verified by the system"
+      : "System-rendered identity";
+
     return html`
       <span
         class="badge"
@@ -259,13 +314,15 @@ export class CFProfileBadge extends BaseElement {
         data-cf-profile-badge
         data-state="${this._state}"
       >
-        <cf-avatar
-          part="avatar"
-          exportparts="avatar"
-          .src="${this._avatar}"
-          .name="${this._name}"
-          size="${this.size}"
-        ></cf-avatar>
+        <span class="aura" part="aura" style="${auraStyle}">
+          <cf-avatar
+            part="avatar"
+            exportparts="avatar"
+            .src="${this._avatar}"
+            .name="${this._name}"
+            size="${this.size}"
+          ></cf-avatar>
+        </span>
         <span class="name" part="name">
           ${this._name ?? "Unknown profile"}
         </span>
@@ -273,7 +330,8 @@ export class CFProfileBadge extends BaseElement {
           class="seal"
           part="seal"
           aria-hidden="true"
-          title="System-rendered identity"
+          title="${sealTitle}"
+          style="${sealStyle}"
         >
           <svg
             viewBox="0 0 24 24"
@@ -284,6 +342,11 @@ export class CFProfileBadge extends BaseElement {
             stroke-linejoin="round"
           >
             <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+            ${verified
+              ? html`
+                <path d="M9 12l2 2 4-4" />
+              `
+              : null}
           </svg>
         </span>
       </span>

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
@@ -260,12 +260,15 @@ export class CFProfileBadge extends BaseElement {
   private async _resolve(): Promise<void> {
     const generation = ++this._resolveGeneration;
     this._cleanup();
+    // Clear any prior verification up-front: a re-bind to a different profile
+    // must not keep showing the previous profile's seal during the async
+    // re-resolve + attestation gap. `_refreshVerification` re-derives it below.
+    this._state = "presented";
+    this._seal = undefined;
 
     const cell = this.profile;
     if (!cell) {
       this._applyValue(undefined);
-      this._state = "presented";
-      this._seal = undefined;
       return;
     }
 
@@ -334,8 +337,14 @@ export class CFProfileBadge extends BaseElement {
         this._seal = undefined;
         this._state = "presented";
       }
-    } catch {
+    } catch (e) {
       if (generation !== this._resolveGeneration || !this.isConnected) return;
+      // Surface the IPC/label-read failure (mirrors `_resolve`'s catch) rather
+      // than silently collapsing every failure to the unverified state.
+      console.error(
+        "cf-profile-badge: failed to read CFC label for verification",
+        e,
+      );
       this._seal = undefined;
       this._state = "presented";
     }

--- a/packages/ui/src/v2/components/cf-profile-badge/identity-seal.test.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/identity-seal.test.ts
@@ -1,0 +1,52 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { identitySeal, normalizeDid } from "./identity-seal.ts";
+
+const DID_A = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+const DID_B = "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRrm6XYMq2dnQ";
+
+describe("identitySeal", () => {
+  it("is deterministic — same DID yields byte-identical output", () => {
+    expect(identitySeal(DID_A)).toEqual(identitySeal(DID_A));
+  });
+
+  it("is stable across trivial formatting differences", () => {
+    // Leading/trailing whitespace and the `did:` prefix case must not change
+    // the aura (normalizeDid trims + canonicalizes the prefix only).
+    expect(identitySeal(`  ${DID_A}  `)).toEqual(identitySeal(DID_A));
+    expect(normalizeDid("  DID:key:abc ")).toBe("did:key:abc");
+  });
+
+  it("distinguishes different identities by primary hue", () => {
+    expect(identitySeal(DID_A).hue).not.toBe(identitySeal(DID_B).hue);
+  });
+
+  it("produces a usable conic-gradient ring and HSL accent", () => {
+    const seal = identitySeal(DID_A);
+    expect(seal.ringGradient).toMatch(/^conic-gradient\(from \d+deg,/);
+    expect(seal.ringGradient).toContain("hsl(");
+    expect(seal.accent).toMatch(/^hsl\(\d+ \d+% \d+%\)$/);
+    expect(seal.angle).toBeGreaterThanOrEqual(0);
+    expect(seal.angle).toBeLessThan(360);
+  });
+
+  it("keeps every derived hue within [0, 360)", () => {
+    for (const did of [DID_A, DID_B, "did:key:short", "ben", ""]) {
+      for (const h of identitySeal(did).hues) {
+        expect(h).toBeGreaterThanOrEqual(0);
+        expect(h).toBeLessThan(360);
+      }
+    }
+  });
+
+  it("does not collapse to one hue for many distinct DIDs", () => {
+    // Sanity: a spread of identities should not all map to the same color.
+    const hues = new Set(
+      Array.from(
+        { length: 64 },
+        (_, i) => identitySeal(`did:key:seed-${i}`).hue,
+      ),
+    );
+    expect(hues.size).toBeGreaterThan(20);
+  });
+});

--- a/packages/ui/src/v2/components/cf-profile-badge/identity-seal.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/identity-seal.ts
@@ -67,9 +67,9 @@ export const normalizeDid = (did: string): string => {
   return /^did:/i.test(trimmed) ? "did:" + trimmed.slice(4) : trimmed;
 };
 
-const RING_STOPS = 5;
-const SATURATION = 68;
-const LIGHTNESS = 56;
+const RING_STOPS = 6;
+const SATURATION = 80;
+const LIGHTNESS = 58;
 
 /**
  * Derives the deterministic identity seal for a principal DID. Same input →

--- a/packages/ui/src/v2/components/cf-profile-badge/identity-seal.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/identity-seal.ts
@@ -1,0 +1,111 @@
+/**
+ * identity-seal — a deterministic, generative identity treatment derived purely
+ * from a principal DID.
+ *
+ * The point: the same identity yields the *same* aura everywhere it appears, so
+ * the treatment reads as a recognizable fingerprint of that person — you learn
+ * your friend's colors. Combined with `cf-profile-badge` only drawing it when
+ * the profile cell carries a runtime-attested `represents-principal` CFC label
+ * (read over trusted IPC on the main thread), the aura becomes hard to forge:
+ * a user-space pattern can mimic the CSS, but not the attestation that unlocks
+ * it, and the colors it would have to reproduce are pinned to a DID it does not
+ * control.
+ *
+ * Pure + framework-free so it is trivially unit-testable and identical wherever
+ * it runs.
+ */
+
+export type IdentitySeal = {
+  /** The DID this seal was derived from (normalized). */
+  did: string;
+  /** Primary hue (0–360), the main per-identity differentiator. */
+  hue: number;
+  /** The ring's ordered hues (degrees), used to build the conic aura. */
+  hues: readonly number[];
+  /** Conic-gradient rotation offset, in degrees. */
+  angle: number;
+  /** Ready-to-use CSS `conic-gradient(...)` for the aura ring. */
+  ringGradient: string;
+  /** Accent color (HSL string) for the seal mark when verified. */
+  accent: string;
+};
+
+/** Deterministic 32-bit FNV-1a hash of a string. */
+const fnv1a = (input: string): number => {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+};
+
+/**
+ * splitmix32 — derives a stream of well-distributed values in [0, 1) from a
+ * 32-bit seed. Deterministic and dependency-free (no Math.random).
+ */
+const splitmix32 = (seed: number): () => number => {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x9e3779b9) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 16), 0x21f0aaad);
+    t = Math.imul(t ^ (t >>> 15), 0x735a2d97);
+    t = t ^ (t >>> 15);
+    return (t >>> 0) / 4294967296;
+  };
+};
+
+/**
+ * Normalizes a DID for hashing so trivial formatting differences (whitespace,
+ * case in the method/value) don't change the aura. The method-specific id is
+ * case-sensitive in general, so we only trim + lowercase the well-known prefix.
+ */
+export const normalizeDid = (did: string): string => {
+  const trimmed = did.trim();
+  // The DID scheme ("did:") is case-insensitive; the method-specific id is not.
+  return /^did:/i.test(trimmed) ? "did:" + trimmed.slice(4) : trimmed;
+};
+
+const RING_STOPS = 5;
+const SATURATION = 68;
+const LIGHTNESS = 56;
+
+/**
+ * Derives the deterministic identity seal for a principal DID. Same input →
+ * byte-identical output, on any thread, in any session.
+ */
+export const identitySeal = (did: string): IdentitySeal => {
+  const normalized = normalizeDid(did);
+  const next = splitmix32(fnv1a(normalized) || 1);
+
+  const hue = Math.floor(next() * 360);
+  // Spread the remaining ring hues around the wheel. A per-identity "span"
+  // controls whether the aura is tight (analogous) or wide (near-complementary),
+  // giving identities distinct character beyond just the base hue.
+  const span = 40 + Math.floor(next() * 140); // 40–180°
+  const direction = next() < 0.5 ? -1 : 1;
+  const hues: number[] = [];
+  for (let i = 0; i < RING_STOPS; i++) {
+    const t = i / (RING_STOPS - 1); // 0..1
+    const jitter = (next() - 0.5) * 18;
+    hues.push(((hue + direction * span * t + jitter) % 360 + 360) % 360);
+  }
+
+  const angle = Math.floor(next() * 360);
+
+  const stops = hues
+    .map((h, i) => {
+      const pos = Math.round((i / RING_STOPS) * 360);
+      return `hsl(${Math.round(h)} ${SATURATION}% ${LIGHTNESS}%) ${pos}deg`;
+    })
+    .join(", ");
+  // Close the loop back to the first hue for a seamless ring.
+  const ringGradient = `conic-gradient(from ${angle}deg, ${stops}, hsl(${
+    Math.round(hues[0])
+  } ${SATURATION}% ${LIGHTNESS}%) 360deg)`;
+
+  const accent = `hsl(${hue} ${SATURATION}% 44%)`;
+
+  return { did: normalized, hue, hues, angle, ringGradient, accent };
+};

--- a/packages/ui/src/v2/components/cf-profile-badge/identity-seal.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/identity-seal.ts
@@ -30,7 +30,13 @@ export type IdentitySeal = {
   accent: string;
 };
 
-/** Deterministic 32-bit FNV-1a hash of a string. */
+/**
+ * Deterministic 32-bit FNV-1a hash of a string.
+ *
+ * Deliberately a tiny non-cryptographic hash, NOT `@commonfabric/content-hash`:
+ * this seeds a *visual* fingerprint and must be synchronous and dependency-free
+ * (content-hash is async SHA-256 for content addressing — the wrong tool here).
+ */
 const fnv1a = (input: string): number => {
   let hash = 0x811c9dc5;
   for (let i = 0; i < input.length; i++) {

--- a/packages/ui/src/v2/core/cfc-label.test.ts
+++ b/packages/ui/src/v2/core/cfc-label.test.ts
@@ -22,6 +22,18 @@ describe("ownerPrincipalFromLabel", () => {
     expect(ownerPrincipalFromLabel(label)).toBe(DID);
   });
 
+  it("trims object-form subjects to match the string-form normalization", () => {
+    const label = view([
+      {
+        path: ["name"],
+        label: {
+          integrity: [{ kind: "represents-principal", subject: `  ${DID}  ` }],
+        },
+      },
+    ]);
+    expect(ownerPrincipalFromLabel(label)).toBe(DID);
+  });
+
   it("extracts the subject from a string-form atom", () => {
     const label = view([
       {

--- a/packages/ui/src/v2/core/cfc-label.test.ts
+++ b/packages/ui/src/v2/core/cfc-label.test.ts
@@ -1,0 +1,53 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import type { CfcLabelView } from "@commonfabric/runner/cfc";
+import { ownerPrincipalFromLabel } from "./cfc-label.ts";
+
+const DID = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+
+const view = (entries: CfcLabelView["entries"]): CfcLabelView => ({
+  version: 1,
+  entries,
+});
+
+describe("ownerPrincipalFromLabel", () => {
+  it("extracts the subject from an object-form represents-principal atom on a field path", () => {
+    // Owner-protected profile fields carry the atom at their own path, not root.
+    const label = view([
+      {
+        path: ["name"],
+        label: { integrity: [{ kind: "represents-principal", subject: DID }] },
+      },
+    ]);
+    expect(ownerPrincipalFromLabel(label)).toBe(DID);
+  });
+
+  it("extracts the subject from a string-form atom", () => {
+    const label = view([
+      {
+        path: ["avatar"],
+        label: { integrity: [`represents-principal:${DID}`] },
+      },
+    ]);
+    expect(ownerPrincipalFromLabel(label)).toBe(DID);
+  });
+
+  it("ignores unrelated integrity atoms", () => {
+    const label = view([
+      {
+        path: [],
+        label: { integrity: ["profile-link", "authored-by:someone"] },
+      },
+      {
+        path: ["x"],
+        label: { integrity: [{ kind: "owned-by", subject: DID }] },
+      },
+    ]);
+    expect(ownerPrincipalFromLabel(label)).toBeUndefined();
+  });
+
+  it("returns undefined for an empty or missing label", () => {
+    expect(ownerPrincipalFromLabel(undefined)).toBeUndefined();
+    expect(ownerPrincipalFromLabel(view([]))).toBeUndefined();
+  });
+});

--- a/packages/ui/src/v2/core/cfc-label.ts
+++ b/packages/ui/src/v2/core/cfc-label.ts
@@ -1,0 +1,90 @@
+/**
+ * Shared helpers for reading CFC labels on the trusted main thread.
+ *
+ * These let a trusted component query a cell's runtime-attested CFC label (over
+ * IPC) and pull the owning principal out of a `represents-principal` integrity
+ * atom. `cf-cfc-authorship` has its own root-scoped, authorship-specific label
+ * reading; this module is intentionally narrower (owner-principal extraction,
+ * scanning every entry) and is the shared home for that concern. A future pass
+ * can fold the authorship reader onto these primitives.
+ */
+import type { CfcLabelView } from "@commonfabric/runner/cfc";
+
+export type { CfcLabelView };
+
+export type CfcLabelQueryable = {
+  getCfcLabel(): Promise<CfcLabelView | undefined>;
+};
+
+export type CfcLabelResolvable = {
+  resolveAsCell(): Promise<unknown> | unknown;
+};
+
+const REPRESENTS_PRINCIPAL = "represents-principal";
+
+export const canQueryCfcLabel = (value: unknown): value is CfcLabelQueryable =>
+  typeof value === "object" && value !== null &&
+  typeof (value as { getCfcLabel?: unknown }).getCfcLabel === "function";
+
+const canResolveAsCell = (value: unknown): value is CfcLabelResolvable =>
+  typeof value === "object" && value !== null &&
+  typeof (value as { resolveAsCell?: unknown }).resolveAsCell === "function";
+
+/**
+ * Reads a cell's CFC label view, resolving the cell first if the handle itself
+ * doesn't expose `getCfcLabel` (e.g. an unresolved link). Returns undefined if
+ * no label can be read.
+ */
+export const readCfcLabelView = async (
+  value: unknown,
+): Promise<CfcLabelView | undefined> => {
+  if (canQueryCfcLabel(value)) {
+    return await value.getCfcLabel();
+  }
+  if (canResolveAsCell(value)) {
+    const resolved = await value.resolveAsCell();
+    if (canQueryCfcLabel(resolved)) {
+      return await resolved.getCfcLabel();
+    }
+  }
+  return undefined;
+};
+
+/**
+ * Extracts the owning principal DID from a `represents-principal` integrity atom
+ * anywhere in the label. Owner-protected profile fields (`name`/`avatar`/…)
+ * carry this atom at their own paths rather than the root, so every entry is
+ * scanned. Supports both the object form (`{ kind, subject }`) and the string
+ * form (`represents-principal:<did>`). Returns the first concrete DID found.
+ */
+export const ownerPrincipalFromLabel = (
+  view: CfcLabelView | undefined,
+): string | undefined => {
+  if (!view) {
+    return undefined;
+  }
+  for (const entry of view.entries) {
+    for (const atom of entry.label.integrity ?? []) {
+      if (typeof atom === "string") {
+        if (atom.startsWith(`${REPRESENTS_PRINCIPAL}:`)) {
+          const subject = atom.slice(REPRESENTS_PRINCIPAL.length + 1).trim();
+          if (subject.length > 0) {
+            return subject;
+          }
+        }
+        continue;
+      }
+      if (typeof atom !== "object" || atom === null || Array.isArray(atom)) {
+        continue;
+      }
+      const record = atom as Record<string, unknown>;
+      if (
+        record.kind === REPRESENTS_PRINCIPAL &&
+        typeof record.subject === "string" && record.subject.trim().length > 0
+      ) {
+        return record.subject;
+      }
+    }
+  }
+  return undefined;
+};

--- a/packages/ui/src/v2/core/cfc-label.ts
+++ b/packages/ui/src/v2/core/cfc-label.ts
@@ -82,7 +82,8 @@ export const ownerPrincipalFromLabel = (
         record.kind === REPRESENTS_PRINCIPAL &&
         typeof record.subject === "string" && record.subject.trim().length > 0
       ) {
-        return record.subject;
+        // Trim to match the string-form branch — both yield a normalized DID.
+        return record.subject.trim();
       }
     }
   }


### PR DESCRIPTION
Adds the **verification seal** to `cf-profile-badge`: when a bound profile cell carries a runtime-attested `represents-principal` CFC label, the badge enters a **verified** state and draws a *generative identity aura derived purely from the owner's principal DID*.

**Stacked on #3879** (the `cf-profile-badge` component). Part of CT-1645.

### What it does
- **`identity-seal.ts`** — pure, deterministic `DID → aura` (FNV‑1a + splitmix32 → a conic‑gradient ring of DID‑derived hues + accent). Framework-free, fully unit-tested.
- **`core/cfc-label.ts`** — shared trusted-thread helpers to read a cell's CFC label (`getCfcLabel()` over IPC) and extract the owner principal from a `represents-principal` atom (scans every entry; owner-protected profile fields carry it at their own paths). Intentionally narrower than `cf-cfc-authorship`'s root-only authorship reader; the shared home for owner-principal extraction.
- **`cf-profile-badge`** — `_refreshVerification` reads the label, derives the seal, and gates the aura ring + accented seal mark on the verified state. On hover, a verified badge **spins the aura + lifts the glow** (respects `prefers-reduced-motion`).

### Why it's meaningful
- **A fingerprint:** the aura is a pure function of the DID, so it is *identical everywhere* that person's badge renders — you learn their colors. Distinct DIDs → distinct auras.
- **Unspoofable in the way that matters:** it only renders when the runtime attests the identity (`represents-principal`), which sandboxed patterns can't mint. A pattern can copy the CSS but can't earn the seal for a DID it doesn't control — and the colors it would have to reproduce are pinned to a DID it doesn't own.

### Verification
- 16 unit-test steps green (`identity-seal`, `cfc-label`, existing badge tests); `deno fmt`/`lint`/`check` clean.
- **Browser-verified end-to-end** against a real attested profile (home Profile tab): the badge read the cross-space profile's `represents-principal` label (owner DID), entered `verified`, and rendered the DID-derived aura — confirmed across two distinct DIDs (blue/magenta vs green auras). The owner-DID extractor matches the live label shape (and the shape asserted in `runner/test/profile-owner-cfc.test.ts`).

### Notes / follow-ups
- The verified seal only renders for a *real attested* profile, so the catalog story (which can't mint a CFC label) shows the plain "presented" badge; the verified state is exercised via the home Profile tab.
- Surfaced while testing: the badge shows the `[NAME]` placeholder ("Profile") instead of the owner-protected `name` on a cross-space read (the `<cf-render>` ProfileHome below shows the same blank name). Pre-existing, separate from the seal — tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a verified identity seal to `cf-profile-badge`: when a runtime‑attested `represents-principal` CFC label is present, the badge shows a deterministic DID‑based aura with a soft glow and an accented checkmark, and reacts on hover. Delivers CT-1645 verified state on the trusted thread and makes the badge hard to spoof.

- **New Features**
  - `cf-profile-badge`: reads the label via `readCfcLabelView` → `ownerPrincipalFromLabel`, enters "verified", and renders a DID‑derived conic‑gradient aura on a dedicated `.aura-ring` layer behind the avatar with a soft hue glow; spins and subtly scales on hover (respects `prefers-reduced-motion`); seal mark is accent‑tinted and shows a check when verified.
  - `core/cfc-label.ts`: `readCfcLabelView` and `ownerPrincipalFromLabel` to fetch labels and extract the owner DID (resolves handles, scans all entries; supports object and string atoms; trims object‑form subjects).
  - `identity-seal.ts`: pure, deterministic DID → aura (FNV‑1a + splitmix32) returning `ringGradient`, `accent`, `hue`, `hues`, and `angle` for a bolder 6‑stop ring.
  - Tests: unit tests for `identity-seal`, `cfc-label`, and badge verification paths; badge stays "presented" without the atom; re‑bind clears any prior seal.

- **Bug Fixes**
  - Clear `_state`/`_seal` up‑front in `_resolve` so a re‑bind never shows a stale seal during the async gap.
  - `_refreshVerification` now logs label‑read errors instead of silently collapsing to unverified.
  - `ownerPrincipalFromLabel` trims object‑form `subject` to match string‑form normalization.
  - Added tests for the superseded‑mid‑read guard and the label‑read failure path; catalog story caption updated to reflect that the verified seal ships and only renders for runtime‑attested profiles.

<sup>Written for commit 4aa68809136f691506f9abd5d62131983b3829bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---

### Performance baseline

Performance Check flagged a wall-time regression on `lunch-poll/main.test.tsx` — a pattern unit test **unrelated to this PR** (this change touches only `packages/ui`). The measured bump (20.4s vs a 19.6s threshold) is CI-runner timing variance, not a code regression; re-running did not clear it. Accepting via the sanctioned baseline mechanism (`docs/development/CI_PERFORMANCE.md`):

NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/lunch-poll/main.test.tsx = 21s
