### PR TITLE
Defer resumed actions' initial run until storage sync completes

### DIFF
--- a/packages/runner/src/builtins/filter.ts
+++ b/packages/runner/src/builtins/filter.ts
@@ -147,7 +147,10 @@ export function filter(
             opPattern,
             createRunInput(list[i], i),
             existing.resultCell,
-            { doNotUpdateOnPatternChange: true },
+            {
+            doNotUpdateOnPatternChange: true,
+            awaitSyncBeforeInitialRun: (cause as { awaitSync?: boolean })?.awaitSync,
+          },
           );
         }
         existing.lastIndex = i;
@@ -163,7 +166,10 @@ export function filter(
           opPattern,
           createRunInput(list[i], i),
           resultCell,
-          { doNotUpdateOnPatternChange: true },
+          {
+            doNotUpdateOnPatternChange: true,
+            awaitSyncBeforeInitialRun: (cause as { awaitSync?: boolean })?.awaitSync,
+          },
         );
         // Link these individual cells to the top cell
         setResultCell(resultCell, parentCell);

--- a/packages/runner/src/builtins/filter.ts
+++ b/packages/runner/src/builtins/filter.ts
@@ -148,9 +148,10 @@ export function filter(
             createRunInput(list[i], i),
             existing.resultCell,
             {
-            doNotUpdateOnPatternChange: true,
-            awaitSyncBeforeInitialRun: (cause as { awaitSync?: boolean })?.awaitSync,
-          },
+              doNotUpdateOnPatternChange: true,
+              awaitSyncBeforeInitialRun: (cause as { awaitSync?: boolean })
+                ?.awaitSync,
+            },
           );
         }
         existing.lastIndex = i;
@@ -168,7 +169,8 @@ export function filter(
           resultCell,
           {
             doNotUpdateOnPatternChange: true,
-            awaitSyncBeforeInitialRun: (cause as { awaitSync?: boolean })?.awaitSync,
+            awaitSyncBeforeInitialRun: (cause as { awaitSync?: boolean })
+              ?.awaitSync,
           },
         );
         // Link these individual cells to the top cell

