### PR TITLE
feat(memory): accept a `FabricBytes` session signature (staged migration, step 1)

### DIFF
--- a/packages/runner/src/storage/v2-remote-session.ts
+++ b/packages/runner/src/storage/v2-remote-session.ts
@@ -150,7 +150,20 @@ export class RemoteSessionFactory implements SessionFactory {
     return {
       invocation,
       authorization: {
-        signature: signature.ok,
+        // The signature is sent as a plain number array. It used to be passed
+        // as a raw `Uint8Array`, which only survived the memory wire boundary
+        // by accident: the encoder's lenient structural fallback flattened it
+        // into a numeric-keyed object that the server's `toByteArray` happened
+        // to accept. Emitting an explicit array makes the wire form intentional
+        // (and keeps it a plain `FabricValue`, so it survives the stricter
+        // codec encoder). The server-side `toByteArray` accepts this form.
+        //
+        // TODO(danfuzz): The signature should travel as a `FabricBytes`, not a
+        // number array. Once consumers that accept `FabricBytes` have fully
+        // propagated, flip this to `new FabricBytes(signature.ok)` and then
+        // retire the array/numeric-object handling in `toByteArray`. (Staged
+        // rollout Z4.)
+        signature: Array.from(signature.ok),
       },
     };
   }

--- a/packages/runner/src/storage/v2-remote-session.ts
+++ b/packages/runner/src/storage/v2-remote-session.ts
@@ -159,10 +159,9 @@ export class RemoteSessionFactory implements SessionFactory {
         // codec encoder). The server-side `toByteArray` accepts this form.
         //
         // TODO(danfuzz): The signature should travel as a `FabricBytes`, not a
-        // number array. Once consumers that accept `FabricBytes` have fully
+        // number array. Once servers that accept `FabricBytes` have fully
         // propagated, flip this to `new FabricBytes(signature.ok)` and then
-        // retire the array/numeric-object handling in `toByteArray`. (Staged
-        // rollout Z4.)
+        // retire the array/numeric-object handling in `toByteArray`.
         signature: Array.from(signature.ok),
       },
     };

--- a/packages/toolshed/routes/storage/memory.ts
+++ b/packages/toolshed/routes/storage/memory.ts
@@ -19,11 +19,10 @@ const toByteArray = (value: unknown): Uint8Array | null => {
     return value;
   }
   // A `FabricBytes` is the intended long-term wire form for the signature.
-  // Accepting it here (ahead of any client producing it) is the "expand" half
-  // of a staged rollout, so that the producer can later flip to `FabricBytes`
-  // without breaking already-deployed servers.
+  // Accepting it here ahead of any client producing it lets the producer flip
+  // to `FabricBytes` later without breaking already-deployed servers.
   // TODO(danfuzz): Once producers emit `FabricBytes`, the array/numeric-object
-  // branches below become legacy and can be retired. (Staged rollout Z4.)
+  // branches below become legacy and can be retired.
   if (value instanceof FabricBytes) {
     return value.slice();
   }

--- a/packages/toolshed/routes/storage/memory.ts
+++ b/packages/toolshed/routes/storage/memory.ts
@@ -1,6 +1,7 @@
 import { MEMORY_PROTOCOL } from "@commonfabric/memory/v2";
 import * as MemoryServer from "@commonfabric/memory/v2/server";
 import { hashOf } from "@commonfabric/data-model/value-hash";
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import * as FS from "@std/fs";
 import * as Path from "@std/path";
 import env from "@/env.ts";
