### PR TITLE
fix(shell): don't start every piece to label the header menu (CT-1623)

### DIFF
--- a/packages/lib-shell/src/runtime.ts
+++ b/packages/lib-shell/src/runtime.ts
@@ -157,7 +157,10 @@ export class RuntimeInternals extends EventTarget {
   #favorites: FavoritesManager;
   #callbacks: RuntimeInternalsCallbacks;
   #spaceRootPattern?: Promise<PageHandle<NameSchema>>;
-  #patternCache: Map<string, Promise<PageHandle<NameSchema>>> = new Map();
+  #patternCache: Map<
+    string,
+    { promise: Promise<PageHandle<NameSchema>>; started: boolean }
+  > = new Map();
   // TODO(runtime-worker-refactor)
   #telemetryMarkers: RuntimeTelemetryMarkerResult[] = [];
 
@@ -245,20 +248,36 @@ export class RuntimeInternals extends EventTarget {
     return pattern;
   }
 
-  getPattern(id: string): Promise<PageHandle<NameSchema>> {
+  /**
+   * Get a piece's page handle. By default this also STARTS the piece
+   * (instantiates its pattern in the worker) — appropriate for the piece
+   * about to be displayed. Pass `start: false` for read-only consumers
+   * (e.g. listing piece names): the persisted result cell is synced and
+   * readable without paying pattern instantiation for every piece
+   * (CT-1623: starting all pieces on reload cost ~10s of dependency
+   * collection, either in the reload wall or on the first interaction).
+   *
+   * Cached per id. A cache entry created with `start: false` is upgraded
+   * (re-fetched with start) when a starting caller asks for the same id.
+   */
+  getPattern(
+    id: string,
+    options?: { start?: boolean },
+  ): Promise<PageHandle<NameSchema>> {
     this.#check();
+    const start = options?.start ?? true;
     const cached = this.#patternCache.get(id);
-    if (cached) {
-      return cached;
+    if (cached && (cached.started || !start)) {
+      return cached.promise;
     }
     const promise = (async () => {
-      const page = await this.#client.getPage<NameSchema>(id, true);
+      const page = await this.#client.getPage<NameSchema>(id, start);
       if (!page) {
         throw new Error(`Pattern not found: ${id}`);
       }
       return page;
     })();
-    this.#patternCache.set(id, promise);
+    this.#patternCache.set(id, { promise, started: start });
     return promise;
   }
 

--- a/packages/lib-shell/test/runtime.test.ts
+++ b/packages/lib-shell/test/runtime.test.ts
@@ -50,6 +50,18 @@ class MockRuntimeClient {
     return Promise.resolve(this.slugByPageId.get(pageId));
   }
 
+  /** Records every (pageId, runIt) pair so tests can assert which calls START
+   * the piece (CT-1623: name listings must not start every piece). */
+  getPageCalls: Array<{ pageId: string; runIt: boolean | undefined }> = [];
+
+  getPage(
+    pageId: string,
+    runIt?: boolean,
+  ): Promise<{ id: () => string }> {
+    this.getPageCalls.push({ pageId, runIt });
+    return Promise.resolve({ id: () => pageId });
+  }
+
   dispose(): Promise<void> {
     return Promise.resolve();
   }
@@ -266,5 +278,91 @@ describe("RuntimeInternals", () => {
       trustSnapshot: null,
     });
     expect(withoutTrust.trustSnapshot).toBeUndefined();
+  });
+
+  // CT-1623: starting a piece is expensive (pattern instantiation + eager
+  // dependency collection in the worker). Read-only consumers like the header
+  // pieces menu must be able to resolve page handles WITHOUT starting, and a
+  // non-started cache entry must not block a later display-path start.
+  describe("getPattern start semantics", () => {
+    const spaceDid = "did:key:z6Mk-lib-shell-runtime-did-pattern" as DID;
+
+    async function makeRuntime() {
+      const { RuntimeInternals } = await import("@commonfabric/lib-shell");
+      const client = new MockRuntimeClient();
+      const runtime = new RuntimeInternals(
+        client as any,
+        spaceDid,
+        undefined,
+        false,
+        spaceDid,
+      );
+      return { client, runtime };
+    }
+
+    it("starts by default (display path)", async () => {
+      const { client, runtime } = await makeRuntime();
+      try {
+        await runtime.getPattern("piece-1");
+        expect(client.getPageCalls).toEqual([
+          { pageId: "piece-1", runIt: true },
+        ]);
+      } finally {
+        await runtime.dispose();
+      }
+    });
+
+    it("does not start when start: false (name listings)", async () => {
+      const { client, runtime } = await makeRuntime();
+      try {
+        await runtime.getPattern("piece-1", { start: false });
+        expect(client.getPageCalls).toEqual([
+          { pageId: "piece-1", runIt: false },
+        ]);
+      } finally {
+        await runtime.dispose();
+      }
+    });
+
+    it("upgrades a non-started cache entry when a starting caller asks", async () => {
+      const { client, runtime } = await makeRuntime();
+      try {
+        await runtime.getPattern("piece-1", { start: false });
+        await runtime.getPattern("piece-1");
+        expect(client.getPageCalls).toEqual([
+          { pageId: "piece-1", runIt: false },
+          { pageId: "piece-1", runIt: true },
+        ]);
+      } finally {
+        await runtime.dispose();
+      }
+    });
+
+    it("serves started entries from cache for both kinds of callers", async () => {
+      const { client, runtime } = await makeRuntime();
+      try {
+        await runtime.getPattern("piece-1");
+        await runtime.getPattern("piece-1");
+        await runtime.getPattern("piece-1", { start: false });
+        expect(client.getPageCalls).toEqual([
+          { pageId: "piece-1", runIt: true },
+        ]);
+      } finally {
+        await runtime.dispose();
+      }
+    });
+
+    it("serves repeated non-started requests from cache", async () => {
+      const { client, runtime } = await makeRuntime();
+      try {
+        await runtime.getPattern("piece-1", { start: false });
+        await runtime.getPattern("piece-1", { start: false });
+        expect(client.getPageCalls).toEqual([
+          { pageId: "piece-1", runIt: false },
+        ]);
+      } finally {
+        await runtime.dispose();
+      }
+    });
   });
 });

