### PR TITLE
CT-1623: cache space-root + sub-pattern compiles across reload

### DIFF
--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -240,6 +240,7 @@ export class PiecesController<T = unknown> {
       };
       pattern = await this.#manager.runtime.patternManager.compilePattern(
         options.customProgram,
+        { space: this.#manager.getSpace() },
       );
     } else {
       if (isHomeSpace) {
@@ -262,12 +263,13 @@ export class PiecesController<T = unknown> {
         this.#manager.runtime.apiUrl,
       );
 
-      // Load and compile the pattern
+      // Load and compile the pattern (cache in the target space — CT-1623).
       const program = await this.#manager.runtime.harness.resolve(
         new HttpProgramResolver(patternUrl.href),
       );
       pattern = await this.#manager.runtime.patternManager.compilePattern(
         program,
+        { space: this.#manager.getSpace() },
       );
     }
 
@@ -375,6 +377,10 @@ export class PiecesController<T = unknown> {
       () =>
         this.#manager.runtime.patternManager.compilePattern(
           program,
+          // Route the space-root compile through the content-addressed cell
+          // cache so the reload (fresh worker) reuses the compiled module set
+          // instead of cold-compiling the home/default-app pattern (CT-1623).
+          { space: this.#manager.getSpace() },
         ),
     );
 

