### PR TITLE
test(data-model): separate round-trip tests from decode() in codec tests

### DIFF
--- a/packages/data-model/test/fabric-instances/FabricError.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricError.test.ts
@@ -293,107 +293,6 @@ describe("FabricError", () => {
   });
 
   describe("static members", () => {
-    // Decoding hand-built state (not via `encode()`): exercises name/type
-    // handling and back-compat that the round-trip `decode()` tests don't.
-    describe("[CODEC].decode() of explicit state", () => {
-      it("creates a `FabricError` from state (null `name` = same as `type`)", () => {
-        const state = {
-          type: "Error",
-          name: null,
-          message: "hello",
-        };
-        const result = FabricError[CODEC].decode(
-          WIRE_TYPE_TAGS.Error,
-          state,
-          dummyContext,
-        ) as unknown as FabricError;
-        expect(result).toBeInstanceOf(FabricError);
-        expect(result.toNativeValue(true)).toBeInstanceOf(Error);
-        expect(result.name).toBe("Error");
-        expect(result.message).toBe("hello");
-      });
-
-      it("creates the correct `Error` subclass from `type` (null `name`)", () => {
-        const cases: [string, ErrorConstructor][] = [
-          ["TypeError", TypeError],
-          ["RangeError", RangeError],
-          ["SyntaxError", SyntaxError],
-          ["ReferenceError", ReferenceError],
-          ["URIError", URIError],
-          ["EvalError", EvalError],
-        ];
-        for (const [type, cls] of cases) {
-          const state = { type, name: null, message: "test" };
-          const result = FabricError[CODEC].decode(
-            WIRE_TYPE_TAGS.Error,
-            state,
-            dummyContext,
-          ) as unknown as FabricError;
-          expect(result.toNativeValue(true)).toBeInstanceOf(cls);
-          expect(result.name).toBe(type);
-        }
-      });
-
-      it("handles `type != name` (e.g. `TypeError` with custom `name`)", () => {
-        const state = {
-          type: "TypeError",
-          name: "CustomTypeName",
-          message: "mismatch",
-        };
-        const result = FabricError[CODEC].decode(
-          WIRE_TYPE_TAGS.Error,
-          state,
-          dummyContext,
-        ) as unknown as FabricError;
-        expect(result.toNativeValue(true)).toBeInstanceOf(TypeError);
-        expect(result.name).toBe("CustomTypeName");
-      });
-
-      it("falls back to `name` when `type` is absent (back-compat)", () => {
-        const state = {
-          name: "TypeError",
-          message: "old format",
-        };
-        const result = FabricError[CODEC].decode(
-          WIRE_TYPE_TAGS.Error,
-          state,
-          dummyContext,
-        ) as unknown as FabricError;
-        expect(result.toNativeValue(true)).toBeInstanceOf(TypeError);
-      });
-
-      it("handles a custom `name`", () => {
-        const state = {
-          type: "Error",
-          name: "MyCustomError",
-          message: "custom",
-        };
-        const result = FabricError[CODEC].decode(
-          WIRE_TYPE_TAGS.Error,
-          state,
-          dummyContext,
-        ) as unknown as FabricError;
-        expect(result.name).toBe("MyCustomError");
-      });
-
-      it("restores cause and custom properties", () => {
-        const state = {
-          type: "Error",
-          name: null,
-          message: "with extras",
-          cause: "something went wrong",
-          code: 404,
-        };
-        const result = FabricError[CODEC].decode(
-          WIRE_TYPE_TAGS.Error,
-          state,
-          dummyContext,
-        ) as unknown as FabricError;
-        expect(result.cause).toBe("something went wrong");
-        expect(result.getExtra("code")).toBe(404);
-      });
-    });
-
     describe("[CODEC]", () => {
       const codec = FabricError[CODEC];
       const expectedTag = WIRE_TYPE_TAGS.Error;
@@ -442,7 +341,97 @@ describe("FabricError", () => {
         });
       });
 
+      // Decoding hand-built state (not via `encode()`): exercises name/type
+      // handling and back-compat that the round-trip tests don't.
       describe("decode()", () => {
+        it("creates a `FabricError` from state (null `name` = same as `type`)", () => {
+          const state = { type: "Error", name: null, message: "hello" };
+          const result = codec.decode(
+            expectedTag,
+            state,
+            context,
+          ) as unknown as FabricError;
+          expect(result).toBeInstanceOf(FabricError);
+          expect(result.toNativeValue(true)).toBeInstanceOf(Error);
+          expect(result.name).toBe("Error");
+          expect(result.message).toBe("hello");
+        });
+
+        it("creates the correct `Error` subclass from `type` (null `name`)", () => {
+          const cases: [string, ErrorConstructor][] = [
+            ["TypeError", TypeError],
+            ["RangeError", RangeError],
+            ["SyntaxError", SyntaxError],
+            ["ReferenceError", ReferenceError],
+            ["URIError", URIError],
+            ["EvalError", EvalError],
+          ];
+          for (const [type, cls] of cases) {
+            const state = { type, name: null, message: "test" };
+            const result = codec.decode(
+              expectedTag,
+              state,
+              context,
+            ) as unknown as FabricError;
+            expect(result.toNativeValue(true)).toBeInstanceOf(cls);
+            expect(result.name).toBe(type);
+          }
+        });
+
+        it("handles `type != name` (e.g. `TypeError` with custom `name`)", () => {
+          const state = {
+            type: "TypeError",
+            name: "CustomTypeName",
+            message: "mismatch",
+          };
+          const result = codec.decode(
+            expectedTag,
+            state,
+            context,
+          ) as unknown as FabricError;
+          expect(result.toNativeValue(true)).toBeInstanceOf(TypeError);
+          expect(result.name).toBe("CustomTypeName");
+        });
+
+        it("falls back to `name` when `type` is absent (back-compat)", () => {
+          const state = { name: "TypeError", message: "old format" };
+          const result = codec.decode(
+            expectedTag,
+            state,
+            context,
+          ) as unknown as FabricError;
+          expect(result.toNativeValue(true)).toBeInstanceOf(TypeError);
+        });
+
+        it("handles a custom `name`", () => {
+          const state = { type: "Error", name: "MyCustomError", message: "x" };
+          const result = codec.decode(
+            expectedTag,
+            state,
+            context,
+          ) as unknown as FabricError;
+          expect(result.name).toBe("MyCustomError");
+        });
+
+        it("restores cause and custom properties", () => {
+          const state = {
+            type: "Error",
+            name: null,
+            message: "with extras",
+            cause: "something went wrong",
+            code: 404,
+          };
+          const result = codec.decode(
+            expectedTag,
+            state,
+            context,
+          ) as unknown as FabricError;
+          expect(result.cause).toBe("something went wrong");
+          expect(result.getExtra("code")).toBe(404);
+        });
+      });
+
+      describe("round trip encode-decode", () => {
         it("round-trips a basic `Error`", () => {
           const se = FabricError.fromNativeError(new Error("hello"));
           const decoded = codec.decode(

--- a/packages/data-model/test/fabric-primitives/FabricBytes.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricBytes.test.ts
@@ -122,6 +122,22 @@ describe("FabricBytes", () => {
       });
 
       describe("decode()", () => {
+        it("decodes non-string state to a `ProblematicValue`", () => {
+          const decoded = codec.decode(expectedTag, 42, context);
+          expect(decoded).toBeInstanceOf(ProblematicValue);
+        });
+
+        it("decodes malformed base64 to a `ProblematicValue`", () => {
+          const decoded = codec.decode(
+            expectedTag,
+            "not valid base64!!",
+            context,
+          );
+          expect(decoded).toBeInstanceOf(ProblematicValue);
+        });
+      });
+
+      describe("round trip encode-decode", () => {
         it("round-trips via encode -> decode", () => {
           const fb = new FabricBytes(new Uint8Array([10, 20, 30, 40]));
           const decoded = codec.decode(
@@ -142,20 +158,6 @@ describe("FabricBytes", () => {
           ) as unknown as FabricBytes;
           expect(decoded).toBeInstanceOf(FabricBytes);
           expect(decoded.length).toBe(0);
-        });
-
-        it("decodes non-string state to a `ProblematicValue`", () => {
-          const decoded = codec.decode(expectedTag, 42, context);
-          expect(decoded).toBeInstanceOf(ProblematicValue);
-        });
-
-        it("decodes malformed base64 to a `ProblematicValue`", () => {
-          const decoded = codec.decode(
-            expectedTag,
-            "not valid base64!!",
-            context,
-          );
-          expect(decoded).toBeInstanceOf(ProblematicValue);
         });
       });
     });

--- a/packages/data-model/test/fabric-primitives/FabricEpochDays.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochDays.test.ts
@@ -75,6 +75,18 @@ describe("FabricEpochDays", () => {
       });
 
       describe("decode()", () => {
+        it("decodes a flat base64 string (epoch zero)", () => {
+          const decoded = codec.decode(
+            expectedTag,
+            "AA",
+            context,
+          ) as unknown as FabricEpochDays;
+          expect(decoded).toBeInstanceOf(FabricEpochDays);
+          expect(decoded.value).toBe(0n);
+        });
+      });
+
+      describe("round trip encode-decode", () => {
         it("round-trips at top level (epoch zero)", () => {
           const sd = new FabricEpochDays(0n);
           const decoded = codec.decode(

--- a/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
@@ -81,6 +81,18 @@ describe("FabricEpochNsec", () => {
       });
 
       describe("decode()", () => {
+        it("decodes a flat base64 string (epoch zero)", () => {
+          const decoded = codec.decode(
+            expectedTag,
+            "AA",
+            context,
+          ) as unknown as FabricEpochNsec;
+          expect(decoded).toBeInstanceOf(FabricEpochNsec);
+          expect(decoded.value).toBe(0n);
+        });
+      });
+
+      describe("round trip encode-decode", () => {
         it("round-trips at top level (epoch zero)", () => {
           const sn = new FabricEpochNsec(0n);
           const decoded = codec.decode(

--- a/packages/data-model/test/fabric-primitives/FabricHash.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricHash.test.ts
@@ -195,18 +195,6 @@ describe("FabricHash", () => {
           );
         });
 
-        it("round-trips via encode -> decode (non-`fid1` tag)", () => {
-          const cid = new FabricHash(SAMPLE_HASH_17, "sha3");
-          const decoded = codec.decode(
-            expectedTag,
-            codec.encode(cid),
-            context,
-          );
-          expect(decoded).toBeInstanceOf(FabricHash);
-          expect((decoded as FabricHash).tag).toBe("sha3");
-          expect((decoded as FabricHash).bytes).toEqual(cid.bytes);
-        });
-
         it("decodes non-object state to a `ProblematicValue`", () => {
           const decoded = codec.decode(expectedTag, 123, context);
           expect(decoded).toBeInstanceOf(ProblematicValue);
@@ -228,6 +216,20 @@ describe("FabricHash", () => {
             context,
           );
           expect(decoded).toBeInstanceOf(ProblematicValue);
+        });
+      });
+
+      describe("round trip encode-decode", () => {
+        it("round-trips via encode -> decode (non-`fid1` tag)", () => {
+          const cid = new FabricHash(SAMPLE_HASH_17, "sha3");
+          const decoded = codec.decode(
+            expectedTag,
+            codec.encode(cid),
+            context,
+          );
+          expect(decoded).toBeInstanceOf(FabricHash);
+          expect((decoded as FabricHash).tag).toBe("sha3");
+          expect((decoded as FabricHash).bytes).toEqual(cid.bytes);
         });
       });
     });

--- a/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
@@ -154,6 +154,13 @@ describe("FabricRegExp", () => {
       });
 
       describe("decode()", () => {
+        it("decodes non-object state to `ProblematicValue`", () => {
+          const decoded = codec.decode(expectedTag, "nope", context);
+          expect(decoded).toBeInstanceOf(ProblematicValue);
+        });
+      });
+
+      describe("round trip encode-decode", () => {
         it("round-trips a regex (source, flags, flavor)", () => {
           const re = new FabricRegExp(/ab+c/gi);
           const decoded = codec.decode(
@@ -177,11 +184,6 @@ describe("FabricRegExp", () => {
           expect(decoded).toBeInstanceOf(FabricRegExp);
           expect(decoded.source).toBe("^x*$");
           expect(decoded.flags).toBe("");
-        });
-
-        it("decodes non-object state to `ProblematicValue`", () => {
-          const decoded = codec.decode(expectedTag, "nope", context);
-          expect(decoded).toBeInstanceOf(ProblematicValue);
         });
       });
     });

--- a/packages/data-model/test/json-wire/BigIntCodec.test.ts
+++ b/packages/data-model/test/json-wire/BigIntCodec.test.ts
@@ -62,107 +62,6 @@ describe("BigIntCodec", () => {
     });
 
     describe("decode()", () => {
-      it("round-trips at top level", () => {
-        const decoded = codec.decode(
-          expectedTag,
-          codec.encode(42n),
-          context,
-        );
-        expect(decoded).toBe(42n);
-      });
-
-      it("round-trips negative bigint", () => {
-        const decoded = codec.decode(
-          expectedTag,
-          codec.encode(-999n),
-          context,
-        );
-        expect(decoded).toBe(-999n);
-      });
-
-      it("round-trips zero bigint", () => {
-        const decoded = codec.decode(
-          expectedTag,
-          codec.encode(0n),
-          context,
-        );
-        expect(decoded).toBe(0n);
-      });
-
-      it("round-trips `1n`", () => {
-        const decoded = codec.decode(
-          expectedTag,
-          codec.encode(1n),
-          context,
-        );
-        expect(decoded).toBe(1n);
-      });
-
-      it("round-trips `-1n`", () => {
-        const decoded = codec.decode(
-          expectedTag,
-          codec.encode(-1n),
-          context,
-        );
-        expect(decoded).toBe(-1n);
-      });
-
-      it("round-trips large bigint", () => {
-        const big = 2n ** 64n;
-        const decoded = codec.decode(
-          expectedTag,
-          codec.encode(big),
-          context,
-        );
-        expect(decoded).toBe(big);
-      });
-
-      it("round-trips large negative bigint", () => {
-        const big = -(2n ** 64n);
-        const decoded = codec.decode(
-          expectedTag,
-          codec.encode(big),
-          context,
-        );
-        expect(decoded).toBe(big);
-      });
-
-      it("round-trips boundary value `127n`", () => {
-        const decoded = codec.decode(
-          expectedTag,
-          codec.encode(127n),
-          context,
-        );
-        expect(decoded).toBe(127n);
-      });
-
-      it("round-trips boundary value `128n`", () => {
-        const decoded = codec.decode(
-          expectedTag,
-          codec.encode(128n),
-          context,
-        );
-        expect(decoded).toBe(128n);
-      });
-
-      it("round-trips boundary value `-128n`", () => {
-        const decoded = codec.decode(
-          expectedTag,
-          codec.encode(-128n),
-          context,
-        );
-        expect(decoded).toBe(-128n);
-      });
-
-      it("round-trips boundary value `-129n`", () => {
-        const decoded = codec.decode(
-          expectedTag,
-          codec.encode(-129n),
-          context,
-        );
-        expect(decoded).toBe(-129n);
-      });
-
       it("accepts unpadded base64url input", () => {
         // "Kg" is the standard unpadded base64url encoding of 42n.
         const result = codec.decode(expectedTag, "Kg", context);
@@ -207,6 +106,65 @@ describe("BigIntCodec", () => {
         expect(result).toBeInstanceOf(ProblematicValue);
         const prob = result as unknown as ProblematicValue;
         expect(prob.wireTypeTag).toBe("BigInt@1");
+      });
+    });
+
+    describe("round trip encode-decode", () => {
+      it("round-trips at top level", () => {
+        const decoded = codec.decode(expectedTag, codec.encode(42n), context);
+        expect(decoded).toBe(42n);
+      });
+
+      it("round-trips negative bigint", () => {
+        const decoded = codec.decode(expectedTag, codec.encode(-999n), context);
+        expect(decoded).toBe(-999n);
+      });
+
+      it("round-trips zero bigint", () => {
+        const decoded = codec.decode(expectedTag, codec.encode(0n), context);
+        expect(decoded).toBe(0n);
+      });
+
+      it("round-trips `1n`", () => {
+        const decoded = codec.decode(expectedTag, codec.encode(1n), context);
+        expect(decoded).toBe(1n);
+      });
+
+      it("round-trips `-1n`", () => {
+        const decoded = codec.decode(expectedTag, codec.encode(-1n), context);
+        expect(decoded).toBe(-1n);
+      });
+
+      it("round-trips large bigint", () => {
+        const big = 2n ** 64n;
+        const decoded = codec.decode(expectedTag, codec.encode(big), context);
+        expect(decoded).toBe(big);
+      });
+
+      it("round-trips large negative bigint", () => {
+        const big = -(2n ** 64n);
+        const decoded = codec.decode(expectedTag, codec.encode(big), context);
+        expect(decoded).toBe(big);
+      });
+
+      it("round-trips boundary value `127n`", () => {
+        const decoded = codec.decode(expectedTag, codec.encode(127n), context);
+        expect(decoded).toBe(127n);
+      });
+
+      it("round-trips boundary value `128n`", () => {
+        const decoded = codec.decode(expectedTag, codec.encode(128n), context);
+        expect(decoded).toBe(128n);
+      });
+
+      it("round-trips boundary value `-128n`", () => {
+        const decoded = codec.decode(expectedTag, codec.encode(-128n), context);
+        expect(decoded).toBe(-128n);
+      });
+
+      it("round-trips boundary value `-129n`", () => {
+        const decoded = codec.decode(expectedTag, codec.encode(-129n), context);
+        expect(decoded).toBe(-129n);
       });
     });
   });

--- a/packages/data-model/test/json-wire/SpecialNumberCodec.test.ts
+++ b/packages/data-model/test/json-wire/SpecialNumberCodec.test.ts
@@ -57,42 +57,6 @@ describe("SpecialNumberCodec", () => {
     });
 
     describe("decode()", () => {
-      it("round-trips `-0` (preserves sign of zero)", () => {
-        const result = codec.decode(
-          expectedTag,
-          codec.encode(-0),
-          context,
-        );
-        expect(Object.is(result, -0)).toBe(true);
-      });
-
-      it("round-trips `NaN`", () => {
-        const result = codec.decode(
-          expectedTag,
-          codec.encode(NaN),
-          context,
-        );
-        expect(Number.isNaN(result)).toBe(true);
-      });
-
-      it("round-trips `+Infinity`", () => {
-        const result = codec.decode(
-          expectedTag,
-          codec.encode(Infinity),
-          context,
-        );
-        expect(result).toBe(Infinity);
-      });
-
-      it("round-trips `-Infinity`", () => {
-        const result = codec.decode(
-          expectedTag,
-          codec.encode(-Infinity),
-          context,
-        );
-        expect(result).toBe(-Infinity);
-      });
-
       it("decodes non-string state to `ProblematicValue`", () => {
         const result = codec.decode(
           expectedTag,
@@ -112,6 +76,36 @@ describe("SpecialNumberCodec", () => {
         expect((result as unknown as ProblematicValue).wireTypeTag).toBe(
           "SpecialNumber@1",
         );
+      });
+    });
+
+    describe("round trip encode-decode", () => {
+      it("round-trips `-0` (preserves sign of zero)", () => {
+        const result = codec.decode(expectedTag, codec.encode(-0), context);
+        expect(Object.is(result, -0)).toBe(true);
+      });
+
+      it("round-trips `NaN`", () => {
+        const result = codec.decode(expectedTag, codec.encode(NaN), context);
+        expect(Number.isNaN(result)).toBe(true);
+      });
+
+      it("round-trips `+Infinity`", () => {
+        const result = codec.decode(
+          expectedTag,
+          codec.encode(Infinity),
+          context,
+        );
+        expect(result).toBe(Infinity);
+      });
+
+      it("round-trips `-Infinity`", () => {
+        const result = codec.decode(
+          expectedTag,
+          codec.encode(-Infinity),
+          context,
+        );
+        expect(result).toBe(-Infinity);
       });
     });
   });

--- a/packages/data-model/test/json-wire/SymbolCodec.test.ts
+++ b/packages/data-model/test/json-wire/SymbolCodec.test.ts
@@ -40,6 +40,20 @@ describe("SymbolCodec", () => {
     });
 
     describe("decode()", () => {
+      it("decodes non-string state to `ProblematicValue`", () => {
+        const result = codec.decode(
+          expectedTag,
+          42,
+          context,
+        );
+        expect(result).toBeInstanceOf(ProblematicValue);
+        expect((result as unknown as ProblematicValue).wireTypeTag).toBe(
+          "Symbol@1",
+        );
+      });
+    });
+
+    describe("round trip encode-decode", () => {
       it("round-trips an interned symbol to the same registry instance", () => {
         const result = codec.decode(
           expectedTag,
@@ -58,18 +72,6 @@ describe("SymbolCodec", () => {
           context,
         );
         expect(result).toBe(Symbol.for(key));
-      });
-
-      it("decodes non-string state to `ProblematicValue`", () => {
-        const result = codec.decode(
-          expectedTag,
-          42,
-          context,
-        );
-        expect(result).toBeInstanceOf(ProblematicValue);
-        expect((result as unknown as ProblematicValue).wireTypeTag).toBe(
-          "Symbol@1",
-        );
       });
     });
   });

--- a/packages/data-model/test/json-wire/UndefinedCodec.test.ts
+++ b/packages/data-model/test/json-wire/UndefinedCodec.test.ts
@@ -39,6 +39,14 @@ describe("UndefinedCodec", () => {
         expect(decoded).toBe(undefined);
       });
 
+      it("throws when decoding non-`null` state", () => {
+        expect(() => codec.decode(expectedTag, 42, context)).toThrow(
+          "expected `null` state",
+        );
+      });
+    });
+
+    describe("round trip encode-decode", () => {
       it("round-trips `undefined` via encode -> decode", () => {
         const decoded = codec.decode(
           expectedTag,
@@ -46,12 +54,6 @@ describe("UndefinedCodec", () => {
           context,
         );
         expect(decoded).toBe(undefined);
-      });
-
-      it("throws when decoding non-`null` state", () => {
-        expect(() => codec.decode(expectedTag, 42, context)).toThrow(
-          "expected `null` state",
-        );
       });
     });
   });


### PR DESCRIPTION
## Summary

Test-only cleanup of the codec unit tests, so that `decode()` describes test decoding *per se* and round-trips live in their own block.

### (1) FabricError — integrate the sidecar
The `describe("[CODEC].decode() of explicit state")` block that lived as a sibling of `[CODEC]` is folded **into** the `[CODEC]` block: its six decode-from-explicit-state tests become `[CODEC] → decode()`, and the former `[CODEC] → decode()` (which was entirely encode→decode round-trips) is renamed `round trip encode-decode`.

### (2) Extract round-trips across the codec tests
`FabricBytes`, `FabricEpochNsec`, `FabricEpochDays`, `FabricRegExp`, `FabricHash`, and the standalone `BigInt` / `SpecialNumber` / `Symbol` / `Undefined` codec tests each conflated two concerns in `decode()`. The `encode → decode` round-trips are moved out into a sibling `describe("round trip encode-decode")`; `decode()` keeps the decode-proper tests (decode of explicit/hand-built state, `ProblematicValue` fallbacks, error cases). `decode()` precedes the round-trip block in every file.

### Decode coverage preserved
`FabricEpochNsec` and `FabricEpochDays` had *only* round-trips under `decode()`, which would have left `decode()` empty. Each gains a decode-from-literal test (`decode("AA") → epoch zero`) — the inverse of its `encode()` test, pinning the wire→value mapping independent of `encode()`.

## Test plan
Test-only; no source changes. `deno check` / `deno fmt --check` clean; `packages/data-model` suite green (36 files / 1736 steps — the +11 steps are the two new decode tests plus the added describe groupings). No assertions removed; round-trip tests are unchanged, just relocated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Test-only cleanup that reorganizes codec tests: `decode()` now covers explicit decoding and error paths, and all encode→decode checks live in a sibling `round trip encode-decode` block. Adds minimal literal decode tests for `FabricEpochDays` and `FabricEpochNsec` to keep `decode()` coverage.

- **Refactors**
  - Moved round-trip cases out of `decode()` in `FabricBytes`, `FabricEpochNsec`, `FabricEpochDays`, `FabricRegExp`, `FabricHash`, `BigInt`, `SpecialNumber`, `Symbol`, and `Undefined`.
  - `FabricError`: folded the sidecar `"[CODEC].decode() of explicit state"` into `[CODEC] → decode()`; renamed the old round-trip `decode()` to `round trip encode-decode`.
  - Kept `decode()` before round-trip in each file; no source changes.

<sup>Written for commit 71530112f9d8480f5ec84ca48d526de3e2f39d73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

