### PR TITLE
test(data-model): move per-type codec tests into per-class files (Z2 reorg)

### DIFF
--- a/packages/data-model/test/fabric-instances/FabricError.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricError.test.ts
@@ -51,7 +51,7 @@ describe("FabricError", () => {
       const se = FabricError.fromNativeError(new Error("orig"));
       se.message = "changed";
       se.name = "Renamed";
-      se.cause = { detail: 1 } as FabricValue;
+      se.cause = { detail: 1 };
       expect(se.message).toBe("changed");
       expect(se.name).toBe("Renamed");
       expect(se.cause).toEqual({ detail: 1 });
@@ -174,7 +174,7 @@ describe("FabricError", () => {
         expect(state.name).toBe("SpecialType");
 
         const restored = FabricError[RECONSTRUCT](
-          state as FabricValue,
+          state,
           dummyContext,
         );
         expect(restored.toNativeValue(true)).toBeInstanceOf(TypeError);
@@ -294,7 +294,7 @@ describe("FabricError", () => {
           type: "Error",
           name: null,
           message: "hello",
-        } as FabricValue;
+        };
         const result = FabricError[RECONSTRUCT](state, dummyContext);
         expect(result).toBeInstanceOf(FabricError);
         expect(result.toNativeValue(true)).toBeInstanceOf(Error);
@@ -312,7 +312,7 @@ describe("FabricError", () => {
           ["EvalError", EvalError],
         ];
         for (const [type, cls] of cases) {
-          const state = { type, name: null, message: "test" } as FabricValue;
+          const state = { type, name: null, message: "test" };
           const result = FabricError[RECONSTRUCT](state, dummyContext);
           expect(result.toNativeValue(true)).toBeInstanceOf(cls);
           expect(result.name).toBe(type);
@@ -324,7 +324,7 @@ describe("FabricError", () => {
           type: "TypeError",
           name: "CustomTypeName",
           message: "mismatch",
-        } as FabricValue;
+        };
         const result = FabricError[RECONSTRUCT](state, dummyContext);
         expect(result.toNativeValue(true)).toBeInstanceOf(TypeError);
         expect(result.name).toBe("CustomTypeName");
@@ -334,7 +334,7 @@ describe("FabricError", () => {
         const state = {
           name: "TypeError",
           message: "old format",
-        } as FabricValue;
+        };
         const result = FabricError[RECONSTRUCT](state, dummyContext);
         expect(result.toNativeValue(true)).toBeInstanceOf(TypeError);
       });
@@ -344,7 +344,7 @@ describe("FabricError", () => {
           type: "Error",
           name: "MyCustomError",
           message: "custom",
-        } as FabricValue;
+        };
         const result = FabricError[RECONSTRUCT](state, dummyContext);
         expect(result.name).toBe("MyCustomError");
       });
@@ -356,7 +356,7 @@ describe("FabricError", () => {
           message: "with extras",
           cause: "something went wrong",
           code: 404,
-        } as FabricValue;
+        };
         const result = FabricError[RECONSTRUCT](state, dummyContext);
         expect(result.cause).toBe("something went wrong");
         expect(result.getExtra("code")).toBe(404);
@@ -371,9 +371,15 @@ describe("FabricError", () => {
         expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.Error);
       });
 
+      it("claims a `FabricError` via `canEncode()`, rejecting other values", () => {
+        expect(codec.canEncode(FabricError.fromNativeError(new Error("x"))))
+          .toBe(true);
+        expect(codec.canEncode("not an error")).toBe(false);
+      });
+
       it("encodes a basic `FabricError` to its `{ type, name, message }` state", () => {
         const se = FabricError.fromNativeError(new Error("test"));
-        const state = codec.encode(se as FabricValue) as Record<
+        const state = codec.encode(se) as Record<
           string,
           unknown
         >;
@@ -385,7 +391,7 @@ describe("FabricError", () => {
       it("encodes `name: null` when `name` matches `type` (`TypeError`)", () => {
         // TypeError: name === constructor.name === "TypeError".
         const se = FabricError.fromNativeError(new TypeError("type check"));
-        const state = codec.encode(se as FabricValue) as Record<
+        const state = codec.encode(se) as Record<
           string,
           unknown
         >;
@@ -398,7 +404,7 @@ describe("FabricError", () => {
         const err = new Error("custom");
         err.name = "MyCustomError";
         const se = FabricError.fromNativeError(err);
-        const state = codec.encode(se as FabricValue) as Record<
+        const state = codec.encode(se) as Record<
           string,
           unknown
         >;
@@ -411,7 +417,7 @@ describe("FabricError", () => {
         const se = FabricError.fromNativeError(new Error("hello"));
         const decoded = codec.decode(
           codec.wireTypeTag,
-          codec.encode(se as FabricValue),
+          codec.encode(se),
           context,
         ) as unknown as FabricError;
         expect(decoded).toBeInstanceOf(FabricError);
@@ -424,7 +430,7 @@ describe("FabricError", () => {
         const se = FabricError.fromNativeError(new TypeError("bad type"));
         const decoded = codec.decode(
           codec.wireTypeTag,
-          codec.encode(se as FabricValue),
+          codec.encode(se),
           context,
         ) as unknown as FabricError;
         expect(decoded).toBeInstanceOf(FabricError);
@@ -437,7 +443,7 @@ describe("FabricError", () => {
         const se = FabricError.fromNativeError(new RangeError("out of range"));
         const decoded = codec.decode(
           codec.wireTypeTag,
-          codec.encode(se as FabricValue),
+          codec.encode(se),
           context,
         ) as unknown as FabricError;
         expect(decoded).toBeInstanceOf(FabricError);
@@ -452,7 +458,7 @@ describe("FabricError", () => {
         );
         const decoded = codec.decode(
           codec.wireTypeTag,
-          codec.encode(outer as FabricValue),
+          codec.encode(outer),
           context,
         ) as unknown as FabricError;
         expect(decoded.message).toBe("outer");
@@ -472,7 +478,7 @@ describe("FabricError", () => {
         const outerSe = FabricError.fromNativeError(outerErr);
         const decoded = codec.decode(
           codec.wireTypeTag,
-          codec.encode(outerSe as FabricValue),
+          codec.encode(outerSe),
           context,
         ) as unknown as FabricError;
         expect(decoded.message).toBe("outer");
@@ -487,7 +493,7 @@ describe("FabricError", () => {
         const se = FabricError.fromNativeError(err);
         const decoded = codec.decode(
           codec.wireTypeTag,
-          codec.encode(se as FabricValue),
+          codec.encode(se),
           context,
         ) as unknown as FabricError;
         expect(decoded.message).toBe("oops");
@@ -505,7 +511,7 @@ describe("FabricError", () => {
         const se = FabricError.fromNativeError(err);
         const decoded = codec.decode(
           codec.wireTypeTag,
-          codec.encode(se as FabricValue),
+          codec.encode(se),
           context,
         ) as unknown as FabricError;
         expect(decoded.name).toBe("MyCustomError");
@@ -516,7 +522,7 @@ describe("FabricError", () => {
         const se = FabricError.fromNativeError(new TypeError("rt"));
         const decoded = codec.decode(
           codec.wireTypeTag,
-          codec.encode(se as FabricValue),
+          codec.encode(se),
           context,
         ) as unknown as FabricError;
         expect(decoded.toNativeValue(true)).toBeInstanceOf(TypeError);
@@ -531,7 +537,7 @@ describe("FabricError", () => {
         const se = FabricError.fromNativeError(err);
         const decoded = codec.decode(
           codec.wireTypeTag,
-          codec.encode(se as FabricValue),
+          codec.encode(se),
           context,
         ) as unknown as FabricError;
         expect(decoded.toNativeValue(true)).toBeInstanceOf(Error);

--- a/packages/data-model/test/fabric-instances/FabricError.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricError.test.ts
@@ -367,182 +367,185 @@ describe("FabricError", () => {
       const codec = FabricError[CODEC];
       const context = EMPTY_RECONSTRUCTION_CONTEXT;
 
-      it("has the `Error` wire type tag", () => {
-        expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.Error);
+      describe("wireTypeTag", () => {
+        it("is the `Error` wire type tag", () => {
+          expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.Error);
+        });
       });
 
-      it("claims a `FabricError` via `canEncode()`, rejecting other values", () => {
-        expect(codec.canEncode(FabricError.fromNativeError(new Error("x"))))
-          .toBe(true);
-        expect(codec.canEncode("not an error")).toBe(false);
+      describe("canEncode()", () => {
+        it("claims a `FabricError`, rejecting other values", () => {
+          expect(codec.canEncode(FabricError.fromNativeError(new Error("x"))))
+            .toBe(true);
+          expect(codec.canEncode("not an error")).toBe(false);
+        });
       });
 
-      it("encodes a basic `FabricError` to its `{ type, name, message }` state", () => {
-        const se = FabricError.fromNativeError(new Error("test"));
-        const state = codec.encode(se) as Record<
-          string,
-          unknown
-        >;
-        expect(state.type).toBe("Error");
-        expect(state.name).toBe(null); // null = same as type (common case)
-        expect(state.message).toBe("test");
+      describe("encode()", () => {
+        it("encodes a basic `FabricError` to its `{ type, name, message }` state", () => {
+          const se = FabricError.fromNativeError(new Error("test"));
+          const state = codec.encode(se) as Record<string, unknown>;
+          expect(state.type).toBe("Error");
+          expect(state.name).toBe(null); // null = same as type (common case)
+          expect(state.message).toBe("test");
+        });
+
+        it("encodes `name: null` when `name` matches `type` (`TypeError`)", () => {
+          // TypeError: name === constructor.name === "TypeError".
+          const se = FabricError.fromNativeError(new TypeError("type check"));
+          const state = codec.encode(se) as Record<string, unknown>;
+          expect(state.type).toBe("TypeError");
+          expect(state.name).toBe(null); // null = same as type
+          expect(state.message).toBe("type check");
+        });
+
+        it("encodes an explicit `name` when `name` differs from `type`", () => {
+          const err = new Error("custom");
+          err.name = "MyCustomError";
+          const se = FabricError.fromNativeError(err);
+          const state = codec.encode(se) as Record<string, unknown>;
+          expect(state.type).toBe("Error");
+          expect(state.name).toBe("MyCustomError");
+          expect(state.message).toBe("custom");
+        });
       });
 
-      it("encodes `name: null` when `name` matches `type` (`TypeError`)", () => {
-        // TypeError: name === constructor.name === "TypeError".
-        const se = FabricError.fromNativeError(new TypeError("type check"));
-        const state = codec.encode(se) as Record<
-          string,
-          unknown
-        >;
-        expect(state.type).toBe("TypeError");
-        expect(state.name).toBe(null); // null = same as type
-        expect(state.message).toBe("type check");
-      });
+      describe("decode()", () => {
+        it("round-trips a basic `Error`", () => {
+          const se = FabricError.fromNativeError(new Error("hello"));
+          const decoded = codec.decode(
+            codec.wireTypeTag,
+            codec.encode(se),
+            context,
+          ) as unknown as FabricError;
+          expect(decoded).toBeInstanceOf(FabricError);
+          expect(decoded.toNativeValue(true)).toBeInstanceOf(Error);
+          expect(decoded.name).toBe("Error");
+          expect(decoded.message).toBe("hello");
+        });
 
-      it("encodes an explicit `name` when `name` differs from `type`", () => {
-        const err = new Error("custom");
-        err.name = "MyCustomError";
-        const se = FabricError.fromNativeError(err);
-        const state = codec.encode(se) as Record<
-          string,
-          unknown
-        >;
-        expect(state.type).toBe("Error");
-        expect(state.name).toBe("MyCustomError");
-        expect(state.message).toBe("custom");
-      });
+        it("round-trips a `TypeError`", () => {
+          const se = FabricError.fromNativeError(new TypeError("bad type"));
+          const decoded = codec.decode(
+            codec.wireTypeTag,
+            codec.encode(se),
+            context,
+          ) as unknown as FabricError;
+          expect(decoded).toBeInstanceOf(FabricError);
+          expect(decoded.toNativeValue(true)).toBeInstanceOf(TypeError);
+          expect(decoded.name).toBe("TypeError");
+          expect(decoded.message).toBe("bad type");
+        });
 
-      it("round-trips a basic `Error`", () => {
-        const se = FabricError.fromNativeError(new Error("hello"));
-        const decoded = codec.decode(
-          codec.wireTypeTag,
-          codec.encode(se),
-          context,
-        ) as unknown as FabricError;
-        expect(decoded).toBeInstanceOf(FabricError);
-        expect(decoded.toNativeValue(true)).toBeInstanceOf(Error);
-        expect(decoded.name).toBe("Error");
-        expect(decoded.message).toBe("hello");
-      });
+        it("round-trips a `RangeError`", () => {
+          const se = FabricError.fromNativeError(
+            new RangeError("out of range"),
+          );
+          const decoded = codec.decode(
+            codec.wireTypeTag,
+            codec.encode(se),
+            context,
+          ) as unknown as FabricError;
+          expect(decoded).toBeInstanceOf(FabricError);
+          expect(decoded.toNativeValue(true)).toBeInstanceOf(RangeError);
+          expect(decoded.name).toBe("RangeError");
+        });
 
-      it("round-trips a `TypeError`", () => {
-        const se = FabricError.fromNativeError(new TypeError("bad type"));
-        const decoded = codec.decode(
-          codec.wireTypeTag,
-          codec.encode(se),
-          context,
-        ) as unknown as FabricError;
-        expect(decoded).toBeInstanceOf(FabricError);
-        expect(decoded.toNativeValue(true)).toBeInstanceOf(TypeError);
-        expect(decoded.name).toBe("TypeError");
-        expect(decoded.message).toBe("bad type");
-      });
+        it("round-trips an `Error` with a (pre-converted) cause", () => {
+          const inner = FabricError.fromNativeError(new Error("inner"));
+          const outer = FabricError.fromNativeError(
+            new Error("outer", { cause: inner }),
+          );
+          const decoded = codec.decode(
+            codec.wireTypeTag,
+            codec.encode(outer),
+            context,
+          ) as unknown as FabricError;
+          expect(decoded.message).toBe("outer");
+          // The cause is a FabricError (the inner wrapper) after round-trip.
+          expect(decoded.cause).toBeInstanceOf(FabricError);
+          expect((decoded.cause as FabricError).message).toBe("inner");
+        });
 
-      it("round-trips a `RangeError`", () => {
-        const se = FabricError.fromNativeError(new RangeError("out of range"));
-        const decoded = codec.decode(
-          codec.wireTypeTag,
-          codec.encode(se),
-          context,
-        ) as unknown as FabricError;
-        expect(decoded).toBeInstanceOf(FabricError);
-        expect(decoded.toNativeValue(true)).toBeInstanceOf(RangeError);
-        expect(decoded.name).toBe("RangeError");
-      });
+        it("round-trips an `Error` whose cause is itself a `FabricError`", () => {
+          // Simulates what `fabricFromNativeValue` produces: a FabricError
+          // wrapping an Error whose cause is itself a FabricError (not a raw
+          // Error). Encoding's recurse on `[DECONSTRUCT]` output must find a
+          // FabricValue, not a raw Error.
+          const innerSe = FabricError.fromNativeError(new Error("inner"));
+          const outerErr = new Error("outer");
+          outerErr.cause = innerSe;
+          const outerSe = FabricError.fromNativeError(outerErr);
+          const decoded = codec.decode(
+            codec.wireTypeTag,
+            codec.encode(outerSe),
+            context,
+          ) as unknown as FabricError;
+          expect(decoded.message).toBe("outer");
+          expect(decoded.cause).toBeInstanceOf(FabricError);
+          expect((decoded.cause as FabricError).message).toBe("inner");
+        });
 
-      it("round-trips an `Error` with a (pre-converted) cause", () => {
-        const inner = FabricError.fromNativeError(new Error("inner"));
-        const outer = FabricError.fromNativeError(
-          new Error("outer", { cause: inner }),
-        );
-        const decoded = codec.decode(
-          codec.wireTypeTag,
-          codec.encode(outer),
-          context,
-        ) as unknown as FabricError;
-        expect(decoded.message).toBe("outer");
-        // The cause is a FabricError (the inner wrapper) after round-trip.
-        expect(decoded.cause).toBeInstanceOf(FabricError);
-        expect((decoded.cause as FabricError).message).toBe("inner");
-      });
+        it("round-trips an `Error` with custom properties", () => {
+          const err = new Error("oops");
+          (err as unknown as Record<string, unknown>).code = 42;
+          (err as unknown as Record<string, unknown>).detail = "more info";
+          const se = FabricError.fromNativeError(err);
+          const decoded = codec.decode(
+            codec.wireTypeTag,
+            codec.encode(se),
+            context,
+          ) as unknown as FabricError;
+          expect(decoded.message).toBe("oops");
+          const native = decoded.toNativeValue(true) as unknown as Record<
+            string,
+            unknown
+          >;
+          expect(native.code).toBe(42);
+          expect(native.detail).toBe("more info");
+        });
 
-      it("round-trips an `Error` whose cause is itself a `FabricError`", () => {
-        // Simulates what `fabricFromNativeValue` produces: a FabricError
-        // wrapping an Error whose cause is itself a FabricError (not a raw
-        // Error). Encoding's recurse on `[DECONSTRUCT]` output must find a
-        // FabricValue, not a raw Error.
-        const innerSe = FabricError.fromNativeError(new Error("inner"));
-        const outerErr = new Error("outer");
-        outerErr.cause = innerSe;
-        const outerSe = FabricError.fromNativeError(outerErr);
-        const decoded = codec.decode(
-          codec.wireTypeTag,
-          codec.encode(outerSe),
-          context,
-        ) as unknown as FabricError;
-        expect(decoded.message).toBe("outer");
-        expect(decoded.cause).toBeInstanceOf(FabricError);
-        expect((decoded.cause as FabricError).message).toBe("inner");
-      });
+        it("round-trips an `Error` with a custom `name`", () => {
+          const err = new Error("custom");
+          err.name = "MyCustomError";
+          const se = FabricError.fromNativeError(err);
+          const decoded = codec.decode(
+            codec.wireTypeTag,
+            codec.encode(se),
+            context,
+          ) as unknown as FabricError;
+          expect(decoded.name).toBe("MyCustomError");
+          expect(decoded.message).toBe("custom");
+        });
 
-      it("round-trips an `Error` with custom properties", () => {
-        const err = new Error("oops");
-        (err as unknown as Record<string, unknown>).code = 42;
-        (err as unknown as Record<string, unknown>).detail = "more info";
-        const se = FabricError.fromNativeError(err);
-        const decoded = codec.decode(
-          codec.wireTypeTag,
-          codec.encode(se),
-          context,
-        ) as unknown as FabricError;
-        expect(decoded.message).toBe("oops");
-        const native = decoded.toNativeValue(true) as unknown as Record<
-          string,
-          unknown
-        >;
-        expect(native.code).toBe(42);
-        expect(native.detail).toBe("more info");
-      });
+        it("round-trips a `TypeError` preserving `name === type` identity", () => {
+          const se = FabricError.fromNativeError(new TypeError("rt"));
+          const decoded = codec.decode(
+            codec.wireTypeTag,
+            codec.encode(se),
+            context,
+          ) as unknown as FabricError;
+          expect(decoded.toNativeValue(true)).toBeInstanceOf(TypeError);
+          expect(decoded.name).toBe("TypeError");
+          expect(decoded.toNativeValue(true).constructor.name).toBe(
+            "TypeError",
+          );
+        });
 
-      it("round-trips an `Error` with a custom `name`", () => {
-        const err = new Error("custom");
-        err.name = "MyCustomError";
-        const se = FabricError.fromNativeError(err);
-        const decoded = codec.decode(
-          codec.wireTypeTag,
-          codec.encode(se),
-          context,
-        ) as unknown as FabricError;
-        expect(decoded.name).toBe("MyCustomError");
-        expect(decoded.message).toBe("custom");
-      });
-
-      it("round-trips a `TypeError` preserving `name === type` identity", () => {
-        const se = FabricError.fromNativeError(new TypeError("rt"));
-        const decoded = codec.decode(
-          codec.wireTypeTag,
-          codec.encode(se),
-          context,
-        ) as unknown as FabricError;
-        expect(decoded.toNativeValue(true)).toBeInstanceOf(TypeError);
-        expect(decoded.name).toBe("TypeError");
-        expect(decoded.toNativeValue(true).constructor.name).toBe("TypeError");
-      });
-
-      it("round-trips an `Error` with mismatched `name` and `type`", () => {
-        // Error constructor is "Error" but name is overridden.
-        const err = new Error("mismatch");
-        err.name = "CustomName";
-        const se = FabricError.fromNativeError(err);
-        const decoded = codec.decode(
-          codec.wireTypeTag,
-          codec.encode(se),
-          context,
-        ) as unknown as FabricError;
-        expect(decoded.toNativeValue(true)).toBeInstanceOf(Error);
-        expect(decoded.name).toBe("CustomName");
-        expect(decoded.toNativeValue(true).constructor.name).toBe("Error");
+        it("round-trips an `Error` with mismatched `name` and `type`", () => {
+          // Error constructor is "Error" but name is overridden.
+          const err = new Error("mismatch");
+          err.name = "CustomName";
+          const se = FabricError.fromNativeError(err);
+          const decoded = codec.decode(
+            codec.wireTypeTag,
+            codec.encode(se),
+            context,
+          ) as unknown as FabricError;
+          expect(decoded.toNativeValue(true)).toBeInstanceOf(Error);
+          expect(decoded.name).toBe("CustomName");
+          expect(decoded.toNativeValue(true).constructor.name).toBe("Error");
+        });
       });
     });
   });

--- a/packages/data-model/test/fabric-instances/FabricError.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricError.test.ts
@@ -7,7 +7,9 @@ import {
   type FabricValue,
   IS_DEEP_FROZEN,
 } from "@/interface.ts";
-import { DECONSTRUCT, RECONSTRUCT } from "@/wire-common/interface.ts";
+import { CODEC, DECONSTRUCT, RECONSTRUCT } from "@/wire-common/interface.ts";
+import { WIRE_TYPE_TAGS } from "@/wire-common/wire-type-tags.ts";
+import { EMPTY_RECONSTRUCTION_CONTEXT } from "@/wire-common/EmptyReconstructionContext.ts";
 import { FabricError } from "@/fabric-instances/FabricError.ts";
 import { FabricNativeWrapper } from "@/fabric-instances/FabricNativeWrapper.ts";
 import {
@@ -358,6 +360,183 @@ describe("FabricError", () => {
         const result = FabricError[RECONSTRUCT](state, dummyContext);
         expect(result.cause).toBe("something went wrong");
         expect(result.getExtra("code")).toBe(404);
+      });
+    });
+
+    describe("[CODEC]", () => {
+      const codec = FabricError[CODEC];
+      const context = EMPTY_RECONSTRUCTION_CONTEXT;
+
+      it("has the `Error` wire type tag", () => {
+        expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.Error);
+      });
+
+      it("encodes a basic `FabricError` to its `{ type, name, message }` state", () => {
+        const se = FabricError.fromNativeError(new Error("test"));
+        const state = codec.encode(se as FabricValue) as Record<
+          string,
+          unknown
+        >;
+        expect(state.type).toBe("Error");
+        expect(state.name).toBe(null); // null = same as type (common case)
+        expect(state.message).toBe("test");
+      });
+
+      it("encodes `name: null` when `name` matches `type` (`TypeError`)", () => {
+        // TypeError: name === constructor.name === "TypeError".
+        const se = FabricError.fromNativeError(new TypeError("type check"));
+        const state = codec.encode(se as FabricValue) as Record<
+          string,
+          unknown
+        >;
+        expect(state.type).toBe("TypeError");
+        expect(state.name).toBe(null); // null = same as type
+        expect(state.message).toBe("type check");
+      });
+
+      it("encodes an explicit `name` when `name` differs from `type`", () => {
+        const err = new Error("custom");
+        err.name = "MyCustomError";
+        const se = FabricError.fromNativeError(err);
+        const state = codec.encode(se as FabricValue) as Record<
+          string,
+          unknown
+        >;
+        expect(state.type).toBe("Error");
+        expect(state.name).toBe("MyCustomError");
+        expect(state.message).toBe("custom");
+      });
+
+      it("round-trips a basic `Error`", () => {
+        const se = FabricError.fromNativeError(new Error("hello"));
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(se as FabricValue),
+          context,
+        ) as unknown as FabricError;
+        expect(decoded).toBeInstanceOf(FabricError);
+        expect(decoded.toNativeValue(true)).toBeInstanceOf(Error);
+        expect(decoded.name).toBe("Error");
+        expect(decoded.message).toBe("hello");
+      });
+
+      it("round-trips a `TypeError`", () => {
+        const se = FabricError.fromNativeError(new TypeError("bad type"));
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(se as FabricValue),
+          context,
+        ) as unknown as FabricError;
+        expect(decoded).toBeInstanceOf(FabricError);
+        expect(decoded.toNativeValue(true)).toBeInstanceOf(TypeError);
+        expect(decoded.name).toBe("TypeError");
+        expect(decoded.message).toBe("bad type");
+      });
+
+      it("round-trips a `RangeError`", () => {
+        const se = FabricError.fromNativeError(new RangeError("out of range"));
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(se as FabricValue),
+          context,
+        ) as unknown as FabricError;
+        expect(decoded).toBeInstanceOf(FabricError);
+        expect(decoded.toNativeValue(true)).toBeInstanceOf(RangeError);
+        expect(decoded.name).toBe("RangeError");
+      });
+
+      it("round-trips an `Error` with a (pre-converted) cause", () => {
+        const inner = FabricError.fromNativeError(new Error("inner"));
+        const outer = FabricError.fromNativeError(
+          new Error("outer", { cause: inner }),
+        );
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(outer as FabricValue),
+          context,
+        ) as unknown as FabricError;
+        expect(decoded.message).toBe("outer");
+        // The cause is a FabricError (the inner wrapper) after round-trip.
+        expect(decoded.cause).toBeInstanceOf(FabricError);
+        expect((decoded.cause as FabricError).message).toBe("inner");
+      });
+
+      it("round-trips an `Error` whose cause is itself a `FabricError`", () => {
+        // Simulates what `fabricFromNativeValue` produces: a FabricError
+        // wrapping an Error whose cause is itself a FabricError (not a raw
+        // Error). Encoding's recurse on `[DECONSTRUCT]` output must find a
+        // FabricValue, not a raw Error.
+        const innerSe = FabricError.fromNativeError(new Error("inner"));
+        const outerErr = new Error("outer");
+        outerErr.cause = innerSe;
+        const outerSe = FabricError.fromNativeError(outerErr);
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(outerSe as FabricValue),
+          context,
+        ) as unknown as FabricError;
+        expect(decoded.message).toBe("outer");
+        expect(decoded.cause).toBeInstanceOf(FabricError);
+        expect((decoded.cause as FabricError).message).toBe("inner");
+      });
+
+      it("round-trips an `Error` with custom properties", () => {
+        const err = new Error("oops");
+        (err as unknown as Record<string, unknown>).code = 42;
+        (err as unknown as Record<string, unknown>).detail = "more info";
+        const se = FabricError.fromNativeError(err);
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(se as FabricValue),
+          context,
+        ) as unknown as FabricError;
+        expect(decoded.message).toBe("oops");
+        const native = decoded.toNativeValue(true) as unknown as Record<
+          string,
+          unknown
+        >;
+        expect(native.code).toBe(42);
+        expect(native.detail).toBe("more info");
+      });
+
+      it("round-trips an `Error` with a custom `name`", () => {
+        const err = new Error("custom");
+        err.name = "MyCustomError";
+        const se = FabricError.fromNativeError(err);
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(se as FabricValue),
+          context,
+        ) as unknown as FabricError;
+        expect(decoded.name).toBe("MyCustomError");
+        expect(decoded.message).toBe("custom");
+      });
+
+      it("round-trips a `TypeError` preserving `name === type` identity", () => {
+        const se = FabricError.fromNativeError(new TypeError("rt"));
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(se as FabricValue),
+          context,
+        ) as unknown as FabricError;
+        expect(decoded.toNativeValue(true)).toBeInstanceOf(TypeError);
+        expect(decoded.name).toBe("TypeError");
+        expect(decoded.toNativeValue(true).constructor.name).toBe("TypeError");
+      });
+
+      it("round-trips an `Error` with mismatched `name` and `type`", () => {
+        // Error constructor is "Error" but name is overridden.
+        const err = new Error("mismatch");
+        err.name = "CustomName";
+        const se = FabricError.fromNativeError(err);
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(se as FabricValue),
+          context,
+        ) as unknown as FabricError;
+        expect(decoded.toNativeValue(true)).toBeInstanceOf(Error);
+        expect(decoded.name).toBe("CustomName");
+        expect(decoded.toNativeValue(true).constructor.name).toBe("Error");
       });
     });
   });

--- a/packages/data-model/test/fabric-instances/FabricMap.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricMap.test.ts
@@ -7,7 +7,9 @@ import {
   type FabricValue,
   IS_DEEP_FROZEN,
 } from "@/interface.ts";
-import { DECONSTRUCT, RECONSTRUCT } from "@/wire-common/interface.ts";
+import { CODEC, DECONSTRUCT, RECONSTRUCT } from "@/wire-common/interface.ts";
+import { WIRE_TYPE_TAGS } from "@/wire-common/wire-type-tags.ts";
+import { EMPTY_RECONSTRUCTION_CONTEXT } from "@/wire-common/EmptyReconstructionContext.ts";
 import { FabricMap } from "@/fabric-instances/FabricMap.ts";
 import { FabricNativeWrapper } from "@/fabric-instances/FabricNativeWrapper.ts";
 import { FrozenMap } from "@/frozen-builtins.ts";
@@ -119,6 +121,43 @@ describe("FabricMap", () => {
         expect(() => FabricMap[RECONSTRUCT](null, dummyContext)).toThrow(
           "not yet implemented",
         );
+      });
+    });
+
+    // Nominal coverage: the codec exists and reports its wire tag and claims
+    // its instances, but `encode()`/`decode()` are still stubs that delegate
+    // to the not-yet-implemented `[DECONSTRUCT]`/`[RECONSTRUCT]` protocol.
+    describe("[CODEC]", () => {
+      const codec = FabricMap[CODEC];
+      const context = EMPTY_RECONSTRUCTION_CONTEXT;
+
+      describe("wireTypeTag", () => {
+        it("is the `Map` wire type tag", () => {
+          expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.Map);
+        });
+      });
+
+      describe("canEncode()", () => {
+        it("claims a `FabricMap`, rejecting other values", () => {
+          expect(codec.canEncode(new FabricMap(new Map()))).toBe(true);
+          expect(codec.canEncode("not a map")).toBe(false);
+        });
+      });
+
+      describe("encode()", () => {
+        it("throws (stub, via `[DECONSTRUCT]`)", () => {
+          expect(() => codec.encode(new FabricMap(new Map()))).toThrow(
+            "not yet implemented",
+          );
+        });
+      });
+
+      describe("decode()", () => {
+        it("throws (stub, via `[RECONSTRUCT]`)", () => {
+          expect(() => codec.decode(codec.wireTypeTag, null, context)).toThrow(
+            "not yet implemented",
+          );
+        });
       });
     });
   });

--- a/packages/data-model/test/fabric-instances/FabricSet.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricSet.test.ts
@@ -7,7 +7,9 @@ import {
   type FabricValue,
   IS_DEEP_FROZEN,
 } from "@/interface.ts";
-import { DECONSTRUCT } from "@/wire-common/interface.ts";
+import { CODEC, DECONSTRUCT } from "@/wire-common/interface.ts";
+import { WIRE_TYPE_TAGS } from "@/wire-common/wire-type-tags.ts";
+import { EMPTY_RECONSTRUCTION_CONTEXT } from "@/wire-common/EmptyReconstructionContext.ts";
 import { FabricSet } from "@/fabric-instances/FabricSet.ts";
 import { FrozenSet } from "@/frozen-builtins.ts";
 import { deepFreeze, isDeepFrozenFabricValue } from "@/deep-freeze.ts";
@@ -93,6 +95,45 @@ describe("FabricSet", () => {
         expect(() => fs[IS_DEEP_FROZEN](subIsDeepFrozen)).toThrow(
           "FabricSet: not yet implemented",
         );
+      });
+    });
+  });
+
+  describe("static members", () => {
+    // Nominal coverage: the codec exists and reports its wire tag and claims
+    // its instances, but `encode()`/`decode()` are still stubs that delegate
+    // to the not-yet-implemented `[DECONSTRUCT]`/`[RECONSTRUCT]` protocol.
+    describe("[CODEC]", () => {
+      const codec = FabricSet[CODEC];
+      const context = EMPTY_RECONSTRUCTION_CONTEXT;
+
+      describe("wireTypeTag", () => {
+        it("is the `Set` wire type tag", () => {
+          expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.Set);
+        });
+      });
+
+      describe("canEncode()", () => {
+        it("claims a `FabricSet`, rejecting other values", () => {
+          expect(codec.canEncode(new FabricSet(new Set()))).toBe(true);
+          expect(codec.canEncode("not a set")).toBe(false);
+        });
+      });
+
+      describe("encode()", () => {
+        it("throws (stub, via `[DECONSTRUCT]`)", () => {
+          expect(() => codec.encode(new FabricSet(new Set()))).toThrow(
+            "not yet implemented",
+          );
+        });
+      });
+
+      describe("decode()", () => {
+        it("throws (stub, via `[RECONSTRUCT]`)", () => {
+          expect(() => codec.decode(codec.wireTypeTag, null, context)).toThrow(
+            "not yet implemented",
+          );
+        });
       });
     });
   });

--- a/packages/data-model/test/fabric-primitives/FabricBytes.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricBytes.test.ts
@@ -93,65 +93,69 @@ describe("FabricBytes", () => {
       const codec = FabricBytes[CODEC];
       const context = EMPTY_RECONSTRUCTION_CONTEXT;
 
-      it("has the `Bytes` wire type tag", () => {
-        expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.Bytes);
+      describe("wireTypeTag", () => {
+        it("is the `Bytes` wire type tag", () => {
+          expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.Bytes);
+        });
       });
 
-      it("claims a `FabricBytes` via `canEncode()`, rejecting other values", () => {
-        expect(codec.canEncode(new FabricBytes(new Uint8Array([1, 2, 3]))))
-          .toBe(true);
-        expect(codec.canEncode("not bytes")).toBe(false);
+      describe("canEncode()", () => {
+        it("claims a `FabricBytes`, rejecting other values", () => {
+          expect(codec.canEncode(new FabricBytes(new Uint8Array([1, 2, 3]))))
+            .toBe(true);
+          expect(codec.canEncode("not bytes")).toBe(false);
+        });
       });
 
-      it("encodes to an unpadded base64url string", () => {
-        // [1, 2, 3] -> base64url "AQID".
-        const fb = new FabricBytes(new Uint8Array([1, 2, 3]));
-        expect(codec.encode(fb)).toBe("AQID");
+      describe("encode()", () => {
+        it("encodes to an unpadded base64url string", () => {
+          // [1, 2, 3] -> base64url "AQID".
+          const fb = new FabricBytes(new Uint8Array([1, 2, 3]));
+          expect(codec.encode(fb)).toBe("AQID");
+        });
+
+        it("encodes empty bytes to the empty string", () => {
+          const fb = new FabricBytes(new Uint8Array());
+          expect(codec.encode(fb)).toBe("");
+        });
       });
 
-      it("encodes empty bytes to the empty string", () => {
-        const fb = new FabricBytes(new Uint8Array());
-        expect(codec.encode(fb)).toBe("");
-      });
+      describe("decode()", () => {
+        it("round-trips via encode -> decode", () => {
+          const fb = new FabricBytes(new Uint8Array([10, 20, 30, 40]));
+          const decoded = codec.decode(
+            codec.wireTypeTag,
+            codec.encode(fb),
+            context,
+          ) as unknown as FabricBytes;
+          expect(decoded).toBeInstanceOf(FabricBytes);
+          expect(decoded.slice()).toEqual(new Uint8Array([10, 20, 30, 40]));
+        });
 
-      it("round-trips via encode -> decode", () => {
-        const fb = new FabricBytes(new Uint8Array([10, 20, 30, 40]));
-        const decoded = codec.decode(
-          codec.wireTypeTag,
-          codec.encode(fb),
-          context,
-        ) as unknown as FabricBytes;
-        expect(decoded).toBeInstanceOf(FabricBytes);
-        expect(decoded.slice()).toEqual(new Uint8Array([10, 20, 30, 40]));
-      });
+        it("round-trips empty bytes", () => {
+          const fb = new FabricBytes(new Uint8Array());
+          const decoded = codec.decode(
+            codec.wireTypeTag,
+            codec.encode(fb),
+            context,
+          ) as unknown as FabricBytes;
+          expect(decoded).toBeInstanceOf(FabricBytes);
+          expect(decoded.length).toBe(0);
+        });
 
-      it("round-trips empty bytes", () => {
-        const fb = new FabricBytes(new Uint8Array());
-        const decoded = codec.decode(
-          codec.wireTypeTag,
-          codec.encode(fb),
-          context,
-        ) as unknown as FabricBytes;
-        expect(decoded).toBeInstanceOf(FabricBytes);
-        expect(decoded.length).toBe(0);
-      });
+        it("decodes non-string state to a `ProblematicValue`", () => {
+          const decoded = codec.decode(codec.wireTypeTag, 42, context);
+          expect(decoded).toBeInstanceOf(ProblematicValue);
+        });
 
-      it("decodes non-string state to a `ProblematicValue`", () => {
-        const decoded = codec.decode(
-          codec.wireTypeTag,
-          42,
-          context,
-        );
-        expect(decoded).toBeInstanceOf(ProblematicValue);
-      });
-
-      it("decodes malformed base64 to a `ProblematicValue`", () => {
-        const decoded = codec.decode(
-          codec.wireTypeTag,
-          "not valid base64!!",
-          context,
-        );
-        expect(decoded).toBeInstanceOf(ProblematicValue);
+        it("decodes malformed base64 to a `ProblematicValue`", () => {
+          const decoded = codec.decode(
+            codec.wireTypeTag,
+            "not valid base64!!",
+            context,
+          );
+          expect(decoded).toBeInstanceOf(ProblematicValue);
+        });
       });
     });
   });

--- a/packages/data-model/test/fabric-primitives/FabricBytes.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricBytes.test.ts
@@ -2,7 +2,12 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
 import { FabricInstance, FabricPrimitive } from "@/interface.ts";
+import type { FabricValue } from "@/interface.ts";
 import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
+import { CODEC } from "@/wire-common/interface.ts";
+import { WIRE_TYPE_TAGS } from "@/wire-common/wire-type-tags.ts";
+import { EMPTY_RECONSTRUCTION_CONTEXT } from "@/wire-common/EmptyReconstructionContext.ts";
+import { ProblematicValue } from "@/fabric-instances/ProblematicValue.ts";
 
 describe("FabricBytes", () => {
   // Pure type-identity / supertype check: cross-cutting carve-out per the
@@ -80,6 +85,68 @@ describe("FabricBytes", () => {
         const fb = new FabricBytes(new Uint8Array([1, 2, 3]));
         const target = new Uint8Array(3);
         expect(() => fb.copyInto(target, 0, -1)).toThrow(RangeError);
+      });
+    });
+  });
+
+  describe("static members", () => {
+    describe("[CODEC]", () => {
+      const codec = FabricBytes[CODEC];
+      const context = EMPTY_RECONSTRUCTION_CONTEXT;
+
+      it("has the `Bytes` wire type tag", () => {
+        expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.Bytes);
+      });
+
+      it("encodes to an unpadded base64url string", () => {
+        // [1, 2, 3] -> base64url "AQID".
+        const fb = new FabricBytes(new Uint8Array([1, 2, 3]));
+        expect(codec.encode(fb as FabricValue)).toBe("AQID");
+      });
+
+      it("encodes empty bytes to the empty string", () => {
+        const fb = new FabricBytes(new Uint8Array());
+        expect(codec.encode(fb as FabricValue)).toBe("");
+      });
+
+      it("round-trips via encode -> decode", () => {
+        const fb = new FabricBytes(new Uint8Array([10, 20, 30, 40]));
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(fb as FabricValue),
+          context,
+        ) as unknown as FabricBytes;
+        expect(decoded).toBeInstanceOf(FabricBytes);
+        expect(decoded.slice()).toEqual(new Uint8Array([10, 20, 30, 40]));
+      });
+
+      it("round-trips empty bytes", () => {
+        const fb = new FabricBytes(new Uint8Array());
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(fb as FabricValue),
+          context,
+        ) as unknown as FabricBytes;
+        expect(decoded).toBeInstanceOf(FabricBytes);
+        expect(decoded.length).toBe(0);
+      });
+
+      it("decodes non-string state to a `ProblematicValue`", () => {
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          42 as unknown as FabricValue,
+          context,
+        );
+        expect(decoded).toBeInstanceOf(ProblematicValue);
+      });
+
+      it("decodes malformed base64 to a `ProblematicValue`", () => {
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          "not valid base64!!" as unknown as FabricValue,
+          context,
+        );
+        expect(decoded).toBeInstanceOf(ProblematicValue);
       });
     });
   });

--- a/packages/data-model/test/fabric-primitives/FabricBytes.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricBytes.test.ts
@@ -2,7 +2,6 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
 import { FabricInstance, FabricPrimitive } from "@/interface.ts";
-import type { FabricValue } from "@/interface.ts";
 import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
 import { CODEC } from "@/wire-common/interface.ts";
 import { WIRE_TYPE_TAGS } from "@/wire-common/wire-type-tags.ts";
@@ -98,22 +97,28 @@ describe("FabricBytes", () => {
         expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.Bytes);
       });
 
+      it("claims a `FabricBytes` via `canEncode()`, rejecting other values", () => {
+        expect(codec.canEncode(new FabricBytes(new Uint8Array([1, 2, 3]))))
+          .toBe(true);
+        expect(codec.canEncode("not bytes")).toBe(false);
+      });
+
       it("encodes to an unpadded base64url string", () => {
         // [1, 2, 3] -> base64url "AQID".
         const fb = new FabricBytes(new Uint8Array([1, 2, 3]));
-        expect(codec.encode(fb as FabricValue)).toBe("AQID");
+        expect(codec.encode(fb)).toBe("AQID");
       });
 
       it("encodes empty bytes to the empty string", () => {
         const fb = new FabricBytes(new Uint8Array());
-        expect(codec.encode(fb as FabricValue)).toBe("");
+        expect(codec.encode(fb)).toBe("");
       });
 
       it("round-trips via encode -> decode", () => {
         const fb = new FabricBytes(new Uint8Array([10, 20, 30, 40]));
         const decoded = codec.decode(
           codec.wireTypeTag,
-          codec.encode(fb as FabricValue),
+          codec.encode(fb),
           context,
         ) as unknown as FabricBytes;
         expect(decoded).toBeInstanceOf(FabricBytes);
@@ -124,7 +129,7 @@ describe("FabricBytes", () => {
         const fb = new FabricBytes(new Uint8Array());
         const decoded = codec.decode(
           codec.wireTypeTag,
-          codec.encode(fb as FabricValue),
+          codec.encode(fb),
           context,
         ) as unknown as FabricBytes;
         expect(decoded).toBeInstanceOf(FabricBytes);
@@ -134,7 +139,7 @@ describe("FabricBytes", () => {
       it("decodes non-string state to a `ProblematicValue`", () => {
         const decoded = codec.decode(
           codec.wireTypeTag,
-          42 as unknown as FabricValue,
+          42,
           context,
         );
         expect(decoded).toBeInstanceOf(ProblematicValue);
@@ -143,7 +148,7 @@ describe("FabricBytes", () => {
       it("decodes malformed base64 to a `ProblematicValue`", () => {
         const decoded = codec.decode(
           codec.wireTypeTag,
-          "not valid base64!!" as unknown as FabricValue,
+          "not valid base64!!",
           context,
         );
         expect(decoded).toBeInstanceOf(ProblematicValue);

--- a/packages/data-model/test/fabric-primitives/FabricEpochDays.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochDays.test.ts
@@ -3,7 +3,11 @@ import { expect } from "@std/expect";
 
 import { FabricEpochDays } from "@/fabric-primitives/FabricEpochDays.ts";
 import { FabricInstance, FabricPrimitive } from "@/interface.ts";
+import type { FabricValue } from "@/interface.ts";
 import { shallowFabricFromNativeValue } from "@/fabric-value.ts";
+import { CODEC } from "@/wire-common/interface.ts";
+import { WIRE_TYPE_TAGS } from "@/wire-common/wire-type-tags.ts";
+import { EMPTY_RECONSTRUCTION_CONTEXT } from "@/wire-common/EmptyReconstructionContext.ts";
 
 describe("FabricEpochDays", () => {
   // Pure type-identity / supertype checks: cross-cutting carve-out per the
@@ -40,6 +44,58 @@ describe("FabricEpochDays", () => {
       it("wraps negative values (pre-epoch)", () => {
         const sd = new FabricEpochDays(-365n);
         expect(sd.value).toBe(-365n);
+      });
+    });
+  });
+
+  describe("static members", () => {
+    describe("[CODEC]", () => {
+      const codec = FabricEpochDays[CODEC];
+      const context = EMPTY_RECONSTRUCTION_CONTEXT;
+
+      it("has the `EpochDays` wire type tag", () => {
+        expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.EpochDays);
+      });
+
+      it("encodes to a flat base64 string (epoch zero)", () => {
+        const sd = new FabricEpochDays(0n);
+        // Flat format: base64 string directly, not nested {"/BigInt@1": ...}.
+        expect(codec.encode(sd as FabricValue)).toBe("AA");
+      });
+
+      it("round-trips at top level (epoch zero)", () => {
+        const sd = new FabricEpochDays(0n);
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(sd as FabricValue),
+          context,
+        ) as unknown as FabricEpochDays;
+        expect(decoded).toBeInstanceOf(FabricEpochDays);
+        expect(decoded.value).toBe(0n);
+      });
+
+      it("round-trips positive day count", () => {
+        const days = 19723n; // ~2024-01-01
+        const sd = new FabricEpochDays(days);
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(sd as FabricValue),
+          context,
+        ) as unknown as FabricEpochDays;
+        expect(decoded).toBeInstanceOf(FabricEpochDays);
+        expect(decoded.value).toBe(days);
+      });
+
+      it("round-trips negative day count (pre-epoch)", () => {
+        const days = -365n;
+        const sd = new FabricEpochDays(days);
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(sd as FabricValue),
+          context,
+        ) as unknown as FabricEpochDays;
+        expect(decoded).toBeInstanceOf(FabricEpochDays);
+        expect(decoded.value).toBe(days);
       });
     });
   });

--- a/packages/data-model/test/fabric-primitives/FabricEpochDays.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochDays.test.ts
@@ -52,54 +52,62 @@ describe("FabricEpochDays", () => {
       const codec = FabricEpochDays[CODEC];
       const context = EMPTY_RECONSTRUCTION_CONTEXT;
 
-      it("has the `EpochDays` wire type tag", () => {
-        expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.EpochDays);
+      describe("wireTypeTag", () => {
+        it("is the `EpochDays` wire type tag", () => {
+          expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.EpochDays);
+        });
       });
 
-      it("claims a `FabricEpochDays` via `canEncode()`, rejecting others", () => {
-        expect(codec.canEncode(new FabricEpochDays(0n))).toBe(true);
-        expect(codec.canEncode("not an epoch")).toBe(false);
+      describe("canEncode()", () => {
+        it("claims a `FabricEpochDays`, rejecting other values", () => {
+          expect(codec.canEncode(new FabricEpochDays(0n))).toBe(true);
+          expect(codec.canEncode("not an epoch")).toBe(false);
+        });
       });
 
-      it("encodes to a flat base64 string (epoch zero)", () => {
-        const sd = new FabricEpochDays(0n);
-        // Flat format: base64 string directly, not nested {"/BigInt@1": ...}.
-        expect(codec.encode(sd)).toBe("AA");
+      describe("encode()", () => {
+        it("encodes to a flat base64 string (epoch zero)", () => {
+          const sd = new FabricEpochDays(0n);
+          // Flat format: base64 string directly, not nested {"/BigInt@1": ...}.
+          expect(codec.encode(sd)).toBe("AA");
+        });
       });
 
-      it("round-trips at top level (epoch zero)", () => {
-        const sd = new FabricEpochDays(0n);
-        const decoded = codec.decode(
-          codec.wireTypeTag,
-          codec.encode(sd),
-          context,
-        ) as unknown as FabricEpochDays;
-        expect(decoded).toBeInstanceOf(FabricEpochDays);
-        expect(decoded.value).toBe(0n);
-      });
+      describe("decode()", () => {
+        it("round-trips at top level (epoch zero)", () => {
+          const sd = new FabricEpochDays(0n);
+          const decoded = codec.decode(
+            codec.wireTypeTag,
+            codec.encode(sd),
+            context,
+          ) as unknown as FabricEpochDays;
+          expect(decoded).toBeInstanceOf(FabricEpochDays);
+          expect(decoded.value).toBe(0n);
+        });
 
-      it("round-trips positive day count", () => {
-        const days = 19723n; // ~2024-01-01
-        const sd = new FabricEpochDays(days);
-        const decoded = codec.decode(
-          codec.wireTypeTag,
-          codec.encode(sd),
-          context,
-        ) as unknown as FabricEpochDays;
-        expect(decoded).toBeInstanceOf(FabricEpochDays);
-        expect(decoded.value).toBe(days);
-      });
+        it("round-trips positive day count", () => {
+          const days = 19723n; // ~2024-01-01
+          const sd = new FabricEpochDays(days);
+          const decoded = codec.decode(
+            codec.wireTypeTag,
+            codec.encode(sd),
+            context,
+          ) as unknown as FabricEpochDays;
+          expect(decoded).toBeInstanceOf(FabricEpochDays);
+          expect(decoded.value).toBe(days);
+        });
 
-      it("round-trips negative day count (pre-epoch)", () => {
-        const days = -365n;
-        const sd = new FabricEpochDays(days);
-        const decoded = codec.decode(
-          codec.wireTypeTag,
-          codec.encode(sd),
-          context,
-        ) as unknown as FabricEpochDays;
-        expect(decoded).toBeInstanceOf(FabricEpochDays);
-        expect(decoded.value).toBe(days);
+        it("round-trips negative day count (pre-epoch)", () => {
+          const days = -365n;
+          const sd = new FabricEpochDays(days);
+          const decoded = codec.decode(
+            codec.wireTypeTag,
+            codec.encode(sd),
+            context,
+          ) as unknown as FabricEpochDays;
+          expect(decoded).toBeInstanceOf(FabricEpochDays);
+          expect(decoded.value).toBe(days);
+        });
       });
     });
   });

--- a/packages/data-model/test/fabric-primitives/FabricEpochDays.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochDays.test.ts
@@ -3,7 +3,6 @@ import { expect } from "@std/expect";
 
 import { FabricEpochDays } from "@/fabric-primitives/FabricEpochDays.ts";
 import { FabricInstance, FabricPrimitive } from "@/interface.ts";
-import type { FabricValue } from "@/interface.ts";
 import { shallowFabricFromNativeValue } from "@/fabric-value.ts";
 import { CODEC } from "@/wire-common/interface.ts";
 import { WIRE_TYPE_TAGS } from "@/wire-common/wire-type-tags.ts";
@@ -57,17 +56,22 @@ describe("FabricEpochDays", () => {
         expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.EpochDays);
       });
 
+      it("claims a `FabricEpochDays` via `canEncode()`, rejecting others", () => {
+        expect(codec.canEncode(new FabricEpochDays(0n))).toBe(true);
+        expect(codec.canEncode("not an epoch")).toBe(false);
+      });
+
       it("encodes to a flat base64 string (epoch zero)", () => {
         const sd = new FabricEpochDays(0n);
         // Flat format: base64 string directly, not nested {"/BigInt@1": ...}.
-        expect(codec.encode(sd as FabricValue)).toBe("AA");
+        expect(codec.encode(sd)).toBe("AA");
       });
 
       it("round-trips at top level (epoch zero)", () => {
         const sd = new FabricEpochDays(0n);
         const decoded = codec.decode(
           codec.wireTypeTag,
-          codec.encode(sd as FabricValue),
+          codec.encode(sd),
           context,
         ) as unknown as FabricEpochDays;
         expect(decoded).toBeInstanceOf(FabricEpochDays);
@@ -79,7 +83,7 @@ describe("FabricEpochDays", () => {
         const sd = new FabricEpochDays(days);
         const decoded = codec.decode(
           codec.wireTypeTag,
-          codec.encode(sd as FabricValue),
+          codec.encode(sd),
           context,
         ) as unknown as FabricEpochDays;
         expect(decoded).toBeInstanceOf(FabricEpochDays);
@@ -91,7 +95,7 @@ describe("FabricEpochDays", () => {
         const sd = new FabricEpochDays(days);
         const decoded = codec.decode(
           codec.wireTypeTag,
-          codec.encode(sd as FabricValue),
+          codec.encode(sd),
           context,
         ) as unknown as FabricEpochDays;
         expect(decoded).toBeInstanceOf(FabricEpochDays);

--- a/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
@@ -3,7 +3,11 @@ import { expect } from "@std/expect";
 
 import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
 import { FabricInstance, FabricPrimitive } from "@/interface.ts";
+import type { FabricValue } from "@/interface.ts";
 import { shallowFabricFromNativeValue } from "@/fabric-value.ts";
+import { CODEC } from "@/wire-common/interface.ts";
+import { WIRE_TYPE_TAGS } from "@/wire-common/wire-type-tags.ts";
+import { EMPTY_RECONSTRUCTION_CONTEXT } from "@/wire-common/EmptyReconstructionContext.ts";
 
 describe("FabricEpochNsec", () => {
   // Pure type-identity / supertype checks: cross-cutting carve-out per the
@@ -46,6 +50,71 @@ describe("FabricEpochNsec", () => {
         const nsec = 32503680000000000000n;
         const sn = new FabricEpochNsec(nsec);
         expect(sn.value).toBe(nsec);
+      });
+    });
+  });
+
+  describe("static members", () => {
+    describe("[CODEC]", () => {
+      const codec = FabricEpochNsec[CODEC];
+      const context = EMPTY_RECONSTRUCTION_CONTEXT;
+
+      it("has the `EpochNsec` wire type tag", () => {
+        expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.EpochNsec);
+      });
+
+      it("encodes to a flat base64 string (epoch zero)", () => {
+        const sn = new FabricEpochNsec(0n);
+        // Flat format: base64 string directly, not nested {"/BigInt@1": ...}.
+        expect(codec.encode(sn as FabricValue)).toBe("AA");
+      });
+
+      it("round-trips at top level (epoch zero)", () => {
+        const sn = new FabricEpochNsec(0n);
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(sn as FabricValue),
+          context,
+        ) as unknown as FabricEpochNsec;
+        expect(decoded).toBeInstanceOf(FabricEpochNsec);
+        expect(decoded.value).toBe(0n);
+      });
+
+      it("round-trips positive nanosecond timestamp", () => {
+        // 2024-01-01T00:00:00Z = 1704067200 seconds = 1704067200000000000 nsec
+        const nsec = 1704067200000000000n;
+        const sn = new FabricEpochNsec(nsec);
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(sn as FabricValue),
+          context,
+        ) as unknown as FabricEpochNsec;
+        expect(decoded).toBeInstanceOf(FabricEpochNsec);
+        expect(decoded.value).toBe(nsec);
+      });
+
+      it("round-trips negative nanosecond timestamp (pre-epoch)", () => {
+        const nsec = -86400000000000n; // -1 day in nanoseconds
+        const sn = new FabricEpochNsec(nsec);
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(sn as FabricValue),
+          context,
+        ) as unknown as FabricEpochNsec;
+        expect(decoded).toBeInstanceOf(FabricEpochNsec);
+        expect(decoded.value).toBe(nsec);
+      });
+
+      it("round-trips large future date", () => {
+        // Year 3000-ish
+        const nsec = 32503680000000000000n;
+        const sn = new FabricEpochNsec(nsec);
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(sn as FabricValue),
+          context,
+        ) as unknown as FabricEpochNsec;
+        expect(decoded.value).toBe(nsec);
       });
     });
   });

--- a/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
@@ -58,67 +58,75 @@ describe("FabricEpochNsec", () => {
       const codec = FabricEpochNsec[CODEC];
       const context = EMPTY_RECONSTRUCTION_CONTEXT;
 
-      it("has the `EpochNsec` wire type tag", () => {
-        expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.EpochNsec);
+      describe("wireTypeTag", () => {
+        it("is the `EpochNsec` wire type tag", () => {
+          expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.EpochNsec);
+        });
       });
 
-      it("claims a `FabricEpochNsec` via `canEncode()`, rejecting others", () => {
-        expect(codec.canEncode(new FabricEpochNsec(0n))).toBe(true);
-        expect(codec.canEncode("not an epoch")).toBe(false);
+      describe("canEncode()", () => {
+        it("claims a `FabricEpochNsec`, rejecting other values", () => {
+          expect(codec.canEncode(new FabricEpochNsec(0n))).toBe(true);
+          expect(codec.canEncode("not an epoch")).toBe(false);
+        });
       });
 
-      it("encodes to a flat base64 string (epoch zero)", () => {
-        const sn = new FabricEpochNsec(0n);
-        // Flat format: base64 string directly, not nested {"/BigInt@1": ...}.
-        expect(codec.encode(sn)).toBe("AA");
+      describe("encode()", () => {
+        it("encodes to a flat base64 string (epoch zero)", () => {
+          const sn = new FabricEpochNsec(0n);
+          // Flat format: base64 string directly, not nested {"/BigInt@1": ...}.
+          expect(codec.encode(sn)).toBe("AA");
+        });
       });
 
-      it("round-trips at top level (epoch zero)", () => {
-        const sn = new FabricEpochNsec(0n);
-        const decoded = codec.decode(
-          codec.wireTypeTag,
-          codec.encode(sn),
-          context,
-        ) as unknown as FabricEpochNsec;
-        expect(decoded).toBeInstanceOf(FabricEpochNsec);
-        expect(decoded.value).toBe(0n);
-      });
+      describe("decode()", () => {
+        it("round-trips at top level (epoch zero)", () => {
+          const sn = new FabricEpochNsec(0n);
+          const decoded = codec.decode(
+            codec.wireTypeTag,
+            codec.encode(sn),
+            context,
+          ) as unknown as FabricEpochNsec;
+          expect(decoded).toBeInstanceOf(FabricEpochNsec);
+          expect(decoded.value).toBe(0n);
+        });
 
-      it("round-trips positive nanosecond timestamp", () => {
-        // 2024-01-01T00:00:00Z = 1704067200 seconds = 1704067200000000000 nsec
-        const nsec = 1704067200000000000n;
-        const sn = new FabricEpochNsec(nsec);
-        const decoded = codec.decode(
-          codec.wireTypeTag,
-          codec.encode(sn),
-          context,
-        ) as unknown as FabricEpochNsec;
-        expect(decoded).toBeInstanceOf(FabricEpochNsec);
-        expect(decoded.value).toBe(nsec);
-      });
+        it("round-trips positive nanosecond timestamp", () => {
+          // 2024-01-01T00:00:00Z = 1704067200 seconds = 1704067200000000000 nsec
+          const nsec = 1704067200000000000n;
+          const sn = new FabricEpochNsec(nsec);
+          const decoded = codec.decode(
+            codec.wireTypeTag,
+            codec.encode(sn),
+            context,
+          ) as unknown as FabricEpochNsec;
+          expect(decoded).toBeInstanceOf(FabricEpochNsec);
+          expect(decoded.value).toBe(nsec);
+        });
 
-      it("round-trips negative nanosecond timestamp (pre-epoch)", () => {
-        const nsec = -86400000000000n; // -1 day in nanoseconds
-        const sn = new FabricEpochNsec(nsec);
-        const decoded = codec.decode(
-          codec.wireTypeTag,
-          codec.encode(sn),
-          context,
-        ) as unknown as FabricEpochNsec;
-        expect(decoded).toBeInstanceOf(FabricEpochNsec);
-        expect(decoded.value).toBe(nsec);
-      });
+        it("round-trips negative nanosecond timestamp (pre-epoch)", () => {
+          const nsec = -86400000000000n; // -1 day in nanoseconds
+          const sn = new FabricEpochNsec(nsec);
+          const decoded = codec.decode(
+            codec.wireTypeTag,
+            codec.encode(sn),
+            context,
+          ) as unknown as FabricEpochNsec;
+          expect(decoded).toBeInstanceOf(FabricEpochNsec);
+          expect(decoded.value).toBe(nsec);
+        });
 
-      it("round-trips large future date", () => {
-        // Year 3000-ish
-        const nsec = 32503680000000000000n;
-        const sn = new FabricEpochNsec(nsec);
-        const decoded = codec.decode(
-          codec.wireTypeTag,
-          codec.encode(sn),
-          context,
-        ) as unknown as FabricEpochNsec;
-        expect(decoded.value).toBe(nsec);
+        it("round-trips large future date", () => {
+          // Year 3000-ish
+          const nsec = 32503680000000000000n;
+          const sn = new FabricEpochNsec(nsec);
+          const decoded = codec.decode(
+            codec.wireTypeTag,
+            codec.encode(sn),
+            context,
+          ) as unknown as FabricEpochNsec;
+          expect(decoded.value).toBe(nsec);
+        });
       });
     });
   });

--- a/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
@@ -3,7 +3,6 @@ import { expect } from "@std/expect";
 
 import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
 import { FabricInstance, FabricPrimitive } from "@/interface.ts";
-import type { FabricValue } from "@/interface.ts";
 import { shallowFabricFromNativeValue } from "@/fabric-value.ts";
 import { CODEC } from "@/wire-common/interface.ts";
 import { WIRE_TYPE_TAGS } from "@/wire-common/wire-type-tags.ts";
@@ -63,17 +62,22 @@ describe("FabricEpochNsec", () => {
         expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.EpochNsec);
       });
 
+      it("claims a `FabricEpochNsec` via `canEncode()`, rejecting others", () => {
+        expect(codec.canEncode(new FabricEpochNsec(0n))).toBe(true);
+        expect(codec.canEncode("not an epoch")).toBe(false);
+      });
+
       it("encodes to a flat base64 string (epoch zero)", () => {
         const sn = new FabricEpochNsec(0n);
         // Flat format: base64 string directly, not nested {"/BigInt@1": ...}.
-        expect(codec.encode(sn as FabricValue)).toBe("AA");
+        expect(codec.encode(sn)).toBe("AA");
       });
 
       it("round-trips at top level (epoch zero)", () => {
         const sn = new FabricEpochNsec(0n);
         const decoded = codec.decode(
           codec.wireTypeTag,
-          codec.encode(sn as FabricValue),
+          codec.encode(sn),
           context,
         ) as unknown as FabricEpochNsec;
         expect(decoded).toBeInstanceOf(FabricEpochNsec);
@@ -86,7 +90,7 @@ describe("FabricEpochNsec", () => {
         const sn = new FabricEpochNsec(nsec);
         const decoded = codec.decode(
           codec.wireTypeTag,
-          codec.encode(sn as FabricValue),
+          codec.encode(sn),
           context,
         ) as unknown as FabricEpochNsec;
         expect(decoded).toBeInstanceOf(FabricEpochNsec);
@@ -98,7 +102,7 @@ describe("FabricEpochNsec", () => {
         const sn = new FabricEpochNsec(nsec);
         const decoded = codec.decode(
           codec.wireTypeTag,
-          codec.encode(sn as FabricValue),
+          codec.encode(sn),
           context,
         ) as unknown as FabricEpochNsec;
         expect(decoded).toBeInstanceOf(FabricEpochNsec);
@@ -111,7 +115,7 @@ describe("FabricEpochNsec", () => {
         const sn = new FabricEpochNsec(nsec);
         const decoded = codec.decode(
           codec.wireTypeTag,
-          codec.encode(sn as FabricValue),
+          codec.encode(sn),
           context,
         ) as unknown as FabricEpochNsec;
         expect(decoded.value).toBe(nsec);

--- a/packages/data-model/test/fabric-primitives/FabricHash.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricHash.test.ts
@@ -1,7 +1,6 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
-import type { FabricValue } from "@/interface.ts";
 import { FabricHash } from "@/fabric-primitives/FabricHash.ts";
 import { CODEC } from "@/wire-common/interface.ts";
 import { WIRE_TYPE_TAGS } from "@/wire-common/wire-type-tags.ts";
@@ -160,9 +159,14 @@ describe("FabricHash", () => {
         expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.Hash);
       });
 
+      it("claims a `FabricHash` via `canEncode()`, rejecting other values", () => {
+        expect(codec.canEncode(new FabricHash(SAMPLE_HASH, "fid1"))).toBe(true);
+        expect(codec.canEncode("not a hash")).toBe(false);
+      });
+
       it("encodes to a `{ tag, hash }` object", () => {
         const cid = new FabricHash(SAMPLE_HASH, "fid1");
-        expect(codec.encode(cid as FabricValue)).toEqual({
+        expect(codec.encode(cid)).toEqual({
           tag: "fid1",
           hash: cid.hashString,
         });
@@ -185,7 +189,7 @@ describe("FabricHash", () => {
         const cid = new FabricHash(SAMPLE_HASH_17, "sha3");
         const decoded = codec.decode(
           codec.wireTypeTag,
-          codec.encode(cid as FabricValue),
+          codec.encode(cid),
           context,
         );
         expect(decoded).toBeInstanceOf(FabricHash);
@@ -196,7 +200,7 @@ describe("FabricHash", () => {
       it("decodes non-object state to a `ProblematicValue`", () => {
         const decoded = codec.decode(
           codec.wireTypeTag,
-          123 as unknown as FabricValue,
+          123,
           context,
         );
         expect(decoded).toBeInstanceOf(ProblematicValue);
@@ -205,7 +209,7 @@ describe("FabricHash", () => {
       it("decodes missing/non-string fields to a `ProblematicValue`", () => {
         const decoded = codec.decode(
           codec.wireTypeTag,
-          { tag: "fid1" } as unknown as FabricValue,
+          { tag: "fid1" },
           context,
         );
         expect(decoded).toBeInstanceOf(ProblematicValue);
@@ -214,7 +218,7 @@ describe("FabricHash", () => {
       it("decodes a malformed base64 `hash` to a `ProblematicValue`", () => {
         const decoded = codec.decode(
           codec.wireTypeTag,
-          { tag: "fid1", hash: "not valid base64!!" } as unknown as FabricValue,
+          { tag: "fid1", hash: "not valid base64!!" },
           context,
         );
         expect(decoded).toBeInstanceOf(ProblematicValue);

--- a/packages/data-model/test/fabric-primitives/FabricHash.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricHash.test.ts
@@ -155,73 +155,79 @@ describe("FabricHash", () => {
       const codec = FabricHash[CODEC];
       const context = EMPTY_RECONSTRUCTION_CONTEXT;
 
-      it("has the `Hash` wire type tag", () => {
-        expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.Hash);
-      });
-
-      it("claims a `FabricHash` via `canEncode()`, rejecting other values", () => {
-        expect(codec.canEncode(new FabricHash(SAMPLE_HASH, "fid1"))).toBe(true);
-        expect(codec.canEncode("not a hash")).toBe(false);
-      });
-
-      it("encodes to a `{ tag, hash }` object", () => {
-        const cid = new FabricHash(SAMPLE_HASH, "fid1");
-        expect(codec.encode(cid)).toEqual({
-          tag: "fid1",
-          hash: cid.hashString,
+      describe("wireTypeTag", () => {
+        it("is the `Hash` wire type tag", () => {
+          expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.Hash);
         });
       });
 
-      it("decodes a `{ tag, hash }` object back to a `FabricHash`", () => {
-        const cid = new FabricHash(SAMPLE_HASH, "fid1");
-        const decoded = codec.decode(
-          codec.wireTypeTag,
-          { tag: "fid1", hash: cid.hashString },
-          context,
-        );
-        expect(decoded).toBeInstanceOf(FabricHash);
-        expect((decoded as FabricHash).taggedHashString).toBe(
-          cid.taggedHashString,
-        );
+      describe("canEncode()", () => {
+        it("claims a `FabricHash`, rejecting other values", () => {
+          expect(codec.canEncode(new FabricHash(SAMPLE_HASH, "fid1"))).toBe(
+            true,
+          );
+          expect(codec.canEncode("not a hash")).toBe(false);
+        });
       });
 
-      it("round-trips via encode -> decode (non-`fid1` tag)", () => {
-        const cid = new FabricHash(SAMPLE_HASH_17, "sha3");
-        const decoded = codec.decode(
-          codec.wireTypeTag,
-          codec.encode(cid),
-          context,
-        );
-        expect(decoded).toBeInstanceOf(FabricHash);
-        expect((decoded as FabricHash).tag).toBe("sha3");
-        expect((decoded as FabricHash).bytes).toEqual(cid.bytes);
+      describe("encode()", () => {
+        it("encodes to a `{ tag, hash }` object", () => {
+          const cid = new FabricHash(SAMPLE_HASH, "fid1");
+          expect(codec.encode(cid)).toEqual({
+            tag: "fid1",
+            hash: cid.hashString,
+          });
+        });
       });
 
-      it("decodes non-object state to a `ProblematicValue`", () => {
-        const decoded = codec.decode(
-          codec.wireTypeTag,
-          123,
-          context,
-        );
-        expect(decoded).toBeInstanceOf(ProblematicValue);
-      });
+      describe("decode()", () => {
+        it("decodes a `{ tag, hash }` object back to a `FabricHash`", () => {
+          const cid = new FabricHash(SAMPLE_HASH, "fid1");
+          const decoded = codec.decode(
+            codec.wireTypeTag,
+            { tag: "fid1", hash: cid.hashString },
+            context,
+          );
+          expect(decoded).toBeInstanceOf(FabricHash);
+          expect((decoded as FabricHash).taggedHashString).toBe(
+            cid.taggedHashString,
+          );
+        });
 
-      it("decodes missing/non-string fields to a `ProblematicValue`", () => {
-        const decoded = codec.decode(
-          codec.wireTypeTag,
-          { tag: "fid1" },
-          context,
-        );
-        expect(decoded).toBeInstanceOf(ProblematicValue);
-      });
+        it("round-trips via encode -> decode (non-`fid1` tag)", () => {
+          const cid = new FabricHash(SAMPLE_HASH_17, "sha3");
+          const decoded = codec.decode(
+            codec.wireTypeTag,
+            codec.encode(cid),
+            context,
+          );
+          expect(decoded).toBeInstanceOf(FabricHash);
+          expect((decoded as FabricHash).tag).toBe("sha3");
+          expect((decoded as FabricHash).bytes).toEqual(cid.bytes);
+        });
 
-      it("decodes a malformed base64 `hash` to a `ProblematicValue`", () => {
-        const decoded = codec.decode(
-          codec.wireTypeTag,
-          { tag: "fid1", hash: "not valid base64!!" },
-          context,
-        );
-        expect(decoded).toBeInstanceOf(ProblematicValue);
+        it("decodes non-object state to a `ProblematicValue`", () => {
+          const decoded = codec.decode(codec.wireTypeTag, 123, context);
+          expect(decoded).toBeInstanceOf(ProblematicValue);
+        });
+
+        it("decodes missing/non-string fields to a `ProblematicValue`", () => {
+          const decoded = codec.decode(
+            codec.wireTypeTag,
+            { tag: "fid1" },
+            context,
+          );
+          expect(decoded).toBeInstanceOf(ProblematicValue);
+        });
+
+        it("decodes a malformed base64 `hash` to a `ProblematicValue`", () => {
+          const decoded = codec.decode(
+            codec.wireTypeTag,
+            { tag: "fid1", hash: "not valid base64!!" },
+            context,
+          );
+          expect(decoded).toBeInstanceOf(ProblematicValue);
+        });
       });
     });
   });

--- a/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
@@ -2,7 +2,12 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
 import { FabricInstance, FabricPrimitive } from "@/interface.ts";
+import type { FabricValue } from "@/interface.ts";
 import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
+import { CODEC } from "@/wire-common/interface.ts";
+import { WIRE_TYPE_TAGS } from "@/wire-common/wire-type-tags.ts";
+import { EMPTY_RECONSTRUCTION_CONTEXT } from "@/wire-common/EmptyReconstructionContext.ts";
+import { ProblematicValue } from "@/fabric-instances/ProblematicValue.ts";
 import { isConvertibleNativeInstance } from "@/native-conversion.ts";
 import {
   isFabricCompatible,
@@ -115,6 +120,60 @@ describe("FabricRegExp", () => {
       it("throws for a non-`es2025` flavor (no native representation yet)", () => {
         const re = new FabricRegExp("pcre2", "abc", "g");
         expect(() => re.value).toThrow("pcre2");
+      });
+    });
+  });
+
+  describe("static members", () => {
+    describe("[CODEC]", () => {
+      const codec = FabricRegExp[CODEC];
+      const context = EMPTY_RECONSTRUCTION_CONTEXT;
+
+      it("has the `RegExp` wire type tag", () => {
+        expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.RegExp);
+      });
+
+      it("encodes to a `{ source, flags, flavor }` object", () => {
+        const re = new FabricRegExp(/ab+c/gi);
+        expect(codec.encode(re as FabricValue)).toEqual({
+          flags: "gi",
+          flavor: "es2025",
+          source: "ab+c",
+        });
+      });
+
+      it("round-trips a regex (source, flags, flavor)", () => {
+        const re = new FabricRegExp(/ab+c/gi);
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(re as FabricValue),
+          context,
+        ) as unknown as FabricRegExp;
+        expect(decoded).toBeInstanceOf(FabricRegExp);
+        expect(decoded.source).toBe("ab+c");
+        expect(decoded.flags).toBe("gi");
+        expect(decoded.flavor).toBe("es2025");
+      });
+
+      it("round-trips a flagless regex", () => {
+        const re = new FabricRegExp("es2025", "^x*$", "");
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(re as FabricValue),
+          context,
+        ) as unknown as FabricRegExp;
+        expect(decoded).toBeInstanceOf(FabricRegExp);
+        expect(decoded.source).toBe("^x*$");
+        expect(decoded.flags).toBe("");
+      });
+
+      it("decodes non-object state to `ProblematicValue`", () => {
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          "nope" as unknown as FabricValue,
+          context,
+        );
+        expect(decoded).toBeInstanceOf(ProblematicValue);
       });
     });
   });

--- a/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
@@ -128,56 +128,60 @@ describe("FabricRegExp", () => {
       const codec = FabricRegExp[CODEC];
       const context = EMPTY_RECONSTRUCTION_CONTEXT;
 
-      it("has the `RegExp` wire type tag", () => {
-        expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.RegExp);
-      });
-
-      it("claims a `FabricRegExp` via `canEncode()`, rejecting other values", () => {
-        expect(codec.canEncode(new FabricRegExp(/ab+c/gi))).toBe(true);
-        expect(codec.canEncode("not a regexp")).toBe(false);
-      });
-
-      it("encodes to a `{ source, flags, flavor }` object", () => {
-        const re = new FabricRegExp(/ab+c/gi);
-        expect(codec.encode(re)).toEqual({
-          flags: "gi",
-          flavor: "es2025",
-          source: "ab+c",
+      describe("wireTypeTag", () => {
+        it("is the `RegExp` wire type tag", () => {
+          expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.RegExp);
         });
       });
 
-      it("round-trips a regex (source, flags, flavor)", () => {
-        const re = new FabricRegExp(/ab+c/gi);
-        const decoded = codec.decode(
-          codec.wireTypeTag,
-          codec.encode(re),
-          context,
-        ) as unknown as FabricRegExp;
-        expect(decoded).toBeInstanceOf(FabricRegExp);
-        expect(decoded.source).toBe("ab+c");
-        expect(decoded.flags).toBe("gi");
-        expect(decoded.flavor).toBe("es2025");
+      describe("canEncode()", () => {
+        it("claims a `FabricRegExp`, rejecting other values", () => {
+          expect(codec.canEncode(new FabricRegExp(/ab+c/gi))).toBe(true);
+          expect(codec.canEncode("not a regexp")).toBe(false);
+        });
       });
 
-      it("round-trips a flagless regex", () => {
-        const re = new FabricRegExp("es2025", "^x*$", "");
-        const decoded = codec.decode(
-          codec.wireTypeTag,
-          codec.encode(re),
-          context,
-        ) as unknown as FabricRegExp;
-        expect(decoded).toBeInstanceOf(FabricRegExp);
-        expect(decoded.source).toBe("^x*$");
-        expect(decoded.flags).toBe("");
+      describe("encode()", () => {
+        it("encodes to a `{ source, flags, flavor }` object", () => {
+          const re = new FabricRegExp(/ab+c/gi);
+          expect(codec.encode(re)).toEqual({
+            flags: "gi",
+            flavor: "es2025",
+            source: "ab+c",
+          });
+        });
       });
 
-      it("decodes non-object state to `ProblematicValue`", () => {
-        const decoded = codec.decode(
-          codec.wireTypeTag,
-          "nope",
-          context,
-        );
-        expect(decoded).toBeInstanceOf(ProblematicValue);
+      describe("decode()", () => {
+        it("round-trips a regex (source, flags, flavor)", () => {
+          const re = new FabricRegExp(/ab+c/gi);
+          const decoded = codec.decode(
+            codec.wireTypeTag,
+            codec.encode(re),
+            context,
+          ) as unknown as FabricRegExp;
+          expect(decoded).toBeInstanceOf(FabricRegExp);
+          expect(decoded.source).toBe("ab+c");
+          expect(decoded.flags).toBe("gi");
+          expect(decoded.flavor).toBe("es2025");
+        });
+
+        it("round-trips a flagless regex", () => {
+          const re = new FabricRegExp("es2025", "^x*$", "");
+          const decoded = codec.decode(
+            codec.wireTypeTag,
+            codec.encode(re),
+            context,
+          ) as unknown as FabricRegExp;
+          expect(decoded).toBeInstanceOf(FabricRegExp);
+          expect(decoded.source).toBe("^x*$");
+          expect(decoded.flags).toBe("");
+        });
+
+        it("decodes non-object state to `ProblematicValue`", () => {
+          const decoded = codec.decode(codec.wireTypeTag, "nope", context);
+          expect(decoded).toBeInstanceOf(ProblematicValue);
+        });
       });
     });
   });

--- a/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
@@ -2,7 +2,6 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
 import { FabricInstance, FabricPrimitive } from "@/interface.ts";
-import type { FabricValue } from "@/interface.ts";
 import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
 import { CODEC } from "@/wire-common/interface.ts";
 import { WIRE_TYPE_TAGS } from "@/wire-common/wire-type-tags.ts";
@@ -133,9 +132,14 @@ describe("FabricRegExp", () => {
         expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.RegExp);
       });
 
+      it("claims a `FabricRegExp` via `canEncode()`, rejecting other values", () => {
+        expect(codec.canEncode(new FabricRegExp(/ab+c/gi))).toBe(true);
+        expect(codec.canEncode("not a regexp")).toBe(false);
+      });
+
       it("encodes to a `{ source, flags, flavor }` object", () => {
         const re = new FabricRegExp(/ab+c/gi);
-        expect(codec.encode(re as FabricValue)).toEqual({
+        expect(codec.encode(re)).toEqual({
           flags: "gi",
           flavor: "es2025",
           source: "ab+c",
@@ -146,7 +150,7 @@ describe("FabricRegExp", () => {
         const re = new FabricRegExp(/ab+c/gi);
         const decoded = codec.decode(
           codec.wireTypeTag,
-          codec.encode(re as FabricValue),
+          codec.encode(re),
           context,
         ) as unknown as FabricRegExp;
         expect(decoded).toBeInstanceOf(FabricRegExp);
@@ -159,7 +163,7 @@ describe("FabricRegExp", () => {
         const re = new FabricRegExp("es2025", "^x*$", "");
         const decoded = codec.decode(
           codec.wireTypeTag,
-          codec.encode(re as FabricValue),
+          codec.encode(re),
           context,
         ) as unknown as FabricRegExp;
         expect(decoded).toBeInstanceOf(FabricRegExp);
@@ -170,7 +174,7 @@ describe("FabricRegExp", () => {
       it("decodes non-object state to `ProblematicValue`", () => {
         const decoded = codec.decode(
           codec.wireTypeTag,
-          "nope" as unknown as FabricValue,
+          "nope",
           context,
         );
         expect(decoded).toBeInstanceOf(ProblematicValue);

--- a/packages/data-model/test/json-wire/BigIntCodec.test.ts
+++ b/packages/data-model/test/json-wire/BigIntCodec.test.ts
@@ -1,209 +1,212 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
-import type { FabricValue } from "@/interface.ts";
 import { BigIntCodec } from "@/json-wire/BigIntCodec.ts";
 import { WIRE_TYPE_TAGS } from "@/wire-common/wire-type-tags.ts";
 import { EMPTY_RECONSTRUCTION_CONTEXT } from "@/wire-common/EmptyReconstructionContext.ts";
 import { ProblematicValue } from "@/fabric-instances/ProblematicValue.ts";
 
 describe("BigIntCodec", () => {
-  describe("[CODEC]", () => {
-    const codec = new BigIntCodec();
-    const context = EMPTY_RECONSTRUCTION_CONTEXT;
+  const codec = new BigIntCodec();
+  const context = EMPTY_RECONSTRUCTION_CONTEXT;
 
-    it("has the `BigInt` wire type tag", () => {
-      expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.BigInt);
+  describe("instance members", () => {
+    describe("wireTypeTag", () => {
+      it("is the `BigInt` wire type tag", () => {
+        expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.BigInt);
+      });
     });
 
-    it("encodes `42n` to base64url of two's complement bytes", () => {
-      // 42n -> [0x2a] -> base64 "Kg"
-      expect(codec.encode(42n)).toBe("Kg");
+    describe("canEncode()", () => {
+      it("only claims `bigint` values", () => {
+        // `bigint` serializes to `BigInt@1`, whereas `number` does not -- the
+        // two produce distinct wire forms.
+        expect(codec.canEncode(42n)).toBe(true);
+        expect(codec.canEncode(42)).toBe(false);
+      });
     });
 
-    it('encodes `0n` to base64 `"AA"`', () => {
-      // 0n -> [0x00] -> base64 "AA"
-      expect(codec.encode(0n)).toBe("AA");
+    describe("encode()", () => {
+      it("encodes `42n` to base64url of two's complement bytes", () => {
+        // 42n -> [0x2a] -> base64 "Kg"
+        expect(codec.encode(42n)).toBe("Kg");
+      });
+
+      it('encodes `0n` to base64 `"AA"`', () => {
+        // 0n -> [0x00] -> base64 "AA"
+        expect(codec.encode(0n)).toBe("AA");
+      });
+
+      it('encodes `-1n` to base64url `"_w"`', () => {
+        // -1n -> [0xFF] -> base64url "_w"
+        expect(codec.encode(-1n)).toBe("_w");
+      });
+
+      it('encodes `1n` to base64 `"AQ"`', () => {
+        // 1n -> [0x01] -> base64 "AQ"
+        expect(codec.encode(1n)).toBe("AQ");
+      });
+
+      it("encodes `128n` with sign-extension byte", () => {
+        // 128n -> [0x00, 0x80] -> base64 "AIA"
+        expect(codec.encode(128n)).toBe("AIA");
+      });
+
+      it("produces unpadded base64 output (no trailing `=`)", () => {
+        // 42n produces 1 byte -> 2 base64 chars (would be "Kg==" with padding)
+        const b64 = codec.encode(42n) as string;
+        expect(b64).toBe("Kg");
+        expect(b64).not.toContain("=");
+      });
     });
 
-    it('encodes `-1n` to base64url `"_w"`', () => {
-      // -1n -> [0xFF] -> base64url "_w"
-      expect(codec.encode(-1n)).toBe("_w");
-    });
+    describe("decode()", () => {
+      it("round-trips at top level", () => {
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(42n),
+          context,
+        );
+        expect(decoded).toBe(42n);
+      });
 
-    it('encodes `1n` to base64 `"AQ"`', () => {
-      // 1n -> [0x01] -> base64 "AQ"
-      expect(codec.encode(1n)).toBe("AQ");
-    });
+      it("round-trips negative bigint", () => {
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(-999n),
+          context,
+        );
+        expect(decoded).toBe(-999n);
+      });
 
-    it("encodes `128n` with sign-extension byte", () => {
-      // 128n -> [0x00, 0x80] -> base64 "AIA"
-      expect(codec.encode(128n)).toBe("AIA");
-    });
+      it("round-trips zero bigint", () => {
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(0n),
+          context,
+        );
+        expect(decoded).toBe(0n);
+      });
 
-    it("produces unpadded base64 output (no trailing `=`)", () => {
-      // 42n produces 1 byte -> 2 base64 chars (would be "Kg==" with padding)
-      const b64 = codec.encode(42n) as string;
-      expect(b64).toBe("Kg");
-      expect(b64).not.toContain("=");
-    });
+      it("round-trips `1n`", () => {
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(1n),
+          context,
+        );
+        expect(decoded).toBe(1n);
+      });
 
-    it("round-trips at top level", () => {
-      const decoded = codec.decode(
-        codec.wireTypeTag,
-        codec.encode(42n),
-        context,
-      );
-      expect(decoded).toBe(42n);
-    });
+      it("round-trips `-1n`", () => {
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(-1n),
+          context,
+        );
+        expect(decoded).toBe(-1n);
+      });
 
-    it("round-trips negative bigint", () => {
-      const decoded = codec.decode(
-        codec.wireTypeTag,
-        codec.encode(-999n),
-        context,
-      );
-      expect(decoded).toBe(-999n);
-    });
+      it("round-trips large bigint", () => {
+        const big = 2n ** 64n;
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(big),
+          context,
+        );
+        expect(decoded).toBe(big);
+      });
 
-    it("round-trips zero bigint", () => {
-      const decoded = codec.decode(
-        codec.wireTypeTag,
-        codec.encode(0n),
-        context,
-      );
-      expect(decoded).toBe(0n);
-    });
+      it("round-trips large negative bigint", () => {
+        const big = -(2n ** 64n);
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(big),
+          context,
+        );
+        expect(decoded).toBe(big);
+      });
 
-    it("round-trips `1n`", () => {
-      const decoded = codec.decode(
-        codec.wireTypeTag,
-        codec.encode(1n),
-        context,
-      );
-      expect(decoded).toBe(1n);
-    });
+      it("round-trips boundary value `127n`", () => {
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(127n),
+          context,
+        );
+        expect(decoded).toBe(127n);
+      });
 
-    it("round-trips `-1n`", () => {
-      const decoded = codec.decode(
-        codec.wireTypeTag,
-        codec.encode(-1n),
-        context,
-      );
-      expect(decoded).toBe(-1n);
-    });
+      it("round-trips boundary value `128n`", () => {
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(128n),
+          context,
+        );
+        expect(decoded).toBe(128n);
+      });
 
-    it("round-trips large bigint", () => {
-      const big = 2n ** 64n;
-      const decoded = codec.decode(
-        codec.wireTypeTag,
-        codec.encode(big),
-        context,
-      );
-      expect(decoded).toBe(big);
-    });
+      it("round-trips boundary value `-128n`", () => {
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(-128n),
+          context,
+        );
+        expect(decoded).toBe(-128n);
+      });
 
-    it("round-trips large negative bigint", () => {
-      const big = -(2n ** 64n);
-      const decoded = codec.decode(
-        codec.wireTypeTag,
-        codec.encode(big),
-        context,
-      );
-      expect(decoded).toBe(big);
-    });
+      it("round-trips boundary value `-129n`", () => {
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(-129n),
+          context,
+        );
+        expect(decoded).toBe(-129n);
+      });
 
-    it("round-trips boundary value `127n`", () => {
-      const decoded = codec.decode(
-        codec.wireTypeTag,
-        codec.encode(127n),
-        context,
-      );
-      expect(decoded).toBe(127n);
-    });
+      it("accepts unpadded base64url input", () => {
+        // "Kg" is the standard unpadded base64url encoding of 42n.
+        const result = codec.decode(codec.wireTypeTag, "Kg", context);
+        expect(result).toBe(42n);
+      });
 
-    it("round-trips boundary value `128n`", () => {
-      const decoded = codec.decode(
-        codec.wireTypeTag,
-        codec.encode(128n),
-        context,
-      );
-      expect(decoded).toBe(128n);
-    });
+      it("accepts padded base64 input", () => {
+        // "Kg==" is the padded form of "Kg" (42n) -- padding is accepted by the
+        // web-standard Uint8Array.fromBase64.
+        const result = codec.decode(codec.wireTypeTag, "Kg==", context);
+        expect(result).toBe(42n);
+      });
 
-    it("round-trips boundary value `-128n`", () => {
-      const decoded = codec.decode(
-        codec.wireTypeTag,
-        codec.encode(-128n),
-        context,
-      );
-      expect(decoded).toBe(-128n);
-    });
+      it("decodes non-string state to `ProblematicValue`", () => {
+        const result = codec.decode(
+          codec.wireTypeTag,
+          42,
+          context,
+        );
+        expect(result).toBeInstanceOf(ProblematicValue);
+        const prob = result as unknown as ProblematicValue;
+        expect(prob.wireTypeTag).toBe("BigInt@1");
+        expect(prob.state).toBe(42);
+      });
 
-    it("round-trips boundary value `-129n`", () => {
-      const decoded = codec.decode(
-        codec.wireTypeTag,
-        codec.encode(-129n),
-        context,
-      );
-      expect(decoded).toBe(-129n);
-    });
+      it("decodes `null` state to `ProblematicValue`", () => {
+        const result = codec.decode(codec.wireTypeTag, null, context);
+        expect(result).toBeInstanceOf(ProblematicValue);
+      });
 
-    it("only claims `bigint` values via `canEncode()`", () => {
-      // `bigint` serializes to `BigInt@1`, whereas `number` does not -- the two
-      // produce distinct wire forms.
-      expect(codec.canEncode(42n)).toBe(true);
-      expect(codec.canEncode(42 as unknown as FabricValue)).toBe(false);
-    });
+      it("decodes object state to `ProblematicValue`", () => {
+        const result = codec.decode(
+          codec.wireTypeTag,
+          { bad: true },
+          context,
+        );
+        expect(result).toBeInstanceOf(ProblematicValue);
+      });
 
-    it("accepts unpadded base64url input", () => {
-      // "Kg" is the standard unpadded base64url encoding of 42n.
-      const result = codec.decode(codec.wireTypeTag, "Kg", context);
-      expect(result).toBe(42n);
-    });
-
-    it("accepts padded base64 input", () => {
-      // "Kg==" is the padded form of "Kg" (42n) -- padding is accepted by the
-      // web-standard Uint8Array.fromBase64.
-      const result = codec.decode(codec.wireTypeTag, "Kg==", context);
-      expect(result).toBe(42n);
-    });
-
-    it("decodes non-string state to `ProblematicValue`", () => {
-      const result = codec.decode(
-        codec.wireTypeTag,
-        42 as unknown as FabricValue,
-        context,
-      );
-      expect(result).toBeInstanceOf(ProblematicValue);
-      const prob = result as unknown as ProblematicValue;
-      expect(prob.wireTypeTag).toBe("BigInt@1");
-      expect(prob.state).toBe(42);
-    });
-
-    it("decodes `null` state to `ProblematicValue`", () => {
-      const result = codec.decode(
-        codec.wireTypeTag,
-        null,
-        context,
-      );
-      expect(result).toBeInstanceOf(ProblematicValue);
-    });
-
-    it("decodes object state to `ProblematicValue`", () => {
-      const result = codec.decode(
-        codec.wireTypeTag,
-        { bad: true } as unknown as FabricValue,
-        context,
-      );
-      expect(result).toBeInstanceOf(ProblematicValue);
-    });
-
-    it("decodes empty base64 string to `ProblematicValue`", () => {
-      const result = codec.decode(codec.wireTypeTag, "", context);
-      expect(result).toBeInstanceOf(ProblematicValue);
-      const prob = result as unknown as ProblematicValue;
-      expect(prob.wireTypeTag).toBe("BigInt@1");
+      it("decodes empty base64 string to `ProblematicValue`", () => {
+        const result = codec.decode(codec.wireTypeTag, "", context);
+        expect(result).toBeInstanceOf(ProblematicValue);
+        const prob = result as unknown as ProblematicValue;
+        expect(prob.wireTypeTag).toBe("BigInt@1");
+      });
     });
   });
 });

--- a/packages/data-model/test/json-wire/BigIntCodec.test.ts
+++ b/packages/data-model/test/json-wire/BigIntCodec.test.ts
@@ -1,0 +1,209 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import type { FabricValue } from "@/interface.ts";
+import { BigIntCodec } from "@/json-wire/BigIntCodec.ts";
+import { WIRE_TYPE_TAGS } from "@/wire-common/wire-type-tags.ts";
+import { EMPTY_RECONSTRUCTION_CONTEXT } from "@/wire-common/EmptyReconstructionContext.ts";
+import { ProblematicValue } from "@/fabric-instances/ProblematicValue.ts";
+
+describe("BigIntCodec", () => {
+  describe("[CODEC]", () => {
+    const codec = new BigIntCodec();
+    const context = EMPTY_RECONSTRUCTION_CONTEXT;
+
+    it("has the `BigInt` wire type tag", () => {
+      expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.BigInt);
+    });
+
+    it("encodes `42n` to base64url of two's complement bytes", () => {
+      // 42n -> [0x2a] -> base64 "Kg"
+      expect(codec.encode(42n)).toBe("Kg");
+    });
+
+    it('encodes `0n` to base64 `"AA"`', () => {
+      // 0n -> [0x00] -> base64 "AA"
+      expect(codec.encode(0n)).toBe("AA");
+    });
+
+    it('encodes `-1n` to base64url `"_w"`', () => {
+      // -1n -> [0xFF] -> base64url "_w"
+      expect(codec.encode(-1n)).toBe("_w");
+    });
+
+    it('encodes `1n` to base64 `"AQ"`', () => {
+      // 1n -> [0x01] -> base64 "AQ"
+      expect(codec.encode(1n)).toBe("AQ");
+    });
+
+    it("encodes `128n` with sign-extension byte", () => {
+      // 128n -> [0x00, 0x80] -> base64 "AIA"
+      expect(codec.encode(128n)).toBe("AIA");
+    });
+
+    it("produces unpadded base64 output (no trailing `=`)", () => {
+      // 42n produces 1 byte -> 2 base64 chars (would be "Kg==" with padding)
+      const b64 = codec.encode(42n) as string;
+      expect(b64).toBe("Kg");
+      expect(b64).not.toContain("=");
+    });
+
+    it("round-trips at top level", () => {
+      const decoded = codec.decode(
+        codec.wireTypeTag,
+        codec.encode(42n),
+        context,
+      );
+      expect(decoded).toBe(42n);
+    });
+
+    it("round-trips negative bigint", () => {
+      const decoded = codec.decode(
+        codec.wireTypeTag,
+        codec.encode(-999n),
+        context,
+      );
+      expect(decoded).toBe(-999n);
+    });
+
+    it("round-trips zero bigint", () => {
+      const decoded = codec.decode(
+        codec.wireTypeTag,
+        codec.encode(0n),
+        context,
+      );
+      expect(decoded).toBe(0n);
+    });
+
+    it("round-trips `1n`", () => {
+      const decoded = codec.decode(
+        codec.wireTypeTag,
+        codec.encode(1n),
+        context,
+      );
+      expect(decoded).toBe(1n);
+    });
+
+    it("round-trips `-1n`", () => {
+      const decoded = codec.decode(
+        codec.wireTypeTag,
+        codec.encode(-1n),
+        context,
+      );
+      expect(decoded).toBe(-1n);
+    });
+
+    it("round-trips large bigint", () => {
+      const big = 2n ** 64n;
+      const decoded = codec.decode(
+        codec.wireTypeTag,
+        codec.encode(big),
+        context,
+      );
+      expect(decoded).toBe(big);
+    });
+
+    it("round-trips large negative bigint", () => {
+      const big = -(2n ** 64n);
+      const decoded = codec.decode(
+        codec.wireTypeTag,
+        codec.encode(big),
+        context,
+      );
+      expect(decoded).toBe(big);
+    });
+
+    it("round-trips boundary value `127n`", () => {
+      const decoded = codec.decode(
+        codec.wireTypeTag,
+        codec.encode(127n),
+        context,
+      );
+      expect(decoded).toBe(127n);
+    });
+
+    it("round-trips boundary value `128n`", () => {
+      const decoded = codec.decode(
+        codec.wireTypeTag,
+        codec.encode(128n),
+        context,
+      );
+      expect(decoded).toBe(128n);
+    });
+
+    it("round-trips boundary value `-128n`", () => {
+      const decoded = codec.decode(
+        codec.wireTypeTag,
+        codec.encode(-128n),
+        context,
+      );
+      expect(decoded).toBe(-128n);
+    });
+
+    it("round-trips boundary value `-129n`", () => {
+      const decoded = codec.decode(
+        codec.wireTypeTag,
+        codec.encode(-129n),
+        context,
+      );
+      expect(decoded).toBe(-129n);
+    });
+
+    it("only claims `bigint` values via `canEncode()`", () => {
+      // `bigint` serializes to `BigInt@1`, whereas `number` does not -- the two
+      // produce distinct wire forms.
+      expect(codec.canEncode(42n)).toBe(true);
+      expect(codec.canEncode(42 as unknown as FabricValue)).toBe(false);
+    });
+
+    it("accepts unpadded base64url input", () => {
+      // "Kg" is the standard unpadded base64url encoding of 42n.
+      const result = codec.decode(codec.wireTypeTag, "Kg", context);
+      expect(result).toBe(42n);
+    });
+
+    it("accepts padded base64 input", () => {
+      // "Kg==" is the padded form of "Kg" (42n) -- padding is accepted by the
+      // web-standard Uint8Array.fromBase64.
+      const result = codec.decode(codec.wireTypeTag, "Kg==", context);
+      expect(result).toBe(42n);
+    });
+
+    it("decodes non-string state to `ProblematicValue`", () => {
+      const result = codec.decode(
+        codec.wireTypeTag,
+        42 as unknown as FabricValue,
+        context,
+      );
+      expect(result).toBeInstanceOf(ProblematicValue);
+      const prob = result as unknown as ProblematicValue;
+      expect(prob.wireTypeTag).toBe("BigInt@1");
+      expect(prob.state).toBe(42);
+    });
+
+    it("decodes `null` state to `ProblematicValue`", () => {
+      const result = codec.decode(
+        codec.wireTypeTag,
+        null,
+        context,
+      );
+      expect(result).toBeInstanceOf(ProblematicValue);
+    });
+
+    it("decodes object state to `ProblematicValue`", () => {
+      const result = codec.decode(
+        codec.wireTypeTag,
+        { bad: true } as unknown as FabricValue,
+        context,
+      );
+      expect(result).toBeInstanceOf(ProblematicValue);
+    });
+
+    it("decodes empty base64 string to `ProblematicValue`", () => {
+      const result = codec.decode(codec.wireTypeTag, "", context);
+      expect(result).toBeInstanceOf(ProblematicValue);
+      const prob = result as unknown as ProblematicValue;
+      expect(prob.wireTypeTag).toBe("BigInt@1");
+    });
+  });
+});

--- a/packages/data-model/test/json-wire/JsonEncodingContext.test.ts
+++ b/packages/data-model/test/json-wire/JsonEncodingContext.test.ts
@@ -19,7 +19,6 @@ import { FabricError } from "@/fabric-instances/FabricError.ts";
 import { DECONSTRUCT } from "@/wire-common/interface.ts";
 import { isDeepFrozen } from "@/deep-freeze.ts";
 import { BaseReconstructionContext } from "@/wire-common/BaseReconstructionContext.ts";
-import { shallowFabricFromNativeValue } from "@/fabric-value.ts";
 
 /**
  * Shared test `ReconstructionContext`: `getCell()` always throws (no test
@@ -112,7 +111,7 @@ function fromWireFormat(data: JsonWireValue): FabricValue {
 }
 
 describe("JsonEncodingContext", () => {
-  describe("`Uint8Array` public API", () => {
+  describe("`encodeToBytes()` / `decodeFromBytes()` (bytes entry points)", () => {
     it("returns `Uint8Array` from `encodeToBytes()`", () => {
       const { context } = makeTestContext();
       const result = context.encodeToBytes(42);
@@ -244,352 +243,99 @@ describe("JsonEncodingContext", () => {
     });
   });
 
-  describe("undefined", () => {
-    it('serializes to `{ "/Undefined@1": null }`', () => {
-      const result = toWireFormat(undefined);
-      expect(result).toEqual({ "/Undefined@1": null });
-    });
+  describe("tagged-type round-trips through the full stack", () => {
+    // Representative coverage that the encode→tag-wrap→decode mechanism works
+    // for the standalone-codec and primitive Fabric types, including nesting in
+    // arrays and objects. Per-codec encode/decode detail lives in each type's
+    // own unit test (e.g. `BigIntCodec.test.ts`, `FabricEpochNsec.test.ts`).
 
-    it("round-trips at top level", () => {
+    it("round-trips `undefined` at top level, in arrays, and as object values", () => {
       expect(roundTrip(undefined)).toBe(undefined);
-    });
 
-    it("round-trips in arrays", () => {
       const arr = [1, undefined, 3] as FabricValue;
-      const result = roundTrip(arr) as FabricValue[];
-      expect(result[0]).toBe(1);
-      expect(result[1]).toBe(undefined);
-      expect(1 in result).toBe(true); // not a hole
-      expect(result[2]).toBe(3);
-    });
+      const arrResult = roundTrip(arr) as FabricValue[];
+      expect(arrResult[0]).toBe(1);
+      expect(arrResult[1]).toBe(undefined);
+      expect(1 in arrResult).toBe(true); // not a hole
+      expect(arrResult[2]).toBe(3);
 
-    it("round-trips as object values", () => {
       const obj = { a: 1, b: undefined } as unknown as FabricValue;
-      const result = roundTrip(obj) as Record<string, FabricValue>;
-      expect(result.a).toBe(1);
-      expect(result.b).toBe(undefined);
-      expect("b" in result).toBe(true); // key preserved
+      const objResult = roundTrip(obj) as Record<string, FabricValue>;
+      expect(objResult.a).toBe(1);
+      expect(objResult.b).toBe(undefined);
+      expect("b" in objResult).toBe(true); // key preserved
     });
 
-    it("is distinct from `null`", () => {
-      const serializedNull = toWireFormat(null);
-      const serializedUndef = toWireFormat(undefined);
-      expect(serializedNull).not.toEqual(serializedUndef);
-    });
-  });
+    it("round-trips `bigint` at top level, in arrays, and as object values", () => {
+      expect(roundTrip(42n as FabricValue)).toBe(42n);
 
-  describe("bigint", () => {
-    it("serializes `42n` to base64 of two's complement bytes", () => {
-      const result = toWireFormat(42n as FabricValue);
-      // 42n -> [0x2a] -> base64 "Kg"
-      expect(result).toEqual({ "/BigInt@1": "Kg" });
-    });
-
-    it('serializes `0n` to base64 `"AA"`', () => {
-      const result = toWireFormat(0n as FabricValue);
-      // 0n -> [0x00] -> base64 "AA"
-      expect(result).toEqual({ "/BigInt@1": "AA" });
-    });
-
-    it('serializes `-1n` to base64url `"_w"`', () => {
-      const result = toWireFormat(-1n as FabricValue);
-      // -1n -> [0xFF] -> base64url "_w"
-      expect(result).toEqual({ "/BigInt@1": "_w" });
-    });
-
-    it('serializes `1n` to base64 `"AQ"`', () => {
-      const result = toWireFormat(1n as FabricValue);
-      // 1n -> [0x01] -> base64 "AQ"
-      expect(result).toEqual({ "/BigInt@1": "AQ" });
-    });
-
-    it("serializes `128n` with sign-extension byte", () => {
-      const result = toWireFormat(128n as FabricValue);
-      // 128n -> [0x00, 0x80] -> base64 "AIA"
-      expect(result).toEqual({ "/BigInt@1": "AIA" });
-    });
-
-    it("produces unpadded base64 output (no trailing `=`)", () => {
-      // 42n produces 1 byte -> 2 base64 chars (would be "Kg==" with padding)
-      const result = toWireFormat(42n as FabricValue) as Record<
-        string,
-        string
-      >;
-      const b64 = result["/BigInt@1"];
-      expect(b64).toBe("Kg");
-      expect(b64).not.toContain("=");
-    });
-
-    it("round-trips at top level", () => {
-      const result = roundTrip(42n as FabricValue);
-      expect(result).toBe(42n);
-    });
-
-    it("round-trips negative bigint", () => {
-      const result = roundTrip(-999n as FabricValue);
-      expect(result).toBe(-999n);
-    });
-
-    it("round-trips zero bigint", () => {
-      const result = roundTrip(0n as FabricValue);
-      expect(result).toBe(0n);
-    });
-
-    it("round-trips `1n`", () => {
-      const result = roundTrip(1n as FabricValue);
-      expect(result).toBe(1n);
-    });
-
-    it("round-trips `-1n`", () => {
-      const result = roundTrip(-1n as FabricValue);
-      expect(result).toBe(-1n);
-    });
-
-    it("round-trips large bigint", () => {
-      const big = 2n ** 64n;
-      const result = roundTrip(big as FabricValue);
-      expect(result).toBe(big);
-    });
-
-    it("round-trips large negative bigint", () => {
-      const big = -(2n ** 64n);
-      const result = roundTrip(big as FabricValue);
-      expect(result).toBe(big);
-    });
-
-    it("round-trips boundary value `127n`", () => {
-      expect(roundTrip(127n as FabricValue)).toBe(127n);
-    });
-
-    it("round-trips boundary value `128n`", () => {
-      expect(roundTrip(128n as FabricValue)).toBe(128n);
-    });
-
-    it("round-trips boundary value `-128n`", () => {
-      expect(roundTrip(-128n as FabricValue)).toBe(-128n);
-    });
-
-    it("round-trips boundary value `-129n`", () => {
-      expect(roundTrip(-129n as FabricValue)).toBe(-129n);
-    });
-
-    it("round-trips in arrays", () => {
       const arr = [1, 42n, "hello"] as unknown as FabricValue;
-      const result = roundTrip(arr) as FabricValue[];
-      expect(result[0]).toBe(1);
-      expect(result[1]).toBe(42n);
-      expect(result[2]).toBe("hello");
-    });
+      const arrResult = roundTrip(arr) as FabricValue[];
+      expect(arrResult[0]).toBe(1);
+      expect(arrResult[1]).toBe(42n);
+      expect(arrResult[2]).toBe("hello");
 
-    it("round-trips as object values", () => {
       const obj = { a: 1, b: 42n } as unknown as FabricValue;
-      const result = roundTrip(obj) as Record<string, FabricValue>;
-      expect(result.a).toBe(1);
-      expect(result.b).toBe(42n);
+      const objResult = roundTrip(obj) as Record<string, FabricValue>;
+      expect(objResult.a).toBe(1);
+      expect(objResult.b).toBe(42n);
     });
 
-    it("is distinct from `number`", () => {
-      const serializedNum = toWireFormat(42);
-      const serializedBig = toWireFormat(42n as FabricValue);
-      expect(serializedNum).not.toEqual(serializedBig);
-    });
-
-    it("accepts unpadded base64url input", () => {
-      // "Kg" is the standard unpadded base64url encoding of 42n.
-      const data = { "/BigInt@1": "Kg" } as JsonWireValue;
-      const result = fromWireFormat(data);
-      expect(result).toBe(42n);
-    });
-
-    it("accepts padded base64 input", () => {
-      // "Kg==" is the padded form of "Kg" (42n) -- padding is accepted by the
-      // web-standard Uint8Array.fromBase64.
-      const data = { "/BigInt@1": "Kg==" } as JsonWireValue;
-      const result = fromWireFormat(data);
-      expect(result).toBe(42n);
-    });
-
-    it("deserializes non-string state to `ProblematicValue`", () => {
-      const data = { "/BigInt@1": 42 } as JsonWireValue;
-      const result = fromWireFormat(data);
-      expect(result).toBeInstanceOf(ProblematicValue);
-      const prob = result as unknown as ProblematicValue;
-      expect(prob.wireTypeTag).toBe("BigInt@1");
-      expect(prob.state).toBe(42);
-    });
-
-    it("deserializes `null` state to `ProblematicValue`", () => {
-      const data = { "/BigInt@1": null } as JsonWireValue;
-      const result = fromWireFormat(data);
-      expect(result).toBeInstanceOf(ProblematicValue);
-    });
-
-    it("deserializes object state to `ProblematicValue`", () => {
-      const data = { "/BigInt@1": { bad: true } } as JsonWireValue;
-      const result = fromWireFormat(data);
-      expect(result).toBeInstanceOf(ProblematicValue);
-    });
-
-    it("deserializes empty base64 string to `ProblematicValue`", () => {
-      const data = { "/BigInt@1": "" } as JsonWireValue;
-      const result = fromWireFormat(data);
-      expect(result).toBeInstanceOf(ProblematicValue);
-      const prob = result as unknown as ProblematicValue;
-      expect(prob.wireTypeTag).toBe("BigInt@1");
-    });
-  });
-
-  describe("SpecialNumber", () => {
-    it('serializes `-0` to `/SpecialNumber@1` with state `"-0"`', () => {
-      expect(toWireFormat(-0)).toEqual({ "/SpecialNumber@1": "-0" });
-    });
-
-    it('serializes `NaN` to `/SpecialNumber@1` with state `"NaN"`', () => {
-      expect(toWireFormat(NaN)).toEqual({ "/SpecialNumber@1": "NaN" });
-    });
-
-    it('serializes `+Infinity` to `/SpecialNumber@1` with state `"+Infinity"`', () => {
-      expect(toWireFormat(Infinity)).toEqual({
-        "/SpecialNumber@1": "+Infinity",
-      });
-    });
-
-    it('serializes `-Infinity` to `/SpecialNumber@1` with state `"-Infinity"`', () => {
-      expect(toWireFormat(-Infinity)).toEqual({
-        "/SpecialNumber@1": "-Infinity",
-      });
-    });
-
-    it("does not intercept `+0` (round-trips as a plain number)", () => {
-      expect(toWireFormat(0)).toBe(0);
+    it("round-trips special numbers (`-0`/`NaN`/`±Infinity`) at top level, in arrays, and as object values", () => {
+      // `+0` is not a special number; it round-trips as a plain JSON number.
       expect(roundTrip(0)).toBe(0);
-    });
-
-    it("round-trips `-0` (preserves sign of zero)", () => {
-      const result = roundTrip(-0);
-      expect(Object.is(result, -0)).toBe(true);
-    });
-
-    it("round-trips `NaN`", () => {
+      expect(Object.is(roundTrip(-0), -0)).toBe(true);
       expect(Number.isNaN(roundTrip(NaN))).toBe(true);
-    });
-
-    it("round-trips `+Infinity`", () => {
       expect(roundTrip(Infinity)).toBe(Infinity);
-    });
-
-    it("round-trips `-Infinity`", () => {
       expect(roundTrip(-Infinity)).toBe(-Infinity);
-    });
 
-    it('any `NaN` bit pattern serializes as the literal `"NaN"`', () => {
-      const view = new DataView(new ArrayBuffer(8));
-      view.setBigUint64(0, 0x7ff8000000000001n, false);
-      const nonCanonicalNaN = view.getFloat64(0, false);
-      expect(Number.isNaN(nonCanonicalNaN)).toBe(true);
-      expect(toWireFormat(nonCanonicalNaN)).toEqual({
-        "/SpecialNumber@1": "NaN",
-      });
-    });
-
-    it("round-trips inside arrays", () => {
       const arr = [1, NaN, -0, Infinity, -Infinity, 2] as FabricValue;
-      const result = roundTrip(arr) as number[];
-      expect(result[0]).toBe(1);
-      expect(Number.isNaN(result[1])).toBe(true);
-      expect(Object.is(result[2], -0)).toBe(true);
-      expect(result[3]).toBe(Infinity);
-      expect(result[4]).toBe(-Infinity);
-      expect(result[5]).toBe(2);
-    });
+      const arrResult = roundTrip(arr) as number[];
+      expect(arrResult[0]).toBe(1);
+      expect(Number.isNaN(arrResult[1])).toBe(true);
+      expect(Object.is(arrResult[2], -0)).toBe(true);
+      expect(arrResult[3]).toBe(Infinity);
+      expect(arrResult[4]).toBe(-Infinity);
+      expect(arrResult[5]).toBe(2);
 
-    it("round-trips as object values", () => {
       const obj = {
         nz: -0,
         nan: NaN,
         pinf: Infinity,
         ninf: -Infinity,
       } as unknown as FabricValue;
-      const result = roundTrip(obj) as Record<string, number>;
-      expect(Object.is(result.nz, -0)).toBe(true);
-      expect(Number.isNaN(result.nan)).toBe(true);
-      expect(result.pinf).toBe(Infinity);
-      expect(result.ninf).toBe(-Infinity);
+      const objResult = roundTrip(obj) as Record<string, number>;
+      expect(Object.is(objResult.nz, -0)).toBe(true);
+      expect(Number.isNaN(objResult.nan)).toBe(true);
+      expect(objResult.pinf).toBe(Infinity);
+      expect(objResult.ninf).toBe(-Infinity);
     });
 
-    it("non-string state -> `ProblematicValue` (lenient)", () => {
-      const ctx = new JsonEncodingContext({ lenient: true });
-      const runtime = new TestReconstructionContext();
-      const encoded = ENCODING_PREFIX +
-        JSON.stringify({ "/SpecialNumber@1": 0 });
-      const result = ctx.decode(encoded, runtime);
-      expect(result).toBeInstanceOf(ProblematicValue);
-      expect((result as unknown as ProblematicValue).wireTypeTag).toBe(
-        "SpecialNumber@1",
-      );
-    });
+    it("round-trips interned symbols at top level, in arrays, and as object values", () => {
+      const top = roundTrip(Symbol.for("hello") as FabricValue);
+      expect(typeof top).toBe("symbol");
+      expect(top).toBe(Symbol.for("hello"));
 
-    it("unknown literal -> `ProblematicValue` (lenient)", () => {
-      const ctx = new JsonEncodingContext({ lenient: true });
-      const runtime = new TestReconstructionContext();
-      const encoded = ENCODING_PREFIX +
-        JSON.stringify({ "/SpecialNumber@1": "Infinity" }); // missing leading +
-      const result = ctx.decode(encoded, runtime);
-      expect(result).toBeInstanceOf(ProblematicValue);
-      expect((result as unknown as ProblematicValue).wireTypeTag).toBe(
-        "SpecialNumber@1",
-      );
-    });
-  });
-
-  describe("Symbol", () => {
-    it('serializes `Symbol.for("foo")` to `/Symbol@1` with the key as state', () => {
-      expect(toWireFormat(Symbol.for("foo") as FabricValue)).toEqual({
-        "/Symbol@1": "foo",
-      });
-    });
-
-    it('serializes `Symbol.for("")` (empty key)', () => {
-      expect(toWireFormat(Symbol.for("") as FabricValue)).toEqual({
-        "/Symbol@1": "",
-      });
-    });
-
-    it("round-trips an interned symbol to the same registry instance", () => {
-      const result = roundTrip(Symbol.for("hello") as FabricValue);
-      expect(typeof result).toBe("symbol");
-      expect(result).toBe(Symbol.for("hello"));
-    });
-
-    it("round-trips a key with non-ASCII characters", () => {
-      const key = "café-☕-\u{1F600}";
-      const result = roundTrip(Symbol.for(key) as FabricValue);
-      expect(result).toBe(Symbol.for(key));
-    });
-
-    it("round-trips inside arrays", () => {
       const arr = [
         Symbol.for("a"),
         1,
         Symbol.for("b"),
       ] as unknown as FabricValue;
-      const result = roundTrip(arr) as unknown[];
-      expect(result[0]).toBe(Symbol.for("a"));
-      expect(result[1]).toBe(1);
-      expect(result[2]).toBe(Symbol.for("b"));
-    });
+      const arrResult = roundTrip(arr) as unknown[];
+      expect(arrResult[0]).toBe(Symbol.for("a"));
+      expect(arrResult[1]).toBe(1);
+      expect(arrResult[2]).toBe(Symbol.for("b"));
 
-    it("round-trips as object values", () => {
       const obj = {
         kind: Symbol.for("event"),
         flag: Symbol.for("ready"),
       } as unknown as FabricValue;
-      const result = roundTrip(obj) as Record<string, unknown>;
-      expect(result.kind).toBe(Symbol.for("event"));
-      expect(result.flag).toBe(Symbol.for("ready"));
+      const objResult = roundTrip(obj) as Record<string, unknown>;
+      expect(objResult.kind).toBe(Symbol.for("event"));
+      expect(objResult.flag).toBe(Symbol.for("ready"));
     });
 
-    it("loudly fails to encode `Symbol(desc)` (unique / uninterned)", () => {
+    it("loudly fails to encode an unencodable value (unique / uninterned `Symbol`)", () => {
       // `SymbolCodec.canEncode()` returns false for unique symbols (no
       // registry key), so no codec claims them. A default-configured context
       // must then fail loudly rather than silently flatten the symbol to `{}`.
@@ -599,72 +345,13 @@ describe("JsonEncodingContext", () => {
       );
     });
 
-    it("non-string state -> `ProblematicValue` (lenient)", () => {
-      const ctx = new JsonEncodingContext({ lenient: true });
-      const runtime = new TestReconstructionContext();
-      const encodedJson = ENCODING_PREFIX +
-        JSON.stringify({ "/Symbol@1": 42 });
-      const result = ctx.decode(encodedJson, runtime);
-      expect(result).toBeInstanceOf(ProblematicValue);
-      expect((result as unknown as ProblematicValue).wireTypeTag).toBe(
-        "Symbol@1",
-      );
-    });
-  });
-
-  describe("FabricEpochNsec", () => {
-    it("serializes to `/EpochNsec@1` with flat base64", () => {
-      const sn = new FabricEpochNsec(0n);
-      const result = toWireFormat(sn as FabricValue) as Record<
-        string,
-        unknown
-      >;
-      expect(Object.keys(result)).toEqual(["/EpochNsec@1"]);
-      // Flat format: base64 string directly, not nested {"/BigInt@1": ...}
-      expect(result["/EpochNsec@1"]).toBe("AA");
-    });
-
-    it("round-trips at top level (epoch zero)", () => {
-      const sn = new FabricEpochNsec(0n);
-      const result = roundTrip(
-        sn as FabricValue,
+    it("round-trips `FabricEpochNsec` at top level and in nested structures", () => {
+      const top = roundTrip(
+        new FabricEpochNsec(1704067200000000000n) as FabricValue,
       ) as unknown as FabricEpochNsec;
-      expect(result).toBeInstanceOf(FabricEpochNsec);
-      expect(result.value).toBe(0n);
-    });
+      expect(top).toBeInstanceOf(FabricEpochNsec);
+      expect(top.value).toBe(1704067200000000000n);
 
-    it("round-trips positive nanosecond timestamp", () => {
-      // 2024-01-01T00:00:00Z = 1704067200 seconds = 1704067200000000000 nsec
-      const nsec = 1704067200000000000n;
-      const sn = new FabricEpochNsec(nsec);
-      const result = roundTrip(
-        sn as FabricValue,
-      ) as unknown as FabricEpochNsec;
-      expect(result).toBeInstanceOf(FabricEpochNsec);
-      expect(result.value).toBe(nsec);
-    });
-
-    it("round-trips negative nanosecond timestamp (pre-epoch)", () => {
-      const nsec = -86400000000000n; // -1 day in nanoseconds
-      const sn = new FabricEpochNsec(nsec);
-      const result = roundTrip(
-        sn as FabricValue,
-      ) as unknown as FabricEpochNsec;
-      expect(result).toBeInstanceOf(FabricEpochNsec);
-      expect(result.value).toBe(nsec);
-    });
-
-    it("round-trips large future date", () => {
-      // Year 3000-ish
-      const nsec = 32503680000000000000n;
-      const sn = new FabricEpochNsec(nsec);
-      const result = roundTrip(
-        sn as FabricValue,
-      ) as unknown as FabricEpochNsec;
-      expect(result.value).toBe(nsec);
-    });
-
-    it("round-trips in nested structure", () => {
       const obj = {
         timestamp: new FabricEpochNsec(42000000000n),
         label: "test",
@@ -675,50 +362,14 @@ describe("JsonEncodingContext", () => {
       expect(ts).toBeInstanceOf(FabricEpochNsec);
       expect(ts.value).toBe(42000000000n);
     });
-  });
 
-  describe("FabricEpochDays", () => {
-    it("serializes to `/EpochDays@1` with flat base64", () => {
-      const sd = new FabricEpochDays(0n);
-      const result = toWireFormat(sd as FabricValue) as Record<
-        string,
-        unknown
-      >;
-      expect(Object.keys(result)).toEqual(["/EpochDays@1"]);
-      // Flat format: base64 string directly, not nested {"/BigInt@1": ...}
-      expect(result["/EpochDays@1"]).toBe("AA");
-    });
-
-    it("round-trips at top level (epoch zero)", () => {
-      const sd = new FabricEpochDays(0n);
-      const result = roundTrip(
-        sd as FabricValue,
+    it("round-trips `FabricEpochDays` at top level and in nested structures", () => {
+      const top = roundTrip(
+        new FabricEpochDays(19723n) as FabricValue,
       ) as unknown as FabricEpochDays;
-      expect(result).toBeInstanceOf(FabricEpochDays);
-      expect(result.value).toBe(0n);
-    });
+      expect(top).toBeInstanceOf(FabricEpochDays);
+      expect(top.value).toBe(19723n);
 
-    it("round-trips positive day count", () => {
-      const days = 19723n; // ~2024-01-01
-      const sd = new FabricEpochDays(days);
-      const result = roundTrip(
-        sd as FabricValue,
-      ) as unknown as FabricEpochDays;
-      expect(result).toBeInstanceOf(FabricEpochDays);
-      expect(result.value).toBe(days);
-    });
-
-    it("round-trips negative day count (pre-epoch)", () => {
-      const days = -365n;
-      const sd = new FabricEpochDays(days);
-      const result = roundTrip(
-        sd as FabricValue,
-      ) as unknown as FabricEpochDays;
-      expect(result).toBeInstanceOf(FabricEpochDays);
-      expect(result.value).toBe(days);
-    });
-
-    it("round-trips in nested structure", () => {
       const obj = {
         date: new FabricEpochDays(19723n),
         label: "birthday",
@@ -729,41 +380,16 @@ describe("JsonEncodingContext", () => {
       expect(d).toBeInstanceOf(FabricEpochDays);
       expect(d.value).toBe(19723n);
     });
-  });
 
-  describe("FabricRegExp", () => {
-    it("serializes to `/RegExp@1` with `{ source, flags, flavor }`", () => {
-      const re = new FabricRegExp(/ab+c/gi);
-      const result = toWireFormat(re as FabricValue) as Record<
-        string,
-        unknown
-      >;
-      expect(Object.keys(result)).toEqual(["/RegExp@1"]);
-      expect(result["/RegExp@1"]).toEqual({
-        flags: "gi",
-        flavor: "es2025",
-        source: "ab+c",
-      });
-    });
+    it("round-trips `FabricRegExp` at top level and in nested structures", () => {
+      const top = roundTrip(
+        new FabricRegExp(/ab+c/gi) as FabricValue,
+      ) as unknown as FabricRegExp;
+      expect(top).toBeInstanceOf(FabricRegExp);
+      expect(top.source).toBe("ab+c");
+      expect(top.flags).toBe("gi");
+      expect(top.flavor).toBe("es2025");
 
-    it("round-trips a regex (source, flags, flavor)", () => {
-      const re = new FabricRegExp(/ab+c/gi);
-      const result = roundTrip(re as FabricValue) as unknown as FabricRegExp;
-      expect(result).toBeInstanceOf(FabricRegExp);
-      expect(result.source).toBe("ab+c");
-      expect(result.flags).toBe("gi");
-      expect(result.flavor).toBe("es2025");
-    });
-
-    it("round-trips a flagless regex", () => {
-      const re = new FabricRegExp("es2025", "^x*$", "");
-      const result = roundTrip(re as FabricValue) as unknown as FabricRegExp;
-      expect(result).toBeInstanceOf(FabricRegExp);
-      expect(result.source).toBe("^x*$");
-      expect(result.flags).toBe("");
-    });
-
-    it("round-trips in a nested structure", () => {
       const obj = {
         pattern: new FabricRegExp(/\d+/g),
         label: "digits",
@@ -774,11 +400,6 @@ describe("JsonEncodingContext", () => {
       expect(re).toBeInstanceOf(FabricRegExp);
       expect(re.source).toBe("\\d+");
       expect(re.flags).toBe("g");
-    });
-
-    it("decodes non-object state to `ProblematicValue`", () => {
-      const result = fromWireFormat({ "/RegExp@1": "nope" } as JsonWireValue);
-      expect(result).toBeInstanceOf(ProblematicValue);
     });
   });
 
@@ -795,203 +416,6 @@ describe("JsonEncodingContext", () => {
       const { context } = makeTestContext();
       expect(() => context.encode(new Map() as unknown as FabricValue))
         .toThrow("no applicable codec");
-    });
-  });
-
-  describe("`Date` -> `FabricEpochNsec` conversion", () => {
-    it("converts `Date(0)` to `FabricEpochNsec(0n)`", () => {
-      const date = new Date(0);
-      const result = shallowFabricFromNativeValue(
-        date,
-      ) as unknown as FabricEpochNsec;
-      expect(result).toBeInstanceOf(FabricEpochNsec);
-      expect(result.value).toBe(0n);
-    });
-
-    it("converts `Date` to nanoseconds (`msec * 1_000_000`)", () => {
-      const date = new Date("2024-01-01T00:00:00.000Z");
-      const result = shallowFabricFromNativeValue(
-        date,
-      ) as unknown as FabricEpochNsec;
-      expect(result).toBeInstanceOf(FabricEpochNsec);
-      const expectedNsec = BigInt(date.getTime()) * 1_000_000n;
-      expect(result.value).toBe(expectedNsec);
-    });
-
-    it("converts negative `Date` to negative nanoseconds", () => {
-      const date = new Date(-86400000); // -1 day
-      const result = shallowFabricFromNativeValue(
-        date,
-      ) as unknown as FabricEpochNsec;
-      expect(result).toBeInstanceOf(FabricEpochNsec);
-      expect(result.value).toBe(-86400000000000n);
-    });
-  });
-
-  describe("FabricError", () => {
-    it("serializes basic `FabricError` to `/Error@1`", () => {
-      const se = FabricError.fromNativeError(new Error("test"));
-      const result = toWireFormat(
-        se as FabricValue,
-      ) as Record<string, unknown>;
-      expect(Object.keys(result)).toEqual(["/Error@1"]);
-      const state = result["/Error@1"] as Record<string, unknown>;
-      expect(state.type).toBe("Error");
-      expect(state.name).toBe(null); // null = same as type (common case)
-      expect(state.message).toBe("test");
-    });
-
-    it("round-trips basic `Error` via `FabricError`", () => {
-      const se = FabricError.fromNativeError(new Error("hello"));
-      const result = roundTrip(
-        se as FabricValue,
-      ) as unknown as FabricError;
-      expect(result).toBeInstanceOf(FabricError);
-      expect(result.toNativeValue(true)).toBeInstanceOf(Error);
-      expect(result.name).toBe("Error");
-      expect(result.message).toBe("hello");
-    });
-
-    it("round-trips `TypeError`", () => {
-      const se = FabricError.fromNativeError(new TypeError("bad type"));
-      const result = roundTrip(
-        se as FabricValue,
-      ) as unknown as FabricError;
-      expect(result).toBeInstanceOf(FabricError);
-      expect(result.toNativeValue(true)).toBeInstanceOf(TypeError);
-      expect(result.name).toBe("TypeError");
-      expect(result.message).toBe("bad type");
-    });
-
-    it("round-trips `RangeError`", () => {
-      const se = FabricError.fromNativeError(new RangeError("out of range"));
-      const result = roundTrip(
-        se as FabricValue,
-      ) as unknown as FabricError;
-      expect(result).toBeInstanceOf(FabricError);
-      expect(result.toNativeValue(true)).toBeInstanceOf(RangeError);
-      expect(result.name).toBe("RangeError");
-    });
-
-    it("round-trips `Error` with cause", () => {
-      const inner = FabricError.fromNativeError(new Error("inner"));
-      const outer = FabricError.fromNativeError(
-        new Error("outer", { cause: inner }),
-      );
-      const result = roundTrip(
-        outer as FabricValue,
-      ) as unknown as FabricError;
-      expect(result.message).toBe("outer");
-      // The cause was serialized as a FabricError (the inner wrapper).
-      // After round-trip, the cause is a FabricError.
-      expect(result.cause).toBeInstanceOf(FabricError);
-      expect(
-        (result.cause as FabricError).message,
-      ).toBe("inner");
-    });
-
-    it("round-trips `Error` with custom properties", () => {
-      const err = new Error("oops");
-      (err as unknown as Record<string, unknown>).code = 42;
-      (err as unknown as Record<string, unknown>).detail = "more info";
-      const se = FabricError.fromNativeError(err);
-      const result = roundTrip(
-        se as FabricValue,
-      ) as unknown as FabricError;
-      expect(result.message).toBe("oops");
-      expect(
-        (result.toNativeValue(true) as unknown as Record<string, unknown>).code,
-      ).toBe(42);
-      expect(
-        (result.toNativeValue(true) as unknown as Record<string, unknown>)
-          .detail,
-      ).toBe("more info");
-    });
-
-    it("round-trips `Error` with custom `name`", () => {
-      const err = new Error("custom");
-      err.name = "MyCustomError";
-      const se = FabricError.fromNativeError(err);
-      const result = roundTrip(
-        se as FabricValue,
-      ) as unknown as FabricError;
-      expect(result.name).toBe("MyCustomError");
-      expect(result.message).toBe("custom");
-    });
-
-    it("emits `name: null` in the wire format when `name` matches `type` (`TypeError`)", () => {
-      // TypeError: name === constructor.name === "TypeError"
-      const se = FabricError.fromNativeError(new TypeError("type check"));
-      const result = toWireFormat(
-        se as FabricValue,
-      ) as Record<string, unknown>;
-      const state = result["/Error@1"] as Record<string, unknown>;
-      expect(state.type).toBe("TypeError");
-      expect(state.name).toBe(null); // null = same as type
-      expect(state.message).toBe("type check");
-    });
-
-    it("emits explicit `name` in the wire format when `name` differs from `type`", () => {
-      const err = new Error("custom");
-      err.name = "MyCustomError";
-      const se = FabricError.fromNativeError(err);
-      const result = toWireFormat(
-        se as FabricValue,
-      ) as Record<string, unknown>;
-      const state = result["/Error@1"] as Record<string, unknown>;
-      expect(state.type).toBe("Error");
-      expect(state.name).toBe("MyCustomError");
-      expect(state.message).toBe("custom");
-    });
-
-    it("round-trips `TypeError` preserving `name === type` identity", () => {
-      // After round-trip, name and type should both be "TypeError",
-      // and the Error should reconstruct as a TypeError instance.
-      const se = FabricError.fromNativeError(new TypeError("rt"));
-      const result = roundTrip(
-        se as FabricValue,
-      ) as unknown as FabricError;
-      expect(result.toNativeValue(true)).toBeInstanceOf(TypeError);
-      expect(result.name).toBe("TypeError");
-      expect(result.toNativeValue(true).constructor.name).toBe("TypeError");
-    });
-
-    it("round-trips `Error` with mismatched `name` and `type`", () => {
-      // Error constructor is "Error" but name is overridden.
-      const err = new Error("mismatch");
-      err.name = "CustomName";
-      const se = FabricError.fromNativeError(err);
-      const result = roundTrip(
-        se as FabricValue,
-      ) as unknown as FabricError;
-      expect(result.toNativeValue(true)).toBeInstanceOf(Error);
-      expect(result.name).toBe("CustomName");
-      expect(result.toNativeValue(true).constructor.name).toBe("Error");
-    });
-
-    it("has `.wireTypeTag` property", () => {
-      const se = FabricError.fromNativeError(new Error("test"));
-      expect(se.wireTypeTag).toBe("Error@1");
-    });
-
-    it("round-trips `FabricError` with pre-converted cause (raw `Error`)", () => {
-      // Simulates what fabricFromNativeValue produces: a FabricError
-      // wrapping an Error whose cause is itself a FabricError (not a
-      // raw Error). The serializer's recurse on [DECONSTRUCT] output
-      // must find FabricValue, not raw Error.
-      const innerSe = FabricError.fromNativeError(new Error("inner"));
-      const outerErr = new Error("outer");
-      outerErr.cause = innerSe;
-      const outerSe = FabricError.fromNativeError(outerErr);
-
-      const result = roundTrip(
-        outerSe as FabricValue,
-      ) as unknown as FabricError;
-      expect(result.message).toBe("outer");
-      expect(result.cause).toBeInstanceOf(FabricError);
-      expect(
-        (result.cause as FabricError).message,
-      ).toBe("inner");
     });
   });
 

--- a/packages/data-model/test/json-wire/SpecialNumberCodec.test.ts
+++ b/packages/data-model/test/json-wire/SpecialNumberCodec.test.ts
@@ -1,0 +1,113 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import type { FabricValue } from "@/interface.ts";
+import { SpecialNumberCodec } from "@/json-wire/SpecialNumberCodec.ts";
+import { WIRE_TYPE_TAGS } from "@/wire-common/wire-type-tags.ts";
+import { EMPTY_RECONSTRUCTION_CONTEXT } from "@/wire-common/EmptyReconstructionContext.ts";
+import { ProblematicValue } from "@/fabric-instances/ProblematicValue.ts";
+
+describe("SpecialNumberCodec", () => {
+  describe("[CODEC]", () => {
+    const codec = new SpecialNumberCodec();
+    const context = EMPTY_RECONSTRUCTION_CONTEXT;
+
+    it("has the `SpecialNumber` wire type tag", () => {
+      expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.SpecialNumber);
+    });
+
+    it('encodes `-0` to the literal `"-0"`', () => {
+      expect(codec.encode(-0)).toBe("-0");
+    });
+
+    it('encodes `NaN` to the literal `"NaN"`', () => {
+      expect(codec.encode(NaN)).toBe("NaN");
+    });
+
+    it('encodes `+Infinity` to the literal `"+Infinity"`', () => {
+      expect(codec.encode(Infinity)).toBe("+Infinity");
+    });
+
+    it('encodes `-Infinity` to the literal `"-Infinity"`', () => {
+      expect(codec.encode(-Infinity)).toBe("-Infinity");
+    });
+
+    it("does not intercept `+0` (`canEncode()` is `false`)", () => {
+      expect(codec.canEncode(0)).toBe(false);
+    });
+
+    it("claims the four special numeric values via `canEncode()`", () => {
+      expect(codec.canEncode(-0)).toBe(true);
+      expect(codec.canEncode(NaN)).toBe(true);
+      expect(codec.canEncode(Infinity)).toBe(true);
+      expect(codec.canEncode(-Infinity)).toBe(true);
+      // Ordinary finite numbers are not claimed.
+      expect(codec.canEncode(42)).toBe(false);
+    });
+
+    it("round-trips `-0` (preserves sign of zero)", () => {
+      const result = codec.decode(codec.wireTypeTag, codec.encode(-0), context);
+      expect(Object.is(result, -0)).toBe(true);
+    });
+
+    it("round-trips `NaN`", () => {
+      const result = codec.decode(
+        codec.wireTypeTag,
+        codec.encode(NaN),
+        context,
+      );
+      expect(Number.isNaN(result)).toBe(true);
+    });
+
+    it("round-trips `+Infinity`", () => {
+      const result = codec.decode(
+        codec.wireTypeTag,
+        codec.encode(Infinity),
+        context,
+      );
+      expect(result).toBe(Infinity);
+    });
+
+    it("round-trips `-Infinity`", () => {
+      const result = codec.decode(
+        codec.wireTypeTag,
+        codec.encode(-Infinity),
+        context,
+      );
+      expect(result).toBe(-Infinity);
+    });
+
+    it('any `NaN` bit pattern encodes as the literal `"NaN"`', () => {
+      const view = new DataView(new ArrayBuffer(8));
+      view.setBigUint64(0, 0x7ff8000000000001n, false);
+      const nonCanonicalNaN = view.getFloat64(0, false);
+      expect(Number.isNaN(nonCanonicalNaN)).toBe(true);
+      expect(codec.encode(nonCanonicalNaN)).toBe("NaN");
+    });
+
+    it("decodes non-string state to `ProblematicValue`", () => {
+      const result = codec.decode(
+        codec.wireTypeTag,
+        0 as unknown as FabricValue,
+        context,
+      );
+      expect(result).toBeInstanceOf(ProblematicValue);
+      expect((result as unknown as ProblematicValue).wireTypeTag).toBe(
+        "SpecialNumber@1",
+      );
+    });
+
+    it("decodes an unknown literal to `ProblematicValue`", () => {
+      // "Infinity" (missing leading +) is not a recognized literal.
+      const result = codec.decode(
+        codec.wireTypeTag,
+        "Infinity",
+        context,
+      );
+      expect(result).toBeInstanceOf(ProblematicValue);
+      expect((result as unknown as ProblematicValue).wireTypeTag).toBe(
+        "SpecialNumber@1",
+      );
+    });
+  });
+});

--- a/packages/data-model/test/json-wire/SpecialNumberCodec.test.ts
+++ b/packages/data-model/test/json-wire/SpecialNumberCodec.test.ts
@@ -1,113 +1,117 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
-import type { FabricValue } from "@/interface.ts";
 import { SpecialNumberCodec } from "@/json-wire/SpecialNumberCodec.ts";
 import { WIRE_TYPE_TAGS } from "@/wire-common/wire-type-tags.ts";
 import { EMPTY_RECONSTRUCTION_CONTEXT } from "@/wire-common/EmptyReconstructionContext.ts";
 import { ProblematicValue } from "@/fabric-instances/ProblematicValue.ts";
 
 describe("SpecialNumberCodec", () => {
-  describe("[CODEC]", () => {
-    const codec = new SpecialNumberCodec();
-    const context = EMPTY_RECONSTRUCTION_CONTEXT;
+  const codec = new SpecialNumberCodec();
+  const context = EMPTY_RECONSTRUCTION_CONTEXT;
 
-    it("has the `SpecialNumber` wire type tag", () => {
-      expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.SpecialNumber);
+  describe("instance members", () => {
+    describe("wireTypeTag", () => {
+      it("is the `SpecialNumber` wire type tag", () => {
+        expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.SpecialNumber);
+      });
     });
 
-    it('encodes `-0` to the literal `"-0"`', () => {
-      expect(codec.encode(-0)).toBe("-0");
+    describe("canEncode()", () => {
+      it("claims the four special numeric values, rejects ordinary ones", () => {
+        expect(codec.canEncode(-0)).toBe(true);
+        expect(codec.canEncode(NaN)).toBe(true);
+        expect(codec.canEncode(Infinity)).toBe(true);
+        expect(codec.canEncode(-Infinity)).toBe(true);
+        // Ordinary finite numbers (and `+0`) are not claimed.
+        expect(codec.canEncode(42)).toBe(false);
+        expect(codec.canEncode(0)).toBe(false);
+      });
     });
 
-    it('encodes `NaN` to the literal `"NaN"`', () => {
-      expect(codec.encode(NaN)).toBe("NaN");
+    describe("encode()", () => {
+      it('encodes `-0` to the literal `"-0"`', () => {
+        expect(codec.encode(-0)).toBe("-0");
+      });
+
+      it('encodes `NaN` to the literal `"NaN"`', () => {
+        expect(codec.encode(NaN)).toBe("NaN");
+      });
+
+      it('encodes `+Infinity` to the literal `"+Infinity"`', () => {
+        expect(codec.encode(Infinity)).toBe("+Infinity");
+      });
+
+      it('encodes `-Infinity` to the literal `"-Infinity"`', () => {
+        expect(codec.encode(-Infinity)).toBe("-Infinity");
+      });
+
+      it('any `NaN` bit pattern encodes as the literal `"NaN"`', () => {
+        const view = new DataView(new ArrayBuffer(8));
+        view.setBigUint64(0, 0x7ff8000000000001n, false);
+        const nonCanonicalNaN = view.getFloat64(0, false);
+        expect(Number.isNaN(nonCanonicalNaN)).toBe(true);
+        expect(codec.encode(nonCanonicalNaN)).toBe("NaN");
+      });
     });
 
-    it('encodes `+Infinity` to the literal `"+Infinity"`', () => {
-      expect(codec.encode(Infinity)).toBe("+Infinity");
-    });
+    describe("decode()", () => {
+      it("round-trips `-0` (preserves sign of zero)", () => {
+        const result = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(-0),
+          context,
+        );
+        expect(Object.is(result, -0)).toBe(true);
+      });
 
-    it('encodes `-Infinity` to the literal `"-Infinity"`', () => {
-      expect(codec.encode(-Infinity)).toBe("-Infinity");
-    });
+      it("round-trips `NaN`", () => {
+        const result = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(NaN),
+          context,
+        );
+        expect(Number.isNaN(result)).toBe(true);
+      });
 
-    it("does not intercept `+0` (`canEncode()` is `false`)", () => {
-      expect(codec.canEncode(0)).toBe(false);
-    });
+      it("round-trips `+Infinity`", () => {
+        const result = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(Infinity),
+          context,
+        );
+        expect(result).toBe(Infinity);
+      });
 
-    it("claims the four special numeric values via `canEncode()`", () => {
-      expect(codec.canEncode(-0)).toBe(true);
-      expect(codec.canEncode(NaN)).toBe(true);
-      expect(codec.canEncode(Infinity)).toBe(true);
-      expect(codec.canEncode(-Infinity)).toBe(true);
-      // Ordinary finite numbers are not claimed.
-      expect(codec.canEncode(42)).toBe(false);
-    });
+      it("round-trips `-Infinity`", () => {
+        const result = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(-Infinity),
+          context,
+        );
+        expect(result).toBe(-Infinity);
+      });
 
-    it("round-trips `-0` (preserves sign of zero)", () => {
-      const result = codec.decode(codec.wireTypeTag, codec.encode(-0), context);
-      expect(Object.is(result, -0)).toBe(true);
-    });
+      it("decodes non-string state to `ProblematicValue`", () => {
+        const result = codec.decode(
+          codec.wireTypeTag,
+          0,
+          context,
+        );
+        expect(result).toBeInstanceOf(ProblematicValue);
+        expect((result as unknown as ProblematicValue).wireTypeTag).toBe(
+          "SpecialNumber@1",
+        );
+      });
 
-    it("round-trips `NaN`", () => {
-      const result = codec.decode(
-        codec.wireTypeTag,
-        codec.encode(NaN),
-        context,
-      );
-      expect(Number.isNaN(result)).toBe(true);
-    });
-
-    it("round-trips `+Infinity`", () => {
-      const result = codec.decode(
-        codec.wireTypeTag,
-        codec.encode(Infinity),
-        context,
-      );
-      expect(result).toBe(Infinity);
-    });
-
-    it("round-trips `-Infinity`", () => {
-      const result = codec.decode(
-        codec.wireTypeTag,
-        codec.encode(-Infinity),
-        context,
-      );
-      expect(result).toBe(-Infinity);
-    });
-
-    it('any `NaN` bit pattern encodes as the literal `"NaN"`', () => {
-      const view = new DataView(new ArrayBuffer(8));
-      view.setBigUint64(0, 0x7ff8000000000001n, false);
-      const nonCanonicalNaN = view.getFloat64(0, false);
-      expect(Number.isNaN(nonCanonicalNaN)).toBe(true);
-      expect(codec.encode(nonCanonicalNaN)).toBe("NaN");
-    });
-
-    it("decodes non-string state to `ProblematicValue`", () => {
-      const result = codec.decode(
-        codec.wireTypeTag,
-        0 as unknown as FabricValue,
-        context,
-      );
-      expect(result).toBeInstanceOf(ProblematicValue);
-      expect((result as unknown as ProblematicValue).wireTypeTag).toBe(
-        "SpecialNumber@1",
-      );
-    });
-
-    it("decodes an unknown literal to `ProblematicValue`", () => {
-      // "Infinity" (missing leading +) is not a recognized literal.
-      const result = codec.decode(
-        codec.wireTypeTag,
-        "Infinity",
-        context,
-      );
-      expect(result).toBeInstanceOf(ProblematicValue);
-      expect((result as unknown as ProblematicValue).wireTypeTag).toBe(
-        "SpecialNumber@1",
-      );
+      it("decodes an unknown literal to `ProblematicValue`", () => {
+        // "Infinity" (missing leading +) is not a recognized literal.
+        const result = codec.decode(codec.wireTypeTag, "Infinity", context);
+        expect(result).toBeInstanceOf(ProblematicValue);
+        expect((result as unknown as ProblematicValue).wireTypeTag).toBe(
+          "SpecialNumber@1",
+        );
+      });
     });
   });
 });

--- a/packages/data-model/test/json-wire/SymbolCodec.test.ts
+++ b/packages/data-model/test/json-wire/SymbolCodec.test.ts
@@ -1,0 +1,68 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import type { FabricValue } from "@/interface.ts";
+import { SymbolCodec } from "@/json-wire/SymbolCodec.ts";
+import { WIRE_TYPE_TAGS } from "@/wire-common/wire-type-tags.ts";
+import { EMPTY_RECONSTRUCTION_CONTEXT } from "@/wire-common/EmptyReconstructionContext.ts";
+import { ProblematicValue } from "@/fabric-instances/ProblematicValue.ts";
+
+describe("SymbolCodec", () => {
+  describe("[CODEC]", () => {
+    const codec = new SymbolCodec();
+    const context = EMPTY_RECONSTRUCTION_CONTEXT;
+
+    it("has the `Symbol` wire type tag", () => {
+      expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.Symbol);
+    });
+
+    it('encodes `Symbol.for("foo")` to its registry key', () => {
+      expect(codec.encode(Symbol.for("foo"))).toBe("foo");
+    });
+
+    it('encodes `Symbol.for("")` (empty key)', () => {
+      expect(codec.encode(Symbol.for(""))).toBe("");
+    });
+
+    it("round-trips an interned symbol to the same registry instance", () => {
+      const result = codec.decode(
+        codec.wireTypeTag,
+        codec.encode(Symbol.for("hello")),
+        context,
+      );
+      expect(typeof result).toBe("symbol");
+      expect(result).toBe(Symbol.for("hello"));
+    });
+
+    it("round-trips a key with non-ASCII characters", () => {
+      const key = "café-☕-\u{1F600}";
+      const result = codec.decode(
+        codec.wireTypeTag,
+        codec.encode(Symbol.for(key)),
+        context,
+      );
+      expect(result).toBe(Symbol.for(key));
+    });
+
+    it("does not claim `Symbol(desc)` (unique / uninterned) via `canEncode()`", () => {
+      // Unique symbols have no registry key, so the codec declines them; this
+      // is what lets a default-configured context fail loudly rather than
+      // silently flatten the symbol.
+      expect(codec.canEncode(Symbol("nope"))).toBe(false);
+      // Registry-interned symbols are claimed.
+      expect(codec.canEncode(Symbol.for("yes"))).toBe(true);
+    });
+
+    it("decodes non-string state to `ProblematicValue`", () => {
+      const result = codec.decode(
+        codec.wireTypeTag,
+        42 as unknown as FabricValue,
+        context,
+      );
+      expect(result).toBeInstanceOf(ProblematicValue);
+      expect((result as unknown as ProblematicValue).wireTypeTag).toBe(
+        "Symbol@1",
+      );
+    });
+  });
+});

--- a/packages/data-model/test/json-wire/SymbolCodec.test.ts
+++ b/packages/data-model/test/json-wire/SymbolCodec.test.ts
@@ -1,68 +1,75 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
-import type { FabricValue } from "@/interface.ts";
 import { SymbolCodec } from "@/json-wire/SymbolCodec.ts";
 import { WIRE_TYPE_TAGS } from "@/wire-common/wire-type-tags.ts";
 import { EMPTY_RECONSTRUCTION_CONTEXT } from "@/wire-common/EmptyReconstructionContext.ts";
 import { ProblematicValue } from "@/fabric-instances/ProblematicValue.ts";
 
 describe("SymbolCodec", () => {
-  describe("[CODEC]", () => {
-    const codec = new SymbolCodec();
-    const context = EMPTY_RECONSTRUCTION_CONTEXT;
+  const codec = new SymbolCodec();
+  const context = EMPTY_RECONSTRUCTION_CONTEXT;
 
-    it("has the `Symbol` wire type tag", () => {
-      expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.Symbol);
+  describe("instance members", () => {
+    describe("wireTypeTag", () => {
+      it("is the `Symbol` wire type tag", () => {
+        expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.Symbol);
+      });
     });
 
-    it('encodes `Symbol.for("foo")` to its registry key', () => {
-      expect(codec.encode(Symbol.for("foo"))).toBe("foo");
+    describe("canEncode()", () => {
+      it("claims interned symbols, rejects unique ones", () => {
+        // Unique symbols have no registry key, so the codec declines them; this
+        // is what lets a default-configured context fail loudly rather than
+        // silently flatten the symbol.
+        expect(codec.canEncode(Symbol("nope"))).toBe(false);
+        // Registry-interned symbols are claimed.
+        expect(codec.canEncode(Symbol.for("yes"))).toBe(true);
+      });
     });
 
-    it('encodes `Symbol.for("")` (empty key)', () => {
-      expect(codec.encode(Symbol.for(""))).toBe("");
+    describe("encode()", () => {
+      it('encodes `Symbol.for("foo")` to its registry key', () => {
+        expect(codec.encode(Symbol.for("foo"))).toBe("foo");
+      });
+
+      it('encodes `Symbol.for("")` (empty key)', () => {
+        expect(codec.encode(Symbol.for(""))).toBe("");
+      });
     });
 
-    it("round-trips an interned symbol to the same registry instance", () => {
-      const result = codec.decode(
-        codec.wireTypeTag,
-        codec.encode(Symbol.for("hello")),
-        context,
-      );
-      expect(typeof result).toBe("symbol");
-      expect(result).toBe(Symbol.for("hello"));
-    });
+    describe("decode()", () => {
+      it("round-trips an interned symbol to the same registry instance", () => {
+        const result = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(Symbol.for("hello")),
+          context,
+        );
+        expect(typeof result).toBe("symbol");
+        expect(result).toBe(Symbol.for("hello"));
+      });
 
-    it("round-trips a key with non-ASCII characters", () => {
-      const key = "café-☕-\u{1F600}";
-      const result = codec.decode(
-        codec.wireTypeTag,
-        codec.encode(Symbol.for(key)),
-        context,
-      );
-      expect(result).toBe(Symbol.for(key));
-    });
+      it("round-trips a key with non-ASCII characters", () => {
+        const key = "café-☕-\u{1F600}";
+        const result = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(Symbol.for(key)),
+          context,
+        );
+        expect(result).toBe(Symbol.for(key));
+      });
 
-    it("does not claim `Symbol(desc)` (unique / uninterned) via `canEncode()`", () => {
-      // Unique symbols have no registry key, so the codec declines them; this
-      // is what lets a default-configured context fail loudly rather than
-      // silently flatten the symbol.
-      expect(codec.canEncode(Symbol("nope"))).toBe(false);
-      // Registry-interned symbols are claimed.
-      expect(codec.canEncode(Symbol.for("yes"))).toBe(true);
-    });
-
-    it("decodes non-string state to `ProblematicValue`", () => {
-      const result = codec.decode(
-        codec.wireTypeTag,
-        42 as unknown as FabricValue,
-        context,
-      );
-      expect(result).toBeInstanceOf(ProblematicValue);
-      expect((result as unknown as ProblematicValue).wireTypeTag).toBe(
-        "Symbol@1",
-      );
+      it("decodes non-string state to `ProblematicValue`", () => {
+        const result = codec.decode(
+          codec.wireTypeTag,
+          42,
+          context,
+        );
+        expect(result).toBeInstanceOf(ProblematicValue);
+        expect((result as unknown as ProblematicValue).wireTypeTag).toBe(
+          "Symbol@1",
+        );
+      });
     });
   });
 });

--- a/packages/data-model/test/json-wire/UndefinedCodec.test.ts
+++ b/packages/data-model/test/json-wire/UndefinedCodec.test.ts
@@ -1,0 +1,49 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import type { FabricValue } from "@/interface.ts";
+import { UndefinedCodec } from "@/json-wire/UndefinedCodec.ts";
+import { WIRE_TYPE_TAGS } from "@/wire-common/wire-type-tags.ts";
+import { EMPTY_RECONSTRUCTION_CONTEXT } from "@/wire-common/EmptyReconstructionContext.ts";
+
+describe("UndefinedCodec", () => {
+  describe("[CODEC]", () => {
+    const codec = new UndefinedCodec();
+    const context = EMPTY_RECONSTRUCTION_CONTEXT;
+
+    it("has the `Undefined` wire type tag", () => {
+      expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.Undefined);
+    });
+
+    it("encodes `undefined` to `null` state", () => {
+      expect(codec.encode(undefined)).toBe(null);
+    });
+
+    it("decodes `null` state back to `undefined`", () => {
+      const decoded = codec.decode(codec.wireTypeTag, null, context);
+      expect(decoded).toBe(undefined);
+    });
+
+    it("round-trips `undefined` via encode -> decode", () => {
+      const decoded = codec.decode(
+        codec.wireTypeTag,
+        codec.encode(undefined),
+        context,
+      );
+      expect(decoded).toBe(undefined);
+    });
+
+    it("is distinct from `null` (encodes `null` state, not the `null` value itself)", () => {
+      // `undefined` serializes to the `Undefined@1` tag with `null` state,
+      // whereas `null` is a JSON-native value that is not codec-handled.
+      expect(codec.canEncode(undefined)).toBe(true);
+      expect(codec.canEncode(null)).toBe(false);
+    });
+
+    it("throws when decoding non-`null` state", () => {
+      expect(() =>
+        codec.decode(codec.wireTypeTag, 42 as unknown as FabricValue, context)
+      ).toThrow("expected `null` state");
+    });
+  });
+});

--- a/packages/data-model/test/json-wire/UndefinedCodec.test.ts
+++ b/packages/data-model/test/json-wire/UndefinedCodec.test.ts
@@ -1,49 +1,57 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
-import type { FabricValue } from "@/interface.ts";
 import { UndefinedCodec } from "@/json-wire/UndefinedCodec.ts";
 import { WIRE_TYPE_TAGS } from "@/wire-common/wire-type-tags.ts";
 import { EMPTY_RECONSTRUCTION_CONTEXT } from "@/wire-common/EmptyReconstructionContext.ts";
 
 describe("UndefinedCodec", () => {
-  describe("[CODEC]", () => {
-    const codec = new UndefinedCodec();
-    const context = EMPTY_RECONSTRUCTION_CONTEXT;
+  const codec = new UndefinedCodec();
+  const context = EMPTY_RECONSTRUCTION_CONTEXT;
 
-    it("has the `Undefined` wire type tag", () => {
-      expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.Undefined);
+  describe("instance members", () => {
+    describe("wireTypeTag", () => {
+      it("is the `Undefined` wire type tag", () => {
+        expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.Undefined);
+      });
     });
 
-    it("encodes `undefined` to `null` state", () => {
-      expect(codec.encode(undefined)).toBe(null);
+    describe("canEncode()", () => {
+      it("claims `undefined`, rejects `null` (and other values)", () => {
+        // `undefined` serializes to the `Undefined@1` tag with `null` state,
+        // whereas `null` is a JSON-native value that is not codec-handled.
+        expect(codec.canEncode(undefined)).toBe(true);
+        expect(codec.canEncode(null)).toBe(false);
+        expect(codec.canEncode(0)).toBe(false);
+      });
     });
 
-    it("decodes `null` state back to `undefined`", () => {
-      const decoded = codec.decode(codec.wireTypeTag, null, context);
-      expect(decoded).toBe(undefined);
+    describe("encode()", () => {
+      it("encodes `undefined` to `null` state", () => {
+        expect(codec.encode(undefined)).toBe(null);
+      });
     });
 
-    it("round-trips `undefined` via encode -> decode", () => {
-      const decoded = codec.decode(
-        codec.wireTypeTag,
-        codec.encode(undefined),
-        context,
-      );
-      expect(decoded).toBe(undefined);
-    });
+    describe("decode()", () => {
+      it("decodes `null` state back to `undefined`", () => {
+        const decoded = codec.decode(codec.wireTypeTag, null, context);
+        expect(decoded).toBe(undefined);
+      });
 
-    it("is distinct from `null` (encodes `null` state, not the `null` value itself)", () => {
-      // `undefined` serializes to the `Undefined@1` tag with `null` state,
-      // whereas `null` is a JSON-native value that is not codec-handled.
-      expect(codec.canEncode(undefined)).toBe(true);
-      expect(codec.canEncode(null)).toBe(false);
-    });
+      it("round-trips `undefined` via encode -> decode", () => {
+        const decoded = codec.decode(
+          codec.wireTypeTag,
+          codec.encode(undefined),
+          context,
+        );
+        expect(decoded).toBe(undefined);
+      });
 
-    it("throws when decoding non-`null` state", () => {
-      expect(() =>
-        codec.decode(codec.wireTypeTag, 42 as unknown as FabricValue, context)
-      ).toThrow("expected `null` state");
+      it("throws when decoding non-`null` state", () => {
+        expect(() => codec.decode(codec.wireTypeTag, 42, context)).toThrow(
+          "expected `null` state",
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

Test-only reorganization: each wire codec is now tested in its own type's unit-test file, leaving `JsonEncodingContext.test.ts` to exercise the **mechanism** rather than re-test every type. Follows the `FabricHash.test.ts` exemplar — `describe("static members") → describe("[CODEC]")` testing `X[CODEC].encode`/`.decode` directly with `EMPTY_RECONSTRUCTION_CONTEXT`.

### Moves
- **Out of `JsonEncodingContext.test.ts`** → per-type files: `undefined`, `bigint`, `SpecialNumber`, `Symbol`, `FabricEpochNsec`, `FabricEpochDays`, `FabricRegExp`, `FabricError`, and the `Date → FabricEpochNsec` conversion section (the last was already covered in `native-conversion.test.ts`, so its JEC duplicate was dropped).
- **New standalone codec tests**: `UndefinedCodec`, `BigIntCodec`, `SpecialNumberCodec`, `SymbolCodec`.
- **New `[CODEC]` coverage** for `FabricError` and `FabricBytes` (previously untested at the codec level); `[CODEC]` sections added to the `FabricEpochNsec`/`EpochDays`/`RegExp` test files.
- **Kept in `JsonEncodingContext.test.ts`** (mechanism): primitives round-trip, un-registered-instance mandate guard, dense/sparse arrays, plain objects + key ordering, `/object`/`/quote` escaping, unknown tags, circular refs, lenient `ProblematicValue`, freeze guarantees, deep-frozen contract/invariant, complex round-trips. The old "Uint8Array public API" section was renamed to "encodeToBytes() / decodeFromBytes() (bytes entry points)" — it tests the byte entry points, not the `FabricBytes` codec. A consolidated `tagged-type round-trips through the full stack` section preserves the tag-wrap+nesting coverage the shallow per-class codec tests can't exercise.

### Coverage
Preserved and grown vs the branch base: **`expect()` 2142 → 2175**, **`it()` 1153 → 1164** (the apparent "drop" some intermediate counts showed was duplication during the move). No assertion dropped; `FabricError`/`FabricBytes` codec tests are net-new.

## Test plan
- `deno task check` clean, `deno fmt --check` clean.
- `packages/data-model` suite: **35 passed / 1644 steps / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reorganized JSON wire codec tests so each codec is tested in its type’s test file, and `JsonEncodingContext.test.ts` focuses on the encoding mechanism. Added nominal `[CODEC]` coverage for `FabricMap` and `FabricSet`, and standardized codec test layout (`wireTypeTag`/`canEncode()`/`encode()`/`decode()`).

- **Refactors**
  - Moved per-type codec tests out of `JsonEncodingContext.test.ts` into per-class files for `Undefined`, `BigInt`, `SpecialNumber`, `Symbol`, `FabricEpochNsec`, `FabricEpochDays`, `FabricRegExp`, and `FabricError`; dropped the duplicate `Date → FabricEpochNsec` section.
  - Added standalone tests for `UndefinedCodec`, `BigIntCodec`, `SpecialNumberCodec`, `SymbolCodec`.
  - Added `[CODEC]` sections and coverage for `FabricError` and `FabricBytes`; added `[CODEC]` sections to `FabricEpochNsec`/`FabricEpochDays`/`FabricRegExp`; added nominal `[CODEC]` tests for `FabricMap` and `FabricSet` (wire type tag, `canEncode()`, and stub `encode()`/`decode()` that throw).
  - Collated all `fabric-*` `[CODEC]` tests by instance method across `FabricHash`, `FabricBytes`, `FabricEpochNsec`, `FabricEpochDays`, `FabricRegExp`, and `FabricError`; expanded `canEncode()` coverage and removed needless casts.
  - Kept mechanism coverage in `JsonEncodingContext.test.ts` (tag wrapping, recursion, escaping, unknown tags, circular refs, freezing, lenient mode, complex round-trips) and renamed “Uint8Array public API” to “encodeToBytes() / decodeFromBytes() (bytes entry points)”. All tests pass (35 suites, 0 failures; 1689 steps).

<sup>Written for commit 9b876de0e2539cb6f961fe5f59d99620c8ff6cf0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


