### PR TITLE
fix(integration): stop leaking dev servers and make port handling race-free

### DIFF
--- a/docs/development/LOCAL_DEV_SERVERS.md
+++ b/docs/development/LOCAL_DEV_SERVERS.md
@@ -18,8 +18,21 @@
 ```
 
 `start-local-dev.sh` validates required commands before launching anything and
-waits for both servers to return HTTP 200 before reporting success. Set
-`LOCAL_DEV_STARTUP_TIMEOUT` to adjust the readiness timeout in seconds.
+waits for both servers to bind their ports and return HTTP 200 before reporting
+success. Set `LOCAL_DEV_STARTUP_TIMEOUT` to adjust the readiness timeout in
+seconds.
+
+**Exit codes (`start-local-dev.sh`):**
+| Code | Meaning |
+|------|---------|
+| `0` | Both servers started and became ready. |
+| `3` | A server could not bind because its port is already in use; retry on a different port offset. |
+| other non-zero | Any other startup failure (build error, crash, readiness timeout). |
+
+Code `3` is reported only when a server's actual bind fails, not from a port
+pre-check, so it carries no check-then-bind race. The toolshed and the shell dev
+server exit with the same code, and `deno task integration` relies on it to
+retry a generated offset on a collision while aborting on any other failure.
 
 **URLs:**
 | What | URL |

--- a/packages/felt/dev-server.ts
+++ b/packages/felt/dev-server.ts
@@ -37,7 +37,13 @@ export class DevServer {
     this.html = this.getHtml({ useReloadSocket, outDir });
     this.socketScript = this.getSocketScript({ hostname, port });
     this._server = Deno.serve(
-      { port, hostname, onListen() {} },
+      {
+        port,
+        hostname,
+        onListen() {
+          console.log(`Dev server listening on http://${hostname}:${port}`);
+        },
+      },
       this.onRequest.bind(this),
     );
   }

--- a/packages/felt/felt.ts
+++ b/packages/felt/felt.ts
@@ -104,14 +104,25 @@ export class Felt {
       return;
     }
 
