### PR TITLE
perf(data-model): O(1) codec dispatch for primitives; remove the linear scan

### DIFF
--- a/packages/data-model/src/json-wire/CodecRegistry.ts
+++ b/packages/data-model/src/json-wire/CodecRegistry.ts
@@ -3,6 +3,13 @@ import type { FabricCodec } from "@/wire-common/interface.ts";
 import type { Constructor } from "@commonfabric/utils/types";
 
 /**
+ * Sentinel returned by {@link CodecRegistry#codecFromValue} for a
+ * self-representing value -- one that is its own wire form (encoded as-is, with
+ * no codec and no tag).
+ */
+export const SELF_REP = "self-rep" as const;
+
+/**
  * Gets the constructor function ("class") of the given value, if any, for the
  * purposes of fast-path lookup.
  */
@@ -50,6 +57,12 @@ export class CodecRegistry {
   readonly #primitiveCodecs = new Map<string, FabricCodec>();
 
   /**
+   * Primitive `type`s that are self-representing (encoded as-is). Keyed the
+   * same way as {@link #primitiveCodecs}.
+   */
+  readonly #selfRepTypes = new Set<string>();
+
+  /**
    * Registers a codec, indexing it by its `wireTypeTag` (for decode) and its
    * `uniqueHandledClass` (for encode). If either is `undefined`, then the codec
    * is left unregistered with the corresponding index. And whether or not it
@@ -92,17 +105,40 @@ export class CodecRegistry {
   }
 
   /**
-   * Finds a codec that can encode the given value. Returns `undefined` if none
-   * matches (the caller should fall through to structural handling for
-   * primitives, arrays, and plain objects).
+   * Registers a primitive `type` (a `typeof` result, or `"null"`) as
+   * self-representing: a value of that type is its own wire form, so
+   * {@link #codecFromValue} returns {@link SELF_REP} for it. `"object"` is not
+   * allowed. A type may be both self-representing and have a
+   * {@link #registerPrimitive} codec (e.g. `"number"`: finite numbers are
+   * self-representing, special ones go through a codec); the codec is tried
+   * first.
    */
-  codecFromValue(value: FabricValue): FabricCodec | undefined {
+  registerSelfRep(type: string): void {
+    if (type === "object") {
+      throw new Error('`registerSelfRep()` does not accept `"object"`.');
+    }
+
+    this.#selfRepTypes.add(type);
+  }
+
+  /**
+   * Finds how to encode the given value: a `FabricCodec` that can encode it,
+   * {@link SELF_REP} if it is a self-representing primitive, or `undefined` if
+   * neither matches (the caller falls through to structural handling for
+   * arrays and plain objects, or fails for an unencodable value).
+   */
+  codecFromValue(
+    value: FabricValue,
+  ): FabricCodec | typeof SELF_REP | undefined {
     // Fast path: primitive-type dispatch.
     const type = (value === null) ? "null" : typeof value;
     if (type !== "object") {
       const codec = this.#primitiveCodecs.get(type);
       if (codec && codec.canEncode(value)) {
         return codec;
+      }
+      if (this.#selfRepTypes.has(type)) {
+        return SELF_REP;
       }
     }
 

--- a/packages/data-model/src/json-wire/CodecRegistry.ts
+++ b/packages/data-model/src/json-wire/CodecRegistry.ts
@@ -44,6 +44,12 @@ export class CodecRegistry {
   readonly #classMap = new Map<Constructor, FabricCodec>();
 
   /**
+   * Primitive `type` -> codec map for the O(1) encode fast path on primitives.
+   * Keyed by `typeof` result (or `"null"`).
+   */
+  readonly #primitiveCodecs = new Map<string, FabricCodec>();
+
+  /**
    * Registers a codec, indexing it by its `wireTypeTag` (for decode) and its
    * `uniqueHandledClass` (for encode). If either is `undefined`, then the codec
    * is left unregistered with the corresponding index. And whether or not it
@@ -64,11 +70,43 @@ export class CodecRegistry {
   }
 
   /**
+   * Registers a codec for a primitive `type` -- a `typeof` result (e.g.
+   * `"bigint"`, `"symbol"`) or `"null"` for the `null` value. `"object"` is not
+   * allowed: object values are matched by class via {@link #register}. Indexes
+   * the codec by its `wireTypeTag` (for decode) and by `type` (for the O(1)
+   * encode fast path on primitives).
+   */
+  registerPrimitive(type: string, codec: FabricCodec): void {
+    if (type === "object") {
+      throw new Error(
+        '`registerPrimitive()` does not accept `"object"`; use `register()`.',
+      );
+    }
+
+    this.#primitiveCodecs.set(type, codec);
+
+    const tag = codec.wireTypeTag;
+    if (tag !== undefined) {
+      this.#tagMap.set(tag, codec);
+    }
+  }
+
+  /**
    * Finds a codec that can encode the given value. Returns `undefined` if none
    * matches (the caller should fall through to structural handling for
    * primitives, arrays, and plain objects).
    */
   codecFromValue(value: FabricValue): FabricCodec | undefined {
+    // Fast path: primitive-type dispatch.
+    const type = (value === null) ? "null" : typeof value;
+    if (type !== "object") {
+      const codec = this.#primitiveCodecs.get(type);
+      if (codec && codec.canEncode(value)) {
+        return codec;
+      }
+    }
+
+    // Class fast-path, then linear scan.
     const constructorFn = constructorOf(value);
     if (constructorFn) {
       const codec = this.#classMap.get(constructorFn);

--- a/packages/data-model/src/json-wire/CodecRegistry.ts
+++ b/packages/data-model/src/json-wire/CodecRegistry.ts
@@ -10,6 +10,21 @@ import type { Constructor } from "@commonfabric/utils/types";
 export const SELF_REP = "self-rep" as const;
 
 /**
+ * The primitive `type` keys the registry accepts: the `typeof` results that are
+ * encodable `FabricValue` primitives, plus `"null"` for the `null` value.
+ * `"object"` and `"function"` are deliberately excluded -- object values are
+ * matched by class via {@link CodecRegistry#register}.
+ */
+export type PrimitiveTypeName =
+  | "null"
+  | "undefined"
+  | "boolean"
+  | "number"
+  | "bigint"
+  | "string"
+  | "symbol";
+
+/**
  * Gets the constructor function ("class") of the given value, if any, for the
  * purposes of fast-path lookup.
  */
@@ -52,15 +67,13 @@ export class CodecRegistry {
 
   /**
    * Primitive `type` -> codec map for the O(1) encode fast path on primitives.
-   * Keyed by `typeof` result (or `"null"`).
    */
-  readonly #primitiveCodecs = new Map<string, FabricCodec>();
+  readonly #primitiveCodecs = new Map<PrimitiveTypeName, FabricCodec>();
 
   /**
-   * Primitive `type`s that are self-representing (encoded as-is). Keyed the
-   * same way as {@link #primitiveCodecs}.
+   * Primitive `type`s that are self-representing (encoded as-is).
    */
-  readonly #selfRepTypes = new Set<string>();
+  readonly #selfRepTypes = new Set<PrimitiveTypeName>();
 
   /**
    * Registers a codec, indexing it by its `wireTypeTag` (for decode) and its
@@ -83,19 +96,11 @@ export class CodecRegistry {
   }
 
   /**
-   * Registers a codec for a primitive `type` -- a `typeof` result (e.g.
-   * `"bigint"`, `"symbol"`) or `"null"` for the `null` value. `"object"` is not
-   * allowed: object values are matched by class via {@link #register}. Indexes
-   * the codec by its `wireTypeTag` (for decode) and by `type` (for the O(1)
-   * encode fast path on primitives).
+   * Registers a codec for a primitive `type` (see {@link PrimitiveTypeName}).
+   * Indexes the codec by its `wireTypeTag` (for decode) and by `type` (for the
+   * O(1) encode fast path on primitives).
    */
-  registerPrimitive(type: string, codec: FabricCodec): void {
-    if (type === "object") {
-      throw new Error(
-        '`registerPrimitive()` does not accept `"object"`; use `register()`.',
-      );
-    }
-
+  registerPrimitive(type: PrimitiveTypeName, codec: FabricCodec): void {
     this.#primitiveCodecs.set(type, codec);
 
     const tag = codec.wireTypeTag;
@@ -105,19 +110,14 @@ export class CodecRegistry {
   }
 
   /**
-   * Registers a primitive `type` (a `typeof` result, or `"null"`) as
+   * Registers a primitive `type` (see {@link PrimitiveTypeName}) as
    * self-representing: a value of that type is its own wire form, so
-   * {@link #codecFromValue} returns {@link SELF_REP} for it. `"object"` is not
-   * allowed. A type may be both self-representing and have a
-   * {@link #registerPrimitive} codec (e.g. `"number"`: finite numbers are
-   * self-representing, special ones go through a codec); the codec is tried
-   * first.
+   * {@link #codecFromValue} returns {@link SELF_REP} for it. A type may be both
+   * self-representing and have a {@link #registerPrimitive} codec (e.g.
+   * `"number"`: finite numbers are self-representing, special ones go through a
+   * codec); the codec is tried first.
    */
-  registerSelfRep(type: string): void {
-    if (type === "object") {
-      throw new Error('`registerSelfRep()` does not accept `"object"`.');
-    }
-
+  registerSelfRep(type: PrimitiveTypeName): void {
     this.#selfRepTypes.add(type);
   }
 
@@ -130,9 +130,10 @@ export class CodecRegistry {
   codecFromValue(
     value: FabricValue,
   ): FabricCodec | typeof SELF_REP | undefined {
-    // Fast path: primitive-type dispatch.
+    // Fast path: primitive-type dispatch. (`typeof` can't yield `"function"`
+    // for a `FabricValue`, but the guard narrows the type for the lookups.)
     const type = (value === null) ? "null" : typeof value;
-    if (type !== "object") {
+    if (type !== "object" && type !== "function") {
       const codec = this.#primitiveCodecs.get(type);
       if (codec && codec.canEncode(value)) {
         return codec;

--- a/packages/data-model/src/json-wire/CodecRegistry.ts
+++ b/packages/data-model/src/json-wire/CodecRegistry.ts
@@ -25,8 +25,8 @@ export type PrimitiveTypeName =
   | "symbol";
 
 /**
- * Gets the constructor function ("class") of the given value, if any, for the
- * purposes of fast-path lookup.
+ * Gets the constructor function ("class") of the given value, if any, for
+ * class-based codec lookup.
  */
 function constructorOf(
   value: FabricValue,
@@ -52,21 +52,18 @@ function constructorOf(
 }
 
 /**
- * Registry of `FabricCodec`s. Provides tag-based lookup for decoding and
- * class-fast-path / linear-scan matching for encoding.
+ * Registry of `FabricCodec`s. Provides tag-based lookup for decoding, and
+ * primitive-type and class matching for encoding.
  */
 export class CodecRegistry {
-  /** Ordered list of codecs, scanned for encode matching. */
-  readonly #codecs: FabricCodec[] = [];
-
   /** Tag -> codec map for O(1) decode dispatch. */
   readonly #tagMap = new Map<string, FabricCodec>();
 
-  /** Class -> codec map for the O(1) encode fast path. */
+  /** Class -> codec map for O(1) encode dispatch on object values. */
   readonly #classMap = new Map<Constructor, FabricCodec>();
 
   /**
-   * Primitive `type` -> codec map for the O(1) encode fast path on primitives.
+   * Primitive `type` -> codec map for O(1) encode dispatch on primitives.
    */
   readonly #primitiveCodecs = new Map<PrimitiveTypeName, FabricCodec>();
 
@@ -77,10 +74,9 @@ export class CodecRegistry {
 
   /**
    * Registers a codec, indexing it by its `wireTypeTag` (for decode) and its
-   * `uniqueHandledClass` (for encode). If either is `undefined`, then the codec
-   * is left unregistered with the corresponding index. And whether or not it
-   * has something `undefined`, it is added to the ordered list used by the
-   * encode linear scan.
+   * `uniqueHandledClass` (for encode dispatch). Either may be `undefined`,
+   * in which case the codec is left unindexed for the corresponding lookup;
+   * note that a codec with no `uniqueHandledClass` is unreachable for encoding.
    */
   register(codec: FabricCodec): void {
     const uniqueClass = codec.uniqueHandledClass;
@@ -92,13 +88,12 @@ export class CodecRegistry {
     if (tag !== undefined) {
       this.#tagMap.set(tag, codec);
     }
-    this.#codecs.push(codec);
   }
 
   /**
    * Registers a codec for a primitive `type` (see {@link PrimitiveTypeName}).
-   * Indexes the codec by its `wireTypeTag` (for decode) and by `type` (for the
-   * O(1) encode fast path on primitives).
+   * Indexes the codec by its `wireTypeTag` (for decode) and by `type` (for O(1)
+   * encode dispatch on primitives).
    */
   registerPrimitive(type: PrimitiveTypeName, codec: FabricCodec): void {
     this.#primitiveCodecs.set(type, codec);
@@ -130,9 +125,8 @@ export class CodecRegistry {
   codecFromValue(
     value: FabricValue,
   ): FabricCodec | typeof SELF_REP | undefined {
-    // Primitive fast path: dispatch on the value's primitive `type` key (its
-    // `typeof`, or `"null"`). The type's codec is tried first, then
-    // self-representation.
+    // Primitive dispatch on the value's primitive `type` key (its `typeof`, or
+    // `"null"`). The type's codec is tried first, then self-representation.
     let type: PrimitiveTypeName | undefined;
     const valueType = typeof value;
     switch (valueType) {
@@ -165,21 +159,14 @@ export class CodecRegistry {
       if (this.#selfRepTypes.has(type)) {
         return SELF_REP;
       }
-      // No primitive match -- fall through to the class/scan below (retained
-      // for now; primitives in the default registry never reach it).
+      // No primitive match -- fall through to the class lookup below.
     }
 
-    // Class fast-path, then linear scan.
+    // Match by the value's exact constructor.
     const constructorFn = constructorOf(value);
     if (constructorFn) {
       const codec = this.#classMap.get(constructorFn);
       if (codec && codec.canEncode(value)) {
-        return codec;
-      }
-    }
-
-    for (const codec of this.#codecs) {
-      if (codec.canEncode(value)) {
         return codec;
       }
     }

--- a/packages/data-model/src/json-wire/CodecRegistry.ts
+++ b/packages/data-model/src/json-wire/CodecRegistry.ts
@@ -139,12 +139,14 @@ export class CodecRegistry {
         type = valueType;
         break;
       }
+
       case "object": {
         if (value === null) {
           type = "null";
         }
         break;
       }
+
       case "function": {
         // Not a `FabricValue`; nothing can encode it.
         return undefined;

--- a/packages/data-model/src/json-wire/CodecRegistry.ts
+++ b/packages/data-model/src/json-wire/CodecRegistry.ts
@@ -130,10 +130,34 @@ export class CodecRegistry {
   codecFromValue(
     value: FabricValue,
   ): FabricCodec | typeof SELF_REP | undefined {
-    // Fast path: primitive-type dispatch. (`typeof` can't yield `"function"`
-    // for a `FabricValue`, but the guard narrows the type for the lookups.)
-    const type = (value === null) ? "null" : typeof value;
-    if (type !== "object" && type !== "function") {
+    // Primitive fast path: dispatch on the value's primitive `type` key (its
+    // `typeof`, or `"null"`). The type's codec is tried first, then
+    // self-representation.
+    let type: PrimitiveTypeName | undefined;
+    const valueType = typeof value;
+    switch (valueType) {
+      case "bigint":
+      case "boolean":
+      case "number":
+      case "string":
+      case "symbol":
+      case "undefined": {
+        type = valueType;
+        break;
+      }
+      case "object": {
+        if (value === null) {
+          type = "null";
+        }
+        break;
+      }
+      case "function": {
+        // Not a `FabricValue`; nothing can encode it.
+        return undefined;
+      }
+    }
+
+    if (type !== undefined) {
       const codec = this.#primitiveCodecs.get(type);
       if (codec && codec.canEncode(value)) {
         return codec;
@@ -141,6 +165,8 @@ export class CodecRegistry {
       if (this.#selfRepTypes.has(type)) {
         return SELF_REP;
       }
+      // No primitive match -- fall through to the class/scan below (retained
+      // for now; primitives in the default registry never reach it).
     }
 
     // Class fast-path, then linear scan.

--- a/packages/data-model/src/json-wire/JsonEncodingContext.ts
+++ b/packages/data-model/src/json-wire/JsonEncodingContext.ts
@@ -12,7 +12,7 @@ import { UnknownValue } from "@/fabric-instances/UnknownValue.ts";
 import { ProblematicValue } from "@/fabric-instances/ProblematicValue.ts";
 import { createDefaultRegistry } from "./createDefaultRegistry.ts";
 import type { JsonWireValue } from "./interface.ts";
-import type { CodecRegistry } from "./CodecRegistry.ts";
+import { type CodecRegistry, SELF_REP } from "./CodecRegistry.ts";
 import { WIRE_META_TAGS } from "@/wire-common/wire-meta-tags.ts";
 
 /**
@@ -207,6 +207,10 @@ export class JsonEncodingContext implements SerializationContext<string> {
   ): JsonWireValue {
     // Try the registry first.
     const codec = registry.codecFromValue(value);
+    if (codec === SELF_REP) {
+      // A self-representing primitive is its own wire form.
+      return value as JsonWireValue;
+    }
     if (codec) {
       const seen = _seen ?? new Set<object>();
       let addedToSeen = false;

--- a/packages/data-model/src/json-wire/JsonEncodingContext.ts
+++ b/packages/data-model/src/json-wire/JsonEncodingContext.ts
@@ -248,15 +248,9 @@ export class JsonEncodingContext implements SerializationContext<string> {
       );
     }
 
-    // Primitives
-    if (
-      value === null || typeof value === "boolean" ||
-      typeof value === "number" || typeof value === "string"
-    ) {
-      return value as JsonWireValue;
-    }
-
-    // Past this point, `typeof value === "object"`.
+    // Self-representing primitives (`null`, `boolean`, finite `number`,
+    // `string`) returned `SELF_REP` above. Past this point, `value` is an
+    // `object` -- an array or a plain object.
 
     // Arrays
     if (Array.isArray(value)) {

--- a/packages/data-model/src/json-wire/JsonEncodingContext.ts
+++ b/packages/data-model/src/json-wire/JsonEncodingContext.ts
@@ -210,7 +210,7 @@ export class JsonEncodingContext implements SerializationContext<string> {
     if (codec === SELF_REP) {
       // A self-representing primitive is its own wire form.
       return value as JsonWireValue;
-    } if (codec) {
+    } else if (codec) {
       const seen = _seen ?? new Set<object>();
       let addedToSeen = false;
 

--- a/packages/data-model/src/json-wire/JsonEncodingContext.ts
+++ b/packages/data-model/src/json-wire/JsonEncodingContext.ts
@@ -205,13 +205,12 @@ export class JsonEncodingContext implements SerializationContext<string> {
     _seen?: Set<object>,
     registry: CodecRegistry = defaultRegistry,
   ): JsonWireValue {
-    // Try the registry first.
     const codec = registry.codecFromValue(value);
+
     if (codec === SELF_REP) {
       // A self-representing primitive is its own wire form.
       return value as JsonWireValue;
-    }
-    if (codec) {
+    } if (codec) {
       const seen = _seen ?? new Set<object>();
       let addedToSeen = false;
 
@@ -248,9 +247,8 @@ export class JsonEncodingContext implements SerializationContext<string> {
       );
     }
 
-    // Self-representing primitives (`null`, `boolean`, finite `number`,
-    // `string`) returned `SELF_REP` above. Past this point, `value` is an
-    // `object` -- an array or a plain object.
+    // Self-representing primitives returned `SELF_REP` above. Past this point,
+    // `value` is an `object`.
 
     // Arrays
     if (Array.isArray(value)) {

--- a/packages/data-model/src/json-wire/createDefaultRegistry.ts
+++ b/packages/data-model/src/json-wire/createDefaultRegistry.ts
@@ -15,10 +15,13 @@ import { UndefinedCodec } from "./UndefinedCodec.ts";
  * is the source of truth for which classes participate, so the wire-format
  * surface is curated there rather than by the imports here. The four
  * JS-primitive codecs (`bigint`, special `number`, interned `symbol`,
- * `undefined`) have no owned class and are registered as standalone codecs.
+ * `undefined`) have no owned class and are registered by `typeof` via
+ * `registerPrimitive()`.
  *
- * `null`, `boolean`, finite `number`, `string`, arrays, and plain objects are
- * handled as fallthrough in the serializer after no codec matches.
+ * The self-representing primitive types (`null`, `boolean`, finite `number`,
+ * `string`) are registered via `registerSelfRep()`, so `codecFromValue()`
+ * reports them directly; arrays and plain objects are handled structurally by
+ * the serializer after no codec matches.
  *
  * `UnknownValue` / `ProblematicValue` are registered (via `instanceCodecClasses`)
  * but their codecs declare no preferred wire tag: the encode path resolves each
@@ -42,6 +45,15 @@ export function createDefaultRegistry(): CodecRegistry {
   registry.registerPrimitive("number", new SpecialNumberCodec());
   registry.registerPrimitive("symbol", new SymbolCodec());
   registry.registerPrimitive("undefined", new UndefinedCodec());
+
+  // Self-representing primitives: emitted as-is (their own wire form).
+  // `number` is registered both ways -- finite numbers self-represent, while
+  // `-0` / `NaN` / `±Infinity` go through the SpecialNumber codec above (which
+  // `codecFromValue()` tries first).
+  registry.registerSelfRep("null");
+  registry.registerSelfRep("boolean");
+  registry.registerSelfRep("number");
+  registry.registerSelfRep("string");
 
   return registry;
 }

--- a/packages/data-model/src/json-wire/createDefaultRegistry.ts
+++ b/packages/data-model/src/json-wire/createDefaultRegistry.ts
@@ -36,11 +36,12 @@ export function createDefaultRegistry(): CodecRegistry {
     registry.register(cls[CODEC]);
   }
 
-  // JS primitives that need tagged encoding (no owned class to host a codec).
-  registry.register(new BigIntCodec());
-  registry.register(new SpecialNumberCodec());
-  registry.register(new SymbolCodec());
-  registry.register(new UndefinedCodec());
+  // JS primitives that need tagged encoding (no owned class to host a codec),
+  // registered by `typeof` for O(1) encode dispatch.
+  registry.registerPrimitive("bigint", new BigIntCodec());
+  registry.registerPrimitive("number", new SpecialNumberCodec());
+  registry.registerPrimitive("symbol", new SymbolCodec());
+  registry.registerPrimitive("undefined", new UndefinedCodec());
 
   return registry;
 }

--- a/packages/data-model/test/json-wire/CodecRegistry.test.ts
+++ b/packages/data-model/test/json-wire/CodecRegistry.test.ts
@@ -169,13 +169,6 @@ describe("CodecRegistry", () => {
       );
       expect(registry.codecFromValue(99n)).toBeUndefined();
     });
-
-    it('rejects `"object"`', () => {
-      const registry = new CodecRegistry();
-      expect(() =>
-        registry.registerPrimitive("object", new TestCodec("X@1", undefined))
-      ).toThrow('does not accept `"object"`');
-    });
   });
 
   describe("registerSelfRep()", () => {
@@ -192,13 +185,6 @@ describe("CodecRegistry", () => {
       registry.registerSelfRep("number");
       expect(registry.codecFromValue(42)).toBe(codec); // codec match
       expect(registry.codecFromValue(99)).toBe(SELF_REP); // self-rep fallback
-    });
-
-    it('rejects `"object"`', () => {
-      const registry = new CodecRegistry();
-      expect(() => registry.registerSelfRep("object")).toThrow(
-        'does not accept `"object"`',
-      );
     });
   });
 

--- a/packages/data-model/test/json-wire/CodecRegistry.test.ts
+++ b/packages/data-model/test/json-wire/CodecRegistry.test.ts
@@ -9,7 +9,7 @@ import { BaseFabricCodec } from "@/wire-common/BaseFabricCodec.ts";
 import type { ReconstructionContext } from "@/wire-common/interface.ts";
 import { UnknownValue } from "@/fabric-instances/UnknownValue.ts";
 import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
-import { FabricInstance, type FabricValue } from "@/interface.ts";
+import { type FabricValue } from "@/interface.ts";
 
 /**
  * Test codec that matches a single pre-set value (by `===`) and records
@@ -69,44 +69,25 @@ function buildRegistry(
 describe("CodecRegistry", () => {
   describe("codecFromValue()", () => {
     for (
-      const { fastPath, classSource, example, counter } of [
+      const { classSource, example, counter } of [
+        { classSource: Boolean, example: false, counter: [1, 2, 3] },
+        { classSource: BigInt, example: 914n, counter: true },
+        { classSource: Number, example: 123, counter: "florp" },
+        { classSource: String, example: "blorp", counter: null },
         {
-          fastPath: true,
-          classSource: Boolean,
-          example: false,
-          counter: [1, 2, 3],
-        },
-        { fastPath: true, classSource: BigInt, example: 914n, counter: true },
-        { fastPath: true, classSource: Number, example: 123, counter: "florp" },
-        {
-          fastPath: true,
-          classSource: String,
-          example: "blorp",
-          counter: null,
-        },
-        {
-          fastPath: true,
           classSource: Symbol,
           example: Symbol.for("bleep"),
           counter: undefined,
         },
         {
-          fastPath: true,
           classSource: FabricRegExp, // a `FabricPrimitive`
           example: new FabricRegExp(/123/),
           counter: { a: "boop" },
         },
         {
-          fastPath: true,
           classSource: UnknownValue, // a `FabricInstance`
           example: new UnknownValue("Unk@12", { muffin: "corn" }),
           counter: 123n,
-        },
-        {
-          fastPath: false, // registered under a base class, so misses classMap
-          classSource: FabricInstance,
-          example: new UnknownValue("Unk@34", { biscuit: "butter" }),
-          counter: null,
         },
       ] as const
     ) {
@@ -115,29 +96,17 @@ describe("CodecRegistry", () => {
       const counterStr = toCompactDebugString(counter);
       const cls = classSource as unknown as Constructor;
 
-      if (fastPath) {
-        it(`given ${exampleStr}, finds the ${sourceName} codec via the fast path`, () => {
-          const { first, handler, last, registry } = buildRegistry(
-            cls,
-            example as FabricValue,
-          );
-          expect(registry.codecFromValue(example as FabricValue)).toBe(handler);
-          expect(first.canEncodeCalled).toBe(false);
-          expect(handler.canEncodeCalled).toBe(true);
-          expect(last.canEncodeCalled).toBe(false);
-        });
-      } else {
-        it(`given ${exampleStr}, finds the ${sourceName} codec via the slow path`, () => {
-          const { first, handler, last, registry } = buildRegistry(
-            cls,
-            example as FabricValue,
-          );
-          expect(registry.codecFromValue(example as FabricValue)).toBe(handler);
-          expect(first.canEncodeCalled).toBe(true);
-          expect(handler.canEncodeCalled).toBe(true);
-          expect(last.canEncodeCalled).toBe(false);
-        });
-      }
+      it(`given ${exampleStr}, finds the ${sourceName} codec by class`, () => {
+        const { first, handler, last, registry } = buildRegistry(
+          cls,
+          example as FabricValue,
+        );
+        expect(registry.codecFromValue(example as FabricValue)).toBe(handler);
+        // Only the class-matched codec is consulted -- there is no linear scan.
+        expect(first.canEncodeCalled).toBe(false);
+        expect(handler.canEncodeCalled).toBe(true);
+        expect(last.canEncodeCalled).toBe(false);
+      });
 
       it(`returns undefined for ${counterStr} (no ${sourceName} match)`, () => {
         const { first, handler, last, registry } = buildRegistry(
@@ -145,9 +114,10 @@ describe("CodecRegistry", () => {
           example as FabricValue,
         );
         expect(registry.codecFromValue(counter as FabricValue)).toBeUndefined();
-        expect(first.canEncodeCalled).toBe(true);
-        expect(handler.canEncodeCalled).toBe(true);
-        expect(last.canEncodeCalled).toBe(true);
+        // A class miss consults no codec (no linear scan).
+        expect(first.canEncodeCalled).toBe(false);
+        expect(handler.canEncodeCalled).toBe(false);
+        expect(last.canEncodeCalled).toBe(false);
       });
     }
   });

--- a/packages/data-model/test/json-wire/CodecRegistry.test.ts
+++ b/packages/data-model/test/json-wire/CodecRegistry.test.ts
@@ -152,6 +152,32 @@ describe("CodecRegistry", () => {
     }
   });
 
+  describe("registerPrimitive()", () => {
+    it("dispatches a primitive value to its codec (encode + decode)", () => {
+      const registry = new CodecRegistry();
+      const codec = new TestCodec("Big@1", undefined, 42n);
+      registry.registerPrimitive("bigint", codec);
+      expect(registry.codecFromValue(42n)).toBe(codec);
+      expect(registry.codecFromTag("Big@1")).toBe(codec);
+    });
+
+    it("returns undefined when the codec's `canEncode()` rejects", () => {
+      const registry = new CodecRegistry();
+      registry.registerPrimitive(
+        "bigint",
+        new TestCodec("Big@1", undefined, 42n),
+      );
+      expect(registry.codecFromValue(99n)).toBeUndefined();
+    });
+
+    it('rejects `"object"`', () => {
+      const registry = new CodecRegistry();
+      expect(() =>
+        registry.registerPrimitive("object", new TestCodec("X@1", undefined))
+      ).toThrow('does not accept `"object"`');
+    });
+  });
+
   describe("codecFromTag()", () => {
     it("returns the codec registered under a tag", () => {
       const registry = new CodecRegistry();

--- a/packages/data-model/test/json-wire/CodecRegistry.test.ts
+++ b/packages/data-model/test/json-wire/CodecRegistry.test.ts
@@ -4,7 +4,7 @@ import { expect } from "@std/expect";
 import type { Constructor } from "@commonfabric/utils/types";
 
 import { toCompactDebugString } from "@/value-debug.ts";
-import { CodecRegistry } from "@/json-wire/CodecRegistry.ts";
+import { CodecRegistry, SELF_REP } from "@/json-wire/CodecRegistry.ts";
 import { BaseFabricCodec } from "@/wire-common/BaseFabricCodec.ts";
 import type { ReconstructionContext } from "@/wire-common/interface.ts";
 import { UnknownValue } from "@/fabric-instances/UnknownValue.ts";
@@ -175,6 +175,30 @@ describe("CodecRegistry", () => {
       expect(() =>
         registry.registerPrimitive("object", new TestCodec("X@1", undefined))
       ).toThrow('does not accept `"object"`');
+    });
+  });
+
+  describe("registerSelfRep()", () => {
+    it("returns `SELF_REP` for a self-representing primitive value", () => {
+      const registry = new CodecRegistry();
+      registry.registerSelfRep("string");
+      expect(registry.codecFromValue("hi")).toBe(SELF_REP);
+    });
+
+    it("tries the type's codec before falling to self-rep", () => {
+      const registry = new CodecRegistry();
+      const codec = new TestCodec("Num@1", undefined, 42);
+      registry.registerPrimitive("number", codec);
+      registry.registerSelfRep("number");
+      expect(registry.codecFromValue(42)).toBe(codec); // codec match
+      expect(registry.codecFromValue(99)).toBe(SELF_REP); // self-rep fallback
+    });
+
+    it('rejects `"object"`', () => {
+      const registry = new CodecRegistry();
+      expect(() => registry.registerSelfRep("object")).toThrow(
+        'does not accept `"object"`',
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Addresses the performance note on #3936: encoding a primitive used to start with a `#classMap` miss and then a **full linear scan** over every registered codec's `canEncode()`. This reworks `CodecRegistry` so both primitive *and* object encoding are O(1), and removes the scan entirely.

### How encoding dispatches now (`codecFromValue`)
1. **Primitive** — `switch (typeof value)` (with `"null"` for `null`) → `#primitiveCodecs` (a codec, tried via `canEncode`) or `#selfRepTypes` (the `SELF_REP` sentinel, meaning "its own wire form").
2. **Object** — `#classMap`, keyed by the value's exact constructor.

No iteration on either path.

### New registry API
- `registerPrimitive(type, codec)` — register a codec by primitive `type` (a `typeof` result, or `"null"`), indexed for both encode (by type) and decode (by `wireTypeTag`). The four standalone JS-primitive codecs (`bigint`, special `number`, `symbol`, `undefined`) use this.
- `registerSelfRep(type)` — mark a primitive type as self-representing; `null` / `boolean` / `string` / `number` use this.
- `PrimitiveTypeName` — a union of the valid primitive `type` keys, so `"object"` / `"function"` / typos are compile errors rather than runtime checks.
- `SELF_REP` — sentinel returned by `codecFromValue` for self-representing values; `JsonEncodingContext` emits such a value as-is (the old primitive special-case is gone).

### The number split (part 5)
`"number"` is registered **both** ways: the SpecialNumber codec is tried first (catching `-0` / `NaN` / `±Infinity`), and finite numbers fall to `SELF_REP`. `"symbol"` stays codec-only, so an uninterned symbol matches neither and is correctly unencodable.

### Linear scan removal
Every `register()`-ed codec declares a concrete leaf-class `uniqueHandledClass` and all encoded values are exact instances, so the class map matches them all — the scan over `#codecs` was dead weight (it only enabled base-class / `canEncode`-only registration, used by no production codec). Dropped the `#codecs` list, the scan loop, and `register()`'s push to it; `register()` is now exact-class-only for encoding.

## Commits
Built and tested incrementally (working system at each step): `registerPrimitive` → `registerSelfRep`/`SELF_REP` → route-all-primitives (self-rep + number split) → `PrimitiveTypeName` typing → `switch` dispatch → scan removal (plus comment/style tweaks).

## Test plan
- `deno check` / `deno lint` / `deno fmt --check` clean.
- `packages/data-model` suite green (36 files). `CodecRegistry` tests reworked: class-map dispatch (a class miss now consults no codec, proving there's no scan); plus new `registerPrimitive` / `registerSelfRep` coverage.
- Existing primitive / special-number / `UnknownValue` round-trip tests pass unchanged through the new dispatch.
- Should recover the `pattern-unit` baselines flagged in #3936's perf note — worth a perf-check rerun to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes encode dispatch O(1) for primitives and objects by routing primitives via a `typeof` map and exact-class matching; removes the linear scan in `CodecRegistry` for faster encoding.

- **Refactors**
  - Added `registerPrimitive(type, codec)` typed by `PrimitiveTypeName`; indexes for decode by tag and for encode by primitive type.
  - Added `registerSelfRep(type)` and `SELF_REP`; `JsonEncodingContext` emits self-representing primitives as-is.
  - Split `"number"` handling: tries `SpecialNumber` first (`-0`/`NaN`/`±Infinity`), otherwise finite numbers self-represent.
  - Kept exact-constructor dispatch via `#classMap`; removed `#codecs` and the `canEncode()` linear scan.

- **Migration**
  - Codecs must declare a concrete `uniqueHandledClass` to encode; base-class-only or `canEncode()`-only registration no longer matches.
  - Register primitive codecs with `registerPrimitive()` and mark self-representing types with `registerSelfRep()` as needed.

<sup>Written for commit 404fe92af630a6a000dff6fd803a28d16055d5d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