--- a/packages/shell/integration/piece.test.ts
+++ b/packages/shell/integration/piece.test.ts
@@ -246,17 +246,11 @@ describe("shell piece tests", () => {
         return await page.evaluate(() => !!globalThis.commonfabric?.rt);
       });
       await waitForSpaceRootPattern(page);
-      // Ensure the space-root/sub-pattern compile-cache write-backs are durable
-      // before we snapshot the baseline and load the piece. Otherwise a write
-      // still in flight can be missed by the piece load's cache read, forcing an
-      // in-client recompile (the flake this test guards against). This awaits
-      // persistence specifically, NOT reactive idle.
-      await page.evaluate(async () => {
-        await globalThis.commonfabric?.rt?.flushCompileCacheWrites();
-      });
-      const clientCompileCountBeforePieceLoad =
-        await getClientEngineCompileCount(page);
-
+      // First in-browser load of the piece: pieces are no longer eagerly
+      // started when the space loads (CT-1623 — the header used to start every
+      // piece just to label its menu), so this navigation performs the cold
+      // in-client compile and seeds the compilation cache. The cache contract
+      // is asserted below against a fresh worker.
       await page.evaluate(async (spaceName, pieceId) => {
         await globalThis.app.setView({ spaceName, pieceId });
       }, { args: [SPACE_NAME, pieceId] });
