### PR TITLE
fix(profiles): clear draft name + pass picker profile as a link so Set default/Use run

### DIFF
--- a/packages/patterns/system/profile-create.tsx
+++ b/packages/patterns/system/profile-create.tsx
@@ -71,6 +71,9 @@ export const submitProfileCreation = handler<
         initialName: name,
       }) as ProfileHomeOutput,
     );
+    // Clear the draft name input after a successful create (mirrors the form
+    // handlers in self.tsx / home's space input).
+    draftName?.set("");
   }
 });
 
@@ -81,7 +84,12 @@ export const setDefaultProfile = handler<
   unknown,
   {
     defaultProfile: Writable<ProfileHomeOutput | undefined>;
-    profile: ProfileHomeOutput;
+    // Take the profile as a LINK cell, not a resolved value: resolving the full
+    // ProfileHomeOutput requires reading its owner-protected name/avatar/elements
+    // across the profile's space boundary, which returns undefined (CT-1667 read
+    // gap) → the action argument fails schema validation → "stream action argument
+    // is undefined … not running". We only need the link to write into defaultProfile.
+    profile: Cell<ProfileHomeOutput>;
   }
 >((_, { defaultProfile, profile }) => {
   if (profile) {
@@ -95,7 +103,9 @@ export const setMruProfile = handler<
   unknown,
   {
     mru: Writable<ProfileHomeOutput[]>;
-    profile: ProfileHomeOutput;
+    // Link cell, not a resolved value — same CT-1667 cross-space-read reason as
+    // setDefaultProfile above (resolving the owner-protected fields yields undefined).
+    profile: Cell<ProfileHomeOutput>;
   }
 >((_, { mru, profile }) => {
   if (!profile) return;


### PR DESCRIPTION
## Motivation

Surfaced during **CT-1669** end-to-end validation of the home **Profile** tab (Berni's #3830 multi-profile picker). Two picker bugs, both fixed in the pattern layer.

## Fixes (`profile-create.tsx` only)

**1. Draft name not cleared on create.** `submitProfileCreation` appended the profile but never reset `draftName`, so the input kept the just-used name. Added `draftName?.set("")` after a successful create.

**2. "Set default" / "Use" silently no-op (throw).** `setDefaultProfile` / `setMruProfile` typed the picker profile as a resolved `ProfileHomeOutput` (required `name`/`avatar`/`elements`). The runner resolves that value → reads the profile's **owner-protected fields across its space boundary** → they return `undefined` (the **CT-1667** cross-space read gap) → the resolved object fails its required-field schema → `runner.ts:2993` `!isValidArgument` → **`stream action argument is undefined (potential schema mismatch) -- not running`**. The action silently did nothing.

Fix: take the profile as a **`Cell<ProfileHomeOutput>` link** — we only need the link to write into `defaultProfile`/`mru`, so no owner-protected read is required and the argument validates.

## Verification
- `cf check` clean on `profile-create.tsx` + `profile-picker.tsx`; `fmt`/`lint` clean.
- **Confirmed working in the browser** (Ben): Set default / Use now stamp the default/MRU; create clears the name field.

## Scope / follow-ups (the underlying gaps, tracked separately)
This PR **works around** the cross-space read gap; it does not fix it. Surfaces that must *display* another space's owner-protected profile fields remain blocked:
- **CT-1667** (cross-space owner-protected read) — elevated to High; this PR is the evidence it's now functionally breaking, not cosmetic.
- **CT-1687** — inSpace-created profile pieces have no stored source (profile link → "Failed to load piece"; profiles uneditable).

## Context
Multi-profile foundation: #3830. Epic: CT-1645. Sibling: the home "Self" tab wiring in #3952.

> cc @bfollington — this touches the #3830 picker surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Home → Profile picker so creating a profile clears the input, and “Set default”/“Use” work reliably. Addresses CT-1669 validation by avoiding the CT-1667 cross-space read failure.

- **Bug Fixes**
  - Clear the draft name after create by resetting `draftName` in `submitProfileCreation`.
  - Update `setDefaultProfile` and `setMruProfile` to take a `Cell<ProfileHomeOutput>` link instead of a resolved object, avoiding owner-protected cross-space reads that caused silent no-ops; default/MRU now update as expected.

<sup>Written for commit dbe3104cf0950fa37d186d1da2b49e248c84e8ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

