### PR TITLE
fix(runner): register verified binding metadata for non-exported handlers (CT-1665)

### DIFF
--- a/packages/runner/src/builder/module.ts
+++ b/packages/runner/src/builder/module.ts
@@ -157,8 +157,9 @@ export function createNodeFactory<T = any, R = any>(
   // look-alike never acquires the brand. (Patterns brand separately in
   // builder/pattern.ts.)
   brandTrustedBuilderArtifact(factory);
-  // CT-1665: surface the factory so the engine can register verified binding
-  // metadata for non-exported lift/derive/computed bindings (see handlerInternal).
+  // CT-1665: surface the factory so the legacy/AMD eval path can register verified
+  // binding metadata for non-exported lift/derive/computed bindings (the ESM loader
+  // instead reuses `__cfReg`; see handlerInternal and Engine.evaluate).
   // Only JS-function modules can be trusted-binding writers (and carry
   // `__cfVerifiedBindingIdentity`); `type: "ref"` builtins never do — so the guard
   // is semantically correct. It is also load-safe: an implementation-less builtin
@@ -491,11 +492,13 @@ function handlerInternal<E, T>(
     return eventStream;
   }, module);
 
-  // CT-1665: surface the factory so the engine can register its verified binding
-  // metadata after evaluation. The transformer-emitted `__cfBindVerifiedBinding`
-  // annotates THIS object (the builder's return value) once the module body
-  // finishes; a non-exported binding is otherwise unreachable from the capture
-  // walk and CFC would reject its owner-protected writes.
+  // CT-1665: surface the factory so the legacy/AMD eval path can register its
+  // verified binding metadata after evaluation (the ESM loader instead reuses the
+  // transformer's `__cfReg` registrations — see Engine.evaluate vs evaluateGraph).
+  // The transformer-emitted `__cfBindVerifiedBinding` annotates THIS object (the
+  // builder's return value) once the module body finishes; a non-exported binding
+  // is otherwise unreachable from the export-namespace capture walk and CFC would
+  // reject its owner-protected writes.
   registerVerifiedBindingCandidate(factory);
 
   return factory;

--- a/packages/runner/src/builder/module.ts
+++ b/packages/runner/src/builder/module.ts
@@ -160,11 +160,13 @@ export function createNodeFactory<T = any, R = any>(
   // CT-1665: surface the factory so the engine can register verified binding
   // metadata for non-exported lift/derive/computed bindings (see handlerInternal).
   // Only JS-function modules can be trusted-binding writers (and carry
-  // `__cfVerifiedBindingIdentity`); `type: "ref"` builtins never do. Guarding on
-  // the implementation also keeps an implementation-less builtin node factory
-  // built at module load (e.g. builtins/sqlite/query-node.ts) from touching the
-  // registrar before function-hardening.ts has initialized under a circular
-  // import.
+  // `__cfVerifiedBindingIdentity`); `type: "ref"` builtins never do — so the guard
+  // is semantically correct. It is also load-safe: an implementation-less builtin
+  // node factory is created at module-load time (e.g. builtins/sqlite/query-node.ts)
+  // and is reached via a module.ts import cycle BEFORE module.ts has evaluated its
+  // own `import` of function-hardening.ts, so calling the registrar there would hit
+  // its still-uninitialized module-scope `let` (a TDZ throw). Function modules are
+  // only ever built later, at pattern-build time, well clear of that window.
   if (typeof module.implementation === "function") {
     registerVerifiedBindingCandidate(factory);
   }

--- a/packages/runner/src/builder/module.ts
+++ b/packages/runner/src/builder/module.ts
@@ -29,6 +29,7 @@ import { getLogger } from "@commonfabric/utils/logger";
 import { createRef } from "../create-ref.ts";
 import {
   hardenVerifiedFunction,
+  registerVerifiedBindingCandidate,
   registerVerifiedFunctionImplementation,
 } from "../sandbox/function-hardening.ts";
 
@@ -156,6 +157,17 @@ export function createNodeFactory<T = any, R = any>(
   // look-alike never acquires the brand. (Patterns brand separately in
   // builder/pattern.ts.)
   brandTrustedBuilderArtifact(factory);
+  // CT-1665: surface the factory so the engine can register verified binding
+  // metadata for non-exported lift/derive/computed bindings (see handlerInternal).
+  // Only JS-function modules can be trusted-binding writers (and carry
+  // `__cfVerifiedBindingIdentity`); `type: "ref"` builtins never do. Guarding on
+  // the implementation also keeps an implementation-less builtin node factory
+  // built at module load (e.g. builtins/sqlite/query-node.ts) from touching the
+  // registrar before function-hardening.ts has initialized under a circular
+  // import.
+  if (typeof module.implementation === "function") {
+    registerVerifiedBindingCandidate(factory);
+  }
   return factory;
 }
 
@@ -476,6 +488,13 @@ function handlerInternal<E, T>(
 
     return eventStream;
   }, module);
