### PR TITLE
feat(home): surface the private self-model as a "Self" tab + fix neurotype input (CT-1669)

### DIFF
--- a/packages/patterns/self.tsx
+++ b/packages/patterns/self.tsx
@@ -512,12 +512,12 @@ const Self = pattern<SelfInput, SelfOutput>(
               <cf-select
                 $value={systemField}
                 items={neurotypeSystemItems}
-                style="min-width: 130px;"
+                style="flex: 0 0 150px;"
               />
               <cf-input
                 $value={resultField}
                 placeholder="e.g. INTJ, 5w4…"
-                style="flex: 1;"
+                style="flex: 1 1 auto; min-width: 0;"
               />
               <cf-button
                 onClick={recordNeurotypeFromForm({

--- a/packages/patterns/system/home.tsx
+++ b/packages/patterns/system/home.tsx
@@ -9,6 +9,7 @@ import {
   Writable,
 } from "commonfabric";
 import FavoritesManager from "./favorites-manager.tsx";
+import Self from "../self.tsx";
 import {
   type CreateProfileEvent,
   submitProfileCreation,
@@ -160,6 +161,10 @@ export default pattern<Record<string, never>, HomeOutput>((_) => {
 
   // Child components
   const favoritesComponent = FavoritesManager({});
+  // Private self-model — the "real you" tier (values, neurotype, meaning Q&A),
+  // home-local and never shared. Distinct from the outward profile/personas in
+  // the Profile tab. Owns its own durable cell (seeded via Default<>).
+  const selfComponent = Self({});
   const activeTab = new Writable("spaces").for("activeTab");
 
   return {
@@ -175,8 +180,10 @@ export default pattern<Record<string, never>, HomeOutput>((_) => {
             <cf-tab value="spaces">Spaces</cf-tab>
             <cf-tab value="favorites">Favorites</cf-tab>
             <cf-tab value="profile">Profile</cf-tab>
+            <cf-tab value="self">Self</cf-tab>
           </cf-tab-list>
           <cf-tab-panel value="favorites">{favoritesComponent}</cf-tab-panel>
+          <cf-tab-panel value="self">{selfComponent}</cf-tab-panel>
           <cf-tab-panel value="profile">
             <cf-vstack gap="4" style={{ padding: "1rem" }}>
               <h2 style={{ margin: 0, fontSize: "16px" }}>Profile</h2>


### PR DESCRIPTION
## Motivation

The private **self-model** (`packages/patterns/self.tsx`, CT-1669) shipped with **no home-space entry point** — nothing imported it, no wish consumed it — so the "real you" tier (values, neurotype, meaning-alignment Q&A) was unreachable in the running system. This wires it into a new top-level **"Self" tab** in the home space, kept **distinct from the Profile tab** per the two-tier model (profile = outward personas; self/values = private, home-local).

## What's in this PR

- **`home.tsx`** — `import Self`, `const selfComponent = Self({})`, a `<cf-tab value="self">Self</cf-tab>` + `<cf-tab-panel value="self">{selfComponent}</cf-tab-panel>`, mirroring how `FavoritesManager`/`ProfilePicker` are embedded.
- **`self.tsx`** — small layout fix found in E2E: the "Record Neurotype" row crushed the result input between the select and the button. Pin the select (`flex: 0 0 150px`) and let the input flex (`flex: 1 1 auto; min-width: 0`).

## Depends on #3950 (merged)

`Self({})` owns its durable cell, which only seeds correctly with the CT-1669 seed fix (#3950, merged). Without it the tab would crash on first capture.

## Verification

- `cf check` clean on `home.tsx` + `self.tsx`; `fmt`/`lint` clean.
- Deployed via `cf piece set-home … --root packages/patterns` and **end-to-end tested in the browser**: the Self tab renders; recording a neurotype / answering a meaning prompt / adding a value card all persist (the capture paths were also verified at the data layer under #3950).

## Context

- Epic **CT-1669**; series CT-1670 (#3907) / CT-1672 (#3908) / CT-1674 (#3910); seed fix **#3950**.
- Profile-picker fixes from the same E2E pass are split into **#3955** (Berni's #3830 surface).

> ⏳ Draft pending `cf-review`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
