### PR TITLE
perf(runner): skip redundant SES re-verification on integrity-gated warm hits (CT-1623)

### DIFF
--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -405,9 +405,18 @@ export class Engine extends EventTarget implements Harness {
         graph.records.set(spec, record as VirtualModuleRecord);
       }
 
-      // Security-verify every authored module body before it can execute.
-      for (const [specifier, body] of graph.compiledBodies) {
-        verifyCompiledModuleBody(body, specifier);
+      // Security-verify every authored module body before it can execute —
+      // EXCEPT a trusted full hit. On an integrity-gated warm full hit
+      // (`trustedBodies` + every body present in the cache) the CFC integrity
+      // label is the security boundary, so re-running the SES body verifier is
+      // redundant per-load work (threat model: `docs/specs/module-loading.md`,
+      // "the persistent compilation cache"). Freshly compiled bodies (miss /
+      // partial) and untrusted direct injections are always verified.
+      const trustBodies = fullHit && options.trustedBodies === true;
+      if (!trustBodies) {
+        for (const [specifier, body] of graph.compiledBodies) {
+          verifyCompiledModuleBody(body, specifier);
+        }
       }
 
       const mainSpecifier = graph.specifierByPath.get(mappedProgram.main);
@@ -796,7 +805,7 @@ export class Engine extends EventTarget implements Harness {
   async evaluateCachedModules(
     modules: readonly CachedCompiledModule[],
     entryIdentity: string,
-    options: { sourceFiles?: Source[] } = {},
+    options: { sourceFiles?: Source[]; trustedBodies?: boolean } = {},
   ): Promise<EvaluateResult> {
     await this.getRuntimeInternals();
     const { runtimeExports } = await this.getRuntimeInternals();
@@ -826,11 +835,17 @@ export class Engine extends EventTarget implements Harness {
       graph.records.set(spec, record as VirtualModuleRecord);
     }
 
-    // Security-verify every cached body + the whole graph before executing —
-    // the cache's integrity label is still only client-asserted, so cached
-    // bytes are not trusted unverified (mirrors the compile path).
-    for (const [specifier, body] of graph.compiledBodies) {
-      verifyCompiledModuleBody(body, specifier);
+    // Security-verify every cached body before executing — EXCEPT a trusted
+    // warm hit. These bodies always come from the integrity-gated compiled set
+    // (`loadCompiledClosure` reads with `requiredIntegrity`, fail-closed), so
+    // with `trustedBodies` the CFC integrity label is the security boundary and
+    // re-running the SES body verifier is redundant per-load work (threat model:
+    // `docs/specs/module-loading.md`, "the persistent compilation cache"). The
+    // structural graph verify below always runs.
+    if (options.trustedBodies !== true) {
+      for (const [specifier, body] of graph.compiledBodies) {
+        verifyCompiledModuleBody(body, specifier);
+      }
     }
     const mainSpecifier = `cf:module/${entryIdentity}`;
     if (!graph.records.has(mainSpecifier)) {

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -406,13 +406,20 @@ export class Engine extends EventTarget implements Harness {
       }
 
       // Security-verify every authored module body before it can execute —
-      // EXCEPT a trusted full hit. On an integrity-gated warm full hit
-      // (`trustedBodies` + every body present in the cache) the CFC integrity
-      // label is the security boundary, so re-running the SES body verifier is
-      // redundant per-load work (threat model: `docs/specs/module-loading.md`,
-      // "the persistent compilation cache"). Freshly compiled bodies (miss /
-      // partial) and untrusted direct injections are always verified.
-      const trustBodies = fullHit && options.trustedBodies === true;
+      // EXCEPT a trusted, integrity-gated full hit. The CFC integrity label is
+      // the security boundary for cache hits, so re-running the SES body verifier
+      // on integrity-gated bytes is redundant per-load work (threat model:
+      // `docs/specs/module-loading.md`, "the persistent compilation cache").
+      // Trust is gated on PROVENANCE, not just the opt-in flag: the bodies must
+      // have arrived via the lazy `precompiledModulesFor` channel (the cache
+      // callback, which reads the compiled set with `requiredIntegrity`,
+      // fail-closed) — NOT a direct, caller-supplied `precompiledModules` map,
+      // which is untrusted injection. Freshly compiled bodies (miss / partial)
+      // are likewise always verified.
+      const trustBodies = fullHit &&
+        options.trustedBodies === true &&
+        options.precompiledModules === undefined &&
+        options.precompiledModulesFor !== undefined;
       if (!trustBodies) {
         for (const [specifier, body] of graph.compiledBodies) {
           verifyCompiledModuleBody(body, specifier);

--- a/packages/runner/src/harness/types.ts
+++ b/packages/runner/src/harness/types.ts
@@ -48,6 +48,15 @@ export interface TypeScriptHarnessProcessOptions {
     entryIdentity: string;
     identities: string[];
   }) => Promise<Map<string, CompiledModuleArtifact> | undefined>;
+  // Trust the precompiled bodies on a FULL hit: skip the per-module SES body
+  // verifier (`verifyCompiledModuleBody`). Set ONLY when the bodies came from an
+  // integrity-gated read (the `compileCache` set, loaded with `requiredIntegrity`
+  // via `loadCompiledClosure`) — the CFC integrity label, not the SES verifier,
+  // is the security boundary for cache hits (see the threat model in
+  // `docs/specs/module-loading.md` §"the persistent compilation cache"). Ignored
+  // on a miss/partial hit: freshly compiled bodies are always SES-verified.
+  // Never set for direct `precompiledModules` injection (untrusted bytes).
+  trustedBodies?: boolean;
 }
 
 /** A cached/compiled per-module artifact: emitted JS plus optional source map. */
@@ -166,7 +175,7 @@ export interface Harness extends EventTarget {
   evaluateCachedModules?(
     modules: readonly CachedCompiledModule[],
     entryIdentity: string,
-    options?: { sourceFiles?: Source[] },
+    options?: { sourceFiles?: Source[]; trustedBodies?: boolean },
   ): Promise<EvaluateResult>;
 
   // Cold recovery: recompile cacheable modules from the stored (already-resolved,

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -643,6 +643,13 @@ export class PatternManager {
     let compiled;
     try {
       compiled = await harness.compileToRecordGraph!(program, {
+        // The bodies returned below come from `loadCompiledClosure`, an
+        // integrity-gated (`requiredIntegrity`, fail-closed) read of the
+        // compiled set. On a full hit the CFC integrity label is the security
+        // boundary, so skip the redundant per-module SES re-verification (threat
+        // model: docs/specs/module-loading.md). A partial/miss returns undefined
+        // below → fresh compile → bodies are SES-verified as usual.
+        trustedBodies: true,
         precompiledModulesFor: async ({ entryIdentity, identities }) => {
           // Concurrency-safe timing: explicit start (no shared timer key, which
           // parallel compiles would clobber). Same for the others below.
@@ -761,7 +768,10 @@ export class PatternManager {
       const result = await harness.evaluateCachedModules!(
         cachedModules,
         entryIdentity,
-        { sourceFiles: program.files },
+        // Bodies came from the integrity-gated compiled-set read
+        // (`loadCompiledClosure`, `requiredIntegrity`), so the CFC label is the
+        // security boundary — skip redundant SES body re-verification.
+        { sourceFiles: program.files, trustedBodies: true },
       );
       return this.patternFromEvaluation(result, program, entryIdentity);
     } catch (error) {
@@ -844,9 +854,13 @@ export class PatternManager {
 
     try {
       // Source-free: no sourceFiles. Sub-patterns fall back to identity.
+      // Bodies came from the integrity-gated compiled-set read
+      // (`loadCompiledClosure`, `requiredIntegrity`), so trust the CFC label and
+      // skip redundant SES body re-verification.
       const result = await harness.evaluateCachedModules(
         cachedModules,
         entryIdentity,
+        { trustedBodies: true },
       );
       const pattern = this.patternFromMain(result, symbol, entryIdentity);
       this.esmCacheStats.byIdentityHits++;

--- a/packages/runner/test/esm-engine.test.ts
+++ b/packages/runner/test/esm-engine.test.ts
@@ -256,7 +256,7 @@ describe("Engine.compileToRecordGraph", () => {
       // verifier is skipped, so the graph assembles despite the disallowed body.
       const trusted = await engine.compileToRecordGraph(MULTI, {
         trustedBodies: true,
-        precompiledModulesFor: async () => tampered,
+        precompiledModulesFor: () => Promise.resolve(tampered),
       });
       expect(trusted.graph.compiledBodies.size).toBeGreaterThan(0);
     });

--- a/packages/runner/test/esm-engine.test.ts
+++ b/packages/runner/test/esm-engine.test.ts
@@ -217,11 +217,12 @@ describe("Engine.compileToRecordGraph", () => {
       expect((main as { total(): number }).total()).toBe(42);
     });
 
-    it("still security-verifies cached bodies on a warm hit (no blind trust)", async () => {
-      // Step 4.3.6 / threat model: while the compiled-set integrity label is
-      // only client-asserted, a warm hit must NOT blindly trust cached bytes —
-      // the engine re-runs the ESM body verifier on every emitted body. Feed a
-      // full (so fullHit) set where one body has disallowed top-level code.
+    it("security-verifies UNtrusted direct precompiled injection (no blind trust)", async () => {
+      // Direct `precompiledModules` injection is NOT integrity-gated, so it is
+      // always SES-verified (unlike a `trustedBodies` integrity-gated full hit —
+      // see the test below). Without `trustedBodies` the engine re-runs the ESM
+      // body verifier on every emitted body. Feed a full (so fullHit) set where
+      // one body has disallowed top-level code.
       const first = await engine.compileToRecordGraph(MULTI);
       const tampered = new Map(
         first.modules.map((m) => [m.identity, { js: m.js }]),
@@ -232,6 +233,36 @@ describe("Engine.compileToRecordGraph", () => {
       await expect(
         engine.compileToRecordGraph(MULTI, { precompiledModules: tampered }),
       ).rejects.toThrow();
+    });
+
+    it("trusts an integrity-gated full hit and skips body re-verification", async () => {
+      // Spec (module-loading.md, threat model "the persistent compilation
+      // cache"): on a warm hit the CFC integrity label — not the SES verifier —
+      // is the security boundary, so re-verifying integrity-gated bodies is
+      // redundant per-load work. A FULL hit flagged `trustedBodies` must NOT
+      // re-run `verifyCompiledModuleBody`. Feed the same tampered-but-full set as
+      // the test above (disallowed top-level code in the entry body): untrusted
+      // it is rejected; trusted it assembles the graph without re-verification.
+      // `compileToRecordGraph` only verifies + builds (no eval), so the
+      // disallowed body never executes — success proves the verifier was skipped.
+      const first = await engine.compileToRecordGraph(MULTI);
+      const tampered = new Map(
+        first.modules.map((m) => [m.identity, { js: m.js }]),
+      );
+      tampered.set(first.entryIdentity, {
+        js: `"use strict";\nfetch("https://evil.example");\n`,
+      });
+      // Untrusted direct injection is still verified (rejected).
+      await expect(
+        engine.compileToRecordGraph(MULTI, { precompiledModules: tampered }),
+      ).rejects.toThrow();
+      // Trusted full hit: the SES body verifier is skipped, so the graph
+      // assembles successfully despite the disallowed body.
+      const trusted = await engine.compileToRecordGraph(MULTI, {
+        precompiledModules: tampered,
+        trustedBodies: true,
+      });
+      expect(trusted.graph.compiledBodies.size).toBeGreaterThan(0);
     });
 
     it("ignores a partial precompiled set and recompiles the whole program", async () => {

--- a/packages/runner/test/esm-engine.test.ts
+++ b/packages/runner/test/esm-engine.test.ts
@@ -239,12 +239,12 @@ describe("Engine.compileToRecordGraph", () => {
       // Spec (module-loading.md, threat model "the persistent compilation
       // cache"): on a warm hit the CFC integrity label — not the SES verifier —
       // is the security boundary, so re-verifying integrity-gated bodies is
-      // redundant per-load work. A FULL hit flagged `trustedBodies` must NOT
-      // re-run `verifyCompiledModuleBody`. Feed the same tampered-but-full set as
-      // the test above (disallowed top-level code in the entry body): untrusted
-      // it is rejected; trusted it assembles the graph without re-verification.
-      // `compileToRecordGraph` only verifies + builds (no eval), so the
-      // disallowed body never executes — success proves the verifier was skipped.
+      // redundant per-load work. A FULL hit delivered through the integrity-gated
+      // `precompiledModulesFor` channel and flagged `trustedBodies` must NOT
+      // re-run `verifyCompiledModuleBody`. The body has disallowed top-level code:
+      // untrusted it is rejected; trusted it assembles the graph without
+      // re-verification. `compileToRecordGraph` only verifies + builds (no eval),
+      // so the disallowed body never executes — success proves verify was skipped.
       const first = await engine.compileToRecordGraph(MULTI);
       const tampered = new Map(
         first.modules.map((m) => [m.identity, { js: m.js }]),
@@ -252,17 +252,33 @@ describe("Engine.compileToRecordGraph", () => {
       tampered.set(first.entryIdentity, {
         js: `"use strict";\nfetch("https://evil.example");\n`,
       });
-      // Untrusted direct injection is still verified (rejected).
-      await expect(
-        engine.compileToRecordGraph(MULTI, { precompiledModules: tampered }),
-      ).rejects.toThrow();
-      // Trusted full hit: the SES body verifier is skipped, so the graph
-      // assembles successfully despite the disallowed body.
+      // Trusted full hit via the integrity-gated lazy channel: the SES body
+      // verifier is skipped, so the graph assembles despite the disallowed body.
       const trusted = await engine.compileToRecordGraph(MULTI, {
-        precompiledModules: tampered,
         trustedBodies: true,
+        precompiledModulesFor: async () => tampered,
       });
       expect(trusted.graph.compiledBodies.size).toBeGreaterThan(0);
+    });
+
+    it("never trusts direct precompiledModules injection, even with trustedBodies", async () => {
+      // Provenance guard: `trustedBodies` skips verification ONLY for bodies that
+      // arrived via the integrity-gated `precompiledModulesFor` channel. A direct,
+      // caller-supplied `precompiledModules` map is untrusted injection and MUST
+      // still be SES-verified — the opt-in flag alone cannot unlock the skip.
+      const first = await engine.compileToRecordGraph(MULTI);
+      const tampered = new Map(
+        first.modules.map((m) => [m.identity, { js: m.js }]),
+      );
+      tampered.set(first.entryIdentity, {
+        js: `"use strict";\nfetch("https://evil.example");\n`,
+      });
+      await expect(
+        engine.compileToRecordGraph(MULTI, {
+          precompiledModules: tampered,
+          trustedBodies: true,
+        }),
+      ).rejects.toThrow();
     });
 
     it("ignores a partial precompiled set and recompiles the whole program", async () => {

--- a/packages/runner/test/load-by-identity.test.ts
+++ b/packages/runner/test/load-by-identity.test.ts
@@ -148,4 +148,37 @@ describe("load by module identity (warm + version-bump recovery)", () => {
       result: 10,
     });
   });
+
+  it("trusts integrity-gated cached bodies and skips body re-verification", async () => {
+    // Spec (module-loading.md, threat model): a warm hit loaded from the
+    // integrity-gated compiled set trusts the CFC label, so `trustedBodies`
+    // skips the per-module SES verifier. Tamper the entry body with a
+    // verify-rejectable but eval-safe top-level statement (a bare call
+    // expression — rejected by classification, harmless to execute) appended
+    // after the module's exports so `default` still resolves.
+    const { modules, entryIdentity } = await engine.compileToRecordGraph(
+      PROGRAM,
+    );
+    const tamperedCached = toCached(modules).map((m) =>
+      m.identity === entryIdentity
+        ? { ...m, code: `${m.code}\nObject.keys({});\n` }
+        : m
+    );
+    // Untrusted: the SES body verifier rejects the tampered body before eval.
+    await expect(
+      engine.evaluateCachedModules(tamperedCached, entryIdentity, {
+        sourceFiles: PROGRAM.files,
+      }),
+    ).rejects.toThrow();
+    // Trusted (integrity-gated warm hit): body verification is skipped, so the
+    // graph evaluates and the pattern runs correctly.
+    const trusted = await engine.evaluateCachedModules(
+      tamperedCached,
+      entryIdentity,
+      { sourceFiles: PROGRAM.files, trustedBodies: true },
+    );
+    expect(await runPattern(trusted.main, 3, "trusted cached run")).toEqual({
+      result: 6,
+    });
+  });
 });


### PR DESCRIPTION
## What

On a warm ESM cache hit (incl. page-refresh reload), the loader re-ran the per-module SES body verifier (`verifyCompiledModuleBody`) on **every** module — re-parsing each compiled body — even though the bytes came straight from the **integrity-gated** compiled set.

The spec already settled that this is redundant:

> *"The label — not the SES verifier — is the security boundary for cache hits… re-verifying integrity-labeled cache hits adds no protection beyond the label while costing per-load work."* — `docs/specs/module-loading.md` §"the persistent compilation cache"
> *"Warm full hit … **No TS compile and no SES re-verification.** … warm hits trust the integrity label."* — `module-loading-implementation-plan.md` §4.1.3

The compiled set is read with `requiredIntegrity` (fail-closed) via `loadCompiledClosure`; a missing/invalid CFC integrity label is treated as a miss → recompile-from-source → which **does** SES-verify. So the label check is the boundary, and the per-load re-parse was pure redundant cost. The code had diverged, re-verifying with a "label is still only client-asserted" comment.

## Change

- New explicit `trustedBodies` option on `compileToRecordGraph` (via `TypeScriptHarnessProcessOptions`) and `evaluateCachedModules`.
- When set **and** the bodies are a full hit, skip the per-module body verifier. The structural `verifyModuleGraph` still runs; freshly compiled (miss/partial) bodies and **untrusted direct `precompiledModules` injection** are always SES-verified.
- Flag set only at the three integrity-gated call sites (`compileViaCellCache`, `tryWarmLoadByIdentity`, `loadPatternByIdentity`), all of which read through `loadCompiledClosure`.

Inert when the `esmModuleLoader` flag is off (AMD path unaffected).

## Why

Removes the per-module re-parse that dominated ESM warm-reload cost for large patterns (home/default-app/notebook) — the regression eating the `patterns integration` perf margin under the flag flip (#3782).

## Tests (red-green)

- `esm-engine.test.ts`: a `trustedBodies` full hit assembles a tampered-but-full graph without re-verification; untrusted direct injection is still rejected.
- `load-by-identity.test.ts`: `evaluateCachedModules` with `trustedBodies` evaluates a verify-rejectable (eval-safe) body; default still rejects.
- Full cache/esm/identity/verifier/pattern-manager suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip redundant SES body verification on integrity-gated warm ESM cache hits to cut reload time (CT-1623). Adds a provenance-gated `trustedBodies` option so full hits from the integrity-checked compiled set skip per-module checks; partial hits and direct injections still verify.

- **New Features**
  - Add `trustedBodies` to `compileToRecordGraph` and `evaluateCachedModules` (types updated).
  - Skip SES body checks only on full hits via integrity-gated `precompiledModulesFor`; direct `precompiledModules` and misses/partials always verify. Structural graph verification still runs.
  - Set `trustedBodies` only at integrity-gated call sites in `pattern-manager` (`compileViaCellCache`, `tryWarmLoadByIdentity`, `loadPatternByIdentity`). AMD path unchanged.

- **Refactors**
  - Drop needless async in `esm-engine.test.ts` to satisfy lint.

<sup>Written for commit 69f4b6309b1a0b6a5b1c6401cbbff8ab0667adaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

