### PR TITLE
feat(patterns): meaning-alignment Q&A v1 for the Self pattern (CT-1674)

### DIFF
--- a/packages/patterns/self.test.tsx
+++ b/packages/patterns/self.test.tsx
@@ -16,14 +16,18 @@
  */
 import { computed, handler, pattern, Writable } from "commonfabric";
 import Self, {
+  addValueCardFromForm,
   appendResponse,
   appendValue,
   EMPTY_SELF_MODEL,
+  MEANING_PROMPTS,
   type Neurotype,
   type NeurotypeSystem,
   type QAResponse,
   recordNeurotypeFromForm,
+  recordReflectionFromForm,
   removeNeurotypeBySystem,
+  removeValueCardByIndex,
   type SelfModel,
   upsertNeurotype,
   type ValueCard,
@@ -140,7 +144,7 @@ export default pattern(() => {
   const assert_value_count_1 = computed(
     () => after_add_curiosity.values.length === 1,
   );
-  const assert_value_title = computed(
+  const assert_value_title_curiosity = computed(
     () => after_add_curiosity.values[0]?.title === "Curiosity",
   );
 
@@ -336,6 +340,154 @@ export default pattern(() => {
   });
 
   // =========================================================================
+  // CT-1674 Meaning & Values Tests — fresh selfModel3 to avoid state bleed
+  // =========================================================================
+
+  const selfModel3 = new Writable<SelfModel>(EMPTY_SELF_MODEL);
+
+  // Test 9: MEANING_PROMPTS sanity — 8 entries, correct kinds present
+  const assert_meaning_prompts_count = computed(
+    () => MEANING_PROMPTS.length === 8,
+  );
+  const assert_meaning_prompts_has_open = computed(
+    () => MEANING_PROMPTS.some((p) => p.kind === "open"),
+  );
+  const assert_meaning_prompts_has_scissor = computed(
+    () => MEANING_PROMPTS.some((p) => p.kind === "scissor"),
+  );
+  const assert_meaning_prompts_has_closing = computed(
+    () => MEANING_PROMPTS.some((p) => p.kind === "closing"),
+  );
+
+  // Test 10: recordReflectionFromForm appends QAResponse(track:"meaning") + clears answerField
+  const promptId10 = MEANING_PROMPTS[0].id; // "open-life"
+  const currentPromptId10 = new Writable<string>(promptId10);
+  const answerField10 = new Writable<string>(
+    "I work as a designer and live with my partner.",
+  );
+
+  const action_record_reflection = recordReflectionFromForm({
+    selfModel: selfModel3,
+    currentPromptId: currentPromptId10,
+    answerField: answerField10,
+  });
+
+  const assert_reflection_appended = computed(
+    () => selfModel3.get().responses.length === 1,
+  );
+  const assert_reflection_track_meaning = computed(
+    () => selfModel3.get().responses[0]?.track === "meaning",
+  );
+  const assert_reflection_prompt_id = computed(
+    () => selfModel3.get().responses[0]?.promptId === promptId10,
+  );
+  const assert_reflection_prompt_text = computed(
+    () => selfModel3.get().responses[0]?.prompt === MEANING_PROMPTS[0].text,
+  );
+  const assert_reflection_answer = computed(
+    () =>
+      selfModel3.get().responses[0]?.answer ===
+        "I work as a designer and live with my partner.",
+  );
+  const assert_answer_field_cleared = computed(
+    () => answerField10.get() === "",
+  );
+
+  // Test 11: addValueCardFromForm appends ValueCard with attendingTo/stance/contextTags + clears fields
+  const selfModel4 = new Writable<SelfModel>(EMPTY_SELF_MODEL);
+  const titleField11 = new Writable<string>("Direct feedback");
+  const attendingToField11 = new Writable<string>(
+    "a disagreement at the moment it is live",
+  );
+  const stanceField11 = new Writable<
+    "descriptive" | "aspirational" | "conflicted"
+  >("descriptive");
+  const contextTagsField11 = new Writable<string>("work, team");
+
+  const action_add_value_from_form = addValueCardFromForm({
+    selfModel: selfModel4,
+    titleField: titleField11,
+    attendingToField: attendingToField11,
+    stanceField: stanceField11,
+    contextTagsField: contextTagsField11,
+  });
+
+  const assert_value_appended = computed(
+    () => selfModel4.get().values.length === 1,
+  );
+  const assert_value_title = computed(
+    () => selfModel4.get().values[0]?.title === "Direct feedback",
+  );
+  const assert_value_attending_to = computed(
+    () =>
+      selfModel4.get().values[0]?.attendingTo ===
+        "a disagreement at the moment it is live",
+  );
+  const assert_value_stance = computed(
+    () => selfModel4.get().values[0]?.stance === "descriptive",
+  );
+  const assert_value_context_tags = computed(() => {
+    const tags = selfModel4.get().values[0]?.contextTags;
+    return (
+      Array.isArray(tags) &&
+      tags.length === 2 &&
+      tags[0] === "work" &&
+      tags[1] === "team"
+    );
+  });
+  const assert_title_field_cleared = computed(() => titleField11.get() === "");
+  const assert_attending_field_cleared = computed(
+    () => attendingToField11.get() === "",
+  );
+  const assert_context_tags_field_cleared = computed(
+    () => contextTagsField11.get() === "",
+  );
+
+  // Test 12: removeValueCardByIndex removes correct entry
+  const selfModel5 = new Writable<SelfModel>(EMPTY_SELF_MODEL);
+  const titleField12a = new Writable<string>("First value");
+  const attendingToField12a = new Writable<string>("");
+  const stanceField12a = new Writable<
+    "descriptive" | "aspirational" | "conflicted"
+  >("descriptive");
+  const contextTagsField12a = new Writable<string>("");
+
+  const action_add_first_value = addValueCardFromForm({
+    selfModel: selfModel5,
+    titleField: titleField12a,
+    attendingToField: attendingToField12a,
+    stanceField: stanceField12a,
+    contextTagsField: contextTagsField12a,
+  });
+
+  const titleField12b = new Writable<string>("Second value");
+  const attendingToField12b = new Writable<string>("");
+  const stanceField12b = new Writable<
+    "descriptive" | "aspirational" | "conflicted"
+  >("aspirational");
+  const contextTagsField12b = new Writable<string>("");
+
+  const action_add_second_value = addValueCardFromForm({
+    selfModel: selfModel5,
+    titleField: titleField12b,
+    attendingToField: attendingToField12b,
+    stanceField: stanceField12b,
+    contextTagsField: contextTagsField12b,
+  });
+
+  const action_remove_first_value_card = removeValueCardByIndex({
+    selfModel: selfModel5,
+    index: 0,
+  });
+
+  const assert_only_second_remains = computed(
+    () => selfModel5.get().values.length === 1,
+  );
+  const assert_second_value_title = computed(
+    () => selfModel5.get().values[0]?.title === "Second value",
+  );
+
+  // =========================================================================
   // Test Sequence
   // =========================================================================
   return {
@@ -355,7 +507,7 @@ export default pattern(() => {
 
       // === A4: appendValue — first card ===
       { assertion: assert_value_count_1 },
-      { assertion: assert_value_title },
+      { assertion: assert_value_title_curiosity },
 
       // === A5: appendValue — second card, order preserved ===
       { assertion: assert_value_count_2 },
@@ -403,6 +555,39 @@ export default pattern(() => {
       // === Test 8: removeNeurotypeBySystem removes correct entry ===
       { action: action_remove_enneagram_by_system },
       { assertion: assert_only_mbti_after_remove },
+
+      // === Test 9: MEANING_PROMPTS sanity ===
+      { assertion: assert_meaning_prompts_count },
+      { assertion: assert_meaning_prompts_has_open },
+      { assertion: assert_meaning_prompts_has_scissor },
+      { assertion: assert_meaning_prompts_has_closing },
+
+      // === Test 10: recordReflectionFromForm appends + clears ===
+      { action: action_record_reflection },
+      { assertion: assert_reflection_appended },
+      { assertion: assert_reflection_track_meaning },
+      { assertion: assert_reflection_prompt_id },
+      { assertion: assert_reflection_prompt_text },
+      { assertion: assert_reflection_answer },
+      { assertion: assert_answer_field_cleared },
+
+      // === Test 11: addValueCardFromForm appends with full fields + clears ===
+      { action: action_add_value_from_form },
+      { assertion: assert_value_appended },
+      { assertion: assert_value_title },
+      { assertion: assert_value_attending_to },
+      { assertion: assert_value_stance },
+      { assertion: assert_value_context_tags },
+      { assertion: assert_title_field_cleared },
+      { assertion: assert_attending_field_cleared },
+      { assertion: assert_context_tags_field_cleared },
+
+      // === Test 12: removeValueCardByIndex removes correct entry ===
+      { action: action_add_first_value },
+      { action: action_add_second_value },
+      { action: action_remove_first_value_card },
+      { assertion: assert_only_second_remains },
+      { assertion: assert_second_value_title },
     ],
   };
 });

--- a/packages/patterns/self.tsx
+++ b/packages/patterns/self.tsx
@@ -13,6 +13,7 @@
 import {
   computed,
   handler,
+  ifElse,
   NAME,
   pattern,
   safeDateNow,
@@ -621,29 +622,33 @@ const Self = pattern<SelfInput, SelfOutput>(
               <h3 style={{ margin: 0, fontSize: "14px", fontWeight: "600" }}>
                 Recorded reflections
               </h3>
-              {selfModel.key("responses").map((r) => (
-                <cf-vstack
-                  gap="1"
-                  style={{
-                    padding: "8px",
-                    background: "#f9fafb",
-                    borderRadius: "6px",
-                  }}
-                >
-                  <span
+              {selfModel.key("responses").map((r) =>
+                ifElse(
+                  computed(() => r.track === "meaning"),
+                  <cf-vstack
+                    gap="1"
                     style={{
-                      fontSize: "12px",
-                      color: "#6b7280",
-                      fontStyle: "italic",
+                      padding: "8px",
+                      background: "#f9fafb",
+                      borderRadius: "6px",
                     }}
                   >
-                    {r.prompt}
-                  </span>
-                  <span style={{ fontSize: "13px", color: "#111827" }}>
-                    {r.answer}
-                  </span>
-                </cf-vstack>
-              ))}
+                    <span
+                      style={{
+                        fontSize: "12px",
+                        color: "#6b7280",
+                        fontStyle: "italic",
+                      }}
+                    >
+                      {r.prompt}
+                    </span>
+                    <span style={{ fontSize: "13px", color: "#111827" }}>
+                      {r.answer}
+                    </span>
+                  </cf-vstack>,
+                  null,
+                )
+              )}
             </cf-vstack>
 
             {/* -- Your values section -- */}

--- a/packages/patterns/self.tsx
+++ b/packages/patterns/self.tsx
@@ -11,6 +11,7 @@
  *   const self = wish<SelfOutput>({ query: "#self-model" });
  */
 import {
+  computed,
   handler,
   NAME,
   pattern,
@@ -39,7 +40,75 @@ export interface ValueCard {
   description?: string;
   weight?: number;
   sourcePromptId?: string;
+  // CT-1674: meaning-alignment fields
+  attendingTo?: string;
+  stance?: "descriptive" | "aspirational" | "conflicted";
+  contextTags?: string[];
+  sourceTrack?: Track;
 }
+
+// ============================================================================
+// MEANING-ALIGNMENT TYPES (CT-1674)
+// ============================================================================
+
+export type Track = "open" | "scissor" | "closing";
+
+export interface ReflectivePrompt {
+  id: string;
+  text: string;
+  kind: Track;
+}
+
+export const MEANING_PROMPTS: ReflectivePrompt[] = [
+  {
+    id: "open-life",
+    kind: "open",
+    text:
+      "Tell me a bit about your life right now — whatever you'd want a thoughtful system to know about you. Start with what you do and the most important people in your life.",
+  },
+  {
+    id: "sc-conflict",
+    kind: "scissor",
+    text:
+      "Recall the last time a colleague or someone close said something that you thought was wrong, or that landed badly. What did you do with it — said something in the moment, followed up privately later, or let it go?",
+  },
+  {
+    id: "sc-waiting",
+    kind: "scissor",
+    text:
+      "Think of the most recent time you were waiting on something that mattered and couldn't speed it up. Did you move your attention away from it, stay close and hold the tension, or start preparing for both outcomes?",
+  },
+  {
+    id: "sc-rhythms",
+    kind: "scissor",
+    text:
+      "Is there a recurring shape to your weeks — a difference between some days and others, not just by schedule but by who you are in them? Is that contrast the whole shape of your life, a quiet undertone, or not really a thing for you?",
+  },
+  {
+    id: "sc-unscheduled",
+    kind: "scissor",
+    text:
+      "Recall the most recent full day with no hard commitments — genuinely yours. By the end, did it feel good, wasted, or like a work day in different clothes?",
+  },
+  {
+    id: "sc-commitment",
+    kind: "scissor",
+    text:
+      "Think back to the last time you committed to something for a friend or family member and it became clear you couldn't pull it off as promised. Did you tell them early, show up with a smaller version, or say nothing and scramble?",
+  },
+  {
+    id: "sc-narrative",
+    kind: "scissor",
+    text:
+      "Think of the phase of life you're in right now. Last time you tried to name what it's for — could you name it, are you between chapters, or do you not really think in phases-with-purposes?",
+  },
+  {
+    id: "close-navigating",
+    kind: "closing",
+    text:
+      "What are some things you're navigating right now that you'd want help with?",
+  },
+];
 
 export interface QAResponse {
   promptId: string;
@@ -282,6 +351,89 @@ export const removeNeurotypeBySystem = handler<
   selfModel.set(withoutNeurotype(selfModel.get(), system));
 });
 
+/**
+ * Record a meaning reflection from form fields (state-reading handler).
+ * Looks up the prompt in MEANING_PROMPTS by currentPromptId; if answerField
+ * is non-empty, appends a QAResponse(track:"meaning") and clears answerField.
+ */
+export const recordReflectionFromForm = handler<
+  unknown,
+  {
+    selfModel: Writable<SelfModel>;
+    currentPromptId: Writable<string>;
+    answerField: Writable<string>;
+  }
+>((_event, { selfModel, currentPromptId, answerField }) => {
+  const answer = answerField.get().trim();
+  if (!answer) return;
+  const promptId = currentPromptId.get();
+  const prompt = MEANING_PROMPTS.find((p) => p.id === promptId);
+  if (!prompt) return;
+  const response: QAResponse = {
+    promptId: prompt.id,
+    prompt: prompt.text,
+    answer,
+    track: "meaning",
+    answeredAt: safeDateNow(),
+  };
+  selfModel.set(appendResponse(selfModel.get(), response));
+  answerField.set("");
+});
+
+/**
+ * Add a value card from form fields (state-reading handler).
+ * Reads titleField, attendingToField, stanceField, contextTagsField;
+ * if title non-empty, appends a ValueCard and clears all fields.
+ */
+export const addValueCardFromForm = handler<
+  unknown,
+  {
+    selfModel: Writable<SelfModel>;
+    titleField: Writable<string>;
+    attendingToField: Writable<string>;
+    stanceField: Writable<"descriptive" | "aspirational" | "conflicted">;
+    contextTagsField: Writable<string>;
+  }
+>((
+  _event,
+  { selfModel, titleField, attendingToField, stanceField, contextTagsField },
+) => {
+  const title = titleField.get().trim();
+  if (!title) return;
+  const attendingTo = attendingToField.get().trim() || undefined;
+  const stance = stanceField.get();
+  const rawTags = contextTagsField.get();
+  const contextTags = rawTags
+    .split(",")
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0);
+  const card: ValueCard = {
+    title,
+    attendingTo,
+    stance,
+    contextTags: contextTags.length > 0 ? contextTags : undefined,
+  };
+  selfModel.set(appendValue(selfModel.get(), card));
+  titleField.set("");
+  attendingToField.set("");
+  // stanceField intentionally retains the last-selected stance (3-way enum, no neutral)
+  contextTagsField.set("");
+});
+
+/**
+ * Remove a value card by index (state-reading handler, for per-row binding).
+ */
+export const removeValueCardByIndex = handler<
+  unknown,
+  { selfModel: Writable<SelfModel>; index: number }
+>((_event, { selfModel, index }) => {
+  const current = selfModel.get();
+  selfModel.set({
+    ...current,
+    values: current.values.filter((_, i) => i !== index),
+  });
+});
+
 // ============================================================================
 // MAIN PATTERN
 // ============================================================================
@@ -295,17 +447,45 @@ const Self = pattern<SelfInput, SelfOutput>(
     const selfModel = injectedSelfModel ??
       new Writable<SelfModel>(EMPTY_SELF_MODEL).for("selfModel");
 
-    // Local form field cells
+    // Local form field cells — neurotype
     const systemField = new Writable<NeurotypeSystem>("mbti").for(
       "systemField",
     );
     const resultField = new Writable<string>("").for("resultField");
+
+    // Local form field cells — meaning reflections
+    const currentPromptId = new Writable<string>(MEANING_PROMPTS[0].id).for(
+      "currentPromptId",
+    );
+    const answerField = new Writable<string>("").for("answerField");
+
+    // Local form field cells — value cards
+    const titleField = new Writable<string>("").for("titleField");
+    const attendingToField = new Writable<string>("").for("attendingToField");
+    const stanceField = new Writable<
+      "descriptive" | "aspirational" | "conflicted"
+    >("descriptive").for("stanceField");
+    const contextTagsField = new Writable<string>("").for("contextTagsField");
 
     const neurotypeSystemItems: { label: string; value: NeurotypeSystem }[] = [
       { label: "MBTI", value: "mbti" },
       { label: "Enneagram", value: "enneagram" },
       { label: "Big Five", value: "big5" },
       { label: "Custom", value: "custom" },
+    ];
+
+    const promptSelectItems = MEANING_PROMPTS.map((p) => ({
+      label: p.text.slice(0, 60) + (p.text.length > 60 ? "…" : ""),
+      value: p.id,
+    }));
+
+    const stanceItems: {
+      label: string;
+      value: "descriptive" | "aspirational" | "conflicted";
+    }[] = [
+      { label: "Descriptive (how I already attend)", value: "descriptive" },
+      { label: "Aspirational (how I want to attend)", value: "aspirational" },
+      { label: "Conflicted (unclear or in tension)", value: "conflicted" },
     ];
 
     return {
@@ -319,7 +499,7 @@ const Self = pattern<SelfInput, SelfOutput>(
             Self Model
           </h2>
           <p style={{ margin: 0, fontSize: "13px", color: "#6b7280" }}>
-            Your private neurotype self-report. Never shared.
+            Your private self-model. Never shared.
           </p>
 
           <cf-vstack gap="2">
@@ -377,6 +557,170 @@ const Self = pattern<SelfInput, SelfOutput>(
                 </cf-button>
               </cf-hstack>
             ))}
+          </cf-vstack>
+
+          {
+            /* ================================================================
+              MEANING & VALUES (CT-1674)
+          ================================================================ */
+          }
+          <cf-vstack
+            gap="3"
+            style={{ borderTop: "1px solid #e5e7eb", paddingTop: "16px" }}
+          >
+            <h2
+              style={{ margin: "0 0 4px", fontSize: "16px", fontWeight: "600" }}
+            >
+              Meaning &amp; Values
+            </h2>
+            <p style={{ margin: 0, fontSize: "13px", color: "#6b7280" }}>
+              Reflective prompts and your value cards — what you attend to that
+              matters.
+            </p>
+
+            {/* -- Reflect section -- */}
+            <cf-vstack gap="2">
+              <h3 style={{ margin: 0, fontSize: "14px", fontWeight: "600" }}>
+                Reflect
+              </h3>
+              <cf-select
+                $value={currentPromptId}
+                items={promptSelectItems}
+                style="width: 100%;"
+              />
+              <p
+                style={{
+                  margin: "4px 0",
+                  fontSize: "13px",
+                  color: "#374151",
+                  fontStyle: "italic",
+                }}
+              >
+                {computed(() =>
+                  MEANING_PROMPTS.find((x) => x.id === currentPromptId.get())
+                    ?.text ?? ""
+                )}
+              </p>
+              <cf-textarea
+                $value={answerField}
+                placeholder="Your reflection…"
+                style="width: 100%;"
+              />
+              <cf-button
+                onClick={recordReflectionFromForm({
+                  selfModel,
+                  currentPromptId,
+                  answerField,
+                })}
+              >
+                Record reflection
+              </cf-button>
+            </cf-vstack>
+
+            <cf-vstack gap="2">
+              <h3 style={{ margin: 0, fontSize: "14px", fontWeight: "600" }}>
+                Recorded reflections
+              </h3>
+              {selfModel.key("responses").map((r) => (
+                <cf-vstack
+                  gap="1"
+                  style={{
+                    padding: "8px",
+                    background: "#f9fafb",
+                    borderRadius: "6px",
+                  }}
+                >
+                  <span
+                    style={{
+                      fontSize: "12px",
+                      color: "#6b7280",
+                      fontStyle: "italic",
+                    }}
+                  >
+                    {r.prompt}
+                  </span>
+                  <span style={{ fontSize: "13px", color: "#111827" }}>
+                    {r.answer}
+                  </span>
+                </cf-vstack>
+              ))}
+            </cf-vstack>
+
+            {/* -- Your values section -- */}
+            <cf-vstack gap="2">
+              <h3 style={{ margin: 0, fontSize: "14px", fontWeight: "600" }}>
+                Add a value
+              </h3>
+              <cf-input
+                $value={titleField}
+                placeholder="Title"
+                style="width: 100%;"
+              />
+              <cf-input
+                $value={attendingToField}
+                placeholder="What you attend to (e.g. a disagreement at the moment it is live)"
+                style="width: 100%;"
+              />
+              <cf-select
+                $value={stanceField}
+                items={stanceItems}
+                style="width: 100%;"
+              />
+              <cf-input
+                $value={contextTagsField}
+                placeholder="Context tags, comma-separated (e.g. work, solo)"
+                style="width: 100%;"
+              />
+              <cf-button
+                onClick={addValueCardFromForm({
+                  selfModel,
+                  titleField,
+                  attendingToField,
+                  stanceField,
+                  contextTagsField,
+                })}
+              >
+                Add value
+              </cf-button>
+            </cf-vstack>
+
+            <cf-vstack gap="2">
+              <h3 style={{ margin: 0, fontSize: "14px", fontWeight: "600" }}>
+                Your values
+              </h3>
+              {selfModel.key("values").map((v, index) => (
+                <cf-hstack gap="2" align="start">
+                  <cf-vstack gap="1" style={{ flex: "1" }}>
+                    <span
+                      style={{ fontSize: "13px", fontWeight: "600" }}
+                    >
+                      {v.title}
+                    </span>
+                    {v.attendingTo
+                      ? (
+                        <span style={{ fontSize: "12px", color: "#374151" }}>
+                          Attending to: {v.attendingTo}
+                        </span>
+                      )
+                      : <span />}
+                    {v.stance
+                      ? (
+                        <span style={{ fontSize: "12px", color: "#6b7280" }}>
+                          {v.stance}
+                        </span>
+                      )
+                      : <span />}
+                  </cf-vstack>
+                  <cf-button
+                    size="sm"
+                    variant="ghost"
+                    onClick={removeValueCardByIndex({ selfModel, index })}
+                  >
+                    ✕
+                  </cf-button>
+                </cf-hstack>
+              ))}
+            </cf-vstack>
           </cf-vstack>
         </cf-vstack>
       ),


### PR DESCRIPTION
## Motivation

The private **self-model** (CT-1670 #3907 schema, CT-1672 #3908 neurotype) gets its centerpiece: **meaning-alignment Q&A**. Instead of slogans ("I value family"), this elicits *what you actually attend to* in concrete situations — the [Meaning Alignment Institute](https://meaningalignment.org) "attention policy" lineage. The prompts and value model here are adapted faithfully from internal design material (`cfc-specs/meaningful-attention/` — a three-register "scissor" elicitation method).

This is **static, free-text v1**: the prompts are reflective questions answered in free text, and value cards are authored by hand. The LLM magic — distilling a free-text answer into a validated attention policy via the rule-in/rule-out triage, plus adaptive selection and forced-choice options — is the **next** stacked PR (criteria already captured in the research notes).

## What's in this PR (only `self.tsx` + tests)

**Schema (additive):**
- `ValueCard` gains `attendingTo?` (the load-bearing noun-phrase: *what you attend to*), `stance?: "descriptive" | "aspirational" | "conflicted"`, `contextTags?: string[]`, `sourceTrack?`.
- New `ReflectivePrompt { id; text; kind: "open" | "scissor" | "closing" }` + `MEANING_PROMPTS` — 8 starter prompts adapted verbatim from the scissor set (open + 6 scissors across orthogonal axes + closing).

**UI — new "Meaning & Values" section** (below the neurotype section):
- *Reflect:* pick a prompt (`cf-select`) → its text shows → free-text answer (`cf-textarea`) → **Record reflection** → `recordResponse(track: "meaning")`; a list of recorded reflections.
- *Your values:* an add-value form (title + *what you attend to* + descriptive/aspirational stance + comma-separated context tags) → `addValueCard`; a list of value cards (title + attendingTo + stance) with remove.

**Wiring:** new state-reading form handlers (`recordReflectionFromForm`, `addValueCardFromForm`, `removeValueCardByIndex`) mirroring CT-1672's idiom (a click event can't carry form values, so the handler reads them from bound state). All prior payload-based exports unchanged.

## Why it's safe to merge on its own

- Additive, only `self.tsx` (+ tests); no `home.tsx`/`profile.tsx`/`#3830`/runtime files touched. Stacked on **#3908**; merge after it.
- 46 tests pass (20 prior + new form-handler cases); `deno task cf check` clean.

## Testing

```
deno task cf test packages/patterns/self.test.tsx   # 46 passed, 0 failed
deno task cf check packages/patterns/self.tsx        # OK
```
New cases: record-reflection-from-form (appends `QAResponse(track:"meaning")` + clears), add-value-from-form (`attendingTo` + `stance` + parsed `contextTags`, clears), remove-value-by-index, `MEANING_PROMPTS` shape.

## Review note (known item)

The selected-prompt text renders via a scalar `currentPromptId.map(...)`. It type-checks and the handler logic is fully tested, but scalar-cell `.map` for a derived view is an unusual idiom here — **verify it reacts correctly when the pattern is deployed**, and if not, swap to `computed(() => MEANING_PROMPTS.find(...)?.text)`. (Tests cover the data round-trip, not render reactivity.)

## Scope / not here

- **No LLM distillation** (free-text → attention policy + `attendingTo` + `✔️/⬇A/⬇I` triage + stance) — next stacked PR; criteria in `cfc-specs` research.
- **No forced-choice scissor options**, no adaptive/hole-focused selection, no examples/bindings/embeddings, no sibling artifacts (manifestation stance, anti-patterns).

## Context & links

- This issue: **CT-1674** — Meaning-alignment Q&A v1.
- Builds on: **CT-1670** (#3907), **CT-1672** (#3908). Epic: **CT-1669**.
- Final series step (tracked): **CT-1673** — strip the legacy `learned`/blackboard.
- Sibling tier: **CT-1645** + **#3830**.

Draft: third of the private-tier stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds meaning‑alignment Q&A v1 to the private Self pattern (CT‑1674), with 8 reflective prompts, free‑text answers recorded under `track: "meaning"`, and a simple Values UI to author and manage value cards. Also fixes prompt text reactivity and filters the reflections list to show only meaning‑track entries.

- New Features
  - Export `ReflectivePrompt`, `MEANING_PROMPTS` (8 prompts), and `Track`; extend `ValueCard` with `attendingTo`, `stance`, `contextTags`, `sourceTrack`.
  - New “Meaning & Values” UI: pick prompt → answer → record reflection (`track: "meaning"`); add/remove value cards.
  - Handlers: `recordReflectionFromForm`, `addValueCardFromForm`, `removeValueCardByIndex`.

- Bug Fixes
  - Recorded reflections list now filters to `track === "meaning"`.
  - Prompt text uses `computed(...)` to avoid map-on-scalar render issues.

<sup>Written for commit b2cc8a289e933384b6c6b59f5669eb2e042edf97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

