### PR TITLE
feat(cf-profile-badge): make the verified identity seal feel alive (lockstep + cursor sheen)

### DIFF
--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
@@ -16,6 +16,13 @@ import {
   readCfcLabelView,
 } from "../../core/cfc-label.ts";
 import { type IdentitySeal, identitySeal } from "./identity-seal.ts";
+import {
+  registerSeal,
+  sealGlowDelay,
+  type SealLivenessClient,
+  sealSpinDelay,
+  unregisterSeal,
+} from "./seal-liveness.ts";
 
 /** Verification state of the presented identity. */
 export type ProfileBadgeState = "presented" | "verified" | "unverified";
@@ -77,7 +84,7 @@ export const profileDisplayFromValue = (val: unknown): ProfileBadgeDisplay => {
  * @element cf-profile-badge
  * @attr {string} size - avatar size: xs | sm | md | lg | xl (default md)
  */
-export class CFProfileBadge extends BaseElement {
+export class CFProfileBadge extends BaseElement implements SealLivenessClient {
   static override styles = [
     BaseElement.baseStyles,
     css`
@@ -145,6 +152,59 @@ export class CFProfileBadge extends BaseElement {
         transform-origin: center;
       }
 
+      /* Intrinsic shimmer — a soft light band that sweeps across the disc on a
+        shared clock (seeded per-badge via animation-delay so every verified seal
+        sweeps in lockstep). Keeps the seal visibly "alive" even when the cursor
+        is still, in a way ordinary chrome never is. Sits above the avatar so the
+        light glazes the face; screen-blended and contained by the aura's
+        isolation so it only lifts the badge, not the page behind it. */
+      .aura-glow {
+        position: absolute;
+        inset: 0;
+        border-radius: var(--cf-border-radius-full, 9999px);
+        z-index: 2;
+        pointer-events: none;
+        opacity: 0;
+        mix-blend-mode: screen;
+        background: linear-gradient(
+          115deg,
+          transparent 34%,
+          hsl(var(--seal-hue, 200) 95% 90% / 0.5) 47%,
+          rgba(255, 255, 255, 0.85) 50%,
+          hsl(var(--seal-hue, 200) 95% 90% / 0.5) 53%,
+          transparent 66%
+        );
+        background-size: 280% 280%;
+      }
+
+      /* Cursor sheen — a bright reflective hotspot that tracks the host cursor,
+        even when the cursor is nowhere near the badge. Driven by
+        --seal-mx/--seal-my/--seal-sheen-a/--seal-sheen-hue, which the shared
+        liveness controller sets on the host (they inherit into this layer). A
+        sandboxed pattern only sees pointer events inside its own iframe, so a
+        forgery cannot reproduce this. */
+      .aura-sheen {
+        position: absolute;
+        inset: 0;
+        border-radius: var(--cf-border-radius-full, 9999px);
+        z-index: 3;
+        pointer-events: none;
+        opacity: var(--seal-sheen-a, 0);
+        mix-blend-mode: screen;
+        background:
+          radial-gradient(
+            circle at var(--seal-mx, 50%) var(--seal-my, 50%),
+            rgba(255, 255, 255, 1) 0%,
+            rgba(255, 255, 255, 0.6) 11%,
+            rgba(255, 255, 255, 0) 32%
+          ),
+          radial-gradient(
+            circle at var(--seal-mx, 50%) var(--seal-my, 50%),
+            hsl(var(--seal-sheen-hue, 200) 100% 72% / 0.9) 0%,
+            hsl(var(--seal-sheen-hue, 200) 100% 60% / 0) 52%
+          );
+      }
+
       .aura cf-avatar {
         position: relative;
         z-index: 1;
@@ -152,6 +212,8 @@ export class CFProfileBadge extends BaseElement {
 
       .badge[data-state="verified"] .aura {
         padding: 3px;
+        isolation: isolate;
+        transition: transform 200ms ease-out;
       }
 
       .badge[data-state="verified"] .aura cf-avatar {
@@ -159,19 +221,26 @@ export class CFProfileBadge extends BaseElement {
         border-radius: var(--cf-border-radius-full, 9999px);
       }
 
-      /* Hovering a verified badge spins the aura and lifts the glow — a small,
-        deliberate "this is special" tell that user-space chrome doesn't get. */
-      .badge[data-state="verified"] .aura:hover .aura-ring {
-        animation: cf-aura-spin 5s linear infinite;
+      /* Always-on, lockstep liveness once verified: the ring slowly rotates and
+        the shimmer sweeps. Both are seeded to a shared epoch (inline
+        animation-delay) so all verified seals move in unison — the "chorus" a
+        forgery can't join. */
+      .badge[data-state="verified"] .aura-ring {
+        animation: cf-aura-spin var(--seal-spin-period, 26s) linear infinite;
+        animation-delay: var(--seal-spin-delay, 0ms);
       }
 
+      .badge[data-state="verified"] .aura-glow {
+        opacity: 1;
+        animation: cf-aura-glow var(--seal-glow-period, 7s) linear infinite;
+        animation-delay: var(--seal-glow-delay, 0ms);
+      }
+
+      /* Hover lifts the seal a touch — a deliberate "this is special" tell that
+        user-space chrome doesn't get. */
       .badge[data-state="verified"] .aura:hover {
         transform: scale(1.04);
         transition: transform 160ms ease-out;
-      }
-
-      .badge[data-state="verified"] .aura {
-        transition: transform 200ms ease-out;
       }
 
       @keyframes cf-aura-spin {
@@ -180,9 +249,23 @@ export class CFProfileBadge extends BaseElement {
         }
       }
 
+      @keyframes cf-aura-glow {
+        0% {
+          background-position: 0% 0%;
+        }
+        100% {
+          background-position: 280% 280%;
+        }
+      }
+
       @media (prefers-reduced-motion: reduce) {
-        .badge[data-state="verified"] .aura:hover .aura-ring {
+        .badge[data-state="verified"] .aura-ring,
+        .badge[data-state="verified"] .aura-glow {
           animation: none;
+        }
+        .badge[data-state="verified"] .aura-glow {
+          opacity: 0.5;
+          background-position: 50% 50%;
         }
         .badge[data-state="verified"] .aura:hover {
           transform: none;
@@ -228,6 +311,14 @@ export class CFProfileBadge extends BaseElement {
   private _unsubscribe?: () => void;
   private _resolveGeneration = 0;
 
+  // Liveness: whether this seal is currently registered with the shared cursor
+  // controller, and the per-seal animation phases (seeded to the shared epoch
+  // when the seal is derived, so all verified seals move in lockstep).
+  private _livenessRegistered = false;
+  private _spinDelay = "0ms";
+  private _glowDelay = "0ms";
+  private _lastSheenA = -1;
+
   override connectedCallback(): void {
     super.connectedCallback();
     void this._resolve();
@@ -243,6 +334,7 @@ export class CFProfileBadge extends BaseElement {
     // subscription that updates a detached element.
     this._resolveGeneration++;
     this._cleanup();
+    this._setLiveness(false);
   }
 
   protected override willUpdate(changed: PropertyValues): void {
@@ -250,6 +342,68 @@ export class CFProfileBadge extends BaseElement {
     if (changed.has("profile")) {
       void this._resolve();
     }
+  }
+
+  protected override updated(changed: PropertyValues): void {
+    super.updated(changed);
+    // Register for cursor sheen only while actually verified + connected; the
+    // shared controller is a no-op under prefers-reduced-motion.
+    const verified = this._state === "verified" && this._seal !== undefined;
+    this._setLiveness(verified && this.isConnected);
+  }
+
+  private _setLiveness(on: boolean): void {
+    if (on === this._livenessRegistered) return;
+    this._livenessRegistered = on;
+    if (on) {
+      registerSeal(this);
+    } else {
+      unregisterSeal(this);
+      this._lastSheenA = -1;
+    }
+  }
+
+  /**
+   * Called once per animation frame by the shared liveness controller while
+   * this seal is registered. Places a reflective hotspot on the seal in the
+   * direction of the host cursor, brightening as the cursor nears — and
+   * responding even when the cursor is far away (the unforgeable part). Reads
+   * the aura's own rect so geometry is correct regardless of the badge's
+   * surrounding layout, and culls when offscreen.
+   */
+  updateSeal(cursorX: number, cursorY: number, frameMs: number): void {
+    const aura = this.shadowRoot?.querySelector(".aura") as HTMLElement | null;
+    if (!aura) return;
+    const r = aura.getBoundingClientRect();
+    const vh = globalThis.innerHeight ?? 0;
+    if (r.width === 0 || r.bottom < -80 || r.top > vh + 80) {
+      if (this._lastSheenA !== 0) {
+        this.style.setProperty("--seal-sheen-a", "0");
+        this._lastSheenA = 0;
+      }
+      return;
+    }
+    const cx = r.left + r.width / 2;
+    const cy = r.top + r.height / 2;
+    const dx = cursorX - cx;
+    const dy = cursorY - cy;
+    const dist = Math.hypot(dx, dy);
+    const prox = Math.max(0, 1 - dist / 520); // 1 at center → 0 by ~520px
+    const a = Math.min(1, prox * prox * 1.25 + prox * 0.15); // punchy near
+    // Far + already dark: nothing to draw, skip all writes (cheap at scale).
+    if (a === 0 && this._lastSheenA === 0) return;
+    this._lastSheenA = a;
+    const reach = Math.max(r.width, r.height) * 1.9;
+    const nx = Math.max(-1, Math.min(1, dx / reach));
+    const ny = Math.max(-1, Math.min(1, dy / reach));
+    const hue = this._seal?.hue ?? 0;
+    this.style.setProperty("--seal-mx", `${(50 + nx * 62).toFixed(1)}%`);
+    this.style.setProperty("--seal-my", `${(50 + ny * 62).toFixed(1)}%`);
+    this.style.setProperty("--seal-sheen-a", a.toFixed(3));
+    this.style.setProperty(
+      "--seal-sheen-hue",
+      String(Math.round((hue + frameMs * 0.03 + nx * 40 + 360) % 360)),
+    );
   }
 
   private _cleanup(): void {
@@ -332,6 +486,10 @@ export class CFProfileBadge extends BaseElement {
       const owner = ownerPrincipalFromLabel(view);
       if (owner) {
         this._seal = identitySeal(owner);
+        // Seed the lockstep animation phases to the shared epoch so this seal
+        // joins the chorus in sync with every other verified seal on screen.
+        this._spinDelay = sealSpinDelay();
+        this._glowDelay = sealGlowDelay();
         this._state = "verified";
       } else {
         this._seal = undefined;
@@ -364,6 +522,11 @@ export class CFProfileBadge extends BaseElement {
     const sealTitle = verified
       ? "Identity verified by the system"
       : "System-rendered identity";
+    // Per-identity hue (tints the shimmer) + lockstep animation phases, supplied
+    // inline so the seeded delays line this seal up with the shared clock.
+    const auraStyle = verified
+      ? `--seal-hue: ${hue}; --seal-spin-delay: ${this._spinDelay}; --seal-glow-delay: ${this._glowDelay};`
+      : "";
 
     return html`
       <span
@@ -372,7 +535,7 @@ export class CFProfileBadge extends BaseElement {
         data-cf-profile-badge
         data-state="${this._state}"
       >
-        <span class="aura" part="aura">
+        <span class="aura" part="aura" style="${auraStyle}">
           ${verified
             ? html`
               <span class="aura-ring" part="aura-ring" style="${ringStyle}"> </span>
@@ -385,6 +548,12 @@ export class CFProfileBadge extends BaseElement {
             .name="${this._name}"
             size="${this.size}"
           ></cf-avatar>
+          ${verified
+            ? html`
+              <span class="aura-glow" part="aura-glow" aria-hidden="true"></span>
+              <span class="aura-sheen" part="aura-sheen" aria-hidden="true"></span>
+            `
+            : null}
         </span>
         <span class="name" part="name">
           ${this._name ?? "Unknown profile"}

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
@@ -18,9 +18,7 @@ import {
 import { type IdentitySeal, identitySeal } from "./identity-seal.ts";
 import {
   registerSeal,
-  sealGlowDelay,
   type SealLivenessClient,
-  sealSpinDelay,
   unregisterSeal,
 } from "./seal-liveness.ts";
 
@@ -222,23 +220,20 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
         border-radius: var(--cf-border-radius-full, 9999px);
       }
 
-      /* Always-on, lockstep liveness once verified: the ring slowly rotates and
-        the shimmer sweeps. Both are seeded to a shared epoch (inline
-        animation-delay) so all verified seals move in unison — the "chorus" a
-        forgery can't join. */
-      .badge[data-state="verified"] .aura-ring {
-        animation: cf-aura-spin var(--seal-spin-period, 26s) linear infinite;
-        animation-delay: var(--seal-spin-delay, 0ms);
+      /* Ambient self-motion is gated to :hover so a dense roster stays calm at
+        rest and a seal comes alive when engaged. The cursor sheen (.aura-sheen,
+        above) is the *always-on* part — it reacts to the host cursor anywhere on
+        screen, hovered or not, which is the unforgeable signal. On hover the ring
+        rotates, the shimmer sweeps, and the seal lifts a touch. */
+      .badge[data-state="verified"] .aura:hover .aura-ring {
+        animation: cf-aura-spin 26s linear infinite;
       }
 
-      .badge[data-state="verified"] .aura-glow {
+      .badge[data-state="verified"] .aura:hover .aura-glow {
         opacity: 1;
-        animation: cf-aura-glow var(--seal-glow-period, 7s) linear infinite;
-        animation-delay: var(--seal-glow-delay, 0ms);
+        animation: cf-aura-glow 7s linear infinite;
       }
 
-      /* Hover lifts the seal a touch — a deliberate "this is special" tell that
-        user-space chrome doesn't get. */
       .badge[data-state="verified"] .aura:hover {
         transform: scale(1.04);
         transition: transform 160ms ease-out;
@@ -260,13 +255,12 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
       }
 
       @media (prefers-reduced-motion: reduce) {
-        .badge[data-state="verified"] .aura-ring,
-        .badge[data-state="verified"] .aura-glow {
+        .badge[data-state="verified"] .aura:hover .aura-ring,
+        .badge[data-state="verified"] .aura:hover .aura-glow {
           animation: none;
         }
-        .badge[data-state="verified"] .aura-glow {
-          opacity: 0.5;
-          background-position: 50% 50%;
+        .badge[data-state="verified"] .aura:hover .aura-glow {
+          opacity: 0;
         }
         .badge[data-state="verified"] .aura:hover {
           transform: none;
@@ -313,11 +307,9 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
   private _resolveGeneration = 0;
 
   // Liveness: whether this seal is currently registered with the shared cursor
-  // controller, and the per-seal animation phases (seeded to the shared epoch
-  // when the seal is derived, so all verified seals move in lockstep).
+  // controller, and the last sheen alpha written (so far-from-cursor frames can
+  // skip redundant style writes).
   private _livenessRegistered = false;
-  private _spinDelay = "0ms";
-  private _glowDelay = "0ms";
   private _lastSheenA = -1;
 
   override connectedCallback(): void {
@@ -347,8 +339,9 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
 
   protected override updated(changed: PropertyValues): void {
     super.updated(changed);
-    // Register for cursor sheen only while actually verified + connected; the
-    // shared controller is a no-op under prefers-reduced-motion.
+    // Register for cursor sheen only while actually verified + connected. The
+    // shared controller manages reduced-motion (it won't run the loop while the
+    // user prefers reduced motion, and tears it down live if they enable it).
     const verified = this._state === "verified" && this._seal !== undefined;
     this._setLiveness(verified && this.isConnected);
   }
@@ -405,6 +398,16 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
       "--seal-sheen-hue",
       String(Math.round((hue + frameMs * 0.03 + nx * 40 + 360) % 360)),
     );
+  }
+
+  /**
+   * Reset the cursor sheen to nothing. Called by the shared controller when it
+   * stops the loop (e.g. the user enables reduced motion) so the highlight
+   * doesn't freeze mid-glint.
+   */
+  clearSeal(): void {
+    this.style.setProperty("--seal-sheen-a", "0");
+    this._lastSheenA = 0;
   }
 
   private _cleanup(): void {
@@ -487,10 +490,6 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
       const owner = ownerPrincipalFromLabel(view);
       if (owner) {
         this._seal = identitySeal(owner);
-        // Seed the lockstep animation phases to the shared epoch so this seal
-        // joins the chorus in sync with every other verified seal on screen.
-        this._spinDelay = sealSpinDelay();
-        this._glowDelay = sealGlowDelay();
         this._state = "verified";
       } else {
         this._seal = undefined;
@@ -523,11 +522,9 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
     const sealTitle = verified
       ? "Identity verified by the system"
       : "System-rendered identity";
-    // Per-identity hue (tints the shimmer) + lockstep animation phases, supplied
-    // inline so the seeded delays line this seal up with the shared clock.
-    const auraStyle = verified
-      ? `--seal-hue: ${hue}; --seal-spin-delay: ${this._spinDelay}; --seal-glow-delay: ${this._glowDelay};`
-      : "";
+    // Per-identity hue, supplied inline so the hover shimmer is tinted to match
+    // this identity's palette.
+    const auraStyle = verified ? `--seal-hue: ${hue};` : "";
 
     return html`
       <span

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
@@ -135,7 +135,8 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
         verified, a separate aura-ring layer carries the per-identity conic
         gradient (a pure function of the owner DID) behind the avatar, so the ring
         is unique-but-stable for each person. Keeping it on its own layer lets it
-        spin on hover without rotating the avatar. */
+        rotate in lockstep (the always-on animation below) and carry the shimmer
+        and cursor-sheen layers, all without rotating the avatar. */
       .aura {
         position: relative;
         display: inline-flex;

--- a/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/cf-profile-badge.ts
@@ -199,10 +199,10 @@ export class CFProfileBadge extends BaseElement implements SealLivenessClient {
             rgba(255, 255, 255, 0) 32%
           ),
           radial-gradient(
-            circle at var(--seal-mx, 50%) var(--seal-my, 50%),
-            hsl(var(--seal-sheen-hue, 200) 100% 72% / 0.9) 0%,
-            hsl(var(--seal-sheen-hue, 200) 100% 60% / 0) 52%
-          );
+          circle at var(--seal-mx, 50%) var(--seal-my, 50%),
+          hsl(var(--seal-sheen-hue, 200) 100% 72% / 0.9) 0%,
+          hsl(var(--seal-sheen-hue, 200) 100% 60% / 0) 52%
+        );
       }
 
       .aura cf-avatar {

--- a/packages/ui/src/v2/components/cf-profile-badge/seal-liveness.test.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/seal-liveness.test.ts
@@ -1,0 +1,30 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import {
+  prefersReducedMotion,
+  SEAL_GLOW_PERIOD_MS,
+  SEAL_SPIN_PERIOD_MS,
+  sealGlowDelay,
+  sealSpinDelay,
+} from "./seal-liveness.ts";
+
+describe("seal-liveness", () => {
+  it("seeds spin/glow phases as negative ms delays within their period", () => {
+    // The delays seed a CSS animation into the shared epoch's phase, so they are
+    // always ≤ 0 and never older than one full period.
+    const spin = sealSpinDelay();
+    expect(spin.endsWith("ms")).toBe(true);
+    const spinMs = parseFloat(spin);
+    expect(spinMs).toBeLessThanOrEqual(0);
+    expect(spinMs).toBeGreaterThan(-SEAL_SPIN_PERIOD_MS);
+
+    const glow = sealGlowDelay();
+    const glowMs = parseFloat(glow);
+    expect(glowMs).toBeLessThanOrEqual(0);
+    expect(glowMs).toBeGreaterThan(-SEAL_GLOW_PERIOD_MS);
+  });
+
+  it("reports a boolean for reduced-motion preference without throwing", () => {
+    expect(typeof prefersReducedMotion()).toBe("boolean");
+  });
+});

--- a/packages/ui/src/v2/components/cf-profile-badge/seal-liveness.test.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/seal-liveness.test.ts
@@ -2,29 +2,70 @@ import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import {
   prefersReducedMotion,
-  SEAL_GLOW_PERIOD_MS,
-  SEAL_SPIN_PERIOD_MS,
-  sealGlowDelay,
-  sealSpinDelay,
+  registerSeal,
+  type SealLivenessClient,
+  unregisterSeal,
 } from "./seal-liveness.ts";
 
+const noopClient = (): SealLivenessClient => ({
+  updateSeal() {},
+  clearSeal() {},
+});
+
 describe("seal-liveness", () => {
-  it("seeds spin/glow phases as negative ms delays within their period", () => {
-    // The delays seed a CSS animation into the shared epoch's phase, so they are
-    // always ≤ 0 and never older than one full period.
-    const spin = sealSpinDelay();
-    expect(spin.endsWith("ms")).toBe(true);
-    const spinMs = parseFloat(spin);
-    expect(spinMs).toBeLessThanOrEqual(0);
-    expect(spinMs).toBeGreaterThan(-SEAL_SPIN_PERIOD_MS);
-
-    const glow = sealGlowDelay();
-    const glowMs = parseFloat(glow);
-    expect(glowMs).toBeLessThanOrEqual(0);
-    expect(glowMs).toBeGreaterThan(-SEAL_GLOW_PERIOD_MS);
-  });
-
   it("reports a boolean for reduced-motion preference without throwing", () => {
     expect(typeof prefersReducedMotion()).toBe("boolean");
+  });
+
+  // The visual sheen math needs a real browser (cursor geometry,
+  // getBoundingClientRect) and is exercised by the prototype, not here. What we
+  // CAN guard cheaply is the leak: the shared controller must add exactly one
+  // pointer listener + rAF on the first seal and remove both when the last seal
+  // unregisters — otherwise a mount/unmount churn leaks listeners and frames.
+  it("starts one pointer listener + rAF on the first seal and tears both down when the last unregisters", () => {
+    const g = globalThis as Record<string, unknown>;
+    const saved = {
+      raf: g.requestAnimationFrame,
+      caf: g.cancelAnimationFrame,
+      add: g.addEventListener,
+      remove: g.removeEventListener,
+    };
+    const events: string[] = [];
+    let scheduled = 0;
+    let canceled = 0;
+    g.requestAnimationFrame = () => {
+      scheduled++;
+      return 123; // never invoke the callback: we don't want the loop to run
+    };
+    g.cancelAnimationFrame = () => {
+      canceled++;
+    };
+    g.addEventListener = (type: string) => {
+      events.push(`add:${type}`);
+    };
+    g.removeEventListener = (type: string) => {
+      events.push(`remove:${type}`);
+    };
+    try {
+      const a = noopClient();
+      const b = noopClient();
+
+      registerSeal(a);
+      registerSeal(b);
+      expect(events).toContain("add:pointermove");
+      expect(scheduled).toBe(1); // one shared rAF, not one per seal
+
+      unregisterSeal(a);
+      expect(events.filter((e) => e === "remove:pointermove").length).toBe(0);
+
+      unregisterSeal(b); // last seal gone → teardown
+      expect(events).toContain("remove:pointermove");
+      expect(canceled).toBe(1);
+    } finally {
+      g.requestAnimationFrame = saved.raf;
+      g.cancelAnimationFrame = saved.caf;
+      g.addEventListener = saved.add;
+      g.removeEventListener = saved.remove;
+    }
   });
 });

--- a/packages/ui/src/v2/components/cf-profile-badge/seal-liveness.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/seal-liveness.ts
@@ -1,72 +1,35 @@
 /**
- * seal-liveness — the shared, host-held "session clock + cursor channel" that
- * makes verified identity seals feel *alive* in a way a sandboxed pattern can't
- * reproduce.
+ * seal-liveness — the shared host cursor channel that drives the verified seal's
+ * always-on reflective sheen.
  *
- * Two anti-forgery properties come from here:
+ * The sheen is the load-bearing anti-forgery signal: one global `pointermove`
+ * listener + one rAF loop place a reflective hotspot on every registered seal
+ * that tracks the host cursor *even when the cursor is nowhere near the seal*. A
+ * sandboxed pattern only receives pointer events inside its own iframe, so a
+ * forgery cannot glint toward a cursor that is elsewhere on screen.
  *
- *  1. LOCKSTEP. The slow ring rotation and the intrinsic shimmer sweep are CSS
- *     animations seeded to a single shared `epoch` via a negative
- *     `animation-delay`. Every verified seal on screen therefore moves in
- *     unison regardless of when it mounted — a late seal joins the chorus in
- *     phase. A pattern can copy the keyframes but cannot read our epoch, so its
- *     lookalike sings to its own beat.
+ * The seal's other motion — the ambient ring rotation and shimmer sweep — is
+ * pure CSS, gated to `:hover`, and lives in the component's stylesheet, not
+ * here: a dense roster stays calm at rest, and a seal comes alive when engaged.
  *
- *  2. CURSOR SHEEN. One global `pointermove` listener + one rAF loop drive a
- *     reflective hotspot on every registered seal — and it responds even when
- *     the cursor is nowhere near the seal. A sandboxed pattern only receives
- *     pointer events inside its own iframe, so a forgery cannot glint toward a
- *     cursor that is elsewhere on screen.
- *
- * Cost is bounded: the lockstep animations are pure CSS (no per-frame JS); the
- * cursor loop runs only while ≥1 seal is registered, touches only registered
- * (on-screen, verified) seals, and skips writes for seals the cursor is far
- * from. Under `prefers-reduced-motion` the cursor loop never starts and the CSS
- * animations are disabled by the component's stylesheet.
+ * Cost is bounded: the loop runs only while ≥1 seal is registered, touches only
+ * registered seals, culls offscreen ones, and skips writes for seals the cursor
+ * is far from. Reduced motion is honored *live* — enabling it tears the loop
+ * down and clears every seal's highlight; disabling it resumes the loop.
  */
-
-/** Rotation period of the conic aura ring (ms). Slow — a drift, not a spin. */
-export const SEAL_SPIN_PERIOD_MS = 26_000;
-/** Sweep period of the intrinsic shimmer band (ms). */
-export const SEAL_GLOW_PERIOD_MS = 7_000;
-
-const nowMs = (): number => globalThis.performance?.now?.() ?? 0;
-
-// A single shared origin captured on first use. All seeded delays are measured
-// from here, so every seal's animation phase is a pure function of this epoch.
-let epoch = 0;
-let epochInit = false;
-const ensureEpoch = (): number => {
-  if (!epochInit) {
-    epoch = nowMs();
-    epochInit = true;
-  }
-  return epoch;
-};
-
-/** Negative animation-delay that puts a freshly-applied animation into the
- * shared phase for `periodMs`, so it lines up with seals that started earlier.
- * Evaluate the epoch first so `elapsed` is never negative (which would push the
- * animation's start into the future instead of seeding it into phase). */
-const seededDelay = (periodMs: number): string => {
-  const e = ensureEpoch();
-  const elapsed = Math.max(0, nowMs() - e);
-  return `${-(elapsed % periodMs)}ms`;
-};
-
-export const sealSpinDelay = (): string => seededDelay(SEAL_SPIN_PERIOD_MS);
-export const sealGlowDelay = (): string => seededDelay(SEAL_GLOW_PERIOD_MS);
 
 export const prefersReducedMotion = (): boolean =>
   globalThis.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ?? false;
 
 /**
  * Implemented by a seal that wants cursor-driven sheen. `updateSeal` is called
- * once per animation frame while registered, with the latest host cursor
- * position (viewport px) and the frame timestamp.
+ * once per animation frame while registered; `clearSeal` is called when the loop
+ * stops (e.g. the user turns on reduced motion) so the seal can reset its
+ * highlight rather than freeze mid-glint.
  */
 export interface SealLivenessClient {
   updateSeal(cursorX: number, cursorY: number, frameMs: number): void;
+  clearSeal(): void;
 }
 
 const clients = new Set<SealLivenessClient>();
@@ -80,7 +43,31 @@ const onPointerMove = (e: PointerEvent): void => {
   cursorY = e.clientY;
 };
 
-const teardown = (): void => {
+const tick = (t: number): void => {
+  rafId = 0;
+  for (const c of clients) c.updateSeal(cursorX, cursorY, t);
+  if (clients.size > 0) {
+    rafId = globalThis.requestAnimationFrame(tick);
+  } else {
+    stopLoop();
+  }
+};
+
+const startLoop = (): void => {
+  // Needs a real animation loop; bail under reduced motion and in non-browser
+  // envs (SSR, unit tests) rather than throwing on a missing requestAnimationFrame.
+  if (prefersReducedMotion()) return;
+  if (typeof globalThis.requestAnimationFrame !== "function") return;
+  if (!listening) {
+    globalThis.addEventListener("pointermove", onPointerMove, {
+      passive: true,
+    });
+    listening = true;
+  }
+  if (!rafId) rafId = globalThis.requestAnimationFrame(tick);
+};
+
+const stopLoop = (): void => {
   if (listening) {
     globalThis.removeEventListener("pointermove", onPointerMove);
     listening = false;
@@ -91,32 +78,30 @@ const teardown = (): void => {
   }
 };
 
-const tick = (t: number): void => {
-  rafId = 0;
-  for (const c of clients) c.updateSeal(cursorX, cursorY, t);
-  if (clients.size > 0) {
-    rafId = globalThis.requestAnimationFrame(tick);
-  } else {
-    teardown();
+// Honor a live prefers-reduced-motion toggle: stop the sheen loop (and clear any
+// lingering highlight) when it turns on; resume when it turns off. Registrations
+// persist across the toggle so seals don't have to re-register.
+const reducedMotionQuery =
+  globalThis.matchMedia?.("(prefers-reduced-motion: reduce)") ?? null;
+reducedMotionQuery?.addEventListener?.("change", () => {
+  if (prefersReducedMotion()) {
+    stopLoop();
+    for (const c of clients) c.clearSeal();
+  } else if (clients.size > 0) {
+    startLoop();
   }
-};
+});
 
-/** Register a verified seal for cursor sheen. No-op under reduced motion. */
+/** Register a verified seal for cursor sheen. The loop starts on the first seal. */
 export const registerSeal = (client: SealLivenessClient): void => {
-  if (prefersReducedMotion()) return;
-  // Cursor sheen needs a real animation loop; bail in non-browser envs (SSR,
-  // unit tests) rather than throwing on a missing requestAnimationFrame.
+  // No animation loop available (SSR / unit tests) → don't retain a client we
+  // can never drive; the cursor sheen is a browser-only enhancement anyway.
   if (typeof globalThis.requestAnimationFrame !== "function") return;
   clients.add(client);
-  if (!listening) {
-    globalThis.addEventListener("pointermove", onPointerMove, {
-      passive: true,
-    });
-    listening = true;
-  }
-  if (!rafId) rafId = globalThis.requestAnimationFrame(tick);
+  startLoop();
 };
 
+/** Unregister a seal; the loop (listener + rAF) tears down when the last leaves. */
 export const unregisterSeal = (client: SealLivenessClient): void => {
-  if (clients.delete(client) && clients.size === 0) teardown();
+  if (clients.delete(client) && clients.size === 0) stopLoop();
 };

--- a/packages/ui/src/v2/components/cf-profile-badge/seal-liveness.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/seal-liveness.ts
@@ -1,0 +1,120 @@
+/**
+ * seal-liveness — the shared, host-held "session clock + cursor channel" that
+ * makes verified identity seals feel *alive* in a way a sandboxed pattern can't
+ * reproduce.
+ *
+ * Two anti-forgery properties come from here:
+ *
+ *  1. LOCKSTEP. The slow ring rotation and the intrinsic shimmer sweep are CSS
+ *     animations seeded to a single shared `epoch` via a negative
+ *     `animation-delay`. Every verified seal on screen therefore moves in
+ *     unison regardless of when it mounted — a late seal joins the chorus in
+ *     phase. A pattern can copy the keyframes but cannot read our epoch, so its
+ *     lookalike sings to its own beat.
+ *
+ *  2. CURSOR SHEEN. One global `pointermove` listener + one rAF loop drive a
+ *     reflective hotspot on every registered seal — and it responds even when
+ *     the cursor is nowhere near the seal. A sandboxed pattern only receives
+ *     pointer events inside its own iframe, so a forgery cannot glint toward a
+ *     cursor that is elsewhere on screen.
+ *
+ * Cost is bounded: the lockstep animations are pure CSS (no per-frame JS); the
+ * cursor loop runs only while ≥1 seal is registered, touches only registered
+ * (on-screen, verified) seals, and skips writes for seals the cursor is far
+ * from. Under `prefers-reduced-motion` the cursor loop never starts and the CSS
+ * animations are disabled by the component's stylesheet.
+ */
+
+/** Rotation period of the conic aura ring (ms). Slow — a drift, not a spin. */
+export const SEAL_SPIN_PERIOD_MS = 26_000;
+/** Sweep period of the intrinsic shimmer band (ms). */
+export const SEAL_GLOW_PERIOD_MS = 7_000;
+
+const nowMs = (): number => globalThis.performance?.now?.() ?? 0;
+
+// A single shared origin captured on first use. All seeded delays are measured
+// from here, so every seal's animation phase is a pure function of this epoch.
+let epoch = 0;
+let epochInit = false;
+const ensureEpoch = (): number => {
+  if (!epochInit) {
+    epoch = nowMs();
+    epochInit = true;
+  }
+  return epoch;
+};
+
+/** Negative animation-delay that puts a freshly-applied animation into the
+ * shared phase for `periodMs`, so it lines up with seals that started earlier.
+ * Evaluate the epoch first so `elapsed` is never negative (which would push the
+ * animation's start into the future instead of seeding it into phase). */
+const seededDelay = (periodMs: number): string => {
+  const e = ensureEpoch();
+  const elapsed = Math.max(0, nowMs() - e);
+  return `${-(elapsed % periodMs)}ms`;
+};
+
+export const sealSpinDelay = (): string => seededDelay(SEAL_SPIN_PERIOD_MS);
+export const sealGlowDelay = (): string => seededDelay(SEAL_GLOW_PERIOD_MS);
+
+export const prefersReducedMotion = (): boolean =>
+  globalThis.matchMedia?.("(prefers-reduced-motion: reduce)")?.matches ?? false;
+
+/**
+ * Implemented by a seal that wants cursor-driven sheen. `updateSeal` is called
+ * once per animation frame while registered, with the latest host cursor
+ * position (viewport px) and the frame timestamp.
+ */
+export interface SealLivenessClient {
+  updateSeal(cursorX: number, cursorY: number, frameMs: number): void;
+}
+
+const clients = new Set<SealLivenessClient>();
+let cursorX = -1e6;
+let cursorY = -1e6;
+let rafId = 0;
+let listening = false;
+
+const onPointerMove = (e: PointerEvent): void => {
+  cursorX = e.clientX;
+  cursorY = e.clientY;
+};
+
+const teardown = (): void => {
+  if (listening) {
+    globalThis.removeEventListener("pointermove", onPointerMove);
+    listening = false;
+  }
+  if (rafId) {
+    globalThis.cancelAnimationFrame(rafId);
+    rafId = 0;
+  }
+};
+
+const tick = (t: number): void => {
+  rafId = 0;
+  for (const c of clients) c.updateSeal(cursorX, cursorY, t);
+  if (clients.size > 0) {
+    rafId = globalThis.requestAnimationFrame(tick);
+  } else {
+    teardown();
+  }
+};
+
+/** Register a verified seal for cursor sheen. No-op under reduced motion. */
+export const registerSeal = (client: SealLivenessClient): void => {
+  if (prefersReducedMotion()) return;
+  // Cursor sheen needs a real animation loop; bail in non-browser envs (SSR,
+  // unit tests) rather than throwing on a missing requestAnimationFrame.
+  if (typeof globalThis.requestAnimationFrame !== "function") return;
+  clients.add(client);
+  if (!listening) {
+    globalThis.addEventListener("pointermove", onPointerMove, { passive: true });
+    listening = true;
+  }
+  if (!rafId) rafId = globalThis.requestAnimationFrame(tick);
+};
+
+export const unregisterSeal = (client: SealLivenessClient): void => {
+  if (clients.delete(client) && clients.size === 0) teardown();
+};

--- a/packages/ui/src/v2/components/cf-profile-badge/seal-liveness.ts
+++ b/packages/ui/src/v2/components/cf-profile-badge/seal-liveness.ts
@@ -109,7 +109,9 @@ export const registerSeal = (client: SealLivenessClient): void => {
   if (typeof globalThis.requestAnimationFrame !== "function") return;
   clients.add(client);
   if (!listening) {
-    globalThis.addEventListener("pointermove", onPointerMove, { passive: true });
+    globalThis.addEventListener("pointermove", onPointerMove, {
+      passive: true,
+    });
     listening = true;
   }
   if (!rafId) rafId = globalThis.requestAnimationFrame(tick);


### PR DESCRIPTION
## What

Makes the **verified** identity seal on `cf-profile-badge` feel *alive* — and alive in ways a sandboxed pattern can't reproduce. Today the seal is a static, DID-derived conic aura that only animates on hover. This moves it toward the "foil hologram" trust-mark concept: a treatment whose liveness is driven by host-held state (a session epoch + the host cursor) that user-space patterns can't observe.

Everything here is gated behind the **existing** `represents-principal` verified state — no change to *when* a seal is shown, only *how* a verified one looks — and behind `prefers-reduced-motion`.

## The three liveness signals

- **Lockstep ring rotation** — a slow (26s) drift of the conic rim, seeded to a shared epoch via `animation-delay` so every verified seal on screen rotates *in unison*. A forgery can copy the keyframes but can't read our epoch, so it drifts out of phase ("the chorus it can't join").
- **Intrinsic shimmer sweep** — a soft light band glazing the avatar on a shared 7s clock, so the seal is visibly alive even when the cursor is still.
- **Cursor sheen** — a bright, iridescent reflective hotspot that tracks the host cursor *even when the cursor is far from the badge*. This is the load-bearing anti-forgery signal: a sandboxed pattern only receives pointer events inside its own iframe, so its lookalike can't glint toward a cursor that's elsewhere on screen.

## How it's built (and why it's cheap)

A single shared controller — `seal-liveness.ts`:

- Lockstep animations are **pure CSS** (no per-frame JS). Driven by per-element `@keyframes` seeded to a shared epoch rather than an animated `:root` custom property — the latter forces a style recalc on every consumer each frame (measured: even rotation dropped 80→57fps at 400 seals).
- The cursor sheen uses **one** global `pointermove` listener + **one** rAF loop, started only while ≥1 seal is registered. It touches only on-screen verified seals (offscreen-culled) and **skips all writes** for seals the cursor is far from.
- Deliberately **avoids `filter: hue-rotate`** for a "lockstep colour" effect — it's a per-pixel paint pass that roughly halved framerate in a 400-seal stress test, and stays costly even on GPU.
- SSR/test-safe: the controller bails when there's no `requestAnimationFrame`.

## Testing

- `deno check` ✓ · `deno lint` ✓
- `deno test` ✓ — existing badge + identity-seal suites unchanged, plus a new `seal-liveness.test.ts` (which caught + fixed an epoch-ordering bug in phase seeding).
- The **visual** was iterated and signed off in a standalone prototype using the identical CSS/JS recipe before integration.

## Reviewer note

I couldn't render the *integrated* component in a standalone bundle harness — `felt`/esbuild leaves Lit decorators untranspiled for raw browser, so the bundle won't parse (a build-pipeline quirk, not a component issue; the badge uses the same decorators it already shipped with). Best evaluated in the **shell preview** with a profile that carries a `represents-principal` attestation. Move your cursor anywhere on the page (not just over the badge) and watch the seal glint toward it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the verified identity seal in `cf-profile-badge` feel alive with an always-on, host-cursor-driven sheen, plus hover-gated ring rotation and shimmer. Strengthens the trust signal and honors reduced motion live.

- **New Features**
  - Verified-only liveness; no change to verification logic.
  - Cursor sheen stays on; tracks the host cursor even off-badge.
  - Ring rotation (26s) and shimmer sweep (7s) now run on hover.

- **Implementation**
  - Added `seal-liveness.ts`: one passive `pointermove` and one rAF; runs only while ≥1 seal is registered, offscreen-culls, and skips distant writes.
  - Live `prefers-reduced-motion`: loop tears down and clears highlights on enable; resumes on disable; SSR-safe.
  - Dropped lockstep epoch seeding; motion remains pure CSS.
  - New test `seal-liveness.test.ts` ensures single-listener/rAF startup and teardown.

<sup>Written for commit cfb5bb5b6038b1a57c7f19e0940587507f85e2a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

