### PR TITLE
refactor: make lift function-first, drop Schema<T> overload (CT-1625)

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -1982,29 +1982,25 @@ export type PatternToolFunction = <
   extraParams?: StripCell<E> extends Partial<T> ? Opaque<E> : never,
 ) => PatternToolResult<E>;
 
-// Function-first, matching PatternFunction/HandlerFunction convention: the
-// callback leads, schemas trail and are optional. Schemas are plain JSONSchema
-// values and are NOT materialized into the callback input type. The no-input
-// (computed-origin) form is `lift(fn, false)`: argumentSchema:false keeps the
-// no-input application valid (the runner's isValidArgument check passes on
-// `argumentSchema === false`), which the transformer emits as `lift(fn, false)()`.
+// Public (schema-light) surface, matching PatternFunction's index.ts shape: the
+// callback is the only argument and the types come from the callback itself. The
+// schema-bearing, type-materializing overloads (where the callback's input type
+// is derived FROM the supplied JSONSchema) live in `commonfabric/schema`
+// (api/schema.ts) so that schema and type can never contradict each other — the
+// same split pattern already used for pattern()/handler(). Transformer-emitted
+// `__cfHelpers.lift(...)` is untyped (`__cfHelpers: any`), so it does not depend
+// on these overloads; only authored `lift(...)` calls resolve against them.
 export interface LiftFunction {
   <T, R>(
     implementation: (input: T) => R,
-    argumentSchema?: JSONSchema,
-    resultSchema?: JSONSchema,
   ): ModuleFactory<StripCell<T>, StripCell<R>>;
 
   <T>(
     implementation: (input: T) => any,
-    argumentSchema?: JSONSchema,
-    resultSchema?: JSONSchema,
   ): ModuleFactory<StripCell<T>, StripCell<ReturnType<typeof implementation>>>;
 
   <T extends (...args: any[]) => any>(
     implementation: T,
-    argumentSchema?: JSONSchema,
-    resultSchema?: JSONSchema,
   ): ModuleFactory<StripCell<Parameters<T>[0]>, StripCell<ReturnType<T>>>;
 }
 

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -1982,35 +1982,30 @@ export type PatternToolFunction = <
   extraParams?: StripCell<E> extends Partial<T> ? Opaque<E> : never,
 ) => PatternToolResult<E>;
 
+// Function-first, matching PatternFunction/HandlerFunction convention: the
+// callback leads, schemas trail and are optional. Schemas are plain JSONSchema
+// values and are NOT materialized into the callback input type. The no-input
+// (computed-origin) form is `lift(fn, false)`: argumentSchema:false keeps the
+// no-input application valid (the runner's isValidArgument check passes on
+// `argumentSchema === false`), which the transformer emits as `lift(fn, false)()`.
 export interface LiftFunction {
   <T, R>(
     implementation: (input: T) => R,
+    argumentSchema?: JSONSchema,
+    resultSchema?: JSONSchema,
   ): ModuleFactory<StripCell<T>, StripCell<R>>;
 
   <T>(
     implementation: (input: T) => any,
+    argumentSchema?: JSONSchema,
+    resultSchema?: JSONSchema,
   ): ModuleFactory<StripCell<T>, StripCell<ReturnType<typeof implementation>>>;
 
   <T extends (...args: any[]) => any>(
     implementation: T,
-  ): ModuleFactory<StripCell<Parameters<T>[0]>, StripCell<ReturnType<T>>>;
-
-  // Two-arg form: lift(argumentSchema, fn). Listed before the all-optional
-  // catch-all so `lift(false, fn)` resolves here (fn in slot 2) instead of
-  // matching the catch-all and rejecting fn as a resultSchema. The transformer
-  // emits no-input (computed-origin) lifts as `lift(false, fn)()`:
-  // argumentSchema:false keeps the no-input application valid (the runner's
-  // isValidArgument check passes on `argumentSchema === false`).
-  <T, R>(
-    argumentSchema: JSONSchema,
-    implementation: (input: T) => R,
-  ): ModuleFactory<StripCell<T>, StripCell<R>>;
-
-  <T, R>(
     argumentSchema?: JSONSchema,
     resultSchema?: JSONSchema,
-    implementation?: (input: T) => R,
-  ): ModuleFactory<StripCell<T>, StripCell<R>>;
+  ): ModuleFactory<StripCell<Parameters<T>[0]>, StripCell<ReturnType<T>>>;
 }
 
 // Helper type to make non-Cell and non-Stream properties readonly in handler state.

--- a/packages/api/schema.ts
+++ b/packages/api/schema.ts
@@ -28,6 +28,7 @@ import type {
   ReadonlyCell,
   SELF,
   Stream,
+  StripCell,
   WriteonlyCell,
 } from "commonfabric";
 
@@ -387,13 +388,28 @@ declare module "commonfabric" {
     ): PatternFactory<SchemaWithoutCell<IS>, any>;
   }
 
-  // Augment LiftFunction with schema-based overload
+  // Augment LiftFunction with schema-based overloads (callback-first, matching
+  // the index.ts ordering and the PatternFunction shape above). The callback's
+  // input/result types are MATERIALIZED from the supplied JSONSchema literals via
+  // Schema<>, so the provided schema and the callback's types can never
+  // contradict — the schema is the single source of truth.
   interface LiftFunction {
-    <T extends JSONSchema = JSONSchema, R extends JSONSchema = JSONSchema>(
-      argumentSchema: T,
-      resultSchema: R,
-      implementation: (input: Schema<T>) => Schema<R>,
-    ): ModuleFactory<SchemaWithoutCell<T>, SchemaWithoutCell<R>>;
+    // Callback + two schemas: input type from argSchema, result type from resSchema.
+    <IS extends JSONSchema = JSONSchema, OS extends JSONSchema = JSONSchema>(
+      implementation: (input: Schema<IS>) => Schema<OS>,
+      argumentSchema: IS,
+      resultSchema: OS,
+    ): ModuleFactory<SchemaWithoutCell<IS>, SchemaWithoutCell<OS>>;
+
+    // Callback + one schema: input type from argSchema; result type inferred from
+    // the callback's return.
+    <IS extends JSONSchema = JSONSchema>(
+      implementation: (input: Schema<IS>) => any,
+      argumentSchema: IS,
+    ): ModuleFactory<
+      SchemaWithoutCell<IS>,
+      StripCell<ReturnType<typeof implementation>>
+    >;
   }
 
   // Augment HandlerFunction with schema-based overload

--- a/packages/runner/src/builder/module.ts
+++ b/packages/runner/src/builder/module.ts
@@ -320,67 +320,50 @@ export function resolveSourceLocationFromStack(
  *
  * @returns A module node factory that also serializes as module.
  */
-// Two-arg form: lift(argumentSchema, fn). Listed before the three-arg overload
-// so `lift(false, fn)` resolves here (the impl in slot 2) rather than matching
-// the three-arg signature and erroring on a missing resultSchema. Used by the
-// transformer to emit no-input lifts as `lift(false, fn)()`.
-export function lift<T extends JSONSchema = JSONSchema, R = any>(
-  argumentSchema: T,
-  implementation: (input: Schema<T>) => R,
-  options?: DeriveSchedulerOptions,
-): ModuleFactory<SchemaWithoutCell<T>, R>;
-export function lift<
-  T extends JSONSchema = JSONSchema,
-  R extends JSONSchema = JSONSchema,
->(
-  argumentSchema: T,
-  resultSchema: R,
-  implementation: (input: Schema<T>) => Schema<R>,
-  options?: DeriveSchedulerOptions,
-): ModuleFactory<SchemaWithoutCell<T>, SchemaWithoutCell<R>>;
+// Function-first form, matching pattern()/handler() convention: the callback
+// leads, schemas trail and are optional. The argument/result schemas are plain
+// JSONSchema values that are NOT materialized into the callback input type — the
+// callback's own (or transformer-inferred) type stands. The no-input form is
+// `lift(fn, false)`: argumentSchema:false makes the no-arg application valid
+// (the runner's isValidArgument check passes on `argumentSchema === false`),
+// which is how computed-origin (zero-capture) lifts lower.
 export function lift<T, R>(
   implementation: (input: T) => R,
+  argumentSchema?: JSONSchema,
+  resultSchema?: JSONSchema,
   options?: DeriveSchedulerOptions,
-): ModuleFactory<T, R>;
+): ModuleFactory<StripCell<T>, StripCell<R>>;
 export function lift<T>(
   implementation: (input: T) => any,
+  argumentSchema?: JSONSchema,
+  resultSchema?: JSONSchema,
   options?: DeriveSchedulerOptions,
-): ModuleFactory<T, ReturnType<typeof implementation>>;
+): ModuleFactory<StripCell<T>, StripCell<ReturnType<typeof implementation>>>;
 export function lift<T extends (...args: any[]) => any>(
   implementation: T,
+  argumentSchema?: JSONSchema,
+  resultSchema?: JSONSchema,
   options?: DeriveSchedulerOptions,
-): ModuleFactory<Parameters<T>[0], ReturnType<T>>;
+): ModuleFactory<StripCell<Parameters<T>[0]>, StripCell<ReturnType<T>>>;
 export function lift<T, R>(
-  argumentSchema?: JSONSchema | ((input: any) => any),
-  resultSchema?: JSONSchema | ((input: any) => any) | DeriveSchedulerOptions,
   implementation?: ((input: T) => R) | DeriveSchedulerOptions,
+  argumentSchema?: JSONSchema | DeriveSchedulerOptions,
+  resultSchema?: JSONSchema | DeriveSchedulerOptions,
   options?: DeriveSchedulerOptions,
 ): ModuleFactory<T, R> {
-  if (typeof argumentSchema === "function") {
-    // lift(fn)
-    implementation = argumentSchema;
-    options = resultSchema as DeriveSchedulerOptions | undefined;
-    argumentSchema = resultSchema = undefined;
-  } else if (typeof resultSchema === "function") {
-    // lift(argumentSchema, fn) — two-arg form. The middle slot is the
-    // implementation, not a result schema. Used by the transformer to emit
-    // no-input lifts as `lift(false, fn)()`: argumentSchema:false makes the
-    // application valid with no input (see runner's isValidArgument check),
-    // which is how computed-origin (zero-capture) lifts lower without the
-    // legacy `lift(fn)({})` empty-object stopgap.
-    options = implementation as DeriveSchedulerOptions | undefined;
-    implementation = resultSchema;
-    resultSchema = undefined;
-  }
-  const resolvedImplementation = implementation as
-    | ((input: T) => R)
-    | undefined;
+  const resolvedImplementation =
+    (typeof implementation === "function" ? implementation : undefined) as
+      | ((input: T) => R)
+      | undefined;
+  const resolvedArgumentSchema = argumentSchema as JSONSchema | undefined;
   const resolvedResultSchema = resultSchema as JSONSchema | undefined;
 
   return createNodeFactory({
     type: "javascript",
     implementation: resolvedImplementation,
-    ...(argumentSchema !== undefined ? { argumentSchema } : {}),
+    ...(resolvedArgumentSchema !== undefined
+      ? { argumentSchema: resolvedArgumentSchema }
+      : {}),
     ...(resolvedResultSchema !== undefined
       ? { resultSchema: resolvedResultSchema }
       : {}),

--- a/packages/runner/src/sandbox/compiled-bundle-verifier.ts
+++ b/packages/runner/src/sandbox/compiled-bundle-verifier.ts
@@ -972,28 +972,26 @@ function callbackIndexesForBuilder(
     case "computed":
       return args.length >= 1 ? [0] : [];
     case "lift": {
-      // `lift` is overloaded on the TYPE of its leading arguments, not on
-      // arity (see the runtime dispatch in builder/module.ts): the callback is
-      // whichever of the first few positions is the function.
-      //   lift(fn, options?)                         → callback at 0
-      //   lift(argSchema, fn, options?)              → callback at 1
-      //   lift(argSchema, resSchema, fn, options?)   → callback at 2
-      // So index purely on arity is wrong — `lift(fn, options)` is a valid
-      // 2-arg form with the callback at 0, while `lift(false, fn)` (the
-      // no-input form, PR #3709) is a 2-arg form with the callback at 1.
-      // Mirror the runtime: pick the first position that parses as a direct
-      // callback. (Newly reachable at module scope as of CT-1644, which hoists
-      // `lift(...)()` computations to a module-scope const; previously these
-      // only appeared inline inside a handler/pattern body, unverified here.)
+      // `lift` is function-first, matching pattern()/handler(): the callback
+      // leads and schemas trail (see the runtime dispatch in builder/module.ts).
+      //   lift(fn)                          → callback at 0
+      //   lift(fn, argSchema)               → callback at 0
+      //   lift(fn, argSchema, resSchema)    → callback at 0
+      //   lift(fn, false)                   → callback at 0 (no-input form)
+      // The callback is always position 0. Scan the leading position(s)
+      // defensively and pick the first that parses as a direct callback.
+      // (Reachable at module scope as of CT-1644, which hoists `lift(...)()`
+      // computations to a module-scope const; previously these only appeared
+      // inline inside a handler/pattern body, unverified here.)
       for (let i = 0; i < Math.min(args.length, 3); i++) {
         if (resolveTrustedBuilderCallback(source, args[i]!, env)) {
           return [i];
         }
       }
-      // No direct callback found in the leading positions; fall back to the
-      // canonical schema-prefixed slot so the caller still emits the
-      // "must receive a direct callback" diagnostic against the right argument.
-      return args.length >= 3 ? [2] : args.length >= 1 ? [args.length - 1] : [];
+      // No direct callback found; fall back to position 0 (where the callback
+      // belongs) so the caller still emits the "must receive a direct callback"
+      // diagnostic against the right argument.
+      return args.length >= 1 ? [0] : [];
     }
     case "handler":
       if (

--- a/packages/runner/test/compiled-module-verifier.test.ts
+++ b/packages/runner/test/compiled-module-verifier.test.ts
@@ -23,14 +23,14 @@ function verify(body: string) {
 }
 
 describe("verifyCompiledModuleBody() classifier shapes", () => {
-  it("accepts the 2-arg no-input lift(false, fn) form at module scope", () => {
-    // CT-1644: Phase 2 hoists a `lift(false, fn)()` computation to a module-
-    // scope const, surfacing the 2-arg no-input form (PR #3709) to the
-    // module-scope verifier. The callback is the SECOND argument; the
-    // verifier must read it at index 1, not 0 (where `false` sits).
+  it("accepts the no-input lift(fn, false) form at module scope", () => {
+    // CT-1644: Phase 2 hoists a `lift(fn, false)()` computation to a module-
+    // scope const, surfacing the no-input form (argumentSchema:false) to the
+    // module-scope verifier. lift is function-first, so the callback is the
+    // FIRST argument and `false` (the argument schema) trails at index 1.
     const body = `
 ${IMPORT}
-const __cfLift_1 = (0, commonfabric_1.lift)(false, () => 42);
+const __cfLift_1 = (0, commonfabric_1.lift)(() => 42, false);
 exports.default = (0, commonfabric_1.handler)(false, false, () => [__cfLift_1()][0]);
 `;
 

--- a/packages/runner/test/default-app-note-create.bench.ts
+++ b/packages/runner/test/default-app-note-create.bench.ts
@@ -46,7 +46,10 @@ const noteSchema = {
     content: { type: "string" },
     tags: { type: "array", items: { type: "string" } },
   },
-  required: ["title"],
+  // All three fields are always populated by noteValue(); marking them required
+  // makes the schema-materialized callback input match the `Note` type under
+  // lift's function-first schema-mode overload (CT-1625).
+  required: ["title", "content", "tags"],
   additionalProperties: false,
 } as const satisfies JSONSchema;
 
@@ -132,10 +135,10 @@ async function setupNoteCreateGraph(
 
   // Derived home view: reads (and therefore resolves + traverses) every note.
   const titlesOf = lift(
-    noteListSchema,
-    { type: "array", items: { type: "string" } } as const satisfies JSONSchema,
     (items: Note[]) =>
       items.map((note) => `${note.title} (${note.tags?.length ?? 0})`),
+    noteListSchema,
+    { type: "array", items: { type: "string" } } as const satisfies JSONSchema,
   );
   const homeView = pattern<{ items: Note[] }, unknown>(
     ({ items }) => ({ titles: titlesOf(items) }),

--- a/packages/runner/test/generate-object-tools.test.ts
+++ b/packages/runner/test/generate-object-tools.test.ts
@@ -1690,6 +1690,12 @@ describe("generateObject with tools", () => {
     );
 
     const parseResultSchema = lift(
+      ({ resultSchema }) => {
+        if (typeof resultSchema === "string") {
+          return JSON.parse(resultSchema);
+        }
+        return resultSchema;
+      },
       {
         type: "object",
         properties: {
@@ -1705,12 +1711,6 @@ describe("generateObject with tools", () => {
         additionalProperties: false,
       },
       true,
-      ({ resultSchema }) => {
-        if (typeof resultSchema === "string") {
-          return JSON.parse(resultSchema);
-        }
-        return resultSchema;
-      },
     );
 
     const subAgentPattern = pattern<any, any>(
@@ -2157,6 +2157,12 @@ describe("generateObject with tools", () => {
     );
 
     const parseResultSchema = lift(
+      ({ resultSchema }) => {
+        if (typeof resultSchema === "string") {
+          return JSON.parse(resultSchema);
+        }
+        return resultSchema;
+      },
       {
         type: "object",
         properties: {
@@ -2172,12 +2178,6 @@ describe("generateObject with tools", () => {
         additionalProperties: false,
       },
       true,
-      ({ resultSchema }) => {
-        if (typeof resultSchema === "string") {
-          return JSON.parse(resultSchema);
-        }
-        return resultSchema;
-      },
     );
     const subAgentPattern = pattern<any, any>(
       ({

--- a/packages/runner/test/module.test.ts
+++ b/packages/runner/test/module.test.ts
@@ -91,9 +91,10 @@ describe("module", () => {
       } as const satisfies JSONSchema;
 
       const greet = lift(
+        ({ name, age }: { name: string; age?: number }) =>
+          `Hello ${name}${age ? `, age ${age}` : ""}!`,
         schema,
         { type: "string" } as const satisfies JSONSchema,
-        ({ name, age }) => `Hello ${name}${age ? `, age ${age}` : ""}!`,
       );
 
       expect(isModule(greet)).toBe(true);
@@ -118,9 +119,10 @@ describe("module", () => {
       } as const satisfies JSONSchema;
 
       const greet = lift(
+        ({ name, age }: { name: string; age?: number }) =>
+          `Hello ${name}${age ? `, age ${age}` : ""}!`,
         inputSchema,
         outputSchema,
-        ({ name, age }) => `Hello ${name}${age ? `, age ${age}` : ""}!`,
       );
 
       expect(isModule(greet)).toBe(true);

--- a/packages/runner/test/pattern-scope.test.ts
+++ b/packages/runner/test/pattern-scope.test.ts
@@ -1132,6 +1132,12 @@ Deno.test("lift can read session-scoped cell passed from pattern input", async (
     assertEquals(sessionTarget.get(), "a");
 
     const isSessionOpen = lift(
+      (
+        { sessionTarget, id }: {
+          sessionTarget: Cell<string | null>;
+          id: string;
+        },
+      ) => sessionTarget.get() === id,
       {
         type: "object",
         properties: {
@@ -1144,12 +1150,6 @@ Deno.test("lift can read session-scoped cell passed from pattern input", async (
         required: ["sessionTarget", "id"],
       },
       { type: "boolean" },
-      (
-        { sessionTarget, id }: {
-          sessionTarget: Cell<string | null>;
-          id: string;
-        },
-      ) => sessionTarget.get() === id,
     );
 
     const Root = pattern<{ sessionTarget: Cell<string | null> }>(
@@ -1225,9 +1225,9 @@ Deno.test("broad computed output links to narrower scoped result", async () => {
 
     const Root = pattern<{ secret: number }>(({ secret }) => ({
       value: lift(
-        { type: "number" },
-        { type: "number" },
         (x: number) => x + 1,
+        { type: "number" },
+        { type: "number" },
       )(secret),
     }));
 
@@ -1283,14 +1283,14 @@ Deno.test("opaque JS action result uses narrowest effective output scope", async
     secret.set(41);
 
     const structured = lift(
+      (_x: number) => ({
+        nested: computed(() => 42),
+      }),
       { type: "number" },
       {
         type: "object",
         properties: { nested: { type: "number" } },
       },
-      (_x: number) => ({
-        nested: computed(() => 42),
-      }),
     );
     const Root = pattern<{ secret: number }>(({ secret }) => ({
       value: structured(secret),
@@ -1340,15 +1340,15 @@ Deno.test("opaque JS action result schema scope participates in effective output
     const { computed, lift, pattern } =
       createTrustedBuilder(runtime).commonfabric;
     const structured = lift(
+      (_x: number) => ({
+        nested: computed(() => 42),
+      }),
       { type: "number" },
       {
         type: "object",
         properties: { nested: { type: "number" } },
         scope: "session",
       },
-      (_x: number) => ({
-        nested: computed(() => 42),
-      }),
     );
     const Root = pattern<{ value: number }>(({ value }) => ({
       value: structured(value),
@@ -1405,9 +1405,9 @@ Deno.test("map keeps outer list scope and narrows per-element result cells", asy
     item.set(20);
 
     const increment = lift(
-      { type: "number" },
-      { type: "number" },
       (x: number) => x + 1,
+      { type: "number" },
+      { type: "number" },
     );
     const Root = pattern<{ values: number[] }>(({ values }) => ({
       mapped: (values as any).mapWithPattern(
@@ -1966,10 +1966,10 @@ Deno.test("map materializes list through session boxed space-scoped reference", 
           required: ["selectedRoomRef"],
         } as const;
         const messageCount = lift(
-          selectedRoomRefInputSchema,
-          { type: "number" } as const,
           (current: any) =>
             current.selectedRoomRef.get()?.messages?.length ?? 0,
+          selectedRoomRefInputSchema,
+          { type: "number" } as const,
         )({ selectedRoomRef });
         const isEmpty = lift(
           (current: number) => current === 0,
@@ -1981,10 +1981,10 @@ Deno.test("map materializes list through session boxed space-scoped reference", 
             "div",
             null,
             (lift(
-              selectedRoomRefInputSchema,
-              { type: "unknown" } as const,
               (current: any) =>
                 current.selectedRoomRef.get()?.messages as Message[],
+              selectedRoomRefInputSchema,
+              { type: "unknown" } as const,
             )({ selectedRoomRef }) as any).mapWithPattern(
               pattern(({ element, index, array }: Opaque<any>) =>
                 (((message: any) =>
@@ -2060,9 +2060,9 @@ Deno.test("filter narrows output list when scoped element controls cardinality",
     item.set(20);
 
     const positive = lift(
+      (x: number) => x > 0,
       { type: "number" },
       { type: "boolean" },
-      (x: number) => x > 0,
     );
     const Root = pattern<{ values: number[] }>(({ values }) => ({
       filtered: (values as any).filterWithPattern(
@@ -2123,9 +2123,9 @@ Deno.test("flatMap narrows output list when scoped element controls cardinality"
     item.set(20);
 
     const expand = lift(
+      (x: number) => [x, x + 1],
       { type: "number" },
       { type: "array", items: { type: "number" } },
-      (x: number) => [x, x + 1],
     );
     const Root = pattern<{ values: number[] }>(({ values }) => ({
       expanded: (values as any).flatMapWithPattern(
@@ -2268,6 +2268,12 @@ Deno.test("session scoped derived chains update when broad inputs change", async
       },
     } as const;
     const selectMessages = lift(
+      (
+        { conversation, room }: {
+          conversation: Conversation;
+          room: RoomId;
+        },
+      ) => conversation.rooms[room] ?? [],
       {
         type: "object",
         properties: {
@@ -2277,27 +2283,21 @@ Deno.test("session scoped derived chains update when broad inputs change", async
         required: ["conversation", "room"],
       } as const,
       messageListSchema,
-      (
-        { conversation, room }: {
-          conversation: Conversation;
-          room: RoomId;
-        },
-      ) => conversation.rooms[room] ?? [],
     );
     const countMessages = lift(
+      (messages: { body: string }[]) => messages.length,
       messageListSchema,
       { type: "number" } as const,
-      (messages: { body: string }[]) => messages.length,
     );
     const countLobby = lift(
+      (conversation: Conversation) => conversation.rooms.lobby.length,
       conversationSchema,
       { type: "number" } as const,
-      (conversation: Conversation) => conversation.rooms.lobby.length,
     );
     const isZero = lift(
+      (count: number) => count === 0,
       { type: "number" } as const,
       { type: "boolean" } as const,
-      (count: number) => count === 0,
     );
     const conversation = runtime.getCell<Conversation>(
       space,

--- a/packages/runner/test/pattern.test.ts
+++ b/packages/runner/test/pattern.test.ts
@@ -78,9 +78,9 @@ describe("pattern", () => {
 
   it("uniquifies repeated stable internal paths with schemas", () => {
     const isPositive = lift(
+      (value: number) => value > 0,
       { type: "number" } as const satisfies JSONSchema,
       { type: "boolean" } as const satisfies JSONSchema,
-      (value: number) => value > 0,
     );
 
     const testPattern = pattern(() => {
@@ -165,9 +165,9 @@ describe("pattern", () => {
     } as const satisfies JSONSchema;
 
     const double = lift(
+      (x: number) => x * 2,
       inputSchema,
       outputSchema,
-      (x: number) => x * 2,
     );
 
     const patternInputSchema = {
@@ -295,12 +295,12 @@ describe("pattern", () => {
       required: ["double"],
     } as const satisfies JSONSchema;
 
-    const double = lift<JSONSchema, JSONSchema>(
-      ArgumentSchema,
-      ResultSchema,
-      ({ x }) => ({
+    const double = lift(
+      ({ x }: { x: number }) => ({
         double: x * 2,
       }),
+      ArgumentSchema,
+      ResultSchema,
     );
 
     const doublePattern = pattern<{ x: number }, { double: number }>(
@@ -398,12 +398,14 @@ describe("pattern", () => {
       required: ["capitalized"],
     } as const satisfies JSONSchema;
 
-    const capitalize = lift<JSONSchema, JSONSchema>(
-      ArgumentSchema,
-      ResultSchema,
-      ({ word }) => ({
+    // Input typed loosely (the original used the schema-first overload whose
+    // input was JSONSchema); this lift is applied below with `{ ssn }`.
+    const capitalize = lift(
+      ({ word }: any) => ({
         capitalized: word.charAt(0).toUpperCase() + word.slice(1),
       }),
+      ArgumentSchema,
+      ResultSchema,
     );
 
     const UserSchema = {

--- a/packages/runner/test/patterns-dynamic.test.ts
+++ b/packages/runner/test/patterns-dynamic.test.ts
@@ -110,12 +110,12 @@ describe("Pattern Runner - Dynamic Patterns", () => {
       ({ values }) => {
         // Compute item count from values
         const itemCount = lift(
+          (arr: number[]) => (Array.isArray(arr) ? arr.length : 0),
           {
             type: "array",
             items: { type: "number" },
           } as const satisfies JSONSchema,
           { type: "number" } as const satisfies JSONSchema,
-          (arr: number[]) => (Array.isArray(arr) ? arr.length : 0),
         )(values);
 
         return { values, itemCount };
@@ -144,6 +144,20 @@ describe("Pattern Runner - Dynamic Patterns", () => {
 
     // Lift that dynamically instantiates itemCountPattern for each group
     const instantiateGroups = lift(
+      ({ groups }: any) => {
+        const raw = groups.get();
+        const list = Array.isArray(raw) ? raw : [];
+        const children = [];
+        for (let index = 0; index < list.length; index++) {
+          const groupCell = groups.key(index)!;
+          const valuesCell = groupCell.key("values");
+          const child = itemCountPattern({
+            values: valuesCell,
+          });
+          children.push(child);
+        }
+        return children;
+      },
       {
         type: "object",
         properties: {
@@ -171,24 +185,19 @@ describe("Pattern Runner - Dynamic Patterns", () => {
           },
         },
       } as const satisfies JSONSchema,
-      ({ groups }) => {
-        const raw = groups.get();
-        const list = Array.isArray(raw) ? raw : [];
-        const children = [];
-        for (let index = 0; index < list.length; index++) {
-          const groupCell = groups.key(index)!;
-          const valuesCell = groupCell.key("values");
-          const child = itemCountPattern({
-            values: valuesCell,
-          });
-          children.push(child);
-        }
-        return children;
-      },
     );
 
     // Lift that sums itemCount from all groups
     const computeTotalItems = lift(
+      (entries: Array<{ itemCount?: number }>) => {
+        if (!Array.isArray(entries)) {
+          return 0;
+        }
+        return entries.reduce((sum, entry) => {
+          const count = entry?.itemCount;
+          return typeof count === "number" ? sum + count : sum;
+        }, 0);
+      },
       {
         type: "array",
         items: {
@@ -199,15 +208,6 @@ describe("Pattern Runner - Dynamic Patterns", () => {
         },
       } as const satisfies JSONSchema,
       { type: "number" } as const satisfies JSONSchema,
-      (entries: Array<{ itemCount?: number }>) => {
-        if (!Array.isArray(entries)) {
-          return 0;
-        }
-        return entries.reduce((sum, entry) => {
-          const count = entry?.itemCount;
-          return typeof count === "number" ? sum + count : sum;
-        }, 0);
-      },
     );
 
     // Outer pattern that uses instantiateGroups and computeTotalItems
@@ -1288,7 +1288,7 @@ describe("Pattern Runner - Dynamic Patterns", () => {
     // this shape — see IDerivable note in api/index.ts.
     const isEvenPattern = pattern<{ element: number }>(
       ({ element }) => {
-        return lift(numberSchema, booleanSchema, (x: number) => x % 2 === 0)(
+        return lift((x: number) => x % 2 === 0, numberSchema, booleanSchema)(
           element,
         );
       },
@@ -1324,9 +1324,9 @@ describe("Pattern Runner - Dynamic Patterns", () => {
     const duplicatePattern = pattern<{ element: number }>(
       ({ element }) => {
         return lift(
+          (x: number) => [x, x * 10],
           numberSchema,
           numberArraySchema,
-          (x: number) => [x, x * 10],
         )(
           element,
         );

--- a/packages/runner/test/patterns-lift.test.ts
+++ b/packages/runner/test/patterns-lift.test.ts
@@ -78,44 +78,44 @@ describe("Pattern Runner - Lift", () => {
     };
 
     const multiply = lift(
-      {
-        type: "object",
-        properties: { x: { type: "number" }, y: { type: "number" } },
-        required: ["x", "y"],
-      } as const satisfies JSONSchema,
-      { type: "number" } as const satisfies JSONSchema,
       ({ x, y }) => {
         runCounts.multiply++;
         return x * y;
       },
+      {
+        type: "object",
+        properties: { x: { type: "number" }, y: { type: "number" } },
+        required: ["x", "y"],
+      } as const satisfies JSONSchema,
+      { type: "number" } as const satisfies JSONSchema,
     );
 
     const multiplyGenerator = lift(
-      {
-        type: "object",
-        properties: { x: { type: "number" }, y: { type: "number" } },
-        required: ["x", "y"],
-      } as const satisfies JSONSchema,
-      { type: "number" } as const satisfies JSONSchema,
-      (args) => {
+      (args: { x: number; y: number }) => {
         runCounts.multiplyGenerator++;
         return multiply(args);
       },
-    );
-
-    const multiplyGenerator2 = lift(
       {
         type: "object",
         properties: { x: { type: "number" }, y: { type: "number" } },
         required: ["x", "y"],
       } as const satisfies JSONSchema,
       { type: "number" } as const satisfies JSONSchema,
+    );
+
+    const multiplyGenerator2 = lift(
       ({ x, y }) => {
         runCounts.multiplyGenerator2++;
         // Now passing literals, so will hardcode values in pattern and hence
         // re-run when values change
         return multiply({ x, y });
       },
+      {
+        type: "object",
+        properties: { x: { type: "number" }, y: { type: "number" } },
+        required: ["x", "y"],
+      } as const satisfies JSONSchema,
+      { type: "number" } as const satisfies JSONSchema,
     );
 
     const multiplyPattern = pattern<{ x: number; y: number }>(
@@ -334,6 +334,12 @@ describe("Pattern Runner - Lift", () => {
     // - second: a Cell that we'll read with sample() (non-reactive)
     const computeWithSample = lift(
       // Input schema: first is reactive, second is asCell
+      ({ first, second }) => {
+        liftRunCount++;
+        // Use sample() to read the second cell non-reactively
+        const secondValue = second.sample();
+        return first + secondValue;
+      },
       {
         type: "object",
         properties: {
@@ -342,15 +348,7 @@ describe("Pattern Runner - Lift", () => {
         },
         required: ["first", "second"],
       } as const satisfies JSONSchema,
-      // Output schema
       { type: "number" },
-      // The lift function
-      ({ first, second }) => {
-        liftRunCount++;
-        // Use sample() to read the second cell non-reactively
-        const secondValue = second.sample();
-        return first + secondValue;
-      },
     );
 
     const sampleP = pattern<{ first: number; second: number }>(
@@ -439,12 +437,12 @@ describe("Pattern Runner - Lift", () => {
     const pattern1 = pattern<{ value: number }>(
       ({ value }) => {
         const doubled = lift(
-          { type: "number" } as const satisfies JSONSchema,
-          { type: "number" } as const satisfies JSONSchema,
           (x: number) => {
             lift1Runs++;
             return x * 2;
           },
+          { type: "number" } as const satisfies JSONSchema,
+          { type: "number" } as const satisfies JSONSchema,
         )(value);
         return { result: doubled };
       },
@@ -453,12 +451,12 @@ describe("Pattern Runner - Lift", () => {
     const pattern2 = pattern<{ value: number }>(
       ({ value }) => {
         const tripled = lift(
-          { type: "number" } as const satisfies JSONSchema,
-          { type: "number" } as const satisfies JSONSchema,
           (x: number) => {
             lift2Runs++;
             return x * 3;
           },
+          { type: "number" } as const satisfies JSONSchema,
+          { type: "number" } as const satisfies JSONSchema,
         )(value);
         return { result: tripled };
       },

--- a/packages/runner/test/patterns-schemas.test.ts
+++ b/packages/runner/test/patterns-schemas.test.ts
@@ -65,9 +65,9 @@ describe("Pattern Runner - Schemas", () => {
       multiplier: number;
     }>(({ settings, multiplier }) => {
       const result = lift(
+        ({ settings, multiplier }) => settings.value * multiplier!,
         schema,
         { type: "number" },
-        ({ settings, multiplier }) => settings.value * multiplier!,
       )({ settings, multiplier });
       return { result };
     });
@@ -135,13 +135,13 @@ describe("Pattern Runner - Schemas", () => {
     const sumPattern = pattern<{ data: { items: Array<{ value: number }> } }>(
       ({ data }) => {
         const result = lift(
-          schema,
-          { type: "number" },
           ({ data }) =>
             data.items.reduce(
               (sum: number, item: any) => sum + item.get().value,
               0,
             ),
+          schema,
+          { type: "number" },
         )({ data });
         return { result };
       },
@@ -195,13 +195,13 @@ describe("Pattern Runner - Schemas", () => {
     >(
       ({ context }) => {
         const result = lift(
-          schema,
-          { type: "number" },
-          ({ context }) =>
+          ({ context }: any) =>
             Object.values(context ?? {}).reduce(
-              (sum: number, val) => sum + val.get(),
+              (sum: number, val: any) => sum + val.get(),
               0,
             ),
+          schema,
+          { type: "number" },
         )({ context });
         return { result };
       },

--- a/packages/runner/test/push-pull-patterns.bench.ts
+++ b/packages/runner/test/push-pull-patterns.bench.ts
@@ -479,7 +479,7 @@ async function setupMapScenario(
     (index) => index + 1,
   );
 
-  const double = env.lift(numberSchema, numberSchema, (x: number) => x * 2);
+  const double = env.lift((x: number) => x * 2, numberSchema, numberSchema);
   const doublePattern = unaryNumberListOpPattern(
     env,
     // deno-lint-ignore no-explicit-any
@@ -524,9 +524,9 @@ async function setupFilterScenario(
   );
 
   const isPositive = env.lift(
+    (x: number) => x > 0,
     numberSchema,
     booleanSchema,
-    (x: number) => x > 0,
   );
   const filterPatternFn = unaryNumberListOpPattern(
     env,
@@ -572,9 +572,9 @@ async function setupFlatMapScenario(
   );
 
   const expand = env.lift(
+    (x: number) => (x > 0 ? [x, x * 10] : []),
     numberSchema,
     numberArraySchema,
-    (x: number) => (x > 0 ? [x, x * 10] : []),
   );
   const flatMapPatternFn = unaryNumberListOpPattern(
     env,
@@ -619,7 +619,7 @@ async function setupObjectMapScenario(
     (index) => index + 1,
   );
 
-  const double = env.lift(numberSchema, numberSchema, (x: number) => x * 2);
+  const double = env.lift((x: number) => x * 2, numberSchema, numberSchema);
   const doublePattern = unaryNumberObjectListOpPattern(
     env,
     // deno-lint-ignore no-explicit-any
@@ -665,9 +665,9 @@ async function setupObjectFilterScenario(
   );
 
   const isPositive = env.lift(
+    (x: number) => x > 0,
     numberSchema,
     booleanSchema,
-    (x: number) => x > 0,
   );
   const filterPatternFn = unaryNumberObjectListOpPattern(
     env,
@@ -714,9 +714,9 @@ async function setupObjectFlatMapScenario(
   );
 
   const expand = env.lift(
+    (x: number) => (x > 0 ? [x, x * 10] : []),
     numberSchema,
     numberArraySchema,
-    (x: number) => (x > 0 ? [x, x * 10] : []),
   );
   const flatMapPatternFn = unaryNumberObjectListOpPattern(
     env,
@@ -768,9 +768,9 @@ async function setupFanoutScenario(
 
   for (let i = 0; i < FANOUT_WIDTH; i++) {
     const addOffset = env.lift(
-      numberSchema,
-      numberSchema,
       (value: number) => value + i + 1,
+      numberSchema,
+      numberSchema,
     );
     const derivePattern = env.pattern<{ value: number }>(
       ({ value }) => ({

--- a/packages/runner/test/schema-to-ts.test.ts
+++ b/packages/runner/test/schema-to-ts.test.ts
@@ -2,12 +2,11 @@ import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import "@commonfabric/utils/equal-ignoring-symbols";
 
-import { handler, lift } from "../src/builder/module.ts";
+import { handler } from "../src/builder/module.ts";
 import { createBuilder } from "../src/builder/factory.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import {
   type AnyCellWrapping,
-  type JSONSchema,
   type OpaqueRef,
   Schema,
 } from "../src/builder/types.ts";
@@ -645,63 +644,15 @@ describe("Schema-to-TS Type Conversion", () => {
     expectType<ExpectedDynamicObject, DynamicObjectSchema>();
   });
 
-  it("should correctly infer types when using lift with JSON schema", () => {
-    // Define input and output schemas
-    const inputSchema = {
-      type: "object",
-      properties: {
-        name: { type: "string" },
-        count: { type: "number" },
-        tags: {
-          type: "array",
-          items: { type: "string" },
-        },
-      },
-      required: ["name"],
-    } as const satisfies JSONSchema;
-
-    const outputSchema = {
-      type: "object",
-      properties: {
-        processed: { type: "boolean" },
-        nameLength: { type: "number" },
-        firstTag: { type: "string" },
-      },
-      //required: ["processed", "nameLength"],
-    } as const satisfies JSONSchema;
-
-    // Create a module using lift with JSON schemas
-    // This tests type inference - TypeScript should infer the correct input and output types
-    const processModule = lift(
-      inputSchema,
-      outputSchema,
-      (input) => {
-        // This will only compile if input is correctly typed according to inputSchema
-        const nameLength = input.name.length;
-        const firstTag = input.tags?.[0] || "";
-        const _count = input.count || 0;
-
-        // This will only compile if the return type matches outputSchema
-        return {
-          processed: true,
-          nameLength,
-          firstTag,
-        };
-      },
-    );
-
-    // Test with actual data
-    processModule({
-      name: "Test",
-      count: 5,
-      tags: ["important", "test"],
-    });
-
-    // Check that optional property works
-    processModule({
-      name: "NoTags",
-    });
-  });
+  // (Removed: "should correctly infer types when using lift with JSON schema".)
+  // That test asserted lift's schema-first overload materialized the callback
+  // input type FROM the argument schema via Schema<T> — i.e. `lift(inputSchema,
+  // outputSchema, (input) => …)` typed `input` from `inputSchema`. CT-1625
+  // removed that schema->type materialization variant of lift (it was used
+  // nowhere outside this test) and reordered lift to function-first
+  // (`lift(fn, argSchema?, resSchema?)`) to match pattern()/handler(). The
+  // Schema<> type utility itself is unchanged and still covered by the tests
+  // above; only lift's use of it as an overload was retired.
 
   it("should correctly infer types when using handler with JSON schema", () => {
     // Define event and state schemas

--- a/packages/runner/test/schema-to-ts.test.ts
+++ b/packages/runner/test/schema-to-ts.test.ts
@@ -3,10 +3,18 @@ import { expect } from "@std/expect";
 import "@commonfabric/utils/equal-ignoring-symbols";
 
 import { handler } from "../src/builder/module.ts";
+// Bring lift's schema-bearing, type-materializing overloads into scope. They live
+// in `@commonfabric/api/schema` (CT-1625) — the facade module that augments
+// LiftFunction. The lift materialization test below is compile-time only and
+// declares a locally-typed `lift` (the facade `lift` is `declare const`, no
+// runtime value). (handler still materializes via its module.ts overloads.)
+import type { LiftFunction } from "@commonfabric/api";
+import "@commonfabric/api/schema";
 import { createBuilder } from "../src/builder/factory.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import {
   type AnyCellWrapping,
+  type JSONSchema,
   type OpaqueRef,
   Schema,
 } from "../src/builder/types.ts";
@@ -22,6 +30,11 @@ import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
 const space = signer.did();
+
+// Compile-time-only handle to lift's schema-augmented facade type (CT-1625). The
+// runtime `lift` is `declare const` (no JS), and the materialization test uses this
+// purely for type-checking, never calling it at runtime.
+declare const lift: LiftFunction;
 
 // Helper function to check type compatibility at compile time
 // This doesn't run any actual tests, but ensures types are correct
@@ -644,15 +657,77 @@ describe("Schema-to-TS Type Conversion", () => {
     expectType<ExpectedDynamicObject, DynamicObjectSchema>();
   });
 
-  // (Removed: "should correctly infer types when using lift with JSON schema".)
-  // That test asserted lift's schema-first overload materialized the callback
-  // input type FROM the argument schema via Schema<T> — i.e. `lift(inputSchema,
-  // outputSchema, (input) => …)` typed `input` from `inputSchema`. CT-1625
-  // removed that schema->type materialization variant of lift (it was used
-  // nowhere outside this test) and reordered lift to function-first
-  // (`lift(fn, argSchema?, resSchema?)`) to match pattern()/handler(). The
-  // Schema<> type utility itself is unchanged and still covered by the tests
-  // above; only lift's use of it as an overload was retired.
+  it("should correctly infer types when using lift with JSON schema", () => {
+    // CT-1625: lift's schema-bearing overloads are now FUNCTION-FIRST and live in
+    // `commonfabric/schema` (api/schema.ts), where the callback's input type is
+    // MATERIALIZED from the supplied JSONSchema via Schema<> — same split as
+    // pattern()/handler(). `api/index.ts` only carries the schema-light callback-
+    // only form. This test pins the materialization: with the schema-augmented
+    // facade in scope, `lift(fn, argumentSchema, resultSchema)` types the callback's
+    // (un-annotated) input from `argumentSchema` and checks the return against
+    // `resultSchema`. The schema is the single source of truth, so a provided type
+    // and a provided schema can never contradict. Compile-time-only: uses the
+    // module-scope `declare const lift` (no runtime value needed).
+    const inputSchema = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        count: { type: "number" },
+        tags: {
+          type: "array",
+          items: { type: "string" },
+        },
+      },
+      required: ["name", "count"],
+    } as const satisfies JSONSchema;
+
+    const outputSchema = {
+      type: "object",
+      properties: {
+        processed: { type: "boolean" },
+        nameLength: { type: "number" },
+        firstTag: { type: "string" },
+      },
+      required: ["processed", "nameLength", "firstTag"],
+    } as const satisfies JSONSchema;
+
+    // This is a compile-time type test (like the Schema<> tests above): the value
+    // lies entirely in type-checking. The assertions live in a function that is
+    // type-checked but NEVER invoked, because the facade `lift` has no runtime
+    // value (declare const). The test "passing" at runtime just confirms the file
+    // compiled.
+    const _typeAssertions = () => {
+      // Callback-first + two schemas. `input` is materialized from inputSchema:
+      // this only compiles if input.name is string, input.count is number, etc.
+      lift(
+        (input) => {
+          const nameLength = input.name.length;
+          const firstTag = input.tags?.[0] || "";
+          const _count = input.count + 1;
+          return {
+            processed: true,
+            nameLength,
+            firstTag,
+          };
+        },
+        inputSchema,
+        outputSchema,
+      );
+
+      // Negative proof that materialization is actually active: `input.count` is
+      // `number` (from inputSchema), so a string method on it must error. If
+      // materialization were NOT happening (input typed `any`/unconstrained), this
+      // would compile and the @ts-expect-error would itself fail.
+      lift(
+        // @ts-expect-error count is number per inputSchema; .toUpperCase() invalid
+        (input) => input.count.toUpperCase(),
+        inputSchema,
+      );
+    };
+    void _typeAssertions; // referenced, never called
+
+    expect(true).toBe(true); // marker: the value lies in compile-time type-checking
+  });
 
   it("should correctly infer types when using handler with JSON schema", () => {
     // Define event and state schemas

--- a/packages/ts-transformers/src/transformers/schema-injection.ts
+++ b/packages/ts-transformers/src/transformers/schema-injection.ts
@@ -2205,7 +2205,10 @@ function isSingleEmptyObjectInput(
 }
 
 function prependSchemaArguments(
-  context: Pick<TransformationContext, "factory" | "cfHelpers" | "sourceFile">,
+  context: Pick<
+    TransformationContext,
+    "factory" | "cfHelpers" | "sourceFile" | "markSchemaInjected"
+  >,
   node: ts.CallExpression,
   argumentTypeNode: ts.TypeNode,
   argumentType: ts.Type | undefined,
@@ -2241,25 +2244,35 @@ function prependSchemaArguments(
     }
   }
 
-  // For the lift-applied shape (__cfHelpers.lift(cb)(input)), schemas must
-  // be prepended to the INNER lift call's arguments, not the outer applied
-  // call's. The outer call's input stays at index 0; the inner call gains
-  // [argSchema, resSchema, ...originalInnerArgs].
+  // For the lift-applied shape (__cfHelpers.lift(cb)(input)), schemas are
+  // spliced into the INNER lift call's arguments in function-first order:
+  // `lift(cb, argSchema, resSchema, options?)`. The inner call's args are
+  // `[callback, ...trailingOptions]` (an optional DeriveSchedulerOptions object
+  // may follow the callback — see lift-applied-strategy). The schemas go AFTER
+  // the callback but BEFORE any trailing options, mirroring the runtime
+  // signature `lift(fn, argumentSchema?, resultSchema?, options?)`. The outer
+  // applied call's input stays untouched.
   const innerLiftCall = getLiftAppliedInnerCall(node);
   if (innerLiftCall) {
+    const [innerCallback, ...trailingInnerArgs] = innerLiftCall.arguments;
+    const calleeArgs = innerCallback ? [innerCallback] : [];
     // No-input case: a single empty object literal `{}` as the outer input
     // means a genuinely zero-capture computation (computed-origin). By this
     // stage ClosureTransformer has already reified any captures into the
     // input, so an empty input here is final. Emit the canonical no-input
-    // form `lift(false, cb)()`: `false` argument schema (matching computed's
+    // form `lift(cb, false)()`: `false` argument schema (matching computed's
     // runtime semantics — keeps the no-arg application valid) and no outer
     // input. We deliberately omit the result schema, again matching computed.
     if (isSingleEmptyObjectInput(node.arguments)) {
       const rebuiltInner = context.factory.createCallExpression(
         innerLiftCall.expression,
         innerLiftCall.typeArguments,
-        [context.factory.createFalse(), ...innerLiftCall.arguments],
+        [...calleeArgs, context.factory.createFalse(), ...trailingInnerArgs],
       );
+      // The inner lift is fully schema-injected now; mark it so the re-descent
+      // (which re-enters the rebuilt tree to reach the callback body) self-skips
+      // the builder-lift branch instead of injecting a second schema pair.
+      context.markSchemaInjected(rebuiltInner);
       return context.factory.createCallExpression(
         rebuiltInner,
         undefined,
@@ -2270,8 +2283,11 @@ function prependSchemaArguments(
     const rebuiltInner = context.factory.createCallExpression(
       innerLiftCall.expression,
       innerLiftCall.typeArguments,
-      [argSchemaCall, resSchemaCall, ...innerLiftCall.arguments],
+      [...calleeArgs, argSchemaCall, resSchemaCall, ...trailingInnerArgs],
     );
+    // The inner lift is fully schema-injected now; mark it so the re-descent
+    // does not re-enter the builder-lift branch and inject a second pair.
+    context.markSchemaInjected(rebuiltInner);
     return context.factory.createCallExpression(
       rebuiltInner,
       undefined,
@@ -2282,7 +2298,7 @@ function prependSchemaArguments(
   return context.factory.createCallExpression(
     node.expression,
     undefined,
-    [argSchemaCall, resSchemaCall, ...node.arguments],
+    [...node.arguments, argSchemaCall, resSchemaCall],
   );
 }
 

--- a/packages/ts-transformers/test/closures/module-scope-helper-hoisting.test.ts
+++ b/packages/ts-transformers/test/closures/module-scope-helper-hoisting.test.ts
@@ -42,8 +42,10 @@ Deno.test("Closure Transformer hoists nested computed callbacks that close over 
   // const is module-scope, which is the property this test guards: a computed
   // closing over the module-scoped helper `formatDateShort` becomes a named,
   // module-scope, self-contained unit.
+  // lift is function-first: the callback leads, schemas trail. The hoisted call
+  // carries explicit `<In, Out>` type args, so match `lift<…>(` then the callback.
   const hoistedMatch = normalized.match(
-    /const (__cfLift_\d+) = __cfHelpers\.lift[\s\S]*?, \(\{ dateStr \}\) => formatDateShort\(dateStr\)\);/,
+    /const (__cfLift_\d+) = __cfHelpers\.lift<[\s\S]*?>\(\(\{ dateStr \}\) => formatDateShort\(dateStr\)/,
   );
 
   assert(hoistedMatch, `expected hoisted lift in output:\n${output}`);

--- a/packages/ts-transformers/test/fixtures/ast-transform/authored-ifelse-reactive-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/authored-ifelse-reactive-roots.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 const identity = __cfHardenFn(<T,>(value: T) => value);
 const __cfLift_1 = __cfHelpers.lift<{
     name: string;
-}, string>({
+}, string>(({ name }) => identity(name.trim()), {
     type: "object",
     properties: {
         name: {
@@ -24,10 +24,10 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["name"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ name }) => identity(name.trim()));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     count: number;
-}, number>({
+}, number>(({ count }) => count + 1, {
     type: "object",
     properties: {
         count: {
@@ -37,10 +37,10 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["count"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ count }) => count + 1);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     cell: __cfHelpers.Writable<number>;
-}, number>({
+}, number>(({ cell }) => cell.get(), {
     type: "object",
     properties: {
         cell: {
@@ -51,10 +51,10 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["cell"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ cell }) => cell.get());
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_4 = __cfHelpers.lift<{
     name: string;
-}, string>({
+}, string>(({ name }) => name.trim(), {
     type: "object",
     properties: {
         name: {
@@ -64,10 +64,10 @@ const __cfLift_4 = __cfHelpers.lift<{
     required: ["name"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ name }) => name.trim());
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_5 = __cfHelpers.lift<{
     name: string;
-}, string>({
+}, string>(({ name }) => name.trim(), {
     type: "object",
     properties: {
         name: {
@@ -77,7 +77,7 @@ const __cfLift_5 = __cfHelpers.lift<{
     required: ["name"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ name }) => name.trim());
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: authored-ifelse-reactive-roots
 // Verifies: authored ifElse outside JSX and top-level receiver-method roots lower reactively
 //   ifElse(show, count + 1, 0)         → compute-wrapped branch

--- a/packages/ts-transformers/test/fixtures/ast-transform/builder-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/builder-conditional.expected.jsx
@@ -19,7 +19,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         count: number;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.count > 0, {
     type: "object",
     properties: {
         state: {
@@ -35,7 +35,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.count > 0);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: builder-conditional
 // Verifies: ternary in JSX is transformed to ifElse() with a lift-applied condition
 //   state.count > 0 ? <p>A</p> : <p>B</p> → __cfHelpers.ifElse(...schemas, lift(...)({...}), <p>A</p>, <p>B</p>)

--- a/packages/ts-transformers/test/fixtures/ast-transform/computed-alias-const-rewrite.expected.js
+++ b/packages/ts-transformers/test/fixtures/ast-transform/computed-alias-const-rewrite.expected.js
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 // FIXTURE: computed-alias-const-rewrite
 // Verifies: stable const aliases to `computed()` still lower to `derive()`.
 const alias = computed;
-const __cfLift_1 = __cfHelpers.lift(false, () => 1);
+const __cfLift_1 = __cfHelpers.lift(() => 1, false);
 export default __cfLift_1();
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }

--- a/packages/ts-transformers/test/fixtures/ast-transform/computed-object-literal-input.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/computed-object-literal-input.expected.jsx
@@ -23,11 +23,11 @@ const acceptedCount = __cfHelpers.__cf_data(cell<number>(0, {
 const rejectedCount = __cfHelpers.__cf_data(cell<number>(0, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema).for("rejectedCount", true));
-const __cfLift_1 = lift({
+const __cfLift_1 = lift((value: string) => value, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, (value: string) => value);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-object-literal-input
 // Verifies: cell(), lift(), and computed() all get schemas injected from type annotations
 //   cell<string>("initial")             → cell<string>("initial", { type: "string" })
@@ -35,26 +35,26 @@ const __cfLift_1 = lift({
 //   computed(() => `...`)               → captures lift outputs into lift(inputSchema, outputSchema, { ... }, fn)
 // Context: No export default; first export-relevant statement is the cells/lifts/computed at top level
 const normalizedStage = __cfHelpers.__cf_data(__cfLift_1(stage).for("normalizedStage", true));
-const __cfLift_2 = lift({
+const __cfLift_2 = lift((count: number) => count, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, (count: number) => count);
+} as const satisfies __cfHelpers.JSONSchema);
 const attempts = __cfHelpers.__cf_data(__cfLift_2(attemptCount).for("attempts", true));
-const __cfLift_3 = lift({
+const __cfLift_3 = lift((count: number) => count, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, (count: number) => count);
+} as const satisfies __cfHelpers.JSONSchema);
 const accepted = __cfHelpers.__cf_data(__cfLift_3(acceptedCount).for("accepted", true));
-const __cfLift_4 = lift({
+const __cfLift_4 = lift((count: number) => count, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, (count: number) => count);
+} as const satisfies __cfHelpers.JSONSchema);
 const rejected = __cfHelpers.__cf_data(__cfLift_4(rejectedCount).for("rejected", true));
-const __cfLift_5 = __cfHelpers.lift(false, () => `stage:${normalizedStage} attempts:${attempts}` +
-    ` accepted:${accepted} rejected:${rejected}`);
+const __cfLift_5 = __cfHelpers.lift(() => `stage:${normalizedStage} attempts:${attempts}` +
+    ` accepted:${accepted} rejected:${rejected}`, false);
 const _summary = __cfHelpers.__cf_data(__cfLift_5().for("_summary", true));
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }

--- a/packages/ts-transformers/test/fixtures/ast-transform/counter-pattern-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/counter-pattern-no-name.expected.jsx
@@ -49,7 +49,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         value: number;
     };
-}, number>({
+}, number>(({ state }) => state.value + 1, {
     type: "object",
     properties: {
         state: {
@@ -65,7 +65,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.value + 1);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: counter-pattern-no-name
 // Verifies: same transforms as counter-pattern apply even when the file has no unique name
 //   handler<unknown, CounterState>(fn) → handler(true, stateSchema, fn)

--- a/packages/ts-transformers/test/fixtures/ast-transform/counter-pattern.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/counter-pattern.expected.jsx
@@ -49,7 +49,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         value: number;
     };
-}, number>({
+}, number>(({ state }) => state.value + 1, {
     type: "object",
     properties: {
         state: {
@@ -65,7 +65,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.value + 1);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: counter-pattern
 // Verifies: full pattern with handlers, ternary, str template, and schema generation
 //   handler<unknown, CounterState>(fn) → handler(true, stateSchema, fn)

--- a/packages/ts-transformers/test/fixtures/ast-transform/event-handler-no-compute-wrap.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/event-handler-no-compute-wrap.expected.jsx
@@ -34,7 +34,7 @@ const handleClick = handler({
 });
 const __cfLift_1 = __cfHelpers.lift<{
     count: Default<number, 0>;
-}, number>({
+}, number>(({ count }) => count + 1, {
     type: "object",
     properties: {
         count: {
@@ -45,7 +45,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["count"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ count }) => count + 1);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: event-handler-no-compute-wrap
 // Verifies: handler invocations in JSX are NOT wrapped in a reactive compute
 // wrapper (formerly derive, now lift-applied post-CT-1615), while

--- a/packages/ts-transformers/test/fixtures/ast-transform/lift-explicit-toschema.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/lift-explicit-toschema.expected.jsx
@@ -15,9 +15,12 @@ interface CharmEntry {
     id: string;
     name: string;
 }
-// Test: Explicit toSchema with undefined result schema
-// This overload pattern: lift(toSchema<T>(), undefined, fn)
-const logCharmsList = lift({
+// Test: Explicit toSchema, function-first order.
+// This overload pattern: lift(fn, toSchema<T>())  (result schema omitted)
+const logCharmsList = lift(({ charmsList }) => {
+    console.log("logCharmsList: ", charmsList.get());
+    return charmsList;
+}, {
     type: "object",
     properties: {
         charmsList: {
@@ -25,7 +28,7 @@ const logCharmsList = lift({
             items: {
                 $ref: "#/$defs/CharmEntry"
             },
-            asCell: ["readonly"]
+            asCell: ["cell"]
         }
     },
     required: ["charmsList"],
@@ -43,25 +46,26 @@ const logCharmsList = lift({
             required: ["id", "name"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, undefined, ({ charmsList }) => {
-    console.log("logCharmsList: ", charmsList.get());
-    return charmsList;
-});
-const getStatus = lift({
+} as const satisfies __cfHelpers.JSONSchema);
+const getStatus = lift(({ status }) => status, {
     type: "object",
     properties: {
         status: {
             "enum": ["open", "closed"]
+        },
+        ignored: {
+            type: "string",
+            "enum": ["draft"]
         }
     },
-    required: ["status"],
+    required: ["status", "ignored"],
     description: "Status input"
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ status }) => status);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: lift-explicit-toschema
 // Verifies: lift() with explicit toSchema<T>() is replaced by the generated JSON schema
-//   lift(toSchema<{ charmsList: Cell<CharmEntry[]> }>(), undefined, fn) → lift(generatedSchema, undefined, fn)
+//   lift(fn, toSchema<{ charmsList: Cell<CharmEntry[]> }>()) → lift(fn, generatedSchema)
 // Context: The toSchema() call is compiled away and replaced with the actual JSON schema object
 export default __cfHelpers.__cf_data({ logCharmsList, getStatus });
 // @ts-ignore: Internals

--- a/packages/ts-transformers/test/fixtures/ast-transform/lift-explicit-toschema.input.tsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/lift-explicit-toschema.input.tsx
@@ -5,27 +5,26 @@ interface CharmEntry {
   name: string;
 }
 
-// Test: Explicit toSchema with undefined result schema
-// This overload pattern: lift(toSchema<T>(), undefined, fn)
+// Test: Explicit toSchema, function-first order.
+// This overload pattern: lift(fn, toSchema<T>())  (result schema omitted)
 const logCharmsList = lift(
-  toSchema<{ charmsList: Cell<CharmEntry[]> }>(),
-  undefined,
   ({ charmsList }) => {
     console.log("logCharmsList: ", charmsList.get());
     return charmsList;
   },
+  toSchema<{ charmsList: Cell<CharmEntry[]> }>(),
 );
 
 const getStatus = lift(
+  ({ status }) => status,
   toSchema<{ status: "open" | "closed"; ignored: "draft" }>({
     description: "Status input",
   }),
   toSchema<string>(),
-  ({ status }) => status,
 );
 
 // FIXTURE: lift-explicit-toschema
 // Verifies: lift() with explicit toSchema<T>() is replaced by the generated JSON schema
-//   lift(toSchema<{ charmsList: Cell<CharmEntry[]> }>(), undefined, fn) → lift(generatedSchema, undefined, fn)
+//   lift(fn, toSchema<{ charmsList: Cell<CharmEntry[]> }>()) → lift(fn, generatedSchema)
 // Context: The toSchema() call is compiled away and replaced with the actual JSON schema object
 export default { logCharmsList, getStatus };

--- a/packages/ts-transformers/test/fixtures/ast-transform/non-jsx-wildcard-traversal-call-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/non-jsx-wildcard-traversal-call-roots.expected.jsx
@@ -27,7 +27,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         wishes: [{ id: string; status: string; }, { id: string; status: string; }];
     };
-}, string>({
+}, string>(({ state }) => JSON.stringify(state.wishes[1]), {
     type: "object",
     properties: {
         state: {
@@ -55,12 +55,12 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => JSON.stringify(state.wishes[1]));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         wishes: [{ id: string; status: string; }, { id: string; status: string; }];
     };
-}, string[]>({
+}, string[]>(({ state }) => Object.keys(state.wishes[1]), {
     type: "object",
     properties: {
         state: {
@@ -91,12 +91,12 @@ const __cfLift_2 = __cfHelpers.lift<{
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => Object.keys(state.wishes[1]));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         wishes: [{ id: string; status: string; }, { id: string; status: string; }];
     };
-}, string[]>({
+}, string[]>(({ state }) => Object.values(state.wishes[1]), {
     type: "object",
     properties: {
         state: {
@@ -127,12 +127,12 @@ const __cfLift_3 = __cfHelpers.lift<{
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => Object.values(state.wishes[1]));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_4 = __cfHelpers.lift<{
     state: {
         wishes: [{ id: string; status: string; }, { id: string; status: string; }];
     };
-}, [string, string][]>({
+}, [string, string][]>(({ state }) => Object.entries(state.wishes[1]), {
     type: "object",
     properties: {
         state: {
@@ -166,7 +166,7 @@ const __cfLift_4 = __cfHelpers.lift<{
             type: "string"
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => Object.entries(state.wishes[1]));
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: non-jsx-wildcard-traversal-call-roots
 // Verifies: wildcard traversal calls lower as whole call roots outside JSX
 export default pattern((state) => ({

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-array-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-array-map.expected.jsx
@@ -30,7 +30,9 @@ const adder = handler(false as const satisfies __cfHelpers.JSONSchema, {
 });
 const __cfLift_1 = __cfHelpers.lift<{
     values: unknown[];
-}, void>({
+}, void>(({ values }) => {
+    console.log("values#", values?.length);
+}, {
     type: "object",
     properties: {
         values: {
@@ -43,9 +45,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["values"]
 } as const satisfies __cfHelpers.JSONSchema, {
     asCell: ["opaque"]
-} as const satisfies __cfHelpers.JSONSchema, ({ values }) => {
-    console.log("values#", values?.length);
-});
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const value = __cf_pattern_input.key("element");
     const index = __cf_pattern_input.key("index");

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-call-arg-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-call-arg-conditional.expected.jsx
@@ -16,7 +16,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         done: boolean;
     };
-}, "Done" | "Pending">({
+}, "Done" | "Pending">(({ state }) => identity(state.done ? "Done" : "Pending"), {
     type: "object",
     properties: {
         state: {
@@ -32,7 +32,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     "enum": ["Done", "Pending"]
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => identity(state.done ? "Done" : "Pending"));
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: pattern-call-arg-conditional
 // Verifies: top-level ordinary helper calls with reactive arguments are lifted
 //   as whole calls rather than lowering only the inner argument expression.

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-call-root-containers.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-call-root-containers.expected.jsx
@@ -16,7 +16,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         done: boolean;
     };
-}, "Done" | "Pending">({
+}, "Done" | "Pending">(({ state }) => identity(state.done ? "Done" : "Pending"), {
     type: "object",
     properties: {
         state: {
@@ -32,12 +32,12 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     "enum": ["Done", "Pending"]
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => identity(state.done ? "Done" : "Pending"));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         done: boolean;
     };
-}, "Done" | "Pending">({
+}, "Done" | "Pending">(({ state }) => identity(state.done ? "Done" : "Pending"), {
     type: "object",
     properties: {
         state: {
@@ -53,7 +53,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     "enum": ["Done", "Pending"]
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => identity(state.done ? "Done" : "Pending"));
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: pattern-call-root-containers
 // Verifies: top-level ordinary call roots whole-wrap consistently across
 //   non-JSX container kinds instead of lowering only their nested conditional
@@ -101,7 +101,7 @@ const __cfLift_3 = __cfHelpers.lift<{
     state: {
         done: boolean;
     };
-}, "Done" | "Pending">({
+}, "Done" | "Pending">(({ state }) => identity(state.done ? "Done" : "Pending"), {
     type: "object",
     properties: {
         state: {
@@ -117,7 +117,7 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     "enum": ["Done", "Pending"]
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => identity(state.done ? "Done" : "Pending"));
+} as const satisfies __cfHelpers.JSONSchema);
 export default pattern((state) => __cfLift_3({ state: {
         done: state.key("done")
     } }).for("__patternResult", true), {

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-local-helper-call-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-local-helper-call-roots.expected.jsx
@@ -16,7 +16,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         count: number;
     };
-}, number>({
+}, number>(({ state }) => double(state.count + 1), {
     type: "object",
     properties: {
         state: {
@@ -32,7 +32,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => double(state.count + 1));
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: pattern-local-helper-call-roots
 // Verifies: top-level ordinary local helper calls with reactive inputs are
 //   lifted as whole calls, while plain inputs stay plain.

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-object-binary-add.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-object-binary-add.expected.jsx
@@ -15,7 +15,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         count: number;
     };
-}, number>({
+}, number>(({ state }) => state.count + 1, {
     type: "object",
     properties: {
         state: {
@@ -31,7 +31,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.count + 1);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: pattern-object-binary-add
 // Verifies: top-level non-JSX arithmetic in an object property is lowered after
 //   closure normalization into a direct lift-applied computation rather than left

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-object-prefix-not.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-object-prefix-not.expected.jsx
@@ -15,7 +15,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         done: boolean;
     };
-}, boolean>({
+}, boolean>(({ state }) => !state.done, {
     type: "object",
     properties: {
         state: {
@@ -31,7 +31,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => !state.done);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: pattern-object-prefix-not
 // Verifies: top-level non-JSX unary boolean negation in an object property is
 //   lowered after closure normalization into a direct lift-applied computation.

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-top-level-root-lowering.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-top-level-root-lowering.expected.jsx
@@ -18,7 +18,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             name: string;
         };
     };
-}, string>({
+}, string>(({ state }) => identity(state.user.name), {
     type: "object",
     properties: {
         state: {
@@ -40,12 +40,12 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => identity(state.user.name));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         maybeUser?: { name: string; } | undefined;
     };
-}, string | undefined>({
+}, string | undefined>(({ state }) => identity(state.maybeUser?.name), {
     type: "object",
     properties: {
         state: {
@@ -66,13 +66,13 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => identity(state.maybeUser?.name));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         a: number;
         b: number;
     };
-}, number>({
+}, number>(({ state }) => Math.max(state.a, state.b), {
     type: "object",
     properties: {
         state: {
@@ -91,12 +91,12 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => Math.max(state.a, state.b));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_4 = __cfHelpers.lift<{
     state: {
         float: string;
     };
-}, number>({
+}, number>(({ state }) => parseInt(state.float), {
     type: "object",
     properties: {
         state: {
@@ -112,12 +112,12 @@ const __cfLift_4 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => parseInt(state.float));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_5 = __cfHelpers.lift<{
     state: {
         label?: string | null | undefined;
     };
-}, string>({
+}, string>(({ state }) => state.label ?? "Pending", {
     type: "object",
     properties: {
         state: {
@@ -132,7 +132,7 @@ const __cfLift_5 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.label ?? "Pending");
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: pattern-top-level-root-lowering
 // Verifies: top-level non-JSX ordinary helper calls with reactive inputs are
 //   lifted as whole calls instead of lowering only inner argument expressions.

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-two-schemas.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-two-schemas.expected.jsx
@@ -21,7 +21,7 @@ interface Result {
 }
 const __cfLift_1 = __cfHelpers.lift<{
     count: number;
-}, number>({
+}, number>(({ count }) => count * 2, {
     type: "object",
     properties: {
         count: {
@@ -31,7 +31,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["count"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ count }) => count * 2);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: pattern-two-schemas
 // Verifies: pattern with both input and output schemas already present preserves them
 //   pattern<Input, Result>(fn, inputSchema, outputSchema) → pattern(fn, inputSchema, outputSchema) (schemas kept)

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-with-name-and-type.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-with-name-and-type.expected.jsx
@@ -18,7 +18,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     input: {
         value: number;
     };
-}, number>({
+}, number>(({ input }) => input.value * 2, {
     type: "object",
     properties: {
         input: {
@@ -34,7 +34,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["input"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ input }) => input.value * 2);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: pattern-with-name-and-type
 // Verifies: pattern with inline typed parameter generates input and output schemas
 //   pattern((input: MyInput) => ...)   → pattern((input) => ..., inputSchema, outputSchema)

--- a/packages/ts-transformers/test/fixtures/ast-transform/pattern-with-type.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/pattern-with-type.expected.jsx
@@ -18,7 +18,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     input: {
         value: number;
     };
-}, number>({
+}, number>(({ input }) => input.value * 2, {
     type: "object",
     properties: {
         input: {
@@ -34,7 +34,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["input"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ input }) => input.value * 2);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: pattern-with-type
 // Verifies: pattern with inline typed parameter generates input and output schemas
 //   pattern((input: MyInput) => ...)   → pattern((input) => ..., inputSchema, outputSchema)

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-alias.expected.jsx
@@ -18,9 +18,9 @@ type AliasResult = {
     length: number;
 };
 declare const state: AliasInput;
-const __cfLift_1 = __cfHelpers.lift(false, (): AliasResult => ({
+const __cfLift_1 = __cfHelpers.lift((): AliasResult => ({
     length: state.text.length,
-}));
+}), false);
 // FIXTURE: schema-generation-computed-alias
 // Verifies: a reactive builder imported under an alias still gets schema injection
 //   computedAlias((): AliasResult => ...) → captures `state` and lowers to lift(inputSchema, outputSchema, ...)

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-inside-jsx.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-inside-jsx.expected.jsx
@@ -12,7 +12,7 @@ const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 declare const value: number;
-const __cfLift_1 = __cfHelpers.lift(false, () => value * 2);
+const __cfLift_1 = __cfHelpers.lift(() => value * 2, false);
 // FIXTURE: schema-generation-computed-inside-jsx
 // Verifies: a reactive builder inside a JSX expression still gets schemas injected
 //   computed(() => value * 2) → captures `value` and lowers to lift(inputSchema, outputSchema, ...)

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-multiple-returns.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-multiple-returns.expected.jsx
@@ -12,12 +12,12 @@ const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 declare const flag: boolean;
-const __cfLift_1 = __cfHelpers.lift(false, () => {
+const __cfLift_1 = __cfHelpers.lift(() => {
     if (flag) {
         return "hello";
     }
     return 42;
-});
+}, false);
 // FIXTURE: schema-generation-computed-multiple-returns
 // Verifies: a reactive builder with multiple return paths infers a union output schema
 //   computed(() => { ... }) → output schema is an enum union of the returned literals

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-untyped.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed-untyped.expected.jsx
@@ -12,7 +12,7 @@ const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 declare const total: number;
-const __cfLift_1 = __cfHelpers.lift(false, () => total * 2);
+const __cfLift_1 = __cfHelpers.lift(() => total * 2, false);
 // FIXTURE: schema-generation-computed-untyped
 // Verifies: a reactive builder with no generic type args infers schemas from captured values
 //   computed(() => total * 2) → captures `total` ({ type: "number" }) and infers output from the body

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-computed.expected.jsx
@@ -18,9 +18,9 @@ type DeriveResult = {
     doubled: number;
 };
 declare const source: DeriveInput;
-const __cfLift_1 = __cfHelpers.lift(false, (): DeriveResult => ({
+const __cfLift_1 = __cfHelpers.lift((): DeriveResult => ({
     doubled: source.count * 2,
-}));
+}), false);
 // FIXTURE: schema-generation-computed
 // Verifies: computed() closure-extracts a captured value into a lift() with input
 // (capture) and output schemas generated from type info

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-lift-cell-array.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-lift-cell-array.expected.jsx
@@ -21,7 +21,10 @@ interface CharmEntry {
 // Context: Cell wrapper must produce `asCell: true` in the schema; output schema inferred from return type
 // Test that lift with single generic parameter preserves Cell wrapper
 // This was broken on main - Cell would be unwrapped to ProxyArray
-const logCharmsList = lift({
+const logCharmsList = lift(({ charmsList }) => {
+    console.log("logCharmsList: ", charmsList.get());
+    return charmsList;
+}, {
     type: "object",
     properties: {
         charmsList: {
@@ -67,10 +70,7 @@ const logCharmsList = lift({
             required: ["id", "name"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ charmsList }) => {
-    console.log("logCharmsList: ", charmsList.get());
-    return charmsList;
-});
+} as const satisfies __cfHelpers.JSONSchema);
 export default logCharmsList;
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-lift-inside-jsx.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-lift-inside-jsx.expected.jsx
@@ -25,7 +25,10 @@ const currentYear = 2024;
 //   lift((person: Person): PersonWithYear => ...) → lift(inputSchema, outputSchema, fn)
 // Context: lift() appears as a JSX child expression; schemas derived from param + return type annotations
 export const result = (<div>
-    {lift({
+    {lift((person: Person): PersonWithYear => ({
+        name: person.name,
+        birthYear: currentYear - person.age,
+    }), {
         type: "object",
         properties: {
             name: {
@@ -47,10 +50,7 @@ export const result = (<div>
             }
         },
         required: ["name", "birthYear"]
-    } as const satisfies __cfHelpers.JSONSchema, (person: Person): PersonWithYear => ({
-        name: person.name,
-        birthYear: currentYear - person.age,
-    }))}
+    } as const satisfies __cfHelpers.JSONSchema)}
   </div>);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-lift-no-generics.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-lift-no-generics.expected.jsx
@@ -21,7 +21,9 @@ type LiftResult = {
 // Verifies: lift() with no generic type args infers schemas from inline param and return type
 //   lift((args: LiftArgs): LiftResult => ...) → lift(inputSchema, outputSchema, fn)
 // Context: Types come from function parameter and return type annotations, not generic args
-export const doubleValue = lift({
+export const doubleValue = lift((args: LiftArgs): LiftResult => ({
+    doubled: args.value * 2,
+}), {
     type: "object",
     properties: {
         value: {
@@ -37,9 +39,7 @@ export const doubleValue = lift({
         }
     },
     required: ["doubled"]
-} as const satisfies __cfHelpers.JSONSchema, (args: LiftArgs): LiftResult => ({
-    doubled: args.value * 2,
-}));
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-lift-typed-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-lift-typed-param.expected.jsx
@@ -16,11 +16,11 @@ const __cfAmdHooks = undefined;
 //   lift((value: number) => value * 2) → lift({ type: "number" }, { type: "number" }, fn)
 // Context: Single primitive param; output type inferred from expression body
 // Lift requires explicit type annotation for proper schema generation
-export const doubleValue = lift({
+export const doubleValue = lift((value: number) => value * 2, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, (value: number) => value * 2);
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-lift.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/schema-generation-lift.expected.jsx
@@ -20,7 +20,9 @@ type LiftResult = {
 // FIXTURE: schema-generation-lift
 // Verifies: lift() with generic type args generates input and output schemas
 //   lift<LiftArgs, LiftResult>(fn) → lift(inputSchema, outputSchema, fn)
-export const doubleValue = lift({
+export const doubleValue = lift(({ value }) => ({
+    doubled: value * 2,
+}), {
     type: "object",
     properties: {
         value: {
@@ -36,9 +38,7 @@ export const doubleValue = lift({
         }
     },
     required: ["doubled"]
-} as const satisfies __cfHelpers.JSONSchema, ({ value }) => ({
-    doubled: value * 2,
-}));
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/ast-transform/str-template-call-interpolation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/str-template-call-interpolation.expected.jsx
@@ -22,7 +22,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     cell: {
         value: number;
     };
-}, string>({
+}, string>(({ cell }) => format(cell.value), {
     type: "object",
     properties: {
         cell: {
@@ -38,12 +38,12 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["cell"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ cell }) => format(cell.value));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     cell: {
         value: number;
     };
-}, number>({
+}, number>(({ cell }) => cell.value + 1, {
     type: "object",
     properties: {
         cell: {
@@ -59,7 +59,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["cell"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ cell }) => cell.value + 1);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: str-template-call-interpolation
 // Verifies: reactive lowering of expressions interpolated into a str`` tagged template.
 //   The str runtime lifts its interpolation over the values it receives, so any value

--- a/packages/ts-transformers/test/fixtures/ast-transform/ternary_computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/ast-transform/ternary_computed.expected.jsx
@@ -18,7 +18,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         value: number;
     };
-}, number>({
+}, number>(({ state }) => state.value + 1, {
     type: "object",
     properties: {
         state: {
@@ -34,12 +34,12 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.value + 1);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         value: number;
     };
-}, number>({
+}, number>(({ state }) => state.value + 2, {
     type: "object",
     properties: {
         state: {
@@ -55,7 +55,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.value + 2);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: ternary_computed
 // Verifies: ternary with expressions on both sides produces ifElse() with a lift-applied computation for each branch
 //   state.value + 1 ? state.value + 2 : "undefined" → ifElse(...schemas, lift(...)({...}), lift(...)({...}), "undefined")

--- a/packages/ts-transformers/test/fixtures/closures/action-in-ternary-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-in-ternary-branch.expected.jsx
@@ -41,7 +41,10 @@ const __cfLift_1 = __cfHelpers.lift<{
     card: {
         description: string;
     };
-}, boolean | "">({
+}, boolean | "">(({ card }) => {
+    const desc = card.description;
+    return desc && desc.length > 0;
+}, {
     type: "object",
     properties: {
         card: {
@@ -57,10 +60,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["card"]
 } as const satisfies __cfHelpers.JSONSchema, {
     "enum": [false, true, ""]
-} as const satisfies __cfHelpers.JSONSchema, ({ card }) => {
-    const desc = card.description;
-    return desc && desc.length > 0;
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: action-in-ternary-branch
 // Verifies: action() result used in a ternary branch alongside computed() keeps
 //   local JSX rewrites instead of forcing a whole-branch lift-applied computation

--- a/packages/ts-transformers/test/fixtures/closures/action-in-ternary-with-explicit-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/action-in-ternary-with-explicit-computed.expected.jsx
@@ -42,7 +42,10 @@ const __cfLift_1 = __cfHelpers.lift<{
         description: string;
     };
     startEditing: __cfHelpers.Stream<void>;
-}, __cfHelpers.JSXElement>({
+}, __cfHelpers.JSXElement>(({ card, startEditing }) => (<div>
+                <span>{card.description}</span>
+                <cf-button onClick={startEditing}>Edit</cf-button>
+              </div>), {
     type: "object",
     properties: {
         card: {
@@ -79,10 +82,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ card, startEditing }) => (<div>
-                <span>{card.description}</span>
-                <cf-button onClick={startEditing}>Edit</cf-button>
-              </div>));
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: action-in-ternary-with-explicit-computed
 // Verifies: action() referenced inside an explicit computed() in JSX is captured in the lift-applied wrapper
 //   action(() => ...) → handler(...)({ isEditing })

--- a/packages/ts-transformers/test/fixtures/closures/cell-map-with-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/cell-map-with-captures.expected.jsx
@@ -20,7 +20,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         multiplier: number;
     };
-}, number>({
+}, number>(({ value, state }) => value * state.multiplier, {
     type: "object",
     properties: {
         value: {
@@ -39,7 +39,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["value", "state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ value, state }) => value * state.multiplier);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const value = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");

--- a/packages/ts-transformers/test/fixtures/closures/cfreg-export-forms.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/cfreg-export-forms.expected.jsx
@@ -20,21 +20,21 @@ const __cfAmdHooks = undefined;
 // The trailing `__cfReg({ ... })` should therefore contain only `internalHelper`
 // and the synthetic `__cfPattern_1` (the `.map` op) — never `exportedLift`,
 // `reexportedLift`, or the default pattern.
-const internalHelper = lift({
+const internalHelper = lift((x: number) => x + 1, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, (x: number) => x + 1);
-export const exportedLift = lift({
+} as const satisfies __cfHelpers.JSONSchema);
+export const exportedLift = lift((x: number) => x * 2, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, (x: number) => x * 2);
-const reexportedLift = lift({
+} as const satisfies __cfHelpers.JSONSchema);
+const reexportedLift = lift((x: number) => x - 1, {
     type: "number"
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, (x: number) => x - 1);
+} as const satisfies __cfHelpers.JSONSchema);
 export { reexportedLift };
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const x = __cf_pattern_input.key("element");

--- a/packages/ts-transformers/test/fixtures/closures/computed-all-literal-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-all-literal-types.expected.jsx
@@ -16,7 +16,11 @@ const __cfLift_1 = __cfHelpers.lift<{
     numLiteral: number;
     floatLiteral: number;
     strLiteral: string;
-}, string>({
+}, string>(({ value, numLiteral, floatLiteral, boolLiteral, strLiteral }) => {
+    // Use all captured literals to ensure they're all widened
+    const combined = value.get() + numLiteral + floatLiteral;
+    return boolLiteral ? strLiteral + combined : "";
+}, {
     type: "object",
     properties: {
         value: {
@@ -36,11 +40,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["value", "numLiteral", "floatLiteral", "strLiteral"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ value, numLiteral, floatLiteral, boolLiteral, strLiteral }) => {
-    // Use all captured literals to ensure they're all widened
-    const combined = value.get() + numLiteral + floatLiteral;
-    return boolLiteral ? strLiteral + combined : "";
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // Test that all literal types are widened in closure captures
 // FIXTURE: computed-all-literal-types
 // Verifies: literal values (number, string, boolean, float) are captured and their types widened in schemas

--- a/packages/ts-transformers/test/fixtures/closures/computed-array-element-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-array-element-access.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     value: __cfHelpers.ReadonlyCell<number>;
     factors: number[];
-}, number>({
+}, number>(({ value, factors }) => value.get() * factors[1]!, {
     type: "object",
     properties: {
         value: {
@@ -31,7 +31,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["value", "factors"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ value, factors }) => value.get() * factors[1]!);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-array-element-access
 // Verifies: an array variable accessed by index inside a computed is captured as a whole array
 //   computed(() => expr) → lift(schema, schema)({ value, factors })

--- a/packages/ts-transformers/test/fixtures/closures/computed-array-length.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-array-length.expected.jsx
@@ -29,7 +29,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     allCharms: {
         length: number;
     };
-}, string>({
+}, string>(({ allCharms }) => `Charms (${allCharms.length})`, {
     type: "object",
     properties: {
         allCharms: {
@@ -45,12 +45,12 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["allCharms"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ allCharms }) => `Charms (${allCharms.length})`);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     allCharms: {
         length: number;
     };
-}, number>({
+}, number>(({ allCharms }) => allCharms.length, {
     type: "object",
     properties: {
         allCharms: {
@@ -66,7 +66,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["allCharms"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ allCharms }) => allCharms.length);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const charm = __cf_pattern_input.key("element");
     return (<li>{charm.key("name")}</li>);

--- a/packages/ts-transformers/test/fixtures/closures/computed-basic-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-basic-capture.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     value: __cfHelpers.ReadonlyCell<number>;
     multiplier: __cfHelpers.ReadonlyCell<number>;
-}, number>({
+}, number>(({ value, multiplier }) => value.get() * multiplier.get(), {
     type: "object",
     properties: {
         value: {
@@ -29,7 +29,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["value", "multiplier"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ value, multiplier }) => value.get() * multiplier.get());
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-basic-capture
 // Verifies: computed(() => expr) with two cell captures is closure-extracted into a lift-applied computation
 //   computed(() => value.get() * multiplier.get()) → lift(({ value, multiplier }) => value.get() * multiplier.get())({ value, multiplier })

--- a/packages/ts-transformers/test/fixtures/closures/computed-collision-property.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-collision-property.expected.jsx
@@ -13,7 +13,10 @@ const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     multiplier: __cfHelpers.ReadonlyCell<number>;
-}, { multiplier: number; value: number; }>({
+}, { multiplier: number; value: number; }>(({ multiplier }) => ({
+    multiplier: multiplier.get(),
+    value: multiplier.get() * 3,
+}), {
     type: "object",
     properties: {
         multiplier: {
@@ -33,10 +36,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     },
     required: ["multiplier", "value"]
-} as const satisfies __cfHelpers.JSONSchema, ({ multiplier }) => ({
-    multiplier: multiplier.get(),
-    value: multiplier.get() * 3,
-}));
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-collision-property
 // Verifies: a captured cell named the same as a returned object property does not rename the property
 //   computed(() => ({ multiplier: multiplier.get(), value: ... })) → lift(...)({ multiplier })

--- a/packages/ts-transformers/test/fixtures/closures/computed-collision-shorthand.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-collision-shorthand.expected.jsx
@@ -13,7 +13,10 @@ const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     multiplier: __cfHelpers.ReadonlyCell<number>;
-}, { value: number; data: { multiplier: __cfHelpers.Cell<number>; }; }>({
+}, { value: number; data: { multiplier: __cfHelpers.Cell<number>; }; }>(({ multiplier }) => ({
+    value: multiplier.get() * 3,
+    data: { multiplier: multiplier },
+}), {
     type: "object",
     properties: {
         multiplier: {
@@ -40,10 +43,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     },
     required: ["value", "data"]
-} as const satisfies __cfHelpers.JSONSchema, ({ multiplier }) => ({
-    value: multiplier.get() * 3,
-    data: { multiplier: multiplier },
-}));
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-collision-shorthand
 // Verifies: a shorthand property `{ multiplier }` over a captured cell expands correctly
 //   computed(() => ({ value, data: { multiplier } })) → lift(...)({ multiplier })

--- a/packages/ts-transformers/test/fixtures/closures/computed-complex-expression.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-complex-expression.expected.jsx
@@ -15,7 +15,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     a: __cfHelpers.ReadonlyCell<number>;
     b: __cfHelpers.ReadonlyCell<number>;
     c: __cfHelpers.ReadonlyCell<number>;
-}, number>({
+}, number>(({ a, b, c }) => (a.get() * b.get() + c.get()) / 2, {
     type: "object",
     properties: {
         a: {
@@ -34,7 +34,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["a", "b", "c"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ a, b, c }) => (a.get() * b.get() + c.get()) / 2);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-complex-expression
 // Verifies: computed(() => expr) with three cell captures in an arithmetic expression
 //   computed(() => (a.get() * b.get() + c.get()) / 2) → lift(({ a, b, c }) => ...)({ a, b, c })

--- a/packages/ts-transformers/test/fixtures/closures/computed-conditional-expression.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-conditional-expression.expected.jsx
@@ -16,7 +16,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     threshold: __cfHelpers.ReadonlyCell<number>;
     a: __cfHelpers.ReadonlyCell<number>;
     b: __cfHelpers.ReadonlyCell<number>;
-}, number>({
+}, number>(({ value, threshold, a, b }) => value.get() > threshold.get() ? a.get() : b.get(), {
     type: "object",
     properties: {
         value: {
@@ -39,7 +39,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["value", "threshold", "a", "b"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ value, threshold, a, b }) => value.get() > threshold.get() ? a.get() : b.get());
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-conditional-expression
 // Verifies: computed(() => expr) with four cell captures in a ternary expression
 //   computed(() => value.get() > threshold.get() ? a.get() : b.get()) → lift(({ value, threshold, a, b }) => ...)({ value, threshold, a, b })

--- a/packages/ts-transformers/test/fixtures/closures/computed-destructured-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-destructured-map.expected.jsx
@@ -26,7 +26,10 @@ const __cfLift_1 = __cfHelpers.lift<{
     items: {
         done: boolean;
     }[];
-}, { tasks: Item[]; view: string; }>({
+}, { tasks: Item[]; view: string; }>(({ items }) => ({
+    tasks: items.filter((i) => !i.done),
+    view: "inbox",
+}), {
     type: "object",
     properties: {
         items: {
@@ -71,13 +74,13 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["name", "done"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ items }) => ({
-    tasks: items.filter((i) => !i.done),
-    view: "inbox",
-}));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     result: { tasks: Item[]; view: string; };
-}, __cfHelpers.JSXElement[]>({
+}, __cfHelpers.JSXElement[]>(({ result }) => {
+    const { tasks } = result;
+    return tasks.map((task) => <li>{task.name}</li>);
+}, {
     type: "object",
     properties: {
         result: {
@@ -137,10 +140,7 @@ const __cfLift_2 = __cfHelpers.lift<{
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ result }) => {
-    const { tasks } = result;
-    return tasks.map((task) => <li>{task.name}</li>);
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-destructured-map
 // Verifies: .map() on a destructured property of a computed result inside another computed() is NOT transformed to .mapWithPattern()
 //   computed(() => { const { tasks } = result; return tasks.map(fn) }) → lift(({ result }) => { const { tasks } = result; return tasks.map(fn) })(...)

--- a/packages/ts-transformers/test/fixtures/closures/computed-destructured-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-destructured-param.expected.jsx
@@ -18,7 +18,10 @@ interface Point {
 const __cfLift_1 = __cfHelpers.lift<{
     point: __cfHelpers.ReadonlyCell<Point>;
     multiplier: __cfHelpers.ReadonlyCell<number>;
-}, number>({
+}, number>(({ point, multiplier }) => {
+    const { x, y } = point.get();
+    return (x + y) * multiplier.get();
+}, {
     type: "object",
     properties: {
         point: {
@@ -47,10 +50,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     }
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ point, multiplier }) => {
-    const { x, y } = point.get();
-    return (x + y) * multiplier.get();
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-destructured-param
 // Verifies: a captured cell works alongside destructuring inside the computed body
 //   computed(() => { const { x, y } = point.get(); ... }) → lift(...)({ point, multiplier })

--- a/packages/ts-transformers/test/fixtures/closures/computed-filter-map-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-filter-map-chain.expected.jsx
@@ -22,7 +22,11 @@ const __cfLift_1 = __cfHelpers.lift<{
             preference: "liked" | "disliked";
         }[];
     };
-}, string[]>({
+}, string[]>(({ state }) => {
+    return state.preferences
+        .filter((p) => p.preference === "liked")
+        .map((p) => p.ingredient);
+}, {
     type: "object",
     properties: {
         state: {
@@ -53,11 +57,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => {
-    return state.preferences
-        .filter((p) => p.preference === "liked")
-        .map((p) => p.ingredient);
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-filter-map-chain
 // Verifies: .filter() and .map() inside computed() are NOT transformed
 // Context: Inside computed(), OpaqueRef auto-unwraps to plain array, so

--- a/packages/ts-transformers/test/fixtures/closures/computed-in-computed-property-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-in-computed-property-access.expected.jsx
@@ -11,11 +11,11 @@ import { computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift(false, () => ({ bar: 1 }));
-const __cfLift_2 = __cfHelpers.lift(false, () => {
+const __cfLift_1 = __cfHelpers.lift(() => ({ bar: 1 }), false);
+const __cfLift_2 = __cfHelpers.lift(() => {
     const foo = __cfLift_1().for("foo", true);
     return foo.key("bar");
-});
+}, false);
 // FIXTURE: computed-in-computed-property-access
 // Verifies: property access on a computed() result declared INSIDE another computed()
 //   gets transformed to .key() access

--- a/packages/ts-transformers/test/fixtures/closures/computed-in-computed-scoped-no-false-rewrite.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-in-computed-scoped-no-false-rewrite.expected.jsx
@@ -12,15 +12,15 @@ const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const config = __cfHelpers.__cf_data({ bar: "module-level" });
-const __cfLift_1 = __cfHelpers.lift(false, () => ({ bar: 1 }));
-const __cfLift_2 = __cfHelpers.lift(false, () => {
+const __cfLift_1 = __cfHelpers.lift(() => ({ bar: 1 }), false);
+const __cfLift_2 = __cfHelpers.lift(() => {
     const condition = 1 > 0;
     if (condition) {
         const config = __cfLift_1().for("config", true);
         return config.key("bar");
     }
     return config.bar;
-});
+}, false);
 // FIXTURE: computed-in-computed-scoped-no-false-rewrite
 // Verifies: a block-scoped computed() result named `config` does NOT cause
 //   the module-level `config.bar` to be rewritten to `config.key("bar")`.

--- a/packages/ts-transformers/test/fixtures/closures/computed-inside-map-with-method-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-inside-map-with-method-chain.expected.jsx
@@ -28,7 +28,10 @@ const __cfLift_1 = __cfHelpers.lift<{
     item: {
         subItems: SubItem[];
     };
-}, string>({
+}, string>(({ item }) => item.subItems
+    .filter((s) => s.active)
+    .map((s) => s.name)
+    .join(", "), {
     type: "object",
     properties: {
         item: {
@@ -64,10 +67,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     }
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ item }) => item.subItems
-    .filter((s) => s.active)
-    .map((s) => s.name)
-    .join(", "));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return (<div>

--- a/packages/ts-transformers/test/fixtures/closures/computed-jsx-local-function.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-jsx-local-function.expected.jsx
@@ -13,7 +13,10 @@ const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     count: number;
-}, __cfHelpers.JSXElement>({
+}, __cfHelpers.JSXElement>(({ count }) => {
+    const format = (value: number) => `Count: ${value}`;
+    return <span>{format(count)}</span>;
+}, {
     type: "object",
     properties: {
         count: {
@@ -41,10 +44,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ count }) => {
-    const format = (value: number) => `Count: ${value}`;
-    return <span>{format(count)}</span>;
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-jsx-local-function
 // Verifies: computed() with a locally-defined function inside the callback is closure-extracted
 //   computed(() => { const format = ...; return <span>{format(count)}</span> }) → lift(({ count }) => { ... })({ count })

--- a/packages/ts-transformers/test/fixtures/closures/computed-local-var-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-local-var-map.expected.jsx
@@ -26,7 +26,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     items: {
         price: number;
     }[];
-}, Item[]>({
+}, Item[]>(({ items }) => items.filter((i) => i.price > 100), {
     type: "object",
     properties: {
         items: {
@@ -62,12 +62,15 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["name", "price"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ items }) => items.filter((i) => i.price > 100));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     filtered: {
         name: string;
     }[];
-}, __cfHelpers.JSXElement[]>({
+}, __cfHelpers.JSXElement[]>(({ filtered }) => {
+    const localVar = filtered;
+    return localVar.map((item) => <li>{item.name}</li>);
+}, {
     type: "object",
     properties: {
         filtered: {
@@ -110,10 +113,7 @@ const __cfLift_2 = __cfHelpers.lift<{
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ filtered }) => {
-    const localVar = filtered;
-    return localVar.map((item) => <li>{item.name}</li>);
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-local-var-map
 // Verifies: .map() on a local variable assigned from a computed result inside another computed() is NOT transformed to .mapWithPattern()
 //   computed(() => { const localVar = filtered; return localVar.map(fn) }) → lift(({ filtered }) => { const localVar = filtered; return localVar.map(fn) })(...)

--- a/packages/ts-transformers/test/fixtures/closures/computed-local-variable.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-local-variable.expected.jsx
@@ -15,7 +15,10 @@ const __cfLift_1 = __cfHelpers.lift<{
     a: __cfHelpers.ReadonlyCell<number>;
     b: __cfHelpers.ReadonlyCell<number>;
     c: __cfHelpers.ReadonlyCell<number>;
-}, number>({
+}, number>(({ a, b, c }) => {
+    const sum = a.get() + b.get();
+    return sum * c.get();
+}, {
     type: "object",
     properties: {
         a: {
@@ -34,10 +37,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["a", "b", "c"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ a, b, c }) => {
-    const sum = a.get() + b.get();
-    return sum * c.get();
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-local-variable
 // Verifies: callback-local variables are not captured, but outer cells are
 //   computed(() => { const sum = a.get() + b.get(); return sum * c.get() }) → lift(...)({ a, b, c })

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-conditional.expected.jsx
@@ -22,7 +22,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         items: Item[];
     };
-}, Item[]>({
+}, Item[]>(({ state }) => state.items, {
     type: "object",
     properties: {
         state: {
@@ -66,12 +66,12 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["done"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     row: {
         done: boolean;
     };
-}, string>({
+}, string>(({ row }) => identity(row.done ? "Done" : "Pending"), {
     type: "object",
     properties: {
         row: {
@@ -87,7 +87,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["row"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ row }) => identity(row.done ? "Done" : "Pending"));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     const label = __cfLift_2({ row: {

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-logical-and.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-call-arg-logical-and.expected.jsx
@@ -22,7 +22,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         items: Item[];
     };
-}, Item[]>({
+}, Item[]>(({ state }) => state.items, {
     type: "object",
     properties: {
         state: {
@@ -66,12 +66,12 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["done"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     row: {
         done: boolean;
     };
-}, unknown>({
+}, unknown>(({ row }) => identity(row.done && "Done"), {
     type: "object",
     properties: {
         row: {
@@ -87,7 +87,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["row"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "unknown"
-} as const satisfies __cfHelpers.JSONSchema, ({ row }) => identity(row.done && "Done"));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     const label = __cfLift_2({ row: {

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-call-root-containers.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-call-root-containers.expected.jsx
@@ -22,7 +22,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         items: Item[];
     };
-}, Item[]>({
+}, Item[]>(({ state }) => state.items, {
     type: "object",
     properties: {
         state: {
@@ -66,12 +66,12 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["done"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     row: {
         done: boolean;
     };
-}, string>({
+}, string>(({ row }) => identity(row.done ? "Done" : "Pending"), {
     type: "object",
     properties: {
         row: {
@@ -87,12 +87,12 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["row"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ row }) => identity(row.done ? "Done" : "Pending"));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     row: {
         done: boolean;
     };
-}, string>({
+}, string>(({ row }) => identity(row.done ? "Done" : "Pending"), {
     type: "object",
     properties: {
         row: {
@@ -108,7 +108,7 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["row"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ row }) => identity(row.done ? "Done" : "Pending"));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     return ({
@@ -157,7 +157,7 @@ const __cfLift_4 = __cfHelpers.lift<{
     row: {
         done: boolean;
     };
-}, string>({
+}, string>(({ row }) => identity(row.done ? "Done" : "Pending"), {
     type: "object",
     properties: {
         row: {
@@ -173,7 +173,7 @@ const __cfLift_4 = __cfHelpers.lift<{
     required: ["row"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ row }) => identity(row.done ? "Done" : "Pending"));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     return __cfLift_4({ row: {

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-direct-return-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-direct-return-conditional.expected.jsx
@@ -21,7 +21,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         items: Item[];
     };
-}, Item[]>({
+}, Item[]>(({ state }) => state.items, {
     type: "object",
     properties: {
         state: {
@@ -65,7 +65,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["done"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     return __cfHelpers.ifElse({

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-in-derived-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-in-derived-branch.expected.jsx
@@ -21,7 +21,9 @@ interface PatternInput {
 }
 const __cfLift_1 = __cfHelpers.lift<{
     people: __cfHelpers.ReadonlyCell<Person[]>;
-}, { name: string; rank: number; isFirst: boolean; }[]>({
+}, { name: string; rank: number; isFirst: boolean; }[]>(({ people }) => [...people.get()]
+    .sort((a, b) => a.rank - b.rank)
+    .map((p) => ({ name: p.name, rank: p.rank, isFirst: p.rank === 1 })), {
     type: "object",
     properties: {
         people: {
@@ -64,12 +66,10 @@ const __cfLift_1 = __cfHelpers.lift<{
         },
         required: ["name", "rank", "isFirst"]
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ people }) => [...people.get()]
-    .sort((a, b) => a.rank - b.rank)
-    .map((p) => ({ name: p.name, rank: p.rank, isFirst: p.rank === 1 })));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     people: __cfHelpers.ReadonlyCell<unknown[]>;
-}, number>({
+}, number>(({ people }) => people.get().length, {
     type: "object",
     properties: {
         people: {
@@ -83,7 +83,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["people"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ people }) => people.get().length);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-map-in-derived-branch
 // Verifies: moving a reactive computation out of a JSX slot forces the whole
 //   branch into derive(), so nested maps run in compute context and stay plain

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-in-ternary-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-in-ternary-branch.expected.jsx
@@ -21,7 +21,9 @@ interface PatternInput {
 }
 const __cfLift_1 = __cfHelpers.lift<{
     people: __cfHelpers.ReadonlyCell<Person[]>;
-}, { name: string; rank: number; isFirst: boolean; }[]>({
+}, { name: string; rank: number; isFirst: boolean; }[]>(({ people }) => [...people.get()]
+    .sort((a, b) => a.rank - b.rank)
+    .map((p) => ({ name: p.name, rank: p.rank, isFirst: p.rank === 1 })), {
     type: "object",
     properties: {
         people: {
@@ -64,12 +66,10 @@ const __cfLift_1 = __cfHelpers.lift<{
         },
         required: ["name", "rank", "isFirst"]
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ people }) => [...people.get()]
-    .sort((a, b) => a.rank - b.rank)
-    .map((p) => ({ name: p.name, rank: p.rank, isFirst: p.rank === 1 })));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     people: __cfHelpers.ReadonlyCell<unknown[]>;
-}, number>({
+}, number>(({ people }) => people.get().length, {
     type: "object",
     properties: {
         people: {
@@ -83,7 +83,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["people"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ people }) => people.get().length);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const person = __cf_pattern_input.key("element");
     return (<span>{person.key("name")}</span>);
@@ -132,7 +132,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     count: number;
-}, string>({
+}, string>(({ count }) => count + " people", {
     type: "object",
     properties: {
         count: {
@@ -142,7 +142,7 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["count"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ count }) => count + " people");
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element");
     return (<li>

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-input-no-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-input-no-captures.expected.jsx
@@ -26,7 +26,7 @@ interface Item {
 }
 const __cfLift_1 = __cfHelpers.lift<{
     items: __cfHelpers.ReadonlyCell<Item[]>;
-}, number>({
+}, number>(({ items }) => items.get().map((item) => item.value).length, {
     type: "object",
     properties: {
         items: {
@@ -54,7 +54,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     }
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ items }) => items.get().map((item) => item.value).length);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-map-input-no-captures
 // Verifies: a computed over a captured cell array uses a plain .map() (not .mapWithPattern)
 //   computed(() => items.get().map(...).length) → lift(...)({ items })

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-local-array-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-local-array-conditional.expected.jsx
@@ -21,7 +21,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         items: Item[];
     };
-}, Item[]>({
+}, Item[]>(({ state }) => state.items, {
     type: "object",
     properties: {
         state: {
@@ -65,10 +65,10 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["done"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     view: string[];
-}, string | undefined>({
+}, string | undefined>(({ view }) => view[0], {
     type: "object",
     properties: {
         view: {
@@ -81,7 +81,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["view"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
-} as const satisfies __cfHelpers.JSONSchema, ({ view }) => view[0]);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     const view = [__cfHelpers.ifElse({

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-local-call-root.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-local-call-root.expected.jsx
@@ -22,7 +22,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         items: Item[];
     };
-}, Item[]>({
+}, Item[]>(({ state }) => state.items, {
     type: "object",
     properties: {
         state: {
@@ -66,12 +66,12 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["done"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     row: {
         done: boolean;
     };
-}, string>({
+}, string>(({ row }) => identity(row.done ? "Done" : "Pending"), {
     type: "object",
     properties: {
         row: {
@@ -87,7 +87,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["row"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ row }) => identity(row.done ? "Done" : "Pending"));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     const label = __cfLift_2({ row: {

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-conditional.expected.jsx
@@ -21,7 +21,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         items: Item[];
     };
-}, Item[]>({
+}, Item[]>(({ state }) => state.items, {
     type: "object",
     properties: {
         state: {
@@ -65,7 +65,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["done"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     const view = { status: __cfHelpers.ifElse({

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-logical-or.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-local-object-logical-or.expected.jsx
@@ -21,7 +21,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         items: Item[];
     };
-}, Item[]>({
+}, Item[]>(({ state }) => state.items, {
     type: "object",
     properties: {
         state: {
@@ -65,7 +65,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["done"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     const view = { status: __cfHelpers.unless({

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-pre-resolved-return-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-pre-resolved-return-conditional.expected.jsx
@@ -23,7 +23,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             done: boolean;
         }[];
     };
-}, { done: boolean; }[]>({
+}, { done: boolean; }[]>(({ state }) => state.items.map((item) => ({ done: item.done })), {
     type: "object",
     properties: {
         state: {
@@ -57,7 +57,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         },
         required: ["done"]
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items.map((item) => ({ done: item.done })));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const row = __cf_pattern_input.key("element");
     return __cfHelpers.ifElse({

--- a/packages/ts-transformers/test/fixtures/closures/computed-map-union-return.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-map-union-return.expected.jsx
@@ -27,7 +27,26 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         messages: Message[];
     };
-}, string | null>({
+}, string | null>(({ state }) => {
+    const messages = state.messages;
+    if (!messages || messages.length === 0)
+        return null;
+    for (let i = messages.length - 1; i >= 0; i--) {
+        const msg = messages[i]!;
+        if (msg.role === "assistant") {
+            // This map call inside the computed callback was the key issue
+            const content = typeof msg.content === "string"
+                ? msg.content
+                : msg.content.map((part) => {
+                    if (part.type === "text")
+                        return part.text || "";
+                    return "";
+                }).join("");
+            return content;
+        }
+    }
+    return null;
+}, {
     type: "object",
     properties: {
         state: {
@@ -86,26 +105,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }, {
             type: "null"
         }]
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => {
-    const messages = state.messages;
-    if (!messages || messages.length === 0)
-        return null;
-    for (let i = messages.length - 1; i >= 0; i--) {
-        const msg = messages[i]!;
-        if (msg.role === "assistant") {
-            // This map call inside the computed callback was the key issue
-            const content = typeof msg.content === "string"
-                ? msg.content
-                : msg.content.map((part) => {
-                    if (part.type === "text")
-                        return part.text || "";
-                    return "";
-                }).join("");
-            return content;
-        }
-    }
-    return null;
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-map-union-return
 // Verifies: a computed returning a union type (string | null) with a nested .map() infers the correct output schema
 //   computed(() => { ...; return content }) → lift(schema, anyOf[string, null])({ messages })

--- a/packages/ts-transformers/test/fixtures/closures/computed-method-call-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-method-call-capture.expected.jsx
@@ -23,7 +23,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             value: number;
         };
     };
-}, number>({
+}, number>(({ value, state }) => value.get() + state.counter.value, {
     type: "object",
     properties: {
         value: {
@@ -49,7 +49,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["value", "state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ value, state }) => value.get() + state.counter.value);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-method-call-capture
 // Verifies: a deep property access on a captured object is restructured into a nested capture object
 //   computed(() => value.get() + state.counter.value) → lift(...)({ value, state: { counter: { value } } })

--- a/packages/ts-transformers/test/fixtures/closures/computed-multiple-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-multiple-captures.expected.jsx
@@ -15,7 +15,10 @@ const __cfLift_1 = __cfHelpers.lift<{
     a: __cfHelpers.ReadonlyCell<number>;
     b: __cfHelpers.ReadonlyCell<number>;
     c: __cfHelpers.ReadonlyCell<number>;
-}, number>({
+}, number>(({ a, b, c }) => {
+    const sum = a.get() + b.get();
+    return sum * c.get();
+}, {
     type: "object",
     properties: {
         a: {
@@ -34,10 +37,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["a", "b", "c"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ a, b, c }) => {
-    const sum = a.get() + b.get();
-    return sum * c.get();
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-multiple-captures
 // Verifies: computed() with a multi-statement body capturing three cells is closure-extracted
 //   computed(() => { const sum = a.get() + b.get(); return sum * c.get() }) → lift(({ a, b, c }) => { ... })({ a, b, c })

--- a/packages/ts-transformers/test/fixtures/closures/computed-nested-callback.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-nested-callback.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     numbers: __cfHelpers.ReadonlyCell<number[]>;
     multiplier: __cfHelpers.ReadonlyCell<number>;
-}, number[]>({
+}, number[]>(({ numbers, multiplier }) => numbers.get().map((n) => n * multiplier.get()), {
     type: "object",
     properties: {
         numbers: {
@@ -35,7 +35,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     items: {
         type: "number"
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ numbers, multiplier }) => numbers.get().map((n) => n * multiplier.get()));
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-nested-callback
 // Verifies: capture extraction works with a nested .map() over a captured cell's array value
 //   computed(() => numbers.get().map(n => n * multiplier.get())) → lift(...)({ numbers, multiplier })

--- a/packages/ts-transformers/test/fixtures/closures/computed-nested-property.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-nested-property.expected.jsx
@@ -13,7 +13,10 @@ const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     counter: __cfHelpers.ReadonlyCell<{ count: number; }>;
-}, number>({
+}, number>(({ counter }) => {
+    const current = counter.get();
+    return current.count * 2;
+}, {
     type: "object",
     properties: {
         counter: {
@@ -30,10 +33,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["counter"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ counter }) => {
-    const current = counter.get();
-    return current.count * 2;
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-nested-property
 // Verifies: computed() capturing a cell with an object value and accessing a nested property
 //   computed(() => { const current = counter.get(); return current.count * 2 }) → lift(({ counter }) => { ... })({ counter })

--- a/packages/ts-transformers/test/fixtures/closures/computed-nested.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-nested.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     a: __cfHelpers.ReadonlyCell<number>;
     b: __cfHelpers.ReadonlyCell<number>;
-}, number>({
+}, number>(({ a, b }) => a.get() + b.get(), {
     type: "object",
     properties: {
         a: {
@@ -29,10 +29,10 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["a", "b"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ a, b }) => a.get() + b.get());
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     sum: number;
-}, number>({
+}, number>(({ sum }) => sum * 2, {
     type: "object",
     properties: {
         sum: {
@@ -42,7 +42,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["sum"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ sum }) => sum * 2);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-nested
 // Verifies: chained computed() calls where the second captures the result of the first
 //   computed(() => a.get() + b.get()) → lift(({ a, b }) => a.get() + b.get())({ a, b })

--- a/packages/ts-transformers/test/fixtures/closures/computed-no-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-no-captures.expected.jsx
@@ -11,7 +11,7 @@ import { computed, pattern } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const __cfLift_1 = __cfHelpers.lift(false, () => 42);
+const __cfLift_1 = __cfHelpers.lift(() => 42, false);
 // FIXTURE: computed-no-captures
 // Verifies: computed(() => expr) with no external captures is transformed to
 // lift(false, fn)() with no input object.

--- a/packages/ts-transformers/test/fixtures/closures/computed-nullable-optional-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-nullable-optional-chain.expected.jsx
@@ -17,15 +17,15 @@ type Question = {
     category: string;
     priority: number;
 };
-const __cfLift_1 = __cfHelpers.lift(false, (): Question | null => {
+const __cfLift_1 = __cfHelpers.lift((): Question | null => {
     // In real code this would filter and return first match, or null
     return null;
-});
+}, false);
 const __cfLift_2 = __cfHelpers.lift<{
     topQuestion: {
         question: string;
     } | null;
-}, string>({
+}, string>(({ topQuestion }) => topQuestion?.question || "", {
     type: "object",
     properties: {
         topQuestion: {
@@ -45,10 +45,10 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["topQuestion"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ topQuestion }) => topQuestion?.question || "");
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     topQuestion: Question | null;
-}, string>({
+}, string>(({ topQuestion }) => topQuestion === null ? "" : topQuestion.question, {
     type: "object",
     properties: {
         topQuestion: {
@@ -79,12 +79,12 @@ const __cfLift_3 = __cfHelpers.lift<{
     }
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ topQuestion }) => topQuestion === null ? "" : topQuestion.question);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_4 = __cfHelpers.lift<{
     topQuestion: {
         category: string;
     } | null;
-}, string>({
+}, string>(({ topQuestion }) => topQuestion?.category || "", {
     type: "object",
     properties: {
         topQuestion: {
@@ -104,10 +104,10 @@ const __cfLift_4 = __cfHelpers.lift<{
     required: ["topQuestion"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ topQuestion }) => topQuestion?.category || "");
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_5 = __cfHelpers.lift<{
     topQuestion: Question | null;
-}, string>({
+}, string>(({ topQuestion }) => topQuestion === null ? "" : topQuestion.category, {
     type: "object",
     properties: {
         topQuestion: {
@@ -138,7 +138,7 @@ const __cfLift_5 = __cfHelpers.lift<{
     }
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ topQuestion }) => topQuestion === null ? "" : topQuestion.category);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-nullable-optional-chain
 // Verifies: computed() capturing a nullable computed result preserves anyOf [type, null] in schema
 //   computed(() => topQuestion?.question || "") → lift(({ topQuestion }) => topQuestion?.question || "")({ topQuestion })

--- a/packages/ts-transformers/test/fixtures/closures/computed-optional-chaining.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-optional-chaining.expected.jsx
@@ -16,7 +16,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     config: __cfHelpers.ReadonlyCell<{
         multiplier?: number;
     } | null>;
-}, number>({
+}, number>(({ value, config }) => value.get() * (config.get()?.multiplier ?? 1), {
     type: "object",
     properties: {
         value: {
@@ -40,7 +40,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["value", "config"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ value, config }) => value.get() * (config.get()?.multiplier ?? 1));
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-optional-chaining
 // Verifies: computed() with optional chaining and nullish coalescing on captured cells
 //   computed(() => value.get() * (config.get()?.multiplier ?? 1)) → lift(({ value, config }) => ...)({ value, config })

--- a/packages/ts-transformers/test/fixtures/closures/computed-pattern-param-mixed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-pattern-param-mixed.expected.jsx
@@ -19,7 +19,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     };
     offset: number;
     threshold: __cfHelpers.ReadonlyCell<number>;
-}, number>({
+}, number>(({ value, config, offset, threshold }) => (value.get() + config.base + offset) * config.multiplier + threshold.get(), {
     type: "object",
     properties: {
         value: {
@@ -49,7 +49,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["value", "config", "offset", "threshold"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ value, config, offset, threshold }) => (value.get() + config.base + offset) * config.multiplier + threshold.get());
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-pattern-param-mixed
 // Verifies: computed() capturing a mix of cells, pattern params, and plain locals
 //   computed(() => (value.get() + config.base + offset) * config.multiplier + threshold.get()) → lift(...)({ value, config: { base, multiplier }, offset, threshold })

--- a/packages/ts-transformers/test/fixtures/closures/computed-pattern-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-pattern-param.expected.jsx
@@ -16,7 +16,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     config: {
         multiplier: number;
     };
-}, number>({
+}, number>(({ value, config }) => value.get() * config.multiplier, {
     type: "object",
     properties: {
         value: {
@@ -36,7 +36,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["value", "config"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ value, config }) => value.get() * config.multiplier);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-pattern-param
 // Verifies: computed() inside a pattern captures the pattern parameter as a structured object
 //   computed(() => value.get() * config.multiplier) → lift(({ value, config }) => ...)({ value, config: { multiplier: config.key("multiplier") } })

--- a/packages/ts-transformers/test/fixtures/closures/computed-pattern-typed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-pattern-typed.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     value: __cfHelpers.ReadonlyCell<number>;
     multiplier: number;
-}, number>({
+}, number>(({ value, multiplier }) => value.get() * multiplier, {
     type: "object",
     properties: {
         value: {
@@ -28,7 +28,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["value", "multiplier"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ value, multiplier }) => value.get() * multiplier);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-pattern-typed
 // Verifies: computed() inside a typed pattern with destructured params is closure-extracted
 //   computed(() => value.get() * multiplier) → lift(({ value, multiplier }) => value.get() * multiplier)({ value, multiplier })

--- a/packages/ts-transformers/test/fixtures/closures/computed-property-access-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-property-access-map.expected.jsx
@@ -26,7 +26,10 @@ const __cfLift_1 = __cfHelpers.lift<{
     items: {
         done: boolean;
     }[];
-}, { tasks: Item[]; view: string; }>({
+}, { tasks: Item[]; view: string; }>(({ items }) => ({
+    tasks: items.filter((i) => !i.done),
+    view: "inbox",
+}), {
     type: "object",
     properties: {
         items: {
@@ -71,17 +74,16 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["name", "done"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ items }) => ({
-    tasks: items.filter((i) => !i.done),
-    view: "inbox",
-}));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     result: {
         tasks: {
             name: string;
         }[];
     };
-}, __cfHelpers.JSXElement[]>({
+}, __cfHelpers.JSXElement[]>(({ result }) => {
+    return result.tasks.map((task) => <li>{task.name}</li>);
+}, {
     type: "object",
     properties: {
         result: {
@@ -130,9 +132,7 @@ const __cfLift_2 = __cfHelpers.lift<{
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ result }) => {
-    return result.tasks.map((task) => <li>{task.name}</li>);
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-property-access-map
 // Verifies: .map() on a property access of a computed result inside another computed() is NOT transformed to .mapWithPattern()
 //   computed(() => result.tasks.map(fn)) → lift(({ result }) => result.tasks.map(fn))({ result: { tasks: result.key("tasks") } })

--- a/packages/ts-transformers/test/fixtures/closures/computed-property-result.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-property-result.expected.jsx
@@ -15,7 +15,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     value: __cfHelpers.ReadonlyCell<number>;
     config: { multiplier: number; divisor: number; };
     key: string;
-}, number>({
+}, number>(({ value, config, key }) => value.get() * config[key], {
     type: "object",
     properties: {
         value: {
@@ -41,7 +41,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["value", "config", "key"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ value, config, key }) => value.get() * config[key]);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-property-result
 // Verifies: computed property access with a dynamic key captures both the object and the key
 //   computed(() => expr) → lift(schema, schema)({ value, config, key })

--- a/packages/ts-transformers/test/fixtures/closures/computed-reserved-names.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-reserved-names.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     value: __cfHelpers.ReadonlyCell<number>;
     __cf_reserved: __cfHelpers.ReadonlyCell<number>;
-}, number>({
+}, number>(({ value, __cf_reserved }) => value.get() * __cf_reserved.get(), {
     type: "object",
     properties: {
         value: {
@@ -29,7 +29,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["value", "__cf_reserved"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ value, __cf_reserved }) => value.get() * __cf_reserved.get());
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-reserved-names
 // Verifies: variables with __cf_ prefixed names are captured without special treatment
 //   computed(() => value.get() * __cf_reserved.get()) → lift(...)({ value, __cf_reserved })

--- a/packages/ts-transformers/test/fixtures/closures/computed-result-in-derive-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-result-in-derive-captures.expected.jsx
@@ -28,7 +28,10 @@ const __cfLift_1 = __cfHelpers.lift<{
             done: boolean;
         }[];
     };
-}, { count: number; total: number; }>({
+}, { count: number; total: number; }>(({ state }) => ({
+    count: state.items.filter((i) => i.done).length,
+    total: state.items.length,
+}), {
     type: "object",
     properties: {
         state: {
@@ -62,16 +65,13 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     },
     required: ["count", "total"]
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => ({
-    count: state.items.filter((i) => i.done).length,
-    total: state.items.length,
-}));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     stats: {
         count: number;
         total: number;
     };
-}, string>({
+}, string>(({ stats }) => `${stats.count} of ${stats.total} done`, {
     type: "object",
     properties: {
         stats: {
@@ -90,7 +90,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["stats"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ stats }) => `${stats.count} of ${stats.total} done`);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-result-in-derive-captures
 // Verifies: computed() result properties captured in a subsequent lift-applied computation use .key() access
 //   computed(() => `${stats.count} of ${stats.total} done`) → lift(({ stats }) => ...)({ stats: { count: stats.key("count"), total: stats.key("total") } })

--- a/packages/ts-transformers/test/fixtures/closures/computed-result-property-in-return.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-result-property-in-return.expected.jsx
@@ -24,7 +24,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         items: string[];
     };
-}, string>({
+}, string>(({ state }) => state.items.join(", "), {
     type: "object",
     properties: {
         state: {
@@ -43,12 +43,12 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items.join(", "));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     summary: {
         length: number;
     };
-}, number>({
+}, number>(({ summary }) => summary.length, {
     type: "object",
     properties: {
         summary: {
@@ -64,7 +64,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["summary"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ summary }) => summary.length);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-result-property-in-return
 // Verifies: .length on a computed() string result is captured via .key("length") in a subsequent lift-applied computation
 //   computed(() => summary.length) → lift(({ summary }) => summary.length)({ summary: { length: summary.key("length") } })

--- a/packages/ts-transformers/test/fixtures/closures/computed-template-literal-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-template-literal-capture.expected.jsx
@@ -13,7 +13,7 @@ const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     token: string;
-}, string>({
+}, string>(({ token }) => `http://api.example.com?token=${token}`, {
     type: "object",
     properties: {
         token: {
@@ -23,10 +23,12 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["token"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ token }) => `http://api.example.com?token=${token}`);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     token: string;
-}, { headers: { Authorization: string; }; }>({
+}, { headers: { Authorization: string; }; }>(({ token }) => ({
+    headers: { Authorization: `Bearer ${token}` },
+}), {
     type: "object",
     properties: {
         token: {
@@ -48,9 +50,7 @@ const __cfLift_2 = __cfHelpers.lift<{
         }
     },
     required: ["headers"]
-} as const satisfies __cfHelpers.JSONSchema, ({ token }) => ({
-    headers: { Authorization: `Bearer ${token}` },
-}));
+} as const satisfies __cfHelpers.JSONSchema);
 // CT-1334: computed() with template literal capturing pattern parameter.
 // The `token` from pattern destructuring must be captured as an explicit
 // input to the lift-applied call, so the callback receives the

--- a/packages/ts-transformers/test/fixtures/closures/computed-template-literal.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-template-literal.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     prefix: __cfHelpers.ReadonlyCell<string>;
     value: __cfHelpers.ReadonlyCell<number>;
-}, string>({
+}, string>(({ prefix, value }) => `${prefix.get()}${value.get()}`, {
     type: "object",
     properties: {
         prefix: {
@@ -29,7 +29,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["prefix", "value"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ prefix, value }) => `${prefix.get()}${value.get()}`);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-template-literal
 // Verifies: captured cells used inside a template literal expression are extracted
 //   computed(() => `${prefix.get()}${value.get()}`) → lift(...)({ value, prefix })

--- a/packages/ts-transformers/test/fixtures/closures/computed-type-assertion.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-type-assertion.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     value: __cfHelpers.ReadonlyCell<number>;
     multiplier: __cfHelpers.ReadonlyCell<number>;
-}, number>({
+}, number>(({ value, multiplier }) => (value.get() * multiplier.get()) as number, {
     type: "object",
     properties: {
         value: {
@@ -29,7 +29,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["value", "multiplier"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ value, multiplier }) => (value.get() * multiplier.get()) as number);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-type-assertion
 // Verifies: a type assertion (`as number`) in the callback body is preserved after capture extraction
 //   computed(() => (value.get() * multiplier.get()) as number) → lift(...)({ value, multiplier })

--- a/packages/ts-transformers/test/fixtures/closures/computed-union-undefined.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-union-undefined.expected.jsx
@@ -21,7 +21,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         required: number;
         unionUndefined?: number | undefined;
     };
-}, number>({
+}, number>(({ value, config }) => value.get() + config.required + (config.unionUndefined ?? 0), {
     type: "object",
     properties: {
         value: {
@@ -44,7 +44,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["value", "config"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ value, config }) => value.get() + config.required + (config.unionUndefined ?? 0));
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-union-undefined
 // Verifies: captured properties with `number | undefined` union types produce correct schemas
 //   computed(() => ...) → lift(...)({ value, config: { required, unionUndefined } })

--- a/packages/ts-transformers/test/fixtures/closures/computed-with-closed-over-cell-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-with-closed-over-cell-map.expected.jsx
@@ -39,7 +39,9 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 const __cfLift_1 = __cfHelpers.lift<{
     numbers: __cfHelpers.ReadonlyCell<number[]>;
     multiplier: __cfHelpers.ReadonlyCell<number>;
-}, number[]>({
+}, number[]>(({ numbers, multiplier }) => numbers.mapWithPattern(__cfPattern_1, {
+    multiplier: multiplier
+}), {
     type: "object",
     properties: {
         numbers: {
@@ -60,9 +62,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     items: {
         type: "number"
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ numbers, multiplier }) => numbers.mapWithPattern(__cfPattern_1, {
-    multiplier: multiplier
-}));
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-with-closed-over-cell-map
 // Verifies: .map() on a closed-over Cell inside computed() IS transformed to .mapWithPattern()
 //   computed(() => numbers.map(n => n * multiplier.get())) → lift(({ numbers, multiplier }) => numbers.mapWithPattern(pattern(fn, ...), { multiplier }))({ numbers, multiplier })

--- a/packages/ts-transformers/test/fixtures/closures/computed-write-capability-materializer.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-write-capability-materializer.expected.jsx
@@ -1,0 +1,129 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { computed, pattern, Writable } from "commonfabric";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+interface Item {
+    title: string;
+}
+const __cfLift_1 = __cfHelpers.lift<{
+    items: __cfHelpers.ReadonlyCell<Item[]>;
+    processed: __cfHelpers.WriteonlyCell<string[]>;
+}, void>(({ processed, items }) => {
+    processed.set(items.get().map((i) => i.title));
+}, {
+    type: "object",
+    properties: {
+        items: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Item"
+            },
+            asCell: ["readonly"]
+        },
+        processed: {
+            type: "array",
+            items: {
+                type: "string"
+            },
+            asCell: ["writeonly"]
+        }
+    },
+    required: ["items", "processed"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                title: {
+                    type: "string"
+                }
+            },
+            required: ["title"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema, {
+    asCell: ["opaque"]
+} as const satisfies __cfHelpers.JSONSchema, { materializerWriteInputPaths: [["processed"]] });
+// FIXTURE: computed-write-capability-materializer
+// Verifies: a computed() that WRITES to a captured cell (`.set(...)`) produces a
+//   write-capability capture, which the lift-applied strategy emits with a
+//   trailing `{ materializerWriteInputPaths: [...] }` options object.
+//   The schema injection must keep function-first order:
+//     lift(cb, argumentSchema, resultSchema, { materializerWriteInputPaths })
+//   i.e. the options object stays LAST, after both schemas — NOT scrambled into
+//   the argumentSchema slot. (CT-1625 regression: the function-first reorder
+//   originally appended schemas after the options, corrupting the call.)
+export default pattern(() => {
+    const items = new Writable<Item[]>([{ title: "a" }], {
+        type: "array",
+        items: {
+            $ref: "#/$defs/Item"
+        },
+        $defs: {
+            Item: {
+                type: "object",
+                properties: {
+                    title: {
+                        type: "string"
+                    }
+                },
+                required: ["title"]
+            }
+        }
+    } as const satisfies __cfHelpers.JSONSchema).for("items", true);
+    const processed = new Writable<string[]>([], {
+        type: "array",
+        items: {
+            type: "string"
+        }
+    } as const satisfies __cfHelpers.JSONSchema).for("processed", true);
+    __cfLift_1({
+        processed: processed,
+        items: items
+    });
+    return { items: items.for(["__patternResult", "items"], true), processed: processed.for(["__patternResult", "processed"], true) };
+}, false as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        items: {
+            type: "array",
+            items: {
+                $ref: "#/$defs/Item"
+            },
+            asCell: ["cell"]
+        },
+        processed: {
+            type: "array",
+            items: {
+                type: "string"
+            },
+            asCell: ["cell"]
+        }
+    },
+    required: ["items", "processed"],
+    $defs: {
+        Item: {
+            type: "object",
+            properties: {
+                title: {
+                    type: "string"
+                }
+            },
+            required: ["title"]
+        }
+    }
+} as const satisfies __cfHelpers.JSONSchema);
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);
+__cfReg({
+    __cfLift_1
+});

--- a/packages/ts-transformers/test/fixtures/closures/computed-write-capability-materializer.input.tsx
+++ b/packages/ts-transformers/test/fixtures/closures/computed-write-capability-materializer.input.tsx
@@ -1,0 +1,25 @@
+import { computed, pattern, Writable } from "commonfabric";
+
+interface Item {
+  title: string;
+}
+
+// FIXTURE: computed-write-capability-materializer
+// Verifies: a computed() that WRITES to a captured cell (`.set(...)`) produces a
+//   write-capability capture, which the lift-applied strategy emits with a
+//   trailing `{ materializerWriteInputPaths: [...] }` options object.
+//   The schema injection must keep function-first order:
+//     lift(cb, argumentSchema, resultSchema, { materializerWriteInputPaths })
+//   i.e. the options object stays LAST, after both schemas — NOT scrambled into
+//   the argumentSchema slot. (CT-1625 regression: the function-first reorder
+//   originally appended schemas after the options, corrupting the call.)
+export default pattern(() => {
+  const items = new Writable<Item[]>([{ title: "a" }]);
+  const processed = new Writable<string[]>([]);
+
+  computed(() => {
+    processed.set(items.get().map((i) => i.title));
+  });
+
+  return { items, processed };
+});

--- a/packages/ts-transformers/test/fixtures/closures/filter-flatmap-plain-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/filter-flatmap-plain-captures.expected.jsx
@@ -16,7 +16,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         label: string;
     };
     suffix: string;
-}, boolean>({
+}, boolean>(({ item, suffix }) => item.label.endsWith(suffix), {
     type: "object",
     properties: {
         item: {
@@ -35,7 +35,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["item", "suffix"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ item, suffix }) => item.label.endsWith(suffix));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const suffix = __cf_pattern_input.params.suffix;
@@ -82,7 +82,7 @@ const __cfLift_2 = __cfHelpers.lift<{
         tags: string[];
     };
     prefix: string;
-}, string[]>({
+}, string[]>(({ item, prefix }) => [prefix + item.tags[0]], {
     type: "object",
     properties: {
         prefix: {
@@ -107,7 +107,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ item, prefix }) => [prefix + item.tags[0]]);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const prefix = __cf_pattern_input.params.prefix;

--- a/packages/ts-transformers/test/fixtures/closures/filter-map-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/filter-map-chain.expected.jsx
@@ -58,7 +58,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         taxRate: number;
     };
-}, number>({
+}, number>(({ item, state }) => item.price * (1 + state.taxRate), {
     type: "object",
     properties: {
         item: {
@@ -83,7 +83,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["item", "state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ item, state }) => item.price * (1 + state.taxRate));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");

--- a/packages/ts-transformers/test/fixtures/closures/ifelse-factory-boundaries.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/ifelse-factory-boundaries.expected.jsx
@@ -11,7 +11,11 @@ import { handler, ifElse, lift, pattern, UI, Writable } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const moduleHasSettings = lift({
+const moduleHasSettings = lift(({ piece }: {
+    piece: {
+        settingsUI?: string;
+    };
+}) => !!piece?.settingsUI, {
     type: "object",
     properties: {
         piece: {
@@ -26,11 +30,7 @@ const moduleHasSettings = lift({
     required: ["piece"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ piece }: {
-    piece: {
-        settingsUI?: string;
-    };
-}) => !!piece?.settingsUI);
+} as const satisfies __cfHelpers.JSONSchema);
 const selectMessage = handler({
     type: "unknown"
 } as const satisfies __cfHelpers.JSONSchema, {
@@ -121,7 +121,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     msg: {
         type: string;
     };
-}, boolean>({
+}, boolean>(({ msg }) => msg.type === "system", {
     type: "object",
     properties: {
         msg: {
@@ -137,7 +137,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["msg"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ msg }) => msg.type === "system");
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const msg = __cf_pattern_input.key("element");
     const selectedId = __cf_pattern_input.key("params", "selectedId");

--- a/packages/ts-transformers/test/fixtures/closures/inline-action-in-ternary-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/inline-action-in-ternary-branch.expected.jsx
@@ -47,7 +47,11 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         isEditing: __cfHelpers.ReadonlyCell<boolean>;
     };
-}, __cfHelpers.JSXElement>({
+}, __cfHelpers.JSXElement>(({ state }) => (<cf-button onClick={__cfHandler_1({
+    state: {
+        isEditing: state.isEditing
+    }
+})}>Edit</cf-button>), {
     type: "object",
     properties: {
         state: {
@@ -82,11 +86,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => (<cf-button onClick={__cfHandler_1({
-    state: {
-        isEditing: state.isEditing
-    }
-})}>Edit</cf-button>));
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: inline-action-in-ternary-branch
 // Verifies: inline arrow handler inside explicit computed() in a ternary branch is extracted and captured in a lift-applied computation
 //   computed(() => <cf-button onClick={() => state.isEditing.set(true)} />) → lift(..., handler(...)(...))({ state: { isEditing: asCell } })

--- a/packages/ts-transformers/test/fixtures/closures/lift-result-type-cf-ref-normalized.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/lift-result-type-cf-ref-normalized.expected.jsx
@@ -13,7 +13,7 @@ const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     count: number;
-}, __cfHelpers.JSXElement>({
+}, __cfHelpers.JSXElement>(({ count }) => <span>{count}</span>, {
     type: "object",
     properties: {
         count: {
@@ -41,7 +41,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ count }) => <span>{count}</span>);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: lift-result-type-cf-ref-normalized
 // Verifies: a synthesized lift's RESULT type argument that is a commonfabric
 // type (here JSXElement, the type of the returned JSX) is emitted as the

--- a/packages/ts-transformers/test/fixtures/closures/map-and-handler.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-and-handler.expected.jsx
@@ -25,7 +25,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         discount: number;
     };
-}, number>({
+}, number>(({ item, state }) => item.price * state.discount, {
     type: "object",
     properties: {
         item: {
@@ -50,7 +50,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["item", "state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ item, state }) => item.price * state.discount);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {
@@ -154,7 +154,7 @@ const __cfLift_2 = __cfHelpers.lift<{
         items: { price: number; }[];
         selectedIndex: __cfHelpers.Cell<number>;
     };
-}, number>({
+}, number>(({ state }) => state.items[state.selectedIndex.get()]?.price ?? 0, {
     type: "object",
     properties: {
         state: {
@@ -183,14 +183,14 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items[state.selectedIndex.get()]?.price ?? 0);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         items: { price: number; }[];
         selectedIndex: __cfHelpers.Cell<number>;
         discount: number;
     };
-}, number>({
+}, number>(({ state }) => (state.items[state.selectedIndex.get()]?.price ?? 0) * state.discount, {
     type: "object",
     properties: {
         state: {
@@ -222,7 +222,7 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => (state.items[state.selectedIndex.get()]?.price ?? 0) * state.discount);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-and-handler
 // Verifies: .map() in JSX is transformed to .mapWithPattern() and inline handler inside map body is extracted
 //   state.items.map((item, index) => JSX) → state.key("items").mapWithPattern(pattern(...), { state: { discount, selectedIndex } })

--- a/packages/ts-transformers/test/fixtures/closures/map-body-destructure-cases.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-body-destructure-cases.expected.jsx
@@ -68,7 +68,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_1 = __cfHelpers.lift<{
     spotPreferences: string[];
-}, boolean>({
+}, boolean>(({ spotPreferences }) => spotPreferences.length > 0, {
     type: "object",
     properties: {
         spotPreferences: {
@@ -81,10 +81,10 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["spotPreferences"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ spotPreferences }) => spotPreferences.length > 0);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     spotPreferences: string[];
-}, string>({
+}, string>(({ spotPreferences }) => spotPreferences.map((n) => "#" + n).join(", "), {
     type: "object",
     properties: {
         spotPreferences: {
@@ -97,7 +97,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["spotPreferences"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ spotPreferences }) => spotPreferences.map((n) => "#" + n).join(", "));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const person = __cf_pattern_input.key("element");
     const name = person.key("name"), spotPreferences = person.key("spotPreferences");

--- a/packages/ts-transformers/test/fixtures/closures/map-callback-schema-params.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-callback-schema-params.expected.jsx
@@ -72,7 +72,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         discount: number;
     };
-}, number>({
+}, number>(({ item, state }) => item.price * state.discount, {
     type: "object",
     properties: {
         item: {
@@ -97,7 +97,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["item", "state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ item, state }) => item.price * state.discount);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");

--- a/packages/ts-transformers/test/fixtures/closures/map-capture-derived-from-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-capture-derived-from-param.expected.jsx
@@ -22,7 +22,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     settings: {
         multiplier: number;
     };
-}, number>({
+}, number>(({ item, settings }) => item * settings.multiplier, {
     type: "object",
     properties: {
         item: {
@@ -41,7 +41,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["item", "settings"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ item, settings }) => item * settings.multiplier);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const settings = __cf_pattern_input.key("params", "settings");

--- a/packages/ts-transformers/test/fixtures/closures/map-cell-receiver-in-lift.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-cell-receiver-in-lift.expected.jsx
@@ -35,12 +35,12 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-export const fn = lift(false as const satisfies __cfHelpers.JSONSchema, {
+export const fn = lift(() => items.mapWithPattern(__cfPattern_1, {}), false as const satisfies __cfHelpers.JSONSchema, {
     type: "array",
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema, () => items.mapWithPattern(__cfPattern_1, {}));
+} as const satisfies __cfHelpers.JSONSchema);
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
 __cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/closures/map-computed-alias-side-effect.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-computed-alias-side-effect.expected.jsx
@@ -22,7 +22,7 @@ interface State {
 const __cfLift_1 = __cfHelpers.lift<{
     element: any;
     __cf_amount_key: any;
-}, number | undefined>({
+}, number | undefined>(({ element, __cf_amount_key }) => element[__cf_amount_key], {
     type: "object",
     properties: {
         element: true,
@@ -31,7 +31,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["element", "__cf_amount_key"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "undefined"]
-} as const satisfies __cfHelpers.JSONSchema, ({ element, __cf_amount_key }) => element[__cf_amount_key]);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const element = __cf_pattern_input.key("element");
     const __cf_amount_key = nextKey();

--- a/packages/ts-transformers/test/fixtures/closures/map-computed-alias-with-plain-binding.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-computed-alias-with-plain-binding.expected.jsx
@@ -25,7 +25,7 @@ interface State {
 const __cfLift_1 = __cfHelpers.lift<{
     element: any;
     __cf_val_key: any;
-}, number>({
+}, number>(({ element, __cf_val_key }) => element[__cf_val_key], {
     type: "object",
     properties: {
         element: true,
@@ -34,11 +34,11 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["element", "__cf_val_key"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ element, __cf_val_key }) => element[__cf_val_key]);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     foo: number;
     val: number;
-}, number>({
+}, number>(({ foo, val }) => foo + val, {
     type: "object",
     properties: {
         foo: {
@@ -51,7 +51,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["foo", "val"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ foo, val }) => foo + val);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const element = __cf_pattern_input.key("element");
     const __cf_val_key = dynamicKey();

--- a/packages/ts-transformers/test/fixtures/closures/map-computed-fallback-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-computed-fallback-alias.expected.jsx
@@ -25,7 +25,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     msg: {
         reactions?: Reaction[] | undefined;
     };
-}, Reaction[]>({
+}, Reaction[]>(({ msg }) => (msg.reactions ?? []) as Reaction[], {
     type: "object",
     properties: {
         msg: {
@@ -68,7 +68,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["emoji"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ msg }) => (msg.reactions ?? []) as Reaction[]);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const reaction = __cf_pattern_input.key("element");
     const msg = __cf_pattern_input.key("params", "msg");

--- a/packages/ts-transformers/test/fixtures/closures/map-conditional-expression.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-conditional-expression.expected.jsx
@@ -27,7 +27,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         threshold: number;
     };
-}, boolean>({
+}, boolean>(({ item, state }) => item.price > state.threshold, {
     type: "object",
     properties: {
         item: {
@@ -52,7 +52,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["item", "state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ item, state }) => item.price > state.threshold);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     item: {
         price: number;
@@ -60,7 +60,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     state: {
         discount: number;
     };
-}, number>({
+}, number>(({ item, state }) => item.price * (1 - state.discount), {
     type: "object",
     properties: {
         item: {
@@ -85,7 +85,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["item", "state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ item, state }) => item.price * (1 - state.discount));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");

--- a/packages/ts-transformers/test/fixtures/closures/map-conditional-inline-handler-send.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-conditional-inline-handler-send.expected.jsx
@@ -63,7 +63,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         votes: VoteEvent[];
     };
-}, __cfHelpers.Stream<unknown>>({
+}, __cfHelpers.Stream<unknown>>(({ castVote, state }) => castVote({ votes: state.votes }).for({ stream: "boundCastVote" }), {
     type: "object",
     properties: {
         castVote: {
@@ -115,7 +115,7 @@ const __cfLift_1 = __cfHelpers.lift<{
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "unknown",
     asCell: ["stream"]
-} as const satisfies __cfHelpers.JSONSchema, ({ castVote, state }) => castVote({ votes: state.votes }).for({ stream: "boundCastVote" }));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/closures/map-destructured-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-destructured-alias.expected.jsx
@@ -22,7 +22,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         discount: number;
     };
-}, number>({
+}, number>(({ cost, state }) => cost * state.discount, {
     type: "object",
     properties: {
         cost: {
@@ -41,7 +41,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["cost", "state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ cost, state }) => cost * state.discount);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const cost = __cf_pattern_input.key("element", "price");
     const state = __cf_pattern_input.key("params", "state");

--- a/packages/ts-transformers/test/fixtures/closures/map-destructured-computed-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-destructured-computed-alias.expected.jsx
@@ -22,7 +22,7 @@ interface State {
 const __cfLift_1 = __cfHelpers.lift<{
     element: any;
     __cf_val_key: any;
-}, number>({
+}, number>(({ element, __cf_val_key }) => element[__cf_val_key], {
     type: "object",
     properties: {
         element: true,
@@ -31,7 +31,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["element", "__cf_val_key"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ element, __cf_val_key }) => element[__cf_val_key]);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const element = __cf_pattern_input.key("element");
     const __cf_val_key = dynamicKey;

--- a/packages/ts-transformers/test/fixtures/closures/map-destructured-param.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-destructured-param.expected.jsx
@@ -24,7 +24,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         scale: number;
     };
-}, number>({
+}, number>(({ x, state }) => x * state.scale, {
     type: "object",
     properties: {
         x: {
@@ -43,13 +43,13 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["x", "state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ x, state }) => x * state.scale);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     y: number;
     state: {
         scale: number;
     };
-}, number>({
+}, number>(({ y, state }) => y * state.scale, {
     type: "object",
     properties: {
         y: {
@@ -68,7 +68,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["y", "state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ y, state }) => y * state.scale);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const x = __cf_pattern_input.key("element", "x");
     const y = __cf_pattern_input.key("element", "y");

--- a/packages/ts-transformers/test/fixtures/closures/map-element-access-opaque.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-element-access-opaque.expected.jsx
@@ -20,7 +20,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         tagCounts: Record<string, number>;
     };
     tag: string;
-}, number | undefined>({
+}, number | undefined>(({ state, tag }) => state.tagCounts[tag], {
     type: "object",
     properties: {
         state: {
@@ -43,7 +43,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state", "tag"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "undefined"]
-} as const satisfies __cfHelpers.JSONSchema, ({ state, tag }) => state.tagCounts[tag]);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const tag = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");

--- a/packages/ts-transformers/test/fixtures/closures/map-element-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-element-computed.expected.jsx
@@ -23,7 +23,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     item: {
         name: string;
     };
-}, string>({
+}, string>(({ item }) => item.name.toUpperCase(), {
     type: "object",
     properties: {
         item: {
@@ -39,7 +39,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["item"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ item }) => item.name.toUpperCase());
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const index = __cf_pattern_input.key("index");

--- a/packages/ts-transformers/test/fixtures/closures/map-import-reference.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-import-reference.expected.jsx
@@ -29,7 +29,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     item: {
         price: number;
     };
-}, string>({
+}, string>(({ item }) => formatPrice(item.price * (1 + TAX_RATE)), {
     type: "object",
     properties: {
         item: {
@@ -45,7 +45,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["item"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ item }) => formatPrice(item.price * (1 + TAX_RATE)));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return (<div>

--- a/packages/ts-transformers/test/fixtures/closures/map-index-param-used.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-index-param-used.expected.jsx
@@ -24,7 +24,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         offset: number;
     };
-}, number>({
+}, number>(({ index, state }) => index + state.offset, {
     type: "object",
     properties: {
         index: {
@@ -43,7 +43,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["index", "state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ index, state }) => index + state.offset);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const index = __cf_pattern_input.key("index");

--- a/packages/ts-transformers/test/fixtures/closures/map-local-helper-call-root.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-local-helper-call-root.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 const identity = __cfHardenFn(<T,>(value: T) => value);
 const __cfLift_1 = __cfHelpers.lift<{
     item: string;
-}, string>({
+}, string>(({ item }) => identity(item.toUpperCase()), {
     type: "object",
     properties: {
         item: {
@@ -24,7 +24,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["item"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ item }) => identity(item.toUpperCase()));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return __cfLift_1({ item: item }).for("__patternResult", true);

--- a/packages/ts-transformers/test/fixtures/closures/map-multiple-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-multiple-captures.expected.jsx
@@ -31,7 +31,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         taxRate: number;
     };
     multiplier: number;
-}, number>({
+}, number>(({ item, state, multiplier }) => item.price * item.quantity * state.discount * state.taxRate * multiplier + shippingCost, {
     type: "object",
     properties: {
         item: {
@@ -65,7 +65,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["item", "state", "multiplier"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ item, state, multiplier }) => item.price * item.quantity * state.discount * state.taxRate * multiplier + shippingCost);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");

--- a/packages/ts-transformers/test/fixtures/closures/map-multiple-similar-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-multiple-similar-captures.expected.jsx
@@ -34,7 +34,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             discount: number;
         };
     };
-}, number>({
+}, number>(({ item, state }) => item.price * state.checkout.discount * state.upsell.discount, {
     type: "object",
     properties: {
         item: {
@@ -74,7 +74,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["item", "state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ item, state }) => item.price * state.checkout.discount * state.upsell.discount);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");

--- a/packages/ts-transformers/test/fixtures/closures/map-parking-style-join.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-parking-style-join.expected.jsx
@@ -37,7 +37,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         editingPersonName: string | null;
     };
     personName: string;
-}, boolean>({
+}, boolean>(({ state, personName }) => state.editingPersonName === personName, {
     type: "object",
     properties: {
         state: {
@@ -60,13 +60,13 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state", "personName"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state, personName }) => state.editingPersonName === personName);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         removePersonConfirmTarget: string | null;
     };
     personName: string;
-}, boolean>({
+}, boolean>(({ state, personName }) => state.removePersonConfirmTarget === personName, {
     type: "object",
     properties: {
         state: {
@@ -89,7 +89,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["state", "personName"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state, personName }) => state.removePersonConfirmTarget === personName);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         spots: {
@@ -98,7 +98,12 @@ const __cfLift_3 = __cfHelpers.lift<{
             active: boolean;
         }[];
     };
-}, { label: string; value: string; }[]>({
+}, { label: string; value: string; }[]>(({ state }) => state.spots
+    .filter((s) => s.active)
+    .map((s) => ({
+    label: "#" + s.spotNumber + (s.label ? " - " + s.label : ""),
+    value: s.spotNumber,
+})), {
     type: "object",
     properties: {
         state: {
@@ -141,17 +146,12 @@ const __cfLift_3 = __cfHelpers.lift<{
         },
         required: ["label", "value"]
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.spots
-    .filter((s) => s.active)
-    .map((s) => ({
-    label: "#" + s.spotNumber + (s.label ? " - " + s.label : ""),
-    value: s.spotNumber,
-})));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_4 = __cfHelpers.lift<{
     activeSpotOpts: {
         length: number;
     };
-}, boolean>({
+}, boolean>(({ activeSpotOpts }) => activeSpotOpts.length > 0, {
     type: "object",
     properties: {
         activeSpotOpts: {
@@ -167,10 +167,10 @@ const __cfLift_4 = __cfHelpers.lift<{
     required: ["activeSpotOpts"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ activeSpotOpts }) => activeSpotOpts.length > 0);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_5 = __cfHelpers.lift<{
     spotPreferences: string[];
-}, boolean>({
+}, boolean>(({ spotPreferences }) => spotPreferences.length > 0, {
     type: "object",
     properties: {
         spotPreferences: {
@@ -183,10 +183,10 @@ const __cfLift_5 = __cfHelpers.lift<{
     required: ["spotPreferences"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ spotPreferences }) => spotPreferences.length > 0);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_6 = __cfHelpers.lift<{
     spotPreferences: string[];
-}, string>({
+}, string>(({ spotPreferences }) => spotPreferences.map((n) => "#" + n).join(", "), {
     type: "object",
     properties: {
         spotPreferences: {
@@ -199,7 +199,7 @@ const __cfLift_6 = __cfHelpers.lift<{
     required: ["spotPreferences"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ spotPreferences }) => spotPreferences.map((n) => "#" + n).join(", "));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const person = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");

--- a/packages/ts-transformers/test/fixtures/closures/map-plain-array-no-transform.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-plain-array-no-transform.expected.jsx
@@ -19,7 +19,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         multiplier: number;
     };
     n: number;
-}, number>({
+}, number>(({ state, n }) => n * state.multiplier, {
     type: "object",
     properties: {
         n: {
@@ -38,7 +38,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["n", "state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state, n }) => n * state.multiplier);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-plain-array-no-transform
 // Verifies: .map() on a plain (non-reactive) array is NOT transformed to mapWithPattern
 //   plainArray.map(fn) → plainArray.map(fn) (unchanged)

--- a/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-alias-in-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-alias-in-computed.expected.jsx
@@ -30,7 +30,12 @@ const __cfLift_1 = __cfHelpers.lift<{
         name: string;
     };
     todayDate: string;
-}, boolean>({
+}, boolean>(({ logs, habit, todayDate }) => {
+    const logList = logs.get();
+    return logList.some((log) => log.habitName === habit.name &&
+        log.date === todayDate &&
+        log.completed);
+}, {
     type: "object",
     properties: {
         logs: {
@@ -73,12 +78,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     }
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ logs, habit, todayDate }) => {
-    const logList = logs.get();
-    return logList.some((log) => log.habitName === habit.name &&
-        log.date === todayDate &&
-        log.completed);
-});
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const habit = __cf_pattern_input.key("element");
     const logs = __cf_pattern_input.key("params", "logs");

--- a/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-in-computed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-plain-array-some-in-computed.expected.jsx
@@ -30,7 +30,9 @@ const __cfLift_1 = __cfHelpers.lift<{
         name: string;
     };
     todayDate: string;
-}, boolean>({
+}, boolean>(({ logs, habit, todayDate }) => logs.get().some((log) => log.habitName === habit.name &&
+    log.date === todayDate &&
+    log.completed), {
     type: "object",
     properties: {
         logs: {
@@ -73,9 +75,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     }
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ logs, habit, todayDate }) => logs.get().some((log) => log.habitName === habit.name &&
-    log.date === todayDate &&
-    log.completed));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const habit = __cf_pattern_input.key("element");
     const logs = __cf_pattern_input.key("params", "logs");

--- a/packages/ts-transformers/test/fixtures/closures/map-receiver-method-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-receiver-method-roots.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 const identity = __cfHardenFn(<T,>(value: T) => value);
 const __cfLift_1 = __cfHelpers.lift<{
     item: string;
-}, string>({
+}, string>(({ item }) => item.toUpperCase(), {
     type: "object",
     properties: {
         item: {
@@ -24,7 +24,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["item"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ item }) => item.toUpperCase());
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return <span>{__cfLift_1({ item: item })}</span>;
@@ -59,7 +59,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     item: string;
-}, string>({
+}, string>(({ item }) => identity(item.toUpperCase()), {
     type: "object",
     properties: {
         item: {
@@ -69,7 +69,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["item"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ item }) => identity(item.toUpperCase()));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return <span>{__cfLift_2({ item: item })}</span>;

--- a/packages/ts-transformers/test/fixtures/closures/map-regains-reactive-aliases.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-regains-reactive-aliases.expected.jsx
@@ -11,7 +11,7 @@ import { Default, computed, lift, pattern, wish } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const passthrough = lift({
+const passthrough = lift((items: string[]) => items, {
     type: "array",
     items: {
         type: "string"
@@ -21,12 +21,12 @@ const passthrough = lift({
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema, (items: string[]) => items);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         items: string[];
     };
-}, string[]>({
+}, string[]>(({ state }) => state.items, {
     type: "object",
     properties: {
         state: {
@@ -48,10 +48,10 @@ const __cfLift_1 = __cfHelpers.lift<{
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     inner: string[];
-}, string[]>({
+}, string[]>(({ inner }) => inner, {
     type: "object",
     properties: {
         inner: {
@@ -67,7 +67,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ inner }) => inner);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return item + "!";
@@ -84,7 +84,10 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     inner: string[];
-}, string[]>({
+}, string[]>(({ inner }) => {
+    const foo = __cfLift_2({ inner: inner }).for("foo", true);
+    return foo.mapWithPattern(__cfPattern_1, {});
+}, {
     type: "object",
     properties: {
         inner: {
@@ -100,10 +103,7 @@ const __cfLift_3 = __cfHelpers.lift<{
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ inner }) => {
-    const foo = __cfLift_2({ inner: inner }).for("foo", true);
-    return foo.mapWithPattern(__cfPattern_1, {});
-});
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return item + "!";
@@ -120,7 +120,10 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_4 = __cfHelpers.lift<{
     inner: string[];
-}, string[]>({
+}, string[]>(({ inner }) => {
+    const foo = passthrough(inner).for("foo", true);
+    return foo.mapWithPattern(__cfPattern_2, {});
+}, {
     type: "object",
     properties: {
         inner: {
@@ -136,10 +139,7 @@ const __cfLift_4 = __cfHelpers.lift<{
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ inner }) => {
-    const foo = passthrough(inner).for("foo", true);
-    return foo.mapWithPattern(__cfPattern_2, {});
-});
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return item + "!";
@@ -154,7 +154,7 @@ const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const __cfLift_5 = __cfHelpers.lift(false, () => {
+const __cfLift_5 = __cfHelpers.lift(() => {
     const foo = wish<Default<string[], [
     ]>>({ query: "#items" }, {
         type: "array",
@@ -164,10 +164,10 @@ const __cfLift_5 = __cfHelpers.lift(false, () => {
         "default": []
     } as const satisfies __cfHelpers.JSONSchema).result!;
     return foo.mapWithPattern(__cfPattern_3, {});
-});
+}, false);
 const __cfLift_6 = __cfHelpers.lift<{
     inner: string[];
-}, string[]>({
+}, string[]>(({ inner }) => inner, {
     type: "object",
     properties: {
         inner: {
@@ -183,7 +183,7 @@ const __cfLift_6 = __cfHelpers.lift<{
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ inner }) => inner);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return item.key("length") > 1;
@@ -214,30 +214,11 @@ const __cfPattern_5 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_7 = __cfHelpers.lift<{
     inner: string[];
-}, string[]>({
-    type: "object",
-    properties: {
-        inner: {
-            type: "array",
-            items: {
-                type: "string"
-            }
-        }
-    },
-    required: ["inner"]
-} as const satisfies __cfHelpers.JSONSchema, {
-    type: "array",
-    items: {
-        type: "string"
-    }
-} as const satisfies __cfHelpers.JSONSchema, ({ inner }) => {
+}, string[]>(({ inner }) => {
     const foo = __cfLift_6({ inner: inner }).for("foo", true);
     const filtered = foo.filterWithPattern(__cfPattern_4, {}).for("filtered", true);
     return filtered.mapWithPattern(__cfPattern_5, {});
-});
-const __cfLift_8 = __cfHelpers.lift<{
-    inner: string[];
-}, string[]>({
+}, {
     type: "object",
     properties: {
         inner: {
@@ -253,7 +234,26 @@ const __cfLift_8 = __cfHelpers.lift<{
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ inner }) => inner);
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_8 = __cfHelpers.lift<{
+    inner: string[];
+}, string[]>(({ inner }) => inner, {
+    type: "object",
+    properties: {
+        inner: {
+            type: "array",
+            items: {
+                type: "string"
+            }
+        }
+    },
+    required: ["inner"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "array",
+    items: {
+        type: "string"
+    }
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_6 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return item.key("length") > 1;
@@ -270,7 +270,7 @@ const __cfPattern_6 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_9 = __cfHelpers.lift<{
     item: string;
-}, string>({
+}, string>(({ item }) => item.toUpperCase(), {
     type: "object",
     properties: {
         item: {
@@ -280,7 +280,7 @@ const __cfLift_9 = __cfHelpers.lift<{
     required: ["item"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ item }) => item.toUpperCase());
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_7 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return __cfLift_9({ item: item }).for("__patternResult", true);
@@ -297,7 +297,11 @@ const __cfPattern_7 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_10 = __cfHelpers.lift<{
     inner: string[];
-}, string[]>({
+}, string[]>(({ inner }) => {
+    const foo = __cfLift_8({ inner: inner }).for("foo", true);
+    const filtered = foo.filterWithPattern(__cfPattern_6, {}).for("filtered", true);
+    return filtered.mapWithPattern(__cfPattern_7, {});
+}, {
     type: "object",
     properties: {
         inner: {
@@ -313,11 +317,7 @@ const __cfLift_10 = __cfHelpers.lift<{
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ inner }) => {
-    const foo = __cfLift_8({ inner: inner }).for("foo", true);
-    const filtered = foo.filterWithPattern(__cfPattern_6, {}).for("filtered", true);
-    return filtered.mapWithPattern(__cfPattern_7, {});
-});
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: map-regains-reactive-aliases
 // Verifies: compute-owned aliases that still resolve to reactive array roots
 // are rewritten back to mapWithPattern/filterWithPattern when used in pattern

--- a/packages/ts-transformers/test/fixtures/closures/map-root-fallback-wrappers.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-root-fallback-wrappers.expected.jsx
@@ -16,7 +16,7 @@ interface Item {
 }
 const __cfLift_1 = __cfHelpers.lift<{
     items?: Item[] | undefined;
-}, Item[]>({
+}, Item[]>(({ items }) => items ?? [], {
     type: "object",
     properties: {
         items: {
@@ -53,7 +53,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["id"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ items }) => items ?? []);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return <span data-inline-id={item.key("id")}>{item.key("id")}</span>;
@@ -99,7 +99,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     items?: Item[] | undefined;
-}, Item[]>({
+}, Item[]>(({ items }) => (items as Item[] | undefined) ?? [], {
     type: "object",
     properties: {
         items: {
@@ -136,7 +136,7 @@ const __cfLift_2 = __cfHelpers.lift<{
             required: ["id"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ items }) => (items as Item[] | undefined) ?? []);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return (<span data-cast-id={item.key("id")}>{item.key("id")}</span>);
@@ -182,7 +182,7 @@ const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     items?: Item[] | undefined;
-}, Item[]>({
+}, Item[]>(({ items }) => (items satisfies Item[] | undefined) ?? [], {
     type: "object",
     properties: {
         items: {
@@ -219,7 +219,7 @@ const __cfLift_3 = __cfHelpers.lift<{
             required: ["id"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ items }) => (items satisfies Item[] | undefined) ?? []);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return (<span data-satisfies-id={item.key("id")}>{item.key("id")}</span>);

--- a/packages/ts-transformers/test/fixtures/closures/map-single-capture-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-single-capture-no-name.expected.jsx
@@ -24,7 +24,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         discount: number;
     };
-}, number>({
+}, number>(({ item, state }) => item.price * state.discount, {
     type: "object",
     properties: {
         item: {
@@ -49,7 +49,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["item", "state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ item, state }) => item.price * state.discount);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");

--- a/packages/ts-transformers/test/fixtures/closures/map-single-capture-with-type-arg-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-single-capture-with-type-arg-no-name.expected.jsx
@@ -24,7 +24,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         discount: number;
     };
-}, number>({
+}, number>(({ item, state }) => item.price * state.discount, {
     type: "object",
     properties: {
         item: {
@@ -49,7 +49,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["item", "state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ item, state }) => item.price * state.discount);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");

--- a/packages/ts-transformers/test/fixtures/closures/map-single-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-single-capture.expected.jsx
@@ -24,7 +24,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         discount: number;
     };
-}, number>({
+}, number>(({ item, state }) => item.price * state.discount, {
     type: "object",
     properties: {
         item: {
@@ -49,7 +49,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["item", "state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ item, state }) => item.price * state.discount);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");

--- a/packages/ts-transformers/test/fixtures/closures/map-template-literal.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-template-literal.expected.jsx
@@ -28,7 +28,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     item: {
         name: string;
     };
-}, string>({
+}, string>(({ state, item }) => `${state.prefix} ${item.name} ${state.suffix}`, {
     type: "object",
     properties: {
         state: {
@@ -56,7 +56,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state", "item"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state, item }) => `${state.prefix} ${item.name} ${state.suffix}`);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");

--- a/packages/ts-transformers/test/fixtures/closures/map-ternary-inside-nested-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/map-ternary-inside-nested-map.expected.jsx
@@ -36,7 +36,7 @@ interface PatternInput {
 }
 const __cfLift_1 = __cfHelpers.lift<{
     items: __cfHelpers.ReadonlyCell<unknown[]>;
-}, boolean>({
+}, boolean>(({ items }) => items.get().length > 0, {
     type: "object",
     properties: {
         items: {
@@ -50,14 +50,14 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["items"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ items }) => items.get().length > 0);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     item: {
         tags: {
             length: number;
         };
     };
-}, boolean>({
+}, boolean>(({ item }) => item.tags.length > 0, {
     type: "object",
     properties: {
         item: {
@@ -79,7 +79,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["item"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ item }) => item.tags.length > 0);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const tag = __cf_pattern_input.key("element");
     const showInactive = __cf_pattern_input.key("params", "showInactive");

--- a/packages/ts-transformers/test/fixtures/closures/nested-computed-in-ifelse.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/nested-computed-in-ifelse.expected.jsx
@@ -24,30 +24,10 @@ const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     secondToggle: __cfHelpers.ReadonlyCell<boolean>;
-}, { background: string; }>({
-    type: "object",
-    properties: {
-        secondToggle: {
-            type: "boolean",
-            asCell: ["readonly"]
-        }
-    },
-    required: ["secondToggle"]
-} as const satisfies __cfHelpers.JSONSchema, {
-    type: "object",
-    properties: {
-        background: {
-            type: "string"
-        }
-    },
-    required: ["background"]
-} as const satisfies __cfHelpers.JSONSchema, ({ secondToggle }) => {
+}, { background: string; }>(({ secondToggle }) => {
     const val = secondToggle.get();
     return { background: val ? "green" : "red" };
-});
-const __cfLift_2 = __cfHelpers.lift<{
-    secondToggle: __cfHelpers.ReadonlyCell<boolean>;
-}, { background: string; }>({
+}, {
     type: "object",
     properties: {
         secondToggle: {
@@ -64,11 +44,31 @@ const __cfLift_2 = __cfHelpers.lift<{
         }
     },
     required: ["background"]
-} as const satisfies __cfHelpers.JSONSchema, ({ secondToggle }) => {
+} as const satisfies __cfHelpers.JSONSchema);
+const __cfLift_2 = __cfHelpers.lift<{
+    secondToggle: __cfHelpers.ReadonlyCell<boolean>;
+}, { background: string; }>(({ secondToggle }) => {
     // This .get() should NOT be wrapped in an extra lift-applied computation
     const val = secondToggle.get();
     return { background: val ? "green" : "red" };
-});
+}, {
+    type: "object",
+    properties: {
+        secondToggle: {
+            type: "boolean",
+            asCell: ["readonly"]
+        }
+    },
+    required: ["secondToggle"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        background: {
+            type: "string"
+        }
+    },
+    required: ["background"]
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: nested-computed-in-ifelse
 // Verifies: computed() inside ifElse branches transforms to the lift-applied form without double-wrapping .get()
 //   computed(() => { secondToggle.get(); ... }) → lift(({ secondToggle }) => { secondToggle.get(); ... })({ secondToggle })

--- a/packages/ts-transformers/test/fixtures/closures/nested-map-fallback-receiver.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/nested-map-fallback-receiver.expected.jsx
@@ -44,7 +44,7 @@ const __cfHandler_1 = __cfHelpers.handler({
 } as const satisfies __cfHelpers.JSONSchema, (p, { assignName }) => assignName.set(p.name));
 const __cfLift_1 = __cfHelpers.lift<{
     people: __cfHelpers.PerSpace<__cfHelpers.Cell<Person[]>>;
-}, readonly Person[]>({
+}, readonly Person[]>(({ people }) => people.get(), {
     type: "object",
     properties: {
         people: {
@@ -86,7 +86,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["name"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ people }) => people.get());
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/closures/pattern-computed-opaque-ref-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-computed-opaque-ref-map.expected.jsx
@@ -13,7 +13,7 @@ const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     items: number[] & {} & { [SELF]: OpaqueRef<any>; };
-}, number[]>({
+}, number[]>(({ items }) => items.map((n) => n * 2), {
     type: "object",
     properties: {
         items: {
@@ -29,7 +29,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     items: {
         type: "number"
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ items }) => items.map((n) => n * 2));
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: pattern-computed-opaque-ref-map
 // Verifies: .map() on an OpaqueRef inside computed() is NOT transformed to mapWithPattern
 //   computed(() => items.map((n) => n * 2)) → lift(({ items }) => items.map((n) => n * 2))({ items })

--- a/packages/ts-transformers/test/fixtures/closures/pattern-nested-jsx-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-nested-jsx-map.expected.jsx
@@ -36,7 +36,7 @@ interface PatternInput {
 }
 const __cfLift_1 = __cfHelpers.lift<{
     items: __cfHelpers.ReadonlyCell<unknown[]>;
-}, boolean>({
+}, boolean>(({ items }) => items.get().length > 0, {
     type: "object",
     properties: {
         items: {
@@ -50,13 +50,13 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["items"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ items }) => items.get().length > 0);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     i: number;
     item: {
         selectedIndex: number;
     };
-}, boolean>({
+}, boolean>(({ i, item }) => i === item.selectedIndex, {
     type: "object",
     properties: {
         i: {
@@ -75,7 +75,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["i", "item"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ i, item }) => i === item.selectedIndex);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const tag = __cf_pattern_input.key("element");
     const i = __cf_pattern_input.key("index");

--- a/packages/ts-transformers/test/fixtures/closures/pattern-opaque-destructure-temporary-root-names.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-opaque-destructure-temporary-root-names.expected.jsx
@@ -13,7 +13,7 @@ const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     messages: string[];
-}, string>({
+}, string>(({ messages }) => messages[0] ?? "", {
     type: "object",
     properties: {
         messages: {
@@ -26,16 +26,16 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["messages"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ messages }) => messages[0] ?? "");
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     result: any;
-}, any>({
+}, any>(({ result }) => result?.title ?? "Untitled", {
     type: "object",
     properties: {
         result: true
     },
     required: ["result"]
-} as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema, ({ result }) => result?.title ?? "Untitled");
+} as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: pattern-opaque-destructure-temporary-root-names
 // Verifies: destructured opaque temporaries preserve generated root suffixes
 //   const { result } = generateObject(...) uses the synthesized __cf_destructure_* binding consistently

--- a/packages/ts-transformers/test/fixtures/closures/pattern-preserve-opaque-input.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/pattern-preserve-opaque-input.expected.jsx
@@ -17,7 +17,7 @@ interface State {
 }
 const __cfLift_1 = __cfHelpers.lift<{
     input: __cfHelpers.Writable<State>;
-}, string>({
+}, string>(({ input }) => input.key("foo").get(), {
     type: "object",
     properties: {
         input: {
@@ -42,7 +42,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     }
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ input }) => input.key("foo").get());
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: pattern-preserve-opaque-input
 // Verifies: Writable<T> pattern input is preserved as an opaque ref, with JSX .get() wrapped in a lift-applied computation
 //   input.key("foo").get() in JSX → lift(({ input }) => input.key("foo").get())({ input })

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-basic-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-basic-capture.expected.jsx
@@ -22,7 +22,9 @@ type Output = {
 const __cfLift_1 = __cfHelpers.lift<{
     query: string;
     content: string;
-}, string[]>({
+}, string[]>(({ content, query }) => {
+    return content.split("\n").filter((c: string) => c.includes(query));
+}, {
     type: "object",
     properties: {
         query: {
@@ -38,9 +40,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ content, query }) => {
-    return content.split("\n").filter((c: string) => c.includes(query));
-});
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = pattern((__cf_pattern_input: {
     query: string;
     content: string;

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-local-var.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-local-var.expected.jsx
@@ -21,7 +21,7 @@ type Output = {
 };
 const __cfLift_1 = __cfHelpers.lift<{
     language: string;
-}, string>({
+}, string>(({ language }) => `Translate to ${language}.`, {
     type: "object",
     properties: {
         language: {
@@ -31,10 +31,10 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["language"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ language }) => `Translate to ${language}.`);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     content: string;
-}, string>({
+}, string>(({ content }) => content, {
     type: "object",
     properties: {
         content: {
@@ -44,13 +44,17 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["content"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ content }) => content);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     genResult: {
         pending: boolean;
         result?: string | undefined;
     };
-}, string | undefined>({
+}, string | undefined>(({ genResult }) => {
+    if (genResult.pending)
+        return undefined;
+    return genResult.result;
+}, {
     type: "object",
     properties: {
         genResult: {
@@ -69,11 +73,7 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["genResult"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
-} as const satisfies __cfHelpers.JSONSchema, ({ genResult }) => {
-    if (genResult.pending)
-        return undefined;
-    return genResult.result;
-});
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = pattern((__cf_pattern_input: {
     language: string;
     content: string;

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-multiple-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-multiple-captures.expected.jsx
@@ -22,7 +22,9 @@ type Output = {
 };
 const __cfLift_1 = __cfHelpers.lift<{
     value: number;
-}, string>({
+}, string>(({ value }) => {
+    return prefix.get() + String(value * multiplier.get());
+}, {
     type: "object",
     properties: {
         value: {
@@ -32,9 +34,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["value"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ value }) => {
-    return prefix.get() + String(value * multiplier.get());
-});
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = pattern((__cf_pattern_input: {
     value: number;
 }) => {

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-no-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-no-captures.expected.jsx
@@ -17,7 +17,9 @@ type Output = {
 const __cfLift_1 = __cfHelpers.lift<{
     query: string;
     content: string;
-}, string[]>({
+}, string[]>(({ content, query }) => {
+    return content.split("\n").filter((c: string) => c.includes(query));
+}, {
     type: "object",
     properties: {
         query: {
@@ -33,9 +35,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ content, query }) => {
-    return content.split("\n").filter((c: string) => c.includes(query));
-});
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = pattern((__cf_pattern_input: {
     query: string;
     content: string;

--- a/packages/ts-transformers/test/fixtures/closures/patternTool-with-existing-params.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/patternTool-with-existing-params.expected.jsx
@@ -25,7 +25,9 @@ type Output = {
 const __cfLift_1 = __cfHelpers.lift<{
     value: number;
     offset: number;
-}, number>({
+}, number>(({ value, offset }) => {
+    return value * multiplier.get() + offset;
+}, {
     type: "object",
     properties: {
         value: {
@@ -38,9 +40,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["value", "offset"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ value, offset }) => {
-    return value * multiplier.get() + offset;
-});
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = pattern((__cf_pattern_input: {
     value: number;
     offset: number;

--- a/packages/ts-transformers/test/fixtures/closures/readonly-capture-named-alias-nested-cell.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/closures/readonly-capture-named-alias-nested-cell.expected.jsx
@@ -28,7 +28,7 @@ type EntriesValue = Entry[] | Default<[
 const firstName = __cfHardenFn((entries: Cell<EntriesValue>): string => (entries.get() ?? [])[0]?.profile.get().name ?? "");
 const __cfLift_1 = __cfHelpers.lift<{
     entries: __cfHelpers.ReadonlyCell<EntriesValue>;
-}, string>({
+}, string>(({ entries }) => firstName(entries), {
     type: "object",
     properties: {
         entries: {
@@ -64,7 +64,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     }
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ entries }) => firstName(entries));
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: readonly-capture-named-alias-nested-cell
 // Verifies (BEHAVIOR LOCK): a by-reference, read-only-used capture of a bare
 //   `Cell<EntriesValue>` (EntriesValue = Entry[] | Default<[]>, Entry has a

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/authored-ifelse-jsx-branches.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/authored-ifelse-jsx-branches.expected.jsx
@@ -16,7 +16,7 @@ interface Item {
 }
 const __cfLift_1 = __cfHelpers.lift<{
     limit: number;
-}, boolean>({
+}, boolean>(({ limit }) => limit > 0, {
     type: "object",
     properties: {
         limit: {
@@ -26,7 +26,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["limit"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ limit }) => limit > 0);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return <span>{item.key("name")}</span>;
@@ -72,7 +72,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     count: __cfHelpers.ReadonlyCell<number>;
-}, number>({
+}, number>(({ count }) => count.get(), {
     type: "object",
     properties: {
         count: {
@@ -83,7 +83,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["count"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ count }) => count.get());
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: authored-ifelse-jsx-branches
 // Verifies: authored ifElse in JSX lowers both conditions and reactive branches correctly
 //   ifElse(limit > 0, items.map(...), <span>Hidden</span>) → derived condition + pattern-lowered map branch

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/cell-get-in-ifelse-predicate.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/cell-get-in-ifelse-predicate.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     messageCount: number;
     dismissedIndex: __cfHelpers.ReadonlyCell<number>;
-}, boolean>({
+}, boolean>(({ showHistory, messageCount, dismissedIndex }) => showHistory && messageCount !== dismissedIndex.get(), {
     type: "object",
     properties: {
         messageCount: {
@@ -28,7 +28,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["messageCount", "dismissedIndex"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ showHistory, messageCount, dismissedIndex }) => showHistory && messageCount !== dismissedIndex.get());
+} as const satisfies __cfHelpers.JSONSchema);
 // Reproduction of bug: .get() called on Cell inside ifElse predicate
 // The transformer wraps predicates in a lift-applied computation, which unwraps Cells,
 // but fails to remove the .get() calls

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/complex-expressions.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/complex-expressions.expected.jsx
@@ -19,7 +19,7 @@ interface Problem {
 const __cfLift_1 = __cfHelpers.lift<{
     price: number;
     discount: number;
-}, number>({
+}, number>(({ price, discount }) => price - discount, {
     type: "object",
     properties: {
         price: {
@@ -32,12 +32,12 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["price", "discount"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ price, discount }) => price - discount);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     price: number;
     discount: number;
     tax: number;
-}, number>({
+}, number>(({ price, discount, tax }) => (price - discount) * (1 + tax), {
     type: "object",
     properties: {
         price: {
@@ -53,7 +53,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["price", "discount", "tax"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ price, discount, tax }) => (price - discount) * (1 + tax));
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: complex-expressions
 // Verifies: multi-variable arithmetic in JSX is wrapped in a lift-applied computation with captured refs
 //   {price - discount}             → lift((...) => price - discount)({ price, discount })

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/computed-boundary-nested-ternaries.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/computed-boundary-nested-ternaries.expected.jsx
@@ -13,7 +13,7 @@ const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     bar: boolean;
-}, "B" | "C">({
+}, "B" | "C">(({ bar }) => bar ? "B" : "C", {
     type: "object",
     properties: {
         bar: {
@@ -23,7 +23,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["bar"]
 } as const satisfies __cfHelpers.JSONSchema, {
     "enum": ["B", "C"]
-} as const satisfies __cfHelpers.JSONSchema, ({ bar }) => bar ? "B" : "C");
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: computed-boundary-nested-ternaries
 // Verifies: outer branch lowering does not structurally lower nested ternaries inside computed callbacks
 //   show ? computed(() => bar ? "B" : "C") : "D" → outer branch lowers, inner ternary stays authored
@@ -75,7 +75,7 @@ export const OuterTernary = pattern((__cf_pattern_input) => {
 const __cfLift_2 = __cfHelpers.lift<{
     foo: boolean;
     bar: boolean;
-}, "A" | "B" | "C">({
+}, "A" | "B" | "C">(({ foo, bar }) => foo ? "A" : bar ? "B" : "C", {
     type: "object",
     properties: {
         foo: {
@@ -88,7 +88,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["foo", "bar"]
 } as const satisfies __cfHelpers.JSONSchema, {
     "enum": ["A", "B", "C"]
-} as const satisfies __cfHelpers.JSONSchema, ({ foo, bar }) => foo ? "A" : bar ? "B" : "C");
+} as const satisfies __cfHelpers.JSONSchema);
 export const AuthoredIfElse = pattern((__cf_pattern_input) => {
     const show = __cf_pattern_input.key("show");
     const foo = __cf_pattern_input.key("foo");

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/conditional-empty-check.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/conditional-empty-check.expected.jsx
@@ -13,7 +13,7 @@ const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     items: __cfHelpers.Cell<string[]>;
-}, boolean>({
+}, boolean>(({ items }) => !items.get().length, {
     type: "object",
     properties: {
         items: {
@@ -27,7 +27,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["items"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ items }) => !items.get().length);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: conditional-empty-check
 // Verifies: !cell.get().length && <JSX> is transformed to when() with a lift-applied predicate
 //   !items.get().length && <span> → when(lift(({items}) => !items.get().length)({items}), <span>)

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/derived-property-access-with-derived-key.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/derived-property-access-with-derived-key.expected.jsx
@@ -21,7 +21,10 @@ interface Assignment {
 }
 const __cfLift_1 = __cfHelpers.lift<{
     items: Item[];
-}, { aisle: string; item: Item; }[]>({
+}, { aisle: string; item: Item; }[]>(({ items }) => items.map((item, idx) => ({
+    aisle: `Aisle ${(idx % 3) + 1}`,
+    item: item,
+})), {
     type: "object",
     properties: {
         items: {
@@ -76,13 +79,19 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["name", "done"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ items }) => items.map((item, idx) => ({
-    aisle: `Aisle ${(idx % 3) + 1}`,
-    item: item,
-})));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     itemsWithAisles: { aisle: string; item: Item; }[];
-}, Record<string, Assignment[]>>({
+}, Record<string, Assignment[]>>(({ itemsWithAisles }) => {
+    const groups: Record<string, Assignment[]> = {};
+    for (const assignment of itemsWithAisles) {
+        if (!groups[assignment.aisle]) {
+            groups[assignment.aisle] = [];
+        }
+        groups[assignment.aisle]!.push(assignment);
+    }
+    return groups;
+}, {
     type: "object",
     properties: {
         itemsWithAisles: {
@@ -153,19 +162,10 @@ const __cfLift_2 = __cfHelpers.lift<{
             required: ["name", "done"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ itemsWithAisles }) => {
-    const groups: Record<string, Assignment[]> = {};
-    for (const assignment of itemsWithAisles) {
-        if (!groups[assignment.aisle]) {
-            groups[assignment.aisle] = [];
-        }
-        groups[assignment.aisle]!.push(assignment);
-    }
-    return groups;
-});
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     groupedByAisle: Record<string, Assignment[]>;
-}, string[]>({
+}, string[]>(({ groupedByAisle }) => Object.keys(groupedByAisle).sort(), {
     type: "object",
     properties: {
         groupedByAisle: {
@@ -212,11 +212,11 @@ const __cfLift_3 = __cfHelpers.lift<{
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ groupedByAisle }) => Object.keys(groupedByAisle).sort());
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_4 = __cfHelpers.lift<{
     groupedByAisle: Record<string, Assignment[]>;
     aisleName: string;
-}, Assignment[] | undefined>({
+}, Assignment[] | undefined>(({ groupedByAisle, aisleName }) => groupedByAisle[aisleName], {
     type: "object",
     properties: {
         groupedByAisle: {
@@ -297,7 +297,7 @@ const __cfLift_4 = __cfHelpers.lift<{
             required: ["name", "done"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ groupedByAisle, aisleName }) => groupedByAisle[aisleName]);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const assignment = __cf_pattern_input.key("element");
     return (<div>

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-both-opaque.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-both-opaque.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     items: __cfHelpers.Cell<string[]>;
     index: __cfHelpers.Cell<number>;
-}, string | undefined>({
+}, string | undefined>(({ items, index }) => items.get()[index.get()], {
     type: "object",
     properties: {
         items: {
@@ -32,7 +32,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["items", "index"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
-} as const satisfies __cfHelpers.JSONSchema, ({ items, index }) => items.get()[index.get()]);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: element-access-both-opaque
 // Verifies: element access where both array and index are cell-backed OpaqueRefs is wrapped in a lift-applied computation
 //   items.get()[index.get()] → lift(({items, index}) => items.get()[index.get()])({ items, index })

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-complex.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-complex.expected.jsx
@@ -37,7 +37,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         row: number;
         col: number;
     };
-}, number | undefined>({
+}, number | undefined>(({ state }) => state.matrix[state.row]![state.col], {
     type: "object",
     properties: {
         state: {
@@ -65,7 +65,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "undefined"]
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.matrix[state.row]![state.col]);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         nested: {
@@ -74,7 +74,7 @@ const __cfLift_2 = __cfHelpers.lift<{
         };
         row: number;
     };
-}, string | undefined>({
+}, string | undefined>(({ state }) => state.nested.arrays[state.nested.index]![state.row], {
     type: "object",
     properties: {
         state: {
@@ -108,12 +108,12 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.nested.arrays[state.nested.index]![state.row]);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         items: string[];
     };
-}, string | undefined>({
+}, string | undefined>(({ state }) => state.items[state.items.length - 1], {
     type: "object",
     properties: {
         state: {
@@ -132,12 +132,12 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items[state.items.length - 1]);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_4 = __cfHelpers.lift<{
     state: {
         arr: number[];
     };
-}, number>({
+}, number>(({ state }) => state.arr[0]! + state.arr[state.arr.length - 1]!, {
     type: "object",
     properties: {
         state: {
@@ -156,14 +156,14 @@ const __cfLift_4 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.arr[0]! + state.arr[state.arr.length - 1]!);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_5 = __cfHelpers.lift<{
     state: {
         arr: number[];
         a: number;
         b: number;
     };
-}, number | undefined>({
+}, number | undefined>(({ state }) => state.arr[state.a + state.b], {
     type: "object",
     properties: {
         state: {
@@ -188,13 +188,13 @@ const __cfLift_5 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "undefined"]
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.arr[state.a + state.b]);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_6 = __cfHelpers.lift<{
     state: {
         items: string[];
         row: number;
     };
-}, string | undefined>({
+}, string | undefined>(({ state }) => state.items[state.row % state.items.length], {
     type: "object",
     properties: {
         state: {
@@ -216,13 +216,13 @@ const __cfLift_6 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items[state.row % state.items.length]);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_7 = __cfHelpers.lift<{
     state: {
         arr: number[];
         a: number;
     };
-}, number | undefined>({
+}, number | undefined>(({ state }) => state.arr[Math.min(state.a * 2, state.arr.length - 1)], {
     type: "object",
     properties: {
         state: {
@@ -244,14 +244,14 @@ const __cfLift_7 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "undefined"]
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.arr[Math.min(state.a * 2, state.arr.length - 1)]);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_8 = __cfHelpers.lift<{
     state: {
         users: { name: string; scores: number[]; }[];
         selectedUser: number;
         selectedScore: number;
     };
-}, number | undefined>({
+}, number | undefined>(({ state }) => state.users[state.selectedUser]!.scores[state.selectedScore], {
     type: "object",
     properties: {
         state: {
@@ -288,13 +288,13 @@ const __cfLift_8 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "undefined"]
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.users[state.selectedUser]!.scores[state.selectedScore]);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_9 = __cfHelpers.lift<{
     state: {
         items: string[];
         indices: number[];
     };
-}, string | undefined>({
+}, string | undefined>(({ state }) => state.items[state.indices[0]!], {
     type: "object",
     properties: {
         state: {
@@ -319,12 +319,12 @@ const __cfLift_9 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items[state.indices[0]!]);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_10 = __cfHelpers.lift<{
     state: {
         arr: number[];
     };
-}, number | undefined>({
+}, number | undefined>(({ state }) => state.arr[state.arr[0]!], {
     type: "object",
     properties: {
         state: {
@@ -343,7 +343,7 @@ const __cfLift_10 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "undefined"]
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.arr[state.arr[0]!]);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_11 = __cfHelpers.lift<{
     state: {
         nested: {
@@ -351,7 +351,7 @@ const __cfLift_11 = __cfHelpers.lift<{
             index: number;
         };
     };
-}, number>({
+}, number>(({ state }) => state.nested.arrays[state.nested.index]!.length, {
     type: "object",
     properties: {
         state: {
@@ -382,13 +382,13 @@ const __cfLift_11 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.nested.arrays[state.nested.index]!.length);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_12 = __cfHelpers.lift<{
     state: {
         users: { name: string; scores: number[]; }[];
         selectedUser: number;
     };
-}, number>({
+}, number>(({ state }) => state.users[state.selectedUser]!.name.length, {
     type: "object",
     properties: {
         state: {
@@ -422,13 +422,13 @@ const __cfLift_12 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.users[state.selectedUser]!.name.length);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_13 = __cfHelpers.lift<{
     state: {
         arr: number[];
         a: number;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.arr[state.a]! > 10, {
     type: "object",
     properties: {
         state: {
@@ -450,13 +450,13 @@ const __cfLift_13 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.arr[state.a]! > 10);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_14 = __cfHelpers.lift<{
     state: {
         items: string[];
         b: number;
     };
-}, string>({
+}, string>(({ state }) => state.items[state.b]!, {
     type: "object",
     properties: {
         state: {
@@ -478,14 +478,14 @@ const __cfLift_14 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items[state.b]!);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_15 = __cfHelpers.lift<{
     state: {
         matrix: number[][];
         row: number;
         col: number;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.matrix[state.row]![state.col]! > 0, {
     type: "object",
     properties: {
         state: {
@@ -513,14 +513,14 @@ const __cfLift_15 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.matrix[state.row]![state.col]! > 0);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_16 = __cfHelpers.lift<{
     state: {
         arr: number[];
         a: number;
         b: number;
     };
-}, number>({
+}, number>(({ state }) => state.arr[state.a]! * state.arr[state.b]!, {
     type: "object",
     properties: {
         state: {
@@ -545,13 +545,13 @@ const __cfLift_16 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.arr[state.a]! * state.arr[state.b]!);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_17 = __cfHelpers.lift<{
     state: {
         items: string[];
         indices: number[];
     };
-}, string>({
+}, string>(({ state }) => state.items[0]! + " - " + state.items[state.indices[0]!]!, {
     type: "object",
     properties: {
         state: {
@@ -576,12 +576,12 @@ const __cfLift_17 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items[0]! + " - " + state.items[state.indices[0]!]!);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_18 = __cfHelpers.lift<{
     state: {
         arr: number[];
     };
-}, number>({
+}, number>(({ state }) => state.arr[0]! + state.arr[1]! + state.arr[2]!, {
     type: "object",
     properties: {
         state: {
@@ -600,7 +600,7 @@ const __cfLift_18 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.arr[0]! + state.arr[1]! + state.arr[2]!);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: element-access-complex
 // Verifies: complex element-access patterns (nested, computed, chained, conditional) are wrapped in a lift-applied computation
 //   state.matrix[state.row]![state.col]         → lift(...)({ matrix, row, col })

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-simple.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/element-access-simple.expected.jsx
@@ -23,7 +23,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         items: string[];
         index: number;
     };
-}, string | undefined>({
+}, string | undefined>(({ state }) => state.items[state.index], {
     type: "object",
     properties: {
         state: {
@@ -45,12 +45,12 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items[state.index]);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         items: string[];
     };
-}, string | undefined>({
+}, string | undefined>(({ state }) => state.items[state.items.length - 1], {
     type: "object",
     properties: {
         state: {
@@ -69,14 +69,14 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items[state.items.length - 1]);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         matrix: number[][];
         row: number;
         col: number;
     };
-}, number | undefined>({
+}, number | undefined>(({ state }) => state.matrix[state.row]![state.col], {
     type: "object",
     properties: {
         state: {
@@ -104,7 +104,7 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "undefined"]
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.matrix[state.row]![state.col]);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: element-access-simple
 // Verifies: dynamic element access on reactive arrays is wrapped in a lift-applied computation
 //   state.items[state.index]            → lift(({state}) => state.items[state.index])({ items, index })

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/filter-callback-local-consts.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/filter-callback-local-consts.expected.jsx
@@ -28,7 +28,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     file: {
         type: string;
     };
-}, boolean>({
+}, boolean>(({ file }) => file.type === "folder", {
     type: "object",
     properties: {
         file: {
@@ -44,7 +44,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["file"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ file }) => file.type === "folder");
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const file = __cf_pattern_input.key("element");
     const isFolder = __cfLift_1({ file: {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/flatmap-callback-expression-statement.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/flatmap-callback-expression-statement.expected.jsx
@@ -29,7 +29,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         name: string;
         type: string;
     };
-}, void>({
+}, void>(({ file }) => console.log("mapping", file.name, file.type), {
     type: "object",
     properties: {
         file: {
@@ -48,7 +48,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["file"]
 } as const satisfies __cfHelpers.JSONSchema, {
     asCell: ["opaque"]
-} as const satisfies __cfHelpers.JSONSchema, ({ file }) => console.log("mapping", file.name, file.type));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const file = __cf_pattern_input.key("element");
     __cfLift_1({ file: {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-captures.expected.jsx
@@ -60,7 +60,7 @@ const __cfHandler_1 = __cfHelpers.handler({
 });
 const __cfLift_1 = __cfHelpers.lift<{
     path: __cfHelpers.Cell<string[]>;
-}, readonly string[]>({
+}, readonly string[]>(({ path }) => path.get(), {
     type: "object",
     properties: {
         path: {
@@ -77,10 +77,10 @@ const __cfLift_1 = __cfHelpers.lift<{
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ path }) => path.get());
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     path: __cfHelpers.Cell<string[]>;
-}, readonly string[]>({
+}, readonly string[]>(({ path }) => path.get(), {
     type: "object",
     properties: {
         path: {
@@ -97,12 +97,12 @@ const __cfLift_2 = __cfHelpers.lift<{
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ path }) => path.get());
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     entries: Writable<Default<Entry[], [
     ]>>;
     p: readonly string[];
-}, Entry[]>({
+}, Entry[]>(({ entries, p }) => visibleEntries(entries, p[0] || ""), {
     type: "object",
     properties: {
         entries: {
@@ -148,7 +148,7 @@ const __cfLift_3 = __cfHelpers.lift<{
             required: ["name"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ entries, p }) => visibleEntries(entries, p[0] || ""));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-default-input-local-chain-map-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-default-input-local-chain-map-capture.expected.jsx
@@ -108,7 +108,7 @@ const __cfHandler_2 = __cfHelpers.handler({
 });
 const __cfLift_1 = __cfHelpers.lift<{
     path: __cfHelpers.Cell<string[]>;
-}, readonly string[]>({
+}, readonly string[]>(({ path }) => path.get(), {
     type: "object",
     properties: {
         path: {
@@ -125,10 +125,14 @@ const __cfLift_1 = __cfHelpers.lift<{
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ path }) => path.get());
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     unsorted: Entry[];
-}, Entry[]>({
+}, Entry[]>(({ unsorted }) => [...unsorted].sort((a: Entry, b: Entry) => {
+    if (a.type === b.type)
+        return 0;
+    return a.type === "file" ? -1 : 1;
+}), {
     type: "object",
     properties: {
         unsorted: {
@@ -196,11 +200,7 @@ const __cfLift_2 = __cfHelpers.lift<{
             required: ["id", "name", "type"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ unsorted }) => [...unsorted].sort((a: Entry, b: Entry) => {
-    if (a.type === b.type)
-        return 0;
-    return a.type === "file" ? -1 : 1;
-}));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfHandler_3 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-filter-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-filter-capture.expected.jsx
@@ -32,7 +32,7 @@ function visibleEntries(entries: Writable<Default<Entry[], [
 __cfHardenFn(visibleEntries);
 const __cfLift_1 = __cfHelpers.lift<{
     path: __cfHelpers.Cell<string[]>;
-}, readonly string[]>({
+}, readonly string[]>(({ path }) => path.get(), {
     type: "object",
     properties: {
         path: {
@@ -49,12 +49,12 @@ const __cfLift_1 = __cfHelpers.lift<{
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ path }) => path.get());
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     entries: Writable<Default<Entry[], [
     ]>>;
     p: readonly string[];
-}, Entry[]>({
+}, Entry[]>(({ entries, p }) => visibleEntries(entries, p[0] || ""), {
     type: "object",
     properties: {
         entries: {
@@ -100,13 +100,13 @@ const __cfLift_2 = __cfHelpers.lift<{
             required: ["name"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ entries, p }) => visibleEntries(entries, p[0] || ""));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     entry: {
         name: string;
     };
     labelPrefix: __cfHelpers.Cell<string>;
-}, boolean>({
+}, boolean>(({ entry, labelPrefix }) => entry.name.startsWith(`${labelPrefix}`), {
     type: "object",
     properties: {
         entry: {
@@ -126,7 +126,7 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["entry", "labelPrefix"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ entry, labelPrefix }) => entry.name.startsWith(`${labelPrefix}`));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element");
     const labelPrefix = __cf_pattern_input.key("params", "labelPrefix");

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-flatmap-fallback-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-flatmap-fallback-capture.expected.jsx
@@ -30,7 +30,7 @@ const visibleEntries = __cfHardenFn((entries: Entry[], prefix: string) => entrie
 const __cfLift_1 = __cfHelpers.lift<{
     entries: Entry[];
     prefix: string;
-}, Entry[]>({
+}, Entry[]>(({ entries, prefix }) => visibleEntries(entries, prefix), {
     type: "object",
     properties: {
         entries: {
@@ -71,13 +71,13 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["name"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ entries, prefix }) => visibleEntries(entries, prefix));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     entry: {
         name: string;
     };
     labelPrefix: string;
-}, boolean>({
+}, boolean>(({ entry, labelPrefix }) => entry.name.startsWith(labelPrefix), {
     type: "object",
     properties: {
         entry: {
@@ -96,7 +96,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["entry", "labelPrefix"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ entry, labelPrefix }) => entry.name.startsWith(labelPrefix));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element");
     const labelPrefix = __cf_pattern_input.key("params", "labelPrefix");

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-capture.expected.jsx
@@ -36,7 +36,7 @@ function visibleEntries(entries: Writable<Default<Entry[], [
 __cfHardenFn(visibleEntries);
 const __cfLift_1 = __cfHelpers.lift<{
     path: __cfHelpers.Cell<string[]>;
-}, readonly string[]>({
+}, readonly string[]>(({ path }) => path.get(), {
     type: "object",
     properties: {
         path: {
@@ -53,12 +53,12 @@ const __cfLift_1 = __cfHelpers.lift<{
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ path }) => path.get());
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     entries: Writable<Default<Entry[], [
     ]>>;
     p: readonly string[];
-}, Entry[]>({
+}, Entry[]>(({ entries, p }) => visibleEntries(entries, p[0] || ""), {
     type: "object",
     properties: {
         entries: {
@@ -104,7 +104,7 @@ const __cfLift_2 = __cfHelpers.lift<{
             required: ["name"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ entries, p }) => visibleEntries(entries, p[0] || ""));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element");
     const labelPrefix = __cf_pattern_input.key("params", "labelPrefix");

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-fallback-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-final-map-fallback-capture.expected.jsx
@@ -30,7 +30,7 @@ const visibleEntries = __cfHardenFn((entries: Entry[], prefix: string) => entrie
 const __cfLift_1 = __cfHelpers.lift<{
     entries: Entry[];
     prefix: string;
-}, Entry[]>({
+}, Entry[]>(({ entries, prefix }) => visibleEntries(entries, prefix), {
     type: "object",
     properties: {
         entries: {
@@ -71,7 +71,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["name"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ entries, prefix }) => visibleEntries(entries, prefix));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element");
     const labelPrefix = __cf_pattern_input.key("params", "labelPrefix");

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-local-initializer-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/helper-owned-jsx-iife-local-initializer-captures.expected.jsx
@@ -68,7 +68,7 @@ const __cfHandler_1 = __cfHelpers.handler({
 });
 const __cfLift_1 = __cfHelpers.lift<{
     path: __cfHelpers.Cell<string[]>;
-}, readonly string[]>({
+}, readonly string[]>(({ path }) => path.get(), {
     type: "object",
     properties: {
         path: {
@@ -85,11 +85,11 @@ const __cfLift_1 = __cfHelpers.lift<{
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ path }) => path.get());
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     tree: __cfHelpers.Cell<Entry[]>;
     p: readonly string[];
-}, readonly Entry[]>({
+}, readonly Entry[]>(({ tree, p }) => findChildren(tree, p), {
     type: "object",
     properties: {
         tree: {
@@ -158,10 +158,10 @@ const __cfLift_2 = __cfHelpers.lift<{
             required: ["id", "name", "type"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ tree, p }) => findChildren(tree, p));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     unsorted: readonly Entry[];
-}, Entry[]>({
+}, Entry[]>(({ unsorted }) => [...unsorted].sort((a: Entry, b: Entry) => a.name.localeCompare(b.name)), {
     type: "object",
     properties: {
         unsorted: {
@@ -223,7 +223,7 @@ const __cfLift_3 = __cfHelpers.lift<{
             required: ["id", "name", "type"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ unsorted }) => [...unsorted].sort((a: Entry, b: Entry) => a.name.localeCompare(b.name)));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfHandler_2 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/ifelse-undefined-value.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/ifelse-undefined-value.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     pending: boolean;
     result: unknown;
-}, boolean>({
+}, boolean>(({ pending, result }) => pending || !result, {
     type: "object",
     properties: {
         pending: {
@@ -27,10 +27,10 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["pending", "result"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ pending, result }) => pending || !result);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     result: unknown;
-}, boolean>({
+}, boolean>(({ result }) => !!result, {
     type: "object",
     properties: {
         result: {
@@ -40,7 +40,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["result"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ result }) => !!result);
+} as const satisfies __cfHelpers.JSONSchema);
 // Tests ifElse where ifTrue is explicitly undefined
 // This pattern is common: ifElse(pending, undefined, { result })
 // The transformer must handle this correctly - the undefined is a VALUE, not a missing argument

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-arithmetic-operations.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-arithmetic-operations.expected.jsx
@@ -21,7 +21,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         count: number;
     };
-}, number>({
+}, number>(({ state }) => state.count + 1, {
     type: "object",
     properties: {
         state: {
@@ -37,12 +37,12 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.count + 1);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         count: number;
     };
-}, number>({
+}, number>(({ state }) => state.count - 1, {
     type: "object",
     properties: {
         state: {
@@ -58,12 +58,12 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.count - 1);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         count: number;
     };
-}, number>({
+}, number>(({ state }) => state.count * 2, {
     type: "object",
     properties: {
         state: {
@@ -79,12 +79,12 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.count * 2);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_4 = __cfHelpers.lift<{
     state: {
         price: number;
     };
-}, number>({
+}, number>(({ state }) => state.price / 2, {
     type: "object",
     properties: {
         state: {
@@ -100,12 +100,12 @@ const __cfLift_4 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.price / 2);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_5 = __cfHelpers.lift<{
     state: {
         count: number;
     };
-}, number>({
+}, number>(({ state }) => state.count % 3, {
     type: "object",
     properties: {
         state: {
@@ -121,13 +121,13 @@ const __cfLift_5 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.count % 3);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_6 = __cfHelpers.lift<{
     state: {
         price: number;
         discount: number;
     };
-}, number>({
+}, number>(({ state }) => state.price - (state.price * state.discount), {
     type: "object",
     properties: {
         state: {
@@ -146,13 +146,13 @@ const __cfLift_6 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.price - (state.price * state.discount));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_7 = __cfHelpers.lift<{
     state: {
         price: number;
         quantity: number;
     };
-}, number>({
+}, number>(({ state }) => state.price * state.quantity, {
     type: "object",
     properties: {
         state: {
@@ -171,13 +171,13 @@ const __cfLift_7 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.price * state.quantity);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_8 = __cfHelpers.lift<{
     state: {
         price: number;
         quantity: number;
     };
-}, number>({
+}, number>(({ state }) => (state.price * state.quantity) * 1.08, {
     type: "object",
     properties: {
         state: {
@@ -196,7 +196,7 @@ const __cfLift_8 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => (state.price * state.quantity) * 1.08);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_9 = __cfHelpers.lift<{
     state: {
         count: number;
@@ -204,7 +204,8 @@ const __cfLift_9 = __cfHelpers.lift<{
         price: number;
         discount: number;
     };
-}, number>({
+}, number>(({ state }) => (state.count + state.quantity) * state.price -
+    (state.price * state.discount), {
     type: "object",
     properties: {
         state: {
@@ -229,13 +230,12 @@ const __cfLift_9 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => (state.count + state.quantity) * state.price -
-    (state.price * state.discount));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_10 = __cfHelpers.lift<{
     state: {
         count: number;
     };
-}, number>({
+}, number>(({ state }) => state.count * state.count * state.count, {
     type: "object",
     properties: {
         state: {
@@ -251,12 +251,12 @@ const __cfLift_10 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.count * state.count * state.count);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_11 = __cfHelpers.lift<{
     state: {
         price: number;
     };
-}, number>({
+}, number>(({ state }) => state.price - 10, {
     type: "object",
     properties: {
         state: {
@@ -272,12 +272,12 @@ const __cfLift_11 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.price - 10);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_12 = __cfHelpers.lift<{
     state: {
         price: number;
     };
-}, number>({
+}, number>(({ state }) => state.price + 10, {
     type: "object",
     properties: {
         state: {
@@ -293,7 +293,7 @@ const __cfLift_12 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.price + 10);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: jsx-arithmetic-operations
 // Verifies: arithmetic expressions with reactive refs in JSX are wrapped in a lift-applied computation
 //   {state.count + 1}                      → lift(({state}) => state.count + 1)({ count })

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-array-method-sink-calls.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-array-method-sink-calls.expected.jsx
@@ -21,7 +21,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         items: number[];
         threshold: number;
     };
-}, string>({
+}, string>(({ state }) => state.items.filter((x) => x > state.threshold).join(", "), {
     type: "object",
     properties: {
         state: {
@@ -43,14 +43,14 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items.filter((x) => x > state.threshold).join(", "));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         items: number[];
         threshold: number;
         factor: number;
     };
-}, string>({
+}, string>(({ state }) => state.items.filter((x) => x > state.threshold).map((x) => x * state.factor).join(", "), {
     type: "object",
     properties: {
         state: {
@@ -75,13 +75,13 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items.filter((x) => x > state.threshold).map((x) => x * state.factor).join(", "));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         items: number[];
         threshold: number;
     };
-}, string>({
+}, string>(({ state }) => state.items.filter((x) => x > state.threshold).join(", ").toUpperCase(), {
     type: "object",
     properties: {
         state: {
@@ -103,13 +103,14 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items.filter((x) => x > state.threshold).join(", ").toUpperCase());
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_4 = __cfHelpers.lift<{
     state: {
         items: number[];
         threshold: number;
     };
-}, string>({
+}, string>(({ state }) => state.items.filter((x) => x > state.threshold).join(", ").toUpperCase()
+    .trim(), {
     type: "object",
     properties: {
         state: {
@@ -131,8 +132,7 @@ const __cfLift_4 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items.filter((x) => x > state.threshold).join(", ").toUpperCase()
-    .trim());
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: jsx-array-method-sink-calls
 // Verifies: direct JSX sink receiver-methods over structural array-method chains can use the shared post-closure path
 //   state.items.filter(fn).join(", ")                        → shared post-closure lift-applied computation over the sink call

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-complex-mixed.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-complex-mixed.expected.jsx
@@ -30,7 +30,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }[];
         filter: string;
     };
-}, number>({
+}, number>(({ state }) => state.items.filter((i) => i.name.includes(state.filter)).length, {
     type: "object",
     properties: {
         state: {
@@ -58,7 +58,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items.filter((i) => i.name.includes(state.filter)).length);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     item: {
         price: number;
@@ -66,7 +66,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     state: {
         discount: number;
     };
-}, string>({
+}, string>(({ item, state }) => (item.price * (1 - state.discount)).toFixed(2), {
     type: "object",
     properties: {
         item: {
@@ -91,7 +91,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["item", "state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ item, state }) => (item.price * (1 - state.discount)).toFixed(2));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     item: {
         price: number;
@@ -100,7 +100,8 @@ const __cfLift_3 = __cfHelpers.lift<{
         discount: number;
         taxRate: number;
     };
-}, string>({
+}, string>(({ item, state }) => (item.price * (1 - state.discount) * (1 + state.taxRate))
+    .toFixed(2), {
     type: "object",
     properties: {
         item: {
@@ -128,8 +129,7 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["item", "state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ item, state }) => (item.price * (1 - state.discount) * (1 + state.taxRate))
-    .toFixed(2));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
@@ -230,7 +230,7 @@ const __cfLift_4 = __cfHelpers.lift<{
     state: {
         items: Item[];
     };
-}, number>({
+}, number>(({ state }) => state.items.filter((i) => i.active).length, {
     type: "object",
     properties: {
         state: {
@@ -255,12 +255,12 @@ const __cfLift_4 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items.filter((i) => i.active).length);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_5 = __cfHelpers.lift<{
     state: {
         discount: number;
     };
-}, number>({
+}, number>(({ state }) => state.discount * 100, {
     type: "object",
     properties: {
         state: {
@@ -276,12 +276,12 @@ const __cfLift_5 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.discount * 100);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_6 = __cfHelpers.lift<{
     state: {
         taxRate: number;
     };
-}, number>({
+}, number>(({ state }) => state.taxRate * 100, {
     type: "object",
     properties: {
         state: {
@@ -297,12 +297,12 @@ const __cfLift_6 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.taxRate * 100);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_7 = __cfHelpers.lift<{
     state: {
         items: Item[];
     };
-}, boolean>({
+}, boolean>(({ state }) => state.items.every((i) => i.active), {
     type: "object",
     properties: {
         state: {
@@ -327,12 +327,12 @@ const __cfLift_7 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items.every((i) => i.active));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_8 = __cfHelpers.lift<{
     state: {
         items: Item[];
     };
-}, boolean>({
+}, boolean>(({ state }) => state.items.some((i) => i.active), {
     type: "object",
     properties: {
         state: {
@@ -357,12 +357,12 @@ const __cfLift_8 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items.some((i) => i.active));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_9 = __cfHelpers.lift<{
     state: {
         items: Item[];
     };
-}, boolean>({
+}, boolean>(({ state }) => state.items.some((i) => i.price > 100), {
     type: "object",
     properties: {
         state: {
@@ -387,14 +387,14 @@ const __cfLift_9 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items.some((i) => i.price > 100));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_10 = __cfHelpers.lift<{
     state: {
         filter: {
             length: number;
         };
     };
-}, boolean>({
+}, boolean>(({ state }) => state.filter.length > 0, {
     type: "object",
     properties: {
         state: {
@@ -416,7 +416,7 @@ const __cfLift_10 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.filter.length > 0);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: jsx-complex-mixed
 // Verifies: mixed transforms -- map, filter, arithmetic, ternary/ifElse, attribute bindings in one pattern
 //   .filter(fn)              → .filterWithPattern(pattern(...), {captures})

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-conditional-rendering-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-conditional-rendering-no-name.expected.jsx
@@ -23,7 +23,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         count: number;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.count > 10, {
     type: "object",
     properties: {
         state: {
@@ -39,12 +39,12 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.count > 10);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         score: number;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.score >= 90, {
     type: "object",
     properties: {
         state: {
@@ -60,12 +60,12 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.score >= 90);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         score: number;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.score >= 80, {
     type: "object",
     properties: {
         state: {
@@ -81,12 +81,12 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.score >= 80);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_4 = __cfHelpers.lift<{
     state: {
         count: number;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.count === 0, {
     type: "object",
     properties: {
         state: {
@@ -102,12 +102,12 @@ const __cfLift_4 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.count === 0);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_5 = __cfHelpers.lift<{
     state: {
         count: number;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.count === 1, {
     type: "object",
     properties: {
         state: {
@@ -123,12 +123,12 @@ const __cfLift_5 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.count === 1);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_6 = __cfHelpers.lift<{
     state: {
         userType: string;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.userType === "admin", {
     type: "object",
     properties: {
         state: {
@@ -144,12 +144,12 @@ const __cfLift_6 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.userType === "admin");
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_7 = __cfHelpers.lift<{
     state: {
         userType: string;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.userType === "user", {
     type: "object",
     properties: {
         state: {
@@ -165,12 +165,12 @@ const __cfLift_7 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.userType === "user");
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_8 = __cfHelpers.lift<{
     state: {
         count: number;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.count > 0, {
     type: "object",
     properties: {
         state: {
@@ -186,12 +186,12 @@ const __cfLift_8 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.count > 0);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_9 = __cfHelpers.lift<{
     state: {
         count: number;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.count < 10, {
     type: "object",
     properties: {
         state: {
@@ -207,12 +207,12 @@ const __cfLift_9 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.count < 10);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_10 = __cfHelpers.lift<{
     state: {
         score: number;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.score > 100, {
     type: "object",
     properties: {
         state: {
@@ -228,12 +228,12 @@ const __cfLift_10 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.score > 100);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_11 = __cfHelpers.lift<{
     state: {
         count: number;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.count > 5, {
     type: "object",
     properties: {
         state: {
@@ -249,7 +249,7 @@ const __cfLift_11 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.count > 5);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: jsx-conditional-rendering-no-name
 // Verifies: same conditional rendering transforms work when pattern has no NAME export
 //   cond ? a : b             → ifElse(schema..., cond, a, b)

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-conditional-rendering.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-conditional-rendering.expected.jsx
@@ -23,7 +23,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         count: number;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.count > 10, {
     type: "object",
     properties: {
         state: {
@@ -39,12 +39,12 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.count > 10);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         score: number;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.score >= 90, {
     type: "object",
     properties: {
         state: {
@@ -60,12 +60,12 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.score >= 90);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         score: number;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.score >= 80, {
     type: "object",
     properties: {
         state: {
@@ -81,12 +81,12 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.score >= 80);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_4 = __cfHelpers.lift<{
     state: {
         count: number;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.count === 0, {
     type: "object",
     properties: {
         state: {
@@ -102,12 +102,12 @@ const __cfLift_4 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.count === 0);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_5 = __cfHelpers.lift<{
     state: {
         count: number;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.count === 1, {
     type: "object",
     properties: {
         state: {
@@ -123,12 +123,12 @@ const __cfLift_5 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.count === 1);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_6 = __cfHelpers.lift<{
     state: {
         userType: string;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.userType === "admin", {
     type: "object",
     properties: {
         state: {
@@ -144,12 +144,12 @@ const __cfLift_6 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.userType === "admin");
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_7 = __cfHelpers.lift<{
     state: {
         userType: string;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.userType === "user", {
     type: "object",
     properties: {
         state: {
@@ -165,12 +165,12 @@ const __cfLift_7 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.userType === "user");
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_8 = __cfHelpers.lift<{
     state: {
         count: number;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.count > 0, {
     type: "object",
     properties: {
         state: {
@@ -186,12 +186,12 @@ const __cfLift_8 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.count > 0);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_9 = __cfHelpers.lift<{
     state: {
         count: number;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.count < 10, {
     type: "object",
     properties: {
         state: {
@@ -207,12 +207,12 @@ const __cfLift_9 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.count < 10);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_10 = __cfHelpers.lift<{
     state: {
         score: number;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.score > 100, {
     type: "object",
     properties: {
         state: {
@@ -228,12 +228,12 @@ const __cfLift_10 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.score > 100);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_11 = __cfHelpers.lift<{
     state: {
         count: number;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.count > 5, {
     type: "object",
     properties: {
         state: {
@@ -249,7 +249,7 @@ const __cfLift_11 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.count > 5);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: jsx-conditional-rendering
 // Verifies: ternary expressions and ifElse() calls in JSX are transformed to reactive ifElse()
 //   cond ? a : b             → ifElse(schema, schema, schema, schema, cond, a, b)

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-direct-branch-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-direct-branch-roots.expected.jsx
@@ -17,7 +17,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             done: boolean;
         };
     };
-}, boolean>({
+}, boolean>(({ state }) => !state.task.done, {
     type: "object",
     properties: {
         state: {
@@ -39,12 +39,12 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => !state.task.done);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         label?: string | null | undefined;
     };
-}, string>({
+}, string>(({ state }) => state.label ?? "Pending", {
     type: "object",
     properties: {
         state: {
@@ -59,7 +59,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.label ?? "Pending");
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: jsx-direct-branch-roots
 // Verifies: direct JSX branch roots lower structurally without leaving raw
 //   child expressions in place.

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-filter-length-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-filter-length-roots.expected.jsx
@@ -16,7 +16,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         items: number[];
         threshold: number;
     };
-}, number>({
+}, number>(({ state }) => state.items.filter((x) => x > state.threshold).length, {
     type: "object",
     properties: {
         state: {
@@ -38,13 +38,13 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items.filter((x) => x > state.threshold).length);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         items: number[];
         threshold: number;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.items.filter((x) => x > state.threshold).length > 0, {
     type: "object",
     properties: {
         state: {
@@ -66,13 +66,13 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items.filter((x) => x > state.threshold).length > 0);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         items: number[];
         threshold: number;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.items.filter((x) => x > state.threshold).length > 0, {
     type: "object",
     properties: {
         state: {
@@ -94,7 +94,7 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items.filter((x) => x > state.threshold).length > 0);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: jsx-filter-length-roots
 // Verifies: structural filter-length wrappers use the shared post-closure path
 //   instead of rewriting the filter callback itself to filterWithPattern().

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-function-calls.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-function-calls.expected.jsx
@@ -25,7 +25,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         a: number;
         b: number;
     };
-}, number>({
+}, number>(({ state }) => Math.max(state.a, state.b), {
     type: "object",
     properties: {
         state: {
@@ -44,12 +44,12 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => Math.max(state.a, state.b));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         a: number;
     };
-}, number>({
+}, number>(({ state }) => Math.min(state.a, 10), {
     type: "object",
     properties: {
         state: {
@@ -65,13 +65,13 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => Math.min(state.a, 10));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         a: number;
         b: number;
     };
-}, number>({
+}, number>(({ state }) => Math.abs(state.a - state.b), {
     type: "object",
     properties: {
         state: {
@@ -90,12 +90,12 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => Math.abs(state.a - state.b));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_4 = __cfHelpers.lift<{
     state: {
         price: number;
     };
-}, number>({
+}, number>(({ state }) => Math.round(state.price), {
     type: "object",
     properties: {
         state: {
@@ -111,12 +111,12 @@ const __cfLift_4 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => Math.round(state.price));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_5 = __cfHelpers.lift<{
     state: {
         price: number;
     };
-}, number>({
+}, number>(({ state }) => Math.floor(state.price), {
     type: "object",
     properties: {
         state: {
@@ -132,12 +132,12 @@ const __cfLift_5 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => Math.floor(state.price));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_6 = __cfHelpers.lift<{
     state: {
         price: number;
     };
-}, number>({
+}, number>(({ state }) => Math.ceil(state.price), {
     type: "object",
     properties: {
         state: {
@@ -153,12 +153,12 @@ const __cfLift_6 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => Math.ceil(state.price));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_7 = __cfHelpers.lift<{
     state: {
         a: number;
     };
-}, number>({
+}, number>(({ state }) => Math.sqrt(state.a), {
     type: "object",
     properties: {
         state: {
@@ -174,12 +174,12 @@ const __cfLift_7 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => Math.sqrt(state.a));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_8 = __cfHelpers.lift<{
     state: {
         name: string;
     };
-}, string>({
+}, string>(({ state }) => state.name.toUpperCase(), {
     type: "object",
     properties: {
         state: {
@@ -195,12 +195,12 @@ const __cfLift_8 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.name.toUpperCase());
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_9 = __cfHelpers.lift<{
     state: {
         name: string;
     };
-}, string>({
+}, string>(({ state }) => state.name.toLowerCase(), {
     type: "object",
     properties: {
         state: {
@@ -216,12 +216,12 @@ const __cfLift_9 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.name.toLowerCase());
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_10 = __cfHelpers.lift<{
     state: {
         text: string;
     };
-}, string>({
+}, string>(({ state }) => state.text.substring(0, 5), {
     type: "object",
     properties: {
         state: {
@@ -237,12 +237,12 @@ const __cfLift_10 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.text.substring(0, 5));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_11 = __cfHelpers.lift<{
     state: {
         text: string;
     };
-}, string>({
+}, string>(({ state }) => state.text.replace("old", "new"), {
     type: "object",
     properties: {
         state: {
@@ -258,12 +258,12 @@ const __cfLift_11 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.text.replace("old", "new"));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_12 = __cfHelpers.lift<{
     state: {
         text: string;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.text.includes("test"), {
     type: "object",
     properties: {
         state: {
@@ -279,12 +279,12 @@ const __cfLift_12 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.text.includes("test"));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_13 = __cfHelpers.lift<{
     state: {
         name: string;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.name.startsWith("A"), {
     type: "object",
     properties: {
         state: {
@@ -300,12 +300,12 @@ const __cfLift_13 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.name.startsWith("A"));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_14 = __cfHelpers.lift<{
     state: {
         price: number;
     };
-}, string>({
+}, string>(({ state }) => state.price.toFixed(2), {
     type: "object",
     properties: {
         state: {
@@ -321,12 +321,12 @@ const __cfLift_14 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.price.toFixed(2));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_15 = __cfHelpers.lift<{
     state: {
         price: number;
     };
-}, string>({
+}, string>(({ state }) => state.price.toPrecision(4), {
     type: "object",
     properties: {
         state: {
@@ -342,12 +342,12 @@ const __cfLift_15 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.price.toPrecision(4));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_16 = __cfHelpers.lift<{
     state: {
         float: string;
     };
-}, number>({
+}, number>(({ state }) => parseInt(state.float), {
     type: "object",
     properties: {
         state: {
@@ -363,12 +363,12 @@ const __cfLift_16 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => parseInt(state.float));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_17 = __cfHelpers.lift<{
     state: {
         float: string;
     };
-}, number>({
+}, number>(({ state }) => parseFloat(state.float), {
     type: "object",
     properties: {
         state: {
@@ -384,12 +384,12 @@ const __cfLift_17 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => parseFloat(state.float));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_18 = __cfHelpers.lift<{
     state: {
         values: number[];
     };
-}, number>({
+}, number>(({ state }) => state.values.reduce((a, b) => a + b, 0), {
     type: "object",
     properties: {
         state: {
@@ -408,12 +408,12 @@ const __cfLift_18 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.values.reduce((a, b) => a + b, 0));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_19 = __cfHelpers.lift<{
     state: {
         values: number[];
     };
-}, number>({
+}, number>(({ state }) => Math.max(...state.values), {
     type: "object",
     properties: {
         state: {
@@ -432,12 +432,12 @@ const __cfLift_19 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => Math.max(...state.values));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_20 = __cfHelpers.lift<{
     state: {
         values: number[];
     };
-}, string>({
+}, string>(({ state }) => state.values.join(", "), {
     type: "object",
     properties: {
         state: {
@@ -456,12 +456,12 @@ const __cfLift_20 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.values.join(", "));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_21 = __cfHelpers.lift<{
     state: {
         a: number;
     };
-}, number>({
+}, number>(({ state }) => Math.pow(state.a, 2), {
     type: "object",
     properties: {
         state: {
@@ -477,12 +477,12 @@ const __cfLift_21 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => Math.pow(state.a, 2));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_22 = __cfHelpers.lift<{
     state: {
         a: number;
     };
-}, number>({
+}, number>(({ state }) => Math.round(Math.sqrt(state.a)), {
     type: "object",
     properties: {
         state: {
@@ -498,12 +498,12 @@ const __cfLift_22 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => Math.round(Math.sqrt(state.a)));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_23 = __cfHelpers.lift<{
     state: {
         name: string;
     };
-}, string>({
+}, string>(({ state }) => state.name.trim().toUpperCase(), {
     type: "object",
     properties: {
         state: {
@@ -519,13 +519,13 @@ const __cfLift_23 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.name.trim().toUpperCase());
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_24 = __cfHelpers.lift<{
     state: {
         a: number;
         b: number;
     };
-}, number>({
+}, number>(({ state }) => Math.max(state.a + 1, state.b * 2), {
     type: "object",
     properties: {
         state: {
@@ -544,7 +544,7 @@ const __cfLift_24 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => Math.max(state.a + 1, state.b * 2));
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: jsx-function-calls
 // Verifies: function/method calls with reactive args in JSX are wrapped in a lift-applied computation
 //   Math.max(state.a, state.b)     → lift(({state}) => Math.max(state.a, state.b))({ a, b })

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-property-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-property-access.expected.jsx
@@ -48,7 +48,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             age: number;
         };
     };
-}, number>({
+}, number>(({ state }) => state.user.age + 1, {
     type: "object",
     properties: {
         state: {
@@ -70,14 +70,14 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.user.age + 1);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         user: {
             name: string;
         };
     };
-}, string>({
+}, string>(({ state }) => state.user.name.toUpperCase(), {
     type: "object",
     properties: {
         state: {
@@ -99,7 +99,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.user.name.toUpperCase());
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         user: {
@@ -108,7 +108,7 @@ const __cfLift_3 = __cfHelpers.lift<{
             };
         };
     };
-}, boolean>({
+}, boolean>(({ state }) => state.user.profile.location.includes("City"), {
     type: "object",
     properties: {
         state: {
@@ -136,13 +136,13 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.user.profile.location.includes("City"));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_4 = __cfHelpers.lift<{
     state: {
         items: string[];
         index: number;
     };
-}, string | undefined>({
+}, string | undefined>(({ state }) => state.items[state.index], {
     type: "object",
     properties: {
         state: {
@@ -164,12 +164,12 @@ const __cfLift_4 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items[state.index]);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_5 = __cfHelpers.lift<{
     state: {
         items: string[];
     };
-}, string | undefined>({
+}, string | undefined>(({ state }) => state.items[state.items.length - 1], {
     type: "object",
     properties: {
         state: {
@@ -188,13 +188,13 @@ const __cfLift_5 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items[state.items.length - 1]);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_6 = __cfHelpers.lift<{
     state: {
         numbers: number[];
         index: number;
     };
-}, number | undefined>({
+}, number | undefined>(({ state }) => state.numbers[state.index], {
     type: "object",
     properties: {
         state: {
@@ -216,7 +216,7 @@ const __cfLift_6 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "undefined"]
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.numbers[state.index]);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_7 = __cfHelpers.lift<{
     state: {
         config: {
@@ -225,7 +225,7 @@ const __cfLift_7 = __cfHelpers.lift<{
             };
         };
     };
-}, string>({
+}, string>(({ state }) => state.config.theme.fontSize + "px", {
     type: "object",
     properties: {
         state: {
@@ -253,7 +253,7 @@ const __cfLift_7 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.config.theme.fontSize + "px");
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_8 = __cfHelpers.lift<{
     state: {
         user: {
@@ -263,7 +263,7 @@ const __cfLift_8 = __cfHelpers.lift<{
             };
         };
     };
-}, string>({
+}, string>(({ state }) => state.user.name + " from " + state.user.profile.location, {
     type: "object",
     properties: {
         state: {
@@ -294,7 +294,7 @@ const __cfLift_8 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.user.name + " from " + state.user.profile.location);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_9 = __cfHelpers.lift<{
     state: {
         config: {
@@ -303,7 +303,7 @@ const __cfLift_9 = __cfHelpers.lift<{
             };
         };
     };
-}, number>({
+}, number>(({ state }) => state.config.theme.fontSize + 2, {
     type: "object",
     properties: {
         state: {
@@ -331,7 +331,7 @@ const __cfLift_9 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.config.theme.fontSize + 2);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: jsx-property-access
 // Verifies: nested property access chains in JSX are converted to .key() or wrapped in a lift-applied computation
 //   state.user.name                → state.key("user", "name")  (simple access, no lift)

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-string-operations.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-string-operations.expected.jsx
@@ -24,7 +24,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         firstName: string;
         lastName: string;
     };
-}, string>({
+}, string>(({ state }) => state.title + ": " + state.firstName + " " + state.lastName, {
     type: "object",
     properties: {
         state: {
@@ -46,13 +46,13 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.title + ": " + state.firstName + " " + state.lastName);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         firstName: string;
         lastName: string;
     };
-}, string>({
+}, string>(({ state }) => state.firstName + state.lastName, {
     type: "object",
     properties: {
         state: {
@@ -71,12 +71,12 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.firstName + state.lastName);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         firstName: string;
     };
-}, string>({
+}, string>(({ state }) => "Hello, " + state.firstName + "!", {
     type: "object",
     properties: {
         state: {
@@ -92,12 +92,12 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => "Hello, " + state.firstName + "!");
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_4 = __cfHelpers.lift<{
     state: {
         firstName: string;
     };
-}, string>({
+}, string>(({ state }) => `Welcome, ${state.firstName}!`, {
     type: "object",
     properties: {
         state: {
@@ -113,13 +113,13 @@ const __cfLift_4 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => `Welcome, ${state.firstName}!`);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_5 = __cfHelpers.lift<{
     state: {
         firstName: string;
         lastName: string;
     };
-}, string>({
+}, string>(({ state }) => `Full name: ${state.firstName} ${state.lastName}`, {
     type: "object",
     properties: {
         state: {
@@ -138,14 +138,14 @@ const __cfLift_5 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => `Full name: ${state.firstName} ${state.lastName}`);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_6 = __cfHelpers.lift<{
     state: {
         title: string;
         firstName: string;
         lastName: string;
     };
-}, string>({
+}, string>(({ state }) => `${state.title}: ${state.firstName} ${state.lastName}`, {
     type: "object",
     properties: {
         state: {
@@ -167,12 +167,12 @@ const __cfLift_6 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => `${state.title}: ${state.firstName} ${state.lastName}`);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_7 = __cfHelpers.lift<{
     state: {
         firstName: string;
     };
-}, string>({
+}, string>(({ state }) => state.firstName.toUpperCase(), {
     type: "object",
     properties: {
         state: {
@@ -188,12 +188,12 @@ const __cfLift_7 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.firstName.toUpperCase());
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_8 = __cfHelpers.lift<{
     state: {
         title: string;
     };
-}, string>({
+}, string>(({ state }) => state.title.toLowerCase(), {
     type: "object",
     properties: {
         state: {
@@ -209,12 +209,12 @@ const __cfLift_8 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.title.toLowerCase());
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_9 = __cfHelpers.lift<{
     state: {
         message: string;
     };
-}, string>({
+}, string>(({ state }) => state.message.substring(0, 5), {
     type: "object",
     properties: {
         state: {
@@ -230,13 +230,13 @@ const __cfLift_9 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.message.substring(0, 5));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_10 = __cfHelpers.lift<{
     state: {
         firstName: string;
         count: number;
     };
-}, string>({
+}, string>(({ state }) => state.firstName + " has " + state.count + " items", {
     type: "object",
     properties: {
         state: {
@@ -255,13 +255,13 @@ const __cfLift_10 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.firstName + " has " + state.count + " items");
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_11 = __cfHelpers.lift<{
     state: {
         firstName: string;
         count: number;
     };
-}, string>({
+}, string>(({ state }) => `${state.firstName} has ${state.count} items`, {
     type: "object",
     properties: {
         state: {
@@ -280,12 +280,12 @@ const __cfLift_11 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => `${state.firstName} has ${state.count} items`);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_12 = __cfHelpers.lift<{
     state: {
         count: number;
     };
-}, string>({
+}, string>(({ state }) => "Count: " + state.count, {
     type: "object",
     properties: {
         state: {
@@ -301,7 +301,7 @@ const __cfLift_12 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => "Count: " + state.count);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: jsx-string-operations
 // Verifies: string concatenation, template literals, and string methods in JSX are wrapped in a lift-applied computation
 //   state.title + ": " + state.firstName → lift(...)({ title, firstName })

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-wildcard-traversal-call-roots.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/jsx-wildcard-traversal-call-roots.expected.jsx
@@ -27,7 +27,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         wishes: [{ id: string; status: string; }, { id: string; status: string; }];
     };
-}, string>({
+}, string>(({ state }) => JSON.stringify(state.wishes[1]), {
     type: "object",
     properties: {
         state: {
@@ -55,12 +55,12 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => JSON.stringify(state.wishes[1]));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         wishes: [{ id: string; status: string; }, { id: string; status: string; }];
     };
-}, string[]>({
+}, string[]>(({ state }) => Object.keys(state.wishes[1]), {
     type: "object",
     properties: {
         state: {
@@ -91,12 +91,12 @@ const __cfLift_2 = __cfHelpers.lift<{
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => Object.keys(state.wishes[1]));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         wishes: [{ id: string; status: string; }, { id: string; status: string; }];
     };
-}, string[]>({
+}, string[]>(({ state }) => Object.values(state.wishes[1]), {
     type: "object",
     properties: {
         state: {
@@ -127,12 +127,12 @@ const __cfLift_3 = __cfHelpers.lift<{
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => Object.values(state.wishes[1]));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_4 = __cfHelpers.lift<{
     state: {
         wishes: [{ id: string; status: string; }, { id: string; status: string; }];
     };
-}, [string, string][]>({
+}, [string, string][]>(({ state }) => Object.entries(state.wishes[1]), {
     type: "object",
     properties: {
         state: {
@@ -166,7 +166,7 @@ const __cfLift_4 = __cfHelpers.lift<{
             type: "string"
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => Object.entries(state.wishes[1]));
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: jsx-wildcard-traversal-call-roots
 // Verifies: wildcard traversal calls lower as whole JSX call roots
 export default pattern((state) => ({

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-and-non-jsx.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-and-non-jsx.expected.jsx
@@ -13,7 +13,7 @@ const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     user: __cfHelpers.Cell<{ name: string; age: number; }>;
-}, boolean>({
+}, boolean>(({ user }) => user.get().name.length > 0, {
     type: "object",
     properties: {
         user: {
@@ -30,10 +30,10 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["user"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ user }) => user.get().name.length > 0);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     user: __cfHelpers.Cell<{ name: string; age: number; }>;
-}, string>({
+}, string>(({ user }) => `Hello, ${user.get().name}!`, {
     type: "object",
     properties: {
         user: {
@@ -50,10 +50,10 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["user"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ user }) => `Hello, ${user.get().name}!`);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     user: __cfHelpers.Cell<{ name: string; age: number; }>;
-}, boolean>({
+}, boolean>(({ user }) => user.get().age > 18, {
     type: "object",
     properties: {
         user: {
@@ -70,10 +70,10 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["user"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ user }) => user.get().age > 18);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_4 = __cfHelpers.lift<{
     user: __cfHelpers.Cell<{ name: string; age: number; }>;
-}, number>({
+}, number>(({ user }) => user.get().age, {
     type: "object",
     properties: {
         user: {
@@ -90,7 +90,7 @@ const __cfLift_4 = __cfHelpers.lift<{
     required: ["user"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ user }) => user.get().age);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: logical-and-non-jsx
 // Verifies: && with non-JSX right side still lowers through when(), with predicate/value derived separately
 //   user.get().name.length > 0 && `Hello...` → when(lift(...)(predicate), lift(...)(template))

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-complex-expressions.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-complex-expressions.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     items: __cfHelpers.Cell<string[]>;
     isEnabled: __cfHelpers.Cell<boolean>;
-}, Readonly<boolean>>({
+}, Readonly<boolean>>(({ items, isEnabled }) => items.get().length > 0 && isEnabled.get(), {
     type: "object",
     properties: {
         items: {
@@ -32,11 +32,11 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["items", "isEnabled"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ items, isEnabled }) => items.get().length > 0 && isEnabled.get());
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     count: __cfHelpers.Cell<number>;
     items: __cfHelpers.Cell<string[]>;
-}, boolean>({
+}, boolean>(({ count, items }) => (count.get() > 10 || items.get().length > 5), {
     type: "object",
     properties: {
         count: {
@@ -54,7 +54,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["count", "items"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ count, items }) => (count.get() > 10 || items.get().length > 5));
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: logical-complex-expressions
 // Verifies: nested && and mixed || && with JSX are transformed to when() with lift-applied predicates
 //   a && b && <JSX>     → when(lift(...)({ a, b }), <JSX>)

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-mixed-and-or.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-mixed-and-or.expected.jsx
@@ -13,7 +13,7 @@ const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     user: __cfHelpers.Cell<{ name: string; age: number; }>;
-}, string | false>({
+}, string | false>(({ user }) => (user.get().name.length > 0 && user.get().name), {
     type: "object",
     properties: {
         user: {
@@ -35,10 +35,10 @@ const __cfLift_1 = __cfHelpers.lift<{
             type: "boolean",
             "enum": [false]
         }]
-} as const satisfies __cfHelpers.JSONSchema, ({ user }) => (user.get().name.length > 0 && user.get().name));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     defaultMessage: __cfHelpers.Cell<string>;
-}, string>({
+}, string>(({ defaultMessage }) => defaultMessage.get(), {
     type: "object",
     properties: {
         defaultMessage: {
@@ -49,10 +49,10 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["defaultMessage"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ defaultMessage }) => defaultMessage.get());
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     user: __cfHelpers.Cell<{ name: string; age: number; }>;
-}, boolean>({
+}, boolean>(({ user }) => user.get().age > 18, {
     type: "object",
     properties: {
         user: {
@@ -69,10 +69,10 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["user"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ user }) => user.get().age > 18);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_4 = __cfHelpers.lift<{
     user: __cfHelpers.Cell<{ name: string; age: number; }>;
-}, string>({
+}, string>(({ user }) => user.get().name, {
     type: "object",
     properties: {
         user: {
@@ -89,10 +89,11 @@ const __cfLift_4 = __cfHelpers.lift<{
     required: ["user"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ user }) => user.get().name);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_5 = __cfHelpers.lift<{
     user: __cfHelpers.Cell<{ name: string; age: number; }>;
-}, string | false>({
+}, string | false>(({ user }) => (user.get().name.length > 0 && `Hello ${user.get().name}`) ||
+    (user.get().age > 0 && `Age: ${user.get().age}`), {
     type: "object",
     properties: {
         user: {
@@ -117,8 +118,7 @@ const __cfLift_5 = __cfHelpers.lift<{
             type: "boolean",
             "enum": [false]
         }]
-} as const satisfies __cfHelpers.JSONSchema, ({ user }) => (user.get().name.length > 0 && `Hello ${user.get().name}`) ||
-    (user.get().age > 0 && `Age: ${user.get().age}`));
+} as const satisfies __cfHelpers.JSONSchema);
 // Tests mixed && and || operators: (a && b) || c
 // The && should use when, the || should use unless
 // FIXTURE: logical-mixed-and-or

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-nullish-coalescing.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-nullish-coalescing.expected.jsx
@@ -13,7 +13,7 @@ const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     config: __cfHelpers.Cell<{ timeout: number | null; retries: number | undefined; }>;
-}, number>({
+}, number>(({ config }) => (config.get().timeout ?? 30), {
     type: "object",
     properties: {
         config: {
@@ -34,10 +34,10 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["config"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ config }) => (config.get().timeout ?? 30));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     config: __cfHelpers.Cell<{ timeout: number | null; retries: number | undefined; }>;
-}, boolean>({
+}, boolean>(({ config }) => (config.get().retries ?? 3) > 0, {
     type: "object",
     properties: {
         config: {
@@ -53,10 +53,10 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["config"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ config }) => (config.get().retries ?? 3) > 0);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     items: __cfHelpers.Cell<string[]>;
-}, string | false>({
+}, string | false>(({ items }) => items.get().length > 0 && (items.get()[0] ?? "empty"), {
     type: "object",
     properties: {
         items: {
@@ -75,7 +75,7 @@ const __cfLift_3 = __cfHelpers.lift<{
             type: "boolean",
             "enum": [false]
         }]
-} as const satisfies __cfHelpers.JSONSchema, ({ items }) => items.get().length > 0 && (items.get()[0] ?? "empty"));
+} as const satisfies __cfHelpers.JSONSchema);
 // Tests nullish coalescing (??) interaction with && and ||
 // ?? should NOT be transformed to when/unless (different semantics)
 // FIXTURE: logical-nullish-coalescing

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-or-unless.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-or-unless.expected.jsx
@@ -13,7 +13,7 @@ const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     items: __cfHelpers.Cell<string[]>;
-}, number>({
+}, number>(({ items }) => items.get().length, {
     type: "object",
     properties: {
         items: {
@@ -27,7 +27,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["items"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ items }) => items.get().length);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: logical-or-unless
 // Verifies: || with JSX fallback on right side is transformed to unless()
 //   items.get().length || <span>List is empty</span> → unless(lift(...)(...length), <span>List is empty</span>)

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-triple-and-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-triple-and-chain.expected.jsx
@@ -13,7 +13,7 @@ const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     user: __cfHelpers.Cell<{ active: boolean; verified: boolean; name: string; }>;
-}, boolean>({
+}, boolean>(({ user }) => user.get().active && user.get().verified, {
     type: "object",
     properties: {
         user: {
@@ -33,10 +33,10 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["user"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ user }) => user.get().active && user.get().verified);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     user: __cfHelpers.Cell<{ active: boolean; verified: boolean; name: string; }>;
-}, string>({
+}, string>(({ user }) => user.get().name, {
     type: "object",
     properties: {
         user: {
@@ -53,7 +53,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["user"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ user }) => user.get().name);
+} as const satisfies __cfHelpers.JSONSchema);
 // Tests triple && chain: a && b && c
 // Should produce nested when calls or lower the entire chain to a lift-applied computation
 // FIXTURE: logical-triple-and-chain

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/logical-triple-or-chain.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/logical-triple-or-chain.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     primary: __cfHelpers.Cell<string>;
     secondary: __cfHelpers.Cell<string>;
-}, number>({
+}, number>(({ primary, secondary }) => primary.get().length || secondary.get().length, {
     type: "object",
     properties: {
         primary: {
@@ -29,10 +29,10 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["primary", "secondary"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ primary, secondary }) => primary.get().length || secondary.get().length);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     items: __cfHelpers.Cell<string[]>;
-}, number | undefined>({
+}, number | undefined>(({ items }) => items.get()[0]?.length || items.get()[1]?.length, {
     type: "object",
     properties: {
         items: {
@@ -46,7 +46,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["items"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["number", "undefined"]
-} as const satisfies __cfHelpers.JSONSchema, ({ items }) => items.get()[0]?.length || items.get()[1]?.length);
+} as const satisfies __cfHelpers.JSONSchema);
 // Tests triple || chain: a || b || c
 // Should produce nested unless calls
 // FIXTURE: logical-triple-or-chain

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-array-length-conditional.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-array-length-conditional.expected.jsx
@@ -13,7 +13,7 @@ const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     list: __cfHelpers.Cell<string[]>;
-}, boolean>({
+}, boolean>(({ list }) => list.get().length > 0, {
     type: "object",
     properties: {
         list: {
@@ -27,7 +27,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["list"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ list }) => list.get().length > 0);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const name = __cf_pattern_input.key("element");
     return (<span>{name}</span>);

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-aliased-const-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-aliased-const-computation.expected.jsx
@@ -30,7 +30,7 @@ interface Output {
 }
 const __cfLift_1 = __cfHelpers.lift<{
     kind: string;
-}, boolean>({
+}, boolean>(({ kind }) => kind === "folder", {
     type: "object",
     properties: {
         kind: {
@@ -40,7 +40,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["kind"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ kind }) => kind === "folder");
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const file = __cf_pattern_input.key("element");
     const kind = file.key("type");

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-array-destructured-alias-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-array-destructured-alias-computation.expected.jsx
@@ -33,7 +33,7 @@ interface Output {
 }
 const __cfLift_1 = __cfHelpers.lift<{
     kind: string;
-}, boolean>({
+}, boolean>(({ kind }) => kind === "folder", {
     type: "object",
     properties: {
         kind: {
@@ -43,7 +43,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["kind"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ kind }) => kind === "folder");
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const file = __cf_pattern_input.key("element");
     const __cf_destructure_1 = file.key("tags"), kind = __cf_destructure_1.key("0");

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-element-property-helper-comparison.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-element-property-helper-comparison.expected.jsx
@@ -42,7 +42,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         messages: [
         ];
     }>>;
-}, Message[]>({
+}, Message[]>(({ selectedRoom }) => selectedRoom.get()?.messages, {
     type: "object",
     properties: {
         selectedRoom: {
@@ -96,13 +96,13 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["author", "body"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ selectedRoom }) => selectedRoom.get()?.messages);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     message: {
         author: string;
     };
     name: Writable<Default<string, "">>;
-}, boolean>({
+}, boolean>(({ message, name }) => message.author === senderName(name.get()), {
     type: "object",
     properties: {
         message: {
@@ -123,12 +123,12 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["message", "name"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ message, name }) => message.author === senderName(name.get()));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     message: {
         author: string;
     };
-}, boolean>({
+}, boolean>(({ message }) => message.author === "Alice", {
     type: "object",
     properties: {
         message: {
@@ -144,7 +144,7 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["message"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ message }) => message.author === "Alice");
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const message = __cf_pattern_input.key("element");
     const name = __cf_pattern_input.key("params", "name");

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-expression-statement.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-expression-statement.expected.jsx
@@ -34,7 +34,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         name: string;
         type: string;
     };
-}, void>({
+}, void>(({ file }) => console.log("mapping", file.name, file.type), {
     type: "object",
     properties: {
         file: {
@@ -53,7 +53,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["file"]
 } as const satisfies __cfHelpers.JSONSchema, {
     asCell: ["opaque"]
-} as const satisfies __cfHelpers.JSONSchema, ({ file }) => console.log("mapping", file.name, file.type));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const file = __cf_pattern_input.key("element");
     __cfLift_1({ file: {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-helper-call-over-alias.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-helper-call-over-alias.expected.jsx
@@ -31,7 +31,7 @@ interface Output {
 const describeKind = __cfHardenFn((kind: "file" | "folder"): string => kind === "folder" ? "dir" : "doc");
 const __cfLift_1 = __cfHelpers.lift<{
     kind: string;
-}, string>({
+}, string>(({ kind }) => describeKind(kind), {
     type: "object",
     properties: {
         kind: {
@@ -41,7 +41,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["kind"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ kind }) => describeKind(kind));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const file = __cf_pattern_input.key("element");
     const kind = file.key("type");

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-local-consts.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-local-consts.expected.jsx
@@ -33,7 +33,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     file: {
         type: string;
     };
-}, boolean>({
+}, boolean>(({ file }) => file.type === "folder", {
     type: "object",
     properties: {
         file: {
@@ -49,12 +49,12 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["file"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ file }) => file.type === "folder");
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     file: {
         contentType: string;
     };
-}, boolean>({
+}, boolean>(({ file }) => file.contentType !== "binary", {
     type: "object",
     properties: {
         file: {
@@ -70,7 +70,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["file"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ file }) => file.contentType !== "binary");
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const file = __cf_pattern_input.key("element");
     const isFolder = __cfLift_1({ file: {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-aggregate-alias-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-aggregate-alias-computation.expected.jsx
@@ -32,7 +32,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     meta: {
         kind: string;
     };
-}, boolean>({
+}, boolean>(({ meta }) => meta.kind === "folder", {
     type: "object",
     properties: {
         meta: {
@@ -48,7 +48,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["meta"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ meta }) => meta.kind === "folder");
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const file = __cf_pattern_input.key("element");
     const meta = { kind: file.key("type") };

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-destructured-alias-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-object-destructured-alias-computation.expected.jsx
@@ -30,7 +30,7 @@ interface Output {
 }
 const __cfLift_1 = __cfHelpers.lift<{
     kind: string;
-}, boolean>({
+}, boolean>(({ kind }) => kind === "folder", {
     type: "object",
     properties: {
         kind: {
@@ -40,7 +40,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["kind"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ kind }) => kind === "folder");
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const file = __cf_pattern_input.key("element");
     const kind = file.key("type");

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-tuple-aggregate-alias-computation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-callback-tuple-aggregate-alias-computation.expected.jsx
@@ -30,7 +30,7 @@ interface Output {
 }
 const __cfLift_1 = __cfHelpers.lift<{
     info: readonly ["file" | "folder", string];
-}, boolean>({
+}, boolean>(({ info }) => info[0] === "folder", {
     type: "object",
     properties: {
         info: {
@@ -43,7 +43,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["info"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ info }) => info[0] === "folder");
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const file = __cf_pattern_input.key("element");
     const info = [file.key("type"), file.key("name")] as const;

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-single-capture-no-name.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-single-capture-no-name.expected.jsx
@@ -13,7 +13,7 @@ const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     people: __cfHelpers.Cell<{ id: string; name: string; }[]>;
-}, boolean>({
+}, boolean>(({ people }) => people.get().length > 0, {
     type: "object",
     properties: {
         people: {
@@ -27,7 +27,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["people"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ people }) => people.get().length > 0);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const person = __cf_pattern_input.key("element");
     const index = __cf_pattern_input.key("index");

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/map-single-capture.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/map-single-capture.expected.jsx
@@ -13,7 +13,7 @@ const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     people: __cfHelpers.Cell<{ id: string; name: string; }[]>;
-}, boolean>({
+}, boolean>(({ people }) => people.get().length > 0, {
     type: "object",
     properties: {
         people: {
@@ -27,7 +27,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["people"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ people }) => people.get().length > 0);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const person = __cf_pattern_input.key("element");
     const index = __cf_pattern_input.key("index");

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/method-chains.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/method-chains.expected.jsx
@@ -37,7 +37,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         text: string;
     };
-}, string>({
+}, string>(({ state }) => state.text.trim().toLowerCase(), {
     type: "object",
     properties: {
         state: {
@@ -53,13 +53,13 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.text.trim().toLowerCase());
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         text: string;
         searchTerm: string;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.text.toLowerCase().includes(state.searchTerm.toLowerCase()), {
     type: "object",
     properties: {
         state: {
@@ -78,12 +78,12 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.text.toLowerCase().includes(state.searchTerm.toLowerCase()));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         text: string;
     };
-}, string>({
+}, string>(({ state }) => state.text.trim().toLowerCase().replace("old", "new").toUpperCase(), {
     type: "object",
     properties: {
         state: {
@@ -99,13 +99,13 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.text.trim().toLowerCase().replace("old", "new").toUpperCase());
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_4 = __cfHelpers.lift<{
     state: {
         items: number[];
         threshold: number;
     };
-}, number>({
+}, number>(({ state }) => state.items.filter((x) => x > state.threshold).length, {
     type: "object",
     properties: {
         state: {
@@ -127,7 +127,7 @@ const __cfLift_4 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items.filter((x) => x > state.threshold).length);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const x = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
@@ -163,7 +163,7 @@ const __cfLift_5 = __cfHelpers.lift<{
     state: {
         factor: number;
     };
-}, number>({
+}, number>(({ x, state }) => x * state.factor, {
     type: "object",
     properties: {
         x: {
@@ -182,7 +182,7 @@ const __cfLift_5 = __cfHelpers.lift<{
     required: ["x", "state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ x, state }) => x * state.factor);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const x = __cf_pattern_input.key("element");
     const state = __cf_pattern_input.key("params", "state");
@@ -242,7 +242,7 @@ const __cfLift_6 = __cfHelpers.lift<{
         start: number;
         end: number;
     };
-}, number>({
+}, number>(({ state }) => state.items.filter((x) => x > state.start).filter((x) => x < state.end).length, {
     type: "object",
     properties: {
         state: {
@@ -267,14 +267,14 @@ const __cfLift_6 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items.filter((x) => x > state.start).filter((x) => x < state.end).length);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_7 = __cfHelpers.lift<{
     state: {
         items: number[];
         start: number;
         end: number;
     };
-}, string>({
+}, string>(({ state }) => state.items.slice(state.start, state.end).join(", "), {
     type: "object",
     properties: {
         state: {
@@ -299,13 +299,13 @@ const __cfLift_7 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items.slice(state.start, state.end).join(", "));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_8 = __cfHelpers.lift<{
     state: {
         names: string[];
         prefix: string;
     };
-}, string>({
+}, string>(({ state }) => state.names.filter((n) => n.startsWith(state.prefix)).join(", "), {
     type: "object",
     properties: {
         state: {
@@ -327,13 +327,13 @@ const __cfLift_8 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.names.filter((n) => n.startsWith(state.prefix)).join(", "));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_9 = __cfHelpers.lift<{
     state: {
         names: string[];
         searchTerm: string;
     };
-}, string | undefined>({
+}, string | undefined>(({ state }) => state.names.find((n) => n.includes(state.searchTerm)), {
     type: "object",
     properties: {
         state: {
@@ -355,10 +355,10 @@ const __cfLift_9 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.names.find((n) => n.includes(state.searchTerm)));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_10 = __cfHelpers.lift<{
     name: string;
-}, string>({
+}, string>(({ name }) => name.trim().toLowerCase().replace(" ", "-"), {
     type: "object",
     properties: {
         name: {
@@ -368,7 +368,7 @@ const __cfLift_10 = __cfHelpers.lift<{
     required: ["name"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ name }) => name.trim().toLowerCase().replace(" ", "-"));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
     const name = __cf_pattern_input.key("element");
     return (<li>{__cfLift_10({ name: name })}</li>);
@@ -406,7 +406,7 @@ const __cfLift_11 = __cfHelpers.lift<{
         prices: number[];
         discount: number;
     };
-}, number>({
+}, number>(({ state }) => state.prices.reduce((sum, price) => sum + price * (1 - state.discount), 0), {
     type: "object",
     properties: {
         state: {
@@ -428,13 +428,14 @@ const __cfLift_11 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.prices.reduce((sum, price) => sum + price * (1 - state.discount), 0));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_12 = __cfHelpers.lift<{
     state: {
         items: number[];
         factor: number;
     };
-}, number>({
+}, number>(({ state }) => (state.items.reduce((a, b) => a + b, 0) / state.items.length) *
+    state.factor, {
     type: "object",
     properties: {
         state: {
@@ -456,14 +457,13 @@ const __cfLift_12 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => (state.items.reduce((a, b) => a + b, 0) / state.items.length) *
-    state.factor);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_13 = __cfHelpers.lift<{
     state: {
         prices: number[];
         discount: number;
     };
-}, string>({
+}, string>(({ state }) => (state.prices[0]! * (1 - state.discount)).toFixed(2), {
     type: "object",
     properties: {
         state: {
@@ -485,13 +485,13 @@ const __cfLift_13 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => (state.prices[0]! * (1 - state.discount)).toFixed(2));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_14 = __cfHelpers.lift<{
     state: {
         text: string;
         prefix: string;
     };
-}, string>({
+}, string>(({ state }) => (state.text.length > 10 ? state.text : state.prefix).trim(), {
     type: "object",
     properties: {
         state: {
@@ -510,13 +510,14 @@ const __cfLift_14 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => (state.text.length > 10 ? state.text : state.prefix).trim());
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_15 = __cfHelpers.lift<{
     state: {
         text: string;
         prefix: string;
     };
-}, string>({
+}, string>(({ state }) => (state.text + " " + state.prefix).trim().toLowerCase().split(" ")
+    .join("-"), {
     type: "object",
     properties: {
         state: {
@@ -535,14 +536,13 @@ const __cfLift_15 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => (state.text + " " + state.prefix).trim().toLowerCase().split(" ")
-    .join("-"));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_16 = __cfHelpers.lift<{
     state: {
         users: { name: string; age: number; active: boolean; }[];
         minAge: number;
     };
-}, number>({
+}, number>(({ state }) => state.users.filter((u) => u.age >= state.minAge && u.active).length, {
     type: "object",
     properties: {
         state: {
@@ -573,12 +573,12 @@ const __cfLift_16 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.users.filter((u) => u.age >= state.minAge && u.active).length);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_17 = __cfHelpers.lift<{
     u: {
         name: string;
     };
-}, string>({
+}, string>(({ u }) => u.name.toUpperCase(), {
     type: "object",
     properties: {
         u: {
@@ -594,12 +594,12 @@ const __cfLift_17 = __cfHelpers.lift<{
     required: ["u"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ u }) => u.name.toUpperCase());
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_18 = __cfHelpers.lift<{
     u: {
         name: string;
     };
-}, string>({
+}, string>(({ u }) => u.name.toLowerCase(), {
     type: "object",
     properties: {
         u: {
@@ -615,7 +615,7 @@ const __cfLift_18 = __cfHelpers.lift<{
     required: ["u"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ u }) => u.name.toLowerCase());
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_4 = __cfHelpers.pattern(__cf_pattern_input => {
     const u = __cf_pattern_input.key("element");
     return (<li>{__cfHelpers.ifElse({
@@ -677,7 +677,7 @@ const __cfLift_19 = __cfHelpers.lift<{
         users: { name: string; age: number; active: boolean; }[];
         minAge: number;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.users.some((u) => u.age >= state.minAge), {
     type: "object",
     properties: {
         state: {
@@ -705,12 +705,12 @@ const __cfLift_19 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.users.some((u) => u.age >= state.minAge));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_20 = __cfHelpers.lift<{
     state: {
         users: { name: string; age: number; active: boolean; }[];
     };
-}, boolean>({
+}, boolean>(({ state }) => state.users.every((u) => u.active), {
     type: "object",
     properties: {
         state: {
@@ -735,13 +735,13 @@ const __cfLift_20 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.users.every((u) => u.active));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_21 = __cfHelpers.lift<{
     state: {
         text: string;
         prefix: string;
     };
-}, number>({
+}, number>(({ state }) => state.text.trim().length + state.prefix.trim().length, {
     type: "object",
     properties: {
         state: {
@@ -760,13 +760,13 @@ const __cfLift_21 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.text.trim().length + state.prefix.trim().length);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_22 = __cfHelpers.lift<{
     state: {
         text: string;
         threshold: number;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.text.trim().length > state.threshold, {
     type: "object",
     properties: {
         state: {
@@ -785,13 +785,13 @@ const __cfLift_22 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.text.trim().length > state.threshold);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_23 = __cfHelpers.lift<{
     state: {
         words: string[];
         separator: string;
     };
-}, string>({
+}, string>(({ state }) => state.words.join(state.separator).toUpperCase(), {
     type: "object",
     properties: {
         state: {
@@ -813,7 +813,7 @@ const __cfLift_23 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.words.join(state.separator).toUpperCase());
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: method-chains
 // Verifies: chained method calls and array method chains in JSX are wrapped in a lift-applied computation
 //   state.text.trim().toLowerCase()          → lift(...)({ text })

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-cell-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-cell-map.expected.jsx
@@ -57,7 +57,10 @@ const createCellRef = lift(({ isInitialized, storedCellRef }) => {
             items: true
         } as const satisfies __cfHelpers.JSONSchema);
         newCellRef.set([]);
-        storedCellRef.set(newCellRef);
+        // Local cast: the schema types storedCellRef as a cell of a generic object,
+        // but this fixture stores an array cell into it; the schema accuracy isn't
+        // what this transformer fixture exercises.
+        (storedCellRef as Cell<unknown>).set(newCellRef);
         isInitialized.set(true);
         return {
             cellRef: newCellRef,
@@ -76,6 +79,7 @@ const createCellRef = lift(({ isInitialized, storedCellRef }) => {
         isInitialized: { type: "boolean", "default": false, asCell: ["cell"] },
         storedCellRef: { type: "object", asCell: ["cell"] },
     },
+    required: ["isInitialized", "storedCellRef"],
 });
 // Add a charm to the array and navigate to it
 // we get a new isInitialized passed in for each
@@ -101,6 +105,7 @@ const addCharmAndNavigate = lift(({ charm, cellRef, isInitialized }) => {
         cellRef: { type: "array", asCell: ["cell"] },
         isInitialized: { type: "boolean", asCell: ["cell"] },
     },
+    required: ["charm", "isInitialized"],
 });
 // Create a new SimplePattern and add it to the array
 const createSimplePattern = handler({

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-cell-map.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-cell-map.expected.jsx
@@ -49,13 +49,7 @@ const SimplePattern = pattern(() => ({
     }
 } as const satisfies __cfHelpers.JSONSchema);
 // Create a cell to store an array of charms
-const createCellRef = lift({
-    type: "object",
-    properties: {
-        isInitialized: { type: "boolean", "default": false, asCell: ["cell"] },
-        storedCellRef: { type: "object", asCell: ["cell"] },
-    },
-}, undefined, ({ isInitialized, storedCellRef }) => {
+const createCellRef = lift(({ isInitialized, storedCellRef }) => {
     if (!isInitialized.get()) {
         console.log("Creating cellRef - first time");
         const newCellRef = Cell.for<any[]>("charmsArray").asSchema({
@@ -76,20 +70,19 @@ const createCellRef = lift({
     return {
         cellRef: storedCellRef,
     };
+}, {
+    type: "object",
+    properties: {
+        isInitialized: { type: "boolean", "default": false, asCell: ["cell"] },
+        storedCellRef: { type: "object", asCell: ["cell"] },
+    },
 });
 // Add a charm to the array and navigate to it
 // we get a new isInitialized passed in for each
 // charm we add to the list. this makes sure
 // we only try to add the charm once to the list
 // and we only call navigateTo once
-const addCharmAndNavigate = lift({
-    type: "object",
-    properties: {
-        charm: { type: "object" },
-        cellRef: { type: "array", asCell: ["cell"] },
-        isInitialized: { type: "boolean", asCell: ["cell"] },
-    },
-}, undefined, ({ charm, cellRef, isInitialized }) => {
+const addCharmAndNavigate = lift(({ charm, cellRef, isInitialized }) => {
     if (!isInitialized.get()) {
         if (cellRef) {
             cellRef.push(charm);
@@ -101,6 +94,13 @@ const addCharmAndNavigate = lift({
         }
     }
     return undefined;
+}, {
+    type: "object",
+    properties: {
+        charm: { type: "object" },
+        cellRef: { type: "array", asCell: ["cell"] },
+        isInitialized: { type: "boolean", asCell: ["cell"] },
+    },
 });
 // Create a new SimplePattern and add it to the array
 const createSimplePattern = handler({
@@ -143,7 +143,7 @@ const goToCharm = handler({
 });
 const __cfLift_1 = __cfHelpers.lift<{
     cellRef: unknown[];
-}, boolean>({
+}, boolean>(({ cellRef }) => !cellRef?.length, {
     type: "object",
     properties: {
         cellRef: {
@@ -156,16 +156,16 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["cellRef"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ cellRef }) => !cellRef?.length);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     charm: any;
-}, any>({
+}, any>(({ charm }) => charm[__cfHelpers.NAME], {
     type: "object",
     properties: {
         charm: true
     },
     required: ["charm"]
-} as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema, ({ charm }) => charm[__cfHelpers.NAME]);
+} as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const charm = __cf_pattern_input.key("element");
     const index = __cf_pattern_input.key("index");

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-cell-map.input.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-cell-map.input.tsx
@@ -18,14 +18,6 @@ const SimplePattern = pattern(() => ({
 
 // Create a cell to store an array of charms
 const createCellRef = lift(
-  {
-    type: "object",
-    properties: {
-      isInitialized: { type: "boolean", "default": false, asCell: ["cell"] },
-      storedCellRef: { type: "object", asCell: ["cell"] },
-    },
-  },
-  undefined,
   ({ isInitialized, storedCellRef }) => {
     if (!isInitialized.get()) {
       console.log("Creating cellRef - first time");
@@ -44,6 +36,13 @@ const createCellRef = lift(
       cellRef: storedCellRef,
     };
   },
+  {
+    type: "object",
+    properties: {
+      isInitialized: { type: "boolean", "default": false, asCell: ["cell"] },
+      storedCellRef: { type: "object", asCell: ["cell"] },
+    },
+  },
 );
 
 // Add a charm to the array and navigate to it
@@ -52,15 +51,6 @@ const createCellRef = lift(
 // we only try to add the charm once to the list
 // and we only call navigateTo once
 const addCharmAndNavigate = lift(
-  {
-    type: "object",
-    properties: {
-      charm: { type: "object" },
-      cellRef: { type: "array", asCell: ["cell"] },
-      isInitialized: { type: "boolean", asCell: ["cell"] },
-    },
-  },
-  undefined,
   ({ charm, cellRef, isInitialized }) => {
     if (!isInitialized.get()) {
       if (cellRef) {
@@ -72,6 +62,14 @@ const addCharmAndNavigate = lift(
       }
     }
     return undefined;
+  },
+  {
+    type: "object",
+    properties: {
+      charm: { type: "object" },
+      cellRef: { type: "array", asCell: ["cell"] },
+      isInitialized: { type: "boolean", asCell: ["cell"] },
+    },
   },
 );
 

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-cell-map.input.tsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-cell-map.input.tsx
@@ -23,7 +23,10 @@ const createCellRef = lift(
       console.log("Creating cellRef - first time");
       const newCellRef = Cell.for<any[]>("charmsArray");
       newCellRef.set([]);
-      storedCellRef.set(newCellRef);
+      // Local cast: the schema types storedCellRef as a cell of a generic object,
+      // but this fixture stores an array cell into it; the schema accuracy isn't
+      // what this transformer fixture exercises.
+      (storedCellRef as Cell<unknown>).set(newCellRef);
       isInitialized.set(true);
       return {
         cellRef: newCellRef,
@@ -42,6 +45,7 @@ const createCellRef = lift(
       isInitialized: { type: "boolean", "default": false, asCell: ["cell"] },
       storedCellRef: { type: "object", asCell: ["cell"] },
     },
+    required: ["isInitialized", "storedCellRef"],
   },
 );
 
@@ -70,6 +74,7 @@ const addCharmAndNavigate = lift(
       cellRef: { type: "array", asCell: ["cell"] },
       isInitialized: { type: "boolean", asCell: ["cell"] },
     },
+    required: ["charm", "isInitialized"],
   },
 );
 

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-operations.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/opaque-ref-operations.expected.jsx
@@ -13,7 +13,7 @@ const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     count: __cfHelpers.Cell<number>;
-}, number>({
+}, number>(({ count }) => count.get() + 1, {
     type: "object",
     properties: {
         count: {
@@ -24,10 +24,10 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["count"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ count }) => count.get() + 1);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     count: __cfHelpers.Cell<number>;
-}, number>({
+}, number>(({ count }) => count.get() * 2, {
     type: "object",
     properties: {
         count: {
@@ -38,10 +38,10 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["count"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ count }) => count.get() * 2);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     price: __cfHelpers.Cell<number>;
-}, number>({
+}, number>(({ price }) => price.get() * 1.1, {
     type: "object",
     properties: {
         price: {
@@ -52,7 +52,7 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["price"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ price }) => price.get() * 1.1);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: opaque-ref-operations
 // Verifies: arithmetic on cell-backed OpaqueRefs in JSX is wrapped in a lift-applied computation with asCell schema
 //   {count}           → {count}  (bare ref, no transform)

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/optional-chain-captures.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/optional-chain-captures.expected.jsx
@@ -26,7 +26,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     item: {
         maybe?: { value: number; } | undefined;
     };
-}, number>({
+}, number>(({ item }) => item.maybe?.value ?? 0, {
     type: "object",
     properties: {
         item: {
@@ -47,7 +47,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["item"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ item }) => item.maybe?.value ?? 0);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return (<span>{__cfLift_1({ item: {

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/optional-element-access.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/optional-element-access.expected.jsx
@@ -13,7 +13,7 @@ const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     list: __cfHelpers.Cell<string[] | undefined>;
-}, boolean>({
+}, boolean>(({ list }) => !list.get()?.[0], {
     type: "object",
     properties: {
         list: {
@@ -31,7 +31,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["list"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ list }) => !list.get()?.[0]);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: optional-element-access
 // Verifies: optional element access (?.[0]) in a negated && guard is transformed to when(lift(...)(...))
 //   !list.get()?.[0] && <span> → when(lift(({list}) => !list.get()?.[0])({ list }), <span>)

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/parameterized-inline-call-root.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/parameterized-inline-call-root.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     prefix: string;
     count: number;
-}, string>({
+}, string>(({ prefix, count }) => ((value: number) => prefix + value)(count), {
     type: "object",
     properties: {
         prefix: {
@@ -27,7 +27,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["prefix", "count"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ prefix, count }) => ((value: number) => prefix + value)(count));
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: parameterized-inline-call-root
 // Verifies: helper-owned parameterized inline-function call roots lower as a
 // shared post-closure lift-applied computation around the whole call, not as a lift-applied computation inside the

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/parent-suppression-edge.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/parent-suppression-edge.expected.jsx
@@ -96,7 +96,8 @@ const __cfLift_1 = __cfHelpers.lift<{
             };
         };
     };
-}, string>({
+}, string>(({ state }) => state.user.name + " from " + state.user.profile.location + " - " +
+    state.user.profile.bio, {
     type: "object",
     properties: {
         state: {
@@ -130,15 +131,14 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.user.name + " from " + state.user.profile.location + " - " +
-    state.user.profile.bio);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         user: {
             age: number;
         };
     };
-}, number>({
+}, number>(({ state }) => state.user.age * 12, {
     type: "object",
     properties: {
         state: {
@@ -160,14 +160,14 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.user.age * 12);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         user: {
             age: number;
         };
     };
-}, number>({
+}, number>(({ state }) => state.user.age * 365, {
     type: "object",
     properties: {
         state: {
@@ -189,7 +189,7 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.user.age * 365);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_4 = __cfHelpers.lift<{
     state: {
         user: {
@@ -199,7 +199,8 @@ const __cfLift_4 = __cfHelpers.lift<{
             };
         };
     };
-}, string>({
+}, string>(({ state }) => state.user.name + " has notifications on with " +
+    state.user.settings.theme + " theme", {
     type: "object",
     properties: {
         state: {
@@ -230,15 +231,14 @@ const __cfLift_4 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.user.name + " has notifications on with " +
-    state.user.settings.theme + " theme");
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_5 = __cfHelpers.lift<{
     state: {
         user: {
             name: string;
         };
     };
-}, string>({
+}, string>(({ state }) => state.user.name + " has notifications off", {
     type: "object",
     properties: {
         state: {
@@ -260,7 +260,7 @@ const __cfLift_5 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.user.name + " has notifications off");
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_6 = __cfHelpers.lift<{
     state: {
         config: {
@@ -273,7 +273,9 @@ const __cfLift_6 = __cfHelpers.lift<{
             };
         };
     };
-}, number>({
+}, number>(({ state }) => state.config.theme.spacing.small +
+    state.config.theme.spacing.medium +
+    state.config.theme.spacing.large, {
     type: "object",
     properties: {
         state: {
@@ -313,16 +315,14 @@ const __cfLift_6 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.config.theme.spacing.small +
-    state.config.theme.spacing.medium +
-    state.config.theme.spacing.large);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_7 = __cfHelpers.lift<{
     state: {
         user: {
             name: string;
         };
     };
-}, string>({
+}, string>(({ state }) => state.user.name.toUpperCase(), {
     type: "object",
     properties: {
         state: {
@@ -344,14 +344,14 @@ const __cfLift_7 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.user.name.toUpperCase());
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_8 = __cfHelpers.lift<{
     state: {
         user: {
             email: string;
         };
     };
-}, string>({
+}, string>(({ state }) => state.user.email.toLowerCase(), {
     type: "object",
     properties: {
         state: {
@@ -373,7 +373,7 @@ const __cfLift_8 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.user.email.toLowerCase());
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: parent-suppression-edge
 // Verifies: property access suppression -- sibling properties share a captured parent in a lift-applied computation
 //   {state.user.name} ... {state.user.age} → individual .key() or shared lift(...)({ user: {...} })

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-statements-vs-jsx.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-statements-vs-jsx.expected.jsx
@@ -46,7 +46,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         value: number;
     };
-}, number>({
+}, number>(({ state }) => state.value + 1, {
     type: "object",
     properties: {
         state: {
@@ -62,12 +62,12 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.value + 1);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         value: number;
     };
-}, number>({
+}, number>(({ state }) => state.value - 1, {
     type: "object",
     properties: {
         state: {
@@ -83,12 +83,12 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.value - 1);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     state: {
         value: number;
     };
-}, number>({
+}, number>(({ state }) => state.value * 2, {
     type: "object",
     properties: {
         state: {
@@ -104,12 +104,12 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.value * 2);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_4 = __cfHelpers.lift<{
     state: {
         value: number;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.value > 10, {
     type: "object",
     properties: {
         state: {
@@ -125,7 +125,7 @@ const __cfLift_4 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.value > 10);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: pattern-statements-vs-jsx
 // Verifies: only JSX-context expressions are transformed; statement-context expressions are left alone
 //   const next = state.value + 1    → NOT transformed (statement context)

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-vs-computed-logical-and.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-vs-computed-logical-and.expected.jsx
@@ -65,7 +65,7 @@ export const PatternLogicalAnd = pattern((__cf_pattern_input) => {
 } as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_1 = __cfHelpers.lift<{
     bar: string;
-}, string | false>({
+}, string | false>(({ foo, bar }) => foo && bar, {
     type: "object",
     properties: {
         bar: {
@@ -80,7 +80,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             type: "boolean",
             "enum": [false]
         }]
-} as const satisfies __cfHelpers.JSONSchema, ({ foo, bar }) => foo && bar);
+} as const satisfies __cfHelpers.JSONSchema);
 export const ComputedLogicalAnd = pattern((__cf_pattern_input) => {
     const foo = __cf_pattern_input.key("foo");
     const bar = __cf_pattern_input.key("bar");

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-with-cells.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/pattern-with-cells.expected.jsx
@@ -15,7 +15,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     cell: {
         value: number;
     };
-}, number>({
+}, number>(({ cell }) => cell.value + 1, {
     type: "object",
     properties: {
         cell: {
@@ -31,12 +31,12 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["cell"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ cell }) => cell.value + 1);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     cell: {
         value: number;
     };
-}, number>({
+}, number>(({ cell }) => cell.value * 2, {
     type: "object",
     properties: {
         cell: {
@@ -52,7 +52,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["cell"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ cell }) => cell.value * 2);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: pattern-with-cells
 // Verifies: pattern input property access is transformed to .key() and arithmetic to a lift-applied computation
 //   cell.value       → cell.key("value")

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/safe-context-and-jsx.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/safe-context-and-jsx.expected.jsx
@@ -14,7 +14,7 @@ const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     show: boolean;
-}, boolean>({
+}, boolean>(({ show }) => show, {
     type: "object",
     properties: {
         show: {
@@ -24,7 +24,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["show"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ show }) => show);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: safe-context-and-jsx
 // Verifies: && and || with JSX inside handler callbacks are transformed to when()/unless()
 //   computed(() => show) && <span> → when(computed(() => show), <span>)
@@ -122,7 +122,7 @@ const MyHandler = handler({
 });
 const __cfLift_2 = __cfHelpers.lift<{
     value: string | null;
-}, string | null>({
+}, string | null>(({ value }) => value, {
     type: "object",
     properties: {
         value: {
@@ -140,7 +140,7 @@ const __cfLift_2 = __cfHelpers.lift<{
         }, {
             type: "null"
         }]
-} as const satisfies __cfHelpers.JSONSchema, ({ value }) => value);
+} as const satisfies __cfHelpers.JSONSchema);
 // Test: || with JSX inside handler callback should transform to unless()
 const MyHandler2 = handler({
     type: "object",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-branch-ownership.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-branch-ownership.expected.jsx
@@ -31,7 +31,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         items: Item[];
     };
-}, Item[]>({
+}, Item[]>(({ state }) => [...state.items].sort((a, b) => a.value - b.value), {
     type: "object",
     properties: {
         state: {
@@ -81,14 +81,14 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["name", "value"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => [...state.items].sort((a, b) => a.value - b.value));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         items: {
             length: number;
         };
     };
-}, number>({
+}, number>(({ state }) => state.items.length, {
     type: "object",
     properties: {
         state: {
@@ -110,10 +110,10 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items.length);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     state: any;
-}, boolean>({
+}, boolean>(({ state }) => state.recentEvents.length === 0, {
     type: "object",
     properties: {
         state: true
@@ -121,7 +121,7 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.recentEvents.length === 0);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const event = __cf_pattern_input.key("element");
     const idx = __cf_pattern_input.key("index");

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-hoisted-compute-plain-map-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-hoisted-compute-plain-map-branch.expected.jsx
@@ -19,7 +19,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         items: Item[];
     };
-}, Item[]>({
+}, Item[]>(({ state }) => [...state.items].sort((a, b) => a.value - b.value), {
     type: "object",
     properties: {
         state: {
@@ -69,14 +69,14 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["name", "value"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => [...state.items].sort((a, b) => a.value - b.value));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     state: {
         items: {
             length: number;
         };
     };
-}, number>({
+}, number>(({ state }) => state.items.length, {
     type: "object",
     properties: {
         state: {
@@ -98,7 +98,7 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.items.length);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: ternary-hoisted-compute-plain-map-branch
 // Verifies: once a ternary JSX branch is wholly compute-wrapped, compute-owned
 // array maps inside that branch stay plain Array.map() calls.

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-pure-jsx-map-branch.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/ternary-pure-jsx-map-branch.expected.jsx
@@ -16,7 +16,7 @@ interface TagEvent {
 }
 const __cfLift_1 = __cfHelpers.lift<{
     recentEvents: TagEvent[];
-}, boolean>({
+}, boolean>(({ recentEvents }) => recentEvents.length === 0, {
     type: "object",
     properties: {
         recentEvents: {
@@ -29,7 +29,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["recentEvents"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ recentEvents }) => recentEvents.length === 0);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const event = __cf_pattern_input.key("element");
     const idx = __cf_pattern_input.key("index");

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/wrapped-element-binding-reads.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/wrapped-element-binding-reads.expected.jsx
@@ -39,7 +39,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         name: string;
     };
     prefix: string;
-}, boolean>({
+}, boolean>(({ entry, prefix }) => (entry).name === prefix, {
     type: "object",
     properties: {
         entry: {
@@ -58,13 +58,13 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["entry", "prefix"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ entry, prefix }) => (entry).name === prefix);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     entry: {
         name: string;
     };
     prefix: string;
-}, boolean>({
+}, boolean>(({ entry, prefix }) => entry!.name === prefix, {
     type: "object",
     properties: {
         entry: {
@@ -83,13 +83,13 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["entry", "prefix"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ entry, prefix }) => entry!.name === prefix);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     entry: {
         name: string;
     };
     prefix: string;
-}, boolean>({
+}, boolean>(({ entry, prefix }) => (entry as Entry).name === prefix, {
     type: "object",
     properties: {
         entry: {
@@ -108,7 +108,7 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["entry", "prefix"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ entry, prefix }) => (entry as Entry).name === prefix);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element");
     const prefix = __cf_pattern_input.key("params", "prefix");

--- a/packages/ts-transformers/test/fixtures/kitchensink/branch-lowered-capture-preservation.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/branch-lowered-capture-preservation.expected.jsx
@@ -99,7 +99,13 @@ interface Item {
 }
 const __cfLift_1 = __cfHelpers.lift<{
     items: Item[];
-}, { entry: Item; index: number; isExpanded: boolean; isPinned: boolean; allowMultiple: boolean; }[]>({
+}, { entry: Item; index: number; isExpanded: boolean; isPinned: boolean; allowMultiple: boolean; }[]>(({ items }) => items.map((entry, index) => ({
+    entry,
+    index,
+    isExpanded: index === 0,
+    isPinned: entry.pinned || false,
+    allowMultiple: entry.allowMultiple,
+})), {
     type: "object",
     properties: {
         items: {
@@ -173,18 +179,12 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["allowMultiple"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ items }) => items.map((entry, index) => ({
-    entry,
-    index,
-    isExpanded: index === 0,
-    isPinned: entry.pinned || false,
-    allowMultiple: entry.allowMultiple,
-})));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     entry: {
         collapsed?: boolean | undefined;
     };
-}, boolean>({
+}, boolean>(({ entry }) => !entry.collapsed, {
     type: "object",
     properties: {
         entry: {
@@ -203,12 +203,14 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["entry"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ entry }) => !entry.collapsed);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     entry: {
         note?: string | undefined;
     };
-}, { fontWeight: string; }>({
+}, { fontWeight: string; }>(({ entry }) => ({
+    fontWeight: entry?.note ? "700" : "400",
+}), {
     type: "object",
     properties: {
         entry: {
@@ -229,14 +231,12 @@ const __cfLift_3 = __cfHelpers.lift<{
         }
     },
     required: ["fontWeight"]
-} as const satisfies __cfHelpers.JSONSchema, ({ entry }) => ({
-    fontWeight: entry?.note ? "700" : "400",
-}));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_4 = __cfHelpers.lift<{
     entry: {
         note?: string | undefined;
     };
-}, string>({
+}, string>(({ entry }) => entry?.note || "Add note...", {
     type: "object",
     properties: {
         entry: {
@@ -251,10 +251,10 @@ const __cfLift_4 = __cfHelpers.lift<{
     required: ["entry"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ entry }) => entry?.note || "Add note...");
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_5 = __cfHelpers.lift<{
     isExpanded: boolean;
-}, boolean>({
+}, boolean>(({ isExpanded }) => !isExpanded, {
     type: "object",
     properties: {
         isExpanded: {
@@ -264,10 +264,10 @@ const __cfLift_5 = __cfHelpers.lift<{
     required: ["isExpanded"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ isExpanded }) => !isExpanded);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_6 = __cfHelpers.lift<{
     isExpanded: boolean;
-}, boolean>({
+}, boolean>(({ isExpanded }) => !isExpanded, {
     type: "object",
     properties: {
         isExpanded: {
@@ -277,7 +277,7 @@ const __cfLift_6 = __cfHelpers.lift<{
     required: ["isExpanded"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ isExpanded }) => !isExpanded);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const entry = __cf_pattern_input.key("element", "entry");
     const index = __cf_pattern_input.key("element", "index");

--- a/packages/ts-transformers/test/fixtures/kitchensink/helper-owned-compute-branches.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/helper-owned-compute-branches.expected.jsx
@@ -40,7 +40,9 @@ const __cfLift_1 = __cfHelpers.lift<{
             archived: boolean;
         }[];
     };
-}, Project[]>({
+}, Project[]>(({ state }) => state.showArchived
+    ? state.projects
+    : state.projects.filter((project) => !project.archived), {
     type: "object",
     properties: {
         state: {
@@ -112,12 +114,10 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["text", "active"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.showArchived
-    ? state.projects
-    : state.projects.filter((project) => !project.archived));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     memberIndex: number;
-}, boolean>({
+}, boolean>(({ memberIndex }) => memberIndex === 0, {
     type: "object",
     properties: {
         memberIndex: {
@@ -127,13 +127,13 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["memberIndex"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ memberIndex }) => memberIndex === 0);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     project: {
         name: string;
     };
     member: string;
-}, string>({
+}, string>(({ project, member }) => `${project.name}-${member}`, {
     type: "object",
     properties: {
         project: {
@@ -152,7 +152,7 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["project", "member"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ project, member }) => `${project.name}-${member}`);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const member = __cf_pattern_input.key("element");
     const memberIndex = __cf_pattern_input.key("index");
@@ -233,7 +233,51 @@ const __cfLift_4 = __cfHelpers.lift<{
         prefix: string;
     };
     fallbackMembers: __cfHelpers.ReadonlyCell<string[]>;
-}, (__cfHelpers.VNode | __cfHelpers.UIRenderable)[]>({
+}, (__cfHelpers.VNode | __cfHelpers.UIRenderable)[]>(({ visibleProjects, state, fallbackMembers }) => 
+// [TRANSFORM] .map() stays plain: visibleProjects is a captured computed input, plain inside this compute
+visibleProjects.map((project, projectIndex) => {
+    // [TRANSFORM] .map() stays plain: ["alpha","beta"] is a literal array
+    const plainPreview = ["alpha", "beta"].map((label, labelIndex) => `${project.name}-${labelIndex}-${label}`);
+    // [TRANSFORM] ifElse: schema args injected on authored ifElse
+    return ifElse({
+        type: "boolean"
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{}, {
+                type: "object",
+                properties: {}
+            }]
+    } as const satisfies __cfHelpers.JSONSchema, {
+        anyOf: [{}, {
+                type: "object",
+                properties: {}
+            }]
+    } as const satisfies __cfHelpers.JSONSchema, {} as const satisfies __cfHelpers.JSONSchema, project.badges.length > 0, <div>
+          <h3>{project.name}</h3>
+          {/* [TRANSFORM] .map() stays plain: project.badges is compute-owned data inside computed */}
+          {project.badges.map((badge, badgeIndex) => (<span>
+              {badge.active
+                ? `${state.prefix}${badge.text}-${projectIndex}`
+                : badgeIndex === 0
+                    ? `${project.name}:${badge.text}`
+                    : ""}
+            </span>))}
+          {/* [TRANSFORM] .map() → mapWithPattern: fallbackMembers is a Writable (reactive Cell), lowered even inside computed */}
+          {fallbackMembers.mapWithPattern(__cfPattern_1, {
+            project: {
+                name: project.name
+            }
+        })}
+          {/* [TRANSFORM] .map() stays plain: plainPreview is a local literal array */}
+          {plainPreview.map((label) => <i>{label}</i>)}
+        </div>, <div>
+          {/* [TRANSFORM] .map() stays plain: project.members is compute-owned data inside computed */}
+          {project.members.map((member, memberIndex) => (<span>
+              {memberIndex === projectIndex
+                ? `${state.prefix}${member}`
+                : member}
+            </span>))}
+        </div>);
+}), {
     type: "object",
     properties: {
         visibleProjects: {
@@ -307,51 +351,7 @@ const __cfLift_4 = __cfHelpers.lift<{
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ visibleProjects, state, fallbackMembers }) => 
-// [TRANSFORM] .map() stays plain: visibleProjects is a captured computed input, plain inside this compute
-visibleProjects.map((project, projectIndex) => {
-    // [TRANSFORM] .map() stays plain: ["alpha","beta"] is a literal array
-    const plainPreview = ["alpha", "beta"].map((label, labelIndex) => `${project.name}-${labelIndex}-${label}`);
-    // [TRANSFORM] ifElse: schema args injected on authored ifElse
-    return ifElse({
-        type: "boolean"
-    } as const satisfies __cfHelpers.JSONSchema, {
-        anyOf: [{}, {
-                type: "object",
-                properties: {}
-            }]
-    } as const satisfies __cfHelpers.JSONSchema, {
-        anyOf: [{}, {
-                type: "object",
-                properties: {}
-            }]
-    } as const satisfies __cfHelpers.JSONSchema, {} as const satisfies __cfHelpers.JSONSchema, project.badges.length > 0, <div>
-          <h3>{project.name}</h3>
-          {/* [TRANSFORM] .map() stays plain: project.badges is compute-owned data inside computed */}
-          {project.badges.map((badge, badgeIndex) => (<span>
-              {badge.active
-                ? `${state.prefix}${badge.text}-${projectIndex}`
-                : badgeIndex === 0
-                    ? `${project.name}:${badge.text}`
-                    : ""}
-            </span>))}
-          {/* [TRANSFORM] .map() → mapWithPattern: fallbackMembers is a Writable (reactive Cell), lowered even inside computed */}
-          {fallbackMembers.mapWithPattern(__cfPattern_1, {
-            project: {
-                name: project.name
-            }
-        })}
-          {/* [TRANSFORM] .map() stays plain: plainPreview is a local literal array */}
-          {plainPreview.map((label) => <i>{label}</i>)}
-        </div>, <div>
-          {/* [TRANSFORM] .map() stays plain: project.members is compute-owned data inside computed */}
-          {project.members.map((member, memberIndex) => (<span>
-              {memberIndex === projectIndex
-                ? `${state.prefix}${member}`
-                : member}
-            </span>))}
-        </div>);
-}));
+} as const satisfies __cfHelpers.JSONSchema);
 // [TRANSFORM] pattern: type param stripped; input+output schemas appended after callback
 export default pattern((state) => {
     // [TRANSFORM] new Writable: schema arg injected

--- a/packages/ts-transformers/test/fixtures/kitchensink/nested-computed-output-maps.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/nested-computed-output-maps.expected.jsx
@@ -67,7 +67,7 @@ const jumpToComment = handler({
     required: ["selectedCommentId", "threadId", "commentId", "lane", "outerIndex", "innerIndex"]
 } as const satisfies __cfHelpers.JSONSchema, (_event, state) => state);
 // [TRANSFORM] lift: input and output schemas injected
-const passthroughLabels = lift({
+const passthroughLabels = lift((labels: string[]) => labels, {
     type: "array",
     items: {
         type: "string"
@@ -77,13 +77,21 @@ const passthroughLabels = lift({
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema, (labels: string[]) => labels);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_1 = __cfHelpers.lift<{
     state: {
         threads: Thread[];
         showFlagged: boolean;
     };
-}, { thread: Thread; outerIndex: number; visibleComments: Comment[]; }[]>({
+}, { thread: Thread; outerIndex: number; visibleComments: Comment[]; }[]>(({ state }) => 
+// [TRANSFORM] .map() stays plain: state.threads is a captured input, plain inside this computed
+state.threads.map((thread, outerIndex) => ({
+    thread,
+    outerIndex,
+    visibleComments: state.showFlagged
+        ? thread.comments.filter((comment) => comment.flagged)
+        : thread.comments,
+})), {
     type: "object",
     properties: {
         state: {
@@ -211,18 +219,10 @@ const __cfLift_1 = __cfHelpers.lift<{
             required: ["id", "title", "muted", "comments"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => 
-// [TRANSFORM] .map() stays plain: state.threads is a captured input, plain inside this computed
-state.threads.map((thread, outerIndex) => ({
-    thread,
-    outerIndex,
-    visibleComments: state.showFlagged
-        ? thread.comments.filter((comment) => comment.flagged)
-        : thread.comments,
-})));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     visibleComments: Comment[];
-}, Comment[]>({
+}, Comment[]>(({ visibleComments }) => visibleComments, {
     type: "object",
     properties: {
         visibleComments: {
@@ -284,11 +284,11 @@ const __cfLift_2 = __cfHelpers.lift<{
             required: ["id", "text", "flagged", "reactions"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ visibleComments }) => visibleComments);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     reboundIndex: number;
     outerIndex: number;
-}, boolean>({
+}, boolean>(({ reboundIndex, outerIndex }) => reboundIndex === outerIndex, {
     type: "object",
     properties: {
         reboundIndex: {
@@ -301,7 +301,7 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["reboundIndex", "outerIndex"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ reboundIndex, outerIndex }) => reboundIndex === outerIndex);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_4 = __cfHelpers.lift<{
     state: {
         lane: string;
@@ -309,7 +309,7 @@ const __cfLift_4 = __cfHelpers.lift<{
     comment: {
         id: string;
     };
-}, string>({
+}, string>(({ state, comment }) => `${state.lane}:${comment.id}`, {
     type: "object",
     properties: {
         state: {
@@ -334,7 +334,7 @@ const __cfLift_4 = __cfHelpers.lift<{
     required: ["state", "comment"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state, comment }) => `${state.lane}:${comment.id}`);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const comment = __cf_pattern_input.key("element");
     const reboundIndex = __cf_pattern_input.key("index");
@@ -423,7 +423,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 const __cfLift_5 = __cfHelpers.lift<{
     edgeIndex: number;
     outerIndex: number;
-}, boolean>({
+}, boolean>(({ edgeIndex, outerIndex }) => edgeIndex === outerIndex, {
     type: "object",
     properties: {
         edgeIndex: {
@@ -436,13 +436,13 @@ const __cfLift_5 = __cfHelpers.lift<{
     required: ["edgeIndex", "outerIndex"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ edgeIndex, outerIndex }) => edgeIndex === outerIndex);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_6 = __cfHelpers.lift<{
     state: {
         lane: string;
     };
     edge: string;
-}, string>({
+}, string>(({ state, edge }) => `${state.lane}:${edge}`, {
     type: "object",
     properties: {
         state: {
@@ -461,7 +461,7 @@ const __cfLift_6 = __cfHelpers.lift<{
     required: ["state", "edge"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state, edge }) => `${state.lane}:${edge}`);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_2 = __cfHelpers.pattern(__cf_pattern_input => {
     const edge = __cf_pattern_input.key("element");
     const edgeIndex = __cf_pattern_input.key("index");
@@ -555,7 +555,69 @@ const __cfLift_7 = __cfHelpers.lift<{
     state: {
         lane: string;
     };
-}, __cfHelpers.JSXElement[]>({
+}, __cfHelpers.JSXElement[]>(({ visibleThreads, selectedCommentId, state }) => 
+// [TRANSFORM] .map() stays plain: visibleThreads is a captured input, plain inside this computed
+visibleThreads.map(({ thread, outerIndex, visibleComments }) => {
+    // [TRANSFORM] .map() stays plain: ["top","bottom"] is a literal array
+    const plainSeparators = ["top", "bottom"].map((edge) => `${thread.title}-${edge}`);
+    const liftedSeparators = passthroughLabels(plainSeparators).for("liftedSeparators", true);
+    // [TRANSFORM] computed() → lift() (nested): captures visibleComments from outer computed scope
+    const reboundComments = __cfLift_2({ visibleComments: visibleComments }).for("reboundComments", true);
+    return (<article>
+          <h2>{thread.title}</h2>
+          {/* [TRANSFORM] .map() stays plain: visibleComments is destructured from captured computed input */}
+          {visibleComments.map((comment, innerIndex) => (<div>
+              <button type="button" onClick={jumpToComment({
+                selectedCommentId: selectedCommentId,
+                threadId: thread.id,
+                commentId: comment.id,
+                lane: state.lane,
+                outerIndex,
+                innerIndex,
+            })}>
+                {comment.flagged
+                ? <strong>{comment.text}</strong>
+                : /* [TRANSFORM] ifElse: schema-injected authored ifElse(thread.muted, ..., ...) */ ifElse({
+                    type: "boolean"
+                } as const satisfies __cfHelpers.JSONSchema, {
+                    anyOf: [{}, {
+                            type: "object",
+                            properties: {}
+                        }]
+                } as const satisfies __cfHelpers.JSONSchema, {
+                    anyOf: [{}, {
+                            type: "object",
+                            properties: {}
+                        }]
+                } as const satisfies __cfHelpers.JSONSchema, {} as const satisfies __cfHelpers.JSONSchema, thread.muted, <em>{comment.text}</em>, <span>{comment.text}</span>)}
+              </button>
+              {/* [TRANSFORM] .map() stays plain: comment.reactions is compute-owned nested array data */}
+              {comment.reactions.map((reaction, reactionIndex) => (<span>
+                  {reactionIndex === innerIndex
+                    ? `${state.lane}:${reaction}`
+                    : reaction}
+                </span>))}
+            </div>))}
+          {/* [TRANSFORM] .map() → mapWithPattern: reboundComments is output of nested computed() — reactive even inside outer computed */}
+          {/* [TRANSFORM] closure captures: outerIndex (via params opaque), state.lane (via params reactive .key()) */}
+          {reboundComments.mapWithPattern(__cfPattern_1, {
+            outerIndex: outerIndex,
+            state: {
+                lane: state.lane
+            }
+        })}
+          {/* [TRANSFORM] .map() → mapWithPattern: liftedSeparators is output of lift() — reactive even inside outer computed */}
+          {/* [TRANSFORM] closure captures: outerIndex (via params opaque), state.lane (via params reactive .key()) */}
+          {liftedSeparators.mapWithPattern(__cfPattern_2, {
+            outerIndex: outerIndex,
+            state: {
+                lane: state.lane
+            }
+        })}
+          {/* [TRANSFORM] .map() stays plain: plainSeparators is a local literal array */}
+          {plainSeparators.map((edge) => <small>{edge}</small>)}
+        </article>);
+}), {
     type: "object",
     properties: {
         visibleThreads: {
@@ -654,72 +716,10 @@ const __cfLift_7 = __cfHelpers.lift<{
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ visibleThreads, selectedCommentId, state }) => 
-// [TRANSFORM] .map() stays plain: visibleThreads is a captured input, plain inside this computed
-visibleThreads.map(({ thread, outerIndex, visibleComments }) => {
-    // [TRANSFORM] .map() stays plain: ["top","bottom"] is a literal array
-    const plainSeparators = ["top", "bottom"].map((edge) => `${thread.title}-${edge}`);
-    const liftedSeparators = passthroughLabels(plainSeparators).for("liftedSeparators", true);
-    // [TRANSFORM] computed() → lift() (nested): captures visibleComments from outer computed scope
-    const reboundComments = __cfLift_2({ visibleComments: visibleComments }).for("reboundComments", true);
-    return (<article>
-          <h2>{thread.title}</h2>
-          {/* [TRANSFORM] .map() stays plain: visibleComments is destructured from captured computed input */}
-          {visibleComments.map((comment, innerIndex) => (<div>
-              <button type="button" onClick={jumpToComment({
-                selectedCommentId: selectedCommentId,
-                threadId: thread.id,
-                commentId: comment.id,
-                lane: state.lane,
-                outerIndex,
-                innerIndex,
-            })}>
-                {comment.flagged
-                ? <strong>{comment.text}</strong>
-                : /* [TRANSFORM] ifElse: schema-injected authored ifElse(thread.muted, ..., ...) */ ifElse({
-                    type: "boolean"
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{}, {
-                            type: "object",
-                            properties: {}
-                        }]
-                } as const satisfies __cfHelpers.JSONSchema, {
-                    anyOf: [{}, {
-                            type: "object",
-                            properties: {}
-                        }]
-                } as const satisfies __cfHelpers.JSONSchema, {} as const satisfies __cfHelpers.JSONSchema, thread.muted, <em>{comment.text}</em>, <span>{comment.text}</span>)}
-              </button>
-              {/* [TRANSFORM] .map() stays plain: comment.reactions is compute-owned nested array data */}
-              {comment.reactions.map((reaction, reactionIndex) => (<span>
-                  {reactionIndex === innerIndex
-                    ? `${state.lane}:${reaction}`
-                    : reaction}
-                </span>))}
-            </div>))}
-          {/* [TRANSFORM] .map() → mapWithPattern: reboundComments is output of nested computed() — reactive even inside outer computed */}
-          {/* [TRANSFORM] closure captures: outerIndex (via params opaque), state.lane (via params reactive .key()) */}
-          {reboundComments.mapWithPattern(__cfPattern_1, {
-            outerIndex: outerIndex,
-            state: {
-                lane: state.lane
-            }
-        })}
-          {/* [TRANSFORM] .map() → mapWithPattern: liftedSeparators is output of lift() — reactive even inside outer computed */}
-          {/* [TRANSFORM] closure captures: outerIndex (via params opaque), state.lane (via params reactive .key()) */}
-          {liftedSeparators.mapWithPattern(__cfPattern_2, {
-            outerIndex: outerIndex,
-            state: {
-                lane: state.lane
-            }
-        })}
-          {/* [TRANSFORM] .map() stays plain: plainSeparators is a local literal array */}
-          {plainSeparators.map((edge) => <small>{edge}</small>)}
-        </article>);
-}));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_8 = __cfHelpers.lift<{
     labelIndex: number;
-}, boolean>({
+}, boolean>(({ labelIndex }) => labelIndex === 0, {
     type: "object",
     properties: {
         labelIndex: {
@@ -729,13 +729,13 @@ const __cfLift_8 = __cfHelpers.lift<{
     required: ["labelIndex"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ labelIndex }) => labelIndex === 0);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_9 = __cfHelpers.lift<{
     state: {
         lane: string;
     };
     label: string;
-}, string>({
+}, string>(({ state, label }) => `${state.lane}:${label}`, {
     type: "object",
     properties: {
         state: {
@@ -754,7 +754,7 @@ const __cfLift_9 = __cfHelpers.lift<{
     required: ["state", "label"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, ({ state, label }) => `${state.lane}:${label}`);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
     const label = __cf_pattern_input.key("element");
     const labelIndex = __cf_pattern_input.key("index");

--- a/packages/ts-transformers/test/fixtures/kitchensink/nested-writable-pattern-branches.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/kitchensink/nested-writable-pattern-branches.expected.jsx
@@ -67,7 +67,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         sections: __cfHelpers.ReadonlyCell<unknown[]>;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.sections.get().length > 0, {
     type: "object",
     properties: {
         state: {
@@ -87,12 +87,12 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.sections.get().length > 0);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
     task: {
         note?: string | undefined;
     };
-}, boolean>({
+}, boolean>(({ task }) => task.note !== undefined, {
     type: "object",
     properties: {
         task: {
@@ -107,11 +107,11 @@ const __cfLift_2 = __cfHelpers.lift<{
     required: ["task"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ task }) => task.note !== undefined);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_3 = __cfHelpers.lift<{
     tagIndex: number;
     taskIndex: number;
-}, boolean>({
+}, boolean>(({ tagIndex, taskIndex }) => tagIndex === taskIndex, {
     type: "object",
     properties: {
         tagIndex: {
@@ -124,7 +124,7 @@ const __cfLift_3 = __cfHelpers.lift<{
     required: ["tagIndex", "taskIndex"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ tagIndex, taskIndex }) => tagIndex === taskIndex);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const tag = __cf_pattern_input.key("element");
     const tagIndex = __cf_pattern_input.key("index");
@@ -399,7 +399,13 @@ const __cfLift_4 = __cfHelpers.lift<{
         };
         title: string;
     };
-}, __cfHelpers.JSXElement>({
+}, __cfHelpers.JSXElement>(({ section }) => 
+// [TRANSFORM] ternary preserved inside the ifElse(expanded) false branch:
+//   section.tasks.length > 0 ? <small>...collapsed</small> : <small>empty</small>
+//   → plain local ternary inside the JSX branch
+section.tasks.length > 0
+    ? <small>{section.title} collapsed</small>
+    : <small>empty</small>, {
     type: "object",
     properties: {
         section: {
@@ -442,13 +448,7 @@ const __cfLift_4 = __cfHelpers.lift<{
             required: ["$UI"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, ({ section }) => 
-// [TRANSFORM] ternary preserved inside the ifElse(expanded) false branch:
-//   section.tasks.length > 0 ? <small>...collapsed</small> : <small>empty</small>
-//   → plain local ternary inside the JSX branch
-section.tasks.length > 0
-    ? <small>{section.title} collapsed</small>
-    : <small>empty</small>);
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_3 = __cfHelpers.pattern(__cf_pattern_input => {
     const section = __cf_pattern_input.key("element");
     const sectionIndex = __cf_pattern_input.key("index");

--- a/packages/ts-transformers/test/fixtures/schema-injection/builder-input-full-shape-continuity.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/builder-input-full-shape-continuity.expected.jsx
@@ -14,7 +14,10 @@ const __cfAmdHooks = undefined;
 // FIXTURE: builder-input-full-shape-continuity
 // Verifies: builder input schemas stay conservative/full-shape when the authored contract
 // does not justify path shrinking.
-const liftWrapped = lift({
+const liftWrapped = lift((input: Writable<{
+    foo: string;
+    bar: string;
+}>) => input.get().foo, {
     type: "object",
     properties: {
         foo: {
@@ -25,10 +28,7 @@ const liftWrapped = lift({
     asCell: ["readonly"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, (input: Writable<{
-    foo: string;
-    bar: string;
-}>) => input.get().foo);
+} as const satisfies __cfHelpers.JSONSchema);
 const patternFullShape = pattern((input: Writable<{
     foo: string;
     bar: string;
@@ -64,7 +64,10 @@ const patternExplicit = pattern((input) => input.key("foo"), {
     type: "string",
     asCell: ["cell"]
 } as const satisfies __cfHelpers.JSONSchema);
-const liftPassthrough = lift({
+const liftPassthrough = lift((input: Writable<{
+    foo: string;
+    bar: string;
+}>) => input, {
     type: "object",
     properties: {
         foo: {
@@ -88,10 +91,7 @@ const liftPassthrough = lift({
     },
     required: ["foo", "bar"],
     asCell: ["cell"]
-} as const satisfies __cfHelpers.JSONSchema, (input: Writable<{
-    foo: string;
-    bar: string;
-}>) => input);
+} as const satisfies __cfHelpers.JSONSchema);
 const helper = __cfHardenFn((value: Writable<{
     foo: string;
     bar: string;
@@ -115,7 +115,14 @@ const patternHelper = pattern((input: Writable<{
     type: "string",
     asCell: ["cell"]
 } as const satisfies __cfHelpers.JSONSchema);
-const wildcardLift = lift({
+const wildcardLift = lift((input: Writable<{
+    foo: string;
+    bar: string;
+}>) => {
+    const foo = input.key("foo").get();
+    Object.keys(input.get());
+    return foo;
+}, {
     type: "object",
     properties: {
         foo: {
@@ -129,14 +136,7 @@ const wildcardLift = lift({
     asCell: ["readonly"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, (input: Writable<{
-    foo: string;
-    bar: string;
-}>) => {
-    const foo = input.key("foo").get();
-    Object.keys(input.get());
-    return foo;
-});
+} as const satisfies __cfHelpers.JSONSchema);
 export default __cfHelpers.__cf_data({
     liftWrapped,
     patternFullShape,

--- a/packages/ts-transformers/test/fixtures/schema-injection/builder-input-path-shrink.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/builder-input-path-shrink.expected.jsx
@@ -14,7 +14,10 @@ const __cfAmdHooks = undefined;
 // FIXTURE: builder-input-path-shrink
 // Verifies: builder input schemas shrink to observed paths when reads/writes are specific,
 // including explicit type arguments and interprocedural helper calls.
-const liftOptional = lift({
+const liftOptional = lift((input: Writable<{
+    foo: string | undefined;
+    bar: string;
+}>) => input.key("foo").get(), {
     type: "object",
     properties: {
         foo: {
@@ -24,15 +27,12 @@ const liftOptional = lift({
     asCell: ["readonly"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
-} as const satisfies __cfHelpers.JSONSchema, (input: Writable<{
-    foo: string | undefined;
-    bar: string;
-}>) => input.key("foo").get());
+} as const satisfies __cfHelpers.JSONSchema);
 const deriveInput = __cfHelpers.__cf_data({} as Writable<{
     foo: string;
     bar: string;
 }>);
-const __cfLift_1 = __cfHelpers.lift(false, () => deriveInput.key("foo").get());
+const __cfLift_1 = __cfHelpers.lift(() => deriveInput.key("foo").get(), false);
 const computedObserved = __cfHelpers.__cf_data(__cfLift_1().for("computedObserved", true));
 const handlerObserved = handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
@@ -82,7 +82,10 @@ const helper = __cfHardenFn((value: Writable<{
     foo: string;
     bar: string;
 }>) => value.key("foo").get());
-const liftInterprocedural = lift({
+const liftInterprocedural = lift((input: Writable<{
+    foo: string;
+    bar: string;
+}>) => helper(input), {
     type: "object",
     properties: {
         foo: {
@@ -93,11 +96,14 @@ const liftInterprocedural = lift({
     asCell: ["readonly"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, (input: Writable<{
+} as const satisfies __cfHelpers.JSONSchema);
+const liftWriteOnly = lift((input: Writable<{
     foo: string;
     bar: string;
-}>) => helper(input));
-const liftWriteOnly = lift({
+}>) => {
+    input.key("foo").set("updated");
+    return 1;
+}, {
     type: "object",
     properties: {
         foo: {
@@ -108,14 +114,8 @@ const liftWriteOnly = lift({
     asCell: ["writeonly"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, (input: Writable<{
-    foo: string;
-    bar: string;
-}>) => {
-    input.key("foo").set("updated");
-    return 1;
-});
-const liftExplicit = lift({
+} as const satisfies __cfHelpers.JSONSchema);
+const liftExplicit = lift((input) => input.key("foo").get(), {
     type: "object",
     properties: {
         foo: {
@@ -126,7 +126,7 @@ const liftExplicit = lift({
     asCell: ["readonly"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, (input) => input.key("foo").get());
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfHandler_1 = __cfHelpers.handler(false as const satisfies __cfHelpers.JSONSchema, {
     type: "object",
     properties: {

--- a/packages/ts-transformers/test/fixtures/schema-injection/capability-wrapper-narrowing.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/capability-wrapper-narrowing.expected.jsx
@@ -28,7 +28,7 @@ type State = {
 // FIXTURE: capability-wrapper-narrowing
 // Verifies: lift inputs narrow from Writable<> to the least capable cell
 // wrapper required by callback usage.
-const readOnly = lift({
+const readOnly = lift((input: Writable<State>) => input.key("foo").get(), {
     type: "object",
     properties: {
         foo: {
@@ -39,8 +39,11 @@ const readOnly = lift({
     asCell: ["readonly"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
-} as const satisfies __cfHelpers.JSONSchema, (input: Writable<State>) => input.key("foo").get());
-const setOnly = lift({
+} as const satisfies __cfHelpers.JSONSchema);
+const setOnly = lift((input: Writable<State>) => {
+    input.key("foo").set("updated");
+    return 1;
+}, {
     type: "object",
     properties: {
         foo: {
@@ -51,11 +54,11 @@ const setOnly = lift({
     asCell: ["writeonly"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, (input: Writable<State>) => {
-    input.key("foo").set("updated");
+} as const satisfies __cfHelpers.JSONSchema);
+const updateOnly = lift((input: Writable<State>) => {
+    input.key("profile").update({ name: "Ada" });
     return 1;
-});
-const updateOnly = lift({
+}, {
     type: "object",
     properties: {
         profile: {
@@ -80,11 +83,11 @@ const updateOnly = lift({
     }
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, (input: Writable<State>) => {
-    input.key("profile").update({ name: "Ada" });
+} as const satisfies __cfHelpers.JSONSchema);
+const pushOnly = lift((input: Writable<State>) => {
+    input.key("items").push({ id: "1", label: "First" });
     return 1;
-});
-const pushOnly = lift({
+}, {
     type: "object",
     properties: {
         items: {
@@ -112,11 +115,11 @@ const pushOnly = lift({
     }
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, (input: Writable<State>) => {
-    input.key("items").push({ id: "1", label: "First" });
+} as const satisfies __cfHelpers.JSONSchema);
+const readWrite = lift((input: Writable<State>) => {
+    input.key("foo").set(input.key("foo").get().toUpperCase());
     return 1;
-});
-const readWrite = lift({
+}, {
     type: "object",
     properties: {
         foo: {
@@ -127,16 +130,13 @@ const readWrite = lift({
     asCell: ["cell"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, (input: Writable<State>) => {
-    input.key("foo").set(input.key("foo").get().toUpperCase());
-    return 1;
-});
-const comparable = lift({
+} as const satisfies __cfHelpers.JSONSchema);
+const comparable = lift((input: Writable<State>) => input.equals(input), {
     type: "unknown",
     asCell: ["comparable"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, (input: Writable<State>) => input.equals(input));
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
     const item = __cf_pattern_input.key("element");
     return item.key("id");
@@ -165,7 +165,7 @@ const __cfPattern_1 = __cfHelpers.pattern(__cf_pattern_input => {
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "string"
 } as const satisfies __cfHelpers.JSONSchema);
-const opaqueMap = lift({
+const opaqueMap = lift((input: Writable<Item[]>) => input.mapWithPattern(__cfPattern_1, {}), {
     type: "array",
     items: {
         $ref: "#/$defs/Item"
@@ -190,7 +190,7 @@ const opaqueMap = lift({
     items: {
         type: "string"
     }
-} as const satisfies __cfHelpers.JSONSchema, (input: Writable<Item[]>) => input.mapWithPattern(__cfPattern_1, {}));
+} as const satisfies __cfHelpers.JSONSchema);
 export { comparable, opaqueMap, pushOnly, readOnly, readWrite, setOnly, updateOnly, };
 // @ts-ignore: Internals
 function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }

--- a/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection-shorthand.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection-shorthand.expected.jsx
@@ -11,7 +11,15 @@ import { Cell, computed, lift, pattern, Writable } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const liftSummary = lift({
+const liftSummary = lift(({ primary, secondary }) => {
+    const primaryValue = primary.get();
+    const secondaryValue = secondary.get();
+    return {
+        primary: primaryValue,
+        secondary: secondaryValue,
+        difference: primaryValue - secondaryValue,
+    };
+}, {
     type: "object",
     properties: {
         primary: {
@@ -38,20 +46,12 @@ const liftSummary = lift({
         }
     },
     required: ["primary", "secondary", "difference"]
-} as const satisfies __cfHelpers.JSONSchema, ({ primary, secondary }) => {
-    const primaryValue = primary.get();
-    const secondaryValue = secondary.get();
-    return {
-        primary: primaryValue,
-        secondary: secondaryValue,
-        difference: primaryValue - secondaryValue,
-    };
-});
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_1 = __cfHelpers.lift<{
     summary: {
         difference: any;
     };
-}, any>({
+}, any>(({ summary }) => summary.difference, {
     type: "object",
     properties: {
         summary: {
@@ -63,7 +63,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     },
     required: ["summary"]
-} as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema, ({ summary }) => summary.difference);
+} as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: context-lift-result-property-projection-shorthand
 // Verifies: shorthand object returns preserve the projected computed() result type
 //   return { difference } → result schema difference: number

--- a/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/context-lift-result-property-projection.expected.jsx
@@ -11,7 +11,15 @@ import { Cell, computed, lift, pattern, Writable } from "commonfabric";
 const define = undefined;
 const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
-const liftSummary = lift({
+const liftSummary = lift(({ primary, secondary }) => {
+    const primaryValue = primary.get();
+    const secondaryValue = secondary.get();
+    return {
+        primary: primaryValue,
+        secondary: secondaryValue,
+        difference: primaryValue - secondaryValue,
+    };
+}, {
     type: "object",
     properties: {
         primary: {
@@ -38,20 +46,12 @@ const liftSummary = lift({
         }
     },
     required: ["primary", "secondary", "difference"]
-} as const satisfies __cfHelpers.JSONSchema, ({ primary, secondary }) => {
-    const primaryValue = primary.get();
-    const secondaryValue = secondary.get();
-    return {
-        primary: primaryValue,
-        secondary: secondaryValue,
-        difference: primaryValue - secondaryValue,
-    };
-});
+} as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_1 = __cfHelpers.lift<{
     summary: {
         difference: any;
     };
-}, any>({
+}, any>(({ summary }) => summary.difference, {
     type: "object",
     properties: {
         summary: {
@@ -63,7 +63,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     },
     required: ["summary"]
-} as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema, ({ summary }) => summary.difference);
+} as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: context-lift-result-property-projection
 // Verifies: a reactive builder preserves projected property schemas when the captured
 // input comes from a typed lift() result rather than falling back to unknown

--- a/packages/ts-transformers/test/fixtures/schema-injection/db-query-consumer-decode.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-injection/db-query-consumer-decode.expected.jsx
@@ -21,7 +21,11 @@ interface User {
 // `result.items.author_cf_link` carries `asCell: ["cell"]`. Combined with the
 // runtime storing a sigil OBJECT (Piece A), that asCell read rehydrates the
 // column to a live Cell.
-const readAuthor = lift({
+const readAuthor = lift((qv: {
+    result?: Array<{
+        author_cf_link: Cell<User>;
+    }>;
+}) => qv.result?.[0]?.author_cf_link, {
     type: "object",
     properties: {
         result: {
@@ -67,11 +71,7 @@ const readAuthor = lift({
             required: ["name"]
         }
     }
-} as const satisfies __cfHelpers.JSONSchema, (qv: {
-    result?: Array<{
-        author_cf_link: Cell<User>;
-    }>;
-}) => qv.result?.[0]?.author_cf_link);
+} as const satisfies __cfHelpers.JSONSchema);
 export default pattern(() => {
     const db = sqliteDatabase().for("db", true);
     const q = db.query<{

--- a/packages/ts-transformers/test/fixtures/schema-transform/boolean-result-schema-normalization.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/boolean-result-schema-normalization.expected.jsx
@@ -15,7 +15,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     state: {
         score: number;
     };
-}, boolean>({
+}, boolean>(({ state }) => state.score > 100, {
     type: "object",
     properties: {
         state: {
@@ -31,7 +31,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["state"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "boolean"
-} as const satisfies __cfHelpers.JSONSchema, ({ state }) => state.score > 100);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: boolean-result-schema-normalization
 // Verifies: boolean result schemas stay normalized as `type: "boolean"` instead
 // of expanding into literal `true` / `false` enums.

--- a/packages/ts-transformers/test/fixtures/schema-transform/cell-get-binding-autowrap.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/cell-get-binding-autowrap.expected.jsx
@@ -13,7 +13,7 @@ const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     layout: __cfHelpers.Writable<string>;
-}, number>({
+}, number>(({ layout }) => layout.get().trim().length, {
     type: "object",
     properties: {
         layout: {
@@ -24,7 +24,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["layout"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ layout }) => layout.get().trim().length);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: cell-get-binding-autowrap
 // Verifies: a bare `cell.get()` that feeds a computation at a variable-initializer
 //   binding is auto-wrapped into a lift, the same way it is in a JSX expression.

--- a/packages/ts-transformers/test/fixtures/schema-transform/pattern-any-result-override.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/pattern-any-result-override.expected.jsx
@@ -16,7 +16,7 @@ declare function fetchAny(): any;
 const __cfLift_1 = __cfHelpers.lift<{
     result: any;
     prompt: string;
-}, any>({
+}, any>(({ result, prompt }) => result?.title || prompt || "Untitled", {
     type: "object",
     properties: {
         result: true,
@@ -25,7 +25,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     },
     required: ["result", "prompt"]
-} as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema, ({ result, prompt }) => result?.title || prompt || "Untitled");
+} as const satisfies __cfHelpers.JSONSchema, true as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: pattern-any-result-override
 // Verifies: explicit Output type parameter overrides inferred `any` return type for schema generation
 //   pattern<Input, string>() → output schema { type: "string" } instead of inferred any

--- a/packages/ts-transformers/test/fixtures/schema-transform/pattern-explicit-types.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/pattern-explicit-types.expected.jsx
@@ -19,7 +19,7 @@ interface Output extends Input {
 }
 const __cfLift_1 = __cfHelpers.lift<{
     input: { foo: string; } & {} & { [SELF]: Output; };
-}, { bar: number; foo: string; [SELF]: Output; }>({
+}, { bar: number; foo: string; [SELF]: Output; }>(({ input }) => ({ ...input, bar: 123 }), {
     type: "object",
     properties: {
         input: {
@@ -44,7 +44,7 @@ const __cfLift_1 = __cfHelpers.lift<{
         }
     },
     required: ["bar", "foo"]
-} as const satisfies __cfHelpers.JSONSchema, ({ input }) => ({ ...input, bar: 123 }));
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: pattern-explicit-types
 // Verifies: explicit Input and Output type parameters generate separate input/output schemas
 //   pattern<Input, Output>() → input schema from Input, output schema from Output (includes inherited fields)

--- a/packages/ts-transformers/test/fixtures/schema-transform/reactive-array-element-access-schema.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/reactive-array-element-access-schema.expected.jsx
@@ -14,7 +14,7 @@ const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     items: __cfHelpers.Cell<string[]>;
     index: __cfHelpers.Cell<number>;
-}, string | undefined>({
+}, string | undefined>(({ items, index }) => items.get()[index.get()], {
     type: "object",
     properties: {
         items: {
@@ -32,7 +32,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["items", "index"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: ["string", "undefined"]
-} as const satisfies __cfHelpers.JSONSchema, ({ items, index }) => items.get()[index.get()]);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: reactive-array-element-access-schema
 // Verifies: reactive array element access preserves `string | undefined` in the
 // emitted result schema.

--- a/packages/ts-transformers/test/fixtures/schema-transform/with-opaque-ref.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/with-opaque-ref.expected.jsx
@@ -31,7 +31,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     cell: {
         value: __cfHelpers.Cell<number>;
     };
-}, number>({
+}, number>(({ cell }) => cell.value.get() * 2, {
     type: "object",
     properties: {
         cell: {
@@ -48,7 +48,7 @@ const __cfLift_1 = __cfHelpers.lift<{
     required: ["cell"]
 } as const satisfies __cfHelpers.JSONSchema, {
     type: "number"
-} as const satisfies __cfHelpers.JSONSchema, ({ cell }) => cell.value.get() * 2);
+} as const satisfies __cfHelpers.JSONSchema);
 // FIXTURE: with-opaque-ref
 // Verifies: Cell<> fields generate asCell in schema and a reactive builder gets input/output schemas injected
 //   Cell<number> → { type: "number", asCell: true }


### PR DESCRIPTION
Reorders `lift` to **function-first** — callback leads, schemas trail — matching `pattern()`. The schema-bearing, **type-materializing** overloads (where the callback's input type is derived *from* the supplied JSONSchema via `Schema<>`) live in `commonfabric/schema` (`api/schema.ts`); `api/index.ts` carries only the schema-light callback-only form. This mirrors the split `pattern()`/`handler()` already use, so a provided type and a provided schema can never contradict.

## Why

Per CT-1625 + Berni's review: lift's type surface was duplicated and inconsistent. The fix is twofold — (1) make lift function-first (matching `pattern()`), and (2) put the `Schema<>`-materializing overloads in the on-demand `commonfabric/schema` module as the single canonical schema-mode, rather than as ad-hoc overloads on the runtime/facade that could disagree with hand-written types.

The no-input (computed-origin) form is `lift(fn, false)` — `argumentSchema: false` keeps the no-arg application valid; byte-identical runtime spec to the old `lift(false, fn)`.

## Changes

- **`runner/src/builder/module.ts`** — function-first runtime overloads + simplified impl dispatch (callback at arg 0; no `typeof arg === "function"` sniffing).
- **`api/index.ts`** — `LiftFunction` is the schema-light surface: callback-only overloads, no schema params.
- **`api/schema.ts`** — `LiftFunction` augmentation: **callback-first, `Schema<>`-materializing** overloads (`lift(fn, argSchema, resSchema)` materializes the callback input from `argSchema`), mirroring the existing `PatternFunction` augmentation.
- **`ts-transformers/schema-injection.ts`** — emit `lift(cb, argSchema, resSchema, options?)`.
- **`compiled-bundle-verifier.ts`** — callback-slot updated to position 0.
- ~10 runner test files + goldens flipped to function-first. `schema-to-ts.test.ts` gains a **materialization test** for the new schema.ts overloads (with a `@ts-expect-error` negative proof that the callback input is genuinely typed from the schema).

## Two bugs fixed along the way (neither visible in goldens alone)

1. **Schema doubling** — hoisted-and-applied lifts were schema-injected twice (the second pass was masked by a schema-first positional check). Fixed by marking the rebuilt inner lift injected so the re-descent self-skips.
2. **Options scrambling** — a `computed()` that writes to a captured cell emits a trailing `{ materializerWriteInputPaths }` options object. The function-first append put it *before* the schemas, so the runtime read it as the `argumentSchema`, breaking 5 write-capability pattern tests at runtime. Fixed by splicing schemas between the callback and trailing options. Added a regression fixture (`computed-write-capability-materializer`) since no golden covered this path — only `integration pattern-tests` caught it.

## Follow-up: handler is still schema-first

This PR reorders only `lift`. `handler(eventSchema, stateSchema, cb)` remains schema-first; reordering it to match (and applying the same index.ts/schema.ts split) is tracked in CT-1678.

## Verification

- ts-transformers 292/0, runner 547/0, integration pattern-tests 54/54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---BEGIN COPY-PASTE---
NEW_PERF_BASELINE: test: pattern-unit-4/pattern-unit-tests = 243s
---END COPY-PASTE---