### PR TITLE
refactor(data-model): move ExplicitTagValue onto [CODEC]; remove [RECONSTRUCT]

### DIFF
--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -356,15 +356,7 @@ export class FabricError extends FabricNativeWrapper<Error> {
         super(WIRE_TYPE_TAGS.Error, FabricError);
       }
 
-      /**
-       * @inheritDoc
-       *
-       * Deconstructs into a flat record with `type`, `name`, `message`,
-       * `stack`, `cause`, and the extras-bag entries. Does NOT recurse into
-       * nested values -- the serialization system handles that. `name` is
-       * emitted as `null` when it equals `type` (the common case) to avoid
-       * redundancy.
-       */
+      /** @inheritDoc */
       encode(value: FabricError): FabricValue {
         const state: Record<string, FabricValue> = {
           type: value.type,
@@ -383,13 +375,7 @@ export class FabricError extends FabricNativeWrapper<Error> {
         return state as FabricValue;
       }
 
-      /**
-       * @inheritDoc
-       *
-       * Reconstructs a `FabricError` from its essential state (flat record).
-       * Nested values in `state` have already been reconstructed by the
-       * serialization system. Honors `context.shouldDeepFreeze`.
-       */
+      /** @inheritDoc */
       decode(
         _wireTypeTag: string,
         state: FabricValue,

--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -3,7 +3,6 @@ import {
   CODEC,
   DECONSTRUCT,
   type FabricCodec,
-  RECONSTRUCT,
   type ReconstructionContext,
 } from "@/wire-common/interface.ts";
 import { BaseFabricCodec } from "@/wire-common/BaseFabricCodec.ts";
@@ -78,7 +77,7 @@ export type FabricErrorState = {
  * extras bag mirrors this by gating `setExtra` / `deleteExtra` on the
  * frozen state. The serialization layer handles `FabricError` via its static
  * `[CODEC]`, which is the source of truth for the encoded form; the
- * `[DECONSTRUCT]` / `[RECONSTRUCT]` protocol members delegate to it.
+ * `[DECONSTRUCT]` protocol member delegates to it.
  * See Section 1.4.1 of the formal spec.
  */
 export class FabricError extends FabricNativeWrapper<Error> {
@@ -349,21 +348,6 @@ export class FabricError extends FabricNativeWrapper<Error> {
       reconstructContext,
     ) as FabricError;
     return frozen ? deepFreeze(result) : result;
-  }
-
-  /**
-   * Reconstructs a `FabricError` from its essential state (flat record).
-   * Delegates to this class's `[CODEC]`, the source of truth for decoding.
-   */
-  static [RECONSTRUCT](
-    state: FabricValue,
-    context: ReconstructionContext,
-  ): FabricError {
-    return FabricError[CODEC].decode(
-      WIRE_TYPE_TAGS.Error,
-      state,
-      context,
-    ) as FabricError;
   }
 
   static #codec = Object.freeze(

--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -334,26 +334,26 @@ export class FabricError extends FabricNativeWrapper<Error> {
   override deepClone(frozen: boolean): FabricError {
     if (frozen && isDeepFrozen(this)) return this;
 
-    // `[RECONSTRUCT]` honors `context.shouldDeepFreeze`. This clone path owns
-    // its own frozenness decision via the wrapper `frozen ? deepFreeze :
-    // result` below, so pre-freezing inside `[RECONSTRUCT]` would be
-    // redundant when `frozen` is true and wrong when it is false. Match
-    // contexts to this clone's intent.
+    // The codec honors `context.shouldDeepFreeze`. This clone path owns its own
+    // frozenness decision via the wrapper `frozen ? deepFreeze : result` below,
+    // so pre-freezing inside the codec would be redundant when `frozen` is true
+    // and wrong when it is false. Match the context to this clone's intent.
+    const codec = FabricError[CODEC];
     const reconstructContext = new EmptyReconstructionContext(
       frozen,
       "no runtime context (FabricError deep-clone path).",
     );
-    const result = FabricError[RECONSTRUCT](
-      this[DECONSTRUCT](),
+    const result = codec.decode(
+      WIRE_TYPE_TAGS.Error,
+      codec.encode(this),
       reconstructContext,
-    );
+    ) as FabricError;
     return frozen ? deepFreeze(result) : result;
   }
 
   /**
    * Reconstructs a `FabricError` from its essential state (flat record).
    * Delegates to this class's `[CODEC]`, the source of truth for decoding.
-   * `[RECONSTRUCT]` remains the protocol entry point relied on by `deepClone`.
    */
   static [RECONSTRUCT](
     state: FabricValue,

--- a/packages/data-model/src/fabric-instances/FabricMap.ts
+++ b/packages/data-model/src/fabric-instances/FabricMap.ts
@@ -3,7 +3,6 @@ import {
   CODEC,
   DECONSTRUCT,
   type FabricCodec,
-  RECONSTRUCT,
   type ReconstructionContext,
 } from "@/wire-common/interface.ts";
 import { BaseFabricCodec } from "@/wire-common/BaseFabricCodec.ts";
@@ -14,9 +13,8 @@ import { FabricNativeWrapper } from "./FabricNativeWrapper.ts";
 /**
  * Wrapper for `Map` instances. Stub -- the static `[CODEC]` (the source of
  * truth) throws until `Map` support is fully implemented, and the
- * `[DECONSTRUCT]` / `[RECONSTRUCT]` protocol members delegate to it. Extra
- * properties beyond the wrapped collection are not supported on non-`Error`
- * wrappers.
+ * `[DECONSTRUCT]` protocol member delegates to it. Extra properties beyond the
+ * wrapped collection are not supported on non-`Error` wrappers.
  */
 export class FabricMap
   extends FabricNativeWrapper<Map<FabricValue, FabricValue>> {
@@ -78,21 +76,6 @@ export class FabricMap
   /** @inheritDoc */
   protected toNativeThawed(): Map<FabricValue, FabricValue> {
     return new Map(this.map);
-  }
-
-  /**
-   * Delegates to this class's `[CODEC]` (the source of truth), which throws
-   * until `Map` support is implemented.
-   */
-  static [RECONSTRUCT](
-    state: FabricValue,
-    context: ReconstructionContext,
-  ): FabricMap {
-    return FabricMap[CODEC].decode(
-      WIRE_TYPE_TAGS.Map,
-      state,
-      context,
-    ) as FabricMap;
   }
 
   static #codec = Object.freeze(

--- a/packages/data-model/src/fabric-instances/FabricSet.ts
+++ b/packages/data-model/src/fabric-instances/FabricSet.ts
@@ -3,7 +3,6 @@ import {
   CODEC,
   DECONSTRUCT,
   type FabricCodec,
-  RECONSTRUCT,
   type ReconstructionContext,
 } from "@/wire-common/interface.ts";
 import { BaseFabricCodec } from "@/wire-common/BaseFabricCodec.ts";
@@ -14,9 +13,8 @@ import { FabricNativeWrapper } from "./FabricNativeWrapper.ts";
 /**
  * Wrapper for `Set` instances. Stub -- the static `[CODEC]` (the source of
  * truth) throws until `Set` support is fully implemented, and the
- * `[DECONSTRUCT]` / `[RECONSTRUCT]` protocol members delegate to it. Extra
- * properties beyond the wrapped collection are not supported on non-`Error`
- * wrappers.
+ * `[DECONSTRUCT]` protocol member delegates to it. Extra properties beyond the
+ * wrapped collection are not supported on non-`Error` wrappers.
  */
 export class FabricSet extends FabricNativeWrapper<Set<FabricValue>> {
   constructor(readonly set: Set<FabricValue>) {
@@ -77,21 +75,6 @@ export class FabricSet extends FabricNativeWrapper<Set<FabricValue>> {
   /** @inheritDoc */
   protected toNativeThawed(): Set<FabricValue> {
     return new Set(this.set);
-  }
-
-  /**
-   * Delegates to this class's `[CODEC]` (the source of truth), which throws
-   * until `Set` support is implemented.
-   */
-  static [RECONSTRUCT](
-    state: FabricValue,
-    context: ReconstructionContext,
-  ): FabricSet {
-    return FabricSet[CODEC].decode(
-      WIRE_TYPE_TAGS.Set,
-      state,
-      context,
-    ) as FabricSet;
   }
 
   static #codec = Object.freeze(

--- a/packages/data-model/src/fabric-instances/ProblematicValue.ts
+++ b/packages/data-model/src/fabric-instances/ProblematicValue.ts
@@ -3,7 +3,6 @@ import {
   CODEC,
   DECONSTRUCT,
   type FabricCodec,
-  RECONSTRUCT,
   type ReconstructionContext,
 } from "@/wire-common/interface.ts";
 import { BaseFabricCodec } from "@/wire-common/BaseFabricCodec.ts";
@@ -74,22 +73,6 @@ export class ProblematicValue extends ExplicitTagValue {
 
   protected shallowUnfrozenClone(): ProblematicValue {
     return new ProblematicValue(this.wireTypeTag, this.state, this.error);
-  }
-
-  /**
-   * Reconstructs a `ProblematicValue` from its `[DECONSTRUCT]` envelope.
-   * Forwards to `[CODEC].decode` with the preserved tag and bare state; the
-   * envelope's `error` is dropped, since it is not part of the codec form.
-   */
-  static [RECONSTRUCT](
-    state: { type: string; state: FabricValue; error: string },
-    context: ReconstructionContext,
-  ): ProblematicValue {
-    return ProblematicValue[CODEC].decode(
-      state.type,
-      state.state,
-      context,
-    ) as ProblematicValue;
   }
 
   static #codec = Object.freeze(

--- a/packages/data-model/src/fabric-instances/ProblematicValue.ts
+++ b/packages/data-model/src/fabric-instances/ProblematicValue.ts
@@ -101,6 +101,15 @@ export class ProblematicValue extends ExplicitTagValue {
       /**
        * @inheritDoc
        *
+       * Reads the preserved per-instance tag off the value.
+       */
+      override tagForValue(value: ProblematicValue): string {
+        return value.wireTypeTag;
+      }
+
+      /**
+       * @inheritDoc
+       *
        * Deconstructs into a `{ type, state, error }` envelope carrying the
        * preserved tag, raw state, and failure description. Does NOT recurse
        * into `state` -- the serialization system handles that.

--- a/packages/data-model/src/fabric-instances/ProblematicValue.ts
+++ b/packages/data-model/src/fabric-instances/ProblematicValue.ts
@@ -39,11 +39,12 @@ export class ProblematicValue extends ExplicitTagValue {
   /**
    * @inheritDoc
    *
-   * Delegates to this class's `[CODEC]`, the source of truth for the encoded
-   * form.
+   * Returns the `{ type, state, error }` envelope (preserved tag, raw state,
+   * and failure description). This is the protocol/hashing form; the wire form
+   * (via `[CODEC]`) is the bare `state`, with the tag carried separately.
    */
   [DECONSTRUCT](): FabricValue {
-    return ProblematicValue[CODEC].encode(this);
+    return { type: this.wireTypeTag, state: this.state, error: this.error };
   }
 
   /**
@@ -76,8 +77,9 @@ export class ProblematicValue extends ExplicitTagValue {
   }
 
   /**
-   * Reconstructs a `ProblematicValue` from its essential state. Delegates to
-   * this class's `[CODEC]`, the source of truth for decoding.
+   * Reconstructs a `ProblematicValue` from its `[DECONSTRUCT]` envelope.
+   * Forwards to `[CODEC].decode` with the preserved tag and bare state; the
+   * envelope's `error` is dropped, since it is not part of the codec form.
    */
   static [RECONSTRUCT](
     state: { type: string; state: FabricValue; error: string },
@@ -85,7 +87,7 @@ export class ProblematicValue extends ExplicitTagValue {
   ): ProblematicValue {
     return ProblematicValue[CODEC].decode(
       state.type,
-      state,
+      state.state,
       context,
     ) as ProblematicValue;
   }
@@ -110,31 +112,29 @@ export class ProblematicValue extends ExplicitTagValue {
       /**
        * @inheritDoc
        *
-       * Deconstructs into a `{ type, state, error }` envelope carrying the
-       * preserved tag, raw state, and failure description. Does NOT recurse
-       * into `state` -- the serialization system handles that.
+       * Returns the bare inner `state`. The tag travels separately (via
+       * {@link #tagForValue}), and the failure `error` is not part of the
+       * codec form -- so a `ProblematicValue` round-trips to the same storage
+       * form as the value it stands in for. Does NOT recurse into `state` --
+       * the serialization system handles that.
        */
       encode(value: ProblematicValue): FabricValue {
-        return {
-          type: value.wireTypeTag,
-          state: value.state,
-          error: value.error,
-        };
+        return value.state;
       }
 
       /**
        * @inheritDoc
        *
-       * Reconstructs a `ProblematicValue` from its `{ type, state, error }`
-       * envelope. Honors `context.shouldDeepFreeze`.
+       * Reconstructs a `ProblematicValue` from its wire `wireTypeTag` and bare
+       * `state`. The original failure `error` is not carried by the codec form,
+       * so the result has none. Honors `context.shouldDeepFreeze`.
        */
       decode(
-        _wireTypeTag: string,
+        wireTypeTag: string,
         state: FabricValue,
         context: ReconstructionContext,
       ): FabricValue {
-        const s = state as { type: string; state: FabricValue; error: string };
-        const result = new ProblematicValue(s.type, s.state, s.error);
+        const result = new ProblematicValue(wireTypeTag, state, "");
         // Honor `shouldDeepFreeze`: produce the type's correct deep-frozen
         // form via its `[DEEP_FREEZE]` member (recursing through `deepFreeze`).
         return context.shouldDeepFreeze ? deepFreeze(result) : result;

--- a/packages/data-model/src/fabric-instances/ProblematicValue.ts
+++ b/packages/data-model/src/fabric-instances/ProblematicValue.ts
@@ -83,35 +83,17 @@ export class ProblematicValue extends ExplicitTagValue {
         super(undefined, ProblematicValue);
       }
 
-      /**
-       * @inheritDoc
-       *
-       * Reads the preserved per-instance tag off the value.
-       */
+      /** @inheritDoc */
       override tagForValue(value: ProblematicValue): string {
         return value.wireTypeTag;
       }
 
-      /**
-       * @inheritDoc
-       *
-       * Returns the bare inner `state`. The tag travels separately (via
-       * {@link #tagForValue}), and the failure `error` is not part of the
-       * codec form -- so a `ProblematicValue` round-trips to the same storage
-       * form as the value it stands in for. Does NOT recurse into `state` --
-       * the serialization system handles that.
-       */
+      /** @inheritDoc */
       encode(value: ProblematicValue): FabricValue {
         return value.state;
       }
 
-      /**
-       * @inheritDoc
-       *
-       * Reconstructs a `ProblematicValue` from its wire `wireTypeTag` and bare
-       * `state`. The original failure `error` is not carried by the codec form,
-       * so the result has none. Honors `context.shouldDeepFreeze`.
-       */
+      /** @inheritDoc */
       decode(
         wireTypeTag: string,
         state: FabricValue,

--- a/packages/data-model/src/fabric-instances/ProblematicValue.ts
+++ b/packages/data-model/src/fabric-instances/ProblematicValue.ts
@@ -1,9 +1,12 @@
 import { DEEP_FREEZE, type FabricValue, IS_DEEP_FROZEN } from "@/interface.ts";
 import {
+  CODEC,
   DECONSTRUCT,
+  type FabricCodec,
   RECONSTRUCT,
   type ReconstructionContext,
 } from "@/wire-common/interface.ts";
+import { BaseFabricCodec } from "@/wire-common/BaseFabricCodec.ts";
 import { ExplicitTagValue } from "./ExplicitTagValue.ts";
 import { deepFreeze } from "@/deep-freeze.ts";
 
@@ -33,8 +36,14 @@ export class ProblematicValue extends ExplicitTagValue {
     return this.#error;
   }
 
+  /**
+   * @inheritDoc
+   *
+   * Delegates to this class's `[CODEC]`, the source of truth for the encoded
+   * form.
+   */
   [DECONSTRUCT](): FabricValue {
-    return { type: this.wireTypeTag, state: this.state, error: this.error };
+    return ProblematicValue[CODEC].encode(this);
   }
 
   /**
@@ -66,13 +75,66 @@ export class ProblematicValue extends ExplicitTagValue {
     return new ProblematicValue(this.wireTypeTag, this.state, this.error);
   }
 
+  /**
+   * Reconstructs a `ProblematicValue` from its essential state. Delegates to
+   * this class's `[CODEC]`, the source of truth for decoding.
+   */
   static [RECONSTRUCT](
     state: { type: string; state: FabricValue; error: string },
     context: ReconstructionContext,
   ): ProblematicValue {
-    const result = new ProblematicValue(state.type, state.state, state.error);
-    // Honor `shouldDeepFreeze`: produce the type's correct deep-frozen form
-    // via its `[DEEP_FREEZE]` member (recursing through `deepFreeze`).
-    return context.shouldDeepFreeze ? deepFreeze(result) : result;
+    return ProblematicValue[CODEC].decode(
+      state.type,
+      state,
+      context,
+    ) as ProblematicValue;
+  }
+
+  static #codec = Object.freeze(
+    new (class ProblematicValueCodec extends BaseFabricCodec {
+      constructor() {
+        // No preferred wire tag: a `ProblematicValue` round-trips to its
+        // *preserved* tag, which varies per instance.
+        super(undefined, ProblematicValue);
+      }
+
+      /**
+       * @inheritDoc
+       *
+       * Deconstructs into a `{ type, state, error }` envelope carrying the
+       * preserved tag, raw state, and failure description. Does NOT recurse
+       * into `state` -- the serialization system handles that.
+       */
+      encode(value: ProblematicValue): FabricValue {
+        return {
+          type: value.wireTypeTag,
+          state: value.state,
+          error: value.error,
+        };
+      }
+
+      /**
+       * @inheritDoc
+       *
+       * Reconstructs a `ProblematicValue` from its `{ type, state, error }`
+       * envelope. Honors `context.shouldDeepFreeze`.
+       */
+      decode(
+        _wireTypeTag: string,
+        state: FabricValue,
+        context: ReconstructionContext,
+      ): FabricValue {
+        const s = state as { type: string; state: FabricValue; error: string };
+        const result = new ProblematicValue(s.type, s.state, s.error);
+        // Honor `shouldDeepFreeze`: produce the type's correct deep-frozen
+        // form via its `[DEEP_FREEZE]` member (recursing through `deepFreeze`).
+        return context.shouldDeepFreeze ? deepFreeze(result) : result;
+      }
+    })(),
+  );
+
+  /** The codec for instances of this class. */
+  static get [CODEC](): FabricCodec {
+    return this.#codec;
   }
 }

--- a/packages/data-model/src/fabric-instances/UnknownValue.ts
+++ b/packages/data-model/src/fabric-instances/UnknownValue.ts
@@ -3,7 +3,6 @@ import {
   CODEC,
   DECONSTRUCT,
   type FabricCodec,
-  RECONSTRUCT,
   type ReconstructionContext,
 } from "@/wire-common/interface.ts";
 import { BaseFabricCodec } from "@/wire-common/BaseFabricCodec.ts";
@@ -59,21 +58,6 @@ export class UnknownValue extends ExplicitTagValue {
 
   protected shallowUnfrozenClone(): UnknownValue {
     return new UnknownValue(this.wireTypeTag, this.state);
-  }
-
-  /**
-   * Reconstructs an `UnknownValue` from its `[DECONSTRUCT]` envelope. Forwards
-   * to `[CODEC].decode` with the preserved tag and bare state.
-   */
-  static [RECONSTRUCT](
-    state: { type: string; state: FabricValue },
-    context: ReconstructionContext,
-  ): UnknownValue {
-    return UnknownValue[CODEC].decode(
-      state.type,
-      state.state,
-      context,
-    ) as UnknownValue;
   }
 
   static #codec = Object.freeze(

--- a/packages/data-model/src/fabric-instances/UnknownValue.ts
+++ b/packages/data-model/src/fabric-instances/UnknownValue.ts
@@ -1,9 +1,12 @@
 import { DEEP_FREEZE, type FabricValue, IS_DEEP_FROZEN } from "@/interface.ts";
 import {
+  CODEC,
   DECONSTRUCT,
+  type FabricCodec,
   RECONSTRUCT,
   type ReconstructionContext,
 } from "@/wire-common/interface.ts";
+import { BaseFabricCodec } from "@/wire-common/BaseFabricCodec.ts";
 import { ExplicitTagValue } from "./ExplicitTagValue.ts";
 import { deepFreeze } from "@/deep-freeze.ts";
 
@@ -18,8 +21,14 @@ export class UnknownValue extends ExplicitTagValue {
     super(wireTypeTag, state);
   }
 
+  /**
+   * @inheritDoc
+   *
+   * Delegates to this class's `[CODEC]`, the source of truth for the encoded
+   * form.
+   */
   [DECONSTRUCT](): FabricValue {
-    return { type: this.wireTypeTag, state: this.state };
+    return UnknownValue[CODEC].encode(this);
   }
 
   /**
@@ -51,13 +60,62 @@ export class UnknownValue extends ExplicitTagValue {
     return new UnknownValue(this.wireTypeTag, this.state);
   }
 
+  /**
+   * Reconstructs an `UnknownValue` from its essential state. Delegates to this
+   * class's `[CODEC]`, the source of truth for decoding.
+   */
   static [RECONSTRUCT](
     state: { type: string; state: FabricValue },
     context: ReconstructionContext,
   ): UnknownValue {
-    const result = new UnknownValue(state.type, state.state);
-    // Honor `shouldDeepFreeze`: produce the type's correct deep-frozen form
-    // via its `[DEEP_FREEZE]` member (recursing through `deepFreeze`).
-    return context.shouldDeepFreeze ? deepFreeze(result) : result;
+    return UnknownValue[CODEC].decode(
+      state.type,
+      state,
+      context,
+    ) as UnknownValue;
+  }
+
+  static #codec = Object.freeze(
+    new (class UnknownValueCodec extends BaseFabricCodec {
+      constructor() {
+        // No preferred wire tag: an `UnknownValue` round-trips to its
+        // *preserved* tag, which varies per instance.
+        super(undefined, UnknownValue);
+      }
+
+      /**
+       * @inheritDoc
+       *
+       * Deconstructs into a `{ type, state }` envelope carrying the preserved
+       * tag and raw state. Does NOT recurse into `state` -- the serialization
+       * system handles that.
+       */
+      encode(value: UnknownValue): FabricValue {
+        return { type: value.wireTypeTag, state: value.state };
+      }
+
+      /**
+       * @inheritDoc
+       *
+       * Reconstructs an `UnknownValue` from its `{ type, state }` envelope.
+       * Honors `context.shouldDeepFreeze`.
+       */
+      decode(
+        _wireTypeTag: string,
+        state: FabricValue,
+        context: ReconstructionContext,
+      ): FabricValue {
+        const s = state as { type: string; state: FabricValue };
+        const result = new UnknownValue(s.type, s.state);
+        // Honor `shouldDeepFreeze`: produce the type's correct deep-frozen
+        // form via its `[DEEP_FREEZE]` member (recursing through `deepFreeze`).
+        return context.shouldDeepFreeze ? deepFreeze(result) : result;
+      }
+    })(),
+  );
+
+  /** The codec for instances of this class. */
+  static get [CODEC](): FabricCodec {
+    return this.#codec;
   }
 }

--- a/packages/data-model/src/fabric-instances/UnknownValue.ts
+++ b/packages/data-model/src/fabric-instances/UnknownValue.ts
@@ -68,33 +68,17 @@ export class UnknownValue extends ExplicitTagValue {
         super(undefined, UnknownValue);
       }
 
-      /**
-       * @inheritDoc
-       *
-       * Reads the preserved per-instance tag off the value.
-       */
+      /** @inheritDoc */
       override tagForValue(value: UnknownValue): string {
         return value.wireTypeTag;
       }
 
-      /**
-       * @inheritDoc
-       *
-       * Returns the bare inner `state`. The tag travels separately (via
-       * {@link #tagForValue}), so an `UnknownValue` round-trips to the same
-       * storage form as the value it stands in for. Does NOT recurse into
-       * `state` -- the serialization system handles that.
-       */
+      /** @inheritDoc */
       encode(value: UnknownValue): FabricValue {
         return value.state;
       }
 
-      /**
-       * @inheritDoc
-       *
-       * Reconstructs an `UnknownValue` from its wire `wireTypeTag` and bare
-       * `state`. Honors `context.shouldDeepFreeze`.
-       */
+      /** @inheritDoc */
       decode(
         wireTypeTag: string,
         state: FabricValue,

--- a/packages/data-model/src/fabric-instances/UnknownValue.ts
+++ b/packages/data-model/src/fabric-instances/UnknownValue.ts
@@ -24,11 +24,12 @@ export class UnknownValue extends ExplicitTagValue {
   /**
    * @inheritDoc
    *
-   * Delegates to this class's `[CODEC]`, the source of truth for the encoded
-   * form.
+   * Returns the `{ type, state }` envelope (preserved tag and raw state). This
+   * is the protocol/hashing form; the wire form (via `[CODEC]`) is the bare
+   * `state`, with the tag carried separately.
    */
   [DECONSTRUCT](): FabricValue {
-    return UnknownValue[CODEC].encode(this);
+    return { type: this.wireTypeTag, state: this.state };
   }
 
   /**
@@ -61,8 +62,8 @@ export class UnknownValue extends ExplicitTagValue {
   }
 
   /**
-   * Reconstructs an `UnknownValue` from its essential state. Delegates to this
-   * class's `[CODEC]`, the source of truth for decoding.
+   * Reconstructs an `UnknownValue` from its `[DECONSTRUCT]` envelope. Forwards
+   * to `[CODEC].decode` with the preserved tag and bare state.
    */
   static [RECONSTRUCT](
     state: { type: string; state: FabricValue },
@@ -70,7 +71,7 @@ export class UnknownValue extends ExplicitTagValue {
   ): UnknownValue {
     return UnknownValue[CODEC].decode(
       state.type,
-      state,
+      state.state,
       context,
     ) as UnknownValue;
   }
@@ -95,27 +96,27 @@ export class UnknownValue extends ExplicitTagValue {
       /**
        * @inheritDoc
        *
-       * Deconstructs into a `{ type, state }` envelope carrying the preserved
-       * tag and raw state. Does NOT recurse into `state` -- the serialization
-       * system handles that.
+       * Returns the bare inner `state`. The tag travels separately (via
+       * {@link #tagForValue}), so an `UnknownValue` round-trips to the same
+       * storage form as the value it stands in for. Does NOT recurse into
+       * `state` -- the serialization system handles that.
        */
       encode(value: UnknownValue): FabricValue {
-        return { type: value.wireTypeTag, state: value.state };
+        return value.state;
       }
 
       /**
        * @inheritDoc
        *
-       * Reconstructs an `UnknownValue` from its `{ type, state }` envelope.
-       * Honors `context.shouldDeepFreeze`.
+       * Reconstructs an `UnknownValue` from its wire `wireTypeTag` and bare
+       * `state`. Honors `context.shouldDeepFreeze`.
        */
       decode(
-        _wireTypeTag: string,
+        wireTypeTag: string,
         state: FabricValue,
         context: ReconstructionContext,
       ): FabricValue {
-        const s = state as { type: string; state: FabricValue };
-        const result = new UnknownValue(s.type, s.state);
+        const result = new UnknownValue(wireTypeTag, state);
         // Honor `shouldDeepFreeze`: produce the type's correct deep-frozen
         // form via its `[DEEP_FREEZE]` member (recursing through `deepFreeze`).
         return context.shouldDeepFreeze ? deepFreeze(result) : result;

--- a/packages/data-model/src/fabric-instances/UnknownValue.ts
+++ b/packages/data-model/src/fabric-instances/UnknownValue.ts
@@ -86,6 +86,15 @@ export class UnknownValue extends ExplicitTagValue {
       /**
        * @inheritDoc
        *
+       * Reads the preserved per-instance tag off the value.
+       */
+      override tagForValue(value: UnknownValue): string {
+        return value.wireTypeTag;
+      }
+
+      /**
+       * @inheritDoc
+       *
        * Deconstructs into a `{ type, state }` envelope carrying the preserved
        * tag and raw state. Does NOT recurse into `state` -- the serialization
        * system handles that.

--- a/packages/data-model/src/fabric-instances/index.ts
+++ b/packages/data-model/src/fabric-instances/index.ts
@@ -2,6 +2,8 @@ import type { FabricClassWithCodec } from "@/wire-common/interface.ts";
 import { FabricError } from "./FabricError.ts";
 import { FabricMap } from "./FabricMap.ts";
 import { FabricSet } from "./FabricSet.ts";
+import { ProblematicValue } from "./ProblematicValue.ts";
+import { UnknownValue } from "./UnknownValue.ts";
 
 export { BaseFabricInstance } from "./BaseFabricInstance.ts";
 export { ExplicitTagValue } from "./ExplicitTagValue.ts";
@@ -15,11 +17,13 @@ export { FabricSet } from "./FabricSet.ts";
 /**
  * The concrete instance classes whose instances are available over the wire,
  * each via its static `[CODEC]`. This is the curated source of truth for which
- * instance types participate in serialization. (`ExplicitTagValue`'s subclasses
- * `UnknownValue` / `ProblematicValue` are live-graph stand-ins carrying a
- * per-instance tag. They do define a `[CODEC]` -- the source of truth for their
- * `[DECONSTRUCT]` / `[RECONSTRUCT]` form -- but it has no preferred wire tag and
- * is intentionally absent here: the encoding context handles them directly.)
+ * instance types participate in serialization.
+ *
+ * `UnknownValue` / `ProblematicValue` (the `ExplicitTagValue` subclasses) are
+ * included too. Their codecs have no preferred wire tag -- the encode path uses
+ * `tagForValue()` to read each instance's preserved per-instance tag -- and
+ * they are not tag-routed on decode (an unrecognized tag is wrapped in an
+ * `UnknownValue` by the encoding context, not decoded via a codec).
  *
  * Returned frozen so callers cannot mutate the shared list.
  */
@@ -31,4 +35,6 @@ const CODEC_CLASSES: readonly FabricClassWithCodec[] = Object.freeze([
   FabricError,
   FabricMap,
   FabricSet,
+  ProblematicValue,
+  UnknownValue,
 ]);

--- a/packages/data-model/src/fabric-instances/index.ts
+++ b/packages/data-model/src/fabric-instances/index.ts
@@ -15,11 +15,11 @@ export { FabricSet } from "./FabricSet.ts";
 /**
  * The concrete instance classes whose instances are available over the wire,
  * each via its static `[CODEC]`. This is the curated source of truth for which
- * instance types participate in serialization: add a class here once it gains
- * a `[CODEC]`. (`ExplicitTagValue` and its subclasses `UnknownValue` /
- * `ProblematicValue` are live-graph stand-ins carrying a per-instance tag,
- * handled directly by the encoding context rather than via a `[CODEC]`, so
- * they are intentionally absent.)
+ * instance types participate in serialization. (`ExplicitTagValue`'s subclasses
+ * `UnknownValue` / `ProblematicValue` are live-graph stand-ins carrying a
+ * per-instance tag. They do define a `[CODEC]` -- the source of truth for their
+ * `[DECONSTRUCT]` / `[RECONSTRUCT]` form -- but it has no preferred wire tag and
+ * is intentionally absent here: the encoding context handles them directly.)
  *
  * Returned frozen so callers cannot mutate the shared list.
  */

--- a/packages/data-model/src/interface.ts
+++ b/packages/data-model/src/interface.ts
@@ -16,7 +16,7 @@
 
 /**
  * Abstract base class for all fabric-system value types. This is the common
- * superclass of `FabricInstance` (protocol types with `[DECONSTRUCT]`/`[RECONSTRUCT]`)
+ * superclass of `FabricInstance` (protocol types with `[DECONSTRUCT]`)
  * and `FabricPrimitive` (immutable special primitives). It enables a single
  * `instanceof FabricSpecialObject` check wherever code needs to recognize any
  * fabric-system value without caring which branch of the hierarchy it
@@ -72,8 +72,7 @@ export const IS_DEEP_FROZEN: unique symbol = Symbol.for(
  *
  * Subclasses must implement `[DECONSTRUCT]()`, `[DEEP_FREEZE]()`,
  * `[IS_DEEP_FROZEN]()`, `deepClone()`, and `shallowClone()` (the latter is
- * normally inherited from `BaseFabricInstance`). Subclasses must also
- * define a static member `[RECONSTRUCT]()`.
+ * normally inherited from `BaseFabricInstance`).
  */
 export abstract class FabricInstance extends FabricSpecialObject {
   /**

--- a/packages/data-model/src/json-wire/CodecRegistry.ts
+++ b/packages/data-model/src/json-wire/CodecRegistry.ts
@@ -44,9 +44,11 @@ export class CodecRegistry {
   readonly #classMap = new Map<Constructor, FabricCodec>();
 
   /**
-   * Registers a codec, indexing it by its `wireTypeTag` (for decode) and, when
-   * it declares a `uniqueHandledClass`, by that class (for the encode fast
-   * path). It also joins the ordered list used by the encode linear scan.
+   * Registers a codec, indexing it by its `wireTypeTag` (for decode) and its
+   * `uniqueHandledClass` (for encode). If either is `undefined`, then the codec
+   * is left unregistered with the corresponding index. And whether or not it
+   * has something `undefined`, it is added to the ordered list used by the
+   * encode linear scan.
    */
   register(codec: FabricCodec): void {
     const uniqueClass = codec.uniqueHandledClass;
@@ -54,7 +56,10 @@ export class CodecRegistry {
       this.#classMap.set(uniqueClass, codec);
     }
 
-    this.#tagMap.set(codec.wireTypeTag, codec);
+    const tag = codec.wireTypeTag;
+    if (tag !== undefined) {
+      this.#tagMap.set(tag, codec);
+    }
     this.#codecs.push(codec);
   }
 

--- a/packages/data-model/src/json-wire/JsonEncodingContext.ts
+++ b/packages/data-model/src/json-wire/JsonEncodingContext.ts
@@ -1,7 +1,7 @@
 import { isPlainObject } from "@commonfabric/utils/types";
 import { utf8SortedKeysOf } from "@commonfabric/utils/utf8";
 
-import { type FabricValue } from "@/interface.ts";
+import { FabricSpecialObject, type FabricValue } from "@/interface.ts";
 import { toCompactDebugString } from "@/value-debug.ts";
 import {
   type ReconstructionContext,
@@ -235,14 +235,13 @@ export class JsonEncodingContext implements SerializationContext<string> {
       }
 
       return result;
-    }
-
-    // Every `FabricInstance` must be representable by a registered codec. An
-    // un-codec'd instance is a programming error, not something to silently
-    // encode as a plain object.
-    if (value instanceof BaseFabricInstance) {
+    } else if (value instanceof FabricSpecialObject) {
+      // Every `FabricSpecialObject` (that is, all objects that are
+      // `FabricValue`s other than plain objects and plain arrays must be
+      // recognized by a registered codec. Complain here since we didn't find a
+      // `codec` above.
       throw new Error(
-        `No codec registered for fabric instance: ${value.constructor.name}`,
+        `No codec registered for fabric object class: ${value.constructor.name}`,
       );
     }
 

--- a/packages/data-model/src/json-wire/JsonEncodingContext.ts
+++ b/packages/data-model/src/json-wire/JsonEncodingContext.ts
@@ -220,10 +220,12 @@ export class JsonEncodingContext implements SerializationContext<string> {
         addedToSeen = true;
       }
 
-      // `tagForValue` (not `wireTypeTag`): a codec may have no single preferred
-      // tag -- `UnknownValue` / `ProblematicValue` carry a per-instance tag, so
-      // the wire form shows that preserved tag rather than a fixed codec tag.
+      // We use `tagForValue()` here rather than relying on any direct property
+      // of `value`, because `value` might not actually know what codec is being
+      // used for it, and it is up to the _codec_ not the value per se to
+      // determine the correct tag.
       const tag = codec.tagForValue(value);
+
       const unprocessedState = codec.encode(value);
       const finalState = this.#encodeValue(unprocessedState, seen, registry);
       const result: JsonWireValue = { [`/${tag}`]: finalState };
@@ -235,8 +237,8 @@ export class JsonEncodingContext implements SerializationContext<string> {
       return result;
     }
 
-    // Every other `FabricInstance` must be representable by a registered codec.
-    // An un-codec'd instance is a programming error, not something to silently
+    // Every `FabricInstance` must be representable by a registered codec. An
+    // un-codec'd instance is a programming error, not something to silently
     // encode as a plain object.
     if (value instanceof BaseFabricInstance) {
       throw new Error(

--- a/packages/data-model/src/json-wire/JsonEncodingContext.ts
+++ b/packages/data-model/src/json-wire/JsonEncodingContext.ts
@@ -9,7 +9,6 @@ import {
 } from "@/wire-common/interface.ts";
 import { deepFreeze } from "@/deep-freeze.ts";
 import { BaseFabricInstance } from "@/fabric-instances/BaseFabricInstance.ts";
-import { ExplicitTagValue } from "@/fabric-instances/ExplicitTagValue.ts";
 import { UnknownValue } from "@/fabric-instances/UnknownValue.ts";
 import { ProblematicValue } from "@/fabric-instances/ProblematicValue.ts";
 import { createDefaultRegistry } from "./createDefaultRegistry.ts";
@@ -221,7 +220,10 @@ export class JsonEncodingContext implements SerializationContext<string> {
         addedToSeen = true;
       }
 
-      const tag = codec.wireTypeTag;
+      // `tagForValue` (not `wireTypeTag`): a codec may have no single preferred
+      // tag -- `UnknownValue` / `ProblematicValue` carry a per-instance tag, so
+      // the wire form shows that preserved tag rather than a fixed codec tag.
+      const tag = codec.tagForValue(value);
       const unprocessedState = codec.encode(value);
       const finalState = this.#encodeValue(unprocessedState, seen, registry);
       const result: JsonWireValue = { [`/${tag}`]: finalState };
@@ -230,25 +232,6 @@ export class JsonEncodingContext implements SerializationContext<string> {
         seen.delete(value as object);
       }
 
-      return result;
-    }
-
-    // `ExplicitTagValue` (`UnknownValue` / `ProblematicValue`): live-graph
-    // stand-ins for values that arrived with an unknown tag or failed to
-    // decode. They round-trip to their *preserved* tag plus raw state, so the
-    // wire form shows that original tag -- never an `ExplicitTagValue` tag.
-    // Uses `.state` directly (NOT `[DECONSTRUCT]()`, whose shape differs).
-    if (value instanceof ExplicitTagValue) {
-      const seen = _seen ?? new Set<object>();
-      if (seen.has(value)) {
-        throw new Error("Circular reference detected during serialization");
-      }
-      seen.add(value);
-      const result = this.wrapTag(
-        value.wireTypeTag,
-        this.#encodeValue(value.state, seen, registry),
-      );
-      seen.delete(value);
       return result;
     }
 
@@ -299,12 +282,12 @@ export class JsonEncodingContext implements SerializationContext<string> {
       return result as JsonWireValue;
     }
 
-    // Codec values, `ExplicitTagValue`, `FabricInstance`, primitives, and
-    // arrays were all handled above. The only legitimate remaining shape is a
-    // *plain* object. Anything else -- a non-object (e.g. an uninterned/unique
-    // `symbol`) or a non-plain object (a class instance with no codec) -- is
-    // unencodable and must fail loudly rather than be silently mis-encoded as
-    // a plain object.
+    // Codec values (including `UnknownValue` / `ProblematicValue`),
+    // `FabricInstance`, primitives, and arrays were all handled above. The only
+    // legitimate remaining shape is a *plain* object. Anything else -- a
+    // non-object (e.g. an uninterned/unique `symbol`) or a non-plain object (a
+    // class instance with no codec) -- is unencodable and must fail loudly
+    // rather than be silently mis-encoded as a plain object.
     if (!isPlainObject(value)) {
       throw new Error(
         `Cannot encode ${

--- a/packages/data-model/src/json-wire/JsonEncodingContext.ts
+++ b/packages/data-model/src/json-wire/JsonEncodingContext.ts
@@ -252,6 +252,8 @@ export class JsonEncodingContext implements SerializationContext<string> {
       return value as JsonWireValue;
     }
 
+    // Past this point, `typeof value === "object"`.
+
     // Arrays
     if (Array.isArray(value)) {
       const seen = _seen ?? new Set<object>();
@@ -282,12 +284,11 @@ export class JsonEncodingContext implements SerializationContext<string> {
       return result as JsonWireValue;
     }
 
-    // Codec values (including `UnknownValue` / `ProblematicValue`),
-    // `FabricInstance`, primitives, and arrays were all handled above. The only
-    // legitimate remaining shape is a *plain* object. Anything else -- a
-    // non-object (e.g. an uninterned/unique `symbol`) or a non-plain object (a
-    // class instance with no codec) -- is unencodable and must fail loudly
-    // rather than be silently mis-encoded as a plain object.
+    // The only legit object we can have at this point is a plain object. (The
+    // other `FabricValue` object cases were handled above. So, if we find
+    // ourselves looking at a non-plain object at this point, it's always an
+    // error (and probably a case that can be tracked down to a typesystem lie
+    // of some sort).
     if (!isPlainObject(value)) {
       throw new Error(
         `Cannot encode ${

--- a/packages/data-model/src/json-wire/JsonEncodingContext.ts
+++ b/packages/data-model/src/json-wire/JsonEncodingContext.ts
@@ -8,7 +8,6 @@ import {
   type SerializationContext,
 } from "@/wire-common/interface.ts";
 import { deepFreeze } from "@/deep-freeze.ts";
-import { BaseFabricInstance } from "@/fabric-instances/BaseFabricInstance.ts";
 import { UnknownValue } from "@/fabric-instances/UnknownValue.ts";
 import { ProblematicValue } from "@/fabric-instances/ProblematicValue.ts";
 import { createDefaultRegistry } from "./createDefaultRegistry.ts";

--- a/packages/data-model/src/json-wire/createDefaultRegistry.ts
+++ b/packages/data-model/src/json-wire/createDefaultRegistry.ts
@@ -20,9 +20,10 @@ import { UndefinedCodec } from "./UndefinedCodec.ts";
  * `null`, `boolean`, finite `number`, `string`, arrays, and plain objects are
  * handled as fallthrough in the serializer after no codec matches.
  *
- * `ExplicitTagValue` / `UnknownValue` / `ProblematicValue` are live-graph
- * stand-ins that carry a per-instance tag and are handled directly by the
- * encoding context, so they are not registered here.
+ * `UnknownValue` / `ProblematicValue` are registered (via `instanceCodecClasses`)
+ * but their codecs declare no preferred wire tag: the encode path resolves each
+ * instance's tag with `tagForValue()`, and an unrecognized tag on decode is
+ * wrapped in an `UnknownValue` by the encoding context rather than tag-routed.
  */
 export function createDefaultRegistry(): CodecRegistry {
   const registry = new CodecRegistry();

--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -72,7 +72,7 @@ const ERROR_CLASS_BY_TYPE: ReadonlyMap<string, ErrorConstructor> = new Map([
 ]);
 
 /**
- * Helper for `FabricError.[RECONSTRUCT]()`, which returns the `Error`
+ * Helper for `FabricError`'s codec `decode()`, which returns the `Error`
  * constructor for the given type string (e.g. `"TypeError"`). Falls back
  * to the base `Error` constructor for unknown types.
  */

--- a/packages/data-model/src/wire-common/BaseFabricCodec.ts
+++ b/packages/data-model/src/wire-common/BaseFabricCodec.ts
@@ -45,6 +45,21 @@ export abstract class BaseFabricCodec implements FabricCodec {
     return (cls !== undefined) && (value instanceof cls);
   }
 
+  /**
+   * @inheritDoc
+   *
+   * Returns this codec's preferred {@link #wireTypeTag}. A codec with no
+   * preferred tag (whose instances carry per-instance tags) must override this.
+   */
+  tagForValue(_value: FabricValue): string {
+    if (this.#wireTypeTag === undefined) {
+      throw new Error(
+        "Shouldn't happen: codec has no preferred tag; `tagForValue()` must be overridden.",
+      );
+    }
+    return this.#wireTypeTag;
+  }
+
   /** @inheritDoc */
   abstract decode(
     wireTypeTag: string,

--- a/packages/data-model/src/wire-common/BaseFabricCodec.ts
+++ b/packages/data-model/src/wire-common/BaseFabricCodec.ts
@@ -6,15 +6,18 @@ import type { FabricCodec, ReconstructionContext } from "./interface.ts";
  * Base class for `FabricCodec` which provides commonly-needed functionality.
  */
 export abstract class BaseFabricCodec implements FabricCodec {
-  #wireTypeTag: string;
+  #wireTypeTag: string | undefined;
   #uniqueHandledClass: Constructor | undefined;
 
   /**
    * Constructs an instance.
    */
   constructor(
-    /** The preferred wire type tag. */
-    wireTypeTag: string,
+    /**
+     * The preferred wire type tag, or `undefined` for a codec with no single
+     * preferred tag.
+     */
+    wireTypeTag: string | undefined,
     /**
      * The unique class (constructor function), if any, whose _direct_ instances
      * this instance handles.
@@ -31,7 +34,7 @@ export abstract class BaseFabricCodec implements FabricCodec {
   }
 
   /** @inheritDoc */
-  get wireTypeTag(): string {
+  get wireTypeTag(): string | undefined {
     return this.#wireTypeTag;
   }
 

--- a/packages/data-model/src/wire-common/index.ts
+++ b/packages/data-model/src/wire-common/index.ts
@@ -1,12 +1,9 @@
 export {
   CODEC,
   DECONSTRUCT,
-  type FabricClass,
   type FabricClassWithCodec,
   type FabricCodec,
   type FabricDeconstructable,
-  type FabricValueConverter,
-  RECONSTRUCT,
   type ReconstructionContext,
   type SerializationContext,
 } from "./interface.ts";

--- a/packages/data-model/src/wire-common/interface.ts
+++ b/packages/data-model/src/wire-common/interface.ts
@@ -50,11 +50,13 @@ export interface FabricCodec {
 
   /**
    * The unique preferred wire format tag that is associated with the format
-   * this instance decodes from. The codec system uses this to mark state
-   * produced by {@link #encode} on this instance and (by default) routes state
-   * so marked back to this instance (or an equivalent) for decoding.
+   * this instance decodes from, or `undefined` for a codec with no single
+   * preferred tag. When defined, the codec system uses it to mark state
+   * produced by {@link #encode} and (by default) routes state so marked back to
+   * this instance (or an equivalent) for decoding; a codec with no tag is not
+   * registered for tag-based decode dispatch.
    */
-  get wireTypeTag(): string;
+  get wireTypeTag(): string | undefined;
 
   /**
    * Returns `true` if this handler can encode the state of the given value.

--- a/packages/data-model/src/wire-common/interface.ts
+++ b/packages/data-model/src/wire-common/interface.ts
@@ -14,12 +14,6 @@ export const CODEC: unique symbol = Symbol.for("data-model.codec");
 export const DECONSTRUCT: unique symbol = Symbol.for("data-model.deconstruct");
 
 /**
- * Well-known symbol for binding the method
- * `FabricClass[RECONSTRUCT]`.
- */
-export const RECONSTRUCT: unique symbol = Symbol.for("data-model.reconstruct");
-
-/**
  * Interface for deconstructable fabric objects, which is all of them, but
  * TypeScript doesn't let us say that given how the class/interface hierarchy
  * under `FabricSpecialObject` is set up.
@@ -108,36 +102,7 @@ export interface FabricClassWithCodec {
 }
 
 /**
- * Interface for classes that can reconstruct fabric objects from essential
- * state. The static `[RECONSTRUCT]` method is separate from the constructor
- * to support reconstruction-specific context and instance interning.
- * See Section 2.4 of the formal spec.
- */
-export interface FabricClass<T extends FabricInstance> {
-  /**
-   * Reconstructs an instance from essential state. Nested values in `state`
-   * have already been reconstructed by the serialization system. May return
-   * an existing instance (interning) rather than creating a new one.
-   */
-  [RECONSTRUCT](state: FabricValue, context: ReconstructionContext): T;
-}
-
-/**
- * Converter that can reconstruct arbitrary values (not necessarily
- * fabric _objects_) from essential state. Used for built-in JS types like
- * `Error` that participate in the serialization protocol but don't implement
- * `FabricInstance`. See Section 1.4.1 of the formal spec.
- */
-export interface FabricValueConverter<T> {
-  /**
-   * Reconstructs a value from essential state. Nested values in `state`
-   * have already been reconstructed by the serialization system.
-   */
-  [RECONSTRUCT](state: FabricValue, context: ReconstructionContext): T;
-}
-
-/**
- * The minimal interface that `[RECONSTRUCT]` implementations may depend on.
+ * The minimal interface that codec `decode()` implementations may depend on.
  * Provided by the `Runtime` in practice, but defined as an interface here to
  * avoid a circular dependency between the fabric protocol and the runner.
  * See Section 2.5 of the formal spec.
@@ -161,14 +126,8 @@ export interface ReconstructionContext {
    * free by extending `BaseReconstructionContext`, which centralizes the
    * getter; the `cloneIfNecessary`-style `true` default lives there.
    *
-   * Enforcement: the concrete `[RECONSTRUCT]` implementations query this and
-   * abide by it — they produce a deep-frozen result when it is `true`. The
-   * one place this is *not* applied is the class-registry fallback
-   * call-site wrap (`json-encoding-context.ts`'s `cls[RECONSTRUCT]` path);
-   * that call-site deep-freeze is a separate follow-on's responsibility and
-   * is intentionally NOT covered here. The per-implementation honoring is
-   * sufficient for correctness regardless: each impl freezes its own output
-   * when asked.
+   * Enforcement: each codec's `decode()` queries this and abides by it,
+   * producing a deep-frozen result when it is `true`.
    */
   get shouldDeepFreeze(): boolean;
 }

--- a/packages/data-model/src/wire-common/interface.ts
+++ b/packages/data-model/src/wire-common/interface.ts
@@ -64,6 +64,15 @@ export interface FabricCodec {
   canEncode(value: FabricValue): boolean;
 
   /**
+   * Returns the wire type tag to use when encoding the given value. Only ever
+   * called on a value for which {@link #canEncode} has returned `true`. Unlike
+   * {@link #wireTypeTag} -- the codec's single preferred tag, if it has one --
+   * this is the concrete tag for a _specific_ value; a codec whose instances
+   * each carry their own per-instance tag reads it from the value.
+   */
+  tagForValue(value: FabricValue): string;
+
+  /**
    * Decodes a value from the given essential state, which is (alleged / supposed)
    * to be a value that was produced by an earlier call to {@link #encode} on
    * a compatible class to this one. The result is expected to be a _shallow_

--- a/packages/data-model/test/fabric-instances/FabricError.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricError.test.ts
@@ -365,11 +365,12 @@ describe("FabricError", () => {
 
     describe("[CODEC]", () => {
       const codec = FabricError[CODEC];
+      const expectedTag = WIRE_TYPE_TAGS.Error;
       const context = EMPTY_RECONSTRUCTION_CONTEXT;
 
       describe("wireTypeTag", () => {
         it("is the `Error` wire type tag", () => {
-          expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.Error);
+          expect(codec.wireTypeTag).toBe(expectedTag);
         });
       });
 
@@ -414,7 +415,7 @@ describe("FabricError", () => {
         it("round-trips a basic `Error`", () => {
           const se = FabricError.fromNativeError(new Error("hello"));
           const decoded = codec.decode(
-            codec.wireTypeTag,
+            expectedTag,
             codec.encode(se),
             context,
           ) as unknown as FabricError;
@@ -427,7 +428,7 @@ describe("FabricError", () => {
         it("round-trips a `TypeError`", () => {
           const se = FabricError.fromNativeError(new TypeError("bad type"));
           const decoded = codec.decode(
-            codec.wireTypeTag,
+            expectedTag,
             codec.encode(se),
             context,
           ) as unknown as FabricError;
@@ -442,7 +443,7 @@ describe("FabricError", () => {
             new RangeError("out of range"),
           );
           const decoded = codec.decode(
-            codec.wireTypeTag,
+            expectedTag,
             codec.encode(se),
             context,
           ) as unknown as FabricError;
@@ -457,7 +458,7 @@ describe("FabricError", () => {
             new Error("outer", { cause: inner }),
           );
           const decoded = codec.decode(
-            codec.wireTypeTag,
+            expectedTag,
             codec.encode(outer),
             context,
           ) as unknown as FabricError;
@@ -477,7 +478,7 @@ describe("FabricError", () => {
           outerErr.cause = innerSe;
           const outerSe = FabricError.fromNativeError(outerErr);
           const decoded = codec.decode(
-            codec.wireTypeTag,
+            expectedTag,
             codec.encode(outerSe),
             context,
           ) as unknown as FabricError;
@@ -492,7 +493,7 @@ describe("FabricError", () => {
           (err as unknown as Record<string, unknown>).detail = "more info";
           const se = FabricError.fromNativeError(err);
           const decoded = codec.decode(
-            codec.wireTypeTag,
+            expectedTag,
             codec.encode(se),
             context,
           ) as unknown as FabricError;
@@ -510,7 +511,7 @@ describe("FabricError", () => {
           err.name = "MyCustomError";
           const se = FabricError.fromNativeError(err);
           const decoded = codec.decode(
-            codec.wireTypeTag,
+            expectedTag,
             codec.encode(se),
             context,
           ) as unknown as FabricError;
@@ -521,7 +522,7 @@ describe("FabricError", () => {
         it("round-trips a `TypeError` preserving `name === type` identity", () => {
           const se = FabricError.fromNativeError(new TypeError("rt"));
           const decoded = codec.decode(
-            codec.wireTypeTag,
+            expectedTag,
             codec.encode(se),
             context,
           ) as unknown as FabricError;
@@ -538,7 +539,7 @@ describe("FabricError", () => {
           err.name = "CustomName";
           const se = FabricError.fromNativeError(err);
           const decoded = codec.decode(
-            codec.wireTypeTag,
+            expectedTag,
             codec.encode(se),
             context,
           ) as unknown as FabricError;

--- a/packages/data-model/test/fabric-instances/FabricError.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricError.test.ts
@@ -7,7 +7,7 @@ import {
   type FabricValue,
   IS_DEEP_FROZEN,
 } from "@/interface.ts";
-import { CODEC, DECONSTRUCT, RECONSTRUCT } from "@/wire-common/interface.ts";
+import { CODEC, DECONSTRUCT } from "@/wire-common/interface.ts";
 import { WIRE_TYPE_TAGS } from "@/wire-common/wire-type-tags.ts";
 import { EMPTY_RECONSTRUCTION_CONTEXT } from "@/wire-common/EmptyReconstructionContext.ts";
 import { FabricError } from "@/fabric-instances/FabricError.ts";
@@ -150,14 +150,18 @@ describe("FabricError", () => {
         expect("stack" in state).toBe(false);
       });
 
-      it("round-trips through `[DECONSTRUCT]`/`[RECONSTRUCT]`", () => {
+      it("round-trips through `[DECONSTRUCT]` and `[CODEC].decode()`", () => {
         const original = new Error("round trip");
         original.name = "CustomError";
         (original as unknown as Record<string, unknown>).code = 42;
         const se = FabricError.fromNativeError(original);
 
         const state = se[DECONSTRUCT]();
-        const restored = FabricError[RECONSTRUCT](state, dummyContext);
+        const restored = FabricError[CODEC].decode(
+          WIRE_TYPE_TAGS.Error,
+          state,
+          dummyContext,
+        ) as unknown as FabricError;
 
         expect(restored.name).toBe("CustomError");
         expect(restored.message).toBe("round trip");
@@ -173,10 +177,11 @@ describe("FabricError", () => {
         expect(state.type).toBe("TypeError");
         expect(state.name).toBe("SpecialType");
 
-        const restored = FabricError[RECONSTRUCT](
+        const restored = FabricError[CODEC].decode(
+          WIRE_TYPE_TAGS.Error,
           state,
           dummyContext,
-        );
+        ) as unknown as FabricError;
         expect(restored.toNativeValue(true)).toBeInstanceOf(TypeError);
         expect(restored.name).toBe("SpecialType");
       });
@@ -288,14 +293,20 @@ describe("FabricError", () => {
   });
 
   describe("static members", () => {
-    describe("[RECONSTRUCT]", () => {
+    // Decoding hand-built state (not via `encode()`): exercises name/type
+    // handling and back-compat that the round-trip `decode()` tests don't.
+    describe("[CODEC].decode() of explicit state", () => {
       it("creates a `FabricError` from state (null `name` = same as `type`)", () => {
         const state = {
           type: "Error",
           name: null,
           message: "hello",
         };
-        const result = FabricError[RECONSTRUCT](state, dummyContext);
+        const result = FabricError[CODEC].decode(
+          WIRE_TYPE_TAGS.Error,
+          state,
+          dummyContext,
+        ) as unknown as FabricError;
         expect(result).toBeInstanceOf(FabricError);
         expect(result.toNativeValue(true)).toBeInstanceOf(Error);
         expect(result.name).toBe("Error");
@@ -313,7 +324,11 @@ describe("FabricError", () => {
         ];
         for (const [type, cls] of cases) {
           const state = { type, name: null, message: "test" };
-          const result = FabricError[RECONSTRUCT](state, dummyContext);
+          const result = FabricError[CODEC].decode(
+            WIRE_TYPE_TAGS.Error,
+            state,
+            dummyContext,
+          ) as unknown as FabricError;
           expect(result.toNativeValue(true)).toBeInstanceOf(cls);
           expect(result.name).toBe(type);
         }
@@ -325,7 +340,11 @@ describe("FabricError", () => {
           name: "CustomTypeName",
           message: "mismatch",
         };
-        const result = FabricError[RECONSTRUCT](state, dummyContext);
+        const result = FabricError[CODEC].decode(
+          WIRE_TYPE_TAGS.Error,
+          state,
+          dummyContext,
+        ) as unknown as FabricError;
         expect(result.toNativeValue(true)).toBeInstanceOf(TypeError);
         expect(result.name).toBe("CustomTypeName");
       });
@@ -335,7 +354,11 @@ describe("FabricError", () => {
           name: "TypeError",
           message: "old format",
         };
-        const result = FabricError[RECONSTRUCT](state, dummyContext);
+        const result = FabricError[CODEC].decode(
+          WIRE_TYPE_TAGS.Error,
+          state,
+          dummyContext,
+        ) as unknown as FabricError;
         expect(result.toNativeValue(true)).toBeInstanceOf(TypeError);
       });
 
@@ -345,7 +368,11 @@ describe("FabricError", () => {
           name: "MyCustomError",
           message: "custom",
         };
-        const result = FabricError[RECONSTRUCT](state, dummyContext);
+        const result = FabricError[CODEC].decode(
+          WIRE_TYPE_TAGS.Error,
+          state,
+          dummyContext,
+        ) as unknown as FabricError;
         expect(result.name).toBe("MyCustomError");
       });
 
@@ -357,7 +384,11 @@ describe("FabricError", () => {
           cause: "something went wrong",
           code: 404,
         };
-        const result = FabricError[RECONSTRUCT](state, dummyContext);
+        const result = FabricError[CODEC].decode(
+          WIRE_TYPE_TAGS.Error,
+          state,
+          dummyContext,
+        ) as unknown as FabricError;
         expect(result.cause).toBe("something went wrong");
         expect(result.getExtra("code")).toBe(404);
       });

--- a/packages/data-model/test/fabric-instances/FabricMap.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricMap.test.ts
@@ -129,11 +129,12 @@ describe("FabricMap", () => {
     // to the not-yet-implemented `[DECONSTRUCT]`/`[RECONSTRUCT]` protocol.
     describe("[CODEC]", () => {
       const codec = FabricMap[CODEC];
+      const expectedTag = WIRE_TYPE_TAGS.Map;
       const context = EMPTY_RECONSTRUCTION_CONTEXT;
 
       describe("wireTypeTag", () => {
         it("is the `Map` wire type tag", () => {
-          expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.Map);
+          expect(codec.wireTypeTag).toBe(expectedTag);
         });
       });
 
@@ -154,7 +155,7 @@ describe("FabricMap", () => {
 
       describe("decode()", () => {
         it("throws (stub, via `[RECONSTRUCT]`)", () => {
-          expect(() => codec.decode(codec.wireTypeTag, null, context)).toThrow(
+          expect(() => codec.decode(expectedTag, null, context)).toThrow(
             "not yet implemented",
           );
         });

--- a/packages/data-model/test/fabric-instances/FabricMap.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricMap.test.ts
@@ -7,14 +7,14 @@ import {
   type FabricValue,
   IS_DEEP_FROZEN,
 } from "@/interface.ts";
-import { CODEC, DECONSTRUCT, RECONSTRUCT } from "@/wire-common/interface.ts";
+import { CODEC, DECONSTRUCT } from "@/wire-common/interface.ts";
 import { WIRE_TYPE_TAGS } from "@/wire-common/wire-type-tags.ts";
 import { EMPTY_RECONSTRUCTION_CONTEXT } from "@/wire-common/EmptyReconstructionContext.ts";
 import { FabricMap } from "@/fabric-instances/FabricMap.ts";
 import { FabricNativeWrapper } from "@/fabric-instances/FabricNativeWrapper.ts";
 import { FrozenMap } from "@/frozen-builtins.ts";
 import { deepFreeze, isDeepFrozenFabricValue } from "@/deep-freeze.ts";
-import { dummyContext, subFreeze, subIsDeepFrozen } from "./fixtures.ts";
+import { subFreeze, subIsDeepFrozen } from "./fixtures.ts";
 
 describe("FabricMap", () => {
   // Pure type-identity / supertype checks: cross-cutting carve-out per the
@@ -116,17 +116,9 @@ describe("FabricMap", () => {
   });
 
   describe("static members", () => {
-    describe("[RECONSTRUCT]", () => {
-      it("throws (stub)", () => {
-        expect(() => FabricMap[RECONSTRUCT](null, dummyContext)).toThrow(
-          "not yet implemented",
-        );
-      });
-    });
-
     // Nominal coverage: the codec exists and reports its wire tag and claims
-    // its instances, but `encode()`/`decode()` are still stubs that delegate
-    // to the not-yet-implemented `[DECONSTRUCT]`/`[RECONSTRUCT]` protocol.
+    // its instances, but `encode()` / `decode()` are throwing stubs until
+    // `Map` support is implemented.
     describe("[CODEC]", () => {
       const codec = FabricMap[CODEC];
       const expectedTag = WIRE_TYPE_TAGS.Map;
@@ -146,7 +138,7 @@ describe("FabricMap", () => {
       });
 
       describe("encode()", () => {
-        it("throws (stub, via `[DECONSTRUCT]`)", () => {
+        it("throws (stub)", () => {
           expect(() => codec.encode(new FabricMap(new Map()))).toThrow(
             "not yet implemented",
           );
@@ -154,7 +146,7 @@ describe("FabricMap", () => {
       });
 
       describe("decode()", () => {
-        it("throws (stub, via `[RECONSTRUCT]`)", () => {
+        it("throws (stub)", () => {
           expect(() => codec.decode(expectedTag, null, context)).toThrow(
             "not yet implemented",
           );

--- a/packages/data-model/test/fabric-instances/FabricSet.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricSet.test.ts
@@ -101,8 +101,8 @@ describe("FabricSet", () => {
 
   describe("static members", () => {
     // Nominal coverage: the codec exists and reports its wire tag and claims
-    // its instances, but `encode()`/`decode()` are still stubs that delegate
-    // to the not-yet-implemented `[DECONSTRUCT]`/`[RECONSTRUCT]` protocol.
+    // its instances, but `encode()` / `decode()` are throwing stubs until
+    // `Set` support is implemented.
     describe("[CODEC]", () => {
       const codec = FabricSet[CODEC];
       const expectedTag = WIRE_TYPE_TAGS.Set;
@@ -122,7 +122,7 @@ describe("FabricSet", () => {
       });
 
       describe("encode()", () => {
-        it("throws (stub, via `[DECONSTRUCT]`)", () => {
+        it("throws (stub)", () => {
           expect(() => codec.encode(new FabricSet(new Set()))).toThrow(
             "not yet implemented",
           );
@@ -130,7 +130,7 @@ describe("FabricSet", () => {
       });
 
       describe("decode()", () => {
-        it("throws (stub, via `[RECONSTRUCT]`)", () => {
+        it("throws (stub)", () => {
           expect(() => codec.decode(expectedTag, null, context)).toThrow(
             "not yet implemented",
           );

--- a/packages/data-model/test/fabric-instances/FabricSet.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricSet.test.ts
@@ -105,11 +105,12 @@ describe("FabricSet", () => {
     // to the not-yet-implemented `[DECONSTRUCT]`/`[RECONSTRUCT]` protocol.
     describe("[CODEC]", () => {
       const codec = FabricSet[CODEC];
+      const expectedTag = WIRE_TYPE_TAGS.Set;
       const context = EMPTY_RECONSTRUCTION_CONTEXT;
 
       describe("wireTypeTag", () => {
         it("is the `Set` wire type tag", () => {
-          expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.Set);
+          expect(codec.wireTypeTag).toBe(expectedTag);
         });
       });
 
@@ -130,7 +131,7 @@ describe("FabricSet", () => {
 
       describe("decode()", () => {
         it("throws (stub, via `[RECONSTRUCT]`)", () => {
-          expect(() => codec.decode(codec.wireTypeTag, null, context)).toThrow(
+          expect(() => codec.decode(expectedTag, null, context)).toThrow(
             "not yet implemented",
           );
         });

--- a/packages/data-model/test/fabric-instances/ProblematicValue.test.ts
+++ b/packages/data-model/test/fabric-instances/ProblematicValue.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
 import { DEEP_FREEZE, type FabricValue, IS_DEEP_FROZEN } from "@/interface.ts";
-import { DECONSTRUCT } from "@/wire-common/interface.ts";
+import { CODEC, DECONSTRUCT } from "@/wire-common/interface.ts";
 import { ProblematicValue } from "@/fabric-instances/ProblematicValue.ts";
 import { ExplicitTagValue } from "@/fabric-instances/ExplicitTagValue.ts";
 import { deepFreeze, isDeepFrozenFabricValue } from "@/deep-freeze.ts";
@@ -64,6 +64,17 @@ describe("ProblematicValue", () => {
         expect(Object.isFrozen(pv)).toBe(true);
         expect(Object.isFrozen(child)).toBe(true);
         expect(pv[IS_DEEP_FROZEN](subIsDeepFrozen)).toBe(true);
+      });
+    });
+  });
+
+  describe("static members", () => {
+    describe("[CODEC]", () => {
+      describe("tagForValue()", () => {
+        it("returns the value's own (per-instance) wire type tag", () => {
+          const pv = new ProblematicValue("Weird@7", "s", "oops");
+          expect(ProblematicValue[CODEC].tagForValue(pv)).toBe("Weird@7");
+        });
       });
     });
   });

--- a/packages/data-model/test/fabric-instances/UnknownValue.test.ts
+++ b/packages/data-model/test/fabric-instances/UnknownValue.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
 import { DEEP_FREEZE, type FabricValue, IS_DEEP_FROZEN } from "@/interface.ts";
-import { DECONSTRUCT } from "@/wire-common/interface.ts";
+import { CODEC, DECONSTRUCT } from "@/wire-common/interface.ts";
 import { UnknownValue } from "@/fabric-instances/UnknownValue.ts";
 import { ExplicitTagValue } from "@/fabric-instances/ExplicitTagValue.ts";
 import { deepFreeze, isDeepFrozenFabricValue } from "@/deep-freeze.ts";
@@ -60,6 +60,17 @@ describe("UnknownValue", () => {
         expect(Object.isFrozen(uv)).toBe(true);
         expect(Object.isFrozen(child)).toBe(true);
         expect(uv[IS_DEEP_FROZEN](subIsDeepFrozen)).toBe(true);
+      });
+    });
+  });
+
+  describe("static members", () => {
+    describe("[CODEC]", () => {
+      describe("tagForValue()", () => {
+        it("returns the value's own (per-instance) wire type tag", () => {
+          const uv = new UnknownValue("Weird@7", "s");
+          expect(UnknownValue[CODEC].tagForValue(uv)).toBe("Weird@7");
+        });
       });
     });
   });

--- a/packages/data-model/test/fabric-primitives/FabricBytes.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricBytes.test.ts
@@ -91,11 +91,12 @@ describe("FabricBytes", () => {
   describe("static members", () => {
     describe("[CODEC]", () => {
       const codec = FabricBytes[CODEC];
+      const expectedTag = WIRE_TYPE_TAGS.Bytes;
       const context = EMPTY_RECONSTRUCTION_CONTEXT;
 
       describe("wireTypeTag", () => {
         it("is the `Bytes` wire type tag", () => {
-          expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.Bytes);
+          expect(codec.wireTypeTag).toBe(expectedTag);
         });
       });
 
@@ -124,7 +125,7 @@ describe("FabricBytes", () => {
         it("round-trips via encode -> decode", () => {
           const fb = new FabricBytes(new Uint8Array([10, 20, 30, 40]));
           const decoded = codec.decode(
-            codec.wireTypeTag,
+            expectedTag,
             codec.encode(fb),
             context,
           ) as unknown as FabricBytes;
@@ -135,7 +136,7 @@ describe("FabricBytes", () => {
         it("round-trips empty bytes", () => {
           const fb = new FabricBytes(new Uint8Array());
           const decoded = codec.decode(
-            codec.wireTypeTag,
+            expectedTag,
             codec.encode(fb),
             context,
           ) as unknown as FabricBytes;
@@ -144,13 +145,13 @@ describe("FabricBytes", () => {
         });
 
         it("decodes non-string state to a `ProblematicValue`", () => {
-          const decoded = codec.decode(codec.wireTypeTag, 42, context);
+          const decoded = codec.decode(expectedTag, 42, context);
           expect(decoded).toBeInstanceOf(ProblematicValue);
         });
 
         it("decodes malformed base64 to a `ProblematicValue`", () => {
           const decoded = codec.decode(
-            codec.wireTypeTag,
+            expectedTag,
             "not valid base64!!",
             context,
           );

--- a/packages/data-model/test/fabric-primitives/FabricEpochDays.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochDays.test.ts
@@ -50,11 +50,12 @@ describe("FabricEpochDays", () => {
   describe("static members", () => {
     describe("[CODEC]", () => {
       const codec = FabricEpochDays[CODEC];
+      const expectedTag = WIRE_TYPE_TAGS.EpochDays;
       const context = EMPTY_RECONSTRUCTION_CONTEXT;
 
       describe("wireTypeTag", () => {
         it("is the `EpochDays` wire type tag", () => {
-          expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.EpochDays);
+          expect(codec.wireTypeTag).toBe(expectedTag);
         });
       });
 
@@ -77,7 +78,7 @@ describe("FabricEpochDays", () => {
         it("round-trips at top level (epoch zero)", () => {
           const sd = new FabricEpochDays(0n);
           const decoded = codec.decode(
-            codec.wireTypeTag,
+            expectedTag,
             codec.encode(sd),
             context,
           ) as unknown as FabricEpochDays;
@@ -89,7 +90,7 @@ describe("FabricEpochDays", () => {
           const days = 19723n; // ~2024-01-01
           const sd = new FabricEpochDays(days);
           const decoded = codec.decode(
-            codec.wireTypeTag,
+            expectedTag,
             codec.encode(sd),
             context,
           ) as unknown as FabricEpochDays;
@@ -101,7 +102,7 @@ describe("FabricEpochDays", () => {
           const days = -365n;
           const sd = new FabricEpochDays(days);
           const decoded = codec.decode(
-            codec.wireTypeTag,
+            expectedTag,
             codec.encode(sd),
             context,
           ) as unknown as FabricEpochDays;

--- a/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
@@ -56,11 +56,12 @@ describe("FabricEpochNsec", () => {
   describe("static members", () => {
     describe("[CODEC]", () => {
       const codec = FabricEpochNsec[CODEC];
+      const expectedTag = WIRE_TYPE_TAGS.EpochNsec;
       const context = EMPTY_RECONSTRUCTION_CONTEXT;
 
       describe("wireTypeTag", () => {
         it("is the `EpochNsec` wire type tag", () => {
-          expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.EpochNsec);
+          expect(codec.wireTypeTag).toBe(expectedTag);
         });
       });
 
@@ -83,7 +84,7 @@ describe("FabricEpochNsec", () => {
         it("round-trips at top level (epoch zero)", () => {
           const sn = new FabricEpochNsec(0n);
           const decoded = codec.decode(
-            codec.wireTypeTag,
+            expectedTag,
             codec.encode(sn),
             context,
           ) as unknown as FabricEpochNsec;
@@ -96,7 +97,7 @@ describe("FabricEpochNsec", () => {
           const nsec = 1704067200000000000n;
           const sn = new FabricEpochNsec(nsec);
           const decoded = codec.decode(
-            codec.wireTypeTag,
+            expectedTag,
             codec.encode(sn),
             context,
           ) as unknown as FabricEpochNsec;
@@ -108,7 +109,7 @@ describe("FabricEpochNsec", () => {
           const nsec = -86400000000000n; // -1 day in nanoseconds
           const sn = new FabricEpochNsec(nsec);
           const decoded = codec.decode(
-            codec.wireTypeTag,
+            expectedTag,
             codec.encode(sn),
             context,
           ) as unknown as FabricEpochNsec;
@@ -121,7 +122,7 @@ describe("FabricEpochNsec", () => {
           const nsec = 32503680000000000000n;
           const sn = new FabricEpochNsec(nsec);
           const decoded = codec.decode(
-            codec.wireTypeTag,
+            expectedTag,
             codec.encode(sn),
             context,
           ) as unknown as FabricEpochNsec;

--- a/packages/data-model/test/fabric-primitives/FabricHash.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricHash.test.ts
@@ -153,11 +153,12 @@ describe("FabricHash", () => {
 
     describe("[CODEC]", () => {
       const codec = FabricHash[CODEC];
+      const expectedTag = WIRE_TYPE_TAGS.Hash;
       const context = EMPTY_RECONSTRUCTION_CONTEXT;
 
       describe("wireTypeTag", () => {
         it("is the `Hash` wire type tag", () => {
-          expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.Hash);
+          expect(codec.wireTypeTag).toBe(expectedTag);
         });
       });
 
@@ -184,7 +185,7 @@ describe("FabricHash", () => {
         it("decodes a `{ tag, hash }` object back to a `FabricHash`", () => {
           const cid = new FabricHash(SAMPLE_HASH, "fid1");
           const decoded = codec.decode(
-            codec.wireTypeTag,
+            expectedTag,
             { tag: "fid1", hash: cid.hashString },
             context,
           );
@@ -197,7 +198,7 @@ describe("FabricHash", () => {
         it("round-trips via encode -> decode (non-`fid1` tag)", () => {
           const cid = new FabricHash(SAMPLE_HASH_17, "sha3");
           const decoded = codec.decode(
-            codec.wireTypeTag,
+            expectedTag,
             codec.encode(cid),
             context,
           );
@@ -207,13 +208,13 @@ describe("FabricHash", () => {
         });
 
         it("decodes non-object state to a `ProblematicValue`", () => {
-          const decoded = codec.decode(codec.wireTypeTag, 123, context);
+          const decoded = codec.decode(expectedTag, 123, context);
           expect(decoded).toBeInstanceOf(ProblematicValue);
         });
 
         it("decodes missing/non-string fields to a `ProblematicValue`", () => {
           const decoded = codec.decode(
-            codec.wireTypeTag,
+            expectedTag,
             { tag: "fid1" },
             context,
           );
@@ -222,7 +223,7 @@ describe("FabricHash", () => {
 
         it("decodes a malformed base64 `hash` to a `ProblematicValue`", () => {
           const decoded = codec.decode(
-            codec.wireTypeTag,
+            expectedTag,
             { tag: "fid1", hash: "not valid base64!!" },
             context,
           );

--- a/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
@@ -126,11 +126,12 @@ describe("FabricRegExp", () => {
   describe("static members", () => {
     describe("[CODEC]", () => {
       const codec = FabricRegExp[CODEC];
+      const expectedTag = WIRE_TYPE_TAGS.RegExp;
       const context = EMPTY_RECONSTRUCTION_CONTEXT;
 
       describe("wireTypeTag", () => {
         it("is the `RegExp` wire type tag", () => {
-          expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.RegExp);
+          expect(codec.wireTypeTag).toBe(expectedTag);
         });
       });
 
@@ -156,7 +157,7 @@ describe("FabricRegExp", () => {
         it("round-trips a regex (source, flags, flavor)", () => {
           const re = new FabricRegExp(/ab+c/gi);
           const decoded = codec.decode(
-            codec.wireTypeTag,
+            expectedTag,
             codec.encode(re),
             context,
           ) as unknown as FabricRegExp;
@@ -169,7 +170,7 @@ describe("FabricRegExp", () => {
         it("round-trips a flagless regex", () => {
           const re = new FabricRegExp("es2025", "^x*$", "");
           const decoded = codec.decode(
-            codec.wireTypeTag,
+            expectedTag,
             codec.encode(re),
             context,
           ) as unknown as FabricRegExp;
@@ -179,7 +180,7 @@ describe("FabricRegExp", () => {
         });
 
         it("decodes non-object state to `ProblematicValue`", () => {
-          const decoded = codec.decode(codec.wireTypeTag, "nope", context);
+          const decoded = codec.decode(expectedTag, "nope", context);
           expect(decoded).toBeInstanceOf(ProblematicValue);
         });
       });

--- a/packages/data-model/test/json-wire/BigIntCodec.test.ts
+++ b/packages/data-model/test/json-wire/BigIntCodec.test.ts
@@ -8,12 +8,13 @@ import { ProblematicValue } from "@/fabric-instances/ProblematicValue.ts";
 
 describe("BigIntCodec", () => {
   const codec = new BigIntCodec();
+  const expectedTag = WIRE_TYPE_TAGS.BigInt;
   const context = EMPTY_RECONSTRUCTION_CONTEXT;
 
   describe("instance members", () => {
     describe("wireTypeTag", () => {
       it("is the `BigInt` wire type tag", () => {
-        expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.BigInt);
+        expect(codec.wireTypeTag).toBe(expectedTag);
       });
     });
 
@@ -63,7 +64,7 @@ describe("BigIntCodec", () => {
     describe("decode()", () => {
       it("round-trips at top level", () => {
         const decoded = codec.decode(
-          codec.wireTypeTag,
+          expectedTag,
           codec.encode(42n),
           context,
         );
@@ -72,7 +73,7 @@ describe("BigIntCodec", () => {
 
       it("round-trips negative bigint", () => {
         const decoded = codec.decode(
-          codec.wireTypeTag,
+          expectedTag,
           codec.encode(-999n),
           context,
         );
@@ -81,7 +82,7 @@ describe("BigIntCodec", () => {
 
       it("round-trips zero bigint", () => {
         const decoded = codec.decode(
-          codec.wireTypeTag,
+          expectedTag,
           codec.encode(0n),
           context,
         );
@@ -90,7 +91,7 @@ describe("BigIntCodec", () => {
 
       it("round-trips `1n`", () => {
         const decoded = codec.decode(
-          codec.wireTypeTag,
+          expectedTag,
           codec.encode(1n),
           context,
         );
@@ -99,7 +100,7 @@ describe("BigIntCodec", () => {
 
       it("round-trips `-1n`", () => {
         const decoded = codec.decode(
-          codec.wireTypeTag,
+          expectedTag,
           codec.encode(-1n),
           context,
         );
@@ -109,7 +110,7 @@ describe("BigIntCodec", () => {
       it("round-trips large bigint", () => {
         const big = 2n ** 64n;
         const decoded = codec.decode(
-          codec.wireTypeTag,
+          expectedTag,
           codec.encode(big),
           context,
         );
@@ -119,7 +120,7 @@ describe("BigIntCodec", () => {
       it("round-trips large negative bigint", () => {
         const big = -(2n ** 64n);
         const decoded = codec.decode(
-          codec.wireTypeTag,
+          expectedTag,
           codec.encode(big),
           context,
         );
@@ -128,7 +129,7 @@ describe("BigIntCodec", () => {
 
       it("round-trips boundary value `127n`", () => {
         const decoded = codec.decode(
-          codec.wireTypeTag,
+          expectedTag,
           codec.encode(127n),
           context,
         );
@@ -137,7 +138,7 @@ describe("BigIntCodec", () => {
 
       it("round-trips boundary value `128n`", () => {
         const decoded = codec.decode(
-          codec.wireTypeTag,
+          expectedTag,
           codec.encode(128n),
           context,
         );
@@ -146,7 +147,7 @@ describe("BigIntCodec", () => {
 
       it("round-trips boundary value `-128n`", () => {
         const decoded = codec.decode(
-          codec.wireTypeTag,
+          expectedTag,
           codec.encode(-128n),
           context,
         );
@@ -155,7 +156,7 @@ describe("BigIntCodec", () => {
 
       it("round-trips boundary value `-129n`", () => {
         const decoded = codec.decode(
-          codec.wireTypeTag,
+          expectedTag,
           codec.encode(-129n),
           context,
         );
@@ -164,20 +165,20 @@ describe("BigIntCodec", () => {
 
       it("accepts unpadded base64url input", () => {
         // "Kg" is the standard unpadded base64url encoding of 42n.
-        const result = codec.decode(codec.wireTypeTag, "Kg", context);
+        const result = codec.decode(expectedTag, "Kg", context);
         expect(result).toBe(42n);
       });
 
       it("accepts padded base64 input", () => {
         // "Kg==" is the padded form of "Kg" (42n) -- padding is accepted by the
         // web-standard Uint8Array.fromBase64.
-        const result = codec.decode(codec.wireTypeTag, "Kg==", context);
+        const result = codec.decode(expectedTag, "Kg==", context);
         expect(result).toBe(42n);
       });
 
       it("decodes non-string state to `ProblematicValue`", () => {
         const result = codec.decode(
-          codec.wireTypeTag,
+          expectedTag,
           42,
           context,
         );
@@ -188,13 +189,13 @@ describe("BigIntCodec", () => {
       });
 
       it("decodes `null` state to `ProblematicValue`", () => {
-        const result = codec.decode(codec.wireTypeTag, null, context);
+        const result = codec.decode(expectedTag, null, context);
         expect(result).toBeInstanceOf(ProblematicValue);
       });
 
       it("decodes object state to `ProblematicValue`", () => {
         const result = codec.decode(
-          codec.wireTypeTag,
+          expectedTag,
           { bad: true },
           context,
         );
@@ -202,7 +203,7 @@ describe("BigIntCodec", () => {
       });
 
       it("decodes empty base64 string to `ProblematicValue`", () => {
-        const result = codec.decode(codec.wireTypeTag, "", context);
+        const result = codec.decode(expectedTag, "", context);
         expect(result).toBeInstanceOf(ProblematicValue);
         const prob = result as unknown as ProblematicValue;
         expect(prob.wireTypeTag).toBe("BigInt@1");

--- a/packages/data-model/test/json-wire/JsonEncodingContext.test.ts
+++ b/packages/data-model/test/json-wire/JsonEncodingContext.test.ts
@@ -1016,7 +1016,7 @@ describe("JsonEncodingContext", () => {
       const context = new JsonEncodingContext({ lenient: true });
       const runtime = new TestReconstructionContext();
 
-      // Map@1 always throws on RECONSTRUCT ("not yet implemented"),
+      // Map@1's codec always throws on decode ("not yet implemented"),
       // triggering lenient wrapping.
       const data = {
         "/Map@1": [["key", "value"]],

--- a/packages/data-model/test/json-wire/SpecialNumberCodec.test.ts
+++ b/packages/data-model/test/json-wire/SpecialNumberCodec.test.ts
@@ -8,12 +8,13 @@ import { ProblematicValue } from "@/fabric-instances/ProblematicValue.ts";
 
 describe("SpecialNumberCodec", () => {
   const codec = new SpecialNumberCodec();
+  const expectedTag = WIRE_TYPE_TAGS.SpecialNumber;
   const context = EMPTY_RECONSTRUCTION_CONTEXT;
 
   describe("instance members", () => {
     describe("wireTypeTag", () => {
       it("is the `SpecialNumber` wire type tag", () => {
-        expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.SpecialNumber);
+        expect(codec.wireTypeTag).toBe(expectedTag);
       });
     });
 
@@ -58,7 +59,7 @@ describe("SpecialNumberCodec", () => {
     describe("decode()", () => {
       it("round-trips `-0` (preserves sign of zero)", () => {
         const result = codec.decode(
-          codec.wireTypeTag,
+          expectedTag,
           codec.encode(-0),
           context,
         );
@@ -67,7 +68,7 @@ describe("SpecialNumberCodec", () => {
 
       it("round-trips `NaN`", () => {
         const result = codec.decode(
-          codec.wireTypeTag,
+          expectedTag,
           codec.encode(NaN),
           context,
         );
@@ -76,7 +77,7 @@ describe("SpecialNumberCodec", () => {
 
       it("round-trips `+Infinity`", () => {
         const result = codec.decode(
-          codec.wireTypeTag,
+          expectedTag,
           codec.encode(Infinity),
           context,
         );
@@ -85,7 +86,7 @@ describe("SpecialNumberCodec", () => {
 
       it("round-trips `-Infinity`", () => {
         const result = codec.decode(
-          codec.wireTypeTag,
+          expectedTag,
           codec.encode(-Infinity),
           context,
         );
@@ -94,7 +95,7 @@ describe("SpecialNumberCodec", () => {
 
       it("decodes non-string state to `ProblematicValue`", () => {
         const result = codec.decode(
-          codec.wireTypeTag,
+          expectedTag,
           0,
           context,
         );
@@ -106,7 +107,7 @@ describe("SpecialNumberCodec", () => {
 
       it("decodes an unknown literal to `ProblematicValue`", () => {
         // "Infinity" (missing leading +) is not a recognized literal.
-        const result = codec.decode(codec.wireTypeTag, "Infinity", context);
+        const result = codec.decode(expectedTag, "Infinity", context);
         expect(result).toBeInstanceOf(ProblematicValue);
         expect((result as unknown as ProblematicValue).wireTypeTag).toBe(
           "SpecialNumber@1",

--- a/packages/data-model/test/json-wire/SymbolCodec.test.ts
+++ b/packages/data-model/test/json-wire/SymbolCodec.test.ts
@@ -8,12 +8,13 @@ import { ProblematicValue } from "@/fabric-instances/ProblematicValue.ts";
 
 describe("SymbolCodec", () => {
   const codec = new SymbolCodec();
+  const expectedTag = WIRE_TYPE_TAGS.Symbol;
   const context = EMPTY_RECONSTRUCTION_CONTEXT;
 
   describe("instance members", () => {
     describe("wireTypeTag", () => {
       it("is the `Symbol` wire type tag", () => {
-        expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.Symbol);
+        expect(codec.wireTypeTag).toBe(expectedTag);
       });
     });
 
@@ -41,7 +42,7 @@ describe("SymbolCodec", () => {
     describe("decode()", () => {
       it("round-trips an interned symbol to the same registry instance", () => {
         const result = codec.decode(
-          codec.wireTypeTag,
+          expectedTag,
           codec.encode(Symbol.for("hello")),
           context,
         );
@@ -52,7 +53,7 @@ describe("SymbolCodec", () => {
       it("round-trips a key with non-ASCII characters", () => {
         const key = "café-☕-\u{1F600}";
         const result = codec.decode(
-          codec.wireTypeTag,
+          expectedTag,
           codec.encode(Symbol.for(key)),
           context,
         );
@@ -61,7 +62,7 @@ describe("SymbolCodec", () => {
 
       it("decodes non-string state to `ProblematicValue`", () => {
         const result = codec.decode(
-          codec.wireTypeTag,
+          expectedTag,
           42,
           context,
         );

--- a/packages/data-model/test/json-wire/UndefinedCodec.test.ts
+++ b/packages/data-model/test/json-wire/UndefinedCodec.test.ts
@@ -7,12 +7,13 @@ import { EMPTY_RECONSTRUCTION_CONTEXT } from "@/wire-common/EmptyReconstructionC
 
 describe("UndefinedCodec", () => {
   const codec = new UndefinedCodec();
+  const expectedTag = WIRE_TYPE_TAGS.Undefined;
   const context = EMPTY_RECONSTRUCTION_CONTEXT;
 
   describe("instance members", () => {
     describe("wireTypeTag", () => {
       it("is the `Undefined` wire type tag", () => {
-        expect(codec.wireTypeTag).toBe(WIRE_TYPE_TAGS.Undefined);
+        expect(codec.wireTypeTag).toBe(expectedTag);
       });
     });
 
@@ -34,13 +35,13 @@ describe("UndefinedCodec", () => {
 
     describe("decode()", () => {
       it("decodes `null` state back to `undefined`", () => {
-        const decoded = codec.decode(codec.wireTypeTag, null, context);
+        const decoded = codec.decode(expectedTag, null, context);
         expect(decoded).toBe(undefined);
       });
 
       it("round-trips `undefined` via encode -> decode", () => {
         const decoded = codec.decode(
-          codec.wireTypeTag,
+          expectedTag,
           codec.encode(undefined),
           context,
         );
@@ -48,7 +49,7 @@ describe("UndefinedCodec", () => {
       });
 
       it("throws when decoding non-`null` state", () => {
-        expect(() => codec.decode(codec.wireTypeTag, 42, context)).toThrow(
+        expect(() => codec.decode(expectedTag, 42, context)).toThrow(
           "expected `null` state",
         );
       });

--- a/packages/data-model/test/native-conversion.test.ts
+++ b/packages/data-model/test/native-conversion.test.ts
@@ -7,7 +7,8 @@ import {
   type FabricValue,
   IS_DEEP_FROZEN,
 } from "@/interface.ts";
-import { DECONSTRUCT, RECONSTRUCT } from "@/wire-common/interface.ts";
+import { CODEC, DECONSTRUCT } from "@/wire-common/interface.ts";
+import { WIRE_TYPE_TAGS } from "@/wire-common/wire-type-tags.ts";
 import { FabricError } from "@/fabric-instances/FabricError.ts";
 import { FabricMap } from "@/fabric-instances/FabricMap.ts";
 import { FabricSet } from "@/fabric-instances/FabricSet.ts";
@@ -377,7 +378,7 @@ describe("native-conversion", () => {
     });
   });
 
-  describe("`[RECONSTRUCT]` honors `shouldDeepFreeze`", () => {
+  describe("codec `decode()` honors `shouldDeepFreeze`", () => {
     const frozenCtx = new DummyReconstructionContext(true);
     const mutableCtx = new DummyReconstructionContext(false);
 
@@ -387,32 +388,38 @@ describe("native-conversion", () => {
         name: null,
         message: "boom",
       } as unknown as FabricValue;
-      const frozen = FabricError[RECONSTRUCT](state, frozenCtx);
+      const frozen = FabricError[CODEC].decode(
+        WIRE_TYPE_TAGS.Error,
+        state,
+        frozenCtx,
+      );
       expect(isDeepFrozen(frozen)).toBe(true);
-      const mutable = FabricError[RECONSTRUCT](state, mutableCtx);
+      const mutable = FabricError[CODEC].decode(
+        WIRE_TYPE_TAGS.Error,
+        state,
+        mutableCtx,
+      );
       expect(Object.isFrozen(mutable)).toBe(false);
     });
 
     it("`ProblematicValue`: `shouldDeepFreeze` is `true` => deep-frozen, `false` => mutable", () => {
-      const state = {
-        type: "Bad@1",
-        state: { x: 1 },
-        error: "oops",
-      } as unknown as { type: string; state: FabricValue; error: string };
-      const frozen = ProblematicValue[RECONSTRUCT](state, frozenCtx);
+      // Tag travels separately; the bare inner state is the codec payload.
+      const state = { x: 1 } as unknown as FabricValue;
+      const frozen = ProblematicValue[CODEC].decode("Bad@1", state, frozenCtx);
       expect(isDeepFrozen(frozen)).toBe(true);
-      const mutable = ProblematicValue[RECONSTRUCT](state, mutableCtx);
+      const mutable = ProblematicValue[CODEC].decode(
+        "Bad@1",
+        state,
+        mutableCtx,
+      );
       expect(Object.isFrozen(mutable)).toBe(false);
     });
 
     it("`UnknownValue`: `shouldDeepFreeze` is `true` => deep-frozen, `false` => mutable", () => {
-      const state = { type: "Fancy@3", state: { y: 2 } } as unknown as {
-        type: string;
-        state: FabricValue;
-      };
-      const frozen = UnknownValue[RECONSTRUCT](state, frozenCtx);
+      const state = { y: 2 } as unknown as FabricValue;
+      const frozen = UnknownValue[CODEC].decode("Fancy@3", state, frozenCtx);
       expect(isDeepFrozen(frozen)).toBe(true);
-      const mutable = UnknownValue[RECONSTRUCT](state, mutableCtx);
+      const mutable = UnknownValue[CODEC].decode("Fancy@3", state, mutableCtx);
       expect(Object.isFrozen(mutable)).toBe(false);
     });
   });

--- a/packages/data-model/test/wire-common/BaseFabricCodec.test.ts
+++ b/packages/data-model/test/wire-common/BaseFabricCodec.test.ts
@@ -1,0 +1,52 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import type { FabricValue } from "@/interface.ts";
+import { BaseFabricCodec } from "@/wire-common/BaseFabricCodec.ts";
+import type { ReconstructionContext } from "@/wire-common/interface.ts";
+
+/**
+ * Minimal concrete `BaseFabricCodec` for exercising the base class's own
+ * behavior. `encode` / `decode` are not under test here, so they throw.
+ */
+class TestCodec extends BaseFabricCodec {
+  encode(_value: FabricValue): FabricValue {
+    throw new Error("Unimplemented.");
+  }
+
+  decode(
+    _wireTypeTag: string,
+    _state: FabricValue,
+    _context: ReconstructionContext,
+  ): FabricValue {
+    throw new Error("Unimplemented.");
+  }
+}
+
+describe("BaseFabricCodec", () => {
+  describe("instance members", () => {
+    describe("wireTypeTag", () => {
+      it("returns the tag passed to the constructor", () => {
+        expect(new TestCodec("Foo@1", undefined).wireTypeTag).toBe("Foo@1");
+      });
+
+      it("is `undefined` when constructed with no preferred tag", () => {
+        expect(new TestCodec(undefined, undefined).wireTypeTag).toBe(undefined);
+      });
+    });
+
+    describe("tagForValue()", () => {
+      it("returns the codec's preferred `wireTypeTag`", () => {
+        const codec = new TestCodec("Foo@1", undefined);
+        expect(codec.tagForValue("anything" as FabricValue)).toBe("Foo@1");
+      });
+
+      it("throws when the codec has no preferred tag (must be overridden)", () => {
+        const codec = new TestCodec(undefined, undefined);
+        expect(() => codec.tagForValue("anything" as FabricValue)).toThrow(
+          "no preferred tag",
+        );
+      });
+    });
+  });
+});

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -852,8 +852,7 @@ export function normalizeAndDiff(
   // primitive whose state is private, flatten it to `{}`), which
   // is meaningless at the change-emission level. Emit a single change at
   // this link with the value as-is — the storage layer's JSON encoding handles
-  // serialization (via `[DECONSTRUCT]`/`[RECONSTRUCT]` for instances, the codec
-  // for primitives). Placed after the write-redirect
+  // serialization (via each type's `[CODEC]`). Placed after the write-redirect
   // resolution above so writes through a redirect land on the target,
   // not on the redirect itself.
   if (newValue instanceof FabricSpecialObject) {


### PR DESCRIPTION
## Summary

A staged arc that finishes moving the `ExplicitTagValue` snowflakes (`UnknownValue` / `ProblematicValue`) onto the `[CODEC]` model, then removes the now-dead `[RECONSTRUCT]` protocol entirely. Each commit is self-contained and behavior-preserving on the wire.

### Commits
1. **Extract `[CODEC]` for `ProblematicValue` / `UnknownValue`** — the `[DECONSTRUCT]`/`[RECONSTRUCT]` logic moves into each class's static `[CODEC]`; the protocol members forward to it. These codecs declare **no preferred wire tag** (their instances carry a per-instance tag), so `FabricCodec.wireTypeTag` (and `BaseFabricCodec`) became `string | undefined` and `CodecRegistry.register` only tag-indexes a tagged codec.
2. **`FabricCodec.tagForValue(value)`** — the per-value tag accessor: the fixed `wireTypeTag` for ordinary codecs, the instance's own tag for the snowflakes. (Only called when `canEncode()` is true.)
3. **Codecs encode/decode bare `state`** — `encode` → the inner `state`, `decode(wireTypeTag, state)` consumes the tag. So a snowflake round-trips to the *same* storage form as the value it stands in for. `ProblematicValue`'s runtime `error` is intentionally dropped on the codec path (the constructor still takes it for the failure-construction paths; `[DECONSTRUCT]` still carries it in its envelope).
4. **Route `ExplicitTagValue` through `[CODEC]`** in `JsonEncodingContext` — register the two codecs and drop the bespoke `ExplicitTagValue` arm; the encode path resolves the tag via `codec.tagForValue(value)`. Wire form is byte-identical to the old special-case.
5. **Repoint `FabricError.deepClone` at `[CODEC]`** — calls `[CODEC].encode`/`decode` directly instead of `[DECONSTRUCT]`/`[RECONSTRUCT]`. This was the last non-test caller of any `[RECONSTRUCT]`.
6. **Remove `[RECONSTRUCT]` entirely** — the symbol, the `FabricClass` / `FabricValueConverter` interfaces (which only typed it), the five static methods, and the matching exports. Decoding now lives solely in each codec's `decode()`. Tests that exercised reconstruction are repointed at `[CODEC].decode()`; stale doc comments refreshed.

### Notes
- `FabricMap` / `FabricSet` remain throwing stubs throughout (the throw lives in their codec; implementing real `Map`/`Set` support is separate work).
- The decode path is unchanged for the snowflakes: they declare no wire tag, so an unrecognized tag is still wrapped in an `UnknownValue` by the encoding context rather than tag-routed.

## Test plan
- `deno check` / `deno lint` / `deno fmt --check` clean.
- `packages/data-model` suite: **36 passed / 1721 steps / 0 failed** (includes the `UnknownValue` encode/round-trip tests, exercised unchanged through the new routing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Performance Baseline

The following _might_ be evidence of a real regression, and if so I know what it is and will be addressed soon: Namely, the act of encoding primitives always starts by looking in the codec registry to see if there is an applicable codec, and if not found via map it iterates over all the codecs. This is definitely slow and not the right thing to do in the long run!

NEW_PERF_BASELINE: subtest: pattern-unit-3/pattern-unit-tests > packages/patterns/google/core/util/google-auth-manager.test.tsx = 20s
NEW_PERF_BASELINE: subtest: pattern-unit-3/pattern-unit-tests > packages/patterns/google/core/experimental/gmail-agentic-search.test.tsx = 35s
NEW_PERF_BASELINE: subtest: pattern-unit-3/pattern-unit-tests > packages/patterns/google/core/gmail-importer.test.tsx = 23s
NEW_PERF_BASELINE: job: Pattern Reload Integration Tests = 129s
NEW_PERF_BASELINE: subtest: pattern-unit-3/pattern-unit-tests > packages/patterns/factory-outputs/lot-watch/main.test.tsx = 55s
NEW_PERF_BASELINE: test: pattern-unit-3/pattern-unit-tests = 340s
NEW_PERF_BASELINE: subtest: pattern-unit-3/pattern-unit-tests > packages/patterns/factory-outputs/parking-coordinator/main.test.tsx = 156s

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves `UnknownValue` and `ProblematicValue` to `[CODEC]`, adds per-value tag routing, and removes the `[RECONSTRUCT]` protocol. Wire format is unchanged; all decoding is handled by codecs.

- **Refactors**
  - Added `FabricCodec.tagForValue(value)`; `UnknownValue`/`ProblematicValue` return each instance’s preserved tag.
  - `wireTypeTag` is now `string | undefined`; `CodecRegistry.register()` only tag-indexes codecs that declare a tag.
  - `UnknownValue`/`ProblematicValue` codecs encode bare `state` and decode from `(wireTypeTag, state)`; `ProblematicValue.error` stays off the wire.
  - Routed `ExplicitTagValue` through codecs in `JsonEncodingContext`; tag comes from `codec.tagForValue(value)`. Wire form is unchanged.
  - Registered `UnknownValue`/`ProblematicValue` via `fabric-instances/index.ts`; they declare no preferred tag and are not tag-routed on decode (unknown tags still wrap to `UnknownValue`).
  - Switched `FabricError.deepClone()` to use its codec `encode`/`decode`.
  - Removed `[RECONSTRUCT]`, its symbol, related interfaces, and all static implementations; updated docs/tests.
  - `FabricMap`/`FabricSet` remain stubs; their codecs still throw “not yet implemented”.
  - In `JsonEncodingContext`, improved missing-codec detection: throws for any `FabricSpecialObject` with no registered codec and clarifies the error message.

- **Migration**
  - Replace `Class[RECONSTRUCT](state, ctx)` with `Class[CODEC].decode(tag, state, ctx)`.
  - If you used `codec.decode(codec.wireTypeTag, ...)`, pass a known tag (e.g. `WIRE_TYPE_TAGS.Error`); when encoding, use `codec.tagForValue(value)` to emit the correct tag.

<sup>Written for commit 22f2b815db00154769865bcbfb52a9a1dde87d93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

