### PR TITLE
test(runner): pattern-binding unwrap micro-bench + reload bindNodeIO analysis

### DIFF
--- a/packages/runner/test/pattern-binding.bench.ts
+++ b/packages/runner/test/pattern-binding.bench.ts
@@ -1,0 +1,273 @@
+// Micro-benchmark for `unwrapOneLevelAndBindtoDoc`.
+//
+// CONTEXT / CONCLUSION: reload profiling showed `bindNodeIO` is ~90% of per-node
+// instantiation cost during the `raw:map` notes-list reconcile (~3ms/node, up to
+// ~52ms for one node). `bindNodeIO` = unwrapOneLevelAndBindtoDoc(in/out) +
+// findAllWriteRedirectCells(in/out). This bench was written to study the unwrap
+// part — and it PROVED unwrap is NOT the bottleneck:
+//   * unwrap is ~1.9µs/alias (5.2µs with $ref/$defs schemas) and linear — a real
+//     UI node (~30 aliases) is sub-millisecond.
+//   * A browser split-probe confirmed it: per reload, bio/unwrap = 6ms total
+//     across 133 nodes, while bio/findRedir (findAllWriteRedirectCells) = 356ms.
+// So the real cost is `findAllWriteRedirectCells`, which is NOT a pure transform:
+// it follows every write-redirect link via
+// `parseLink -> runtime.getCellFromLink -> linkCell.getRaw() -> recurse`, i.e.
+// recursive cell/storage resolution per node. That part needs a Runtime, so it
+// isn't covered by this pure micro-bench (TODO: add an emulate-runtime bench for
+// findAllWriteRedirectCells to study/optimize the actual hotspot).
+//
+// unwrapOneLevelAndBindtoDoc itself is PURE (CFC schema traversal + deep
+// clone/rebind of the binding tree; no storage/tx), studied in isolation below.
+//
+// Run as a bench:        deno bench -A packages/runner/test/pattern-binding.bench.ts
+// Run directly (study):  deno run  -A packages/runner/test/pattern-binding.bench.ts
+//                        deno run  -A packages/runner/test/pattern-binding.bench.ts 2000   # custom size
+
+import { unwrapOneLevelAndBindtoDoc } from "../src/pattern-binding.ts";
+import { ContextualFlowControl } from "../src/cfc.ts";
+import type { NormalizedFullLink } from "../src/link-types.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+
+const cfc = new ContextualFlowControl();
+
+// A notebook-ish argument schema: notes[] of records with a few fields. Real
+// UI bindings alias into argument.notes[i].<field>, so scopedLinkForPath walks
+// this schema per path key per alias.
+const ARG_SCHEMA: JSONSchema = {
+  type: "object",
+  properties: {
+    notes: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          title: { type: "string" },
+          body: { type: "string" },
+          done: { type: "boolean" },
+          meta: {
+            type: "object",
+            properties: {
+              created: { type: "number" },
+              tags: { type: "array", items: { type: "string" } },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+function link(
+  id: string,
+  schema: JSONSchema | undefined,
+): NormalizedFullLink {
+  return {
+    id: `of:${id}` as NormalizedFullLink["id"],
+    space: "did:key:zBench" as NormalizedFullLink["space"],
+    scope: "space",
+    path: [],
+    ...(schema !== undefined ? { schema } : {}),
+  };
+}
+
+// A $ref/$defs schema as the CTS transformer actually emits (recursive piece
+// shape + asCell markers), to test whether ref resolution in getSchemaAtPath is
+// what's slow.
+const REF_SCHEMA: JSONSchema = {
+  type: "object",
+  properties: {
+    notes: {
+      type: "array",
+      items: { $ref: "#/$defs/Note", asCell: ["cell"] },
+    },
+  },
+  $defs: {
+    Note: {
+      type: "object",
+      properties: {
+        title: { type: "string" },
+        body: { type: "string" },
+        done: { type: "boolean" },
+        mentioned: { type: "array", items: { $ref: "#/$defs/Note" } },
+        meta: {
+          type: "object",
+          properties: {
+            created: { type: "number" },
+            tags: { type: "array", items: { type: "string" } },
+          },
+        },
+      },
+    },
+  },
+} as unknown as JSONSchema;
+
+const withSchema = {
+  arg: link("argument", ARG_SCHEMA),
+  internal: link("internal", ARG_SCHEMA),
+  result: link("result", undefined),
+};
+const refSchema = {
+  arg: link("argument", REF_SCHEMA),
+  internal: link("internal", REF_SCHEMA),
+  result: link("result", undefined),
+};
+const noSchema = {
+  arg: link("argument", undefined),
+  internal: link("internal", undefined),
+  result: link("result", undefined),
+};
+
+type BuildOpts = {
+  /** number of `$alias` leaves (≈ the cell references in the binding) */
+  aliases: number;
+  /** depth of each alias path into the schema (1..4) */
+  pathDepth?: number;
+  /** put an explicit asCell schema on each alias (as the transformer emits) */
+  aliasSchema?: boolean;
+};
+
+const FIELDS = ["title", "body", "done"] as const;
+
+function aliasPath(i: number, depth: number): string[] {
+  const p: string[] = ["notes", String(i % 50)];
+  if (depth >= 2) p.push(FIELDS[i % FIELDS.length]);
+  if (depth >= 3) p.push("meta", "created"); // deeper variant
+  return p.slice(0, Math.max(1, depth + 1));
+}
+
+function makeAlias(i: number, opts: BuildOpts): unknown {
+  return {
+    $alias: {
+      cell: "argument",
+      path: aliasPath(i, opts.pathDepth ?? 2),
+      ...(opts.aliasSchema
+        ? { schema: { type: "string", asCell: ["cell"] } }
+        : {}),
+    },
+  };
+}
+
+// Build a VNode-tree binding (what a node's `[UI]` inputBindings look like):
+// a tree of {type:"vnode", name, props, children:[...]} with alias leaves.
+function makeUiBinding(opts: BuildOpts): unknown {
+  let leaf = 0;
+  const child = (): unknown => {
+    if (leaf >= opts.aliases) {
+      return { type: "vnode", name: "span", props: {}, children: ["·"] };
+    }
+    const a = makeAlias(leaf++, opts);
+    return {
+      type: "vnode",
+      name: "cf-cell-link",
+      props: { $cell: a, style: { fontSize: "12px" } },
+      children: [a],
+    };
+  };
+  // ~branching factor 4 until all aliases are placed
+  const children: unknown[] = [];
+  while (leaf < opts.aliases) {
+    const group: unknown[] = [];
+    for (let k = 0; k < 4 && leaf < opts.aliases; k++) group.push(child());
+    children.push({
+      type: "vnode",
+      name: "cf-vstack",
+      props: {},
+      children: group,
+    });
+  }
+  return { type: "vnode", name: "cf-screen", props: {}, children };
+}
+
+type Links = typeof withSchema;
+
+function op(binding: unknown, links: Links = withSchema): void {
+  unwrapOneLevelAndBindtoDoc(
+    cfc,
+    binding,
+    links.arg,
+    links.internal,
+    links.result,
+  );
+}
+
+// ---- deno bench cases ------------------------------------------------------
+for (const aliases of [10, 30, 100, 300]) {
+  const binding = makeUiBinding({ aliases, pathDepth: 2 });
+  Deno.bench(
+    `unwrapOneLevelAndBindtoDoc aliases=${aliases}`,
+    () => op(binding),
+  );
+}
+
+// ---- direct-run study harness ---------------------------------------------
+function time(
+  label: string,
+  binding: unknown,
+  iters: number,
+  links: Links = withSchema,
+): void {
+  for (let i = 0; i < Math.min(200, iters); i++) op(binding, links); // warmup
+  const t0 = performance.now();
+  for (let i = 0; i < iters; i++) op(binding, links);
+  const ms = performance.now() - t0;
+  const nsPerOp = (ms * 1e6) / iters;
+  console.log(label.padEnd(44), `${nsPerOp.toFixed(0).padStart(9)} ns/op`);
+}
+
+if (import.meta.main) {
+  const custom = Number(Deno.args[0]);
+  const sizes = Number.isFinite(custom) && custom > 0
+    ? [custom]
+    : [1, 10, 30, 100, 300, 1000];
+
+  console.log("\n# scaling: ns/op and ns/alias (pathDepth=2, link schema on)");
+  for (const aliases of sizes) {
+    const binding = makeUiBinding({ aliases, pathDepth: 2 });
+    const iters = aliases >= 300 ? 2000 : 20000;
+    for (let i = 0; i < 200; i++) op(binding);
+    const t0 = performance.now();
+    for (let i = 0; i < iters; i++) op(binding);
+    const ms = performance.now() - t0;
+    const nsPerOp = (ms * 1e6) / iters;
+    console.log(
+      `aliases=${String(aliases).padStart(5)}`,
+      `${nsPerOp.toFixed(0).padStart(9)} ns/op`,
+      `${(nsPerOp / Math.max(1, aliases)).toFixed(0).padStart(6)} ns/alias`,
+    );
+  }
+
+  console.log("\n# what drives it (aliases=100, 20000 iters each)");
+  const N = 100;
+  time(
+    "baseline (depth2, link schema)",
+    makeUiBinding({ aliases: N, pathDepth: 2 }),
+    20000,
+  );
+  time(
+    "depth1 (shallow paths)",
+    makeUiBinding({ aliases: N, pathDepth: 1 }),
+    20000,
+  );
+  time(
+    "depth4 (deep paths)",
+    makeUiBinding({ aliases: N, pathDepth: 4 }),
+    20000,
+  );
+  time(
+    "no link schema (scopedLinkForPath cheap)",
+    makeUiBinding({ aliases: N, pathDepth: 2 }),
+    20000,
+    noSchema,
+  );
+  time(
+    "aliasSchema on (transformer-style)",
+    makeUiBinding({ aliases: N, pathDepth: 2, aliasSchema: true }),
+    20000,
+  );
+  time(
+    "$ref/$defs schema (transformer-style)",
+    makeUiBinding({ aliases: N, pathDepth: 3 }),
+    20000,
+    refSchema,
+  );
+}


### PR DESCRIPTION
Adds a standalone micro-benchmark, `packages/runner/test/pattern-binding.bench.ts`, plus the reload-cost analysis that motivated it. **No production change** — this subsystem is slated for rewrite, so the goal here is to capture findings + leave a study tool.

```
deno bench -A packages/runner/test/pattern-binding.bench.ts          # bench mode
deno run  -A packages/runner/test/pattern-binding.bench.ts           # direct study harness
deno run  -A packages/runner/test/pattern-binding.bench.ts 2000      # custom alias count
```

## Context

After the reload re-run fix (#3918), the dominant *compute* in a default-app notebook reload (ESM + persistent scheduler state) is the notes-list `raw:map` reconcile (~340 ms, runCount 1). Profiling that:

- On reload the map's in-memory `elementRuns` cache is empty, so **every row hits the "new element" branch** and gets a full `runtime.runner.run(opPattern, …)` — all 7 note-row sub-patterns are re-instantiated synchronously inside the one map action (~48 ms/row). Data rehydrates (the row computeds no longer re-run, per #3918), but the live reactive wiring is rebuilt from scratch.
- Per-node instantiation is ~90% **`bindNodeIO`** (the rest — function discovery/compile, immutable-input cell, materializer detection, `subscribe` — is each <6 ms total across 150 nodes; compile is cached, so it's *not* recompilation).

`bindNodeIO` = `unwrapOneLevelAndBindtoDoc(inputs)` + `unwrapOneLevelAndBindtoDoc(outputs)` + `findAllWriteRedirectCells(inputs/outputs)`. I initially assumed the `unwrap` (deep clone + CFC schema-walk of the binding tree) was the cost.

## What the bench shows (the surprise)

`unwrapOneLevelAndBindtoDoc` is **pure and cheap**:

```
# scaling (pathDepth=2, link schema on)
aliases=    1      3056 ns/op   3056 ns/alias
aliases=  100    191670 ns/op   1917 ns/alias
aliases= 1000   1952260 ns/op   1952 ns/alias   # linear, ~1.9 us/alias

# what drives it (aliases=100)
baseline (depth2, link schema)        190434 ns/op
no link schema                         97804 ns/op   # CFC schema-walk ~half the cost
$ref/$defs schema (transformer-style) 524403 ns/op   # ref resolution ~2.8x, still ~5us/alias
```

So even with realistic `$ref`/`$defs` schemas, a real UI node (~30 aliases) unwraps in **sub-millisecond** — it cannot account for the ~3 ms/node (52 ms max) measured.

## The real cost: `findAllWriteRedirectCells`

A browser split-probe inside `bindNodeIO` settled it (per reload, 133 nodes):

| within `bindNodeIO` | total | avg | max |
|---|---|---|---|
| `unwrap` (clone/rebind) | **6 ms** | 0.045 ms | 0.2 ms |
| `findAllWriteRedirectCells` | **356 ms** | 2.68 ms | 52.2 ms |

`findAllWriteRedirectCells` (`pattern-binding.ts`) is **not** a pure transform: for every write-redirect it does `parseLink → runtime.getCellFromLink(link) → linkCell.getRaw() → recurse into the linked cell's raw value`. That's recursive cell/storage resolution per node, O(size of the resolved values it walks) — the 52 ms node is the one whose redirects resolve into the large notebook doc and it recurses the whole thing. It runs for all 7 rows on reload.

(Adjacent, separate cost in the same settle: ~290 ms of dependency `populate`, one ~256 ms — likely the notebook top-level UI effect deep-reading the rehydrated 7-note structure.)

## Lever (not pursued here)

The 7 rows share the same `opPattern`, so the redirect *shape* is identical — `findAllWriteRedirectCells` re-resolves a structurally-identical set N times, every reload. Memoizing/templating it per pattern (or caching `getCellFromLink`/`getRaw` within a reconcile, or bounding the recursion) is the lever. Left for the upcoming rewrite.

`findAllWriteRedirectCells` itself needs a `Runtime` (it follows links into storage), so it isn't in this pure micro-bench — there's a `TODO` in the file to add an emulate-runtime bench for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a standalone micro-benchmark for unwrap performance in `bindNodeIO` at `packages/runner/test/pattern-binding.bench.ts`, plus a direct-run study harness. No production changes; this is a study tool that confirms the reload hotspot is `findAllWriteRedirectCells`, not `unwrapOneLevelAndBindtoDoc`.

- **New Features**
  - Run via `deno bench -A packages/runner/test/pattern-binding.bench.ts` or `deno run -A packages/runner/test/pattern-binding.bench.ts [aliases]`.
  - Measures scaling by alias count and path depth, with/without link schemas, and with `$ref/$defs` schemas.
  - Findings: `unwrapOneLevelAndBindtoDoc` is ~1.9–5.2 µs/alias (sub-ms per typical node); `findAllWriteRedirectCells` is the dominant cost and remains out of scope for this bench.

<sup>Written for commit 140bb5fe84d42f6c4a1cbf766109ee933a07118c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

