### PR TITLE
test(runner): full-corpus ESM↔AMD verifier differential parity oracle (CT-1623)

### DIFF
--- a/docs/specs/module-loading-implementation-plan.md
+++ b/docs/specs/module-loading-implementation-plan.md
@@ -15,9 +15,9 @@ steps with the files each touches, exit criteria, and validation commands.
 | 0 — Loader shape confirmation | Done | SES `importNow` + virtual (third-party) module records load synchronously, incl. cycles. `ModuleSource`/`StaticModuleRecord` are not exposed by this `ses` build, so the loader uses `{ imports, exports, execute }` records. |
 | 1 — Decouple identity | Done (merged) | Per-module Merkle hash; scheduler implementation fingerprint is content-addressed and entry-point/TCB independent. Shipped behind `EXPERIMENTAL_PERSISTENT_SCHEDULER_STATE`. |
 | 2 — ESM emission + SES module loading | Done (behind `CF_ESM_MODULE_LOADER`, default off) | `compileToRecordGraph` + `evaluateRecordGraph` (`engine.ts`) run the full `CommonFabricTransformerPipeline` (not bare `transpileModule`), assemble content-addressed records, register per-load/per-module source maps, and load multi-module programs end-to-end. Engine integration, `export *` re-exports, live module-namespace bindings (#3797), and CFC verified-source location resolution (#3785, #3787) are all wired. The flag is now also plumbed to the browser client (#3796). |
-| 3 — Verifier port | Classification ported + wired; corpus parity oracle pending | The deep SES_SANDBOXING module-item classification (`verifyCompiledModuleBody`, reusing the shared `classifyModuleItems` core) runs **per module** in the ESM compile path (`engine.ts`). `verifyModuleGraph` validates graph shape/wiring. Additional hardening landed beyond the original plan: import-edge target validation (#3778), pattern provenance brand (#3779), frozen exported patterns (#3777). **Remaining (release gate):** the full-corpus differential parity oracle — `esm-verifier-parity.test.ts` currently covers crafted CF-shaped fixtures only, not every pattern-corpus verdict. |
+| 3 — Verifier port | Classification ported + wired; **corpus parity oracle landed** | The deep SES_SANDBOXING module-item classification (`verifyCompiledModuleBody`, reusing the shared `classifyModuleItems` core) runs **per module** in the ESM compile path (`engine.ts`). `verifyModuleGraph` validates graph shape/wiring. Additional hardening landed beyond the original plan: import-edge target validation (#3778), pattern provenance brand (#3779), frozen exported patterns (#3777). The full-corpus differential parity oracle now exists — `esm-verifier-differential.test.ts` compiles the SAME authored source through BOTH real paths (`Engine.compile` AMD vs `Engine.compileToRecordGraph` ESM, verify-only, no eval) and asserts identical accept/reject verdicts, with the AMD verifier as the trusted oracle: synthetic fixtures cover the reject surface, and the entire top-level `packages/patterns` corpus (the `all.test.ts` set) covers accept parity. `esm-verifier-parity.test.ts` (crafted compiled bodies) remains the unit-level companion. |
 | 4 — Per-module compilation cache | Done (behind `CF_ESM_MODULE_LOADER`, default off) | Content-addressed cell cache built and wired into the ESM `PatternManager` load path (`compilation-cache/cell-cache.ts`, `pattern-manager.ts`). Per space: source set `pattern:<identity>` (self-verifying via Merkle recompute) + compiled set `compileCache:<runtimeVersion>/<identity>` (CFC `addIntegrity` on write, fail-closed on read). A warm full hit feeds cached bodies back through `compileToRecordGraph` and skips the TypeScript compile / transformer pipeline; a miss compiles and writes both sets back on a fresh transaction. Gated on `cfcEnforcementMode !== "disabled"`. **Divergence from the original design:** the plan assumed the per-module `cf:module/<hash>` identity was already entry-point independent, but the ESM compile path resolved a `/<computeId>/`-prefixed program, leaking the whole-program prefix into the identity — so cross-program dedup and the spec's entry-point-independence guarantee did not actually hold. Step 5a (`computeModuleIdentities` in `module-record-compiler.ts`) strips the prefix for identity computation only, making identities prefix-free/dedupable while leaving source maps + `fn.src` resolution on the prefixed path untouched. Full runner suite green flag-on and flag-off. |
-| 5 — Default-on + AMD removal | Not started (intentionally) | Gated on the Phase 3 corpus parity oracle + a green full-suite flag-on sweep + benchmarks. The canary PR (#3782) is the standing CI signal for flag-on. The flag stays **off** by default. |
+| 5 — Default-on + AMD removal | Not started (intentionally) | Phase 3 corpus parity oracle is now ✅ landed (`esm-verifier-differential.test.ts`); remaining gates are a green full-suite flag-on sweep + benchmarks. The canary PR (#3782) is the standing CI signal for flag-on. The flag stays **off** by default. |
 
 Phases 0–1 merged earlier. Phases 2–4 mechanism merged behind the default-off
 flag (#3763), then substantially completed by follow-up work: ESM source-location
@@ -267,12 +267,16 @@ path); behavior parity with AMD.
 
 ## Phase 3 — Verifier port (gates default-on for untrusted code)
 
-> **Status: Classification ported and wired; corpus parity oracle pending.**
+> **Status: Classification ported and wired; corpus parity oracle landed.**
 > `verifyCompiledModuleBody` (reusing the shared `classifyModuleItems` core) runs
 > per module in the ESM compile path (`engine.ts`), and `verifyModuleGraph`
-> checks graph shape/wiring. The remaining release gate is the full-corpus
-> differential parity oracle — `packages/runner/test/esm-verifier-parity.test.ts`
-> exists but covers crafted CF-shaped fixtures, not every pattern-corpus verdict.
+> checks graph shape/wiring. The full-corpus differential parity oracle now
+> exists — `packages/runner/test/esm-verifier-differential.test.ts` runs the same
+> authored source through both compile paths (verify-only, no eval) and asserts
+> the AMD and ESM verifiers reach the same verdict, across synthetic reject
+> fixtures and the entire top-level `packages/patterns` corpus.
+> `esm-verifier-parity.test.ts` (crafted compiled bodies fed straight to the ESM
+> body verifier) remains as the unit-level companion.
 
 The bundle verifier currently parses AMD `define()` calls and must verify
 `ModuleSource` records before ESM can run untrusted patterns by default.
@@ -286,12 +290,14 @@ The bundle verifier currently parses AMD `define()` calls and must verify
   the parser feeding them changes.
 - **Parity harness:** for the full pattern corpus, assert every verdict the AMD
   verifier produces is reproduced by the `ModuleSource` verifier. Treat any
-  divergence as a release blocker.
+  divergence as a release blocker. **Landed** as
+  `packages/runner/test/esm-verifier-differential.test.ts` (synthetic reject
+  fixtures + the full top-level `packages/patterns` corpus; AMD as the oracle).
 
-**Files:** the three verifier files above; new parity test under
-`packages/runner/test/`.
-**Exit:** verifier parity green across the corpus; ESM path is now safe for
-untrusted execution.
+**Files:** the three verifier files above; parity test
+`packages/runner/test/esm-verifier-differential.test.ts`.
+**Exit:** verifier parity green across the corpus (✅ — full top-level corpus +
+reject fixtures pass); ESM path is now safe for untrusted execution.
 
 ---
 
@@ -489,7 +495,8 @@ compilation-cache tests pass under both loaders; no correctness regression.
 
 ## Phase 5 — Default-on and cleanup
 
-> **Status: Not started.** Gated on the Phase 3 corpus parity oracle, a green
+> **Status: Not started.** The Phase 3 corpus parity oracle is now landed
+> (`esm-verifier-differential.test.ts`); remaining gates are a green
 > full-suite flag-on sweep (`CF_ESM_MODULE_LOADER=1 deno task test` +
 > `deno task integration` from the repo root), and benchmarks. The canary
 > PR (#3782) is the standing flag-on CI signal.

--- a/packages/runner/test/esm-verifier-differential.test.ts
+++ b/packages/runner/test/esm-verifier-differential.test.ts
@@ -1,0 +1,270 @@
+import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { join } from "@std/path";
+import { Identity } from "@commonfabric/identity";
+import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import { Engine } from "../src/harness/engine.ts";
+import type { RuntimeProgram } from "../src/harness/types.ts";
+
+// End-to-end differential verifier parity oracle (Phase 3 / D3 of
+// docs/specs/module-loading-implementation-plan.md) — the release gate that must
+// be green before `CF_ESM_MODULE_LOADER` can be flipped on by default.
+//
+// `esm-verifier-parity.test.ts` feeds crafted *compiled* bodies straight to
+// `verifyCompiledModuleBody`. This runs the SAME authored TypeScript source
+// through BOTH real compile paths and asserts the two verifiers reach the SAME
+// accept/reject verdict:
+//
+//   AMD: Engine.compile()            → bundle pre-flight + classification
+//   ESM: Engine.compileToRecordGraph → per-module body classification + graph
+//
+// Both methods verify unconditionally and WITHOUT evaluating, so the verdict is
+// the verifier's alone. The AMD verifier is the trusted oracle; a divergence
+// (one path accepts what the other rejects) is the release blocker.
+//
+// Two layers of coverage:
+//   1. Synthetic fixtures — exercise the REJECT surface (real patterns never
+//      contain SES violations, so reject-parity can only be tested with crafted
+//      sources) plus a few key accept shapes.
+//   2. The real pattern corpus (`packages/patterns/*.tsx`) — the same top-level
+//      set `all.test.ts` ("Compile all patterns") compiles+executes on the AMD
+//      path, so every file is a known AMD-accept. The ESM verifier must accept
+//      each one too; an ESM rejection of a shipped pattern is the divergence the
+//      gate exists to catch.
+
+const signer = await Identity.fromPassphrase(
+  "esm verifier differential oracle",
+);
+
+// Top-level pattern corpus (non-recursive), matching `all.test.ts`. Subdirs hold
+// multi-file sub-modules that are not standalone compile entry points.
+const CORPUS_DIR = join(import.meta.dirname!, "..", "..", "patterns");
+
+// Files under the corpus dir that are not standalone compilable patterns.
+// Mirrors `all.test.ts`'s skip list.
+const CORPUS_SKIP = new Set<string>([
+  // (none beyond non-.tsx / subdir entries today; add with justification)
+]);
+
+type Verdict = { accepted: boolean; error?: string };
+
+interface Fixture {
+  readonly name: string;
+  /** Authored entry-module source. */
+  readonly main: string;
+  /** Extra files (multi-module fixtures), keyed by absolute path. */
+  readonly extra?: Readonly<Record<string, string>>;
+  readonly expect: "accept" | "reject";
+}
+
+const IMPORT =
+  `import { Cell, __cf_data, computed, handler, pattern } from "commonfabric";`;
+
+const FIXTURES: readonly Fixture[] = [
+  // ---- Accept: valid authored patterns ----
+  {
+    name: "minimal pattern default export",
+    main: `${IMPORT}\nexport default pattern(() => ({ value: 1 }));`,
+    expect: "accept",
+  },
+  {
+    name: "handler + pattern wiring",
+    main: [
+      IMPORT,
+      "const inc = handler<unknown, { count: Cell<number> }>(",
+      "  (_e, { count }) => { count.set(count.get() + 1); },",
+      ");",
+      "export default pattern<{ count: number }>(({ count }) => {",
+      "  return { count, inc: inc({ count }) };",
+      "});",
+    ].join("\n"),
+    expect: "accept",
+  },
+  {
+    name: "computed value",
+    main: [
+      IMPORT,
+      "export default pattern(() => {",
+      "  return { doubled: computed(() => 42) };",
+      "});",
+    ].join("\n"),
+    expect: "accept",
+  },
+  // The CF transformer wraps top-level object/call-result const exports so the
+  // authored forms are safe — both verifiers accept (the raw, un-transformed
+  // compiled-body forms are rejected by esm-verifier-parity.test.ts instead).
+  {
+    name: "object-literal const export (transformer-wrapped)",
+    main: `export const config = { a: 1, b: 2 };\n` +
+      `export default function f() { return config; }`,
+    expect: "accept",
+  },
+  {
+    name: "top-level call-result const export (transformer-wrapped)",
+    main: `const parsed = JSON.parse("{}");\n` +
+      `export default function f() { return parsed; }`,
+    expect: "accept",
+  },
+  {
+    name: "__cf_data-wrapped mutable config export",
+    main: `${IMPORT}\nexport const config = __cf_data({ a: 1, b: 2 });\n` +
+      `export default pattern(() => ({ value: 1 }));`,
+    expect: "accept",
+  },
+  {
+    name: "multi-module: entry imports a helper",
+    main: `import { helper } from "./util.ts";\n${IMPORT}\n` +
+      `export default pattern(() => ({ value: helper(1) }));`,
+    extra: { "/util.ts": "export const helper = (x: number) => x + 1;" },
+    expect: "accept",
+  },
+
+  // ---- Reject: SES module-item violations ----
+  {
+    name: "top-level mutable binding (let)",
+    main: [
+      "let leaked = 0;",
+      "export default function next() {",
+      "  leaked += 1;",
+      "  return leaked;",
+      "}",
+    ].join("\n"),
+    expect: "reject",
+  },
+  {
+    name: "top-level class declaration export",
+    main: `export class Foo { x = 1; }\n` +
+      `export default function f() { return new Foo(); }`,
+    expect: "reject",
+  },
+  {
+    name: "top-level generator declaration export",
+    main: `export function* gen() { yield 1; }\n` +
+      `export default function f() { return gen(); }`,
+    expect: "reject",
+  },
+  {
+    name: "import from a disallowed specifier (node:fs)",
+    main: `import * as fs from "node:fs";\n` +
+      `export default function f() { return fs; }`,
+    expect: "reject",
+  },
+  {
+    name: "dynamic import attempt",
+    main: [
+      IMPORT,
+      "export default pattern(() => {",
+      '  const p = import("./evil.ts");',
+      "  return { p };",
+      "});",
+    ].join("\n"),
+    extra: { "/evil.ts": "export const x = 1;" },
+    expect: "reject",
+  },
+];
+
+async function verdict(run: () => Promise<unknown>): Promise<Verdict> {
+  try {
+    await run();
+    return { accepted: true };
+  } catch (error) {
+    return {
+      accepted: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+let runtime: Runtime;
+let engine: Engine;
+let storageManager: ReturnType<typeof StorageManager.emulate>;
+
+function setup() {
+  storageManager = StorageManager.emulate({ as: signer });
+  runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  engine = runtime.harness as Engine;
+}
+
+async function teardown() {
+  await runtime?.dispose();
+  await storageManager?.close();
+}
+
+/** Run both verifiers on a program and assert they reach the same verdict. */
+async function assertParity(
+  program: RuntimeProgram,
+  context: string,
+): Promise<Verdict> {
+  const amd = await verdict(() => engine.compile(program));
+  const esm = await verdict(() => engine.compileToRecordGraph(program));
+  expect(
+    esm.accepted,
+    `${context}: verdict divergence — AMD ${
+      amd.accepted ? "accepted" : `rejected (${amd.error})`
+    }, ESM ${esm.accepted ? "accepted" : `rejected (${esm.error})`}`,
+  ).toBe(amd.accepted);
+  return amd;
+}
+
+describe("ESM↔AMD verifier differential parity (synthetic fixtures)", () => {
+  beforeAll(setup);
+  afterAll(teardown);
+
+  for (const f of FIXTURES) {
+    it(`${f.expect}: ${f.name}`, async () => {
+      const program: RuntimeProgram = {
+        main: "/main.tsx",
+        files: [
+          { name: "/main.tsx", contents: f.main },
+          ...Object.entries(f.extra ?? {}).map(([name, contents]) => ({
+            name,
+            contents,
+          })),
+        ],
+      };
+
+      const amd = await assertParity(program, f.name);
+      // The shared verdict must match the documented expectation.
+      expect(amd.accepted).toBe(f.expect === "accept");
+    });
+  }
+});
+
+describe("ESM↔AMD verifier differential parity (pattern corpus)", () => {
+  beforeAll(setup);
+  afterAll(teardown);
+
+  const corpus: string[] = [];
+  for (const e of Deno.readDirSync(CORPUS_DIR)) {
+    if (!e.isFile || !e.name.endsWith(".tsx")) continue;
+    if (CORPUS_SKIP.has(e.name)) continue;
+    corpus.push(e.name);
+  }
+  corpus.sort();
+
+  it("found the corpus", () => {
+    // Guard against a silently-empty walk (wrong path / moved corpus) turning
+    // the gate into a no-op.
+    expect(corpus.length).toBeGreaterThan(20);
+  });
+
+  for (const name of corpus) {
+    it(`parity: ${name}`, async () => {
+      const program = await engine.resolve(
+        new FileSystemProgramResolver(join(CORPUS_DIR, name), CORPUS_DIR),
+      );
+      const amd = await assertParity(program, name);
+      // Every shipped top-level pattern compiles+executes on AMD (all.test.ts),
+      // so the trusted oracle must accept it. If this fails, the corpus changed
+      // shape (or AMD regressed) — investigate before trusting the parity result.
+      expect(amd.accepted, `${name}: AMD oracle unexpectedly rejected`).toBe(
+        true,
+      );
+    });
+  }
+});


### PR DESCRIPTION
## What

The **Phase 3 release gate** for flipping `CF_ESM_MODULE_LOADER` on by default: prove the ESM `ModuleSource` verifier reproduces the AMD bundle verifier's accept/reject verdict across the real pattern corpus, with the **AMD verifier as the trusted oracle**. Any divergence (one path accepts what the other rejects) is the release blocker.

## Relation to the earlier closed draft (#3801)

#3801 (`verifier-parity-oracle`, closed) proved the differential *mechanism* on **12 crafted fixtures** but never touched the real corpus — so it didn't actually close the gate. This revives that proven mechanism and drives the **accept side from the full top-level `packages/patterns` corpus**, which is what the spec ("for the full pattern corpus … treat any divergence as a release blocker") requires.

## How

`esm-verifier-differential.test.ts` compiles the **same authored source** through **both** real paths:
- **AMD:** `Engine.compile()` → bundle pre-flight + classification
- **ESM:** `Engine.compileToRecordGraph()` → per-module body classification + graph verify

Both **verify without evaluating**, so the verdict is the verifier's alone. Comparison is boolean `accepted` parity (reject *messages* differ by parser; comparing booleans avoids false divergences). The harness is **flag-independent** — it calls both engine entry points directly, so it runs in normal CI without `CF_ESM_MODULE_LOADER` plumbing.

Two coverage layers:
1. **Synthetic fixtures** — the REJECT surface (top-level `let` / class / generator / disallowed specifier / dynamic `import()`) + key accept shapes. Real patterns never contain SES violations, so reject-parity can only be tested with crafted sources.
2. **Full top-level `packages/patterns` corpus** — the same set `all.test.ts` compiles+executes on AMD (so every file is a known AMD-accept). The ESM verifier must accept each; an ESM rejection of a shipped pattern is exactly the divergence the gate catches.

## Result

**73 steps green** — 60 corpus patterns + 12 fixtures + an empty-walk guard. Full ESM↔AMD parity. ~62s.

## Scope note

Corpus = top-level `packages/patterns/*.tsx` (60 files), matching `all.test.ts`. Subdir `.tsx` are multi-file sub-modules, not standalone compile entries. Generated-patterns / home-schemas have no top-level `.tsx`. Easy to extend the walk later if those become standalone.

## Spec

Marks the Phase 3 corpus parity oracle **landed**; Phase 5 default-on is now gated only on a green flag-on suite sweep + benchmarks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a full-corpus ESM↔AMD verifier differential parity oracle to prove the ESM `ModuleSource` verifier matches the AMD bundle verifier before turning `CF_ESM_MODULE_LOADER` on by default. Addresses Linear CT-1623 by landing the Phase 3 gate; any verdict divergence blocks release.

- **New Features**
  - Adds `packages/runner/test/esm-verifier-differential.test.ts` to run the same authored source through both compile paths (`Engine.compile` AMD, `Engine.compileToRecordGraph` ESM), verify-only, and compare boolean accept/reject with AMD as the oracle.
  - Covers synthetic reject fixtures (top-level `let`, class, generator, disallowed `node:` import, dynamic `import()`), plus all top-level `packages/patterns/*.tsx`; includes an empty-walk guard.
  - Updates `docs/specs/module-loading-implementation-plan.md` to mark the corpus parity oracle as landed and clarify remaining Phase 5 gates.

<sup>Written for commit 8a69b20b341955bfadb1b3dd1577277c95b3f502. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

