### PR TITLE
fix(patterns): seed the owned self-model cell so standalone capture works (CT-1669)

### DIFF
--- a/packages/patterns/self.test.tsx
+++ b/packages/patterns/self.test.tsx
@@ -9,8 +9,8 @@
  *    so asserting against them covers the real code paths.
  *
  * B) Own-cell init test: instantiates Self({}) with no injection and asserts
- *    the owned cell starts as EMPTY_SELF_MODEL (exercises the previously
- *    untested right-hand branch of the ?? in Self).
+ *    the owned cell seeds to EMPTY_SELF_MODEL via Default<> (the production
+ *    home-local path; CT-1669 regression guard — see section B).
  *
  * Run: deno task cf test packages/patterns/self.test.tsx --verbose
  */
@@ -215,8 +215,8 @@ export default pattern(() => {
 
   // =========================================================================
   // B) Own-cell init test
-  //    Instantiate Self with NO injection — exercises the right-hand branch of
-  //    `injectedSelfModel ?? new Writable<SelfModel>(EMPTY_SELF_MODEL).for("selfModel")`
+  //    Instantiate Self with NO injection — the production home-local path that
+  //    seeds the owned cell from Default<typeof EMPTY_SELF_MODEL> (CT-1669).
   // =========================================================================
 
   // Instantiate with NO injection — the REAL production path (home-local, the

--- a/packages/patterns/self.test.tsx
+++ b/packages/patterns/self.test.tsx
@@ -219,27 +219,17 @@ export default pattern(() => {
   //    `injectedSelfModel ?? new Writable<SelfModel>(EMPTY_SELF_MODEL).for("selfModel")`
   // =========================================================================
 
-  // Instantiate with no injection purely to exercise the own-cell branch
-  // (`.for("selfModel")`); its result isn't read (a cell-result proxy can't be
-  // unwrapped in a computed body), so it is intentionally unused.
-  const _selfOwned = Self({});
-
-  // The own-cell value is verified indirectly: accessing a Self result's
-  // properties inside a computed() body is not auto-unwrapped. Extract the cell
-  // value via a named
-  // computed() body is not auto-unwrapped. Extract the cell value via a named
-  // Writable that we inject — then verify the own-cell branch's initial state
-  // by checking that a freshly-owned Self starts at EMPTY_SELF_MODEL.
-  // We do this by injecting a known-empty Writable and asserting the pattern
-  // treats it as empty (which exercises identical reactive wiring to the own
-  // branch), plus the own-cell branch itself is type-checked via Self({}) above.
-  const ownedCheck = new Writable<SelfModel>(EMPTY_SELF_MODEL);
-  const selfOwnedViaInject = Self({ selfModel: ownedCheck });
-
-  // These computed values read through the named selfModel output, which CTS
-  // auto-unwraps correctly because selfOwnedViaInject.selfModel resolves via
-  // the reactive graph.
-  const ownedModel = computed(() => selfOwnedViaInject.selfModel);
+  // Instantiate with NO injection — the REAL production path (home-local, the
+  // way the Self tab runs it). Regression guard for CT-1669: the old
+  // `injectedSelfModel ?? new Writable<SelfModel>(EMPTY_SELF_MODEL).for("selfModel")`
+  // left the owned cell UNDEFINED — a `new Writable(initial)` on the RIGHT of ??
+  // is lowered to a lift whose value is undefined when uninjected — so every
+  // capture handler threw on `selfModel.get().neurotypes` (caught only by a live
+  // deploy, never by the injected tests). The fix seeds the owned cell via
+  // `Default<typeof EMPTY_SELF_MODEL>`. We now read the ACTUAL owned cell (not an
+  // injected stand-in), so this test fails if the seeding ever regresses.
+  const selfOwned = Self({});
+  const ownedModel = computed(() => selfOwned.selfModel);
 
   const assert_owned_responses_empty = computed(
     () => ownedModel.responses.length === 0,

--- a/packages/patterns/self.tsx
+++ b/packages/patterns/self.tsx
@@ -12,6 +12,7 @@
  */
 import {
   computed,
+  type Default,
   handler,
   ifElse,
   NAME,
@@ -297,7 +298,7 @@ interface SelfInput {
    * and for parent patterns that want to own the storage).
    * When omitted the pattern creates and owns its own durable cell.
    */
-  selfModel?: Writable<SelfModel>;
+  selfModel?: Writable<SelfModel | Default<typeof EMPTY_SELF_MODEL>>;
 }
 
 /** Private self-model — the user's values, neurotype, and reflective answers. #self-model */
@@ -440,13 +441,13 @@ export const removeValueCardByIndex = handler<
 // ============================================================================
 
 const Self = pattern<SelfInput, SelfOutput>(
-  ({ selfModel: injectedSelfModel }) => {
-    // Use the injected cell when provided (e.g. from tests); otherwise own one.
-    // The explicit .for("selfModel") is required here: `new Writable(...)` sits
-    // on the RIGHT of ??, so the CTS transformer does NOT auto-inject a .for
-    // cause for it. Without this call the owned cell has no stable id.
-    const selfModel = injectedSelfModel ??
-      new Writable<SelfModel>(EMPTY_SELF_MODEL).for("selfModel");
+  ({ selfModel }) => {
+    // `selfModel` is seeded with EMPTY_SELF_MODEL via Default<> when the pattern
+    // owns its cell (home-local, no injection) and may be injected by tests or
+    // parent patterns. Previously this used `injected ?? new Writable(...).for()`,
+    // but a `new Writable(initial)` on the RIGHT of ?? is lowered to a lift whose
+    // value is undefined when uninjected — so the owned cell never seeded and
+    // every capture handler threw on `selfModel.get().neurotypes` (CT-1669).
 
     // Local form field cells — neurotype
     const systemField = new Writable<NeurotypeSystem>("mbti").for(


### PR DESCRIPTION
## Motivation — found by the Phase-0 end-to-end probe

While standing up the latest code to do real end-to-end validation of the private self-model, the **first live deploy caught a shipping bug**: deployed standalone (no injected cell — i.e. exactly how it will run behind the home-space "Self" tab), the self-model **captures nothing**. The first capture handler throws:

```
TypeError: Cannot read properties of undefined (reading 'neurotypes')
    at upsertNeurotype (self.tsx:181)   ← selfModel.get() is undefined
    at recordNeurotype handler (self.tsx:243)
```

## Root cause

```ts
const selfModel = injectedSelfModel ??
  new Writable<SelfModel>(EMPTY_SELF_MODEL).for("selfModel");
```

A `new Writable(initial)` on the **right of `??`** is lowered by the CTS transformer to a **lift whose value is `undefined` when uninjected**, so the *owned* cell (the real home-local path) was never seeded with `EMPTY_SELF_MODEL`. Every capture handler then crashes on `selfModel.get().neurotypes`.

**Why all 49 tests were green:** they all inject `selfModel` (`Self({ selfModel })`), so the `??` always fell left and the broken owned branch never ran. The existing "own-cell test" even *admitted* (in its comments) that it verified the owned cell **indirectly via an injected stand-in** — so it structurally could not catch this. The cf-review on #3907 explicitly flagged this owned-cell path as "untested… suspected-safe today" — it wasn't.

## Fix

Make `selfModel` an input seeded with `Default<typeof EMPTY_SELF_MODEL>` (the idiom `favorites-manager` and the former `learned` cell use), dropping the `??` and manual `.for()`. Both the owned (Default-seeded) and injected paths now work.

## Verification

**Live local deploy** (`cf piece new self.tsx` → `call` → `step` → `get`) — all three capture paths now record **well-formed, durable** data:

| Path | Recorded |
|---|---|
| `recordNeurotype` | `{system:"mbti", result:"INTJ", source:"self-reported", recordedAt:1781054263506}` |
| `addValueCard` | `{title:"Deep work", description:…, weight:0.8, sourcePromptId:"open-life"}` |
| `recordResponse` | `{promptId:"open-life", prompt:…, answer:…, track:"meaning", answeredAt:✓}` |

Re-read on a fresh invocation → `n:1, v:1, r:1` (persists).

**Regression test (now a real guard):** the own-cell test reads the **actual** `Self({})` cell instead of an injected stand-in. Against the pre-fix `self.tsx` it **fails 3/3** ("Expected true, got undefined"); against the fix, **49/49 pass**. `cf check` + `deno fmt`/`lint` clean.

## Context & links

- Epic **CT-1669** (private self-model). Built in **CT-1670** (#3907 — which flagged this owned-cell path as untested), **CT-1672** (#3908), **CT-1674** (#3910).
- Prereq for the upcoming home-space **"Self" tab** wiring (without this, the tab would crash on first use).

> ⏳ Draft pending `cf-review`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Seeds the owned `selfModel` in the `Self` pattern so standalone runs can capture and persist data without crashing. Addresses CT-1669 by fixing the uninjected path used by the Home “Self” tab.

- **Bug Fixes**
  - Replace `injected ?? new Writable(...).for()` with a `Default<typeof EMPTY_SELF_MODEL>`-seeded `selfModel` input (`Writable<SelfModel | Default<...>>`) so owned and injected paths both work.
  - Update the own-cell test to use `Self({})` and read the actual owned cell; clean up stale `??` references in comments.
  - Verified locally: `recordNeurotype`, `addValueCard`, and `recordResponse` persist correctly.

<sup>Written for commit fc6de89d17a9d8c7707d61ebb88b9cad92cbd1cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

