### PR TITLE
Infer fetchData result type from mode

### DIFF
--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -2107,14 +2107,23 @@ export type FetchOptions = {
   method?: "GET" | "POST" | "PUT" | "DELETE" | "PATCH" | "OPTIONS" | "HEAD";
   redirect?: "follow" | "error" | "manual";
 };
-export type FetchDataFunction = <T>(
+export type FetchDataFunction = <
+  T = never,
+  M extends "json" | "text" = "json",
+>(
   params: Opaque<{
     url: string;
-    mode?: "json" | "text";
+    mode?: M;
     options?: FetchOptions;
     result?: T;
   }>,
-) => OpaqueRef<{ pending: boolean; result: T; error?: any }>;
+) => OpaqueRef<{
+  pending: boolean;
+  // When the caller pins T (explicitly or via `result`), use it. Otherwise
+  // derive from mode: "text" -> string, "json"/omitted -> any.
+  result: [T] extends [never] ? ([M] extends ["json"] ? any : string) : T;
+  error?: any;
+}>;
 
 export type FetchProgramFunction = (
   params: Opaque<{ url: string }>,

--- a/packages/runner/src/builder/built-in.ts
+++ b/packages/runner/src/builder/built-in.ts
@@ -133,14 +133,23 @@ export const generateText = createNodeFactory({
 export const fetchData = createNodeFactory({
   type: "ref",
   implementation: "fetchData",
-}) as <T>(
+}) as <
+  T = never,
+  M extends "json" | "text" = "json",
+>(
   params: Opaque<{
     url: string;
-    mode?: "json" | "text";
+    mode?: M;
     options?: FetchOptions;
     result?: T;
   }>,
-) => OpaqueRef<{ pending: boolean; result: T; error?: unknown }>;
+) => OpaqueRef<{
+  pending: boolean;
+  // When the caller pins T (explicitly or via `result`), use it. Otherwise
+  // derive from mode: "text" -> string, "json"/omitted -> any.
+  result: [T] extends [never] ? ([M] extends ["json"] ? any : string) : T;
+  error?: unknown;
+}>;
 
 export const fetchProgram = createNodeFactory({
   type: "ref",

--- a/packages/ts-transformers/test/fixtures/jsx-expressions/ifelse-undefined-value.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/jsx-expressions/ifelse-undefined-value.expected.jsx
@@ -13,7 +13,7 @@ const runtimeDeps = undefined;
 const __cfAmdHooks = undefined;
 const __cfLift_1 = __cfHelpers.lift<{
     pending: boolean;
-    result: unknown;
+    result: string;
 }, boolean>(({ pending, result }) => pending || !result, {
     type: "object",
     properties: {
@@ -21,7 +21,7 @@ const __cfLift_1 = __cfHelpers.lift<{
             type: "boolean"
         },
         result: {
-            type: "unknown"
+            type: "string"
         }
     },
     required: ["pending", "result"]
@@ -29,12 +29,12 @@ const __cfLift_1 = __cfHelpers.lift<{
     type: "boolean"
 } as const satisfies __cfHelpers.JSONSchema);
 const __cfLift_2 = __cfHelpers.lift<{
-    result: unknown;
+    result: string;
 }, boolean>(({ result }) => !!result, {
     type: "object",
     properties: {
         result: {
-            type: "unknown"
+            type: "string"
         }
     },
     required: ["result"]
@@ -63,21 +63,21 @@ export default pattern(() => {
         type: "object",
         properties: {
             result: {
-                type: "unknown"
+                type: "string"
             }
         },
         required: ["result"]
     } as const satisfies __cfHelpers.JSONSchema, {
         anyOf: [{
+                type: "undefined"
+            }, {
                 type: "object",
                 properties: {
                     result: {
-                        type: "unknown"
+                        type: "string"
                     }
                 },
                 required: ["result"]
-            }, {
-                type: "undefined"
             }]
     } as const satisfies __cfHelpers.JSONSchema, __cfLift_1({
         pending: pending,
@@ -90,7 +90,7 @@ export default pattern(() => {
         type: "object",
         properties: {
             data: {
-                type: "unknown"
+                type: "string"
             }
         },
         required: ["data"]
@@ -98,15 +98,15 @@ export default pattern(() => {
         type: "undefined"
     } as const satisfies __cfHelpers.JSONSchema, {
         anyOf: [{
+                type: "undefined"
+            }, {
                 type: "object",
                 properties: {
                     data: {
-                        type: "unknown"
+                        type: "string"
                     }
                 },
                 required: ["data"]
-            }, {
-                type: "undefined"
             }]
     } as const satisfies __cfHelpers.JSONSchema, __cfLift_2({ result: result }).for(["output2", 4], true), { data: result }, undefined).for("output2", true);
     return {


### PR DESCRIPTION
Make the builder-level `fetchData` signature derive its `result` type from `mode`: "text" -> string, "json"/omitted -> any. When the caller pins the generic `T` (explicitly or via the `result` hint) that still wins, so all existing call sites keep their current types.

Applied to both the public `FetchDataFunction` type in packages/api/index.ts (which the commonfabric.d.ts bundle symlinks to) and the runner-internal factory cast in packages/runner/src/builder/built-in.ts.

Verified: full-repo `deno check` shows no new errors vs the clean tree, and the runner fetchData suites + ct-1334 integration test pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Infer `fetchData` result type from `mode` to reduce manual typing and improve safety. "text" now yields `string`; "json" or omitted yields `any`, unless a generic `T` or `result` hint is provided.

- **Refactors**
  - Updated public `FetchDataFunction` in `packages/api/index.ts` and runner factory cast in `packages/runner/src/builder/built-in.ts` to use `mode`-aware generics.
  - Regenerated `packages/ts-transformers/test/fixtures/jsx-expressions/ifelse-undefined-value.expected.jsx` so text-mode infers `result: string` and emitted lift types/JSON schemas match; all suites pass (`deno check`, runner `fetchData`, `ct-1334`, ts-transformers).

<sup>Written for commit f0f5b14b14cb211e381117d8e82266b92f6658f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

