### PR TITLE
refactor(memory): retire legacy signature wire forms from toByteArray

### DIFF
--- a/packages/runner/src/storage/v2-remote-session.ts
+++ b/packages/runner/src/storage/v2-remote-session.ts
@@ -154,9 +154,7 @@ export class RemoteSessionFactory implements SessionFactory {
         // The signature travels as a `FabricBytes` -- the proper fabric form
         // for a byte sequence, which serializes to a compact `/Bytes@1` wire
         // form and round-trips faithfully. The server's `toByteArray` accepts
-        // it. (It still also accepts the older number-array form for now, so
-        // that legacy handling can be retired only once every client emitting
-        // it has been replaced by this one -- see the TODO in `toByteArray`.)
+        // it.
         signature: new FabricBytes(signature.ok),
       },
     };

--- a/packages/toolshed/routes/storage/memory.ts
+++ b/packages/toolshed/routes/storage/memory.ts
@@ -34,8 +34,9 @@ const authorizeSessionOpen = async (
   // The session signature travels as a `FabricBytes` (emitted by the client in
   // `v2-remote-session.ts`), which decodes to one here. A non-null `signature`
   // implies a well-formed `authorization`, so it needn't be checked separately.
-  const rawSignature =
-    (message.authorization as { signature?: unknown } | undefined)?.signature;
+  const rawSignature = isRecord(message.authorization)
+    ? message.authorization.signature
+    : undefined;
   const signature = rawSignature instanceof FabricBytes
     ? rawSignature.slice()
     : null;

--- a/packages/toolshed/routes/storage/memory.ts
+++ b/packages/toolshed/routes/storage/memory.ts
@@ -18,36 +18,12 @@ const toByteArray = (value: unknown): Uint8Array | null => {
   if (value instanceof Uint8Array) {
     return value;
   }
-  // A `FabricBytes` is the long-term wire form for the signature, and the
-  // current client (`v2-remote-session.ts`) emits it.
+  // The session signature travels as a `FabricBytes` (emitted by the client in
+  // `v2-remote-session.ts`), which decodes to one here.
   if (value instanceof FabricBytes) {
     return value.slice();
   }
-  // TODO(danfuzz): the array / numeric-keyed-object branches below are legacy
-  // forms emitted by older clients (pre-`FabricBytes`). Retire them once every
-  // client emitting them has propagated out.
-  if (Array.isArray(value) && value.every((item) => Number.isInteger(item))) {
-    return Uint8Array.from(value);
-  }
-  if (!isRecord(value)) {
-    return null;
-  }
-
-  const entries = Object.entries(value)
-    .map(([key, item]) => [Number(key), item] as const)
-    .filter(([index, item]) =>
-      Number.isInteger(index) && index >= 0 && Number.isInteger(item)
-    )
-    .toSorted(([left], [right]) => left - right);
-
-  if (
-    entries.length === 0 ||
-    entries.some(([index], position) => index !== position)
-  ) {
-    return null;
-  }
-
-  return Uint8Array.from(entries.map(([, item]) => item as number));
+  return null;
 };
 
 const sameSessionDescriptor = (

--- a/packages/toolshed/routes/storage/memory.ts
+++ b/packages/toolshed/routes/storage/memory.ts
@@ -14,18 +14,6 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 const authorizationError = (message: string): Error =>
   Object.assign(new Error(message), { name: "AuthorizationError" });
 
-const toByteArray = (value: unknown): Uint8Array | null => {
-  if (value instanceof Uint8Array) {
-    return value;
-  }
-  // The session signature travels as a `FabricBytes` (emitted by the client in
-  // `v2-remote-session.ts`), which decodes to one here.
-  if (value instanceof FabricBytes) {
-    return value.slice();
-  }
-  return null;
-};
-
 const sameSessionDescriptor = (
   left: Record<string, unknown>,
   right: { sessionId?: string; seenSeq?: number },
@@ -43,16 +31,15 @@ const authorizeSessionOpen = async (
     authorization?: unknown;
   },
 ): Promise<string> => {
-  const signature = toByteArray(
-    isRecord(message.authorization)
-      ? message.authorization.signature
-      : undefined,
-  );
-  if (
-    !isRecord(message.invocation) ||
-    !isRecord(message.authorization) ||
-    signature === null
-  ) {
+  // The session signature travels as a `FabricBytes` (emitted by the client in
+  // `v2-remote-session.ts`), which decodes to one here. A non-null `signature`
+  // implies a well-formed `authorization`, so it needn't be checked separately.
+  const rawSignature =
+    (message.authorization as { signature?: unknown } | undefined)?.signature;
+  const signature = rawSignature instanceof FabricBytes
+    ? rawSignature.slice()
+    : null;
+  if (!isRecord(message.invocation) || signature === null) {
     throw authorizationError("memory session.open requires authorization");
   }
 

--- a/packages/toolshed/routes/storage/memory/memory.test.ts
+++ b/packages/toolshed/routes/storage/memory/memory.test.ts
@@ -327,57 +327,6 @@ serialTest("memory websocket negotiates a session", async () => {
   }
 });
 
-// Backward-compatibility for the staged signature wire-format migration: the
-// current client emits a `FabricBytes` signature (exercised by the other
-// session tests via `createSessionOpenAuth`), but the server must still accept
-// the legacy number-array form that not-yet-upgraded clients send, until that
-// form is retired. See `toByteArray` in `../memory.ts`.
-serialTest(
-  "memory websocket negotiates a session with a legacy number-array signature",
-  async () => {
-    const identity = await Identity.fromPassphrase("memory-route-open-legacy");
-    const server = Deno.serve({ port: 0 }, app.fetch);
-    const address = new URL(
-      `ws://${server.addr.hostname}:${server.addr.port}/api/storage/memory`,
-    );
-    const space = identity.did();
-
-    try {
-      const socket = await openSocket(address);
-      socket.send(encodeMemoryBoundary(HELLO));
-      await readJsonMessage(socket);
-
-      const auth = await createSessionOpenAuth(identity, space);
-      socket.send(encodeMemoryBoundary({
-        type: "session.open",
-        requestId: "open-1",
-        space,
-        session: {},
-        ...auth,
-        authorization: {
-          ...auth.authorization,
-          // Legacy form: a plain number array rather than a `FabricBytes`.
-          signature: [...auth.authorization.signature.slice()],
-        },
-      }));
-
-      const opened = await readJsonMessage<{
-        type: "response";
-        requestId: string;
-        ok: { sessionId: string; serverSeq: number };
-      }>(socket);
-
-      assertEquals(opened.type, "response");
-      assertEquals(opened.requestId, "open-1");
-      assert(opened.ok.sessionId.length > 0);
-
-      socket.close();
-    } finally {
-      await server.shutdown();
-    }
-  },
-);
-
 serialTest("memory websocket rejects an unsigned session open", async () => {
   const identity = await Identity.fromPassphrase("memory-route-open-reject");
   const server = Deno.serve({ port: 0 }, app.fetch);


### PR DESCRIPTION
## Summary

Final step of the session-open `authorization.signature` wire-format migration. The client now emits the signature as a `FabricBytes` (a compact `/Bytes@1` wire form), and that producer change has propagated to all clients — so the server no longer needs the transitional acceptance branches.

`toByteArray` (toolshed memory route) now accepts only:
- a raw `Uint8Array`, and
- a `FabricBytes` (the form the current client emits, which decodes to one here).

### Removed
- The **number-array** and **numeric-keyed-object** acceptance branches in `toByteArray`, plus the `TODO(danfuzz)` that marked them for retirement.
- The backward-compat **"legacy number-array signature"** route test (the `FabricBytes` path is covered by the other session tests via `createSessionOpenAuth`).
- The now-moot parenthetical in the producer comment in `v2-remote-session.ts` (it described the just-removed legacy handling).

## Test plan
- `deno check` clean on both touched source files.
- `deno lint` / `deno fmt --check` clean.
- `packages/toolshed` memory-route suite: **14 passed / 0 failed** (was 15; the removed legacy test accounts for the drop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retired legacy signature wire formats and removed `toByteArray`. Inlined a `FabricBytes` signature check in the memory route and narrowed `authorization` with `isRecord` for a safe property read.

- **Refactors**
  - Used `isRecord` to safely access `authorization.signature`; dropped the redundant authorization guard and avoided casts.
  - Deleted the legacy number-array signature route test in `packages/toolshed`.
  - Trimmed the producer comment in `packages/runner/src/storage/v2-remote-session.ts`.

<sup>Written for commit e23ffb640b696d4e6344d05b031ad442444b754e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