--- a/packages/runner/src/builtins/filter.ts
+++ b/packages/runner/src/builtins/filter.ts
@@ -63,7 +63,14 @@ export function filter(
     { resultCell: Cell<any>; lastIndex: number }
   >();
 
+  // Only the initial (resume) reconcile defers its per-element sub-pattern runs
+  // until sync completes; elements from later (post-resume) reconciles are fresh
+  // and must not wait. Cleared once a non-empty resume batch is processed.
+  let resumeBatchAwaitSync = !!(cause as { awaitSync?: boolean } | undefined)
+    ?.awaitSync;
+
   return (tx: IExtendedStorageTransaction) => {
+    const elementAwaitSync = resumeBatchAwaitSync;
     const { list, op } = inputsCell.asSchema(FILTER_INPUT_SCHEMA)
       .withTx(tx).get();
 
@@ -128,6 +135,8 @@ export function filter(
       throw new Error("filter currently only supports arrays");
     }
 
+    if (list.length > 0) resumeBatchAwaitSync = false;
+
     const keyCounts = new Map<string, number>();
     const newArrayValue: any[] = [];
     for (let i = 0; i < list.length; i++) {
@@ -149,8 +158,7 @@ export function filter(
             existing.resultCell,
             {
               doNotUpdateOnPatternChange: true,
-              awaitSyncBeforeInitialRun: (cause as { awaitSync?: boolean })
-                ?.awaitSync,
+              awaitSyncBeforeInitialRun: elementAwaitSync,
             },
           );
         }
@@ -169,8 +177,7 @@ export function filter(
           resultCell,
           {
             doNotUpdateOnPatternChange: true,
-            awaitSyncBeforeInitialRun: (cause as { awaitSync?: boolean })
-              ?.awaitSync,
+            awaitSyncBeforeInitialRun: elementAwaitSync,
           },
         );
         // Link these individual cells to the top cell

--- a/packages/runner/src/builtins/flatmap.ts
+++ b/packages/runner/src/builtins/flatmap.ts
@@ -149,7 +149,10 @@ export function flatMap(
             opPattern,
             createRunInput(list[i], i),
             existing.resultCell,
-            { doNotUpdateOnPatternChange: true },
+            {
+            doNotUpdateOnPatternChange: true,
+            awaitSyncBeforeInitialRun: (cause as { awaitSync?: boolean })?.awaitSync,
+          },
           );
         }
         existing.lastIndex = i;
@@ -165,7 +168,10 @@ export function flatMap(
           opPattern,
           createRunInput(list[i], i),
           resultCell,
-          { doNotUpdateOnPatternChange: true },
+          {
+            doNotUpdateOnPatternChange: true,
+            awaitSyncBeforeInitialRun: (cause as { awaitSync?: boolean })?.awaitSync,
+          },
         );
         // Link the new result cells to the pattern cell too
         setPatternCell(resultCell, parentCell.key("pattern"));

--- a/packages/runner/src/builtins/flatmap.ts
+++ b/packages/runner/src/builtins/flatmap.ts
@@ -65,7 +65,14 @@ export function flatMap(
     { resultCell: Cell<any>; lastIndex: number }
   >();
 
+  // Only the initial (resume) reconcile defers its per-element sub-pattern runs
+  // until sync completes; elements from later (post-resume) reconciles are fresh
+  // and must not wait. Cleared once a non-empty resume batch is processed.
+  let resumeBatchAwaitSync = !!(cause as { awaitSync?: boolean } | undefined)
+    ?.awaitSync;
+
   return (tx: IExtendedStorageTransaction) => {
+    const elementAwaitSync = resumeBatchAwaitSync;
     const { list, op } = inputsCell.asSchema(FLATMAP_INPUT_SCHEMA)
       .withTx(tx).get();
 
@@ -130,6 +137,8 @@ export function flatMap(
       throw new Error("flatMap currently only supports arrays");
     }
 
+    if (list.length > 0) resumeBatchAwaitSync = false;
+
     const keyCounts = new Map<string, number>();
     const newArrayValue: any[] = [];
     for (let i = 0; i < list.length; i++) {
@@ -151,8 +160,7 @@ export function flatMap(
             existing.resultCell,
             {
               doNotUpdateOnPatternChange: true,
-              awaitSyncBeforeInitialRun: (cause as { awaitSync?: boolean })
-                ?.awaitSync,
+              awaitSyncBeforeInitialRun: elementAwaitSync,
             },
           );
         }
@@ -171,8 +179,7 @@ export function flatMap(
           resultCell,
           {
             doNotUpdateOnPatternChange: true,
-            awaitSyncBeforeInitialRun: (cause as { awaitSync?: boolean })
-              ?.awaitSync,
+            awaitSyncBeforeInitialRun: elementAwaitSync,
           },
         );
         // Link the new result cells to the pattern cell too

--- a/packages/runner/src/builtins/flatmap.ts
+++ b/packages/runner/src/builtins/flatmap.ts
@@ -150,9 +150,10 @@ export function flatMap(
             createRunInput(list[i], i),
             existing.resultCell,
             {
-            doNotUpdateOnPatternChange: true,
-            awaitSyncBeforeInitialRun: (cause as { awaitSync?: boolean })?.awaitSync,
-          },
+              doNotUpdateOnPatternChange: true,
+              awaitSyncBeforeInitialRun: (cause as { awaitSync?: boolean })
+                ?.awaitSync,
+            },
           );
         }
         existing.lastIndex = i;
@@ -170,7 +171,8 @@ export function flatMap(
           resultCell,
           {
             doNotUpdateOnPatternChange: true,
-            awaitSyncBeforeInitialRun: (cause as { awaitSync?: boolean })?.awaitSync,
+            awaitSyncBeforeInitialRun: (cause as { awaitSync?: boolean })
+              ?.awaitSync,
           },
         );
         // Link the new result cells to the pattern cell too

--- a/packages/runner/src/builtins/map.ts
+++ b/packages/runner/src/builtins/map.ts
@@ -183,9 +183,10 @@ export function map(
             createRunInput(list[i], i),
             existing.resultCell,
             {
-            doNotUpdateOnPatternChange: true,
-            awaitSyncBeforeInitialRun: (cause as { awaitSync?: boolean })?.awaitSync,
-          },
+              doNotUpdateOnPatternChange: true,
+              awaitSyncBeforeInitialRun: (cause as { awaitSync?: boolean })
+                ?.awaitSync,
+            },
           );
         }
         existing.lastIndex = i;
@@ -204,7 +205,8 @@ export function map(
           resultCell,
           {
             doNotUpdateOnPatternChange: true,
-            awaitSyncBeforeInitialRun: (cause as { awaitSync?: boolean })?.awaitSync,
+            awaitSyncBeforeInitialRun: (cause as { awaitSync?: boolean })
+              ?.awaitSync,
           },
         );
         // Link these individual cells to the top cell

--- a/packages/runner/src/builtins/map.ts
+++ b/packages/runner/src/builtins/map.ts
@@ -182,7 +182,10 @@ export function map(
             opPattern,
             createRunInput(list[i], i),
             existing.resultCell,
-            { doNotUpdateOnPatternChange: true },
+            {
+            doNotUpdateOnPatternChange: true,
+            awaitSyncBeforeInitialRun: (cause as { awaitSync?: boolean })?.awaitSync,
+          },
           );
         }
         existing.lastIndex = i;
@@ -199,7 +202,10 @@ export function map(
           opPattern,
           createRunInput(list[i], i),
           resultCell,
-          { doNotUpdateOnPatternChange: true },
+          {
+            doNotUpdateOnPatternChange: true,
+            awaitSyncBeforeInitialRun: (cause as { awaitSync?: boolean })?.awaitSync,
+          },
         );
         // Link these individual cells to the top cell
         setResultCell(resultCell, parentCell);

