### PR TITLE
fix(runner): treat FabricPrimitives as atomic in the write path (FabricInstance→FabricSpecialObject)

### DIFF
--- a/packages/data-model/src/fabric-value.ts
+++ b/packages/data-model/src/fabric-value.ts
@@ -7,6 +7,7 @@ export {
   type FabricNativeObject,
   type FabricObject,
   FabricPrimitive,
+  FabricSpecialObject,
   type FabricValue,
   type FabricValueLayer,
 } from "./interface.ts";

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -7,6 +7,7 @@ import {
 import {
   cloneIfNecessary,
   FabricInstance,
+  FabricSpecialObject,
   type FabricValue,
   shallowFabricFromNativeValue,
 } from "@commonfabric/data-model/fabric-value";
@@ -2556,18 +2557,23 @@ export function recursivelyAddIDIfNeeded<T>(
   // - Sparse arrays (holes preserved)
   const converted = shallowFabricFromNativeValue(value);
 
-  // `FabricInstance` returned by the conversion step (e.g. `FabricError`
-  // wrapping a native `Error`). Same handling as the up-front
-  // `FabricInstance` branch above: record identity, walk via
-  // `[DECONSTRUCT]()` for side effects, return the instance unchanged.
-  if (converted instanceof FabricInstance) {
+  // A `FabricSpecialObject` returned by the conversion step (e.g. `FabricError`
+  // wrapping a native `Error`, or `FabricEpochNsec` wrapping a native `Date`).
+  // These are atomic fabric values and must be returned unchanged rather than
+  // walked as records (their state is private, so the record branch below would
+  // flatten them to `{}`). Only `FabricInstance`s carry nested `FabricValue`s
+  // that need `[ID]` assignment via `[DECONSTRUCT]()`; `FabricPrimitive`s are
+  // leaves.
+  if (converted instanceof FabricSpecialObject) {
     seen.set(value, converted);
 
-    // See above in re this cast.
-    const deconstructable = converted as unknown as FabricDeconstructable;
-    const state = deconstructable[DECONSTRUCT]();
-    if (isRecord(state) || Array.isArray(state)) {
-      recursivelyAddIDIfNeeded(state, frame, seen);
+    if (converted instanceof FabricInstance) {
+      // See above in re this cast.
+      const deconstructable = converted as unknown as FabricDeconstructable;
+      const state = deconstructable[DECONSTRUCT]();
+      if (isRecord(state) || Array.isArray(state)) {
+        recursivelyAddIDIfNeeded(state, frame, seen);
+      }
     }
     return converted as T;
   }
@@ -2600,9 +2606,13 @@ export function recursivelyAddIDIfNeeded<T>(
 
     sourceArray.forEach((el, i) => {
       const v = recursivelyAddIDIfNeeded(el, frame, seen);
-      // For objects on arrays only: Add ID if not already present.
+      // For objects on arrays only: Add ID if not already present. A
+      // `FabricSpecialObject` is an atomic fabric leaf, not a plain container —
+      // `{ [ID]: …, ...v }` would spread away its private state (flattening e.g.
+      // a `FabricEpochNsec` to `{[ID]: …}`), so it must be left intact.
       if (
-        isObject(v) && !isCellLink(v) && !(ID in v)
+        isObject(v) && !isCellLink(v) && !(ID in v) &&
+        !(v instanceof FabricSpecialObject)
       ) {
         changed = true;
         const withId = { [ID]: frame.generatedIdCounter++, ...v };
@@ -2874,7 +2884,19 @@ export function cellConstructorFactory<Wrap extends HKT>(kind: CellKind) {
         kind,
       );
 
-      // Set the initial value only if value is defined
+      // Set the initial value only if value is defined.
+      // TODO(danfuzz): native values in a `Cell.of(...)` initial value are NOT
+      // normalized to their fabric form (e.g. a `Date` stays a raw `Date`
+      // instead of becoming a `FabricEpochNsec`), unlike the `set()` write path
+      // (which runs `recursivelyAddIDIfNeeded`). The raw value flows both into
+      // `setInitialValue()` and into the schema `default` via
+      // `schemaWithDefaultAndScope()` above, and reaches storage/encode from
+      // there -- so a `Cell.of(new Date())` throws under the strict codec.
+      // (Normalizing only the `setInitialValue()` arg is insufficient; the
+      // schema-`default` copy still leaks the raw value, and embedding a
+      // `FabricSpecialObject` in a hashed schema `default` is its own hazard.)
+      // Fixing this cleanly is entangled with the initial-value / schema-default
+      // materialization path; left for that follow-up.
       if (value !== undefined) {
         cell.setInitialValue(value);
       }

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -1,8 +1,8 @@
 import { isObject, isRecord } from "@commonfabric/utils/types";
 import {
   fabricFromNativeValue,
-  FabricInstance,
   type FabricObject,
+  FabricSpecialObject,
   type FabricValue,
   shallowFabricFromNativeValue,
 } from "@commonfabric/data-model/fabric-value";
@@ -844,17 +844,19 @@ export function normalizeAndDiff(
     return changes;
   }
 
-  // `FabricInstance` values are atomic from this layer's perspective: their
+  // `FabricSpecialObject` values (`FabricInstance` wrappers and `FabricPrimitive`
+  // leaves alike) are atomic from this layer's perspective: their
   // own-enumerable properties are implementation details, not
   // user-visible structure, and iterating them via the generic
-  // `isRecord` branch below would walk wrapper-internal fields, which
+  // `isRecord` branch below would walk wrapper-internal fields (or, for a
+  // primitive whose state is private, flatten it to `{}`), which
   // is meaningless at the change-emission level. Emit a single change at
-  // this link with the wrapper as the
-  // value — the storage layer's JSON encoding handles serialization via
-  // `[DECONSTRUCT]`/`[RECONSTRUCT]`. Placed after the write-redirect
+  // this link with the value as-is — the storage layer's JSON encoding handles
+  // serialization (via `[DECONSTRUCT]`/`[RECONSTRUCT]` for instances, the codec
+  // for primitives). Placed after the write-redirect
   // resolution above so writes through a redirect land on the target,
   // not on the redirect itself.
-  if (newValue instanceof FabricInstance) {
+  if (newValue instanceof FabricSpecialObject) {
     diffLogger.debug(
       "diff",
       () => `[BRANCH_FABRIC_INSTANCE] Atomic FabricInstance at path=${pathStr}`,

--- a/packages/runner/test/cell-static-methods.test.ts
+++ b/packages/runner/test/cell-static-methods.test.ts
@@ -921,11 +921,8 @@ describe("Cell Static Methods", () => {
     });
 
     it("should round-trip a FabricEpochNsec timestamp value", () => {
-      // A native `Date` is NOT a supported cell value: the write path doesn't
-      // normalize it to a `FabricValue`, so it's lost (flattened to `{}` or
-      // promoted to a bogus link) and the codec rejects it outright. The fabric
-      // representation of a timestamp is `FabricEpochNsec`, which round-trips
-      // faithfully.
+      // `FabricEpochNsec` is the fabric representation of a timestamp; it
+      // round-trips faithfully as an atomic leaf.
       withinHandlerContext(runtime, space, tx, () => {
         const epoch = new FabricEpochNsec(
           BigInt(Date.parse("2024-01-01T00:00:00Z")) * 1_000_000n,
@@ -936,6 +933,71 @@ describe("Cell Static Methods", () => {
         expect(got.wireTypeTag).toBe("EpochNsec@1");
       });
     });
+
+    // A native `Date` written via `set()` is normalized to a `FabricEpochNsec`
+    // (top-level and nested alike). These use a self-contained runtime that
+    // drains the storage sync before dispose: the shared `afterEach` disposes
+    // without awaiting the sync a commit triggers, which races for writes that
+    // persist (a latent harness fragility unrelated to this behavior).
+    const DATE_ISO = "2024-01-01T00:00:00Z";
+    const DATE_NS = BigInt(Date.parse(DATE_ISO)) * 1_000_000n;
+    const assertEpochNsec = (got: unknown) => {
+      const v = got as { value?: bigint; wireTypeTag?: string };
+      expect(v?.wireTypeTag).toBe("EpochNsec@1");
+      expect(v?.value).toBe(DATE_NS);
+    };
+    const inFreshRuntime = async (
+      fn: (
+        cellApi: typeof Cell,
+        rt: Runtime,
+        localTx: IExtendedStorageTransaction,
+      ) => void,
+    ) => {
+      const sm = StorageManager.emulate({ as: signer });
+      const rt = new Runtime({
+        apiUrl: new URL(import.meta.url),
+        storageManager: sm,
+      });
+      const localTx = rt.edit();
+      const cellApi = createTrustedBuilder(rt).commonfabric.Cell;
+      try {
+        withinHandlerContext(
+          rt,
+          space,
+          localTx,
+          () => fn(cellApi, rt, localTx),
+        );
+        await localTx.commit();
+        await sm.synced();
+      } finally {
+        await rt.dispose().catch(() => {});
+        await sm.close().catch(() => {});
+      }
+    };
+
+    it("normalizes a top-level Date to FabricEpochNsec (set)", async () => {
+      await inFreshRuntime((Cell) => {
+        const cell = Cell.of<unknown>(0);
+        cell.set(new Date(DATE_ISO));
+        assertEpochNsec(cell.get());
+      });
+    });
+
+    it("normalizes a nested Date to FabricEpochNsec (set)", async () => {
+      await inFreshRuntime((Cell) => {
+        const cell = Cell.of<unknown>(0);
+        cell.set([new Date(DATE_ISO)]);
+        assertEpochNsec((cell.get() as unknown[])[0]);
+      });
+    });
+
+    // TODO(danfuzz): the `Cell.of(new Date(...))` cases (top-level and nested)
+    // are intentionally absent: unlike `set()`, the `Cell.of` initial-value path
+    // doesn't normalize native values (see the TODO in `createWithDefault` in
+    // `cell.ts`), so the raw `Date` reaches encode and throws under the strict
+    // codec. `get()` *appears* to convert (read-side projection), but the
+    // committed form is still raw. Add `... (Cell.of)` cases once that path
+    // normalizes its initial value the way `set()` does.
 
     it("should handle creating cell with mixed type array", () => {
       withinHandlerContext(runtime, space, tx, () => {


### PR DESCRIPTION
## Summary

Tactical fix for a real asymmetry: a native `Error` survives a cell write (→ `FabricError`) but a native `Date` was silently destroyed (→ `{}`). The cause isn't that `Date` lacks a conversion — `shallowFabricFromNativeValue` converts both — it's that the write path's guards only special-cased `FabricInstance`. `FabricError` is a `FabricInstance` (kept intact); `FabricEpochNsec`/`FabricBytes`/`FabricRegExp`/`FabricHash` are `FabricPrimitive`s — a *sibling* of `FabricInstance` under `FabricSpecialObject` — so they fell through to the generic record walk and got flattened to `{}` (their state is private).

`FabricSpecialObject` is the common base of both, and `interface.ts` documents it as the idiom for recognizing "any" fabric special object. This broadens the write-path guards to it; both subclasses are atomic fabric leaves that must be left intact.

### Changes
- **`recursivelyAddIDIfNeeded`** (`cell.ts`): post-conversion guard keeps any `FabricSpecialObject` (runs the `[DECONSTRUCT]` ID-walk only for `FabricInstance`s — `FabricPrimitive`s are leaves with no nested `FabricValue`s); the array-element ID-wrap skips `FabricSpecialObject`s so `{ [ID]: …, ...v }` can't spread away a primitive's private state.
- **`normalizeAndDiff`** (`data-updating.ts`): the atomic-value branch matches any `FabricSpecialObject`.
- Re-export `FabricSpecialObject` from `data-model/fabric-value`.

A `Date` written via `set()` now round-trips as a `FabricEpochNsec` (top-level and nested), pinned by new cross-product tests.

### Deliberately out of scope (TODO(danfuzz) in place)
- **`Cell.of(new Date())`** (top-level and nested): the `Cell.of` initial-value path stashes the raw value via `setInitialValue()` *and* embeds it in the schema `default` (`schemaWithDefaultAndScope`), so it reaches encode raw and throws under the strict codec. Normalizing only the `setInitialValue()` arg is insufficient, and embedding a `FabricSpecialObject` in a hashed schema `default` is its own hazard — entangled with the initial-value/materialization path, left for a follow-up. (`get()` *appears* to convert via the read-side projection, but the committed form is still raw, so those test cases are intentionally absent.)

## Test plan
- New `normalizes a … Date to FabricEpochNsec (set)` cross-product tests (top-level + nested), using a self-contained runtime that drains the storage sync before dispose (the shared `afterEach` disposes without awaiting the commit-triggered sync — a latent harness fragility, unrelated to this behavior).
- Full suites green: `packages/runner` **538 passed / 0 failed**, `packages/data-model` **31 passed / 0 failed**; `deno task check` + `deno fmt` clean on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes data loss when writing native values by treating all `FabricSpecialObject`s as atomic in the write and diff paths. `Date` values now normalize to `FabricEpochNsec` and round-trip via `set()` (top-level and nested).

- **Bug Fixes**
  - `packages/runner/src/cell.ts` (`recursivelyAddIDIfNeeded`): After `shallowFabricFromNativeValue`, keep any `FabricSpecialObject`; only run `[DECONSTRUCT]` for `FabricInstance`. Skip array ID wrapping for `FabricSpecialObject` to avoid spreading private state.
  - `packages/runner/src/data-updating.ts` (`normalizeAndDiff`): Treat any `FabricSpecialObject` (both `FabricInstance` and `FabricPrimitive`) as atomic when emitting changes.
  - `packages/data-model/src/fabric-value.ts`: Re-export `FabricSpecialObject`.
  - Tests: `set(new Date(...))` normalizes to `FabricEpochNsec` and round-trips for top-level and nested cases. Note: `Cell.of(new Date(...))` is unchanged and not yet normalized.

<sup>Written for commit 0515b3fe5bf7fee222cfb0c6d2b1ee20b769cfa3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

