### PR TITLE
feat(runner): content-addressable builder artifacts via __cfReg (CT-1623)

### DIFF
--- a/packages/runner/src/builder/module.ts
+++ b/packages/runner/src/builder/module.ts
@@ -22,6 +22,7 @@ import {
   connectInputAndOutputs,
 } from "./node-utils.ts";
 import { moduleToJSON } from "./json-utils.ts";
+import { brandTrustedBuilderArtifact } from "./pattern-metadata.ts";
 import { getTopFrame } from "./pattern.ts";
 import { generateHandlerSchema } from "../schema.ts";
 import { getLogger } from "@commonfabric/utils/logger";
@@ -148,6 +149,13 @@ export function createNodeFactory<T = any, R = any>(
   }, module) as ModuleFactory<T, R>;
   factory.asScope = (scope: CellScope) =>
     createNodeFactory({ ...module, defaultScope: scope });
+  // Provenance brand: every node factory (lift / handler / byRef / the list-op
+  // factories) is a trusted builder artifact, so a hoisted one registered via
+  // `__cfReg` may receive a content-addressed `{ identity, symbol }` reference.
+  // Only the trusted builders call `createNodeFactory`, so a `__cf_data`-forged
+  // look-alike never acquires the brand. (Patterns brand separately in
+  // builder/pattern.ts.)
+  brandTrustedBuilderArtifact(factory);
   return factory;
 }
 

--- a/packages/runner/src/builder/pattern-metadata.ts
+++ b/packages/runner/src/builder/pattern-metadata.ts
@@ -34,6 +34,25 @@ const verifiedLoadIdByValue = new WeakMap<object, string>();
 // derivation copies and independently re-resolves node implementations).
 const trustedPatterns = new WeakSet<object>();
 
