### PR TITLE
test(runner): lock __cfReg invariants + clarify forward-ref/trust-gate semantics (CT-1623 follow-up)

### DIFF
--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -922,6 +922,15 @@ export class PatternManager {
         `No "${symbol}" export or hoist registration found in compiled pattern.`,
       );
     }
+    // Gate is pattern-only on purpose: `seedVerifiedLoadIds` is CFC's
+    // pattern-specific verified-load association, so it must not run for a
+    // lift/handler. The forward `{ identity, symbol }` ref for a NON-pattern
+    // artifact is NOT skipped here — `registerEvaluatedModules` (called at the
+    // top of this method) already set it via `indexArtifact`, whose gate is the
+    // wider `isTrustedBuilderArtifact`. Keep that ordering: widening this gate
+    // instead would (wrongly) seed load-ids for non-patterns, and narrowing
+    // `indexArtifact` would drop exported lift/handler forward refs — the gap
+    // Codex flagged on an earlier revision of #3912.
     if (isTrustedPattern(pattern)) {
       this.valueToEntryRef.set(pattern, { identity: entryIdentity, symbol });
       if (loadId) {
@@ -1008,8 +1017,18 @@ export class PatternManager {
     else bucket = new Map<string, unknown>();
     bucket.set(symbol, value);
     this.addressableByIdentity.set(identity, bucket);
-    // Forward map — don't overwrite an existing ref (e.g. a value that is both a
-    // `__cfReg` entry and an export, or whose entry ref the caller set first).
+    // Forward map is FIRST-WRITE-WINS, deliberately, on two grounds:
+    //   - One artifact instance legitimately reachable under two refs (e.g. both
+    //     a `__cfReg` entry AND an export, or set first by `patternFromMain`)
+    //     keeps a single canonical `{ identity, symbol }` for serialization.
+    //   - The reverse index above already overwrote, so by-identity LOOKUP
+    //     (`artifactFromIdentitySync`) is always fresh; the forward ref only
+    //     needs to be A valid name for the value, not the newest.
+    // Caveat: if the SAME instance is later re-registered under a CHANGED
+    // identity (a content edit that preserves object identity across re-eval),
+    // the forward ref stays pinned to the original — acceptable because the
+    // value is, by content identity, the original. `getArtifactEntryRef`
+    // consumers tolerate this (it resolves to a real, addressable artifact).
     if (!this.valueToEntryRef.has(value as object)) {
       this.valueToEntryRef.set(value as object, { identity, symbol });
     }

--- a/packages/runner/test/cfreg-security.test.ts
+++ b/packages/runner/test/cfreg-security.test.ts
@@ -111,3 +111,88 @@ describe("HoistRegistrationSink stays untouched on a rejected registration", () 
     expect(sink.get("id")?.has("__cfPattern_1")).toBe(true);
   });
 });
+
+// CT-1623 follow-up: lock the CONTRACT between the transformer's emitted
+// `__cfReg({ … })` shape and the verifier's static approval check. The transformer
+// and the verifier hold two independent definitions of "a valid registration
+// call"; if they drift, a real registration silently routes to the rejecting
+// registrar (fail-closed, but a confusing breakage). These pin the exact shapes
+// the transformer emits (builder-call-hoisting.ts: a trailing call whose argument
+// is a multiline shorthand object of previously-declared top-level bindings) as
+// APPROVED, and assert the tamper shapes the verifier is meant to refuse are not.
+describe("transformer __cfReg emit round-trips through the verifier", () => {
+  it("approves the exact multiline shorthand shape the transformer emits", () => {
+    // Mirrors builder-call-hoisting.ts: `factory.createObjectLiteralExpression(
+    // …, /* multiline */ true)` over shorthand assignments — one entry per line.
+    const body = `${IMPORT}
+const __cfPattern_1 = (0, cf.pattern)((s) => s);
+const __cfLift_1 = (0, cf.lift)((x) => x);
+__cfReg({
+    __cfPattern_1,
+    __cfLift_1
+});`;
+    expect(verifyCompiledModuleBody(body, "/main.tsx").hasHoistRegistration)
+      .toBe(true);
+  });
+
+  it("approves the single-entry trailing-comma form", () => {
+    const body = `${IMPORT}
+const __cfLift_1 = (0, cf.lift)((x) => x);
+__cfReg({
+    __cfLift_1,
+});`;
+    expect(verifyCompiledModuleBody(body, "/main.tsx").hasHoistRegistration)
+      .toBe(true);
+  });
+
+  it("does NOT approve a __cfReg over a binding that was never declared", () => {
+    // Every key must be a previously-seen top-level binding. A registration that
+    // names an undeclared symbol is not a valid call (the whole statement then
+    // falls through to unknown-identifier rejection — the body is refused).
+    const body = `${IMPORT}\n__cfReg({ __cfPattern_99 });`;
+    expect(() => verifyCompiledModuleBody(body, "/main.tsx")).toThrow();
+  });
+
+  it("does NOT approve a key:value (non-shorthand) registration", () => {
+    // Only shorthand identifiers are a valid registration; `key: value` lets the
+    // value be an arbitrary expression, so the call shape is refused.
+    const body =
+      `${IMPORT}\nconst __cfLift_1 = (0, cf.lift)((x) => x);\n__cfReg({ __cfLift_1: globalThis });`;
+    expect(() => verifyCompiledModuleBody(body, "/main.tsx")).toThrow();
+  });
+
+  it("refuses a second top-level __cfReg call (tampering signal)", () => {
+    const body = `${IMPORT}
+const __cfLift_1 = (0, cf.lift)((x) => x);
+__cfReg({ __cfLift_1 });
+__cfReg({ __cfLift_1 });`;
+    expect(() => verifyCompiledModuleBody(body, "/main.tsx")).toThrow();
+  });
+});
+
+// CT-1623 follow-up: pin the staleness-overwrite contract at the public sink
+// layer. `indexArtifact` overwrites the reverse mapping on re-eval so by-identity
+// LOOKUP is always fresh; the same freshness must hold one layer down, where a
+// module that re-evaluates (same identity, fresh artifact instance) re-stages and
+// commits. A second commit under the same identity must REPLACE the prior staged
+// map, not merge a stale instance into it.
+describe("re-registration under the same identity commits the fresh staged set", () => {
+  it("a later commit replaces the sink entry for that identity", () => {
+    const sink: HoistRegistrationSink = new Map();
+
+    const first = brandTrustedBuilderArtifact({});
+    const r1 = createHoistRegistrar("idX", sink);
+    r1.register({ __cfLift_1: first });
+    r1.commit();
+    expect(sink.get("idX")?.get("__cfLift_1")).toBe(first);
+
+    // Re-eval of the same module identity yields a fresh registrar + instance.
+    const second = brandTrustedBuilderArtifact({});
+    const r2 = createHoistRegistrar("idX", sink);
+    r2.register({ __cfLift_1: second });
+    r2.commit();
+    // The sink reflects the freshest instance, never the stale one.
+    expect(sink.get("idX")?.get("__cfLift_1")).toBe(second);
+    expect(sink.get("idX")?.get("__cfLift_1")).not.toBe(first);
+  });
+});


