### PR TITLE
fix(runner): sync internal/argument meta docs before setup reads them (CT-1666)

### DIFF
--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -1683,6 +1683,28 @@ export class Runner {
     };
   }
 
+  /**
+   * Sync the result cell's `internal` and `argument` meta-linked docs.
+   *
+   * They are separate content-addressed docs reached only via the result
+   * cell's meta links, so they are not loaded by syncing the result cell or the
+   * pattern's node inputs/outputs. `applySetupState` reads the persisted
+   * `internal` synchronously; awaiting these here keeps a build-time default
+   * from transiently clobbering a persisted value on a cold read (CT-1666).
+   *
+   * The result cell must already be synced so its meta links are readable.
+   */
+  private async syncMetaCells(resultCell: Cell<any>): Promise<void> {
+    const promises: Promise<unknown>[] = [];
+    for (const field of ["argument", "internal"] as const) {
+      const link = getMetaLink(resultCell, field);
+      if (link === undefined) continue;
+      const maybePromise = this.runtime.getCellFromLink(link).sync();
+      if (maybePromise instanceof Promise) promises.push(maybePromise);
+    }
+    await Promise.all(promises);
+  }
+
   private async syncCellsForRunningPattern(
     resultCell: Cell<any>,
     pattern: Module | Pattern,
@@ -1709,6 +1731,16 @@ export class Runner {
     await Promise.all(promises);
 
     await resultCell.sync();
+
+    // Also load the `internal` and `argument` meta-linked docs. These live in
+    // separate content-addressed docs reached only via the result cell's meta
+    // links -- not through the schema/value graph synced above -- so they are
+    // not covered by `resultCell.sync()` or the node input/output sync below.
+    // `applySetupState` reads the persisted `internal` synchronously and merges
+    // the pattern's build-time defaults UNDER it (persisted wins). Without this
+    // awaited load that read races storage and can see `undefined`, letting a
+    // build-time default transiently clobber the persisted value (CT-1666).
+    await this.syncMetaCells(resultCell);
 
     // We could support this by replicating what happens in runner, but since
     // we're calling this again when returning false, this is good enough for now.

--- a/packages/runner/test/rehydrate-internal-default.test.ts
+++ b/packages/runner/test/rehydrate-internal-default.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import * as MemoryV2Server from "@commonfabric/memory/v2/server";
+import { EmulatedStorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { type Pattern } from "../src/builder/types.ts";
+import { Runtime } from "../src/runtime.ts";
+import { getMetaLink } from "../src/link-utils.ts";
+import { trustExecutable } from "./support/trusted-builder.ts";
+
+const signer = await Identity.fromPassphrase("test operator");
+const space = signer.did();
+
+// Two storage managers that share ONE in-memory server (the persistence
+// boundary) but keep SEPARATE client caches. This models a reload: the second
+// runtime starts cold and must fetch persisted docs from the server, rather
+// than reading the first runtime's warm cache.
+class SharedServerStorageManager extends EmulatedStorageManager {
+  constructor(as: Identity, server: MemoryV2Server.Server) {
+    super({ as, address: new URL("memory://") }, () => server);
+  }
+  // The shared server is owned by the test, not by either manager. Closing one
+  // manager must not close the server out from under the other; close only this
+  // manager's client by invoking the grandparent (plain StorageManager) close.
+  override close(): Promise<void> {
+    const baseClose = Object.getPrototypeOf(EmulatedStorageManager.prototype)
+      .close as (this: EmulatedStorageManager) => Promise<void>;
+    return baseClose.call(this);
+  }
+}
+
+// Regression coverage for CT-1666.
+//
+// A pattern's internal cell carries a build-time default (in home.tsx,
+// `const activeTab = new Writable("spaces").for("activeTab")` →
+// `pattern.initial.internal = { activeTab: "spaces" }`). After the user picks a
+// value ("profile") and it is persisted, re-running the pattern must NOT revert
+// the cell to the build-time default.
+//
+// `Runner.applySetupState` reads the persisted internal value and merges the
+// build-time default UNDER it (persisted wins). But the internal cell lives in
+// a separate content-addressed doc reached only via the result cell's meta link
+// — not through the schema/value graph — so the run's awaited sync gate
+// (`syncCellsForRunningPattern`) did not load it. The fix makes that gate sync
+// the `internal`/`argument` meta docs, so the persisted value is loaded before
+// the pattern (re)starts and renders.
+//
+// `activeTab` is intentionally internal-only here (never exported in `result`),
+// matching home.tsx where it is bound only to `<cf-tabs $value={activeTab}>`.
+//
+// A fresh runtime sharing the same emulated store rehydrates from a cold client
+// cache, exercising the load path the gate is responsible for.
+describe("rehydrate internal default (CT-1666)", () => {
+  let server: MemoryV2Server.Server;
+  let sm1: SharedServerStorageManager;
+  let sm2: SharedServerStorageManager;
+
+  const pattern: Pattern = {
+    argumentSchema: {},
+    resultSchema: {},
+    initial: { internal: { activeTab: "spaces" } },
+    result: {},
+    nodes: [],
+  };
+
+  const internalCellOf = (runtime: Runtime, resultCell: { sourceURI: string }) => {
+    const internalLink = getMetaLink(resultCell as never, "internal");
+    expect(internalLink).toBeDefined();
+    return runtime.getCellFromLink(internalLink!);
+  };
+
+  beforeEach(() => {
+    server = new MemoryV2Server.Server({
+      authorizeSessionOpen(message) {
+        const principal = (message.authorization as { principal?: unknown })
+          ?.principal;
+        return typeof principal === "string" ? principal : undefined;
+      },
+    });
+    sm1 = new SharedServerStorageManager(signer, server);
+    sm2 = new SharedServerStorageManager(signer, server);
+  });
+  afterEach(async () => {
+    await sm1?.close();
+    await sm2?.close();
+    await server?.close();
+  });
+
+  it("preserves a user-set internal value across a cold-cache reload", async () => {
+    const rt1 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm1,
+    });
+    const rt2 = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager: sm2,
+    });
+    try {
+      // Session 1: first run seeds the build-time default, then the user picks
+      // "profile". Persist it to the shared server.
+      const rc1 = rt1.getCell<Record<string, never>>(space, "home-result");
+      await rt1.runSynced(rc1, trustExecutable(rt1, pattern), {});
+      await rc1.pull();
+
+      const internal1 = internalCellOf(rt1, rc1);
+      expect(internal1.key("activeTab").get()).toEqual("spaces");
+
+      const tx = rt1.edit();
+      internal1.key("activeTab").withTx(tx).set("profile");
+      await tx.commit();
+      await sm1.synced();
+      expect(internal1.key("activeTab").get()).toEqual("profile");
+
+      // Session 2: a fresh runtime with a COLD cache rehydrates the SAME result
+      // cell and re-runs the pattern through the awaited sync gate. The persisted
+      // "profile" must survive — it must not be reverted to the build-time
+      // default "spaces".
+      const rc2 = rt2.getCell<Record<string, never>>(space, "home-result");
+      await rt2.runSynced(rc2, trustExecutable(rt2, pattern), {});
+      await rc2.pull();
+
+      const internal2 = internalCellOf(rt2, rc2);
+      expect(internal2.key("activeTab").get()).toEqual("profile");
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+});

--- a/packages/runner/test/rehydrate-internal-default.test.ts
+++ b/packages/runner/test/rehydrate-internal-default.test.ts
@@ -63,7 +63,10 @@ describe("rehydrate internal default (CT-1666)", () => {
     nodes: [],
   };
 
-  const internalCellOf = (runtime: Runtime, resultCell: { sourceURI: string }) => {
+  const internalCellOf = (
+    runtime: Runtime,
+    resultCell: { sourceURI: string },
+  ) => {
     const internalLink = getMetaLink(resultCell as never, "internal");
     expect(internalLink).toBeDefined();
     return runtime.getCellFromLink(internalLink!);


### PR DESCRIPTION
## CT-1666: flaky `activeTab` revert to `"spaces"` on home navigation

### Root cause
The home pattern's `const activeTab = new Writable("spaces").for("activeTab")` lowers the `"spaces"` default into `pattern.initial.internal`. The only runtime writer of that value is `Runner.applySetupState`, which merges the default **under** the persisted `previousInternal` (persisted wins):

```js
Object.assign({}, defaults.internal, pattern.initial.internal, previousInternal)
```

`previousInternal` is read **synchronously** from the internal cell — a separate content-addressed doc reached only via the result cell's **meta link**, not the schema/value graph. The awaited sync gate `syncCellsForRunningPattern` (used by `runSynced` and the `runtime.start` resume path that home navigation takes) synced the result cell and node I/O but **never the internal meta-doc**. On a cold read `previousInternal` races storage to `undefined`, so the build-time `"spaces"` default clobbers the persisted `"profile"`, hiding `cf-tab-panel[value="profile"]` and timing out the trusted "Create profile" click.

It self-heals via server conflict-retry, which is why it's a **transient** ~80% visual flake (confirmed by the late-async-revert workaround on `feat/multi-profile-picker`).

### Fix
Add `Runner.syncMetaCells()` and await the `internal`/`argument` meta-linked docs inside `syncCellsForRunningPattern`, so the persisted value is loaded before the pattern (re)starts and the UI wires up. No-op when already loaded.

### Tests
- New `packages/runner/test/rehydrate-internal-default.test.ts` — two runtimes sharing one emulated server (cold second cache) locks in the cold-cache rehydration invariant.
- `runner.test.ts`, `ensure-piece-running.test.ts`, and the `piece` package suite all pass.

### Validation note
The in-memory emulator loads docs within microtasks, so it **cannot reproduce the transient red→green** — the regression test guards the invariant, not the timing. Definitive validation is the multi-profile `deno task integration patterns home-profile` case (on `feat/multi-profile-picker`), where the `[home-profile] activeTab fell back off "profile"` warning should stop firing. Happy to run that if wanted.

Linear: CT-1666

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CT-1666: a race where the home `activeTab` reverted to the "spaces" default on navigation. We now sync the result cell’s `internal` and `argument` meta docs before setup so persisted state loads first.

- **Bug Fixes**
  - Await syncing of `internal`/`argument` meta-linked docs in `syncCellsForRunningPattern` via `syncMetaCells()` to prevent defaults from clobbering persisted values on cold reads.
  - Added `rehydrate-internal-default.test.ts` to verify cold-cache rehydration preserves user-selected `activeTab` ("profile").

<sup>Written for commit a227f650beb77d9c10b064c3216005b6b0fd3eee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

