### PR TITLE
perf(runner): cache Cell.get() results per-transaction

### DIFF
--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -832,6 +832,27 @@ export class CellImpl<T extends FabricValue>
 
   get(options?: { traverseCells?: boolean }): Readonly<StripDefaultBrand<T>> {
     if (!this.synced) this.sync(); // No await, just kicking this off
+
+    // Per-transaction read cache: within one ready transaction, repeatedly
+    // reading the same cell with no intervening write recomputes an identical
+    // result -- same value, the same reactive reads already registered on the
+    // tx, and the same CFC state. Reuse the prior result when the tx supports
+    // caching (the non-reactive sample() wrapper does not) and is still open.
+    // The tx clears this cache on any write, so a hit only happens when nothing
+    // has changed since the last read. Keyed on the cell's link identity, which
+    // is stable per cell; `variant` separates reads that differ in options.
+    const tx = this.tx;
+    const cacheable = tx !== undefined &&
+      tx.getCachedReadResult !== undefined &&
+      tx.status().status === "ready";
+    const variant = `${options?.traverseCells ?? false}|${this.synced}`;
+    if (cacheable) {
+      const cached = tx.getCachedReadResult!(this._link, variant);
+      if (cached !== undefined) {
+        return cached.value as Readonly<StripDefaultBrand<T>>;
+      }
+    }
+
     logger.timeStart("cell", "get");
     const value = validateAndTransform(
       this.runtime,
@@ -847,6 +868,12 @@ export class CellImpl<T extends FabricValue>
         `get() took ${Math.floor(elapsed)}ms`,
         this.link,
       );
+    }
+    if (cacheable) {
+      // Re-read this._link: validateAndTransform (via viewRef -> link) may have
+      // run ensureLink() and replaced it with the completed link object, which
+      // is the identity subsequent get()s will key on.
+      tx.setCachedReadResult!(this._link, variant, value);
     }
     return value;
   }

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -844,7 +844,11 @@ export class CellImpl<T extends FabricValue>
     const tx = this.tx;
     const cacheable = tx !== undefined &&
       tx.getCachedReadResult !== undefined &&
