### PR TITLE
feat(patterns): neurotype self-report UI for the Self pattern (CT-1672)

### DIFF
--- a/packages/patterns/self.test.tsx
+++ b/packages/patterns/self.test.tsx
@@ -14,13 +14,16 @@
  *
  * Run: deno task cf test packages/patterns/self.test.tsx --verbose
  */
-import { computed, pattern, Writable } from "commonfabric";
+import { computed, handler, pattern, Writable } from "commonfabric";
 import Self, {
   appendResponse,
   appendValue,
   EMPTY_SELF_MODEL,
   type Neurotype,
+  type NeurotypeSystem,
   type QAResponse,
+  recordNeurotypeFromForm,
+  removeNeurotypeBySystem,
   type SelfModel,
   upsertNeurotype,
   type ValueCard,
@@ -69,6 +72,22 @@ const MEANING_RESPONSE: QAResponse = {
   track: "meaning",
   answeredAt: 2000,
 };
+
+// ---------------------------------------------------------------------------
+// Test-local void handler — data baked into state so the runner fires it as
+// Stream<void> with no payload.  Used only for the removeValueCard step.
+// ---------------------------------------------------------------------------
+
+const doRemoveValueCard = handler<
+  void,
+  { selfModel: Writable<SelfModel>; index: number }
+>((_event, { selfModel, index }) => {
+  const current = selfModel.get();
+  selfModel.set({
+    ...current,
+    values: current.values.filter((_, i) => i !== index),
+  });
+});
 
 // ---------------------------------------------------------------------------
 // Test pattern
@@ -229,6 +248,94 @@ export default pattern(() => {
   );
 
   // =========================================================================
+  // Test 5b: removeValueCard removes by index — fresh cell with one value card
+  // =========================================================================
+
+  const selfModelValues = new Writable<SelfModel>(
+    appendValue(EMPTY_SELF_MODEL, CURIOSITY_CARD),
+  );
+
+  const action_remove_first_value = doRemoveValueCard({
+    selfModel: selfModelValues,
+    index: 0,
+  });
+
+  const assert_values_empty_after_remove = computed(
+    () => selfModelValues.get().values.length === 0,
+  );
+
+  // =========================================================================
+  // Form handler tests (CT-1672) — use a fresh selfModel to avoid state bleed
+  // =========================================================================
+
+  const selfModel2 = new Writable<SelfModel>(EMPTY_SELF_MODEL);
+  const systemField = new Writable<NeurotypeSystem>("enneagram");
+  const resultField = new Writable<string>("5w4");
+
+  // Test 6: recordNeurotypeFromForm records entry + clears resultField
+  const action_form_record_enneagram = recordNeurotypeFromForm({
+    selfModel: selfModel2,
+    systemField,
+    resultField,
+  });
+
+  const assert_form_recorded_enneagram = computed(() =>
+    selfModel2
+      .get()
+      .neurotypes.some(
+        (n) =>
+          n.system === "enneagram" &&
+          n.result === "5w4" &&
+          n.source === "self-reported",
+      )
+  );
+
+  const assert_result_field_cleared = computed(
+    () => resultField.get() === "",
+  );
+
+  // Test 7: upsert via form — record mbti "INTJ" then "ENFP", expect length 1 + "ENFP"
+  const systemField2 = new Writable<NeurotypeSystem>("mbti");
+  const resultField2a = new Writable<string>("INTJ");
+  const action_form_record_mbti_intj = recordNeurotypeFromForm({
+    selfModel: selfModel2,
+    systemField: systemField2,
+    resultField: resultField2a,
+  });
+
+  // After action_form_record_mbti_intj, resultField2a is cleared; set it to ENFP for upsert.
+  const resultField2b = new Writable<string>("ENFP");
+  const action_form_upsert_mbti_enfp = recordNeurotypeFromForm({
+    selfModel: selfModel2,
+    systemField: systemField2,
+    resultField: resultField2b,
+  });
+
+  const assert_form_upsert_length_one = computed(
+    () =>
+      selfModel2.get().neurotypes.filter((n) => n.system === "mbti").length ===
+        1,
+  );
+
+  const assert_form_upsert_result_enfp = computed(
+    () =>
+      selfModel2
+        .get()
+        .neurotypes.find((n) => n.system === "mbti")?.result === "ENFP",
+  );
+
+  // Test 8: removeNeurotypeBySystem — after two systems, remove enneagram, only mbti remains
+  const action_remove_enneagram_by_system = removeNeurotypeBySystem({
+    selfModel: selfModel2,
+    system: "enneagram",
+  });
+
+  const assert_only_mbti_after_remove = computed(() => {
+    const neurotypes = selfModel2.get().neurotypes;
+    return neurotypes.length === 1 && neurotypes[0]?.system === "mbti";
+  });
+
+  // =========================================================================
   // Test Sequence
   // =========================================================================
   return {
@@ -277,6 +384,25 @@ export default pattern(() => {
       { assertion: assert_owned_responses_empty },
       { assertion: assert_owned_values_empty },
       { assertion: assert_owned_neurotypes_empty },
+
+      // === Test 5b: removeValueCard removes by index ===
+      { action: action_remove_first_value },
+      { assertion: assert_values_empty_after_remove },
+
+      // === Test 6: recordNeurotypeFromForm records + clears resultField ===
+      { action: action_form_record_enneagram },
+      { assertion: assert_form_recorded_enneagram },
+      { assertion: assert_result_field_cleared },
+
+      // === Test 7: upsert via form — same system replaces, length stays 1 ===
+      { action: action_form_record_mbti_intj },
+      { action: action_form_upsert_mbti_enfp },
+      { assertion: assert_form_upsert_length_one },
+      { assertion: assert_form_upsert_result_enfp },
+
+      // === Test 8: removeNeurotypeBySystem removes correct entry ===
+      { action: action_remove_enneagram_by_system },
+      { assertion: assert_only_mbti_after_remove },
     ],
   };
 });

--- a/packages/patterns/self.tsx
+++ b/packages/patterns/self.tsx
@@ -243,6 +243,46 @@ export interface SelfOutput {
 }
 
 // ============================================================================
+// FORM HANDLERS (state-reading, for UI binding)
+// ============================================================================
+
+/**
+ * Record a neurotype entry from form fields (state-reading handler).
+ * Reads systemField + resultField from state; upserts into selfModel;
+ * clears resultField after recording.
+ */
+export const recordNeurotypeFromForm = handler<
+  unknown,
+  {
+    selfModel: Writable<SelfModel>;
+    systemField: Writable<NeurotypeSystem>;
+    resultField: Writable<string>;
+  }
+>((_event, { selfModel, systemField, resultField }) => {
+  const result = resultField.get().trim();
+  if (!result) return;
+  const system = systemField.get();
+  const entry: Neurotype = {
+    system,
+    result,
+    source: "self-reported",
+    recordedAt: safeDateNow(),
+  };
+  selfModel.set(upsertNeurotype(selfModel.get(), entry));
+  resultField.set("");
+});
+
+/**
+ * Remove a neurotype by system (state-reading handler, for per-row binding).
+ */
+export const removeNeurotypeBySystem = handler<
+  unknown,
+  { selfModel: Writable<SelfModel>; system: NeurotypeSystem }
+>((_event, { selfModel, system }) => {
+  selfModel.set(withoutNeurotype(selfModel.get(), system));
+});
+
+// ============================================================================
 // MAIN PATTERN
 // ============================================================================
 
@@ -255,21 +295,90 @@ const Self = pattern<SelfInput, SelfOutput>(
     const selfModel = injectedSelfModel ??
       new Writable<SelfModel>(EMPTY_SELF_MODEL).for("selfModel");
 
+    // Local form field cells
+    const systemField = new Writable<NeurotypeSystem>("mbti").for(
+      "systemField",
+    );
+    const resultField = new Writable<string>("").for("resultField");
+
+    const neurotypeSystemItems: { label: string; value: NeurotypeSystem }[] = [
+      { label: "MBTI", value: "mbti" },
+      { label: "Enneagram", value: "enneagram" },
+      { label: "Big Five", value: "big5" },
+      { label: "Custom", value: "custom" },
+    ];
+
     return {
       [NAME]: "My Self",
       // [UI] must be a static VNode — not wrapped in computed().
       [UI]: (
-        <div style={{ padding: "16px", fontFamily: "sans-serif" }}>
+        <cf-vstack gap="4" style={{ padding: "16px" }}>
           <h2
-            style={{ margin: "0 0 8px", fontSize: "16px", fontWeight: "600" }}
+            style={{ margin: "0 0 4px", fontSize: "16px", fontWeight: "600" }}
           >
             Self Model
           </h2>
           <p style={{ margin: 0, fontSize: "13px", color: "#6b7280" }}>
-            Your private values, neurotype, and reflective answers. Never
-            shared.
+            Your private neurotype self-report. Never shared.
           </p>
-        </div>
+
+          <cf-vstack gap="2">
+            <h3 style={{ margin: 0, fontSize: "14px", fontWeight: "600" }}>
+              Record Neurotype
+            </h3>
+            <cf-hstack gap="2" align="end">
+              <cf-select
+                $value={systemField}
+                items={neurotypeSystemItems}
+                style="min-width: 130px;"
+              />
+              <cf-input
+                $value={resultField}
+                placeholder="e.g. INTJ, 5w4…"
+                style="flex: 1;"
+              />
+              <cf-button
+                onClick={recordNeurotypeFromForm({
+                  selfModel,
+                  systemField,
+                  resultField,
+                })}
+              >
+                Record
+              </cf-button>
+            </cf-hstack>
+          </cf-vstack>
+
+          <cf-vstack gap="2">
+            <h3 style={{ margin: 0, fontSize: "14px", fontWeight: "600" }}>
+              Neurotypes
+            </h3>
+            {selfModel.key("neurotypes").map((n) => (
+              <cf-hstack gap="2" align="center">
+                <span
+                  style={{
+                    fontSize: "13px",
+                    fontWeight: "600",
+                    minWidth: "90px",
+                  }}
+                >
+                  {n.system}
+                </span>
+                <span style={{ fontSize: "13px", flex: "1" }}>{n.result}</span>
+                <cf-button
+                  size="sm"
+                  variant="ghost"
+                  onClick={removeNeurotypeBySystem({
+                    selfModel,
+                    system: n.system,
+                  })}
+                >
+                  ✕
+                </cf-button>
+              </cf-hstack>
+            ))}
+          </cf-vstack>
+        </cf-vstack>
       ),
       selfModel,
       // Bind each handler to this instance's selfModel cell.


### PR DESCRIPTION
## Motivation

CT-1670 (#3907) landed the **private self-model** data layer — the home-local, never-shared "real you" (values, neurotype, reflective Q&A), distinct from outward `profile`s. This PR gives it its **first capture surface**: a minimal self-report neurotype form, so the schema + handlers are exercised by a real UI rather than only tests.

Self-report first (start small): you pick a system and type your result. The questionnaire/instrument-driven assessment, and the meaning-alignment value Q&A, are later PRs in this stack.

## What's in this PR

Edits **only** `packages/patterns/self.tsx` (+ its tests). The `Self` pattern's placeholder `[UI]` becomes a working surface:

- **Record:** a `cf-select` (mbti / enneagram / big5 / custom) + `cf-input` (result, e.g. "INTJ", "5w4") + a **Record** `cf-button`. Records with `source: "self-reported"`, **upsert by system**, and clears the input after.
- **List:** current neurotypes (system + result), each with a ✕ **Remove** control.
- Two new state-reading handlers to bridge form fields → mutations (`recordNeurotypeFromForm`, `removeNeurotypeBySystem`), mirroring the `home.tsx` `removeSpaceHandler({ name, spaces })` idiom (a button's click event can't carry form values, so the handler reads them from bound state). The original payload-based `recordNeurotype`/`removeNeurotype` exports are unchanged (programmatic API).

## Why it's safe to merge on its own

- **Additive, self-contained:** only `self.tsx` (+ tests) change; the `[UI]` is a self-contained surface on a pattern that owns its own cell. No `home.tsx`, no `profile.tsx`, no runtime/CFC, no `#3830` files touched.
- **Stacked on #3907** (CT-1670): base is `ct-1670-self-model-schema`; merge after #3907. Collision-free with the multi-profile PR #3830 (same reasoning as #3907 — nothing under this path is shared).
- All tests green (original 21 + 5 new = 26); `deno task cf check` clean.

## Testing

```
deno task cf test packages/patterns/self.test.tsx   # 26 passed, 0 failed
deno task cf check packages/patterns/self.tsx        # OK
```

New cases: record-from-form (records + clears the field), form upsert-by-system (replace same system), remove-by-system.

## Scope / not here

- **No meaning-alignment value Q&A** (ValueCards) — next PR; needs the prompt methodology scoped first.
- **No `assessed` source / instrument scoring / `detail` facets** — self-report only for now.
- **No home Profile-tab wiring** — slots in next to Berni's picker after #3830 (CT-1647).
- Minor known nit: `recordNeurotypeFromForm` duplicates the upsert-by-system logic from `recordNeurotype`; can be factored into a shared helper in a later cleanup.

## Context & links

- This issue: **CT-1672** — Neurotype capture UI (self-report) in the Self pattern.
- Builds on: **CT-1670** (#3907) — self-model schema + handlers.
- Epic: **CT-1669** — Private self-model.
- Sibling tier (shared/outward): **CT-1645** + **#3830** (multi-profile). Future publish boundary: **CT-1646**.

Draft: second of a small stack building the private tier incrementally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a minimal neurotype self-report UI to the Self pattern so users can record and manage their type in the private self-model. CT-1672, built on CT-1670, using state-reading form handlers wired to shared helpers with upsert-by-system.

- New Features
  - UI in `packages/patterns/self.tsx`: `cf-select` system (`mbti`/`enneagram`/`big5`/`custom`), `cf-input` result, Record button (upsert by system, `source: "self-reported"`, clears input).
  - Lists current neurotypes with per-row remove.
  - Adds `recordNeurotypeFromForm` and `removeNeurotypeBySystem` for UI binding; both call `upsertNeurotype`/`withoutNeurotype`. Programmatic `recordNeurotype`/`removeNeurotype` unchanged.

- Bug Fixes
  - Expanded tests to cover form handlers, upsert-by-system, and remove-by-system; now 29 passing.
  - Deduped review artifacts and fixed Deno lint warnings; rebuilt on `main` after CT-1670 merge.

<sup>Written for commit 51b0980f608e468e1e2d0122ff7e6c9f7d9e4357. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