@@ -16,6 +17,15 @@ const authorizationError = (message: string): Error =>
 const toByteArray = (value: unknown): Uint8Array | null => {
   if (value instanceof Uint8Array) {
     return value;
+  }
+  // A `FabricBytes` is the intended long-term wire form for the signature.
+  // Accepting it here (ahead of any client producing it) is the "expand" half
+  // of a staged rollout, so that the producer can later flip to `FabricBytes`
+  // without breaking already-deployed servers.
+  // TODO(danfuzz): Once producers emit `FabricBytes`, the array/numeric-object
+  // branches below become legacy and can be retired. (Staged rollout Z4.)
+  if (value instanceof FabricBytes) {
+    return value.slice();
   }
   if (Array.isArray(value) && value.every((item) => Number.isInteger(item))) {
     return Uint8Array.from(value);

--- a/packages/toolshed/routes/storage/memory/memory.test.ts
+++ b/packages/toolshed/routes/storage/memory/memory.test.ts
@@ -8,6 +8,7 @@ import {
   MEMORY_PROTOCOL,
 } from "@commonfabric/memory/v2";
 import { hashOf } from "@commonfabric/data-model/value-hash";
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { createSession, Identity } from "@commonfabric/identity";
 import { type JSONSchema, Runtime } from "@commonfabric/runner";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
@@ -323,6 +324,55 @@ serialTest("memory websocket negotiates a session", async () => {
     await server.shutdown();
   }
 });
+
+// Forward-compatibility for the staged signature wire-format migration: the
+// server must accept a session-open signature sent as a `FabricBytes` (the
+// intended long-term form), ahead of any client actually producing it. See
+// `toByteArray` in `../memory.ts`.
+serialTest(
+  "memory websocket negotiates a session with a `FabricBytes` signature",
+  async () => {
+    const identity = await Identity.fromPassphrase("memory-route-open-bytes");
+    const server = Deno.serve({ port: 0 }, app.fetch);
+    const address = new URL(
+      `ws://${server.addr.hostname}:${server.addr.port}/api/storage/memory`,
+    );
+    const space = identity.did();
+
+    try {
+      const socket = await openSocket(address);
+      socket.send(encodeMemoryBoundary(HELLO));
+      await readJsonMessage(socket);
+
+      const auth = await createSessionOpenAuth(identity, space);
+      socket.send(encodeMemoryBoundary({
+        type: "session.open",
+        requestId: "open-1",
+        space,
+        session: {},
+        ...auth,
+        authorization: {
+          ...auth.authorization,
+          signature: new FabricBytes(auth.authorization.signature),
+        },
+      }));
+
+      const opened = await readJsonMessage<{
+        type: "response";
+        requestId: string;
+        ok: { sessionId: string; serverSeq: number };
+      }>(socket);
+
+      assertEquals(opened.type, "response");
+      assertEquals(opened.requestId, "open-1");
+      assert(opened.ok.sessionId.length > 0);
+
+      socket.close();
+    } finally {
+      await server.shutdown();
+    }
+  },
+);
 
 serialTest("memory websocket rejects an unsigned session open", async () => {
   const identity = await Identity.fromPassphrase("memory-route-open-reject");


### PR DESCRIPTION
## Summary

This is **step 1 ("expand")** of a staged migration of the session-open `authorization.signature` toward a real `FabricBytes` wire form. It supersedes #3901 (which jumped straight to producing `FabricBytes` without first teaching consumers to accept it — that breaks auth on any not-yet-updated server).

### Background

The signature is a raw `Uint8Array`. Today it only survives the memory wire boundary *by accident*: `encodeMemoryBoundary`'s lenient structural fallback flattens it into a numeric-keyed object (`{"0":…}`), and the server's `toByteArray` happens to decode that form. The stricter codec encoder in flight (#3900) correctly refuses a raw `Uint8Array`, so the producer must stop relying on the accident — and the long-term intent is for the signature to travel as a `FabricBytes`.

### Changes

- **Consumer** (`toByteArray`, `packages/toolshed/routes/storage/memory.ts`): accept a `FabricBytes` (the intended long-term form) in addition to the existing `Uint8Array` / number-array / numeric-object forms — *ahead of* any client producing it. This is the expand half of expand/migrate/contract.
- **Producer** (`packages/runner/src/storage/v2-remote-session.ts`): emit the signature as an explicit `Array.from(signature.ok)` number array rather than relying on the lenient fallback. It stays a plain `FabricValue` (survives the strict encoder) and is accepted by `toByteArray`'s existing array branch. A `TODO(danfuzz)` marks the eventual flip to `FabricBytes`.

### Staged rollout (this is step 1)

1. **(this PR)** Expand consumer to accept `FabricBytes`; make the producer's wire form intentional. *Wait for propagation.*
2. Land the data-model codec rework (#3900) — safe now that the producer no longer emits a raw `Uint8Array`.
3. Flip the producer to emit `FabricBytes` (gate: all servers have step 1).
4. Contract: remove the legacy array/numeric-object handling from `toByteArray` (gate: all clients have step 3).

## Test plan

- New `memory websocket negotiates a session with a \`FabricBytes\` signature` test opens a session end-to-end with the signature sent as a `FabricBytes`, proving the consumer's expand branch through the real decode path.
- Existing session-open tests (`negotiates`, `rejects unsigned`, `resumes`, `requires hello`, and the runtime-based `authorizes session opens` — which exercises the real producer) all pass, confirming the number-array producer form and the unchanged existing forms still work.
- `deno check` + `deno fmt` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make session-open signatures forward-compatible by accepting `FabricBytes` on the server and intentionally sending a number array from the client. This is step 1 of the staged migration toward a real `FabricBytes` wire form and keeps auth working with the stricter codec.

- **Migration**
  - Consumer: `toByteArray` in `packages/toolshed/routes/storage/memory.ts` now accepts `FabricBytes` (alongside existing forms).
  - Producer: `packages/runner/src/storage/v2-remote-session.ts` sends `Array.from(signature.ok)` instead of a raw `Uint8Array` so it survives the strict encoder.
  - Tests: Added an end-to-end memory websocket test that opens a session with a `FabricBytes` signature.
  - Cleanup: Removed internal backlog references from migration comments.

<sup>Written for commit 00fafff4daad683159245d2c8694c10bec79b485. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

