### PR TITLE
Multi-runtime/multi-browser test harness + fixes for the cfc-group-chat-demo multi-user regressions

### DIFF
--- a/docs/common/patterns/multi-user-patterns.md
+++ b/docs/common/patterns/multi-user-patterns.md
@@ -308,6 +308,18 @@ inside the child pattern or handler.
 Use pattern tests for deterministic state transitions and browser/integration
 tests for identity behavior.
 
+For headless multi-user coverage, use the multi-runtime harness
+(`packages/patterns/integration/multi-runtime-harness.ts`): it opens the same
+piece in several worker-isolated runtimes (distinct identities, or one
+identity in two sessions) against one shared in-process storage server, so
+`PerUser`/`PerSession` partitioning and cross-client propagation are actually
+exercised — no toolshed or browser needed. See
+`cfc-group-chat-demo-multi-runtime.test.ts` for usage, and
+`cfc-group-chat-demo-two-browsers.test.ts` for the two-simultaneous-browser
+variant that guards the real DOM/event stack. A single runtime (or one page
+that switches identities) cannot catch cross-user leaks or
+fails-to-propagate bugs.
+
 Expected visibility:
 
 - `PerSpace<T>` data should be visible to every identity in the same space.

--- a/docs/development/debugging/gotchas/scoped-cell-pitfalls.md
+++ b/docs/development/debugging/gotchas/scoped-cell-pitfalls.md
@@ -143,7 +143,40 @@ that breaks it nested. See
 the three idiomatic alternatives (map the cell directly; pre-bake into a
 top-level `computed`; local `computed()` bridge per row).
 
-## 6. `Math.random()` throws under SES
+## 6. Don't share `perUser`/`perSession` cells through `PerSpace` data
+
+**Symptom:** Other participants see "Unnamed user" / empty values where a
+user's profile (or similar per-user record) should appear, while the owning
+user sees their own data fine.
+
+A user/session-scoped cell instance is isolated **by reader**
+(`docs/specs/scoped-cell-instances.md`): the same link resolves to each
+reader's own instance. So registering a `Writable.perUser.of(...)` cell in a
+shared (`PerSpace`) list hands every other participant a link to *their own*
+empty instance — the data can never propagate.
+
+```typescript
+// WRONG — other users dereference this to their own empty instance.
+const profile = Writable.perUser.of<TrustedProfile>(snapshot);
+registerProfile(sharedProfiles, profile);
+
+// CORRECT — mint a space-scoped cell; per-user distinctness comes from
+// creation (per-invocation cause on each user's first save) plus a PerUser
+// pointer that remembers which cell is "mine".
+const profile = currentProfileCell(myProfile) ??
+  Writable.perSpace.of<TrustedProfile>(snapshot);
+myProfile.set({ profile });
+registerProfile(sharedProfiles, profile);
+```
+
+Rule of thumb: scope controls _who reads which instance_, not _who owns the
+data_. Anything that must be visible to other users belongs in a space-scoped
+cell; use `PerUser` for the pointer, not the shared record. Fixed in
+`packages/patterns/cfc-group-chat-demo/trusted.tsx`; guarded by the
+multi-runtime test
+`packages/patterns/integration/cfc-group-chat-demo-multi-runtime.test.ts`.
+
+## 7. `Math.random()` throws under SES
 
 **Symptom:** `TypeError: secure mode %SharedMath%.random() throws` when a
 handler runs.

--- a/packages/patterns/cfc-group-chat-demo/trusted.tsx
+++ b/packages/patterns/cfc-group-chat-demo/trusted.tsx
@@ -411,19 +411,19 @@ export const applyTrustedProfileSave = (
     trimmedName,
     existingProfile,
   ) as TrustedProfile;
-  // Each user's profile must be its OWN cell. The previous
-  // `Writable.for("profile")` used a constant cause, so every user sharing the
-  // space derived the *same* underlying entity: all message `authorProfile`
-  // links redirected to one shared profile cell holding whoever saved last.
-  // Authorship verification then compared each message's signature against that
-  // single (current-user) profile, so genuine messages from other users read
-  // as unverified while imported "fake" messages read as verified — a
-  // nondeterministic outcome that made the integration test flaky. A
-  // per-user-scoped cell is isolated by active DID (see
-  // docs/common/patterns/multi-user-patterns.md), giving each user a distinct
-  // profile entity.
+  // Each user's profile must be its OWN cell, but it must stay SPACE-scoped:
+  // the cell is shared through the registry and through message
+  // `authorProfile` links, and a user/session-scoped instance is isolated by
+  // reader (docs/specs/scoped-cell-instances.md) — other participants would
+  // dereference it to their own empty instance and see "Unnamed user".
+  // Distinctness per user comes from creation, not scope: the cell is minted
+  // on each user's FIRST save (per-invocation cause) and remembered in the
+  // PerUser `myProfile` pointer, so later saves update the same entity. (The
+  // earlier `Writable.for("profile")` variant used a constant cause, which
+  // collapsed every user onto one shared entity and broke authorship
+  // verification.)
   const profile = currentProfileCell(myProfile) ??
-    Writable.perUser.of<TrustedProfile>(nextSnapshot);
+    Writable.perSpace.of<TrustedProfile>(nextSnapshot);
   profile.set(nextSnapshot);
   myProfile.set({ profile });
   registerProfile(profiles, profile);

--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -281,6 +281,24 @@ export async function fillCfInput(
   }
 }
 
+/** Read the current value of a cf-input's inner input element. */
+export async function readCfInputValue(
+  page: Page,
+  selector: string,
+  { timeout = DEFAULT_CFC_BROWSER_TIMEOUT }: { timeout?: number } = {},
+): Promise<string> {
+  const field = await page.waitForSelector(selector, {
+    strategy: "pierce",
+    timeout,
+  });
+  return await field.evaluate((element: Element): string => {
+    const input = element instanceof HTMLInputElement
+      ? element
+      : element.shadowRoot?.querySelector("input");
+    return input instanceof HTMLInputElement ? input.value : "";
+  });
+}
+
 export async function waitForRuntimeIdle(
   page: Page,
   { timeout = DEFAULT_CFC_BROWSER_TIMEOUT }: { timeout?: number } = {},

--- a/packages/patterns/integration/cfc-browser-helpers.ts
+++ b/packages/patterns/integration/cfc-browser-helpers.ts
@@ -281,7 +281,11 @@ export async function fillCfInput(
   }
 }
 
-/** Read the current value of a cf-input's inner input element. */
+/**
+ * Read the current value of a cf-input's inner input element. Throws when the
+ * selector does not resolve to an actual input, so an absent control cannot
+ * masquerade as an empty value in assertions.
+ */
 export async function readCfInputValue(
   page: Page,
   selector: string,
@@ -291,12 +295,20 @@ export async function readCfInputValue(
     strategy: "pierce",
     timeout,
   });
