### PR TITLE
Test for presence in the deep-frozen object cache first.

### DIFF
--- a/packages/data-model/src/value-hash.ts
+++ b/packages/data-model/src/value-hash.ts
@@ -508,15 +508,27 @@ function hashOfInternal(
     }
 
     case "object": {
-      if (value === null) return NULL_HASH;
+      if (value === null) {
+        return NULL_HASH;
+      }
+
+      const obj = value as object;
+
+      // Even if we don't know that `obj` is deep-frozen, it's okay to look it
+      // up in the cache for same (we just won't find it if it's not
+      // deep-frozen). And doing this lookup first minimizes the number of
+      // checks needed on the fast path.
+      const cached = frozenObjectHashCache.get(obj);
+      if (cached !== undefined) {
+        return cached;
+      }
+
       if (isDeepFrozen(value)) {
-        const obj = value as object;
-        const cached = frozenObjectHashCache.get(obj);
-        if (cached !== undefined) return cached;
         const result = computeHash(value);
         frozenObjectHashCache.set(obj, result);
         return result;
       }
+
       return stringOkay ? computeHashAsString(value) : computeHash(value);
     }
 


### PR DESCRIPTION
This makes it so that it takes one less `WeakMap` lookup to find the hash of a deep-frozen object (instead of first checking to see if it's in fact deep-frozen, which involves _another_ `WeakMap` lookup).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimize deep-frozen object hashing by checking the cache first, then computing only if needed. Removes one `WeakMap` lookup on the fast path in `packages/data-model` to reduce overhead.

<sup>Written for commit d356aae6dbb66ea6ee9fa07c6d2c7bd6fbeeab05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