--- a/packages/runner/src/builtins/compile-and-run.ts
+++ b/packages/runner/src/builtins/compile-and-run.ts
@@ -208,7 +208,8 @@ export function compileAndRun(
     // Capture requestId for this compilation run
     const thisRequestId = requestId;
 
-    const compilePromise = runtime.patternManager.compileOrGetPattern(program)
+    const compilePromise = runtime.patternManager
+      .compileOrGetPattern(program, parentCell.space)
       .catch(
         (err) => {
           // Only process this error if the request hasn't been superseded

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -1068,7 +1068,11 @@ async function fetchSuggestionPattern(
     if (!program) {
       throw new WishError("Can't load suggestion.tsx");
     }
-    const pattern = await runtime.patternManager.compilePattern(program);
+    // Cache the (space-independent) system pattern in the user's home space so
+    // it's reused across reloads for this user (CT-1623, per-space cache).
+    const pattern = await runtime.patternManager.compilePattern(program, {
+      space: runtime.userIdentityDID,
+    });
 
     if (!pattern) throw new WishError("Can't compile suggestion.tsx");
 
@@ -1090,7 +1094,11 @@ async function fetchProfileCreatePattern(
     if (!program) {
       throw new WishError("Can't load profile-create.tsx");
     }
-    const pattern = await runtime.patternManager.compilePattern(program);
+    // Cache the (space-independent) system pattern in the user's home space so
+    // it's reused across reloads for this user (CT-1623, per-space cache).
+    const pattern = await runtime.patternManager.compilePattern(program, {
+      space: runtime.userIdentityDID,
+    });
 
     if (!pattern) throw new WishError("Can't compile profile-create.tsx");
 

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -742,10 +742,20 @@ export class Engine extends EventTarget implements Harness {
       // for sub-pattern resolution.
       const exportMap: Record<string, Exports> = {};
       const exportsByValue = new Map<unknown, RuntimeProgram>();
+      // Per-module namespaces keyed by content identity (stripped from the
+      // `cf:module/<identity>` specifier) for the in-memory identity cache.
+      const exportsByIdentity = new Map<string, Exports>();
+      const MODULE_SPECIFIER_PREFIX = "cf:module/";
       for (const [path, specifier] of graph.specifierByPath) {
         const namespace = loaded.importNow(specifier) as Exports;
         const fileName = ctx.fileNameForPath(path);
         exportMap[fileName] = namespace;
+        if (specifier.startsWith(MODULE_SPECIFIER_PREFIX)) {
+          exportsByIdentity.set(
+            specifier.slice(MODULE_SPECIFIER_PREFIX.length),
+            namespace,
+          );
+        }
         for (const [exportName, value] of Object.entries(namespace)) {
           // Only object/function exports are sub-pattern candidates. Skip the
           // `__esModule` flag and primitives, which would otherwise collide in
@@ -767,7 +777,7 @@ export class Engine extends EventTarget implements Harness {
       this.executableRegistry.captureVerifiedValue(loadId, exportMap);
       this.runtimeInternals?.exportsCallback(exportsByValue);
 
-      return { main, exportMap, loadId };
+      return { main, exportMap, loadId, exportsByIdentity };
     } finally {
       logger.timeEnd("evaluateRecordGraph");
     }

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -578,8 +578,15 @@ export class Engine extends EventTarget implements Harness {
   ): EvaluateResult {
     const prefix = `/${id}`;
     // Register module hashes up front so the canonical `cf:module/<hash>/<path>`
-    // sources are available for the verified set below.
-    this.registerModuleHashes(id, files);
+    // sources are available for the verified set below. Derive them from the
+    // graph's RESOLVED per-module identities (the same content-addressed
+    // `cf:module/<identity>` the cache + source-free reload use), NOT by
+    // re-hashing the raw `files` — those disagree (the resolved set folds the
+    // injected modules into each module's Merkle hash), which would make a
+    // function's `fn.src` (hence its implementationRef) differ between this
+    // source-based compile and a source-free by-identity reload, breaking
+    // `getExecutableFunction` for resumed callables (CT-1623).
+    this.registerModuleHashesFromGraph(id, graph);
     const verifiedSources = new Set<string>();
     const addVerifiedSource = (value: string | undefined) => {
       if (typeof value !== "string" || value.length === 0) return;
@@ -1069,6 +1076,41 @@ export class Engine extends EventTarget implements Harness {
       this.canonicalSourceByPrefixed.set(
         `/${id}${path}`,
         `cf:module/${hash}${path}`,
+      );
+    }
+  }
+
+  /**
+   * Like {@link registerModuleHashes}, but takes the RESOLVED per-module
+   * identities straight from the compiled graph (`cf:module/<identity>` in
+   * `graph.specifierByPath`) instead of re-hashing the raw program files.
+   *
+   * The two must agree: the cache key, the record-graph specifiers, and the
+   * source-free by-identity reload (`evaluateCachedModules`) all use the
+   * resolved identity (which folds the injected/resolved modules into each
+   * module's Merkle hash). Re-hashing the raw `program.files` here would yield a
+   * DIFFERENT hash for the same module, so a function's `fn.src` — and thus its
+   * minted `implementationRef` — would differ between this source-based compile
+   * and a source-free reload, and `getExecutableFunction` would miss when a
+   * resumed piece invokes a callable (CT-1623). Keying matches the source map's
+   * bundle paths (`/<id>/<authoredPath>`, plus injected modules under their own
+   * specifier path), and the canonical value matches the source-free form.
+   */
+  private registerModuleHashesFromGraph(
+    id: string,
+    graph: CompiledModuleGraph,
+  ): void {
+    const prefix = `/${id}`;
+    for (const [name, specifier] of graph.specifierByPath) {
+      if (!specifier.startsWith("cf:module/")) continue;
+      const identity = specifier.slice("cf:module/".length);
+      const authoredPath = name.startsWith(`${prefix}/`)
+        ? name.slice(prefix.length)
+        : name;
+      this.moduleHashByPrefixedSource.set(name, identity);
+      this.canonicalSourceByPrefixed.set(
+        name,
+        `cf:module/${identity}${authoredPath}`,
       );
     }
   }

--- a/packages/runner/src/harness/types.ts
+++ b/packages/runner/src/harness/types.ts
@@ -93,6 +93,15 @@ export interface EvaluateResult {
   main?: Exports;
   exportMap?: Record<string, Exports>;
   loadId?: string;
+  /**
+   * Per-module namespaces keyed by content identity (the prefix-free
+   * `cf:module/<identity>` hash). Lets the runner register every module in a
+   * just-evaluated bundle into an in-memory identity->Pattern cache, so a later
+   * by-identity load of a sub-pattern reuses the already-live module instead of
+   * re-reading the closure from storage and re-evaluating it (CT-1623).
+   * Populated only on the ESM evaluate paths.
+   */
+  exportsByIdentity?: Map<string, Exports>;
 }
 
 export interface EvaluateOptions {

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -22,6 +22,7 @@ import type {
   CompiledModuleArtifact,
   CompileResult,
   EvaluateResult,
+  Exports,
 } from "./harness/types.ts";
 import { RuntimeProgram } from "./harness/types.ts";
 import type { CachedCompiledModule } from "./sandbox/module-record-compiler.ts";
@@ -47,6 +48,11 @@ const logger = getLogger("pattern-manager");
  * Set conservatively to prevent OOM in long-running processes and tests.
  */
 const MAX_PATTERN_CACHE_SIZE = 100;
+// Bound for the in-memory identity->module cache. Higher than the pattern cache
+// because a single bundle contributes one entry per module (a big space-root
+// bundle is ~10 modules), and entries are cheap (a reference to an already-live
+// namespace).
+const MAX_EVALUATED_MODULE_CACHE_SIZE = 1000;
 
 export const patternMetaSchema = internSchema(
   {
@@ -111,6 +117,16 @@ export class PatternManager {
   private pendingMetaById = new Map<URI, Partial<PatternMeta>>();
   // ESM content-addressed compile-cache instrumentation.
   private esmCacheStats = { hits: 0, misses: 0, byIdentityHits: 0 };
+  // In-memory identity -> module-namespace cache (CT-1623). Populated for EVERY
+  // module of an evaluated ESM bundle (keyed by prefix-free content identity),
+  // so a by-identity load of a sub-pattern reuses the already-live module from
+  // its parent's bundle instead of re-reading the closure from storage and
+  // re-evaluating it in SES. Content-addressed, so a hit is always the same
+  // bytes — never stale. Bounded (FIFO) to cap memory.
+  private modulesByIdentity = new Map<
+    string,
+    { exports: Exports; loadId?: string }
+  >();
   // In-flight compiled-cache write-backs (fire-and-forget); awaited by
   // flushCompileCacheWrites() for graceful shutdown / deterministic tests.
   private compileCacheWrites = new Set<Promise<unknown>>();
@@ -782,6 +798,14 @@ export class PatternManager {
     ) {
       return undefined;
     }
+    // In-memory fast path (CT-1623): the module may already be live from a
+    // parent bundle's evaluation (e.g. a sub-pattern of the just-loaded
+    // space root). Reuse it directly — no storage closure read, no SES re-eval.
+    const live = this.patternFromEvaluatedModule(entryIdentity, symbol);
+    if (live) {
+      this.esmCacheStats.byIdentityHits++;
+      return live;
+    }
     const cacheOpts = {
       runtimeVersion: COMPILE_CACHE_RUNTIME_VERSION,
       compilerDid: this.runtime.userIdentityDID,
@@ -844,10 +868,12 @@ export class PatternManager {
    * happens by identity via the source closure, not from the pattern object.
    */
   private patternFromMain(
-    { main, loadId }: EvaluateResult,
+    result: EvaluateResult,
     symbol: string,
     entryIdentity: string,
   ): Pattern {
+    this.registerEvaluatedModules(result);
+    const { main, loadId } = result;
     if (!main) {
       throw new Error("Pattern compilation produced no exports.");
     }
@@ -861,6 +887,67 @@ export class PatternManager {
         this.seedVerifiedLoadIds(pattern, loadId);
       }
     }
+    return pattern;
+  }
+
+  /**
+   * Index every module of a just-evaluated ESM bundle by its content identity
+   * (CT-1623). Lets `loadPatternByIdentity` reuse a sub-pattern module already
+   * evaluated as part of its parent's bundle — no storage read, no SES re-eval.
+   */
+  private registerEvaluatedModules(result: EvaluateResult): void {
+    const byId = result.exportsByIdentity;
+    if (!byId) return;
+    for (const [identity, exports] of byId) {
+      // Refresh insertion order (Map is FIFO-ordered) so eviction is ~LRU.
+      this.modulesByIdentity.delete(identity);
+      this.modulesByIdentity.set(identity, { exports, loadId: result.loadId });
+      // Give each pattern-exporting sub-module a content-addressed entry ref so
+      // its result cell reloads BY IDENTITY (and hits the in-memory module
+      // cache / cell cache) instead of falling back to a source recompile via
+      // loadPattern. Without this only the bundle entry carried a ref, so every
+      // sub-pattern cold-recompiled on reload (CT-1623). Don't overwrite an
+      // existing ref (the entry's is set authoritatively by the caller).
+      for (const exportName of Object.keys(exports)) {
+        if (exportName === "__esModule") continue;
+        const value = exports[exportName];
+        if (
+          (typeof value === "object" || typeof value === "function") &&
+          value !== null && isTrustedPattern(value as Pattern) &&
+          !this.patternToEntryRef.has(value as Pattern)
+        ) {
+          this.patternToEntryRef.set(value as Pattern, {
+            identity,
+            symbol: exportName,
+          });
+        }
+      }
+    }
+    while (this.modulesByIdentity.size > MAX_EVALUATED_MODULE_CACHE_SIZE) {
+      const oldest = this.modulesByIdentity.keys().next().value;
+      if (oldest === undefined) break;
+      this.modulesByIdentity.delete(oldest);
+    }
+  }
+
+  /**
+   * Reuse a module already evaluated in-memory (as part of any bundle) for a
+   * by-identity load, skipping the storage closure read + SES re-evaluation.
+   * Returns undefined on a miss so the caller falls back to the cache path.
+   */
+  private patternFromEvaluatedModule(
+    entryIdentity: string,
+    symbol: string,
+  ): Pattern | undefined {
+    const cached = this.modulesByIdentity.get(entryIdentity);
+    if (!cached || !(symbol in cached.exports)) return undefined;
+    const pattern = cached.exports[symbol] as Pattern;
+    if (!isTrustedPattern(pattern)) return undefined;
+    // Refresh recency.
+    this.modulesByIdentity.delete(entryIdentity);
+    this.modulesByIdentity.set(entryIdentity, cached);
+    this.patternToEntryRef.set(pattern, { identity: entryIdentity, symbol });
+    if (cached.loadId) this.seedVerifiedLoadIds(pattern, cached.loadId);
     return pattern;
   }
 
@@ -908,10 +995,12 @@ export class PatternManager {
 
   // Resolve a Pattern from an evaluate result (shared by the AMD and ESM paths).
   private patternFromEvaluation(
-    { main, loadId }: EvaluateResult,
+    result: EvaluateResult,
     program: RuntimeProgram,
     entryIdentity?: string,
   ): Pattern {
+    this.registerEvaluatedModules(result);
+    const { main, loadId } = result;
     if (!main) {
       throw new Error("Pattern compilation produced no exports.");
     }
@@ -959,9 +1048,16 @@ export class PatternManager {
    * Provides single-flight deduplication based on program content.
    *
    * @param input - Source code string or RuntimeProgram to compile
+   * @param space - When provided, routes the ESM compile through the
+   *   content-addressed cell cache in this space (CT-1623): cold compiles write
+   *   their module set back, and subsequent loads of the same source skip the TS
+   *   compile. Without it (e.g. tests), compilation is uncached as before.
    * @returns The compiled pattern (from cache, in-flight compilation, or new)
    */
-  compileOrGetPattern(input: string | RuntimeProgram): Promise<Pattern> {
+  compileOrGetPattern(
+    input: string | RuntimeProgram,
+    space?: MemorySpace,
+  ): Promise<Pattern> {
     // Normalize to RuntimeProgram
     let program: RuntimeProgram;
     if (typeof input === "string") {
@@ -990,8 +1086,12 @@ export class PatternManager {
       return inProgress;
     }
 
-    // Compile with single-flight pattern
-    const compilationPromise = this.compilePattern(program)
+    // Compile with single-flight pattern. Pass the cell-cache context when a
+    // space is available so nested/dynamic compiles benefit from the cache too.
+    const compilationPromise = this.compilePattern(
+      program,
+      space ? { space } : undefined,
+    )
       .then((pattern) => {
         // Register directly with pre-computed patternId to avoid double-hashing
         // (registerPattern would recompute the same hash from program)

--- a/packages/runner/src/piece-helpers.ts
+++ b/packages/runner/src/piece-helpers.ts
@@ -100,7 +100,11 @@ export async function compileAndSavePattern(
       files: [{ name: "/main.tsx", contents: patternSrc }],
     };
   }
-  const pattern = await runtime.patternManager.compilePattern(patternSrc);
+  // Route through the content-addressed cell cache in the target space so the
+  // saved pattern's compiled module set is reused on subsequent loads (CT-1623).
+  const pattern = await runtime.patternManager.compilePattern(patternSrc, {
+    space: options.space,
+  });
   if (!pattern) {
     throw new Error("No default pattern found in the compiled exports.");
   }

--- a/packages/runner/test/by-identity-handler-exec.test.ts
+++ b/packages/runner/test/by-identity-handler-exec.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+const signer = await Identity.fromPassphrase("by-identity-handler-exec");
+const space = signer.did();
+
+// CT-1623: a piece RESUMED from storage in a fresh runtime under the ESM loader
+// loads its pattern source-free BY IDENTITY and must still resolve + execute its
+// callable functions. The FUSE integration (cf exec <handler>) exposed a gap:
+// "JavaScript module is missing an executable implementation" (runner.ts
+// getFallbackJavaScriptImplementation). This uses the REAL fuse-exec fixture
+// (non-default export, schema handlers with asCell state, a patternTool) and
+// drives: create + run the piece → persist → resume in a fresh runtime → invoke
+// the `recordMessage` handler.
+const FIXTURE_SRC = Deno.readTextFileSync(
+  new URL(
+    "../../cli/integration/pattern/fuse-exec.tsx",
+    import.meta.url,
+  ),
+);
+
+const RESULT_CAUSE = "by-identity fuse-exec resume";
+
+const PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  mainExport: "customPatternExport",
+  files: [{ name: "/main.tsx", contents: FIXTURE_SRC }],
+};
+
+describe("resume the fuse-exec piece by identity and invoke its handler", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+
+  const newRuntime = () =>
+    new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      experimental: { esmModuleLoader: true },
+    });
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+  });
+  afterEach(async () => {
+    await storageManager?.close();
+  });
+
+  it("invokes recordMessage after resuming the piece from storage", async () => {
+    const rt1 = newRuntime();
+    const rt2 = newRuntime();
+    try {
+      // Session 1: compile + run the piece, invoke once (control), persist.
+      const tx1 = rt1.edit();
+      const pm1 = rt1.patternManager;
+      const cold = await pm1.compilePattern(PROGRAM, { space, tx: tx1 });
+      expect(pm1.getPatternEntryRef(cold)?.symbol).toBe("customPatternExport");
+      const resultCell1 = rt1.getCell<Record<string, unknown>>(
+        space,
+        RESULT_CAUSE,
+        undefined,
+        tx1,
+      );
+      const r1 = rt1.run(tx1, cold, {}, resultCell1);
+      await tx1.commit();
+      await r1.pull();
+      // CONTROL: full-source handler executes in the originating runtime.
+      r1.key("recordMessage").send({ message: "hello" });
+      const ctrl = await r1.pull() as { messageCount: number };
+      expect(ctrl.messageCount).toBe(1);
+
+      await pm1.flushCompileCacheWrites();
+      await rt1.storageManager.synced();
+
+      // Session 2: fresh runtime resumes the SAME piece from storage (source-free
+      // by identity), then invokes the handler — the path `cf exec` takes.
+      const pm2 = rt2.patternManager;
+      const tx2 = rt2.edit();
+      const resultCell2 = rt2.getCell<Record<string, unknown>>(
+        space,
+        RESULT_CAUSE,
+        undefined,
+        tx2,
+      );
+      await tx2.commit();
+      // Force the storage-rehydration path (as cf exec hits it): the resumed
+      // piece's nodes come from the PERSISTED graph (module.implementation is a
+      // ref, not a live function), so resolution relies solely on
+      // getExecutableFunction — the path that fails under source-free by-identity.
+      await resultCell2.sync();
+      const started = await rt2.start(resultCell2);
+      expect(started).toBe(true);
+      expect(pm2.getCompileCacheStats().byIdentityHits).toBe(1);
+
+      await resultCell2.pull();
+      const before =
+        (resultCell2.getAsQueryResult() as { messageCount: number })
+          .messageCount;
+      resultCell2.key("recordMessage").send({ message: "world" });
+      await resultCell2.pull();
+      const after = (resultCell2.getAsQueryResult() as { messageCount: number })
+        .messageCount;
+      expect(after).toBe(before + 1);
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## What

Under the ESM module loader, a page-refresh reload cold-compiled the **space-root pattern** (home/default-app) and its **sub-patterns** on every load. Two causes:

1. `ensureDefaultPattern`/`recreateDefaultPattern` (and the nested compile paths) called `compilePattern()` **without** a cell-cache context, so the space root never wrote back and never warmed.
2. Only the bundle **entry** got a `{identity, symbol}` ref, so sub-pattern result cells reloaded via a source recompile (`loadPattern`); and `loadPatternByIdentity` always re-read the closure from storage and re-evaluated it in SES — even though the parent bundle had just evaluated those modules live in the same compartment.

## Fix

- **Thread the cell-cache `space`** through every compile path that lacked it: `ensureDefaultPattern`/`recreateDefaultPattern`, `compileOrGetPattern` (+ the `compile-and-run` builtin via `parentCell.space`), `compileAndSavePattern`, and the `wish` system patterns (cached per `userIdentityDID`). **AMD is unaffected** — the cell cache is ESM-only.
- **In-memory identity→module cache.** `evaluateGraph` now returns `exportsByIdentity` (per-module namespaces keyed by the prefix-free `cf:module/<identity>`). PatternManager indexes every evaluated module into a FIFO-bounded `modulesByIdentity` map and gives each pattern-exporting sub-module a content-addressed entry ref so its result cell reloads by identity. `loadPatternByIdentity` checks the in-memory cache first and **reuses the live module** — no storage closure read, no SES re-eval — falling back to storage (then `loadPattern`) on a miss.

Content-addressed, so an in-memory hit is always the same bytes (never stale).

## Measured (local ESM, counter reload to convergence)

| | first reload | steady-state reload (2nd) |
|---|---|---|
| before | ~11.3s | ~1.7s |
| after | ~5.2s | **~0.6s, compiles=0** |

## Notes

- Scope is the ESM compile/cache path; no behavior change under AMD.
- All by-identity / compile-cache / ESM unit tests pass; counter + nested-counter integration tests pass.
- **Follow-up (separate):** the first reload in a *fresh* space still cold-compiles the sub-patterns the first time they're instantiated (they have no cached body yet there); in production a populated space warms them on first load. Whole-suite ESM perf vs the AMD baseline is a known, separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)