### PR TITLE
runner: stabilize patternToJSON serialization + exact-object getPatternEntryRef lookup

### DIFF
--- a/packages/runner/src/builder/json-utils.ts
+++ b/packages/runner/src/builder/json-utils.ts
@@ -440,6 +440,25 @@ export function moduleToJSON(module: Module) {
 }
 
 export function patternToJSON(pattern: Pattern) {
+  // Serialize only the STABLE program identity ({main, mainExport}), never the
+  // authored `files`. The `files` array serializes non-canonically (two
+  // encodings -> two content ids), so embedding it dragged a session-varying
+  // blob into every serialized pattern and thrashed link ids / re-ran actions
+  // on reload. {main, mainExport} are deterministic strings, so they reload
+  // stably; they are kept because consumers read them (e.g. the CLI
+  // `dev --pattern-json` output asserts `program.mainExport`). The full
+  // program-with-files is still recovered from the pattern-meta cell
+  // (savePattern -> `rawMeta.program`) and the `pattern:<identity>` source docs;
+  // sub-patterns are referenced by {identity, symbol} on the ESM path.
+  const program = getPatternProgram(pattern);
+  const programIdentity = program
+    ? {
+      main: program.main,
+      ...(program.mainExport !== undefined
+        ? { mainExport: program.mainExport }
+        : {}),
+    }
+    : undefined;
   return {
     argumentSchema: pattern.argumentSchema,
     resultSchema: pattern.resultSchema,
@@ -449,6 +468,6 @@ export function patternToJSON(pattern: Pattern) {
     ...(pattern.initial ? { initial: pattern.initial } : {}),
     result: pattern.result,
     nodes: pattern.nodes,
-    program: getPatternProgram(pattern),
+    ...(programIdentity ? { program: programIdentity } : {}),
   };
 }

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -1038,9 +1038,13 @@ export class PatternManager {
   getPatternEntryRef(
     pattern: Pattern | Module,
   ): { identity: string; symbol: string } | undefined {
-    return this.patternToEntryRef.get(
-      this.findOriginalPattern(pattern as Pattern),
-    );
+    // `patternToEntryRef` is keyed by the EXACT exported value (the entry, set
+    // by patternFromMain/patternFromEvaluation, and every imported sub-pattern,
+    // set by registerEvaluatedModules). Check the exact object FIRST, then the
+    // normalized original: a copied/wrapped pattern whose `unsafe_originalPattern`
+    // root differs from the keyed object would otherwise never resolve its ref.
+    return this.patternToEntryRef.get(pattern as Pattern) ??
+      this.patternToEntryRef.get(this.findOriginalPattern(pattern as Pattern));
   }
 
   /**

--- a/packages/runner/test/load-by-identity-meta-bridge.test.ts
+++ b/packages/runner/test/load-by-identity-meta-bridge.test.ts
@@ -6,6 +6,7 @@ import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
 import { Runtime } from "../src/runtime.ts";
 import type { RuntimeProgram } from "../src/harness/types.ts";
 import { getPatternProgram } from "../src/builder/pattern-metadata.ts";
+import { ignoreReadForScheduling } from "../src/storage/reactivity-log.ts";
 
 const signer = await Identity.fromPassphrase("load-by-identity-meta-bridge");
 const space = signer.did();
@@ -209,6 +210,105 @@ describe("load by identity — pattern-metadata bridge", () => {
     } finally {
       await rt2.dispose();
       await rt1.dispose();
+    }
+  });
+
+  it("tags an imported sub-pattern with its OWN module identity", async () => {
+    // End-to-end guard: a pattern IMPORTED and composed by a parent (never the
+    // selected entry of any compile) must still acquire a {identity, symbol}
+    // reference, so its composed sub-piece's result cell carries `patternIdentity`
+    // meta and the runtime can reload it by identity. The ref is supplied by
+    // `registerEvaluatedModules` (which tags every trusted sub-pattern export in
+    // the per-load WeakMap, keyed by the exact value) and resolved by
+    // `getPatternEntryRef`'s exact-object-first lookup. This asserts the
+    // user-facing invariant — that the sub-piece's recorded identity is the
+    // CHILD module's, distinct from the parent's — not any single mechanism.
+    const childFile = {
+      name: "/child.tsx",
+      contents: [
+        "import { pattern } from 'commonfabric';",
+        "export default pattern<{ value: number }>(({ value }) => {",
+        "  return { echo: value };",
+        "});",
+      ].join("\n"),
+    };
+    const PARENT: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [
+        childFile,
+        {
+          name: "/main.tsx",
+          contents: [
+            "import { pattern } from 'commonfabric';",
+            "import child from './child.tsx';",
+            "export default pattern<{ value: number }>(({ value }) => {",
+            "  const c = child({ value });",
+            "  return { result: c.echo, child: c };",
+            "});",
+          ].join("\n"),
+        },
+      ],
+    };
+    const CHILD_ONLY: RuntimeProgram = {
+      main: "/child.tsx",
+      files: [childFile],
+    };
+
+    const rt = newRuntime();
+    try {
+      const pm = rt.patternManager;
+
+      // Learn the child module's content identity by compiling it standalone.
+      // Same bytes + same resolved imports → same content-addressed identity as
+      // the imported sub-module inside PARENT.
+      const txc = rt.edit();
+      const childStandalone = await pm.compilePattern(CHILD_ONLY, {
+        space,
+        tx: txc,
+      });
+      const childRef = pm.getPatternEntryRef(childStandalone);
+      txc.abort?.("child identity learned");
+      expect(childRef?.symbol).toBe("default");
+      const childIdentity = childRef!.identity;
+
+      // Compile + run the parent that composes the child.
+      const tx = rt.edit();
+      const parent = await pm.compilePattern(PARENT, { space, tx });
+      const parentRef = pm.getPatternEntryRef(parent);
+      expect(parentRef?.identity).toBeTruthy();
+      // Distinct per-module identities — the child is not the parent.
+      expect(parentRef!.identity).not.toBe(childIdentity);
+
+      const resultCell = rt.getCell<
+        { result: number; child: { echo: number } }
+      >(
+        space,
+        "sub-pattern entry-ref run",
+        undefined,
+        tx,
+      );
+      const r = rt.run(tx, parent, { value: 5 }, resultCell);
+      await tx.commit();
+      await r.pull();
+      const out = r.getAsQueryResult() as {
+        result: number;
+        child: { echo: number };
+      };
+      expect(out.result).toBe(5);
+      expect(out.child).toEqual({ echo: 5 });
+
+      // The composed CHILD sub-piece (a non-entry pattern) carries a
+      // patternIdentity meta referencing the CHILD module — only possible
+      // because the side-table tags every exported pattern, not just the entry.
+      const childResultCell = resultCell.key("child").resolveAsCell();
+      const meta = childResultCell.getMetaRaw("patternIdentity", {
+        meta: ignoreReadForScheduling,
+      }) as { identity?: unknown; symbol?: unknown } | undefined;
+      expect(meta).toBeTruthy();
+      expect(meta?.symbol).toBe("default");
+      expect(meta?.identity).toBe(childIdentity);
+    } finally {
+      await rt.dispose();
     }
   });
 });


### PR DESCRIPTION
## What & why

Two small, independent runner fixes that reduce reload churn and tighten by-identity pattern resolution.

> **Scope note:** this PR was originally larger — it added a module-level side-table to tag every exported pattern (entry + imported sub-pattern) with a `{identity, symbol}` reference. Review found that machinery **redundant**: origin/main's #3892 (CT-1623) `registerEvaluatedModules` already tags every trusted sub-pattern export in `patternToEntryRef`, keyed by the exact value, on every ESM path (compile + by-identity reload). The side-table has been dropped; what remains is the genuinely-additive part.

### Commit 1 — `getPatternEntryRef` checks the exact exported object before the original
`patternToEntryRef` is keyed by the exact exported value (entry via `patternFromMain`/`patternFromEvaluation`; sub-patterns via #3892's `registerEvaluatedModules`). The lookup previously normalized to the `unsafe_originalPattern` root first, so a copied/wrapped pattern whose root differs from the keyed object could never resolve its ref. Now it checks the exact object first, then falls back to the normalized original. Adds an **end-to-end guard**: a child sub-pattern composed by a parent (never the selected entry of any compile) must have its sub-piece result cell carry a `patternIdentity` meta referencing the *child* module, distinct from the parent — the user-facing invariant the by-identity reload relies on.

### Commit 2 — serialize only the stable `{main, mainExport}` program identity, not `files`
`patternToJSON` embedded the full program-with-files in every serialized pattern. The authored `files` array serializes non-canonically (two encodings → two content ids), so the same sub-pattern oscillated between two link ids across a reload, re-dirtying actions that should have rehydrated. Keep only the deterministic `{main, mainExport}` (consumers read it — the CLI `dev --pattern-json` output asserts `program.mainExport`) and drop the session-varying `files`. The full program-with-files is still recovered from the pattern-meta cell (`savePattern → rawMeta.program`) and `pattern:<identity>` source docs on reload.

## Tests
- New end-to-end guard in `load-by-identity-meta-bridge.test.ts` (composed sub-piece carries child-module `patternIdentity` meta).
- by-identity suite + pattern-manager + serialization + reload-rehydration: green.
- `cli dev --pattern-json` named-export assertion: green.
- lint + typecheck: clean.

NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/habit-tracker/habit-tracker.test.tsx = 14s

🤖 Generated with [Claude Code](https://claude.com/claude-code)