### PR TITLE
test(toolshed): session-open auth helper sends an intentional number-array signature

### DIFF
--- a/packages/toolshed/routes/storage/memory/memory.test.ts
+++ b/packages/toolshed/routes/storage/memory/memory.test.ts
@@ -48,8 +48,13 @@ const createSessionOpenAuth = async (
   }
   return {
     invocation,
+    // Mirror the production producer: send the signature as an explicit number
+    // array (a plain `FabricValue`), not a raw `Uint8Array` that only survives
+    // the wire boundary via the encoder's lenient structural fallback.
+    // TODO(danfuzz): When the producer flips to sending a `FabricBytes`, update
+    // this helper to match.
     authorization: {
-      signature: signature.ok,
+      signature: Array.from(signature.ok),
     },
   };
 };
@@ -353,7 +358,9 @@ serialTest(
         ...auth,
         authorization: {
           ...auth.authorization,
-          signature: new FabricBytes(auth.authorization.signature),
+          signature: new FabricBytes(
+            Uint8Array.from(auth.authorization.signature),
+          ),
         },
       }));
 


### PR DESCRIPTION
## Summary

A prep PR (no-op on `main`) that the codec migration (#3900) needs.

The memory-route session tests build their own session-open auth via an inline `createSessionOpenAuth` helper, independent of the production producer. That helper sent the signature as a raw `Uint8Array` — which only survived the wire boundary via the encoder's lenient structural fallback (flattened to a numeric-keyed object that `toByteArray` happens to accept). That's the same accident the production producer was moved off of in #3902.

Under #3900's stricter codec encoder, encoding a raw `Uint8Array` correctly throws (`Cannot encode a Uint8Array instance: no applicable codec`), so `memory websocket negotiates a session` / `resumes a requested session id` fail. This makes the test helper send an explicit number array instead, mirroring the production producer.

### Changes
- `createSessionOpenAuth` helper now returns `signature: Array.from(signature.ok)` (with a `TODO(danfuzz)` to flip to `FabricBytes` when the producer does).
- The existing `FabricBytes`-signature test reconstructs a `Uint8Array` for the `FabricBytes` constructor, since the helper now yields a number array.

### Why a separate PR
The failure only manifests under #3900's strict encoder, but the fix is behaviorally a no-op on `main` (the number array decodes identically via `toByteArray`'s array branch). Landing it on its own keeps #3900 a clean data-model change; #3900 picks this up via `main`.

## Test plan
- `deno test` of the memory-route session suite passes on `main` (6/6, including the `FabricBytes` round-trip).
- `deno check` + `deno fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Performance Baseline

This PR just fixes a unit test file, so the following accounts for a spurious perf check failure:

NEW_PERF_BASELINE: subtest: pattern-unit-2/pattern-unit-tests > packages/patterns/cfc-staged-publish/main.test.tsx = 17s


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update memory-route session tests so the session-open auth helper sends `authorization.signature` as a number[] instead of a `Uint8Array`, matching production and avoiding codec errors under the stricter encoder. Updated the `FabricBytes` test to reconstruct a `Uint8Array` via `Uint8Array.from`; no behavior change on `main`.

<sup>Written for commit dac1129ffed5a8c71762b6f3b1ebe646faefbb8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

