### PR TITLE
[codex] Persist chat replay requests through store

### DIFF
--- a/packages/cf-harness/src/interactive-chat-service.ts
+++ b/packages/cf-harness/src/interactive-chat-service.ts
@@ -60,6 +60,7 @@ export interface CreateHarnessInteractiveChatServiceOptions {
   randomUUID?: () => string;
   onEvent?: HarnessInteractiveChatEventListener;
   sessionStore?: HarnessChatSessionStore;
+  maxInMemoryEvents?: number;
 }
 
 interface HarnessInteractiveChatSessionRecord {
@@ -293,6 +294,7 @@ export class HarnessInteractiveChatService {
   readonly #randomUUID: () => string;
   readonly #onEvent?: HarnessInteractiveChatEventListener;
   readonly #sessionStore?: HarnessChatSessionStore;
+  readonly #maxInMemoryEvents?: number;
   readonly #sessions = new Map<string, HarnessInteractiveChatSessionRecord>();
   readonly #events: HarnessChatEventEnvelope[] = [];
   #emitQueue: Promise<void> = Promise.resolve();
@@ -306,6 +308,14 @@ export class HarnessInteractiveChatService {
     this.#randomUUID = options.randomUUID ?? defaultRandomUUID;
     this.#onEvent = options.onEvent;
     this.#sessionStore = options.sessionStore;
+    if (
+      options.maxInMemoryEvents !== undefined &&
+      (!Number.isInteger(options.maxInMemoryEvents) ||
+        options.maxInMemoryEvents < 0)
+    ) {
+      throw new Error("maxInMemoryEvents must be a non-negative integer");
+    }
+    this.#maxInMemoryEvents = options.maxInMemoryEvents;
   }
 
   async initializeFromStore(): Promise<void> {
@@ -336,6 +346,7 @@ export class HarnessInteractiveChatService {
       this.#events.length,
       ...await this.#sessionStore.listEvents(),
     );
+    this.#pruneInMemoryEvents();
     this.#sequence = Math.max(
       await this.#sessionStore.latestSequence(),
       ...this.#events.map((event) => event.sequence),
@@ -369,6 +380,19 @@ export class HarnessInteractiveChatService {
     };
   }
 
+  async listEventsForReplay(
+    params: HarnessChatListEventsParams = {},
+  ): Promise<HarnessChatListEventsResult> {
+    if (this.#sessionStore === undefined) {
+      return this.listEvents(params);
+    }
+    const [events, latestSequence] = await Promise.all([
+      this.#sessionStore.listEvents(params),
+      this.#sessionStore.latestSequence(),
+    ]);
+    return { events, latestSequence };
+  }
+
   turns(
     sessionId?: string,
     options: Omit<HarnessChatListTurnsParams, "sessionId"> = {},
@@ -390,6 +414,17 @@ export class HarnessInteractiveChatService {
   ): HarnessChatListTurnsResult {
     return {
       turns: this.turns(params.sessionId, { status: params.status }),
+    };
+  }
+
+  async listTurnsForReplay(
+    params: HarnessChatListTurnsParams = {},
+  ): Promise<HarnessChatListTurnsResult> {
+    if (this.#sessionStore === undefined) {
+      return this.listTurns(params);
+    }
+    return {
+      turns: await this.#sessionStore.listTurns(params),
     };
   }
 
@@ -528,12 +563,12 @@ export class HarnessInteractiveChatService {
       case "list_events":
         return createHarnessChatOkResponse(
           request.requestId,
-          this.listEvents(request.params),
+          await this.listEventsForReplay(request.params),
         );
       case "list_turns":
         return createHarnessChatOkResponse(
           request.requestId,
-          this.listTurns(request.params),
+          await this.listTurnsForReplay(request.params),
         );
       default:
         return createHarnessChatErrorResponse(requestId, {
@@ -1073,6 +1108,7 @@ export class HarnessInteractiveChatService {
     }
     this.#sequence = sequence;
     this.#events.push(envelope);
+    this.#pruneInMemoryEvents();
     if (record !== undefined && nextStatus !== undefined) {
       record.status = nextStatus;
     }
@@ -1080,6 +1116,16 @@ export class HarnessInteractiveChatService {
       record.turns.set(nextTurn.turn.turnId, nextTurn);
     }
     await this.#onEvent?.(envelope);
+  }
+
+  #pruneInMemoryEvents(): void {
+    if (
+      this.#maxInMemoryEvents === undefined ||
+      this.#events.length <= this.#maxInMemoryEvents
+    ) {
+      return;
+    }
+    this.#events.splice(0, this.#events.length - this.#maxInMemoryEvents);
   }
 }
 

--- a/packages/cf-harness/test/interactive-chat-service.test.ts
+++ b/packages/cf-harness/test/interactive-chat-service.test.ts
@@ -1,9 +1,14 @@
 import { assertEquals, assertRejects } from "@std/assert";
 import {
+  createHarnessChatEventEnvelope,
+  createHarnessChatSessionStatus,
   HARNESS_CHAT_PROTOCOL_VERSION,
   HARNESS_CHAT_REQUEST_TYPE,
   type HarnessChatBrowserAccessLease,
+  type HarnessChatListEventsResult,
+  type HarnessChatListTurnsResult,
   type HarnessChatRequestEnvelope,
+  type HarnessChatTurnRecord,
 } from "../src/contracts/interactive-chat.ts";
 import {
   HarnessInteractiveChatService,
@@ -845,6 +850,109 @@ Deno.test("interactive service reserves turn start before durable duplicate chec
   const firstResult = await first;
   assertEquals(firstResult.ok, true);
   await service.waitForTurn("session-1", "turn-1");
+});
+
+Deno.test("interactive service handles replay requests from durable store", async () => {
+  const session = createHarnessChatSessionStatus({
+    sessionId: "durable-session",
+    createdAt: "2026-05-22T00:00:00.000Z",
+    workspace: { hostPath: "/workspace" },
+  });
+  const durableEvent = createHarnessChatEventEnvelope({
+    sessionId: session.sessionId,
+    sequence: 42,
+    emittedAt: "2026-05-22T00:00:42.000Z",
+    event: {
+      kind: "session_started",
+      session,
+    },
+  });
+  const durableTurn: HarnessChatTurnRecord = {
+    sessionId: session.sessionId,
+    turn: {
+      turnId: "durable-turn",
+      status: "completed",
+      startedAt: "2026-05-22T00:00:01.000Z",
+      updatedAt: "2026-05-22T00:00:02.000Z",
+      endedAt: "2026-05-22T00:00:02.000Z",
+    },
+    input: { text: "Persisted turn" },
+    policy: session.policy,
+  };
+  let eventsOptions: unknown;
+  let turnsOptions: unknown;
+  const store: HarnessChatSessionStore = {
+    saveSession: () => {},
+    getSession: () => undefined,
+    listSessions: () => [],
+    saveSessionAndAppendEvent: () => {},
+    saveSessionTurnAndAppendEvent: () => true,
+    appendEvent: () => {},
+    listEvents: (options) => {
+      eventsOptions = options;
+      return [durableEvent];
+    },
+    latestSequence: () => 77,
+    saveTurn: () => {},
+    getTurn: () => undefined,
+    listTurns: (options) => {
+      turnsOptions = options;
+      return [durableTurn];
+    },
+  };
+  const service = new HarnessInteractiveChatService({
+    createPromptLoop: () => ({
+      runTranscript: (options) => Promise.resolve(makeResult(options, "Done.")),
+    }),
+    sessionStore: store,
+  });
+
+  const events = await service.handleRequest({
+    type: HARNESS_CHAT_REQUEST_TYPE,
+    protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+    requestId: "req-events",
+    method: "list_events",
+    params: {
+      sessionId: session.sessionId,
+      afterSequence: 41,
+      limit: 1,
+    },
+  });
+  assertEquals(events.ok, true);
+  assertEquals(
+    events.ok ? (events.result as HarnessChatListEventsResult) : undefined,
+    {
+      events: [durableEvent],
+      latestSequence: 77,
+    },
+  );
+  assertEquals(eventsOptions, {
+    sessionId: session.sessionId,
+    afterSequence: 41,
+    limit: 1,
+  });
+
+  const turns = await service.handleRequest({
+    type: HARNESS_CHAT_REQUEST_TYPE,
+    protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+    requestId: "req-turns",
+    method: "list_turns",
+    params: {
+      sessionId: session.sessionId,
+      status: "completed",
+    },
+  });
+  assertEquals(turns.ok, true);
+  assertEquals(
+    turns.ok ? (turns.result as HarnessChatListTurnsResult) : undefined,
+    {
+      turns: [durableTurn],
+    },
+  );
+  assertEquals(turnsOptions, {
+    sessionId: session.sessionId,
+    status: "completed",
+  });
 });
 
 Deno.test("interactive service rejects missing sessions and concurrent turns", async () => {

--- a/packages/cf-harness/test/sqlite-session-store.test.ts
+++ b/packages/cf-harness/test/sqlite-session-store.test.ts
@@ -3,6 +3,9 @@ import { toFileUrl } from "@std/path";
 import {
   createHarnessChatEventEnvelope,
   createHarnessChatSessionStatus,
+  HARNESS_CHAT_PROTOCOL_VERSION,
+  HARNESS_CHAT_REQUEST_TYPE,
+  type HarnessChatListEventsResult,
 } from "../src/contracts/interactive-chat.ts";
 import {
   HarnessInteractiveChatService,
@@ -171,6 +174,77 @@ Deno.test("sqlite session store persists chat sessions and replayable events", a
     assertEquals(
       duplicate.ok === false ? duplicate.error.code : "",
       "session_exists",
+    );
+  } finally {
+    store.close();
+    await Deno.remove(path);
+  }
+});
+
+Deno.test("sqlite session replay survives bounded in-memory event retention", async () => {
+  const path = await Deno.makeTempFile({ suffix: ".sqlite" });
+  const store = await openSqliteHarnessChatSessionStore({
+    url: toFileUrl(path),
+  });
+  const createPromptLoop: HarnessInteractivePromptLoopFactory = () => ({
+    runTranscript: async (options) => {
+      const result = makeResult(options, "Pruned from memory.");
+      await options.onTranscriptEvent?.({
+        message: result.transcript[result.transcript.length - 1],
+        transcript: result.transcript,
+      });
+      return result;
+    },
+  });
+
+  try {
+    const service = new HarnessInteractiveChatService({
+      createPromptLoop,
+      now: nextIsoNow(),
+      sessionStore: store,
+      maxInMemoryEvents: 2,
+    });
+
+    await service.startSession("req-1", {
+      sessionId: "session-pruned",
+      workspace: { hostPath: "/workspace" },
+    });
+    await service.startTurn("req-2", {
+      sessionId: "session-pruned",
+      turnId: "turn-1",
+      input: { text: "Generate enough events to prune" },
+    });
+    await service.waitForTurn("session-pruned", "turn-1");
+
+    assertEquals(
+      service.events("session-pruned").map((event) => event.event.kind),
+      ["assistant_completed", "turn_completed"],
+    );
+
+    const replay = await service.handleRequest({
+      type: HARNESS_CHAT_REQUEST_TYPE,
+      protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+      requestId: "req-replay",
+      method: "list_events",
+      params: {
+        sessionId: "session-pruned",
+        afterSequence: 0,
+      },
+    });
+    assertEquals(replay.ok, true);
+    const result = replay.ok
+      ? replay.result as HarnessChatListEventsResult
+      : undefined;
+    assertEquals(result?.latestSequence, 5);
+    assertEquals(
+      result?.events.map((event) => event.event.kind),
+      [
+        "session_started",
+        "turn_started",
+        "assistant_delta",
+        "assistant_completed",
+        "turn_completed",
+      ],
     );
   } finally {
     store.close();


### PR DESCRIPTION
## Summary

This PR tightens cf-harness interactive chat replay behavior now that sessions, turns, and events are persisted in SQLite.

- Route protocol `list_events` requests through the configured durable session store when one exists, including durable `latestSequence` lookup.
- Route protocol `list_turns` requests through the configured durable session store when one exists.
- Keep existing synchronous `service.listEvents()` / `service.listTurns()` helpers unchanged for in-process callers.
- Add opt-in `maxInMemoryEvents` support so embedders can bound the service hot event cache without weakening durable protocol replay.
- Add focused coverage for store-backed replay and SQLite replay after in-memory pruning.

## Why

For a chat-server-like cf-harness runtime, reconnect/replay should not depend on an unbounded in-memory event array. This keeps the protocol replay path durable-store-backed while preserving current default behavior and API compatibility.

## Validation

- `deno fmt packages/cf-harness/src/interactive-chat-service.ts packages/cf-harness/test/interactive-chat-service.test.ts packages/cf-harness/test/sqlite-session-store.test.ts`
- `deno check packages/cf-harness/src/interactive-chat-service.ts packages/cf-harness/test/interactive-chat-service.test.ts packages/cf-harness/test/sqlite-session-store.test.ts`
- `deno test --allow-all packages/cf-harness/test/interactive-chat-service.test.ts packages/cf-harness/test/sqlite-session-store.test.ts packages/cf-harness/test/interactive-chat-stdio.test.ts` (`43 passed`)
- `deno fmt --check packages/cf-harness/src/interactive-chat-service.ts packages/cf-harness/test/interactive-chat-service.test.ts packages/cf-harness/test/sqlite-session-store.test.ts`
- `deno lint packages/cf-harness/src/interactive-chat-service.ts packages/cf-harness/test/interactive-chat-service.test.ts packages/cf-harness/test/sqlite-session-store.test.ts`
- `git diff --check`
- `git diff --cached --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make chat replay durable in `cf-harness` by routing protocol replay requests through the session store, so reconnect no longer depends on in-memory events. Adds an optional cap for in-memory events without changing APIs.

- **New Features**
  - Route protocol `list_events`/`list_turns` through the configured session store and use durable `latestSequence`.
  - Keep in-process `service.listEvents()`/`service.listTurns()` behavior unchanged.
  - Add optional `maxInMemoryEvents` to cap the hot event cache; prune memory while replay remains store-backed. Includes focused tests, including SQLite after pruning.

<sup>Written for commit b9905067934f9c82462922d857234042822a8261. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