### PR DESCRIPTION
## What

Follow-ups on #3912 (CT-1623, content-addressable builder artifacts via `__cfReg`), turning a few review observations from a post-merge read into **tests + comments that guard against regression**. No behavior change — pure invariant-locking, all on the off-by-default `esmModuleLoader` path.

Splitting these out rather than commenting so they're reviewable/mergeable on their own; happy to fold or drop any.

## Changes

**`pattern-manager.ts` — comments only**
- `patternFromMain`: document *why* the forward-ref gate here is pattern-only (`seedVerifiedLoadIds` is CFC's pattern-specific verified-load association), and that non-pattern artifacts (lift/handler) get their forward ref from `indexArtifact`'s wider `isTrustedBuilderArtifact` gate earlier in the same method. That ordering is load-bearing: widening this gate would wrongly seed load-ids for non-patterns, and narrowing `indexArtifact` would drop exported lift/handler forward refs — the exact gap Codex flagged on an earlier revision. The comment pins it so a future edit doesn't silently reintroduce it.
- `indexArtifact`: make the forward map's **first-write-wins** policy explicit, including the re-eval-under-changed-identity caveat (the reverse index stays fresh via overwrite, so by-identity *lookup* is always correct; the forward ref only needs to be *a* valid name for the value).

**`cfreg-security.test.ts` — new tests**
- **Transformer ↔ verifier round-trip:** feed the verifier the exact `__cfReg` shapes the transformer emits (multiline shorthand object; single-entry trailing comma) and assert `hasHoistRegistration === true`. The transformer's emitter and the verifier's `isHoistRegistrationCallNormalized` are two independent definitions of "a valid registration call" — if they drift, a real registration silently routes to the rejecting registrar (fail-closed, but a confusing breakage). These lock the contract. Plus negatives: undeclared binding, `key: value` (non-shorthand), and a duplicate top-level `__cfReg` are all refused.
- **Staleness-overwrite at the sink layer:** a re-registration under the same identity commits the *fresh* staged set — mirrors `indexArtifact`'s reverse-index overwrite one layer down.

## Testing

`cfreg-security` 6/6, `cfreg-builder-identity` 2/2, `esm-verifier-adversarial` corpus intact; `deno fmt --check` + `deno lint` + `deno check` clean.

## Not included (flagging for your call)

Two items from the same read I did **not** turn into code, since they're judgment calls you own:
- The bounded-cache sizing (`MAX_EVALUATED_MODULE_CACHE_SIZE` shared by `modulesByIdentity` + `addressableByIdentity`) — once the flag is on, worth watching whether op-by-identity hit rates hold under real multi-pattern sessions (degrades correctly to `$opFallback`, just defeats the dedup). No action now.
- Whether exported `export const foo = lift(...)` *should* eventually route through `__cfReg` too (your description notes the CommonJS-emit reason it doesn't, as an optional follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add tests and comments to lock the `__cfReg` contract from CT-1623 and clarify forward-ref/trust-gate semantics in the runner. No behavior change; this hardens the content-addressable path under the off-by-default `esmModuleLoader`.

- **Refactors**
  - Document why `patternFromMain` seeds forward refs only for patterns (`isTrustedPattern`) and how non-pattern artifacts get theirs earlier via `indexArtifact` under `isTrustedBuilderArtifact`.
  - Make the forward map’s first-write-wins policy explicit, noting reverse-index freshness and the re-eval-under-changed-identity caveat.

- **New Tests**
  - Verify the transformer’s emitted `__cfReg({ ... })` shapes are accepted by the verifier (multiline shorthand object; single-entry with trailing comma), and reject undeclared bindings, non-shorthand `key: value`, and duplicate top-level `__cfReg`.
  - Ensure re-registration under the same identity replaces the staged set at the sink, mirroring `indexArtifact`’s reverse-index overwrite.

<sup>Written for commit 12ca8b4e9f99fe4e5cbca0681eaf9594d2efffa4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

