### PR TITLE
refactor(data-model): make [CODEC] the source of truth for instance serialization

### DIFF
--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -76,8 +76,9 @@ export type FabricErrorState = {
  * writable own properties: assigning to one throws once the instance is
  * `Object.freeze`'d (strict-mode non-writable-property semantics). The
  * extras bag mirrors this by gating `setExtra` / `deleteExtra` on the
- * frozen state. The serialization layer handles `FabricError` via its
- * static `[CODEC]` (`[DECONSTRUCT]` to encode, `[RECONSTRUCT]` to decode).
+ * frozen state. The serialization layer handles `FabricError` via its static
+ * `[CODEC]`, which is the source of truth for the encoded form; the
+ * `[DECONSTRUCT]` / `[RECONSTRUCT]` protocol members delegate to it.
  * See Section 1.4.1 of the formal spec.
  */
 export class FabricError extends FabricNativeWrapper<Error> {
@@ -224,30 +225,14 @@ export class FabricError extends FabricNativeWrapper<Error> {
   }
 
   /**
-   * Deconstructs into essential state for serialization. Returns a flat
-   * record with `type`, `name`, `message`, `stack`, `cause`, and custom
-   * enumerable properties from the extras bag. Does NOT recurse into nested
-   * values -- the serialization system handles that.
+   * @inheritDoc
    *
-   * `name` is emitted as `null` when it equals `type` (the common case) to
-   * avoid redundancy.
+   * Delegates to this class's `[CODEC]`, which is the source of truth for the
+   * encoded form. `[DECONSTRUCT]` remains the protocol entry point relied on by
+   * hashing and `[ID]` assignment.
    */
   [DECONSTRUCT](): FabricValue {
-    const state: Record<string, FabricValue> = {
-      type: this.type,
-      name: this.name === this.type ? null : this.name,
-      message: this.message,
-    };
-    if (this.stack !== undefined) {
-      state.stack = this.stack;
-    }
-    if (this.cause !== undefined) {
-      state.cause = this.cause;
-    }
-    for (const [key, value] of this.#extras) {
-      state[key] = value;
-    }
-    return state as FabricValue;
+    return FabricError[CODEC].encode(this);
   }
 
   /**
@@ -367,40 +352,18 @@ export class FabricError extends FabricNativeWrapper<Error> {
 
   /**
    * Reconstructs a `FabricError` from its essential state (flat record).
-   * Nested values in `state` have already been reconstructed by the
-   * serialization system.
+   * Delegates to this class's `[CODEC]`, the source of truth for decoding.
+   * `[RECONSTRUCT]` remains the protocol entry point relied on by `deepClone`.
    */
   static [RECONSTRUCT](
     state: FabricValue,
     context: ReconstructionContext,
   ): FabricError {
-    const s = state as Record<string, FabricValue>;
-    const type = (s.type as string) ?? (s.name as string) ?? "Error";
-    // `null` `name` means "same as `type`" (the wire-level optimization).
-    const name = (s.name as string | null | undefined) ?? type;
-    const message = (s.message as string) ?? "";
-    const stack = s.stack as string | undefined;
-    const cause = s.cause;
-
-    const extras: Array<[string, FabricValue]> = [];
-    for (const key of Object.keys(s)) {
-      if (FABRIC_ERROR_RESERVED_KEYS.has(key) || UNSAFE_KEYS.has(key)) {
-        continue;
-      }
-      extras.push([key, s[key]]);
-    }
-
-    const result = new FabricError({
-      type,
-      name,
-      message,
-      stack,
-      cause,
-      extras,
-    });
-    // Honor `shouldDeepFreeze`: produce the type's correct deep-frozen form
-    // via its `[DEEP_FREEZE]` member (recursing through `deepFreeze`).
-    return context.shouldDeepFreeze ? deepFreeze(result) : result;
+    return FabricError[CODEC].decode(
+      WIRE_TYPE_TAGS.Error,
+      state,
+      context,
+    ) as FabricError;
   }
 
   static #codec = Object.freeze(
@@ -409,18 +372,72 @@ export class FabricError extends FabricNativeWrapper<Error> {
         super(WIRE_TYPE_TAGS.Error, FabricError);
       }
 
-      /** @inheritDoc */
+      /**
+       * @inheritDoc
+       *
+       * Deconstructs into a flat record with `type`, `name`, `message`,
+       * `stack`, `cause`, and the extras-bag entries. Does NOT recurse into
+       * nested values -- the serialization system handles that. `name` is
+       * emitted as `null` when it equals `type` (the common case) to avoid
+       * redundancy.
+       */
       encode(value: FabricError): FabricValue {
-        return value[DECONSTRUCT]();
+        const state: Record<string, FabricValue> = {
+          type: value.type,
+          name: value.name === value.type ? null : value.name,
+          message: value.message,
+        };
+        if (value.stack !== undefined) {
+          state.stack = value.stack;
+        }
+        if (value.cause !== undefined) {
+          state.cause = value.cause;
+        }
+        for (const [key, val] of value.extraEntries()) {
+          state[key] = val;
+        }
+        return state as FabricValue;
       }
 
-      /** @inheritDoc */
+      /**
+       * @inheritDoc
+       *
+       * Reconstructs a `FabricError` from its essential state (flat record).
+       * Nested values in `state` have already been reconstructed by the
+       * serialization system. Honors `context.shouldDeepFreeze`.
+       */
       decode(
         _wireTypeTag: string,
         state: FabricValue,
         context: ReconstructionContext,
       ): FabricValue {
-        return FabricError[RECONSTRUCT](state, context);
+        const s = state as Record<string, FabricValue>;
+        const type = (s.type as string) ?? (s.name as string) ?? "Error";
+        // `null` `name` means "same as `type`" (the wire-level optimization).
+        const name = (s.name as string | null | undefined) ?? type;
+        const message = (s.message as string) ?? "";
+        const stack = s.stack as string | undefined;
+        const cause = s.cause;
+
+        const extras: Array<[string, FabricValue]> = [];
+        for (const key of Object.keys(s)) {
+          if (FABRIC_ERROR_RESERVED_KEYS.has(key) || UNSAFE_KEYS.has(key)) {
+            continue;
+          }
+          extras.push([key, s[key]]);
+        }
+
+        const result = new FabricError({
+          type,
+          name,
+          message,
+          stack,
+          cause,
+          extras,
+        });
+        // Honor `shouldDeepFreeze`: produce the type's correct deep-frozen
+        // form via its `[DEEP_FREEZE]` member (recursing through `deepFreeze`).
+        return context.shouldDeepFreeze ? deepFreeze(result) : result;
       }
     })(),
   );

