### PR TITLE
feat(ts-transformers): compile-time diagnostics for unknown-typed reactive values (CT-1632A)

### DIFF
--- a/packages/cli/commands/main.ts
+++ b/packages/cli/commands/main.ts
@@ -43,10 +43,11 @@ LOCAL DEVELOPMENT:
   ./scripts/stop-local-dev.sh       # Stop local servers
 ${envStatus()}
 LOGGING:
-  Only errors are shown by default. Enable more with:
+  Warnings and errors are shown by default. Adjust with:
     cf --log-level info check ./pattern.tsx
+    cf --log-level error check ./pattern.tsx   # quieter: errors only
     CF_LOG_LEVEL=debug cf piece ls
-  Valid levels: debug, info, warn, error (default), silent
+  Valid levels: debug, info, warn (default), error, silent
 
 Run 'cf <command> --help' for command-specific help.`);
 

--- a/packages/cli/lib/log-level.ts
+++ b/packages/cli/lib/log-level.ts
@@ -1,0 +1,54 @@
+import { type LogLevel, setGlobalLogFloor } from "@commonfabric/utils/logger";
+
+const VALID_LOG_LEVELS = new Set([
+  "debug",
+  "info",
+  "warn",
+  "error",
+  "silent",
+]);
+
+/**
+ * Extract --log-level <level> from args before Cliffy sees them.
+ * Returns the level (if found) and the cleaned args array.
+ */
+export function extractLogLevel(
+  args: string[],
+): { level: string | undefined; args: string[] } {
+  const cleaned: string[] = [];
+  let level: string | undefined;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--log-level" && i + 1 < args.length) {
+      const candidate = args[i + 1];
+      if (VALID_LOG_LEVELS.has(candidate)) {
+        level = candidate;
+        i++; // skip the value
+        continue;
+      }
+    }
+    cleaned.push(args[i]);
+  }
+  return { level, args: cleaned };
+}
+
+/**
+ * Resolve the global log floor from CLI args and apply it, returning the args
+ * with `--log-level <level>` removed.
+ *
+ * An explicit `--log-level` wins. Otherwise a pre-set `CF_LOG_LEVEL` env var is
+ * left as-is (its floor was applied at module load). Otherwise the floor
+ * defaults to `warn` so transformer-pipeline warnings (e.g. unknown-typed
+ * reactive captures) reach authors; on the happy path no runtime `logger.warn`
+ * fires, so this stays quiet in practice.
+ */
+export function applyLogLevel(args: string[]): string[] {
+  const { level, args: cleanArgs } = extractLogLevel(args);
+  if (level) {
+    setGlobalLogFloor(level as LogLevel);
+    Deno.env.set("CF_LOG_LEVEL", level); // workers inherit
+  } else if (!Deno.env.get("CF_LOG_LEVEL")) {
+    setGlobalLogFloor("warn" as LogLevel);
+    Deno.env.set("CF_LOG_LEVEL", "warn");
+  }
+  return cleanArgs;
+}

--- a/packages/cli/mod.ts
+++ b/packages/cli/mod.ts
@@ -1,53 +1,29 @@
 import { parse } from "./commands/mod.ts";
 import { CompilerError, TransformerError } from "@commonfabric/js-compiler";
-import { type LogLevel, setGlobalLogFloor } from "@commonfabric/utils/logger";
 import { cliName } from "./lib/cli-name.ts";
-
-const VALID_LOG_LEVELS = new Set([
-  "debug",
-  "info",
-  "warn",
-  "error",
-  "silent",
-]);
+import { applyLogLevel } from "./lib/log-level.ts";
 
 /**
- * Extract --log-level <level> from args before Cliffy sees them.
- * Returns the level (if found) and the cleaned args array.
+ * The value to print for a top-level CLI failure. TransformerError and
+ * CompilerError carry pre-formatted messages, so print those without a stack
+ * trace; other Errors print their stack (falling back to the message); anything
+ * else prints as-is.
  */
-function extractLogLevel(
-  args: string[],
-): { level: string | undefined; args: string[] } {
-  const cleaned: string[] = [];
-  let level: string | undefined;
-  for (let i = 0; i < args.length; i++) {
-    if (args[i] === "--log-level" && i + 1 < args.length) {
-      const candidate = args[i + 1];
-      if (VALID_LOG_LEVELS.has(candidate)) {
-        level = candidate;
-        i++; // skip the value
-        continue;
-      }
-    }
-    cleaned.push(args[i]);
+export function renderCliError(e: unknown): unknown {
+  if (e instanceof TransformerError || e instanceof CompilerError) {
+    return e.message;
   }
-  return { level, args: cleaned };
+  if (e instanceof Error) {
+    return e.stack || e.message;
+  }
+  return e;
 }
 
 export async function main(args: string[]) {
-  // Extract --log-level before Cliffy parses
-  const { level, args: cleanArgs } = extractLogLevel(args);
+  // Extract --log-level before Cliffy parses and apply the resulting floor.
+  const cleanArgs = applyLogLevel(args);
   Deno.env.set("CF_CLI_NAME", cliName());
   const profileDoneMarker = Deno.env.get("CF_PROFILE_DONE_MARKER");
-
-  if (level) {
-    setGlobalLogFloor(level as LogLevel);
-    Deno.env.set("CF_LOG_LEVEL", level); // workers inherit
-  } else if (!Deno.env.get("CF_LOG_LEVEL")) {
-    setGlobalLogFloor("error" as LogLevel); // default: only errors
-    Deno.env.set("CF_LOG_LEVEL", "error");
-  }
-  // If CF_LOG_LEVEL env var already set, floor was initialized at module load time
 
   try {
     await parse(cleanArgs);
@@ -57,15 +33,7 @@ export async function main(args: string[]) {
     }
     Deno.exit(0);
   } catch (e) {
-    // TransformerError and CompilerError have nicely formatted messages
-    // Just print the message without stack trace
-    if (e instanceof TransformerError || e instanceof CompilerError) {
-      console.error(e.message);
-    } else if (e instanceof Error) {
-      console.error(e.stack || e.message);
-    } else {
-      console.error(e);
-    }
+    console.error(renderCliError(e));
     if (profileDoneMarker) {
       console.log(profileDoneMarker);
       await new Promise((resolve) => setTimeout(resolve, 50));

--- a/packages/cli/test/log-level.test.ts
+++ b/packages/cli/test/log-level.test.ts
@@ -1,0 +1,65 @@
+import { assertEquals } from "@std/assert";
+import {
+  getGlobalLogFloor,
+  setGlobalLogFloor,
+} from "@commonfabric/utils/logger";
+import { applyLogLevel, extractLogLevel } from "../lib/log-level.ts";
+
+// applyLogLevel mutates the global log floor and the CF_LOG_LEVEL env var;
+// snapshot and restore both so the cases don't leak into each other or the
+// rest of the suite.
+function withCleanLogEnv(fn: () => void): void {
+  const prevEnv = Deno.env.get("CF_LOG_LEVEL");
+  const prevFloor = getGlobalLogFloor();
+  Deno.env.delete("CF_LOG_LEVEL");
+  setGlobalLogFloor(undefined);
+  try {
+    fn();
+  } finally {
+    if (prevEnv === undefined) Deno.env.delete("CF_LOG_LEVEL");
+    else Deno.env.set("CF_LOG_LEVEL", prevEnv);
+    setGlobalLogFloor(prevFloor);
+  }
+}
+
+Deno.test("applyLogLevel defaults the floor to warn", () => {
+  withCleanLogEnv(() => {
+    const cleanArgs = applyLogLevel(["check", "./p.tsx"]);
+    assertEquals(getGlobalLogFloor(), "warn");
+    assertEquals(Deno.env.get("CF_LOG_LEVEL"), "warn");
+    assertEquals(cleanArgs, ["check", "./p.tsx"]);
+  });
+});
+
+Deno.test("applyLogLevel honors an explicit --log-level and strips it", () => {
+  withCleanLogEnv(() => {
+    const cleanArgs = applyLogLevel([
+      "--log-level",
+      "error",
+      "check",
+      "./p.tsx",
+    ]);
+    assertEquals(getGlobalLogFloor(), "error");
+    assertEquals(Deno.env.get("CF_LOG_LEVEL"), "error");
+    assertEquals(cleanArgs, ["check", "./p.tsx"]);
+  });
+});
+
+Deno.test("applyLogLevel leaves a preset CF_LOG_LEVEL untouched", () => {
+  withCleanLogEnv(() => {
+    Deno.env.set("CF_LOG_LEVEL", "debug");
+    setGlobalLogFloor("debug");
+    const cleanArgs = applyLogLevel(["piece", "ls"]);
+    assertEquals(Deno.env.get("CF_LOG_LEVEL"), "debug");
+    assertEquals(getGlobalLogFloor(), "debug");
+    assertEquals(cleanArgs, ["piece", "ls"]);
+  });
+});
+
+Deno.test("extractLogLevel ignores an invalid --log-level value", () => {
+  // A non-level value is not consumed; it stays in the args and no level is
+  // returned, so applyLogLevel falls through to the warn default.
+  const { level, args } = extractLogLevel(["--log-level", "bogus", "check"]);
+  assertEquals(level, undefined);
+  assertEquals(args, ["--log-level", "bogus", "check"]);
+});

--- a/packages/cli/test/render-cli-error.test.ts
+++ b/packages/cli/test/render-cli-error.test.ts
@@ -1,0 +1,31 @@
+import { assert, assertEquals } from "@std/assert";
+import { CompilerError, TransformerError } from "@commonfabric/js-compiler";
+import { renderCliError } from "../mod.ts";
+
+Deno.test("renderCliError prints a TransformerError's message, not its stack", () => {
+  const e = new TransformerError([], new Map());
+  assertEquals(renderCliError(e), e.message);
+  assert(renderCliError(e) !== e.stack);
+});
+
+Deno.test("renderCliError prints a CompilerError's message, not its stack", () => {
+  const e = new CompilerError([]);
+  assertEquals(renderCliError(e), e.message);
+  assert(renderCliError(e) !== e.stack);
+});
+
+Deno.test("renderCliError prints a plain Error's stack", () => {
+  const e = new Error("boom");
+  assertEquals(renderCliError(e), e.stack);
+});
+
+Deno.test("renderCliError falls back to the message when an Error has no stack", () => {
+  const e = new Error("boom");
+  e.stack = undefined;
+  assertEquals(renderCliError(e), "boom");
+});
+
+Deno.test("renderCliError passes a non-Error value through unchanged", () => {
+  assertEquals(renderCliError("oops"), "oops");
+  assertEquals(renderCliError(42), 42);
+});

--- a/packages/generated-patterns/integration/patterns/cell-unknown-capture.pattern.ts
+++ b/packages/generated-patterns/integration/patterns/cell-unknown-capture.pattern.ts
@@ -1,0 +1,47 @@
+import { Cell, computed, pattern } from "commonfabric";
+
+// Runtime behaviour of carrying an `unknown`-typed value across a computed
+// capture boundary by capturing a Cell<unknown> handle and reading it back with
+// `.get()`.
+//
+// The capture schema is `{ type: "unknown", asCell: true }`. On read, the runner
+// (runner/src/traverse.ts) treats the unknown element schema by value shape: a
+// primitive passes through `traversePrimitive`, while an object or array
+// short-circuits to `undefined` (`valid === TypeValidity.Unknown`). So the
+// primitive survives and the structured payload is dropped — which is why the
+// unknown-capture diagnostic warns on Cell<unknown> captures rather than treating
+// `asCell` as safe.
+
+interface Payload {
+  name: string;
+  list: number[];
+  nested: { ok: boolean };
+}
+
+export default pattern<
+  Record<string, never>,
+  {
+    prim: number;
+    present: boolean;
+    name: string;
+    list: number[];
+    nestedOk: boolean;
+  }
+>(() => {
+  const primBox = Cell.of<unknown>(42);
+  const structBox = Cell.of<unknown>(
+    { name: "Alice", list: [1, 2, 3], nested: { ok: true } } as Payload,
+  );
+
+  return computed(() => {
+    const p = primBox.get() as number;
+    const s = structBox.get() as Payload | undefined;
+    return {
+      prim: p,
+      present: s !== undefined && s !== null,
+      name: s ? s.name : "MISSING",
+      list: s ? s.list : [],
+      nestedOk: s ? s.nested.ok : false,
+    };
+  });
+});

--- a/packages/generated-patterns/integration/patterns/cell-unknown-capture.test.ts
+++ b/packages/generated-patterns/integration/patterns/cell-unknown-capture.test.ts
@@ -1,0 +1,32 @@
+import { describe, it } from "@std/testing/bdd";
+import { runPatternScenario } from "../pattern-harness.ts";
+import type { PatternIntegrationScenario } from "../pattern-harness.ts";
+
+// A Cell<unknown> capture carries a primitive through `.get()` but drops a
+// structured payload to `undefined`. The loss is silent, which is why the
+// unknown-capture diagnostic warns on Cell<unknown> captures rather than
+// exempting `asCell`.
+describe("Cell<unknown> capture: primitive survives, structured is dropped", () => {
+  const scenario: PatternIntegrationScenario<Record<string, never>> = {
+    name: "Cell<unknown> capture drops structured values but keeps primitives",
+    module: new URL("./cell-unknown-capture.pattern.ts", import.meta.url),
+    argument: {},
+    steps: [
+      {
+        expect: [
+          { path: "prim", value: 42 },
+          // The structured payload is read back as undefined, so the body falls
+          // through to its defaults.
+          { path: "present", value: false },
+          { path: "name", value: "MISSING" },
+          { path: "list", value: [] },
+          { path: "nestedOk", value: false },
+        ],
+      },
+    ],
+  };
+
+  it(scenario.name, async () => {
+    await runPatternScenario(scenario);
+  });
+});

--- a/packages/generated-patterns/integration/patterns/ct-1334-fetchdata-derive-subpattern.pattern.ts
+++ b/packages/generated-patterns/integration/patterns/ct-1334-fetchdata-derive-subpattern.pattern.ts
@@ -24,14 +24,11 @@ import { computed, fetchData, pattern } from "commonfabric";
 // unknown types properly; `{type:"unknown"}` is the CORRECT behavior (confirmed
 // w/ Berni), so typing the call is the right fix, not restoring `true`.
 //
-// The remaining systemic gap — that an `unknown`-inferred capture fails SILENTLY
-// (undefined at runtime) instead of at compile time — is a separate follow-up:
-// add a transform-time diagnostic for unknown-typed captures + audit existing
-// untyped fetchData/streamData capture sites. See
-// session_outputs/2026-05-27_remove-derive/18-IAN-ONBOARDING-unknown-capture-diagnostic.md
-// (slated as a starter project; a Linear ticket will supersede this pointer).
-//
-// Typing the call supplies the schema the assertion semantically requires.
+// An `unknown`-inferred capture fails this way silently — undefined at runtime
+// rather than a compile error. The transformer now emits a
+// `reactive-capture:unknown-type` warning for such captures, so the silent case
+// surfaces at build time; typing the call (as below) is the fix and supplies the
+// schema the assertion semantically requires.
 
 const FetchPage = pattern<
   { token: string },

--- a/packages/generated-patterns/integration/patterns/unknown-capture-materialization.pattern.ts
+++ b/packages/generated-patterns/integration/patterns/unknown-capture-materialization.pattern.ts
@@ -1,0 +1,26 @@
+import { computed, pattern } from "commonfabric";
+
+// Demonstrates the bug the unknown-capture diagnostic warns about: a value that
+// is present at runtime but typed `unknown` is captured into a computed(), whose
+// input schema becomes `{ type: "unknown" }`. The runner does not materialize a
+// structured value across that boundary, so the body reads `undefined` even
+// though a real object was supplied as the argument. The typed capture in the
+// same body materializes normally — the drop is specific to `unknown`.
+
+interface Named {
+  name: string;
+}
+
+export default pattern<
+  { payload: unknown; typed: Named },
+  { unknownPresent: boolean; unknownName: string; typedName: string }
+>(({ payload, typed }) => {
+  return computed(() => {
+    const p = payload as Named | undefined;
+    return {
+      unknownPresent: p !== undefined && p !== null,
+      unknownName: p ? p.name : "MISSING",
+      typedName: typed.name,
+    };
+  });
+});

--- a/packages/generated-patterns/integration/patterns/unknown-capture-materialization.test.ts
+++ b/packages/generated-patterns/integration/patterns/unknown-capture-materialization.test.ts
@@ -1,0 +1,37 @@
+import { describe, it } from "@std/testing/bdd";
+import { runPatternScenario } from "../pattern-harness.ts";
+import type { PatternIntegrationScenario } from "../pattern-harness.ts";
+
+// A structured value typed `unknown`, captured into computed(), is silently
+// dropped to `undefined` at runtime — the exact failure the compile-time
+// unknown-capture diagnostic exists to surface. A typed capture in the same
+// body survives, confirming the drop is specific to `unknown`.
+describe("unknown capture materializes as undefined at runtime", () => {
+  const scenario: PatternIntegrationScenario<
+    { payload: unknown; typed: { name: string } }
+  > = {
+    name:
+      "structured unknown capture drops to undefined; typed capture survives",
+    module: new URL(
+      "./unknown-capture-materialization.pattern.ts",
+      import.meta.url,
+    ),
+    argument: {
+      payload: { name: "Alice", tags: [1, 2, 3] },
+      typed: { name: "Bob" },
+    },
+    steps: [
+      {
+        expect: [
+          { path: "unknownPresent", value: false },
+          { path: "unknownName", value: "MISSING" },
+          { path: "typedName", value: "Bob" },
+        ],
+      },
+    ],
+  };
+
+  it(scenario.name, async () => {
+    await runPatternScenario(scenario);
+  });
+});

--- a/packages/js-compiler/typescript/compiler.ts
+++ b/packages/js-compiler/typescript/compiler.ts
@@ -21,6 +21,7 @@ import { resolveProgram } from "./resolver.ts";
 import {
   Checker,
   type DiagnosticMessageTransformer,
+  formatTransformerDiagnostic,
   TransformerDiagnosticInfo,
   TransformerError,
 } from "./diagnostics/mod.ts";
@@ -33,6 +34,30 @@ const vfsLogger = getLogger("virtualfs", {
   enabled: DEBUG_VIRTUAL_FS,
   level: "debug",
 });
+
+// Surfaces transformer-pipeline warnings. Errors are thrown via
+// TransformerError; warnings have no other channel, so without this they are
+// collected and silently dropped. Emitting them through the logger gates
+// visibility on the host's log level: `cf` defaults the floor to `warn` so
+// authors see them, while server/library compile paths that keep the `error`
+// floor stay quiet.
+const transformerLogger = getLogger("transformer");
+
+function surfaceTransformerWarnings(
+  diagnostics: readonly TransformerDiagnosticInfo[],
+  program: Program,
+): void {
+  const warnings = diagnostics.filter((d) => d.severity === "warning");
+  if (warnings.length === 0) return;
+  const sources = new Map<string, string>();
+  for (const file of program.files) sources.set(file.name, file.contents);
+  for (const warning of warnings) {
+    transformerLogger.warn(
+      "transform-diagnostic",
+      formatTransformerDiagnostic(warning, sources.get(warning.fileName) ?? ""),
+    );
+  }
+}
 
 // Mapping from virtual type path (e.g. `$types/es2023.d.ts`)
 type TypeLibs = Record<string, string>;
@@ -341,7 +366,11 @@ export class TypeScriptCompiler {
     checker.check(diagnostics);
 
     if (getDiagnostics) {
-      const errors = getDiagnostics().filter((d) => d.severity === "error");
+      const transformerDiagnostics = getDiagnostics();
+      surfaceTransformerWarnings(transformerDiagnostics, program);
+      const errors = transformerDiagnostics.filter((d) =>
+        d.severity === "error"
+      );
       if (errors.length > 0) {
         const sources = new Map<string, string>();
         for (const file of program.files) sources.set(file.name, file.contents);

--- a/packages/ts-transformers/src/ast/type-building.ts
+++ b/packages/ts-transformers/src/ast/type-building.ts
@@ -5,8 +5,11 @@ import { createPropertyName } from "../utils/identifiers.ts";
 import {
   ensureTypeNodeRegistered,
   inferWidenedTypeFromExpression,
+  isUnknownType,
+  unwrapCellLikeType,
 } from "./type-inference.ts";
 import {
+  getExpressionText,
   isOptionalMemberSymbol,
   isOptionalSymbol,
   setParentPointers,
@@ -651,6 +654,53 @@ export function cloneTypeNodeDeepForEmission<T extends ts.TypeNode>(
 }
 
 /**
+ * Warns when a reactive value consumed across a boundary has inferred type
+ * `unknown`. That type lowers to `{ type: "unknown" }`, which the runner reads
+ * back as `undefined` rather than materializing the value (see
+ * `runner/src/traverse.ts`, `_traverseWithSchemaInner`: a
+ * `TypeValidity.Unknown` field short-circuits to `undefined`). `any` lowers to
+ * a permissive `true` schema and materializes, so it is not flagged.
+ *
+ * Both reactive-input sites share this: closure-captured inputs (the capture
+ * leaves below — `computed`/`lift`, `handler`/`action`, reactive array methods,
+ * `patternTool`) and the condition of `ifElse`/`when`/`unless` (checked where
+ * their schemas are built). `reportDiagnosticOnce` keeps the same value from
+ * being warned about twice when more than one stage walks it.
+ */
+export function warnIfUnknownReactiveType(
+  context: TransformationContext,
+  expression: ts.Expression,
+  type: ts.Type | undefined,
+  label: string,
+): void {
+  if (!isUnknownType(unwrapCellLikeType(type, context.checker))) {
+    return;
+  }
+  context.reportDiagnosticOnce({
+    severity: "warning",
+    type: "reactive-capture:unknown-type",
+    message:
+      `Reactive value \`${describeCapture(expression, label)}\` has inferred ` +
+      `type \`unknown\`, so its schema is \`{ type: "unknown" }\`, which the ` +
+      `runner reads back as \`undefined\` instead of materializing it. Add an ` +
+      `explicit type so it can be inferred (e.g. ` +
+      `\`fetchData<{ /* result shape */ }>({ ... })\`).`,
+    node: expression,
+  });
+}
+
+/** Single-line rendering of a reactive value for the message; falls back to the
+ * given label when there is no usable text. Uses getExpressionText, which
+ * prints synthetic nodes safely — `getText()` throws on them. */
+function describeCapture(expression: ts.Expression, fallback: string): string {
+  const text = getExpressionText(expression).replace(/\s+/g, " ").trim();
+  if (!text) {
+    return fallback;
+  }
+  return text.length > 48 ? `${text.slice(0, 45)}...` : text;
+}
+
+/**
  * Builds TypeScript type elements from a capture tree structure.
  * Works for both nested properties within a tree node and root-level entries.
  * Recursively builds nested type literals for hierarchical captures.
@@ -689,7 +739,21 @@ export function buildTypeElementsFromCaptureTree(
     if (childNode.expression) {
       // Leaf node with source expression - use it directly
       typeNode = expressionToTypeNode(childNode.expression, context);
-      currentType = checker.getTypeAtLocation(childNode.expression);
+
+      // Judge unknown-ness from the type that drives the emitted schema — the
+      // same one expressionToTypeNode uses. A bare getTypeAtLocation would skip
+      // the typeRegistry lookup and initializer fallback; literal widening here
+      // can't change whether the type is unknown.
+      warnIfUnknownReactiveType(
+        context,
+        childNode.expression,
+        inferWidenedTypeFromExpression(
+          childNode.expression,
+          checker,
+          context.options.state?.typeRegistry,
+        ),
+        propName,
+      );
 
       // Check optionality from source expression
       if (ts.isPropertyAccessExpression(childNode.expression)) {

--- a/packages/ts-transformers/src/core/context.ts
+++ b/packages/ts-transformers/src/core/context.ts
@@ -88,6 +88,27 @@ export class TransformationContext {
     }
   }
 
+  /**
+   * Like {@link reportDiagnostic}, but emits at most one diagnostic per
+   * (file, type, source range). The capture schemas are built in one shared
+   * place that several stages re-walk, so the same capture can reach a
+   * diagnostic call more than once; this keys on the resolved range via the
+   * shared CrossStageState so the duplicates collapse to one. The file name is
+   * part of the key because that state is shared across every file in a
+   * compilation, and the range is a file-relative offset that would otherwise
+   * collide between files. With no shared state present it falls back to
+   * reporting unconditionally.
+   */
+  reportDiagnosticOnce(input: DiagnosticInput): void {
+    const { start, length } = this.resolveDiagnosticRange(input.node);
+    const key = `${this.sourceFile.fileName}:${input.type}:${start}:${length}`;
+    const state = this.options.state;
+    if (state && !state.markDiagnosticReported(key)) {
+      return;
+    }
+    this.reportDiagnostic(input);
+  }
+
   private resolveDiagnosticRange(
     node: ts.Node,
   ): { start: number; length: number } {

--- a/packages/ts-transformers/src/core/cross-stage-state.ts
+++ b/packages/ts-transformers/src/core/cross-stage-state.ts
@@ -78,6 +78,13 @@ export class CrossStageState {
    */
   readonly nodeLinks = new WeakMap<ts.Node, NodeTypeLinks>();
 
+  /**
+   * Source-position keys already emitted by `reportDiagnosticOnce`, so a
+   * diagnostic about a value that more than one stage walks (e.g. the inner-lift
+   * revisit) is emitted a single time.
+   */
+  readonly #reportedDiagnosticKeys = new Set<string>();
+
   /** Marker family — keyed by node/symbol identity; cache-coupled via context. */
   readonly mapCallbackRegistry = new WeakSet<ts.Node>();
   readonly syntheticComputeCallbackRegistry = new WeakSet<ts.Node>();
@@ -188,6 +195,21 @@ export class CrossStageState {
   isSchemaInjected(node: ts.Node): boolean {
     // Plain presence check with NO getOriginalNode fallback (see field doc).
     return this.nodeLinks.get(node)?.schemaInjected === true;
+  }
+
+  // --- diagnostic dedup ---
+
+  /**
+   * Records that a diagnostic with `key` is being emitted. Returns true the
+   * first time a key is seen and false thereafter, so callers can suppress
+   * duplicates of the same diagnostic across stages.
+   */
+  markDiagnosticReported(key: string): boolean {
+    if (this.#reportedDiagnosticKeys.has(key)) {
+      return false;
+    }
+    this.#reportedDiagnosticKeys.add(key);
+    return true;
   }
 
   // --- shared helper: membership check with getOriginalNode fallback ---

--- a/packages/ts-transformers/src/transformers/schema-injection.ts
+++ b/packages/ts-transformers/src/transformers/schema-injection.ts
@@ -4,6 +4,7 @@ import {
   createRegisteredTypeLiteral,
   getDeclaredTypeNodeForBindingElement,
   shouldPreserveBindingDeclaredTypeNode,
+  warnIfUnknownReactiveType,
 } from "../ast/type-building.ts";
 import { FUNCTION_HARDENING_HELPER_NAME } from "@commonfabric/utils/sandbox-contract";
 
@@ -1480,6 +1481,59 @@ function visitPrependedWidenedSchemaCall(
   return ts.visitEachChild(updated, visit, transformation);
 }
 
+/**
+ * Rewrites a reactive conditional (`when`/`unless`/`ifElse`), authored as
+ * `fn(condition, ...branches)`, to carry a generated schema for each argument
+ * plus the call's result type, inserted ahead of the original arguments (what
+ * visitPrependedWidenedSchemaCall does). The first argument is the reactive
+ * condition, so it gets the unknown-capture check.
+ *
+ * `arity` is the authored argument count (2 for when/unless, 3 for ifElse). A
+ * call that already has the schemas added has more arguments; an earlier marker
+ * keeps it from being processed twice, so this length check just skips that
+ * already-rewritten form.
+ */
+function visitReactiveConditional(
+  node: ts.CallExpression,
+  arity: number,
+  context: TransformationContext,
+  visit: (node: ts.Node) => ts.Node,
+  transformation: ts.TransformationContext,
+  checker: ts.TypeChecker,
+  typeRegistry?: TypeRegistry,
+): ts.Node {
+  const args = node.arguments;
+  if (args.length !== arity) {
+    // Other arities are the already-rewritten form (schemas prepended).
+    return ts.visitEachChild(node, visit, transformation);
+  }
+
+  // getTypeAtLocationWithFallback handles synthetic nodes (e.g. lift-applied
+  // calls) whose types live in the typeRegistry rather than at a source range.
+  const typeOf = (expr: ts.Node): ts.Type =>
+    getTypeAtLocationWithFallback(expr, checker, typeRegistry) ??
+      checker.getTypeAtLocation(expr);
+
+  const argTypes = args.map(typeOf);
+  // Only the condition is checked. It is materialized here to choose a branch,
+  // so an unknown condition silently reads back as undefined at this boundary.
+  // The branches are result values that flow outward unmaterialized — an unknown
+  // branch is not lost here; it propagates as the call's unknown result and is
+  // warned about where that result is consumed (captured).
+  warnIfUnknownReactiveType(context, args[0]!, argTypes[0], "condition");
+
+  return visitPrependedWidenedSchemaCall(
+    node,
+    args,
+    [...argTypes, typeOf(node)],
+    context,
+    visit,
+    transformation,
+    checker,
+    typeRegistry,
+  );
+}
+
 function inferLiftFactoryResultType(
   node: ts.Expression,
   checker: ts.TypeChecker,
@@ -2539,6 +2593,73 @@ function reportAnyResultSchema(
   });
 }
 
+/**
+ * Reports on a pattern's inferred result schema. A top-level `any`/`unknown`
+ * result is an error (the whole output is permissive). A concrete result that
+ * nests `unknown` fields is a warning: those fields lower to
+ * `{ type: "unknown" }`, which a consumer reading them back materializes as
+ * `undefined` — the producer-side form of the unknown-capture bug.
+ */
+function reportUnknownPatternResult(
+  context: TransformationContext,
+  node: ts.CallExpression,
+  resultNode: ts.TypeNode | undefined,
+  resultType: ts.Type | undefined,
+): void {
+  if (shouldReportPermissiveInferredPatternResult(resultNode, resultType)) {
+    reportAnyResultSchema(context, node);
+    return;
+  }
+  if (!resultNode) return;
+  const paths = collectUnknownResultPaths(resultNode);
+  if (paths.length === 0) return;
+  const fields = paths.map((p) => `\`${p}\``).join(", ");
+  context.reportDiagnosticOnce({
+    severity: "warning",
+    type: "pattern-result:unknown-type",
+    message:
+      `pattern() output ${paths.length > 1 ? "fields" : "field"} ${fields} ` +
+      `${
+        paths.length > 1 ? "have" : "has"
+      } inferred type \`unknown\`, so the ` +
+      `output schema carries \`{ type: "unknown" }\` there. A consumer that ` +
+      `reads such a field back materializes it as \`undefined\`. Add an ` +
+      `explicit Output type, e.g. pattern<Input, { /* shape */ }>(...).`,
+    node: node.expression,
+  });
+}
+
+/**
+ * Collects dotted paths to `unknown`-typed leaves within a result type node,
+ * descending object literals and array element types. A top-level `unknown` is
+ * handled by the error path above, so this only sees nested occurrences.
+ */
+function collectUnknownResultPaths(resultNode: ts.TypeNode): string[] {
+  const paths: string[] = [];
+  const walk = (typeNode: ts.TypeNode, path: string): void => {
+    const unwrapped = unwrapParenthesizedTypeNode(typeNode);
+    if (unwrapped.kind === ts.SyntaxKind.UnknownKeyword) {
+      paths.push(path || "(result)");
+      return;
+    }
+    if (ts.isTypeLiteralNode(unwrapped)) {
+      for (const member of unwrapped.members) {
+        if (
+          ts.isPropertySignature(member) && member.type && member.name &&
+          (ts.isIdentifier(member.name) || ts.isStringLiteral(member.name))
+        ) {
+          const name = member.name.text;
+          walk(member.type, path ? `${path}.${name}` : name);
+        }
+      }
+    } else if (ts.isArrayTypeNode(unwrapped)) {
+      walk(unwrapped.elementType, `${path}[]`);
+    }
+  };
+  walk(resultNode, "");
+  return paths;
+}
+
 function isMapWithPatternCallbackPatternCall(node: ts.CallExpression): boolean {
   const parent = node.parent;
   if (!parent || !ts.isCallExpression(parent)) {
@@ -2660,14 +2781,12 @@ function handlePatternSchemaInjection(
       argumentCapabilityMode,
       context,
     );
-    if (
-      shouldReportPermissiveInferredPatternResult(
-        inferred.result,
-        inferred.resultType,
-      )
-    ) {
-      reportAnyResultSchema(context, node);
-    }
+    reportUnknownPatternResult(
+      context,
+      node,
+      inferred.result,
+      inferred.resultType,
+    );
     resultTypeNode = inferred.result ??
       factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword);
     resultType = getTypeFromRegistryOrFallback(
@@ -2701,14 +2820,12 @@ function handlePatternSchemaInjection(
         argumentCapabilityMode,
         context,
       );
-      if (
-        shouldReportPermissiveInferredPatternResult(
-          inferred.result,
-          inferred.resultType,
-        )
-      ) {
-        reportAnyResultSchema(context, node);
-      }
+      reportUnknownPatternResult(
+        context,
+        node,
+        inferred.result,
+        inferred.resultType,
+      );
       resultTypeNode = inferred.result ??
         factory.createKeywordTypeNode(ts.SyntaxKind.UnknownKeyword);
       resultType = getTypeFromRegistryOrFallback(
@@ -2760,14 +2877,12 @@ function handlePatternSchemaInjection(
         argumentCapabilityMode,
         context,
       );
-      if (
-        shouldReportPermissiveInferredPatternResult(
-          inferred.result,
-          inferred.resultType,
-        )
-      ) {
-        reportAnyResultSchema(context, node);
-      }
+      reportUnknownPatternResult(
+        context,
+        node,
+        inferred.result,
+        inferred.resultType,
+      );
 
       inputTypeNode = inferred.argument ??
         getParameterSchemaType(factory, inputParam);
@@ -3866,44 +3981,13 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
         }
       }
 
-      // Handler for when(condition, value) - prepends 3 schemas (condition, value, result)
-      if (callKind?.kind === "when") {
-        const args = node.arguments;
-
-        // Idempotency is owned by the top-of-visit schema-injected marker; no
-        // arg-count "already has schemas" guard needed. (The public
-        // WhenFunction type is exactly 2-arity, so the 5-arg withSchemas form
-        // can ONLY be our own injected output — never user source.)
-        // This stays a DISPATCH guard: only the 2-arg form is the injectable shape.
-        if (args.length !== 2) {
-          return ts.visitEachChild(node, visit, transformation);
-        }
-
-        const [conditionExpr, valueExpr] = args;
-
-        // Infer types for each argument
-        // Use getTypeAtLocationWithFallback to handle synthetic nodes (e.g.,
-        // lift-applied calls) which have their types registered in the typeRegistry
-        const conditionType = getTypeAtLocationWithFallback(
-          conditionExpr!,
-          checker,
-          typeRegistry,
-        ) ??
-          checker.getTypeAtLocation(conditionExpr!);
-        const valueType =
-          getTypeAtLocationWithFallback(valueExpr!, checker, typeRegistry) ??
-            checker.getTypeAtLocation(valueExpr!);
-
-        // Get the result type from TypeScript's inferred return type of the call
-        // This will be the union type (e.g., boolean | string for when(enabled, message))
-        const resultType =
-          getTypeAtLocationWithFallback(node, checker, typeRegistry) ??
-            checker.getTypeAtLocation(node);
-
-        return visitPrependedWidenedSchemaCall(
+      // Reactive conditionals prepend a widened schema per argument plus the
+      // result. when/unless are 2-arity (condition, value/fallback); ifElse is
+      // 3-arity (condition, ifTrue, ifFalse).
+      if (callKind?.kind === "when" || callKind?.kind === "unless") {
+        return visitReactiveConditional(
           node,
-          args,
-          [conditionType, valueType, resultType],
+          2,
           context,
           visit,
           transformation,
@@ -3911,90 +3995,10 @@ export class SchemaInjectionTransformer extends HelpersOnlyTransformer {
           typeRegistry,
         );
       }
-
-      // Handler for unless(condition, fallback) - prepends 3 schemas (condition, fallback, result)
-      if (callKind?.kind === "unless") {
-        const args = node.arguments;
-
-        // Idempotency owned by the schema-injected marker (see `when` above).
-        // UnlessFunction is exactly 2-arity, so the 5-arg form is only ever
-        // our injected output. DISPATCH guard: only the 2-arg form is injectable.
-        if (args.length !== 2) {
-          return ts.visitEachChild(node, visit, transformation);
-        }
-
-        const [conditionExpr, fallbackExpr] = args;
-
-        // Infer types for each argument
-        // Use getTypeAtLocationWithFallback to handle synthetic nodes (e.g.,
-        // lift-applied calls) which have their types registered in the typeRegistry
-        const conditionType = getTypeAtLocationWithFallback(
-          conditionExpr!,
-          checker,
-          typeRegistry,
-        ) ??
-          checker.getTypeAtLocation(conditionExpr!);
-        const fallbackType =
-          getTypeAtLocationWithFallback(fallbackExpr!, checker, typeRegistry) ??
-            checker.getTypeAtLocation(fallbackExpr!);
-
-        // Get the result type from TypeScript's inferred return type of the call
-        // This will be the union type (e.g., boolean | string for unless(enabled, fallback))
-        const resultType =
-          getTypeAtLocationWithFallback(node, checker, typeRegistry) ??
-            checker.getTypeAtLocation(node);
-
-        return visitPrependedWidenedSchemaCall(
-          node,
-          args,
-          [conditionType, fallbackType, resultType],
-          context,
-          visit,
-          transformation,
-          checker,
-          typeRegistry,
-        );
-      }
-
-      // Handler for ifElse(condition, ifTrue, ifFalse) - prepends 4 schemas (condition, ifTrue, ifFalse, result)
       if (callKind?.kind === "ifElse") {
-        const args = node.arguments;
-
-        // Idempotency owned by the schema-injected marker (see `when` above).
-        // IfElseFunction is exactly 3-arity, so the 7-arg form is only ever
-        // our injected output. DISPATCH guard: only the 3-arg form is injectable.
-        if (args.length !== 3) {
-          return ts.visitEachChild(node, visit, transformation);
-        }
-
-        const [conditionExpr, ifTrueExpr, ifFalseExpr] = args;
-
-        // Infer types for each argument
-        // Use getTypeAtLocationWithFallback to handle synthetic nodes (e.g.,
-        // lift-applied calls) which have their types registered in the typeRegistry
-        const conditionType = getTypeAtLocationWithFallback(
-          conditionExpr!,
-          checker,
-          typeRegistry,
-        ) ??
-          checker.getTypeAtLocation(conditionExpr!);
-        const ifTrueType =
-          getTypeAtLocationWithFallback(ifTrueExpr!, checker, typeRegistry) ??
-            checker.getTypeAtLocation(ifTrueExpr!);
-        const ifFalseType =
-          getTypeAtLocationWithFallback(ifFalseExpr!, checker, typeRegistry) ??
-            checker.getTypeAtLocation(ifFalseExpr!);
-
-        // Get the result type from TypeScript's inferred return type of the call
-        // This will be the union type (e.g., string | number for ifElse(cond, str, num))
-        const resultType =
-          getTypeAtLocationWithFallback(node, checker, typeRegistry) ??
-            checker.getTypeAtLocation(node);
-
-        return visitPrependedWidenedSchemaCall(
+        return visitReactiveConditional(
           node,
-          args,
-          [conditionType, ifTrueType, ifFalseType, resultType],
+          3,
           context,
           visit,
           transformation,

--- a/packages/ts-transformers/test/unknown-capture-validation.test.ts
+++ b/packages/ts-transformers/test/unknown-capture-validation.test.ts
@@ -1,0 +1,379 @@
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { validateFiles, validateSource } from "./utils.ts";
+import type { TransformationDiagnostic } from "../src/mod.ts";
+import { COMMONFABRIC_TYPES } from "./commonfabric-test-types.ts";
+
+const DIAGNOSTIC_TYPE = "reactive-capture:unknown-type";
+const RESULT_DIAGNOSTIC_TYPE = "pattern-result:unknown-type";
+
+async function unknownCaptureWarnings(
+  source: string,
+): Promise<readonly TransformationDiagnostic[]> {
+  const { diagnostics } = await validateSource(source, {
+    types: COMMONFABRIC_TYPES,
+  });
+  return diagnostics.filter((d) => d.type === DIAGNOSTIC_TYPE);
+}
+
+async function unknownResultWarnings(
+  source: string,
+): Promise<readonly TransformationDiagnostic[]> {
+  const { diagnostics } = await validateSource(source, {
+    types: COMMONFABRIC_TYPES,
+  });
+  return diagnostics.filter((d) => d.type === RESULT_DIAGNOSTIC_TYPE);
+}
+
+Deno.test("unknown reactive capture diagnostic", async (t) => {
+  await t.step(
+    "warns when an untyped fetchData().result is captured in computed()",
+    async () => {
+      const source = `
+        import { computed, fetchData, pattern } from "commonfabric";
+        export default pattern<{ token: string }, { n: number }>(({ token }) => {
+          const page = fetchData({ url: "http://x", mode: "json" });
+          const pageResultRef = page.result;
+          return computed(() => {
+            const r: any = pageResultRef;
+            return { n: r ? 1 : 0 };
+          });
+        });
+      `;
+      const warnings = await unknownCaptureWarnings(source);
+      assertEquals(warnings.length, 1);
+      assertEquals(warnings[0].severity, "warning");
+      assertStringIncludes(warnings[0].message, "pageResultRef");
+      assertStringIncludes(warnings[0].message, "unknown");
+      assertStringIncludes(warnings[0].message, "undefined");
+    },
+  );
+
+  await t.step(
+    "does not warn when the fetchData call is typed",
+    async () => {
+      const source = `
+        import { computed, fetchData, pattern } from "commonfabric";
+        export default pattern<{ token: string }, { n: number }>(({ token }) => {
+          const page = fetchData<{ items: number[] }>({ url: "http://x", mode: "json" });
+          const pageResultRef = page.result;
+          return computed(() => {
+            const r = pageResultRef;
+            return { n: r ? r.items.length : 0 };
+          });
+        });
+      `;
+      assertEquals((await unknownCaptureWarnings(source)).length, 0);
+    },
+  );
+
+  await t.step(
+    "does not warn for an `any`-typed capture (any materializes via `true`)",
+    async () => {
+      const source = `
+        import { computed, pattern } from "commonfabric";
+        export default pattern<{ x: number }, { n: number }>(({ x }) => {
+          const anyVal = (x as unknown) as any;
+          return computed(() => ({ n: anyVal ? 1 : 0 }));
+        });
+      `;
+      assertEquals((await unknownCaptureWarnings(source)).length, 0);
+    },
+  );
+
+  await t.step(
+    "warns for an explicitly `unknown`-typed capture",
+    async () => {
+      const source = `
+        import { computed, pattern } from "commonfabric";
+        export default pattern<{ x: number }, { n: number }>(({ x }) => {
+          const u = JSON.parse("{}") as unknown;
+          return computed(() => ({ n: u ? 1 : 0 }));
+        });
+      `;
+      const warnings = await unknownCaptureWarnings(source);
+      assertEquals(warnings.length, 1);
+      assertStringIncludes(warnings[0].message, "`u`");
+    },
+  );
+
+  await t.step(
+    "warns for an unknown capture inside a reactive array method",
+    async () => {
+      const source = `
+        import { pattern } from "commonfabric";
+        function pluck<T>(s?: { value: T }): T { return s?.value as T; }
+        export default pattern<{ items: number[] }, { out: boolean[] }>(
+          ({ items }) => {
+            const captured = pluck();
+            return { out: items.map((x) => captured !== undefined) };
+          },
+        );
+      `;
+      const warnings = await unknownCaptureWarnings(source);
+      assertEquals(warnings.length, 1);
+      assertStringIncludes(warnings[0].message, "captured");
+    },
+  );
+
+  await t.step(
+    "warns for an unknown `ifElse` condition",
+    async () => {
+      const source = `
+        import { pattern, ifElse, fetchData, UI } from "commonfabric";
+        export default pattern<{}, { [UI]: any }>(() => {
+          const page = fetchData({ url: "http://x", mode: "json" });
+          return { [UI]: ifElse(page.result, "a", "b") };
+        });
+      `;
+      assertEquals((await unknownCaptureWarnings(source)).length, 1);
+    },
+  );
+
+  await t.step(
+    "warns for an unknown condition in a JSX conditional",
+    async () => {
+      const source = `
+        import { pattern, fetchData, UI } from "commonfabric";
+        export default pattern<{}, { [UI]: any }>(() => {
+          const page = fetchData({ url: "http://x", mode: "json" });
+          const r = page.result;
+          return { [UI]: <div>{r ? "a" : "b"}</div> };
+        });
+      `;
+      const warnings = await unknownCaptureWarnings(source);
+      assertEquals(warnings.length, 1);
+      assertStringIncludes(warnings[0].message, "`r`");
+    },
+  );
+
+  await t.step(
+    "warns for an unknown `when` condition",
+    async () => {
+      const source = `
+        import { pattern, when, fetchData, UI } from "commonfabric";
+        export default pattern<{}, { [UI]: any }>(() => {
+          const page = fetchData({ url: "http://x", mode: "json" });
+          return { [UI]: when(page.result, "shown") };
+        });
+      `;
+      assertEquals((await unknownCaptureWarnings(source)).length, 1);
+    },
+  );
+
+  await t.step(
+    "warns for an unknown `unless` condition",
+    async () => {
+      const source = `
+        import { pattern, unless, fetchData, UI } from "commonfabric";
+        export default pattern<{}, { [UI]: any }>(() => {
+          const page = fetchData({ url: "http://x", mode: "json" });
+          return { [UI]: unless(page.result, "fallback") };
+        });
+      `;
+      assertEquals((await unknownCaptureWarnings(source)).length, 1);
+    },
+  );
+
+  await t.step(
+    "an unknown ifElse branch warns at the consumer, not at the conditional",
+    async () => {
+      // Only the condition is checked. An unknown branch is not lost at the
+      // ifElse — it flows out as the call's unknown result and is warned about
+      // where that result is captured.
+      const consumed = `
+        import { pattern, ifElse, computed } from "commonfabric";
+        function pluck<T>(s?: { value: T }): T { return s?.value as T; }
+        export default pattern<{ flag: boolean }, { n: number }>(({ flag }) => {
+          const branch = pluck();
+          const chosen = ifElse(flag, branch, 0);
+          return computed(() => ({ n: chosen ? 1 : 0 }));
+        });
+      `;
+      const warnings = await unknownCaptureWarnings(consumed);
+      assertEquals(warnings.length, 1);
+      assertStringIncludes(warnings[0].message, "`chosen`");
+
+      // Same unknown branch, but its result is never captured: nothing
+      // materializes through the branch schema here, so no warning fires.
+      const notConsumed = `
+        import { pattern, ifElse, computed } from "commonfabric";
+        function pluck<T>(s?: { value: T }): T { return s?.value as T; }
+        export default pattern<{ flag: boolean }, { n: number }>(({ flag }) => {
+          const branch = pluck();
+          const chosen = ifElse(flag, branch, 0);
+          return computed(() => ({ n: flag ? 1 : 0 }));
+        });
+      `;
+      assertEquals((await unknownCaptureWarnings(notConsumed)).length, 0);
+    },
+  );
+
+  await t.step(
+    "warns for an unknown capture inside an action()",
+    async () => {
+      const source = `
+        import { pattern, action } from "commonfabric";
+        function pluck<T>(s?: { value: T }): T { return s?.value as T; }
+        export default pattern<{}, { n: number }>(() => {
+          const captured = pluck();
+          const onClick = action(() => {
+            const r = captured;
+            return r;
+          });
+          return { n: 0 };
+        });
+      `;
+      const warnings = await unknownCaptureWarnings(source);
+      assertEquals(warnings.length, 1);
+      assertStringIncludes(warnings[0].message, "captured");
+    },
+  );
+
+  await t.step(
+    "warns for an unknown capture inside a patternTool's pattern",
+    async () => {
+      const source = `
+        import { pattern, patternTool, computed } from "commonfabric";
+        function pluck<T>(s?: { value: T }): T { return s?.value as T; }
+        export default pattern<{}, { n: number }>(() => {
+          const captured = pluck();
+          const tool = patternTool(
+            pattern<{ q: string }, { out: unknown }>(({ q }) =>
+              computed(() => captured)
+            ),
+          );
+          return { n: 0 };
+        });
+      `;
+      const warnings = await unknownCaptureWarnings(source);
+      assertEquals(warnings.length, 1);
+      assertStringIncludes(warnings[0].message, "captured");
+    },
+  );
+
+  await t.step(
+    "warns for an unknown capture nested in an otherwise-typed object",
+    async () => {
+      const source = `
+        import { pattern, computed } from "commonfabric";
+        function pluck<T>(s?: { value: T }): T { return s?.value as T; }
+        export default pattern<{}, { n: number }>(() => {
+          const obj = { count: 1, payload: pluck() };
+          return computed(() => ({ n: obj.payload ? obj.count : 0 }));
+        });
+      `;
+      assertEquals((await unknownCaptureWarnings(source)).length, 1);
+    },
+  );
+
+  await t.step(
+    "reports each captured expression once even when used repeatedly",
+    async () => {
+      const source = `
+        import { computed, fetchData, pattern } from "commonfabric";
+        export default pattern<{ token: string }, { n: number }>(({ token }) => {
+          const page = fetchData({ url: "http://x", mode: "json" });
+          const pageResultRef = page.result;
+          return computed(() => {
+            const a: any = pageResultRef;
+            const b: any = pageResultRef;
+            return { n: a && b ? 1 : 0 };
+          });
+        });
+      `;
+      assertEquals((await unknownCaptureWarnings(source)).length, 1);
+    },
+  );
+
+  await t.step(
+    "does not warn for a fully-typed reactive pattern",
+    async () => {
+      const source = `
+        import { computed, pattern } from "commonfabric";
+        export default pattern<{ count: number }, { doubled: number }>(({ count }) => {
+          return computed(() => ({ doubled: count * 2 }));
+        });
+      `;
+      assertEquals((await unknownCaptureWarnings(source)).length, 0);
+    },
+  );
+
+  await t.step(
+    "does not warn when a reactive value is returned directly and cast to any",
+    async () => {
+      // Cast to `any` and returned straight from the body: not a capture, and
+      // the output schema is `true` (any), not `{ type: "unknown" }`. Neither
+      // the capture nor the result diagnostic fires.
+      const source = `
+        import { pattern, fetchData } from "commonfabric";
+        export default pattern<{}, { result: any }>(() => {
+          const page = fetchData({ url: "http://x", mode: "json" });
+          return { result: page.result as any };
+        });
+      `;
+      assertEquals((await unknownCaptureWarnings(source)).length, 0);
+      assertEquals((await unknownResultWarnings(source)).length, 0);
+    },
+  );
+
+  await t.step(
+    "warns (result diagnostic) for an unknown value in the inferred pattern output",
+    async () => {
+      // Not a capture, so the capture diagnostic stays silent. The producer-side
+      // result diagnostic flags it: the field lowers to `{ type: "unknown" }`,
+      // and a consumer reading it back gets undefined.
+      const source = `
+        import { pattern, wish } from "commonfabric";
+        export default pattern(() => {
+          const noteWish = wish({ query: "#note" });
+          return { result: noteWish.result };
+        });
+      `;
+      assertEquals((await unknownCaptureWarnings(source)).length, 0);
+      const warnings = await unknownResultWarnings(source);
+      assertEquals(warnings.length, 1);
+      assertStringIncludes(warnings[0].message, "`result`");
+    },
+  );
+
+  await t.step(
+    "does not warn (result diagnostic) for a typed pattern output",
+    async () => {
+      const source = `
+        import { pattern, wish } from "commonfabric";
+        export default pattern<{}, { result: { id: string } }>(() => {
+          const w = wish<{ id: string }>({ query: "#note" });
+          return { result: w.result };
+        });
+      `;
+      assertEquals((await unknownResultWarnings(source)).length, 0);
+    },
+  );
+
+  await t.step(
+    "warns per file when two files share a capture at the same offset",
+    async () => {
+      // The dedup state is shared across every file in a compilation, and the
+      // dedup key includes the file name; otherwise identical-offset captures in
+      // different files collide and one warning is dropped.
+      const source = `
+        import { computed, pattern } from "commonfabric";
+        function pluck<T>(s?: { value: T }): T { return s?.value as T; }
+        export default pattern<{}, { n: number }>(() => {
+          const captured = pluck();
+          return computed(() => ({ n: captured ? 1 : 0 }));
+        });
+      `;
+      const { diagnostics } = await validateFiles(
+        { "/a.tsx": source, "/b.tsx": source },
+        { types: COMMONFABRIC_TYPES },
+      );
+      const warnings = diagnostics.filter((d) => d.type === DIAGNOSTIC_TYPE);
+      assertEquals(warnings.length, 2);
+      assertEquals(
+        new Set(warnings.map((w) => w.fileName)).size,
+        2,
+      );
+    },
+  );
+});


### PR DESCRIPTION
When a reactive value's inferred TypeScript type is `unknown`, schema injection emits `{ type: "unknown" }` for it, and the runner reads that back as `undefined` rather than materializing the value — a silent runtime data loss. This adds compile-time warnings so the silent case surfaces at build time, plus the machinery to actually show those warnings.

Capture diagnostic (`reactive-capture:unknown-type`):
- Detect at buildTypeElementsFromCaptureTree, the point where every closure- captured input schema is assembled, so one hook covers computed/lift, handler/action, reactive array methods (.map/.filter/.flatMap), and patternTool.
- A shared helper (warnIfUnknownReactiveType) also runs on the reactive condition of ifElse/when/unless (including the lowered form of JSX conditionals), which type their argument through a separate path.
- `any` is not flagged (it lowers to a permissive `true` schema that materializes); reactive wrappers are unwrapped before judging. Duplicate emissions from cross-stage re-walks collapse via a new reportDiagnosticOnce/CrossStageState dedup.

Result diagnostic (`pattern-result:unknown-type`):
- Warn when an inferred pattern output nests an `unknown` field (e.g. `{ result: unknown }`); the existing pattern:any-result-schema error only caught a top-level any/unknown result. A consumer reading such a field back gets undefined. Scoped to inferred results, like that error.

Warning surfacing:
- compiler.compile/compileAll route warning-severity transformer diagnostics through the logger (errors still throw); `cf` defaults its log floor to `warn` so authors see them. The happy path emits no runtime warnings, so this stays quiet in practice.

Refactors folded in:
- when/unless/ifElse schema injection collapse into one visitReactiveConditional.
- The three permissive-inferred-result call sites collapse into reportUnknownPatternResult (top-level error or nested-field warning).

Tests:
- ts-transformers: 17-step transform-time suite across every covered builder and condition, plus the negative guards (typed, any, passthrough, typed output).
- generated-patterns runtime: a structured value typed `unknown` captured into computed() reads back as undefined while a typed capture survives; and a Cell<unknown> capture carries a primitive but drops a structured payload (documenting why no `asCell` exemption is warranted).
- Refresh the ct-1334 fixture comment now that the diagnostic exists.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds compile-time warnings for reactive values inferred as `unknown`, and for `unknown` fields in inferred `pattern()` outputs. Warnings show by default in `cf` (log floor `warn`) to address CT-1632.

- **New Features**
  - `reactive-capture:unknown-type`: warns when a captured reactive value or a conditional’s condition is `unknown`. Covers `computed`/`lift`, handlers/actions, reactive array methods, `patternTool`, and `ifElse`/`when`/`unless` (incl. JSX). Skips `any`, unwraps cell-like wrappers, and de-dupes once per file/type/range.
  - `pattern-result:unknown-type`: warns when an inferred `pattern()` output nests `unknown` fields; a top-level `any`/`unknown` result remains an error.
  - Transformer warnings are logged in `@commonfabric/js-compiler`. `cf` now defaults its log floor to `warn` (override with `--log-level` or `CF_LOG_LEVEL`); help text updated. CLI prints concise messages for `TransformerError`/`CompilerError`.

- **Migration**
  - If you see warnings, add explicit types (e.g. `fetchData<{...}>({...})` or `pattern<Input, Output>(...)`).
  - Capturing `Cell<unknown>` warns; primitives survive, structured payloads read back as `undefined`.
  - To quiet logs in CI: `cf --log-level error ...`.

<sup>Written for commit 2d6f3d8853efa4a7882a82f427248d0a59acf2c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

