### PR TITLE
Move the two `*ReconstructionContext` classes into `wire-common`.

### DIFF
--- a/packages/data-model/deno.json
+++ b/packages/data-model/deno.json
@@ -24,10 +24,8 @@
     ]
   },
   "exports": {
-    "./BaseReconstructionContext": "./src/BaseReconstructionContext.ts",
     "./cell-rep": "./src/cell-rep.ts",
     "./deep-freeze": "./src/deep-freeze.ts",
-    "./EmptyReconstructionContext": "./src/EmptyReconstructionContext.ts",
     "./fabric-instances": "./src/fabric-instances/index.ts",
     "./fabric-primitives": "./src/fabric-primitives/index.ts",
     "./fabric-value": "./src/fabric-value.ts",
@@ -38,6 +36,7 @@
     "./native-type-tags": "./src/native-type-tags.ts",
     "./schema-hash": "./src/schema-hash.ts",
     "./schema-utils": "./src/schema-utils.ts",
+    "./SchemaAndHash": "./src/SchemaAndHash.ts",
     "./value-debug": "./src/value-debug.ts",
     "./value-hash": "./src/value-hash.ts",
     "./wire-common": "./src/wire-common/index.ts"

--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -7,7 +7,7 @@ import {
 import { deepFreeze, isDeepFrozen } from "../deep-freeze.ts";
 import { WIRE_TYPE_TAGS } from "../wire-common/wire-type-tags.ts";
 import { FrozenSet } from "../frozen-builtins.ts";
-import { EmptyReconstructionContext } from "../EmptyReconstructionContext.ts";
+import { EmptyReconstructionContext } from "../wire-common/EmptyReconstructionContext.ts";
 import { FabricNativeWrapper } from "./FabricNativeWrapper.ts";
 import { errorClassFromType, UNSAFE_KEYS } from "../native-conversion.ts";
 

--- a/packages/data-model/src/json-wire/json-encoding.ts
+++ b/packages/data-model/src/json-wire/json-encoding.ts
@@ -1,7 +1,7 @@
 import { isInstance } from "@commonfabric/utils/types";
 import type { FabricValue } from "../fabric-value.ts";
 import type { ReconstructionContext } from "../wire-common/interface.ts";
-import { EmptyReconstructionContext } from "../EmptyReconstructionContext.ts";
+import { EmptyReconstructionContext } from "../wire-common/EmptyReconstructionContext.ts";
 import { JsonEncodingContext } from "./JsonEncodingContext.ts";
 
 /** Shared JSON encoding context. */

--- a/packages/data-model/src/wire-common/BaseReconstructionContext.ts
+++ b/packages/data-model/src/wire-common/BaseReconstructionContext.ts
@@ -4,8 +4,8 @@
  * via a single shared implementation instead of repeating it.
  */
 
-import type { FabricInstance } from "./interface.ts";
-import type { ReconstructionContext } from "./wire-common/interface.ts";
+import type { FabricInstance } from "../interface.ts";
+import type { ReconstructionContext } from "./interface.ts";
 
 /**
  * Abstract base that supplies the `shouldDeepFreeze` getter from a

--- a/packages/data-model/src/wire-common/EmptyReconstructionContext.ts
+++ b/packages/data-model/src/wire-common/EmptyReconstructionContext.ts
@@ -5,8 +5,8 @@
  * structurally flat).
  */
 
-import type { FabricInstance } from "./interface.ts";
-import type { ReconstructionContext } from "./wire-common/interface.ts";
+import type { FabricInstance } from "../interface.ts";
+import type { ReconstructionContext } from "./interface.ts";
 import { BaseReconstructionContext } from "./BaseReconstructionContext.ts";
 
 /**

--- a/packages/data-model/src/wire-common/index.ts
+++ b/packages/data-model/src/wire-common/index.ts
@@ -10,3 +10,8 @@ export {
 
 export { WIRE_META_TAGS } from "./wire-meta-tags.ts";
 export { WIRE_TYPE_TAGS } from "./wire-type-tags.ts";
+export { BaseReconstructionContext } from "./BaseReconstructionContext.ts";
+export {
+  EMPTY_RECONSTRUCTION_CONTEXT,
+  EmptyReconstructionContext,
+} from "./EmptyReconstructionContext.ts";

--- a/packages/data-model/test/EmptyReconstructionContext.test.ts
+++ b/packages/data-model/test/EmptyReconstructionContext.test.ts
@@ -3,12 +3,12 @@ import { expect } from "@std/expect";
 import {
   EMPTY_RECONSTRUCTION_CONTEXT,
   EmptyReconstructionContext,
-} from "../src/EmptyReconstructionContext.ts";
+} from "../src/wire-common/EmptyReconstructionContext.ts";
 
 describe("EmptyReconstructionContext", () => {
   describe("EMPTY_RECONSTRUCTION_CONTEXT", () => {
     it("is a singleton (re-import yields the same instance)", async () => {
-      const reimported = (await import("../src/EmptyReconstructionContext.ts"))
+      const reimported = (await import("../src/wire-common/EmptyReconstructionContext.ts"))
         .EMPTY_RECONSTRUCTION_CONTEXT;
       expect(reimported).toBe(EMPTY_RECONSTRUCTION_CONTEXT);
     });

--- a/packages/data-model/test/EmptyReconstructionContext.test.ts
+++ b/packages/data-model/test/EmptyReconstructionContext.test.ts
@@ -8,8 +8,9 @@ import {
 describe("EmptyReconstructionContext", () => {
   describe("EMPTY_RECONSTRUCTION_CONTEXT", () => {
     it("is a singleton (re-import yields the same instance)", async () => {
-      const reimported = (await import("../src/wire-common/EmptyReconstructionContext.ts"))
-        .EMPTY_RECONSTRUCTION_CONTEXT;
+      const reimported =
+        (await import("../src/wire-common/EmptyReconstructionContext.ts"))
+          .EMPTY_RECONSTRUCTION_CONTEXT;
       expect(reimported).toBe(EMPTY_RECONSTRUCTION_CONTEXT);
     });
 

--- a/packages/data-model/test/fabric-instances/fixtures.ts
+++ b/packages/data-model/test/fabric-instances/fixtures.ts
@@ -1,4 +1,4 @@
-import { BaseReconstructionContext } from "../../src/BaseReconstructionContext.ts";
+import { BaseReconstructionContext } from "../../src/wire-common/BaseReconstructionContext.ts";
 import type { FabricValue } from "../../src/interface.ts";
 import { deepFreeze, isDeepFrozen } from "../../src/deep-freeze.ts";
 

--- a/packages/data-model/test/json-wire/JsonEncodingContext.test.ts
+++ b/packages/data-model/test/json-wire/JsonEncodingContext.test.ts
@@ -9,7 +9,7 @@ import { FabricEpochDays } from "../../src/fabric-primitives/FabricEpochDays.ts"
 import { FabricEpochNsec } from "../../src/fabric-primitives/FabricEpochNsec.ts";
 import { FabricError } from "../../src/fabric-instances/FabricError.ts";
 import { isDeepFrozen } from "../../src/deep-freeze.ts";
-import { BaseReconstructionContext } from "../../src/BaseReconstructionContext.ts";
+import { BaseReconstructionContext } from "../../src/wire-common/BaseReconstructionContext.ts";
 import { shallowFabricFromNativeValue } from "../../src/fabric-value.ts";
 
 /**

--- a/packages/data-model/test/json-wire/json-encoding.test.ts
+++ b/packages/data-model/test/json-wire/json-encoding.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../../src/json-wire/json-encoding.ts";
 import { FabricError } from "../../src/fabric-instances/FabricError.ts";
 import type { FabricValue } from "../../src/fabric-value.ts";
-import { BaseReconstructionContext } from "../../src/BaseReconstructionContext.ts";
+import { BaseReconstructionContext } from "../../src/wire-common/BaseReconstructionContext.ts";
 
 /** Mock runtime for deserialization calls. */
 class MockRuntime extends BaseReconstructionContext {

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -5,7 +5,7 @@ import {
 } from "@commonfabric/data-model/json-wire";
 import { internPathSelector } from "@commonfabric/data-model/schema-utils";
 import type { FabricValue, SchemaPathSelector } from "./interface.ts";
-import { EmptyReconstructionContext } from "@commonfabric/data-model/EmptyReconstructionContext";
+import { EmptyReconstructionContext } from "@commonfabric/data-model/wire-common";
 import { isObject, isRecord } from "@commonfabric/utils/types";
 
 export const MEMORY_PROTOCOL = "memory" as const;

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -18,7 +18,7 @@ import {
   resetPersistentSchedulerStateConfig,
   setPersistentSchedulerStateConfig,
 } from "@commonfabric/memory/v2";
-import { EmptyReconstructionContext } from "@commonfabric/data-model/EmptyReconstructionContext";
+import { EmptyReconstructionContext } from "@commonfabric/data-model/wire-common";
 import type {
   ClientCommit,
   ConfirmedRead,

--- a/packages/toolshed/routes/blobs/blobs.index.ts
+++ b/packages/toolshed/routes/blobs/blobs.index.ts
@@ -8,7 +8,7 @@ import { isDID } from "@commonfabric/identity";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import { JsonEncodingContext } from "@commonfabric/data-model/json-wire";
-import { EmptyReconstructionContext } from "@commonfabric/data-model/EmptyReconstructionContext";
+import { EmptyReconstructionContext } from "@commonfabric/data-model/wire-common";
 import {
   decodeMemoryBoundary,
   encodeMemoryBoundary,

--- a/skills/cf-review/check-facts.ts
+++ b/skills/cf-review/check-facts.ts
@@ -76,7 +76,7 @@ export async function collectErrors(): Promise<string[]> {
   }
 
   // Every `@commonfabric/...` specifier the skill names must resolve. Subpath
-  // segments allow PascalCase / dots (e.g. data-model/BaseReconstructionContext).
+  // segments allow PascalCase / dots (e.g. data-model/SchemaAndHash).
   const specifiers = new Set(
     skill.match(/@commonfabric\/[a-z0-9-]+(?:\/[\w.-]+)*/g) ?? [],
   );


### PR DESCRIPTION
As it says on the tin. This PR moves two classes that were missed in the last PR, getting them to live next to where their corresponding interface is defined.

## Performance Baseline

This PR just moves a couple files, no behavior change, so the following accounts for a spurious perf check failure:

NEW_PERF_BASELINE: job: Pattern Integration Tests (1/4) = 161s


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved `BaseReconstructionContext` and `EmptyReconstructionContext` into `wire-common` next to the `ReconstructionContext` interface, added re-exports in `wire-common/index`, and updated imports across the repo. Also cleaned up `deno.json` subpath exports and added `./SchemaAndHash`. No behavior changes; one follow-up commit is formatting-only.

- **Migration**
  - Replace imports from `@commonfabric/data-model/EmptyReconstructionContext` and `@commonfabric/data-model/BaseReconstructionContext` with `@commonfabric/data-model/wire-common`.

<sup>Written for commit 492557ab0910217b1713444de3109c5d5545543b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

