### PR TITLE
refactor(data-model): route value-hash through [CODEC]; remove [DECONSTRUCT]

### DIFF
--- a/packages/data-model/src/fabric-instances/BaseFabricInstance.ts
+++ b/packages/data-model/src/fabric-instances/BaseFabricInstance.ts
@@ -18,11 +18,6 @@ export abstract class BaseFabricInstance extends FabricInstance {
   //
 
   /**
-   * The type tag to use for this instance to identify it in wire protocols.
-   */
-  abstract get wireTypeTag(): string;
-
-  /**
    * Returns a new unfrozen copy of this instance with the same data. Called
    * by `shallowClone()` when a new instance is needed.
    */

--- a/packages/data-model/src/fabric-instances/BaseFabricInstance.ts
+++ b/packages/data-model/src/fabric-instances/BaseFabricInstance.ts
@@ -48,32 +48,4 @@ export abstract class BaseFabricInstance extends FabricInstance
     // incompatible with abstract class types due to protected members.
     return frozen ? Object.freeze(copy) as FabricInstance : copy;
   }
-
-  //
-  // Static members
-  //
-
-  /**
-   * Gets the `.wireTypeTag` from a value which is _supposed_ to be an instance
-   * of this class but is only statically known / assumed to be an instance of
-   * the fully abstract `FabricInstance`. Throws a "shouldn't happen" error if
-   * there's trouble.
-   */
-  static wireTypeTagOf(value: FabricInstance | FabricDeconstructable): string {
-    if (!(value instanceof BaseFabricInstance)) {
-      throw new Error(
-        "Shouldn't happen: Encountered a `FabricInstance` which is not a `BaseFabricInstance`.",
-      );
-    }
-
-    const result = value.wireTypeTag;
-
-    if (typeof result !== "string") {
-      throw new Error(
-        "Shouldn't happen: Encountered a `BaseFabricInstance` with a non-string `wireTypeTag`.",
-      );
-    }
-
-    return result;
-  }
 }

--- a/packages/data-model/src/fabric-instances/BaseFabricInstance.ts
+++ b/packages/data-model/src/fabric-instances/BaseFabricInstance.ts
@@ -1,5 +1,4 @@
-import { FabricInstance, type FabricValue } from "@/interface.ts";
-import { DECONSTRUCT, FabricDeconstructable } from "@/wire-common/interface.ts";
+import { FabricInstance } from "@/interface.ts";
 
 /**
  * Abstract base class providing shared scaffolding for `FabricInstance`
@@ -13,14 +12,10 @@ import { DECONSTRUCT, FabricDeconstructable } from "@/wire-common/interface.ts";
  * `shallowClone()`/`shallowUnfrozenClone()` template-method split), at which
  * point individual subclasses stop implementing `deepClone()` directly.
  */