--- a/packages/data-model/src/fabric-instances/FabricMap.ts
+++ b/packages/data-model/src/fabric-instances/FabricMap.ts
@@ -12,9 +12,11 @@ import { FrozenMap } from "@/frozen-builtins.ts";
 import { FabricNativeWrapper } from "./FabricNativeWrapper.ts";
 
 /**
- * Wrapper for `Map` instances. Stub -- `[DECONSTRUCT]` and `[RECONSTRUCT]`
- * throw until `Map` support is fully implemented. Extra properties beyond the
- * wrapped collection are not supported on non-`Error` wrappers.
+ * Wrapper for `Map` instances. Stub -- the static `[CODEC]` (the source of
+ * truth) throws until `Map` support is fully implemented, and the
+ * `[DECONSTRUCT]` / `[RECONSTRUCT]` protocol members delegate to it. Extra
+ * properties beyond the wrapped collection are not supported on non-`Error`
+ * wrappers.
  */
 export class FabricMap
   extends FabricNativeWrapper<Map<FabricValue, FabricValue>> {
@@ -27,8 +29,14 @@ export class FabricMap
     return WIRE_TYPE_TAGS.Map;
   }
 
+  /**
+   * @inheritDoc
+   *
+   * Delegates to this class's `[CODEC]` (the source of truth), which throws
+   * until `Map` support is implemented.
+   */
   [DECONSTRUCT](): FabricValue {
-    throw new Error("FabricMap: not yet implemented");
+    return FabricMap[CODEC].encode(this);
   }
 
   /**
@@ -72,11 +80,19 @@ export class FabricMap
     return new Map(this.map);
   }
 
+  /**
+   * Delegates to this class's `[CODEC]` (the source of truth), which throws
+   * until `Map` support is implemented.
+   */
   static [RECONSTRUCT](
-    _state: FabricValue,
-    _context: ReconstructionContext,
+    state: FabricValue,
+    context: ReconstructionContext,
   ): FabricMap {
-    throw new Error("FabricMap: not yet implemented");
+    return FabricMap[CODEC].decode(
+      WIRE_TYPE_TAGS.Map,
+      state,
+      context,
+    ) as FabricMap;
   }
 
   static #codec = Object.freeze(
