### PR TITLE
feat(storage): per-space host resolution (spaceHostMap)

### DIFF
--- a/packages/background-charm-service/cast-admin.ts
+++ b/packages/background-charm-service/cast-admin.ts
@@ -58,7 +58,7 @@ async function castPattern() {
     apiUrl: new URL(toolshedUrl),
     storageManager: StorageManager.open({
       as: identity,
-      address: new URL("/api/storage/memory", toolshedUrl),
+      apiUrl: new URL(toolshedUrl),
     }),
   });
 

--- a/packages/background-charm-service/cast-admin.ts
+++ b/packages/background-charm-service/cast-admin.ts
@@ -58,7 +58,7 @@ async function castPattern() {
     apiUrl: new URL(toolshedUrl),
     storageManager: StorageManager.open({
       as: identity,
-      apiUrl: new URL(toolshedUrl),
+      memoryHost: new URL(toolshedUrl),
     }),
   });
 

--- a/packages/background-charm-service/src/main.ts
+++ b/packages/background-charm-service/src/main.ts
@@ -29,7 +29,7 @@ const runtime = new Runtime({
   apiUrl: new URL(env.API_URL),
   storageManager: StorageManager.open({
     as: identity,
-    apiUrl: new URL(env.API_URL),
+    memoryHost: new URL(env.API_URL),
   }),
   experimental: {
     modernCellRep: env.EXPERIMENTAL_MODERN_CELL_REP,

--- a/packages/background-charm-service/src/main.ts
+++ b/packages/background-charm-service/src/main.ts
@@ -29,7 +29,7 @@ const runtime = new Runtime({
   apiUrl: new URL(env.API_URL),
   storageManager: StorageManager.open({
     as: identity,
-    address: new URL("/api/storage/memory", env.API_URL),
+    apiUrl: new URL(env.API_URL),
   }),
   experimental: {
     modernCellRep: env.EXPERIMENTAL_MODERN_CELL_REP,

--- a/packages/background-charm-service/src/worker.ts
+++ b/packages/background-charm-service/src/worker.ts
@@ -102,7 +102,7 @@ async function initialize(
     apiUrl: new URL(toolshedUrl),
     storageManager: StorageManager.open({
       as: identity,
-      address: new URL("/api/storage/memory", toolshedUrl),
+      apiUrl: new URL(toolshedUrl),
     }),
     patternEnvironment: { apiUrl },
     consoleHandler: consoleHandler,

--- a/packages/background-charm-service/src/worker.ts
+++ b/packages/background-charm-service/src/worker.ts
@@ -102,7 +102,7 @@ async function initialize(
     apiUrl: new URL(toolshedUrl),
     storageManager: StorageManager.open({
       as: identity,
-      apiUrl: new URL(toolshedUrl),
+      memoryHost: new URL(toolshedUrl),
     }),
     patternEnvironment: { apiUrl },
     consoleHandler: consoleHandler,

--- a/packages/cli/lib/acl.ts
+++ b/packages/cli/lib/acl.ts
@@ -40,7 +40,7 @@ export async function createRuntime(
     experimental: experimentalOptionsFromEnv(),
     storageManager: StorageManager.open({
       as: session.as,
-      apiUrl: new URL(config.apiUrl),
+      memoryHost: new URL(config.apiUrl),
       spaceIdentity: session.spaceIdentity,
     }),
   });

--- a/packages/cli/lib/acl.ts
+++ b/packages/cli/lib/acl.ts
@@ -40,7 +40,7 @@ export async function createRuntime(
     experimental: experimentalOptionsFromEnv(),
     storageManager: StorageManager.open({
       as: session.as,
-      address: new URL("/api/storage/memory", config.apiUrl),
+      apiUrl: new URL(config.apiUrl),
       spaceIdentity: session.spaceIdentity,
     }),
   });

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -195,7 +195,7 @@ export async function loadManager(config: SpaceConfig): Promise<PieceManager> {
         experimental: experimentalOptionsFromEnv(),
         storageManager: StorageManager.open({
           as: session.as,
-          apiUrl: new URL(config.apiUrl),
+          memoryHost: new URL(config.apiUrl),
           spaceIdentity: session.spaceIdentity,
         }),
         errorHandlers: [

--- a/packages/cli/lib/piece.ts
+++ b/packages/cli/lib/piece.ts
@@ -195,7 +195,7 @@ export async function loadManager(config: SpaceConfig): Promise<PieceManager> {
         experimental: experimentalOptionsFromEnv(),
         storageManager: StorageManager.open({
           as: session.as,
-          address: new URL("/api/storage/memory", config.apiUrl),
+          apiUrl: new URL(config.apiUrl),
           spaceIdentity: session.spaceIdentity,
         }),
         errorHandlers: [

--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -58,6 +58,11 @@ export type RuntimeInternalsCreateOptions = RuntimeInternalsCallbacks & {
   identity: Identity;
   view: RuntimeView;
   apiUrl: URL;
+  /**
+   * Optional space DID → host base URL map forwarded to the worker.
+   * Spaces absent from the map resolve to `apiUrl` (the default host).
+   */
+  spaceHostMap?: Record<string, string>;
   experimental?: ExperimentalRuntimeFlags;
   cfcEnforcementMode?: RuntimeCfcEnforcementMode;
   trustSnapshot?: RuntimeTrustSnapshot | null;
@@ -111,6 +116,7 @@ export function fetchBuildHash(): Promise<string | undefined> {
 export function createRuntimeClientOptions({
   session,
   apiUrl,
+  spaceHostMap,
   buildHash,
   experimental,
   cfcEnforcementMode = "enforce-explicit",
@@ -118,6 +124,7 @@ export function createRuntimeClientOptions({
 }: {
   session: Session;
   apiUrl: URL;
+  spaceHostMap?: Record<string, string>;
   buildHash?: string;
   experimental?: ExperimentalRuntimeFlags;
   cfcEnforcementMode?: RuntimeCfcEnforcementMode;
@@ -132,6 +139,7 @@ export function createRuntimeClientOptions({
 
   return {
     apiUrl,
+    spaceHostMap,
     identity: session.as,
     spaceIdentity: session.spaceIdentity,
     spaceDid: session.space,
@@ -421,6 +429,7 @@ export class RuntimeInternals extends EventTarget {
     identity,
     view,
     apiUrl,
+    spaceHostMap,
     experimental,
     cfcEnforcementMode,
     trustSnapshot,
@@ -503,6 +512,7 @@ export class RuntimeInternals extends EventTarget {
       createRuntimeClientOptions({
         session,
         apiUrl,
+        spaceHostMap,
         buildHash,
         experimental,
         cfcEnforcementMode,

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -154,7 +154,7 @@ export class PiecesController<T = unknown> {
       apiUrl: new URL(apiUrl),
       storageManager: StorageManager.open({
         as: session.as,
-        apiUrl: new URL(apiUrl),
+        memoryHost: new URL(apiUrl),
         spaceIdentity: session.spaceIdentity,
       }),
       cfcEnforcementMode: "enforce-explicit",

--- a/packages/piece/src/ops/pieces-controller.ts
+++ b/packages/piece/src/ops/pieces-controller.ts
@@ -154,7 +154,7 @@ export class PiecesController<T = unknown> {
       apiUrl: new URL(apiUrl),
       storageManager: StorageManager.open({
         as: session.as,
-        address: new URL("/api/storage/memory", apiUrl),
+        apiUrl: new URL(apiUrl),
         spaceIdentity: session.spaceIdentity,
       }),
       cfcEnforcementMode: "enforce-explicit",

--- a/packages/runner/integration/array_push.test.ts
+++ b/packages/runner/integration/array_push.test.ts
@@ -63,7 +63,7 @@ function createRuntime(identity: Identity, base: URL): Runtime {
     apiUrl: base,
     storageManager: StorageManager.open({
       as: identity,
-      address: new URL("/api/storage/memory", base),
+      apiUrl: new URL(base),
     }),
     experimental: {
       modernCellRep: readExperimentalFlag("EXPERIMENTAL_MODERN_CELL_REP"),

--- a/packages/runner/integration/array_push.test.ts
+++ b/packages/runner/integration/array_push.test.ts
@@ -63,7 +63,7 @@ function createRuntime(identity: Identity, base: URL): Runtime {
     apiUrl: base,
     storageManager: StorageManager.open({
       as: identity,
-      apiUrl: new URL(base),
+      memoryHost: new URL(base),
     }),
     experimental: {
       modernCellRep: readExperimentalFlag("EXPERIMENTAL_MODERN_CELL_REP"),

--- a/packages/runner/integration/basic-persistence.test.ts
+++ b/packages/runner/integration/basic-persistence.test.ts
@@ -23,7 +23,7 @@ async function test() {
     apiUrl: new URL(API_URL),
     storageManager: StorageManager.open({
       as: identity,
-      address: new URL("/api/storage/memory", API_URL),
+      apiUrl: new URL(API_URL),
     }),
   });
 
@@ -54,7 +54,7 @@ async function test() {
     apiUrl: new URL(API_URL),
     storageManager: StorageManager.open({
       as: identity,
-      address: new URL("/api/storage/memory", API_URL),
+      apiUrl: new URL(API_URL),
     }),
   });
 

--- a/packages/runner/integration/basic-persistence.test.ts
+++ b/packages/runner/integration/basic-persistence.test.ts
@@ -23,7 +23,7 @@ async function test() {
     apiUrl: new URL(API_URL),
     storageManager: StorageManager.open({
       as: identity,
-      apiUrl: new URL(API_URL),
+      memoryHost: new URL(API_URL),
     }),
   });
 
@@ -54,7 +54,7 @@ async function test() {
     apiUrl: new URL(API_URL),
     storageManager: StorageManager.open({
       as: identity,
-      apiUrl: new URL(API_URL),
+      memoryHost: new URL(API_URL),
     }),
   });
 

--- a/packages/runner/integration/derive_array_leak.test.ts
+++ b/packages/runner/integration/derive_array_leak.test.ts
@@ -95,7 +95,7 @@ async function runTest() {
   // Create storage manager
   const storageManager = StorageManager.open({
     as: session.as,
-    address: new URL("/api/storage/memory", API_URL),
+    apiUrl: new URL(API_URL),
   });
 
   // Create runtime

--- a/packages/runner/integration/derive_array_leak.test.ts
+++ b/packages/runner/integration/derive_array_leak.test.ts
@@ -95,7 +95,7 @@ async function runTest() {
   // Create storage manager
   const storageManager = StorageManager.open({
     as: session.as,
-    apiUrl: new URL(API_URL),
+    memoryHost: new URL(API_URL),
   });
 
   // Create runtime

--- a/packages/runner/integration/memory-v2-reactivity.test.ts
+++ b/packages/runner/integration/memory-v2-reactivity.test.ts
@@ -24,7 +24,7 @@ const createRuntime = (identity: Identity, base: URL) =>
     apiUrl: base,
     storageManager: StorageManager.open({
       as: identity,
-      apiUrl: new URL(base),
+      memoryHost: new URL(base),
     }),
   });
 

--- a/packages/runner/integration/memory-v2-reactivity.test.ts
+++ b/packages/runner/integration/memory-v2-reactivity.test.ts
@@ -24,7 +24,7 @@ const createRuntime = (identity: Identity, base: URL) =>
     apiUrl: base,
     storageManager: StorageManager.open({
       as: identity,
-      address: new URL("/api/storage/memory", base),
+      apiUrl: new URL(base),
     }),
   });
 

--- a/packages/runner/integration/pattern-and-data-persistence.test.ts
+++ b/packages/runner/integration/pattern-and-data-persistence.test.ts
@@ -95,7 +95,7 @@ interface TestContext {
 function createTestContext(identity: Identity): TestContext {
   const storageManager = StorageManager.open({
     as: identity,
-    address: new URL("/api/storage/memory", API_URL),
+    apiUrl: new URL(API_URL),
   });
   const runtime = new Runtime({
     apiUrl: API_URL,

--- a/packages/runner/integration/pattern-and-data-persistence.test.ts
+++ b/packages/runner/integration/pattern-and-data-persistence.test.ts
@@ -95,7 +95,7 @@ interface TestContext {
 function createTestContext(identity: Identity): TestContext {
   const storageManager = StorageManager.open({
     as: identity,
-    apiUrl: new URL(API_URL),
+    memoryHost: new URL(API_URL),
   });
   const runtime = new Runtime({
     apiUrl: API_URL,

--- a/packages/runner/integration/reconnection.test.ts
+++ b/packages/runner/integration/reconnection.test.ts
@@ -24,7 +24,7 @@ const createRuntime = (identity: Identity, base: URL) =>
     apiUrl: base,
     storageManager: StorageManager.open({
       as: identity,
-      apiUrl: new URL(base),
+      memoryHost: new URL(base),
     }),
   });
 

--- a/packages/runner/integration/reconnection.test.ts
+++ b/packages/runner/integration/reconnection.test.ts
@@ -24,7 +24,7 @@ const createRuntime = (identity: Identity, base: URL) =>
     apiUrl: base,
     storageManager: StorageManager.open({
       as: identity,
-      address: new URL("/api/storage/memory", base),
+      apiUrl: new URL(base),
     }),
   });
 

--- a/packages/runner/integration/sqlite-cfc-label-link.test.ts
+++ b/packages/runner/integration/sqlite-cfc-label-link.test.ts
@@ -24,7 +24,7 @@ async function runTest(base: URL) {
     apiUrl: base,
     storageManager: StorageManager.open({
       as: account,
-      apiUrl: new URL(base),
+      memoryHost: new URL(base),
     }),
   });
   const space = account.did();

--- a/packages/runner/integration/sqlite-cfc-label-link.test.ts
+++ b/packages/runner/integration/sqlite-cfc-label-link.test.ts
@@ -24,7 +24,7 @@ async function runTest(base: URL) {
     apiUrl: base,
     storageManager: StorageManager.open({
       as: account,
-      address: new URL("/api/storage/memory", base),
+      apiUrl: new URL(base),
     }),
   });
   const space = account.did();

--- a/packages/runner/integration/sqlite-cfc-label.test.ts
+++ b/packages/runner/integration/sqlite-cfc-label.test.ts
@@ -26,7 +26,7 @@ async function runTest(base: URL) {
     apiUrl: base,
     storageManager: StorageManager.open({
       as: account,
-      address: new URL("/api/storage/memory", base),
+      apiUrl: new URL(base),
     }),
   });
   const space = account.did();

--- a/packages/runner/integration/sqlite-cfc-label.test.ts
+++ b/packages/runner/integration/sqlite-cfc-label.test.ts
@@ -26,7 +26,7 @@ async function runTest(base: URL) {
     apiUrl: base,
     storageManager: StorageManager.open({
       as: account,
-      apiUrl: new URL(base),
+      memoryHost: new URL(base),
     }),
   });
   const space = account.did();

--- a/packages/runner/integration/sqlite-db-query-decode.test.ts
+++ b/packages/runner/integration/sqlite-db-query-decode.test.ts
@@ -23,7 +23,7 @@ async function runTest(base: URL) {
     apiUrl: base,
     storageManager: StorageManager.open({
       as: account,
-      apiUrl: new URL(base),
+      memoryHost: new URL(base),
     }),
   });
   const space = account.did();

--- a/packages/runner/integration/sqlite-db-query-decode.test.ts
+++ b/packages/runner/integration/sqlite-db-query-decode.test.ts
@@ -23,7 +23,7 @@ async function runTest(base: URL) {
     apiUrl: base,
     storageManager: StorageManager.open({
       as: account,
-      address: new URL("/api/storage/memory", base),
+      apiUrl: new URL(base),
     }),
   });
   const space = account.did();

--- a/packages/runner/integration/sync-schema-path.test.ts
+++ b/packages/runner/integration/sync-schema-path.test.ts
@@ -41,7 +41,7 @@ async function test() {
     apiUrl: new URL(API_URL),
     storageManager: StorageManager.open({
       as: identity,
-      apiUrl: new URL(API_URL),
+      memoryHost: new URL(API_URL),
     }),
   });
   const addressSchema = {
@@ -113,7 +113,7 @@ async function test() {
     apiUrl: new URL(API_URL),
     storageManager: StorageManager.open({
       as: identity,
-      apiUrl: new URL(API_URL),
+      memoryHost: new URL(API_URL),
     }),
   });
 

--- a/packages/runner/integration/sync-schema-path.test.ts
+++ b/packages/runner/integration/sync-schema-path.test.ts
@@ -41,7 +41,7 @@ async function test() {
     apiUrl: new URL(API_URL),
     storageManager: StorageManager.open({
       as: identity,
-      address: new URL("/api/storage/memory", API_URL),
+      apiUrl: new URL(API_URL),
     }),
   });
   const addressSchema = {
@@ -113,7 +113,7 @@ async function test() {
     apiUrl: new URL(API_URL),
     storageManager: StorageManager.open({
       as: identity,
-      address: new URL("/api/storage/memory", API_URL),
+      apiUrl: new URL(API_URL),
     }),
   });
 

--- a/packages/runner/src/storage/cache.deno.ts
+++ b/packages/runner/src/storage/cache.deno.ts
@@ -18,7 +18,7 @@ export class StorageManager extends V2Storage.StorageManager {
   }
 
   static emulate(
-    options: Omit<V2Storage.Options, "address">,
+    options: Omit<V2Storage.Options, "apiUrl">,
   ): EmulatedStorageManager {
     return EmulatedStorageManager.emulate(options);
   }

--- a/packages/runner/src/storage/cache.deno.ts
+++ b/packages/runner/src/storage/cache.deno.ts
@@ -18,7 +18,7 @@ export class StorageManager extends V2Storage.StorageManager {
   }
 
   static emulate(
-    options: Omit<V2Storage.Options, "apiUrl">,
+    options: Omit<V2Storage.Options, "memoryHost" | "spaceHostMap">,
   ): EmulatedStorageManager {
     return EmulatedStorageManager.emulate(options);
   }

--- a/packages/runner/src/storage/v2-emulate.ts
+++ b/packages/runner/src/storage/v2-emulate.ts
@@ -25,12 +25,12 @@ export class EmulatedStorageManager extends StorageManager {
   #server?: MemoryV2Server.Server;
 
   static emulate(
-    options: Omit<Options, "address">,
+    options: Omit<Options, "apiUrl">,
   ): EmulatedStorageManager {
     return new this(
       {
         ...options,
-        address: new URL("memory://"),
+        apiUrl: new URL("memory://"),
       },
       () =>
         new MemoryV2Server.Server({

--- a/packages/runner/src/storage/v2-emulate.ts
+++ b/packages/runner/src/storage/v2-emulate.ts
@@ -25,12 +25,14 @@ export class EmulatedStorageManager extends StorageManager {
   #server?: MemoryV2Server.Server;
 
   static emulate(
-    options: Omit<Options, "apiUrl">,
+    options: Omit<Options, "memoryHost" | "spaceHostMap">,
   ): EmulatedStorageManager {
     return new this(
       {
         ...options,
-        apiUrl: new URL("memory://"),
+        // Placeholder: the emulated session factory is loopback and never
+        // resolves a storage address against this.
+        memoryHost: new URL("memory://"),
       },
       () =>
         new MemoryV2Server.Server({

--- a/packages/runner/src/storage/v2-remote-session.ts
+++ b/packages/runner/src/storage/v2-remote-session.ts
@@ -30,6 +30,23 @@ export const toSpaceWebSocketAddress = (
   return next;
 };
 
+/** Path every memory host serves its storage endpoint under. */
+export const MEMORY_STORAGE_PATH = "/api/storage/memory";
+
+/**
+ * Build the per-space storage-endpoint resolver: a space present in
+ * `spaceHostMap` resolves against that host's base URL, everything else
+ * against `defaultApiUrl`. Host selection lives here, next to the
+ * websocket address builders, so the storage-endpoint join happens in
+ * exactly one place.
+ */
+export const createStorageAddressResolver = (
+  defaultApiUrl: URL,
+  spaceHostMap?: Record<string, string>,
+): (space: MemorySpace) => URL =>
+(space) =>
+  new URL(MEMORY_STORAGE_PATH, spaceHostMap?.[space] ?? defaultApiUrl);
+
 class WebSocketTransport implements MemoryClient.Transport {
   #receiver: (payload: string) => void = () => {};
   #closeReceiver: (error?: Error) => void = () => {};
@@ -126,7 +143,7 @@ class WebSocketTransport implements MemoryClient.Transport {
 
 export class RemoteSessionFactory implements SessionFactory {
   constructor(
-    private readonly address: URL,
+    private readonly resolveAddress: (space: MemorySpace) => URL,
     private readonly defaultSigner: Signer,
   ) {}
 
@@ -163,7 +180,7 @@ export class RemoteSessionFactory implements SessionFactory {
   async create(space: MemorySpace, signer = this.defaultSigner) {
     const client = await MemoryClient.connect({
       transport: new WebSocketTransport(
-        toSpaceWebSocketAddress(this.address, space),
+        toSpaceWebSocketAddress(this.resolveAddress(space), space),
       ),
     });
     const session = await client.mount(

--- a/packages/runner/src/storage/v2-remote-session.ts
+++ b/packages/runner/src/storage/v2-remote-session.ts
@@ -44,8 +44,7 @@ export const createStorageAddressResolver = (
   defaultApiUrl: URL,
   spaceHostMap?: Record<string, string>,
 ): (space: MemorySpace) => URL =>
-(space) =>
-  new URL(MEMORY_STORAGE_PATH, spaceHostMap?.[space] ?? defaultApiUrl);
+(space) => new URL(MEMORY_STORAGE_PATH, spaceHostMap?.[space] ?? defaultApiUrl);
 
 class WebSocketTransport implements MemoryClient.Transport {
   #receiver: (payload: string) => void = () => {};

--- a/packages/runner/src/storage/v2-remote-session.ts
+++ b/packages/runner/src/storage/v2-remote-session.ts
@@ -36,15 +36,32 @@ export const MEMORY_STORAGE_PATH = "/api/storage/memory";
 /**
  * Build the per-space storage-endpoint resolver: a space present in
  * `spaceHostMap` resolves against that host's base URL, everything else
- * against `defaultApiUrl`. Host selection lives here, next to the
+ * against `defaultHost`. Host selection lives here, next to the
  * websocket address builders, so the storage-endpoint join happens in
  * exactly one place.
+ *
+ * Map entries are validated eagerly so a malformed host fails at
+ * configuration time with the offending space named, not later inside
+ * session creation as a bare `Invalid URL`.
  */
 export const createStorageAddressResolver = (
-  defaultApiUrl: URL,
+  defaultHost: URL,
   spaceHostMap?: Record<string, string>,
-): (space: MemorySpace) => URL =>
-(space) => new URL(MEMORY_STORAGE_PATH, spaceHostMap?.[space] ?? defaultApiUrl);
+): (space: MemorySpace) => URL => {
+  const overrides = new Map<string, URL>();
+  for (const [space, host] of Object.entries(spaceHostMap ?? {})) {
+    try {
+      overrides.set(space, new URL(MEMORY_STORAGE_PATH, host));
+    } catch (cause) {
+      throw new Error(
+        `Invalid spaceHostMap entry for ${space}: "${host}"`,
+        { cause },
+      );
+    }
+  }
+  const fallback = new URL(MEMORY_STORAGE_PATH, defaultHost);
+  return (space) => new URL(overrides.get(space) ?? fallback);
+};
 
 class WebSocketTransport implements MemoryClient.Transport {
   #receiver: (payload: string) => void = () => {};

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -81,6 +81,7 @@ import {
   watchIdForEntry,
 } from "./v2-watch.ts";
 import {
+  createStorageAddressResolver,
   RemoteSessionFactory,
   type SessionFactory,
 } from "./v2-remote-session.ts";
@@ -370,7 +371,18 @@ const dropMaterializedSuffix = (
 
 export interface Options {
   as: Signer;
-  address: URL;
+  /**
+   * Default host base URL. The storage endpoint path
+   * (`/api/storage/memory`) is joined internally — pass the host, not
+   * the full endpoint.
+   */
+  apiUrl: URL;
+  /**
+   * Optional space DID → host base URL overrides. A space listed here
+   * opens its storage connection against that host; absent map or
+   * absent entry resolves to `apiUrl`.
+   */
+  spaceHostMap?: Record<string, string>;
   id?: string;
   settings?: IRemoteStorageProviderSettings;
   spaceIdentity?: Signer;
@@ -531,7 +543,10 @@ export class StorageManager implements IStorageManager {
   static open(options: Options) {
     return new this(
       options,
-      new RemoteSessionFactory(options.address, options.as),
+      new RemoteSessionFactory(
+        createStorageAddressResolver(options.apiUrl, options.spaceHostMap),
+        options.as,
+      ),
     );
   }
 

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -372,15 +372,17 @@ const dropMaterializedSuffix = (
 export interface Options {
   as: Signer;
   /**
-   * Default host base URL. The storage endpoint path
+   * Base URL of the default memory host. The storage endpoint path
    * (`/api/storage/memory`) is joined internally — pass the host, not
    * the full endpoint.
    */
-  apiUrl: URL;
+  memoryHost: URL;
   /**
    * Optional space DID → host base URL overrides. A space listed here
    * opens its storage connection against that host; absent map or
-   * absent entry resolves to `apiUrl`.
+   * absent entry resolves to `memoryHost`. The map is fixed for the
+   * manager's lifetime (the per-space provider cache assumes space →
+   * host never changes).
    */
   spaceHostMap?: Record<string, string>;
   id?: string;
@@ -544,7 +546,7 @@ export class StorageManager implements IStorageManager {
     return new this(
       options,
       new RemoteSessionFactory(
-        createStorageAddressResolver(options.apiUrl, options.spaceHostMap),
+        createStorageAddressResolver(options.memoryHost, options.spaceHostMap),
         options.as,
       ),
     );

--- a/packages/runner/test/cfc-boundary.test.ts
+++ b/packages/runner/test/cfc-boundary.test.ts
@@ -1881,11 +1881,11 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     const server = new MemoryV2Server.Server();
     const storageManagerA = new SharedV2StorageManager({
       as: signer,
-      apiUrl: new URL("memory://"),
+      memoryHost: new URL("memory://"),
     }, server);
     const storageManagerB = new SharedV2StorageManager({
       as: signer,
-      apiUrl: new URL("memory://"),
+      memoryHost: new URL("memory://"),
     }, server);
     const runtimeA = new Runtime({
       apiUrl: new URL("https://example.com"),
@@ -3770,7 +3770,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     const createStorageManager = () =>
       new SharedV2StorageManager({
         as: signer,
-        apiUrl: new URL("memory://"),
+        memoryHost: new URL("memory://"),
       }, server);
     const storageManager1 = createStorageManager();
     const runtime1 = new Runtime({
@@ -3851,7 +3851,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     const createStorageManager = () =>
       new SharedV2StorageManager({
         as: signer,
-        apiUrl: new URL("memory://"),
+        memoryHost: new URL("memory://"),
       }, server);
     const storageManager1 = createStorageManager();
     const runtime1 = new Runtime({

--- a/packages/runner/test/cfc-boundary.test.ts
+++ b/packages/runner/test/cfc-boundary.test.ts
@@ -1881,11 +1881,11 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     const server = new MemoryV2Server.Server();
     const storageManagerA = new SharedV2StorageManager({
       as: signer,
-      address: new URL("memory://"),
+      apiUrl: new URL("memory://"),
     }, server);
     const storageManagerB = new SharedV2StorageManager({
       as: signer,
-      address: new URL("memory://"),
+      apiUrl: new URL("memory://"),
     }, server);
     const runtimeA = new Runtime({
       apiUrl: new URL("https://example.com"),
@@ -3770,7 +3770,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     const createStorageManager = () =>
       new SharedV2StorageManager({
         as: signer,
-        address: new URL("memory://"),
+        apiUrl: new URL("memory://"),
       }, server);
     const storageManager1 = createStorageManager();
     const runtime1 = new Runtime({
@@ -3851,7 +3851,7 @@ describe("ExtendedStorageTransaction CFC gate", () => {
     const createStorageManager = () =>
       new SharedV2StorageManager({
         as: signer,
-        address: new URL("memory://"),
+        apiUrl: new URL("memory://"),
       }, server);
     const storageManager1 = createStorageManager();
     const runtime1 = new Runtime({

--- a/packages/runner/test/memory-v2-lazy-session.test.ts
+++ b/packages/runner/test/memory-v2-lazy-session.test.ts
@@ -14,13 +14,13 @@ const type = "application/json" as const;
 
 class TestEmulatedStorageManager extends EmulatedStorageManager {
   static emulateWithServerFactory(
-    options: Omit<V2StorageOptions, "apiUrl">,
+    options: Omit<V2StorageOptions, "memoryHost" | "spaceHostMap">,
     serverFactory: () => MemoryV2Server.Server,
   ): TestEmulatedStorageManager {
     return new this(
       {
         ...options,
-        apiUrl: new URL("memory://"),
+        memoryHost: new URL("memory://"),
       },
       serverFactory,
     );
@@ -52,7 +52,7 @@ describe("Memory v2 lazy session creation", () => {
     let sessionCreates = 0;
     const storage = TestStorageManager.create({
       as: signer,
-      apiUrl: new URL("memory://"),
+      memoryHost: new URL("memory://"),
     }, {
       create(_space: MemorySpace) {
         sessionCreates += 1;
@@ -96,7 +96,7 @@ describe("Memory v2 lazy session creation", () => {
     let closes = 0;
     const storage = TestStorageManager.create({
       as: signer,
-      apiUrl: new URL("memory://"),
+      memoryHost: new URL("memory://"),
     }, {
       create(_space: MemorySpace) {
         sessionCreates += 1;
@@ -146,7 +146,7 @@ describe("Memory v2 lazy session creation", () => {
     let closes = 0;
     const storage = TestStorageManager.create({
       as: signer,
-      apiUrl: new URL("memory://"),
+      memoryHost: new URL("memory://"),
     }, {
       create(_space: MemorySpace) {
         sessionCreates += 1;

--- a/packages/runner/test/memory-v2-lazy-session.test.ts
+++ b/packages/runner/test/memory-v2-lazy-session.test.ts
@@ -14,13 +14,13 @@ const type = "application/json" as const;
 
 class TestEmulatedStorageManager extends EmulatedStorageManager {
   static emulateWithServerFactory(
-    options: Omit<V2StorageOptions, "address">,
+    options: Omit<V2StorageOptions, "apiUrl">,
     serverFactory: () => MemoryV2Server.Server,
   ): TestEmulatedStorageManager {
     return new this(
       {
         ...options,
-        address: new URL("memory://"),
+        apiUrl: new URL("memory://"),
       },
       serverFactory,
     );
@@ -52,7 +52,7 @@ describe("Memory v2 lazy session creation", () => {
     let sessionCreates = 0;
     const storage = TestStorageManager.create({
       as: signer,
-      address: new URL("memory://"),
+      apiUrl: new URL("memory://"),
     }, {
       create(_space: MemorySpace) {
         sessionCreates += 1;
@@ -96,7 +96,7 @@ describe("Memory v2 lazy session creation", () => {
     let closes = 0;
     const storage = TestStorageManager.create({
       as: signer,
-      address: new URL("memory://"),
+      apiUrl: new URL("memory://"),
     }, {
       create(_space: MemorySpace) {
         sessionCreates += 1;
@@ -146,7 +146,7 @@ describe("Memory v2 lazy session creation", () => {
     let closes = 0;
     const storage = TestStorageManager.create({
       as: signer,
-      address: new URL("memory://"),
+      apiUrl: new URL("memory://"),
     }, {
       create(_space: MemorySpace) {
         sessionCreates += 1;

--- a/packages/runner/test/memory-v2-reconnect-race.test.ts
+++ b/packages/runner/test/memory-v2-reconnect-race.test.ts
@@ -271,7 +271,7 @@ Deno.test("memory v2 runner does not integrate its own replayed commit after rec
   const sessionFactory = new SingleSessionFactory(transport);
   const storageManager = TestStorageManager.create({
     as: signer,
-    address: new URL("memory://runner-v2-own-replay"),
+    apiUrl: new URL("memory://runner-v2-own-replay"),
   }, sessionFactory);
   const notifications = new NotificationRecorder();
   const writerClient = await MemoryV2Client.connect({
@@ -356,7 +356,7 @@ Deno.test("memory v2 runner deduplicates replayed stacked commits while integrat
   const sessionFactory = new SingleSessionFactory(transport);
   const storageManager = TestStorageManager.create({
     as: signer,
-    address: new URL("memory://runner-v2-stacked-replay"),
+    apiUrl: new URL("memory://runner-v2-stacked-replay"),
   }, sessionFactory);
   const notifications = new NotificationRecorder();
   const writerClient = await MemoryV2Client.connect({
@@ -443,7 +443,7 @@ Deno.test("memory v2 runner restores watched graph state after reconnect and kee
   const sessionFactory = new SingleSessionFactory(transport);
   const storageManager = TestStorageManager.create({
     as: signer,
-    address: new URL("memory://runner-v2-watch-reconnect"),
+    apiUrl: new URL("memory://runner-v2-watch-reconnect"),
   }, sessionFactory);
   const notifications = new NotificationRecorder();
   const writerClient = await MemoryV2Client.connect({
@@ -671,7 +671,7 @@ Deno.test("memory v2 runner keeps later independent pending commits after an ear
   const sessionFactory = new SingleSessionFactory(transport);
   const storageManager = TestStorageManager.create({
     as: signer,
-    address: new URL("memory://runner-v2-reject-then-succeed"),
+    apiUrl: new URL("memory://runner-v2-reject-then-succeed"),
   }, sessionFactory);
   const notifications = new NotificationRecorder();
   const provider = storageManager.open(space) as TestProvider;

--- a/packages/runner/test/memory-v2-reconnect-race.test.ts
+++ b/packages/runner/test/memory-v2-reconnect-race.test.ts
@@ -271,7 +271,7 @@ Deno.test("memory v2 runner does not integrate its own replayed commit after rec
   const sessionFactory = new SingleSessionFactory(transport);
   const storageManager = TestStorageManager.create({
     as: signer,
-    apiUrl: new URL("memory://runner-v2-own-replay"),
+    memoryHost: new URL("memory://runner-v2-own-replay"),
   }, sessionFactory);
   const notifications = new NotificationRecorder();
   const writerClient = await MemoryV2Client.connect({
@@ -356,7 +356,7 @@ Deno.test("memory v2 runner deduplicates replayed stacked commits while integrat
   const sessionFactory = new SingleSessionFactory(transport);
   const storageManager = TestStorageManager.create({
     as: signer,
-    apiUrl: new URL("memory://runner-v2-stacked-replay"),
+    memoryHost: new URL("memory://runner-v2-stacked-replay"),
   }, sessionFactory);
   const notifications = new NotificationRecorder();
   const writerClient = await MemoryV2Client.connect({
@@ -443,7 +443,7 @@ Deno.test("memory v2 runner restores watched graph state after reconnect and kee
   const sessionFactory = new SingleSessionFactory(transport);
   const storageManager = TestStorageManager.create({
     as: signer,
-    apiUrl: new URL("memory://runner-v2-watch-reconnect"),
+    memoryHost: new URL("memory://runner-v2-watch-reconnect"),
   }, sessionFactory);
   const notifications = new NotificationRecorder();
   const writerClient = await MemoryV2Client.connect({
@@ -671,7 +671,7 @@ Deno.test("memory v2 runner keeps later independent pending commits after an ear
   const sessionFactory = new SingleSessionFactory(transport);
   const storageManager = TestStorageManager.create({
     as: signer,
-    apiUrl: new URL("memory://runner-v2-reject-then-succeed"),
+    memoryHost: new URL("memory://runner-v2-reject-then-succeed"),
   }, sessionFactory);
   const notifications = new NotificationRecorder();
   const provider = storageManager.open(space) as TestProvider;

--- a/packages/runner/test/memory-v2-remote-session.test.ts
+++ b/packages/runner/test/memory-v2-remote-session.test.ts
@@ -1,6 +1,9 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
+import type { MemorySpace } from "@commonfabric/memory/interface";
 import {
+  createStorageAddressResolver,
+  MEMORY_STORAGE_PATH,
   toSpaceWebSocketAddress,
   toWebSocketAddress,
 } from "../src/storage/v2-remote-session.ts";
@@ -32,6 +35,65 @@ describe("memory v2 remote session websocket address", () => {
       ).toString(),
     ).toBe(
       "wss://example.test/api/storage/memory?trace=1&space=did%3Akey%3Az6Mk-storage-space",
+    );
+  });
+});
+
+describe("per-space storage address resolution", () => {
+  const spaceA = "did:key:z6Mk-space-a" as MemorySpace;
+  const spaceB = "did:key:z6Mk-space-b" as MemorySpace;
+
+  it("resolves every space to the default host without a map", () => {
+    const resolve = createStorageAddressResolver(
+      new URL("https://host-a.test"),
+    );
+    expect(resolve(spaceA).toString()).toBe(
+      `https://host-a.test${MEMORY_STORAGE_PATH}`,
+    );
+    expect(resolve(spaceB).toString()).toBe(
+      `https://host-a.test${MEMORY_STORAGE_PATH}`,
+    );
+  });
+
+  it("resolves a mapped space to its host and others to the default", () => {
+    const resolve = createStorageAddressResolver(
+      new URL("https://host-a.test"),
+      { [spaceB]: "https://host-b.test:8000" },
+    );
+    expect(resolve(spaceA).toString()).toBe(
+      `https://host-a.test${MEMORY_STORAGE_PATH}`,
+    );
+    expect(resolve(spaceB).toString()).toBe(
+      `https://host-b.test:8000${MEMORY_STORAGE_PATH}`,
+    );
+  });
+
+  it("yields distinct websocket targets for spaces on distinct hosts", () => {
+    const resolve = createStorageAddressResolver(
+      new URL("http://host-a.test"),
+      { [spaceB]: "http://host-b.test" },
+    );
+    const wsA = toSpaceWebSocketAddress(resolve(spaceA), spaceA);
+    const wsB = toSpaceWebSocketAddress(resolve(spaceB), spaceB);
+    expect(wsA.host).not.toBe(wsB.host);
+    expect(wsA.toString()).toBe(
+      `ws://host-a.test${MEMORY_STORAGE_PATH}?space=${
+        encodeURIComponent(spaceA)
+      }`,
+    );
+    expect(wsB.toString()).toBe(
+      `ws://host-b.test${MEMORY_STORAGE_PATH}?space=${
+        encodeURIComponent(spaceB)
+      }`,
+    );
+  });
+
+  it("ignores any path on the host base URL (host selection only)", () => {
+    const resolve = createStorageAddressResolver(
+      new URL("https://host-a.test/some/base/"),
+    );
+    expect(resolve(spaceA).toString()).toBe(
+      `https://host-a.test${MEMORY_STORAGE_PATH}`,
     );
   });
 });

--- a/packages/runner/test/memory-v2-remote-session.test.ts
+++ b/packages/runner/test/memory-v2-remote-session.test.ts
@@ -1,12 +1,14 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
-import type { MemorySpace } from "@commonfabric/memory/interface";
+import { Identity } from "@commonfabric/identity";
+import type { MemorySpace, URI } from "@commonfabric/memory/interface";
 import {
   createStorageAddressResolver,
   MEMORY_STORAGE_PATH,
   toSpaceWebSocketAddress,
   toWebSocketAddress,
 } from "../src/storage/v2-remote-session.ts";
+import { StorageManager } from "../src/storage/v2.ts";
 
 describe("memory v2 remote session websocket address", () => {
   it("upgrades http and https urls to websocket protocols", () => {
@@ -95,5 +97,70 @@ describe("per-space storage address resolution", () => {
     expect(resolve(spaceA).toString()).toBe(
       `https://host-a.test${MEMORY_STORAGE_PATH}`,
     );
+  });
+
+  it("rejects a malformed spaceHostMap entry eagerly, naming the space", () => {
+    expect(() =>
+      createStorageAddressResolver(
+        new URL("https://host-a.test"),
+        { [spaceB]: "not a url" },
+      )
+    ).toThrow(`Invalid spaceHostMap entry for ${spaceB}`);
+  });
+});
+
+/**
+ * Stand-in WebSocket that records every dialed URL and never connects.
+ * Session creation stalls on the silent socket, which is fine: the test
+ * only asserts which hosts were dialed.
+ */
+class RecordingWebSocket extends EventTarget {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  static dialed: string[] = [];
+  readyState = RecordingWebSocket.CONNECTING;
+  constructor(url: string | URL) {
+    super();
+    RecordingWebSocket.dialed.push(url.toString());
+  }
+  send(_payload: string): void {}
+  close(): void {}
+}
+
+describe("StorageManager per-space host wiring", () => {
+  // The pending session promises hold no resources, but their microtask
+  // chains outlive the test body; opt out of the op sanitizer for that.
+  it("dials a mapped space on its host and others on the default", {
+    sanitizeOps: false,
+    sanitizeResources: false,
+  }, async () => {
+    const realWebSocket = globalThis.WebSocket;
+    (globalThis as { WebSocket: unknown }).WebSocket = RecordingWebSocket;
+    try {
+      const signer = await Identity.fromPassphrase("per-space-host-wiring");
+      const spaceA = signer.did();
+      const spaceB = "did:key:z6Mk-other-space" as MemorySpace;
+      const manager = StorageManager.open({
+        as: signer,
+        memoryHost: new URL("http://host-a.test"),
+        spaceHostMap: { [spaceB]: "http://host-b.test" },
+      });
+      manager.open(spaceA).sync("of:wiring-probe" as URI).catch(() => {});
+      manager.open(spaceB).sync("of:wiring-probe" as URI).catch(() => {});
+      const deadline = Date.now() + 2_000;
+      while (RecordingWebSocket.dialed.length < 2 && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      const hosts = RecordingWebSocket.dialed.map((url) => new URL(url).host)
+        .sort();
+      expect(hosts).toEqual(["host-a.test", "host-b.test"]);
+      for (const url of RecordingWebSocket.dialed) {
+        expect(new URL(url).pathname).toBe(MEMORY_STORAGE_PATH);
+      }
+    } finally {
+      (globalThis as { WebSocket: unknown }).WebSocket = realWebSocket;
+    }
   });
 });

--- a/packages/runner/test/memory-v2-remote-session.test.ts
+++ b/packages/runner/test/memory-v2-remote-session.test.ts
@@ -120,10 +120,27 @@ class RecordingWebSocket extends EventTarget {
   static readonly CLOSING = 2;
   static readonly CLOSED = 3;
   static dialed: string[] = [];
+  static #waiters: Array<{ count: number; resolve: () => void }> = [];
   readyState = RecordingWebSocket.CONNECTING;
   constructor(url: string | URL) {
     super();
     RecordingWebSocket.dialed.push(url.toString());
+    RecordingWebSocket.#waiters = RecordingWebSocket.#waiters.filter(
+      (waiter) => {
+        if (RecordingWebSocket.dialed.length >= waiter.count) {
+          waiter.resolve();
+          return false;
+        }
+        return true;
+      },
+    );
+  }
+  /** Resolves once `count` sockets have been dialed — no polling. */
+  static whenDialed(count: number): Promise<void> {
+    if (RecordingWebSocket.dialed.length >= count) return Promise.resolve();
+    return new Promise((resolve) =>
+      RecordingWebSocket.#waiters.push({ count, resolve })
+    );
   }
   send(_payload: string): void {}
   close(): void {}
@@ -149,10 +166,7 @@ describe("StorageManager per-space host wiring", () => {
       });
       manager.open(spaceA).sync("of:wiring-probe" as URI).catch(() => {});
       manager.open(spaceB).sync("of:wiring-probe" as URI).catch(() => {});
-      const deadline = Date.now() + 2_000;
-      while (RecordingWebSocket.dialed.length < 2 && Date.now() < deadline) {
-        await new Promise((resolve) => setTimeout(resolve, 10));
-      }
+      await RecordingWebSocket.whenDialed(2);
       const hosts = RecordingWebSocket.dialed.map((url) => new URL(url).host)
         .sort();
       expect(hosts).toEqual(["host-a.test", "host-b.test"]);

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -425,7 +425,7 @@ const createHarness = () => {
   const sessionFactory = new SingleSessionFactory(transport);
   const storageManager = TestStorageManager.create({
     as: signer,
-    address: new URL(`memory://runner-v2-stacked-${crypto.randomUUID()}`),
+    apiUrl: new URL(`memory://runner-v2-stacked-${crypto.randomUUID()}`),
   }, sessionFactory);
   const notifications = new NotificationRecorder();
   const provider = storageManager.open(space) as TestProvider;

--- a/packages/runner/test/memory-v2-stacked-commit.test.ts
+++ b/packages/runner/test/memory-v2-stacked-commit.test.ts
@@ -425,7 +425,7 @@ const createHarness = () => {
   const sessionFactory = new SingleSessionFactory(transport);
   const storageManager = TestStorageManager.create({
     as: signer,
-    apiUrl: new URL(`memory://runner-v2-stacked-${crypto.randomUUID()}`),
+    memoryHost: new URL(`memory://runner-v2-stacked-${crypto.randomUUID()}`),
   }, sessionFactory);
   const notifications = new NotificationRecorder();
   const provider = storageManager.open(space) as TestProvider;

--- a/packages/runner/test/memory-v2-watch-refresh-race.test.ts
+++ b/packages/runner/test/memory-v2-watch-refresh-race.test.ts
@@ -359,7 +359,7 @@ Deno.test("memory v2 runner batches concurrent watch refreshes", async () => {
   const sessionFactory = new SingleSessionFactory(transport);
   const storageManager = TestStorageManager.create({
     as: signer,
-    address: new URL("memory://runner-v2-watch-refresh-batch"),
+    apiUrl: new URL("memory://runner-v2-watch-refresh-batch"),
   }, sessionFactory);
   const provider = storageManager.open(space) as TestProvider;
 
@@ -387,7 +387,7 @@ Deno.test("memory v2 runner compacts redundant selectors for the same doc", asyn
   const sessionFactory = new SingleSessionFactory(transport);
   const storageManager = TestStorageManager.create({
     as: signer,
-    address: new URL("memory://runner-v2-watch-refresh-compact"),
+    apiUrl: new URL("memory://runner-v2-watch-refresh-compact"),
   }, sessionFactory);
   const provider = storageManager.open(space) as TestProvider;
 
@@ -428,7 +428,7 @@ Deno.test("memory v2 runner deduplicates semantically identical selectors with r
   const sessionFactory = new SingleSessionFactory(transport);
   const storageManager = TestStorageManager.create({
     as: signer,
-    address: new URL("memory://runner-v2-watch-refresh-order"),
+    apiUrl: new URL("memory://runner-v2-watch-refresh-order"),
   }, sessionFactory);
   const provider = storageManager.open(space) as TestProvider;
 
@@ -472,7 +472,7 @@ Deno.test("memory v2 runner incrementally adds later watches after the initial s
   const sessionFactory = new SingleSessionFactory(transport);
   const storageManager = TestStorageManager.create({
     as: signer,
-    address: new URL("memory://runner-v2-watch-add"),
+    apiUrl: new URL("memory://runner-v2-watch-add"),
   }, sessionFactory);
   const provider = storageManager.open(space) as TestProvider;
 
@@ -497,7 +497,7 @@ Deno.test("memory v2 runner does not resend prior pending watches in later batch
   const sessionFactory = new SingleSessionFactory(transport);
   const storageManager = TestStorageManager.create({
     as: signer,
-    address: new URL("memory://runner-v2-watch-add-delta"),
+    apiUrl: new URL("memory://runner-v2-watch-add-delta"),
   }, sessionFactory);
   const provider = storageManager.open(space) as TestProvider;
 
@@ -524,7 +524,7 @@ Deno.test("memory v2 runner resolves synced on a microtask when idle", async () 
   const sessionFactory = new SingleSessionFactory(transport);
   const storageManager = TestStorageManager.create({
     as: signer,
-    address: new URL("memory://runner-v2-synced-microtask"),
+    apiUrl: new URL("memory://runner-v2-synced-microtask"),
   }, sessionFactory);
   using time = new FakeTime();
 
@@ -549,7 +549,7 @@ Deno.test(
     const sessionFactory = new SingleSessionFactory(transport);
     const storageManager = TestStorageManager.create({
       as: signer,
-      address: new URL("memory://runner-v2-synced-cross-space"),
+      apiUrl: new URL("memory://runner-v2-synced-cross-space"),
     }, sessionFactory);
     using time = new FakeTime();
 
@@ -597,7 +597,7 @@ Deno.test("memory v2 runner integrates watch deltas without re-diffing cold watc
   const sessionFactory = new SingleSessionFactory(transport);
   const storageManager = TestStorageManager.create({
     as: signer,
-    address: new URL("memory://runner-v2-watch-delta"),
+    apiUrl: new URL("memory://runner-v2-watch-delta"),
   }, sessionFactory);
   const provider = storageManager.open(space) as TestProvider;
 

--- a/packages/runner/test/memory-v2-watch-refresh-race.test.ts
+++ b/packages/runner/test/memory-v2-watch-refresh-race.test.ts
@@ -359,7 +359,7 @@ Deno.test("memory v2 runner batches concurrent watch refreshes", async () => {
   const sessionFactory = new SingleSessionFactory(transport);
   const storageManager = TestStorageManager.create({
     as: signer,
-    apiUrl: new URL("memory://runner-v2-watch-refresh-batch"),
+    memoryHost: new URL("memory://runner-v2-watch-refresh-batch"),
   }, sessionFactory);
   const provider = storageManager.open(space) as TestProvider;
 
@@ -387,7 +387,7 @@ Deno.test("memory v2 runner compacts redundant selectors for the same doc", asyn
   const sessionFactory = new SingleSessionFactory(transport);
   const storageManager = TestStorageManager.create({
     as: signer,
-    apiUrl: new URL("memory://runner-v2-watch-refresh-compact"),
+    memoryHost: new URL("memory://runner-v2-watch-refresh-compact"),
   }, sessionFactory);
   const provider = storageManager.open(space) as TestProvider;
 
@@ -428,7 +428,7 @@ Deno.test("memory v2 runner deduplicates semantically identical selectors with r
   const sessionFactory = new SingleSessionFactory(transport);
   const storageManager = TestStorageManager.create({
     as: signer,
-    apiUrl: new URL("memory://runner-v2-watch-refresh-order"),
+    memoryHost: new URL("memory://runner-v2-watch-refresh-order"),
   }, sessionFactory);
   const provider = storageManager.open(space) as TestProvider;
 
@@ -472,7 +472,7 @@ Deno.test("memory v2 runner incrementally adds later watches after the initial s
   const sessionFactory = new SingleSessionFactory(transport);
   const storageManager = TestStorageManager.create({
     as: signer,
-    apiUrl: new URL("memory://runner-v2-watch-add"),
+    memoryHost: new URL("memory://runner-v2-watch-add"),
   }, sessionFactory);
   const provider = storageManager.open(space) as TestProvider;
 
@@ -497,7 +497,7 @@ Deno.test("memory v2 runner does not resend prior pending watches in later batch
   const sessionFactory = new SingleSessionFactory(transport);
   const storageManager = TestStorageManager.create({
     as: signer,
-    apiUrl: new URL("memory://runner-v2-watch-add-delta"),
+    memoryHost: new URL("memory://runner-v2-watch-add-delta"),
   }, sessionFactory);
   const provider = storageManager.open(space) as TestProvider;
 
@@ -524,7 +524,7 @@ Deno.test("memory v2 runner resolves synced on a microtask when idle", async () 
   const sessionFactory = new SingleSessionFactory(transport);
   const storageManager = TestStorageManager.create({
     as: signer,
-    apiUrl: new URL("memory://runner-v2-synced-microtask"),
+    memoryHost: new URL("memory://runner-v2-synced-microtask"),
   }, sessionFactory);
   using time = new FakeTime();
 
@@ -549,7 +549,7 @@ Deno.test(
     const sessionFactory = new SingleSessionFactory(transport);
     const storageManager = TestStorageManager.create({
       as: signer,
-      apiUrl: new URL("memory://runner-v2-synced-cross-space"),
+      memoryHost: new URL("memory://runner-v2-synced-cross-space"),
     }, sessionFactory);
     using time = new FakeTime();
 
@@ -597,7 +597,7 @@ Deno.test("memory v2 runner integrates watch deltas without re-diffing cold watc
   const sessionFactory = new SingleSessionFactory(transport);
   const storageManager = TestStorageManager.create({
     as: signer,
-    apiUrl: new URL("memory://runner-v2-watch-delta"),
+    memoryHost: new URL("memory://runner-v2-watch-delta"),
   }, sessionFactory);
   const provider = storageManager.open(space) as TestProvider;
 

--- a/packages/runner/test/rehydrate-internal-default.test.ts
+++ b/packages/runner/test/rehydrate-internal-default.test.ts
@@ -17,7 +17,7 @@ const space = signer.did();
 // than reading the first runtime's warm cache.
 class SharedServerStorageManager extends EmulatedStorageManager {
   constructor(as: Identity, server: MemoryV2Server.Server) {
-    super({ as, address: new URL("memory://") }, () => server);
+    super({ as, apiUrl: new URL("memory://") }, () => server);
   }
   // The shared server is owned by the test, not by either manager. Closing one
   // manager must not close the server out from under the other; close only this

--- a/packages/runner/test/rehydrate-internal-default.test.ts
+++ b/packages/runner/test/rehydrate-internal-default.test.ts
@@ -17,7 +17,7 @@ const space = signer.did();
 // than reading the first runtime's warm cache.
 class SharedServerStorageManager extends EmulatedStorageManager {
   constructor(as: Identity, server: MemoryV2Server.Server) {
-    super({ as, apiUrl: new URL("memory://") }, () => server);
+    super({ as, memoryHost: new URL("memory://") }, () => server);
   }
   // The shared server is owned by the test, not by either manager. Closing one
   // manager must not close the server out from under the other; close only this

--- a/packages/runner/test/storage-close.test.ts
+++ b/packages/runner/test/storage-close.test.ts
@@ -51,7 +51,7 @@ Deno.test("StorageManager.closeNow does not wait for a pending session sync", as
   const signer = await Identity.fromPassphrase("storage-close-pending-sync");
   const storage = TestStorageManager.create({
     as: signer,
-    apiUrl: new URL("http://localhost:65535"),
+    memoryHost: new URL("http://localhost:65535"),
   }, new PendingSessionFactory());
 
   const provider = storage.open(signer.did());
@@ -75,7 +75,7 @@ Deno.test("Provider.destroyNow force-closes after destroy is already pending", a
   const signer = await Identity.fromPassphrase("storage-provider-destroy-now");
   const storage = TestStorageManager.create({
     as: signer,
-    apiUrl: new URL("http://localhost:65535"),
+    memoryHost: new URL("http://localhost:65535"),
   }, new PendingSessionFactory());
 
   const provider = storage.open(signer.did());

--- a/packages/runner/test/storage-close.test.ts
+++ b/packages/runner/test/storage-close.test.ts
@@ -51,7 +51,7 @@ Deno.test("StorageManager.closeNow does not wait for a pending session sync", as
   const signer = await Identity.fromPassphrase("storage-close-pending-sync");
   const storage = TestStorageManager.create({
     as: signer,
-    address: new URL("http://localhost:65535"),
+    apiUrl: new URL("http://localhost:65535"),
   }, new PendingSessionFactory());
 
   const provider = storage.open(signer.did());
@@ -75,7 +75,7 @@ Deno.test("Provider.destroyNow force-closes after destroy is already pending", a
   const signer = await Identity.fromPassphrase("storage-provider-destroy-now");
   const storage = TestStorageManager.create({
     as: signer,
-    address: new URL("http://localhost:65535"),
+    apiUrl: new URL("http://localhost:65535"),
   }, new PendingSessionFactory());
 
   const provider = storage.open(signer.did());

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -47,7 +47,7 @@ const createRuntime = () => {
   const server = new MemoryV2Server.Server();
   const storageManager = new SharedV2StorageManager({
     as: cfcSigner,
-    address: new URL("memory://"),
+    apiUrl: new URL("memory://"),
   }, server);
   const runtime = new Runtime({
     apiUrl: new URL("http://localhost/"),

--- a/packages/runtime-client/backends/runtime-processor.test.ts
+++ b/packages/runtime-client/backends/runtime-processor.test.ts
@@ -47,7 +47,7 @@ const createRuntime = () => {
   const server = new MemoryV2Server.Server();
   const storageManager = new SharedV2StorageManager({
     as: cfcSigner,
-    apiUrl: new URL("memory://"),
+    memoryHost: new URL("memory://"),
   }, server);
   const runtime = new Runtime({
     apiUrl: new URL("http://localhost/"),

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -330,7 +330,8 @@ export class RuntimeProcessor {
     const storageManager = StorageManager.open({
       as: identity,
       spaceIdentity: spaceIdentity,
-      address: new URL("/api/storage/memory", data.apiUrl),
+      apiUrl: apiUrlObj,
+      spaceHostMap: data.spaceHostMap,
     });
 
     // Construct compilation cache if a build hash was provided (browser path).

--- a/packages/runtime-client/backends/runtime-processor.ts
+++ b/packages/runtime-client/backends/runtime-processor.ts
@@ -330,7 +330,7 @@ export class RuntimeProcessor {
     const storageManager = StorageManager.open({
       as: identity,
       spaceIdentity: spaceIdentity,
-      apiUrl: apiUrlObj,
+      memoryHost: apiUrlObj,
       spaceHostMap: data.spaceHostMap,
     });
 

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -118,8 +118,15 @@ export interface BaseRequest {
 }
 
 export interface InitializationData {
-  // URL of backend server.
+  // URL of backend server. Also the default host for spaces absent from
+  // `spaceHostMap` (the home host, which serves static assets).
   apiUrl: string;
+  // Optional space DID → host base URL map. A space listed here has its
+  // storage (and, later, compute) resolved against that host instead of
+  // `apiUrl`. Absent map or absent entry ⇒ `apiUrl`, byte-identical to
+  // the single-host behavior. Plain record: structured-clone-safe — no
+  // functions cross the worker IPC boundary.
+  spaceHostMap?: Record<string, string>;
   // Signer.
   identity: KeyPairRaw;
   // Identity of space.

--- a/packages/runtime-client/protocol/types.ts
+++ b/packages/runtime-client/protocol/types.ts
@@ -119,13 +119,13 @@ export interface BaseRequest {
 
 export interface InitializationData {
   // URL of backend server. Also the default host for spaces absent from
-  // `spaceHostMap` (the home host, which serves static assets).
+  // `spaceHostMap`.
   apiUrl: string;
   // Optional space DID → host base URL map. A space listed here has its
-  // storage (and, later, compute) resolved against that host instead of
-  // `apiUrl`. Absent map or absent entry ⇒ `apiUrl`, byte-identical to
-  // the single-host behavior. Plain record: structured-clone-safe — no
-  // functions cross the worker IPC boundary.
+  // storage resolved against that host instead of `apiUrl`. Absent map or
+  // absent entry ⇒ `apiUrl`, byte-identical to the single-host behavior.
+  // Plain record: structured-clone-safe — no functions cross the worker
+  // IPC boundary. Fixed for the connection's lifetime.
   spaceHostMap?: Record<string, string>;
   // Signer.
   identity: KeyPairRaw;

--- a/packages/runtime-client/runtime-client.ts
+++ b/packages/runtime-client/runtime-client.ts
@@ -87,6 +87,7 @@ export class RuntimeClient extends EventEmitter<RuntimeClientEvents> {
   ): Promise<RuntimeClient> {
     const initialized = await (new RuntimeConnection(transport)).initialize({
       apiUrl: options.apiUrl.toString(),
+      spaceHostMap: options.spaceHostMap,
       identity: options.identity.serialize(),
       spaceIdentity: options.spaceIdentity?.serialize(),
       spaceDid: options.spaceDid,

--- a/packages/toolshed/index.ts
+++ b/packages/toolshed/index.ts
@@ -55,7 +55,7 @@ const initializeRuntime = async () => {
       // default in builder/env.ts (wrong for any non-default port).
       patternEnvironment: { apiUrl: new URL(env.API_URL) },
       storageManager: StorageManager.open({
-        apiUrl: new URL(env.MEMORY_URL),
+        memoryHost: new URL(env.MEMORY_URL),
         as: identity,
       }),
       experimental: {

--- a/packages/toolshed/index.ts
+++ b/packages/toolshed/index.ts
@@ -55,7 +55,7 @@ const initializeRuntime = async () => {
       // default in builder/env.ts (wrong for any non-default port).
       patternEnvironment: { apiUrl: new URL(env.API_URL) },
       storageManager: StorageManager.open({
-        address: new URL("/api/storage/memory", env.MEMORY_URL),
+        apiUrl: new URL(env.MEMORY_URL),
         as: identity,
       }),
       experimental: {

--- a/packages/toolshed/routes/blobs/blobs.test.ts
+++ b/packages/toolshed/routes/blobs/blobs.test.ts
@@ -119,7 +119,7 @@ describe("Blob Routes", () => {
       apiUrl: base,
       storageManager: StorageManager.open({
         as: identity,
-        apiUrl: new URL(base),
+        memoryHost: new URL(base),
       }),
     });
 

--- a/packages/toolshed/routes/blobs/blobs.test.ts
+++ b/packages/toolshed/routes/blobs/blobs.test.ts
@@ -119,7 +119,7 @@ describe("Blob Routes", () => {
       apiUrl: base,
       storageManager: StorageManager.open({
         as: identity,
-        address: new URL("/api/storage/memory", base),
+        apiUrl: new URL(base),
       }),
     });
 

--- a/packages/toolshed/routes/storage/memory/memory.test.ts
+++ b/packages/toolshed/routes/storage/memory/memory.test.ts
@@ -95,7 +95,7 @@ const createRuntime = (identity: Identity, base: URL) =>
     apiUrl: base,
     storageManager: StorageManager.open({
       as: identity,
-      apiUrl: new URL(base),
+      memoryHost: new URL(base),
     }),
   });
 
@@ -138,7 +138,7 @@ serialTest(
     const base = new URL(`http://${server.addr.hostname}:${server.addr.port}`);
     const storageManager = StorageManager.open({
       as: session.as,
-      apiUrl: new URL(base),
+      memoryHost: new URL(base),
       spaceIdentity: session.spaceIdentity,
     });
     const runtime = new Runtime({
@@ -191,7 +191,7 @@ serialTest(
     try {
       storageManager = StorageManager.open({
         as: identity,
-        apiUrl: base,
+        memoryHost: base,
       });
       runtime = new Runtime({
         apiUrl: base,
@@ -246,7 +246,7 @@ serialTest(
         apiUrl: base,
         storageManager: StorageManager.open({
           as: identity,
-          apiUrl: base,
+          memoryHost: base,
         }),
       });
       const tx = runtime1.edit();
@@ -262,7 +262,7 @@ serialTest(
         apiUrl: base,
         storageManager: StorageManager.open({
           as: identity,
-          apiUrl: base,
+          memoryHost: base,
         }),
       });
       const reader = runtime2.getCell(identity.did(), cause);

--- a/packages/toolshed/routes/storage/memory/memory.test.ts
+++ b/packages/toolshed/routes/storage/memory/memory.test.ts
@@ -95,7 +95,7 @@ const createRuntime = (identity: Identity, base: URL) =>
     apiUrl: base,
     storageManager: StorageManager.open({
       as: identity,
-      address: new URL("/api/storage/memory", base),
+      apiUrl: new URL(base),
     }),
   });
 
@@ -138,7 +138,7 @@ serialTest(
     const base = new URL(`http://${server.addr.hostname}:${server.addr.port}`);
     const storageManager = StorageManager.open({
       as: session.as,
-      address: new URL("/api/storage/memory", base),
+      apiUrl: new URL(base),
       spaceIdentity: session.spaceIdentity,
     });
     const runtime = new Runtime({
@@ -180,8 +180,8 @@ serialTest(
   async () => {
     const identity = await Identity.fromPassphrase("memory-route-traffic");
     const server = Deno.serve({ port: 0 }, app.fetch);
-    const address = new URL(
-      `http://${server.addr.hostname}:${server.addr.port}/api/storage/memory`,
+    const base = new URL(
+      `http://${server.addr.hostname}:${server.addr.port}`,
     );
     let runtime: Runtime | undefined;
     let storageManager:
@@ -191,10 +191,10 @@ serialTest(
     try {
       storageManager = StorageManager.open({
         as: identity,
-        address,
+        apiUrl: base,
       });
       runtime = new Runtime({
-        apiUrl: new URL(`http://${server.addr.hostname}:${server.addr.port}`),
+        apiUrl: base,
         storageManager,
       });
       const tx = runtime.edit();
@@ -237,7 +237,6 @@ serialTest(
     const identity = await Identity.fromPassphrase("memory-route-persist");
     const server = Deno.serve({ port: 0 }, app.fetch);
     const base = new URL(`http://${server.addr.hostname}:${server.addr.port}`);
-    const address = new URL("/api/storage/memory", base);
     const cause = `memory-toolshed-persist-${Date.now()}`;
     let runtime1: Runtime | undefined;
     let runtime2: Runtime | undefined;
@@ -247,7 +246,7 @@ serialTest(
         apiUrl: base,
         storageManager: StorageManager.open({
           as: identity,
-          address,
+          apiUrl: base,
         }),
       });
       const tx = runtime1.edit();
@@ -263,7 +262,7 @@ serialTest(
         apiUrl: base,
         storageManager: StorageManager.open({
           as: identity,
-          address,
+          apiUrl: base,
         }),
       });
       const reader = runtime2.getCell(identity.did(), cause);


### PR DESCRIPTION
## What

Lets one runtime open storage connections to **different hosts per space**. `StorageManager` gains an optional `spaceHostMap` (space DID → host base URL); a space listed in the map has its memory websocket dialed against that host, every other space resolves to the default host exactly as today. The map rides into the worker over `InitializationData`, threaded from `lib-shell` → `RuntimeClient.initialize` → `RuntimeProcessor` → `StorageManager.open`.

This is the storage slice of the cross-host ("federation") direction: the storage layer is already multi-space (`StorageManager.#providers = Map<MemorySpace, Provider>`), so giving the session factory a per-space address resolver is all that's needed for distinct hosts to get distinct providers/connections. Page-layer multi-space and per-space compute routing are follow-ups, not in this PR.

## Design points

- **Additive + default-preserving.** Every new field is optional. Absent map or absent entry ⇒ the resolver returns the default host — byte-identical wire behavior to today. No-map paths (all existing callers) are unchanged.
- **The `/api/storage/memory` join now happens in exactly one place** — `createStorageAddressResolver` in `v2-remote-session.ts`, next to the websocket address builders. Every caller used to do the identical `new URL("/api/storage/memory", base)` join by hand.
- **`Options.address` → `Options.memoryHost`** (host base URL, not full endpoint). The rename is deliberate: with the join moving inside, a stale caller passing a full endpoint must fail at type-check, not silently dial a doubled path. It's `memoryHost` rather than `apiUrl` because toolshed wires `env.MEMORY_URL` here while the adjacent `Runtime.apiUrl` is `env.API_URL` — the two hosts are separable in that deployment.
- **Map entries are validated eagerly** at `StorageManager.open`, so a malformed host fails at configuration time naming the offending space, instead of later inside session creation as a bare `Invalid URL`.
- **`spaceIdentity` stays stored-but-never-read** — connections still authenticate as the user; no per-space signer is introduced.
- The map is **fixed for the manager's lifetime**; the per-space provider cache assumes space → host never changes.

## Security note (pre-existing, scoped out, but relevant)

The signed `session.open` invocation (`{iss, cmd, sub: space, args}`) carries no audience binding — no host, nonce, or expiry — so a host that receives one can replay it to any other host serving that space. That's true today with a single `apiUrl` and this PR doesn't widen the trust model (the map comes from the same embedder that already supplies `apiUrl` and the user `Identity`). But it becomes a real concern the moment host maps are derived from *data* (e.g. another user's space pointer) rather than trusted configuration. Audience-binding the session handshake should land before any data-driven map producer does.

## Tests

- Resolver units: default fallback, mapped override, distinct WS targets per host, host-only (path-ignoring) base semantics, eager rejection of malformed entries (`runner/test/memory-v2-remote-session.test.ts`).
- Wiring test: a real `StorageManager.open` with a map, with a stand-in `WebSocket` recording dialed URLs — the mapped space dials its host, the unmapped space dials the default, both on `/api/storage/memory`.
- Full `deno task check`, `deno lint`, `deno fmt --check` green; runner / runtime-client / lib-shell / piece / html suites and toolshed memory+blobs route tests green (the toolshed route tests exercise the moved join against a live server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables per-space storage host routing. `StorageManager` now uses a default `memoryHost` and an optional `spaceHostMap` (space DID → host) to connect different spaces to different hosts; no-map behavior is unchanged. Also stabilizes the wiring test by awaiting a deterministic socket-dial signal (no polling).

- New Features
  - Per-space host resolution via `spaceHostMap`; unmapped spaces use `memoryHost`.
  - Single join point for `/api/storage/memory` via `createStorageAddressResolver`, yielding distinct websocket targets per host.
  - Eager validation of `spaceHostMap` entries with clear errors naming the space.
  - Threads `spaceHostMap` from the shell to the worker (`lib-shell` → `RuntimeClient.initialize` → `RuntimeProcessor` → `StorageManager.open`).
  - Wiring test uses a deterministic “when dialed” signal to avoid flakes.

- Migration
  - Replace `address` with `memoryHost` (pass the host base URL, not the full endpoint). The path is joined internally.
  - If you previously passed a full endpoint, switch to the host base; stale calls will fail at type-check.
  - Optionally supply `spaceHostMap` to override hosts for specific spaces.

<sup>Written for commit 95614ad5f687e2b008609fd4cae4045cc00425fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

