### PR TITLE
test(runner): pin ESM source-location fidelity; de-stale default-on comments (CT-1623)

### DIFF
--- a/docs/specs/module-loading-implementation-plan.md
+++ b/docs/specs/module-loading-implementation-plan.md
@@ -494,6 +494,35 @@ compilation-cache tests pass under both loaders; no correctness regression.
 > `deno task integration` from the repo root), and benchmarks. The canary
 > PR (#3782) is the standing flag-on CI signal.
 
+> **Source-location fidelity: RESOLVED (no longer a default-on blocker).**
+> Earlier code comments in `module-record-compiler.ts` / `engine.ts` flagged
+> `fn.src` / source-location resolution under the ESM loader as "the remaining
+> item before the flag can be enabled by default." That is done. Both consumers
+> resolve flag-on to the canonical reload-stable `cf:module/<hash>/<path>` form:
+> CFC verified-source (`isVerifiedSourceInLoad` → `kind: "verified"`) and the
+> scheduler content-addressed implementation hash. Two mechanisms cover it —
+> Deno's `indexOf`-into-`script` fallback (`resolveLocationFromFunctionSource`)
+> and the per-module source maps the engine registers for browsers (whose stacks
+> surface the per-module eval frame). Covered by
+> `packages/runner/test/esm-source-location.test.ts` (CFC parity + scheduler
+> hash + source-location suffix parity flag-on/flag-off) and the browser
+> eval-frame resolution case in `module.test.ts`. The stale comments were
+> corrected. **Remaining verification (not a blocker):** a full browser
+> integration test under `packages/patterns/integration` driving the shell with
+> `CF_ESM_MODULE_LOADER=1` — the resolution logic + wiring are unit-covered, but
+> end-to-end browser stacks are only exercised by the canary, not a committed
+> assertion.
+
+> **Cross-loader action-identity re-key (state migration, discovered).** The
+> scheduler implementation hash is `cf:module/<hash>:line:col`. The `:line:col`
+> source-location suffix is identical flag-on/flag-off (asserted), but the
+> per-module `<hash>` DIFFERS across loaders: ESM uses the prefix-free
+> `computeModuleIdentities` hash, AMD its legacy whole-program scheme. So
+> flipping the default re-keys persisted scheduler action identity once. This is
+> acceptable (AMD removal below collapses to a single scheme) but the flip must
+> account for it — either accept a one-time re-run of persisted actions or stage
+> the rollout. Tracked here rather than as a source-location regression.
+
 - Flip `EXPERIMENTAL_ESM_MODULE_LOADER` default on after Phases 2–4 are green and
   benchmarks acceptable.
 - Remove the AMD bundler, `packages/js-compiler/typescript/bundler/amd-loader.ts`,
@@ -530,6 +559,7 @@ only loader.
 | Many-small-modules perf regression | 2/4 | Benchmarks; consider one compartment per load with shared map. |
 | Cycle hashing nondeterminism | 1 | SCC condensation with sorted members; determinism test. |
 | Hidden async load site | 0/2 | Synchronous-caller census in Phase 0. |
+| Action-identity re-key on default flip (ESM vs AMD module hash) | 5 | Source-location suffix parity asserted; accept one-time persisted-action re-run or stage rollout; AMD removal collapses to one scheme. |
 
 ## Suggested commit/PR sequence
 

--- a/packages/runner/src/harness/engine.ts
+++ b/packages/runner/src/harness/engine.ts
@@ -671,9 +671,12 @@ export class Engine extends EventTarget implements Harness {
       const loadId = `${ctx.loadIdPrefix}:esm:${this.nextLoadId++}`;
       this.executableRegistry.beginVerifiedLoad(loadId);
       // Register per-module content hashes for parity with the AMD evaluate
-      // path. This wires the scheduler's content-addressed implementation hash;
-      // it becomes effective once source-location resolution under the ESM
-      // loader is wired (see the sourceURL note in module-record-compiler.ts).
+      // path. This wires the scheduler's content-addressed implementation hash.
+      // It is effective flag-on: source-location resolution under the ESM loader
+      // is wired (the `indexOf`-into-`script` fallback plus the per-module source
+      // maps registered below), so `fn.src` resolves to the canonical
+      // `cf:module/<hash>/<path>` form these hashes key on. Covered by
+      // `action-fingerprint.test.ts` and `esm-source-location.test.ts`.
       ctx.registerHashes();
 
       const globals = createModuleCompartmentGlobals({

--- a/packages/runner/src/sandbox/module-record-compiler.ts
+++ b/packages/runner/src/sandbox/module-record-compiler.ts
@@ -507,13 +507,23 @@ export function compileSourcesToRecords(
     // rather than wrapping the whole namespace. Authored sources are ESM.
     const namespaceExports = [...exportNames, "__esModule"];
 
-    // Tag the eval with a sourceURL = the (prefixed) source path. NOTE: under
-    // SES `errorTaming` this is currently stripped from stack traces, so it
-    // does NOT yet make `fn.src` resolve — full source-location fidelity under
-    // the ESM loader (stack traces, and thus the scheduler's content-addressed
-    // implementation hash / CFC verified-source check) requires SES-isolate-
-    // level source-map integration and is tracked as the remaining item before
-    // the flag can be enabled by default. The tag is the hook for that work.
+    // Tag the eval with a sourceURL = the (prefixed) source path. Under Deno's
+    // tamed SES `errorTaming` this is stripped from `new Error().stack`, so the
+    // stack-based resolver (`resolveSourceLocationFromStack`) does not fire there
+    // — but full source-location fidelity under the ESM loader is nonetheless
+    // achieved (scheduler content-addressed implementation hash + CFC
+    // verified-source) via two mechanisms, so this is NOT a remaining blocker for
+    // enabling the flag by default:
+    //   1. Deno: the `indexOf`-into-`script` fallback in
+    //      `resolveLocationFromFunctionSource` (builder/module.ts) maps `fn.src`
+    //      to the canonical `cf:module/<hash>/<path>` form via the per-load
+    //      `sourceLocationContext` the engine pushes.
+    //   2. Browsers (which DO surface the per-module eval frame in stacks): the
+    //      engine registers a per-module source map keyed on THIS `sourceURL`
+    //      (engine.ts, near `loadSourceMap`), so the stack-based resolver
+    //      translates the eval coordinate back to the authored source.
+    // Both paths are covered: `esm-source-location.test.ts` (CFC verified-source
+    // parity, flag-on) and `action-fingerprint.test.ts` (scheduler hash).
     //
     // SECURITY: strip JS line terminators before interpolating into the
     // `//# sourceURL=` line comment. A newline (or U+2028/U+2029) in

--- a/packages/runner/test/esm-source-location.test.ts
+++ b/packages/runner/test/esm-source-location.test.ts
@@ -42,6 +42,14 @@ interface HandlerIdentityProbe {
   verifiedLoadId: string | undefined;
   isVerifiedSourceInLoad: boolean | undefined;
   kind: string | undefined;
+  /**
+   * The scheduler's content-addressed implementation hash for this handler,
+   * derived from `fn.src` via `harness.implementationHashForSource`. This is the
+   * SECOND consumer of ESM source-location fidelity (the first is CFC
+   * verified-source above): the scheduler keys reload-stable action identity on
+   * it, so it must resolve flag-on for the loader to be default-on safe.
+   */
+  implHash: string | undefined;
 }
 
 function probeHandlerIdentity(
@@ -82,7 +90,16 @@ function probeHandlerIdentity(
     harness: runtime.harness,
     implementation: fn as never,
   });
-  return { src, verifiedLoadId, isVerifiedSourceInLoad, kind: identity?.kind };
+  const implHash = typeof src === "string"
+    ? runtime.harness.implementationHashForSource?.(src)
+    : undefined;
+  return {
+    src,
+    verifiedLoadId,
+    isVerifiedSourceInLoad,
+    kind: identity?.kind,
+    implHash,
+  };
 }
 
 describe("ESM loader: verified-source location resolution", () => {
@@ -118,6 +135,11 @@ describe("ESM loader: verified-source location resolution", () => {
     expect(r.verifiedLoadId).toBeDefined();
     expect(r.isVerifiedSourceInLoad).toBe(true);
     expect(r.kind).toBe("verified");
+    // The scheduler's content-addressed implementation hash also resolves
+    // flag-on: `fn.src` reduces to the pure per-module code identity
+    // `cf:module/<hash>:line:col` (no `/path` segment). This is the second
+    // default-on prerequisite — without it, reload-stable action identity breaks.
+    expect(r.implHash).toMatch(/^cf:module\/[^/]+:\d+:\d+$/);
   });
 
   it("matches AMD-path verified-source resolution (parity)", async () => {
@@ -129,5 +151,33 @@ describe("ESM loader: verified-source location resolution", () => {
     expect(r.src).toMatch(/^cf:module\//);
     expect(r.isVerifiedSourceInLoad).toBe(true);
     expect(r.kind).toBe("verified");
+    expect(r.implHash).toMatch(/^cf:module\/[^/]+:\d+:\d+$/);
+  });
+
+  it("resolves the same source-LOCATION suffix flag-on and flag-off", async () => {
+    // The scheduler's implementation hash has two parts: the per-module code
+    // identity (`cf:module/<hash>`) and the source-location suffix
+    // (`:line:col`). This PR is about the LATTER — source-location fidelity — and
+    // it must resolve to the SAME authored coordinate under either loader.
+    //
+    // The per-module `<hash>` deliberately DIFFERS across loaders (ESM uses the
+    // prefix-free per-module `computeModuleIdentities` hash; AMD uses its legacy
+    // whole-program scheme), so a default-on flip re-keys action identity once.
+    // That is a module-identity / state-migration concern tracked under Phase 5
+    // (AMD removal), NOT a source-location regression — assert only the suffix.
+    const suffixOf = (h: string | undefined) => h?.match(/(:\d+:\d+)$/)?.[1];
+
+    makeRuntime(true);
+    const esmCompiled = await runtime.patternManager.compilePattern(program);
+    const esmHash = probeHandlerIdentity(runtime, esmCompiled).implHash;
+    await runtime.dispose();
+    await storageManager.close();
+
+    makeRuntime(false);
+    const amdCompiled = await runtime.patternManager.compilePattern(program);
+    const amdHash = probeHandlerIdentity(runtime, amdCompiled).implHash;
+
+    expect(suffixOf(esmHash)).toMatch(/^:\d+:\d+$/);
+    expect(suffixOf(esmHash)).toBe(suffixOf(amdHash));
   });
 });

--- a/packages/runner/test/module.test.ts
+++ b/packages/runner/test/module.test.ts
@@ -693,5 +693,43 @@ describe("module", () => {
 
       expect(result.location).toBe("/main.tsx:4:26");
     });
+
+    it("resolves an ESM-loader browser eval frame to the canonical cf:module source", () => {
+      // Under the ESM module loader in a BROWSER, `new Error().stack` surfaces
+      // the per-module eval frame whose file is the `//# sourceURL` the loader
+      // tags each `compartment.evaluate` with (the prefixed per-module source
+      // name). The engine registers a per-module source map under that exact
+      // sourceURL (see engine.ts near `loadSourceMap`), and the production
+      // resolver uses `canonicalizingMapPosition`, which maps the coordinate to
+      // the authored source and then upgrades it to the reload-stable canonical
+      // `cf:module/<hash>/<path>` form. Both source-location consumers (CFC
+      // verified-source AND the scheduler implementation hash) require that
+      // canonical output, so pin the browser resolution path here. (Deno's tamed
+      // SES strips this frame, falling back to the indexOf-into-`script` path
+      // exercised by esm-source-location.test.ts — the browser relies on THIS.)
+      const ESM_SOURCE_URL = "/2b3c/main.tsx"; // per-module eval sourceURL
+      const CANONICAL = "cf:module/2b3cZ9hashZ9/main.tsx";
+      const stack = [
+        "Error",
+        "    at getExternalSourceLocation (bundle.js:10:5)",
+        "    at annotateFunctionDebugMetadata (bundle.js:11:5)",
+        "    at createNodeFactory (bundle.js:12:5)",
+        "    at handler (bundle.js:13:5)",
+        // The authored handler, as a browser eval frame keyed on the sourceURL.
+        `    at inc (${ESM_SOURCE_URL}:2:33)`,
+      ].join("\n");
+
+      const result = resolveSourceLocationFromStack(
+        stack,
+        // Mimics `canonicalizingMapPosition`: only the per-module eval frame has
+        // a registered map, and it resolves to the canonical cf:module form.
+        (file, _line, _col) =>
+          file === ESM_SOURCE_URL
+            ? { source: CANONICAL, line: 2, column: 33 }
+            : null,
+      );
+
+      expect(result.location).toBe(`${CANONICAL}:2:33`);
+    });
   });
 });


### PR DESCRIPTION
## What

The next CT-1623 phase that isn't blocked by the ESM loader being on by default: **source-location fidelity** — the prerequisite the code comments named as "the remaining item before the flag can be enabled by default."

Investigation finding: **it's already done.** Source-location resolution under the ESM loader is complete and effective flag-on for both consumers, and the blocker comments were stale. This PR proves it with tests, corrects the comments, and surfaces one genuinely-new finding for the eventual default flip.

## Why it was already done

`engine.ts` wires the per-module + bundle source maps and the `indexOf`-into-`script` fallback that close the gap. Both consumers resolve flag-on to the canonical reload-stable `cf:module/<hash>/<path>` form:
- **CFC verified-source** — `isVerifiedSourceInLoad` → `kind: "verified"` (already asserted by `esm-source-location.test.ts`).
- **Scheduler content-addressed implementation hash** — now asserted (was untested flag-on).

Two mechanisms cover it: Deno's `indexOf` fallback (`resolveLocationFromFunctionSource`) and the per-module source maps the engine registers for browsers (whose stacks surface the per-module eval frame).

## Changes

- **De-stale** the comments in `module-record-compiler.ts` and `engine.ts` — describe the two resolution mechanisms and point at the covering tests, instead of claiming a default-on blocker.
- **Strengthen** `esm-source-location.test.ts` — assert the scheduler implementation hash resolves to `cf:module/<hash>:line:col` flag-on, and that the source-**location** suffix is identical flag-on/flag-off.
- **Add** a browser eval-frame resolution case to `module.test.ts` — a per-module `//# sourceURL` eval frame resolving through a canonicalizing map to the canonical `cf:module` form.
- **Spec** (`module-loading-implementation-plan.md`) — mark source-location fidelity RESOLVED; note the remaining (non-blocking) browser integration-test verification; add a risk row.

## Finding surfaced for default-on

The `:line:col` source-location suffix is identical across loaders, but the per-module `<hash>` **differs** (ESM prefix-free `computeModuleIdentities` vs AMD whole-program). So flipping the default **re-keys scheduler action identity once** — a state-migration concern (accept a one-time re-run or stage the rollout), documented in the Phase 5 plan. Not a source-location regression; collapses to one scheme when AMD is removed.

## Remaining for default-on (out of scope here)

A full browser integration test under `packages/patterns/integration` driving the shell with `CF_ESM_MODULE_LOADER=1`. The resolution logic + wiring are unit-covered; end-to-end browser stacks are exercised by the canary (#3782), not yet a committed assertion.

## Test

- `packages/runner/test/esm-source-location.test.ts` — green flag-on/flag-off (3 steps).
- `packages/runner/test/module.test.ts` — green incl. new browser eval-frame case.
- `packages/runner/test/action-fingerprint.test.ts` — green (referenced by the de-staled comments).
- `deno check` + `deno fmt --check` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins ESM source-location fidelity and clears stale default-on blockers (CT-1623). Verifies CFC verified-source and the scheduler’s implementation hash resolve under the ESM loader; notes a one-time action-identity re-key on default flip.

- **Refactors**
  - Updated comments in `packages/runner/src/sandbox/module-record-compiler.ts` and `packages/runner/src/harness/engine.ts` to describe Deno `indexOf` fallback and browser per-module source maps.
  - Strengthened `packages/runner/test/esm-source-location.test.ts` to assert scheduler hash and line/col parity across loaders; added a browser eval-frame case in `packages/runner/test/module.test.ts`.
  - Marked source-location fidelity as resolved in `docs/specs/module-loading-implementation-plan.md`, and noted the remaining non-blocking browser integration test.

- **Migration**
  - Default flip re-keys scheduler action identity once because `<hash>` differs across loaders in `cf:module/<hash>:line:col`; plan for a one-time re-run or staged rollout.

<sup>Written for commit 4d3a6dd942f024ad6a96af77be627b5cac9e4164. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

