### PR TITLE
[DO NOT MERGE] measure: esmModuleLoader flip + skip-warm-hit-reverify (#3905)

### DIFF
--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -405,9 +405,18 @@ export class Engine extends EventTarget implements Harness {
         graph.records.set(spec, record as VirtualModuleRecord);
       }
 
-      // Security-verify every authored module body before it can execute.
-      for (const [specifier, body] of graph.compiledBodies) {
-        verifyCompiledModuleBody(body, specifier);
+      // Security-verify every authored module body before it can execute —
+      // EXCEPT a trusted full hit. On an integrity-gated warm full hit
+      // (`trustedBodies` + every body present in the cache) the CFC integrity
+      // label is the security boundary, so re-running the SES body verifier is
+      // redundant per-load work (threat model: `docs/specs/module-loading.md`,
+      // "the persistent compilation cache"). Freshly compiled bodies (miss /
+      // partial) and untrusted direct injections are always verified.
+      const trustBodies = fullHit && options.trustedBodies === true;
+      if (!trustBodies) {
+        for (const [specifier, body] of graph.compiledBodies) {
+          verifyCompiledModuleBody(body, specifier);
+        }
       }
 
       const mainSpecifier = graph.specifierByPath.get(mappedProgram.main);
@@ -796,7 +805,7 @@ export class Engine extends EventTarget implements Harness {
   async evaluateCachedModules(
     modules: readonly CachedCompiledModule[],
     entryIdentity: string,
-    options: { sourceFiles?: Source[] } = {},
+    options: { sourceFiles?: Source[]; trustedBodies?: boolean } = {},
   ): Promise<EvaluateResult> {
     await this.getRuntimeInternals();
     const { runtimeExports } = await this.getRuntimeInternals();
@@ -826,11 +835,17 @@ export class Engine extends EventTarget implements Harness {
       graph.records.set(spec, record as VirtualModuleRecord);
     }
 
-    // Security-verify every cached body + the whole graph before executing —
-    // the cache's integrity label is still only client-asserted, so cached
-    // bytes are not trusted unverified (mirrors the compile path).
-    for (const [specifier, body] of graph.compiledBodies) {
-      verifyCompiledModuleBody(body, specifier);
+    // Security-verify every cached body before executing — EXCEPT a trusted
+    // warm hit. These bodies always come from the integrity-gated compiled set
+    // (`loadCompiledClosure` reads with `requiredIntegrity`, fail-closed), so
+    // with `trustedBodies` the CFC integrity label is the security boundary and
+    // re-running the SES body verifier is redundant per-load work (threat model:
+    // `docs/specs/module-loading.md`, "the persistent compilation cache"). The
+    // structural graph verify below always runs.
+    if (options.trustedBodies !== true) {
+      for (const [specifier, body] of graph.compiledBodies) {
+        verifyCompiledModuleBody(body, specifier);
+      }
     }
     const mainSpecifier = `cf:module/${entryIdentity}`;
     if (!graph.records.has(mainSpecifier)) {

--- a/packages/runner/src/harness/types.ts
+++ b/packages/runner/src/harness/types.ts
@@ -48,6 +48,15 @@ export interface TypeScriptHarnessProcessOptions {
     entryIdentity: string;
     identities: string[];
   }) => Promise<Map<string, CompiledModuleArtifact> | undefined>;
+  // Trust the precompiled bodies on a FULL hit: skip the per-module SES body
+  // verifier (`verifyCompiledModuleBody`). Set ONLY when the bodies came from an
+  // integrity-gated read (the `compileCache` set, loaded with `requiredIntegrity`
+  // via `loadCompiledClosure`) — the CFC integrity label, not the SES verifier,
+  // is the security boundary for cache hits (see the threat model in
+  // `docs/specs/module-loading.md` §"the persistent compilation cache"). Ignored
+  // on a miss/partial hit: freshly compiled bodies are always SES-verified.
+  // Never set for direct `precompiledModules` injection (untrusted bytes).
+  trustedBodies?: boolean;
 }
 
 /** A cached/compiled per-module artifact: emitted JS plus optional source map. */
@@ -166,7 +175,7 @@ export interface Harness extends EventTarget {
   evaluateCachedModules?(
     modules: readonly CachedCompiledModule[],
     entryIdentity: string,
-    options?: { sourceFiles?: Source[] },
+    options?: { sourceFiles?: Source[]; trustedBodies?: boolean },
   ): Promise<EvaluateResult>;
 
   // Cold recovery: recompile cacheable modules from the stored (already-resolved,

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -643,6 +643,13 @@ export class PatternManager {
     let compiled;
     try {
       compiled = await harness.compileToRecordGraph!(program, {
+        // The bodies returned below come from `loadCompiledClosure`, an
+        // integrity-gated (`requiredIntegrity`, fail-closed) read of the
+        // compiled set. On a full hit the CFC integrity label is the security
+        // boundary, so skip the redundant per-module SES re-verification (threat
+        // model: docs/specs/module-loading.md). A partial/miss returns undefined
+        // below → fresh compile → bodies are SES-verified as usual.
+        trustedBodies: true,
         precompiledModulesFor: async ({ entryIdentity, identities }) => {
           // Concurrency-safe timing: explicit start (no shared timer key, which
           // parallel compiles would clobber). Same for the others below.
@@ -761,7 +768,10 @@ export class PatternManager {
       const result = await harness.evaluateCachedModules!(
         cachedModules,
         entryIdentity,
-        { sourceFiles: program.files },
+        // Bodies came from the integrity-gated compiled-set read
+        // (`loadCompiledClosure`, `requiredIntegrity`), so the CFC label is the
+        // security boundary — skip redundant SES body re-verification.
+        { sourceFiles: program.files, trustedBodies: true },
       );
       return this.patternFromEvaluation(result, program, entryIdentity);
     } catch (error) {
@@ -844,9 +854,13 @@ export class PatternManager {
 
     try {
       // Source-free: no sourceFiles. Sub-patterns fall back to identity.
+      // Bodies came from the integrity-gated compiled-set read
+      // (`loadCompiledClosure`, `requiredIntegrity`), so trust the CFC label and
+      // skip redundant SES body re-verification.
       const result = await harness.evaluateCachedModules(
         cachedModules,
         entryIdentity,
+        { trustedBodies: true },
       );
       const pattern = this.patternFromMain(result, symbol, entryIdentity);
       this.esmCacheStats.byIdentityHits++;

--- a/packages/runner/src/sandbox/esm-loader-config.ts
+++ b/packages/runner/src/sandbox/esm-loader-config.ts
@@ -4,11 +4,11 @@
  * persistent-scheduler-state ambient flag: the `Runtime` constructor
  * propagates the explicit option here and reads the effective value back.
  *
- * Unlike that one, the default is seeded from the `CF_ESM_MODULE_LOADER`
- * environment variable, so the ESM loader can be exercised suite-wide (e.g. a
+ * The default is ON: the ESM module-record loader is the production default.
+ * Set `CF_ESM_MODULE_LOADER=0` (or `false`) to opt back into the legacy AMD
+ * bundle loader. The env var also lets the loader be selected suite-wide (e.g. a
  * regression cross-check) without threading the option through every `Runtime`
- * construction. The production default stays OFF (the env var is unset), so this
- * is NOT the flag flip — it only makes the flag toggleable from the environment.
+ * construction.
  */
 
 function readEnvDefault(): boolean {
@@ -16,10 +16,12 @@ function readEnvDefault(): boolean {
     const value = (globalThis as {
       Deno?: { env?: { get(name: string): string | undefined } };
     }).Deno?.env?.get?.("CF_ESM_MODULE_LOADER");
-    return value === "1" || value === "true";
+    // Default ON: the ESM module-record loader is the default loader; opt out
+    // with CF_ESM_MODULE_LOADER=0 (or "false").
+    return value !== "0" && value !== "false";
   } catch {
-    // Env access may be denied (no --allow-env); treat as unset / off.
-    return false;
+    // Env access denied (no --allow-env): use the default (ON).
+    return true;
   }
 }
 

--- a/packages/runner/test/esm-engine.test.ts
+++ b/packages/runner/test/esm-engine.test.ts
@@ -217,11 +217,12 @@ describe("Engine.compileToRecordGraph", () => {
       expect((main as { total(): number }).total()).toBe(42);
     });
 
-    it("still security-verifies cached bodies on a warm hit (no blind trust)", async () => {
-      // Step 4.3.6 / threat model: while the compiled-set integrity label is
-      // only client-asserted, a warm hit must NOT blindly trust cached bytes —
-      // the engine re-runs the ESM body verifier on every emitted body. Feed a
-      // full (so fullHit) set where one body has disallowed top-level code.
+    it("security-verifies UNtrusted direct precompiled injection (no blind trust)", async () => {
+      // Direct `precompiledModules` injection is NOT integrity-gated, so it is
+      // always SES-verified (unlike a `trustedBodies` integrity-gated full hit —
+      // see the test below). Without `trustedBodies` the engine re-runs the ESM
+      // body verifier on every emitted body. Feed a full (so fullHit) set where
+      // one body has disallowed top-level code.
       const first = await engine.compileToRecordGraph(MULTI);
       const tampered = new Map(
         first.modules.map((m) => [m.identity, { js: m.js }]),
@@ -232,6 +233,36 @@ describe("Engine.compileToRecordGraph", () => {
       await expect(
         engine.compileToRecordGraph(MULTI, { precompiledModules: tampered }),
       ).rejects.toThrow();
+    });
+
+    it("trusts an integrity-gated full hit and skips body re-verification", async () => {
+      // Spec (module-loading.md, threat model "the persistent compilation
+      // cache"): on a warm hit the CFC integrity label — not the SES verifier —
+      // is the security boundary, so re-verifying integrity-gated bodies is
+      // redundant per-load work. A FULL hit flagged `trustedBodies` must NOT
+      // re-run `verifyCompiledModuleBody`. Feed the same tampered-but-full set as
+      // the test above (disallowed top-level code in the entry body): untrusted
+      // it is rejected; trusted it assembles the graph without re-verification.
+      // `compileToRecordGraph` only verifies + builds (no eval), so the
+      // disallowed body never executes — success proves the verifier was skipped.
+      const first = await engine.compileToRecordGraph(MULTI);
+      const tampered = new Map(
+        first.modules.map((m) => [m.identity, { js: m.js }]),
+      );
+      tampered.set(first.entryIdentity, {
+        js: `"use strict";\nfetch("https://evil.example");\n`,
+      });
+      // Untrusted direct injection is still verified (rejected).
+      await expect(
+        engine.compileToRecordGraph(MULTI, { precompiledModules: tampered }),
+      ).rejects.toThrow();
+      // Trusted full hit: the SES body verifier is skipped, so the graph
+      // assembles successfully despite the disallowed body.
+      const trusted = await engine.compileToRecordGraph(MULTI, {
+        precompiledModules: tampered,
+        trustedBodies: true,
+      });
+      expect(trusted.graph.compiledBodies.size).toBeGreaterThan(0);
     });
 
     it("ignores a partial precompiled set and recompiles the whole program", async () => {

--- a/packages/runner/test/esm-loader-config.test.ts
+++ b/packages/runner/test/esm-loader-config.test.ts
@@ -17,9 +17,10 @@ const envDefault: boolean = (() => {
     const v = (globalThis as {
       Deno?: { env?: { get(name: string): string | undefined } };
     }).Deno?.env?.get?.("CF_ESM_MODULE_LOADER");
-    return v === "1" || v === "true";
+    // Mirror readEnvDefault: ON by default unless explicitly "0"/"false".
+    return v !== "0" && v !== "false";
   } catch {
-    return false;
+    return true;
   }
 })();
 

--- a/packages/runner/test/load-by-identity.test.ts
+++ b/packages/runner/test/load-by-identity.test.ts
@@ -148,4 +148,37 @@ describe("load by module identity (warm + version-bump recovery)", () => {
       result: 10,
     });
   });
+
+  it("trusts integrity-gated cached bodies and skips body re-verification", async () => {
+    // Spec (module-loading.md, threat model): a warm hit loaded from the
+    // integrity-gated compiled set trusts the CFC label, so `trustedBodies`
+    // skips the per-module SES verifier. Tamper the entry body with a
+    // verify-rejectable but eval-safe top-level statement (a bare call
+    // expression — rejected by classification, harmless to execute) appended
+    // after the module's exports so `default` still resolves.
+    const { modules, entryIdentity } = await engine.compileToRecordGraph(
+      PROGRAM,
+    );
+    const tamperedCached = toCached(modules).map((m) =>
+      m.identity === entryIdentity
+        ? { ...m, code: `${m.code}\nObject.keys({});\n` }
+        : m
+    );
+    // Untrusted: the SES body verifier rejects the tampered body before eval.
+    await expect(
+      engine.evaluateCachedModules(tamperedCached, entryIdentity, {
+        sourceFiles: PROGRAM.files,
+      }),
+    ).rejects.toThrow();
+    // Trusted (integrity-gated warm hit): body verification is skipped, so the
+    // graph evaluates and the pattern runs correctly.
+    const trusted = await engine.evaluateCachedModules(
+      tamperedCached,
+      entryIdentity,
+      { sourceFiles: PROGRAM.files, trustedBodies: true },
+    );
+    expect(await runPattern(trusted.main, 3, "trusted cached run")).toEqual({
+      result: 6,
+    });
+  });
 });


### PR DESCRIPTION
Throwaway measurement branch = main + #3905 (skip SES re-verify on integrity-gated warm hits) + the esmModuleLoader flip (#3782). Purpose: re-run the Performance Check to see whether #3905 recovers the `patterns integration` margin (was +13.8%, CLOSE/2s-under-gate on the flip alone). Delete after measuring.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flip the ESM module-record loader on by default and skip SES body re-verification on integrity-gated warm hits to reduce warm-reload cost while preserving security via cache integrity and graph checks. Targets CT-1623 regression by recovering the patterns-integration performance margin.

- New Features
  - Add `trustedBodies` to the runner/harness to skip per-module SES verification on full integrity-gated hits; fresh/partial hits and untrusted injections are still verified, and structural graph verification always runs.
  - Set `trustedBodies: true` at integrity-gated cache read sites in `PatternManager`.
  - Make the ESM loader the default; set `CF_ESM_MODULE_LOADER=0` (or `false`) to opt back into the legacy AMD loader.

- Migration
  - No code changes required. To use the legacy loader in CI/local, set `CF_ESM_MODULE_LOADER=0`.

<sup>Written for commit 8e2aea947329b5d3c224c4114907c98d06bb1374. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