+// Provenance brand for the OTHER trusted builder artifacts — `lift`, `handler`,
+// and the node factories they produce (see builder/module.ts `createNodeFactory`).
+// `pattern()` brands `trustedPatterns` instead. Kept as a separate set so the
+// pattern-only trust gate (`isTrustedPattern`, used by CFC) is unchanged, while
+// `isTrustedBuilderArtifact` accepts any trusted builder output. Like the pattern
+// brand, this is the gate that stops `__cf_data`-forged data from acquiring a
+// content-addressed `{ identity, symbol }` reference via `__cfReg`.
+//
+// Held lazily on this hoisted accessor rather than a top-level `const`/`let`:
+// unlike `pattern()`, `createNodeFactory` is invoked at MODULE-INIT time by some
+// builtins (e.g. builtins/sqlite/query-node), which runs inside the builder
+// import cycle — a top-level binding would still be in its temporal dead zone at
+// that point. A function declaration IS fully hoisted, so caching the `WeakSet`
+// on it sidesteps the init-order dependency entirely.
+function trustedBuilderArtifacts(): WeakSet<object> {
+  const self = trustedBuilderArtifacts as { set?: WeakSet<object> };
+  return (self.set ??= new WeakSet<object>());
+}
+
 function asKey(value: unknown): object | undefined {
   if (value === null) return undefined;
   return (typeof value === "object" || typeof value === "function")
@@ -95,6 +114,40 @@ export function isTrustedPattern(value: unknown): value is Pattern {
     current && (typeof current === "object" || typeof current === "function")
   ) {
     if (trustedPatterns.has(current as object)) return true;
+    if (seen.has(current)) break;
+    seen.add(current);
+    current = (current as Record<symbol, unknown>)[unsafe_originalPattern];
+  }
+  return false;
+}
+
+/** Stamp a value as produced by a trusted non-pattern builder (lift/handler/…). */
+export function brandTrustedBuilderArtifact<T>(value: T): T {
+  const key = asKey(value);
+  if (key) trustedBuilderArtifacts().add(key);
+  return value;
+}
+
+/**
+ * True for any value with trusted-builder provenance — a trusted pattern OR a
+ * branded lift/handler/node-factory — walking the `unsafe_originalPattern` chain
+ * so derivation / serialized copies inherit trust. This is the gate that decides
+ * whether a `__cfReg`-registered value may receive a content-addressed
+ * `{ identity, symbol }` reference; forged plain data carries no brand and is
+ * rejected.
+ */
+export function isTrustedBuilderArtifact(value: unknown): boolean {
+  let current: unknown = value;
+  const seen = new Set<unknown>();
+  while (
+    current && (typeof current === "object" || typeof current === "function")
+  ) {
+    if (
+      trustedBuilderArtifacts().has(current as object) ||
+      trustedPatterns.has(current as object)
+    ) {
+      return true;
+    }
     if (seen.has(current)) break;
     seen.add(current);
     current = (current as Record<symbol, unknown>)[unsafe_originalPattern];

--- a/packages/runner/src/builder/pattern-metadata.ts
+++ b/packages/runner/src/builder/pattern-metadata.ts
@@ -150,7 +150,13 @@ export function isTrustedBuilderArtifact(value: unknown): boolean {
     }
     if (seen.has(current)) break;
     seen.add(current);
-    current = (current as Record<symbol, unknown>)[unsafe_originalPattern];
+    // Fail closed: reading the (module-private) symbol off an exotic value — e.g.
+    // a Proxy with a throwing get trap — must not abort registration/lookup.
+    try {
+      current = (current as Record<symbol, unknown>)[unsafe_originalPattern];
+    } catch {
+      return false;
+    }
   }
   return false;
 }

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -793,7 +793,16 @@ export class Engine extends EventTarget implements Harness {
       this.executableRegistry.captureVerifiedValue(loadId, exportMap);
       this.runtimeInternals?.exportsCallback(exportsByValue);
 
-      return { main, exportMap, loadId, exportsByIdentity };
+      // `graph.registrationSink` was populated by each module's `__cfReg` during
+      // the `importNow` loop above (committed only for modules that evaluated
+      // cleanly).
+      return {
+        main,
+        exportMap,
+        loadId,
+        exportsByIdentity,
+        registrationsByIdentity: graph.registrationSink,
+      };
     } finally {
       logger.timeEnd("evaluateRecordGraph");
     }

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -421,8 +421,23 @@ export class Engine extends EventTarget implements Harness {
         options.precompiledModules === undefined &&
         options.precompiledModulesFor !== undefined;
       if (!trustBodies) {
+        // Verify, and record which modules the verifier approved for hoist
+        // registration — only those get the real `__cfReg` registrar (the rest
+        // get a throwing one, so a smuggled call fails closed).
         for (const [specifier, body] of graph.compiledBodies) {
-          verifyCompiledModuleBody(body, specifier);
+          const { hasHoistRegistration } = verifyCompiledModuleBody(
+            body,
+            specifier,
+          );
+          if (hasHoistRegistration) graph.registrationApproved.add(specifier);
+        }
+      } else {
+        // Trusted integrity-gated bytes: SES verification — and its registration
+        // approval — already ran when the cache entry was sealed, so grant the
+        // real registrar to every module (one without a `__cfReg` call never
+        // invokes it).
+        for (const specifier of graph.compiledBodies.keys()) {
+          graph.registrationApproved.add(specifier);
         }
       }
 
@@ -859,8 +874,20 @@ export class Engine extends EventTarget implements Harness {
     // `docs/specs/module-loading.md`, "the persistent compilation cache"). The
     // structural graph verify below always runs.
     if (options.trustedBodies !== true) {
+      // Verify, and record which modules the verifier approved for hoist
+      // registration — only those get the real `__cfReg` registrar.
       for (const [specifier, body] of graph.compiledBodies) {
-        verifyCompiledModuleBody(body, specifier);
+        const { hasHoistRegistration } = verifyCompiledModuleBody(
+          body,
+          specifier,
+        );
+        if (hasHoistRegistration) graph.registrationApproved.add(specifier);
+      }
+    } else {
+      // Trusted integrity-gated bytes: registration approval was sealed at
+      // first compile; grant the real registrar to every module.
+      for (const specifier of graph.compiledBodies.keys()) {
+        graph.registrationApproved.add(specifier);
       }
     }
     const mainSpecifier = `cf:module/${entryIdentity}`;

--- a/packages/runner/src/harness/types.ts
+++ b/packages/runner/src/harness/types.ts
@@ -7,6 +7,7 @@ import type {
 import type {
   CachedCompiledModule,
   CompiledModuleGraph,
+  HoistRegistrationSink,
 } from "../sandbox/module-record-compiler.ts";
 import type { UnsafeHostTrustOptions } from "../unsafe-host-trust.ts";
 
@@ -111,6 +112,14 @@ export interface EvaluateResult {
    * Populated only on the ESM evaluate paths.
    */
   exportsByIdentity?: Map<string, Exports>;
+  /**
+   * Hoist registrations collected during this evaluation (`__cfReg`): module
+   * content identity → (symbol → live builder artifact). The PatternManager turns
+   * each trusted entry into a content-addressed `{ identity, symbol }` reference
+   * and indexes it for synchronous by-identity resolution. Populated only on the
+   * ESM evaluate paths.
+   */
+  registrationsByIdentity?: HoistRegistrationSink;
 }
 
 export interface EvaluateOptions {

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -981,11 +981,13 @@ export class PatternManager {
     value: unknown,
   ): void {
     if (!isTrustedBuilderArtifact(value)) return;
-    // Reverse index, refreshing recency (FIFO ~ LRU).
+    // Reverse index, refreshing recency (FIFO ~ LRU). Overwrite an existing
+    // symbol so a re-evaluation of the same identity resolves to the FRESH
+    // artifact instance, not a stale one from a prior eval.
     let bucket = this.addressableByIdentity.get(identity);
     if (bucket) this.addressableByIdentity.delete(identity);
     else bucket = new Map<string, unknown>();
-    if (!bucket.has(symbol)) bucket.set(symbol, value);
+    bucket.set(symbol, value);
     this.addressableByIdentity.set(identity, bucket);
     // Forward map — don't overwrite an existing ref (e.g. a value that is both a
     // `__cfReg` entry and an export, or whose entry ref the caller set first).

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -9,6 +9,7 @@ import {
 import {
   getPatternProgram,
   getVerifiedLoadId,
+  isTrustedBuilderArtifact,
   isTrustedPattern,
   setPatternProgram,
   setVerifiedLoadId,
@@ -25,7 +26,10 @@ import type {
   Exports,
 } from "./harness/types.ts";
 import { RuntimeProgram } from "./harness/types.ts";
-import type { CachedCompiledModule } from "./sandbox/module-record-compiler.ts";
+import type {
+  CachedCompiledModule,
+  HoistRegistrationSink,
+} from "./sandbox/module-record-compiler.ts";
 import type { IExtendedStorageTransaction } from "./storage/interface.ts";
 import {
   COMPILE_CACHE_RUNTIME_VERSION,
@@ -100,18 +104,23 @@ export class PatternManager {
   private patternIdMap = new Map<URI, Pattern>();
   // Map from pattern object instance to patternId
   private patternToIdMap = new WeakMap<Pattern, URI>();
-  // Map from pattern object instance to its content-addressed {identity, symbol}
-  // reference — the entry module's identity (prefix-free `cf:module/<hash>`
-  // minus the scheme) and the export name this pattern was selected by. Learned
-  // on the ESM cache path; lets a result cell reference a pattern by
-  // {identity, symbol} and load it straight from the compiled cache without the
-  // program/meta indirection. The symbol is recorded from the authored program
-  // (cold) or the load symbol (warm) — never recomputed from a source-free
-  // pattern's stub program, which would lose a non-"default" export name.
-  private patternToEntryRef = new WeakMap<
-    Pattern,
+  // Map from a builder artifact (pattern / lift / handler) to its content-
+  // addressed {identity, symbol} reference — the module's identity (prefix-free
+  // `cf:module/<hash>` minus the scheme) and the symbol it was registered/exported
+  // under. Learned on the ESM path: for an authored export the symbol is its
+  // export name; for a hoisted artifact it is the `__cfReg` key. Lets a value be
+  // referenced by {identity, symbol} and resolved straight from the in-memory
+  // cache without the program/meta indirection.
+  private valueToEntryRef = new WeakMap<
+    object,
     { identity: string; symbol: string }
   >();
+  // In-memory reverse index for HOISTED builder artifacts (`__cfReg`): module
+  // identity -> (symbol -> live value). The forward map above answers "what is
+  // this value's ref"; this answers "what value does this ref name", which the
+  // list builtins use to resolve a map/filter/flatMap `op` synchronously. Bounded
+  // (FIFO) like `modulesByIdentity`; a miss falls back to an embedded graph.
+  private hoistsByIdentity = new Map<string, Map<string, unknown>>();
   private patternToVerifiedLoadId = new WeakMap<Pattern, string>();
   // Pending metadata set before the meta cell exists (e.g., spec, parents)
   private pendingMetaById = new Map<URI, Partial<PatternMeta>>();
@@ -896,7 +905,7 @@ export class PatternManager {
     }
     const pattern = main[symbol] as Pattern;
     if (isTrustedPattern(pattern)) {
-      this.patternToEntryRef.set(pattern, { identity: entryIdentity, symbol });
+      this.valueToEntryRef.set(pattern, { identity: entryIdentity, symbol });
       if (loadId) {
         this.seedVerifiedLoadIds(pattern, loadId);
       }
@@ -911,37 +920,112 @@ export class PatternManager {
    */
   private registerEvaluatedModules(result: EvaluateResult): void {
     const byId = result.exportsByIdentity;
-    if (!byId) return;
-    for (const [identity, exports] of byId) {
-      // Refresh insertion order (Map is FIFO-ordered) so eviction is ~LRU.
-      this.modulesByIdentity.delete(identity);
-      this.modulesByIdentity.set(identity, { exports, loadId: result.loadId });
-      // Give each pattern-exporting sub-module a content-addressed entry ref so
-      // its result cell reloads BY IDENTITY (and hits the in-memory module
-      // cache / cell cache) instead of falling back to a source recompile via
-      // loadPattern. Without this only the bundle entry carried a ref, so every
-      // sub-pattern cold-recompiled on reload (CT-1623). Don't overwrite an
-      // existing ref (the entry's is set authoritatively by the caller).
-      for (const exportName of Object.keys(exports)) {
-        if (exportName === "__esModule") continue;
-        const value = exports[exportName];
-        if (
-          (typeof value === "object" || typeof value === "function") &&
-          value !== null && isTrustedPattern(value as Pattern) &&
-          !this.patternToEntryRef.has(value as Pattern)
-        ) {
-          this.patternToEntryRef.set(value as Pattern, {
-            identity,
-            symbol: exportName,
-          });
+    if (byId) {
+      for (const [identity, exports] of byId) {
+        // Refresh insertion order (Map is FIFO-ordered) so eviction is ~LRU.
+        this.modulesByIdentity.delete(identity);
+        this.modulesByIdentity.set(identity, {
+          exports,
+          loadId: result.loadId,
+        });
+        // Give each pattern-exporting sub-module a content-addressed entry ref so
+        // its result cell reloads BY IDENTITY (and hits the in-memory module
+        // cache / cell cache) instead of falling back to a source recompile via
+        // loadPattern. Without this only the bundle entry carried a ref, so every
+        // sub-pattern cold-recompiled on reload (CT-1623). Don't overwrite an
+        // existing ref (the entry's is set authoritatively by the caller).
+        for (const exportName of Object.keys(exports)) {
+          if (exportName === "__esModule") continue;
+          const value = exports[exportName];
+          if (
+            (typeof value === "object" || typeof value === "function") &&
+            value !== null && isTrustedPattern(value as Pattern) &&
+            !this.valueToEntryRef.has(value as Pattern)
+          ) {
+            this.valueToEntryRef.set(value as Pattern, {
+              identity,
+              symbol: exportName,
+            });
+          }
         }
       }
+      while (this.modulesByIdentity.size > MAX_EVALUATED_MODULE_CACHE_SIZE) {
+        const oldest = this.modulesByIdentity.keys().next().value;
+        if (oldest === undefined) break;
+        this.modulesByIdentity.delete(oldest);
+      }
     }
-    while (this.modulesByIdentity.size > MAX_EVALUATED_MODULE_CACHE_SIZE) {
-      const oldest = this.modulesByIdentity.keys().next().value;
+
+    this.registerHoistedValues(result.registrationsByIdentity);
+  }
+
+  /**
+   * Index the hoisted builder artifacts a module graph registered via `__cfReg`
+   * (CT-1623). Each entry is a `{ identity, symbol } -> live value` pairing: the
+   * forward `valueToEntryRef` lets the value be serialized by reference, and the
+   * reverse `hoistsByIdentity` lets it be resolved synchronously by reference
+   * (e.g. a map/filter/flatMap `op`).
+   *
+   * SECURITY: only a genuine trusted builder artifact (pattern / lift / handler —
+   * `isTrustedBuilderArtifact`) is indexed. A `__cf_data`-forged plain object in
+   * the registration map carries no brand and is dropped, so it can never acquire
+   * a content-addressed reference or be handed back as a trusted value. (Cross-
+   * module forgery is independently impossible: identity is a content hash, so a
+   * module can only register under its own bytes' identity.)
+   */
+  private registerHoistedValues(sink?: HoistRegistrationSink): void {
+    if (!sink || sink.size === 0) return;
+    for (const [identity, entries] of sink) {
+      let bucket = this.hoistsByIdentity.get(identity);
+      // Refresh recency (FIFO ~ LRU).
+      this.hoistsByIdentity.delete(identity);
+      if (!bucket) bucket = new Map<string, unknown>();
+      for (const [symbol, value] of entries) {
+        if (!isTrustedBuilderArtifact(value)) continue;
+        bucket.set(symbol, value);
+        // Don't overwrite an existing forward ref (e.g. a value that is also an
+        // authored export already keyed by the loop above).
+        if (
+          (typeof value === "object" || typeof value === "function") &&
+          value !== null && !this.valueToEntryRef.has(value as object)
+        ) {
+          this.valueToEntryRef.set(value as object, { identity, symbol });
+        }
+      }
+      if (bucket.size > 0) this.hoistsByIdentity.set(identity, bucket);
+    }
+    while (this.hoistsByIdentity.size > MAX_EVALUATED_MODULE_CACHE_SIZE) {
+      const oldest = this.hoistsByIdentity.keys().next().value;
       if (oldest === undefined) break;
-      this.modulesByIdentity.delete(oldest);
+      this.hoistsByIdentity.delete(oldest);
     }
+  }
+
+  /**
+   * Resolve a content-addressed `{ identity, symbol }` reference to its live
+   * builder artifact, synchronously, from the in-memory caches — or `undefined`
+   * on a miss (the value was never registered, or rolled out of the bounded
+   * cache; callers fall back, e.g. to an embedded op graph). Checks hoisted
+   * artifacts (`__cfReg`) first, then authored module exports. Public so the list
+   * builtins can resolve a map/filter/flatMap `op` during a synchronous Action.
+   */
+  patternFromIdentitySync(
+    identity: string,
+    symbol: string,
+  ): Pattern | undefined {
+    const bucket = this.hoistsByIdentity.get(identity);
+    if (bucket && bucket.has(symbol)) {
+      // Refresh recency.
+      this.hoistsByIdentity.delete(identity);
+      this.hoistsByIdentity.set(identity, bucket);
+      return bucket.get(symbol) as Pattern;
+    }
+    const mod = this.modulesByIdentity.get(identity);
+    const exported = mod?.exports?.[symbol];
+    if (exported !== undefined && isTrustedBuilderArtifact(exported)) {
+      return exported as Pattern;
+    }
+    return undefined;
   }
 
   /**
@@ -960,7 +1044,7 @@ export class PatternManager {
     // Refresh recency.
     this.modulesByIdentity.delete(entryIdentity);
     this.modulesByIdentity.set(entryIdentity, cached);
-    this.patternToEntryRef.set(pattern, { identity: entryIdentity, symbol });
+    this.valueToEntryRef.set(pattern, { identity: entryIdentity, symbol });
     if (cached.loadId) this.seedVerifiedLoadIds(pattern, cached.loadId);
     return pattern;
   }
@@ -1031,7 +1115,7 @@ export class PatternManager {
     if (isTrustedPattern(pattern)) {
       setPatternProgram(pattern, program);
       if (entryIdentity) {
-        this.patternToEntryRef.set(pattern, {
+        this.valueToEntryRef.set(pattern, {
           identity: entryIdentity,
           symbol: exportName,
         });
@@ -1052,13 +1136,13 @@ export class PatternManager {
   getPatternEntryRef(
     pattern: Pattern | Module,
   ): { identity: string; symbol: string } | undefined {
-    // `patternToEntryRef` is keyed by the EXACT exported value (the entry, set
+    // `valueToEntryRef` is keyed by the EXACT exported value (the entry, set
     // by patternFromMain/patternFromEvaluation, and every imported sub-pattern,
     // set by registerEvaluatedModules). Check the exact object FIRST, then the
     // normalized original: a copied/wrapped pattern whose `unsafe_originalPattern`
     // root differs from the keyed object would otherwise never resolve its ref.
-    return this.patternToEntryRef.get(pattern as Pattern) ??
-      this.patternToEntryRef.get(this.findOriginalPattern(pattern as Pattern));
+    return this.valueToEntryRef.get(pattern as Pattern) ??
+      this.valueToEntryRef.get(this.findOriginalPattern(pattern as Pattern));
   }
 
   /**

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -26,10 +26,7 @@ import type {
   Exports,
 } from "./harness/types.ts";
 import { RuntimeProgram } from "./harness/types.ts";
-import type {
-  CachedCompiledModule,
-  HoistRegistrationSink,
-} from "./sandbox/module-record-compiler.ts";
+import type { CachedCompiledModule } from "./sandbox/module-record-compiler.ts";
 import type { IExtendedStorageTransaction } from "./storage/interface.ts";
 import {
   COMPILE_CACHE_RUNTIME_VERSION,
@@ -115,12 +112,14 @@ export class PatternManager {
     object,
     { identity: string; symbol: string }
   >();
-  // In-memory reverse index for HOISTED builder artifacts (`__cfReg`): module
-  // identity -> (symbol -> live value). The forward map above answers "what is
-  // this value's ref"; this answers "what value does this ref name", which the
-  // list builtins use to resolve a map/filter/flatMap `op` synchronously. Bounded
-  // (FIFO) like `modulesByIdentity`; a miss falls back to an embedded graph.
-  private hoistsByIdentity = new Map<string, Map<string, unknown>>();
+  // THE in-memory reverse index for content-addressed builder artifacts: module
+  // identity -> (symbol -> live value). The single source for
+  // `patternFromIdentitySync` (the inverse of the forward `valueToEntryRef`),
+  // populated by ONE path (`indexArtifact`) from BOTH a module's `__cfReg`
+  // registrations (hoists + non-exported top-level) AND its exports — so callers
+  // never look in two places. Bounded (FIFO); a miss returns undefined and
+  // callers fall back (e.g. to an embedded op graph or a source reload).
+  private addressableByIdentity = new Map<string, Map<string, unknown>>();
   private patternToVerifiedLoadId = new WeakMap<Pattern, string>();
   // Pending metadata set before the meta cell exists (e.g., spec, parents)
   private pendingMetaById = new Map<URI, Partial<PatternMeta>>();
@@ -922,31 +921,20 @@ export class PatternManager {
     const byId = result.exportsByIdentity;
     if (byId) {
       for (const [identity, exports] of byId) {
+        // `modulesByIdentity` keeps the whole namespace for MODULE reuse on a
+        // by-identity reload (a separate concern from artifact addressing).
         // Refresh insertion order (Map is FIFO-ordered) so eviction is ~LRU.
         this.modulesByIdentity.delete(identity);
         this.modulesByIdentity.set(identity, {
           exports,
           loadId: result.loadId,
         });
-        // Give each pattern-exporting sub-module a content-addressed entry ref so
-        // its result cell reloads BY IDENTITY (and hits the in-memory module
-        // cache / cell cache) instead of falling back to a source recompile via
-        // loadPattern. Without this only the bundle entry carried a ref, so every
-        // sub-pattern cold-recompiled on reload (CT-1623). Don't overwrite an
-        // existing ref (the entry's is set authoritatively by the caller).
+        // Index each exported builder artifact for addressing by its export name.
+        // (Reload relies on this so a sub-pattern's result cell loads BY IDENTITY
+        // instead of cold-recompiling — CT-1623.)
         for (const exportName of Object.keys(exports)) {
           if (exportName === "__esModule") continue;
-          const value = exports[exportName];
-          if (
-            (typeof value === "object" || typeof value === "function") &&
-            value !== null && isTrustedPattern(value as Pattern) &&
-            !this.valueToEntryRef.has(value as Pattern)
-          ) {
-            this.valueToEntryRef.set(value as Pattern, {
-              identity,
-              symbol: exportName,
-            });
-          }
+          this.indexArtifact(identity, exportName, exports[exportName]);
         }
       }
       while (this.modulesByIdentity.size > MAX_EVALUATED_MODULE_CACHE_SIZE) {
@@ -956,76 +944,74 @@ export class PatternManager {
       }
     }
 
-    this.registerHoistedValues(result.registrationsByIdentity);
+    // Index the hoisted + non-exported top-level builder artifacts the module
+    // registered via `__cfReg`, into the SAME index as the exports above.
+    const sink = result.registrationsByIdentity;
+    if (sink) {
+      for (const [identity, entries] of sink) {
+        for (const [symbol, value] of entries) {
+          this.indexArtifact(identity, symbol, value);
+        }
+      }
+    }
+
+    while (this.addressableByIdentity.size > MAX_EVALUATED_MODULE_CACHE_SIZE) {
+      const oldest = this.addressableByIdentity.keys().next().value;
+      if (oldest === undefined) break;
+      this.addressableByIdentity.delete(oldest);
+    }
   }
 
   /**
-   * Index the hoisted builder artifacts a module graph registered via `__cfReg`
-   * (CT-1623). Each entry is a `{ identity, symbol } -> live value` pairing: the
-   * forward `valueToEntryRef` lets the value be serialized by reference, and the
-   * reverse `hoistsByIdentity` lets it be resolved synchronously by reference
-   * (e.g. a map/filter/flatMap `op`).
+   * Index one content-addressed builder artifact `{ identity, symbol } -> value`,
+   * the single path that populates both the reverse `addressableByIdentity` and
+   * forward `valueToEntryRef` maps — whether the value came from a module's
+   * `__cfReg` registration (hoists + non-exported top-level) or its exports.
    *
    * SECURITY: only a genuine trusted builder artifact (pattern / lift / handler —
-   * `isTrustedBuilderArtifact`) is indexed. A `__cf_data`-forged plain object in
-   * the registration map carries no brand and is dropped, so it can never acquire
-   * a content-addressed reference or be handed back as a trusted value. (Cross-
-   * module forgery is independently impossible: identity is a content hash, so a
-   * module can only register under its own bytes' identity.)
+   * `isTrustedBuilderArtifact`) is indexed. A `__cf_data`-forged plain object
+   * carries no brand and is dropped, so it can never acquire a content-addressed
+   * reference or be handed back as a trusted value. (Cross-module forgery is
+   * independently impossible: identity is a content hash, so a module can only
+   * register under its own bytes' identity.)
    */
-  private registerHoistedValues(sink?: HoistRegistrationSink): void {
-    if (!sink || sink.size === 0) return;
-    for (const [identity, entries] of sink) {
-      let bucket = this.hoistsByIdentity.get(identity);
-      // Refresh recency (FIFO ~ LRU).
-      this.hoistsByIdentity.delete(identity);
-      if (!bucket) bucket = new Map<string, unknown>();
-      for (const [symbol, value] of entries) {
-        if (!isTrustedBuilderArtifact(value)) continue;
-        bucket.set(symbol, value);
-        // Don't overwrite an existing forward ref (e.g. a value that is also an
-        // authored export already keyed by the loop above).
-        if (
-          (typeof value === "object" || typeof value === "function") &&
-          value !== null && !this.valueToEntryRef.has(value as object)
-        ) {
-          this.valueToEntryRef.set(value as object, { identity, symbol });
-        }
-      }
-      if (bucket.size > 0) this.hoistsByIdentity.set(identity, bucket);
-    }
-    while (this.hoistsByIdentity.size > MAX_EVALUATED_MODULE_CACHE_SIZE) {
-      const oldest = this.hoistsByIdentity.keys().next().value;
-      if (oldest === undefined) break;
-      this.hoistsByIdentity.delete(oldest);
+  private indexArtifact(
+    identity: string,
+    symbol: string,
+    value: unknown,
+  ): void {
+    if (!isTrustedBuilderArtifact(value)) return;
+    // Reverse index, refreshing recency (FIFO ~ LRU).
+    let bucket = this.addressableByIdentity.get(identity);
+    if (bucket) this.addressableByIdentity.delete(identity);
+    else bucket = new Map<string, unknown>();
+    if (!bucket.has(symbol)) bucket.set(symbol, value);
+    this.addressableByIdentity.set(identity, bucket);
+    // Forward map — don't overwrite an existing ref (e.g. a value that is both a
+    // `__cfReg` entry and an export, or whose entry ref the caller set first).
+    if (!this.valueToEntryRef.has(value as object)) {
+      this.valueToEntryRef.set(value as object, { identity, symbol });
     }
   }
 
   /**
    * Resolve a content-addressed `{ identity, symbol }` reference to its live
-   * builder artifact, synchronously, from the in-memory caches — or `undefined`
-   * on a miss (the value was never registered, or rolled out of the bounded
-   * cache; callers fall back, e.g. to an embedded op graph). Checks hoisted
-   * artifacts (`__cfReg`) first, then authored module exports. Public so the list
-   * builtins can resolve a map/filter/flatMap `op` during a synchronous Action.
+   * builder artifact, synchronously, from the single in-memory index — or
+   * `undefined` on a miss (never registered, or rolled out of the bounded cache;
+   * callers fall back, e.g. to an embedded op graph or a source reload). Public
+   * so the list builtins can resolve a map/filter/flatMap `op` during a
+   * synchronous Action.
    */
   patternFromIdentitySync(
     identity: string,
     symbol: string,
   ): Pattern | undefined {
-    const bucket = this.hoistsByIdentity.get(identity);
-    if (bucket && bucket.has(symbol)) {
-      // Refresh recency.
-      this.hoistsByIdentity.delete(identity);
-      this.hoistsByIdentity.set(identity, bucket);
-      return bucket.get(symbol) as Pattern;
-    }
-    const mod = this.modulesByIdentity.get(identity);
-    const exported = mod?.exports?.[symbol];
-    if (exported !== undefined && isTrustedBuilderArtifact(exported)) {
-      return exported as Pattern;
-    }
-    return undefined;
+    const bucket = this.addressableByIdentity.get(identity);
+    if (!bucket || !bucket.has(symbol)) return undefined;
+    // Refresh recency.
+    this.addressableByIdentity.delete(identity);
+    this.addressableByIdentity.set(identity, bucket);
+    return bucket.get(symbol) as Pattern;
   }
 
   /**

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -114,7 +114,7 @@ export class PatternManager {
   >();
   // THE in-memory reverse index for content-addressed builder artifacts: module
   // identity -> (symbol -> live value). The single source for
-  // `patternFromIdentitySync` (the inverse of the forward `valueToEntryRef`),
+  // `artifactFromIdentitySync` (the inverse of the forward `valueToEntryRef`),
   // populated by ONE path (`indexArtifact`) from BOTH a module's `__cfReg`
   // registrations (hoists + non-exported top-level) AND its exports — so callers
   // never look in two places. Bounded (FIFO); a miss returns undefined and
@@ -1002,16 +1002,18 @@ export class PatternManager {
    * so the list builtins can resolve a map/filter/flatMap `op` during a
    * synchronous Action.
    */
-  patternFromIdentitySync(
+  artifactFromIdentitySync(
     identity: string,
     symbol: string,
-  ): Pattern | undefined {
+  ): unknown {
     const bucket = this.addressableByIdentity.get(identity);
     if (!bucket || !bucket.has(symbol)) return undefined;
     // Refresh recency.
     this.addressableByIdentity.delete(identity);
     this.addressableByIdentity.set(identity, bucket);
-    return bucket.get(symbol) as Pattern;
+    // Returns the live builder artifact (pattern / lift / handler). Callers know
+    // the kind they expect from the symbol's origin and cast accordingly.
+    return bucket.get(symbol);
   }
 
   /**
@@ -1114,21 +1116,20 @@ export class PatternManager {
   }
 
   /**
-   * The content-addressed {identity, symbol} reference for a pattern object, if
-   * known (learned on the ESM cache path). Lets callers persist a result cell's
-   * reference so the pattern reloads straight from the compiled cache. Returns
-   * undefined for legacy/AMD patterns.
+   * The content-addressed `{ identity, symbol }` reference for a builder artifact
+   * (pattern / lift / handler), if known (learned on the ESM path). Lets callers
+   * persist a result cell's reference so the artifact reloads straight from the
+   * compiled cache. Returns undefined for legacy/AMD artifacts.
    */
-  getPatternEntryRef(
-    pattern: Pattern | Module,
+  getArtifactEntryRef(
+    value: object,
   ): { identity: string; symbol: string } | undefined {
-    // `valueToEntryRef` is keyed by the EXACT exported value (the entry, set
-    // by patternFromMain/patternFromEvaluation, and every imported sub-pattern,
-    // set by registerEvaluatedModules). Check the exact object FIRST, then the
-    // normalized original: a copied/wrapped pattern whose `unsafe_originalPattern`
-    // root differs from the keyed object would otherwise never resolve its ref.
-    return this.valueToEntryRef.get(pattern as Pattern) ??
-      this.valueToEntryRef.get(this.findOriginalPattern(pattern as Pattern));
+    // `valueToEntryRef` is keyed by the EXACT registered/exported value. Check
+    // the exact object FIRST, then the normalized original: a copied/wrapped
+    // artifact whose `unsafe_originalPattern` root differs from the keyed object
+    // would otherwise never resolve its ref.
+    return this.valueToEntryRef.get(value) ??
+      this.valueToEntryRef.get(this.findOriginalPattern(value as Pattern));
   }
 
   /**

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -906,7 +906,7 @@ export class Runner {
     // time); we never recompute it from `pattern`'s program here, since a
     // source-free reloaded pattern only has a stub program (mainExport
     // "default"), which would clobber a non-"default" export name.
-    const entryRef = this.runtime.patternManager.getPatternEntryRef(pattern);
+    const entryRef = this.runtime.patternManager.getArtifactEntryRef(pattern);
     if (entryRef) {
       resultCell.withTx(tx).setMetaRaw("patternIdentity", {
         identity: entryRef.identity,

--- a/packages/runner/src/sandbox/compartment-globals.ts
+++ b/packages/runner/src/sandbox/compartment-globals.ts
@@ -57,6 +57,16 @@ function createCompatibilityGlobals(): Record<string, unknown> {
   }
 
   globals.console = createSafeConsoleGlobal();
+
+  // `__cfReg({ symbol: value })` registers a module's hoisted builder artifacts
+  // for content-addressed `{ identity, symbol }` lookup. The ESM module loader
+  // supplies a real, identity-bound registrar as the module factory's 4th
+  // parameter (which shadows this global inside that wrapper). On the legacy/AMD
+  // bundle path identity addressing is not wired, so this global is a no-op — it
+  // only needs to exist so a transformer-emitted `__cfReg({…})` call resolves
+  // rather than throwing a ReferenceError.
+  globals.__cfReg = freezeSandboxValue(() => undefined);
+
   return globals;
 }
 

--- a/packages/runner/src/sandbox/compiled-bundle-verifier.ts
+++ b/packages/runner/src/sandbox/compiled-bundle-verifier.ts
@@ -265,16 +265,18 @@ export function classifyModuleItems(
   statements: readonly StatementChunk[],
   env: Map<string, BindingInfo>,
   options: ModuleItemClassificationOptions,
-): void {
+): { hasHoistRegistration: boolean } {
   predeclareTopLevelBindings(source, statements, env, options);
 
   logger.timeStart("classifyModuleItems", "statements");
+  // The transformer emits at most one trailing `__cfReg({ … })` registration
+  // call per module; a second is a tampering signal (the runtime registrar also
+  // traps it, but reject it here too). Whether a VALID call was seen is returned
+  // so the loader grants the real registrar only to approved modules and a
+  // throwing one to the rest (fail closed against a smuggled call).
+  let sawHoistRegistration = false;
   try {
     const missingRequiredGuards = new Set(options.requiredGuards);
-    // The transformer emits at most one trailing `__cfReg({ … })` registration
-    // call per module; a second is a tampering signal (the runtime registrar also
-    // traps it, but reject it here too).
-    let sawHoistRegistration = false;
     for (const statement of statements) {
       const trimmed = trimRange(source, statement.start, statement.end);
       if (trimmed.start >= trimmed.end) continue;
@@ -427,6 +429,7 @@ export function classifyModuleItems(
   } finally {
     logger.timeEnd("classifyModuleItems", "statements");
   }
+  return { hasHoistRegistration: sawHoistRegistration };
 }
 
 function predeclareFactoryDependencies(

--- a/packages/runner/src/sandbox/compiled-bundle-verifier.ts
+++ b/packages/runner/src/sandbox/compiled-bundle-verifier.ts
@@ -271,6 +271,10 @@ export function classifyModuleItems(
   logger.timeStart("classifyModuleItems", "statements");
   try {
     const missingRequiredGuards = new Set(options.requiredGuards);
+    // The transformer emits at most one trailing `__cfReg({ … })` registration
+    // call per module; a second is a tampering signal (the runtime registrar also
+    // traps it, but reject it here too).
+    let sawHoistRegistration = false;
     for (const statement of statements) {
       const trimmed = trimRange(source, statement.start, statement.end);
       if (trimmed.start >= trimmed.end) continue;
@@ -380,6 +384,27 @@ export function classifyModuleItems(
         isAllowedFunctionHardeningStatementNormalized(normalized, env) ||
         isAllowedBindingIdentityStatementNormalized(normalized, env)
       ) {
+        continue;
+      }
+
+      // The single trailing `__cfReg({ __cfPattern_1, … })` hoist-registration
+      // call: a shorthand object of top-level builder-artifact bindings. `__cfReg`
+      // is supplied by the module wrapper (the registrar param under the ESM
+      // loader; a no-op global on the AMD path) and is intentionally NOT a
+      // referenceable binding — so any OTHER use (nested, aliased, dynamic) falls
+      // through to the unknown-identifier rejection below. Trust of the registered
+      // values, single-call, and the closed-window guarantee are enforced at
+      // runtime by the registrar (see module-record-compiler.createHoistRegistrar).
+      if (isHoistRegistrationCallNormalized(normalized, env)) {
+        if (sawHoistRegistration) {
+          throw verificationErrorAt(
+            source,
+            filename,
+            statement.start,
+            "A module may contain at most one __cfReg() registration call",
+          );
+        }
+        sawHoistRegistration = true;
         continue;
       }
 
@@ -1457,6 +1482,33 @@ function tryParseCompiledReexportNormalized(
 
 function isCompiledExportStarStatementNormalized(normalized: string): boolean {
   return /^__exportStar\([A-Za-z_$][\w$]*,exports\);?$/.test(normalized);
+}
+
+/**
+ * Recognize the transformer's hoist-registration statement:
+ * `__cfReg({ __cfPattern_1, __cfLift_1, … })` — a call to `__cfReg` with a single
+ * object literal of shorthand properties, each naming a top-level binding. The
+ * shorthand form guarantees every registered value IS a module-level binding (no
+ * arbitrary expression / closure value). Returns false for anything else, so a
+ * non-conforming `__cfReg` use is rejected as unsupported.
+ */
+function isHoistRegistrationCallNormalized(
+  normalized: string,
+  env: Map<string, BindingInfo>,
+): boolean {
+  const match = normalized.match(/^__cfReg\(\{([\s\S]*)\}\);?$/);
+  if (!match) return false;
+  const inner = match[1].replace(/,$/, "").trim();
+  if (inner.length === 0) return false;
+  for (const raw of inner.split(",")) {
+    const name = raw.trim();
+    // Shorthand identifiers only (`{a,b}`); `key:value`, spreads, computed keys,
+    // and string keys all contain a disallowed character and are rejected.
+    if (!/^[A-Za-z_$][\w$]*$/.test(name)) return false;
+    // Each must be a top-level binding the verifier already saw declared.
+    if (!env.has(name)) return false;
+  }
+  return true;
 }
 
 function isCompiledEsModuleMarkerNormalized(normalized: string): boolean {

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -111,6 +111,27 @@ export type HoistRegistrationSink = Map<string, Map<string, unknown>>;
  * Security (trust of the registered values) is enforced separately, per value,
  * by the PatternManager — not here.
  */
+/**
+ * The registrar handed to a module the verifier did NOT approve for hoist
+ * registration (no valid top-level `__cfReg({ … })` call). Any invocation throws
+ * — so a `__cfReg` reference the verifier's static check failed to reject still
+ * fails closed at runtime (terminating the import) instead of registering
+ * attacker-chosen values. `commit` is a no-op (nothing was staged).
+ */
+export function createRejectingRegistrar(): {
+  register: (entries: Record<string, unknown>) => void;
+  commit: () => void;
+} {
+  return {
+    register: () => {
+      throw new Error(
+        "__cfReg called by a module with no verifier-approved registration",
+      );
+    },
+    commit: () => {},
+  };
+}
+
 export function createHoistRegistrar(
   identity: string,
   sink: HoistRegistrationSink,
@@ -289,6 +310,14 @@ export interface CompiledModuleGraph {
    * after evaluation; the PatternManager assigns `{ identity, symbol }` refs.
    */
   registrationSink: HoistRegistrationSink;
+  /**
+   * Specifiers of modules the VERIFIER approved for hoist registration (a valid
+   * top-level `__cfReg({ … })` call). The engine fills this during the verify
+   * pass (before evaluation); a module absent from it gets a throwing registrar
+   * (see `createRejectingRegistrar`), so a `__cfReg` call the static verifier
+   * missed fails closed at runtime instead of registering attacker values.
+   */
+  registrationApproved: Set<string>;
 }
 
 /**
@@ -418,6 +447,7 @@ export function compileSourcesToRecords(
   const compiledBodies = new Map<string, string>();
   const moduleSourceMaps = new Map<string, SourceMap>();
   const registrationSink: HoistRegistrationSink = new Map();
+  const registrationApproved = new Set<string>();
   for (const source of sources) {
     const specifier = specifierByPath.get(source.name)!;
     const moduleHash = identityByPath.get(source.name)!;
@@ -522,10 +552,11 @@ export function compileSourcesToRecords(
         // A throw inside the factory is terminal for this module: SES caches the
         // error and re-throws it on every subsequent importNow (the same
         // contract as a failed AMD factory).
-        const { register, commit } = createHoistRegistrar(
-          moduleHash,
-          registrationSink,
-        );
+        // Grant the real registrar ONLY if the verifier approved this module's
+        // `__cfReg` call; otherwise a throwing one (fail closed).
+        const { register, commit } = registrationApproved.has(specifier)
+          ? createHoistRegistrar(moduleHash, registrationSink)
+          : createRejectingRegistrar();
         populateModuleExports(
           moduleExports,
           exportNames,
@@ -546,6 +577,7 @@ export function compileSourcesToRecords(
     compiledBodies,
     moduleSourceMaps,
     registrationSink,
+    registrationApproved,
   };
 }
 
@@ -629,6 +661,7 @@ export function buildRecordsFromCompiled(
   const moduleSourceMaps = new Map<string, SourceMap>();
   const specifierByPath = new Map<string, string>();
   const registrationSink: HoistRegistrationSink = new Map();
+  const registrationApproved = new Set<string>();
 
   for (const m of modules) {
     const specifier = specifierOf(m.identity);
@@ -668,10 +701,9 @@ export function buildRecordsFromCompiled(
         ) => void;
         const requireShim = (spec: string) =>
           compartment.importNow(resolvedImports[spec] ?? spec);
-        const { register, commit } = createHoistRegistrar(
-          m.identity,
-          registrationSink,
-        );
+        const { register, commit } = registrationApproved.has(specifier)
+          ? createHoistRegistrar(m.identity, registrationSink)
+          : createRejectingRegistrar();
         populateModuleExports(
           moduleExports,
           exportNames,
@@ -692,6 +724,7 @@ export function buildRecordsFromCompiled(
     compiledBodies,
     moduleSourceMaps,
     registrationSink,
+    registrationApproved,
   };
 }
 

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -66,16 +66,81 @@ export function populateModuleExports(
     exports: Record<string, unknown>,
     require: (specifier: string) => Record<string, unknown>,
     module: { exports: Record<string, unknown> },
+    register: (entries: Record<string, unknown>) => void,
   ) => void,
   requireShim: (specifier: string) => Record<string, unknown>,
+  // `__cfReg`: the transformer emits a single trailing `__cfReg({ symbol: value })`
+  // call to register a module's hoisted builder artifacts. It is passed as the
+  // factory's 4th parameter (shadowing the no-op compartment global) so it is
+  // bound to THIS module's evaluation. Defaults to a no-op for callers that do
+  // not register (e.g. tests, runtime modules).
+  register: (entries: Record<string, unknown>) => void = () => {},
 ): void {
   const writeOnceExports = createWriteOnceExports();
   const moduleObject = Object.freeze({ exports: writeOnceExports });
-  factory(writeOnceExports, requireShim, moduleObject);
+  factory(writeOnceExports, requireShim, moduleObject, register);
   for (const name of exportNames) {
     moduleExports[name] = hardenExportedValue(writeOnceExports[name]);
   }
   moduleExports.__esModule = true;
+}
+
+/**
+ * Hoist registrations collected while evaluating a module graph: module content
+ * identity (the prefix-free `cf:module/<hash>`) → (symbol → live value). Only
+ * modules whose factory completed normally are present (see
+ * {@link createHoistRegistrar}). The engine reads this after `importNow` and the
+ * PatternManager turns each trusted entry into a `{ identity, symbol }` ref.
+ */
+export type HoistRegistrationSink = Map<string, Map<string, unknown>>;
+
+/**
+ * Build the per-module `__cfReg` registrar (the module factory's 4th parameter)
+ * plus a `commit` hook. The registrar enforces the integrity invariants that let
+ * the verifier stay simple:
+ *
+ * - **Run-once**: a second `__cfReg(...)` call throws — an injected/duplicate
+ *   registration aborts the import (which is terminal for the module).
+ * - **Closed window**: calls after the module body returns throw, so a closure
+ *   that captured `__cfReg` cannot register late (e.g. from a handler callback).
+ * - **Transactional**: entries are staged locally and only flushed into `sink`
+ *   by `commit()`, which the caller invokes ONLY after the factory returns
+ *   normally. A throw (including the run-once trap) therefore leaves nothing
+ *   behind.
+ *
+ * Security (trust of the registered values) is enforced separately, per value,
+ * by the PatternManager — not here.
+ */
+export function createHoistRegistrar(
+  identity: string,
+  sink: HoistRegistrationSink,
+): {
+  register: (entries: Record<string, unknown>) => void;
+  commit: () => void;
+} {
+  const staged = new Map<string, unknown>();
+  let called = false;
+  let open = true;
+  const register = (entries: Record<string, unknown>) => {
+    if (!open) {
+      throw new Error("__cfReg called after module evaluation completed");
+    }
+    if (called) {
+      throw new Error("__cfReg may be called at most once per module");
+    }
+    called = true;
+    if (entries === null || typeof entries !== "object") {
+      throw new Error("__cfReg expects an object of { symbol: value }");
+    }
+    for (const key of Object.keys(entries)) {
+      staged.set(key, (entries as Record<string, unknown>)[key]);
+    }
+  };
+  const commit = () => {
+    open = false;
+    if (staged.size > 0) sink.set(identity, staged);
+  };
+  return { register, commit };
 }
 
 /**
@@ -218,6 +283,12 @@ export interface CompiledModuleGraph {
   compiledBodies: Map<string, string>;
   /** Per-specifier source map (compiled body → original source), when available. */
   moduleSourceMaps: Map<string, SourceMap>;
+  /**
+   * Hoist registrations, populated as the graph's modules evaluate (`__cfReg`).
+   * Empty until `importNow` runs each module's `execute`. The engine reads it
+   * after evaluation; the PatternManager assigns `{ identity, symbol }` refs.
+   */
+  registrationSink: HoistRegistrationSink;
 }
 
 /**
@@ -346,6 +417,7 @@ export function compileSourcesToRecords(
   const records = new Map<string, VirtualModuleRecord>();
   const compiledBodies = new Map<string, string>();
   const moduleSourceMaps = new Map<string, SourceMap>();
+  const registrationSink: HoistRegistrationSink = new Map();
   for (const source of sources) {
     const specifier = specifierByPath.get(source.name)!;
     const moduleHash = identityByPath.get(source.name)!;
@@ -424,13 +496,16 @@ export function compileSourcesToRecords(
       resolutions,
       execute: (moduleExports, compartment, resolvedImports) => {
         // Evaluate the compiled CommonJS body inside the SES compartment so it
-        // runs under lockdown with confined globals.
+        // runs under lockdown with confined globals. `__cfReg` is the 4th
+        // parameter — the per-module hoist registrar — which shadows the no-op
+        // `__cfReg` compartment global inside this wrapper.
         const factory = compartment.evaluate(
-          `(function (exports, require, module) {\n${compiled}\n})\n//# sourceURL=${sourceUrl}`,
+          `(function (exports, require, module, __cfReg) {\n${compiled}\n})\n//# sourceURL=${sourceUrl}`,
         ) as (
           exports: Record<string, unknown>,
           require: (specifier: string) => Record<string, unknown>,
           module: { exports: Record<string, unknown> },
+          register: (entries: Record<string, unknown>) => void,
         ) => void;
         // The module body writes its exports into a WRITE-ONCE object rather
         // than a plain mutable one. The verifier cannot see a write smuggled
@@ -447,17 +522,31 @@ export function compileSourcesToRecords(
         // A throw inside the factory is terminal for this module: SES caches the
         // error and re-throws it on every subsequent importNow (the same
         // contract as a failed AMD factory).
+        const { register, commit } = createHoistRegistrar(
+          moduleHash,
+          registrationSink,
+        );
         populateModuleExports(
           moduleExports,
           exportNames,
           factory,
           requireShim,
+          register,
         );
+        // Reached only if the factory returned normally — commit staged hoist
+        // registrations (transactional: a throw above skips this).
+        commit();
       },
     });
   }
 
-  return { records, specifierByPath, compiledBodies, moduleSourceMaps };
+  return {
+    records,
+    specifierByPath,
+    compiledBodies,
+    moduleSourceMaps,
+    registrationSink,
+  };
 }
 
 /** A compiled module loaded from the content-addressed cache (no TS source). */
@@ -539,6 +628,7 @@ export function buildRecordsFromCompiled(
   const compiledBodies = new Map<string, string>();
   const moduleSourceMaps = new Map<string, SourceMap>();
   const specifierByPath = new Map<string, string>();
+  const registrationSink: HoistRegistrationSink = new Map();
 
   for (const m of modules) {
     const specifier = specifierOf(m.identity);
@@ -569,22 +659,40 @@ export function buildRecordsFromCompiled(
       resolutions,
       execute: (moduleExports, compartment, resolvedImports) => {
         const factory = compartment.evaluate(
-          `(function (exports, require, module) {\n${compiled}\n})\n//# sourceURL=${sourceUrl}`,
+          `(function (exports, require, module, __cfReg) {\n${compiled}\n})\n//# sourceURL=${sourceUrl}`,
         ) as (
           exports: Record<string, unknown>,
           require: (specifier: string) => Record<string, unknown>,
           module: { exports: Record<string, unknown> },
+          register: (entries: Record<string, unknown>) => void,
         ) => void;
         const requireShim = (spec: string) =>
           compartment.importNow(resolvedImports[spec] ?? spec);
-        populateModuleExports(moduleExports, exportNames, factory, requireShim);
+        const { register, commit } = createHoistRegistrar(
+          m.identity,
+          registrationSink,
+        );
+        populateModuleExports(
+          moduleExports,
+          exportNames,
+          factory,
+          requireShim,
+          register,
+        );
+        commit();
       },
     });
   }
   // Silence unused in the rare all-internal case.
   void byIdentity;
 
-  return { records, specifierByPath, compiledBodies, moduleSourceMaps };
+  return {
+    records,
+    specifierByPath,
+    compiledBodies,
+    moduleSourceMaps,
+    registrationSink,
+  };
 }
 
 /**

--- a/packages/runner/src/sandbox/module-record-verifier.ts
+++ b/packages/runner/src/sandbox/module-record-verifier.ts
@@ -135,7 +135,7 @@ function shadowNamesInStatement(
 export function verifyCompiledModuleBody(
   compiled: string,
   filename = "<module>",
-): void {
+): { hasHoistRegistration: boolean } {
   // Wrap so the AMD parser can extract the top-level statements as a function
   // body; offsets stay consistent with `wrapped` for classification.
   const wrapped = `function () {\n${compiled}\n}`;
@@ -229,7 +229,7 @@ export function verifyCompiledModuleBody(
     classifiable.push(statement);
   });
 
-  classifyModuleItems(wrapped, filename, classifiable, env, {
+  return classifyModuleItems(wrapped, filename, classifiable, env, {
     requiredGuards: EMPTY_BINDING_SET,
     reservedBindings: EMPTY_BINDING_SET,
     missingGuardsErrorAt: 0,

--- a/packages/runner/test/by-identity-handler-exec.test.ts
+++ b/packages/runner/test/by-identity-handler-exec.test.ts
@@ -57,7 +57,7 @@ describe("resume the fuse-exec piece by identity and invoke its handler", () => 
       const tx1 = rt1.edit();
       const pm1 = rt1.patternManager;
       const cold = await pm1.compilePattern(PROGRAM, { space, tx: tx1 });
-      expect(pm1.getPatternEntryRef(cold)?.symbol).toBe("customPatternExport");
+      expect(pm1.getArtifactEntryRef(cold)?.symbol).toBe("customPatternExport");
       const resultCell1 = rt1.getCell<Record<string, unknown>>(
         space,
         RESULT_CAUSE,

--- a/packages/runner/test/cfreg-builder-identity.test.ts
+++ b/packages/runner/test/cfreg-builder-identity.test.ts
@@ -1,0 +1,159 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "../src/runtime.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+import {
+  createHoistRegistrar,
+  type HoistRegistrationSink,
+} from "../src/sandbox/module-record-compiler.ts";
+
+// Unit coverage for the per-module `__cfReg` registrar: run-once, closed-window,
+// and transactional (commit-only-on-success) semantics — the integrity
+// guarantees that let the verifier stay simple.
+describe("createHoistRegistrar", () => {
+  it("stages entries and commits them to the sink", () => {
+    const sink: HoistRegistrationSink = new Map();
+    const { register, commit } = createHoistRegistrar("idA", sink);
+    const a = {}, b = {};
+    register({ __cfPattern_1: a, __cfLift_1: b });
+    // Not visible until commit.
+    expect(sink.has("idA")).toBe(false);
+    commit();
+    expect([...sink.get("idA")!.entries()]).toEqual([
+      ["__cfPattern_1", a],
+      ["__cfLift_1", b],
+    ]);
+  });
+
+  it("throws on a second __cfReg call (run-once trap)", () => {
+    const { register } = createHoistRegistrar("idB", new Map());
+    register({ __cfPattern_1: {} });
+    expect(() => register({ __cfPattern_2: {} })).toThrow(
+      /at most once/,
+    );
+  });
+
+  it("throws when called after the window closes (commit)", () => {
+    const { register, commit } = createHoistRegistrar("idC", new Map());
+    commit();
+    expect(() => register({ __cfPattern_1: {} })).toThrow(
+      /after module evaluation completed/,
+    );
+  });
+
+  it("commits nothing when the module never registered", () => {
+    const sink: HoistRegistrationSink = new Map();
+    const { commit } = createHoistRegistrar("idD", sink);
+    commit();
+    expect(sink.size).toBe(0);
+  });
+
+  it("rejects a non-object registration argument", () => {
+    const { register } = createHoistRegistrar("idE", new Map());
+    expect(() => register(null as never)).toThrow(/object/);
+  });
+});
+
+// End-to-end: under the ESM loader, the hoisted builder artifacts a module
+// produces are registered via `__cfReg` and become addressable by their
+// content-addressed `{ identity, symbol }` reference — with no module exports and
+// no source re-parsing. This source hoists a pattern (the `.map` op) AND a lift
+// (a reactive computation), proving the mechanism generalizes beyond patterns;
+// handlers travel the identical branded node-factory path.
+describe("hoisted builder artifacts are addressable by {identity, symbol}", () => {
+  const PROGRAM: RuntimeProgram = {
+    main: "/main.tsx",
+    files: [{
+      name: "/main.tsx",
+      contents: `import { Cell, pattern, UI } from "commonfabric";
+interface State {
+  items: Array<{ price: number }>;
+  discount: number;
+  selectedIndex: Cell<number>;
+}
+export default pattern<State>((state) => {
+  return {
+    [UI]: (
+      <div>
+        {state.items.map((item, index) => (
+          <div>
+            <span>{item.price * state.discount}</span>
+            <button type="button" onClick={() => state.selectedIndex.set(index)}>
+              Select
+            </button>
+          </div>
+        ))}
+      </div>
+    ),
+  };
+});
+`,
+    }],
+  };
+
+  it("registers pattern and lift hoists and resolves them", async () => {
+    const signer = await Identity.fromPassphrase("cfreg-builder-identity");
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      experimental: { esmModuleLoader: true },
+    });
+    try {
+      const compiled = await runtime.patternManager.compilePattern(PROGRAM);
+      const pm = runtime.patternManager;
+      const entryRef = pm.getPatternEntryRef(compiled);
+      expect(entryRef).toBeDefined();
+      const { identity } = entryRef!;
+
+      // Reach into the reverse index to enumerate what this module registered.
+      const hoists = (pm as unknown as {
+        hoistsByIdentity: Map<string, Map<string, unknown>>;
+      }).hoistsByIdentity.get(identity);
+      const symbols = [...(hoists?.keys() ?? [])];
+
+      // A pattern (map op) and a non-pattern artifact (lift) were both hoisted
+      // and registered — the generalization beyond patterns.
+      expect(symbols.some((s) => s.startsWith("__cfPattern_"))).toBe(true);
+      expect(symbols.some((s) => s.startsWith("__cfLift_"))).toBe(true);
+
+      for (const symbol of symbols) {
+        // Reverse: { identity, symbol } resolves synchronously to a live value.
+        const value = pm.patternFromIdentitySync(identity, symbol);
+        expect(value).toBeDefined();
+        // Forward: that live value reports the same { identity, symbol }.
+        expect(pm.getPatternEntryRef(value as never)).toEqual({
+          identity,
+          symbol,
+        });
+      }
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
+  it("returns undefined for an unknown reference (caller falls back)", async () => {
+    const signer = await Identity.fromPassphrase("cfreg-builder-identity-miss");
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      experimental: { esmModuleLoader: true },
+    });
+    try {
+      expect(
+        runtime.patternManager.patternFromIdentitySync(
+          "cf-module-does-not-exist",
+          "__cfPattern_1",
+        ),
+      ).toBeUndefined();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+});

--- a/packages/runner/test/cfreg-builder-identity.test.ts
+++ b/packages/runner/test/cfreg-builder-identity.test.ts
@@ -111,8 +111,8 @@ export default pattern<State>((state) => {
 
       // Reach into the reverse index to enumerate what this module registered.
       const hoists = (pm as unknown as {
-        hoistsByIdentity: Map<string, Map<string, unknown>>;
-      }).hoistsByIdentity.get(identity);
+        addressableByIdentity: Map<string, Map<string, unknown>>;
+      }).addressableByIdentity.get(identity);
       const symbols = [...(hoists?.keys() ?? [])];
 
       // A pattern (map op) and a non-pattern artifact (lift) were both hoisted

--- a/packages/runner/test/cfreg-builder-identity.test.ts
+++ b/packages/runner/test/cfreg-builder-identity.test.ts
@@ -105,7 +105,7 @@ export default pattern<State>((state) => {
     try {
       const compiled = await runtime.patternManager.compilePattern(PROGRAM);
       const pm = runtime.patternManager;
-      const entryRef = pm.getPatternEntryRef(compiled);
+      const entryRef = pm.getArtifactEntryRef(compiled);
       expect(entryRef).toBeDefined();
       const { identity } = entryRef!;
 
@@ -122,10 +122,10 @@ export default pattern<State>((state) => {
 
       for (const symbol of symbols) {
         // Reverse: { identity, symbol } resolves synchronously to a live value.
-        const value = pm.patternFromIdentitySync(identity, symbol);
+        const value = pm.artifactFromIdentitySync(identity, symbol);
         expect(value).toBeDefined();
         // Forward: that live value reports the same { identity, symbol }.
-        expect(pm.getPatternEntryRef(value as never)).toEqual({
+        expect(pm.getArtifactEntryRef(value as never)).toEqual({
           identity,
           symbol,
         });
@@ -163,11 +163,11 @@ export default pattern<State>((state) => {
     try {
       const compiled = await runtime.patternManager.compilePattern(program);
       const pm = runtime.patternManager;
-      const { identity } = pm.getPatternEntryRef(compiled)!;
+      const { identity } = pm.getArtifactEntryRef(compiled)!;
       // Non-exported const → reachable only via __cfReg.
-      expect(pm.patternFromIdentitySync(identity, "helper")).toBeDefined();
+      expect(pm.artifactFromIdentitySync(identity, "helper")).toBeDefined();
       // Exported pattern → reachable via the module namespace.
-      expect(pm.patternFromIdentitySync(identity, "named")).toBeDefined();
+      expect(pm.artifactFromIdentitySync(identity, "named")).toBeDefined();
     } finally {
       await runtime.dispose();
       await storageManager.close();
@@ -184,7 +184,7 @@ export default pattern<State>((state) => {
     });
     try {
       expect(
-        runtime.patternManager.patternFromIdentitySync(
+        runtime.patternManager.artifactFromIdentitySync(
           "cf-module-does-not-exist",
           "__cfPattern_1",
         ),

--- a/packages/runner/test/cfreg-builder-identity.test.ts
+++ b/packages/runner/test/cfreg-builder-identity.test.ts
@@ -136,6 +136,44 @@ export default pattern<State>((state) => {
     }
   });
 
+  it("registers an authored non-exported top-level builder const", async () => {
+    // A module-scope `const helper = lift(...)` is not a module export, so it
+    // can only be reached via `__cfReg` (keyed by its binding name). An exported
+    // artifact, by contrast, stays addressable through the module namespace.
+    const program: RuntimeProgram = {
+      main: "/main.tsx",
+      files: [{
+        name: "/main.tsx",
+        contents: [
+          "import { pattern, lift } from 'commonfabric';",
+          "const helper = lift((x: number) => x + 1);",
+          "export const named = pattern<{ n: number }>(({ n }) => ({ n }));",
+          "export default pattern<{ items: number[] }>(({ items }) =>",
+          "  ({ vs: items.map((x) => helper(x)) }));",
+        ].join("\n"),
+      }],
+    };
+    const signer = await Identity.fromPassphrase("cfreg-authored-const");
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+      experimental: { esmModuleLoader: true },
+    });
+    try {
+      const compiled = await runtime.patternManager.compilePattern(program);
+      const pm = runtime.patternManager;
+      const { identity } = pm.getPatternEntryRef(compiled)!;
+      // Non-exported const → reachable only via __cfReg.
+      expect(pm.patternFromIdentitySync(identity, "helper")).toBeDefined();
+      // Exported pattern → reachable via the module namespace.
+      expect(pm.patternFromIdentitySync(identity, "named")).toBeDefined();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+
   it("returns undefined for an unknown reference (caller falls back)", async () => {
     const signer = await Identity.fromPassphrase("cfreg-builder-identity-miss");
     const storageManager = StorageManager.emulate({ as: signer });

--- a/packages/runner/test/cfreg-security.test.ts
+++ b/packages/runner/test/cfreg-security.test.ts
@@ -1,0 +1,113 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import {
+  createHoistRegistrar,
+  createRejectingRegistrar,
+  type HoistRegistrationSink,
+} from "../src/sandbox/module-record-compiler.ts";
+import { verifyCompiledModuleBody } from "../src/sandbox/module-record-verifier.ts";
+import {
+  brandTrustedBuilderArtifact,
+  isTrustedBuilderArtifact,
+} from "../src/builder/pattern-metadata.ts";
+import { unsafe_originalPattern } from "../src/builder/types.ts";
+
+// Security invariants for the `__cfReg` content-addressed registration mechanism
+// (CT-1623). The compiled module body is treated as UNTRUSTED; defenses live in
+// four layers (verifier, registrar capability, per-value trust gate, content
+// addressing). The adversarial *verifier* corpus lives in
+// esm-verifier-adversarial.test.ts; this file pins the runtime layers.
+
+const IMPORT = `const cf = require("commonfabric");`;
+
+// The verifier reports whether a module has a VALID approved `__cfReg` call. The
+// loader uses this to grant the real registrar only to approved modules (and a
+// throwing one to the rest) — so this signal is load-bearing.
+describe("verifyCompiledModuleBody reports hoist-registration approval", () => {
+  it("is true for a module with an approved __cfReg call", () => {
+    const body =
+      `${IMPORT}\nconst __cfPattern_1 = (0, cf.pattern)((s) => s);\n__cfReg({ __cfPattern_1 });`;
+    expect(verifyCompiledModuleBody(body, "/main.tsx").hasHoistRegistration)
+      .toBe(true);
+  });
+
+  it("is false for a module with no __cfReg call", () => {
+    const body = `${IMPORT}\nexports.default = (0, cf.pattern)((s) => s);`;
+    expect(verifyCompiledModuleBody(body, "/main.tsx").hasHoistRegistration)
+      .toBe(false);
+  });
+});
+
+// A module the verifier did NOT approve gets the rejecting registrar, so a
+// `__cfReg` call the static check missed (e.g. smuggled inside an accepted
+// expression) fails closed at runtime instead of registering attacker values.
+describe("createRejectingRegistrar", () => {
+  it("throws on any registration attempt", () => {
+    const { register } = createRejectingRegistrar();
+    expect(() => register({ __cfPattern_1: {} })).toThrow(
+      /no verifier-approved registration/,
+    );
+  });
+
+  it("has a no-op commit (nothing was staged)", () => {
+    const { commit } = createRejectingRegistrar();
+    expect(() => commit()).not.toThrow();
+  });
+});
+
+// The load-bearing trust gate: only a genuine branded builder artifact may
+// acquire a content-addressed ref. The verifier intentionally does NOT check the
+// registered value's kind, so `indexArtifact`'s `isTrustedBuilderArtifact` is the
+// single boundary that stops forgery — pin it hard.
+describe("isTrustedBuilderArtifact rejects forged values", () => {
+  it("rejects plain objects, functions, and frozen data", () => {
+    expect(isTrustedBuilderArtifact({})).toBe(false);
+    expect(isTrustedBuilderArtifact(() => {})).toBe(false);
+    expect(isTrustedBuilderArtifact(Object.freeze({ a: 1 }))).toBe(false);
+    expect(isTrustedBuilderArtifact(null)).toBe(false);
+    expect(isTrustedBuilderArtifact(undefined)).toBe(false);
+    expect(isTrustedBuilderArtifact(42)).toBe(false);
+  });
+
+  it("rejects a pattern-shaped object with no brand (forged __cf_data)", () => {
+    const forged = Object.freeze({
+      argumentSchema: true,
+      resultSchema: true,
+      nodes: [],
+    });
+    expect(isTrustedBuilderArtifact(forged)).toBe(false);
+  });
+
+  it("is not fooled by a STRING-keyed 'unsafe_originalPattern'", () => {
+    // The trust chain follows the module-private SYMBOL `unsafe_originalPattern`,
+    // which authored code cannot reference. A string property of the same name
+    // is inert, so it cannot launder trust onto a forged object.
+    const branded = brandTrustedBuilderArtifact({});
+    const forged = { ["unsafe_originalPattern"]: branded };
+    expect(isTrustedBuilderArtifact(forged)).toBe(false);
+  });
+
+  it("accepts a genuinely branded artifact (and copies linking to it)", () => {
+    const artifact = brandTrustedBuilderArtifact({});
+    expect(isTrustedBuilderArtifact(artifact)).toBe(true);
+    // A derivation copy whose symbol chain reaches the branded original inherits
+    // trust (this is the legitimate path the chain walk exists for).
+    const copy = { [unsafe_originalPattern]: artifact };
+    expect(isTrustedBuilderArtifact(copy)).toBe(true);
+  });
+});
+
+// Defense-in-depth on the real registrar (run-once / closed-window /
+// transactional) lives in cfreg-builder-identity.test.ts; here we only assert the
+// rejecting variant, the trust gate, and the approval signal — the pieces the
+// verifier-gating relies on.
+describe("HoistRegistrationSink stays untouched on a rejected registration", () => {
+  it("an approved registrar still stages+commits normally", () => {
+    const sink: HoistRegistrationSink = new Map();
+    const { register, commit } = createHoistRegistrar("id", sink);
+    register({ __cfPattern_1: brandTrustedBuilderArtifact({}) });
+    commit();
+    expect(sink.get("id")?.has("__cfPattern_1")).toBe(true);
+  });
+});

--- a/packages/runner/test/compiled-module-verifier.test.ts
+++ b/packages/runner/test/compiled-module-verifier.test.ts
@@ -166,6 +166,58 @@ describe("verifyCompiledBundleModuleFactories()", () => {
     expect(() => verifyCompiledBundleModuleFactories(bundle)).not.toThrow();
   });
 
+  it("accepts a single trailing __cfReg({ … }) hoist registration", () => {
+    const bundle = `
+((runtimeDeps = {}) => {
+  define("main", ["require", "exports", "commonfabric"], function (require, exports, commonfabric_1) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    const __cfLift_1 = (0, commonfabric_1.lift)(() => 42);
+    const __cfPattern_1 = (0, commonfabric_1.pattern)(() => ({}));
+    exports.default = (0, commonfabric_1.pattern)(() => ({}));
+    __cfReg({ __cfLift_1, __cfPattern_1 });
+  });
+});
+`;
+    expect(() => verifyCompiledBundleModuleFactories(bundle)).not.toThrow();
+  });
+
+  it("rejects a second __cfReg() registration call", () => {
+    const bundle = `
+((runtimeDeps = {}) => {
+  define("main", ["require", "exports", "commonfabric"], function (require, exports, commonfabric_1) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    const __cfPattern_1 = (0, commonfabric_1.pattern)(() => ({}));
+    exports.default = __cfPattern_1;
+    __cfReg({ __cfPattern_1 });
+    __cfReg({ __cfPattern_1 });
+  });
+});
+`;
+    expect(() => verifyCompiledBundleModuleFactories(bundle)).toThrow(
+      "at most one __cfReg() registration call",
+    );
+  });
+
+  it("rejects a __cfReg() referencing an undeclared binding", () => {
+    const bundle = `
+((runtimeDeps = {}) => {
+  define("main", ["require", "exports", "commonfabric"], function (require, exports, commonfabric_1) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.default = (0, commonfabric_1.pattern)(() => ({}));
+    __cfReg({ notDeclared });
+  });
+});
+`;
+    // Not the canonical shape (the name is not a top-level binding) → falls
+    // through to the generic unsupported-statement rejection.
+    expect(() => verifyCompiledBundleModuleFactories(bundle)).toThrow(
+      "unsupported top-level executable code",
+    );
+  });
+
   it("rejects default exports of trusted runtime helper references", () => {
     const bundle = `
 ((runtimeDeps = {}) => {

--- a/packages/runner/test/esm-verifier-adversarial.test.ts
+++ b/packages/runner/test/esm-verifier-adversarial.test.ts
@@ -268,6 +268,74 @@ const ATTACKS: Attack[] = [
     name: "require fast-path defeated by trailing declarator",
     body: `const x = require("commonfabric"), y = globalThis;`,
   },
+
+  // --- `__cfReg` hoist-registration call (CT-1623) ---
+  // `__cfReg` is supplied to the module wrapper as a parameter (the registrar);
+  // it is deliberately NOT a referenceable binding, and only a single top-level
+  // `__cfReg({ <shorthand top-level bindings> })` statement is approved. Every
+  // other shape must be rejected so an attacker can neither register an arbitrary
+  // symbol nor smuggle a second/aliased registrar call.
+  {
+    name: "__cfReg: legitimate single shorthand registration (control)",
+    accept: true,
+    body:
+      `${IMPORT}\nconst __cfPattern_1 = (0, cf.pattern)((s) => s);\n__cfReg({ __cfPattern_1 });`,
+  },
+  {
+    // The case the spec calls out: a name not declared at module level.
+    name: "__cfReg: registers an undeclared (non-module-level) symbol",
+    body: `${IMPORT}\n__cfReg({ smuggled });`,
+  },
+  {
+    name: "__cfReg: a second registration call",
+    body:
+      `${IMPORT}\nconst __cfPattern_1 = (0, cf.pattern)((s) => s);\n__cfReg({ __cfPattern_1 });\n__cfReg({ __cfPattern_1 });`,
+  },
+  {
+    name: "__cfReg: aliased/member-call callee (cf.__cfReg)",
+    body:
+      `${IMPORT}\nconst __cfPattern_1 = (0, cf.pattern)((s) => s);\ncf.__cfReg({ __cfPattern_1 });`,
+  },
+  {
+    name: "__cfReg: reassigned to a local then invoked",
+    body:
+      `${IMPORT}\nconst __cfPattern_1 = (0, cf.pattern)((s) => s);\nconst r = __cfReg;\nr({ __cfPattern_1 });`,
+  },
+  {
+    name: "__cfReg: captured as a variable initializer",
+    body:
+      `${IMPORT}\nconst __cfPattern_1 = (0, cf.pattern)((s) => s);\nconst z = __cfReg({ __cfPattern_1 });\nexports.z = z;`,
+  },
+  {
+    name: "__cfReg: string-keyed property (not shorthand)",
+    body:
+      `${IMPORT}\nconst __cfPattern_1 = (0, cf.pattern)((s) => s);\n__cfReg({ "__cfPattern_1": __cfPattern_1 });`,
+  },
+  {
+    name: "__cfReg: key:value property naming a different binding",
+    body:
+      `${IMPORT}\nconst __cfPattern_1 = (0, cf.pattern)((s) => s);\n__cfReg({ alias: __cfPattern_1 });`,
+  },
+  {
+    name: "__cfReg: computed key",
+    body:
+      `${IMPORT}\nconst __cfPattern_1 = (0, cf.pattern)((s) => s);\n__cfReg({ ["__cfPattern_1"]: __cfPattern_1 });`,
+  },
+  {
+    name: "__cfReg: object spread of an attacker value",
+    body:
+      `${IMPORT}\nconst evil = (0, cf.__cf_data)({ x: 1 });\n__cfReg({ ...evil });`,
+  },
+  {
+    name: "__cfReg: extra trailing argument",
+    body:
+      `${IMPORT}\nconst __cfPattern_1 = (0, cf.pattern)((s) => s);\n__cfReg({ __cfPattern_1 }, globalThis);`,
+  },
+  {
+    name: "__cfReg: unicode-escaped callee",
+    body:
+      `${IMPORT}\nconst __cfPattern_1 = (0, cf.pattern)((s) => s);\n\\u005f\\u005fcfReg({ __cfPattern_1 });`,
+  },
 ];
 
 describe("ESM verifier adversarial corpus", () => {

--- a/packages/runner/test/load-by-identity-meta-bridge.test.ts
+++ b/packages/runner/test/load-by-identity-meta-bridge.test.ts
@@ -110,7 +110,7 @@ describe("load by identity — pattern-metadata bridge", () => {
       const tx1 = rt1.edit();
       const pm1 = rt1.patternManager;
       const cold = await pm1.compilePattern(PROGRAM, { space, tx: tx1 });
-      const entryIdentity = pm1.getPatternEntryRef(cold)?.identity;
+      const entryIdentity = pm1.getArtifactEntryRef(cold)?.identity;
       expect(typeof entryIdentity).toBe("string");
       await tx1.commit();
       await pm1.flushCompileCacheWrites();
@@ -176,8 +176,8 @@ describe("load by identity — pattern-metadata bridge", () => {
       const pm1 = rt1.patternManager;
       const cold = await pm1.compilePattern(NAMED, { space, tx: tx1 });
       // The authored compile records the real export symbol.
-      expect(pm1.getPatternEntryRef(cold)?.symbol).toBe("myPattern");
-      const entryIdentity = pm1.getPatternEntryRef(cold)!.identity;
+      expect(pm1.getArtifactEntryRef(cold)?.symbol).toBe("myPattern");
+      const entryIdentity = pm1.getArtifactEntryRef(cold)!.identity;
       await tx1.commit();
       await pm1.flushCompileCacheWrites();
       await rt1.storageManager.synced();
@@ -191,7 +191,7 @@ describe("load by identity — pattern-metadata bridge", () => {
         space,
       );
       expect(typeof reloaded).toBe("function");
-      expect(pm2.getPatternEntryRef(reloaded!)).toEqual({
+      expect(pm2.getArtifactEntryRef(reloaded!)).toEqual({
         identity: entryIdentity,
         symbol: "myPattern",
       });
@@ -220,7 +220,7 @@ describe("load by identity — pattern-metadata bridge", () => {
     // meta and the runtime can reload it by identity. The ref is supplied by
     // `registerEvaluatedModules` (which tags every trusted sub-pattern export in
     // the per-load WeakMap, keyed by the exact value) and resolved by
-    // `getPatternEntryRef`'s exact-object-first lookup. This asserts the
+    // `getArtifactEntryRef`'s exact-object-first lookup. This asserts the
     // user-facing invariant — that the sub-piece's recorded identity is the
     // CHILD module's, distinct from the parent's — not any single mechanism.
     const childFile = {
@@ -266,7 +266,7 @@ describe("load by identity — pattern-metadata bridge", () => {
         space,
         tx: txc,
       });
-      const childRef = pm.getPatternEntryRef(childStandalone);
+      const childRef = pm.getArtifactEntryRef(childStandalone);
       txc.abort?.("child identity learned");
       expect(childRef?.symbol).toBe("default");
       const childIdentity = childRef!.identity;
@@ -274,7 +274,7 @@ describe("load by identity — pattern-metadata bridge", () => {
       // Compile + run the parent that composes the child.
       const tx = rt.edit();
       const parent = await pm.compilePattern(PARENT, { space, tx });
-      const parentRef = pm.getPatternEntryRef(parent);
+      const parentRef = pm.getArtifactEntryRef(parent);
       expect(parentRef?.identity).toBeTruthy();
       // Distinct per-module identities — the child is not the parent.
       expect(parentRef!.identity).not.toBe(childIdentity);

--- a/packages/runner/test/resume-by-identity.test.ts
+++ b/packages/runner/test/resume-by-identity.test.ts
@@ -60,7 +60,7 @@ describe("resume a result cell by {identity, symbol}", () => {
       const pm1 = rt1.patternManager;
       const compiled = await pm1.compilePattern(PROGRAM, { space, tx: tx1 });
       // The cold ESM compile learned the entry identity.
-      expect(pm1.getPatternEntryRef(compiled)?.identity).toBeTruthy();
+      expect(pm1.getArtifactEntryRef(compiled)?.identity).toBeTruthy();
 
       const resultCell1 = rt1.getCell<{ result: number }>(
         space,

--- a/packages/runner/test/support/legacy-eval-runtime.ts
+++ b/packages/runner/test/support/legacy-eval-runtime.ts
@@ -5,6 +5,14 @@ import {
   SourceMapParser,
 } from "@commonfabric/js-compiler";
 
+// The CF transformer emits a trailing `__cfReg({ … })` hoist-registration call
+// in every module with hoists. This differential harness `eval()`s the AMD
+// bundle directly (no SES compartment), so `__cfReg` must resolve to *something*.
+// Identity addressing is not exercised here, so a no-op global suffices — the
+// same role the no-op `__cfReg` plays on the real legacy/AMD path
+// (compartment-globals.ts).
+(globalThis as Record<string, unknown>).__cfReg ??= () => {};
+
 export interface JsValue {
   invoke(...args: unknown[]): JsValue;
   inner(): unknown;

--- a/packages/ts-transformers/src/transformers/builder-call-hoisting.ts
+++ b/packages/ts-transformers/src/transformers/builder-call-hoisting.ts
@@ -418,7 +418,7 @@ function unwrapDefaultExportExpression(expr: ts.Expression): ts.Expression {
   let current = expr;
   while (
     ts.isParenthesizedExpression(current) || ts.isAsExpression(current) ||
-    ts.isSatisfiesExpression(current)
+    ts.isSatisfiesExpression(current) || ts.isTypeAssertionExpression(current)
   ) {
     current = current.expression;
   }

--- a/packages/ts-transformers/src/transformers/builder-call-hoisting.ts
+++ b/packages/ts-transformers/src/transformers/builder-call-hoisting.ts
@@ -226,6 +226,17 @@ function hoistBuilderCalls(
   // hoisted const).
   const counters = new Map<string, number>();
 
+  // Every hoisted builder-artifact name (`__cfPattern_N`, `__cfLift_N`,
+  // `__cfHandler_N`), in creation order. After the whole file is visited we emit
+  // a SINGLE trailing `__cfReg({ __cfPattern_1, __cfLift_1, … })` call so the
+  // runtime can assign each a content-addressed `{ identity, symbol }` reference
+  // (the property key is the symbol). A single trailing call — rather than
+  // exporting each hoist or registering it inline — keeps the verifier's job to
+  // "exactly one top-level `__cfReg` call" and lets a run-once trap reject any
+  // injected duplicate. See PatternManager.registerHoistedValues / the
+  // `__cfReg` factory parameter wired up by the module-record compiler.
+  const registeredNames: string[] = [];
+
   const visit: ts.Visitor = (node: ts.Node): ts.Node => {
     const visited = ts.visitEachChild(node, visit, context.tsContext);
     if (!ts.isCallExpression(visited)) {
@@ -240,7 +251,9 @@ function hoistBuilderCalls(
 
       const next = (counters.get(builder.prefix) ?? 0) + 1;
       counters.set(builder.prefix, next);
-      const name = factory.createIdentifier(`${builder.prefix}_${next}`);
+      const nameText = `${builder.prefix}_${next}`;
+      const name = factory.createIdentifier(nameText);
+      registeredNames.push(nameText);
       // Carry the hoisted call's identity on the synthetic call-site identifier.
       // The checker can't resolve a synthetic identifier to its const
       // initializer, so detectCallKind would otherwise fail to recognize
@@ -303,6 +316,34 @@ function hoistBuilderCalls(
     pendingHoists = [];
     const visitedStatement = ts.visitNode(statement, visit) as ts.Statement;
     resultStatements.push(...pendingHoists, visitedStatement);
+  }
+
+  // Register every hoisted builder artifact with one trailing call. `__cfReg` is
+  // a free identifier supplied by the module wrapper (the 4th factory parameter
+  // under the ESM loader; a no-op global on the legacy/AMD path). The object uses
+  // shorthand so each value is the module-level `const` binding itself — the
+  // registrar receives `{ symbol -> live value }` and the runtime pairs it with
+  // this module's content identity. Emitted only when there is something to
+  // register, so hoist-free modules are unchanged.
+  if (registeredNames.length > 0) {
+    resultStatements.push(
+      factory.createExpressionStatement(
+        factory.createCallExpression(
+          factory.createIdentifier("__cfReg"),
+          undefined,
+          [
+            factory.createObjectLiteralExpression(
+              registeredNames.map((n) =>
+                factory.createShorthandPropertyAssignment(
+                  factory.createIdentifier(n),
+                )
+              ),
+              true,
+            ),
+          ],
+        ),
+      ),
+    );
   }
 
   return factory.updateSourceFile(sourceFile, resultStatements);

--- a/packages/ts-transformers/src/transformers/builder-call-hoisting.ts
+++ b/packages/ts-transformers/src/transformers/builder-call-hoisting.ts
@@ -313,6 +313,15 @@ function hoistBuilderCalls(
   // `__cfLift`) sees it declared above.
   const resultStatements: ts.Statement[] = [];
   for (const statement of sourceFile.statements) {
+    // Also register AUTHORED top-level builder artifacts (`const foo = lift(...)`,
+    // `export const bar = pattern(...)`), so `__cfReg` is the canonical place a
+    // builder artifact acquires its `{ identity, symbol }` reference — not a
+    // parallel runtime export scan. Detect on the ORIGINAL statement (the checker
+    // resolves real, not synthetic, nodes). Only a direct builder CALL counts, so
+    // an import/alias (`const x = imported`) is never mis-attributed to this
+    // module's identity. The default export is handled separately (it has no
+    // binding name); the runtime trust-filters anything non-branded.
+    collectTopLevelBuilderArtifactNames(statement, context, registeredNames);
     pendingHoists = [];
     const visitedStatement = ts.visitNode(statement, visit) as ts.Statement;
     resultStatements.push(...pendingHoists, visitedStatement);
@@ -347,4 +356,45 @@ function hoistBuilderCalls(
   }
 
   return factory.updateSourceFile(sourceFile, resultStatements);
+}
+
+/**
+ * Collect the names of top-level `const`/`let`/`var` declarations whose
+ * initializer is a direct builder CALL (`pattern(...)`, `lift(...)`,
+ * `handler(...)`, `computed(...)`, …) — i.e. authored module-scope builder
+ * artifacts. These are added to the module's `__cfReg({ … })` registration so
+ * they receive a content-addressed `{ identity, symbol }` reference (symbol = the
+ * binding name), exactly like the synthetic hoists.
+ *
+ * Requiring a builder call (via `detectCallKind`) means a re-export / alias
+ * (`const x = imported`) — whose value belongs to ANOTHER module — is never
+ * registered here, so identity is never mis-attributed. Non-artifact builders are
+ * harmlessly trust-filtered at registration time. Destructuring is skipped.
+ *
+ * EXPORTED declarations are skipped: TypeScript's CommonJS emit rewrites
+ * `export const foo = …` to `exports.foo = …` with NO local `foo` binding, so a
+ * `__cfReg({ foo })` shorthand would read `undefined`. Exported builder artifacts
+ * don't need `__cfReg` anyway — they live in the module namespace and are
+ * addressable by their export name directly. `__cfReg` covers exactly the gap:
+ * the hoisted artifacts and non-exported top-level ones, which never reach the
+ * namespace.
+ */
+function collectTopLevelBuilderArtifactNames(
+  statement: ts.Statement,
+  context: TransformationContext,
+  out: string[],
+): void {
+  if (!ts.isVariableStatement(statement)) return;
+  const isExported = statement.modifiers?.some((m) =>
+    m.kind === ts.SyntaxKind.ExportKeyword
+  );
+  if (isExported) return;
+  for (const decl of statement.declarationList.declarations) {
+    if (!ts.isIdentifier(decl.name)) continue;
+    const init = decl.initializer;
+    if (!init || !ts.isCallExpression(init)) continue;
+    if (detectCallKind(init, context.checker)?.kind === "builder") {
+      out.push(decl.name.text);
+    }
+  }
 }

--- a/packages/ts-transformers/src/transformers/builder-call-hoisting.ts
+++ b/packages/ts-transformers/src/transformers/builder-call-hoisting.ts
@@ -412,6 +412,19 @@ function collectTopLevelBuilderArtifactNames(
  * `foo`), and `export default foo`. Used to keep exported builder artifacts out
  * of `__cfReg` (they are addressable through the module namespace instead).
  */
+/** Strip parentheses and `as` / `satisfies` wrappers to reach the underlying
+ * `export default` expression (so a wrapped identifier is still recognized). */
+function unwrapDefaultExportExpression(expr: ts.Expression): ts.Expression {
+  let current = expr;
+  while (
+    ts.isParenthesizedExpression(current) || ts.isAsExpression(current) ||
+    ts.isSatisfiesExpression(current)
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
 function collectExportedLocalNames(sourceFile: ts.SourceFile): Set<string> {
   const names = new Set<string>();
   for (const statement of sourceFile.statements) {
@@ -431,11 +444,12 @@ function collectExportedLocalNames(sourceFile: ts.SourceFile): Set<string> {
       for (const el of statement.exportClause.elements) {
         names.add((el.propertyName ?? el.name).text);
       }
-    } else if (
-      ts.isExportAssignment(statement) && !statement.isExportEquals &&
-      ts.isIdentifier(statement.expression)
-    ) {
-      names.add(statement.expression.text);
+    } else if (ts.isExportAssignment(statement) && !statement.isExportEquals) {
+      // `export default foo` — unwrap parens / `as` / `satisfies` so a wrapped
+      // identifier (`export default (foo)`, `export default foo satisfies T`) is
+      // still recognized as exporting the local `foo`.
+      const expr = unwrapDefaultExportExpression(statement.expression);
+      if (ts.isIdentifier(expr)) names.add(expr.text);
     }
   }
   return names;

--- a/packages/ts-transformers/src/transformers/builder-call-hoisting.ts
+++ b/packages/ts-transformers/src/transformers/builder-call-hoisting.ts
@@ -311,17 +311,28 @@ function hoistBuilderCalls(
   // post-order traversal already pushed inner/earlier calls first, so a hoist
   // that references another hoist (e.g. `__cfPattern` whose callback calls
   // `__cfLift`) sees it declared above.
+  // Local names that leave the module through ANY export form — `export const`,
+  // `export { x }` / `export { x as y }`, `export default x`. Such artifacts are
+  // addressable through the module namespace by their export name, so they are
+  // NOT also routed through `__cfReg` (and `export const` has no local binding
+  // after CommonJS emit anyway). `__cfReg` covers exactly the gap: hoists and
+  // non-exported top-level builder consts.
+  const exportedLocalNames = collectExportedLocalNames(sourceFile);
+
   const resultStatements: ts.Statement[] = [];
   for (const statement of sourceFile.statements) {
-    // Also register AUTHORED top-level builder artifacts (`const foo = lift(...)`,
-    // `export const bar = pattern(...)`), so `__cfReg` is the canonical place a
-    // builder artifact acquires its `{ identity, symbol }` reference — not a
-    // parallel runtime export scan. Detect on the ORIGINAL statement (the checker
-    // resolves real, not synthetic, nodes). Only a direct builder CALL counts, so
-    // an import/alias (`const x = imported`) is never mis-attributed to this
-    // module's identity. The default export is handled separately (it has no
-    // binding name); the runtime trust-filters anything non-branded.
-    collectTopLevelBuilderArtifactNames(statement, context, registeredNames);
+    // Also register AUTHORED non-exported top-level builder artifacts
+    // (`const foo = lift(...)`), so `__cfReg` covers every top-level builder
+    // artifact that does not reach the namespace. Detect on the ORIGINAL
+    // statement (the checker resolves real, not synthetic, nodes). Only a direct
+    // builder CALL counts, so an import/alias (`const x = imported`) — whose value
+    // belongs to another module — is never mis-attributed to this identity.
+    collectTopLevelBuilderArtifactNames(
+      statement,
+      context,
+      exportedLocalNames,
+      registeredNames,
+    );
     pendingHoists = [];
     const visitedStatement = ts.visitNode(statement, visit) as ts.Statement;
     resultStatements.push(...pendingHoists, visitedStatement);
@@ -371,30 +382,61 @@ function hoistBuilderCalls(
  * registered here, so identity is never mis-attributed. Non-artifact builders are
  * harmlessly trust-filtered at registration time. Destructuring is skipped.
  *
- * EXPORTED declarations are skipped: TypeScript's CommonJS emit rewrites
- * `export const foo = …` to `exports.foo = …` with NO local `foo` binding, so a
- * `__cfReg({ foo })` shorthand would read `undefined`. Exported builder artifacts
- * don't need `__cfReg` anyway — they live in the module namespace and are
- * addressable by their export name directly. `__cfReg` covers exactly the gap:
- * the hoisted artifacts and non-exported top-level ones, which never reach the
- * namespace.
+ * Names in `exportedLocalNames` are skipped: they leave the module through an
+ * export and are addressable by their export name through the namespace (and an
+ * `export const` has no local binding after CommonJS emit anyway, so a shorthand
+ * would read `undefined`). `__cfReg` covers exactly the gap — hoists and
+ * non-exported top-level builder consts.
  */
 function collectTopLevelBuilderArtifactNames(
   statement: ts.Statement,
   context: TransformationContext,
+  exportedLocalNames: ReadonlySet<string>,
   out: string[],
 ): void {
   if (!ts.isVariableStatement(statement)) return;
-  const isExported = statement.modifiers?.some((m) =>
-    m.kind === ts.SyntaxKind.ExportKeyword
-  );
-  if (isExported) return;
   for (const decl of statement.declarationList.declarations) {
     if (!ts.isIdentifier(decl.name)) continue;
+    if (exportedLocalNames.has(decl.name.text)) continue;
     const init = decl.initializer;
     if (!init || !ts.isCallExpression(init)) continue;
     if (detectCallKind(init, context.checker)?.kind === "builder") {
       out.push(decl.name.text);
     }
   }
+}
+
+/**
+ * The set of LOCAL binding names that are exported from the module by any form:
+ * `export const foo`, `export { foo }` / `export { foo as bar }` (the local name
+ * `foo`), and `export default foo`. Used to keep exported builder artifacts out
+ * of `__cfReg` (they are addressable through the module namespace instead).
+ */
+function collectExportedLocalNames(sourceFile: ts.SourceFile): Set<string> {
+  const names = new Set<string>();
+  for (const statement of sourceFile.statements) {
+    if (
+      ts.isVariableStatement(statement) &&
+      statement.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)
+    ) {
+      for (const decl of statement.declarationList.declarations) {
+        if (ts.isIdentifier(decl.name)) names.add(decl.name.text);
+      }
+    } else if (
+      ts.isExportDeclaration(statement) && !statement.moduleSpecifier &&
+      statement.exportClause && ts.isNamedExports(statement.exportClause)
+    ) {
+      // `export { local as exported }`: the LOCAL name is `propertyName` when
+      // aliased, otherwise `name`.
+      for (const el of statement.exportClause.elements) {
+        names.add((el.propertyName ?? el.name).text);
+      }
+    } else if (
+      ts.isExportAssignment(statement) && !statement.isExportEquals &&
+      ts.isIdentifier(statement.expression)
+    ) {
+      names.add(statement.expression.text);
+    }
+  }
+  return names;
 }

--- a/packages/ts-transformers/test/fixtures/ast-transform/authored-ifelse-reactive-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/authored-ifelse-reactive-roots.expected.jsx
@@ -164,3 +164,10 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfLift_4,
+    __cfLift_5
+});

--- a/packages/ts-transformers/test/fixtures/ast-transform/builder-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/builder-conditional.expected.jsx
@@ -116,3 +116,6 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/ast-transform/computed-alias-const-rewrite.expected.js
+++ b/packages/ts-transformers/test/fixtures/ast-transform/computed-alias-const-rewrite.expected.js
@@ -19,3 +19,6 @@ export default __cfLift_1();
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/ast-transform/computed-object-literal-input.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/computed-object-literal-input.expected.jsx
@@ -59,3 +59,10 @@ const _summary = __cfHelpers.__cf_data(__cfLift_5().for("_summary", true));
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfLift_4,
+    __cfLift_5
+});

--- a/packages/ts-transformers/test/fixtures/ast-transform/counter-pattern-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/counter-pattern-no-name.expected.jsx
@@ -144,5 +144,7 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
+    increment,
+    decrement,
     __cfLift_1
 });

--- a/packages/ts-transformers/test/fixtures/ast-transform/counter-pattern-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/counter-pattern-no-name.expected.jsx
@@ -143,3 +143,6 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/ast-transform/counter-pattern.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/counter-pattern.expected.jsx
@@ -144,3 +144,6 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/ast-transform/counter-pattern.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/counter-pattern.expected.jsx
@@ -145,5 +145,7 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
+    increment,
+    decrement,
     __cfLift_1
 });

--- a/packages/ts-transformers/test/fixtures/ast-transform/event-handler-no-compute-wrap.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/event-handler-no-compute-wrap.expected.jsx
@@ -121,5 +121,6 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
+    handleClick,
     __cfLift_1
 });

--- a/packages/ts-transformers/test/fixtures/ast-transform/event-handler-no-compute-wrap.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/event-handler-no-compute-wrap.expected.jsx
@@ -120,3 +120,6 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/ast-transform/handler-object-literal.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/handler-object-literal.expected.jsx
@@ -77,3 +77,6 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    myHandler
+});

--- a/packages/ts-transformers/test/fixtures/ast-transform/lift-explicit-toschema.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/lift-explicit-toschema.expected.jsx
@@ -67,3 +67,7 @@ export default __cfHelpers.__cf_data({ logCharmsList, getStatus });
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    logCharmsList,
+    getStatus
+});

--- a/packages/ts-transformers/test/fixtures/ast-transform/non-jsx-wildcard-traversal-call-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/non-jsx-wildcard-traversal-call-roots.expected.jsx
@@ -235,3 +235,9 @@ export default pattern((state) => ({
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfLift_4
+});

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-array-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-array-map.expected.jsx
@@ -157,3 +157,7 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-array-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-array-map.expected.jsx
@@ -158,6 +158,7 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
+    adder,
     __cfLift_1,
     __cfPattern_1
 });

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-call-arg-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-call-arg-conditional.expected.jsx
@@ -63,3 +63,6 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-call-root-containers.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-call-root-containers.expected.jsx
@@ -134,3 +134,8 @@ export default pattern((state) => __cfLift_3({ state: {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3
+});

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-local-helper-call-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-local-helper-call-roots.expected.jsx
@@ -66,3 +66,6 @@ export default pattern((state) => ({
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-object-binary-add.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-object-binary-add.expected.jsx
@@ -62,3 +62,6 @@ export default pattern((state) => ({
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-object-prefix-not.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-object-prefix-not.expected.jsx
@@ -61,3 +61,6 @@ export default pattern((state) => ({
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-top-level-root-lowering.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-top-level-root-lowering.expected.jsx
@@ -238,3 +238,10 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfLift_4,
+    __cfLift_5
+});

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-two-schemas.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-two-schemas.expected.jsx
@@ -62,3 +62,6 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-with-name-and-type.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-with-name-and-type.expected.jsx
@@ -66,3 +66,6 @@ export default pattern((input: MyInput) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-with-type.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-with-type.expected.jsx
@@ -66,3 +66,6 @@ export default pattern((input: MyInput) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-builders.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-builders.expected.jsx
@@ -138,5 +138,6 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
+    addTodo,
     __cfPattern_1
 });

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-builders.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-builders.expected.jsx
@@ -137,3 +137,6 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-alias.expected.jsx
@@ -29,3 +29,6 @@ export const textLength = __cfHelpers.__cf_data(__cfLift_1().for("textLength", t
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-inside-jsx.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-inside-jsx.expected.jsx
@@ -23,3 +23,6 @@ export const result = (<div>
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-multiple-returns.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-multiple-returns.expected.jsx
@@ -27,3 +27,6 @@ export const multiReturn = __cfHelpers.__cf_data(__cfLift_1().for("multiReturn",
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-untyped.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-untyped.expected.jsx
@@ -21,3 +21,6 @@ export const doubled = __cfHelpers.__cf_data(__cfLift_1().for("doubled", true));
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed.expected.jsx
@@ -29,3 +29,6 @@ export const doubledValue = __cfHelpers.__cf_data(__cfLift_1().for("doubledValue
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-lift-cell-array.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-lift-cell-array.expected.jsx
@@ -75,6 +75,3 @@ export default logCharmsList;
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
-__cfReg({
-    logCharmsList
-});

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-lift-cell-array.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-lift-cell-array.expected.jsx
@@ -75,3 +75,6 @@ export default logCharmsList;
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    logCharmsList
+});

--- a/packages/ts-transformers/test/fixtures/ast-transform/str-template-call-interpolation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/str-template-call-interpolation.expected.jsx
@@ -104,3 +104,7 @@ export default pattern((cell) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2
+});

--- a/packages/ts-transformers/test/fixtures/ast-transform/ternary_computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/ternary_computed.expected.jsx
@@ -125,3 +125,7 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/action-basic.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-basic.expected.jsx
@@ -55,3 +55,6 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfHandler_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/action-generic-event.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-generic-event.expected.jsx
@@ -80,3 +80,6 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfHandler_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/action-in-ternary-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-in-ternary-branch.expected.jsx
@@ -194,3 +194,7 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfHandler_1,
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/action-in-ternary-with-explicit-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-in-ternary-with-explicit-computed.expected.jsx
@@ -200,3 +200,7 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfHandler_1,
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/action-partial.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-partial.expected.jsx
@@ -85,3 +85,7 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfHandler_1,
+    __cfHandler_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/action-required-partial.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-required-partial.expected.jsx
@@ -80,3 +80,7 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfHandler_1,
+    __cfHandler_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/action-result-not-opaque.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-result-not-opaque.expected.jsx
@@ -111,3 +111,7 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfHandler_1,
+    __cfHandler_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/action-self-closure.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-self-closure.expected.jsx
@@ -143,3 +143,7 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfHandler_1,
+    __cfHandler_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/action-with-event.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-with-event.expected.jsx
@@ -79,3 +79,6 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfHandler_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/cell-map-with-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/cell-map-with-captures.expected.jsx
@@ -164,3 +164,7 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/cfreg-export-forms.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/cfreg-export-forms.expected.jsx
@@ -1,0 +1,87 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { lift, pattern } from "commonfabric";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+// FIXTURE: cfreg-export-forms
+// Verifies which top-level builder artifacts are routed through `__cfReg`:
+// - a NON-exported top-level builder const IS registered (by its binding name);
+// - artifacts that leave via ANY export form are NOT (they are addressable
+//   through the module namespace by their export name): inline `export const`,
+//   a separate `export { ... }`, and a default export.
+// The trailing `__cfReg({ ... })` should therefore contain only `internalHelper`
+// and the synthetic `__cfPattern_1` (the `.map` op) — never `exportedLift`,
+// `reexportedLift`, or the default pattern.
+const internalHelper = lift({
+    type: "number"
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "number"
+} as const satisfies __cfHelpers.JSONSchema, (x: number) => x + 1);
+export const exportedLift = lift({
+    type: "number"
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "number"
+} as const satisfies __cfHelpers.JSONSchema, (x: number) => x * 2);
+const reexportedLift = lift({
+    type: "number"
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "number"
+} as const satisfies __cfHelpers.JSONSchema, (x: number) => x - 1);
+export { reexportedLift };
+const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
+    const x = __cf_pattern_input.key("element");
+    return internalHelper(x).for("__patternResult", true);
+}, {
+    type: "object",
+    properties: {
+        element: {
+            type: "number"
+        }
+    },
+    required: ["element"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "number"
+} as const satisfies __cfHelpers.JSONSchema);
+export default pattern((__cf_pattern_input) => {
+    const items = __cf_pattern_input.key("items");
+    return ({
+        vs: items.mapWithPattern(__cfPattern_1, {}).for(["__patternResult", "vs"], true)
+    });
+}, {
+    type: "object",
+    properties: {
+        items: {
+            type: "array",
+            items: {
+                type: "number"
+            }
+        }
+    },
+    required: ["items"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        vs: {
+            type: "array",
+            items: {
+                type: "number"
+            }
+        }
+    },
+    required: ["vs"]
+} as const satisfies __cfHelpers.JSONSchema);
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);
+__cfReg({
+    internalHelper,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/cfreg-export-forms.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/cfreg-export-forms.input.tsx
@@ -1,0 +1,22 @@
+import { lift, pattern } from "commonfabric";
+
+// FIXTURE: cfreg-export-forms
+// Verifies which top-level builder artifacts are routed through `__cfReg`:
+// - a NON-exported top-level builder const IS registered (by its binding name);
+// - artifacts that leave via ANY export form are NOT (they are addressable
+//   through the module namespace by their export name): inline `export const`,
+//   a separate `export { ... }`, and a default export.
+// The trailing `__cfReg({ ... })` should therefore contain only `internalHelper`
+// and the synthetic `__cfPattern_1` (the `.map` op) — never `exportedLift`,
+// `reexportedLift`, or the default pattern.
+
+const internalHelper = lift((x: number) => x + 1);
+
+export const exportedLift = lift((x: number) => x * 2);
+
+const reexportedLift = lift((x: number) => x - 1);
+export { reexportedLift };
+
+export default pattern<{ items: number[] }>(({ items }) => ({
+  vs: items.map((x) => internalHelper(x)),
+}));

--- a/packages/ts-transformers/test/fixtures/closures/computed-all-literal-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-all-literal-types.expected.jsx
@@ -69,3 +69,6 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-array-element-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-array-element-access.expected.jsx
@@ -52,3 +52,6 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-array-length.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-array-length.expected.jsx
@@ -197,3 +197,8 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-basic-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-basic-capture.expected.jsx
@@ -52,3 +52,6 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-collision-property.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-collision-property.expected.jsx
@@ -65,3 +65,6 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-collision-shorthand.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-collision-shorthand.expected.jsx
@@ -77,3 +77,6 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-complex-expression.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-complex-expression.expected.jsx
@@ -61,3 +61,6 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-conditional-expression.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-conditional-expression.expected.jsx
@@ -70,3 +70,6 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-destructured-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-destructured-map.expected.jsx
@@ -213,3 +213,7 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-destructured-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-destructured-param.expected.jsx
@@ -83,3 +83,6 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-filter-map-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-filter-map-chain.expected.jsx
@@ -108,3 +108,6 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-in-computed-property-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-in-computed-property-access.expected.jsx
@@ -32,3 +32,7 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-in-computed-scoped-no-false-rewrite.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-in-computed-scoped-no-false-rewrite.expected.jsx
@@ -37,3 +37,7 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-inside-map-with-method-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-inside-map-with-method-chain.expected.jsx
@@ -238,3 +238,7 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-jsx-local-function.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-jsx-local-function.expected.jsx
@@ -97,3 +97,6 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-local-var-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-local-var-map.expected.jsx
@@ -186,3 +186,7 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-local-variable.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-local-variable.expected.jsx
@@ -64,3 +64,6 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-conditional.expected.jsx
@@ -204,3 +204,8 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-logical-and.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-logical-and.expected.jsx
@@ -204,3 +204,8 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-call-root-containers.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-call-root-containers.expected.jsx
@@ -273,3 +273,11 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfPattern_1,
+    __cfLift_4,
+    __cfPattern_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-direct-return-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-direct-return-conditional.expected.jsx
@@ -169,3 +169,7 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-in-derived-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-in-derived-branch.expected.jsx
@@ -190,3 +190,7 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-in-ternary-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-in-ternary-branch.expected.jsx
@@ -300,3 +300,10 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfPattern_1,
+    __cfLift_3,
+    __cfPattern_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-input-no-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-input-no-captures.expected.jsx
@@ -102,3 +102,6 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-local-array-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-local-array-conditional.expected.jsx
@@ -203,3 +203,8 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-local-call-root.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-local-call-root.expected.jsx
@@ -165,3 +165,8 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-conditional.expected.jsx
@@ -187,3 +187,7 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-logical-or.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-logical-or.expected.jsx
@@ -185,3 +185,7 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-pre-resolved-return-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-pre-resolved-return-conditional.expected.jsx
@@ -156,3 +156,7 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-union-return.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-union-return.expected.jsx
@@ -204,3 +204,6 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-method-call-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-method-call-capture.expected.jsx
@@ -88,3 +88,6 @@ export default pattern((state: State) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-multiple-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-multiple-captures.expected.jsx
@@ -64,3 +64,6 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-nested-callback.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-nested-callback.expected.jsx
@@ -66,3 +66,6 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-nested-property.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-nested-property.expected.jsx
@@ -56,3 +56,6 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-nested.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-nested.expected.jsx
@@ -68,3 +68,7 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-no-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-no-captures.expected.jsx
@@ -24,3 +24,6 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-nullable-optional-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-nullable-optional-chain.expected.jsx
@@ -202,3 +202,10 @@ export default pattern((_) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfLift_4,
+    __cfLift_5
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-optional-chaining.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-optional-chaining.expected.jsx
@@ -74,3 +74,6 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-pattern-param-mixed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-pattern-param-mixed.expected.jsx
@@ -94,3 +94,6 @@ export default pattern((config: {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-pattern-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-pattern-param.expected.jsx
@@ -70,3 +70,6 @@ export default pattern((config: {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-pattern-typed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-pattern-typed.expected.jsx
@@ -59,3 +59,6 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-property-access-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-property-access-map.expected.jsx
@@ -208,3 +208,7 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-property-result.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-property-result.expected.jsx
@@ -64,3 +64,6 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-reserved-names.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-reserved-names.expected.jsx
@@ -52,3 +52,6 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-result-in-derive-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-result-in-derive-captures.expected.jsx
@@ -163,3 +163,7 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-result-property-in-return.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-result-property-in-return.expected.jsx
@@ -107,3 +107,7 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-template-literal-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-template-literal-capture.expected.jsx
@@ -97,3 +97,7 @@ export default pattern((__cf_pattern_input: {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-template-literal.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-template-literal.expected.jsx
@@ -51,3 +51,6 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-type-assertion.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-type-assertion.expected.jsx
@@ -52,3 +52,6 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-union-undefined.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-union-undefined.expected.jsx
@@ -78,3 +78,6 @@ export default pattern((config: Config) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-with-closed-over-cell-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-with-closed-over-cell-map.expected.jsx
@@ -97,3 +97,7 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1,
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/fetch-data-result-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/fetch-data-result-map.expected.jsx
@@ -102,3 +102,6 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/filter-basic.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/filter-basic.expected.jsx
@@ -172,3 +172,7 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1,
+    __cfPattern_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/filter-flatmap-fallback-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/filter-flatmap-fallback-chain.expected.jsx
@@ -184,3 +184,8 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1,
+    __cfPattern_2,
+    __cfPattern_3
+});

--- a/packages/ts-transformers/test/fixtures/closures/filter-flatmap-plain-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/filter-flatmap-plain-captures.expected.jsx
@@ -223,3 +223,9 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1,
+    __cfLift_2,
+    __cfPattern_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/filter-map-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/filter-map-chain.expected.jsx
@@ -239,3 +239,8 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1,
+    __cfLift_1,
+    __cfPattern_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/flatmap-basic.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/flatmap-basic.expected.jsx
@@ -138,3 +138,6 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/handler-basic.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-basic.expected.jsx
@@ -85,3 +85,6 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfHandler_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/handler-computed-key.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-computed-key.expected.jsx
@@ -93,3 +93,6 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfHandler_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/handler-destructured-params.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-destructured-params.expected.jsx
@@ -125,3 +125,6 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfHandler_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/handler-event-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-event-param.expected.jsx
@@ -112,3 +112,6 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfHandler_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/handler-existing-reference.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-existing-reference.expected.jsx
@@ -97,3 +97,6 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    existing
+});

--- a/packages/ts-transformers/test/fixtures/closures/handler-nested-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-nested-map.expected.jsx
@@ -115,3 +115,6 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfHandler_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/handler-no-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-no-captures.expected.jsx
@@ -70,3 +70,6 @@ export default pattern((_state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfHandler_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/handler-reserved-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-reserved-capture.expected.jsx
@@ -77,3 +77,6 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfHandler_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/handler-unused-event.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/handler-unused-event.expected.jsx
@@ -88,3 +88,6 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfHandler_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/helper-owned-handler-nested-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/helper-owned-handler-nested-captures.expected.jsx
@@ -163,3 +163,6 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfHandler_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/hoisted-handler-preserves-capture-schemas.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/hoisted-handler-preserves-capture-schemas.expected.jsx
@@ -229,6 +229,7 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
+    Item,
     __cfHandler_1,
     __cfHandler_2
 });

--- a/packages/ts-transformers/test/fixtures/closures/hoisted-handler-preserves-capture-schemas.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/hoisted-handler-preserves-capture-schemas.expected.jsx
@@ -228,3 +228,7 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfHandler_1,
+    __cfHandler_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/ifelse-factory-boundaries.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/ifelse-factory-boundaries.expected.jsx
@@ -304,3 +304,8 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1,
+    __cfLift_1,
+    __cfPattern_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/ifelse-factory-boundaries.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/ifelse-factory-boundaries.expected.jsx
@@ -305,6 +305,8 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
+    moduleHasSettings,
+    selectMessage,
     __cfPattern_1,
     __cfLift_1,
     __cfPattern_2

--- a/packages/ts-transformers/test/fixtures/closures/inline-action-in-ternary-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/inline-action-in-ternary-branch.expected.jsx
@@ -197,3 +197,7 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfHandler_1,
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-and-handler.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-and-handler.expected.jsx
@@ -307,3 +307,10 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfHandler_1,
+    __cfPattern_1,
+    __cfLift_2,
+    __cfLift_3
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-array-destructure-lowering.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-array-destructure-lowering.expected.jsx
@@ -123,3 +123,6 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-array-destructure-shorthand.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-array-destructure-shorthand.expected.jsx
@@ -174,3 +174,7 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1,
+    __cfPattern_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-array-destructured.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-array-destructured.expected.jsx
@@ -195,3 +195,7 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1,
+    __cfPattern_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-body-destructure-cases.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-body-destructure-cases.expected.jsx
@@ -262,3 +262,9 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1,
+    __cfLift_1,
+    __cfLift_2,
+    __cfPattern_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-callback-schema-params.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-callback-schema-params.expected.jsx
@@ -250,3 +250,8 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1,
+    __cfLift_1,
+    __cfPattern_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-cell-fn.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-cell-fn.expected.jsx
@@ -130,3 +130,6 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-cell-of.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-cell-of.expected.jsx
@@ -130,3 +130,6 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-cell-param-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-cell-param-no-name.expected.jsx
@@ -187,5 +187,6 @@ export default pattern((__cf_pattern_input: InputSchema) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
+    removeItem,
     __cfPattern_1
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-cell-param-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-cell-param-no-name.expected.jsx
@@ -186,3 +186,6 @@ export default pattern((__cf_pattern_input: InputSchema) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-cell-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-cell-param.expected.jsx
@@ -186,3 +186,6 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-cell-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-cell-param.expected.jsx
@@ -187,5 +187,6 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
+    removeItem,
     __cfPattern_1
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-derived-from-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-derived-from-param.expected.jsx
@@ -163,3 +163,7 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-mixed-reactivity.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-mixed-reactivity.expected.jsx
@@ -148,3 +148,6 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-object-literal.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-object-literal.expected.jsx
@@ -136,3 +136,6 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-writable-of.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-writable-of.expected.jsx
@@ -138,3 +138,6 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-cell-receiver-in-lift.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-cell-receiver-in-lift.expected.jsx
@@ -44,3 +44,6 @@ export const fn = lift(false as const satisfies __cfHelpers.JSONSchema, {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-computed-alias-side-effect.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-computed-alias-side-effect.expected.jsx
@@ -132,3 +132,7 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-computed-alias-with-plain-binding.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-computed-alias-with-plain-binding.expected.jsx
@@ -176,3 +176,8 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-computed-fallback-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-computed-fallback-alias.expected.jsx
@@ -279,3 +279,8 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1,
+    __cfPattern_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-conditional-expression.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-conditional-expression.expected.jsx
@@ -256,3 +256,8 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-conditional-inline-handler-send.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-conditional-inline-handler-send.expected.jsx
@@ -328,3 +328,8 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfHandler_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-conditional-inline-handler-send.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-conditional-inline-handler-send.expected.jsx
@@ -329,6 +329,7 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
+    castVote,
     __cfLift_1,
     __cfHandler_1,
     __cfPattern_1

--- a/packages/ts-transformers/test/fixtures/closures/map-destructure-alias-action-collision.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-destructure-alias-action-collision.expected.jsx
@@ -127,3 +127,6 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-destructured-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-destructured-alias.expected.jsx
@@ -169,3 +169,7 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-destructured-computed-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-destructured-computed-alias.expected.jsx
@@ -152,3 +152,7 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-destructured-numeric-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-destructured-numeric-alias.expected.jsx
@@ -114,3 +114,6 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-destructured-opaque-local-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-destructured-opaque-local-capture.expected.jsx
@@ -222,3 +222,7 @@ export default pattern((state) => ({
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1,
+    __cfPattern_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-destructured-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-destructured-param.expected.jsx
@@ -216,3 +216,8 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-destructured-string-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-destructured-string-alias.expected.jsx
@@ -114,3 +114,6 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-element-access-opaque.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-element-access-opaque.expected.jsx
@@ -169,3 +169,7 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-element-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-element-computed.expected.jsx
@@ -159,3 +159,7 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-handler-reference-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-handler-reference-no-name.expected.jsx
@@ -184,5 +184,6 @@ export default pattern((state: State) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
+    handleClick,
     __cfPattern_1
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-handler-reference-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-handler-reference-no-name.expected.jsx
@@ -183,3 +183,6 @@ export default pattern((state: State) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-handler-reference-with-type-arg-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-handler-reference-with-type-arg-no-name.expected.jsx
@@ -183,3 +183,6 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-handler-reference-with-type-arg-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-handler-reference-with-type-arg-no-name.expected.jsx
@@ -184,5 +184,6 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
+    handleClick,
     __cfPattern_1
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-handler-reference.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-handler-reference.expected.jsx
@@ -183,3 +183,6 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-handler-reference.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-handler-reference.expected.jsx
@@ -184,5 +184,6 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
+    handleClick,
     __cfPattern_1
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-import-reference.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-import-reference.expected.jsx
@@ -166,3 +166,7 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-index-param-used.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-index-param-used.expected.jsx
@@ -186,3 +186,7 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-index-shorthand.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-index-shorthand.expected.jsx
@@ -179,3 +179,7 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1,
+    __cfPattern_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-inline-fallback-receivers.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-inline-fallback-receivers.expected.jsx
@@ -311,3 +311,8 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1,
+    __cfPattern_2,
+    __cfPattern_3
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-inside-ifelse-with-handler.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-inside-ifelse-with-handler.expected.jsx
@@ -197,5 +197,6 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
+    removeItem,
     __cfPattern_1
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-inside-ifelse-with-handler.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-inside-ifelse-with-handler.expected.jsx
@@ -196,3 +196,6 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-jsx-map-filter-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-jsx-map-filter-chain.expected.jsx
@@ -190,3 +190,8 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1,
+    __cfPattern_2,
+    __cfPattern_3
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-local-helper-call-root.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-local-helper-call-root.expected.jsx
@@ -68,3 +68,7 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-multiple-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-multiple-captures.expected.jsx
@@ -234,3 +234,7 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-multiple-similar-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-multiple-similar-captures.expected.jsx
@@ -246,3 +246,7 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-nested-callback.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-nested-callback.expected.jsx
@@ -270,3 +270,7 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1,
+    __cfPattern_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-nested-property.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-nested-property.expected.jsx
@@ -186,3 +186,6 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-no-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-no-captures.expected.jsx
@@ -133,3 +133,6 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-outer-element.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-outer-element.expected.jsx
@@ -121,3 +121,6 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-parking-style-join.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-parking-style-join.expected.jsx
@@ -591,3 +591,12 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfLift_4,
+    __cfLift_5,
+    __cfLift_6,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-pattern-factory-result-key-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-pattern-factory-result-key-access.expected.jsx
@@ -198,5 +198,6 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
+    EntryRow,
     __cfPattern_1
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-pattern-factory-result-key-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-pattern-factory-result-key-access.expected.jsx
@@ -197,3 +197,6 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-plain-array-no-transform.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-plain-array-no-transform.expected.jsx
@@ -100,3 +100,6 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-alias-in-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-alias-in-computed.expected.jsx
@@ -265,3 +265,7 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-in-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-in-computed.expected.jsx
@@ -262,3 +262,7 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-receiver-key-lowering.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-receiver-key-lowering.expected.jsx
@@ -128,6 +128,7 @@ const _p = pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
+    _p,
     __cfPattern_1,
     __cfPattern_2
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-receiver-key-lowering.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-receiver-key-lowering.expected.jsx
@@ -127,3 +127,7 @@ const _p = pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1,
+    __cfPattern_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-receiver-method-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-receiver-method-roots.expected.jsx
@@ -158,3 +158,9 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1,
+    __cfLift_2,
+    __cfPattern_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-regains-reactive-aliases.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-regains-reactive-aliases.expected.jsx
@@ -397,6 +397,7 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
+    passthrough,
     __cfLift_1,
     __cfLift_2,
     __cfPattern_1,

--- a/packages/ts-transformers/test/fixtures/closures/map-regains-reactive-aliases.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-regains-reactive-aliases.expected.jsx
@@ -396,3 +396,22 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfPattern_1,
+    __cfLift_3,
+    __cfPattern_2,
+    __cfLift_4,
+    __cfPattern_3,
+    __cfLift_5,
+    __cfLift_6,
+    __cfPattern_4,
+    __cfPattern_5,
+    __cfLift_7,
+    __cfLift_8,
+    __cfPattern_6,
+    __cfLift_9,
+    __cfPattern_7,
+    __cfLift_10
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-root-fallback-wrappers.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-root-fallback-wrappers.expected.jsx
@@ -332,3 +332,11 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1,
+    __cfLift_2,
+    __cfPattern_2,
+    __cfLift_3,
+    __cfPattern_3
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-single-capture-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-single-capture-no-name.expected.jsx
@@ -178,3 +178,7 @@ export default pattern((state: State) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-single-capture-with-type-arg-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-single-capture-with-type-arg-no-name.expected.jsx
@@ -178,3 +178,7 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-single-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-single-capture.expected.jsx
@@ -178,3 +178,7 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-symbol-key-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-symbol-key-access.expected.jsx
@@ -106,3 +106,6 @@ const _p = pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-symbol-key-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-symbol-key-access.expected.jsx
@@ -107,5 +107,6 @@ const _p = pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
+    _p,
     __cfPattern_1
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-template-literal.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-template-literal.expected.jsx
@@ -211,3 +211,7 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-ternary-inside-nested-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-ternary-inside-nested-map.expected.jsx
@@ -362,3 +362,9 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfPattern_1,
+    __cfPattern_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-wish-default-handler-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-wish-default-handler-capture.expected.jsx
@@ -193,5 +193,6 @@ export default pattern((_) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
+    removeItem,
     __cfPattern_1
 });

--- a/packages/ts-transformers/test/fixtures/closures/map-wish-default-handler-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-wish-default-handler-capture.expected.jsx
@@ -192,3 +192,6 @@ export default pattern((_) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-with-array-param-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-with-array-param-no-name.expected.jsx
@@ -106,3 +106,6 @@ export default pattern((_state: any) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/map-with-array-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-with-array-param.expected.jsx
@@ -106,3 +106,6 @@ export default pattern((_state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/nested-computed-in-ifelse.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/nested-computed-in-ifelse.expected.jsx
@@ -142,3 +142,7 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/nested-map-fallback-receiver.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/nested-map-fallback-receiver.expected.jsx
@@ -367,3 +367,10 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfHandler_1,
+    __cfLift_1,
+    __cfHandler_2,
+    __cfPattern_1,
+    __cfPattern_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/pattern-computed-opaque-ref-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-computed-opaque-ref-map.expected.jsx
@@ -55,3 +55,6 @@ export default pattern((items) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/pattern-nested-jsx-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-nested-jsx-map.expected.jsx
@@ -334,3 +334,9 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfPattern_1,
+    __cfPattern_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/pattern-opaque-destructure-temporary-root-names.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-opaque-destructure-temporary-root-names.expected.jsx
@@ -88,3 +88,7 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2
+});

--- a/packages/ts-transformers/test/fixtures/closures/pattern-preserve-opaque-input.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-preserve-opaque-input.expected.jsx
@@ -103,3 +103,6 @@ export default pattern((input: Writable<State>) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/pattern-self-computed-destructure.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-self-computed-destructure.expected.jsx
@@ -38,3 +38,6 @@ const _p = pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    _p
+});

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-basic-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-basic-capture.expected.jsx
@@ -128,3 +128,7 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-local-var.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-local-var.expected.jsx
@@ -162,3 +162,9 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-multiple-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-multiple-captures.expected.jsx
@@ -110,3 +110,7 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-no-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-no-captures.expected.jsx
@@ -118,3 +118,7 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-with-existing-params.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-with-existing-params.expected.jsx
@@ -127,3 +127,7 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/unless-with-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/unless-with-map.expected.jsx
@@ -152,3 +152,6 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/when-with-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/when-with-map.expected.jsx
@@ -157,3 +157,6 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/writable-of-terminal-methods.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/writable-of-terminal-methods.expected.jsx
@@ -114,3 +114,6 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfHandler_1
+});

--- a/packages/ts-transformers/test/fixtures/handler-schema/array-cell-remove-intersection.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/array-cell-remove-intersection.expected.jsx
@@ -98,7 +98,3 @@ export { removeItem, removeItemAlias };
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
-__cfReg({
-    removeItem,
-    removeItemAlias
-});

--- a/packages/ts-transformers/test/fixtures/handler-schema/array-cell-remove-intersection.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/array-cell-remove-intersection.expected.jsx
@@ -98,3 +98,7 @@ export { removeItem, removeItemAlias };
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    removeItem,
+    removeItemAlias
+});

--- a/packages/ts-transformers/test/fixtures/handler-schema/complex-nested-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/complex-nested-types.expected.jsx
@@ -147,6 +147,5 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    userHandler,
     _updateTags
 });

--- a/packages/ts-transformers/test/fixtures/handler-schema/complex-nested-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/complex-nested-types.expected.jsx
@@ -146,3 +146,7 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    userHandler,
+    _updateTags
+});

--- a/packages/ts-transformers/test/fixtures/handler-schema/date-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/date-types.expected.jsx
@@ -47,3 +47,6 @@ export { timedHandler };
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    timedHandler
+});

--- a/packages/ts-transformers/test/fixtures/handler-schema/date-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/date-types.expected.jsx
@@ -47,6 +47,3 @@ export { timedHandler };
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
-__cfReg({
-    timedHandler
-});

--- a/packages/ts-transformers/test/fixtures/handler-schema/identity-only-handler-default-array.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/identity-only-handler-default-array.expected.jsx
@@ -60,3 +60,6 @@ export { removePiece };
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    removePiece
+});

--- a/packages/ts-transformers/test/fixtures/handler-schema/identity-only-handler-default-array.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/identity-only-handler-default-array.expected.jsx
@@ -60,6 +60,3 @@ export { removePiece };
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
-__cfReg({
-    removePiece
-});

--- a/packages/ts-transformers/test/fixtures/handler-schema/identity-only-handler-payload.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/identity-only-handler-payload.expected.jsx
@@ -83,3 +83,7 @@ export { addPiece, trackRecent };
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    addPiece,
+    trackRecent
+});

--- a/packages/ts-transformers/test/fixtures/handler-schema/identity-only-handler-payload.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/identity-only-handler-payload.expected.jsx
@@ -83,7 +83,3 @@ export { addPiece, trackRecent };
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
-__cfReg({
-    addPiece,
-    trackRecent
-});

--- a/packages/ts-transformers/test/fixtures/handler-schema/preserve-explicit-schemas-optional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/preserve-explicit-schemas-optional.expected.jsx
@@ -37,3 +37,6 @@ export { logHandler };
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    logHandler
+});

--- a/packages/ts-transformers/test/fixtures/handler-schema/preserve-explicit-schemas-optional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/preserve-explicit-schemas-optional.expected.jsx
@@ -37,6 +37,3 @@ export { logHandler };
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
-__cfReg({
-    logHandler
-});

--- a/packages/ts-transformers/test/fixtures/handler-schema/preserve-explicit-schemas.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/preserve-explicit-schemas.expected.jsx
@@ -37,3 +37,6 @@ export { logHandler };
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    logHandler
+});

--- a/packages/ts-transformers/test/fixtures/handler-schema/preserve-explicit-schemas.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/preserve-explicit-schemas.expected.jsx
@@ -37,6 +37,3 @@ export { logHandler };
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
-__cfReg({
-    logHandler
-});

--- a/packages/ts-transformers/test/fixtures/handler-schema/simple-handler-writable.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/simple-handler-writable.expected.jsx
@@ -45,6 +45,3 @@ export { myHandler };
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
-__cfReg({
-    myHandler
-});

--- a/packages/ts-transformers/test/fixtures/handler-schema/simple-handler-writable.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/simple-handler-writable.expected.jsx
@@ -45,3 +45,6 @@ export { myHandler };
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    myHandler
+});

--- a/packages/ts-transformers/test/fixtures/handler-schema/simple-handler.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/simple-handler.expected.jsx
@@ -45,6 +45,3 @@ export { myHandler };
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
-__cfReg({
-    myHandler
-});

--- a/packages/ts-transformers/test/fixtures/handler-schema/simple-handler.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/simple-handler.expected.jsx
@@ -45,3 +45,6 @@ export { myHandler };
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    myHandler
+});

--- a/packages/ts-transformers/test/fixtures/handler-schema/sqlite-db-handler-state.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/sqlite-db-handler-state.expected.jsx
@@ -46,3 +46,6 @@ export { writeNote };
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    writeNote
+});

--- a/packages/ts-transformers/test/fixtures/handler-schema/sqlite-db-handler-state.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/sqlite-db-handler-state.expected.jsx
@@ -46,6 +46,3 @@ export { writeNote };
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
-__cfReg({
-    writeNote
-});

--- a/packages/ts-transformers/test/fixtures/handler-schema/unsupported-intersection-index.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/unsupported-intersection-index.expected.jsx
@@ -46,6 +46,3 @@ export { removeItem };
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
-__cfReg({
-    removeItem
-});

--- a/packages/ts-transformers/test/fixtures/handler-schema/unsupported-intersection-index.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/handler-schema/unsupported-intersection-index.expected.jsx
@@ -46,3 +46,6 @@ export { removeItem };
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    removeItem
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/authored-ifelse-jsx-branches.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/authored-ifelse-jsx-branches.expected.jsx
@@ -207,3 +207,8 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1,
+    __cfLift_2
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/cell-get-in-ifelse-predicate.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/cell-get-in-ifelse-predicate.expected.jsx
@@ -109,3 +109,6 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/complex-expressions.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/complex-expressions.expected.jsx
@@ -123,3 +123,7 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/computed-boundary-nested-ternaries.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/computed-boundary-nested-ternaries.expected.jsx
@@ -125,3 +125,7 @@ export const AuthoredIfElse = pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/conditional-empty-check.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/conditional-empty-check.expected.jsx
@@ -95,3 +95,6 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/derived-property-access-with-derived-key.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/derived-property-access-with-derived-key.expected.jsx
@@ -528,3 +528,11 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfLift_4,
+    __cfPattern_1,
+    __cfPattern_2
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-both-opaque.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-both-opaque.expected.jsx
@@ -89,3 +89,6 @@ export default pattern((_state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-complex.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-complex.expected.jsx
@@ -875,3 +875,23 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfLift_4,
+    __cfLift_5,
+    __cfLift_6,
+    __cfLift_7,
+    __cfLift_8,
+    __cfLift_9,
+    __cfLift_10,
+    __cfLift_11,
+    __cfLift_12,
+    __cfLift_13,
+    __cfLift_14,
+    __cfLift_15,
+    __cfLift_16,
+    __cfLift_17,
+    __cfLift_18
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-simple.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-simple.expected.jsx
@@ -195,3 +195,8 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/filter-callback-local-consts.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/filter-callback-local-consts.expected.jsx
@@ -166,3 +166,8 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1,
+    __cfPattern_2
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/flatmap-callback-expression-statement.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/flatmap-callback-expression-statement.expected.jsx
@@ -149,3 +149,7 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-captures.expected.jsx
@@ -334,3 +334,11 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfHandler_1,
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfHandler_2,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-default-input-local-chain-map-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-default-input-local-chain-map-capture.expected.jsx
@@ -540,3 +540,12 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfHandler_1,
+    __cfHandler_2,
+    __cfLift_1,
+    __cfLift_2,
+    __cfHandler_3,
+    __cfHandler_4,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-filter-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-filter-capture.expected.jsx
@@ -286,3 +286,10 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfPattern_1,
+    __cfPattern_2
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-flatmap-fallback-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-flatmap-fallback-capture.expected.jsx
@@ -280,3 +280,9 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfPattern_1,
+    __cfPattern_2
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-capture.expected.jsx
@@ -235,3 +235,8 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-fallback-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-fallback-capture.expected.jsx
@@ -219,3 +219,7 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-local-initializer-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-local-initializer-captures.expected.jsx
@@ -419,3 +419,11 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfHandler_1,
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfHandler_2,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/ifelse-undefined-value.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/ifelse-undefined-value.expected.jsx
@@ -152,3 +152,7 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-arithmetic-operations.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-arithmetic-operations.expected.jsx
@@ -402,3 +402,17 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfLift_4,
+    __cfLift_5,
+    __cfLift_6,
+    __cfLift_7,
+    __cfLift_8,
+    __cfLift_9,
+    __cfLift_10,
+    __cfLift_11,
+    __cfLift_12
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-array-method-sink-calls.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-array-method-sink-calls.expected.jsx
@@ -224,3 +224,9 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfLift_4
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-complex-mixed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-complex-mixed.expected.jsx
@@ -582,3 +582,16 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfPattern_1,
+    __cfLift_4,
+    __cfLift_5,
+    __cfLift_6,
+    __cfLift_7,
+    __cfLift_8,
+    __cfLift_9,
+    __cfLift_10
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-conditional-rendering-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-conditional-rendering-no-name.expected.jsx
@@ -528,3 +528,16 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfLift_4,
+    __cfLift_5,
+    __cfLift_6,
+    __cfLift_7,
+    __cfLift_8,
+    __cfLift_9,
+    __cfLift_10,
+    __cfLift_11
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-conditional-rendering.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-conditional-rendering.expected.jsx
@@ -528,3 +528,16 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfLift_4,
+    __cfLift_5,
+    __cfLift_6,
+    __cfLift_7,
+    __cfLift_8,
+    __cfLift_9,
+    __cfLift_10,
+    __cfLift_11
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-direct-branch-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-direct-branch-roots.expected.jsx
@@ -190,3 +190,7 @@ export default pattern((state) => ({
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-filter-length-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-filter-length-roots.expected.jsx
@@ -174,3 +174,8 @@ export default pattern((state) => ({
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-function-calls.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-function-calls.expected.jsx
@@ -719,3 +719,29 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfLift_4,
+    __cfLift_5,
+    __cfLift_6,
+    __cfLift_7,
+    __cfLift_8,
+    __cfLift_9,
+    __cfLift_10,
+    __cfLift_11,
+    __cfLift_12,
+    __cfLift_13,
+    __cfLift_14,
+    __cfLift_15,
+    __cfLift_16,
+    __cfLift_17,
+    __cfLift_18,
+    __cfLift_19,
+    __cfLift_20,
+    __cfLift_21,
+    __cfLift_22,
+    __cfLift_23,
+    __cfLift_24
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-property-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-property-access.expected.jsx
@@ -613,3 +613,14 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfLift_4,
+    __cfLift_5,
+    __cfLift_6,
+    __cfLift_7,
+    __cfLift_8,
+    __cfLift_9
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-string-operations.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-string-operations.expected.jsx
@@ -417,3 +417,17 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfLift_4,
+    __cfLift_5,
+    __cfLift_6,
+    __cfLift_7,
+    __cfLift_8,
+    __cfLift_9,
+    __cfLift_10,
+    __cfLift_11,
+    __cfLift_12
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-wildcard-traversal-call-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-wildcard-traversal-call-roots.expected.jsx
@@ -237,3 +237,9 @@ export default pattern((state) => ({
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfLift_4
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-and-non-jsx.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-and-non-jsx.expected.jsx
@@ -166,3 +166,9 @@ export default pattern((_state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfLift_4
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-complex-expressions.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-complex-expressions.expected.jsx
@@ -148,3 +148,7 @@ export default pattern((_state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-mixed-and-or.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-mixed-and-or.expected.jsx
@@ -216,3 +216,10 @@ export default pattern((_state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfLift_4,
+    __cfLift_5
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-nullish-coalescing.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-nullish-coalescing.expected.jsx
@@ -177,3 +177,8 @@ export default pattern((_state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-or-unless.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-or-unless.expected.jsx
@@ -91,3 +91,6 @@ export default pattern((_state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-triple-and-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-triple-and-chain.expected.jsx
@@ -132,3 +132,7 @@ export default pattern((_state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-triple-or-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-triple-or-chain.expected.jsx
@@ -122,3 +122,7 @@ export default pattern((_state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-array-length-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-array-length-conditional.expected.jsx
@@ -124,3 +124,7 @@ export default pattern((_state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-aliased-const-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-aliased-const-computation.expected.jsx
@@ -143,3 +143,7 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-array-destructured-alias-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-array-destructured-alias-computation.expected.jsx
@@ -152,3 +152,7 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-direct-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-direct-alias.expected.jsx
@@ -122,3 +122,6 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-element-property-helper-comparison.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-element-property-helper-comparison.expected.jsx
@@ -293,3 +293,9 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-expression-statement.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-expression-statement.expected.jsx
@@ -150,3 +150,7 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-helper-call-over-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-helper-call-over-alias.expected.jsx
@@ -136,3 +136,7 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-local-consts.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-local-consts.expected.jsx
@@ -189,3 +189,8 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-aggregate-alias-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-aggregate-alias-computation.expected.jsx
@@ -153,3 +153,7 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-aggregate-plain-sibling-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-aggregate-plain-sibling-computation.expected.jsx
@@ -122,3 +122,6 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-destructured-alias-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-destructured-alias-computation.expected.jsx
@@ -143,3 +143,7 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-tuple-aggregate-alias-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-tuple-aggregate-alias-computation.expected.jsx
@@ -146,3 +146,7 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-nested-conditional-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-nested-conditional-no-name.expected.jsx
@@ -138,3 +138,6 @@ export default pattern((_state: any) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-nested-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-nested-conditional.expected.jsx
@@ -138,3 +138,6 @@ export default pattern((_state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-single-capture-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-single-capture-no-name.expected.jsx
@@ -147,3 +147,7 @@ export default pattern((_state: any) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-single-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-single-capture.expected.jsx
@@ -147,3 +147,7 @@ export default pattern((_state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/method-chains.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/method-chains.expected.jsx
@@ -1144,3 +1144,32 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfLift_4,
+    __cfPattern_1,
+    __cfLift_5,
+    __cfPattern_2,
+    __cfLift_6,
+    __cfLift_7,
+    __cfLift_8,
+    __cfLift_9,
+    __cfLift_10,
+    __cfPattern_3,
+    __cfLift_11,
+    __cfLift_12,
+    __cfLift_13,
+    __cfLift_14,
+    __cfLift_15,
+    __cfLift_16,
+    __cfLift_17,
+    __cfLift_18,
+    __cfPattern_4,
+    __cfLift_19,
+    __cfLift_20,
+    __cfLift_21,
+    __cfLift_22,
+    __cfLift_23
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-cell-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-cell-map.expected.jsx
@@ -293,6 +293,11 @@ export default pattern(() => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
+    SimplePattern,
+    createCellRef,
+    addCharmAndNavigate,
+    createSimplePattern,
+    goToCharm,
     __cfLift_1,
     __cfLift_2,
     __cfPattern_1

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-cell-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-cell-map.expected.jsx
@@ -292,3 +292,8 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-operations.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-operations.expected.jsx
@@ -106,3 +106,8 @@ export default pattern((_state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/optional-chain-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/optional-chain-captures.expected.jsx
@@ -179,3 +179,7 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/optional-element-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/optional-element-access.expected.jsx
@@ -103,3 +103,6 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/parameterized-inline-call-root.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/parameterized-inline-call-root.expected.jsx
@@ -87,3 +87,6 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/parent-suppression-edge.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/parent-suppression-edge.expected.jsx
@@ -962,3 +962,13 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfLift_4,
+    __cfLift_5,
+    __cfLift_6,
+    __cfLift_7,
+    __cfLift_8
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-statements-vs-jsx.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-statements-vs-jsx.expected.jsx
@@ -218,3 +218,9 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfLift_4
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-statements-vs-jsx.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-statements-vs-jsx.expected.jsx
@@ -219,6 +219,8 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
+    increment,
+    decrement,
     __cfLift_1,
     __cfLift_2,
     __cfLift_3,

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-vs-computed-logical-and.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-vs-computed-logical-and.expected.jsx
@@ -123,3 +123,6 @@ export const ComputedLogicalAnd = pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-with-cells.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-with-cells.expected.jsx
@@ -115,3 +115,7 @@ export default pattern((cell) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/safe-context-and-jsx.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/safe-context-and-jsx.expected.jsx
@@ -238,3 +238,7 @@ const MyHandler2 = handler({
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/safe-context-and-jsx.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/safe-context-and-jsx.expected.jsx
@@ -239,6 +239,8 @@ const MyHandler2 = handler({
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
+    MyHandler,
     __cfLift_1,
+    MyHandler2,
     __cfLift_2
 });

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-branch-ownership.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-branch-ownership.expected.jsx
@@ -337,3 +337,9 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-hoisted-compute-plain-map-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-hoisted-compute-plain-map-branch.expected.jsx
@@ -205,3 +205,7 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-pure-jsx-map-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-pure-jsx-map-branch.expected.jsx
@@ -167,3 +167,7 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/wrapped-element-binding-reads.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/wrapped-element-binding-reads.expected.jsx
@@ -230,3 +230,9 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/kitchensink/branch-lowered-capture-preservation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/branch-lowered-capture-preservation.expected.jsx
@@ -614,3 +614,12 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfLift_4,
+    __cfLift_5,
+    __cfLift_6,
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/kitchensink/branch-lowered-capture-preservation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/branch-lowered-capture-preservation.expected.jsx
@@ -615,6 +615,10 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
+    openNoteEditor,
+    openSettings,
+    toggleExpanded,
+    trashSubPiece,
     __cfLift_1,
     __cfLift_2,
     __cfLift_3,

--- a/packages/ts-transformers/test/fixtures/kitchensink/helper-owned-compute-branches.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/helper-owned-compute-branches.expected.jsx
@@ -468,3 +468,10 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfPattern_1,
+    __cfLift_4
+});

--- a/packages/ts-transformers/test/fixtures/kitchensink/nested-computed-output-maps.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/nested-computed-output-maps.expected.jsx
@@ -1007,6 +1007,8 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
+    jumpToComment,
+    passthroughLabels,
     __cfLift_1,
     __cfLift_2,
     __cfLift_3,

--- a/packages/ts-transformers/test/fixtures/kitchensink/nested-computed-output-maps.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/nested-computed-output-maps.expected.jsx
@@ -1006,3 +1006,18 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfLift_4,
+    __cfPattern_1,
+    __cfLift_5,
+    __cfLift_6,
+    __cfPattern_2,
+    __cfLift_7,
+    __cfLift_8,
+    __cfLift_9,
+    __cfPattern_3,
+    __cfPattern_4
+});

--- a/packages/ts-transformers/test/fixtures/kitchensink/nested-writable-pattern-branches.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/nested-writable-pattern-branches.expected.jsx
@@ -769,6 +769,7 @@ export default pattern((state) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
+    selectTask,
     __cfLift_1,
     __cfLift_2,
     __cfLift_3,

--- a/packages/ts-transformers/test/fixtures/kitchensink/nested-writable-pattern-branches.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/nested-writable-pattern-branches.expected.jsx
@@ -768,3 +768,12 @@ export default pattern((state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfLift_2,
+    __cfLift_3,
+    __cfPattern_1,
+    __cfPattern_2,
+    __cfLift_4,
+    __cfPattern_3
+});

--- a/packages/ts-transformers/test/fixtures/schema-injection/builder-input-full-shape-continuity.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/builder-input-full-shape-continuity.expected.jsx
@@ -148,3 +148,11 @@ export default __cfHelpers.__cf_data({
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    liftWrapped,
+    patternFullShape,
+    patternExplicit,
+    liftPassthrough,
+    patternHelper,
+    wildcardLift
+});

--- a/packages/ts-transformers/test/fixtures/schema-injection/builder-input-path-shrink.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/builder-input-path-shrink.expected.jsx
@@ -180,6 +180,13 @@ export default __cfHelpers.__cf_data({
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
+    liftOptional,
     __cfLift_1,
+    handlerObserved,
+    handlerExplicit,
+    liftInterprocedural,
+    liftWriteOnly,
+    liftExplicit,
+    actionPattern,
     __cfHandler_1
 });

--- a/packages/ts-transformers/test/fixtures/schema-injection/builder-input-path-shrink.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/builder-input-path-shrink.expected.jsx
@@ -179,3 +179,7 @@ export default __cfHelpers.__cf_data({
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1,
+    __cfHandler_1
+});

--- a/packages/ts-transformers/test/fixtures/schema-injection/capability-wrapper-narrowing.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/capability-wrapper-narrowing.expected.jsx
@@ -196,5 +196,12 @@ export { comparable, opaqueMap, pushOnly, readOnly, readWrite, setOnly, updateOn
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
+    readOnly,
+    setOnly,
+    updateOnly,
+    pushOnly,
+    readWrite,
+    comparable,
+    opaqueMap,
     __cfPattern_1
 });

--- a/packages/ts-transformers/test/fixtures/schema-injection/capability-wrapper-narrowing.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/capability-wrapper-narrowing.expected.jsx
@@ -196,12 +196,5 @@ export { comparable, opaqueMap, pushOnly, readOnly, readWrite, setOnly, updateOn
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
-    readOnly,
-    setOnly,
-    updateOnly,
-    pushOnly,
-    readWrite,
-    comparable,
-    opaqueMap,
     __cfPattern_1
 });

--- a/packages/ts-transformers/test/fixtures/schema-injection/capability-wrapper-narrowing.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/capability-wrapper-narrowing.expected.jsx
@@ -195,3 +195,6 @@ export { comparable, opaqueMap, pushOnly, readOnly, readWrite, setOnly, updateOn
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection-shorthand.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection-shorthand.expected.jsx
@@ -99,5 +99,6 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
+    liftSummary,
     __cfLift_1
 });

--- a/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection-shorthand.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection-shorthand.expected.jsx
@@ -98,3 +98,6 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection.expected.jsx
@@ -105,3 +105,6 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection.expected.jsx
@@ -106,5 +106,6 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
+    liftSummary,
     __cfLift_1
 });

--- a/packages/ts-transformers/test/fixtures/schema-injection/context-variations.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/context-variations.expected.jsx
@@ -75,3 +75,7 @@ __cfHardenFn(TestContextVariations);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    testPattern,
+    testHandler
+});

--- a/packages/ts-transformers/test/fixtures/schema-injection/db-query-consumer-decode.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/db-query-consumer-decode.expected.jsx
@@ -122,3 +122,6 @@ export default pattern(() => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    readAuthor
+});

--- a/packages/ts-transformers/test/fixtures/schema-injection/scoped-factory-assignment.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/scoped-factory-assignment.expected.jsx
@@ -86,3 +86,6 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    Child
+});

--- a/packages/ts-transformers/test/fixtures/schema-transform/boolean-result-schema-normalization.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/boolean-result-schema-normalization.expected.jsx
@@ -102,3 +102,6 @@ export default pattern((state: {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/schema-transform/cell-get-binding-autowrap.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/cell-get-binding-autowrap.expected.jsx
@@ -59,3 +59,6 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/schema-transform/nested-default-optional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/nested-default-optional.expected.jsx
@@ -168,3 +168,6 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    increment
+});

--- a/packages/ts-transformers/test/fixtures/schema-transform/opaque-ref-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/opaque-ref-map.expected.jsx
@@ -161,3 +161,7 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1,
+    __cfPattern_2
+});

--- a/packages/ts-transformers/test/fixtures/schema-transform/pattern-any-result-override.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/pattern-any-result-override.expected.jsx
@@ -79,3 +79,6 @@ export const TypedUIOutput = pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/schema-transform/pattern-explicit-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/pattern-explicit-types.expected.jsx
@@ -74,3 +74,6 @@ export default pattern((input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/schema-transform/pattern-with-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/pattern-with-types.expected.jsx
@@ -271,3 +271,6 @@ export default pattern((__cf_pattern_input) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfPattern_1
+});

--- a/packages/ts-transformers/test/fixtures/schema-transform/pattern-with-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/pattern-with-types.expected.jsx
@@ -272,5 +272,6 @@ export default pattern((__cf_pattern_input) => {
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
 __cfReg({
+    addItem,
     __cfPattern_1
 });

--- a/packages/ts-transformers/test/fixtures/schema-transform/reactive-array-element-access-schema.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/reactive-array-element-access-schema.expected.jsx
@@ -85,3 +85,6 @@ export default pattern((_state) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/schema-transform/with-opaque-ref.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/with-opaque-ref.expected.jsx
@@ -87,3 +87,6 @@ export default pattern((cell) => {
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});


### PR DESCRIPTION
## What

Makes every top-level builder artifact in a pattern module — `pattern`, `lift`, `handler` (and the synthetic hoists the transformer creates for `.map`/`.filter`/`.flatMap` ops, inline computeds, actions, etc.) — addressable by a content-addressed `{ identity, symbol }` reference, via a single transformer-emitted `__cfReg({ … })` registration call.

This is the **foundation PR** for CT-1623's "identify a pattern/lift/handler by `{ identity, symbol }`" work. It supersedes the export-the-hoist-then-re-parse-the-compiled-body approach (the `extractSyntheticPatternExports` smell): nothing parses source to discover hoists, and we stop overloading SES module *exports* as a proxy for "trusted, content-addressable top-level symbol." A follow-up PR consumes these refs to pass map/filter/flatMap `op` by identity instead of by embedded graph.

## How

**Transformer** appends one trailing call listing every hoisted artifact plus every authored *non-exported* top-level builder const:
```js
const helper = lift(...);            // authored, non-exported
const __cfPattern_1 = pattern(...);  // synthetic hoist (a .map op)
// …module body…
__cfReg({ helper, __cfPattern_1 });
```
- One trailing call (not per-hoist) keeps the verifier's obligation to "exactly one top-level `__cfReg`" and lets a run-once trap reject any injected duplicate.
- Authored consts are detected via `detectCallKind` (a direct builder *call* only), so an import/alias is never mis-attributed to this module's identity.

**`__cfReg` delivery** — it's the module factory's 4th parameter under the ESM loader (an identity-bound per-module registrar), and a no-op global on the legacy/AMD path (identity addressing is ESM-only). The registrar is **run-once** (2nd call throws), **window-closed** after the body returns (a captured closure can't register late), and **transactional** — entries are staged and committed only when the factory returns normally, so a throw leaves nothing behind.

**Runtime** — `registerHoistedValues` (PatternManager) consumes the registrations: only a genuine trusted builder artifact gets a ref (`isTrustedBuilderArtifact` — patterns brand as before; lift/handler/node-factories now brand in `createNodeFactory`). Forged `__cf_data` plain objects are dropped; cross-module forgery is already impossible since identity is a content hash. Adds the forward `valueToEntryRef` and reverse `hoistsByIdentity` index, plus public `patternFromIdentitySync` (a miss returns `undefined`; callers fall back).

**Verifier** — accepts exactly one top-level `__cfReg({ …shorthand top-level bindings })`; any other `__cfReg` use falls through to the existing unknown-identifier rejection. Defense-in-depth over the runtime trap.

## Two registration channels (by design)

- **Non-exported top-level + hoists → `__cfReg`.** These never reach the module namespace, so `__cfReg` is the only way to address them.
- **Exported artifacts → the module namespace**, addressable by their export name (the existing `registerEvaluatedModules` ref). This is *not* a source parse — it reads the live module interface — so it isn't the smell this PR removes.

Exported artifacts are intentionally **not** routed through `__cfReg`: TypeScript's CommonJS emit rewrites `export const foo = …` to `exports.foo = …` with no local `foo` binding, so a `{ foo }` shorthand would read `undefined`. Unifying them would mean rewriting authored `export const` to the split `const foo = …; export { foo }` form — invasive churn for no functional gain, since the namespace already gives exports a correct, canonical, parse-free ref. (Noted as an optional follow-up.)

## Testing

- `packages/runner` — **531 passed, 0 failed** (with type-check). New `cfreg-builder-identity.test.ts`: registrar run-once/closed-window/transactional unit tests; e2e proving pattern + lift hoists and an authored non-exported const are all addressable + round-trip; `compiled-module-verifier.test.ts`: accept one `__cfReg`, reject a second, reject an undeclared-binding `__cfReg`.
- `packages/ts-transformers` — **290 passed** (goldens regenerated: a trailing `__cfReg({…})`, no exports).
- `packages/generated-patterns` integration — **145/145** patterns pass end-to-end. Legacy/AMD path unaffected (no-op `__cfReg`).

## Notes

- TDZ guard: `createNodeFactory` brands at module-init inside the builder import cycle, where a top-level `const` brand set would be in its TDZ — held on a hoisted-function lazy `WeakSet` instead.
- Stacked: the map/filter/flatMap op-by-identity feature (#3903) will be reworked to consume this and drop its own `extractSyntheticPatternExports` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds content‑addressable references for top‑level builder artifacts via a single transformer‑emitted `__cfReg({ … })`, enabling `{ identity, symbol }` lookup without export parsing. Verifier‑gated with a fail‑closed registrar and a single reverse index with artifact‑generic APIs (CT‑1623).

- **New Features**
  - Transformer appends one trailing `__cfReg({ … })` listing all hoists plus authored non‑exported top‑level builder consts; exported artifacts (all forms) are excluded; keys are symbols, values are live bindings.
  - ESM loader passes a per‑module registrar as the factory’s 4th param; registrar is run‑once, closed‑window, and transactional; non‑approved modules get a rejecting registrar; AMD/legacy path keeps a no‑op `__cfReg`.
  - Verifier reports `{ hasHoistRegistration }`; engine grants the real registrar only to approved modules (trusted bodies grant it to all) and returns `registrationsByIdentity` in `EvaluateResult`.
  - `PatternManager` builds a forward `value → { identity, symbol }` map and a single reverse `identity → symbol → value` index populated from both `__cfReg` and exports; resolves via `artifactFromIdentitySync`.

- **Refactors**
  - Brand non‑pattern builders in `createNodeFactory`; `isTrustedBuilderArtifact` gates indexing and follows `unsafe_originalPattern` safely (fail‑closed on exotic values).
  - Reverse mappings overwrite on re‑eval to return the freshest artifact; `modulesByIdentity` now only caches whole namespaces.
  - API rename: `getPatternEntryRef` → `getArtifactEntryRef`; transformer export detection unwraps wrapped default exports (`(foo)`, `foo as …`, `foo satisfies …`, `<T>foo`) to keep exports out of `__cfReg`.

<sup>Written for commit 1ec8c651db791d90125bf6598f5acf5758355b10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