-  return await field.evaluate((element: Element): string => {
-    const input = element instanceof HTMLInputElement
-      ? element
-      : element.shadowRoot?.querySelector("input");
-    return input instanceof HTMLInputElement ? input.value : "";
-  });
+  const probe = await field.evaluate(
+    (element: Element): { found: boolean; value: string } => {
+      const input = element instanceof HTMLInputElement
+        ? element
+        : element.shadowRoot?.querySelector("input");
+      return input instanceof HTMLInputElement
+        ? { found: true, value: input.value }
+        : { found: false, value: "" };
+    },
+  );
+  if (!probe.found) {
+    throw new Error(`"${selector}" did not resolve to an input element`);
+  }
+  return probe.value;
 }
 
 export async function waitForRuntimeIdle(

--- a/packages/patterns/integration/cfc-group-chat-demo-multi-runtime.test.ts
+++ b/packages/patterns/integration/cfc-group-chat-demo-multi-runtime.test.ts
@@ -94,6 +94,13 @@ async function messages(session: MultiRuntimeSession): Promise<any[]> {
   return ((await session.read(["messages"])) as any[]) ?? [];
 }
 
+// `rooms` defaults to `{}`, so reading the path ["rooms", "list"] would throw
+// before the first room is added; read the parent and pluck the list instead.
+async function rooms(session: MultiRuntimeSession): Promise<any[]> {
+  const value = (await session.read(["rooms"])) as { list?: any[] } | undefined;
+  return value?.list ?? [];
+}
+
 describe("cfc group chat demo across runtimes", () => {
   let harness: MultiRuntimeHarness;
   let alice: MultiRuntimeSession;
@@ -260,10 +267,14 @@ describe("cfc group chat demo across runtimes", () => {
     // Room creation IS admin-gated: bob's attempt must be rejected…
     await addRoom(bob, "Bob's room");
     await harness.settle();
-    const roomsAfterBob = ((await alice.read(["rooms", "list"])) as any[]) ??
-      [];
+    // waitFor retries through transiently-unsynced reads; the room list must
+    // settle as readable AND empty.
+    await harness.waitFor(
+      "alice's room list stays empty after bob's rejected add",
+      async () => (await rooms(alice)).length === 0,
+    );
     assertEquals(
-      roomsAfterBob.map((room) => room?.name),
+      (await rooms(alice)).map((room) => room?.name),
       [],
       "non-admin bob was able to add a room",
     );
@@ -272,10 +283,7 @@ describe("cfc group chat demo across runtimes", () => {
     await addRoom(alice, "Ops");
     await harness.waitFor(
       "bob sees the room alice added",
-      async () =>
-        (((await bob.read(["rooms", "list"])) as any[]) ?? []).some(
-          (room) => room?.name === "Ops",
-        ),
+      async () => (await rooms(bob)).some((room) => room?.name === "Ops"),
     );
   });
 
@@ -293,9 +301,7 @@ describe("cfc group chat demo across runtimes", () => {
     await harness.waitFor(
       "bob can add a room once admin",
       async () =>
-        (((await alice.read(["rooms", "list"])) as any[]) ?? []).some(
-          (room) => room?.name === "Bob's room",
-        ),
+        (await rooms(alice)).some((room) => room?.name === "Bob's room"),
     );
   });
 });

--- a/packages/patterns/integration/cfc-group-chat-demo-multi-runtime.test.ts
+++ b/packages/patterns/integration/cfc-group-chat-demo-multi-runtime.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Multi-runtime tests for the CFC group chat demo.
+ *
+ * Each test opens the same piece in several runtimes (Alice, Bob — distinct
+ * identities — plus a second session for Alice) backed by one shared
+ * in-memory storage server. This exercises what neither the single-runtime
+ * pattern test nor the single-page browser test can: PerUser/PerSession
+ * isolation between concurrently-active users, and live propagation of
+ * PerSpace state between them.
+ *
+ * No toolshed or browser required.
+ */
+
+import { assert, assertEquals } from "@std/assert";
+import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
+import { join } from "@std/path";
+import { Identity } from "@commonfabric/identity";
+import {
+  MultiRuntimeHarness,
+  type MultiRuntimeSession,
+} from "./multi-runtime-harness.ts";
+
+// Trusted surface/action names from cfc-group-chat-demo/trusted.tsx (inlined
+// so the test does not compile the pattern module into the test process).
+const PROFILE_SURFACE = "TrustedGroupChatProfileSurface";
+const SAVE_PROFILE_ACTION = "TrustedGroupChatSaveProfile";
+const SEND_SURFACE = "TrustedGroupChatSendSurface";
+const SEND_ACTION = "TrustedGroupChatSendMessage";
+const ADMIN_SURFACE = "TrustedGroupChatAdminSurface";
+const SET_ADMIN_ACTION = "TrustedGroupChatSetAdmin";
+const ROOM_SURFACE = "TrustedGroupChatRoomSurface";
+const ADD_ROOM_ACTION = "TrustedGroupChatAddRoom";
+
+const PROGRAM_PATH = join(
+  import.meta.dirname!,
+  "..",
+  "cfc-group-chat-demo",
+  "main.tsx",
+);
+const ROOT_PATH = join(import.meta.dirname!, "..");
+
+async function createGroupChatHarness(): Promise<MultiRuntimeHarness> {
+  const alice = await Identity.fromPassphrase("group-chat alice", {
+    implementation: "noble",
+  });
+  const apiUrl = Deno.env.get("MULTI_RUNTIME_API_URL");
+  return await MultiRuntimeHarness.create({
+    programPath: PROGRAM_PATH,
+    rootPath: ROOT_PATH,
+    ...(apiUrl ? { apiUrl: new URL(apiUrl) } : {}),
+    sessions: [
+      { label: "alice", identity: alice },
+      { label: "bob" },
+      // Same user as alice, separate runtime session (≈ second browser tab).
+      { label: "alice-tab2", identity: alice },
+    ],
+  });
+}
+
+async function saveProfile(
+  session: MultiRuntimeSession,
+  name: string,
+): Promise<void> {
+  await session.send("setProfileDraft", name);
+  await session.send("saveProfile", {}, {
+    surface: PROFILE_SURFACE,
+    action: SAVE_PROFILE_ACTION,
+  });
+}
+
+async function sendMessage(
+  session: MultiRuntimeSession,
+  body: string,
+): Promise<void> {
+  await session.send("setMessageDraft", body);
+  await session.send("sendTrustedMessage", {}, {
+    surface: SEND_SURFACE,
+    action: SEND_ACTION,
+  });
+}
+
+async function addRoom(
+  session: MultiRuntimeSession,
+  name: string,
+): Promise<void> {
+  await session.send("setRoomDraft", name);
+  await session.send("addTrustedRoom", {}, {
+    surface: ROOM_SURFACE,
+    action: ADD_ROOM_ACTION,
+  });
+}
+
+async function messages(session: MultiRuntimeSession): Promise<any[]> {
+  return ((await session.read(["messages"])) as any[]) ?? [];
+}
+
+describe("cfc group chat demo across runtimes", () => {
+  let harness: MultiRuntimeHarness;
+  let alice: MultiRuntimeSession;
+  let bob: MultiRuntimeSession;
+  let aliceTab2: MultiRuntimeSession;
+
+  beforeAll(async () => {
+    harness = await createGroupChatHarness();
+    alice = harness.session("alice");
+    bob = harness.session("bob");
+    aliceTab2 = harness.session("alice-tab2");
+  });
+
+  afterAll(async () => {
+    await harness?.dispose();
+  });
+
+  it("shares PerSpace messages between users (harness sanity)", async () => {
+    await saveProfile(alice, "Alice");
+    await harness.waitFor(
+      "alice sees her own profile name",
+      async () => (await alice.read(["currentProfileName"])) === "Alice",
+    );
+
+    await sendMessage(alice, "Hello from Alice");
+    await harness.waitFor(
+      "bob receives alice's message",
+      async () =>
+        (await messages(bob)).some((m) => m?.body === "Hello from Alice"),
+    );
+  });
+
+  it("does not leak the profile name draft to another user", async () => {
+    await alice.send("setProfileDraft", "Alice is typing");
+    await harness.settle();
+
+    const bobDraft = await bob.read(["profileDraft"]);
+    assert(
+      bobDraft === "" || bobDraft === undefined,
+      `PerUser profileDraft leaked across users: bob sees ${
+        JSON.stringify(bobDraft)
+      }`,
+    );
+
+    // PerUser state SHOULD follow the same user into another session.
+    await harness.waitFor(
+      "alice's second session sees her own draft",
+      async () =>
+        (await aliceTab2.read(["profileDraft"])) === "Alice is typing",
+    );
+  });
+
+  it("keeps PerSession drafts isolated between sessions of one user", async () => {
+    await alice.send("setHostMessageDraft", "tab-local host draft");
+    await harness.settle();
+
+    const tab2Draft = await aliceTab2.read(["hostMessageDraft"]);
+    assert(
+      tab2Draft === "" || tab2Draft === undefined,
+      `PerSession hostMessageDraft leaked across sessions: tab2 sees ${
+        JSON.stringify(tab2Draft)
+      }`,
+    );
+    const bobDraft = await bob.read(["hostMessageDraft"]);
+    assert(
+      bobDraft === "" || bobDraft === undefined,
+      `PerSession hostMessageDraft leaked across users: bob sees ${
+        JSON.stringify(bobDraft)
+      }`,
+    );
+  });
+
+  it("keeps each user's saved profile their own", async () => {
+    await saveProfile(bob, "Bob");
+    await harness.waitFor(
+      "bob sees his own profile name",
+      async () => (await bob.read(["currentProfileName"])) === "Bob",
+    );
+    await harness.settle();
+
+    // Bob saving must not clobber Alice's PerUser profile.
+    assertEquals(
+      await alice.read(["currentProfileName"]),
+      "Alice",
+      "alice's profile was clobbered by bob saving his",
+    );
+    assertEquals(
+      await aliceTab2.read(["currentProfileName"]),
+      "Alice",
+      "alice's profile (second session) was clobbered by bob saving his",
+    );
+  });
+
+  it("shows other users' actual profile names, not unnamed placeholders", async () => {
+    await sendMessage(bob, "Hi, this is Bob");
+    await harness.waitFor(
+      "alice receives bob's message",
+      async () =>
+        (await messages(alice)).some((m) => m?.body === "Hi, this is Bob"),
+    );
+
+    const aliceView = (await messages(alice)).find(
+      (m) => m?.body === "Hi, this is Bob",
+    );
+    assertEquals(
+      aliceView?.authorName,
+      "Bob",
+      "message author snapshot name wrong in alice's runtime",
+    );
+    // The live profile behind the message must resolve for OTHER users too —
+    // this is what the participants list and admin panel display.
+    assertEquals(
+      aliceView?.authorProfile?.name,
+      "Bob",
+      "bob's profile does not resolve to his name in alice's runtime",
+    );
+
+    // The shared profile registry must expose both names to everyone.
+    const profilesFromAlice = ((await alice.read(["profiles"])) as any[]) ?? [];
+    const namesFromAlice = profilesFromAlice
+      .map((entry) => entry?.profile?.name)
+      .toSorted();
+    assertEquals(
+      namesFromAlice,
+      ["Alice", "Bob"],
+      "alice cannot resolve all registered profile names",
+    );
+  });
+
+  it("admin lockdown gates room creation but never message sending", async () => {
+    // Alice turns off "everyone is admin" — she becomes the bootstrap admin.
+    await alice.send("toggleEveryoneAdmin", { everyoneIsAdmin: false }, {
+      surface: ADMIN_SURFACE,
+      action: SET_ADMIN_ACTION,
+    });
+    await harness.waitFor(
+      "alice is still admin after lockdown",
+      async () => (await alice.read(["currentUserIsAdmin"])) === true,
+    );
+    await harness.waitFor(
+      "bob is no longer admin after lockdown",
+      async () => (await bob.read(["currentUserIsAdmin"])) === false,
+    );
+
+    // Posting messages is NOT admin-gated: both users must still be able
+    // to send.
+    await sendMessage(bob, "Bob posts after lockdown");
+    await harness.waitFor(
+      "bob's post-lockdown message arrives at alice",
+      async () =>
+        (await messages(alice)).some(
+          (m) => m?.body === "Bob posts after lockdown",
+        ),
+    );
+    await sendMessage(alice, "Alice posts after lockdown");
+    await harness.waitFor(
+      "alice's post-lockdown message arrives at bob",
+      async () =>
+        (await messages(bob)).some(
+          (m) => m?.body === "Alice posts after lockdown",
+        ),
+    );
+
+    // Room creation IS admin-gated: bob's attempt must be rejected…
+    await addRoom(bob, "Bob's room");
+    await harness.settle();
+    const roomsAfterBob = ((await alice.read(["rooms", "list"])) as any[]) ??
+      [];
+    assertEquals(
+      roomsAfterBob.map((room) => room?.name),
+      [],
+      "non-admin bob was able to add a room",
+    );
+
+    // …while admin alice's succeeds.
+    await addRoom(alice, "Ops");
+    await harness.waitFor(
+      "bob sees the room alice added",
+      async () =>
+        (((await bob.read(["rooms", "list"])) as any[]) ?? []).some(
+          (room) => room?.name === "Ops",
+        ),
+    );
+  });
+
+  it("admins can grant admin to another user by name", async () => {
+    await alice.send("toggleParticipantAdmin", { name: "Bob" }, {
+      surface: ADMIN_SURFACE,
+      action: SET_ADMIN_ACTION,
+    });
+    await harness.waitFor(
+      "bob becomes admin after alice grants it",
+      async () => (await bob.read(["currentUserIsAdmin"])) === true,
+    );
+
+    await addRoom(bob, "Bob's room");
+    await harness.waitFor(
+      "bob can add a room once admin",
+      async () =>
+        (((await alice.read(["rooms", "list"])) as any[]) ?? []).some(
+          (room) => room?.name === "Bob's room",
+        ),
+    );
+  });
+});

--- a/packages/patterns/integration/cfc-group-chat-demo-two-browsers.test.ts
+++ b/packages/patterns/integration/cfc-group-chat-demo-two-browsers.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Two-browser-profile test for the CFC group chat demo.
+ *
+ * Unlike cfc-group-chat-demo.test.ts (which switches identity on ONE page),
+ * this drives two SIMULTANEOUS browser instances — separate profiles,
+ * separate identities, same piece — and checks the multi-user contract that
+ * a single page cannot: per-user state isolation while both users are live,
+ * live propagation of shared state, and admin lockdown not interfering with
+ * the other user's ability to post.
+ *
+ * The deeper state-machine coverage lives in the headless
+ * cfc-group-chat-demo-multi-runtime.test.ts; this test guards the real
+ * browser stack (DOM input binding, event provenance, login flow).
+ */
+
+import { env } from "@commonfabric/integration";
+import { Identity } from "@commonfabric/identity";
+import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+import { PiecesController } from "@commonfabric/piece/ops";
+import { ShellIntegration } from "@commonfabric/integration/shell-utils";
+import { assertEquals } from "@std/assert";
+import { afterAll, beforeAll, describe, it } from "@std/testing/bdd";
+import { join } from "@std/path";
+import {
+  clickCfButton,
+  fillCfInput,
+  readCfInputValue,
+  waitForDisabled,
+  waitForRuntimeIdle,
+  waitForText,
+} from "./cfc-browser-helpers.ts";
+
+const { API_URL, FRONTEND_URL, SPACE_NAME } = env;
+const PROPAGATION_TIMEOUT = 60_000;
+
+describe("cfc group chat demo with two concurrent browser profiles", () => {
+  const aliceShell = new ShellIntegration();
+  const bobShell = new ShellIntegration();
+  aliceShell.bindLifecycle();
+  bobShell.bindLifecycle();
+
+  let aliceIdentity: Identity;
+  let bobIdentity: Identity;
+  let cc: PiecesController;
+  let pieceId: string;
+  let pieceSinkCancel: (() => void) | undefined;
+
+  beforeAll(async () => {
+    aliceIdentity = await Identity.generate({ implementation: "noble" });
+    bobIdentity = await Identity.generate({ implementation: "noble" });
+    cc = await PiecesController.initialize({
+      spaceName: SPACE_NAME,
+      apiUrl: new URL(API_URL),
+      identity: aliceIdentity,
+    });
+
+    const sourcePath = join(
+      import.meta.dirname!,
+      "..",
+      "cfc-group-chat-demo",
+      "main.tsx",
+    );
+    const rootPath = join(import.meta.dirname!, "..");
+    const program = await cc.manager().runtime.harness.resolve(
+      new FileSystemProgramResolver(sourcePath, rootPath),
+    );
+    const piece = await cc.create(program, { start: true });
+    pieceId = piece.id;
+    const resultCell = cc.manager().getResult(piece.getCell());
+    pieceSinkCancel = resultCell.sink(() => {});
+  });
+
+  afterAll(async () => {
+    pieceSinkCancel?.();
+    await cc?.dispose();
+  });
+
+  it("keeps per-user state isolated and shared state live across two browsers", async () => {
+    const alice = aliceShell.page();
+    const bob = bobShell.page();
+    const view = { spaceName: SPACE_NAME, pieceId };
+    await Promise.all([
+      aliceShell.goto({
+        frontendUrl: FRONTEND_URL,
+        view,
+        identity: aliceIdentity,
+      }),
+      bobShell.goto({ frontendUrl: FRONTEND_URL, view, identity: bobIdentity }),
+    ]);
+    await waitForRuntimeIdle(alice);
+    await waitForRuntimeIdle(bob);
+    await waitForText(alice, "#group-chat-manager-chip", "No profile");
+    await waitForText(bob, "#group-chat-manager-chip", "No profile");
+
+    // Typing a name in Alice's browser must NOT appear in Bob's input —
+    // the profile draft is per-user state.
+    await fillCfInput(alice, "#trusted-profile-name", "Alice");
+    await waitForRuntimeIdle(alice);
+    await waitForRuntimeIdle(bob);
+    assertEquals(
+      await readCfInputValue(bob, "#trusted-profile-name"),
+      "",
+      "Alice's profile-name draft leaked into Bob's browser",
+    );
+
+    // Alice saves her profile. Her status updates; Bob's profile must stay
+    // unset (not clobbered to Alice's).
+    await waitForDisabled(alice, "#trusted-profile-save", false);
+    await clickCfButton(alice, "#trusted-profile-save");
+    await waitForText(alice, "#trusted-profile-status", "Alice");
+    await waitForRuntimeIdle(alice);
+    await waitForRuntimeIdle(bob);
+    await waitForText(bob, "#trusted-profile-status", "Name not set");
+    await waitForText(bob, "#group-chat-manager-chip", "No profile");
+
+    // Bob saves his own profile. Alice's view must show Bob by his actual
+    // name (not an unnamed placeholder), and her own profile must survive.
+    await fillCfInput(bob, "#trusted-profile-name", "Bob");
+    await waitForDisabled(bob, "#trusted-profile-save", false);
+    await clickCfButton(bob, "#trusted-profile-save");
+    await waitForText(bob, "#trusted-profile-status", "Bob");
+    await waitForText(
+      alice,
+      "#trusted-admin-user-list",
+      "Bob",
+      { timeout: PROPAGATION_TIMEOUT },
+    );
+    await waitForText(alice, "#trusted-profile-status", "Alice");
+    await waitForText(
+      bob,
+      "#trusted-admin-user-list",
+      "Alice",
+      { timeout: PROPAGATION_TIMEOUT },
+    );
+
+    // Shared transcript propagates live in both directions, with snapshot
+    // author names intact.
+    await fillCfInput(alice, "#trusted-message-draft", "Hello from Alice");
+    await waitForDisabled(alice, "#trusted-send-button", false);
+    await clickCfButton(alice, "#trusted-send-button");
+    await waitForText(
+      bob,
+      "#trusted-conversation-preview",
+      "Hello from Alice",
+      { timeout: PROPAGATION_TIMEOUT },
+    );
+
+    // Alice locks down admin. Bob loses admin (cannot add rooms) but must
+    // still be able to POST — message sending is never admin-gated.
+    await clickCfButton(alice, "#trusted-everyone-admin-checkbox");
+    await waitForText(alice, "#group-chat-manager-chip", "Can manage admins");
+    await waitForText(
+      bob,
+      "#trusted-room-admin-hint",
+      "Ask an admin manager to make you an admin",
+      { timeout: PROPAGATION_TIMEOUT },
+    );
+    await fillCfInput(
+      bob,
+      "#trusted-message-draft",
+      "Bob posts after lockdown",
+    );
+    await waitForDisabled(bob, "#trusted-send-button", false);
+    await clickCfButton(bob, "#trusted-send-button");
+    await waitForText(
+      alice,
+      "#trusted-conversation-preview",
+      "Bob posts after lockdown",
+      { timeout: PROPAGATION_TIMEOUT },
+    );
+
+    // Admin Alice can still add rooms, and Bob sees the shared room list.
+    await fillCfInput(alice, "#trusted-room-name", "Ops");
+    await waitForDisabled(alice, "#trusted-room-add-button", false);
+    await clickCfButton(alice, "#trusted-room-add-button");
+    await waitForText(alice, "#rooms-panel", "Ops");
+    await waitForText(
+      bob,
+      "#rooms-panel",
+      "Ops",
+      { timeout: PROPAGATION_TIMEOUT },
+    );
+  });
+});

--- a/packages/patterns/integration/multi-runtime-harness.ts
+++ b/packages/patterns/integration/multi-runtime-harness.ts
@@ -100,7 +100,9 @@ class WorkerClient {
       const timer = setTimeout(() => {
         this.#pending.delete(id);
         reject(
-          new Error(`[${this.label}] ${cmd} timed out after ${RPC_TIMEOUT_MS}ms`),
+          new Error(
+            `[${this.label}] ${cmd} timed out after ${RPC_TIMEOUT_MS}ms`,
+          ),
         );
       }, RPC_TIMEOUT_MS);
       this.#pending.set(id, {
@@ -153,6 +155,18 @@ export class MultiRuntimeSession {
   /** Read a value from the piece result, pulling fresh state first. */
   async read(path: (string | number)[] = []): Promise<unknown> {
     return await this.#client.call("read", { path });
+  }
+
+  /** Inspect the normalized link (id, space, scope) at `path` in the result. */
+  async link(
+    path: (string | number)[] = [],
+  ): Promise<{ id: string; space: string; scope: string; path: string[] }> {
+    return await this.#client.call("link", { path }) as {
+      id: string;
+      space: string;
+      scope: string;
+      path: string[];
+    };
   }
 
   async idle(): Promise<void> {
@@ -216,7 +230,9 @@ export class MultiRuntimeHarness {
           spaceName,
           apiUrl,
         });
-        sessions.push(new MultiRuntimeSession(normalized.label, identity, client));
+        sessions.push(
+          new MultiRuntimeSession(normalized.label, identity, client),
+        );
       }
 
       // A throwaway bootstrap worker creates the piece, then every test

--- a/packages/patterns/integration/multi-runtime-harness.ts
+++ b/packages/patterns/integration/multi-runtime-harness.ts
@@ -1,0 +1,306 @@
+/**
+ * Multi-runtime pattern test harness.
+ *
+ * Runs the same piece in SEVERAL runtimes — one per (identity, session) pair,
+ * each in its own Deno Worker realm — all backed by one shared storage
+ * server. This is the headless equivalent of multiple users (or multiple
+ * tabs of one user) having the same piece open simultaneously, and is the
+ * only way to meaningfully exercise `PerUser` / `PerSession` scoped state
+ * and cross-client reactivity in a pattern test:
+ *
+ * - distinct identities → distinct `user:<did>` storage partitions
+ * - distinct harness sessions → distinct `session:<did>:<id>` partitions
+ * - `PerSpace` state is shared and propagates via subscription push
+ *
+ * Workers are essential, not an optimization: one JS realm cannot host two
+ * runtimes (verified-load registries, frame stacks and similar module-level
+ * state cross-talk), and production never does — every browser tab or CLI
+ * process is its own realm. The storage server is self-hosted in-process
+ * (see multi-runtime-memory-server.ts), so no toolshed is needed; pass
+ * `apiUrl` to target a running toolshed instead.
+ */
+
+import { Identity } from "@commonfabric/identity";
+import { StandaloneMemoryServer } from "./multi-runtime-memory-server.ts";
+import type {
+  TrustedUiDescriptor,
+  WorkerRequest,
+  WorkerResponse,
+} from "./multi-runtime-worker.ts";
+
+export type { TrustedUiDescriptor };
+
+export interface MultiRuntimeSessionSpec {
+  /** Label used in error messages and as the identity passphrase seed. */
+  label: string;
+  /**
+   * Identity for this session. Pass the same Identity in two specs to model
+   * one user with two concurrent sessions (e.g. two browser tabs).
+   */
+  identity?: Identity;
+}
+
+export interface MultiRuntimeHarnessOptions {
+  /** Path to the pattern entry file (e.g. `<dir>/main.tsx`). */
+  programPath: string;
+  /** Module-resolution root, usually the `packages/patterns` directory. */
+  rootPath: string;
+  sessions: (string | MultiRuntimeSessionSpec)[];
+  spaceName?: string;
+  /**
+   * When set, sessions talk to a running toolshed at this URL instead of the
+   * self-hosted in-process storage server.
+   */
+  apiUrl?: URL;
+}
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const RPC_TIMEOUT_MS = 120_000;
+
+class WorkerClient {
+  #worker: Worker;
+  #nextId = 1;
+  #pending = new Map<
+    number,
+    { resolve: (value: unknown) => void; reject: (error: Error) => void }
+  >();
+  readonly label: string;
+
+  constructor(label: string) {
+    this.label = label;
+    this.#worker = new Worker(
+      new URL("./multi-runtime-worker.ts", import.meta.url),
+      { type: "module", name: `multi-runtime:${label}` },
+    );
+    this.#worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
+      const pending = this.#pending.get(event.data.id);
+      if (!pending) return;
+      this.#pending.delete(event.data.id);
+      if ("error" in event.data) {
+        pending.reject(
+          new Error(`[${this.label}] ${event.data.error}`),
+        );
+      } else {
+        pending.resolve(event.data.ok);
+      }
+    };
+    this.#worker.onerror = (event) => {
+      const error = new Error(`[${this.label}] worker error: ${event.message}`);
+      for (const pending of this.#pending.values()) {
+        pending.reject(error);
+      }
+      this.#pending.clear();
+    };
+  }
+
+  call(cmd: string, args: Record<string, unknown> = {}): Promise<unknown> {
+    const id = this.#nextId++;
+    const request: WorkerRequest = { id, cmd, args };
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.#pending.delete(id);
+        reject(
+          new Error(`[${this.label}] ${cmd} timed out after ${RPC_TIMEOUT_MS}ms`),
+        );
+      }, RPC_TIMEOUT_MS);
+      this.#pending.set(id, {
+        resolve: (value) => {
+          clearTimeout(timer);
+          resolve(value);
+        },
+        reject: (error) => {
+          clearTimeout(timer);
+          reject(error);
+        },
+      });
+      this.#worker.postMessage(request);
+    });
+  }
+
+  terminate(): void {
+    this.#worker.terminate();
+    for (const pending of this.#pending.values()) {
+      pending.reject(new Error(`[${this.label}] worker terminated`));
+    }
+    this.#pending.clear();
+  }
+}
+
+export class MultiRuntimeSession {
+  readonly label: string;
+  readonly identity: Identity;
+  #client: WorkerClient;
+
+  constructor(label: string, identity: Identity, client: WorkerClient) {
+    this.label = label;
+    this.identity = identity;
+    this.#client = client;
+  }
+
+  /**
+   * Send an event to a handler stream exposed on the piece result. Pass
+   * `trustedUi` to emulate a genuine user interaction on a trusted CFC
+   * surface (required for trusted-action handlers).
+   */
+  async send(
+    handler: string,
+    event: unknown = {},
+    trustedUi?: TrustedUiDescriptor,
+  ): Promise<void> {
+    await this.#client.call("send", { handler, event, trustedUi });
+  }
+
+  /** Read a value from the piece result, pulling fresh state first. */
+  async read(path: (string | number)[] = []): Promise<unknown> {
+    return await this.#client.call("read", { path });
+  }
+
+  async idle(): Promise<void> {
+    await this.#client.call("idle");
+  }
+
+  async disposeSession(): Promise<void> {
+    try {
+      await this.#client.call("dispose");
+    } finally {
+      this.#client.terminate();
+    }
+  }
+
+  /** @internal */
+  client(): WorkerClient {
+    return this.#client;
+  }
+}
+
+export class MultiRuntimeHarness {
+  readonly sessions: MultiRuntimeSession[];
+  readonly pieceId: string;
+  #server?: StandaloneMemoryServer;
+
+  private constructor(
+    sessions: MultiRuntimeSession[],
+    pieceId: string,
+    server?: StandaloneMemoryServer,
+  ) {
+    this.sessions = sessions;
+    this.pieceId = pieceId;
+    this.#server = server;
+  }
+
+  static async create(
+    options: MultiRuntimeHarnessOptions,
+  ): Promise<MultiRuntimeHarness> {
+    if (options.sessions.length === 0) {
+      throw new Error("MultiRuntimeHarness needs at least one session");
+    }
+    const spaceName = options.spaceName ?? crypto.randomUUID();
+    const server = options.apiUrl ? undefined : StandaloneMemoryServer.start();
+    const apiUrl = (options.apiUrl ?? server!.url).href;
+
+    const sessions: MultiRuntimeSession[] = [];
+    let bootstrap: WorkerClient | undefined;
+    try {
+      for (const spec of options.sessions) {
+        const normalized: MultiRuntimeSessionSpec = typeof spec === "string"
+          ? { label: spec }
+          : spec;
+        const identity = normalized.identity ??
+          await Identity.fromPassphrase(
+            `multi-runtime-harness ${normalized.label}`,
+            { implementation: "noble" },
+          );
+        const client = new WorkerClient(normalized.label);
+        await client.call("init", {
+          rawIdentity: identity.serialize(),
+          spaceName,
+          apiUrl,
+        });
+        sessions.push(new MultiRuntimeSession(normalized.label, identity, client));
+      }
+
+      // A throwaway bootstrap worker creates the piece, then every test
+      // session opens it BY ID from storage. This mirrors production: each
+      // client loads the pattern through a verified load (required for
+      // trusted-action CFC writes), and no session holds special in-memory
+      // compile state.
+      bootstrap = new WorkerClient("bootstrap");
+      await bootstrap.call("init", {
+        rawIdentity: sessions[0].identity.serialize(),
+        spaceName,
+        apiUrl,
+      });
+      const { pieceId } = await bootstrap.call("createPiece", {
+        programPath: options.programPath,
+        rootPath: options.rootPath,
+      }) as { pieceId: string };
+      await bootstrap.call("dispose");
+      bootstrap.terminate();
+      bootstrap = undefined;
+
+      for (const session of sessions) {
+        await session.client().call("openPiece", { pieceId });
+      }
+
+      return new MultiRuntimeHarness(sessions, pieceId, server);
+    } catch (error) {
+      bootstrap?.terminate();
+      for (const session of sessions) {
+        await session.disposeSession().catch(() => {});
+      }
+      await server?.close().catch(() => {});
+      throw error;
+    }
+  }
+
+  session(label: string): MultiRuntimeSession {
+    const session = this.sessions.find((s) => s.label === label);
+    if (!session) {
+      throw new Error(`No session labeled "${label}"`);
+    }
+    return session;
+  }
+
+  /** Let all runtimes finish local work and exchange pending sync traffic. */
+  async settle(rounds = 2): Promise<void> {
+    for (let i = 0; i < rounds; i++) {
+      await Promise.all(this.sessions.map((session) => session.idle()));
+      // Give subscription pushes a macrotask to land before the next round.
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  }
+
+  /**
+   * Poll until `predicate` resolves truthy, settling between attempts.
+   * Use for assertions about state that must cross runtimes.
+   */
+  async waitFor(
+    description: string,
+    predicate: () => Promise<boolean> | boolean,
+    { timeout = DEFAULT_TIMEOUT_MS }: { timeout?: number } = {},
+  ): Promise<void> {
+    const startedAt = Date.now();
+    let lastError: unknown;
+    while (Date.now() - startedAt < timeout) {
+      try {
+        if (await predicate()) return;
+      } catch (error) {
+        lastError = error;
+      }
+      await this.settle(1);
+    }
+    throw new Error(
+      `Timed out waiting for: ${description}` +
+        (lastError ? ` (last error: ${lastError})` : ""),
+    );
+  }
+
+  async dispose(): Promise<void> {
+    for (const session of this.sessions) {
+      await session.disposeSession().catch((error) => {
+        console.warn(`Failed to dispose session "${session.label}":`, error);
+      });
+    }
+    await this.#server?.close();
+  }
+}

--- a/packages/patterns/integration/multi-runtime-memory-server.ts
+++ b/packages/patterns/integration/multi-runtime-memory-server.ts
@@ -78,6 +78,8 @@ const authorizeSessionOpen = async (
   return invocation.iss;
 };
 
+let nextConnectionTag = 0;
+
 export class StandaloneMemoryServer {
   #memory: MemoryServer.Server;
   #http: Deno.HttpServer;
@@ -101,16 +103,52 @@ export class StandaloneMemoryServer {
         return new Response("memory websocket endpoint", { status: 200 });
       }
       const { socket, response } = Deno.upgradeWebSocket(request);
+      const connectionTag = nextConnectionTag++;
       const connection = memory.connect((message) => {
         if (socket.readyState === WebSocket.OPEN) {
           socket.send(encodeMemoryBoundary(message));
         }
       });
+      const debugWrites = Deno.env.get("CF_DEBUG_MEMORY_WRITES") === "1";
       socket.addEventListener("message", (event) => {
         if (typeof event.data !== "string") {
           socket.close(1003, "memory websocket expects text frames");
           connection.close();
           return;
+        }
+        if (debugWrites) {
+          try {
+            const parsed = MemoryServer.parseClientMessage(
+              event.data,
+            ) as unknown as {
+              commit?: { operations?: unknown[] };
+            };
+            const operations = parsed?.commit?.operations as
+              | Array<Record<string, any>>
+              | undefined;
+            if (Array.isArray(operations)) {
+              for (const op of operations) {
+                const detail = op?.op === "patch"
+                  ? ` paths=${
+                    JSON.stringify(
+                      (op.patches ?? []).map((p: { path?: string }) => p?.path),
+                    )
+                  }`
+                  : op?.op === "set"
+                  ? ` keys=${
+                    JSON.stringify(Object.keys(op.value?.value ?? {}))
+                  }`
+                  : "";
+                console.error(
+                  `[memwrite conn=${connectionTag}] op=${op?.op} id=${
+                    String(op?.id).slice(0, 24)
+                  } scope=${op?.scope ?? "(space)"}${detail}`,
+                );
+              }
+            }
+          } catch {
+            // Best-effort logging only.
+          }
         }
         connection.receive(event.data).catch(() => {
           if (socket.readyState === WebSocket.OPEN) {

--- a/packages/patterns/integration/multi-runtime-memory-server.ts
+++ b/packages/patterns/integration/multi-runtime-memory-server.ts
@@ -1,0 +1,133 @@
+/**
+ * Standalone in-memory storage server for multi-runtime tests.
+ *
+ * Serves the same memory v2 websocket protocol (and session.open signature
+ * verification) as toolshed's `/api/storage/memory` route, but in-process on
+ * an ephemeral port with a non-persistent store. This lets several runtimes —
+ * including ones in Deno Workers — share one storage backend without a
+ * toolshed process.
+ */
+
+import { encodeMemoryBoundary, MEMORY_PROTOCOL } from "@commonfabric/memory/v2";
+import * as MemoryServer from "@commonfabric/memory/v2/server";
+import { hashOf } from "@commonfabric/data-model/value-hash";
+import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
+import { VerifierIdentity } from "@commonfabric/identity";
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+const authorizationError = (message: string): Error =>
+  Object.assign(new Error(message), { name: "AuthorizationError" });
+
+const sameSessionDescriptor = (
+  left: Record<string, unknown>,
+  right: { sessionId?: string; seenSeq?: number },
+): boolean =>
+  (typeof left.sessionId === "string" ? left.sessionId : undefined) ===
+    right.sessionId &&
+  (typeof left.seenSeq === "number" ? left.seenSeq : undefined) ===
+    right.seenSeq;
+
+// Same verification as toolshed's memory route: the session principal is the
+// verified issuer of the signed session.open invocation. User/session scoped
+// storage partitioning keys off this principal, so the tests exercise real
+// authentication, not a trusted-client shortcut.
+const authorizeSessionOpen = async (
+  message: {
+    space: string;
+    session: { sessionId?: string; seenSeq?: number };
+    invocation?: Record<string, unknown>;
+    authorization?: unknown;
+  },
+): Promise<string> => {
+  const rawSignature = isRecord(message.authorization)
+    ? message.authorization.signature
+    : undefined;
+  const signature = rawSignature instanceof FabricBytes
+    ? rawSignature.slice()
+    : null;
+  if (!isRecord(message.invocation) || signature === null) {
+    throw authorizationError("memory session.open requires authorization");
+  }
+
+  const invocation = message.invocation;
+  if (
+    typeof invocation.iss !== "string" ||
+    invocation.cmd !== "session.open" ||
+    invocation.sub !== message.space ||
+    !isRecord(invocation.args) ||
+    invocation.args.protocol !== MEMORY_PROTOCOL ||
+    !isRecord(invocation.args.session) ||
+    !sameSessionDescriptor(invocation.args.session, message.session)
+  ) {
+    throw authorizationError("memory session.open authorization mismatch");
+  }
+
+  const issuer = await VerifierIdentity.fromDid(
+    invocation.iss as `did:key:${string}`,
+  );
+  const verified = await issuer.verify({
+    payload: hashOf(invocation).bytes,
+    signature,
+  });
+  if (verified.error) {
+    throw verified.error;
+  }
+
+  return invocation.iss;
+};
+
+export class StandaloneMemoryServer {
+  #memory: MemoryServer.Server;
+  #http: Deno.HttpServer;
+  readonly url: URL;
+
+  private constructor(memory: MemoryServer.Server, http: Deno.HttpServer) {
+    this.#memory = memory;
+    this.#http = http;
+    const address = http.addr as Deno.NetAddr;
+    this.url = new URL(`http://127.0.0.1:${address.port}/`);
+  }
+
+  static start(): StandaloneMemoryServer {
+    const memory = new MemoryServer.Server({ authorizeSessionOpen });
+    const http = Deno.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      onListen: () => {},
+    }, (request) => {
+      if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+        return new Response("memory websocket endpoint", { status: 200 });
+      }
+      const { socket, response } = Deno.upgradeWebSocket(request);
+      const connection = memory.connect((message) => {
+        if (socket.readyState === WebSocket.OPEN) {
+          socket.send(encodeMemoryBoundary(message));
+        }
+      });
+      socket.addEventListener("message", (event) => {
+        if (typeof event.data !== "string") {
+          socket.close(1003, "memory websocket expects text frames");
+          connection.close();
+          return;
+        }
+        connection.receive(event.data).catch(() => {
+          if (socket.readyState === WebSocket.OPEN) {
+            socket.close(1011, "memory websocket receive failure");
+          }
+          connection.close();
+        });
+      });
+      socket.addEventListener("close", () => connection.close());
+      socket.addEventListener("error", () => connection.close());
+      return response;
+    });
+    return new StandaloneMemoryServer(memory, http);
+  }
+
+  async close(): Promise<void> {
+    await this.#http.shutdown();
+    await this.#memory.close();
+  }
+}

--- a/packages/patterns/integration/multi-runtime-worker.ts
+++ b/packages/patterns/integration/multi-runtime-worker.ts
@@ -34,6 +34,7 @@ export interface TrustedUiDescriptor {
 
 let cc: PiecesController | undefined;
 let piece: PieceController | undefined;
+let resultSchema: unknown;
 let resultSinkCancel: (() => void) | undefined;
 
 function controller(): PiecesController {
@@ -46,8 +47,11 @@ function currentPiece(): PieceController {
   return piece;
 }
 
+// Read through the pattern's declared result schema, like the UI does —
+// schema defaults and scope annotations only apply on schema-aware reads.
 function result(): Cell<any> {
-  return controller().manager().getResult(currentPiece().getCell());
+  const raw = controller().manager().getResult(currentPiece().getCell());
+  return resultSchema !== undefined ? raw.asSchema(resultSchema as never) : raw;
 }
 
 async function idle(): Promise<void> {
@@ -55,8 +59,10 @@ async function idle(): Promise<void> {
   await controller().manager().synced();
 }
 
-function attachPiece(next: PieceController): void {
+async function attachPiece(next: PieceController): Promise<void> {
   piece = next;
+  resultSchema = (await next.getPattern() as { resultSchema?: unknown })
+    .resultSchema;
   resultSinkCancel?.();
   // Keep the result graph subscribed so server pushes reach this runtime.
   resultSinkCancel = result().sink(() => {});
@@ -95,13 +101,13 @@ const handlers: Record<
       ),
     );
     const created = await controller().create(program, { start: true });
-    attachPiece(created);
+    await attachPiece(created);
     await idle();
     return { pieceId: created.id };
   },
 
   async openPiece({ pieceId }) {
-    attachPiece(await controller().get(pieceId as string, true));
+    await attachPiece(await controller().get(pieceId as string, true));
     await idle();
     return {};
   },
@@ -142,10 +148,35 @@ const handlers: Record<
   },
 
   async read({ path }) {
-    const value = await currentPiece().result.get(
-      (path ?? []) as (string | number)[],
-    );
-    return sanitizeForTransfer(value);
+    const target = result();
+    await target.pull();
+    let cell = target;
+    for (const segment of (path ?? []) as (string | number)[]) {
+      cell = cell.key(segment as never) as Cell<any>;
+    }
+    return sanitizeForTransfer(cell.get());
+  },
+
+  /**
+   * Inspect the normalized link (id, space, scope) of a cell reached from
+   * the piece result by `path`, resolving links along the way. Lets tests
+   * assert the storage addressing (e.g. scope) of pattern state.
+   */
+  async link({ path }) {
+    const target = result();
+    await target.pull();
+    let cell = target;
+    for (const segment of (path ?? []) as (string | number)[]) {
+      cell = cell.key(segment as never) as Cell<any>;
+    }
+    const resolved = cell.resolveAsCell();
+    const link = resolved.getAsNormalizedFullLink();
+    return sanitizeForTransfer({
+      id: link.id,
+      space: link.space,
+      scope: link.scope,
+      path: link.path,
+    });
   },
 
   async idle() {

--- a/packages/patterns/integration/multi-runtime-worker.ts
+++ b/packages/patterns/integration/multi-runtime-worker.ts
@@ -69,12 +69,14 @@ async function attachPiece(next: PieceController): Promise<void> {
 }
 
 /**
- * Make `value` postMessage-safe: keep JSON data, drop functions/cells.
+ * Make `value` postMessage-safe: keep JSON data, drop functions/cells,
+ * stringify bigints (JSON.stringify throws on them).
  */
 function sanitizeForTransfer(value: unknown): unknown {
   if (value === undefined) return undefined;
   return JSON.parse(JSON.stringify(value, (_key, entry) => {
     if (typeof entry === "function") return undefined;
+    if (typeof entry === "bigint") return entry.toString();
     return entry;
   }));
 }

--- a/packages/patterns/integration/multi-runtime-worker.ts
+++ b/packages/patterns/integration/multi-runtime-worker.ts
@@ -1,0 +1,190 @@
+/**
+ * Worker-side runtime host for the multi-runtime harness.
+ *
+ * Each worker owns ONE full client stack — Identity, StorageManager, Runtime,
+ * PiecesController — in its own JS realm, exactly like one browser tab. The
+ * main thread orchestrates via a tiny request/response protocol.
+ */
+
+import type { Cell } from "@commonfabric/runner";
+import { markRendererTrustedEvent } from "@commonfabric/runner/cfc";
+import { Identity, type KeyPairRaw } from "@commonfabric/identity";
+import {
+  type PieceController,
+  PiecesController,
+} from "@commonfabric/piece/ops";
+import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+
+export interface WorkerRequest {
+  id: number;
+  cmd: string;
+  args: Record<string, unknown>;
+}
+
+export type WorkerResponse =
+  | { id: number; ok: unknown }
+  | { id: number; error: string };
+
+export interface TrustedUiDescriptor {
+  /** `data-ui-pattern` / `data-ui-event-integrity` of the trusted surface. */
+  surface: string;
+  /** `data-ui-action` of the control inside the surface. */
+  action: string;
+}
+
+let cc: PiecesController | undefined;
+let piece: PieceController | undefined;
+let resultSinkCancel: (() => void) | undefined;
+
+function controller(): PiecesController {
+  if (!cc) throw new Error("worker not initialized");
+  return cc;
+}
+
+function currentPiece(): PieceController {
+  if (!piece) throw new Error("no piece attached");
+  return piece;
+}
+
+function result(): Cell<any> {
+  return controller().manager().getResult(currentPiece().getCell());
+}
+
+async function idle(): Promise<void> {
+  await controller().manager().runtime.idle();
+  await controller().manager().synced();
+}
+
+function attachPiece(next: PieceController): void {
+  piece = next;
+  resultSinkCancel?.();
+  // Keep the result graph subscribed so server pushes reach this runtime.
+  resultSinkCancel = result().sink(() => {});
+}
+
+/**
+ * Make `value` postMessage-safe: keep JSON data, drop functions/cells.
+ */
+function sanitizeForTransfer(value: unknown): unknown {
+  if (value === undefined) return undefined;
+  return JSON.parse(JSON.stringify(value, (_key, entry) => {
+    if (typeof entry === "function") return undefined;
+    return entry;
+  }));
+}
+
+const handlers: Record<
+  string,
+  (args: Record<string, unknown>) => Promise<unknown>
+> = {
+  async init({ rawIdentity, spaceName, apiUrl }) {
+    const identity = await Identity.deserialize(rawIdentity as KeyPairRaw);
+    cc = await PiecesController.initialize({
+      apiUrl: new URL(apiUrl as string),
+      identity,
+      spaceName: spaceName as string,
+    });
+    return { did: identity.did() };
+  },
+
+  async createPiece({ programPath, rootPath }) {
+    const program = await controller().manager().runtime.harness.resolve(
+      new FileSystemProgramResolver(
+        programPath as string,
+        rootPath as string,
+      ),
+    );
+    const created = await controller().create(program, { start: true });
+    attachPiece(created);
+    await idle();
+    return { pieceId: created.id };
+  },
+
+  async openPiece({ pieceId }) {
+    attachPiece(await controller().get(pieceId as string, true));
+    await idle();
+    return {};
+  },
+
+  async send({ handler, event, trustedUi }) {
+    const trusted = trustedUi as TrustedUiDescriptor | undefined;
+    let eventValue: unknown = event ?? {};
+    if (trusted) {
+      // Equivalent of a genuine user interaction on a trusted surface: DOM
+      // provenance plus the renderer-trusted mark the html worker reconciler
+      // applies when delivering real DOM events.
+      eventValue = {
+        type: "click",
+        ...(isRecord(event) ? event : {}),
+        provenance: {
+          origin: "dom",
+          trusted: true,
+          ui: {
+            pattern: trusted.surface,
+            eventIntegrity: [trusted.surface],
+            uiContractDataset: { uiAction: trusted.action },
+          },
+        },
+      };
+      markRendererTrustedEvent(eventValue);
+    }
+    const target = result();
+    const { error } = await controller().manager().runtime.editWithRetry(
+      (tx) => {
+        target.key(handler as never).withTx(tx).send(eventValue as never);
+      },
+    );
+    if (error) {
+      throw new Error(`send "${handler}" failed: ${error.message}`);
+    }
+    await idle();
+    return {};
+  },
+
+  async read({ path }) {
+    const value = await currentPiece().result.get(
+      (path ?? []) as (string | number)[],
+    );
+    return sanitizeForTransfer(value);
+  },
+
+  async idle() {
+    await idle();
+    return {};
+  },
+
+  async dispose() {
+    resultSinkCancel?.();
+    resultSinkCancel = undefined;
+    piece = undefined;
+    if (cc) {
+      await cc.dispose();
+      cc = undefined;
+    }
+    return {};
+  },
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value);
+
+self.onmessage = (event: MessageEvent<WorkerRequest>) => {
+  const { id, cmd, args } = event.data;
+  const handler = handlers[cmd];
+  const respond = (response: WorkerResponse) =>
+    (self as unknown as Worker).postMessage(response);
+  if (!handler) {
+    respond({ id, error: `unknown command "${cmd}"` });
+    return;
+  }
+  handler(args).then(
+    (ok) => respond({ id, ok }),
+    (error: unknown) =>
+      respond({
+        id,
+        error: error instanceof Error
+          ? `${error.message}\n${error.stack ?? ""}`
+          : String(error),
+      }),
+  );
+};

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -41,7 +41,7 @@ import {
   getCellOrThrow,
   isCellResultForDereferencing,
 } from "./query-result-proxy.ts";
-import { resolveSchemaForValue } from "./schema.ts";
+import { resolveSchema, resolveSchemaForValue } from "./schema.ts";
 import type {
   IExtendedStorageTransaction,
   IReadOptions,
@@ -943,9 +943,64 @@ export function normalizeAndDiff(
       changes.push(...nestedChanges);
     }
 
+    // The scope-narrowing branch at the top of normalizeAndDiff only fires for
+    // keys present in newValue (e.g. populated from a schema default). A
+    // property whose schema declares a narrower scope but arrives with no
+    // value would leave the base-scope slot empty, so later schema-less writes
+    // (e.g. through a handler's cell reference) would land at the base scope
+    // instead of the narrower instance. Eagerly materialize the redirect for
+    // those keys, and exempt them from removal below so an object rewrite that
+    // omits the key can't strip the redirect either. Only the redirect is
+    // written; the narrower-scope instance's content is left untouched.
+    // (resolveSchema, not resolveSchemaForValue: the latter recurses through
+    // property values and diverges on circular values + recursive $ref
+    // schemas; only the top-level property names are needed here.)
+    const eagerScopedKeys = new Set<string>();
+    const resolvedSchema = resolveSchema(link.schema);
+    const schemaProperties = isRecord(resolvedSchema)
+      ? resolvedSchema.properties
+      : undefined;
+    if (isRecord(schemaProperties)) {
+      for (const key in schemaProperties) {
+        if (key in newValue) continue;
+        const childSchema = runtime.cfc.getSchemaAtPath(link.schema, [key]);
+        const childScope = declaredCellScope(childSchema);
+        if (
+          childScope === undefined ||
+          scopeRank(childScope) <= scopeRank(link.scope)
+        ) {
+          continue;
+        }
+        const childLink: NormalizedFullLink = {
+          ...link,
+          path: [...link.path, key],
+          schema: childSchema,
+        };
+        const scopedLink: NormalizedFullLink = {
+          ...childLink,
+          scope: childScope,
+        };
+        changes.push(
+          ...normalizeAndDiff(
+            runtime,
+            tx,
+            childLink,
+            createSigilLinkFromParsedLink(scopedLink, {
+              base: childLink,
+            }) as unknown,
+            context,
+            options,
+            seen,
+            currentRecord[key],
+          ),
+        );
+        eagerScopedKeys.add(key);
+      }
+    }
+
     // Handle removed keys
     for (const key in currentRecord) {
-      if (!(key in newValue)) {
+      if (!(key in newValue) && !eagerScopedKeys.has(key)) {
         changes.push({
           location: { ...link, path: [...link.path, key] },
           value: undefined,

--- a/packages/runner/src/data-updating.ts
+++ b/packages/runner/src/data-updating.ts
@@ -615,6 +615,38 @@ export function normalizeAndDiff(
     );
   }
 
+  // Scope realization on write: the base-scope slot of a scoped instance
+  // holds a regular link with an explicitly narrower scope (materialized at
+  // setup; see the narrowing branch above and the eager-redirect pass in the
+  // object branch below). A write of *content* arriving at this slot without
+  // a scope-declaring schema (e.g. through a serialized binding whose schema
+  // is scope-silent, like the renderer's $value cell) must follow that link
+  // into the narrower-scope instance — overwriting it would land per-user /
+  // per-session state at the shared base scope. Reference values are exempt:
+  // writing a link re-binds the slot (and the schema-declared narrowing above
+  // already handled scoped re-binds before reaching here).
+  if (isPrimitiveCellLink(currentValue) && !isCellLink(newValue)) {
+    const storedLink = parseLink(currentValue, link);
+    if (scopeRank(storedLink.scope) > scopeRank(link.scope)) {
+      diffLogger.debug(
+        "diff",
+        () =>
+          `[BRANCH_SCOPED_REDIRECT] Following narrower-scope stored link at path=${pathStr} (${link.scope} -> ${storedLink.scope})`,
+      );
+      return normalizeAndDiff(
+        runtime,
+        tx,
+        storedLink.schema === undefined && link.schema !== undefined
+          ? { ...storedLink, schema: link.schema }
+          : storedLink,
+        newValue,
+        context,
+        options,
+        seen,
+      );
+    }
+  }
+
   if (isPrimitiveCellLink(newValue)) {
     diffLogger.debug(
       "diff",

--- a/packages/runner/test/pattern-scope.test.ts
+++ b/packages/runner/test/pattern-scope.test.ts
@@ -2876,3 +2876,81 @@ Deno.test("scoped asCell property with no value gets an eager base-scope redirec
     await storageManager.close();
   }
 });
+
+Deno.test("schema-less write AT a scoped slot follows the stored redirect", async () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const tx = runtime.edit();
+
+  try {
+    const cell = runtime.getCell(
+      space,
+      "write at scoped slot follows redirect",
+      {
+        type: "object",
+        properties: {
+          // Mirrors PerUser<Writable<string | Default<"">>>: a scoped
+          // primitive slot whose default populates the user instance and
+          // leaves a redirect at the base scope.
+          profileDraft: {
+            type: "string",
+            default: "",
+            asCell: [{ kind: "cell", scope: "user" }],
+          },
+        },
+      },
+      tx,
+    );
+
+    cell.set({} as never);
+    runtime.prepareTxForCommit(tx);
+    await tx.commit();
+    await runtime.idle();
+
+    const baseLink = cell.key("profileDraft").getAsNormalizedFullLink();
+    const schemaless = createCell<{ profileDraft: string }>(
+      runtime,
+      { ...cell.getAsNormalizedFullLink(), schema: undefined },
+    );
+    assertEquals(
+      parseLink(
+        schemaless.key("profileDraft").getRaw({ lastNode: "writeRedirect" }),
+        schemaless.key("profileDraft").getAsNormalizedFullLink(),
+      )?.scope,
+      "user",
+    );
+
+    // A schema-less write AT the slot (this is what the browser renderer's
+    // $value binding does: the serialized alias carries the sub-pattern's
+    // scope-silent schema) must follow the stored narrower-scope link into
+    // the user instance, NOT overwrite the redirect with shared base-scope
+    // content.
+    const writeTx = runtime.edit();
+    schemaless.withTx(writeTx).key("profileDraft").set("Alice");
+    runtime.prepareTxForCommit(writeTx);
+    await writeTx.commit();
+    await runtime.idle();
+
+    // The base slot still holds the redirect, not the raw string.
+    assertEquals(
+      parseLink(
+        schemaless.key("profileDraft").getRaw({ lastNode: "writeRedirect" }),
+        schemaless.key("profileDraft").getAsNormalizedFullLink(),
+      )?.scope,
+      "user",
+      "base-scope slot must keep the scoped-instance redirect",
+    );
+    // The content landed in the user partition.
+    const userInstance = createCell<string>(
+      runtime,
+      { ...baseLink, schema: undefined, scope: "user" },
+    );
+    assertEquals(userInstance.getRaw(), "Alice");
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});

--- a/packages/runner/test/pattern-scope.test.ts
+++ b/packages/runner/test/pattern-scope.test.ts
@@ -2778,3 +2778,101 @@ Deno.test("wish result schema scope overrides query-derived scope", async () => 
     await storageManager.close();
   }
 });
+
+Deno.test("scoped asCell property with no value gets an eager base-scope redirect", async () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const tx = runtime.edit();
+
+  try {
+    const cell = runtime.getCell(
+      space,
+      "eager scoped redirect for omitted property",
+      {
+        type: "object",
+        properties: {
+          // Scoped reference with NO value and NO default: the object branch
+          // of normalizeAndDiff must eagerly materialize the base-scope
+          // redirect so later schema-less writes land in the user instance.
+          myProfile: {
+            type: "object",
+            properties: { name: { type: "string" } },
+            asCell: [{ kind: "cell", scope: "user" }],
+          },
+          // Sibling with a default: covered by the existing populated-keys
+          // narrowing; included for contrast.
+          title: { type: "string", default: "untitled" },
+        },
+      },
+      tx,
+    );
+
+    // Write an object that OMITS the scoped property.
+    cell.set({ title: "hello" } as never);
+    runtime.prepareTxForCommit(tx);
+    await tx.commit();
+    await runtime.idle();
+
+    // Inspect the base-scope slot through a schema-less handle (so no
+    // schema-driven scope realization applies on read): it must hold a sigil
+    // link to the user-scoped instance.
+    const baseLink = cell.key("myProfile").getAsNormalizedFullLink();
+    assertEquals(baseLink.scope, "space");
+    const schemaless = createCell<{ myProfile: { name: string } }>(
+      runtime,
+      { ...cell.getAsNormalizedFullLink(), schema: undefined },
+    );
+    const storedRedirect = parseLink(
+      schemaless.key("myProfile").getRaw({ lastNode: "writeRedirect" }),
+      schemaless.key("myProfile"),
+    );
+    assertEquals(storedRedirect?.scope, "user");
+    assertEquals(storedRedirect?.id, baseLink.id);
+
+    // A schema-less write through the stored link (as a handler writing via a
+    // stored cell reference would) must land in the user partition: the path
+    // traverses the redirect, so the content goes to the scoped instance.
+    const writeTx = runtime.edit();
+    schemaless.withTx(writeTx).key("myProfile").key("name").set("Ada");
+    runtime.prepareTxForCommit(writeTx);
+    await writeTx.commit();
+    await runtime.idle();
+
+    const userInstance = createCell<{ name: string }>(
+      runtime,
+      { ...baseLink, schema: undefined, scope: "user" },
+    );
+    assertEquals(userInstance.getRaw(), { name: "Ada" });
+    // The base slot still holds the redirect, not the content.
+    assertEquals(
+      parseLink(
+        schemaless.key("myProfile").getRaw({ lastNode: "writeRedirect" }),
+        schemaless.key("myProfile"),
+      )?.scope,
+      "user",
+    );
+
+    // Rewriting the object without the key must NOT strip the redirect (the
+    // eager keys are exempt from the removed-keys pass).
+    const rewriteTx = runtime.edit();
+    cell.withTx(rewriteTx).set({ title: "hello again" } as never);
+    runtime.prepareTxForCommit(rewriteTx);
+    await rewriteTx.commit();
+    await runtime.idle();
+
+    assertEquals(
+      parseLink(
+        schemaless.key("myProfile").getRaw({ lastNode: "writeRedirect" }),
+        schemaless.key("myProfile"),
+      )?.scope,
+      "user",
+    );
+    assertEquals(userInstance.getRaw(), { name: "Ada" });
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});


### PR DESCRIPTION
## Why

The CFC group chat demo degraded for real multi-user use even though its integration test passed: that test switches identity on ONE page, and the pattern test runs everything in ONE runtime — so per-user/per-session scoping bugs and cross-client propagation bugs could not manifest. Observed symptoms: typing a name in one browser appeared in the other; another user's saved identity showed as unnamed ("Other") instead of their name; disabling "everyone is an admin" left users unable to post.

## Test harness

- **Multi-runtime harness** ([multi-runtime-harness.ts](packages/patterns/integration/multi-runtime-harness.ts)): opens the same piece in N runtimes — one per (identity, session) — each in its own **Deno Worker realm**, all against one **self-hosted in-process memory v2 server** ([multi-runtime-memory-server.ts](packages/patterns/integration/multi-runtime-memory-server.ts), same engine + signed `session.open` verification as toolshed). Workers are required, not an optimization: two runtimes in one JS realm cross-talk through module-level state (verified-load registries / frame stack), which breaks trusted-action CFC identity. The harness can also synthesize trusted-surface UI events headlessly (provenance + renderer-trusted mark), so CFC-gated handlers are drivable without a browser. No toolshed needed; ~10s for the 7-step suite.
- **Headless multi-user suite** ([cfc-group-chat-demo-multi-runtime.test.ts](packages/patterns/integration/cfc-group-chat-demo-multi-runtime.test.ts)): Alice, Bob, and a second session of Alice — PerUser/PerSession isolation, cross-user propagation, profile integrity, admin lockdown semantics, admin granting.
- **Two-simultaneous-browser test** ([cfc-group-chat-demo-two-browsers.test.ts](packages/patterns/integration/cfc-group-chat-demo-two-browsers.test.ts)): two separate browser profiles + identities live on the same piece — typing isolation, live name propagation, no profile clobbering, post-after-lockdown.

## Bugs found and fixed

1. **runner: scoped slots without defaults never got their base-scope redirect** (2833c60). A `PerUser<...>` argument property with no schema default left the base slot empty, so schema-less writes (e.g. handlers inside sub-patterns, whose own input schemas are scope-silent) landed at **space** scope — making `myProfile` a shared field. Each save clobbered everyone else's profile ("Name not set", send button disabled — the "couldn't post" symptom). `normalizeAndDiff` now eagerly materializes the redirect and protects it from removed-key stripping.
2. **runner: schema-less content writes AT a scoped slot clobbered the redirect** (4227d4a). The browser's `$value` binding cell carries the sub-pattern's scope-silent schema; typing overwrote the PerUser draft redirect with raw text at space scope — one user's keystrokes appeared in every other user's input. Such writes now follow the stored narrower-scope link into the scoped instance.
3. **pattern: profiles registered in the shared list were `perUser`-scoped** (78c89f2). User-scoped instances are isolated by reader (scoped-cell spec), so other participants dereferenced them to their own empty instance — names showed as "Unnamed user"/"Other". Profiles are now minted `perSpace` (distinct per user via per-invocation cause + the PerUser `myProfile` pointer). Authorship verification unaffected.

Both runner fixes have focused red→green unit tests in `pattern-scope.test.ts`. Docs: new scoped-cell pitfall + multi-user testing guidance.

## Verification

- New headless multi-runtime suite: 7/7 green (each bug was red first).
- New two-browser suite: green end-to-end (was red on typing isolation before fix 2).
- Runner package suite: 552 passed / 0 failed. Group-chat pattern test (`cf test`): 24/24. Existing single-page browser test + cfc-authorship-chat: green.
- Note: `integration/shared-profile.test.ts` fails on my local dev servers **identically with and without these changes** (pre-existing; profile-create wish input never renders).

## Follow-ups (not in this PR)

- Serialized sub-pattern binding aliases drop the parent's declared scope (pins `scope:"space"`, schema scope-silent). The write-path fixes make this harmless, but folding declared scope into serialized aliases (like builtin-output folding in runner.ts ~3670) would make the graph self-describing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a multi-runtime and multi-browser test harness and fixes per-user/per-session scoping bugs in the CFC group chat. Ensures typing isolation, correct profile visibility, and working admin lockdown, with new headless and browser tests to prevent regressions.

- **New Features**
  - Multi-runtime harness runs N worker-isolated runtimes on one in-process memory v2 server; can synthesize trusted UI events (no toolshed required).
  - New tests: headless multi-user suite and a two-browser test validating real DOM/event provenance.
  - Added `readCfInputValue` for browser tests; fails fast if the selector isn’t an input.

- **Bug Fixes**
  - Runner: eagerly creates base-scope redirects for scoped slots without defaults; schema-less writes at a scoped slot now follow the stored narrower-scope link.
  - Group chat: profiles are now `perSpace` (distinct per user via the `PerUser` `myProfile` pointer), so other users see correct names.
  - Test harness: worker transfer is BigInt-safe to prevent JSON serialization errors.

<sup>Written for commit dd4fb7d900cae090aa65a811b4e2be5db7f70446. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Perf baseline

The two new integration suites add ~25s of wall time to the patterns integration shard (new coverage, not a runtime regression):

NEW_PERF_BASELINE: job: Pattern Integration Tests (1/4) = 141s