@@ -85,18 +101,26 @@ export class FabricMap
         super(WIRE_TYPE_TAGS.Map, FabricMap);
       }
 
-      /** @inheritDoc */
-      encode(value: FabricMap): FabricValue {
-        return value[DECONSTRUCT]();
+      /**
+       * @inheritDoc
+       *
+       * Stub -- throws until `Map` support is implemented.
+       */
+      encode(_value: FabricMap): FabricValue {
+        throw new Error("FabricMap: not yet implemented");
       }
 
-      /** @inheritDoc */
+      /**
+       * @inheritDoc
+       *
+       * Stub -- throws until `Map` support is implemented.
+       */
       decode(
         _wireTypeTag: string,
-        state: FabricValue,
-        context: ReconstructionContext,
+        _state: FabricValue,
+        _context: ReconstructionContext,
       ): FabricValue {
-        return FabricMap[RECONSTRUCT](state, context);
+        throw new Error("FabricMap: not yet implemented");
       }
     })(),
   );

--- a/packages/data-model/src/fabric-instances/FabricSet.ts
+++ b/packages/data-model/src/fabric-instances/FabricSet.ts
@@ -12,9 +12,11 @@ import { FrozenSet } from "@/frozen-builtins.ts";
 import { FabricNativeWrapper } from "./FabricNativeWrapper.ts";
 
 /**
- * Wrapper for `Set` instances. Stub -- `[DECONSTRUCT]` and `[RECONSTRUCT]`
- * throw until `Set` support is fully implemented. Extra properties beyond the
- * wrapped collection are not supported on non-`Error` wrappers.
+ * Wrapper for `Set` instances. Stub -- the static `[CODEC]` (the source of
+ * truth) throws until `Set` support is fully implemented, and the
+ * `[DECONSTRUCT]` / `[RECONSTRUCT]` protocol members delegate to it. Extra
+ * properties beyond the wrapped collection are not supported on non-`Error`
+ * wrappers.
  */
 export class FabricSet extends FabricNativeWrapper<Set<FabricValue>> {
   constructor(readonly set: Set<FabricValue>) {
@@ -26,8 +28,14 @@ export class FabricSet extends FabricNativeWrapper<Set<FabricValue>> {
     return WIRE_TYPE_TAGS.Set;
   }
 
+  /**
+   * @inheritDoc
+   *
+   * Delegates to this class's `[CODEC]` (the source of truth), which throws
+   * until `Set` support is implemented.
+   */
   [DECONSTRUCT](): FabricValue {
-    throw new Error("FabricSet: not yet implemented");
+    return FabricSet[CODEC].encode(this);
   }
 
   /**
@@ -71,11 +79,19 @@ export class FabricSet extends FabricNativeWrapper<Set<FabricValue>> {
     return new Set(this.set);
   }
 
+  /**
+   * Delegates to this class's `[CODEC]` (the source of truth), which throws
+   * until `Set` support is implemented.
+   */
   static [RECONSTRUCT](
-    _state: FabricValue,
-    _context: ReconstructionContext,
+    state: FabricValue,
+    context: ReconstructionContext,
   ): FabricSet {
-    throw new Error("FabricSet: not yet implemented");
+    return FabricSet[CODEC].decode(
+      WIRE_TYPE_TAGS.Set,
+      state,
+      context,
+    ) as FabricSet;
   }
 
   static #codec = Object.freeze(
@@ -84,18 +100,26 @@ export class FabricSet extends FabricNativeWrapper<Set<FabricValue>> {
         super(WIRE_TYPE_TAGS.Set, FabricSet);
       }
 
-      /** @inheritDoc */
-      encode(value: FabricSet): FabricValue {
-        return value[DECONSTRUCT]();
+      /**
+       * @inheritDoc
+       *
+       * Stub -- throws until `Set` support is implemented.
+       */
+      encode(_value: FabricSet): FabricValue {
+        throw new Error("FabricSet: not yet implemented");
       }
 
-      /** @inheritDoc */
+      /**
+       * @inheritDoc
+       *
+       * Stub -- throws until `Set` support is implemented.
+       */
       decode(
         _wireTypeTag: string,
-        state: FabricValue,
-        context: ReconstructionContext,
+        _state: FabricValue,
+        _context: ReconstructionContext,
       ): FabricValue {
-        return FabricSet[RECONSTRUCT](state, context);
+        throw new Error("FabricSet: not yet implemented");
       }
     })(),
   );


