### PR TITLE
fix(memory): stop sibling-field over-dirty causing reload re-runs (CT-1623)

### DIFF
--- a/packages/memory/v2/engine.ts
+++ b/packages/memory/v2/engine.ts
@@ -3803,6 +3803,39 @@ const touchedPathsForPatch = (patch: PatchOp): string[][] => {
   }
 };
 
+// Scheduler reader-dirty propagation uses the EXACT changed leaf paths, not the
+// ancestor/parent paths that `touchedPathsForPatch` adds for add/remove/move.
+//
+// `touchedPathsForPatch` emits a patch's parent path so that whole-container
+// reads are invalidated when a key is added/removed. For the scheduler reader
+// index that parent path is both REDUNDANT and HARMFUL:
+//   - Redundant: `schedulerPathsOverlap` matches a reader of the container
+//     (e.g. read `["value"]`, deep or shallow) against the LEAF write
+//     (e.g. `["value","plusOne"]`) via its bidirectional / length+1 rules, so
+//     shape/whole-object readers are already dirtied by the leaf alone.
+//   - Harmful: the parent write (e.g. `["value"]`) ALSO prefix-matches every
+//     SIBLING reader (`["value","doubled"]`, ...), whose value did not change.
+//     Unlike the in-memory `determineTriggeredActions` (which deep-equals each
+//     read path), the server-side match is purely structural, so those siblings
+//     are marked dirty in `scheduler_action_state` even though they are
+//     unchanged. On reload they rehydrate-as-dirty and re-run — the dominant
+//     residual reload re-run for patterns whose computeds write sibling fields
+//     of a shared result cell (CT-1623).
+// Emitting only the leaf paths keeps every correct match and drops the spurious
+// sibling dirtying.
+const schedulerTouchedLeafPathsForPatch = (patch: PatchOp): string[][] => {
+  switch (patch.op) {
+    case "replace":
+    case "splice":
+      return [parsePointer(patch.path)];
+    case "add":
+    case "remove":
+      return [parsePointer(patch.path)];
+    case "move":
+      return [parsePointer(patch.from), parsePointer(patch.path)];
+  }
+};
+
 const schedulerWriteAddressesForRevisions = (
   space: string,
   revisions: readonly AppliedRevision[],
@@ -3810,7 +3843,7 @@ const schedulerWriteAddressesForRevisions = (
   const writes = new Map<string, SchedulerObservationAddress>();
   for (const revision of revisions) {
     const paths = revision.op === "patch" && revision.patches
-      ? revision.patches.flatMap(touchedPathsForPatch)
+      ? revision.patches.flatMap(schedulerTouchedLeafPathsForPatch)
       : [[]];
     for (const path of paths) {
       const write = normalizeSchedulerAddress({

--- a/packages/runner/test/reload-sibling-overdirty.test.ts
+++ b/packages/runner/test/reload-sibling-overdirty.test.ts
@@ -1,0 +1,157 @@
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import {
+  getLogger,
+  getLoggerCountsBreakdown,
+} from "@commonfabric/utils/logger";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+import { Runtime } from "../src/runtime.ts";
+
+// CT-1623 reload re-run regression guard: sibling-field over-dirty.
+//
+// A pattern whose computeds write SIBLING fields of the same result cell
+// (doubled, plusOne, label) used to persist the up-chain computeds with a
+// spurious server-side `directDirtySeq`, so on reload they rehydrated-as-dirty
+// and RE-RAN even though their inputs were unchanged.
+//
+// Root cause (packages/memory/v2/engine.ts): when a computed FIRST writes its
+// output field, the JSON patch is an `add`, and `touchedPathsForPatch` emits the
+// PARENT container path (e.g. `["value"]`) in addition to the leaf
+// (`["value","plusOne"]`). The server-side scheduler reader index matches that
+// parent write against EVERY sibling reader by path prefix — with no per-field
+// value comparison (unlike the in-memory `determineTriggeredActions`, which
+// deep-equals) — so unchanged siblings are persisted dirty and re-run on reload.
+// The fix makes the scheduler write-address extraction use leaf-only paths
+// (`schedulerTouchedLeafPathsForPatch`); the leaf already matches whole-object /
+// shape readers via `schedulerPathsOverlap`, so the parent path was redundant
+// and only caused the spurious sibling dirtying.
+//
+// This guard asserts the chained computeds persist CLEAN (no directDirtySeq) and
+// rehydrate without misses on reload. Before the fix the first two persisted
+// with directDirtySeq set. Harness note (see reload-rehydration.test.ts): keep
+// runtime A's StorageManager open for B; quiesce A with scheduler.dispose().
+
+const signer = await Identity.fromPassphrase("reload sibling overdirty guard");
+const space = signer.did();
+
+// dbl -> plusOne -> label, all writing sibling fields of the one result cell.
+const PROGRAM: RuntimeProgram = {
+  main: "/main.tsx",
+  files: [{
+    name: "/main.tsx",
+    contents: [
+      "import { pattern, computed, lift } from 'commonfabric';",
+      "const dbl = lift((n: number) => n * 2);",
+      "export default pattern<{ value: number }>(({ value }) => {",
+      "  const doubled = dbl(value);",
+      "  const plusOne = computed(() => (doubled as any) + 1);",
+      "  const label = computed(() => 'v=' + (plusOne as any));",
+      "  return { doubled, plusOne, label };",
+      "});",
+    ].join("\n"),
+  }],
+};
+
+function newRuntime(sm: ReturnType<typeof StorageManager.emulate>) {
+  return new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager: sm,
+    experimental: { persistentSchedulerState: true, esmModuleLoader: true },
+  });
+}
+
+async function mainTsxSnapshots(runtime: Runtime) {
+  const provider = runtime.storageManager.open(space) as {
+    listSchedulerActionSnapshots?: (
+      q: Record<string, unknown>,
+    ) => Promise<{
+      snapshots: {
+        directDirtySeq?: number;
+        staleSeq?: number;
+        observation: { actionId?: string };
+      }[];
+    }>;
+  };
+  const res = await provider.listSchedulerActionSnapshots!({
+    ownerSpace: space,
+    limit: 1000,
+  });
+  return res.snapshots.filter((s) =>
+    (s.observation.actionId ?? "").includes("main.tsx")
+  );
+}
+
+function rehydrationCounts() {
+  const b = getLoggerCountsBreakdown().scheduler ?? {};
+  const get = (k: string) =>
+    (b as Record<string, { total?: number }>)[k]?.total ?? 0;
+  return {
+    ok: get("rehydrate/ok"),
+    missNoSnapshot: get("rehydrate/miss/no-snapshot"),
+  };
+}
+
+Deno.test("reload: sibling-field computeds persist clean and do not re-run", async () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+
+  // CREATE (runtime A).
+  const runtimeA = newRuntime(storageManager);
+  const compiledA = await runtimeA.patternManager.compilePattern(PROGRAM);
+  const tx0 = runtimeA.edit();
+  const resultCellA = runtimeA.getCell<any>(space, "so-result", undefined, tx0);
+  const handleA = runtimeA.run(tx0, compiledA, { value: 5 }, resultCellA);
+  await tx0.commit();
+  for (let k = 0; k < 8; k++) {
+    await handleA.pull();
+    await runtimeA.idle();
+  }
+  await runtimeA.storageManager.synced();
+  expect(resultCellA.getAsQueryResult()).toEqual({
+    doubled: 10,
+    plusOne: 11,
+    label: "v=11",
+  });
+
+  // All three computeds persisted; NONE should carry a spurious dirty/stale seq.
+  // (Before the fix, dbl + plusOne persisted with directDirtySeq set.)
+  const snaps = await mainTsxSnapshots(runtimeA);
+  expect(snaps.length).toBe(3);
+  for (const s of snaps) {
+    expect(s.directDirtySeq).toBeUndefined();
+    expect(s.staleSeq).toBeUndefined();
+  }
+
+  runtimeA.scheduler.dispose();
+  getLogger("scheduler").resetCounts();
+
+  // RELOAD (runtime B, same storage). The computeds rehydrate; none miss.
+  const runtimeB = newRuntime(storageManager);
+  try {
+    const compiledB = await runtimeB.patternManager.compilePattern(PROGRAM);
+    const tx = runtimeB.edit();
+    const resultCellB = runtimeB.getCell<any>(
+      space,
+      "so-result",
+      undefined,
+      tx,
+    );
+    const handleB = runtimeB.run(tx, compiledB, { value: 5 }, resultCellB);
+    await tx.commit();
+    for (let k = 0; k < 8; k++) {
+      await handleB.pull();
+      await runtimeB.idle();
+    }
+    expect(resultCellB.getAsQueryResult()).toEqual({
+      doubled: 10,
+      plusOne: 11,
+      label: "v=11",
+    });
+  } finally {
+    await runtimeB.dispose();
+  }
+
+  const reload = rehydrationCounts();
+  expect(reload.ok).toBeGreaterThan(0);
+  expect(reload.missNoSnapshot).toBe(0);
+});


### PR DESCRIPTION
## Problem

With persistent scheduler state, computeds that rehydrate **cleanly** on reload were re-running anyway — the dominant residual reload re-run after the CT-1623 `awaitSync` (#3886) and by-identity (#3892/#3898) work. They dominate the ~45–50 actions that re-execute per default-app notebook reload despite having a valid persisted observation.

## Root cause — server-side scheduler dirty propagation over-dirties siblings

When a pattern's computeds write **sibling fields of the same result cell** (e.g. `{doubled, plusOne, label}`), each field's first write is a JSON `add`. `touchedPathsForPatch` emits the **parent container path** (`["value"]`) alongside the changed leaf (`["value","plusOne"]`). At commit, `markSchedulerReadersDirtyForWrites` → `findSchedulerReadersForWrite` matches those paths against the scheduler read index via `schedulerPathsOverlap` — **purely structural prefix matching, with no per-field value comparison** (unlike the in-memory `determineTriggeredActions`, which deep-equals). So the parent `["value"]` write prefix-matches **every sibling reader** and marks them dirty in `scheduler_action_state`, even though their value never changed.

Each writer's own clean observation (`upsertSchedulerActionState`) clears only **its own** `direct_dirty_seq`, so the field written *last* in a commit ends clean but its up-chain siblings stay persisted-dirty. On reload, `rehydrateActionFromObservation` sees `directDirtySeq` and re-runs them.

This is **invisible at runtime** (the in-memory scheduler deep-equals and never re-runs the siblings); it only corrupts the **persisted** dirty state → reload.

## Fix

`schedulerWriteAddressesForRevisions` now uses a scheduler-specific **leaf-only** path extraction (`schedulerTouchedLeafPathsForPatch`) instead of `touchedPathsForPatch`. The parent path is **redundant** for the scheduler reader index — `schedulerPathsOverlap` already matches whole-object and shallow/shape readers (read `["value"]`) against the leaf write (`["value","plusOne"]`) via its bidirectional / `length+1` rules — so dropping it keeps every correct match and removes only the spurious sibling dirtying.

`touchedPathsForPatch` itself is untouched (its other caller, `patchOverlapsRead`, is unaffected). Only the persisted server-side dirty is narrowed; runtime reactivity is unchanged.

## Tests

`packages/runner/test/reload-sibling-overdirty.test.ts` (red before / green after, confirmed by stashing the fix): chained computeds writing sibling fields of one result cell persist **clean** (no `directDirtySeq`) and do **not** re-run on reload (`ok>0, missNoSnapshot=0`).

Validated locally with no under-dirtying — 246 tests across the full memory suite (incl. `v2-scheduler-state` reader-dirty propagation + cross-space dirty) and runner scheduler / `scheduler-pull-array` / `scheduler-pull-references` / observations / reactivity / reload / identity / pattern-eval suites.

## Caveats

- Not yet browser-validated for the exact reload re-run delta. The mechanism matches the notebook computed shape (sibling fields of a shared result cell on first run) that dominates the residual; a before/after `integration:reload` would quantify it.
- Addresses the `add`-parent-path over-dirty only. Other residual reload re-run classes (data-arrival-during-settle "reach", `$UI`/link-id churn) are separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes server-side scheduler over-dirtying that caused clean computeds to re-run after reload. Switches to leaf-only path matching so sibling fields aren’t marked dirty, reducing reload re-runs (CT-1623).

- **Bug Fixes**
  - `schedulerWriteAddressesForRevisions` now uses leaf-only paths via `schedulerTouchedLeafPathsForPatch` instead of `touchedPathsForPatch`.
  - Drops parent container paths from scheduler matching; `schedulerPathsOverlap` still dirties whole-object/shape readers from the leaf.
  - Narrows only persisted dirty state; runtime reactivity is unchanged.
  - Adds `packages/runner/test/reload-sibling-overdirty.test.ts` to verify no `directDirtySeq`/`staleSeq` persist and no reload misses.

<sup>Written for commit 90b3da496b7748529c9465b4ba50cf33782f67dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

