### PR TITLE
feat(runner): pass map/filter/flatMap op by {identity, symbol} (CT-1623)

### DIFF
--- a/packages/runner/src/builder/traverse-utils.ts
+++ b/packages/runner/src/builder/traverse-utils.ts
@@ -1,5 +1,10 @@
 import { isRecord } from "@commonfabric/utils/types";
-import { isOpaqueRef, isPattern, type Opaque } from "./types.ts";
+import {
+  isOpaqueRef,
+  isPattern,
+  type Opaque,
+  unsafe_originalPattern,
+} from "./types.ts";
 import { isCell } from "../cell.ts";
 import { isCellResultForDereferencing } from "../query-result-proxy.ts";
 
@@ -34,11 +39,22 @@ export function traverseValue(
     if (Array.isArray(value)) {
       return (value as Array<any>).map((v) => traverseValue(v, fn, seen));
     } else {
-      return Object.fromEntries(
+      const copy = Object.fromEntries(
         Object.entries(value).map((
           [key, v],
         ) => [key, traverseValue(v, fn, seen)]),
       );
+      // `Object.entries` drops symbol keys, so a pattern copied here would lose
+      // its link back to the original (branded, content-addressed) factory —
+      // severing `findOriginalPattern`/`getArtifactEntryRef`, which is how a
+      // pattern passed as an `op` is later identified by `{ identity, symbol }`.
+      // Preserve that link (the deepest original) on the copy. Mirrors the same
+      // `unsafe_originalPattern` retention in `toJSONWithLegacyAliases`.
+      if (isPattern(value)) {
+        (copy as Record<symbol, unknown>)[unsafe_originalPattern] =
+          (value as Record<symbol, unknown>)[unsafe_originalPattern] ?? value;
+      }
+      return copy;
     }
   } else {
     return value;

--- a/packages/runner/src/builtins/filter.ts
+++ b/packages/runner/src/builtins/filter.ts
@@ -25,6 +25,7 @@ import {
   outputSpotFromBinding,
   scopedCell,
 } from "./scope-policy.ts";
+import { resolveOpPattern } from "./op-pattern-ref.ts";
 
 /**
  * Implementation of built-in filter module. Like map, this is called once at
@@ -77,7 +78,7 @@ export function filter(
     const { list, op } = inputsCell.asSchema(FILTER_INPUT_SCHEMA)
       .withTx(tx).get();
 
-    const opPattern = op.getRaw();
+    const opPattern = resolveOpPattern(runtime, op.getRaw(), "filter");
     const argumentUsage = inferListOpArgumentUsage(runtime.cfc, opPattern);
     const outputScope = narrowestCellScope(runtime, tx, [
       inputsCell.key("list"),

--- a/packages/runner/src/builtins/flatmap.ts
+++ b/packages/runner/src/builtins/flatmap.ts
@@ -25,6 +25,7 @@ import {
   outputSpotFromBinding,
   scopedCell,
 } from "./scope-policy.ts";
+import { resolveOpPattern } from "./op-pattern-ref.ts";
 
 /**
  * Implementation of built-in flatMap module. Like map, this is called once at
@@ -79,7 +80,7 @@ export function flatMap(
     const { list, op } = inputsCell.asSchema(FLATMAP_INPUT_SCHEMA)
       .withTx(tx).get();
 
-    const opPattern = op.getRaw();
+    const opPattern = resolveOpPattern(runtime, op.getRaw(), "flatMap");
     const argumentUsage = inferListOpArgumentUsage(runtime.cfc, opPattern);
     const outputScope = narrowestCellScope(runtime, tx, [
       inputsCell.key("list"),

--- a/packages/runner/src/builtins/map.ts
+++ b/packages/runner/src/builtins/map.ts
@@ -35,6 +35,7 @@ import {
   scopedCell,
 } from "./scope-policy.ts";
 import { resolveLink } from "../link-resolution.ts";
+import { resolveOpPattern } from "./op-pattern-ref.ts";
 
 /**
  * Implementation of built-in map module. Unlike regular modules, this will be
@@ -112,8 +113,10 @@ export function map(
     const listCell = sourceListCell.withTx(tx).resolveAsCell();
     const list = listCell.asSchema(MAP_LIST_SCHEMA).withTx(tx).get();
     // .getRaw() because we want the pattern itself and avoid following the
-    // aliases in the pattern.
-    const opPattern = op.getRaw();
+    // aliases in the pattern. The raw value is either a compact
+    // `{ $patternRef }` sentinel (resolved to the live canonical pattern by
+    // identity) or, on the legacy path, the embedded pattern graph itself.
+    const opPattern = resolveOpPattern(runtime, op.getRaw(), "map");
 
     if (!result || result.getAsNormalizedFullLink().scope !== listScope) {
       const resultSchema = trustedFlowPrecisionSchemaForBuiltin(

--- a/packages/runner/src/builtins/op-pattern-ref.ts
+++ b/packages/runner/src/builtins/op-pattern-ref.ts
@@ -1,0 +1,77 @@
+import { isRecord } from "@commonfabric/utils/types";
+import type { Pattern } from "../builder/types.ts";
+import type { Runtime } from "../runtime.ts";
+
+/**
+ * Compact reference to a pattern by its content-addressed `{ identity, symbol }`
+ * entry ref, used in place of an embedded pattern graph for the `op` input of
+ * `map`/`filter`/`flatMap` nodes.
+ *
+ * The runner substitutes this sentinel for the serialized op graph at node
+ * instantiation (see `Runner.substituteOpPatternRefs`), once the op pattern's
+ * entry ref is known. Because it is plain data (no symbol keys), it survives the
+ * `getImmutableCell` JSON round-trip that strips the in-memory
+ * `unsafe_originalPattern` backref — so the builtin reads it back intact and
+ * resolves the live canonical pattern without deserializing a graph or mapping
+ * functions back by `implementationRef`.
+ */
+export interface PatternRefSentinel {
+  $patternRef: { identity: string; symbol: string };
+  /**
+   * The embedded op pattern graph, retained as a correctness fallback.
+   *
+   * The identity fast path resolves the op from the in-memory evaluated-module
+   * cache, which is bounded (FIFO) — a long-lived session that evaluates enough
+   * other modules can evict an op whose map/filter/flatMap node is still live.
+   * Cache residency must therefore be an optimization, not a correctness
+   * requirement: on a miss we deserialize this graph instead of hard-failing a
+   * running node. (#3898 dropped the session-varying `program.files` from
+   * serialized patterns, so retaining the graph no longer reintroduces the
+   * cross-reload id churn that motivated passing the op by identity.)
+   */
+  $opFallback?: Pattern;
+}
+
+export function isPatternRefSentinel(
+  value: unknown,
+): value is PatternRefSentinel {
+  if (!isRecord(value)) return false;
+  const ref = (value as { $patternRef?: unknown }).$patternRef;
+  return isRecord(ref) && typeof ref.identity === "string" &&
+    typeof ref.symbol === "string";
+}
+
+/**
+ * Resolve the `op` value a list builtin (`map`/`filter`/`flatMap`) reads from
+ * its inputs cell into a live `Pattern`.
+ *
+ * - When `op` is a {@link PatternRefSentinel}, resolve it synchronously from the
+ *   in-memory cache via `artifactFromIdentitySync` (the fast path: the op's
+ *   module is part of the parent pattern's bundle, normally still
+ *   live by the time the list Action runs). On a cache miss (the op was evicted
+ *   mid-session — a sync Action cannot await `loadPatternByIdentity`), fall back
+ *   to the sentinel's retained `$opFallback` graph so a running node never breaks
+ *   just because its op rolled out of the bounded cache.
+ * - Otherwise (legacy / ESM loader off / no entry ref), `op` is the embedded
+ *   pattern graph itself, used as-is.
+ */
+export function resolveOpPattern(
+  runtime: Runtime,
+  rawOp: unknown,
+  builtinName: string,
+): Pattern {
+  if (isPatternRefSentinel(rawOp)) {
+    const { identity, symbol } = rawOp.$patternRef;
+    const resolved = runtime.patternManager.artifactFromIdentitySync(
+      identity,
+      symbol,
+    ) as Pattern | undefined;
+    if (resolved) return resolved;
+    if (rawOp.$opFallback) return rawOp.$opFallback;
+    throw new Error(
+      `${builtinName}: op pattern ${identity}#${symbol} is not in the ` +
+        `evaluated-module cache and has no embedded fallback`,
+    );
+  }
+  return rawOp as Pattern;
+}

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -24,7 +24,7 @@ import { sqliteQueryNodeFactory } from "./builtins/sqlite/query-node.ts";
 import { checkSqliteWriteCeiling } from "./builtins/sqlite/write-ceiling.ts";
 import { cfcLabelViewForCell } from "./cfc/label-view.ts";
 import { cfcConfidentialityForObservationNode } from "./cfc/observation.ts";
-import { getTopFrame, pattern } from "./builder/pattern.ts";
+import { getTopFrame } from "./builder/pattern.ts";
 import { createNodeFactory, lift } from "./builder/module.ts";
 import {
   type AnyCell,
@@ -154,6 +154,24 @@ export type RawCellReadOptions = IReadOptions & {
 let mapFactory: NodeFactory<any, any> | undefined;
 let filterFactory: NodeFactory<any, any> | undefined;
 let flatMapFactory: NodeFactory<any, any> | undefined;
+
+/**
+ * Error thrown by the function-form `.map`/`.filter`/`.flatMap` on an
+ * OpaqueRef/Cell. These wrapped the callback in an anonymous inline pattern,
+ * which has no stable content-addressed `{ identity, symbol }` and so cannot be
+ * passed/persisted by identity (CT-1623). Authored pattern code is always
+ * lowered by the TS transformer to the `*WithPattern(pattern(...), params)` form
+ * (with the pattern hoisted to a module export); direct builder-API callers must
+ * use the `*WithPattern` variant explicitly.
+ */
+function throwOpFunctionFormMessage(
+  method: "map" | "filter" | "flatMap",
+): string {
+  return `OpaqueRef.${method}(fn) is no longer supported: an inline pattern has ` +
+    `no stable identity. Authored \`.${method}(...)\` is lowered by the TS ` +
+    `transformer to \`.${method}WithPattern(pattern(...), { params })\`; if you ` +
+    `are calling the builder API directly, use \`.${method}WithPattern(op, params)\`.`;
+}
 
 // WeakMap to store connected nodes for each cell instance
 const cellNodes = new WeakMap<OpaqueCell<unknown>, Set<NodeRef>>();
@@ -1938,31 +1956,13 @@ export class CellImpl<T extends FabricValue>
   }
 
   map<S>(
-    fn: (
+    _fn: (
       element: T extends Array<infer U> ? OpaqueRef<U> : OpaqueRef<T>,
       index: OpaqueRef<number>,
       array: OpaqueRef<T>,
     ) => Opaque<S>,
   ): OpaqueRef<S[]> {
-    // Create the factory if it doesn't exist
-    if (!mapFactory) {
-      mapFactory = createNodeFactory({
-        type: "ref",
-        implementation: "map",
-      });
-    }
-    const op = pattern(
-      ({ element, index, array }: Opaque<any>) => fn(element, index, array),
-    );
-    const result = mapFactory({
-      list: this as unknown as OpaqueRef<T>,
-      op,
-    });
-    const schema = flowPrecisionSchemaForBuiltin("map", op.resultSchema);
-    if (schema !== undefined) {
-      result.setSchema(schema);
-    }
-    return result;
+    throw new Error(throwOpFunctionFormMessage("map"));
   }
 
   /**
@@ -2050,30 +2050,13 @@ export class CellImpl<T extends FabricValue>
    * Output contains cell references to the original elements.
    */
   filter(
-    fn: (
+    _fn: (
       element: T extends Array<infer U> ? OpaqueRef<U> : OpaqueRef<T>,
       index: OpaqueRef<number>,
       array: OpaqueRef<T>,
     ) => Opaque<boolean>,
   ): OpaqueRef<(T extends Array<infer U> ? U : T)[]> {
-    if (!filterFactory) {
-      filterFactory = createNodeFactory({
-        type: "ref",
-        implementation: "filter",
-      });
-    }
-
-    const result = filterFactory({
-      list: this as unknown as OpaqueRef<T>,
-      op: pattern(
-        ({ element, index, array }: Opaque<any>) => fn(element, index, array),
-      ),
-    });
-    const schema = flowPrecisionSchemaForBuiltin("filter");
-    if (schema !== undefined) {
-      result.setSchema(schema);
-    }
-    return result;
+    throw new Error(throwOpFunctionFormMessage("filter"));
   }
 
   /**
@@ -2110,30 +2093,13 @@ export class CellImpl<T extends FabricValue>
    * Each callback should return an array; results are concatenated one level deep.
    */
   flatMap<S>(
-    fn: (
+    _fn: (
       element: T extends Array<infer U> ? OpaqueRef<U> : OpaqueRef<T>,
       index: OpaqueRef<number>,
       array: OpaqueRef<T>,
     ) => Opaque<S[]>,
   ): OpaqueRef<S[]> {
-    if (!flatMapFactory) {
-      flatMapFactory = createNodeFactory({
-        type: "ref",
-        implementation: "flatMap",
-      });
-    }
-
-    const result = flatMapFactory({
-      list: this as unknown as OpaqueRef<T>,
-      op: pattern(
-        ({ element, index, array }: Opaque<any>) => fn(element, index, array),
-      ),
-    });
-    const schema = flowPrecisionSchemaForBuiltin("flatMap");
-    if (schema !== undefined) {
-      result.setSchema(schema);
-    }
-    return result;
+    throw new Error(throwOpFunctionFormMessage("flatMap"));
   }
 
   /**

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -899,10 +899,20 @@ export class PatternManager {
     if (!main) {
       throw new Error("Pattern compilation produced no exports.");
     }
-    if (!(symbol in main)) {
-      throw new Error(`No "${symbol}" export found in compiled pattern.`);
+    // Usually an authored export, but a map/filter/flatMap `op` reloads by a
+    // transformer HOIST symbol (`__cfReg`, e.g. `__cfPattern_1`) that is not an
+    // export — `registerEvaluatedModules` above indexed it, so resolve it there.
+    const pattern =
+      (symbol in main
+        ? main[symbol]
+        : this.addressableByIdentity.get(entryIdentity)?.get(symbol)) as
+          | Pattern
+          | undefined;
+    if (!pattern) {
+      throw new Error(
+        `No "${symbol}" export or hoist registration found in compiled pattern.`,
+      );
     }
-    const pattern = main[symbol] as Pattern;
     if (isTrustedPattern(pattern)) {
       this.valueToEntryRef.set(pattern, { identity: entryIdentity, symbol });
       if (loadId) {
@@ -1028,9 +1038,19 @@ export class PatternManager {
     symbol: string,
   ): Pattern | undefined {
     const cached = this.modulesByIdentity.get(entryIdentity);
-    if (!cached || !(symbol in cached.exports)) return undefined;
-    const pattern = cached.exports[symbol] as Pattern;
-    if (!isTrustedPattern(pattern)) return undefined;
+    if (!cached) return undefined;
+    // The symbol is usually an authored export, but a map/filter/flatMap `op`
+    // result cell references a transformer HOIST (`__cfReg`, e.g. `__cfPattern_1`)
+    // which is NOT a module export — it lives in the artifact index. Resolving it
+    // there (instead of falling through to a cold source recompile) is what keeps
+    // a reloaded op compile-free (CT-1623).
+    const pattern =
+      (symbol in cached.exports
+        ? cached.exports[symbol]
+        : this.addressableByIdentity.get(entryIdentity)?.get(symbol)) as
+          | Pattern
+          | undefined;
+    if (!pattern || !isTrustedPattern(pattern)) return undefined;
     // Refresh recency.
     this.modulesByIdentity.delete(entryIdentity);
     this.modulesByIdentity.set(entryIdentity, cached);

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -3529,6 +3529,50 @@ export class Runner {
     }
   }
 
+  /**
+   * CT-1623: for the list builtins (`map`/`filter`/`flatMap`), annotate the `op`
+   * input with its content-addressed `{ identity, symbol }` entry ref (when
+   * known) so the builtin can resolve the live canonical pattern by identity
+   * instead of deserializing the embedded graph. Mutates `inputBindings` in
+   * place: `op` becomes `{ $patternRef, $opFallback }`.
+   *
+   * Only the `op` key is rewritten — it is the sole pattern-valued input the
+   * builtins rehydrate (`resolveOpPattern`). Rewriting other inputs (e.g. a
+   * pattern captured in `params`) would leave an unresolved `$patternRef` object
+   * that nothing reads back.
+   *
+   * The embedded graph is retained as `$opFallback` (correctness over the
+   * bounded module cache — see `resolveOpPattern`). `inputBindings` here is the
+   * freshly bound (mutable, unfrozen) copy produced by
+   * `unwrapOneLevelAndBindtoDoc`; its pattern values still carry the in-memory
+   * `unsafe_originalPattern` backref, so `getArtifactEntryRef` can resolve the ref
+   * (assigned post-eval by `registerEvaluatedModules`). With no known ref the op
+   * is left as the embedded graph (legacy / ESM-loader-off).
+   */
+  private substituteOpPatternRefs(
+    moduleRefName: string | undefined,
+    inputBindings: FabricValue,
+  ): void {
+    if (
+      moduleRefName !== "map" && moduleRefName !== "filter" &&
+      moduleRefName !== "flatMap"
+    ) {
+      return;
+    }
+    if (!isRecord(inputBindings)) return;
+    const op = (inputBindings as Record<string, unknown>).op;
+    if (!isRecord(op)) return;
+    const ref = this.runtime.patternManager.getArtifactEntryRef(
+      op as unknown as object,
+    );
+    if (ref) {
+      (inputBindings as Record<string, unknown>).op = {
+        $patternRef: { identity: ref.identity, symbol: ref.symbol },
+        $opFallback: op,
+      };
+    }
+  }
+
   private instantiateRawNode(
     tx: IExtendedStorageTransaction,
     module: Module,
@@ -3577,6 +3621,15 @@ export class Runner {
     // For `map` and future other node types that take closures, we need to
     // note the parent pattern on the closure patterns.
     unsafe_noteParentOnPatterns(pattern, mappedInputBindings);
+
+    // CT-1623: for the list builtins, replace a pattern-valued input (the `op`)
+    // with a compact `{ $patternRef }` sentinel when its content-addressed entry
+    // ref is known. This is the post-eval moment where the in-memory op object
+    // (reachable via `unsafe_originalPattern`, preserved through binding) carries
+    // its `{ identity, symbol }`; the sentinel then survives the immutable-cell
+    // JSON round-trip, so the builtin resolves the live canonical pattern by
+    // identity instead of deserializing the embedded graph.
+    this.substituteOpPatternRefs(moduleRefName, mappedInputBindings);
 
     const inputCells = findAllWriteRedirectCells(
       mappedInputBindings,

--- a/packages/runner/test/cfc-flow-precision.test.ts
+++ b/packages/runner/test/cfc-flow-precision.test.ts
@@ -7,6 +7,7 @@ import {
   trustedFlowPrecisionSchemaForBuiltin,
 } from "../src/cfc/flow-precision.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import { type Opaque } from "../src/builder/types.ts";
 
 const signer = await Identity.fromPassphrase("runner-cfc-flow-precision");
 const space = signer.did();
@@ -79,9 +80,24 @@ describe("CFC flow precision claims", () => {
     valuesCell.set([]);
 
     const collectionPattern = pattern<{ values: number[] }>(({ values }) => {
-      mappedRef = values.map((value: number) => value);
-      filteredRef = values.filter((_value: number) => true);
-      flattenedRef = values.flatMap((value: number) => [value]);
+      mappedRef = (values as any).mapWithPattern(
+        pattern(({ element, index, array }: Opaque<any>) =>
+          (((value: number) => value) as any)(element, index, array)
+        ),
+        {},
+      );
+      filteredRef = (values as any).filterWithPattern(
+        pattern(({ element, index, array }: Opaque<any>) =>
+          (((_value: number) => true) as any)(element, index, array)
+        ),
+        {},
+      );
+      flattenedRef = (values as any).flatMapWithPattern(
+        pattern(({ element, index, array }: Opaque<any>) =>
+          (((value: number) => [value]) as any)(element, index, array)
+        ),
+        {},
+      );
       reducedRef = values.reduce(
         (acc: number, value: number) => acc + value,
         0,

--- a/packages/runner/test/cfc-label-view.test.ts
+++ b/packages/runner/test/cfc-label-view.test.ts
@@ -11,7 +11,7 @@ import { Runtime } from "../src/runtime.ts";
 import { parseLink } from "../src/link-utils.ts";
 import { toCell } from "../src/back-to-cell.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
-import { UI } from "../src/builder/types.ts";
+import { type Opaque, UI } from "../src/builder/types.ts";
 import { LINK_V1_TAG } from "../src/sigil-types.ts";
 
 describe("CFC label view helpers", () => {
@@ -1118,14 +1118,19 @@ describe("CFC label view helpers", () => {
       const { commonfabric } = createTrustedBuilder(runtime);
       const { pattern } = commonfabric;
       const renderLabels = pattern<{ items: unknown[] }>(({ items }) => {
-        const rendered = items.map((item) => ({
-          [UI]: {
-            type: "vnode" as const,
-            name: "cf-cfc-label",
-            props: { value: item },
-            children: [],
-          },
-        }));
+        const rendered = (items as any).mapWithPattern(
+          pattern(({ element, index, array }: Opaque<any>) =>
+            (((item: any) => ({
+              [UI]: {
+                type: "vnode" as const,
+                name: "cf-cfc-label",
+                props: { value: item },
+                children: [],
+              },
+            })) as any)(element, index, array)
+          ),
+          {},
+        );
         return { rendered };
       });
 

--- a/packages/runner/test/generate-object-tools.test.ts
+++ b/packages/runner/test/generate-object-tools.test.ts
@@ -19,7 +19,7 @@ import {
   loadConversationFixture,
 } from "@commonfabric/llm/client";
 import type { BuiltInLLMMessage, BuiltInLLMTool } from "@commonfabric/api";
-import type { Cell, JSONSchema } from "../src/builder/types.ts";
+import type { Cell, JSONSchema, Opaque } from "../src/builder/types.ts";
 import { createBuilder } from "../src/builder/factory.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { cfcLabelViewForCell } from "../src/cfc/label-view.ts";
@@ -827,10 +827,15 @@ describe("generateObject with tools", () => {
           { result: Array<{ label: string; value: string }> }
         >(
           ({ items }) => {
-            const result = items.map((item) => ({
-              label: item.label,
-              value: item.value,
-            }));
+            const result = (items as any).mapWithPattern(
+              pattern(({ element, index, array }: Opaque<any>) =>
+                (((item: any) => ({
+                  label: item.label,
+                  value: item.value,
+                })) as any)(element, index, array)
+              ),
+              {},
+            );
             return { result };
           },
           { type: "object", properties: { items: { type: "array" } } },

--- a/packages/runner/test/map-op-by-identity.test.ts
+++ b/packages/runner/test/map-op-by-identity.test.ts
@@ -205,4 +205,28 @@ describe("map op passed by identity (esmModuleLoader)", () => {
     expect(identityMisses).toBeGreaterThan(0);
     cancelSink();
   });
+
+  it("reloads a hoisted op by identity without recompiling", async () => {
+    // A map's sub-pattern result cells carry the op's `{ identity, symbol }`,
+    // where `symbol` is a HOIST (`__cfPattern_1`), not a module export. On reload
+    // the by-identity path must resolve it from the in-memory artifact index — a
+    // cold source recompile here is the CT-1623 "compiles=0 reload" regression
+    // the shell piece test guards. (Without the fix this resolves to undefined /
+    // recompiles, because hoists aren't in `modulesByIdentity.exports`.)
+    const compiled = await runtime.patternManager.compilePattern(PROGRAM);
+    const pm = runtime.patternManager;
+    const entryRef = pm.getArtifactEntryRef(compiled);
+    expect(entryRef).toBeDefined();
+    const missesBefore = pm.getCompileCacheStats().misses;
+
+    const op = await pm.loadPatternByIdentity(
+      entryRef!.identity,
+      "__cfPattern_1",
+      space,
+    );
+
+    expect(op).toBeDefined();
+    // Resolved from the live in-memory index — no cold recompile.
+    expect(pm.getCompileCacheStats().misses).toBe(missesBefore);
+  });
 });

--- a/packages/runner/test/map-op-by-identity.test.ts
+++ b/packages/runner/test/map-op-by-identity.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import {
+  isPatternRefSentinel,
+  resolveOpPattern,
+} from "../src/builtins/op-pattern-ref.ts";
+
+const signer = await Identity.fromPassphrase("map-op-by-identity");
+const space = signer.did();
+
+// Unit coverage for the sentinel shape + resolver, independent of the runtime.
+describe("op-pattern-ref helpers", () => {
+  it("recognizes a well-formed sentinel and rejects others", () => {
+    expect(
+      isPatternRefSentinel({
+        $patternRef: { identity: "cf:module/x", symbol: "s" },
+      }),
+    ).toBe(true);
+    expect(isPatternRefSentinel({ $patternRef: { identity: "x" } })).toBe(
+      false,
+    );
+    expect(isPatternRefSentinel({ nodes: [] })).toBe(false);
+    expect(isPatternRefSentinel(null)).toBe(false);
+    expect(isPatternRefSentinel("x")).toBe(false);
+  });
+
+  it("resolves a sentinel via artifactFromIdentitySync", () => {
+    const fakePattern = { argumentSchema: true } as never;
+    const fakeRuntime = {
+      patternManager: {
+        artifactFromIdentitySync: (identity: string, symbol: string) => {
+          expect(identity).toBe("cf:module/abc");
+          expect(symbol).toBe("__cfPattern_1");
+          return fakePattern;
+        },
+      },
+    } as never;
+    const resolved = resolveOpPattern(
+      fakeRuntime,
+      { $patternRef: { identity: "cf:module/abc", symbol: "__cfPattern_1" } },
+      "map",
+    );
+    expect(resolved).toBe(fakePattern);
+  });
+
+  it("falls back to the embedded op graph when the sentinel misses the cache", () => {
+    const fallbackGraph = { argumentSchema: true, nodes: [] } as never;
+    const fakeRuntime = {
+      patternManager: { artifactFromIdentitySync: () => undefined },
+    } as never;
+    const resolved = resolveOpPattern(
+      fakeRuntime,
+      {
+        $patternRef: { identity: "cf:module/miss", symbol: "s" },
+        $opFallback: fallbackGraph,
+      },
+      "map",
+    );
+    // Cache residency must not be a correctness requirement: an evicted op
+    // resolves via the retained embedded graph rather than hard-failing.
+    expect(resolved).toBe(fallbackGraph);
+  });
+
+  it("throws only when the sentinel misses AND has no embedded fallback", () => {
+    const fakeRuntime = {
+      patternManager: { artifactFromIdentitySync: () => undefined },
+    } as never;
+    expect(() =>
+      resolveOpPattern(
+        fakeRuntime,
+        { $patternRef: { identity: "cf:module/miss", symbol: "s" } },
+        "map",
+      )
+    ).toThrow(
+      /op pattern cf:module\/miss#s is not in the evaluated-module cache/,
+    );
+  });
+
+  it("passes a non-sentinel value through unchanged (legacy graph)", () => {
+    const graph = { nodes: [], result: {} } as never;
+    const resolved = resolveOpPattern({} as never, graph, "map");
+    expect(resolved).toBe(graph);
+  });
+});
+
+// End-to-end: under the ESM module loader, the `op` pattern of a `.map` node is
+// passed by its content-addressed `{ identity, symbol }` reference (a
+// `{ $patternRef }` sentinel) and resolved synchronously at runtime via
+// `artifactFromIdentitySync`, instead of being deserialized from an embedded
+// pattern graph.
+describe("map op passed by identity (esmModuleLoader)", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let runtime: Runtime;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      experimental: { esmModuleLoader: true },
+    });
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  const PROGRAM: RuntimeProgram = {
+    main: "/main.tsx",
+    files: [
+      {
+        name: "/main.tsx",
+        contents: [
+          "import { pattern } from 'commonfabric';",
+          "export default pattern<{ items: { v: number }[] }>(({ items }) => {",
+          "  return { vs: items.map((item) => item.v) };",
+          "});",
+        ].join("\n"),
+      },
+    ],
+  };
+
+  it("resolves the map op by identity and produces correct output", async () => {
+    const compiled = await runtime.patternManager.compilePattern(PROGRAM);
+
+    // Spy on the synchronous identity resolver to prove the op took the
+    // `{ $patternRef }` path (not the embedded-graph fallback).
+    const pm = runtime.patternManager;
+    const original = pm.artifactFromIdentitySync.bind(pm);
+    let identityResolves = 0;
+    pm.artifactFromIdentitySync = (identity: string, symbol: string) => {
+      identityResolves++;
+      return original(identity, symbol);
+    };
+
+    const resultCell = runtime.getCell<{ vs: number[] }>(
+      space,
+      "map op by identity",
+      compiled.resultSchema,
+      tx,
+    );
+    const result = runtime.run(
+      tx,
+      compiled,
+      { items: [{ v: 1 }, { v: 2 }, { v: 3 }] },
+      resultCell,
+    );
+    runtime.prepareTxForCommit(tx);
+    await tx.commit();
+    tx = runtime.edit();
+    // A map sets up its own scheduler actions; drive them with a sink + idle.
+    const cancelSink = result.sink(() => {});
+    await runtime.idle();
+
+    expect(await result.key("vs").pull()).toEqual([1, 2, 3]);
+    // The op was resolved by identity at least once (one per mapped row).
+    expect(identityResolves).toBeGreaterThan(0);
+    cancelSink();
+  });
+
+  it("falls back to the embedded op graph when the identity cache evicts the op", async () => {
+    const compiled = await runtime.patternManager.compilePattern(PROGRAM);
+
+    // Simulate the op's module being evicted from the bounded in-memory cache
+    // before the map action runs: force every sync identity lookup to miss.
+    // The map must still produce correct output via the retained `$opFallback`
+    // graph — cache residency is an optimization, not a correctness requirement.
+    const pm = runtime.patternManager;
+    let identityMisses = 0;
+    pm.artifactFromIdentitySync = () => {
+      identityMisses++;
+      return undefined;
+    };
+
+    const resultCell = runtime.getCell<{ vs: number[] }>(
+      space,
+      "map op fallback on eviction",
+      compiled.resultSchema,
+      tx,
+    );
+    const result = runtime.run(
+      tx,
+      compiled,
+      { items: [{ v: 4 }, { v: 5 }, { v: 6 }] },
+      resultCell,
+    );
+    runtime.prepareTxForCommit(tx);
+    await tx.commit();
+    tx = runtime.edit();
+    const cancelSink = result.sink(() => {});
+    await runtime.idle();
+
+    expect(await result.key("vs").pull()).toEqual([4, 5, 6]);
+    // The lookups missed (eviction simulated) yet the map still resolved the op.
+    expect(identityMisses).toBeGreaterThan(0);
+    cancelSink();
+  });
+});

--- a/packages/runner/test/pattern-scope.test.ts
+++ b/packages/runner/test/pattern-scope.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../src/link-utils.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { type Cell, createCell } from "../src/cell.ts";
+import { type Opaque } from "../src/builder/types.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
@@ -1409,7 +1410,12 @@ Deno.test("map keeps outer list scope and narrows per-element result cells", asy
       (x: number) => x + 1,
     );
     const Root = pattern<{ values: number[] }>(({ values }) => ({
-      mapped: values.map((value) => increment(value)),
+      mapped: (values as any).mapWithPattern(
+        pattern(({ element, index, array }: Opaque<any>) =>
+          (((value: any) => increment(value)) as any)(element, index, array)
+        ),
+        {},
+      ),
     }));
 
     const resultCell = runtime.getCell(
@@ -1515,8 +1521,16 @@ Deno.test("map updates when derived list is narrowed by session input", async ()
           current: { conversation: Conversation; selectedRoom: string },
         ) => current.conversation.rooms[current.selectedRoom] ?? [],
       )({ conversation, selectedRoom });
-      const bodies = messages.map((message) =>
-        lift((current: Message) => current.body)(message)
+      const bodies = (messages as any).mapWithPattern(
+        pattern(({ element, index, array }: Opaque<any>) =>
+          (((message: any) =>
+            lift((current: Message) => current.body)(message)) as any)(
+              element,
+              index,
+              array,
+            )
+        ),
+        {},
       );
       return {
         messages,
@@ -1612,8 +1626,16 @@ Deno.test("map materializes initially populated list selected by session input",
           current: { conversation: Conversation; selectedRoom: string },
         ) => current.conversation.rooms[current.selectedRoom] ?? [],
       )({ conversation, selectedRoom });
-      const bodies = messages.map((message) =>
-        lift((current: Message) => current.body)(message)
+      const bodies = (messages as any).mapWithPattern(
+        pattern(({ element, index, array }: Opaque<any>) =>
+          (((message: any) =>
+            lift((current: Message) => current.body)(message)) as any)(
+              element,
+              index,
+              array,
+            )
+        ),
+        {},
       );
       return { messages, bodies };
     });
@@ -1697,8 +1719,16 @@ Deno.test("ifElse selected branch materializes map over session-derived list", a
       const rendered = ifElse(
         isEmpty,
         [],
-        messages.map((message) =>
-          lift((current: Message) => current.body)(message)
+        (messages as any).mapWithPattern(
+          pattern(({ element, index, array }: Opaque<any>) =>
+            (((message: any) =>
+              lift((current: Message) => current.body)(message)) as any)(
+                element,
+                index,
+                array,
+              )
+          ),
+          {},
         ),
       );
       return { rendered };
@@ -1786,12 +1816,16 @@ Deno.test("ifElse selected VNode branch materializes map over session-derived li
         h(
           "div",
           null,
-          messages.map((message) =>
-            h(
-              "span",
-              null,
-              lift((current: Message) => current.body)(message),
-            )
+          (messages as any).mapWithPattern(
+            pattern(({ element, index, array }: Opaque<any>) =>
+              (((message: any) =>
+                h(
+                  "span",
+                  null,
+                  lift((current: Message) => current.body)(message),
+                )) as any)(element, index, array)
+            ),
+            {},
           ),
         ),
       );
@@ -1946,17 +1980,21 @@ Deno.test("map materializes list through session boxed space-scoped reference", 
           h(
             "div",
             null,
-            lift(
+            (lift(
               selectedRoomRefInputSchema,
               { type: "unknown" } as const,
               (current: any) =>
                 current.selectedRoomRef.get()?.messages as Message[],
-            )({ selectedRoomRef }).map((message: any) =>
-              h(
-                "span",
-                null,
-                lift((current: Message) => current.body)(message),
-              )
+            )({ selectedRoomRef }) as any).mapWithPattern(
+              pattern(({ element, index, array }: Opaque<any>) =>
+                (((message: any) =>
+                  h(
+                    "span",
+                    null,
+                    lift((current: Message) => current.body)(message),
+                  )) as any)(element, index, array)
+              ),
+              {},
             ),
           ),
         );
@@ -2027,7 +2065,12 @@ Deno.test("filter narrows output list when scoped element controls cardinality",
       (x: number) => x > 0,
     );
     const Root = pattern<{ values: number[] }>(({ values }) => ({
-      filtered: values.filter((value) => positive(value)),
+      filtered: (values as any).filterWithPattern(
+        pattern(({ element, index, array }: Opaque<any>) =>
+          (((value: any) => positive(value)) as any)(element, index, array)
+        ),
+        {},
+      ),
     }));
 
     const resultCell = runtime.getCell(
@@ -2085,7 +2128,12 @@ Deno.test("flatMap narrows output list when scoped element controls cardinality"
       (x: number) => [x, x + 1],
     );
     const Root = pattern<{ values: number[] }>(({ values }) => ({
-      expanded: values.flatMap((value) => expand(value)),
+      expanded: (values as any).flatMapWithPattern(
+        pattern(({ element, index, array }: Opaque<any>) =>
+          (((value: any) => expand(value)) as any)(element, index, array)
+        ),
+        {},
+      ),
     }));
 
     const resultCell = runtime.getCell(

--- a/packages/runner/test/pattern.test.ts
+++ b/packages/runner/test/pattern.test.ts
@@ -6,6 +6,7 @@ import {
   isPattern,
   type JSONSchema,
   type Module,
+  type Opaque,
   type Pattern,
 } from "../src/builder/types.ts";
 import { lift } from "../src/builder/module.ts";
@@ -238,10 +239,15 @@ describe("pattern", () => {
   it("pattern with map node serializes correctly", () => {
     const doubleArray = pattern<{ values: { x: number }[] }>(
       ({ values }) => {
-        const doubled = values.map(({ x }) => {
-          const double = lift<number>((x) => x * 2);
-          return { doubled: double(x) };
-        });
+        const doubled = (values as any).mapWithPattern(
+          pattern(({ element, index, array }: Opaque<any>) =>
+            ((({ x }: any) => {
+              const double = lift<number>((x) => x * 2);
+              return { doubled: double(x) };
+            }) as any)(element, index, array)
+          ),
+          {},
+        );
         return { doubled };
       },
     );

--- a/packages/runner/test/patterns-core.test.ts
+++ b/packages/runner/test/patterns-core.test.ts
@@ -7,7 +7,7 @@ import "@commonfabric/utils/equal-ignoring-symbols";
 
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { type JSONSchema } from "../src/builder/types.ts";
+import { type JSONSchema, type Opaque } from "../src/builder/types.ts";
 import { createBuilder } from "../src/builder/factory.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { Runtime } from "../src/runtime.ts";
@@ -165,9 +165,14 @@ describe("Pattern Runner - Core", () => {
 
     const multipliedArray = pattern<{ values: { x: number }[] }>(
       ({ values }) => {
-        const multiplied = values.map(({ x }, index, array) => {
-          return { multiplied: multiply({ x, index, array }) };
-        });
+        const multiplied = (values as any).mapWithPattern(
+          pattern(({ element, index, array }: Opaque<any>) =>
+            ((({ x }: any, index: any, array: any) => {
+              return { multiplied: multiply({ x, index, array }) };
+            }) as any)(element, index, array)
+          ),
+          {},
+        );
         return { multiplied };
       },
     );
@@ -205,7 +210,12 @@ describe("Pattern Runner - Core", () => {
 
     const doubleArray = pattern<{ values?: number[] }>(
       ({ values }) => {
-        const doubled = values?.map((x) => double(x)) ?? [];
+        const doubled = (values as any)?.mapWithPattern(
+          pattern(({ element, index, array }: Opaque<any>) =>
+            (((x: any) => double(x)) as any)(element, index, array)
+          ),
+          {},
+        ) ?? [];
         return { doubled };
       },
     );
@@ -233,7 +243,12 @@ describe("Pattern Runner - Core", () => {
 
     const doubleArray = pattern<{ values: number[] }>(
       ({ values }) => {
-        const doubled = values.map((x) => double(x));
+        const doubled = (values as any).mapWithPattern(
+          pattern(({ element, index, array }: Opaque<any>) =>
+            (((x: any) => double(x)) as any)(element, index, array)
+          ),
+          {},
+        );
         return { doubled };
       },
     );

--- a/packages/runner/test/patterns-reduce.test.ts
+++ b/packages/runner/test/patterns-reduce.test.ts
@@ -6,7 +6,7 @@ import "@commonfabric/utils/equal-ignoring-symbols";
 
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { type JSONSchema } from "../src/builder/types.ts";
+import { type JSONSchema, type Opaque } from "../src/builder/types.ts";
 import { createBuilder } from "../src/builder/factory.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { Runtime } from "../src/runtime.ts";
@@ -221,8 +221,13 @@ describe("Pattern Runner - Reduce", () => {
 
     const sumDoubledPattern = pattern<{ values: number[] }>(
       ({ values }) => {
-        const total = values
-          .map((x) => double(x))
+        const total = (values as any)
+          .mapWithPattern(
+            pattern(({ element, index, array }: Opaque<any>) =>
+              (((x: any) => double(x)) as any)(element, index, array)
+            ),
+            {},
+          )
           .reduce((acc: number, x: number) => acc + x, 0);
         return { total };
       },

--- a/packages/runner/test/patterns-regressions.test.ts
+++ b/packages/runner/test/patterns-regressions.test.ts
@@ -6,7 +6,7 @@ import { expect } from "@std/expect";
 
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
-import { NAME } from "../src/builder/types.ts";
+import { NAME, type Opaque } from "../src/builder/types.ts";
 import { createBuilder } from "../src/builder/factory.ts";
 import type { Pattern } from "../src/builder/types.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
@@ -74,12 +74,18 @@ describe("Pattern Runner - Regressions", () => {
     >(
       ({ items }) => {
         // Map over items, returning item name if visible, null otherwise
-        const mapped = items.map((item) =>
-          ifElse(
-            lift((i: { name: string; visible: boolean }) => i.visible)(item),
-            lift((i: { name: string; visible: boolean }) => i.name)(item),
-            null,
-          )
+        const mapped = (items as any).mapWithPattern(
+          pattern(({ element, index, array }: Opaque<any>) =>
+            (((item: any) =>
+              ifElse(
+                lift((i: { name: string; visible: boolean }) => i.visible)(
+                  item,
+                ),
+                lift((i: { name: string; visible: boolean }) => i.name)(item),
+                null,
+              )) as any)(element, index, array)
+          ),
+          {},
         );
         return { items, mapped };
       },


### PR DESCRIPTION
## What

Passes the `op` pattern of `.mapWithPattern` / `.filterWithPattern` / `.flatMapWithPattern` by its content-addressed `{ identity, symbol }` reference instead of an embedded, re-deserialized pattern graph. This is the **feature** that consumes the `__cfReg` content-addressable-artifact foundation merged in #3912.

## How
- At raw-node instantiation, `substituteOpPatternRefs` (runner) replaces a map/filter/flatMap `op` whose ref is known (`getArtifactEntryRef`) with a compact `{ $patternRef: { identity, symbol } }` sentinel, retaining the embedded graph as `$opFallback`. Scoped to the `op` key only.
- The list builtins resolve the sentinel synchronously via `artifactFromIdentitySync` (`resolveOpPattern`) — no graph deserialization, no `implementationRef` remap for the op. On a cache miss (op evicted from the bounded in-memory cache), it falls back to `$opFallback`, so cache residency is an optimization, not a correctness requirement.
- `traverse-utils` preserves the `unsafe_originalPattern` link when a pattern is copied during node wiring, so `getArtifactEntryRef`'s exact-then-original lookup recovers the op copy's ref.
- The function-form `OpaqueRef.map(fn)` / `.filter(fn)` / `.flatMap(fn)` (which wrapped the callback in an anonymous, identity-less inline pattern) now **throw**, pointing at the `*WithPattern` form. Authored code is always lowered by the transformer; in-process builder tests using the function form were rewritten to `*WithPattern`.

## Notes
- Rebased onto current `main` and reworked to consume #3912: the old export-the-hoist + re-parse-the-compiled-body discovery and the standalone `patternFromIdentitySync` are gone — refs/resolution come from #3912's `getArtifactEntryRef` / `artifactFromIdentitySync`.
- Runner suite: 547 passed, 0 failed.
- Follow-ups (separate PRs): remove `implementationRef`; remove `patternId`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)