@@ -290,18 +284,6 @@ describe("shell piece tests", () => {
       };
 
       await waitForActivePattern();
-      const clientCompileCountAfterPieceLoad =
-        await getClientEngineCompileCount(
-          page,
-        );
-      if (
-        clientCompileCountAfterPieceLoad !== clientCompileCountBeforePieceLoad
-      ) {
-        throw new Error(
-          `Expected 0 in-client compilations while loading cf-created piece ${pieceId}; ` +
-            `engine compile count changed from ${clientCompileCountBeforePieceLoad} to ${clientCompileCountAfterPieceLoad}`,
-        );
-      }
 
       await waitFor(async () =>
         (await currentPiece.result.get(["value"])) === 0
@@ -313,6 +295,71 @@ describe("shell piece tests", () => {
       );
 
       await clickPierce(page, "#counter-decrement");
+      await waitFor(async () =>
+        (await currentPiece.result.get(["value"])) === -2
+      );
+
+      // Compilation-cache contract: the piece's cold compile above was written
+      // back to the IDB-backed CachedCompiler. A FRESH worker must then load
+      // the piece from that cache — zero in-client compilations during the
+      // piece load. Flush the write-backs first: a write still in flight when
+      // the fresh worker reads the cache forces a recompile (the flake this
+      // guard exists for).
+      await page.evaluate(async () => {
+        await globalThis.commonfabric?.rt?.flushCompileCacheWrites();
+      });
+      await page.evaluate(async () => {
+        try {
+          await globalThis.commonfabric?.rt?.dispose();
+        } finally {
+          if (globalThis.commonfabric) globalThis.commonfabric.rt = undefined;
+        }
+      });
+      await shell.goto({
+        frontendUrl: FRONTEND_URL,
+        view: {
+          spaceName: SPACE_NAME,
+        },
+        identity,
+      });
+      await waitFor(async () => {
+        return await page.evaluate(() => !!globalThis.commonfabric?.rt);
+      });
+      await waitForSpaceRootPattern(page);
+      // Let the space-root chain's own compiles finish and settle before
+      // baselining (a trailing root compile landing inside the measurement
+      // window would show up as a false piece recompile).
+      let settledCompileCount = await getClientEngineCompileCount(page);
+      await waitFor(async () => {
+        const before = settledCompileCount;
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        settledCompileCount = await getClientEngineCompileCount(page);
+        return settledCompileCount === before;
+      });
+      const compileCountBeforePieceLoad = settledCompileCount;
+      await page.evaluate(async (spaceName, pieceId) => {
+        await globalThis.app.setView({ spaceName, pieceId });
+      }, { args: [SPACE_NAME, pieceId] });
+      await shell.waitForState({
+        view: {
+          spaceName: SPACE_NAME,
+          pieceSlug: slug,
+        },
+        identity,
+      });
+      await waitForActivePattern();
+      const compileCountAfterPieceLoad = await getClientEngineCompileCount(
+        page,
+      );
+      if (compileCountAfterPieceLoad !== compileCountBeforePieceLoad) {
+        throw new Error(
+          `Expected 0 in-client compilations while a fresh worker loads the ` +
+            `cached cf-created piece ${pieceId}; engine compile count ` +
+            `changed from ${compileCountBeforePieceLoad} to ` +
+            `${compileCountAfterPieceLoad}`,
+        );
+      }
+
       await waitFor(async () =>
         (await currentPiece.result.get(["value"])) === -2
       );

--- a/packages/shell/integration/piece.test.ts
+++ b/packages/shell/integration/piece.test.ts
@@ -326,17 +326,17 @@ describe("shell piece tests", () => {
         return await page.evaluate(() => !!globalThis.commonfabric?.rt);
       });
       await waitForSpaceRootPattern(page);
-      // Let the space-root chain's own compiles finish and settle before
-      // baselining (a trailing root compile landing inside the measurement
-      // window would show up as a false piece recompile).
-      let settledCompileCount = await getClientEngineCompileCount(page);
-      await waitFor(async () => {
-        const before = settledCompileCount;
-        await new Promise((resolve) => setTimeout(resolve, 500));
-        settledCompileCount = await getClientEngineCompileCount(page);
-        return settledCompileCount === before;
+      // Settle the space-root chain's own loads before baselining (a trailing
+      // root compile landing inside the measurement window would show up as a
+      // false piece recompile): drain the scheduler, then the compile-cache
+      // write-backs — both deterministic completion signals, no timed waits.
+      await page.evaluate(async () => {
+        await globalThis.commonfabric?.rt?.idle();
+        await globalThis.commonfabric?.rt?.flushCompileCacheWrites();
       });
-      const compileCountBeforePieceLoad = settledCompileCount;
+      const compileCountBeforePieceLoad = await getClientEngineCompileCount(
+        page,
+      );
       await page.evaluate(async (spaceName, pieceId) => {
         await globalThis.app.setView({ spaceName, pieceId });
       }, { args: [SPACE_NAME, pieceId] });

--- a/packages/shell/src/views/HeaderView.ts
+++ b/packages/shell/src/views/HeaderView.ts
@@ -647,7 +647,10 @@ export class XHeaderView extends BaseView {
 
       const results = await Promise.allSettled(
         ids.map(async (id) => {
-          const page = await rt.getPattern(id);
+          // Names come from the persisted result cells — do NOT start every
+          // piece in the space just to label a menu (CT-1623: that cost ~10s
+          // of dependency collection per reload or on first interaction).
+          const page = await rt.getPattern(id, { start: false });
           await page.cell().sync();
           return {
             id: page.id(),


### PR DESCRIPTION
## Problem

On every reload, `HeaderView` builds its pieces-menu name cache by calling `rt.getPattern(id)` for **every piece in the space** — and lib-shell's `getPattern()` hardcoded `getPage(id, runIt: true)`. Starting a piece instantiates its full pattern in the worker, and every instantiated node subscribes with an eager `populateDependencies` walk (~30ms each via `findAllWriteRedirectCells`, the #3929 hotspot).

In the notes workload (13 notes), that's ~340 subscriptions whose collection cost lands in one of two bad places, depending on timing:

- **ESM loader**: pattern loads are fast (by-identity, #3892/#3898), so the notes instantiate while reload-window scheduler executes are still firing → **~11.5s of dependency collection inside the reload wall** (~22s total reload).
- **AMD loader**: the ~5.5s TS compile pushes instantiation past the last execute → 273 populates sit pending indefinitely → the **first user interaction after reload freezes for ~10s** (measured 10,066ms, popDelta exactly the 273 deferred entries).

The names the header needs are in the persisted result cells; running the pieces was never required.

## Fix

- `lib-shell` `getPattern(id, { start })`: default `start: true` keeps the display path (AppView) unchanged. Cache entries created with `start: false` are upgraded (re-fetched with start) when a starting caller asks for the same id, so a name-lookup can never block a later real start.
- `HeaderView` passes `{ start: false }` in the name-cache loop.

## Verification

Unit (red→green): `lib-shell/test/runtime.test.ts` "getPattern start semantics" — 3 of 5 cases fail before the fix (no-start, cache upgrade, non-started cache hits).

Browser (notes workload: 13 notes, reload, measure post-reload worker; local stack, both loaders):

| metric | ESM before | ESM after | AMD before | AMD after |
|---|---|---|---|---|
| reload wall | 21.1–23.3s | **8.40s / 8.39s** | 16.5–16.7s | **11.4s** |
| dependency populates | 340–379 | **40** | 67 (+273 deferred) | **40** |
| pieces instantiated | 37 (all 13 notes ×35 nodes) | **10 (system/home only)** | 24 (all 13 notes) | **10** |
| first click after reload | 48ms | 26–31ms | **10,066ms** | **29ms** |
| summary-index re-runs | 0 | 0 | 0 | 0 |

Steady-state note-add is unchanged (~23s/10 notes in all configurations). lib-shell (5 tests) and shell (12 tests) package suites pass.

## Context

CT-1623 follow-up: the historical reload re-run churn was fixed by #3898 (bisect-verified); this removes the dominant remaining reload cost, which #3898's faster by-identity loads had surfaced inside the ESM reload wall. The per-populate walk cost itself is tracked separately (#3929, subsystem rewrite planned); a possible future hardening is lazy dependency collection for non-demanded pull computations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoid starting every piece when building the header menu. `lib-shell` now supports read-only lookups, and `HeaderView` uses `{ start: false }` to cut reload time and remove first-click freezes (CT-1623).

- **New Features**
  - `lib-shell` `getPattern(id, { start })` (default `true`); cache entries created with `start: false` upgrade when a later caller requests `start: true`.

- **Bug Fixes**
  - `HeaderView` passes `{ start: false }` for the pieces-name cache, reading persisted names without pattern instantiation.
  - Tests: added unit tests for start defaults, non-started cache hits, and cache upgrade; reworked and stabilized the shell integration test to verify the cross-worker compile-cache contract using `rt.idle()` and `flushCompileCacheWrites()` before measuring.

<sup>Written for commit f048914b7e91f8fb3056319a7efde4840e7d2a1d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