-export abstract class BaseFabricInstance extends FabricInstance
-  implements FabricDeconstructable {
+export abstract class BaseFabricInstance extends FabricInstance {
   //
   // Instance members
   //
-
-  /** @inheritDoc */
-  abstract [DECONSTRUCT](): FabricValue;
 
   /**
    * The type tag to use for this instance to identify it in wire protocols.

--- a/packages/data-model/src/fabric-instances/ExplicitTagValue.ts
+++ b/packages/data-model/src/fabric-instances/ExplicitTagValue.ts
@@ -36,7 +36,13 @@ export abstract class ExplicitTagValue extends BaseFabricInstance {
     return this.#state;
   }
 
-  /** @inheritDoc */
+  /**
+   * The wire type tag preserved for this instance. Unlike other fabric types
+   * -- whose tag is a per-class constant carried by the class's `[CODEC]` --
+   * an `ExplicitTagValue` carries a per-instance tag (the original tag of a
+   * value that couldn't be recognized or reconstructed), which its codec's
+   * `tagForValue()` reads back.
+   */
   get wireTypeTag(): string {
     return this.#wireTypeTag;
   }

--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -1,7 +1,6 @@
 import { DEEP_FREEZE, type FabricValue, IS_DEEP_FROZEN } from "@/interface.ts";
 import {
   CODEC,
-  DECONSTRUCT,
   type FabricCodec,
   type ReconstructionContext,
 } from "@/wire-common/interface.ts";
@@ -39,7 +38,7 @@ export type FabricErrorState = {
   /**
    * The `.name` property. Pass `null` (or omit) to mean "same as `type`"; the
    * resulting instance's `.name` is always a concrete string (`null` is a
-   * wire-level optimization at the `[DECONSTRUCT]` boundary, not part of the
+   * wire-level optimization at the `[CODEC]` encode boundary, not part of the
    * public API).
    */
   readonly name?: string | null | undefined;
@@ -76,8 +75,7 @@ export type FabricErrorState = {
  * `Object.freeze`'d (strict-mode non-writable-property semantics). The
  * extras bag mirrors this by gating `setExtra` / `deleteExtra` on the
  * frozen state. The serialization layer handles `FabricError` via its static
- * `[CODEC]`, which is the source of truth for the encoded form; the
- * `[DECONSTRUCT]` protocol member delegates to it.
+ * `[CODEC]`, which is the source of truth for the encoded form.
  * See Section 1.4.1 of the formal spec.
  */
 export class FabricError extends FabricNativeWrapper<Error> {
@@ -221,17 +219,6 @@ export class FabricError extends FabricNativeWrapper<Error> {
   /** Returns the `[key, value]` entries in the extras bag. */
   extraEntries(): IterableIterator<[string, FabricValue]> {
     return this.#extras.entries();
-  }
-
-  /**
-   * @inheritDoc
-   *
-   * Delegates to this class's `[CODEC]`, which is the source of truth for the
-   * encoded form. `[DECONSTRUCT]` remains the protocol entry point relied on by
-   * hashing and `[ID]` assignment.
-   */
-  [DECONSTRUCT](): FabricValue {
-    return FabricError[CODEC].encode(this);
   }
 
   /**

--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -131,11 +131,6 @@ export class FabricError extends FabricNativeWrapper<Error> {
     }
   }
 
-  /** @inheritDoc */
-  get wireTypeTag(): string {
-    return WIRE_TYPE_TAGS.Error;
-  }
-
   /**
    * Shallow conversion from a native `Error`. Used by the shallow conversion
    * layer (`shallowFabricFromNativeValueModern`). The error's `.cause` and

--- a/packages/data-model/src/fabric-instances/FabricError.ts
+++ b/packages/data-model/src/fabric-instances/FabricError.ts
@@ -359,7 +359,7 @@ export class FabricError extends FabricNativeWrapper<Error> {
 
       /** @inheritDoc */
       decode(
-        _wireTypeTag: string,
+        _typeTag: string,
         state: FabricValue,
         context: ReconstructionContext,
       ): FabricValue {

--- a/packages/data-model/src/fabric-instances/FabricMap.ts
+++ b/packages/data-model/src/fabric-instances/FabricMap.ts
@@ -82,7 +82,7 @@ export class FabricMap
        * Stub -- throws until `Map` support is implemented.
        */
       decode(
-        _wireTypeTag: string,
+        _typeTag: string,
         _state: FabricValue,
         _context: ReconstructionContext,
       ): FabricValue {

--- a/packages/data-model/src/fabric-instances/FabricMap.ts
+++ b/packages/data-model/src/fabric-instances/FabricMap.ts
@@ -1,7 +1,6 @@
 import { DEEP_FREEZE, type FabricValue, IS_DEEP_FROZEN } from "@/interface.ts";
 import {
   CODEC,
-  DECONSTRUCT,
   type FabricCodec,
   type ReconstructionContext,
 } from "@/wire-common/interface.ts";
@@ -12,9 +11,8 @@ import { FabricNativeWrapper } from "./FabricNativeWrapper.ts";
 
 /**
  * Wrapper for `Map` instances. Stub -- the static `[CODEC]` (the source of
- * truth) throws until `Map` support is fully implemented, and the
- * `[DECONSTRUCT]` protocol member delegates to it. Extra properties beyond the
- * wrapped collection are not supported on non-`Error` wrappers.
+ * truth) throws until `Map` support is fully implemented. Extra properties
+ * beyond the wrapped collection are not supported on non-`Error` wrappers.
  */
 export class FabricMap
   extends FabricNativeWrapper<Map<FabricValue, FabricValue>> {
@@ -25,16 +23,6 @@ export class FabricMap
   /** @inheritDoc */
   get wireTypeTag(): string {
     return WIRE_TYPE_TAGS.Map;
-  }
-
-  /**
-   * @inheritDoc
-   *
-   * Delegates to this class's `[CODEC]` (the source of truth), which throws
-   * until `Map` support is implemented.
-   */
-  [DECONSTRUCT](): FabricValue {
-    return FabricMap[CODEC].encode(this);
   }
 
   /**

--- a/packages/data-model/src/fabric-instances/FabricMap.ts
+++ b/packages/data-model/src/fabric-instances/FabricMap.ts
@@ -20,11 +20,6 @@ export class FabricMap
     super();
   }
 
-  /** @inheritDoc */
-  get wireTypeTag(): string {
-    return WIRE_TYPE_TAGS.Map;
-  }
-
   /**
    * Stub -- throws until `Map` support is fully implemented. `FabricMap` is
    * not yet used and is being reworked separately; the protocol methods are

--- a/packages/data-model/src/fabric-instances/FabricSet.ts
+++ b/packages/data-model/src/fabric-instances/FabricSet.ts
@@ -19,11 +19,6 @@ export class FabricSet extends FabricNativeWrapper<Set<FabricValue>> {
     super();
   }
 
-  /** @inheritDoc */
-  get wireTypeTag(): string {
-    return WIRE_TYPE_TAGS.Set;
-  }
-
   /**
    * Stub -- throws until `Set` support is fully implemented. `FabricSet` is
    * not yet used and is being reworked separately; the protocol methods are

--- a/packages/data-model/src/fabric-instances/FabricSet.ts
+++ b/packages/data-model/src/fabric-instances/FabricSet.ts
@@ -81,7 +81,7 @@ export class FabricSet extends FabricNativeWrapper<Set<FabricValue>> {
        * Stub -- throws until `Set` support is implemented.
        */
       decode(
-        _wireTypeTag: string,
+        _typeTag: string,
         _state: FabricValue,
         _context: ReconstructionContext,
       ): FabricValue {

--- a/packages/data-model/src/fabric-instances/FabricSet.ts
+++ b/packages/data-model/src/fabric-instances/FabricSet.ts
@@ -1,7 +1,6 @@
 import { DEEP_FREEZE, type FabricValue, IS_DEEP_FROZEN } from "@/interface.ts";
 import {
   CODEC,
-  DECONSTRUCT,
   type FabricCodec,
   type ReconstructionContext,
 } from "@/wire-common/interface.ts";
@@ -12,9 +11,8 @@ import { FabricNativeWrapper } from "./FabricNativeWrapper.ts";
 
 /**
  * Wrapper for `Set` instances. Stub -- the static `[CODEC]` (the source of
- * truth) throws until `Set` support is fully implemented, and the
- * `[DECONSTRUCT]` protocol member delegates to it. Extra properties beyond the
- * wrapped collection are not supported on non-`Error` wrappers.
+ * truth) throws until `Set` support is fully implemented. Extra properties
+ * beyond the wrapped collection are not supported on non-`Error` wrappers.
  */
 export class FabricSet extends FabricNativeWrapper<Set<FabricValue>> {
   constructor(readonly set: Set<FabricValue>) {
@@ -24,16 +22,6 @@ export class FabricSet extends FabricNativeWrapper<Set<FabricValue>> {
   /** @inheritDoc */
   get wireTypeTag(): string {
     return WIRE_TYPE_TAGS.Set;
-  }
-
-  /**
-   * @inheritDoc
-   *
-   * Delegates to this class's `[CODEC]` (the source of truth), which throws
-   * until `Set` support is implemented.
-   */
-  [DECONSTRUCT](): FabricValue {
-    return FabricSet[CODEC].encode(this);
   }
 
   /**

--- a/packages/data-model/src/fabric-instances/ProblematicValue.ts
+++ b/packages/data-model/src/fabric-instances/ProblematicValue.ts
@@ -1,7 +1,6 @@
 import { DEEP_FREEZE, type FabricValue, IS_DEEP_FROZEN } from "@/interface.ts";
 import {
   CODEC,
-  DECONSTRUCT,
   type FabricCodec,
   type ReconstructionContext,
 } from "@/wire-common/interface.ts";
@@ -33,17 +32,6 @@ export class ProblematicValue extends ExplicitTagValue {
   /** Description of what went wrong. */
   get error(): string {
     return this.#error;
-  }
-
-  /**
-   * @inheritDoc
-   *
-   * Returns the `{ type, state, error }` envelope (preserved tag, raw state,
-   * and failure description). This is the protocol/hashing form; the wire form
-   * (via `[CODEC]`) is the bare `state`, with the tag carried separately.
-   */
-  [DECONSTRUCT](): FabricValue {
-    return { type: this.wireTypeTag, state: this.state, error: this.error };
   }
 
   /**

--- a/packages/data-model/src/fabric-instances/ProblematicValue.ts
+++ b/packages/data-model/src/fabric-instances/ProblematicValue.ts
@@ -83,11 +83,11 @@ export class ProblematicValue extends ExplicitTagValue {
 
       /** @inheritDoc */
       decode(
-        wireTypeTag: string,
+        typeTag: string,
         state: FabricValue,
         context: ReconstructionContext,
       ): FabricValue {
-        const result = new ProblematicValue(wireTypeTag, state, "");
+        const result = new ProblematicValue(typeTag, state, "");
         // Honor `shouldDeepFreeze`: produce the type's correct deep-frozen
         // form via its `[DEEP_FREEZE]` member (recursing through `deepFreeze`).
         return context.shouldDeepFreeze ? deepFreeze(result) : result;

--- a/packages/data-model/src/fabric-instances/UnknownValue.ts
+++ b/packages/data-model/src/fabric-instances/UnknownValue.ts
@@ -1,7 +1,6 @@
 import { DEEP_FREEZE, type FabricValue, IS_DEEP_FROZEN } from "@/interface.ts";
 import {
   CODEC,
-  DECONSTRUCT,
   type FabricCodec,
   type ReconstructionContext,
 } from "@/wire-common/interface.ts";
@@ -18,17 +17,6 @@ import { deepFreeze } from "@/deep-freeze.ts";
 export class UnknownValue extends ExplicitTagValue {
   constructor(wireTypeTag: string, state: FabricValue) {
     super(wireTypeTag, state);
-  }
-
-  /**
-   * @inheritDoc
-   *
-   * Returns the `{ type, state }` envelope (preserved tag and raw state). This
-   * is the protocol/hashing form; the wire form (via `[CODEC]`) is the bare
-   * `state`, with the tag carried separately.
-   */
-  [DECONSTRUCT](): FabricValue {
-    return { type: this.wireTypeTag, state: this.state };
   }
 
   /**

--- a/packages/data-model/src/fabric-instances/UnknownValue.ts
+++ b/packages/data-model/src/fabric-instances/UnknownValue.ts
@@ -68,11 +68,11 @@ export class UnknownValue extends ExplicitTagValue {
 
       /** @inheritDoc */
       decode(
-        wireTypeTag: string,
+        typeTag: string,
         state: FabricValue,
         context: ReconstructionContext,
       ): FabricValue {
-        const result = new UnknownValue(wireTypeTag, state);
+        const result = new UnknownValue(typeTag, state);
         // Honor `shouldDeepFreeze`: produce the type's correct deep-frozen
         // form via its `[DEEP_FREEZE]` member (recursing through `deepFreeze`).
         return context.shouldDeepFreeze ? deepFreeze(result) : result;

--- a/packages/data-model/src/fabric-primitives/BaseFabricPrimitive.ts
+++ b/packages/data-model/src/fabric-primitives/BaseFabricPrimitive.ts
@@ -1,5 +1,4 @@
 import { FabricPrimitive } from "@/interface.ts";
-import { FabricDeconstructable } from "@/wire-common/interface.ts";
 
 /**
  * Abstract base class providing shared scaffolding for `FabricPrimitive`
@@ -18,32 +17,4 @@ export abstract class BaseFabricPrimitive extends FabricPrimitive {
    * for which instances of this type do not have a protocol-specific form.
    */
   abstract get wireTypeTag(): string;
-
-  //
-  // Static members
-  //
-
-  /**
-   * Gets the `.wireTypeTag` from a value which is _supposed_ to be an instance
-   * of this class but is only statically known / assumed to be an instance of
-   * the fully abstract `FabricPrimitive`. Throws a "shouldn't happen" error if
-   * there's trouble.
-   */
-  static wireTypeTagOf(value: FabricPrimitive | FabricDeconstructable): string {
-    if (!(value instanceof BaseFabricPrimitive)) {
-      throw new Error(
-        "Shouldn't happen: Encountered a `FabricPrimitive` which is not a `BaseFabricPrimitive`.",
-      );
-    }
-
-    const result = value.wireTypeTag;
-
-    if (typeof result !== "string") {
-      throw new Error(
-        "Shouldn't happen: Encountered a `FabricPrimitive` with a non-string `wireTypeTag`.",
-      );
-    }
-
-    return result;
-  }
 }

--- a/packages/data-model/src/fabric-primitives/BaseFabricPrimitive.ts
+++ b/packages/data-model/src/fabric-primitives/BaseFabricPrimitive.ts
@@ -1,20 +1,12 @@
 import { FabricPrimitive } from "@/interface.ts";
 
 /**
- * Abstract base class providing shared scaffolding for `FabricPrimitive`
- * subclasses. Concrete `FabricPrimitive` classes are intended to extend this,
- * not `FabricPrimitive` directly: `FabricPrimitive` is the pure abstract
- * contract that external code is written against, while `BaseFabricPrimitive`
- * is where shared implementation lives.
+ * Abstract base class for `FabricPrimitive` subclasses. Concrete
+ * `FabricPrimitive` classes extend this, not `FabricPrimitive` directly:
+ * `FabricPrimitive` is the pure abstract contract that external code is written
+ * against, while `BaseFabricPrimitive` is the designated home for shared
+ * implementation. It currently adds no members of its own (its counterpart
+ * `BaseFabricInstance` carries the `shallowClone()` template method).
  */
 export abstract class BaseFabricPrimitive extends FabricPrimitive {
-  //
-  // Instance members
-  //
-
-  /**
-   * The type tag to use for this instance to identify it in wire protocols
-   * for which instances of this type do not have a protocol-specific form.
-   */
-  abstract get wireTypeTag(): string;
 }

--- a/packages/data-model/src/fabric-primitives/FabricBytes.ts
+++ b/packages/data-model/src/fabric-primitives/FabricBytes.ts
@@ -47,11 +47,6 @@ export class FabricBytes extends BaseFabricPrimitive {
   // Instance members
   //
 
-  /** @inheritDoc */
-  get wireTypeTag(): string {
-    return WIRE_TYPE_TAGS.Bytes;
-  }
-
   /** The number of bytes. */
   get length(): number {
     return this.#bytes.length;

--- a/packages/data-model/src/fabric-primitives/FabricBytes.ts
+++ b/packages/data-model/src/fabric-primitives/FabricBytes.ts
@@ -101,13 +101,13 @@ export class FabricBytes extends BaseFabricPrimitive {
 
       /** @inheritDoc */
       decode(
-        wireTypeTag: string,
+        typeTag: string,
         state: FabricValue,
         _context: ReconstructionContext,
       ): FabricBytes | ProblematicValue {
         if (typeof state !== "string") {
           return new ProblematicValue(
-            wireTypeTag,
+            typeTag,
             state,
             `Bytes: expected string state, got ${typeof state}`,
           );
@@ -117,7 +117,7 @@ export class FabricBytes extends BaseFabricPrimitive {
           return new FabricBytes(bytes);
         } catch {
           return new ProblematicValue(
-            wireTypeTag,
+            typeTag,
             state,
             `Bytes: invalid base64: ${state}`,
           );

--- a/packages/data-model/src/fabric-primitives/FabricEpochDays.ts
+++ b/packages/data-model/src/fabric-primitives/FabricEpochDays.ts
@@ -38,11 +38,6 @@ export class FabricEpochDays extends BaseFabricPrimitive
     Object.freeze(this);
   }
 
-  /** @inheritDoc */
-  get wireTypeTag(): string {
-    return WIRE_TYPE_TAGS.EpochDays;
-  }
-
   /** Days from POSIX Epoch. Negative values represent pre-epoch dates. */
   get value(): bigint {
     return this.#value;

--- a/packages/data-model/src/fabric-primitives/FabricEpochDays.ts
+++ b/packages/data-model/src/fabric-primitives/FabricEpochDays.ts
@@ -60,13 +60,13 @@ export class FabricEpochDays extends BaseFabricPrimitive
 
       /** @inheritDoc */
       decode(
-        wireTypeTag: string,
+        typeTag: string,
         state: FabricValue,
         _context: ReconstructionContext,
       ): FabricValue {
         if (typeof state !== "string") {
           return new ProblematicValue(
-            wireTypeTag,
+            typeTag,
             state,
             `EpochDays: expected string state, got ${typeof state}`,
           );
@@ -77,7 +77,7 @@ export class FabricEpochDays extends BaseFabricPrimitive
           );
         } catch {
           return new ProblematicValue(
-            wireTypeTag,
+            typeTag,
             state,
             `EpochDays: invalid base64: ${state}`,
           );

--- a/packages/data-model/src/fabric-primitives/FabricEpochNsec.ts
+++ b/packages/data-model/src/fabric-primitives/FabricEpochNsec.ts
@@ -60,13 +60,13 @@ export class FabricEpochNsec extends BaseFabricPrimitive
 
       /** @inheritDoc */
       decode(
-        wireTypeTag: string,
+        typeTag: string,
         state: FabricValue,
         _context: ReconstructionContext,
       ): FabricValue {
         if (typeof state !== "string") {
           return new ProblematicValue(
-            wireTypeTag,
+            typeTag,
             state,
             `EpochNsec: expected string state, got ${typeof state}`,
           );
@@ -77,7 +77,7 @@ export class FabricEpochNsec extends BaseFabricPrimitive
           );
         } catch {
           return new ProblematicValue(
-            wireTypeTag,
+            typeTag,
             state,
             `EpochNsec: invalid base64: ${state}`,
           );

--- a/packages/data-model/src/fabric-primitives/FabricEpochNsec.ts
+++ b/packages/data-model/src/fabric-primitives/FabricEpochNsec.ts
@@ -38,11 +38,6 @@ export class FabricEpochNsec extends BaseFabricPrimitive
     Object.freeze(this);
   }
 
-  /** @inheritDoc */
-  get wireTypeTag(): string {
-    return WIRE_TYPE_TAGS.EpochNsec;
-  }
-
   /** Nanoseconds from POSIX Epoch. Negative values represent pre-epoch timestamps. */
   get value(): bigint {
     return this.#value;

--- a/packages/data-model/src/fabric-primitives/FabricHash.ts
+++ b/packages/data-model/src/fabric-primitives/FabricHash.ts
@@ -160,13 +160,13 @@ export class FabricHash extends BaseFabricPrimitive implements ApiFabricHash {
 
       /** @inheritDoc */
       decode(
-        wireTypeTag: string,
+        typeTag: string,
         state: FabricValue,
         _context: ReconstructionContext,
       ): FabricValue {
         if (!isPlainObject(state)) {
           return new ProblematicValue(
-            wireTypeTag,
+            typeTag,
             state,
             `Hash: expected object state, got ${typeof state}`,
           );
@@ -174,7 +174,7 @@ export class FabricHash extends BaseFabricPrimitive implements ApiFabricHash {
         const { tag, hash } = state as Record<string, unknown>;
         if (typeof tag !== "string" || typeof hash !== "string") {
           return new ProblematicValue(
-            wireTypeTag,
+            typeTag,
             state,
             "Hash: expected string `tag` and `hash`",
           );
@@ -183,7 +183,7 @@ export class FabricHash extends BaseFabricPrimitive implements ApiFabricHash {
           return new FabricHash(fromBase64url(hash), tag);
         } catch (e) {
           return new ProblematicValue(
-            wireTypeTag,
+            typeTag,
             state,
             `Hash: ${e instanceof Error ? e.message : String(e)}`,
           );

--- a/packages/data-model/src/fabric-primitives/FabricHash.ts
+++ b/packages/data-model/src/fabric-primitives/FabricHash.ts
@@ -64,11 +64,6 @@ export class FabricHash extends BaseFabricPrimitive implements ApiFabricHash {
     Object.freeze(this);
   }
 
-  /** @inheritDoc */
-  get wireTypeTag(): string {
-    return WIRE_TYPE_TAGS.Hash;
-  }
-
   /**
    * CID-link-style accessor, returns the raw hash bytes. Present to satisfy
    * the `EntityId` structural type (`{ "/": string | Uint8Array }`).

--- a/packages/data-model/src/fabric-primitives/FabricRegExp.ts
+++ b/packages/data-model/src/fabric-primitives/FabricRegExp.ts
@@ -91,11 +91,6 @@ export class FabricRegExp extends BaseFabricPrimitive {
     Object.freeze(this);
   }
 
-  /** @inheritDoc */
-  get wireTypeTag(): string {
-    return WIRE_TYPE_TAGS.RegExp;
-  }
-
   /** The pattern source text. */
   get source(): string {
     return this.#source;

--- a/packages/data-model/src/fabric-primitives/FabricRegExp.ts
+++ b/packages/data-model/src/fabric-primitives/FabricRegExp.ts
@@ -142,13 +142,13 @@ export class FabricRegExp extends BaseFabricPrimitive {
 
       /** @inheritDoc */
       decode(
-        wireTypeTag: string,
+        typeTag: string,
         state: FabricValue,
         _context: ReconstructionContext,
       ): FabricValue {
         if (!isPlainObject(state)) {
           return new ProblematicValue(
-            wireTypeTag,
+            typeTag,
             state,
             `RegExp: expected object state, got ${typeof state}`,
           );
@@ -167,7 +167,7 @@ export class FabricRegExp extends BaseFabricPrimitive {
           return new FabricRegExp(flavor, source, flags);
         } catch (e) {
           return new ProblematicValue(
-            wireTypeTag,
+            typeTag,
             state,
             `RegExp: ${e instanceof Error ? e.message : String(e)}`,
           );

--- a/packages/data-model/src/interface.ts
+++ b/packages/data-model/src/interface.ts
@@ -16,8 +16,8 @@
 
 /**
  * Abstract base class for all fabric-system value types. This is the common
- * superclass of `FabricInstance` (protocol types with `[DECONSTRUCT]`)
- * and `FabricPrimitive` (immutable special primitives). It enables a single
+ * superclass of `FabricInstance` (object-like protocol types) and
+ * `FabricPrimitive` (immutable special primitives). It enables a single
  * `instanceof FabricSpecialObject` check wherever code needs to recognize any
  * fabric-system value without caring which branch of the hierarchy it
  * belongs to.
@@ -70,9 +70,9 @@ export const IS_DEEP_FROZEN: unique symbol = Symbol.for(
  * than this class directly; `BaseFabricInstance` is where shared
  * template-method scaffolding (such as `shallowClone()`) lives.
  *
- * Subclasses must implement `[DECONSTRUCT]()`, `[DEEP_FREEZE]()`,
- * `[IS_DEEP_FROZEN]()`, `deepClone()`, and `shallowClone()` (the latter is
- * normally inherited from `BaseFabricInstance`).
+ * Subclasses must implement `[DEEP_FREEZE]()`, `[IS_DEEP_FROZEN]()`,
+ * `deepClone()`, and `shallowClone()` (the latter is normally inherited from
+ * `BaseFabricInstance`).
  */
 export abstract class FabricInstance extends FabricSpecialObject {
   /**

--- a/packages/data-model/src/json-wire/BigIntCodec.ts
+++ b/packages/data-model/src/json-wire/BigIntCodec.ts
@@ -44,13 +44,13 @@ export class BigIntCodec extends BaseFabricCodec {
 
   /** @inheritDoc */
   decode(
-    wireTypeTag: string,
+    typeTag: string,
     state: FabricValue,
     _context: ReconstructionContext,
   ): FabricValue {
     if (typeof state !== "string") {
       return new ProblematicValue(
-        wireTypeTag,
+        typeTag,
         state,
         `bigint: expected string state, got ${typeof state}`,
       );
@@ -59,7 +59,7 @@ export class BigIntCodec extends BaseFabricCodec {
       return bigintFromMinimalTwosComplement(fromBase64url(state));
     } catch {
       return new ProblematicValue(
-        wireTypeTag,
+        typeTag,
         state,
         `bigint: invalid base64: ${state}`,
       );

--- a/packages/data-model/src/json-wire/CodecRegistry.ts
+++ b/packages/data-model/src/json-wire/CodecRegistry.ts
@@ -73,8 +73,8 @@ export class CodecRegistry {
   readonly #selfRepTypes = new Set<PrimitiveTypeName>();
 
   /**
-   * Registers a codec, indexing it by its `wireTypeTag` (for decode) and its
-   * `uniqueHandledClass` (for encode dispatch). Either may be `undefined`,
+   * Registers a codec, indexing it by its `recognizedTypeTag` (for decode) and
+   * its `uniqueHandledClass` (for encode dispatch). Either may be `undefined`,
    * in which case the codec is left unindexed for the corresponding lookup;
    * note that a codec with no `uniqueHandledClass` is unreachable for encoding.
    */
@@ -84,7 +84,7 @@ export class CodecRegistry {
       this.#classMap.set(uniqueClass, codec);
     }
 
-    const tag = codec.wireTypeTag;
+    const tag = codec.recognizedTypeTag;
     if (tag !== undefined) {
       this.#tagMap.set(tag, codec);
     }
@@ -92,13 +92,13 @@ export class CodecRegistry {
 
   /**
    * Registers a codec for a primitive `type` (see {@link PrimitiveTypeName}).
-   * Indexes the codec by its `wireTypeTag` (for decode) and by `type` (for O(1)
-   * encode dispatch on primitives).
+   * Indexes the codec by its `recognizedTypeTag` (for decode) and by `type`
+   * (for O(1) encode dispatch on primitives).
    */
   registerPrimitive(type: PrimitiveTypeName, codec: FabricCodec): void {
     this.#primitiveCodecs.set(type, codec);
 
-    const tag = codec.wireTypeTag;
+    const tag = codec.recognizedTypeTag;
     if (tag !== undefined) {
       this.#tagMap.set(tag, codec);
     }
@@ -177,7 +177,7 @@ export class CodecRegistry {
   }
 
   /** Looks up a codec by tag for decoding. */
-  codecFromTag(wireTypeTag: string): FabricCodec | undefined {
-    return this.#tagMap.get(wireTypeTag);
+  codecFromTag(typeTag: string): FabricCodec | undefined {
+    return this.#tagMap.get(typeTag);
   }
 }

--- a/packages/data-model/src/json-wire/SpecialNumberCodec.ts
+++ b/packages/data-model/src/json-wire/SpecialNumberCodec.ts
@@ -42,13 +42,13 @@ export class SpecialNumberCodec extends BaseFabricCodec {
 
   /** @inheritDoc */
   decode(
-    wireTypeTag: string,
+    typeTag: string,
     state: FabricValue,
     _context: ReconstructionContext,
   ): FabricValue {
     if (typeof state !== "string") {
       return new ProblematicValue(
-        wireTypeTag,
+        typeTag,
         state,
         `SpecialNumber: expected string state, got ${typeof state}`,
       );
@@ -64,7 +64,7 @@ export class SpecialNumberCodec extends BaseFabricCodec {
         return NaN;
       default:
         return new ProblematicValue(
-          wireTypeTag,
+          typeTag,
           state,
           `SpecialNumber: unknown literal ${JSON.stringify(state)}`,
         );

--- a/packages/data-model/src/json-wire/SymbolCodec.ts
+++ b/packages/data-model/src/json-wire/SymbolCodec.ts
@@ -39,13 +39,13 @@ export class SymbolCodec extends BaseFabricCodec {
 
   /** @inheritDoc */
   decode(
-    wireTypeTag: string,
+    typeTag: string,
     state: FabricValue,
     _context: ReconstructionContext,
   ): FabricValue {
     if (typeof state !== "string") {
       return new ProblematicValue(
-        wireTypeTag,
+        typeTag,
         state,
         `Symbol: expected string state, got ${typeof state}`,
       );

--- a/packages/data-model/src/json-wire/UndefinedCodec.ts
+++ b/packages/data-model/src/json-wire/UndefinedCodec.ts
@@ -25,13 +25,13 @@ export class UndefinedCodec extends BaseFabricCodec {
 
   /** @inheritDoc */
   decode(
-    wireTypeTag: string,
+    typeTag: string,
     state: FabricValue,
     _context: ReconstructionContext,
   ): FabricValue {
     if (state !== null) {
       throw new Error(
-        `${wireTypeTag}: expected \`null\` state, got ${typeof state}`,
+        `${typeTag}: expected \`null\` state, got ${typeof state}`,
       );
     }
     return undefined;

--- a/packages/data-model/src/json-wire/createDefaultRegistry.ts
+++ b/packages/data-model/src/json-wire/createDefaultRegistry.ts
@@ -24,7 +24,7 @@ import { UndefinedCodec } from "./UndefinedCodec.ts";
  * the serializer after no codec matches.
  *
  * `UnknownValue` / `ProblematicValue` are registered (via `instanceCodecClasses`)
- * but their codecs declare no preferred wire tag: the encode path resolves each
+ * but their codecs recognize no single wire tag: the encode path resolves each
  * instance's tag with `tagForValue()`, and an unrecognized tag on decode is
  * wrapped in an `UnknownValue` by the encoding context rather than tag-routed.
  */

--- a/packages/data-model/src/native-conversion.ts
+++ b/packages/data-model/src/native-conversion.ts
@@ -262,7 +262,7 @@ export function shallowFabricFromNativeValue(
  * Checks whether a value has a callable `toJSON()` method.
  *
  * TODO: Remove `toJSON()` support once all callers have migrated to
- * `[DECONSTRUCT]`. See spec Section 7.1.
+ * `[CODEC]`-based encoding. See spec Section 7.1.
  *
  * This function is a TypeScript type guard for `{ toJSON: () => unknown }`.
  */
@@ -422,8 +422,8 @@ function fabricFromNativeValueInternal(
 /**
  * Creates a new `Error` with the same class and properties as the original,
  * but with `.cause` and custom enumerable properties recursively converted
- * to `FabricValue`. This ensures that when `FabricError[DECONSTRUCT]`
- * runs at serialization time, all nested values are already `FabricValue`.
+ * to `FabricValue`. This ensures that when `FabricError`'s `[CODEC]` encodes
+ * at serialization time, all nested values are already `FabricValue`.
  *
  * We create a new `Error` rather than mutating the original because the
  * caller's `Error` should not be modified as a side effect of storing it.

--- a/packages/data-model/src/native-type-tags.ts
+++ b/packages/data-model/src/native-type-tags.ts
@@ -157,7 +157,7 @@ export function tagFromNativeValue(value: unknown): NativeTag | null {
     // Exotic `Error` subclasses (e.g. `DOMException`).
     if (Error.isError(value)) return NATIVE_TAGS.Error;
 
-    // `FabricInstance` values (protocol types with `[DECONSTRUCT]`).
+    // `FabricInstance` values (object-like protocol types).
     if (value instanceof FabricInstance) return NATIVE_TAGS.FabricInstance;
 
     // Cross-realm arrays may have a different constructor.

--- a/packages/data-model/src/value-debug.ts
+++ b/packages/data-model/src/value-debug.ts
@@ -9,6 +9,7 @@ import {
   FabricPrimitive,
   FabricSpecialObject,
 } from "./interface.ts";
+import { codecOf } from "@/wire-common/index.ts";
 
 /**
  * Sentinel marker used to wrap content that should appear unquoted in the
@@ -142,10 +143,15 @@ class DebugStringifier {
         if (value instanceof FabricSpecialObject) {
           // The slash here is to suggest that what we're rendering is a known
           // encodable type, and not just an instance of some random class.
-          // TODO(danfuzz): This should get fancier/smarter once the new "codec"
-          // work lands in `data-model`.
-          const fullTag = (value as { wireTypeTag?: string }).wireTypeTag ??
-            className;
+          // TODO(danfuzz): This should get fancier/smarter, e.g. by rendering
+          // some of the instance's actual state instead of an opaque `(...)`.
+          let fullTag;
+          try {
+            fullTag = codecOf(value).tagForValue(value);
+          } catch {
+            // Never let the debug formatter throw; fall back to the class name.
+            fullTag = className;
+          }
           const tag = fullTag.replace(/@.*$/, "");
           return marked(`/${tag}(...)`);
         } else {

--- a/packages/data-model/src/value-hash.ts
+++ b/packages/data-model/src/value-hash.ts
@@ -22,7 +22,7 @@ import { FabricHash } from "@/fabric-primitives/FabricHash.ts";
 import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
 import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
 import { BaseFabricInstance } from "@/fabric-instances/BaseFabricInstance.ts";
-import { DECONSTRUCT } from "@/wire-common/interface.ts";
+import { codecOf } from "@/wire-common/index.ts";
 import { shallowFabricFromNativeValue } from "./native-conversion.ts";
 import { NATIVE_TAGS, tagFromNativeValue } from "./native-type-tags.ts";
 
@@ -304,9 +304,9 @@ function feedObjectValue(
     case NATIVE_TAGS.FabricInstance: {
       const fabInst = value as BaseFabricInstance;
       hasher.update(TAG_INSTANCE_BYTES);
-      const wireTypeTag = BaseFabricInstance.wireTypeTagOf(fabInst);
-      hasher.update(getStringRep(wireTypeTag));
-      const state = fabInst[DECONSTRUCT]();
+      const codec = codecOf(fabInst);
+      hasher.update(getStringRep(codec.tagForValue(fabInst)));
+      const state = codec.encode(fabInst);
       feedValue(hasher, state);
       return;
     }

--- a/packages/data-model/src/wire-common/BaseFabricCodec.ts
+++ b/packages/data-model/src/wire-common/BaseFabricCodec.ts
@@ -6,7 +6,7 @@ import type { FabricCodec, ReconstructionContext } from "./interface.ts";
  * Base class for `FabricCodec` which provides commonly-needed functionality.
  */
 export abstract class BaseFabricCodec implements FabricCodec {
-  #wireTypeTag: string | undefined;
+  #recognizedTypeTag: string | undefined;
   #uniqueHandledClass: Constructor | undefined;
 
   /**
@@ -14,17 +14,17 @@ export abstract class BaseFabricCodec implements FabricCodec {
    */
   constructor(
     /**
-     * The preferred wire type tag, or `undefined` for a codec with no single
-     * preferred tag.
+     * The wire type tag this codec recognizes, or `undefined` for a codec with
+     * no single tag.
      */
-    wireTypeTag: string | undefined,
+    recognizedTypeTag: string | undefined,
     /**
      * The unique class (constructor function), if any, whose _direct_ instances
      * this instance handles.
      */
     uniqueHandledClass: Constructor | undefined,
   ) {
-    this.#wireTypeTag = wireTypeTag;
+    this.#recognizedTypeTag = recognizedTypeTag;
     this.#uniqueHandledClass = uniqueHandledClass;
   }
 
@@ -34,8 +34,8 @@ export abstract class BaseFabricCodec implements FabricCodec {
   }
 
   /** @inheritDoc */
-  get wireTypeTag(): string | undefined {
-    return this.#wireTypeTag;
+  get recognizedTypeTag(): string | undefined {
+    return this.#recognizedTypeTag;
   }
 
   /** @innheritDoc */
@@ -48,21 +48,21 @@ export abstract class BaseFabricCodec implements FabricCodec {
   /**
    * @inheritDoc
    *
-   * Returns this codec's preferred {@link #wireTypeTag}. A codec with no
-   * preferred tag (whose instances carry per-instance tags) must override this.
+   * Returns this codec's {@link #recognizedTypeTag}. A codec with no recognized
+   * tag (whose instances carry per-instance tags) must override this.
    */
   tagForValue(_value: FabricValue): string {
-    if (this.#wireTypeTag === undefined) {
+    if (this.#recognizedTypeTag === undefined) {
       throw new Error(
-        "Shouldn't happen: codec has no preferred tag; `tagForValue()` must be overridden.",
+        "Shouldn't happen: codec has no recognized tag; `tagForValue()` must be overridden.",
       );
     }
-    return this.#wireTypeTag;
+    return this.#recognizedTypeTag;
   }
 
   /** @inheritDoc */
   abstract decode(
-    wireTypeTag: string,
+    typeTag: string,
     state: FabricValue,
     context: ReconstructionContext,
   ): FabricValue;

--- a/packages/data-model/src/wire-common/codecOf.ts
+++ b/packages/data-model/src/wire-common/codecOf.ts
@@ -1,0 +1,25 @@
+import type { FabricSpecialObject } from "@/interface.ts";
+import {
+  CODEC,
+  type FabricClassWithCodec,
+  type FabricCodec,
+} from "./interface.ts";
+
+/**
+ * Gets the `[CODEC]` for the given value's class. Analogous to
+ * `BaseFabricInstance.wireTypeTagOf()` (which returns the wire type tag), but
+ * returns the codec instead. Throws a "shouldn't happen" error if the value's
+ * class has no `[CODEC]`.
+ */
+export function codecOf(value: FabricSpecialObject): FabricCodec {
+  const codec =
+    (value.constructor as unknown as Partial<FabricClassWithCodec>)[CODEC];
+
+  if (codec === undefined) {
+    throw new Error(
+      `Shouldn't happen: no \`[CODEC]\` for \`${value.constructor.name}\`.`,
+    );
+  }
+
+  return codec;
+}

--- a/packages/data-model/src/wire-common/codecOf.ts
+++ b/packages/data-model/src/wire-common/codecOf.ts
@@ -6,10 +6,8 @@ import {
 } from "./interface.ts";
 
 /**
- * Gets the `[CODEC]` for the given value's class. Analogous to
- * `BaseFabricInstance.wireTypeTagOf()` (which returns the wire type tag), but
- * returns the codec instead. Throws a "shouldn't happen" error if the value's
- * class has no `[CODEC]`.
+ * Gets the `[CODEC]` for the given value's class. Throws a "shouldn't happen"
+ * error if the value's class has no `[CODEC]`.
  */
 export function codecOf(value: FabricSpecialObject): FabricCodec {
   const codec =

--- a/packages/data-model/src/wire-common/index.ts
+++ b/packages/data-model/src/wire-common/index.ts
@@ -1,9 +1,7 @@
 export {
   CODEC,
-  DECONSTRUCT,
   type FabricClassWithCodec,
   type FabricCodec,
-  type FabricDeconstructable,
   type ReconstructionContext,
   type SerializationContext,
 } from "./interface.ts";

--- a/packages/data-model/src/wire-common/index.ts
+++ b/packages/data-model/src/wire-common/index.ts
@@ -8,6 +8,7 @@ export {
   type SerializationContext,
 } from "./interface.ts";
 
+export { codecOf } from "./codecOf.ts";
 export { WIRE_META_TAGS } from "./wire-meta-tags.ts";
 export { WIRE_TYPE_TAGS } from "./wire-type-tags.ts";
 export { BaseFabricCodec } from "./BaseFabricCodec.ts";

--- a/packages/data-model/src/wire-common/interface.ts
+++ b/packages/data-model/src/wire-common/interface.ts
@@ -23,14 +23,14 @@ export interface FabricCodec {
   get uniqueHandledClass(): Constructor | undefined;
 
   /**
-   * The unique preferred wire format tag that is associated with the format
-   * this instance decodes from, or `undefined` for a codec with no single
-   * preferred tag. When defined, the codec system uses it to mark state
-   * produced by {@link #encode} and (by default) routes state so marked back to
-   * this instance (or an equivalent) for decoding; a codec with no tag is not
-   * registered for tag-based decode dispatch.
+   * The unique wire format tag that is associated with the format this instance
+   * decodes from, or `undefined` for a codec with no single tag. When defined,
+   * the codec system uses it to mark state produced by {@link #encode} and (by
+   * default) routes state so marked back to this instance (or an equivalent)
+   * for decoding; a codec with no tag is not registered for tag-based decode
+   * dispatch.
    */
-  get wireTypeTag(): string | undefined;
+  get recognizedTypeTag(): string | undefined;
 
   /**
    * Returns `true` if this handler can encode the state of the given value.
@@ -40,9 +40,9 @@ export interface FabricCodec {
   /**
    * Returns the wire type tag to use when encoding the given value. Only ever
    * called on a value for which {@link #canEncode} has returned `true`. Unlike
-   * {@link #wireTypeTag} -- the codec's single preferred tag, if it has one --
-   * this is the concrete tag for a _specific_ value; a codec whose instances
-   * each carry their own per-instance tag reads it from the value.
+   * {@link #recognizedTypeTag} -- the codec's single recognized tag, if it has
+   * one -- this is the concrete tag for a _specific_ value; a codec whose
+   * instances each carry their own per-instance tag reads it from the value.
    */
   tagForValue(value: FabricValue): string;
 
@@ -53,12 +53,12 @@ export interface FabricCodec {
    * decoding. The codec system handles recursively converting `state` contents
    * as necessary.
    *
-   * The given `wireTypeTag` is what was associated with the given `state` and
-   * does not necessarily correspond to {@link #wireTypeTag} (depending on how
-   * an instance of this class got hooked up).
+   * The given `typeTag` is what was associated with the given `state` and
+   * does not necessarily correspond to {@link #recognizedTypeTag} (depending on
+   * how an instance of this class got hooked up).
    */
   decode(
-    wireTypeTag: string,
+    typeTag: string,
     state: FabricValue,
     context: ReconstructionContext,
   ): FabricValue;

--- a/packages/data-model/src/wire-common/interface.ts
+++ b/packages/data-model/src/wire-common/interface.ts
@@ -8,26 +8,6 @@ import type { FabricInstance, FabricValue } from "@/interface.ts";
 export const CODEC: unique symbol = Symbol.for("data-model.codec");
 
 /**
- * Well-known symbol for binding the method
- * `FabricDeconstructable[DECONSTRUCT]`.
- */
-export const DECONSTRUCT: unique symbol = Symbol.for("data-model.deconstruct");
-
-/**
- * Interface for deconstructable fabric objects, which is all of them, but
- * TypeScript doesn't let us say that given how the class/interface hierarchy
- * under `FabricSpecialObject` is set up.
- */
-export interface FabricDeconstructable {
-  /**
-   * Returns the essential state of this instance as a `FabricValue`.
-   * Implementations must _not_ recursively deconstruct nested values; the
-   * serialization system handles that.
-   */
-  [DECONSTRUCT](): FabricValue;
-}
-
-/**
  * Interface for codecs (encoder-decoder objects). These are object which can
  * extract "essential state" out of values (objects per se or otherwise) and
  * also take such "essential state" and produce values that are equivalent (in

--- a/packages/data-model/test/fabric-instances/BaseFabricInstance.test.ts
+++ b/packages/data-model/test/fabric-instances/BaseFabricInstance.test.ts
@@ -7,7 +7,6 @@ import {
   type FabricValue,
   IS_DEEP_FROZEN,
 } from "@/interface.ts";
-import { DECONSTRUCT } from "@/wire-common/interface.ts";
 import { BaseFabricInstance } from "@/fabric-instances/BaseFabricInstance.ts";
 
 /**
@@ -29,10 +28,6 @@ class Probe extends BaseFabricInstance {
   }
 
   get wireTypeTag(): string {
-    return this.#tag;
-  }
-
-  [DECONSTRUCT](): FabricValue {
     return this.#tag;
   }
 

--- a/packages/data-model/test/fabric-instances/FabricError.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricError.test.ts
@@ -28,11 +28,6 @@ describe("FabricError", () => {
     expect(se instanceof FabricInstance).toBe(true);
   });
 
-  it("has the expected `.wireTypeTag`", () => {
-    const se = FabricError.fromNativeError(new Error("test"));
-    expect(se.wireTypeTag).toBe("Error@1");
-  });
-
   it("is an instance of `FabricNativeWrapper`", () => {
     const se = FabricError.fromNativeError(new Error("test"));
     expect(se instanceof FabricNativeWrapper).toBe(true);

--- a/packages/data-model/test/fabric-instances/FabricError.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricError.test.ts
@@ -7,7 +7,7 @@ import {
   type FabricValue,
   IS_DEEP_FROZEN,
 } from "@/interface.ts";
-import { CODEC, DECONSTRUCT } from "@/wire-common/interface.ts";
+import { CODEC } from "@/wire-common/interface.ts";
 import { WIRE_TYPE_TAGS } from "@/wire-common/wire-type-tags.ts";
 import { EMPTY_RECONSTRUCTION_CONTEXT } from "@/wire-common/EmptyReconstructionContext.ts";
 import { FabricError } from "@/fabric-instances/FabricError.ts";
@@ -73,10 +73,13 @@ describe("FabricError", () => {
   });
 
   describe("instance members", () => {
-    describe("[DECONSTRUCT]", () => {
+    describe("`[CODEC]` `encode()` state", () => {
       it("returns `type`, `name=null` (common case), `message`, `stack`", () => {
         const se = FabricError.fromNativeError(new Error("hello"));
-        const state = se[DECONSTRUCT]() as Record<string, FabricValue>;
+        const state = FabricError[CODEC].encode(se) as Record<
+          string,
+          FabricValue
+        >;
         expect(state.type).toBe("Error");
         expect(state.name).toBe(null);
         expect(state.message).toBe("hello");
@@ -85,7 +88,10 @@ describe("FabricError", () => {
 
       it("sets `name` to `null` when `type === name` (`TypeError`)", () => {
         const se = FabricError.fromNativeError(new TypeError("bad"));
-        const state = se[DECONSTRUCT]() as Record<string, FabricValue>;
+        const state = FabricError[CODEC].encode(se) as Record<
+          string,
+          FabricValue
+        >;
         expect(state.type).toBe("TypeError");
         expect(state.name).toBe(null);
       });
@@ -94,7 +100,10 @@ describe("FabricError", () => {
         const err = new TypeError("bad");
         err.name = "CustomName";
         const se = FabricError.fromNativeError(err);
-        const state = se[DECONSTRUCT]() as Record<string, FabricValue>;
+        const state = FabricError[CODEC].encode(se) as Record<
+          string,
+          FabricValue
+        >;
         expect(state.type).toBe("TypeError");
         expect(state.name).toBe("CustomName");
       });
@@ -104,7 +113,10 @@ describe("FabricError", () => {
         const outer = FabricError.fromNativeError(
           new Error("outer", { cause: inner }),
         );
-        const state = outer[DECONSTRUCT]() as Record<string, FabricValue>;
+        const state = FabricError[CODEC].encode(outer) as Record<
+          string,
+          FabricValue
+        >;
         expect(state.cause).toBe(inner);
       });
 
@@ -113,7 +125,10 @@ describe("FabricError", () => {
         (err as unknown as Record<string, unknown>).code = 42;
         (err as unknown as Record<string, unknown>).detail = "more info";
         const se = FabricError.fromNativeError(err);
-        const state = se[DECONSTRUCT]() as Record<string, FabricValue>;
+        const state = FabricError[CODEC].encode(se) as Record<
+          string,
+          FabricValue
+        >;
         expect(state.code).toBe(42);
         expect(state.detail).toBe("more info");
       });
@@ -125,7 +140,10 @@ describe("FabricError", () => {
           enumerable: true,
         });
         const se = FabricError.fromNativeError(err);
-        const state = se[DECONSTRUCT]() as Record<string, FabricValue>;
+        const state = FabricError[CODEC].encode(se) as Record<
+          string,
+          FabricValue
+        >;
         expect("__proto__" in state).toBe(false);
       });
 
@@ -138,7 +156,10 @@ describe("FabricError", () => {
         });
         (err as unknown as Record<string, unknown>).name = "Error";
         const se = FabricError.fromNativeError(err);
-        const state = se[DECONSTRUCT]() as Record<string, FabricValue>;
+        const state = FabricError[CODEC].encode(se) as Record<
+          string,
+          FabricValue
+        >;
         expect(state.message).toBe("original");
       });
 
@@ -146,17 +167,20 @@ describe("FabricError", () => {
         const err = new Error("no stack");
         err.stack = undefined;
         const se = FabricError.fromNativeError(err);
-        const state = se[DECONSTRUCT]() as Record<string, FabricValue>;
+        const state = FabricError[CODEC].encode(se) as Record<
+          string,
+          FabricValue
+        >;
         expect("stack" in state).toBe(false);
       });
 
-      it("round-trips through `[DECONSTRUCT]` and `[CODEC].decode()`", () => {
+      it("round-trips through `[CODEC]` `encode()` and `decode()`", () => {
         const original = new Error("round trip");
         original.name = "CustomError";
         (original as unknown as Record<string, unknown>).code = 42;
         const se = FabricError.fromNativeError(original);
 
-        const state = se[DECONSTRUCT]();
+        const state = FabricError[CODEC].encode(se);
         const restored = FabricError[CODEC].decode(
           WIRE_TYPE_TAGS.Error,
           state,
@@ -173,7 +197,10 @@ describe("FabricError", () => {
         original.name = "SpecialType";
         const se = FabricError.fromNativeError(original);
 
-        const state = se[DECONSTRUCT]() as Record<string, FabricValue>;
+        const state = FabricError[CODEC].encode(se) as Record<
+          string,
+          FabricValue
+        >;
         expect(state.type).toBe("TypeError");
         expect(state.name).toBe("SpecialType");
 
@@ -491,8 +518,8 @@ describe("FabricError", () => {
         it("round-trips an `Error` whose cause is itself a `FabricError`", () => {
           // Simulates what `fabricFromNativeValue` produces: a FabricError
           // wrapping an Error whose cause is itself a FabricError (not a raw
-          // Error). Encoding's recurse on `[DECONSTRUCT]` output must find a
-          // FabricValue, not a raw Error.
+          // Error). Encoding's recurse on `[CODEC]` `encode()` output must find
+          // a FabricValue, not a raw Error.
           const innerSe = FabricError.fromNativeError(new Error("inner"));
           const outerErr = new Error("outer");
           outerErr.cause = innerSe;

--- a/packages/data-model/test/fabric-instances/FabricError.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricError.test.ts
@@ -320,9 +320,9 @@ describe("FabricError", () => {
       const expectedTag = WIRE_TYPE_TAGS.Error;
       const context = EMPTY_RECONSTRUCTION_CONTEXT;
 
-      describe("wireTypeTag", () => {
+      describe("recognizedTypeTag", () => {
         it("is the `Error` wire type tag", () => {
-          expect(codec.wireTypeTag).toBe(expectedTag);
+          expect(codec.recognizedTypeTag).toBe(expectedTag);
         });
       });
 

--- a/packages/data-model/test/fabric-instances/FabricMap.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricMap.test.ts
@@ -7,7 +7,7 @@ import {
   type FabricValue,
   IS_DEEP_FROZEN,
 } from "@/interface.ts";
-import { CODEC, DECONSTRUCT } from "@/wire-common/interface.ts";
+import { CODEC } from "@/wire-common/interface.ts";
 import { WIRE_TYPE_TAGS } from "@/wire-common/wire-type-tags.ts";
 import { EMPTY_RECONSTRUCTION_CONTEXT } from "@/wire-common/EmptyReconstructionContext.ts";
 import { FabricMap } from "@/fabric-instances/FabricMap.ts";
@@ -31,13 +31,6 @@ describe("FabricMap", () => {
   });
 
   describe("instance members", () => {
-    describe("[DECONSTRUCT]", () => {
-      it("throws (stub)", () => {
-        const sm = new FabricMap(new Map());
-        expect(() => sm[DECONSTRUCT]()).toThrow("not yet implemented");
-      });
-    });
-
     describe("toNativeValue()", () => {
       it("returns a `FrozenMap` when `frozen` is `true`", () => {
         const map = new Map<FabricValue, FabricValue>([["a", 1]]);

--- a/packages/data-model/test/fabric-instances/FabricMap.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricMap.test.ts
@@ -19,10 +19,9 @@ import { subFreeze, subIsDeepFrozen } from "./fixtures.ts";
 describe("FabricMap", () => {
   // Pure type-identity / supertype checks: cross-cutting carve-out per the
   // rule (they don't fit a single member, aren't construction mechanics).
-  it("implements `FabricInstance` with expected `.wireTypeTag`", () => {
+  it("implements `FabricInstance`", () => {
     const sm = new FabricMap(new Map());
     expect(sm instanceof FabricInstance).toBe(true);
-    expect(sm.wireTypeTag).toBe("Map@1");
   });
 
   it("is an instance of `FabricNativeWrapper`", () => {

--- a/packages/data-model/test/fabric-instances/FabricMap.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricMap.test.ts
@@ -116,9 +116,9 @@ describe("FabricMap", () => {
       const expectedTag = WIRE_TYPE_TAGS.Map;
       const context = EMPTY_RECONSTRUCTION_CONTEXT;
 
-      describe("wireTypeTag", () => {
+      describe("recognizedTypeTag", () => {
         it("is the `Map` wire type tag", () => {
-          expect(codec.wireTypeTag).toBe(expectedTag);
+          expect(codec.recognizedTypeTag).toBe(expectedTag);
         });
       });
 

--- a/packages/data-model/test/fabric-instances/FabricSet.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricSet.test.ts
@@ -7,7 +7,7 @@ import {
   type FabricValue,
   IS_DEEP_FROZEN,
 } from "@/interface.ts";
-import { CODEC, DECONSTRUCT } from "@/wire-common/interface.ts";
+import { CODEC } from "@/wire-common/interface.ts";
 import { WIRE_TYPE_TAGS } from "@/wire-common/wire-type-tags.ts";
 import { EMPTY_RECONSTRUCTION_CONTEXT } from "@/wire-common/EmptyReconstructionContext.ts";
 import { FabricSet } from "@/fabric-instances/FabricSet.ts";
@@ -25,13 +25,6 @@ describe("FabricSet", () => {
   });
 
   describe("instance members", () => {
-    describe("[DECONSTRUCT]", () => {
-      it("throws (stub)", () => {
-        const ss = new FabricSet(new Set());
-        expect(() => ss[DECONSTRUCT]()).toThrow("not yet implemented");
-      });
-    });
-
     describe("toNativeValue()", () => {
       it("returns a `FrozenSet` when `frozen` is `true`", () => {
         const set = new Set<FabricValue>([1, 2]);

--- a/packages/data-model/test/fabric-instances/FabricSet.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricSet.test.ts
@@ -100,9 +100,9 @@ describe("FabricSet", () => {
       const expectedTag = WIRE_TYPE_TAGS.Set;
       const context = EMPTY_RECONSTRUCTION_CONTEXT;
 
-      describe("wireTypeTag", () => {
+      describe("recognizedTypeTag", () => {
         it("is the `Set` wire type tag", () => {
-          expect(codec.wireTypeTag).toBe(expectedTag);
+          expect(codec.recognizedTypeTag).toBe(expectedTag);
         });
       });
 

--- a/packages/data-model/test/fabric-instances/FabricSet.test.ts
+++ b/packages/data-model/test/fabric-instances/FabricSet.test.ts
@@ -18,10 +18,9 @@ import { subFreeze, subIsDeepFrozen } from "./fixtures.ts";
 describe("FabricSet", () => {
   // Pure type-identity / supertype check: cross-cutting carve-out per the
   // rule (doesn't fit a single member, isn't construction mechanics).
-  it("implements `FabricInstance` with the expected `.wireTypeTag`", () => {
+  it("implements `FabricInstance`", () => {
     const ss = new FabricSet(new Set());
     expect(ss instanceof FabricInstance).toBe(true);
-    expect(ss.wireTypeTag).toBe("Set@1");
   });
 
   describe("instance members", () => {

--- a/packages/data-model/test/fabric-instances/ProblematicValue.test.ts
+++ b/packages/data-model/test/fabric-instances/ProblematicValue.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
 import { DEEP_FREEZE, type FabricValue, IS_DEEP_FROZEN } from "@/interface.ts";
-import { CODEC, DECONSTRUCT } from "@/wire-common/interface.ts";
+import { CODEC } from "@/wire-common/interface.ts";
 import { ProblematicValue } from "@/fabric-instances/ProblematicValue.ts";
 import { ExplicitTagValue } from "@/fabric-instances/ExplicitTagValue.ts";
 import { deepFreeze, isDeepFrozenFabricValue } from "@/deep-freeze.ts";
@@ -26,17 +26,6 @@ describe("ProblematicValue", () => {
   });
 
   describe("instance members", () => {
-    describe("[DECONSTRUCT]", () => {
-      it("returns the type-tagged `state` and `error`", () => {
-        const ps = new ProblematicValue("T@1", "s", "e");
-        expect(ps[DECONSTRUCT]()).toEqual({
-          type: "T@1",
-          state: "s",
-          error: "e",
-        });
-      });
-    });
-
     describe("`[DEEP_FREEZE]` / `[IS_DEEP_FROZEN]`", () => {
       it("via dispatch: recurses state, freezes in place", () => {
         const child = { x: 1 };
@@ -74,6 +63,13 @@ describe("ProblematicValue", () => {
         it("returns the value's own (per-instance) wire type tag", () => {
           const pv = new ProblematicValue("Weird@7", "s", "oops");
           expect(ProblematicValue[CODEC].tagForValue(pv)).toBe("Weird@7");
+        });
+      });
+
+      describe("encode()", () => {
+        it("returns the bare `state` (the tag is carried separately)", () => {
+          const pv = new ProblematicValue("Weird@7", { x: 1 }, "oops");
+          expect(ProblematicValue[CODEC].encode(pv)).toEqual({ x: 1 });
         });
       });
     });

--- a/packages/data-model/test/fabric-instances/UnknownValue.test.ts
+++ b/packages/data-model/test/fabric-instances/UnknownValue.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 
 import { DEEP_FREEZE, type FabricValue, IS_DEEP_FROZEN } from "@/interface.ts";
-import { CODEC, DECONSTRUCT } from "@/wire-common/interface.ts";
+import { CODEC } from "@/wire-common/interface.ts";
 import { UnknownValue } from "@/fabric-instances/UnknownValue.ts";
 import { ExplicitTagValue } from "@/fabric-instances/ExplicitTagValue.ts";
 import { deepFreeze, isDeepFrozenFabricValue } from "@/deep-freeze.ts";
@@ -25,16 +25,6 @@ describe("UnknownValue", () => {
   });
 
   describe("instance members", () => {
-    describe("[DECONSTRUCT]", () => {
-      it("returns the type-tagged `state`", () => {
-        const us = new UnknownValue("Test@1", "state");
-        expect(us[DECONSTRUCT]()).toEqual({
-          type: "Test@1",
-          state: "state",
-        });
-      });
-    });
-
     describe("`[DEEP_FREEZE]` / `[IS_DEEP_FROZEN]`", () => {
       it("via dispatch: recurses state, freezes in place", () => {
         const child = { y: 2 };
@@ -70,6 +60,13 @@ describe("UnknownValue", () => {
         it("returns the value's own (per-instance) wire type tag", () => {
           const uv = new UnknownValue("Weird@7", "s");
           expect(UnknownValue[CODEC].tagForValue(uv)).toBe("Weird@7");
+        });
+      });
+
+      describe("encode()", () => {
+        it("returns the bare `state` (the tag is carried separately)", () => {
+          const uv = new UnknownValue("Weird@7", { data: [1, 2, 3] });
+          expect(UnknownValue[CODEC].encode(uv)).toEqual({ data: [1, 2, 3] });
         });
       });
     });

--- a/packages/data-model/test/fabric-primitives/FabricBytes.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricBytes.test.ts
@@ -94,9 +94,9 @@ describe("FabricBytes", () => {
       const expectedTag = WIRE_TYPE_TAGS.Bytes;
       const context = EMPTY_RECONSTRUCTION_CONTEXT;
 
-      describe("wireTypeTag", () => {
+      describe("recognizedTypeTag", () => {
         it("is the `Bytes` wire type tag", () => {
-          expect(codec.wireTypeTag).toBe(expectedTag);
+          expect(codec.recognizedTypeTag).toBe(expectedTag);
         });
       });
 

--- a/packages/data-model/test/fabric-primitives/FabricEpochDays.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochDays.test.ts
@@ -53,9 +53,9 @@ describe("FabricEpochDays", () => {
       const expectedTag = WIRE_TYPE_TAGS.EpochDays;
       const context = EMPTY_RECONSTRUCTION_CONTEXT;
 
-      describe("wireTypeTag", () => {
+      describe("recognizedTypeTag", () => {
         it("is the `EpochDays` wire type tag", () => {
-          expect(codec.wireTypeTag).toBe(expectedTag);
+          expect(codec.recognizedTypeTag).toBe(expectedTag);
         });
       });
 

--- a/packages/data-model/test/fabric-primitives/FabricEpochDays.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochDays.test.ts
@@ -17,7 +17,7 @@ describe("FabricEpochDays", () => {
     );
   });
 
-  it("is not a `FabricInstance` (no [DECONSTRUCT])", () => {
+  it("is not a `FabricInstance` (it's a `FabricPrimitive`)", () => {
     const sd = new FabricEpochDays(0n);
     expect(sd instanceof FabricInstance).toBe(false);
   });

--- a/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
@@ -59,9 +59,9 @@ describe("FabricEpochNsec", () => {
       const expectedTag = WIRE_TYPE_TAGS.EpochNsec;
       const context = EMPTY_RECONSTRUCTION_CONTEXT;
 
-      describe("wireTypeTag", () => {
+      describe("recognizedTypeTag", () => {
         it("is the `EpochNsec` wire type tag", () => {
-          expect(codec.wireTypeTag).toBe(expectedTag);
+          expect(codec.recognizedTypeTag).toBe(expectedTag);
         });
       });
 

--- a/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricEpochNsec.test.ts
@@ -17,7 +17,7 @@ describe("FabricEpochNsec", () => {
     );
   });
 
-  it("is not a `FabricInstance` (no [DECONSTRUCT])", () => {
+  it("is not a `FabricInstance` (it's a `FabricPrimitive`)", () => {
     const sn = new FabricEpochNsec(0n);
     expect(sn instanceof FabricInstance).toBe(false);
   });

--- a/packages/data-model/test/fabric-primitives/FabricHash.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricHash.test.ts
@@ -156,9 +156,9 @@ describe("FabricHash", () => {
       const expectedTag = WIRE_TYPE_TAGS.Hash;
       const context = EMPTY_RECONSTRUCTION_CONTEXT;
 
-      describe("wireTypeTag", () => {
+      describe("recognizedTypeTag", () => {
         it("is the `Hash` wire type tag", () => {
-          expect(codec.wireTypeTag).toBe(expectedTag);
+          expect(codec.recognizedTypeTag).toBe(expectedTag);
         });
       });
 

--- a/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
+++ b/packages/data-model/test/fabric-primitives/FabricRegExp.test.ts
@@ -129,9 +129,9 @@ describe("FabricRegExp", () => {
       const expectedTag = WIRE_TYPE_TAGS.RegExp;
       const context = EMPTY_RECONSTRUCTION_CONTEXT;
 
-      describe("wireTypeTag", () => {
+      describe("recognizedTypeTag", () => {
         it("is the `RegExp` wire type tag", () => {
-          expect(codec.wireTypeTag).toBe(expectedTag);
+          expect(codec.recognizedTypeTag).toBe(expectedTag);
         });
       });
 

--- a/packages/data-model/test/json-wire/BigIntCodec.test.ts
+++ b/packages/data-model/test/json-wire/BigIntCodec.test.ts
@@ -12,9 +12,9 @@ describe("BigIntCodec", () => {
   const context = EMPTY_RECONSTRUCTION_CONTEXT;
 
   describe("instance members", () => {
-    describe("wireTypeTag", () => {
+    describe("recognizedTypeTag", () => {
       it("is the `BigInt` wire type tag", () => {
-        expect(codec.wireTypeTag).toBe(expectedTag);
+        expect(codec.recognizedTypeTag).toBe(expectedTag);
       });
     });
 

--- a/packages/data-model/test/json-wire/CodecRegistry.test.ts
+++ b/packages/data-model/test/json-wire/CodecRegistry.test.ts
@@ -22,11 +22,11 @@ class TestCodec extends BaseFabricCodec {
   readonly #accept: FabricValue | undefined;
 
   constructor(
-    wireTypeTag: string,
+    recognizedTypeTag: string,
     uniqueHandledClass: Constructor | undefined,
     accept?: FabricValue,
   ) {
-    super(wireTypeTag, uniqueHandledClass);
+    super(recognizedTypeTag, uniqueHandledClass);
     this.#accept = accept;
   }
 
@@ -40,7 +40,7 @@ class TestCodec extends BaseFabricCodec {
   }
 
   decode(
-    _wireTypeTag: string,
+    _typeTag: string,
     _state: FabricValue,
     _context: ReconstructionContext,
   ): FabricValue {

--- a/packages/data-model/test/json-wire/JsonEncodingContext.test.ts
+++ b/packages/data-model/test/json-wire/JsonEncodingContext.test.ts
@@ -16,7 +16,6 @@ import { FabricEpochDays } from "@/fabric-primitives/FabricEpochDays.ts";
 import { FabricEpochNsec } from "@/fabric-primitives/FabricEpochNsec.ts";
 import { FabricRegExp } from "@/fabric-primitives/FabricRegExp.ts";
 import { FabricError } from "@/fabric-instances/FabricError.ts";
-import { DECONSTRUCT } from "@/wire-common/interface.ts";
 import { isDeepFrozen } from "@/deep-freeze.ts";
 import { BaseReconstructionContext } from "@/wire-common/BaseReconstructionContext.ts";
 
@@ -40,10 +39,6 @@ class TestReconstructionContext extends BaseReconstructionContext {
  * mandate guard (every wire form must be explicitly represented).
  */
 class UnregisteredInstance extends BaseFabricInstance {
-  [DECONSTRUCT](): FabricValue {
-    return {};
-  }
-
   get wireTypeTag(): string {
     return "Unregistered@1";
   }

--- a/packages/data-model/test/json-wire/SpecialNumberCodec.test.ts
+++ b/packages/data-model/test/json-wire/SpecialNumberCodec.test.ts
@@ -12,9 +12,9 @@ describe("SpecialNumberCodec", () => {
   const context = EMPTY_RECONSTRUCTION_CONTEXT;
 
   describe("instance members", () => {
-    describe("wireTypeTag", () => {
+    describe("recognizedTypeTag", () => {
       it("is the `SpecialNumber` wire type tag", () => {
-        expect(codec.wireTypeTag).toBe(expectedTag);
+        expect(codec.recognizedTypeTag).toBe(expectedTag);
       });
     });
 

--- a/packages/data-model/test/json-wire/SymbolCodec.test.ts
+++ b/packages/data-model/test/json-wire/SymbolCodec.test.ts
@@ -12,9 +12,9 @@ describe("SymbolCodec", () => {
   const context = EMPTY_RECONSTRUCTION_CONTEXT;
 
   describe("instance members", () => {
-    describe("wireTypeTag", () => {
+    describe("recognizedTypeTag", () => {
       it("is the `Symbol` wire type tag", () => {
-        expect(codec.wireTypeTag).toBe(expectedTag);
+        expect(codec.recognizedTypeTag).toBe(expectedTag);
       });
     });
 

--- a/packages/data-model/test/json-wire/UndefinedCodec.test.ts
+++ b/packages/data-model/test/json-wire/UndefinedCodec.test.ts
@@ -11,9 +11,9 @@ describe("UndefinedCodec", () => {
   const context = EMPTY_RECONSTRUCTION_CONTEXT;
 
   describe("instance members", () => {
-    describe("wireTypeTag", () => {
+    describe("recognizedTypeTag", () => {
       it("is the `Undefined` wire type tag", () => {
-        expect(codec.wireTypeTag).toBe(expectedTag);
+        expect(codec.recognizedTypeTag).toBe(expectedTag);
       });
     });
 

--- a/packages/data-model/test/native-conversion.test.ts
+++ b/packages/data-model/test/native-conversion.test.ts
@@ -7,7 +7,7 @@ import {
   type FabricValue,
   IS_DEEP_FROZEN,
 } from "@/interface.ts";
-import { CODEC, DECONSTRUCT } from "@/wire-common/interface.ts";
+import { CODEC } from "@/wire-common/interface.ts";
 import { WIRE_TYPE_TAGS } from "@/wire-common/wire-type-tags.ts";
 import { FabricError } from "@/fabric-instances/FabricError.ts";
 import { FabricMap } from "@/fabric-instances/FabricMap.ts";
@@ -348,9 +348,6 @@ describe("native-conversion", () => {
           return "Custom@914";
         }
 
-        [DECONSTRUCT](): FabricValue {
-          return { value: 42 };
-        }
         [DEEP_FREEZE](
           _subFreeze: (value: FabricValue) => FabricValue,
         ): FabricValue {

--- a/packages/data-model/test/value-hash.test.ts
+++ b/packages/data-model/test/value-hash.test.ts
@@ -466,7 +466,7 @@ describe("value-hash", () => {
         expect(hex(hashBytesOf(nsec))).not.toBe(hex(hashBytesOf(days)));
       });
     });
-    describe("FabricError (FabricInstance via DECONSTRUCT)", () => {
+    describe("FabricError (FabricInstance via [CODEC])", () => {
       it("matches a byte stream built from `[DECONSTRUCT]` output for `FabricError`", () => {
         // Build the expected byte stream programmatically because the
         // deconstructed state includes `stack` which is environment-dependent.

--- a/packages/data-model/test/value-hash.test.ts
+++ b/packages/data-model/test/value-hash.test.ts
@@ -467,9 +467,9 @@ describe("value-hash", () => {
       });
     });
     describe("FabricError (FabricInstance via [CODEC])", () => {
-      it("matches a byte stream built from `[DECONSTRUCT]` output for `FabricError`", () => {
-        // Build the expected byte stream programmatically because the
-        // deconstructed state includes `stack` which is environment-dependent.
+      it("matches a byte stream built from `[CODEC]` `encode()` output for `FabricError`", () => {
+        // Build the expected byte stream programmatically because the encoded
+        // state includes `stack` which is environment-dependent.
         // We construct the stream the same way `hashOf()` does, then SHA-256 it.
         const error = FabricError.fromNativeError(new Error("test"));
         const enc = new TextEncoder();
@@ -490,8 +490,8 @@ describe("value-hash", () => {
         // Type tag.
         pushShortString("Error@1");
 
-        // Deconstructed state is an object with sorted keys.
-        // FabricError.DECONSTRUCT() returns:
+        // The encoded state is an object with sorted keys.
+        // `FabricError[CODEC].encode()` returns:
         //   { type: "Error", name: null, message: "test", stack: <string> }
         // Keys sorted by UTF-8: message, name, stack, type
         stream.push(0x11); // TAG_OBJECT

--- a/packages/data-model/test/wire-common/BaseFabricCodec.test.ts
+++ b/packages/data-model/test/wire-common/BaseFabricCodec.test.ts
@@ -15,7 +15,7 @@ class TestCodec extends BaseFabricCodec {
   }
 
   decode(
-    _wireTypeTag: string,
+    _typeTag: string,
     _state: FabricValue,
     _context: ReconstructionContext,
   ): FabricValue {
@@ -25,26 +25,30 @@ class TestCodec extends BaseFabricCodec {
 
 describe("BaseFabricCodec", () => {
   describe("instance members", () => {
-    describe("wireTypeTag", () => {
+    describe("recognizedTypeTag", () => {
       it("returns the tag passed to the constructor", () => {
-        expect(new TestCodec("Foo@1", undefined).wireTypeTag).toBe("Foo@1");
+        expect(new TestCodec("Foo@1", undefined).recognizedTypeTag).toBe(
+          "Foo@1",
+        );
       });
 
-      it("is `undefined` when constructed with no preferred tag", () => {
-        expect(new TestCodec(undefined, undefined).wireTypeTag).toBe(undefined);
+      it("is `undefined` when constructed with no recognized tag", () => {
+        expect(new TestCodec(undefined, undefined).recognizedTypeTag).toBe(
+          undefined,
+        );
       });
     });
 
     describe("tagForValue()", () => {
-      it("returns the codec's preferred `wireTypeTag`", () => {
+      it("returns the codec's `recognizedTypeTag`", () => {
         const codec = new TestCodec("Foo@1", undefined);
         expect(codec.tagForValue("anything" as FabricValue)).toBe("Foo@1");
       });
 
-      it("throws when the codec has no preferred tag (must be overridden)", () => {
+      it("throws when the codec has no recognized tag (must be overridden)", () => {
         const codec = new TestCodec(undefined, undefined);
         expect(() => codec.tagForValue("anything" as FabricValue)).toThrow(
-          "no preferred tag",
+          "no recognized tag",
         );
       });
     });

--- a/packages/data-model/test/wire-common/codecOf.test.ts
+++ b/packages/data-model/test/wire-common/codecOf.test.ts
@@ -1,0 +1,24 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { FabricSpecialObject } from "@/interface.ts";
+import { CODEC, codecOf } from "@/wire-common/index.ts";
+import { FabricError } from "@/fabric-instances/FabricError.ts";
+import { FabricBytes } from "@/fabric-primitives/FabricBytes.ts";
+
+describe("codecOf()", () => {
+  it("returns the class's `[CODEC]` for a `FabricInstance`", () => {
+    const err = FabricError.fromNativeError(new Error("x"));
+    expect(codecOf(err)).toBe(FabricError[CODEC]);
+  });
+
+  it("returns the class's `[CODEC]` for a `FabricPrimitive`", () => {
+    const fb = new FabricBytes(new Uint8Array([1, 2, 3]));
+    expect(codecOf(fb)).toBe(FabricBytes[CODEC]);
+  });
+
+  it("throws for a `FabricSpecialObject` with no `[CODEC]`", () => {
+    class NoCodec extends FabricSpecialObject {}
+    expect(() => codecOf(new NoCodec())).toThrow("no `[CODEC]`");
+  });
+});

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -11,10 +11,7 @@ import {
   type FabricValue,
   shallowFabricFromNativeValue,
 } from "@commonfabric/data-model/fabric-value";
-import {
-  DECONSTRUCT,
-  FabricDeconstructable,
-} from "@commonfabric/data-model/wire-common";
+import { codecOf } from "@commonfabric/data-model/wire-common";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import type { MemorySpace } from "@commonfabric/memory/interface";
@@ -2494,21 +2491,15 @@ export function recursivelyAddIDIfNeeded<T>(
   // `FabricInstance`s are opaque with respect to plain-object-like property
   // access; they have class-defined identity. Iterating their own-enumerable
   // properties via the generic walker would descend into wrapper internals
-  // meaninglessly. Instead, walk the observable internal structure via
-  // `[DECONSTRUCT]()` (the same mechanism the serialization system uses) for
-  // side effects only — tracking shared references in `seen` and populating
-  // `frame.generatedIdCounter` for any objects-in-arrays nested inside — then
-  // return the original instance unchanged. Subclasses that haven't implemented
-  // `[DECONSTRUCT]` yet will throw from this path; that's the right signal the
-  // moment they start seeing traffic.
+  // meaninglessly. Instead, walk the observable internal structure via the
+  // class's `[CODEC]` `encode()` (the same mechanism the serialization system
+  // uses) for side effects only — tracking shared references in `seen` and
+  // populating `frame.generatedIdCounter` for any objects-in-arrays nested
+  // inside — then return the original instance unchanged.
   if (value instanceof FabricInstance) {
     seen.set(value, value);
 
-    // All `FabricInstance`s must implement `FabricDeconstructable`, even though
-    // the type system can't let us say that (because of how the `data-model`
-    // separates client vs. internal-implementation concerns).
-    const deconstructable = value as unknown as FabricDeconstructable;
-    const state = deconstructable[DECONSTRUCT]();
+    const state = codecOf(value).encode(value);
     if (isRecord(state) || Array.isArray(state)) {
       recursivelyAddIDIfNeeded(state, frame, seen);
     }
@@ -2528,15 +2519,13 @@ export function recursivelyAddIDIfNeeded<T>(
   // These are atomic fabric values and must be returned unchanged rather than
   // walked as records (their state is private, so the record branch below would
   // flatten them to `{}`). Only `FabricInstance`s carry nested `FabricValue`s
-  // that need `[ID]` assignment via `[DECONSTRUCT]()`; `FabricPrimitive`s are
-  // leaves.
+  // that need `[ID]` assignment via the codec's `encode()`; `FabricPrimitive`s
+  // are leaves.
   if (converted instanceof FabricSpecialObject) {
     seen.set(value, converted);
 
     if (converted instanceof FabricInstance) {
-      // See above in re this cast.
-      const deconstructable = converted as unknown as FabricDeconstructable;
-      const state = deconstructable[DECONSTRUCT]();
+      const state = codecOf(converted).encode(converted);
       if (isRecord(state) || Array.isArray(state)) {
         recursivelyAddIDIfNeeded(state, frame, seen);
       }

--- a/packages/runner/test/cell-core.test.ts
+++ b/packages/runner/test/cell-core.test.ts
@@ -99,13 +99,11 @@ describe("Cell", () => {
     // Error is stored as a `FabricError`-shaped value. `c.get()` returns a
     // proxy view of the stored wrapper — its observable fields (`type`,
     // `name`, `message`, `stack`, etc.) are exposed directly on the
-    // projection, and its `wireTypeTag` is `"Error@1"` (`FabricError`'s tag).
+    // projection.
     const result = c.get() as {
       message: string;
       stack: string;
-      wireTypeTag: string;
     };
-    expect(result.wireTypeTag).toBe("Error@1");
     expect(result.message).toBe("something went wrong");
     expect(typeof result.stack).toBe("string");
     await localTx.commit();
@@ -136,9 +134,7 @@ describe("Cell", () => {
     const result = c.get() as {
       message: string;
       cause: { message: string; stack: string };
-      wireTypeTag: string;
     };
-    expect(result.wireTypeTag).toBe("Error@1");
     expect(result.message).toBe("wrapper error");
     expect(result.cause.message).toBe("root cause");
     expect(typeof result.cause.stack).toBe("string");
@@ -187,9 +183,7 @@ describe("Cell", () => {
 
     const targetResult = target.get() as {
       message: string;
-      wireTypeTag: string;
     };
-    expect(targetResult.wireTypeTag).toBe("Error@1");
     expect(targetResult.message).toBe("through nested redirect");
 
     await localTx.commit();

--- a/packages/runner/test/cell-static-methods.test.ts
+++ b/packages/runner/test/cell-static-methods.test.ts
@@ -930,7 +930,6 @@ describe("Cell Static Methods", () => {
         const cell = Cell.of(epoch);
         const got = cell.get() as FabricEpochNsec;
         expect(got.value).toBe(epoch.value);
-        expect(got.wireTypeTag).toBe("EpochNsec@1");
       });
     });
 
@@ -942,8 +941,7 @@ describe("Cell Static Methods", () => {
     const DATE_ISO = "2024-01-01T00:00:00Z";
     const DATE_NS = BigInt(Date.parse(DATE_ISO)) * 1_000_000n;
     const assertEpochNsec = (got: unknown) => {
-      const v = got as { value?: bigint; wireTypeTag?: string };
-      expect(v?.wireTypeTag).toBe("EpochNsec@1");
+      const v = got as { value?: bigint };
       expect(v?.value).toBe(DATE_NS);
     };
     const inFreshRuntime = async (

--- a/packages/runner/test/fetch-data-mutex.test.ts
+++ b/packages/runner/test/fetch-data-mutex.test.ts
@@ -533,12 +533,10 @@ describe("fetch-data mutex mechanism", () => {
     // with message/stack lost.
     expect(data.error).toBeDefined();
     const fe = data.error as {
-      wireTypeTag: string;
       name: string;
       message: string;
       stack: string;
     };
-    expect(fe.wireTypeTag).toBe("Error@1");
     expect(fe.name).toBe("Error");
     expect(fe.message).toMatch(/HTTP 404/);
     expect(typeof fe.stack).toBe("string");


### PR DESCRIPTION
## Summary

Gets `value-hash` (and the runner's `[ID]`-assignment walker) onto the `[CODEC]` model as the single source of truth for a `FabricInstance`'s encoded state, then removes the now-redundant machinery that the codec supersedes. Each commit is a self-contained, green step.

### What changed

1. **`codecOf()`** — new `wire-common` helper that returns a value's class `[CODEC]` (throws a "shouldn't happen" if absent), analogous to the old `wireTypeTagOf()` but yielding the codec.
2. **`value-hash`** — the `FabricInstance` case in `feedObjectValue()` now hashes via `codecOf(value).tagForValue(value)` + `codec.encode(value)` instead of `wireTypeTagOf()` + `[DECONSTRUCT]`.
3. **`wireTypeTagOf()`** — both impls removed (no remaining callers).
4. **`value-debug`** — renders a `FabricSpecialObject`'s tag via `codecOf(value).tagForValue(value)`, wrapped in `try`/`catch` so the debug formatter can never throw.
5. **runner `cell.ts`** — the `[ID]`-assignment walker reaches nested instance state through `codecOf(value).encode(value)` rather than `[DECONSTRUCT]()`.
6. **`[DECONSTRUCT]`** — removed wholesale (symbol, `FabricDeconstructable` interface, abstract decl, and the delegating concrete impls); nothing calls it once the above land. `[DECONSTRUCT]` tests move to the codec's `encode()` or drop where the codec stub-throw is already covered.
7. **`wireTypeTag` consolidation** — `ExplicitTagValue` is now the sole definer of the instance-level `wireTypeTag` (its per-instance preserved tag). The other classes' getters just mirrored a constant the codec already carries, so they're gone, along with the abstract decls on `BaseFabricInstance`/`BaseFabricPrimitive`.
8. **`FabricCodec.wireTypeTag` → `recognizedTypeTag`** — renamed for clarity against the `decode()` parameter (itself renamed `wireTypeTag` → `typeTag`): `recognizedTypeTag` is the single tag a codec is registered under; `typeTag` is whatever tag a value carried on the wire. Dropped the term "preferred" from the surrounding docs.

### Behavior note

Removing the per-class instance `wireTypeTag` getters means a value read back through a cell no longer exposes `wireTypeTag` on its structural projection (the forwarding proxy only surfaces members the wrapped instance actually defines). The affected cell-projection / round-trip tests drop their `wireTypeTag` assertions; the remaining field checks still guard the round-trip behavior. This trims one facet of the separately-tracked projection-leak gap.

## Test plan

- `packages/data-model`: `deno check`/`lint`/`fmt` clean; 37 files / 1734 steps pass.
- `packages/runner`: full suite green — 549 passed / 2915 steps.
- `deno fmt --check` clean across both packages.

## Performance Baseline

This PR makes a slight rearrangement to how walking of `FabricInstance` contents happens when storing them, but (a) it's just trading one method call for a nearly-equivalent function call, and (b) tests _barely_ exercise `FabricInstance`s. So, with reasonable confidence the following accounts for a spurious perf check failure:

NEW_PERF_BASELINE: subtest: pattern-unit-5/pattern-unit-tests > packages/patterns/todo-list/todo-list.test.tsx = 7s


🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves hashing and the runner’s ID-walker to the `[CODEC]` model and removes `[DECONSTRUCT]`. Simplifies tag handling, adds `codecOf()`, and drops redundant instance `wireTypeTag` getters.

- **Refactors**
  - Added `codecOf(value)` to fetch a value’s class `[CODEC]`.
  - `value-hash`: uses `codec.tagForValue(value)` + `codec.encode(value)` for `FabricInstance`.
  - `value-debug`: renders tags via `codec.tagForValue(value)` with safe fallback.
  - Runner `cell.ts`: walks `FabricInstance` state via `codec.encode(value)`.
  - Removed `[DECONSTRUCT]` symbol/interface and all implementations.
  - Consolidated tags: only `ExplicitTagValue` defines an instance `wireTypeTag`; other getters removed.
  - Renamed `FabricCodec.wireTypeTag` → `recognizedTypeTag`; `decode(wireTypeTag, ...)` → `decode(typeTag, ...)`.
  - Updated codec registry/tag lookups and tests to the new names.

- **Migration**
  - Replace calls to `[DECONSTRUCT]()` with `codecOf(value).encode(value)`.
  - Stop reading `instance.wireTypeTag`; use `codecOf(value).tagForValue(value)` (or `recognizedTypeTag` when a single tag applies).
  - Update codecs and registry code to `recognizedTypeTag` and `decode(typeTag, ...)`.
  - Cell read projections no longer include `wireTypeTag`.
  - Hashing for `UnknownValue`/`ProblematicValue` now uses the bare `state` (matches wire form).

<sup>Written for commit 7eab43b500ed4f6bbc77f6fddefbc4f7ef76bc24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

