### PR TITLE
fix(memory): convert native values to fabric at the wire boundary

### DIFF
--- a/packages/memory/test/v2-test.ts
+++ b/packages/memory/test/v2-test.ts
@@ -4,6 +4,7 @@ import {
   resetModernCellRepConfig,
   setModernCellRepConfig,
 } from "@commonfabric/data-model/cell-rep";
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import {
   compatibleMemoryProtocolFlags,
   decodeMemoryBoundary,
@@ -223,5 +224,39 @@ describe("memory v2 boundary decode", () => {
       decoded.value.nested.count = 2;
     }, TypeError);
     assertEquals(decoded.value.nested.count, 1);
+  });
+});
+
+describe("memory v2 boundary encode", () => {
+  // A `Uint8Array` (such as a session-open signature) must be converted to a
+  // `FabricBytes` before serialization so it survives the wire boundary, rather
+  // than being silently mangled into an empty object by the structural fallback
+  // in the encoder.
+  it("converts a native `Uint8Array` to a `Bytes`-tagged wire form", () => {
+    const bytes = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+    const encoded = encodeMemoryBoundary({ signature: bytes });
+
+    // Proper tagged form, not a mangled `{}`.
+    assert(
+      encoded.includes("Bytes@1"),
+      `expected a Bytes-tagged wire form, got: ${encoded}`,
+    );
+    assertFalse(
+      encoded.includes(`"signature":{}`),
+      `signature was mangled into an empty object: ${encoded}`,
+    );
+  });
+
+  it("round-trips a native `Uint8Array` to a `FabricBytes`", () => {
+    const bytes = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+    const decoded = decodeMemoryBoundary<{ signature: FabricBytes }>(
+      encodeMemoryBoundary({ signature: bytes }),
+    );
+
+    assert(
+      decoded.signature instanceof FabricBytes,
+      `expected a FabricBytes, got: ${decoded.signature}`,
+    );
+    assertEquals(decoded.signature.slice(), bytes);
   });
 });

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -3,6 +3,7 @@ import {
   jsonFromValue,
   valueFromJson,
 } from "@commonfabric/data-model/json-wire";
+import { fabricFromNativeValue } from "@commonfabric/data-model/fabric-value";
 import { internPathSelector } from "@commonfabric/data-model/schema-utils";
 import type { FabricValue, SchemaPathSelector } from "./interface.ts";
 import { EmptyReconstructionContext } from "@commonfabric/data-model/wire-common";
@@ -561,8 +562,15 @@ export const wireMemoryProtocolFlags = (
   persistentSchedulerState: flags.persistentSchedulerState,
 });
 
+/**
+ * Encodes a value for transmission across the memory wire boundary. Native
+ * values are first converted to `FabricValue`s (e.g. a `Uint8Array` -- such as
+ * a session-open signature -- becomes `FabricBytes`) so they serialize
+ * faithfully, rather than being silently mangled by the structural
+ * object/array fallthrough in the encoder.
+ */
 export const encodeMemoryBoundary = (value: unknown): string =>
-  jsonFromValue(value as FabricValue);
+  jsonFromValue(fabricFromNativeValue(value));
 
 export const decodeMemoryBoundary = <Value = FabricValue>(
   source: string,


### PR DESCRIPTION
## Summary

`encodeMemoryBoundary` cast its input straight to `FabricValue` and handed it to `jsonFromValue`. Native values that aren't already `FabricValue`s — notably the raw `Uint8Array` signature carried by a `session.open` message — fell through the encoder's structural object/array fallback and were **silently mangled** (a `Uint8Array` serialized as an empty `{}`).

The fix converts native values via `fabricFromNativeValue()` before serializing, so a `Uint8Array` becomes a `FabricBytes` and serializes to its proper `/Bytes@1` wire form.

This bug was surfaced by an in-flight codec migration (#3900) that adds a strict encode guard — the previously-silent mangling now correctly throws `Cannot encode a Uint8Array instance: no applicable codec.` Landing this fix first lets that branch pick it up cleanly via `main`.

## Test plan

- New `memory v2 boundary encode` tests assert that a native `Uint8Array` (a stand-in for a session-open signature) encodes to a `Bytes@1`-tagged wire form (not a mangled `{}`) and round-trips back to a `FabricBytes` with the original bytes.
- `deno fmt`, `deno task check`, and the full `packages/memory` test suite (162 passed) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes encoding of native values at the memory wire boundary by converting them to Fabric before serialization. `Uint8Array` values (e.g., session-open signatures) now become `FabricBytes` and encode to `/Bytes@1` instead of `{}`.

- **Bug Fixes**
  - `encodeMemoryBoundary` converts inputs via `fabricFromNativeValue` before `jsonFromValue`, preventing structural fallback mangling.
  - Added tests to ensure `Uint8Array` encodes as `Bytes@1` and round-trips to `FabricBytes`.

<sup>Written for commit b46ae77e3b9b8905c0836e8274d3d82b033d3719. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

