### PR TITLE
Better rendering of `Symbol` and non-plain objects in `data-model/value-debug`.

### DIFF
--- a/packages/data-model/src/value-debug.ts
+++ b/packages/data-model/src/value-debug.ts
@@ -4,7 +4,11 @@
 
 import { isPlainObject } from "@commonfabric/utils/types";
 
-import { FabricInstance, FabricPrimitive } from "./interface.ts";
+import {
+  FabricInstance,
+  FabricPrimitive,
+  FabricSpecialObject,
+} from "./interface.ts";
 
 /**
  * Sentinel marker used to wrap content that should appear unquoted in the
@@ -121,14 +125,38 @@ class DebugStringifier {
         // be stringified with full fidelity via `JSON.stringify()`'s default
         // behavior).
 
-        if ((value !== null) && this.#circles.has(value)) {
+        if (value === null) {
+          // Let `JSON.stringify()` just render it directly as `"null"`.
+          return null;
+        } else if (this.#circles.has(value)) {
           if (this.#unusedCircles.has(value)) {
             this.#unusedCircles.delete(value);
             return value;
           }
           return marked("<circle>");
-        } else {
+        } else if (isPlainObject(value) || Array.isArray(value)) {
           return value;
+        }
+
+        // Non-plain object.
+
+        const className =
+          (value as { constructor?: { name?: string } }).constructor?.name ??
+            "<anonymous>";
+
+        if (value instanceof FabricSpecialObject) {
+          // The slash here is to suggest that what we're rendering is a known
+          // encodable type, and not just an instance of some random class.
+          // TODO(danfuzz): This should get fancier/smarter once the new "codec"
+          // work lands in `data-model`.
+          const fullTag = (value as { wireTypeTag?: string }).wireTypeTag ??
+            className;
+          const tag = fullTag.replace(/@.*$/, "");
+          return marked(`/${tag}(...)`);
+        } else {
+          // Non-plain non-fabric object. Punt on attempting to render the
+          // innards.
+          return marked(`new ${className}(...)`);
         }
       }
 

--- a/packages/data-model/src/value-debug.ts
+++ b/packages/data-model/src/value-debug.ts
@@ -120,11 +120,6 @@ class DebugStringifier {
       }
 
       case "object": {
-        // TODO(danfuzz): This case will have to get smarter once we have
-        // `FabricSpecialObject`s flowing through the system (which generally cannot
-        // be stringified with full fidelity via `JSON.stringify()`'s default
-        // behavior).
-
         if (value === null) {
           // Let `JSON.stringify()` just render it directly as `"null"`.
           return null;

--- a/packages/data-model/src/value-debug.ts
+++ b/packages/data-model/src/value-debug.ts
@@ -134,11 +134,18 @@ class DebugStringifier {
 
       case "symbol": {
         const key = Symbol.keyFor(value);
-        return marked(
-          (key === undefined)
-            ? `Symbol(${JSON.stringify(value.description ?? "")})`
-            : `Symbol.for(${JSON.stringify(key)})`,
-        );
+        if (key === undefined) {
+          // Uninterned ("unique") symbol.
+          const description = value.description;
+          return marked(
+            (description === undefined)
+              ? "Symbol()"
+              : `Symbol(${JSON.stringify(description)})`,
+          );
+        } else {
+          // Interned symbol.
+          return marked(`Symbol.for(${JSON.stringify(key)})`);
+        }
       }
 
       case "undefined": {

--- a/packages/data-model/test/value-debug.test.ts
+++ b/packages/data-model/test/value-debug.test.ts
@@ -131,7 +131,11 @@ describe("value-debug", () => {
     });
 
     it("renders an uninterned symbol with no description", () => {
-      expect(toCompactDebugString(Symbol())).toBe('Symbol("")');
+      expect(toCompactDebugString(Symbol())).toBe("Symbol()");
+    });
+
+    it('renders an uninterned symbol with description `""` (empty string)', () => {
+      expect(toCompactDebugString(Symbol(""))).toBe('Symbol("")');
     });
 
     it("renders an uninterned symbol inside a structure", () => {

--- a/packages/data-model/test/value-debug.test.ts
+++ b/packages/data-model/test/value-debug.test.ts
@@ -115,6 +115,21 @@ describe("value-debug", () => {
       expect(toCompactDebugString(anon)).toBe("(...) => {...}");
     });
 
+    it("renders a `FabricInstance` in `/Name` form", () => {
+      const inst = FabricError.fromNativeError(new Error("eek!"));
+      expect(toCompactDebugString(inst)).toBe("/Error(...)");
+    });
+
+    it("renders a `FabricPrimive` in `/Name` form", () => {
+      const inst = new FabricEpochNsec(123456789n);
+      expect(toCompactDebugString(inst)).toBe("/EpochNsec(...)");
+    });
+
+    it("renders a non-plain non-fabric objectg in `new Name` form", () => {
+      const inst = new Set();
+      expect(toCompactDebugString(inst)).toBe("new Set(...)");
+    });
+
     it('renders an interned symbol as `Symbol.for("name")`', () => {
       const s = Symbol.for("my-key");
       expect(toCompactDebugString(s)).toBe('Symbol.for("my-key")');


### PR DESCRIPTION
This PR makes a couple improvements in the `data-model`'s debug-stringification code:

* It fixes the `description === undefined` case of `Symbol` rendering.
* It adds special handling for non-plain objects:
  * `FabricSpecialObject` gets a form that suggests the encoded form (though with innards still missing).
  * Other non-plain objects render as `new ClassName(...)` with the ASCII ellipsis literally there (because there's no generic way to successfully deconstruct an arbitrary non-plain object).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improved debug stringification in `data-model/value-debug` to render `Symbol`s and non-plain objects more clearly. This makes logs easier to read and avoids misleading output.

- **New Features**
  - `FabricSpecialObject` now renders as `/Tag(...)`.
  - Other non-plain objects render as `new ClassName(...)`.

- **Bug Fixes**
  - Uninterned `Symbol` with no description now renders as `Symbol()`.

<sup>Written for commit 83fd12eb67357e59dcf30ef5979826c7c9b071e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

