### PR TITLE
fix(memory): convert native values to fabric at the wire boundary

### DIFF
--- a/packages/memory/test/v2-test.ts
+++ b/packages/memory/test/v2-test.ts
@@ -5,6 +5,10 @@ import {
   setModernCellRepConfig,
 } from "@commonfabric/data-model/cell-rep";
 import {
+  FabricBytes,
+  FabricEpochNsec,
+} from "@commonfabric/data-model/fabric-primitives";
+import {
   compatibleMemoryProtocolFlags,
   decodeMemoryBoundary,
   DEFAULT_BRANCH,
@@ -223,5 +227,47 @@ describe("memory v2 boundary decode", () => {
       decoded.value.nested.count = 2;
     }, TypeError);
     assertEquals(decoded.value.nested.count, 1);
+  });
+});
+
+describe("memory v2 boundary encode", () => {
+  // Native values must be converted to `FabricValue`s before serialization, so
+  // they survive the wire boundary faithfully rather than being flattened to
+  // `{}` by the encoder's structural fallthrough.
+  it("converts a native `Date` to a round-trippable `FabricEpochNsec`", () => {
+    const date = new Date("2024-01-01T00:00:00Z");
+    const wire = encodeMemoryBoundary({ when: date });
+
+    // Proper tagged form, not a mangled `{}`.
+    assert(
+      wire.includes("EpochNsec"),
+      `expected an EpochNsec-tagged wire form, got: ${wire}`,
+    );
+
+    const decoded = decodeMemoryBoundary<{ when: FabricEpochNsec }>(wire);
+    assert(
+      decoded.when instanceof FabricEpochNsec,
+      `expected a FabricEpochNsec, got: ${decoded.when}`,
+    );
+    assertEquals(decoded.when.value, BigInt(date.getTime()) * 1_000_000n);
+  });
+
+  it("converts a native `Uint8Array` to a round-trippable `FabricBytes`", () => {
+    const bytes = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+    const decoded = decodeMemoryBoundary<{ sig: FabricBytes }>(
+      encodeMemoryBoundary({ sig: bytes }),
+    );
+    assert(
+      decoded.sig instanceof FabricBytes,
+      `expected a FabricBytes, got: ${decoded.sig}`,
+    );
+    assertEquals(decoded.sig.slice(), bytes);
+  });
+
+  it("leaves plain JSON values unchanged", () => {
+    const wire = encodeMemoryBoundary({ a: [1, "two", { three: 3 }, true] });
+    assertEquals(decodeMemoryBoundary(wire), {
+      a: [1, "two", { three: 3 }, true],
+    });
   });
 });

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -3,6 +3,7 @@ import {
   jsonFromValue,
   valueFromJson,
 } from "@commonfabric/data-model/json-wire";
+import { fabricFromNativeValue } from "@commonfabric/data-model/fabric-value";
 import { internPathSelector } from "@commonfabric/data-model/schema-utils";
 import type { FabricValue, SchemaPathSelector } from "./interface.ts";
 import { EmptyReconstructionContext } from "@commonfabric/data-model/wire-common";
@@ -582,8 +583,15 @@ export const wireMemoryProtocolFlags = (
   persistentSchedulerState: flags.persistentSchedulerState,
 });
 
+/**
+ * Encodes a value for transmission across the memory wire boundary. Native
+ * values are first converted to `FabricValue`s (e.g. a `Date` becomes a
+ * `FabricEpochNsec`, a `Uint8Array` a `FabricBytes`) so they serialize
+ * faithfully, rather than being lost to the encoder's structural object/array
+ * fallthrough (which silently flattens an unrecognized instance to `{}`).
+ */
 export const encodeMemoryBoundary = (value: unknown): string =>
-  jsonFromValue(value as FabricValue);
+  jsonFromValue(fabricFromNativeValue(value));
 
 export const decodeMemoryBoundary = <Value = FabricValue>(
   source: string,


### PR DESCRIPTION
## Summary

A prep PR (fixes a latent `main` bug; also unblocks the codec migration #3900).

`encodeMemoryBoundary` cast its input straight to `FabricValue` and serialized it. Native values that aren't already `FabricValue`s — a `Date`, a `Uint8Array`, etc. — fell through the encoder's structural object/array fallback and were **silently mangled**: an unrecognized instance flattens to an empty `{}` (total data loss). The most common real case: a cell holding a `Date` (`Cell.of(new Date(...))`).

The fix converts native values via `fabricFromNativeValue()` before serializing, so a `Date` becomes a `FabricEpochNsec`, a `Uint8Array` a `FabricBytes`, etc. — proper tagged wire forms that round-trip faithfully.

### Why now / relation to #3900

The codec migration (#3900) replaces the lenient encoder with a strict one that **correctly throws** on an unconverted native instance (`Cannot encode a Date instance: no applicable codec`) instead of mangling it. Without this fix, #3900 regresses any cell holding a `Date`: I bisected a `runner` test failure (`cell-static-methods.test.ts`, the `Cell.of(new Date())` case) to exactly this — `main` passes (mangles the Date to `{}`), #3900 fails (the deferred write's encode throws inside the async storage flush and surfaces at teardown as a dangling `memory client closed` / `cfc-relevant-transaction-not-prepared` rejection). Applying this fix on #3900 makes that test pass.

It's a strict improvement on `main` too — Dates were being silently lost there.

The signature path is unaffected: post-#3902 the session-open signature is already a plain number array, which `fabricFromNativeValue` leaves untouched (it does **not** become a `FabricBytes`), so `toByteArray` still decodes it.

## Test plan

- New `memory v2 boundary encode` tests: a native `Date` → round-trippable `FabricEpochNsec` (proper `EpochNsec` tag, not `{}`); a native `Uint8Array` → round-trippable `FabricBytes`; plain JSON unchanged.
- Full `packages/memory` suite green (166 passed); `deno check` clean.
- Regression check: toolshed memory-route session tests (signature round-trip, incl. `FabricBytes`) all pass — the number-array signature flows through unchanged.
- Validated against the strict encoder: temporarily applying this fix on #3900 makes `cell-static-methods.test.ts` pass (1/77).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes memory boundary encoding by converting native values (e.g., Date, Uint8Array) to Fabric types before serialization so they round-trip correctly instead of flattening to {}. Prevents data loss and keeps `packages/memory` compatible with the stricter codec.

- **Bug Fixes**
  - `encodeMemoryBoundary()` now applies `fabricFromNativeValue()` before `jsonFromValue()` to produce tagged forms like `FabricEpochNsec` and `FabricBytes`.
  - Added tests for Date and Uint8Array round-trips; plain JSON remains unchanged.

<sup>Written for commit cb6f6fcb867f587daf7b905adaf338a4c470f007. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