-    const server = new DevServer({
-      useReloadSocket: isDev,
-      hostname,
-      redirectToIndex,
-      port,
-      outDir,
-      staticDirs: this.config.staticDirs,
-    });
+    let server: DevServer;
+    try {
+      server = new DevServer({
+        useReloadSocket: isDev,
+        hostname,
+        redirectToIndex,
+        port,
+        outDir,
+        staticDirs: this.config.staticDirs,
+      });
+    } catch (error) {
+      if (error instanceof Deno.errors.AddrInUse) {
+        // Reported only when the actual bind fails. Exit code 3 matches the
+        // dev-server scripts so a port collision can be retried elsewhere.
+        console.error(`Port ${port} is already in use`);
+        Deno.exit(3);
+      }
+      throw error;
+    }
 
     if (isDev) {
       builder.addEventListener("build", (_) => {

--- a/packages/toolshed/index.ts
+++ b/packages/toolshed/index.ts
@@ -143,7 +143,9 @@ async function startServer() {
   } catch (err) {
     if (err instanceof Deno.errors.AddrInUse) {
       console.error(`Port ${env.PORT} is already in use`);
-      Deno.exit(1);
+      // Distinct exit code so callers can tell a port collision from other
+      // startup failures and retry on a different port.
+      Deno.exit(3);
     }
     console.error("Failed to start server:", err);
     Deno.exit(1);

--- a/scripts/start-local-dev.sh
+++ b/scripts/start-local-dev.sh
@@ -29,6 +29,10 @@ INSPECT_BRK=false
 INSPECT_PORT=${INSPECT_PORT:-}
 LOCAL_DEV_STARTUP_TIMEOUT=${LOCAL_DEV_STARTUP_TIMEOUT:-120}
 
+# Exit code emitted when a server cannot bind because its port is already in
+# use. Callers can retry on a different port.
+PORT_IN_USE_EXIT=3
+
 # Parse command line arguments
 FORCE=false
 WATCH=false
@@ -122,33 +126,32 @@ SHELL_PID=""
 TOOLSHED_PID=""
 BG_PID=""
 
-# Check if port is free; kill processes if --force, otherwise error
-check_port() {
+# With --force, kill anything already listening on the port so the server can
+# bind it. Without --force the port is left untouched: each server reports a
+# collision when its own bind fails (exit PORT_IN_USE_EXIT), which avoids a
+# check-then-bind race.
+free_port_if_forced() {
     local port=$1
+    [[ "$FORCE" == "true" ]] || return 0
+
     local pids
     pids=$(get_pids_on_port "$port")
-
     if [[ -n "$pids" ]]; then
-        if [[ "$FORCE" == "true" ]]; then
-            echo "Port $port is in use, killing processes: $pids"
-            echo "$pids" | xargs kill 2>/dev/null
+        echo "Port $port is in use, killing processes: $pids"
+        echo "$pids" | xargs kill 2>/dev/null
+        sleep 1
+        # Force kill if still running
+        pids=$(get_pids_on_port "$port")
+        if [[ -n "$pids" ]]; then
+            echo "Force killing remaining processes: $pids"
+            echo "$pids" | xargs kill -9 2>/dev/null
             sleep 1
-            # Force kill if still running
-            pids=$(get_pids_on_port "$port")
-            if [[ -n "$pids" ]]; then
-                echo "Force killing remaining processes: $pids"
-                echo "$pids" | xargs kill -9 2>/dev/null
-                sleep 1
-            fi
-        else
-            echo "Error: Port $port is already in use" >&2
-            exit 1
         fi
     fi
 }
 
-check_port "$TOOLSHED_PORT"
-check_port "$SHELL_PORT"
+free_port_if_forced "$TOOLSHED_PORT"
+free_port_if_forced "$SHELL_PORT"
 
 show_recent_log() {
     local name=$1
@@ -161,29 +164,24 @@ show_recent_log() {
     fi
 }
 
-kill_port_listeners() {
-    local port=$1
-    local pids
-    pids=$(get_pids_on_port "$port")
+# Kill a process and all of its descendants. Targets only processes this script
+# started, so a foreign server already on one of the ports (for example another
+# run's server during a port collision) is left untouched.
+kill_tree() {
+    local pid=$1
+    [[ -n "$pid" ]] || return 0
 
-    for pid in $pids; do
-        kill "$pid" 2>/dev/null
+    local child
+    for child in $(pgrep -P "$pid" 2>/dev/null); do
+        kill_tree "$child"
     done
+    kill "$pid" 2>/dev/null
 }
 
 cleanup_started_processes() {
-    if [[ -n "$BG_PID" ]]; then
-        kill "$BG_PID" 2>/dev/null
-    fi
-    if [[ -n "$TOOLSHED_PID" ]]; then
-        kill "$TOOLSHED_PID" 2>/dev/null
-    fi
-    if [[ -n "$SHELL_PID" ]]; then
-        kill "$SHELL_PID" 2>/dev/null
-    fi
-
-    kill_port_listeners "$TOOLSHED_PORT"
-    kill_port_listeners "$SHELL_PORT"
+    kill_tree "$BG_PID"
+    kill_tree "$TOOLSHED_PID"
+    kill_tree "$SHELL_PID"
 }
 
 fail_startup() {
@@ -214,6 +212,10 @@ ensure_process_running() {
     echo "Error: $name exited before it became ready (exit $exit_status)." >&2
     cleanup_started_processes
     show_recent_log "$name" "$log_file"
+    if [[ "$exit_status" -eq "$PORT_IN_USE_EXIT" ]]; then
+        echo "($name could not bind its port; it is already in use.)" >&2
+        exit "$PORT_IN_USE_EXIT"
+    fi
     exit 1
 }
 
@@ -253,6 +255,31 @@ wait_for_http() {
         "$name did not become ready at $url within ${LOCAL_DEV_STARTUP_TIMEOUT}s."
 }
 
+# Wait until the server reports a successful bind (its listen marker) or its
+# process exits. ensure_process_running classifies an early exit, surfacing
+# PORT_IN_USE_EXIT when the bind failed because the port was already in use.
+# Waiting on the marker rather than an HTTP probe avoids mistaking another
+# server already on the port for this one.
+wait_for_listen() {
+    local name=$1
+    local marker=$2
+    local pid=$3
+    local log_file=$4
+    local deadline=$((SECONDS + LOCAL_DEV_STARTUP_TIMEOUT))
+
+    echo "Waiting for $name to bind its port..."
+    while (( SECONDS < deadline )); do
+        ensure_process_running "$name" "$pid" "$log_file"
+        if grep -q "$marker" "$log_file" 2>/dev/null; then
+            echo "  $name has bound its port."
+            return
+        fi
+        sleep 1
+    done
+
+    fail_startup "$name did not bind its port within ${LOCAL_DEV_STARTUP_TIMEOUT}s."
+}
+
 # Start shell dev server in background
 cd "$SCRIPT_DIR/../packages/shell"
 TOOLSHED_PORT="$TOOLSHED_PORT" deno task dev-local > "$SHELL_LOG" 2>&1 &
@@ -279,6 +306,7 @@ SHELL_URL="http://localhost:$SHELL_PORT" \
         > "$TOOLSHED_LOG" 2>&1 &
 TOOLSHED_PID=$!
 
+wait_for_listen "shell" "Dev server listening on" "$SHELL_PID" "$SHELL_LOG"
 wait_for_http "shell" "http://localhost:$SHELL_PORT" "$SHELL_PID" "$SHELL_LOG"
 
 # # Function to cleanup background processes
@@ -290,6 +318,7 @@ wait_for_http "shell" "http://localhost:$SHELL_PORT" "$SHELL_PID" "$SHELL_LOG"
 # # Set up trap to cleanup on script exit
 # trap cleanup EXIT INT TERM
 
+wait_for_listen "toolshed" "Server running on" "$TOOLSHED_PID" "$TOOLSHED_LOG"
 wait_for_http \
     "toolshed" "http://localhost:$TOOLSHED_PORT/_health" \
     "$TOOLSHED_PID" "$TOOLSHED_LOG"

--- a/tasks/integration.ts
+++ b/tasks/integration.ts
@@ -92,11 +92,18 @@ async function stopServers(portOffset: number, rootDir: string): Promise<void> {
   );
 }
 
+// start-local-dev.sh exits with this code when a requested port is already in
+// use. Other failures use different codes and are not worth retrying.
+const PORT_IN_USE_EXIT = 3;
+
+// Starts the dev servers for the given offset. Returns the start-local-dev.sh
+// exit code: 0 on success, PORT_IN_USE_EXIT on a port collision, or another
+// non-zero code for any other startup failure.
 async function startServers(
   portOffset: number,
   rootDir: string,
   env: Record<string, string> = {},
-): Promise<boolean> {
+): Promise<number> {
   console.log(`Starting servers with PORT_OFFSET=${portOffset}...`);
   const result = await runCommand(
     ["bash", "scripts/start-local-dev.sh", `--port-offset=${portOffset}`],
@@ -105,14 +112,14 @@ async function startServers(
 
   if (!result.success) {
     console.error("Failed to start servers");
-    return false;
+    return result.code;
   }
 
   // Wait a bit more for servers to be fully ready
   console.log("Waiting for servers to be fully ready...");
   await new Promise((resolve) => setTimeout(resolve, 3000));
 
-  return true;
+  return 0;
 }
 
 /**
@@ -529,6 +536,20 @@ Log files (after servers start):
 `);
 }
 
+/**
+ * Parse a port offset, exiting with a clear error if it is not a non-negative
+ * integer. Shared by --port-offset and the PORT_OFFSET env var so an invalid
+ * value fails fast instead of becoming NaN in URLs and command arguments.
+ */
+function parsePortOffset(value: string, source: string): number {
+  const offset = parseInt(value, 10);
+  if (Number.isNaN(offset) || offset < 0) {
+    console.error(`Invalid port offset from ${source}: "${value}"`);
+    Deno.exit(1);
+  }
+  return offset;
+}
+
 async function main(): Promise<void> {
   const args = Deno.args;
 
@@ -545,11 +566,7 @@ async function main(): Promise<void> {
 
   for (const arg of args) {
     if (arg.startsWith("--port-offset=")) {
-      cliPortOffset = parseInt(arg.split("=")[1], 10);
-      if (isNaN(cliPortOffset) || cliPortOffset < 0) {
-        console.error(`Invalid port offset: ${arg}`);
-        Deno.exit(1);
-      }
+      cliPortOffset = parsePortOffset(arg.split("=")[1], "--port-offset");
     } else if (arg.startsWith("--junit-dir=")) {
       junitDir = arg.split("=")[1];
     } else if (!arg.startsWith("-")) {
@@ -574,25 +591,26 @@ async function main(): Promise<void> {
 
   const rootDir = Deno.cwd();
 
-  // Priority: CLI arg > env var > random
-  const envPortOffset = Deno.env.get("PORT_OFFSET");
+  // Priority: CLI arg > env var > generated. An explicit offset is reused as-is
+  // and its servers are left running; a generated offset is tried at random,
+  // retried on a port collision, and stopped after the run.
+  // An empty or whitespace PORT_OFFSET is treated as unset (use a generated
+  // offset); a non-empty value is validated so a typo fails fast.
+  const envPortOffsetRaw = Deno.env.get("PORT_OFFSET");
+  const envPortOffset =
+    envPortOffsetRaw !== undefined && envPortOffsetRaw.trim() !== ""
+      ? parsePortOffset(envPortOffsetRaw, "PORT_OFFSET")
+      : undefined;
   const portOffsetWasSet = cliPortOffset !== undefined ||
     envPortOffset !== undefined;
-  const portOffset = cliPortOffset ??
-    (envPortOffset ? parseInt(envPortOffset, 10) : undefined) ??
-    Math.floor(Math.random() * 901) + 100; // 100-1000
-
-  const apiUrl = `http://localhost:${ports.toolshed + portOffset}`;
-
-  console.log("Integration Test Runner");
-  console.log("=======================");
   const offsetSource = cliPortOffset !== undefined
     ? " (from --port-offset)"
     : envPortOffset !== undefined
     ? " (from env)"
     : " (generated)";
-  console.log(`PORT_OFFSET: ${portOffset}${offsetSource}`);
-  console.log(`API_URL: ${apiUrl}`);
+
+  console.log("Integration Test Runner");
+  console.log("=======================");
   if (packageFilter) {
     console.log(`Package filter: ${packageFilter}`);
   }
@@ -609,27 +627,89 @@ async function main(): Promise<void> {
     ALL_PACKAGES_WITH_SERVER.includes(pkg)
   );
 
+  // An explicit offset is used directly; a generated offset is replaced with a
+  // free one just before the servers start.
+  let portOffset = cliPortOffset ?? envPortOffset ?? 0;
+  let apiUrl = "";
+
+  // A generated-offset run owns the servers it starts and stops them on the way
+  // out, including after a failure. An explicit offset is left running.
+  let ownsServers = false;
   let serverStarted = false;
+  let cleanedUp = false;
+  let exitCode = 0;
+
+  const cleanup = async (): Promise<void> => {
+    if (cleanedUp) return;
+    cleanedUp = true;
+    if (ownsServers) {
+      console.log("\nCleaning up servers...");
+      await stopServers(portOffset, rootDir);
+    } else if (serverStarted) {
+      console.log("\nLeaving servers running (PORT_OFFSET was set).");
+    }
+  };
+
+  // A signal terminates the process without running `finally`, so stop the
+  // servers from the handler before exiting.
+  const onSignal = () => {
+    console.log("\nInterrupted, cleaning up...");
+    cleanup().finally(() => Deno.exit(130));
+  };
+  Deno.addSignalListener("SIGINT", onSignal);
+  Deno.addSignalListener("SIGTERM", onSignal);
 
   try {
     if (needsServer) {
-      // If PORT_OFFSET was set, stop existing servers first
-      if (portOffsetWasSet) {
-        await stopServers(portOffset, rootDir);
-      }
-
-      // Start servers
       const serverEnv: Record<string, string> = {};
       if (packagesToRun.includes("patterns-reload")) {
         serverEnv.EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE = "true";
       }
 
-      const started = await startServers(portOffset, rootDir, serverEnv);
-      if (!started) {
-        console.error("Failed to start servers, aborting.");
-        Deno.exit(1);
+      if (portOffsetWasSet) {
+        // Reuse the requested offset, stopping anything already on its ports.
+        await stopServers(portOffset, rootDir);
+        apiUrl = `http://localhost:${ports.toolshed + portOffset}`;
+        console.log(`PORT_OFFSET: ${portOffset}${offsetSource}`);
+        console.log(`API_URL: ${apiUrl}`);
+        if (await startServers(portOffset, rootDir, serverEnv) !== 0) {
+          console.error("Failed to start servers, aborting.");
+          exitCode = 1;
+          return;
+        }
+        serverStarted = true;
+      } else {
+        // Try a random offset and let the servers report a real port collision
+        // by failing to bind (PORT_IN_USE_EXIT); retry on a fresh offset only in
+        // that case. Any other failure is not port-related and would recur on
+        // every offset, so it stops the run.
+        const maxStartAttempts = 5;
+        for (let attempt = 1; attempt <= maxStartAttempts; attempt++) {
+          portOffset = Math.floor(Math.random() * 901) + 100; // 100-1000
+          apiUrl = `http://localhost:${ports.toolshed + portOffset}`;
+          console.log(`PORT_OFFSET: ${portOffset}${offsetSource}`);
+          console.log(`API_URL: ${apiUrl}`);
+          // Once an offset is chosen, this run is responsible for stopping
+          // anything started on it, including after a failed attempt.
+          ownsServers = true;
+          const startCode = await startServers(portOffset, rootDir, serverEnv);
+          if (startCode === 0) {
+            serverStarted = true;
+            break;
+          }
+          if (startCode !== PORT_IN_USE_EXIT) {
+            break;
+          }
+          console.warn(
+            `Offset ${portOffset} hit a port collision; retrying...`,
+          );
+        }
+        if (!serverStarted) {
+          console.error("Failed to start servers, aborting.");
+          exitCode = 1;
+          return;
+        }
       }
-      serverStarted = true;
     }
 
     // Run integration tests
@@ -684,17 +764,20 @@ async function main(): Promise<void> {
 
     if (failed.length > 0) {
       console.log(`Failed: ${failed.map((r) => r.pkg).join(", ")}`);
-      Deno.exit(1);
+      exitCode = 1;
     }
+  } catch (error) {
+    console.error("Integration run failed:", error);
+    exitCode = 1;
   } finally {
-    // Clean up: stop servers if we started them and PORT_OFFSET was NOT originally set
-    if (serverStarted && !portOffsetWasSet) {
-      console.log("\nCleaning up servers...");
-      await stopServers(portOffset, rootDir);
-    } else if (serverStarted && portOffsetWasSet) {
-      console.log("\nLeaving servers running (PORT_OFFSET was set).");
-    }
+    Deno.removeSignalListener("SIGINT", onSignal);
+    Deno.removeSignalListener("SIGTERM", onSignal);
+    await cleanup();
+    Deno.exit(exitCode);
   }
 }
 
-main();
+main().catch((error) => {
+  console.error("Integration run failed:", error);
+  Deno.exit(1);
+});


### PR DESCRIPTION
The integration runner starts toolshed and shell dev servers on a port offset, runs the suites, and is meant to stop the servers it started. Two problems made this unreliable, and the dev-server scripts had a matching race in how they reported and cleaned up ports.

Cleanup that always runs. A test failure called Deno.exit() from inside the try block, which skips the finally that stops the servers, so a failed run leaked its toolshed and shell. The runner now tracks an exit code and calls Deno.exit() once, after cleanup, and registers SIGINT/SIGTERM handlers that run the same cleanup (signals also bypass finally). Cleanup is idempotent; a generated-offset run stops the servers it started, while an explicit --port-offset is left running for the caller to manage.

Port collisions detected from real bind failures, not pre-checks. Checking that a port is free and then binding it is a time-of-check/time-of-use race: another run can take the port in between. The toolshed and the felt dev server now exit with code 3 only when their own bind throws AddrInUse. start-local-dev.sh no longer probes ports to decide whether to start (it still kills listeners under --force, which is a deliberate action, not a report); it waits for each server to report a successful bind or to exit, and propagates exit 3 for a bind failure. Readiness keys off the server's own "listening" log line rather than an HTTP probe, because a probe can be answered by a different server already on the port and hide the collision. The runner picks a random offset and retries only on exit 3; any other startup failure is reported on the first attempt instead of retried.

Cleanup never touches foreign processes. start-local-dev.sh previously killed whatever was listening on its ports when startup failed, which in a collision is another run's server. It now kills only the process tree it started, so losing a port race never kills an unrelated server.

Exit codes are documented in docs/development/LOCAL_DEV_SERVERS.md.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops leaking dev servers and makes port handling race-free in the integration runner. Cleanup always runs, and startup retries only on real bind conflicts.

- **Bug Fixes**
  - Cleanup always runs: tracks exit code, handles SIGINT/SIGTERM, and cleans up once; generated offsets are stopped, explicit `--port-offset` is left running (`tasks/integration.ts`).
  - Port races fixed: `packages/felt` and `packages/toolshed` exit with code `3` on `AddrInUse`; the runner picks a random offset and retries only on `3`.
  - Startup safety: `scripts/start-local-dev.sh` waits for “listening” logs then HTTP 200; no pre-probes; propagates exit `3`; with `--force` only kills existing listeners; cleanup kills only its process tree.
  - Visibility: `packages/felt/dev-server.ts` logs when listening.
  - Input/Docs: validate `--port-offset`/`PORT_OFFSET` (non-negative ints; empty env treated as unset); exit codes documented in `docs/development/LOCAL_DEV_SERVERS.md`.

<sup>Written for commit 838137dd892732d7781a2e0deea81007615693a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