### PR DESCRIPTION
## Summary

Inverts the `[CODEC]` ↔ `[DECONSTRUCT]`/`[RECONSTRUCT]` relationship on the concrete `FabricInstance` classes (`FabricError`, `FabricMap`, `FabricSet`) so that **the static `[CODEC]` is the source of truth** for serialization. The real encode/decode logic now lives in each class's codec; the `[DECONSTRUCT]` / `[RECONSTRUCT]` protocol members delegate to it. Previously it was the other way around — the codec delegated to the protocol members.

### Why this direction
The serialization registry already drives everything through `[CODEC]` (`createDefaultRegistry` registers `cls[CODEC]`), so the codec is the natural home for the logic. Inverting removes the bounce through the instance protocol on the serialization path.

### Why `[DECONSTRUCT]` / `[RECONSTRUCT]` stay (as delegators)
They're load-bearing beyond serialization:
- `[DECONSTRUCT]` — called by hashing (`value-hash.ts`) and `[ID]` assignment (`cell.ts`).
- `[RECONSTRUCT]` — called by `FabricError.deepClone`.

So they remain in place, now delegating into the codec. (Eliminating `[DECONSTRUCT]` entirely is a deliberate future step, not this PR.)

### No behavior change
- `FabricError`: the codec's `encode` reads the same state via the public `extraEntries()` — same iteration as the old `#extras` loop; `decode` holds the former `[RECONSTRUCT]` body verbatim (still honors `context.shouldDeepFreeze`).
- `FabricMap` / `FabricSet`: remain throwing stubs; the `"not yet implemented"` throw now lives in the codec, with the protocol members delegating into it.

### Out of scope
`ProblematicValue` / `UnknownValue` have no `[CODEC]` and are untouched — a separate follow-on.

## Test plan
- `deno check` / `deno lint` / `deno fmt --check` clean on all three files.
- `packages/data-model` suite: **35 passed / 1708 steps / 0 failed** (includes the `value-hash` and `JsonEncodingContext` round-trip tests that exercise the `FabricError` codec end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Performance Baseline

This PR rearranges code with de-minimis possible performance (trades an function call in one place for an extra function call in a different place). As such the following accounts for spurious performance check failures:

NEW_PERF_BASELINE: job: CLI Integration Tests (core-piece-call) = 105s
NEW_PERF_BASELINE: job: Package Integration Tests (shell) = 117s
NEW_PERF_BASELINE: job: Package Integration Tests = 117s

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored serialization so each instance’s static `[CODEC]` is the source of truth, with `[DECONSTRUCT]`/`[RECONSTRUCT]` delegating to the codec. No behavior changes; `FabricMap` and `FabricSet` remain stubs.

- **Refactors**
  - Moved encode/decode logic into each class’s `[CODEC]`, aligning with the registry that registers `cls[CODEC]` and removing extra indirection.
  - `FabricError`: codec encodes via `extraEntries()` and decodes the same state; honors `context.shouldDeepFreeze`.
  - `FabricMap`/`FabricSet`: codecs throw “not yet implemented”; protocol members now delegate to these stubs.
  - Kept `[DECONSTRUCT]`/`[RECONSTRUCT]` for hashing, `[ID]` assignment, and `deepClone`.

<sup>Written for commit 818137344832aa0df7642fa816f2aa09b8049af6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