+
+  // CT-1665: surface the factory so the engine can register its verified binding
+  // metadata after evaluation. The transformer-emitted `__cfBindVerifiedBinding`
+  // annotates THIS object (the builder's return value) once the module body
+  // finishes; a non-exported binding is otherwise unreachable from the capture
+  // walk and CFC would reject its owner-protected writes.
+  registerVerifiedBindingCandidate(factory);
 
   return factory;
 }

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -69,7 +69,10 @@ import {
   createModuleCompartmentGlobals,
   createSafeConsoleGlobal,
 } from "../sandbox/compartment-globals.ts";
-import { setVerifiedFunctionRegistrar } from "../sandbox/function-hardening.ts";
+import {
+  setVerifiedBindingCandidateRegistrar,
+  setVerifiedFunctionRegistrar,
+} from "../sandbox/function-hardening.ts";
 import type { UnsafeHostTrustOptions } from "../unsafe-host-trust.ts";
 import { ExecutableRegistry } from "./executable-registry.ts";
 import { CompiledBundleValidator } from "../sandbox/compiled-bundle-validation.ts";
@@ -746,6 +749,14 @@ export class Engine extends EventTarget implements Harness {
       const restoreVerifiedFunctionRegistrar = setVerifiedFunctionRegistrar(
         this.executableRegistry.createVerifiedFunctionRegistrar(loadId),
       );
+      // CT-1665: collect trusted-binding factory objects surfaced by the
+      // builder so their (export-independent) verified binding metadata can be
+      // registered after evaluation.
+      const bindingCandidates: unknown[] = [];
+      const restoreBindingCandidateRegistrar =
+        setVerifiedBindingCandidateRegistrar((candidate) => {
+          bindingCandidates.push(candidate);
+        });
       const frame = pushFrame({
         runtime: this.ctRuntime,
         verifiedLoadId: loadId,
@@ -766,10 +777,17 @@ export class Engine extends EventTarget implements Harness {
       } finally {
         popFrame(frame);
         restoreVerifiedFunctionRegistrar();
+        restoreBindingCandidateRegistrar();
       }
 
       const main = loaded.namespace as Exports;
       this.executableRegistry.captureVerifiedValue(loadId, main);
+      // Record binding metadata for non-exported bindings (CT-1665). The
+      // candidates carry their metadata now that the module body (including the
+      // transformer's `__cfBindVerifiedBinding` calls) has finished executing.
+      this.executableRegistry.captureVerifiedBindingCandidates(
+        bindingCandidates,
+      );
 
       // Build the per-module export map (keyed by normalized source path) from
       // the SAME load, and map each exported value back to its RuntimeProgram
@@ -978,6 +996,14 @@ export class Engine extends EventTarget implements Harness {
       const restoreVerifiedFunctionRegistrar = setVerifiedFunctionRegistrar(
         this.executableRegistry.createVerifiedFunctionRegistrar(loadId),
       );
+      // CT-1665: collect trusted-binding factory objects surfaced by the builder
+      // (see the source-based path) so non-exported bindings resolve their
+      // verified binding metadata on source-free (resume-by-identity) loads too.
+      const bindingCandidates: unknown[] = [];
+      const restoreBindingCandidateRegistrar =
+        setVerifiedBindingCandidateRegistrar((candidate) => {
+          bindingCandidates.push(candidate);
+        });
       const sourceLocationFrame = pushFrame({
         runtime: this.ctRuntime,
         verifiedLoadId: loadId,
@@ -993,6 +1019,7 @@ export class Engine extends EventTarget implements Harness {
       } finally {
         popFrame(sourceLocationFrame);
         restoreVerifiedFunctionRegistrar();
+        restoreBindingCandidateRegistrar();
       }
       if (
         result && typeof result === "object" && "main" in result &&
@@ -1002,6 +1029,9 @@ export class Engine extends EventTarget implements Harness {
         const exportMap = result.exportMap as Record<string, Exports>;
         this.executableRegistry.captureVerifiedValue(loadId, main);
         this.executableRegistry.captureVerifiedValue(loadId, exportMap);
+        this.executableRegistry.captureVerifiedBindingCandidates(
+          bindingCandidates,
+        );
 
         // Create a map from exported values to `RuntimeProgram` that can
         // generate them and pass to the callback from the exports.

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -749,14 +749,6 @@ export class Engine extends EventTarget implements Harness {
       const restoreVerifiedFunctionRegistrar = setVerifiedFunctionRegistrar(
         this.executableRegistry.createVerifiedFunctionRegistrar(loadId),
       );
-      // CT-1665: collect trusted-binding factory objects surfaced by the
-      // builder so their (export-independent) verified binding metadata can be
-      // registered after evaluation.
-      const bindingCandidates: unknown[] = [];
-      const restoreBindingCandidateRegistrar =
-        setVerifiedBindingCandidateRegistrar((candidate) => {
-          bindingCandidates.push(candidate);
-        });
       const frame = pushFrame({
         runtime: this.ctRuntime,
         verifiedLoadId: loadId,
@@ -777,16 +769,27 @@ export class Engine extends EventTarget implements Harness {
       } finally {
         popFrame(frame);
         restoreVerifiedFunctionRegistrar();
-        restoreBindingCandidateRegistrar();
       }
 
       const main = loaded.namespace as Exports;
       this.executableRegistry.captureVerifiedValue(loadId, main);
-      // Record binding metadata for non-exported bindings (CT-1665). The
-      // candidates carry their metadata now that the module body (including the
-      // transformer's `__cfBindVerifiedBinding` calls) has finished executing.
+      // CT-1665: register verified binding metadata for NON-exported trusted
+      // handlers. The export-namespace capture above only reaches exported
+      // builders; a non-exported `const setName = handler(...)` is surfaced
+      // instead by the transformer's trailing `__cfReg({...})` into
+      // `graph.registrationSink` — the same registrations pattern-manager indexes
+      // for `{identity, symbol}` addressing. We reuse that ESM channel rather than
+      // a parallel registrar. The `__cfBindVerifiedBinding` annotations are already
+      // attached (it runs in the module body, ahead of the trailing `__cfReg`), so
+      // each registered factory carries its `__cfVerifiedBindingIdentity`.
+      const registrationCandidates: unknown[] = [];
+      for (const entries of graph.registrationSink.values()) {
+        for (const value of entries.values()) {
+          registrationCandidates.push(value);
+        }
+      }
       this.executableRegistry.captureVerifiedBindingCandidates(
-        bindingCandidates,
+        registrationCandidates,
       );
 
       // Build the per-module export map (keyed by normalized source path) from
@@ -996,9 +999,13 @@ export class Engine extends EventTarget implements Harness {
       const restoreVerifiedFunctionRegistrar = setVerifiedFunctionRegistrar(
         this.executableRegistry.createVerifiedFunctionRegistrar(loadId),
       );
-      // CT-1665: collect trusted-binding factory objects surfaced by the builder
-      // (see the source-based path) so non-exported bindings resolve their
-      // verified binding metadata on source-free (resume-by-identity) loads too.
+      // CT-1665: on the legacy/AMD eval path `__cfReg` is a no-op (identity
+      // addressing is ESM-only), so the ESM sink-based capture used by
+      // `evaluateGraph` does not apply here. Collect the trusted-binding factories
+      // the builder surfaces during evaluation directly, so non-exported handlers
+      // still resolve their verified binding metadata under the default (non-ESM)
+      // loader. (Removable with the registrar + builder hook once the ESM loader
+      // is the default and this path is retired.)
       const bindingCandidates: unknown[] = [];
       const restoreBindingCandidateRegistrar =
         setVerifiedBindingCandidateRegistrar((candidate) => {

--- a/packages/runner/src/harness/executable-registry.ts
+++ b/packages/runner/src/harness/executable-registry.ts
@@ -156,6 +156,38 @@ export class ExecutableRegistry {
     return this.verifiedBindingMetadata.get(implementationRef);
   }
 
+  /**
+   * Record verified binding metadata from trusted-binding factory objects that
+   * the builder surfaced during this load (CT-1665).
+   *
+   * A handler/lift binding declared as a non-exported module-scope const carries
+   * its `__cfVerifiedBindingIdentity` on the FACTORY returned by the builder, but
+   * the node graph only retains the underlying module (which never received the
+   * metadata — the factory is `Object.assign(callable, module)`, a distinct
+   * object) and the post-evaluation capture walk only traverses the module's
+   * exports. The metadata is therefore otherwise never registered, so CFC
+   * `writeAuthorizedBy` rejects the binding's own writes with "requires a trusted
+   * verified binding identity". Recording keyed by the factory's
+   * `implementationRef` (shared with its module/implementation) closes that gap
+   * for both source-based and source-free (resume-by-identity) loads, since both
+   * re-run the module body and re-surface the candidates.
+   */
+  captureVerifiedBindingCandidates(candidates: Iterable<unknown>): void {
+    for (const candidate of candidates) {
+      if (
+        !candidate ||
+        (typeof candidate !== "object" && typeof candidate !== "function")
+      ) {
+        continue;
+      }
+      const implementationRef =
+        (candidate as { implementationRef?: unknown }).implementationRef;
+      if (typeof implementationRef === "string" && implementationRef) {
+        this.recordVerifiedBindingMetadata(implementationRef, candidate);
+      }
+    }
+  }
+
   getVerifiedLoadId(
     implementationRef: string,
     patternId?: string,

--- a/packages/runner/src/sandbox/function-hardening.ts
+++ b/packages/runner/src/sandbox/function-hardening.ts
@@ -22,6 +22,37 @@ export function registerVerifiedFunctionImplementation(
   verifiedFunctionRegistrar?.(implementationRef, fn);
 }
 
+// CT-1665: A trusted-binding builder (handler/lift/...) returns a FACTORY object
+// that the transformer-emitted `__cfBindVerifiedBinding` annotates with the
+// verified binding identity (`__cfVerifiedBindingIdentity`). For an EXPORTED
+// binding that factory is reachable from the module namespace, so the
+// post-evaluation capture walk records its metadata. For a NON-exported
+// module-scope binding (the common shape — e.g. system/profile-home.tsx's
+// setName/setAvatar/addElement) the factory is reachable only through the
+// instantiated node graph, which retains the underlying module (sans metadata),
+// so the metadata is never registered and CFC `writeAuthorizedBy` rejects the
+// binding's own writes. Builders surface every factory here so the engine can
+// record its binding metadata after evaluation regardless of export status.
+type VerifiedBindingCandidateRegistrar = (candidate: unknown) => void;
+
+let verifiedBindingCandidateRegistrar:
+  | VerifiedBindingCandidateRegistrar
+  | undefined;
+
+export function setVerifiedBindingCandidateRegistrar(
+  registrar: VerifiedBindingCandidateRegistrar | undefined,
+): () => void {
+  const previous = verifiedBindingCandidateRegistrar;
+  verifiedBindingCandidateRegistrar = registrar;
+  return () => {
+    verifiedBindingCandidateRegistrar = previous;
+  };
+}
+
+export function registerVerifiedBindingCandidate(candidate: unknown): void {
+  verifiedBindingCandidateRegistrar?.(candidate);
+}
+
 export function hardenVerifiedFunction<T extends (...args: any[]) => unknown>(
   fn: T,
 ): T {

--- a/packages/runner/src/sandbox/function-hardening.ts
+++ b/packages/runner/src/sandbox/function-hardening.ts
@@ -31,8 +31,14 @@ export function registerVerifiedFunctionImplementation(
 // setName/setAvatar/addElement) the factory is reachable only through the
 // instantiated node graph, which retains the underlying module (sans metadata),
 // so the metadata is never registered and CFC `writeAuthorizedBy` rejects the
-// binding's own writes. Builders surface every factory here so the engine can
-// record its binding metadata after evaluation regardless of export status.
+// binding's own writes.
+//
+// This registrar is the LEGACY/AMD load path's channel for surfacing those
+// factories (Engine.evaluate): there is no `__cfReg` there, since identity
+// addressing is ESM-only. The ESM loader instead reuses the transformer's
+// `__cfReg` registrations (Engine.evaluateGraph reads `graph.registrationSink`),
+// so it installs no registrar and these builder calls are inert no-ops under it.
+// This whole channel retires with the legacy loader.
 type VerifiedBindingCandidateRegistrar = (candidate: unknown) => void;
 
 let verifiedBindingCandidateRegistrar:

--- a/packages/runner/test/cfc-nonexported-binding-identity.test.ts
+++ b/packages/runner/test/cfc-nonexported-binding-identity.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+// CT-1665: An owner-protected field bound by `WriteAuthorizedBy<T, typeof fn>`
+// compiles to a verified-binding `writeAuthorizedBy` claim. At commit the CFC
+// verifier resolves the authoring handler's identity via
+// `harness.getVerifiedBindingMetadata(implementationRef)`. That metadata is
+// attached by the transformer's `__cfBindVerifiedBinding` to the FACTORY object
+// the builder returns — but a handler declared as a NON-exported module-scope
+// const (the shape used throughout system/profile-home.tsx) is reachable to the
+// post-evaluation capture walk only via the export namespace, so its metadata
+// was never registered and the write was rejected with
+// "writeAuthorizedBy requires a trusted verified binding identity".
+
+const signer = await Identity.fromPassphrase("ct1665-repro");
+const space = signer.did();
+
+const INTERNAL_SRC = `/// <cts-enable />
+  import { handler, pattern, Writable, WriteAuthorizedBy } from "commonfabric";
+  const setName = handler<{ name?: string }, { name: Writable<string> }>(
+    (event, state) => { state.name.set(event.name ?? ""); },
+  );
+  const setAvatar = handler<{ avatar?: string }, { avatar: Writable<string> }>(
+    (event, state) => { state.avatar.set(event.avatar ?? ""); },
+  );
+  export default pattern(() => {
+    const name = new Writable<WriteAuthorizedBy<string, typeof setName>>("").for("name");
+    const avatar = new Writable<WriteAuthorizedBy<string, typeof setAvatar>>("").for("avatar");
+    return { name, avatar, setName: setName({ name }), setAvatar: setAvatar({ avatar }) };
+  });
+`;
+
+// Same handlers but EXPORTED — worked before the fix; guards against regression.
+const EXPORTED_SRC = INTERNAL_SRC.replace(
+  / {2}const set/g,
+  "  export const set",
+);
+
+const PROFILE_HOME_SRC = Deno.readTextFileSync(
+  new URL("../../patterns/system/profile-home.tsx", import.meta.url),
+);
+
+function programFor(src: string): RuntimeProgram {
+  return { main: "/main.tsx", files: [{ name: "/main.tsx", contents: src }] };
+}
+
+function recordedBindingPaths(rt: Runtime): string[][] {
+  const reg = (rt.harness as any).executableRegistry;
+  const meta = reg.verifiedBindingMetadata as Map<
+    string,
+    { bindingPath?: string[] }
+  >;
+  return [...meta.values()]
+    .map((m) => m.bindingPath)
+    .filter((p): p is string[] => Array.isArray(p));
+}
+
+// Capture the binding metadata resolved through the PUBLIC harness API while a
+// handler runs — the exact lookup the CFC verifier performs at commit. Returns
+// the bindingPaths that resolved to a non-empty result during `fn()`.
+async function bindingPathsResolvedDuring(
+  rt: Runtime,
+  fn: () => void,
+): Promise<string[][]> {
+  const harness = rt.harness as any;
+  const orig = harness.getVerifiedBindingMetadata.bind(harness);
+  const resolved: string[][] = [];
+  harness.getVerifiedBindingMetadata = (ref: string) => {
+    const res = orig(ref);
+    if (res?.bindingPath) resolved.push(res.bindingPath);
+    return res;
+  };
+  try {
+    fn();
+    await (rt as any).idle?.();
+  } finally {
+    harness.getVerifiedBindingMetadata = orig;
+  }
+  return resolved;
+}
+
+describe("CT-1665: verified binding metadata for non-exported handlers", () => {
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+
+  const newRuntime = (esm: boolean) =>
+    new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      cfcEnforcementMode: "observe",
+      ...(esm ? { experimental: { esmModuleLoader: true } } : {}),
+    });
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+  });
+  afterEach(async () => {
+    await storageManager?.close();
+  });
+
+  for (const esm of [false, true]) {
+    for (
+      const [label, src] of [["internal", INTERNAL_SRC], [
+        "exported",
+        EXPORTED_SRC,
+      ]] as const
+    ) {
+      it(`resolves the writer identity when ${label} handlers run (esm=${esm})`, async () => {
+        const rt = newRuntime(esm);
+        try {
+          const tx = rt.edit();
+          const pattern = await rt.patternManager.compilePattern(
+            programFor(src),
+            { space, tx },
+          );
+          const resultCell = rt.getCell<Record<string, unknown>>(
+            space,
+            `ct1665-${label}-${esm}`,
+            undefined,
+            tx,
+          );
+          const r = rt.run(tx, pattern, {}, resultCell);
+          await tx.commit();
+          await r.pull();
+
+          // The metadata is registered for both siblings...
+          const paths = recordedBindingPaths(rt);
+          expect(paths).toContainEqual(["setName"]);
+          expect(paths).toContainEqual(["setAvatar"]);
+
+          // ...and resolves through the verifier's lookup as each handler runs.
+          const onName = await bindingPathsResolvedDuring(rt, () => {
+            r.key("setName").send({ name: "Alice" });
+          });
+          expect(onName).toContainEqual(["setName"]);
+
+          const onAvatar = await bindingPathsResolvedDuring(rt, () => {
+            r.key("setAvatar").send({ avatar: "🦊" });
+          });
+          expect(onAvatar).toContainEqual(["setAvatar"]);
+        } finally {
+          await rt.dispose();
+        }
+      });
+    }
+  }
+
+  it("registers binding metadata for real profile-home setName/setAvatar/addElement", async () => {
+    const rt = newRuntime(true);
+    try {
+      const tx = rt.edit();
+      const pattern = await rt.patternManager.compilePattern(
+        programFor(PROFILE_HOME_SRC),
+        { space, tx },
+      );
+      const resultCell = rt.getCell<Record<string, unknown>>(
+        space,
+        "ct1665-profile",
+        undefined,
+        tx,
+      );
+      const r = rt.run(tx, pattern, { initialName: "Init" }, resultCell);
+      await tx.commit();
+      await r.pull();
+
+      const paths = recordedBindingPaths(rt);
+      expect(paths).toContainEqual(["setName"]);
+      expect(paths).toContainEqual(["setAvatar"]);
+      expect(paths).toContainEqual(["addElement"]);
+    } finally {
+      await rt.dispose();
+    }
+  });
+
+  it("registers binding metadata after resume-by-identity (source-free reload)", async () => {
+    const rt1 = newRuntime(true);
+    const rt2 = newRuntime(true);
+    try {
+      const tx1 = rt1.edit();
+      const pm1 = rt1.patternManager;
+      const cold = await pm1.compilePattern(programFor(INTERNAL_SRC), {
+        space,
+        tx: tx1,
+      });
+      const resultCell1 = rt1.getCell<Record<string, unknown>>(
+        space,
+        "ct1665-resume",
+        undefined,
+        tx1,
+      );
+      const r1 = rt1.run(tx1, cold, {}, resultCell1);
+      await tx1.commit();
+      await r1.pull();
+      await pm1.flushCompileCacheWrites();
+      await rt1.storageManager.synced();
+
+      const pm2 = rt2.patternManager;
+      const tx2 = rt2.edit();
+      const resultCell2 = rt2.getCell<Record<string, unknown>>(
+        space,
+        "ct1665-resume",
+        undefined,
+        tx2,
+      );
+      await tx2.commit();
+      await resultCell2.sync();
+      await rt2.start(resultCell2);
+      await resultCell2.pull();
+
+      expect(pm2.getCompileCacheStats().byIdentityHits).toBeGreaterThan(0);
+      const paths = recordedBindingPaths(rt2);
+      expect(paths).toContainEqual(["setName"]);
+      expect(paths).toContainEqual(["setAvatar"]);
+    } finally {
+      await rt2.dispose();
+      await rt1.dispose();
+    }
+  });
+});

--- a/packages/runner/test/cfc-nonexported-binding-identity.test.ts
+++ b/packages/runner/test/cfc-nonexported-binding-identity.test.ts
@@ -15,6 +15,16 @@ import type { RuntimeProgram } from "../src/harness/types.ts";
 // post-evaluation capture walk only via the export namespace, so its metadata
 // was never registered and the write was rejected with
 // "writeAuthorizedBy requires a trusted verified binding identity".
+//
+// Scope: these tests assert the writer identity is REGISTERED and RESOLVES through
+// the harness's `getVerifiedBindingMetadata` — the exact lookup the CFC verifier
+// performs at commit (`cfc/prepare.ts` writeAuthorizedByReason) — and run under
+// `observe`. That isolates the CT-1665 gap (metadata never registered for
+// non-exported bindings) precisely, white-box. A full enforce-mode, end-to-end
+// "the write is accepted" assertion additionally needs trust-snapshot +
+// owner-principal + trusted-event provenance setup, which profile-owner-cfc.test.ts
+// drives via a mocked authoring identity (a path that, pre-fix, never reached the
+// binding-identity resolution that broke here).
 
 const signer = await Identity.fromPassphrase("ct1665-repro");
 const space = signer.did();


### PR DESCRIPTION
> **Update (rev 3 — consolidated onto `__cfReg`, per framework-owner review):**
> The ESM loader no longer uses a parallel `setVerifiedBindingCandidateRegistrar`.
> `Engine.evaluateGraph` now records verified binding metadata directly from
> `graph.registrationSink` — the same `__cfReg` registrations pattern-manager
> indexes for `{identity, symbol}`. The builder-side registrar is retained **only**
> for the legacy/AMD path (`Engine.evaluate`), where `__cfReg` is a no-op (identity
> addressing is ESM-only) and the production-default loader still runs — so CT-1665
> stays fixed there with no regression; that channel retires with the legacy loader.
> `captureVerifiedBindingCandidates` is unchanged (both paths feed it; only the
> candidate source differs). Rebased onto current `main`. The "Fix" table below
> describes the original registrar approach and is kept for history.

---

## Why

**CT-1665.** Saving owner-protected profile fields (`avatar`, `name`, and profile elements) fails at commit under `enforce-explicit` with:

```
StorageTransactionAborted: writeAuthorizedBy requires a trusted verified binding identity at /avatar
```

The input clears as if it saved, but the transaction aborts — only the toolshed log reveals it. This blocks the profile UX (saving avatar/name and "Add profile card"). `setName` / `setAvatar` / `addElement` in `system/profile-home.tsx` are structurally identical owner-protected writers.

## Root cause

> This **refutes** the issue's original hypothesis (a follow-on to the `implementationRef`-stability work / ref instability). Instrumentation shows the `implementationRef` is stable and the handler function resolves fine — the verified **binding metadata is simply never registered** for these handlers.

Chain (verified by reproduction):

1. `handler()` / `lift()` return a **factory** = `Object.assign(callable, module)`.
2. The transformer's `__cfBindVerifiedBinding(setName, …)` attaches `__cfVerifiedBindingIdentity` to that **factory** (the implementation fn is already `Object.freeze`d by `hardenVerifiedFunction`, so the write to *it* is silently skipped).
3. The reactive node stores `node.module = module` — the **underlying** object, which never received the metadata.
4. `captureVerifiedValue` (which populates `verifiedBindingMetadata`) runs right after module **evaluation** and only walks the module's **export namespace**.

So the factory's metadata reaches the registry **only when the handler is `export`ed**. profile-home's handlers are non-exported module-scope consts → metadata never registered → `getVerifiedBindingMetadata(ref)` misses → `cfc/prepare.ts` rejects the write.

(The shell asymmetry where `name` *appeared* to work while `avatar` didn't is most plausibly the setup-projection / initialization exemption masking the initialized field's first write; all three handlers share the same defect. The element-write `addElement` — folded into this issue — is the same root cause and is also fixed.)

## Fix — runtime only (no transformer, freeze, or serialization changes)

| File | Change |
|---|---|
| `sandbox/function-hardening.ts` | New `setVerifiedBindingCandidateRegistrar` / `registerVerifiedBindingCandidate` hook (mirrors the existing function registrar). |
| `builder/module.ts` | `handlerInternal` and `createNodeFactory` surface their factory via `registerVerifiedBindingCandidate(factory)`. `createNodeFactory` guards on a JS-function implementation (see review note 2). |
| `harness/engine.ts` | Both load paths (source-based **and** source-free resume-by-identity) collect candidates during evaluation and call `executableRegistry.captureVerifiedBindingCandidates(...)` after `captureVerifiedValue`. |
| `harness/executable-registry.ts` | `captureVerifiedBindingCandidates(...)` records each factory's metadata keyed by its (shared) `implementationRef`. |

Recording happens during module **evaluation** (which re-runs on both fresh load and resume), so the fix covers both paths.

## Testing

New `packages/runner/test/cfc-nonexported-binding-identity.test.ts`:
- **RED without the fix** for internal handlers (esm on/off), the real `profile-home` (setName/setAvatar/addElement), and resume-by-identity.
- **GREEN for exported handlers** with *and* without the fix — a regression guard that pins the exact asymmetry.
- All green with the fix. **Full runner suite green (530 passed, 0 failed).**

## For runtime-owner review

A few design points worth a second opinion:

1. **Approach.** Surfacing builder factories during the load, vs. the alternative of attaching the binding identity to the implementation function *before* it's frozen (which would need a transformer change + pattern recompile). I went runtime-only to avoid touching the transformer and to keep the serialized/content-addressed graph untouched (the `669260eee` area).
2. **`createNodeFactory` guard.** Restricting registration to function modules also sidesteps a circular-import TDZ that surfaces when an implementation-less `type:"ref"` builtin (`builtins/sqlite/query-node.ts`) is built at module load *before* `function-hardening.ts` initializes. Ref builtins can't be trusted-binding writers, so the guard is semantically correct as well as necessary — but flagging it.
3. **Trust surface.** Recording reads `__cfVerifiedBindingIdentity` off genuine builder factories during a verified load — the same value the existing exported-handler capture already trusts. I don't believe this widens the trust surface, but it's the kind of thing worth your eyes.

Draft until reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers verified binding metadata for non-exported handlers so `writeAuthorizedBy` works under `enforce-explicit` (CT-1665). Restores saving profile `name`, `avatar`, and profile elements on fresh loads and resume-by-identity.

- **Bug Fixes**
  - Added `setVerifiedBindingCandidateRegistrar`/`registerVerifiedBindingCandidate` in `sandbox/function-hardening.ts` to surface non-exported handler factories on the legacy/AMD path.
  - `handlerInternal` and `createNodeFactory` register factories; `createNodeFactory` guards to JS-function modules.
  - ESM loader records factories from `graph.registrationSink` (transformer `__cfReg`); legacy loader uses the registrar. Both paths (fresh and resume-by-identity) feed `executableRegistry.captureVerifiedBindingCandidates(...)`.
  - Registry stores metadata by `implementationRef` so CFC resolves non-exported handlers.
  - Added `cfc-nonexported-binding-identity.test.ts` covering internal vs. exported handlers, real `system/profile-home.tsx`, and resume.

- **Refactors**
  - Comment polish: clarified the TDZ guard in `createNodeFactory` and documented test scope (no behavior change).

<sup>Written for commit 8079093c197aebbaa4b259f6031832e8ebaf7558. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


