### PR TITLE
fix(ts-transformers): normalize commonfabric refs in synthesized lift/pattern result types

### DIFF
--- a/packages/patterns/system/home.tsx
+++ b/packages/patterns/system/home.tsx
@@ -165,8 +165,14 @@ export default pattern<Record<string, never>, HomeOutput>((_) => {
   // does not re-show the create form (which would let it overwrite a valid
   // link). The `cf-render` below resolves and loads the cross-space profile for
   // display.
+  // `profile` is a Cell whose value is itself a Cell (TrustedProfileLink wraps
+  // Cell<ProfileHomeOutput>), so `profile.get()` returns the inner cell HANDLE,
+  // which is always non-undefined. Read one level deeper — `profile.get()?.get()`
+  // — to test whether the inner cell actually holds a value (i.e. a profile
+  // exists). Using `profile.get() !== undefined` here is always true and would
+  // permanently hide the create surface.
   const hasProfile = computed(() =>
-    profile.get() !== undefined ||
+    profile.get()?.get() !== undefined ||
     (profileName.get() ?? "").trim().length > 0
   );
 

--- a/packages/schema-generator/src/formatters/common-fabric-formatter.ts
+++ b/packages/schema-generator/src/formatters/common-fabric-formatter.ts
@@ -49,19 +49,33 @@ const scopeForWrapperName = (
 ): SchemaScope | undefined =>
   name === undefined ? undefined : SCOPE_WRAPPER_SCOPES[name];
 
-// Cell-capability brands all wrap the SAME structural inner `T`; they differ
-// only in read/write capability. The transformer narrows one to another (e.g.
-// `Cell<T>` → `ReadonlyCell<T>`) to reflect usage, so a node-vs-type brand
-// mismatch among these is a capability narrowing, not a structural change.
-const CELL_CAPABILITY_KINDS: ReadonlySet<WrapperKind> = new Set([
-  "Cell",
-  "ReadonlyCell",
-  "WriteonlyCell",
-  "ComparableCell",
-  "OpaqueCell",
-]);
+// The capability subset of `CellWrapperKind`: brands that all wrap the SAME
+// structural inner `T` and differ only in read/write capability. The transformer
+// narrows one to another (e.g. `Cell<T>` → `ReadonlyCell<T>`) to reflect usage,
+// so a node-vs-type brand mismatch among these is a capability narrowing, not a
+// structural change. `Stream`/`SqliteDb`/`OpaqueRef` are excluded: they carry a
+// distinct structural contract, not a read/write variant of a plain cell.
+//
+// Derived as an exhaustive map over `CellWrapperKind` so that adding a new kind
+// to that union is a compile error here until it's deliberately classified.
+//
+// NB: distinct from `type-utils.ts`'s `CELL_LIKE_WRAPPER_NAMES`, which keys off
+// raw type-node NAMES (where `Writable` is a separate spelling and `OpaqueCell`
+// is split out). This set keys off RESOLVED `CellWrapperKind` values, where
+// `Writable` has already normalized to `Cell` and `OpaqueCell` belongs with the
+// rest.
+const CELL_CAPABILITY_KIND_MAP: Readonly<Record<CellWrapperKind, boolean>> = {
+  Cell: true,
+  ReadonlyCell: true,
+  WriteonlyCell: true,
+  ComparableCell: true,
+  OpaqueCell: true,
+  Stream: false,
+  SqliteDb: false,
+  OpaqueRef: false,
+};
 const isCellCapabilityKind = (kind: WrapperKind): boolean =>
-  CELL_CAPABILITY_KINDS.has(kind);
+  CELL_CAPABILITY_KIND_MAP[kind];
 
 const resolveScopeWrapperNode = (
   typeNode: ts.TypeNode | undefined,

--- a/packages/schema-generator/src/formatters/common-fabric-formatter.ts
+++ b/packages/schema-generator/src/formatters/common-fabric-formatter.ts
@@ -49,6 +49,20 @@ const scopeForWrapperName = (
 ): SchemaScope | undefined =>
   name === undefined ? undefined : SCOPE_WRAPPER_SCOPES[name];
 
+// Cell-capability brands all wrap the SAME structural inner `T`; they differ
+// only in read/write capability. The transformer narrows one to another (e.g.
+// `Cell<T>` → `ReadonlyCell<T>`) to reflect usage, so a node-vs-type brand
+// mismatch among these is a capability narrowing, not a structural change.
+const CELL_CAPABILITY_KINDS: ReadonlySet<WrapperKind> = new Set([
+  "Cell",
+  "ReadonlyCell",
+  "WriteonlyCell",
+  "ComparableCell",
+  "OpaqueCell",
+]);
+const isCellCapabilityKind = (kind: WrapperKind): boolean =>
+  CELL_CAPABILITY_KINDS.has(kind);
+
 const resolveScopeWrapperNode = (
   typeNode: ts.TypeNode | undefined,
 ): ResolvedScopeWrapper | undefined => {
@@ -272,6 +286,14 @@ export class CommonFabricFormatter implements TypeFormatter {
         resolvedWrapper.node,
         context,
         resolvedWrapper.kind,
+        // The synthetic node narrows the resolved type's capability brand (e.g.
+        // the transformer re-wrapped `Cell<T>` as `ReadonlyCell<T>` for read-only
+        // usage). Both brands wrap the SAME structural inner. When the node's own
+        // inner has no source position and degrades to `any`, fall back to the
+        // resolved type's inner so the inner `$ref`/`$defs` survives the re-wrap.
+        isCellCapabilityKind(wrapperInfo.kind)
+          ? wrapperInfo.typeRef
+          : undefined,
       );
     }
 
@@ -347,6 +369,14 @@ export class CommonFabricFormatter implements TypeFormatter {
     typeRefNode: ts.TypeReferenceNode,
     context: GenerationContext,
     wrapperKind: WrapperKind,
+    // When the synthetic node's own inner type degrades to `any`/`unknown` (no
+    // source position to resolve against), the inner type argument of this
+    // type — the capability re-wrap's source wrapper, e.g. `Cell<T>` for a node
+    // narrowed to `ReadonlyCell<T>` — supplies the precise inner so the inner
+    // `$ref`/`$defs` survives. Only consulted as a fallback, so node-driven
+    // results that already resolve (including node-level unions like
+    // `string | undefined`) are left untouched.
+    fallbackInnerTypeRef?: ts.TypeReference,
   ): JSONSchemaMutable {
     const innerTypeNode = typeRefNode.typeArguments?.[0];
     if (!innerTypeNode) {
@@ -365,6 +395,23 @@ export class CommonFabricFormatter implements TypeFormatter {
         context.typeChecker.getTypeFromTypeNode(innerTypeNode);
     } catch {
       innerType = context.typeChecker.getAnyType();
+    }
+
+    // Only adopt the resolved type's inner when the node's inner is a bare named
+    // reference (a `TypeReferenceNode`) that degrades to `any` — the case where
+    // node-driven formatting can recover NOTHING and would emit `{}`, dropping
+    // the inner `$ref`/`$defs`. Structured inner nodes (unions, literals, arrays)
+    // carry recoverable shape even when the checker resolves them to `any` from a
+    // synthetic position, so the node-driven result must win there (e.g. a
+    // `string | undefined` inner whose `| undefined` lives only on the node).
+    if (
+      this.isUnusableInnerType(innerType) && fallbackInnerTypeRef &&
+      ts.isTypeReferenceNode(innerTypeNode)
+    ) {
+      const fallbackInner = fallbackInnerTypeRef.typeArguments?.[0];
+      if (fallbackInner && !this.isUnusableInnerType(fallbackInner)) {
+        innerType = fallbackInner;
+      }
     }
 
     // Keep schema-hint propagation behavior aligned with type-based wrapper formatting.

--- a/packages/schema-generator/src/type-utils.ts
+++ b/packages/schema-generator/src/type-utils.ts
@@ -8,6 +8,12 @@ import type { CellWrapperKind } from "./typescript/cell-brand.ts";
 /**
  * Names that should be treated as Cell-like wrapper types.
  * "Writable" is an alias for "Cell" that better expresses semantic meaning.
+ *
+ * NB: this keys off raw type-node NAMES (hence `Writable` is listed and
+ * `OpaqueCell` is split into `OPAQUE_WRAPPER_NAMES`). It is intentionally
+ * distinct from `common-fabric-formatter.ts`'s `CELL_CAPABILITY_KIND_MAP`,
+ * which keys off RESOLVED `CellWrapperKind` values (where `Writable` has already
+ * normalized to `Cell` and `OpaqueCell` belongs with the rest).
  */
 const CELL_LIKE_WRAPPER_NAMES = new Set([
   "Cell",

--- a/packages/ts-transformers/README.md
+++ b/packages/ts-transformers/README.md
@@ -86,9 +86,11 @@ To see transformed output:
 deno task cf check --show-transformed [--no-run] packages/patterns/lunch-poll/main.tsx
 ```
 
-The command must be run on a pattern inside `labs/` for it to actually execute
-the transform (it resolves the pattern against the workspace). Add `--no-run` to
-emit the transformed output without running the pattern.
+Run it from the repository root, targeting a pattern that lives in the workspace
+(the path is repo-root-relative, e.g. `packages/patterns/lunch-poll/main.tsx`):
+`deno task cf` resolves the pattern against the workspace to execute the
+transform. Add `--no-run` to emit the transformed output without running the
+pattern.
 
 ### Adding New Transformations
 

--- a/packages/ts-transformers/README.md
+++ b/packages/ts-transformers/README.md
@@ -83,8 +83,12 @@ env FIXTURE=map-single-capture deno task test
 To see transformed output:
 
 ```bash
-deno task cf check --show-transformed test/fixtures/closures/map-single-capture.input.tsx
+deno task cf check --show-transformed [--no-run] packages/patterns/lunch-poll/main.tsx
 ```
+
+The command must be run on a pattern inside `labs/` for it to actually execute
+the transform (it resolves the pattern against the workspace). Add `--no-run` to
+emit the transformed output without running the pattern.
 
 ### Adding New Transformations
 

--- a/packages/ts-transformers/src/ast/mod.ts
+++ b/packages/ts-transformers/src/ast/mod.ts
@@ -93,3 +93,7 @@ export {
   unwrapOpaqueLikeType,
   widenLiteralType,
 } from "./type-inference.ts";
+export {
+  qualifyCommonFabricTypeRefs,
+  typeToTypeNodeWithRegistry,
+} from "./type-building.ts";

--- a/packages/ts-transformers/src/ast/type-building.ts
+++ b/packages/ts-transformers/src/ast/type-building.ts
@@ -63,29 +63,37 @@ export function qualifyCommonFabricTypeRefs(
       factory.createIdentifier(leafName),
     );
 
+  const isCommonFabricSymbol = (sym: ts.Symbol | undefined): boolean => {
+    if (!sym) return false;
+    const parent = (sym as unknown as { parent?: ts.Symbol }).parent;
+    return isCommonFabricModuleName(parent?.name) && !!sym.name;
+  };
+
   // From a Type, find the export name in commonfabric (if any).
   //
-  // Prefer `aliasSymbol` over `symbol`: when the user writes `Writable<X>`
-  // and `Writable` is an alias for `Cell`, the Type's `symbol` may be the
-  // underlying `Cell` constructor while `aliasSymbol` correctly points at
-  // `Writable`. Preserving the user's chosen name keeps the emitted
-  // annotation closer to authored intent.
+  // Prefer `aliasSymbol`: when the user writes `Writable<X>` and `Writable` is
+  // itself a commonfabric alias for `Cell`, the Type's `symbol` is the
+  // underlying `Cell` constructor while `aliasSymbol` points at `Writable` —
+  // we want to keep `Writable`.
+  //
+  // Crucially, if `aliasSymbol` is a USER alias (NOT a commonfabric export),
+  // the user has already named this type completely and resolvably (e.g.
+  // `type SharedMessagesCell = Writable<Foo>`). We must NOT fall through to
+  // `type.symbol` and rewrite to the bare underlying commonfabric name: the
+  // alias-reference node carries no type arguments (they're hidden inside the
+  // alias), so rewriting `SharedMessagesCell` -> `__cfHelpers.Cell` would drop
+  // the `<Foo>` entirely, degrading the type to `Cell<unknown>` and breaking
+  // runtime cell materialization. Leave user aliases alone.
   const commonFabricExportName = (
     type: ts.Type | undefined,
   ): string | undefined => {
     if (!type) return undefined;
-    const candidates: (ts.Symbol | undefined)[] = [
-      type.aliasSymbol,
-      type.symbol,
-    ];
-    for (const sym of candidates) {
-      if (!sym) continue;
-      const parent = (sym as unknown as { parent?: ts.Symbol }).parent;
-      if (isCommonFabricModuleName(parent?.name) && sym.name) {
-        return sym.name;
-      }
+    if (type.aliasSymbol) {
+      return isCommonFabricSymbol(type.aliasSymbol)
+        ? type.aliasSymbol.name
+        : undefined;
     }
-    return undefined;
+    return isCommonFabricSymbol(type.symbol) ? type.symbol.name : undefined;
   };
 
   // For a union/intersection member TypeNode, find the constituent Type to

--- a/packages/ts-transformers/src/ast/type-building.ts
+++ b/packages/ts-transformers/src/ast/type-building.ts
@@ -117,12 +117,18 @@ export function qualifyCommonFabricTypeRefs(
       return undefined;
     }
     const memberName = member.typeName.text;
-    for (const constituent of constituents) {
-      if (commonFabricExportName(constituent) === memberName) {
-        return constituent;
-      }
-    }
-    return undefined;
+    // Require an UNAMBIGUOUS match. If two constituents share a commonfabric
+    // export name but differ in their type arguments (e.g. `Cell<A> | Cell<B>`,
+    // both printed as bare `Cell<...>`), name-matching alone can't tell which
+    // member pairs with which constituent. Picking the first would walk the
+    // member's nested type args against the wrong constituent's args and could
+    // mis-rewrite a nested generic. On ambiguity, return undefined: the member
+    // is left unpaired (un-normalized) rather than risk a wrong rewrite — the
+    // safe degradation this helper already documents.
+    const matches = constituents.filter(
+      (constituent) => commonFabricExportName(constituent) === memberName,
+    );
+    return matches.length === 1 ? matches[0] : undefined;
   };
 
   // For a TypeReference Type, get its Nth type argument. Different

--- a/packages/ts-transformers/src/ast/type-building.ts
+++ b/packages/ts-transformers/src/ast/type-building.ts
@@ -88,6 +88,35 @@ export function qualifyCommonFabricTypeRefs(
     return undefined;
   };
 
+  // For a union/intersection member TypeNode, find the constituent Type to
+  // pair it with. Matches by commonfabric export name (order-independent):
+  // a bare member ref `X` is paired with the constituent whose CF export name
+  // is `X`. Returns undefined when there's no constituent info or no match —
+  // in which case the member is walked with no paired Type (safe: it can only
+  // be rewritten via the syntactic Import-form branch, never misattributed).
+  const pairedConstituentForMember = (
+    member: ts.TypeNode,
+    unionOrIntersectionType: ts.Type | undefined,
+  ): ts.Type | undefined => {
+    if (!unionOrIntersectionType) return undefined;
+    const constituents =
+      (unionOrIntersectionType as ts.UnionOrIntersectionType).types;
+    if (!constituents) return undefined;
+
+    // Only bare identifier refs can be name-matched (the case the printer
+    // emits for in-scope/aliasable commonfabric types inside unions).
+    if (!ts.isTypeReferenceNode(member) || !ts.isIdentifier(member.typeName)) {
+      return undefined;
+    }
+    const memberName = member.typeName.text;
+    for (const constituent of constituents) {
+      if (commonFabricExportName(constituent) === memberName) {
+        return constituent;
+      }
+    }
+    return undefined;
+  };
+
   // For a TypeReference Type, get its Nth type argument. Different
   // TypeScript versions expose this via slightly different shapes; try the
   // public ones first.
@@ -250,26 +279,27 @@ export function qualifyCommonFabricTypeRefs(
         : factory.updateArrayTypeNode(node, rewritten);
     }
 
-    // Union / Intersection: walk each member without paired Type info (the
-    // paired Type IS the union/intersection, but mapping individual members
-    // to constituent Types is brittle; recurse and rely on Import-form
-    // detection for nested refs).
-    if (ts.isUnionTypeNode(node)) {
-      const rewritten = node.types.map((t) => walk(t, undefined));
+    // Union / Intersection: walk each member, pairing it with the constituent
+    // Type that matches by commonfabric export name. Index-pairing TypeNode
+    // members to constituent Types is brittle (TS doesn't guarantee matching
+    // order), so we match by NAME instead: for a bare member ref, find the
+    // constituent whose commonfabric export name equals the ref's identifier.
+    // This is order-independent and only ever supplies a paired Type that
+    // would make the member rewrite to that same name — a non-CF member finds
+    // no match and passes through unchanged. The Import-form (ImportTypeNode)
+    // members are still handled syntactically without needing a paired Type.
+    if (ts.isUnionTypeNode(node) || ts.isIntersectionTypeNode(node)) {
+      const rewritten = node.types.map((t) =>
+        walk(t, pairedConstituentForMember(t, pairedType))
+      );
       const changed = rewritten.some((t, i) => t !== node.types[i]);
-      return changed
+      if (!changed) return node;
+      return ts.isUnionTypeNode(node)
         ? factory.updateUnionTypeNode(node, factory.createNodeArray(rewritten))
-        : node;
-    }
-    if (ts.isIntersectionTypeNode(node)) {
-      const rewritten = node.types.map((t) => walk(t, undefined));
-      const changed = rewritten.some((t, i) => t !== node.types[i]);
-      return changed
-        ? factory.updateIntersectionTypeNode(
+        : factory.updateIntersectionTypeNode(
           node,
           factory.createNodeArray(rewritten),
-        )
-        : node;
+        );
     }
 
     // ParenthesizedType, TypeOperator: unwrap and walk inner.

--- a/packages/ts-transformers/src/ast/type-building.ts
+++ b/packages/ts-transformers/src/ast/type-building.ts
@@ -319,7 +319,20 @@ export function qualifyCommonFabricTypeRefs(
     return node;
   };
 
-  return walk(typeNode, rootType);
+  const result = walk(typeNode, rootType);
+
+  // Carry the registry association forward. The walk returns a fresh node when
+  // it rewrites anything, which would otherwise orphan the original node's
+  // typeRegistry entry — downstream consumers (e.g. the SchemaGenerator) look
+  // the emitted node up by identity, and a missing entry silently degrades the
+  // generated schema (e.g. a precise JSXElement schema collapses to `true`).
+  // Registering here means callers that hand an already-built node to the
+  // normalizer can't forget to re-register it.
+  if (result !== typeNode && rootType && context.typeRegistry) {
+    context.typeRegistry.set(result, rootType);
+  }
+
+  return result;
 }
 
 /**

--- a/packages/ts-transformers/src/closures/strategies/array-method-transform.ts
+++ b/packages/ts-transformers/src/closures/strategies/array-method-transform.ts
@@ -5,8 +5,8 @@ import {
   getLoweredArrayMethodName,
   getTypeAtLocationWithFallback,
   registerSyntheticCallType,
+  typeToTypeNodeWithRegistry,
 } from "../../ast/mod.ts";
-import { typeToTypeNodeWithRegistry } from "../../ast/type-building.ts";
 import type { TransformationContext } from "../../core/mod.ts";
 import type { CaptureTreeNode } from "../../utils/capture-tree.ts";
 import {

--- a/packages/ts-transformers/src/closures/strategies/array-method-transform.ts
+++ b/packages/ts-transformers/src/closures/strategies/array-method-transform.ts
@@ -6,6 +6,7 @@ import {
   getTypeAtLocationWithFallback,
   registerSyntheticCallType,
 } from "../../ast/mod.ts";
+import { typeToTypeNodeWithRegistry } from "../../ast/type-building.ts";
 import type { TransformationContext } from "../../core/mod.ts";
 import type { CaptureTreeNode } from "../../utils/capture-tree.ts";
 import {
@@ -222,16 +223,19 @@ function createPatternCallWithParams(
       const isTypeParam = (resultType.flags & ts.TypeFlags.TypeParameter) !== 0;
 
       if (!isTypeParam) {
-        resultTypeNode = checker.typeToTypeNode(
+        // Convert via the canonical chokepoint so commonfabric refs in the
+        // result type normalize to `__cfHelpers.X` (otherwise the emitted
+        // pattern<…, Out> second type arg prints `import("commonfabric").X`).
+        // It also registers the result Type for downstream schema generation.
+        resultTypeNode = typeToTypeNodeWithRegistry(
           resultType,
-          context.sourceFile,
-          ts.NodeBuilderFlags.NoTruncation |
-            ts.NodeBuilderFlags.UseStructuralFallback,
+          {
+            checker,
+            factory,
+            sourceFile: context.sourceFile,
+          },
+          typeRegistry,
         );
-
-        if (resultTypeNode && typeRegistry) {
-          typeRegistry.set(resultTypeNode, resultType);
-        }
       }
     }
   }

--- a/packages/ts-transformers/src/closures/strategies/lift-applied-strategy.ts
+++ b/packages/ts-transformers/src/closures/strategies/lift-applied-strategy.ts
@@ -13,6 +13,7 @@ import {
 } from "../../ast/mod.ts";
 import { analyzeFunctionCapabilities } from "../../policy/capability-analysis.ts";
 import { registerLiftAppliedCallType } from "../../ast/type-inference.ts";
+import { typeToTypeNodeWithRegistry } from "../../ast/type-building.ts";
 import { applyShrinkAndWrap } from "../../transformers/type-shrinking.ts";
 import { getCellKind } from "../../transformers/opaque-ref/opaque-ref.ts";
 import type { CaptureTreeNode } from "../../utils/capture-tree.ts";
@@ -469,17 +470,20 @@ export function transformLiftAppliedCall(
     if (isTypeParam) {
       hasTypeParameter = true;
     } else {
-      resultTypeNode = checker.typeToTypeNode(
+      // Convert via the canonical chokepoint so commonfabric refs in the
+      // result type are normalized to the always-resolvable `__cfHelpers.X`
+      // form (otherwise the emitted `lift<In, Out>` second type arg prints
+      // `import("commonfabric").X`). It also registers the result Type in the
+      // typeRegistry for downstream schema generation.
+      resultTypeNode = typeToTypeNodeWithRegistry(
         resultType,
-        context.sourceFile,
-        ts.NodeBuilderFlags.NoTruncation |
-          ts.NodeBuilderFlags.UseStructuralFallback,
+        {
+          checker,
+          factory,
+          sourceFile: context.sourceFile,
+        },
+        options.state?.typeRegistry,
       );
-
-      // Register the result Type in typeRegistry
-      if (resultTypeNode && options.state?.typeRegistry) {
-        options.state?.typeRegistry.set(resultTypeNode, resultType);
-      }
     }
   }
 

--- a/packages/ts-transformers/src/closures/strategies/lift-applied-strategy.ts
+++ b/packages/ts-transformers/src/closures/strategies/lift-applied-strategy.ts
@@ -13,7 +13,10 @@ import {
 } from "../../ast/mod.ts";
 import { analyzeFunctionCapabilities } from "../../policy/capability-analysis.ts";
 import { registerLiftAppliedCallType } from "../../ast/type-inference.ts";
-import { typeToTypeNodeWithRegistry } from "../../ast/type-building.ts";
+import {
+  qualifyCommonFabricTypeRefs,
+  typeToTypeNodeWithRegistry,
+} from "../../ast/type-building.ts";
 import { applyShrinkAndWrap } from "../../transformers/type-shrinking.ts";
 import { getCellKind } from "../../transformers/opaque-ref/opaque-ref.ts";
 import type { CaptureTreeNode } from "../../utils/capture-tree.ts";
@@ -457,8 +460,29 @@ export function transformLiftAppliedCall(
   let hasTypeParameter = false;
 
   if (callback.type) {
-    // Explicit return type annotation
-    resultTypeNode = callback.type;
+    // Explicit return type annotation. This may be a synthesized annotation
+    // attached upstream (pos < 0) that still carries raw
+    // `import("commonfabric").X` refs, so normalize it to `__cfHelpers.X`
+    // before it flows into the emitted lift type argument. The normalizer's
+    // ImportTypeNode branch is purely syntactic, so it works without a paired
+    // Type; pass the registered Type when available for nested bare refs.
+    const registeredResultType = options.state?.typeRegistry?.get(callback.type);
+    resultTypeNode = qualifyCommonFabricTypeRefs(
+      callback.type,
+      registeredResultType,
+      { checker, factory, typeRegistry: options.state?.typeRegistry },
+    );
+    // qualifyCommonFabricTypeRefs returns a fresh node when it rewrites, but
+    // does not carry the registry association forward. Re-register the new
+    // node with the original annotation's Type so the SchemaGenerator can
+    // still recover it (otherwise it falls back to the permissive `true`
+    // schema instead of the precise JSXElement/vnode schema).
+    if (
+      registeredResultType && resultTypeNode !== callback.type &&
+      options.state?.typeRegistry
+    ) {
+      options.state.typeRegistry.set(resultTypeNode, registeredResultType);
+    }
   } else if (signature) {
     // Infer from callback signature
     resultType = signature.getReturnType();

--- a/packages/ts-transformers/src/closures/strategies/lift-applied-strategy.ts
+++ b/packages/ts-transformers/src/closures/strategies/lift-applied-strategy.ts
@@ -8,15 +8,13 @@ import {
   detectCallKind,
   getLiftAppliedInputAndCallback,
   getTypeFromTypeNodeWithFallback,
+  qualifyCommonFabricTypeRefs,
   setParentPointers,
+  typeToTypeNodeWithRegistry,
   unwrapOpaqueLikeType,
 } from "../../ast/mod.ts";
 import { analyzeFunctionCapabilities } from "../../policy/capability-analysis.ts";
 import { registerLiftAppliedCallType } from "../../ast/type-inference.ts";
-import {
-  qualifyCommonFabricTypeRefs,
-  typeToTypeNodeWithRegistry,
-} from "../../ast/type-building.ts";
 import { applyShrinkAndWrap } from "../../transformers/type-shrinking.ts";
 import { getCellKind } from "../../transformers/opaque-ref/opaque-ref.ts";
 import type { CaptureTreeNode } from "../../utils/capture-tree.ts";
@@ -465,24 +463,13 @@ export function transformLiftAppliedCall(
     // `import("commonfabric").X` refs, so normalize it to `__cfHelpers.X`
     // before it flows into the emitted lift type argument. The normalizer's
     // ImportTypeNode branch is purely syntactic, so it works without a paired
-    // Type; pass the registered Type when available for nested bare refs.
-    const registeredResultType = options.state?.typeRegistry?.get(callback.type);
+    // Type; pass the registered Type when available so it both qualifies nested
+    // bare refs and carries the registry association onto the rewritten node.
     resultTypeNode = qualifyCommonFabricTypeRefs(
       callback.type,
-      registeredResultType,
+      options.state?.typeRegistry?.get(callback.type),
       { checker, factory, typeRegistry: options.state?.typeRegistry },
     );
-    // qualifyCommonFabricTypeRefs returns a fresh node when it rewrites, but
-    // does not carry the registry association forward. Re-register the new
-    // node with the original annotation's Type so the SchemaGenerator can
-    // still recover it (otherwise it falls back to the permissive `true`
-    // schema instead of the precise JSXElement/vnode schema).
-    if (
-      registeredResultType && resultTypeNode !== callback.type &&
-      options.state?.typeRegistry
-    ) {
-      options.state.typeRegistry.set(resultTypeNode, registeredResultType);
-    }
   } else if (signature) {
     // Infer from callback signature
     resultType = signature.getReturnType();

--- a/packages/ts-transformers/src/closures/utils/schema-factory.ts
+++ b/packages/ts-transformers/src/closures/utils/schema-factory.ts
@@ -6,6 +6,7 @@ import {
   buildTypeElementsFromCaptureTree,
   createRegisteredTypeLiteral,
   expressionToTypeNode,
+  typeToTypeNodeWithRegistry,
 } from "../../ast/type-building.ts";
 import {
   inferArrayElementType,
@@ -253,14 +254,13 @@ export class SchemaFactory {
     // Infer from parameter location
     const type = checker.getTypeAtLocation(eventParam);
 
-    // Try to convert Type to TypeNode
-    const typeNode = checker.typeToTypeNode(
+    // Convert via the canonical chokepoint: normalizes commonfabric refs to
+    // `__cfHelpers.X`, registers the node for schema generation, and falls back
+    // to `unknown` if conversion fails.
+    return typeToTypeNodeWithRegistry(
       type,
-      this.context.sourceFile,
-      ts.NodeBuilderFlags.NoTruncation |
-        ts.NodeBuilderFlags.UseStructuralFallback,
-    ) ?? factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword);
-
-    return registerTypeForNode(typeNode, type, typeRegistry);
+      { checker, factory, sourceFile: this.context.sourceFile },
+      typeRegistry,
+    );
   }
 }

--- a/packages/ts-transformers/src/transformers/builtins/lift-applied.ts
+++ b/packages/ts-transformers/src/transformers/builtins/lift-applied.ts
@@ -21,6 +21,7 @@ import {
   buildCaptureTypeElements,
   createRegisteredTypeLiteral,
   expressionToTypeNode,
+  typeToTypeNodeWithRegistry,
 } from "../../ast/type-building.ts";
 import { registerLiftAppliedCallType } from "../../ast/type-inference.ts";
 import type { TransformationContext } from "../../core/mod.ts";
@@ -347,22 +348,18 @@ function buildResultTypeNode(
     return factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword);
   }
 
-  // Convert to TypeNode, preserving Cell<T> if present
-  const resultTypeNode = checker.typeToTypeNode(
+  // Convert to TypeNode via the canonical chokepoint: it normalizes
+  // commonfabric refs to the always-resolvable `__cfHelpers.X` form (so the
+  // emitted result type arg doesn't print `import("commonfabric").X`),
+  // registers the Type for the SchemaGeneratorTransformer, and falls back to
+  // `unknown` if conversion fails.
+  return typeToTypeNodeWithRegistry(
     resultType,
-    context.sourceFile,
-    ts.NodeBuilderFlags.NoTruncation |
-      ts.NodeBuilderFlags.UseStructuralFallback,
+    {
+      checker,
+      factory,
+      sourceFile: context.sourceFile,
+    },
+    context.options.state?.typeRegistry,
   );
-
-  if (resultTypeNode) {
-    // Register the type in typeRegistry for SchemaGeneratorTransformer
-    if (context.options.state?.typeRegistry) {
-      context.options.state?.typeRegistry.set(resultTypeNode, resultType);
-    }
-    return resultTypeNode;
-  }
-
-  // Fallback to unknown if we can't infer
-  return factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword);
 }

--- a/packages/ts-transformers/src/transformers/expression-rewrite/rewrite-helpers.ts
+++ b/packages/ts-transformers/src/transformers/expression-rewrite/rewrite-helpers.ts
@@ -4,6 +4,7 @@ import {
   detectCallKind,
   type NormalizedDataFlow,
   setParentPointers,
+  typeToTypeNodeWithRegistry,
 } from "../../ast/mod.ts";
 import { isModuleScopedDeclaration } from "../../ast/scope-analysis.ts";
 import { TransformationContext } from "../../core/mod.ts";
@@ -133,11 +134,14 @@ export function createReactiveWrapperForExpression(
 
   try {
     resultType = checker.getTypeAtLocation(expression);
-    resultTypeNode = checker.typeToTypeNode(
+    // Build via the canonical chokepoint so commonfabric refs normalize to
+    // `__cfHelpers.X` and the node is registered for schema generation. (The
+    // call-node registration below still keys the lift-applied CallExpression
+    // to its result Type.)
+    resultTypeNode = typeToTypeNodeWithRegistry(
       resultType,
-      sourceFile,
-      ts.NodeBuilderFlags.NoTruncation |
-        ts.NodeBuilderFlags.UseStructuralFallback,
+      { checker, factory, sourceFile },
+      context.options.state?.typeRegistry,
     );
   } catch {
     resultTypeNode = undefined;

--- a/packages/ts-transformers/src/transformers/type-shrinking.ts
+++ b/packages/ts-transformers/src/transformers/type-shrinking.ts
@@ -1,6 +1,9 @@
 import ts from "typescript";
 import { getPropertyNameText } from "@commonfabric/schema-generator/property-name";
-import { createRegisteredTypeLiteral } from "../ast/type-building.ts";
+import {
+  createRegisteredTypeLiteral,
+  typeToTypeNodeWithRegistry,
+} from "../ast/type-building.ts";
 import { createPropertyName } from "../utils/identifiers.ts";
 import { uniquePaths } from "../utils/path-serialization.ts";
 import {
@@ -769,10 +772,12 @@ function buildShrunkTypeNodeFromType(
     return undefined;
   }
   if (normalizedFullShapePaths.some((path) => path.length === 0)) {
-    const node = checker.typeToTypeNode(type, sourceFile, typeToNodeFlags) ??
-      factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword);
-    typeRegistry?.set(node, type);
-    return node;
+    return typeToTypeNodeWithRegistry(
+      type,
+      { checker, factory, sourceFile },
+      typeRegistry,
+      typeToNodeFlags,
+    );
   }
 
   // Keep array-like roots as arrays. Narrowing `T[]` to `{ length: number }`
@@ -802,24 +807,32 @@ function buildShrunkTypeNodeFromType(
           typeRegistry,
           fullShapeItemPaths,
         ) ??
-          checker.typeToTypeNode(elementType, sourceFile, typeToNodeFlags) ??
-          factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword);
+          typeToTypeNodeWithRegistry(
+            elementType,
+            { checker, factory, sourceFile },
+            typeRegistry,
+            typeToNodeFlags,
+          );
         const arrayNode = factory.createArrayTypeNode(elementNode);
         ensureTypeNodeRegistered(arrayNode, checker, typeRegistry);
         return arrayNode;
       }
     }
-    const node = checker.typeToTypeNode(type, sourceFile, typeToNodeFlags) ??
-      factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword);
-    typeRegistry?.set(node, type);
-    return node;
+    return typeToTypeNodeWithRegistry(
+      type,
+      { checker, factory, sourceFile },
+      typeRegistry,
+      typeToNodeFlags,
+    );
   }
 
   if (normalized.some((path) => path.length === 0)) {
-    const node = checker.typeToTypeNode(type, sourceFile, typeToNodeFlags) ??
-      factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword);
-    typeRegistry?.set(node, type);
-    return node;
+    return typeToTypeNodeWithRegistry(
+      type,
+      { checker, factory, sourceFile },
+      typeRegistry,
+      typeToNodeFlags,
+    );
   }
 
   // Strip nullish constituents from union types (e.g. `T | undefined`) so the
@@ -849,15 +862,14 @@ function buildShrunkTypeNodeFromType(
             constituent.flags &
             (ts.TypeFlags.Undefined | ts.TypeFlags.Null | ts.TypeFlags.Void)
           ) {
-            const node = checker.typeToTypeNode(
-              constituent,
-              sourceFile,
-              typeToNodeFlags,
+            nullishMembers.push(
+              typeToTypeNodeWithRegistry(
+                constituent,
+                { checker, factory, sourceFile },
+                typeRegistry,
+                typeToNodeFlags,
+              ),
             );
-            if (node) {
-              typeRegistry?.set(node, constituent);
-              nullishMembers.push(node);
-            }
           }
         }
       }
@@ -913,12 +925,12 @@ function buildShrunkTypeNodeFromType(
     // root-level primitive projections (e.g. `summary.length`) are still
     // handled by the recursive shrink above.
     if (!hasDirectAccess && isPrimitiveScalarLikeType(propType)) {
-      const propTypeNode = checker.typeToTypeNode(
+      const propTypeNode = typeToTypeNodeWithRegistry(
         propType,
-        sourceFile,
+        { checker, factory, sourceFile },
+        typeRegistry,
         typeToNodeFlags,
-      ) ?? factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword);
-      typeRegistry?.set(propTypeNode, propType);
+      );
       properties.push(
         factory.createPropertySignature(
           undefined,
@@ -953,11 +965,12 @@ function buildShrunkTypeNodeFromType(
     }
 
     const propTypeNode = shrunkChild ??
-      checker.typeToTypeNode(propType, sourceFile, typeToNodeFlags) ??
-      factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword);
-    if (!shrunkChild) {
-      typeRegistry?.set(propTypeNode, propType);
-    }
+      typeToTypeNodeWithRegistry(
+        propType,
+        { checker, factory, sourceFile },
+        typeRegistry,
+        typeToNodeFlags,
+      );
 
     properties.push(
       factory.createPropertySignature(

--- a/packages/ts-transformers/test/fixtures/closures/action-in-ternary-with-explicit-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-in-ternary-with-explicit-computed.expected.jsx
@@ -42,7 +42,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         description: string;
     };
     startEditing: __cfHelpers.Stream<void>;
-}, import("commonfabric").JSXElement>({
+}, __cfHelpers.JSXElement>({
     type: "object",
     properties: {
         card: {

--- a/packages/ts-transformers/test/fixtures/closures/computed-collision-shorthand.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-collision-shorthand.expected.jsx
@@ -13,7 +13,7 @@ const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     multiplier: __cfHelpers.ReadonlyCell<number>;
-}, { value: number; data: { multiplier: import("commonfabric").Cell<number>; }; }>({
+}, { value: number; data: { multiplier: __cfHelpers.Cell<number>; }; }>({
     type: "object",
     properties: {
         multiplier: {

--- a/packages/ts-transformers/test/fixtures/closures/computed-destructured-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-destructured-map.expected.jsx
@@ -77,7 +77,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 }));
 const __cfLift_2 = __cfHelpers.lift<{
     result: { tasks: Item[]; view: string; };
-}, import("commonfabric").JSXElement[]>({
+}, __cfHelpers.JSXElement[]>({
     type: "object",
     properties: {
         result: {

--- a/packages/ts-transformers/test/fixtures/closures/computed-jsx-local-function.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-jsx-local-function.expected.jsx
@@ -13,7 +13,7 @@ const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     count: number;
-}, import("commonfabric").JSXElement>({
+}, __cfHelpers.JSXElement>({
     type: "object",
     properties: {
         count: {

--- a/packages/ts-transformers/test/fixtures/closures/computed-local-var-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-local-var-map.expected.jsx
@@ -67,7 +67,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     filtered: {
         name: string;
     }[];
-}, import("commonfabric").JSXElement[]>({
+}, __cfHelpers.JSXElement[]>({
     type: "object",
     properties: {
         filtered: {

--- a/packages/ts-transformers/test/fixtures/closures/computed-property-access-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-property-access-map.expected.jsx
@@ -81,7 +81,7 @@ const __cfLift_2 = __cfHelpers.lift<{
             name: string;
         }[];
     };
-}, import("commonfabric").JSXElement[]>({
+}, __cfHelpers.JSXElement[]>({
     type: "object",
     properties: {
         result: {

--- a/packages/ts-transformers/test/fixtures/closures/inline-action-in-ternary-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/inline-action-in-ternary-branch.expected.jsx
@@ -47,7 +47,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         isEditing: __cfHelpers.ReadonlyCell<boolean>;
     };
-}, import("commonfabric").JSXElement>({
+}, __cfHelpers.JSXElement>({
     type: "object",
     properties: {
         state: {

--- a/packages/ts-transformers/test/fixtures/closures/lift-result-type-cf-ref-normalized.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/lift-result-type-cf-ref-normalized.expected.jsx
@@ -99,3 +99,6 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/lift-result-type-cf-ref-normalized.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/lift-result-type-cf-ref-normalized.expected.jsx
@@ -1,0 +1,101 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { computed, pattern, UI } from "commonfabric";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+const __cfLift_1 = __cfHelpers.lift<{
+    count: number;
+}, __cfHelpers.JSXElement>({
+    type: "object",
+    properties: {
+        count: {
+            type: "number"
+        }
+    },
+    required: ["count"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    anyOf: [{
+            $ref: "https://commonfabric.org/schemas/vnode.json"
+        }, {
+            $ref: "#/$defs/UIRenderable"
+        }, {
+            type: "object",
+            properties: {}
+        }],
+    $defs: {
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, ({ count }) => <span>{count}</span>);
+// FIXTURE: lift-result-type-cf-ref-normalized
+// Verifies: a synthesized lift's RESULT type argument that is a commonfabric
+// type (here JSXElement, the type of the returned JSX) is emitted as the
+// canonical __cfHelpers.JSXElement form, NOT the inline TS import-type form
+// the printer produces by default.
+//
+// Regression guard for the bug where lift result-type construction bypassed the
+// qualifyCommonFabricTypeRefs normalizer. The companion invariant test
+// (test/no-import-type-in-output.test.ts) guards every path globally; this
+// fixture pins the specific JSX-returning-computed shape with a legible,
+// minimal diff so a regression is obvious here too.
+export default pattern((__cf_pattern_input) => {
+    const count = __cf_pattern_input.key("count");
+    return {
+        [UI]: <div>{__cfLift_1({ count: count })}</div>,
+    };
+}, {
+    type: "object",
+    properties: {
+        count: {
+            type: "number"
+        }
+    },
+    required: ["count"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        $UI: {
+            $ref: "#/$defs/JSXElement"
+        }
+    },
+    required: ["$UI"],
+    $defs: {
+        JSXElement: {
+            anyOf: [{
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }, {
+                    $ref: "#/$defs/UIRenderable"
+                }, {
+                    type: "object",
+                    properties: {}
+                }]
+        },
+        UIRenderable: {
+            type: "object",
+            properties: {
+                $UI: {
+                    $ref: "https://commonfabric.org/schemas/vnode.json"
+                }
+            },
+            required: ["$UI"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/lift-result-type-cf-ref-normalized.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/lift-result-type-cf-ref-normalized.input.tsx
@@ -1,0 +1,18 @@
+import { computed, pattern, UI } from "commonfabric";
+
+// FIXTURE: lift-result-type-cf-ref-normalized
+// Verifies: a synthesized lift's RESULT type argument that is a commonfabric
+// type (here JSXElement, the type of the returned JSX) is emitted as the
+// canonical __cfHelpers.JSXElement form, NOT the inline TS import-type form
+// the printer produces by default.
+//
+// Regression guard for the bug where lift result-type construction bypassed the
+// qualifyCommonFabricTypeRefs normalizer. The companion invariant test
+// (test/no-import-type-in-output.test.ts) guards every path globally; this
+// fixture pins the specific JSX-returning-computed shape with a legible,
+// minimal diff so a regression is obvious here too.
+export default pattern<{ count: number }>(({ count }) => {
+  return {
+    [UI]: <div>{computed(() => <span>{count}</span>)}</div>,
+  };
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-mixed-reactivity.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-mixed-reactivity.expected.jsx
@@ -46,7 +46,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
                 },
                 limit: {
                     type: "number",
-                    asCell: ["cell"]
+                    asCell: ["readonly"]
                 }
             },
             required: ["label", "derived", "limit"]
@@ -77,7 +77,9 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 // FIXTURE: map-capture-mixed-reactivity
 // Verifies: captures of different reactivity kinds are annotated distinctly in the schema
 //   label (plain string) → params.label (type: "string", accessed via .params)
-//   limit (cell) → params.limit (asCell: true)
+//   limit (cell, READ-only in this callback) → params.limit (asCell: ["readonly"])
+//     — read-only usage yields the precise `readonly` capability, not the broader
+//       `cell`. (The capture is created with cell(100) but never written here.)
 //   derived (state.threshold) → params.derived (asOpaque: true)
 // Context: Three capture kinds — plain value, cell, and state-derived — in one map callback
 export default pattern((state) => {

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-mixed-reactivity.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-mixed-reactivity.input.tsx
@@ -8,7 +8,9 @@ interface State {
 // FIXTURE: map-capture-mixed-reactivity
 // Verifies: captures of different reactivity kinds are annotated distinctly in the schema
 //   label (plain string) → params.label (type: "string", accessed via .params)
-//   limit (cell) → params.limit (asCell: true)
+//   limit (cell, READ-only in this callback) → params.limit (asCell: ["readonly"])
+//     — read-only usage yields the precise `readonly` capability, not the broader
+//       `cell`. (The capture is created with cell(100) but never written here.)
 //   derived (state.threshold) → params.derived (asOpaque: true)
 // Context: Three capture kinds — plain value, cell, and state-derived — in one map callback
 export default pattern<State>((state) => {

--- a/packages/ts-transformers/test/fixtures/closures/map-conditional-inline-handler-send.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-conditional-inline-handler-send.expected.jsx
@@ -63,7 +63,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         votes: VoteEvent[];
     };
-}, import("commonfabric").Stream<unknown>>({
+}, __cfHelpers.Stream<unknown>>({
     type: "object",
     properties: {
         castVote: {
@@ -112,7 +112,10 @@ const __cfLift_1 = __cfHelpers.lift<{
             "enum": ["space", "user", "session"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema, ({ castVote, state }) => castVote({ votes: state.votes }).for({ stream: "boundCastVote" }));
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "unknown",
+    asCell: ["stream"]
+} as const satisfies __cfHelpers.JSONSchema, ({ castVote, state }) => castVote({ votes: state.votes }).for({ stream: "boundCastVote" }));
 const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/closures/readonly-capture-named-alias-nested-cell.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/readonly-capture-named-alias-nested-cell.expected.jsx
@@ -1,0 +1,118 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { Cell, computed, Default, pattern, Writable } from "commonfabric";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+// `Entry[] | Default<[]>` aliased as EntriesValue; Entry contains a nested Cell.
+// Creating the cell with `Writable.of<EntriesValue>(...)` gives it the BARE
+// `Cell<EntriesValue>` type (not a user alias), so the chokepoint normalizes the
+// capture node to `__cfHelpers.Cell<EntriesValue>`. That makes it visible to the
+// capability re-wrap, which narrows the read-only capture to `ReadonlyCell`.
+interface Entry {
+    readonly profile: Cell<{
+        name: string;
+    }>;
+}
+type EntriesValue = Entry[] | Default<[
+]>;
+// Reads the cell only (passed by reference, never written) — makes the capture
+// read-only and triggers the Cell -> ReadonlyCell narrowing.
+const firstName = __cfHardenFn((entries: Cell<EntriesValue>): string => (entries.get() ?? [])[0]?.profile.get().name ?? "");
+const __cfLift_1 = __cfHelpers.lift<{
+    entries: __cfHelpers.ReadonlyCell<EntriesValue>;
+}, string>({
+    type: "object",
+    properties: {
+        entries: {
+            $ref: "#/$defs/EntriesValue",
+            asCell: ["readonly"]
+        }
+    },
+    required: ["entries"],
+    $defs: {
+        EntriesValue: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Entry"
+            },
+            "default": []
+        },
+        Entry: {
+            type: "object",
+            properties: {
+                profile: {
+                    type: "object",
+                    properties: {
+                        name: {
+                            type: "string"
+                        }
+                    },
+                    required: ["name"],
+                    asCell: ["cell"]
+                }
+            },
+            required: ["profile"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "string"
+} as const satisfies __cfHelpers.JSONSchema, ({ entries }) => firstName(entries));
+// FIXTURE: readonly-capture-named-alias-nested-cell
+// Verifies (BEHAVIOR LOCK): a by-reference, read-only-used capture of a bare
+//   `Cell<EntriesValue>` (EntriesValue = Entry[] | Default<[]>, Entry has a
+//   nested `Cell`) is branded `__cfHelpers.ReadonlyCell<EntriesValue>` with
+//   schema `{ $ref: "#/$defs/EntriesValue", asCell: ["readonly"] }`. The Cell ->
+//   ReadonlyCell capability narrowing must PRESERVE the inner `$ref` (and thus
+//   the nested `profile` Cell materialized in $defs), NOT collapse the capture to
+//   a bare `{ asCell: ["readonly"] }`.
+//
+// NOTE: this is a behavior lock, not a standalone regression repro. The schema-gen
+//   `$ref`-drop bug this guards against only manifests when the inner type comes
+//   from a CROSS-FILE import (so a synthetic reference to it degrades to `any` in
+//   the schema generator's checker context). The fixture harness type-checks each
+//   fixture as a single file, so the inner resolves here regardless of the fix.
+//   The genuine fail-without/pass-with regression guard is the pattern test
+//   packages/patterns/cfc-group-chat-demo/main.test.tsx (the `profiles` capture).
+//   This fixture pins the intended single-file output with a legible diff so a
+//   future change to the readonly-rewrap path is obvious here too.
+export default pattern(() => {
+    const entries = Writable.of<EntriesValue>([] as EntriesValue, {
+        type: "array",
+        items: {
+            $ref: "#/$defs/Entry"
+        },
+        "default": [],
+        $defs: {
+            Entry: {
+                type: "object",
+                properties: {
+                    profile: {
+                        type: "object",
+                        properties: {
+                            name: {
+                                type: "string"
+                            }
+                        },
+                        required: ["name"],
+                        asCell: ["cell"]
+                    }
+                },
+                required: ["profile"]
+            }
+        }
+    } as const satisfies __cfHelpers.JSONSchema).for("entries", true);
+    return __cfLift_1({ entries: entries }).for("__patternResult", true);
+}, false as const satisfies __cfHelpers.JSONSchema, {
+    type: "string"
+} as const satisfies __cfHelpers.JSONSchema);
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/readonly-capture-named-alias-nested-cell.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/readonly-capture-named-alias-nested-cell.expected.jsx
@@ -116,3 +116,6 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/readonly-capture-named-alias-nested-cell.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/readonly-capture-named-alias-nested-cell.input.tsx
@@ -1,0 +1,39 @@
+import { Cell, computed, Default, pattern, Writable } from "commonfabric";
+
+// `Entry[] | Default<[]>` aliased as EntriesValue; Entry contains a nested Cell.
+// Creating the cell with `Writable.of<EntriesValue>(...)` gives it the BARE
+// `Cell<EntriesValue>` type (not a user alias), so the chokepoint normalizes the
+// capture node to `__cfHelpers.Cell<EntriesValue>`. That makes it visible to the
+// capability re-wrap, which narrows the read-only capture to `ReadonlyCell`.
+interface Entry {
+  readonly profile: Cell<{ name: string }>;
+}
+type EntriesValue = Entry[] | Default<[]>;
+
+// Reads the cell only (passed by reference, never written) — makes the capture
+// read-only and triggers the Cell -> ReadonlyCell narrowing.
+const firstName = (entries: Cell<EntriesValue>): string =>
+  (entries.get() ?? [])[0]?.profile.get().name ?? "";
+
+// FIXTURE: readonly-capture-named-alias-nested-cell
+// Verifies (BEHAVIOR LOCK): a by-reference, read-only-used capture of a bare
+//   `Cell<EntriesValue>` (EntriesValue = Entry[] | Default<[]>, Entry has a
+//   nested `Cell`) is branded `__cfHelpers.ReadonlyCell<EntriesValue>` with
+//   schema `{ $ref: "#/$defs/EntriesValue", asCell: ["readonly"] }`. The Cell ->
+//   ReadonlyCell capability narrowing must PRESERVE the inner `$ref` (and thus
+//   the nested `profile` Cell materialized in $defs), NOT collapse the capture to
+//   a bare `{ asCell: ["readonly"] }`.
+//
+// NOTE: this is a behavior lock, not a standalone regression repro. The schema-gen
+//   `$ref`-drop bug this guards against only manifests when the inner type comes
+//   from a CROSS-FILE import (so a synthetic reference to it degrades to `any` in
+//   the schema generator's checker context). The fixture harness type-checks each
+//   fixture as a single file, so the inner resolves here regardless of the fix.
+//   The genuine fail-without/pass-with regression guard is the pattern test
+//   packages/patterns/cfc-group-chat-demo/main.test.tsx (the `profiles` capture).
+//   This fixture pins the intended single-file output with a legible diff so a
+//   future change to the readonly-rewrap path is obvious here too.
+export default pattern(() => {
+  const entries = Writable.of<EntriesValue>([] as EntriesValue);
+  return computed(() => firstName(entries));
+});

--- a/packages/ts-transformers/test/fixtures/kitchensink/helper-owned-compute-branches.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/helper-owned-compute-branches.expected.jsx
@@ -233,7 +233,7 @@ const __cfLift_4 = __cfHelpers.lift<{
         prefix: string;
     };
     fallbackMembers: __cfHelpers.ReadonlyCell<string[]>;
-}, (import("commonfabric").VNode | import("commonfabric").UIRenderable)[]>({
+}, (__cfHelpers.VNode | __cfHelpers.UIRenderable)[]>({
     type: "object",
     properties: {
         visibleProjects: {

--- a/packages/ts-transformers/test/fixtures/kitchensink/nested-computed-output-maps.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/nested-computed-output-maps.expected.jsx
@@ -555,7 +555,7 @@ const __cfLift_7 = __cfHelpers.lift<{
     state: {
         lane: string;
     };
-}, import("commonfabric").JSXElement[]>({
+}, __cfHelpers.JSXElement[]>({
     type: "object",
     properties: {
         visibleThreads: {

--- a/packages/ts-transformers/test/fixtures/kitchensink/nested-writable-pattern-branches.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/nested-writable-pattern-branches.expected.jsx
@@ -399,7 +399,7 @@ const __cfLift_4 = __cfHelpers.lift<{
         };
         title: string;
     };
-}, import("commonfabric").JSXElement>({
+}, __cfHelpers.JSXElement>({
     type: "object",
     properties: {
         section: {

--- a/packages/ts-transformers/test/no-import-type-in-output.test.ts
+++ b/packages/ts-transformers/test/no-import-type-in-output.test.ts
@@ -18,7 +18,7 @@ import { walk } from "@std/fs";
 const FIXTURES_ROOT = new URL("./fixtures/", import.meta.url);
 const FORBIDDEN = 'import("commonfabric")';
 
-Deno.test("no golden output contains the inline import(\"commonfabric\") type form", async () => {
+Deno.test('no golden output contains the inline import("commonfabric") type form', async () => {
   const offenders: string[] = [];
 
   for await (

--- a/packages/ts-transformers/test/no-import-type-in-output.test.ts
+++ b/packages/ts-transformers/test/no-import-type-in-output.test.ts
@@ -1,0 +1,46 @@
+import { assertEquals } from "@std/assert";
+import { walk } from "@std/fs";
+
+// Invariant: no transformed output (golden) may reference a commonfabric export
+// via the inline `import("commonfabric").X` import-type form. The transformer
+// injects `import { __cfHelpers } from "commonfabric"` and re-exposes the whole
+// namespace as `__cfHelpers`, so every commonfabric type must be emitted as the
+// always-resolvable `__cfHelpers.X` qualified form. The inline import-type form
+// leaks when a synthesized type annotation (e.g. a lift's result type) bypasses
+// the `qualifyCommonFabricTypeRefs` normalizer.
+//
+// This guard covers EVERY transform path at once (any path that synthesizes an
+// emitted type annotation), not just the ones an individual fixture happens to
+// exercise. A regression in the normalizer or a new un-normalized
+// `checker.typeToTypeNode` call site that reaches emit will fail here with the
+// exact file:line.
+
+const FIXTURES_ROOT = new URL("./fixtures/", import.meta.url);
+const FORBIDDEN = 'import("commonfabric")';
+
+Deno.test("no golden output contains the inline import(\"commonfabric\") type form", async () => {
+  const offenders: string[] = [];
+
+  for await (
+    const entry of walk(FIXTURES_ROOT, {
+      includeDirs: false,
+      match: [/\.expected\.[a-z]+$/],
+    })
+  ) {
+    const content = await Deno.readTextFile(entry.path);
+    const lines = content.split("\n");
+    lines.forEach((line, i) => {
+      if (line.includes(FORBIDDEN)) {
+        offenders.push(`${entry.path}:${i + 1}: ${line.trim()}`);
+      }
+    });
+  }
+
+  assertEquals(
+    offenders,
+    [],
+    `Found ${offenders.length} inline import("commonfabric") reference(s) in ` +
+      `golden output. These must be the canonical __cfHelpers.X form. ` +
+      `Offenders:\n${offenders.join("\n")}`,
+  );
+});

--- a/packages/ts-transformers/test/typetotypenode-call-sites.test.ts
+++ b/packages/ts-transformers/test/typetotypenode-call-sites.test.ts
@@ -33,20 +33,20 @@ const SRC_ROOT = new URL("../src/", import.meta.url);
 // allowed to bypass the chokepoint. Update deliberately.
 const ALLOWED: Record<string, string> = {
   // The chokepoint's own implementation — this IS the sanctioned wrapper.
-  "ast/type-building.ts": "chokepoint implementation (typeToTypeNodeWithRegistry)",
+  "ast/type-building.ts":
+    "chokepoint implementation (typeToTypeNodeWithRegistry)",
   // Internal-only: node is inspected for any/unknown and discarded, never emitted.
   // No emit, no registry consumer → neither bug class applies.
-  "transformers/schema-injection.ts": "internal-only: node checked for any/unknown, not emitted",
+  "transformers/schema-injection.ts":
+    "internal-only: node checked for any/unknown, not emitted",
   // Shared low-level helper with try/catch; callers that emit should prefer the
   // chokepoint. Tracked for migration in the universal phase.
-  "ast/type-inference.ts": "[emit+concrete] low-level typeToTypeNode helper (try/catch); migrate emitting callers",
+  "ast/type-inference.ts":
+    "[emit+concrete] low-level typeToTypeNode helper (try/catch); migrate emitting callers",
   // type-shrinking builds shrunk TypeNodes used in emitted lift/pattern type
   // args. Candidate for chokepoint migration; pinned here until then.
-  "transformers/type-shrinking.ts": "[emit+concrete] shrunk type nodes; migrate to chokepoint (import-leak + registry-degrade)",
-  // Compute-wrapper arrow return type (emit-reaching). Migrate to chokepoint.
-  "transformers/expression-rewrite/rewrite-helpers.ts": "[emit+concrete] compute-wrapper arrow return type; migrate to chokepoint",
-  // Event parameter type for schema (emit-reaching). Migrate to chokepoint.
-  "closures/utils/schema-factory.ts": "[emit+concrete] event param type for schema; migrate to chokepoint",
+  "transformers/type-shrinking.ts":
+    "[emit+concrete] shrunk type nodes; migrate to chokepoint (import-leak + registry-degrade)",
 };
 
 Deno.test("raw checker.typeToTypeNode call sites match the reviewed allowlist", async () => {

--- a/packages/ts-transformers/test/typetotypenode-call-sites.test.ts
+++ b/packages/ts-transformers/test/typetotypenode-call-sites.test.ts
@@ -17,6 +17,15 @@ import { relative } from "@std/path";
 // or add it here WITH a justification (it's genuinely internal-only / is the
 // chokepoint's own implementation). The goal is that "raw typeToTypeNode" is
 // always a reviewed decision, never an accident.
+//
+// NB: both bug classes share THIS producer set. The registry-degradation class
+// can't be caught at the consumer (SchemaGenerator) — by the time a degraded
+// node reaches it, the node has already been rewritten to an `unknown`-bearing
+// form, indistinguishable from an intentional `unknown`. So the producer-side
+// sweep below is the practical guard for the registry class too: migrating an
+// emit-reaching site to the chokepoint closes BOTH the import-leak and the
+// registry-degradation risk at once (the chokepoint normalizes AND registers).
+// Entries that can emit a concrete (non-keyword) type are marked [emit+concrete].
 
 const SRC_ROOT = new URL("../src/", import.meta.url);
 
@@ -26,17 +35,18 @@ const ALLOWED: Record<string, string> = {
   // The chokepoint's own implementation — this IS the sanctioned wrapper.
   "ast/type-building.ts": "chokepoint implementation (typeToTypeNodeWithRegistry)",
   // Internal-only: node is inspected for any/unknown and discarded, never emitted.
+  // No emit, no registry consumer → neither bug class applies.
   "transformers/schema-injection.ts": "internal-only: node checked for any/unknown, not emitted",
   // Shared low-level helper with try/catch; callers that emit should prefer the
   // chokepoint. Tracked for migration in the universal phase.
-  "ast/type-inference.ts": "low-level typeToTypeNode helper (try/catch); migrate emitting callers",
+  "ast/type-inference.ts": "[emit+concrete] low-level typeToTypeNode helper (try/catch); migrate emitting callers",
   // type-shrinking builds shrunk TypeNodes used in emitted lift/pattern type
   // args. Candidate for chokepoint migration; pinned here until then.
-  "transformers/type-shrinking.ts": "shrunk type nodes (emit-reaching); migrate to chokepoint",
+  "transformers/type-shrinking.ts": "[emit+concrete] shrunk type nodes; migrate to chokepoint (import-leak + registry-degrade)",
   // Compute-wrapper arrow return type (emit-reaching). Migrate to chokepoint.
-  "transformers/expression-rewrite/rewrite-helpers.ts": "compute-wrapper arrow return type; migrate to chokepoint",
+  "transformers/expression-rewrite/rewrite-helpers.ts": "[emit+concrete] compute-wrapper arrow return type; migrate to chokepoint",
   // Event parameter type for schema (emit-reaching). Migrate to chokepoint.
-  "closures/utils/schema-factory.ts": "event param type for schema; migrate to chokepoint",
+  "closures/utils/schema-factory.ts": "[emit+concrete] event param type for schema; migrate to chokepoint",
 };
 
 Deno.test("raw checker.typeToTypeNode call sites match the reviewed allowlist", async () => {

--- a/packages/ts-transformers/test/typetotypenode-call-sites.test.ts
+++ b/packages/ts-transformers/test/typetotypenode-call-sites.test.ts
@@ -43,10 +43,19 @@ const ALLOWED: Record<string, string> = {
   // chokepoint. Tracked for migration in the universal phase.
   "ast/type-inference.ts":
     "[emit+concrete] low-level typeToTypeNode helper (try/catch); migrate emitting callers",
-  // type-shrinking builds shrunk TypeNodes used in emitted lift/pattern type
-  // args. Candidate for chokepoint migration; pinned here until then.
+  // type-shrinking: the emit-reaching shrink paths were migrated to the
+  // chokepoint. THREE raw calls remain, each genuinely special (not workarounds):
+  //   - getArrayElementTypeNode (~1684): result feeds validateShrinkCoverage ->
+  //     reportDiagnostic (validation, never emitted); its `undefined`-on-failure
+  //     return is load-bearing for the caller's union-member iteration.
+  //   - createIdentityOnlyNullishTypeNode (~2303): nullish-only types (no
+  //     commonfabric refs possible) with a custom null-literal/undefined-keyword
+  //     fallback, not the chokepoint's `unknown`.
+  //   - identity-only union member (~2361): the node is INSPECTED
+  //     (isCellLikeTypeNode / preservedWrapperFor) to build a fresh unknown-based
+  //     replacement; never emitted directly.
   "transformers/type-shrinking.ts":
-    "[emit+concrete] shrunk type nodes; migrate to chokepoint (import-leak + registry-degrade)",
+    "3 special sites: validation-only (undefined contract), nullish-only custom fallback, inspected-not-emitted",
 };
 
 Deno.test("raw checker.typeToTypeNode call sites match the reviewed allowlist", async () => {

--- a/packages/ts-transformers/test/typetotypenode-call-sites.test.ts
+++ b/packages/ts-transformers/test/typetotypenode-call-sites.test.ts
@@ -1,0 +1,84 @@
+import { assertEquals } from "@std/assert";
+import { walk } from "@std/fs";
+import { relative } from "@std/path";
+
+// STATIC SWEEP — bypass guard for the type→TypeNode chokepoint.
+//
+// `typeToTypeNodeWithRegistry` (src/ast/type-building.ts) is the sanctioned way
+// to convert a ts.Type into an emittable TypeNode: it normalizes commonfabric
+// refs to `__cfHelpers.X` and registers the node in the typeRegistry. A raw
+// `checker.typeToTypeNode(...)` call does neither, so any new raw call site is a
+// latent source of two bug classes we've already hit:
+//   1. inline `import("commonfabric").X` leaking into emitted type args
+//   2. unregistered emitted nodes silently degrading generated schemas
+//
+// This test pins the exact set of raw call sites. When you add or remove one,
+// this test fails — forcing a conscious choice: route it through the chokepoint,
+// or add it here WITH a justification (it's genuinely internal-only / is the
+// chokepoint's own implementation). The goal is that "raw typeToTypeNode" is
+// always a reviewed decision, never an accident.
+
+const SRC_ROOT = new URL("../src/", import.meta.url);
+
+// Each allowed raw call site, keyed by "relative/path.ts:line", with WHY it is
+// allowed to bypass the chokepoint. Update deliberately.
+const ALLOWED: Record<string, string> = {
+  // The chokepoint's own implementation — this IS the sanctioned wrapper.
+  "ast/type-building.ts": "chokepoint implementation (typeToTypeNodeWithRegistry)",
+  // Internal-only: node is inspected for any/unknown and discarded, never emitted.
+  "transformers/schema-injection.ts": "internal-only: node checked for any/unknown, not emitted",
+  // Shared low-level helper with try/catch; callers that emit should prefer the
+  // chokepoint. Tracked for migration in the universal phase.
+  "ast/type-inference.ts": "low-level typeToTypeNode helper (try/catch); migrate emitting callers",
+  // type-shrinking builds shrunk TypeNodes used in emitted lift/pattern type
+  // args. Candidate for chokepoint migration; pinned here until then.
+  "transformers/type-shrinking.ts": "shrunk type nodes (emit-reaching); migrate to chokepoint",
+  // Compute-wrapper arrow return type (emit-reaching). Migrate to chokepoint.
+  "transformers/expression-rewrite/rewrite-helpers.ts": "compute-wrapper arrow return type; migrate to chokepoint",
+  // Event parameter type for schema (emit-reaching). Migrate to chokepoint.
+  "closures/utils/schema-factory.ts": "event param type for schema; migrate to chokepoint",
+};
+
+Deno.test("raw checker.typeToTypeNode call sites match the reviewed allowlist", async () => {
+  // file (relative) -> count of raw calls
+  const found = new Map<string, number>();
+
+  for await (
+    const entry of walk(SRC_ROOT, {
+      includeDirs: false,
+      exts: [".ts"],
+    })
+  ) {
+    const content = await Deno.readTextFile(entry.path);
+    const rel = relative(SRC_ROOT.pathname, entry.path);
+    for (const line of content.split("\n")) {
+      // Match `.typeToTypeNode(` but not our own wrapper name.
+      if (/\.typeToTypeNode\(/.test(line)) {
+        found.set(rel, (found.get(rel) ?? 0) + 1);
+      }
+    }
+  }
+
+  const foundFiles = [...found.keys()].sort();
+  const allowedFiles = Object.keys(ALLOWED).sort();
+
+  // Any file with raw calls that ISN'T allowlisted is a new bypass.
+  const unexpected = foundFiles.filter((f) => !(f in ALLOWED));
+  // Any allowlisted file that no longer has raw calls — stale entry to remove.
+  const stale = allowedFiles.filter((f) => !found.has(f));
+
+  assertEquals(
+    { unexpected, stale },
+    { unexpected: [], stale: [] },
+    `Raw checker.typeToTypeNode call sites drifted from the allowlist.\n` +
+      (unexpected.length
+        ? `NEW bypasses (route through typeToTypeNodeWithRegistry, or allowlist ` +
+          `with justification): ${unexpected.join(", ")}\n`
+        : "") +
+      (stale.length
+        ? `STALE allowlist entries (no raw calls remain — remove them): ${
+          stale.join(", ")
+        }\n`
+        : ""),
+  );
+});


### PR DESCRIPTION
## What

Synthesized `lift<In, Out>(...)` / `pattern<…, Out>(...)` calls printed their **result** type argument using TypeScript's inline import-type form, e.g. `import("commonfabric").JSXElement`, instead of the canonical `__cfHelpers.X` form. The runner exposes `__cfHelpers` as a self-reference to the whole commonfabric namespace, so `__cfHelpers.X` always resolves; the inline `import(...)` form does not reliably typecheck against the user's imports.

Spotted in the transformed output of `packages/patterns/lunch-poll` (5 occurrences of `import("commonfabric").JSXElement`).

While fixing that, the same chokepoint-migration work surfaced **two related, independently-reviewable bugs** that ride along in this PR — a schema-generator `$ref`-drop on capability re-wraps, and a downstream nested-cell existence check in `home.tsx`. Both are called out under **Also in this PR** below.

## Root cause

A correct normalizer already exists — `qualifyCommonFabricTypeRefs` (wrapped by the `typeToTypeNodeWithRegistry` chokepoint) — which rewrites commonfabric refs to `__cfHelpers.X` and registers the node's Type for schema generation. The lift **input** type arg routed through it; the **result** type arg paths called `checker.typeToTypeNode` directly, bypassing it. That asymmetry was the bug.

## Fix

- Route the lift/pattern result-type paths through the chokepoint:
  - `transformers/builtins/lift-applied.ts` (`buildResultTypeNode`)
  - `closures/strategies/lift-applied-strategy.ts` (signature-inferred result **and** the `callback.type` propagation path, found via instrumentation — a synthesized annotation can carry a raw import node)
  - `closures/strategies/array-method-transform.ts` (mapWithPattern result)
- Extend the migration to the remaining emit-reaching `checker.typeToTypeNode` sites so the chokepoint covers them all: `transformers/type-shrinking.ts` (7 shrink-result conversions), `transformers/expression-rewrite/rewrite-helpers.ts` (compute-wrapper arrow return), and `closures/utils/schema-factory.ts` (event parameter type). Three raw calls remain, deliberately allowlisted (non-emitting / load-bearing undefined return / inspected-not-emitted).
- Fix a latent normalizer bug this surfaced (`ast/type-building.ts`): union/intersection members weren't qualified (`(VNode | UIRenderable)[]` came out bare). Now matched to constituent Types **by export name**, and — per cubic review — requiring an **unambiguous** match (two constituents sharing an export name but differing in type args are left unpaired rather than mis-rewritten).
- Don't collapse **user aliases** to bare commonfabric names: a non-generic user alias whose underlying type is a commonfabric generic (`type SharedMessagesCell = Writable<SharedMessagesValue>`) was being rewritten to bare `__cfHelpers.Cell`, dropping the type argument. Only rewrite when the node's own name is a commonfabric export.
- Harden the normalizer to **self-register** the rewritten node's Type — removes a footgun where a missing registry entry silently degrades the generated schema (precise type → permissive `true`).
- Promote `typeToTypeNodeWithRegistry` + `qualifyCommonFabricTypeRefs` into the `ast/mod.ts` barrel as the canonical entry.

## Also in this PR

Two behavior fixes outside the type-normalizer, surfaced by the chokepoint migration:

- **schema-generator: preserve inner `$ref` when a capability re-wrap narrows a cell's brand** (`schema-generator/src/formatters/common-fabric-formatter.ts`, `type-utils.ts`). When type-shrinking re-wraps `Cell<T>` as `ReadonlyCell<T>` for read-only usage, the node's brand no longer matches the resolved type's brand, which routed schema generation through the node-driven path. For a bare named-reference inner with no source position the checker returns `any`, so the inner schema collapsed to `{}` and the `$ref`/`$defs` were dropped — the runtime then failed to materialize nested cells (`profile.get is not a function` in cfc-group-chat-demo). Fix: when a synthetic node narrows a **cell-capability** brand and its own inner degrades to `any`, fall back to the resolved type's inner so the `$ref` survives while keeping the narrowed brand. Also refactors `CELL_CAPABILITY_KINDS` to an exhaustive `Record<CellWrapperKind, boolean>` so a new kind is a compile error until classified (no behavior change).
- **`packages/patterns/system/home.tsx`: read profile existence at the right cell depth.** `profile` is a `Cell` whose value is itself a `Cell` (`TrustedProfileLink` wraps `Cell<ProfileHomeOutput>`), so `profile.get()` returns the inner cell **handle** — always non-undefined. The existence check `profile.get() !== undefined` was therefore permanently true, hiding the profile-create surface. Now reads one level deeper: `profile.get()?.get() !== undefined`. This was masked until the schema-gen fix above made the nested-cell schema honest.

## Guards added

- **Golden invariant** (`test/no-import-type-in-output.test.ts`): no `*.expected.*` may contain `import("commonfabric")`. Covers every transform path at once.
- **Static call-site sweep** (`test/typetotypenode-call-sites.test.ts`): raw `checker.typeToTypeNode` sites must match a reviewed allowlist with per-site justification; new bypasses fail. Documents that this producer set is shared by two bug classes (import-leak + registry-degradation) and marks `[emit+concrete]` sites still pending migration to the chokepoint.
- **Minimal fixture** (`lift-result-type-cf-ref-normalized`): a JSX-returning computed → `lift<{count}, __cfHelpers.JSXElement>`, a legible regression signal.
- **Behavior-lock fixture** (`readonly-capture-named-alias-nested-cell`): pins that a Cell→ReadonlyCell capability narrowing preserves the inner `$ref` + nested cell in `$defs` (the genuine fail-without/pass-with guard for the schema-gen fix is the cfc-group-chat-demo pattern test).

## Result

Zero `import("commonfabric")` in any fixture output. `deno task test` → 292 passed / 0 failed; lint clean. Full pattern integration suite 19/0; schema-generator 24/0.

## Notes
- A few goldens additionally gain more-correct output schemas once the result type is a real `__cfHelpers.X` rather than an opaque import-type: `map-conditional-inline-handler-send` (`true` → `{ type: "unknown", asCell: ["stream"] }` — the Stream is now recognized) and `map-capture-mixed-reactivity`'s read-only `limit` capture (`asCell: ["cell"]` → `asCell: ["readonly"]`).
- The two refreshed closure goldens (`lift-result-type-cf-ref-normalized`, `readonly-capture-named-alias-nested-cell`) gain the trailing `__cfReg({ … })` hoist-registration block introduced by CT-1623 (#3912), which landed on main while this PR was open. Purely additive; matches every other closure golden.
- Remaining `[emit+concrete]` allowlist sites (type-shrinking cluster, rewrite-helpers, schema-factory, type-inference) are tracked for a follow-up migration to the chokepoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes all synthesized type annotations to the canonical `__cfHelpers.X` form and routes every emit-reaching type→TypeNode conversion through a single chokepoint. Preserves inner `$ref` in capability re‑wraps, tightens schema hints, and fixes a nested‑cell existence check in Home.

- **Bug Fixes**
  - Route all emit-reaching conversions through `typeToTypeNodeWithRegistry` and normalize CF refs: `lift-applied`, `lift-applied-strategy`, `array-method-transform`, expression-rewrite helpers, schema-factory, and `type-shrinking` emit paths (three raw calls remain allowlisted and non‑emitting).
  - Harden the normalizer: handle explicit callback return annotations; auto-register rewritten nodes; require unique union/intersection member pairing by export name; preserve user-defined aliases (don’t collapse non‑`commonfabric` `aliasSymbol`s).
  - Schema generation: when a capability re‑wrap narrows a cell brand (e.g. `Cell<T>` → `ReadonlyCell<T>`), keep the inner `$ref`/`$defs`; if the node’s inner degrades to `any`, fall back to the resolved type’s inner. Improves annotations (e.g. `asCell: ["readonly"]`, Streams recognized).
  - Guards: invariant banning `import("commonfabric")` in all goldens; static sweep that pins raw `checker.typeToTypeNode` sites to a reviewed allowlist; add JSX normalization and nested‑cell behavior‑lock fixtures.
  - `packages/patterns/system/home.tsx`: read profile existence one level deeper (`profile.get()?.get()`), restoring the create UI when no profile exists.

- **Refactors**
  - Derive cell capability kinds exhaustively from `CellWrapperKind` in `@commonfabric/schema-generator`; no behavior change.
  - Promote `qualifyCommonFabricTypeRefs`/`typeToTypeNodeWithRegistry` via `ast/mod.ts`; README shows a real `--show-transformed` example and the `--no-run` flag.
  - Refresh two closure goldens to include the trailing `__cfReg` hoist registration for consistency.

<sup>Written for commit 42ee029780313f9955797e75dccb7e6b5308f00c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
