### PR TITLE
fix(runner): flush classic-path compile-cache write so cf pieces don't recompile

### DIFF
--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -583,8 +583,17 @@ export class PatternManager {
       if (!compileResult) {
         loadedFromCache = false;
         compileResult = await this.runtime.harness.compile(program);
-        // Fire-and-forget cache write
-        cachedCompiler.set(programHash, compileResult).catch(() => {});
+        // Fire-and-forget cache write — does not block the load. Tracked in
+        // compileCacheWrites so flushCompileCacheWrites() can await it (graceful
+        // shutdown / deterministic tests), matching the ESM-path write-backs.
+        // Without this, a subsequent load of the same program can read the cache
+        // before this write lands and recompile (the piece.test.ts
+        // "0 in-client compilations" flake).
+        const cacheWrite = cachedCompiler.set(programHash, compileResult).catch(
+          () => {},
+        );
+        this.compileCacheWrites.add(cacheWrite);
+        cacheWrite.finally(() => this.compileCacheWrites.delete(cacheWrite));
       }
       return this.evaluateToPattern(compileResult, program, {
         skipBundleValidation: loadedFromCache,

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -640,6 +640,13 @@ export class RuntimeProcessor {
     await this.runtime.idle();
   }
 
+  // Persistence durability, distinct from handleIdle's reactive quiescence:
+  // awaits in-flight compile-cache write-backs so a subsequent load reads the
+  // freshly-written entry instead of recompiling.
+  async handleFlushCompileCacheWrites(): Promise<void> {
+    await this.runtime.patternManager.flushCompileCacheWrites();
+  }
+
   async handlePieceCreate(
     request: PageCreateRequest,
   ): Promise<PageResponse> {
@@ -1037,6 +1044,8 @@ export class RuntimeProcessor {
         return await this.handleEnsureHomePatternRunning(request);
       case RequestType.Idle:
         return await this.handleIdle();
+      case RequestType.FlushCompileCacheWrites:
+        return await this.handleFlushCompileCacheWrites();
       case RequestType.PageCreate:
         return await this.handlePieceCreate(
           request,

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -49,6 +49,7 @@ export enum RequestType {
   GetHomeSpaceCell = "runtime:getHomeSpaceCell",
   EnsureHomePatternRunning = "runtime:ensureHomePatternRunning",
   Idle = "runtime:idle",
+  FlushCompileCacheWrites = "runtime:flushCompileCacheWrites",
   GetGraphSnapshot = "runtime:getGraphSnapshot",
   SetPullMode = "runtime:setPullMode",
   GetLoggerCounts = "runtime:getLoggerCounts",
@@ -218,6 +219,16 @@ export interface EnsureHomePatternRunningRequest extends BaseRequest {
 
 export interface IdleRequest extends BaseRequest {
   type: RequestType.Idle;
+}
+
+/**
+ * Await all in-flight compile-cache write-backs (persistence durability), as
+ * distinct from `Idle` (reactive/scheduler quiescence). Used by tests that
+ * assert a precompiled pattern loads without an in-client recompile: the cache
+ * write must be durable before a subsequent load reads it.
+ */
+export interface FlushCompileCacheWritesRequest extends BaseRequest {
+  type: RequestType.FlushCompileCacheWrites;
 }
 
 export interface GetGraphSnapshotRequest extends BaseRequest {
@@ -589,6 +600,7 @@ export type IPCClientRequest =
   | GetWriteStackTraceRequest
   | SetWriteStackTraceMatchersRequest
   | IdleRequest
+  | FlushCompileCacheWritesRequest
   | PageCreateRequest
   | PageGetSpaceDefault
   | RecreateSpaceRootPatternRequest
@@ -773,6 +785,10 @@ export type Commands = {
   };
   [RequestType.Idle]: {
     request: IdleRequest;
+    response: EmptyResponse;
+  };
+  [RequestType.FlushCompileCacheWrites]: {
+    request: FlushCompileCacheWritesRequest;
     response: EmptyResponse;
   };
   [RequestType.GetGraphSnapshot]: {

--- a/packages/runtime-client/runtime-client.ts
+++ b/packages/runtime-client/runtime-client.ts
@@ -148,6 +148,18 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
     await this.#conn.request<RequestType.Idle>({ type: RequestType.Idle });
   }
 
+  /**
+   * Await all in-flight compile-cache write-backs in the worker. Distinct from
+   * `idle()` (reactive/scheduler quiescence): this guarantees persistence
+   * durability, so a subsequent load of an already-compiled pattern reads the
+   * cached entry instead of recompiling in-client.
+   */
+  async flushCompileCacheWrites(): Promise<void> {
+    await this.#conn.request<RequestType.FlushCompileCacheWrites>({
+      type: RequestType.FlushCompileCacheWrites,
+    });
+  }
+
   async createPage<T = unknown>(
     input: string | URL | Program,
     options?: { argument?: JSONValue; run?: boolean },

--- a/packages/shell/integration/piece.test.ts
+++ b/packages/shell/integration/piece.test.ts
@@ -246,6 +246,14 @@ describe("shell piece tests", () => {
         return await page.evaluate(() => !!globalThis.commonfabric?.rt);
       });
       await waitForSpaceRootPattern(page);
+      // Ensure the space-root/sub-pattern compile-cache write-backs are durable
+      // before we snapshot the baseline and load the piece. Otherwise a write
+      // still in flight can be missed by the piece load's cache read, forcing an
+      // in-client recompile (the flake this test guards against). This awaits
+      // persistence specifically, NOT reactive idle.
+      await page.evaluate(async () => {
+        await globalThis.commonfabric?.rt?.flushCompileCacheWrites();
+      });
       const clientCompileCountBeforePieceLoad =
         await getClientEngineCompileCount(page);
 


### PR DESCRIPTION
## Summary

Fixes the flaky shell integration test `packages/shell/integration/piece.test.ts > "can view and interact with a piece"`, which intermittently fails on `main` with:

```
Expected 0 in-client compilations while loading cf-created piece <fid>;
engine compile count changed from N to N+1
```

(Observed e.g. in [run 27045005912](https://github.com/commontoolsinc/labs/actions/runs/27045005912/job/79829140885) — attempt 1 failed, re-run passed. ~2 of every 3 recent shell-job flakes on main were this assertion.)

## Root cause

The classic-path compile-cache write in `PatternManager.compilePattern()` was fire-and-forget **and untracked**:

```ts
// before
cachedCompiler.set(programHash, compileResult).catch(() => {});
```

It was never added to `compileCacheWrites`, so `flushCompileCacheWrites()` did **not** await it — unlike the ESM-path write-backs and the entry-identity meta write, which *are* tracked. As a result, a subsequent load of the same program could read the cache **before that write landed** and recompile in-client.

The test exercises exactly this: the space-root load compiles + caches the piece's pattern, but its cache write is sometimes still in flight when the explicit piece load reads the cache → `notFound` miss → in-client recompile → the assertion fires.

## Evidence

Local instrumentation of the `CachedCompiler` get/set outcomes (surfaced over the existing logger-timing RPC) showed a cache write completing **inside** the test's measurement window in ~12% of runs — the exact race surface. It's benign unless the in-flight write is the piece's *own* entry, which is the flake.

- **Before the fix:** ~12% of runs showed a `set-done` landing inside the measurement window.
- **After the fix:** 0/30 instrumented runs showed it; 12/12 full-test runs (both steps, clean build) green.

## The fix

1. **runner** (`pattern-manager.ts`) — add the classic-path `cachedCompiler.set()` write to `compileCacheWrites` so `flushCompileCacheWrites()` awaits it, matching the ESM path. *This is the actual bug fix.*
2. **runtime-client** — expose `flushCompileCacheWrites` over the worker RPC (mirrors `Idle`). This is **persistence durability**, deliberately kept distinct from `idle()`'s **reactive/scheduler quiescence**: a compile-cache write is opportunistic persistence, not part of reactive convergence, so bundling it into `idle()` would tax unrelated callers and muddy the semantics. `idle()` is unchanged.
3. **shell** (`piece.test.ts`) — flush compile-cache writes after the space-root load and before snapshotting the baseline. The test now asserts the true contract — "0 in-client compilations once the precompiled artifact is durably available" — instead of depending on write timing.

## Test plan

- [x] `deno check` + `deno fmt --check` clean on all changed files
- [x] 30× instrumented loop: race surface eliminated (0/30)
- [x] 12× full-test loop on a clean build (no instrumentation): 12/12 green
- [ ] CI over the coming days (this is the real judge for an intermittent flake)

## Notes

- The diff is small (5 files, +56/-2).
- While investigating I noticed the *other* step in this file (`loads a slug piece and reloads when cf piece new repoints the slug`) can intermittently hang on an Astral reload wait — a **separate** flake, unrelated to compilation caching. Not touched here; may warrant its own ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in compile-cache persistence that caused in-client recompiles of CF pieces and a flaky shell test. Classic-path cache writes are now tracked and flushable so subsequent loads read the cache instead of recompiling.

- **Bug Fixes**
  - `runner`: track the classic-path `cachedCompiler.set()` promise in `compileCacheWrites` and await it via `flushCompileCacheWrites()`.
  - `runtime-client`: add `flushCompileCacheWrites` RPC and client method; keep `idle()` semantics unchanged.
  - `shell`: in `piece.test.ts`, flush compile-cache writes after loading the space root and before measuring compile counts.

<sup>Written for commit d8dc0f7c80858889ab0a19d0623ee4f8bd45ba71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

