### PR TITLE
refactor: throw on unreachable conditional-early-return guards

### DIFF
--- a/packages/html/src/render-utils.ts
+++ b/packages/html/src/render-utils.ts
@@ -59,9 +59,12 @@ export const getBindingPropName = (key: string): string => {
   return key.startsWith("$") ? key.slice(1) : key;
 };
 
+// key must be an event property (one that starts with "on"; can be checked with isEventProp).
 export const cleanEventProp = (key: string) => {
   if (!key.startsWith("on")) {
-    return null;
+    throw new Error(
+      'cleanEventProp requires an event prop key (starts with "on")',
+    );
   }
   return key.slice(2).toLowerCase();
 };

--- a/packages/runner/src/scheduler/dependency-graph.ts
+++ b/packages/runner/src/scheduler/dependency-graph.ts
@@ -225,7 +225,10 @@ export function backfillDependentsForNewWrites(
   writer: Action,
   writes: readonly IMemorySpaceAddress[],
 ): void {
-  if (writes.length === 0) return;
+  // Caller must ensure writes is non-empty.
+  if (writes.length === 0) {
+    throw new Error("backfillDependentsForNewWrites requires non-empty writes");
+  }
   const readers = new Set<Action>();
   for (const write of writes) {
     for (const action of state.triggerIndex.collectReadersForWrite(write)) {

--- a/packages/schema-generator/src/type-utils.ts
+++ b/packages/schema-generator/src/type-utils.ts
@@ -806,8 +806,9 @@ function followAliasToWrapperNode(
   kind: NodeWrapperKind;
   node: ts.TypeReferenceNode;
 } | undefined {
+  // Caller must ensure typeNode.typeName is an Identifier.
   if (!ts.isIdentifier(typeNode.typeName)) {
-    return undefined;
+    throw new Error("followAliasToWrapperNode requires an Identifier typeName");
   }
 
   const typeName = typeNode.typeName.text;

--- a/packages/shell/src/views/QuickJumpView.ts
+++ b/packages/shell/src/views/QuickJumpView.ts
@@ -171,7 +171,10 @@ export class XQuickJumpView extends BaseView {
   }
 
   private score(item: PieceItem, q: string): number {
-    if (!q) return 0;
+    // Caller must pass a non-empty query.
+    if (!q) {
+      throw new Error("score requires a non-empty query");
+    }
     const n = item.name.toLowerCase();
     const i = item.id.toLowerCase();
     const ql = q.toLowerCase();

--- a/packages/shell/src/views/SchedulerSourceView.ts
+++ b/packages/shell/src/views/SchedulerSourceView.ts
@@ -437,7 +437,10 @@ export class XSchedulerSource extends LitElement {
   }
 
   private handleLineClick(entries: ActionEntry[]) {
-    if (entries.length === 0) return;
+    // Caller must pass a non-empty entries array.
+    if (entries.length === 0) {
+      throw new Error("handleLineClick requires a non-empty entries array");
+    }
 
     // If clicking the same line again, cycle to next entry
     const currentId = this.selectedNodeId;

--- a/packages/ts-transformers/src/closures/strategies/action-strategy.ts
+++ b/packages/ts-transformers/src/closures/strategies/action-strategy.ts
@@ -45,12 +45,15 @@ export class ActionStrategy implements ClosureTransformationStrategy {
     return ts.isCallExpression(node) && isActionCall(node, context);
   }
 
+  // Caller must pass a call expression.
   transform(
     node: ts.Node,
     context: TransformationContext,
     visitor: ts.Visitor,
   ): ts.Node | undefined {
-    if (!ts.isCallExpression(node)) return undefined;
+    if (!ts.isCallExpression(node)) {
+      throw new Error("ActionStrategy.transform requires a call expression");
+    }
     return transformActionCall(node, context, visitor);
   }
 }

--- a/packages/ts-transformers/src/closures/strategies/array-method-strategy.ts
+++ b/packages/ts-transformers/src/closures/strategies/array-method-strategy.ts
@@ -26,12 +26,17 @@ export class ArrayMethodStrategy implements ClosureTransformationStrategy {
     return !!arrayMethodInfo && !arrayMethodInfo.lowered;
   }
 
+  // Caller must pass a call expression.
   transform(
     node: ts.Node,
     context: TransformationContext,
     visitor: ts.Visitor,
   ): ts.Node | undefined {
-    if (!ts.isCallExpression(node)) return undefined;
+    if (!ts.isCallExpression(node)) {
+      throw new Error(
+        "ArrayMethodStrategy.transform requires a call expression",
+      );
+    }
 
     const callback = node.arguments[0];
     if (callback && isFunctionLikeExpression(callback)) {

--- a/packages/ts-transformers/src/closures/strategies/handler-strategy.ts
+++ b/packages/ts-transformers/src/closures/strategies/handler-strategy.ts
@@ -18,6 +18,7 @@ export class HandlerStrategy implements ClosureTransformationStrategy {
     return false;
   }
 
+  // Caller must pass a JSX attribute node.
   transform(
     node: ts.Node,
     context: TransformationContext,
@@ -26,7 +27,7 @@ export class HandlerStrategy implements ClosureTransformationStrategy {
     if (ts.isJsxAttribute(node)) {
       return transformHandlerJsxAttribute(node, context, visitor);
     }
-    return undefined;
+    throw new Error("HandlerStrategy.transform requires a JSX attribute node");
   }
 }
 

--- a/packages/ts-transformers/src/closures/strategies/lift-applied-strategy.ts
+++ b/packages/ts-transformers/src/closures/strategies/lift-applied-strategy.ts
@@ -93,12 +93,17 @@ export class LiftAppliedStrategy implements ClosureTransformationStrategy {
     return ts.isCallExpression(node) && isLiftAppliedCall(node, context);
   }
 
+  // Caller must pass a call expression.
   transform(
     node: ts.Node,
     context: TransformationContext,
     visitor: ts.Visitor,
   ): ts.Node | undefined {
-    if (!ts.isCallExpression(node)) return undefined;
+    if (!ts.isCallExpression(node)) {
+      throw new Error(
+        "LiftAppliedStrategy.transform requires a call expression",
+      );
+    }
     return transformLiftAppliedCall(node, context, visitor);
   }
 }

--- a/packages/ts-transformers/src/transformers/builtins/lift-applied.ts
+++ b/packages/ts-transformers/src/transformers/builtins/lift-applied.ts
@@ -184,12 +184,15 @@ function createLiftAppliedInputArgs(
   ];
 }
 
+// Caller must pass a non-empty refs array.
 export function createLiftAppliedCall(
   expression: ts.Expression,
   refs: readonly ts.Expression[],
   options: LiftAppliedCallOptions,
 ): ts.Expression | undefined {
-  if (refs.length === 0) return undefined;
+  if (refs.length === 0) {
+    throw new Error("createLiftAppliedCall requires a non-empty refs array");
+  }
 
   const { factory, tsContext, cfHelpers, context } = options;
   const { captureTree, fallbackEntries, refToParamName } =

--- a/packages/ts-transformers/src/utils/path-serialization.ts
+++ b/packages/ts-transformers/src/utils/path-serialization.ts
@@ -14,7 +14,10 @@ export function encodePath(path: readonly string[]): string {
  * Decodes a serialized path key produced by {@link encodePath}.
  */
 export function decodePath(path: string): readonly string[] {
-  if (!path) return [];
+  // Caller must pass a non-empty encoded path (the output of encodePath).
+  if (!path) {
+    throw new Error("decodePath requires a non-empty encoded path");
+  }
   const parsed = JSON.parse(path);
   if (isStringArray(parsed)) {
     return parsed;


### PR DESCRIPTION
Audit of functions whose first statement is a conditional early return used as a silent decline, converting the cases that are unreachable because every caller already guarantees the guarded condition. Each gets a one-line comment stating the precondition the caller must satisfy, where the type signature does not express it.

ts-transformers — closure-strategy dispatch guards. The four strategies are invoked only by the dispatcher in closures/transformer.ts, which calls transform() only after the strategy's own canTransform() returns true, so the node-kind guard at the top of each transform() can never take its negative branch (HandlerStrategy: JsxAttribute; Action/ArrayMethod/LiftApplied: CallExpression). ArrayMethodStrategy keeps its second return undefined (the callback-shape decline), which is reachable.

ts-transformers — createLiftAppliedCall: all callers pass a non-empty refs array (literal arrays, a length-checked array, or a non-empty wrapperDataFlows fed through unionWithEnclosingScopeFreeIdentifiers).

Repo-wide argument-contract guards:
- runner  backfillDependentsForNewWrites: writes non-empty (caller gates on addedWrites.length > 0)
- ts-transformers  decodePath: path non-empty (values are JSON.stringify output)
- schema-generator  followAliasToWrapperNode: typeName is an Identifier (callers narrow first)
- html  cleanEventProp: key is an event prop (caller gates on isEventProp)
- shell  handleLineClick: entries non-empty (buildAnnotations pushes >= 1)
- shell  score: query non-empty (caller returns early on empty query)

Verified by independent caller audits and the affected package test suites (ts-transformers 290, schema-generator 24, html 28, shell 12, runner 547 — all passing; the throws are never hit on covered paths).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace unreachable early-return guards with explicit throws to enforce preconditions across the codebase. No behavior change for valid callers; callers that violate contracts now get clear errors.

- **Refactors**
  - `ts-transformers`: `ActionStrategy`, `ArrayMethodStrategy`, `HandlerStrategy`, `LiftAppliedStrategy` `transform()` now require specific node kinds; `createLiftAppliedCall` requires non-empty `refs`; `decodePath` requires a non-empty encoded string. `ArrayMethodStrategy` still returns `undefined` when the callback shape doesn’t match (reachable).
  - `runner`: `backfillDependentsForNewWrites` requires non-empty `writes`.
  - `schema-generator`: `followAliasToWrapperNode` requires an `Identifier` `typeName`.
  - `html`: `cleanEventProp` requires an event prop key starting with "on".
  - `shell`: `handleLineClick` requires non-empty `entries`; `score` requires a non-empty query.

- **Migration**
  - Ensure callers satisfy these preconditions; otherwise an error is thrown.
  - No changes needed if current call sites already validate inputs (all package tests pass).

<sup>Written for commit b0082e42e8138b3896a53a4fab68e58c3e8cde24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

