### PR TITLE
feat(runner): emit the session-open signature as a FabricBytes (staged migration, step 3)

### DIFF
--- a/packages/runner/src/storage/v2-remote-session.ts
+++ b/packages/runner/src/storage/v2-remote-session.ts
@@ -1,4 +1,5 @@
 import { hashOf } from "@commonfabric/data-model/value-hash";
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
 import { type MemorySpace, type Signer } from "@commonfabric/memory/interface";
 import * as MemoryClient from "@commonfabric/memory/v2/client";
 import { MEMORY_PROTOCOL } from "@commonfabric/memory/v2";
@@ -150,19 +151,13 @@ export class RemoteSessionFactory implements SessionFactory {
     return {
       invocation,
       authorization: {
-        // The signature is sent as a plain number array. It used to be passed
-        // as a raw `Uint8Array`, which only survived the memory wire boundary
-        // by accident: the encoder's lenient structural fallback flattened it
-        // into a numeric-keyed object that the server's `toByteArray` happened
-        // to accept. Emitting an explicit array makes the wire form intentional
-        // (and keeps it a plain `FabricValue`, so it survives the stricter
-        // codec encoder). The server-side `toByteArray` accepts this form.
-        //
-        // TODO(danfuzz): The signature should travel as a `FabricBytes`, not a
-        // number array. Once servers that accept `FabricBytes` have fully
-        // propagated, flip this to `new FabricBytes(signature.ok)` and then
-        // retire the array/numeric-object handling in `toByteArray`.
-        signature: Array.from(signature.ok),
+        // The signature travels as a `FabricBytes` -- the proper fabric form
+        // for a byte sequence, which serializes to a compact `/Bytes@1` wire
+        // form and round-trips faithfully. The server's `toByteArray` accepts
+        // it. (It still also accepts the older number-array form for now, so
+        // that legacy handling can be retired only once every client emitting
+        // it has been replaced by this one -- see the TODO in `toByteArray`.)
+        signature: new FabricBytes(signature.ok),
       },
     };
   }

--- a/packages/toolshed/routes/storage/memory.ts
+++ b/packages/toolshed/routes/storage/memory.ts
@@ -18,14 +18,14 @@ const toByteArray = (value: unknown): Uint8Array | null => {
   if (value instanceof Uint8Array) {
     return value;
   }
-  // A `FabricBytes` is the intended long-term wire form for the signature.
-  // Accepting it here ahead of any client producing it lets the producer flip
-  // to `FabricBytes` later without breaking already-deployed servers.
-  // TODO(danfuzz): Once producers emit `FabricBytes`, the array/numeric-object
-  // branches below become legacy and can be retired.
+  // A `FabricBytes` is the long-term wire form for the signature, and the
+  // current client (`v2-remote-session.ts`) emits it.
   if (value instanceof FabricBytes) {
     return value.slice();
   }
+  // TODO(danfuzz): the array / numeric-keyed-object branches below are legacy
+  // forms emitted by older clients (pre-`FabricBytes`). Retire them once every
+  // client emitting them has propagated out.
   if (Array.isArray(value) && value.every((item) => Number.isInteger(item))) {
     return Uint8Array.from(value);
   }

--- a/packages/toolshed/routes/storage/memory/memory.test.ts
+++ b/packages/toolshed/routes/storage/memory/memory.test.ts
@@ -48,13 +48,10 @@ const createSessionOpenAuth = async (
   }
   return {
     invocation,
-    // Mirror the production producer: send the signature as an explicit number
-    // array (a plain `FabricValue`), not a raw `Uint8Array` that only survives
-    // the wire boundary via the encoder's lenient structural fallback.
-    // TODO(danfuzz): When the producer flips to sending a `FabricBytes`, update
-    // this helper to match.
+    // Mirror the production producer (`v2-remote-session.ts`): send the
+    // signature as a `FabricBytes`.
     authorization: {
-      signature: Array.from(signature.ok),
+      signature: new FabricBytes(signature.ok),
     },
   };
 };
