### PR TITLE
[codex] Expose chat event retention config

### DIFF
--- a/packages/cf-harness/README.md
+++ b/packages/cf-harness/README.md
@@ -181,7 +181,10 @@ deno run -A src/interactive-chat-stdio.ts \
 The stdio transport reads one interactive chat request envelope per line from
 stdin and writes response/event envelopes as newline-delimited JSON. Pass
 `--chat-session-db` or set `CF_HARNESS_CHAT_SESSION_DB` to persist sessions,
-turn records, and replayable events across process restarts.
+turn records, and replayable events across process restarts. Pass
+`--chat-max-in-memory-events` or set `CF_HARNESS_CHAT_MAX_IN_MEMORY_EVENTS` to
+bound the transport's in-memory event cache while keeping durable replay
+available through SQLite.
 
 Initial prompt image attachments:
 

--- a/packages/cf-harness/src/interactive-chat-stdio.ts
+++ b/packages/cf-harness/src/interactive-chat-stdio.ts
@@ -46,6 +46,7 @@ export interface RunHarnessInteractiveChatStdioOptions {
   input?: ReadableStream<Uint8Array>;
   output?: WritableStream<Uint8Array>;
   sessionDbPath?: string;
+  maxInMemoryEvents?: number;
   createPromptLoop?: HarnessInteractivePromptLoopFactory;
   createService?: (
     onEvent: (event: HarnessChatEventEnvelope) => void | Promise<void>,
@@ -54,10 +55,12 @@ export interface RunHarnessInteractiveChatStdioOptions {
 
 export interface HarnessInteractiveChatStdioCliOptions {
   sessionDbPath?: string;
+  maxInMemoryEvents?: number;
   help: boolean;
 }
 
 const CHAT_SESSION_DB_ENV = "CF_HARNESS_CHAT_SESSION_DB";
+const CHAT_MAX_IN_MEMORY_EVENTS_ENV = "CF_HARNESS_CHAT_MAX_IN_MEMORY_EVENTS";
 
 const invalidRequestResponse = (
   message: string,
@@ -71,11 +74,13 @@ const invalidRequestResponse = (
 const usageText = `Usage: deno run -A src/interactive-chat-stdio.ts [options]
 
 Options:
-  --chat-session-db <path>  Persist chat sessions, turns, and events in SQLite
-  --help                   Print this help text to stderr
+  --chat-session-db <path>             Persist chat sessions, turns, and events in SQLite
+  --chat-max-in-memory-events <count>  Retain at most count events in memory
+  --help                              Print this help text to stderr
 
 Environment:
-  ${CHAT_SESSION_DB_ENV}    Default SQLite chat session DB path
+  ${CHAT_SESSION_DB_ENV}                 Default SQLite chat session DB path
+  ${CHAT_MAX_IN_MEMORY_EVENTS_ENV}       Default in-memory event retention cap
 `;
 
 const nonEmptyOptionValue = (
@@ -88,11 +93,29 @@ const nonEmptyOptionValue = (
   return value;
 };
 
+const parseNonNegativeIntegerOption = (
+  name: string,
+  value: string | undefined,
+): number => {
+  const rawValue = nonEmptyOptionValue(name, value).trim();
+  if (!/^\d+$/.test(rawValue)) {
+    throw new Error(`${name} requires a non-negative integer value`);
+  }
+  return Number(rawValue);
+};
+
 export const parseHarnessInteractiveChatStdioCliOptions = (
   args: readonly string[],
   env: Record<string, string | undefined> = Deno.env.toObject(),
 ): HarnessInteractiveChatStdioCliOptions => {
   let sessionDbPath = env[CHAT_SESSION_DB_ENV];
+  let maxInMemoryEvents = env[CHAT_MAX_IN_MEMORY_EVENTS_ENV] === undefined ||
+      env[CHAT_MAX_IN_MEMORY_EVENTS_ENV]?.trim() === ""
+    ? undefined
+    : parseNonNegativeIntegerOption(
+      CHAT_MAX_IN_MEMORY_EVENTS_ENV,
+      env[CHAT_MAX_IN_MEMORY_EVENTS_ENV],
+    );
   let help = false;
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index];
@@ -112,12 +135,25 @@ export const parseHarnessInteractiveChatStdioCliOptions = (
       );
       continue;
     }
+    if (arg === "--chat-max-in-memory-events") {
+      index += 1;
+      maxInMemoryEvents = parseNonNegativeIntegerOption(arg, args[index]);
+      continue;
+    }
+    if (arg.startsWith("--chat-max-in-memory-events=")) {
+      maxInMemoryEvents = parseNonNegativeIntegerOption(
+        "--chat-max-in-memory-events",
+        arg.slice("--chat-max-in-memory-events=".length),
+      );
+      continue;
+    }
     throw new Error(`unsupported interactive chat stdio argument: ${arg}`);
   }
   return {
     ...(sessionDbPath !== undefined && sessionDbPath.trim() !== ""
       ? { sessionDbPath }
       : {}),
+    ...(maxInMemoryEvents !== undefined ? { maxInMemoryEvents } : {}),
     help,
   };
 };
@@ -488,6 +524,9 @@ export const runHarnessInteractiveChatStdio = async (
             ? { createPromptLoop: options.createPromptLoop }
             : {}),
           ...(sessionStore !== undefined ? { sessionStore } : {}),
+          ...(options.maxInMemoryEvents !== undefined
+            ? { maxInMemoryEvents: options.maxInMemoryEvents }
+            : {}),
         });
         await service.initializeFromStore();
         return service;

--- a/packages/cf-harness/src/interactive-chat-stdio.ts
+++ b/packages/cf-harness/src/interactive-chat-stdio.ts
@@ -101,7 +101,11 @@ const parseNonNegativeIntegerOption = (
   if (!/^\d+$/.test(rawValue)) {
     throw new Error(`${name} requires a non-negative integer value`);
   }
-  return Number(rawValue);
+  const parsed = Number(rawValue);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new Error(`${name} requires a safe non-negative integer value`);
+  }
+  return parsed;
 };
 
 export const parseHarnessInteractiveChatStdioCliOptions = (

--- a/packages/cf-harness/test/interactive-chat-stdio.test.ts
+++ b/packages/cf-harness/test/interactive-chat-stdio.test.ts
@@ -758,6 +758,14 @@ Deno.test("interactive stdio CLI parses runtime options", () => {
   assertThrows(
     () =>
       parseHarnessInteractiveChatStdioCliOptions([
+        "--chat-max-in-memory-events=9007199254740992",
+      ], {}),
+    Error,
+    "--chat-max-in-memory-events requires a safe non-negative integer value",
+  );
+  assertThrows(
+    () =>
+      parseHarnessInteractiveChatStdioCliOptions([
         "--chat-max-in-memory-events",
       ], {}),
     Error,

--- a/packages/cf-harness/test/interactive-chat-stdio.test.ts
+++ b/packages/cf-harness/test/interactive-chat-stdio.test.ts
@@ -1,4 +1,9 @@
-import { assertEquals, assertRejects, assertStringIncludes } from "@std/assert";
+import {
+  assertEquals,
+  assertRejects,
+  assertStringIncludes,
+  assertThrows,
+} from "@std/assert";
 import { fromFileUrl, join } from "@std/path";
 import {
   HARNESS_CHAT_PROTOCOL_VERSION,
@@ -608,6 +613,54 @@ Deno.test("interactive stdio CLI persists sessions across process invocations", 
   }
 });
 
+Deno.test("interactive stdio bounds in-memory event replay when configured", async () => {
+  const output = captureOutputLines();
+  await runHarnessInteractiveChatStdio({
+    maxInMemoryEvents: 0,
+    input: encodeInputLines([
+      JSON.stringify({
+        type: HARNESS_CHAT_REQUEST_TYPE,
+        protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+        requestId: "req-start",
+        method: "start_session",
+        params: {
+          sessionId: "session-pruned",
+          workspace: { hostPath: "/workspace" },
+        },
+      }),
+      JSON.stringify({
+        type: HARNESS_CHAT_REQUEST_TYPE,
+        protocolVersion: HARNESS_CHAT_PROTOCOL_VERSION,
+        requestId: "req-events",
+        method: "list_events",
+        params: {
+          sessionId: "session-pruned",
+          afterSequence: 0,
+        },
+      }),
+    ]),
+    output: output.output,
+  });
+
+  const envelopes = decodeLines(output.lines());
+  assertEquals(
+    envelopes.filter((envelope) => "event" in envelope).map((envelope) =>
+      "event" in envelope ? envelope.event.kind : undefined
+    ),
+    ["session_started"],
+  );
+  const response = envelopes.find((envelope) =>
+    "ok" in envelope && envelope.requestId === "req-events"
+  );
+  const result = response !== undefined && "ok" in response && response.ok
+    ? response.result as HarnessChatListEventsResult
+    : undefined;
+  assertEquals(result, {
+    events: [],
+    latestSequence: 1,
+  });
+});
+
 Deno.test({
   name:
     "interactive stdio CLI reports invalid SQLite session DB startup failures",
@@ -632,7 +685,7 @@ Deno.test({
   },
 });
 
-Deno.test("interactive stdio CLI parses SQLite session DB options", () => {
+Deno.test("interactive stdio CLI parses runtime options", () => {
   assertEquals(
     parseHarnessInteractiveChatStdioCliOptions([], {
       CF_HARNESS_CHAT_SESSION_DB: "/tmp/chat.sqlite",
@@ -655,14 +708,60 @@ Deno.test("interactive stdio CLI parses SQLite session DB options", () => {
     },
   );
   assertEquals(
+    parseHarnessInteractiveChatStdioCliOptions([], {
+      CF_HARNESS_CHAT_MAX_IN_MEMORY_EVENTS: "3",
+    }),
+    {
+      maxInMemoryEvents: 3,
+      help: false,
+    },
+  );
+  assertEquals(
+    parseHarnessInteractiveChatStdioCliOptions([
+      "--chat-max-in-memory-events",
+      "0",
+    ], {}),
+    {
+      maxInMemoryEvents: 0,
+      help: false,
+    },
+  );
+  assertEquals(
     parseHarnessInteractiveChatStdioCliOptions([
       "--chat-session-db=/tmp/inline.sqlite",
+      "--chat-max-in-memory-events=2",
       "--help",
     ], {}),
     {
       sessionDbPath: "/tmp/inline.sqlite",
+      maxInMemoryEvents: 2,
       help: true,
     },
+  );
+  assertThrows(
+    () =>
+      parseHarnessInteractiveChatStdioCliOptions([
+        "--chat-max-in-memory-events",
+        "-1",
+      ], {}),
+    Error,
+    "--chat-max-in-memory-events requires a non-negative integer value",
+  );
+  assertThrows(
+    () =>
+      parseHarnessInteractiveChatStdioCliOptions([
+        "--chat-max-in-memory-events=1.5",
+      ], {}),
+    Error,
+    "--chat-max-in-memory-events requires a non-negative integer value",
+  );
+  assertThrows(
+    () =>
+      parseHarnessInteractiveChatStdioCliOptions([
+        "--chat-max-in-memory-events",
+      ], {}),
+    Error,
+    "--chat-max-in-memory-events requires a non-empty value",
   );
 });
 


### PR DESCRIPTION
## Summary

Stacked on #3889.

This PR exposes the cf-harness interactive chat in-memory event retention cap through the stdio runtime.

- Add `--chat-max-in-memory-events <count>` / `--chat-max-in-memory-events=<count>` CLI support.
- Add `CF_HARNESS_CHAT_MAX_IN_MEMORY_EVENTS` env support.
- Validate the cap as a non-negative integer and reject missing, negative, fractional, or non-numeric values.
- Pass the configured cap through to `createHarnessInteractiveChatService`.
- Document the new option in the cf-harness README next to `--chat-session-db`.
- Add stdio tests for parsing and observable retention behavior.

## Why

#3889 makes durable replay independent from the service hot event cache. This follow-up makes the retention cap configurable for stdio/server-style use without changing the default unbounded behavior.

## Validation

- `deno fmt packages/cf-harness/README.md packages/cf-harness/src/interactive-chat-stdio.ts packages/cf-harness/test/interactive-chat-stdio.test.ts`
- `deno check packages/cf-harness/src/interactive-chat-stdio.ts packages/cf-harness/test/interactive-chat-stdio.test.ts`
- `deno test --allow-all packages/cf-harness/test/interactive-chat-stdio.test.ts packages/cf-harness/test/sqlite-session-store.test.ts packages/cf-harness/test/interactive-chat-service.test.ts` (`44 passed`)
- `deno fmt --check packages/cf-harness/README.md packages/cf-harness/src/interactive-chat-stdio.ts packages/cf-harness/test/interactive-chat-stdio.test.ts`
- `deno lint packages/cf-harness/src/interactive-chat-stdio.ts packages/cf-harness/test/interactive-chat-stdio.test.ts`
- `git diff --check`
- `git diff --cached --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose a cap for in-memory chat event retention in the `cf-harness` stdio transport. Adds CLI/env config with strict validation; default remains unbounded and SQLite durable replay is unchanged.

- **New Features**
  - CLI: `--chat-max-in-memory-events <count>` (or `--chat-max-in-memory-events=<count>`); Env: `CF_HARNESS_CHAT_MAX_IN_MEMORY_EVENTS`.
  - Validates a safe non-negative integer; rejects missing, negative, fractional, non-numeric, or unsafe values.
  - Plumbs `maxInMemoryEvents` into `createHarnessInteractiveChatService` to bound in-memory replay only.
  - Updated README and tests for parsing, validation errors (including unsafe caps), and bounded replay behavior.

<sup>Written for commit a142ba3450c50b3f8388db62b84eb05f54d9926e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