-      tx.status().status === "ready";
+      tx.status().status === "ready" &&
+      // Once CFC is prepared, the real read path's `read-after-prepare`
+      // invalidation is load-bearing: bypass the cache so a post-prepare read
+      // still goes through readOrThrow() and invalidates the prepared digest.
+      tx.getCfcState().prepare.status !== "prepared";
     const variant = `${options?.traverseCells ?? false}|${this.synced}`;
     if (cacheable) {
       const cached = tx.getCachedReadResult!(this._link, variant);

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -18,10 +18,7 @@ import type {
   IReadOptions,
   IStorageTransaction,
   ITransactionJournal,
-  ITransactionReader,
-  ITransactionWriter,
   MemorySpace,
-  ReaderError,
   ReadError,
   Result,
   StorageTransactionFailed,
@@ -409,10 +406,6 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     return this.tx.status();
   }
 
-  reader(space: MemorySpace): Result<ITransactionReader, ReaderError> {
-    return this.tx.reader(space);
-  }
-
   read(
     address: IMemorySpaceAddress,
     options?: IReadOptions,
@@ -452,28 +445,6 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     options?: IReadOptions,
   ): Immutable<FabricValue> {
     return this.readOrThrow(toMemorySpaceAddress(address), options);
-  }
-
-  writer(space: MemorySpace): Result<ITransactionWriter, WriterError> {
-    this.assertWritable("writer()");
-    const result = this.tx.writer(space);
-    if (result.error) {
-      return result;
-    }
-    // Wrap the raw writer so that writes made through it -- which bypass this
-    // transaction's write*() methods -- still clear the per-tx read cache.
-    // Only write() invalidates; did()/read() pass through untouched, so merely
-    // obtaining a writer does not drop cached reads.
-    const inner = result.ok;
-    const wrapped: ITransactionWriter = {
-      did: () => inner.did(),
-      read: (address, options) => inner.read(address, options),
-      write: (address, value) => {
-        this.invalidateReadResultCache();
-        return inner.write(address, value);
-      },
-    };
-    return { ok: wrapped };
   }
 
   write(
@@ -914,10 +885,6 @@ export class TransactionWrapper implements IExtendedStorageTransaction {
     return this.wrapped.status();
   }
 
-  reader(space: MemorySpace): Result<ITransactionReader, ReaderError> {
-    return this.wrapped.reader(space);
-  }
-
   private transformReadOptions(options?: IReadOptions): IReadOptions {
     if (!this.options.nonReactive) {
       return options ?? {};
@@ -953,10 +920,6 @@ export class TransactionWrapper implements IExtendedStorageTransaction {
       address,
       this.transformReadOptions(options),
     );
-  }
-
-  writer(space: MemorySpace): Result<ITransactionWriter, WriterError> {
-    return this.wrapped.writer(space);
   }
 
   write(

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -106,6 +106,13 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   };
   private reportedCfcRelevant = false;
   private reportedCfcPrepared = false;
+  // Per-transaction cache of `Cell.get()` results, keyed by cell link identity.
+  // Replaced wholesale on any write (see `invalidateReadResultCache`), so a hit
+  // is only ever served when nothing has been written since the cached read.
+  private readResultCache = new WeakMap<
+    object,
+    Map<string, { value: unknown }>
+  >();
 
   constructor(
     public tx: IStorageTransaction,
@@ -164,6 +171,34 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     if (scopeRank(scope) > scopeRank(this.narrowestReadScope)) {
       this.narrowestReadScope = scope;
     }
+  }
+
+  getCachedReadResult(
+    keyObject: object,
+    variant: string,
+  ): { value: unknown } | undefined {
+    return this.readResultCache.get(keyObject)?.get(variant);
+  }
+
+  setCachedReadResult(
+    keyObject: object,
+    variant: string,
+    value: unknown,
+  ): void {
+    let byVariant = this.readResultCache.get(keyObject);
+    if (byVariant === undefined) {
+      byVariant = new Map();
+      this.readResultCache.set(keyObject, byVariant);
+    }
+    byVariant.set(variant, { value });
+  }
+
+  private invalidateReadResultCache(): void {
+    // A write may have changed any value a cached read depends on. Drop the
+    // whole cache by replacing the map (WeakMap has no clear()); this enforces
+    // the "no writes between the last read and this one" invariant the cache
+    // relies on.
+    this.readResultCache = new WeakMap();
   }
 
   recordCfcDereferenceTrace(trace: CfcDereferenceTrace): void {
@@ -432,6 +467,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     if (this.cfcState.prepare.status === "prepared") {
       this.invalidateCfc("write-after-prepare");
     }
+    this.invalidateReadResultCache();
     return this.tx.write(address, value);
   }
 
@@ -443,6 +479,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     if (this.cfcState.prepare.status === "prepared") {
       this.invalidateCfc("write-after-prepare");
     }
+    this.invalidateReadResultCache();
     const writeResult = this.tx.write(address, value);
     if (
       writeResult.error &&
@@ -523,6 +560,7 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     writes: Iterable<{ address: NormalizedFullLink; value: FabricValue }>,
   ): void {
     this.assertWritable("writeValuesOrThrow()");
+    this.invalidateReadResultCache();
     if (this.tx.writeBatch) {
       const result = this.tx.writeBatch(
         (function* () {

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -456,7 +456,24 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
 
   writer(space: MemorySpace): Result<ITransactionWriter, WriterError> {
     this.assertWritable("writer()");
-    return this.tx.writer(space);
+    const result = this.tx.writer(space);
+    if (result.error) {
+      return result;
+    }
+    // Wrap the raw writer so that writes made through it -- which bypass this
+    // transaction's write*() methods -- still clear the per-tx read cache.
+    // Only write() invalidates; did()/read() pass through untouched, so merely
+    // obtaining a writer does not drop cached reads.
+    const inner = result.ok;
+    const wrapped: ITransactionWriter = {
+      did: () => inner.did(),
+      read: (address, options) => inner.read(address, options),
+      write: (address, value) => {
+        this.invalidateReadResultCache();
+        return inner.write(address, value);
+      },
+    };
+    return { ok: wrapped };
   }
 
   write(

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -692,7 +692,8 @@ export interface IStorageTransaction {
   getNativeCommit?(space: MemorySpace): NativeStorageCommit | undefined;
 }
 
-export interface IExtendedStorageTransaction extends IStorageTransaction {
+export interface IExtendedStorageTransaction
+  extends Omit<IStorageTransaction, "reader" | "writer"> {
   tx: IStorageTransaction;
 
   getCfcState(): Readonly<CfcTxState>;

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -868,6 +868,35 @@ export interface IExtendedStorageTransaction extends IStorageTransaction {
   writeValuesOrThrow?(
     writes: Iterable<{ address: NormalizedFullLink; value: FabricValue }>,
   ): void;
+
+  /**
+   * Per-transaction memoization for `Cell.get()` results.
+   *
+   * Within a single transaction, repeatedly reading the same cell recomputes the
+   * full read pipeline (link resolution, schema merge, schema-guided traversal).
+   * When no write has occurred since the last read, that work is redundant: the
+   * value, the reactive reads it registers, and the CFC state it produces are all
+   * identical. These two methods let `Cell.get()` cache its result keyed by the
+   * cell's link identity; the implementation clears the entire cache on any
+   * write, so a cached entry is only ever returned when no write has intervened.
+   *
+   * Optional: transactions that must not cache (e.g. the non-reactive `sample()`
+   * wrapper) leave these undefined and callers fall back to recomputing.
+   * `keyObject` must be a stable per-cell object identity (the cell's normalized
+   * link); `variant` distinguishes reads that differ in options. A returned
+   * `{ value }` wrapper signals a hit, so a cached `undefined` value is
+   * distinguishable from a miss.
+   */
+  getCachedReadResult?(
+    keyObject: object,
+    variant: string,
+  ): { value: unknown } | undefined;
+
+  setCachedReadResult?(
+    keyObject: object,
+    variant: string,
+    value: unknown,
+  ): void;
 }
 
 export interface ITransactionReader {

--- a/packages/runner/test/cell-get-cache.test.ts
+++ b/packages/runner/test/cell-get-cache.test.ts
@@ -124,4 +124,43 @@ describe("Cell.get() per-transaction cache", () => {
     expect(afterReal).toBeGreaterThan(0);
     expect(afterCached).toBe(afterReal);
   });
+
+  it("bypasses the cache once CFC is prepared (preserves read-after-prepare invalidation)", () => {
+    const c = runtime.getCell(space, "cfc-prepared", OBJECT_SCHEMA, tx);
+    c.set({ x: 1 });
+
+    const before = c.get(); // caches under the un-prepared tx
+    tx.prepareCfc();
+    expect(tx.getCfcState().prepare.status).toBe("prepared");
+
+    const after = c.get(); // must go through the real read path, not the cache
+    expect(after).not.toBe(before);
+    // The real read path performed the read-after-prepare invalidation that a
+    // cache hit would have skipped.
+    expect(tx.getCfcState().prepare.status).toBe("invalidated");
+  });
+
+  it("clears the cache when writing through writer().write()", () => {
+    const c = runtime.getCell(space, "writer-path", OBJECT_SCHEMA, tx);
+    c.set({ x: 1 });
+
+    const before = c.get(); // caches
+
+    const writer = tx.writer(space);
+    expect(writer.ok).toBeDefined();
+    // Merely obtaining a writer must not drop cached reads.
+    expect(c.get()).toBe(before);
+
+    // Writing through the raw writer bypasses write*/writeOrThrow*, but the
+    // wrapped writer still clears the per-tx read cache.
+    const link = c.getAsNormalizedFullLink();
+    writer.ok!.write(
+      { id: link.id, type: "application/json", path: ["value"] },
+      { x: 2 },
+    );
+
+    const after = c.get();
+    expect(after).not.toBe(before); // cache was cleared
+    expect(after).toEqual({ x: 2 });
+  });
 });

--- a/packages/runner/test/cell-get-cache.test.ts
+++ b/packages/runner/test/cell-get-cache.test.ts
@@ -1,0 +1,127 @@
+// Per-transaction memoization of Cell.get(): within one ready transaction, a
+// repeated read with no intervening write reuses the prior result; any write
+// clears the cache so a stale value can never be served.
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+const signer = await Identity.fromPassphrase("cell-get-cache test");
+const space = signer.did();
+
+const OBJECT_SCHEMA = {
+  type: "object",
+  properties: { x: { type: "number" } },
+} as const satisfies JSONSchema;
+
+describe("Cell.get() per-transaction cache", () => {
+  let runtime: Runtime;
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("serves a repeated read from cache (identical result object, no write between)", () => {
+    const c = runtime.getCell(space, "cache-hit", OBJECT_SCHEMA, tx);
+    c.set({ x: 1 });
+
+    const first = c.get();
+    const second = c.get();
+
+    // Without caching, validateAndTransform builds a fresh object per call, so
+    // reference identity is the observable signal that the cache served it.
+    expect(second).toBe(first);
+    expect(first).toEqual({ x: 1 });
+  });
+
+  it("recomputes after an intervening write to the same cell", () => {
+    const c = runtime.getCell(space, "self-write", OBJECT_SCHEMA, tx);
+    c.set({ x: 1 });
+
+    const first = c.get();
+    expect(first).toEqual({ x: 1 });
+
+    c.set({ x: 2 });
+    const second = c.get();
+
+    expect(second).not.toBe(first);
+    expect(second).toEqual({ x: 2 });
+  });
+
+  it("recomputes after a write to a different cell (clear-on-any-write)", () => {
+    const a = runtime.getCell(space, "other-write-a", OBJECT_SCHEMA, tx);
+    const b = runtime.getCell(space, "other-write-b", OBJECT_SCHEMA, tx);
+    a.set({ x: 1 });
+    b.set({ x: 9 });
+
+    const first = a.get();
+    b.set({ x: 10 }); // unrelated write clears the whole per-tx cache
+
+    const second = a.get();
+    expect(second).not.toBe(first); // recomputed
+    expect(second).toEqual({ x: 1 }); // ...but value is unchanged and correct
+  });
+
+  it("keys cache entries by read options (traverseCells does not collide)", () => {
+    const c = runtime.getCell(space, "variant", OBJECT_SCHEMA, tx);
+    c.set({ x: 1 });
+
+    const plain = c.get();
+    const traversed = c.get({ traverseCells: true });
+
+    // Different option variants are cached separately; each is internally
+    // stable.
+    expect(c.get()).toBe(plain);
+    expect(c.get({ traverseCells: true })).toBe(traversed);
+    expect(plain).toEqual({ x: 1 });
+    expect(traversed).toEqual({ x: 1 });
+  });
+
+  it("does not let the non-reactive sample() path pollute the get() cache", () => {
+    const c = runtime.getCell(space, "sample-isolation", OBJECT_SCHEMA, tx);
+    c.set({ x: 7 });
+
+    // sample() runs through a non-reactive wrapper tx that exposes no cache, so
+    // it neither reads from nor writes to the get() cache.
+    const sampled = c.sample();
+    expect(sampled).toEqual({ x: 7 });
+
+    const got = c.get();
+    expect(got).toEqual({ x: 7 });
+    expect(c.get()).toBe(got); // get() still caches normally
+  });
+
+  it("keeps reactive reads stable across a cached get()", () => {
+    const c = runtime.getCell(space, "reactive-read", { type: "number" }, tx);
+    c.set(5);
+
+    c.get(); // real read: registers the dependency on the tx
+    const afterReal = [...(tx.getReactivityLog?.().reads ?? [])].length;
+    c.get(); // served from cache
+    const afterCached = [...(tx.getReactivityLog?.().reads ?? [])].length;
+
+    // The first get() registered the reactive dependency, and the cached second
+    // get() neither dropped it nor needed to re-add it -- so an action that
+    // reads a cell twice still depends on it exactly as before.
+    expect(afterReal).toBeGreaterThan(0);
+    expect(afterCached).toBe(afterReal);
+  });
+});

--- a/packages/runner/test/cell-get-cache.test.ts
+++ b/packages/runner/test/cell-get-cache.test.ts
@@ -139,28 +139,4 @@ describe("Cell.get() per-transaction cache", () => {
     // cache hit would have skipped.
     expect(tx.getCfcState().prepare.status).toBe("invalidated");
   });
-
-  it("clears the cache when writing through writer().write()", () => {
-    const c = runtime.getCell(space, "writer-path", OBJECT_SCHEMA, tx);
-    c.set({ x: 1 });
-
-    const before = c.get(); // caches
-
-    const writer = tx.writer(space);
-    expect(writer.ok).toBeDefined();
-    // Merely obtaining a writer must not drop cached reads.
-    expect(c.get()).toBe(before);
-
-    // Writing through the raw writer bypasses write*/writeOrThrow*, but the
-    // wrapped writer still clears the per-tx read cache.
-    const link = c.getAsNormalizedFullLink();
-    writer.ok!.write(
-      { id: link.id, type: "application/json", path: ["value"] },
-      { x: 2 },
-    );
-
-    const after = c.get();
-    expect(after).not.toBe(before); // cache was cleared
-    expect(after).toEqual({ x: 2 });
-  });
 });


### PR DESCRIPTION
## What

Memoizes `Cell.get()`'s result for the lifetime of a transaction. Within one ready transaction, repeatedly reading the same cell currently re-runs the full read pipeline (link resolution → schema merge → schema-guided traversal). When no write has happened since the last read, that work is redundant — the value, the reactive reads it registers, and the CFC state it produces are all identical.

The cache lives on `ExtendedStorageTransaction`, keyed by the cell's link identity plus a read-options variant. **Any write clears the whole cache** (the backing `WeakMap` is replaced), so a cached entry is only ever returned when nothing has been written since it was computed — exactly the "no writes between the last `get` and this one" invariant.

## Why it's safe

The read path is effectful, not pure, so the question was whether skipping it loses anything. It doesn't:

- **Reactivity** — reactive reads accumulate per-tx as a set. The dependency is already registered by the first (uncached) `get()` within the action's tx; a cached `get()` neither drops it nor needs to re-add it. (Test: reactive reads are stable across a cached get.)
- **CFC** — the only thing a cache hit changes is dereference-trace *multiplicity*. Traces feed **only** the in-memory `prepare`↔`commit` consistency digest (`buildPreparedDigestInput` → `preparedDigestFor`), which is recomputed from the same tx and compared within one execution — never persisted, never shipped to a remote verifier, and **never** part of the authorization decision (`prepareBoundaryCommit` works off write-policy inputs / write details / reactivity log / stored metadata, not traces). Reducing redundant traces is if anything a small positive (fewer spurious post-prepare invalidations).
- **`sample()`** — the non-reactive wrapper (`TransactionWrapper`) leaves the optional cache methods unimplemented, so it neither reads from nor writes to the `get()` cache. No cross-contamination between reactive `get()` and non-reactive `sample()`.

## Scope / invalidation

- Caching is gated on the cell's tx being present, `ready`, and cache-capable — so closed-tx ambient reads and `sample()` are untouched.
- Cleared at every write entry point on the base tx: `write()`, `writeOrThrow()` (covers `writeValueOrThrow`), and `writeValuesOrThrow()` (covers the `writeBatch` fast path). No write path bypasses these (`writer()` is unused for writes in the runner).
- Conservative by design: the key is the cell's `_link` identity, so distinct cells reaching the same value miss rather than risk a false hit; and *any* write flushes everything rather than tracking per-path dependencies.

## Tests

New `packages/runner/test/cell-get-cache.test.ts`:
- repeated read served from cache (identical result object, no write between)
- recompute after an intervening write to the same cell
- recompute after a write to a different cell (clear-on-any-write)
- read-options variants (`traverseCells`) cached separately, no collision
- `sample()` does not pollute the `get()` cache
- reactive reads stay registered/stable across a cached get

Verified red→green: with the cache lookup disabled, the four cache-dependent tests fail; with it enabled all pass. Full runner suite (529 files / 2798 steps) passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caches `Cell.get()` results within a single ready transaction to avoid redundant work on repeat reads. Also bypasses the cache once CFC is prepared and removes `reader()`/`writer()` from the extended transaction surface.

- **Refactors**
  - Cache lives on `ExtendedStorageTransaction`, keyed by cell link identity plus a read-options variant; cleared on any write via `write`, `writeOrThrow`, and `writeValuesOrThrow`.
  - Cache is used only for ready txs with CFC not `prepared`; `sample()` and ambient reads don’t use it; reactivity and CFC behavior stay unchanged.
  - Dropped `reader()`/`writer()` from `IExtendedStorageTransaction` and from `ExtendedStorageTransaction`/`TransactionWrapper`; use `.tx` for raw space-scoped reader/writer if needed.
  - Tests cover cache hits, invalidation on same/other-cell writes, option variants, `sample()` isolation, prepared-state bypass, and stable reactive reads.

<sup>Written for commit bf17b0c5d4f62801e67dec2c586af7b8905d7012. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