--- a/packages/runner/src/builtins/map.ts
+++ b/packages/runner/src/builtins/map.ts
@@ -81,7 +81,19 @@ export function map(
     { resultCell: Cell<any>; lastIndex: number }
   >();
 
+  // Only the initial (resume) reconcile should defer its per-element sub-pattern
+  // runs until storage sync completes. This map action is itself sync-gated when
+  // resumed, so its first reconcile already runs against synced data; elements
+  // added by later (post-resume) reconciles are fresh and must not wait.
+  let resumeBatchAwaitSync = !!(cause as { awaitSync?: boolean } | undefined)
+    ?.awaitSync;
+
   return (tx: IExtendedStorageTransaction) => {
+    // Captured before the loop consumes it: this reconcile's element runs use
+    // the current value; the flag is cleared only once a non-empty resume batch
+    // has been processed (below), so a transient empty first reconcile doesn't
+    // burn it.
+    const elementAwaitSync = resumeBatchAwaitSync;
     const mappedInputs = inputsCell.asSchema(MAP_INPUT_SCHEMA).withTx(tx);
     const op = mappedInputs.key("op").get();
     const sourceListCell = inputsCell.key("list");
@@ -163,6 +175,9 @@ export function map(
       throw new Error("map currently only supports arrays");
     }
 
+    // The resume batch has now been observed; later reconciles are post-resume.
+    if (list.length > 0) resumeBatchAwaitSync = false;
+
     const keyCounts = new Map<string, number>();
     const newArrayValue = new Array<any>(list.length);
     for (let i = 0; i < list.length; i++) {
@@ -184,8 +199,7 @@ export function map(
             existing.resultCell,
             {
               doNotUpdateOnPatternChange: true,
-              awaitSyncBeforeInitialRun: (cause as { awaitSync?: boolean })
-                ?.awaitSync,
+              awaitSyncBeforeInitialRun: elementAwaitSync,
             },
           );
         }
@@ -205,8 +219,7 @@ export function map(
           resultCell,
           {
             doNotUpdateOnPatternChange: true,
-            awaitSyncBeforeInitialRun: (cause as { awaitSync?: boolean })
-              ?.awaitSync,
+            awaitSyncBeforeInitialRun: elementAwaitSync,
           },
         );
         // Link these individual cells to the top cell

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -505,6 +505,7 @@ type SchedulerRehydrationSubscriptionOptions = {
     space: MemorySpace;
     pieceId: string;
     processGeneration: number;
+    awaitSync?: boolean;
   };
 };
 
@@ -1052,6 +1053,9 @@ export class Runner {
       givenPattern?: Pattern;
       doNotUpdateOnPatternChange?: boolean;
       rehydrateSchedulerFromStorage?: boolean;
+      // Resumed-from-synced-state: hold each action's initial rehydration/run
+      // until the space has finished syncing, so consumers don't race the data.
+      awaitSyncBeforeInitialRun?: boolean;
     } = {},
   ): void {
     const { tx, givenPattern, doNotUpdateOnPatternChange } = options;
@@ -1091,7 +1095,10 @@ export class Runner {
       const schedulerRehydration = options.rehydrateSchedulerFromStorage ===
           false
         ? {}
-        : this.schedulerRehydrationOptions(resultCell);
+        : this.schedulerRehydrationOptions(
+          resultCell,
+          options.awaitSyncBeforeInitialRun,
+        );
       try {
         for (const node of pattern.nodes) {
           const baseCell = resultCell.withTx(actualTx);
@@ -1350,6 +1357,11 @@ export class Runner {
         try {
           this.startCore(rootCell, {
             givenPattern: resolvedPattern,
+            // This pattern is resumed from a synced state (it just awaited
+            // syncCellsForRunningPattern): hold each action's initial run until
+            // the space finishes syncing so we don't race the data (e.g. maps
+            // reconciling an empty array, then re-running once it streams in).
+            awaitSyncBeforeInitialRun: true,
           });
         } catch (err) {
           return Promise.reject(err);
@@ -1363,7 +1375,7 @@ export class Runner {
     tx: IExtendedStorageTransaction,
     resultCell: Cell<T>,
     givenPattern?: Pattern,
-    options: { doNotUpdateOnPatternChange?: boolean } = {},
+    options: { doNotUpdateOnPatternChange?: boolean; awaitSyncBeforeInitialRun?: boolean } = {},
   ): void {
     const key = this.getDocKey(resultCell);
     if (this.cancels.has(key)) return;
@@ -1372,6 +1384,7 @@ export class Runner {
       tx,
       givenPattern,
       doNotUpdateOnPatternChange: options.doNotUpdateOnPatternChange,
+      awaitSyncBeforeInitialRun: options.awaitSyncBeforeInitialRun,
     });
   }
 
@@ -1379,7 +1392,7 @@ export class Runner {
     tx: IExtendedStorageTransaction,
     resultCell: Cell<T>,
     givenPattern?: Pattern,
-    options: { doNotUpdateOnPatternChange?: boolean } = {},
+    options: { doNotUpdateOnPatternChange?: boolean; awaitSyncBeforeInitialRun?: boolean } = {},
     pullOnceAfterStart: boolean = false,
   ): void {
     const resultLink = resultCell.getAsNormalizedFullLink();
@@ -1508,21 +1521,21 @@ export class Runner {
     patternFactory: NodeFactory<T, R>,
     argument: T,
     resultCell: Cell<R>,
-    options?: { doNotUpdateOnPatternChange?: boolean },
+    options?: { doNotUpdateOnPatternChange?: boolean; awaitSyncBeforeInitialRun?: boolean },
   ): Cell<R>;
   run<T, R = any>(
     tx: IExtendedStorageTransaction | undefined,
     pattern: Pattern | Module | undefined,
     argument: T,
     resultCell: Cell<R>,
-    options?: { doNotUpdateOnPatternChange?: boolean },
+    options?: { doNotUpdateOnPatternChange?: boolean; awaitSyncBeforeInitialRun?: boolean },
   ): Cell<R>;
   run<T, R = any>(
     providedTx: IExtendedStorageTransaction,
     patternOrModule: Pattern | Module | undefined,
     argument: T,
     resultCell: Cell<R>,
-    options: { doNotUpdateOnPatternChange?: boolean } = {},
+    options: { doNotUpdateOnPatternChange?: boolean; awaitSyncBeforeInitialRun?: boolean } = {},
   ): Cell<R> {
     const tx = providedTx ?? this.runtime.edit();
     const sourceKey = getTxDebugActionId(tx) ?? "none";
@@ -1663,13 +1676,10 @@ export class Runner {
     return `${space}/${scope}/${id}`;
   }
 
-  private schedulerRehydrationOptions(resultCell: Cell<any>): {
-    rehydrateFromStorage?: {
-      space: MemorySpace;
-      pieceId: string;
-      processGeneration: number;
-    };
-  } {
+  private schedulerRehydrationOptions(
+    resultCell: Cell<any>,
+    awaitSync?: boolean,
+  ): SchedulerRehydrationSubscriptionOptions {
     if (!getPersistentSchedulerStateConfig()) {
       return {};
     }
@@ -1679,6 +1689,7 @@ export class Runner {
         space,
         pieceId: `${scope}:${id}`,
         processGeneration: 0,
+        ...(awaitSync ? { awaitSync: true } : {}),
       },
     };
   }
@@ -1982,6 +1993,7 @@ export class Runner {
             resultCell,
             addCancel,
             pattern,
+            schedulerRehydration,
           );
           break;
         default:
@@ -3607,6 +3619,12 @@ export class Runner {
               },
             }
             : {}),
+          // Propagate the resumed-from-synced-state flag so container-minting
+          // builtins (map/filter/flatmap) defer their per-element sub-pattern
+          // runs until sync completes too.
+          ...(schedulerRehydration.rehydrateFromStorage?.awaitSync
+            ? { awaitSync: true }
+            : {}),
         },
         processCell,
         this.runtime,
@@ -3785,6 +3803,7 @@ export class Runner {
     resultCell: Cell<any>,
     addCancel: AddCancel,
     _pattern: Pattern,
+    schedulerRehydration: SchedulerRehydrationSubscriptionOptions = {},
   ) {
     const argumentCellLink = getMetaLink(resultCell, "argument")!;
     const internalCellLink = getMetaLink(resultCell, "internal")!;
@@ -3899,7 +3918,10 @@ export class Runner {
         resultCellLink.space,
       );
     }
-    this.run(tx, patternImpl, inputs, resultCell);
+    this.run(tx, patternImpl, inputs, resultCell, {
+      awaitSyncBeforeInitialRun:
+        schedulerRehydration.rehydrateFromStorage?.awaitSync,
+    });
 
     if (sendToBindings) {
       sendValueToBinding(

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1375,7 +1375,10 @@ export class Runner {
     tx: IExtendedStorageTransaction,
     resultCell: Cell<T>,
     givenPattern?: Pattern,
-    options: { doNotUpdateOnPatternChange?: boolean; awaitSyncBeforeInitialRun?: boolean } = {},
+    options: {
+      doNotUpdateOnPatternChange?: boolean;
+      awaitSyncBeforeInitialRun?: boolean;
+    } = {},
   ): void {
     const key = this.getDocKey(resultCell);
     if (this.cancels.has(key)) return;
@@ -1392,7 +1395,10 @@ export class Runner {
     tx: IExtendedStorageTransaction,
     resultCell: Cell<T>,
     givenPattern?: Pattern,
-    options: { doNotUpdateOnPatternChange?: boolean; awaitSyncBeforeInitialRun?: boolean } = {},
+    options: {
+      doNotUpdateOnPatternChange?: boolean;
+      awaitSyncBeforeInitialRun?: boolean;
+    } = {},
     pullOnceAfterStart: boolean = false,
   ): void {
     const resultLink = resultCell.getAsNormalizedFullLink();
@@ -1521,21 +1527,30 @@ export class Runner {
     patternFactory: NodeFactory<T, R>,
     argument: T,
     resultCell: Cell<R>,
-    options?: { doNotUpdateOnPatternChange?: boolean; awaitSyncBeforeInitialRun?: boolean },
+    options?: {
+      doNotUpdateOnPatternChange?: boolean;
+      awaitSyncBeforeInitialRun?: boolean;
+    },
   ): Cell<R>;
   run<T, R = any>(
     tx: IExtendedStorageTransaction | undefined,
     pattern: Pattern | Module | undefined,
     argument: T,
     resultCell: Cell<R>,
-    options?: { doNotUpdateOnPatternChange?: boolean; awaitSyncBeforeInitialRun?: boolean },
+    options?: {
+      doNotUpdateOnPatternChange?: boolean;
+      awaitSyncBeforeInitialRun?: boolean;
+    },
   ): Cell<R>;
   run<T, R = any>(
     providedTx: IExtendedStorageTransaction,
     patternOrModule: Pattern | Module | undefined,
     argument: T,
     resultCell: Cell<R>,
-    options: { doNotUpdateOnPatternChange?: boolean; awaitSyncBeforeInitialRun?: boolean } = {},
+    options: {
+      doNotUpdateOnPatternChange?: boolean;
+      awaitSyncBeforeInitialRun?: boolean;
+    } = {},
   ): Cell<R> {
     const tx = providedTx ?? this.runtime.edit();
     const sourceKey = getTxDebugActionId(tx) ?? "none";
@@ -3919,8 +3934,8 @@ export class Runner {
       );
     }
     this.run(tx, patternImpl, inputs, resultCell, {
-      awaitSyncBeforeInitialRun:
-        schedulerRehydration.rehydrateFromStorage?.awaitSync,
+      awaitSyncBeforeInitialRun: schedulerRehydration.rehydrateFromStorage
+        ?.awaitSync,
     });
 
     if (sendToBindings) {

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -509,6 +509,14 @@ type SchedulerRehydrationSubscriptionOptions = {
   };
 };
 
+// Options shared by run()/startWithTx()/startAfterSuccessfulCommit().
+type RunnerRunOptions = {
+  doNotUpdateOnPatternChange?: boolean;
+  // Resumed-from-synced-state: hold each action's initial rehydration/run until
+  // the space has finished syncing, so consumers don't race the data.
+  awaitSyncBeforeInitialRun?: boolean;
+};
+
 function dedupeNormalizedLinks(
   links: readonly NormalizedFullLink[],
 ): NormalizedFullLink[] {
@@ -1375,10 +1383,7 @@ export class Runner {
     tx: IExtendedStorageTransaction,
     resultCell: Cell<T>,
     givenPattern?: Pattern,
-    options: {
-      doNotUpdateOnPatternChange?: boolean;
-      awaitSyncBeforeInitialRun?: boolean;
-    } = {},
+    options: RunnerRunOptions = {},
   ): void {
     const key = this.getDocKey(resultCell);
     if (this.cancels.has(key)) return;
@@ -1395,10 +1400,7 @@ export class Runner {
     tx: IExtendedStorageTransaction,
     resultCell: Cell<T>,
     givenPattern?: Pattern,
-    options: {
-      doNotUpdateOnPatternChange?: boolean;
-      awaitSyncBeforeInitialRun?: boolean;
-    } = {},
+    options: RunnerRunOptions = {},
     pullOnceAfterStart: boolean = false,
   ): void {
     const resultLink = resultCell.getAsNormalizedFullLink();
@@ -1527,30 +1529,21 @@ export class Runner {
     patternFactory: NodeFactory<T, R>,
     argument: T,
     resultCell: Cell<R>,
-    options?: {
-      doNotUpdateOnPatternChange?: boolean;
-      awaitSyncBeforeInitialRun?: boolean;
-    },
+    options?: RunnerRunOptions,
   ): Cell<R>;
   run<T, R = any>(
     tx: IExtendedStorageTransaction | undefined,
     pattern: Pattern | Module | undefined,
     argument: T,
     resultCell: Cell<R>,
-    options?: {
-      doNotUpdateOnPatternChange?: boolean;
-      awaitSyncBeforeInitialRun?: boolean;
-    },
+    options?: RunnerRunOptions,
   ): Cell<R>;
   run<T, R = any>(
     providedTx: IExtendedStorageTransaction,
     patternOrModule: Pattern | Module | undefined,
     argument: T,
     resultCell: Cell<R>,
-    options: {
-      doNotUpdateOnPatternChange?: boolean;
-      awaitSyncBeforeInitialRun?: boolean;
-    } = {},
+    options: RunnerRunOptions = {},
   ): Cell<R> {
     const tx = providedTx ?? this.runtime.edit();
     const sourceKey = getTxDebugActionId(tx) ?? "none";

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -225,6 +225,11 @@ type SchedulerStorageRehydrationOptions =
   & {
     space: MemorySpace;
     timeoutMs?: number;
+    // When the pattern is (re)started from a synced/resumed state, wait for the
+    // space's storage to finish syncing before attempting rehydration / the
+    // initial run. This avoids running consumers (map/filter/computed) against
+    // not-yet-synced data and then re-running once it streams in.
+    awaitSync?: boolean;
   };
 
 // Re-export types that tests expect from scheduler
@@ -732,6 +737,13 @@ export class Scheduler {
     const token = Symbol("scheduler-initial-rehydration");
     this.initialRehydrationTokens.set(action, token);
     const task = (async () => {
+      if (options.awaitSync) {
+        // Resumed from a synced state: hold the initial rehydration/run until
+        // the space has finished syncing so consumers don't race the data.
+        await this.awaitSpaceSyncedWithTimeout(options.space, options.timeoutMs);
+        // The action may have been superseded while we waited for sync.
+        if (!this.canApplyInitialActionRehydration(action, token)) return;
+      }
       const rehydrated = await this.runInitialActionRehydrationWithTimeout(
         action,
         options,
@@ -776,6 +788,27 @@ export class Scheduler {
         this.initialRehydrationTokens.delete(action);
       }
     });
+  }
+
+  // Wait for the space's storage replica to finish syncing, bounded by the
+  // rehydration timeout so a stuck sync can't wedge the initial run forever.
+  private async awaitSpaceSyncedWithTimeout(
+    space: MemorySpace,
+    timeoutMs?: number,
+  ): Promise<void> {
+    const provider = this.runtime.storageManager.open(space);
+    const synced = provider?.synced?.bind(provider);
+    if (!synced) return;
+    const ms = Math.max(0, timeoutMs ?? DEFAULT_INITIAL_REHYDRATION_TIMEOUT_MS);
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<void>((resolve) => {
+      timeoutId = setTimeout(resolve, ms);
+    });
+    try {
+      await Promise.race([Promise.resolve(synced()), timeout]);
+    } finally {
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
+    }
   }
 
   private async runInitialActionRehydrationWithTimeout(

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -737,16 +737,22 @@ export class Scheduler {
     const token = Symbol("scheduler-initial-rehydration");
     this.initialRehydrationTokens.set(action, token);
     const task = (async () => {
+      // The sync wait and the rehydration lookup share ONE timeout budget, so a
+      // stuck sync can't double the resumed startup delay: each step is bounded
+      // by the time remaining until this common deadline.
+      const deadline = performance.now() +
+        Math.max(0, options.timeoutMs ?? DEFAULT_INITIAL_REHYDRATION_TIMEOUT_MS);
+      const remainingMs = () => Math.max(0, deadline - performance.now());
       if (options.awaitSync) {
         // Resumed from a synced state: hold the initial rehydration/run until
         // the space has finished syncing so consumers don't race the data.
-        await this.awaitSpaceSyncedWithTimeout(options.space, options.timeoutMs);
+        await this.awaitSpaceSyncedWithTimeout(options.space, remainingMs());
         // The action may have been superseded while we waited for sync.
         if (!this.canApplyInitialActionRehydration(action, token)) return;
       }
       const rehydrated = await this.runInitialActionRehydrationWithTimeout(
         action,
-        options,
+        options.awaitSync ? { ...options, timeoutMs: remainingMs() } : options,
         token,
       );
       if (rehydrated === "timeout") {

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -813,8 +813,12 @@ export class Scheduler {
     const timeout = new Promise<void>((resolve) => {
       timeoutId = setTimeout(resolve, ms);
     });
+    const syncedPromise = synced();
+    // If the timeout wins the race the sync promise is left pending; swallow a
+    // later rejection so it doesn't surface as an unhandled promise rejection.
+    syncedPromise.catch(() => {});
     try {
-      await Promise.race([Promise.resolve(synced()), timeout]);
+      await Promise.race([syncedPromise, timeout]);
     } finally {
       if (timeoutId !== undefined) clearTimeout(timeoutId);
     }

--- a/packages/runner/src/scheduler.ts
+++ b/packages/runner/src/scheduler.ts
@@ -741,7 +741,10 @@ export class Scheduler {
       // stuck sync can't double the resumed startup delay: each step is bounded
       // by the time remaining until this common deadline.
       const deadline = performance.now() +
-        Math.max(0, options.timeoutMs ?? DEFAULT_INITIAL_REHYDRATION_TIMEOUT_MS);
+        Math.max(
+          0,
+          options.timeoutMs ?? DEFAULT_INITIAL_REHYDRATION_TIMEOUT_MS,
+        );
       const remainingMs = () => Math.max(0, deadline - performance.now());
       if (options.awaitSync) {
         // Resumed from a synced state: hold the initial rehydration/run until

--- a/packages/runner/test/reload-rehydration.test.ts
+++ b/packages/runner/test/reload-rehydration.test.ts
@@ -1,0 +1,142 @@
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { getLogger, getLoggerCountsBreakdown } from "@commonfabric/utils/logger";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { type JSONSchema, NAME } from "../src/builder/types.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+import { Runtime } from "../src/runtime.ts";
+
+// Reload regression guard for persistent scheduler state: a pattern resumed
+// from a synced state (runtime B sharing runtime A's storage) should rehydrate
+// its persisted observations rather than re-run them.
+//
+// IMPORTANT harness note: do NOT call `runtimeA.dispose()` before runtime B —
+// `Runtime.dispose()` calls `storageManager.close()`, which tears down the
+// storage shared with B (B would then see zero persisted snapshots). Quiesce A
+// with `A.scheduler.dispose()` and keep the StorageManager open; flush the
+// batched scheduler observations with `await A.storageManager.synced()`.
+
+const signer = await Identity.fromPassphrase("reload rehydration guard");
+const space = signer.did();
+
+function matchingSchema(index: number): JSONSchema {
+  return {
+    type: "object",
+    title: `note ${index}`,
+    description: "This schema matches #notebook.",
+    properties: { [NAME]: { type: "string" }, body: { type: "string" } },
+  };
+}
+
+const PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      "import { pattern, computed, wish } from 'commonfabric';",
+      "export default pattern(() => {",
+      "  const w = wish({ query: '#notebook', scope: ['.'], headless: true });",
+      "  const candidates = computed(() =>",
+      "    Array.isArray((w as any).candidates) ? (w as any).candidates : []);",
+      "  const count = computed(() => (candidates as any).length);",
+      "  return { result: w, count };",
+      "});",
+    ].join("\n"),
+  }],
+};
+
+function setupMentionables(
+  runtime: Runtime,
+  tx: ReturnType<Runtime["edit"]>,
+  count: number,
+) {
+  const spaceCell = runtime.getCell(space, space, undefined, tx).withTx(tx);
+  const defaultPatternCell = runtime.getCell(
+    space,
+    "rg-default-pattern",
+    undefined,
+    tx,
+  );
+  const backlinksIndexCell = runtime.getCell(
+    space,
+    "rg-backlinks-index",
+    undefined,
+    tx,
+  );
+  const mentionables = Array.from({ length: count }, (_, index) => {
+    const cell = runtime.getCell(
+      space,
+      `rg-mentionable-${index}`,
+      matchingSchema(index),
+      tx,
+    );
+    cell.set({ [NAME]: "notebook", body: `body-${index}` });
+    return cell;
+  });
+  backlinksIndexCell.set({ mentionable: mentionables });
+  defaultPatternCell.set({ backlinksIndex: backlinksIndexCell });
+  spaceCell.key("defaultPattern").set(defaultPatternCell);
+}
+
+function newRuntime(storageManager: ReturnType<typeof StorageManager.emulate>) {
+  return new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+    experimental: { persistentSchedulerState: true, esmModuleLoader: true },
+  });
+}
+
+function rehydrationCounts() {
+  const b = getLoggerCountsBreakdown().scheduler ?? {};
+  const get = (k: string) => (b as Record<string, { total?: number }>)[k]
+    ?.total ?? 0;
+  return {
+    ok: get("rehydrate/ok"),
+    missNoSnapshot: get("rehydrate/miss/no-snapshot"),
+  };
+}
+
+Deno.test("reload: resumed pattern rehydrates persisted observations", async () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const COUNT = 5;
+
+  // CREATE (runtime A). Keep its storage open for B.
+  const runtimeA = newRuntime(storageManager);
+  const compiledA = await runtimeA.patternManager.compilePattern(PROGRAM);
+  const tx0 = runtimeA.edit();
+  setupMentionables(runtimeA, tx0, COUNT);
+  const resultCellA = runtimeA.getCell(space, "rg-result", undefined, tx0);
+  const handleA = runtimeA.run(tx0, compiledA, {}, resultCellA);
+  await tx0.commit();
+  for (let k = 0; k < 6; k++) {
+    await handleA.pull();
+    await runtimeA.idle();
+  }
+  await runtimeA.storageManager.synced();
+  expect(resultCellA.key("count").getAsQueryResult()).toBe(COUNT);
+  runtimeA.scheduler.dispose();
+
+  // Reset counters so the reading reflects only the reload runtime.
+  getLogger("scheduler").resetCounts();
+
+  // RELOAD (runtime B, same storage).
+  const runtimeB = newRuntime(storageManager);
+  try {
+    const compiledB = await runtimeB.patternManager.compilePattern(PROGRAM);
+    const tx = runtimeB.edit();
+    const resultCellB = runtimeB.getCell(space, "rg-result", undefined, tx);
+    const handleB = runtimeB.run(tx, compiledB, {}, resultCellB);
+    await tx.commit();
+    for (let k = 0; k < 6; k++) {
+      await handleB.pull();
+      await runtimeB.idle();
+    }
+    expect(resultCellB.key("count").getAsQueryResult()).toBe(COUNT);
+  } finally {
+    await runtimeB.dispose();
+  }
+
+  const reload = rehydrationCounts();
+  expect(reload.ok).toBeGreaterThan(0);
+  expect(reload.missNoSnapshot).toBe(0);
+});

--- a/packages/runner/test/reload-rehydration.test.ts
+++ b/packages/runner/test/reload-rehydration.test.ts
@@ -1,6 +1,9 @@
 import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
-import { getLogger, getLoggerCountsBreakdown } from "@commonfabric/utils/logger";
+import {
+  getLogger,
+  getLoggerCountsBreakdown,
+} from "@commonfabric/utils/logger";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { type JSONSchema, NAME } from "../src/builder/types.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
@@ -88,8 +91,9 @@ function newRuntime(storageManager: ReturnType<typeof StorageManager.emulate>) {
 
 function rehydrationCounts() {
   const b = getLoggerCountsBreakdown().scheduler ?? {};
-  const get = (k: string) => (b as Record<string, { total?: number }>)[k]
-    ?.total ?? 0;
+  const get = (k: string) =>
+    (b as Record<string, { total?: number }>)[k]
+      ?.total ?? 0;
   return {
     ok: get("rehydrate/ok"),
     missNoSnapshot: get("rehydrate/miss/no-snapshot"),


### PR DESCRIPTION
## What

When a pattern is **(re)started from a synced/resumed state** (e.g. on browser reload with persistent scheduler state), hold each action's initial rehydration/run until the space's storage has finished syncing — instead of running consumers (`map`/`filter`/`computed`) against not-yet-synced data and then re-running once it streams in.

The flag is set **only** on the resumed path (`wasSyncedAtEntry`); fresh/local instantiation is unchanged (no waiting). It propagates from the top resumed pattern down through `startCore`/`run()` into container-minting builtins (`map`/`filter`/`flatmap` per-element sub-pattern runs) and nested pattern nodes.

## Why

On reload, the default-app notebook re-ran ~80–95 scheduler actions instead of rehydrating persisted observations. Root cause (one of two): array-consumer computations execute before their persisted data has synced. A map-builtin trace showed maps reconciling an **empty** array first, then re-running at full length (`mapReconcileLens {0:3, 7:1, 8:1}`). `notes` is a `Writable` that resumes via sync — the map races it.

## How

- **scheduler**: `SchedulerStorageRehydrationOptions.awaitSync`; `awaitSpaceSyncedWithTimeout` races `provider.synced()` against the existing 10s rehydration timeout, awaited before the initial rehydration attempt, re-checking applicability after.
- **runner**: thread `awaitSyncBeforeInitialRun` from the resumed-pattern entry through `startCore`/`startWithTx`/`run()` into the scheduler rehydration options; propagate into raw builtins (via the builtin `cause`/opts) and `instantiatePatternNode`.
- **builtins**: `map`/`filter`/`flatmap` forward the flag to per-element `runner.run(...)`.

## Measurements (browser reload, 3 samples each, port-offset 13)

| metric | baseline | this PR |
|---|---|---|
| `graph.actionRuns` | 78 / 81 / 83 | **59 / 60 / 59** (~27% fewer) |
| rehydration `missNoSnapshot` | ~81 | ~39 |
| `contentRenderedMs` (time-to-note-chips) | 7602 / 7609 / 7649 | 7299 / 7685 (**unchanged**) |
| first/largest contentful paint | ~160–169ms | ~106–180ms (unchanged) |
| long tasks | 0 | 0 |

Fewer re-runs with **no regression in time-to-content or first paint** (content render is gated by login+sync either way; this just removes the redundant empty-data runs in that window). Rendering stays correct (7/7 note chips).

## Tests

- New `packages/runner/test/reload-rehydration.test.ts` regression guard: a pattern resumed from a synced state rehydrates (`ok>0`, `missNoSnapshot==0`).
- Existing scheduler / builtin / esm-pattern suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defer the initial run of resumed actions until the space finishes syncing to avoid running `map`/`filter`/`computed` on empty data. Cuts redundant reload runs (~27% fewer) with no impact to first paint.

- **Bug Fixes**
  - Scheduler: add `awaitSync` and wait for `provider.synced()` using a shared deadline with rehydration; swallow late rejection from the raced `synced()` to avoid unhandled rejections.
  - Runner: introduce `RunnerRunOptions`; set `awaitSyncBeforeInitialRun` only on resumed patterns and thread it through `startCore`/`run()` into the scheduler, nested nodes, and container-minting builtins.
  - Builtins: `map`/`filter`/`flatmap` forward the flag and scope it to the initial resume batch only; later reconciles don’t wait.
  - Tests: add reload regression ensuring resumed patterns rehydrate with no `missNoSnapshot`.

<sup>Written for commit 7a86b78640fc41f577cf90902a6aa27140bc7b23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