@@ -330,14 +327,15 @@ serialTest("memory websocket negotiates a session", async () => {
   }
 });
 
-// Forward-compatibility for the staged signature wire-format migration: the
-// server must accept a session-open signature sent as a `FabricBytes` (the
-// intended long-term form), ahead of any client actually producing it. See
-// `toByteArray` in `../memory.ts`.
+// Backward-compatibility for the staged signature wire-format migration: the
+// current client emits a `FabricBytes` signature (exercised by the other
+// session tests via `createSessionOpenAuth`), but the server must still accept
+// the legacy number-array form that not-yet-upgraded clients send, until that
+// form is retired. See `toByteArray` in `../memory.ts`.
 serialTest(
-  "memory websocket negotiates a session with a `FabricBytes` signature",
+  "memory websocket negotiates a session with a legacy number-array signature",
   async () => {
-    const identity = await Identity.fromPassphrase("memory-route-open-bytes");
+    const identity = await Identity.fromPassphrase("memory-route-open-legacy");
     const server = Deno.serve({ port: 0 }, app.fetch);
     const address = new URL(
       `ws://${server.addr.hostname}:${server.addr.port}/api/storage/memory`,
@@ -358,9 +356,8 @@ serialTest(
         ...auth,
         authorization: {
           ...auth.authorization,
-          signature: new FabricBytes(
-            Uint8Array.from(auth.authorization.signature),
-          ),
+          // Legacy form: a plain number array rather than a `FabricBytes`.
+          signature: [...auth.authorization.signature.slice()],
         },
       }));
 


### PR DESCRIPTION
## Summary

**Step 3 of the staged session-signature wire-format migration.** The session-open `authorization.signature` now travels as a real `FabricBytes` (compact `/Bytes@1` wire form) instead of the intentional-but-transitional number array introduced in step 1 (#3902).

### Changes
- **Producer** (`v2-remote-session.ts`): `signature: new FabricBytes(signature.ok)` (was `Array.from(signature.ok)`).
- **Consumer** (`toByteArray`, toolshed): no behavior change — it has accepted `FabricBytes` since #3902. Re-pointed its `TODO(danfuzz)`: the array / numeric-keyed-object branches are now the *legacy* path (older clients), to be retired in step 4 once every client emitting them has propagated out.
- **Tests**: the memory-route session tests now exercise the `FabricBytes` signature end-to-end — via the real producer (the runtime-based `authorizes` test) and the `createSessionOpenAuth` helper (now mirrors production). The former dedicated `FabricBytes` test is repurposed to pin that the **legacy number-array** form is still accepted during the migration.

### ⚠️ Propagation gate
This is the "migrate" step and depends on the "expand" step (#3902) being **deployed to all memory servers** first — a server without #3902's `toByteArray` `FabricBytes` branch would reject a `FabricBytes` signature. #3902 is merged; please confirm it has propagated before merging/deploying this. (Step 4 — retiring the legacy `toByteArray` branches — comes later, gated on *this* step propagating to all clients.)

## Test plan
- `packages/toolshed` memory-route session suite: 6/6 (incl. real-producer `authorizes`, helper-based `negotiates`/`resumes`, and the legacy-number-array compat test).
- `deno check` + `deno fmt` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send the session-open authorization.signature as a FabricBytes (compact /Bytes@1) instead of the transitional number array. This aligns the producer with the long-term wire format; the server has accepted FabricBytes since #3902.

- **Migration**
  - Gate: merge/deploy only after #3902 has propagated to all memory servers, or FabricBytes signatures will be rejected.
  - Backward-compat: server still accepts legacy number-array/numeric-object signatures; tests cover FabricBytes end-to-end and pin legacy acceptance. Legacy handling will be removed in step 4.

<sup>Written for commit bdeed480cd85b64144be8321259cbc9b6c82f057. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

