### PR TITLE
perf: profile default-app note create — CDP worker profiler, hotspot benchmarks, findings doc

### DIFF
--- a/docs/development/PERFORMANCE_PROGRAM.md
+++ b/docs/development/PERFORMANCE_PROGRAM.md
@@ -62,9 +62,14 @@ step, and we'll ratchet targets down as we improve.
   (`writersByEntity` is Set-backed), refer() caching (~2x)
 
 **What we don't have:**
-- No measurement of where wall-clock time actually goes in a user-visible flow
 - No breakdown of "pattern load takes Xms: Y% compilation, Z% traversal, ..."
 - No profiling data from real usage
+
+**First flow profiled:** steady-state note creation in the default-app shell
+integration test — see
+[performance/default-app-note-create.md](performance/default-app-note-create.md)
+for the logger + worker-CPU-profile breakdown, the benchmarks derived from it,
+and the ranked optimization candidates.
 
 **What this means:** The optimization backlog below was identified through
 static code analysis — finding provably suboptimal code (O(n) where O(1) is

--- a/docs/development/performance/default-app-note-create.md
+++ b/docs/development/performance/default-app-note-create.md
@@ -1,0 +1,189 @@
+# Default-app note create: profile, hotspots, benchmarks
+
+First end-to-end measurement of a real user flow for the
+[Performance Program](../PERFORMANCE_PROGRAM.md): the **default-app shell
+integration test** (`packages/patterns/integration/default-app.test.ts`),
+which creates notes through the shell UI against a local toolshed with the
+runtime in a browser web-worker.
+
+**Scope: steady-state note creation.** Pattern compilation is explicitly out
+of scope (note 1 of each run is compile-dominated and excluded everywhere
+below). Measured June 2026 on an Apple M3 Max, local stack, emulated user via
+Astral/CDP.
+
+## How to reproduce
+
+Start the local stack, then run the test with the capture env vars:
+
+```bash
+./scripts/start-local-dev.sh --port-offset=73
+
+cd packages/patterns
+API_URL=http://localhost:8073 HEADLESS=1 LOG_LEVEL=warn \
+CF_NOTE_CREATE_TIMING_SERIES=5 \
+CF_CAPTURE_NOTE_CREATE_PROFILE_SERIES=5 \
+CF_CAPTURE_NOTE_CREATE_CPUPROFILE_SERIES=3 \
+CF_CPUPROFILE_DIR=/tmp/cf-profiles \
+deno test --v8-flags=--max-old-space-size=4096 -A \
+  --filter "default-app flow test" ./integration/default-app.test.ts
+```
+
+- `CF_NOTE_CREATE_TIMING_SERIES=N` — wall-clock timing for N note creates.
+- `CF_CAPTURE_NOTE_CREATE_PROFILE_SERIES=N` — logger timing stats
+  (`focusTiming`/`topTiming`/settle history) per note, via
+  `commonfabric.rt.getLoggerCounts()` IPC.
+- `CF_CAPTURE_NOTE_CREATE_CPUPROFILE_SERIES=N` — **new**: V8 sampling
+  profiles of the runtime web-worker for notes 2..N+1, written as
+  `.cpuprofile` (loadable in Chrome DevTools / speedscope) plus a ranked
+  self-time report. Implemented by `packages/integration/cdp-profiler.ts`
+  (`CdpWorkerProfiler`), which attaches a second CDP client to the Astral
+  browser (`ShellIntegration.wsEndpoint()`), auto-attaches to the page's
+  dedicated workers via flattened sessions, and drives `Profiler.start/stop`
+  on the `worker-runtime` target. Note-1 profiles are skipped: they are
+  compile-dominated and big enough to break the CDP websocket message limit.
+
+## Wall-clock: beware the test's 500 ms poll quantum
+
+The test reports ~1.15 s per note create (createToView ~520 ms, returnToHome
+~630 ms), but `waitFor` in `@commonfabric/integration` polls every **500 ms**,
+so each phase is quantized up to the next poll. Subtracting the quantum, the
+real runtime cost is roughly **150–300 ms per note** — consistent with the
+~200 ms of worker CPU the logger measures, plus IPC and main-thread render.
+Don't use the test's wall numbers as an optimization target without fixing
+the poll delay (or use the logger/profile numbers below).
+
+## Logger measurements (steady state, per note create)
+
+Per-note deltas are stable from note 2 on (5-note series):
+
+| Key | Count/note | ms/note |
+|---|---|---|
+| `scheduler/execute` (settle-loop entries) | 14 | ~183 |
+| `scheduler/execute/settle` | 14 | ~130 |
+| `scheduler/run` (action runs) | 61 | ~115 |
+| `scheduler/run/action` (action bodies) | 61 | ~96 |
+| `traverse` | **+41/note growth** (362 → 485) | ~70 |
+| `scheduler/execute/collectDirtyDependencies` | **+28/note growth** (810 → 894) | ~25 |
+| `raw/run/wish` | 5 | ~26 |
+| `scheduler/execute/event/handlerAction` | 4 | ~20 |
+
+Two clear **O(existing-note-count) growth seams**: `traverse` call count and
+dirty-dependency visits grow linearly with list size on every create, i.e.
+quadratic accumulated cost as a space fills up.
+
+Of the wish cost, the `#notebook` hashtag query dominates:
+`wish/phase-query/send-shared-hashtag/#notebook` is ~15 ms per call (6 calls
+across the run) — almost all of the shared-hashtag resolver's `sendResult`.
+
+## Worker CPU profiles (notes 2–4 aggregated, 1446 ms busy)
+
+Profiles taken at 250 µs sampling; analysis maps bundle frames back to source
+files via `worker-runtime.js.map`. "Busy" excludes `(program)`/idle (the
+worker idles between test polls).
+
+### By phase (top-level dispatch)
+
+| Phase | Share of busy CPU | What it is |
+|---|---|---|
+| `handleVDomMount` | **37%** | `WorkerReconciler.mount` — re-mounting the home view's vdom on navigation back; per-child cell subscribe + render |
+| `runPullSettleOrder` | 21% | settle-loop action runs (lifts, maps, wish) |
+| (other) | 17% | GC (5% of busy) + worker IPC encode/decode + misc |
+| `execute` (scheduler) | 11% | dependency collection, scheduling, traverse machinery |
+| `runCommitCallbacks` | 11% | post-commit runner starts; ~24% of this phase is the verified-bindings walk (`seedVerifiedLoadIds`, `verifiedWalkChildValues`, `collectAssociatedFunctions`) |
+| `handleRequest` | 2% | direct IPC requests |
+
+### By subsystem (cross-cutting, share of busy CPU)
+
+| Subsystem | Share | Hot functions |
+|---|---|---|
+| Value hashing | **~29%** | `feedPlainObject` 12%, wasm SHA-256 5%, `feedObjectValue` 3%, `internSchema` 2%, hasher/encoding rest |
+| Deep-freeze | **~12%** | `deepFreezeInProgress` 8%, `checkValue` 3% |
+| Link resolution + schema traverse | ~9% | `resolveLink` 4.3%, `traverseWithSchema` et al. |
+| Storage selector/tx | ~8% | `selector-tracker.ts` 3%, `v2-transaction.ts` 2.8%, `cache.get` 2% |
+| CFC schema refs | ~7.5% | `resolveCfcSchemaRef` 3.5%, `findCfcSchemaRefs` 2.2%, `schemaAtPathInternal` 1.4% |
+| Verified-bindings walk | ~5% | `seedVerifiedLoadIds`, `verifiedWalkChildValues` (CT-1665 machinery) |
+| GC | ~5% | allocation pressure from the above walks |
+
+Both hashing (`hashOf`) and deep-freeze (`isDeepFrozen`) cache **by object
+identity** (WeakMap/WeakSet). Every fresh-identity but structurally-equal
+value — query results, vdom, specs rebuilt per render — pays a full O(tree)
+walk. That's why these two top the chart despite their caches.
+
+## Benchmarks (new)
+
+Each hotspot now has a benchmark that reproduces the integration shape
+in-process, so it can be optimized without a browser:
+
+1. **`packages/runner/test/default-app-note-create.bench.ts`** — macro bench:
+   home doc with linked note docs, lifted derived view, live sink, event
+   handler creating/removing a note. Covers event → preflight → handler →
+   commit → settle → recompute, including the growth seams. Baseline:
+
+   | Existing notes | create+remove cycle (pull) |
+   |---|---|
+   | 0 | 14.3 ms |
+   | 32 | 24.1 ms |
+   | 128 | 59.7 ms |
+
+   Clear O(n): ~0.36 ms per existing note per create.
+
+2. **`packages/html/bench/worker-reconciler-mount.bench.ts`** — the 37%
+   phase: mounts a list vdom whose children are real cells (like piece `[UI]`
+   links) through `rendererVDOMSchema`. Baseline:
+
+   | Case | time |
+   |---|---|
+   | mount+unmount @8 children | 21.9 ms |
+   | mount+unmount @32 children | 83.9 ms |
+   | mount+unmount @128 children | 344.7 ms |
+   | re-mount unchanged tree @32 | 171.5 ms (= 2× first mount: nothing is reused) |
+   | single-child update under live mount @32 | 6.7 ms |
+
+   ~2.7 ms **per child** to mount; a re-mount of an unchanged tree pays full
+   price, and even a one-child update costs milliseconds.
+
+3. **`packages/data-model/bench/value-identity-shapes.bench.ts`** — the
+   identity-cache gap behind the hashing/freeze numbers. Baseline:
+
+   | Case | time |
+   |---|---|
+   | `hashOf` deep-frozen doc, same identity | ~10 ns |
+   | `hashOf` fresh-identity note doc (~30 nodes) | ~5 µs |
+   | `hashOf` fresh-identity home doc @128 notes | **2.1 ms** |
+   | `isDeepFrozen` frozen-but-uncached note doc | 19 µs |
+   | `deepFreeze` fresh home doc @128 notes | 402 µs |
+
+Existing related benches: `scheduler-event-preflight.bench.ts` (the 30-note
+preflight shape), `push-pull-patterns.bench.ts` (map/filter machinery),
+`traverse-replay` harness + `link-resolution.bench.ts`.
+
+## Optimization candidates (ranked by measured impact)
+
+1. **Don't re-mount the home view from scratch on navigation** (37% phase +
+   main-thread twin). Keep the reconciler mount alive across view switches,
+   or memoize per-child render state keyed by cell identity + version so an
+   unchanged child re-mount is O(1). The re-mount bench is the regression
+   guard.
+2. **Make the single-child update path O(1).** 6.7 ms for one chip update at
+   32 children means updates re-read far more than the changed subtree.
+3. **Structural (content) caching for `hashOf`/`isDeepFrozen`**, or freeze +
+   reuse canonical value graphs so the identity caches actually hit. The
+   2.1 ms home-doc hash is paid multiple times per create. Same family as the
+   schema canonicalization win in #3948 (8.4× traverse) — values, not schemas.
+4. **Bound the O(n)-per-create growth** (traverse +41/note, dirty-visits
+   +28/note): incremental list diffing instead of whole-list re-reads in the
+   derived home view. Guarded by the macro bench's @0/@32/@128 spread.
+5. **Memoize CFC schema-ref resolution** (`resolveCfcSchemaRef` /
+   `findCfcSchemaRefs`, 7.5%) — these re-walk schemas that `internSchema`
+   already canonicalizes.
+6. **Cache the verified-bindings commit walk** (`seedVerifiedLoadIds` /
+   `verifiedWalkChildValues`, ~5%, 24% of commit callbacks) per executable +
+   value identity (CT-1665 follow-up).
+7. **Shared-hashtag wish `sendResult`** (~15 ms per `#notebook` query):
+   profile what `sharedWishCellValue` → `sendResult` rewrites each time the
+   resolver is already shared.
+
+Follow-up measurement gaps (not covered here): main-thread (page) profile of
+the same flow (the reconciler has a DOM-applying twin), storage server time,
+and a benchmark for per-note pattern instantiation (`startWithTx` in commit
+callbacks; the macro bench uses plain docs, not running patterns).

--- a/packages/data-model/bench/value-identity-shapes.bench.ts
+++ b/packages/data-model/bench/value-identity-shapes.bench.ts
@@ -1,0 +1,177 @@
+/**
+ * Identity-shape benchmarks for value hashing and deep-freeze.
+ *
+ * Motivated by CPU profiles of the default-app integration test
+ * (docs/development/performance/default-app-note-create.md): in steady-state
+ * note creation, ~29% of runtime-worker busy CPU is value hashing
+ * (`feedPlainObject` + wasm SHA-256) and ~12% is deep-freeze walks
+ * (`deepFreezeInProgress`/`checkValue`).
+ *
+ * Both subsystems cache by OBJECT IDENTITY (`WeakMap`/`WeakSet`), so any
+ * fresh-identity but structurally-equal value — e.g. query results, specs, or
+ * vdom built anew on every render — pays a full O(tree) walk every time.
+ * These benches separate the cache-hit identity path from the cache-defeating
+ * fresh-identity path so the gap (and any future structural-caching fix) is
+ * measurable in isolation.
+ *
+ * Run with:
+ *   deno bench --allow-read --allow-write --allow-net --allow-ffi --allow-env \
+ *     --no-check bench/value-identity-shapes.bench.ts
+ */
+
+import { hashOf } from "../src/value-hash.ts";
+import { deepFreeze, isDeepFrozen } from "../src/deep-freeze.ts";
+
+// ---------------------------------------------------------------------------
+// Doc-shaped test data, mirroring the default-app integration:
+// a note doc (~30 nodes) and a home-list doc holding N note entries.
+// ---------------------------------------------------------------------------
+
+function makeNoteDoc(i: number): Record<string, unknown> {
+  return {
+    title: `📝 New Note #${i.toString(36).padStart(6, "0")}`,
+    content: `Note body ${i} — `.repeat(8),
+    tags: ["#note", `#tag-${i % 7}`],
+    createdAt: `2026-06-09T12:${(i % 60).toString().padStart(2, "0")}:00Z`,
+    meta: {
+      authorDid: `did:key:z6Mk${i.toString(16).padStart(8, "0")}`,
+      revision: i,
+      pinned: i % 5 === 0,
+      layout: { width: 320, height: 200, theme: "default" },
+    },
+  };
+}
+
+function makeHomeDoc(noteCount: number): Record<string, unknown> {
+  return {
+    spaceName: "bench-space",
+    activeTab: "spaces",
+    items: Array.from({ length: noteCount }, (_, i) => makeNoteDoc(i)),
+    counters: { notes: noteCount, pieces: noteCount + 3 },
+  };
+}
+
+/** Recursively Object.freeze without populating the deep-frozen cache. */
+function plainRecursiveFreeze(value: unknown): void {
+  if (value === null || typeof value !== "object") return;
+  for (const child of Object.values(value as object)) {
+    plainRecursiveFreeze(child);
+  }
+  Object.freeze(value);
+}
+
+const COPIES_PER_ITERATION = 32;
+
+function makeCopies<T>(make: () => T, freeze: "none" | "plain" | "deep"): T[] {
+  const copies = Array.from({ length: COPIES_PER_ITERATION }, make);
+  if (freeze === "plain") copies.forEach(plainRecursiveFreeze);
+  if (freeze === "deep") copies.forEach(deepFreeze);
+  return copies;
+}
+
+// ---------------------------------------------------------------------------
+// hashOf
+// ---------------------------------------------------------------------------
+
+const frozenNote = deepFreeze(makeNoteDoc(1));
+const frozenHome128 = deepFreeze(makeHomeDoc(128));
+hashOf(frozenNote);
+hashOf(frozenHome128);
+
+Deno.bench({
+  name: "hashOf: deep-frozen note doc, same identity (cache hit)",
+  group: "hashOf note",
+  baseline: true,
+}, () => {
+  hashOf(frozenNote);
+});
+
+Deno.bench({
+  name: "hashOf: fresh-identity note doc, not frozen (full walk)",
+  group: "hashOf note",
+}, (b) => {
+  const copies = makeCopies(() => makeNoteDoc(1), "none");
+  b.start();
+  for (const copy of copies) hashOf(copy);
+  b.end();
+});
+
+Deno.bench({
+  name: "hashOf: fresh-identity note doc, deep-frozen (WeakMap miss)",
+  group: "hashOf note",
+}, (b) => {
+  const copies = makeCopies(() => makeNoteDoc(1), "deep");
+  b.start();
+  for (const copy of copies) hashOf(copy);
+  b.end();
+});
+
+Deno.bench({
+  name: "hashOf: deep-frozen home doc @128 notes, same identity (cache hit)",
+  group: "hashOf home",
+  baseline: true,
+}, () => {
+  hashOf(frozenHome128);
+});
+
+Deno.bench({
+  name: "hashOf: fresh-identity home doc @128 notes, not frozen (full walk)",
+  group: "hashOf home",
+}, (b) => {
+  const copies = Array.from({ length: 4 }, () => makeHomeDoc(128));
+  b.start();
+  for (const copy of copies) hashOf(copy);
+  b.end();
+});
+
+// ---------------------------------------------------------------------------
+// deep-freeze
+// ---------------------------------------------------------------------------
+
+Deno.bench({
+  name: "isDeepFrozen: cached home doc @128 (cache hit)",
+  group: "deep-freeze",
+  baseline: true,
+}, () => {
+  isDeepFrozen(frozenHome128);
+});
+
+Deno.bench({
+  name: "isDeepFrozen: fresh frozen-but-uncached note doc (full walk)",
+  group: "deep-freeze",
+}, (b) => {
+  const copies = makeCopies(() => makeNoteDoc(1), "plain");
+  b.start();
+  for (const copy of copies) isDeepFrozen(copy);
+  b.end();
+});
+
+Deno.bench({
+  name: "isDeepFrozen: fresh unfrozen note doc (early exit at root)",
+  group: "deep-freeze",
+}, (b) => {
+  const copies = makeCopies(() => makeNoteDoc(1), "none");
+  b.start();
+  for (const copy of copies) isDeepFrozen(copy);
+  b.end();
+});
+
+Deno.bench({
+  name: "deepFreeze: fresh note doc",
+  group: "deep-freeze",
+}, (b) => {
+  const copies = makeCopies(() => makeNoteDoc(1), "none");
+  b.start();
+  for (const copy of copies) deepFreeze(copy);
+  b.end();
+});
+
+Deno.bench({
+  name: "deepFreeze: fresh home doc @128 notes",
+  group: "deep-freeze",
+}, (b) => {
+  const copies = Array.from({ length: 4 }, () => makeHomeDoc(128));
+  b.start();
+  for (const copy of copies) deepFreeze(copy);
+  b.end();
+});

--- a/packages/html/bench/worker-reconciler-mount.bench.ts
+++ b/packages/html/bench/worker-reconciler-mount.bench.ts
@@ -1,0 +1,182 @@
+/**
+ * Worker-reconciler mount/remount benchmarks.
+ *
+ * CPU profiles of the default-app shell integration test
+ * (docs/development/performance/default-app-note-create.md) show that the
+ * single largest runtime-worker phase in a steady-state note-create cycle is
+ * `handleVDomMount` → `WorkerReconciler.mount` → per-child cell subscription
+ * and render: ~37% of busy worker CPU. Navigating back to the home view
+ * re-MOUNTS the whole list, so each child cell is re-read (link resolution,
+ * schema traversal, hashing, freeze checks) even though nothing changed.
+ *
+ * These benches reproduce that shape headlessly: a list vdom whose children
+ * live in real runtime cells (like piece [UI] links), mounted through
+ * `rendererVDOMSchema` with the ops sink discarded.
+ *
+ * Run with:
+ *   deno bench --allow-read --allow-write --allow-net --allow-ffi \
+ *     --allow-env --no-check bench/worker-reconciler-mount.bench.ts
+ */
+
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { Runtime } from "@commonfabric/runner";
+import { rendererVDOMSchema } from "@commonfabric/runner/schemas";
+import type { Cell } from "@commonfabric/runner";
+import { WorkerReconciler } from "../src/worker/reconciler.ts";
+
+const signer = await Identity.fromPassphrase("bench worker reconciler");
+const space = signer.did();
+
+type BenchEnv = {
+  runtime: Runtime;
+  storageManager: ReturnType<typeof StorageManager.emulate>;
+};
+
+function createEnv(): BenchEnv {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  return { runtime, storageManager };
+}
+
+/** A "note chip" vnode subtree, ~the size of a list row in the home view. */
+function noteChipVNode(i: number): unknown {
+  return {
+    type: "vnode",
+    name: "cf-chip",
+    props: {
+      label: `📝 New Note #${i.toString(36)}`,
+      title: `note ${i}`,
+      variant: i % 2 === 0 ? "default" : "accent",
+    },
+    children: [
+      {
+        type: "vnode",
+        name: "span",
+        props: { class: "subtitle" },
+        children: [`updated ${i} minutes ago`],
+      },
+    ],
+  };
+}
+
+type ListEnv = {
+  env: BenchEnv;
+  rootCell: Cell<unknown>;
+  childCells: Cell<unknown>[];
+};
+
+/**
+ * Build a home-like list: a root vnode whose children are LINKS to per-note
+ * cells, each holding its own chip subtree (like per-piece [UI] cells).
+ */
+async function setupList(prefix: string, size: number): Promise<ListEnv> {
+  const env = createEnv();
+  const { runtime } = env;
+  const tx = runtime.edit();
+
+  const childCells: Cell<unknown>[] = [];
+  for (let i = 0; i < size; i++) {
+    const child = runtime.getCell<unknown>(
+      space,
+      `${prefix}:chip:${i}`,
+      undefined,
+      tx,
+    );
+    child.set(noteChipVNode(i));
+    childCells.push(child);
+  }
+
+  const rootCell = runtime.getCell<unknown>(
+    space,
+    `${prefix}:root`,
+    undefined,
+    tx,
+  );
+  rootCell.set({
+    type: "vnode",
+    name: "div",
+    props: { class: "note-list" },
+    children: childCells,
+  });
+
+  await tx.commit();
+  await runtime.idle();
+  return { env, rootCell, childCells };
+}
+
+function mountOnce(listEnv: ListEnv): Promise<void> {
+  const reconciler = new WorkerReconciler({
+    onOps: () => {},
+    onError: (error) => {
+      throw error;
+    },
+  });
+  const cell = listEnv.rootCell.asSchema(rendererVDOMSchema);
+  const cancel = reconciler.mount(cell as Cell<never>);
+  return listEnv.env.runtime.idle().then(() => {
+    cancel();
+    return listEnv.env.runtime.idle();
+  });
+}
+
+for (const size of [8, 32, 128]) {
+  const listEnvPromise = setupList(`mount:${size}`, size);
+  Deno.bench({
+    name: `reconciler mount+unmount @${size} cell children`,
+    group: "reconciler mount",
+    baseline: size === 8,
+  }, async () => {
+    const listEnv = await listEnvPromise;
+    await mountOnce(listEnv);
+  });
+}
+
+// Re-mount of an already-mounted tree (the "navigate back to home" shape):
+// the second mount pays the full per-child resubscribe + re-render cost even
+// though no cell changed.
+{
+  const listEnvPromise = setupList("remount:32", 32);
+  Deno.bench({
+    name: "reconciler re-mount unchanged tree @32 cell children",
+    group: "reconciler remount",
+  }, async () => {
+    const listEnv = await listEnvPromise;
+    await mountOnce(listEnv);
+    await mountOnce(listEnv);
+  });
+}
+
+// Single-child update under a live mount (the "title edited" shape) — should
+// be O(1), not O(list).
+{
+  const listEnvPromise = (async () => {
+    const listEnv = await setupList("update:32", 32);
+    const reconciler = new WorkerReconciler({
+      onOps: () => {},
+      onError: (error) => {
+        throw error;
+      },
+    });
+    reconciler.mount(
+      listEnv.rootCell.asSchema(rendererVDOMSchema) as Cell<never>,
+    );
+    await listEnv.env.runtime.idle();
+    return listEnv;
+  })();
+  let revision = 0;
+  Deno.bench({
+    name: "reconciler single-child update under live mount @32 children",
+    group: "reconciler update",
+  }, async () => {
+    const listEnv = await listEnvPromise;
+    const tx = listEnv.env.runtime.edit();
+    const target = listEnv.childCells[revision++ % listEnv.childCells.length];
+    target.withTx(tx).set(noteChipVNode(1000 + revision));
+    await tx.commit();
+    await listEnv.env.runtime.idle();
+  });
+}

--- a/packages/html/deno.json
+++ b/packages/html/deno.json
@@ -1,7 +1,8 @@
 {
   "name": "@commonfabric/html",
   "tasks": {
-    "test": "deno test --allow-env --allow-ffi --allow-read --allow-net test/*.test.ts test/*.test.tsx"
+    "test": "deno test --allow-env --allow-ffi --allow-read --allow-net test/*.test.ts test/*.test.tsx",
+    "bench": "deno bench --allow-read --allow-write --allow-net --allow-ffi --allow-env --no-check bench/*.bench.ts"
   },
   "exports": {
     ".": "./src/index.ts",

--- a/packages/integration/browser.ts
+++ b/packages/integration/browser.ts
@@ -47,6 +47,14 @@ export class Browser {
     return new Page(page, { timeout: this.timeout });
   }
 
+  // The browser-level CDP websocket endpoint. Chrome supports multiple
+  // concurrent CDP clients, so a second connection (e.g. for CPU profiling
+  // via `cdp-profiler.ts`) can attach alongside Astral's.
+  wsEndpoint(): string {
+    this.checkIsOk();
+    return this.browser!.wsEndpoint();
+  }
+
   async close(): Promise<void> {
     this.checkIsOk();
     const browser = this.browser;

--- a/packages/integration/cdp-profiler.ts
+++ b/packages/integration/cdp-profiler.ts
@@ -1,0 +1,325 @@
+/**
+ * CPU-profiles the runtime web-worker of a running integration browser via
+ * the Chrome DevTools Protocol — no external tooling.
+ *
+ * Connects a second CDP client to the browser websocket endpoint (Chrome
+ * supports multiple concurrent CDP sessions), discovers page targets, and
+ * auto-attaches to their dedicated workers using the flattened session
+ * protocol. `start()`/`stop()` then drive the V8 sampling profiler on the
+ * worker whose script URL matches a substring (default: "worker").
+ *
+ * The resulting profile can be written as a `.cpuprofile` (loadable in Chrome
+ * DevTools / speedscope) plus a ranked self-time text report, mirroring
+ * `packages/runner/test/traverse-replay/profile-driver.ts`.
+ */
+
+export type CPUProfile = {
+  nodes: Array<{
+    id: number;
+    hitCount?: number;
+    callFrame: {
+      functionName: string;
+      url: string;
+      lineNumber: number;
+    };
+    children?: number[];
+  }>;
+  samples?: number[];
+  timeDeltas?: number[];
+  startTime: number;
+  endTime: number;
+};
+
+type AttachedWorker = {
+  sessionId: string;
+  targetId: string;
+  url: string;
+  attachedAt: number;
+};
+
+const SEND_TIMEOUT_MS = 30_000;
+
+export class CdpWorkerProfiler {
+  #ws: WebSocket;
+  #nextId = 1;
+  #pending = new Map<
+    number,
+    {
+      method: string;
+      sessionId?: string;
+      resolve: (result: unknown) => void;
+      reject: (error: Error) => void;
+    }
+  >();
+  #workers = new Map<string, AttachedWorker>();
+  #profilingSessionId: string | undefined;
+
+  private constructor(ws: WebSocket) {
+    this.#ws = ws;
+    ws.onmessage = (event) => this.#onMessage(event);
+    ws.onclose = () => this.#rejectAll("CDP websocket closed");
+    ws.onerror = () => this.#rejectAll("CDP websocket error");
+  }
+
+  #rejectAll(reason: string, sessionId?: string) {
+    for (const [id, pending] of [...this.#pending.entries()]) {
+      if (sessionId !== undefined && pending.sessionId !== sessionId) continue;
+      this.#pending.delete(id);
+      pending.reject(new Error(`${pending.method}: ${reason}`));
+    }
+  }
+
+  /**
+   * Connect to the browser-level websocket endpoint (from
+   * `AstralBrowser#wsEndpoint()`), discover all page targets, and auto-attach
+   * to their dedicated workers.
+   */
+  static async connect(browserWsEndpoint: string): Promise<CdpWorkerProfiler> {
+    const ws = new WebSocket(browserWsEndpoint);
+    await new Promise<void>((resolve, reject) => {
+      ws.onopen = () => resolve();
+      ws.onerror = () => reject(new Error("Could not connect to browser CDP"));
+    });
+    const profiler = new CdpWorkerProfiler(ws);
+    await profiler.#discoverAndAttach();
+    return profiler;
+  }
+
+  #onMessage(event: MessageEvent) {
+    const msg = JSON.parse(event.data as string) as {
+      id?: number;
+      error?: { message: string };
+      result?: unknown;
+      method?: string;
+      params?: Record<string, unknown>;
+    };
+    if (msg.id !== undefined) {
+      const pending = this.#pending.get(msg.id);
+      this.#pending.delete(msg.id);
+      if (!pending) return;
+      if (msg.error) pending.reject(new Error(msg.error.message));
+      else pending.resolve(msg.result);
+      return;
+    }
+    if (msg.method === "Target.attachedToTarget") {
+      const params = msg.params as {
+        sessionId: string;
+        targetInfo: { targetId: string; type: string; url: string };
+      };
+      const { sessionId, targetInfo } = params;
+      if (targetInfo.type === "worker") {
+        this.#workers.set(sessionId, {
+          sessionId,
+          targetId: targetInfo.targetId,
+          url: targetInfo.url,
+          attachedAt: performance.now(),
+        });
+        // Workers wait for the debugger when auto-attached with
+        // waitForDebuggerOnStart; resume just in case (no-op otherwise).
+        this.#send("Runtime.runIfWaitingForDebugger", {}, sessionId)
+          .catch(() => {});
+      } else if (targetInfo.type === "page" || targetInfo.type === "iframe") {
+        // Auto-attach to this page's (future and current) dedicated workers.
+        this.#send("Target.setAutoAttach", {
+          autoAttach: true,
+          waitForDebuggerOnStart: false,
+          flatten: true,
+        }, sessionId).catch(() => {});
+      }
+    } else if (msg.method === "Target.detachedFromTarget") {
+      const params = msg.params as { sessionId: string };
+      this.#workers.delete(params.sessionId);
+      // A command sent to a detached session never gets a response.
+      this.#rejectAll("target detached", params.sessionId);
+    } else if (msg.method === "Target.targetCreated") {
+      const params = msg.params as {
+        targetInfo: { targetId: string; type: string };
+      };
+      if (params.targetInfo.type === "page") {
+        this.#send("Target.attachToTarget", {
+          targetId: params.targetInfo.targetId,
+          flatten: true,
+        }).catch(() => {});
+      }
+    }
+  }
+
+  #send(
+    method: string,
+    params: Record<string, unknown> = {},
+    sessionId?: string,
+  ): Promise<unknown> {
+    const id = this.#nextId++;
+    return new Promise((resolve, reject) => {
+      if (this.#ws.readyState !== WebSocket.OPEN) {
+        reject(new Error(`CDP ${method}: websocket is not open`));
+        return;
+      }
+      const timer = setTimeout(() => {
+        if (this.#pending.delete(id)) {
+          reject(
+            new Error(
+              `CDP ${method} (session ${
+                sessionId ?? "browser"
+              }) timed out after ${SEND_TIMEOUT_MS}ms`,
+            ),
+          );
+        }
+      }, SEND_TIMEOUT_MS);
+      this.#pending.set(id, {
+        method,
+        sessionId,
+        resolve: (result) => {
+          clearTimeout(timer);
+          resolve(result);
+        },
+        reject: (error) => {
+          clearTimeout(timer);
+          reject(error);
+        },
+      });
+      this.#ws.send(JSON.stringify({ id, method, params, sessionId }));
+    });
+  }
+
+  async #discoverAndAttach(): Promise<void> {
+    // Attach (flattened) to all current page targets; new pages arrive via
+    // Target.targetCreated → attachToTarget below.
+    const { targetInfos } = await this.#send("Target.getTargets") as {
+      targetInfos: Array<{ targetId: string; type: string; url: string }>;
+    };
+    for (const info of targetInfos) {
+      if (info.type !== "page") continue;
+      await this.#send("Target.attachToTarget", {
+        targetId: info.targetId,
+        flatten: true,
+      });
+    }
+    // Discover pages created after us (fresh-page load measurements);
+    // Target.targetCreated is handled in #onMessage.
+    await this.#send("Target.setDiscoverTargets", { discover: true });
+  }
+
+  /** Worker sessions currently attached, most recent first. */
+  workers(): AttachedWorker[] {
+    return [...this.#workers.values()].sort(
+      (a, b) => b.attachedAt - a.attachedAt,
+    );
+  }
+
+  /** Wait until a worker whose URL contains `urlSubstring` is attached. */
+  async waitForWorker(
+    urlSubstring: string,
+    timeoutMs = 30_000,
+  ): Promise<AttachedWorker> {
+    const startedAt = performance.now();
+    while (performance.now() - startedAt < timeoutMs) {
+      const worker = this.workers().find((w) => w.url.includes(urlSubstring));
+      if (worker) return worker;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    throw new Error(
+      `Timed out waiting for worker matching "${urlSubstring}". ` +
+        `Attached workers: ${this.workers().map((w) => w.url).join(", ")}`,
+    );
+  }
+
+  /**
+   * Start the sampling profiler on the most recently attached worker whose
+   * URL contains `urlSubstring`.
+   */
+  async start(
+    urlSubstring = "worker",
+    samplingIntervalUs = 250,
+  ): Promise<void> {
+    const worker = await this.waitForWorker(urlSubstring);
+    this.#profilingSessionId = worker.sessionId;
+    await this.#send("Profiler.enable", {}, worker.sessionId);
+    await this.#send(
+      "Profiler.setSamplingInterval",
+      { interval: samplingIntervalUs },
+      worker.sessionId,
+    );
+    await this.#send("Profiler.start", {}, worker.sessionId);
+  }
+
+  /** Stop the profiler started by `start()` and return the profile. */
+  async stop(): Promise<CPUProfile> {
+    const sessionId = this.#profilingSessionId;
+    if (!sessionId) throw new Error("Profiler was not started.");
+    this.#profilingSessionId = undefined;
+    const { profile } = await this.#send(
+      "Profiler.stop",
+      {},
+      sessionId,
+    ) as { profile: CPUProfile };
+    return profile;
+  }
+
+  close(): void {
+    try {
+      this.#ws.close();
+    } catch {
+      // Already closed.
+    }
+  }
+}
+
+/**
+ * Render a ranked self-time report (top frames + by-file) from a profile.
+ * Sample time is attributed via timeDeltas, like
+ * test/traverse-replay/profile-driver.ts.
+ */
+export function renderProfileReport(
+  profile: CPUProfile,
+  label: string,
+  options: { topFrames?: number; topFiles?: number } = {},
+): string {
+  const nodeTime = new Map<number, number>();
+  if (profile.samples && profile.timeDeltas) {
+    for (let i = 0; i < profile.samples.length; i++) {
+      const id = profile.samples[i];
+      nodeTime.set(id, (nodeTime.get(id) ?? 0) + (profile.timeDeltas[i] ?? 0));
+    }
+  }
+  const totalUs = [...nodeTime.values()].reduce((a, b) => a + b, 0);
+
+  const byFrame = new Map<string, number>();
+  const byFile = new Map<string, number>();
+  for (const node of profile.nodes) {
+    const us = nodeTime.get(node.id) ?? 0;
+    if (us === 0) continue;
+    const { functionName, url, lineNumber } = node.callFrame;
+    const file = url.split("/").pop() || "(internal)";
+    const frame = `${functionName || "(anonymous)"} @ ${file}:${
+      lineNumber + 1
+    }`;
+    byFrame.set(frame, (byFrame.get(frame) ?? 0) + us);
+    byFile.set(file, (byFile.get(file) ?? 0) + us);
+  }
+
+  const fmt = (us: number) =>
+    `${(us / 1000).toFixed(0).padStart(7)}ms ${
+      ((us / totalUs) * 100).toFixed(1).padStart(5)
+    }%`;
+
+  let report = `# Worker CPU profile: ${label}\n`;
+  report +=
+    `wall: ${((profile.endTime - profile.startTime) / 1000).toFixed(0)}ms, ` +
+    `sampled: ${(totalUs / 1000).toFixed(0)}ms\n\n`;
+  report += `## Top frames by self time\n`;
+  for (
+    const [frame, us] of [...byFrame.entries()].sort((a, b) => b[1] - a[1])
+      .slice(0, options.topFrames ?? 45)
+  ) {
+    report += `${fmt(us)}  ${frame}\n`;
+  }
+  report += `\n## By file\n`;
+  for (
+    const [file, us] of [...byFile.entries()].sort((a, b) => b[1] - a[1])
+      .slice(0, options.topFiles ?? 15)
+  ) {
+    report += `${fmt(us)}  ${file}\n`;
+  }
+  return report;
+}

--- a/packages/integration/index.ts
+++ b/packages/integration/index.ts
@@ -1,4 +1,5 @@
 export { Browser } from "./browser.ts";
+export { CdpWorkerProfiler, renderProfileReport } from "./cdp-profiler.ts";
 export { dismissDialogs, Page, pipeConsole } from "./page.ts";
 export * as env from "./env.ts";
 export * from "./utils.ts";

--- a/packages/integration/shell-utils.ts
+++ b/packages/integration/shell-utils.ts
@@ -130,6 +130,13 @@ export class ShellIntegration {
     return this.#page!;
   }
 
+  // Browser-level CDP websocket endpoint, for attaching a second CDP client
+  // (e.g. `CdpWorkerProfiler`).
+  wsEndpoint(): string {
+    this.checkIsOk();
+    return this.#browser!.wsEndpoint();
+  }
+
   async newPage(url?: string): Promise<Page> {
     this.checkIsOk();
     const page = await this.#browser!.newPage(url);

--- a/packages/patterns/integration/default-app.test.ts
+++ b/packages/patterns/integration/default-app.test.ts
@@ -1,4 +1,10 @@
-import { env, Page, waitFor } from "@commonfabric/integration";
+import {
+  CdpWorkerProfiler,
+  env,
+  Page,
+  renderProfileReport,
+  waitFor,
+} from "@commonfabric/integration";
 import { ShellIntegration } from "@commonfabric/integration/shell-utils";
 import { describe, it } from "@std/testing/bdd";
 import { Identity } from "@commonfabric/identity";
@@ -147,6 +153,25 @@ const CAPTURE_EVENT_INVOCATION_SERIES = (() => {
     return 0;
   }
 })();
+// CPU-profile the runtime worker for the first N note-create iterations,
+// writing .cpuprofile + ranked self-time reports to CF_CPUPROFILE_DIR
+// (default /tmp).
+const CAPTURE_NOTE_CREATE_CPUPROFILE_SERIES = (() => {
+  try {
+    return parseCaptureSeriesCount(
+      Deno.env.get("CF_CAPTURE_NOTE_CREATE_CPUPROFILE_SERIES"),
+    );
+  } catch {
+    return 0;
+  }
+})();
+const CPUPROFILE_DIR = (() => {
+  try {
+    return Deno.env.get("CF_CPUPROFILE_DIR") ?? "/tmp";
+  } catch {
+    return "/tmp";
+  }
+})();
 const SCHEDULER_PULL_MODE = (() => {
   try {
     const raw = Deno.env.get("CF_SCHEDULER_PULL_MODE");
@@ -286,7 +311,18 @@ describe("default-app flow test", () => {
       NOTE_CREATE_TIMING_SERIES,
       CAPTURE_NOTE_CREATE_PROFILE_SERIES,
       CAPTURE_EVENT_INVOCATION_SERIES,
+      // Profiled notes start at note 2 (note 1 is compile-dominated).
+      CAPTURE_NOTE_CREATE_CPUPROFILE_SERIES > 0
+        ? 1 + CAPTURE_NOTE_CREATE_CPUPROFILE_SERIES
+        : 0,
     );
+
+    let cpuProfiler: CdpWorkerProfiler | undefined;
+    if (CAPTURE_NOTE_CREATE_CPUPROFILE_SERIES > 0) {
+      console.log("Connect CDP worker profiler...");
+      cpuProfiler = await CdpWorkerProfiler.connect(shell.wsEndpoint());
+      await cpuProfiler.waitForWorker("worker-runtime");
+    }
 
     if (CAPTURE_HOME_LOAD_SERIES > 0) {
       const homeLoadSummary = await collectHomeLoadSummaryFromFreshPage(
@@ -336,6 +372,24 @@ describe("default-app flow test", () => {
         await waitFor(async () => {
           return await resetEventInvocationTrace(page);
         });
+      }
+
+      // Skip note 1: its profile is dominated by first-use pattern compile
+      // (out of scope for steady-state measurement) and is large enough to
+      // break the CDP websocket message limit.
+      let profileThisNote = cpuProfiler !== undefined && noteIndex >= 2 &&
+        noteIndex <= 1 + CAPTURE_NOTE_CREATE_CPUPROFILE_SERIES;
+      if (profileThisNote) {
+        console.log(`Start worker CPU profile (note ${noteIndex})...`);
+        try {
+          await cpuProfiler!.start("worker-runtime");
+        } catch (error) {
+          console.warn(
+            `Worker CPU profile start failed (note ${noteIndex}):`,
+            error,
+          );
+          profileThisNote = false;
+        }
       }
 
       console.log(`Click notes drop down (note ${noteIndex})...`);
@@ -485,6 +539,29 @@ describe("default-app flow test", () => {
         JSON.stringify(noteCreateTiming, null, 2),
       );
 
+      if (profileThisNote) {
+        try {
+          const profile = await cpuProfiler!.stop();
+          const outPrefix = `${CPUPROFILE_DIR}/default-app-note-${noteIndex}`;
+          await Deno.writeTextFile(
+            `${outPrefix}.cpuprofile`,
+            JSON.stringify(profile),
+          );
+          const report = renderProfileReport(
+            profile,
+            `note-create iteration ${noteIndex}`,
+          );
+          await Deno.writeTextFile(`${outPrefix}.report.txt`, report);
+          console.log(`Worker CPU profile written: ${outPrefix}.cpuprofile`);
+        } catch (error) {
+          // Profiling is best-effort instrumentation; don't fail the test.
+          console.warn(
+            `Worker CPU profile capture failed (note ${noteIndex}):`,
+            error,
+          );
+        }
+      }
+
       if (noteIndex <= CAPTURE_NOTE_CREATE_PROFILE_SERIES) {
         const noteCreateProfile = await collectNoteCreateProfile(page);
         assert(
@@ -541,6 +618,8 @@ describe("default-app flow test", () => {
         );
       }
     }
+
+    cpuProfiler?.close();
 
     const noteFound = await findNoteInList(page);
     assert(

--- a/packages/runner/test/default-app-note-create.bench.ts
+++ b/packages/runner/test/default-app-note-create.bench.ts
@@ -1,0 +1,239 @@
+/**
+ * Integration-shaped "default-app note create" benchmark.
+ *
+ * Reproduces the hot cycle of the default-app shell integration test
+ * (packages/patterns/integration/default-app.test.ts) inside a single Deno
+ * process so the full event → preflight → handler → commit → settle →
+ * recompute path can be profiled and optimized without a browser:
+ *
+ * - a home doc holds a list of LINKS to per-note docs (like allPieces),
+ * - a lifted view derives display rows from the list (reads every note:
+ *   link resolution + schema traverse + hashing, the integration's read mix),
+ * - a live sink subscribes to the derived view (like the home UI),
+ * - an event handler creates a new note doc and pushes its link (like the
+ *   "New Note" flow), then a second event removes it again so the list size
+ *   stays constant across bench iterations.
+ *
+ * The default-app CPU profiles (docs/development/performance/
+ * default-app-note-create.md) show per-note-create costs that grow linearly
+ * with existing note count (traverse calls +~41/note, dirty-dependency visits
+ * +~28/note). The @0/@32/@128 size variants make that growth visible.
+ *
+ * Complements:
+ * - scheduler-event-preflight.bench.ts (synthetic preflight shape)
+ * - push-pull-patterns.bench.ts (map/filter builtins)
+ * - data-model/bench/value-identity-shapes.bench.ts (hash/freeze leafs)
+ *
+ * Run with:
+ *   deno bench --allow-read --allow-write --allow-net --allow-ffi \
+ *     --allow-env --no-check test/default-app-note-create.bench.ts
+ */
+
+import type { Cell, JSONSchema } from "../src/builder/types.ts";
+import type { EventHandler } from "../src/scheduler.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+import { createTrustedBuilder } from "./support/trusted-builder.ts";
+import {
+  benchSpace,
+  createSchedulerBenchEnv,
+  type SchedulerBenchEnv,
+} from "./scheduler-bench-helpers.ts";
+
+const noteSchema = {
+  type: "object",
+  properties: {
+    title: { type: "string" },
+    content: { type: "string" },
+    tags: { type: "array", items: { type: "string" } },
+  },
+  required: ["title"],
+  additionalProperties: false,
+} as const satisfies JSONSchema;
+
+const noteListSchema = {
+  type: "array",
+  items: noteSchema,
+} as const satisfies JSONSchema;
+
+// Same list, but elements kept as links (for structural edits that shouldn't
+// deep-resolve every note).
+const noteLinkListSchema = {
+  type: "array",
+  items: { ...noteSchema, asCell: ["cell"] },
+} as const satisfies JSONSchema;
+
+const homeArgumentSchema = {
+  type: "object",
+  properties: {
+    items: noteListSchema,
+  },
+  required: ["items"],
+  additionalProperties: false,
+} as const satisfies JSONSchema;
+
+const homeResultSchema = {
+  type: "object",
+  properties: {
+    titles: { type: "array", items: { type: "string" } },
+  },
+  additionalProperties: false,
+} as const satisfies JSONSchema;
+
+type Note = { title: string; content: string; tags: string[] };
+
+function noteValue(i: number): Note {
+  return {
+    title: `📝 New Note #${i.toString(36)}`,
+    content: `Note body ${i} — `.repeat(8),
+    tags: ["#note", `#tag-${i % 7}`],
+  };
+}
+
+type NoteCreateGraph = {
+  env: SchedulerBenchEnv;
+  itemsCell: Cell<Note[]>;
+  eventStream: Cell<unknown>;
+  result: Cell<{ titles: string[] }>;
+  cancels: Array<() => void>;
+};
+
+let causeCounter = 0;
+
+async function setupNoteCreateGraph(
+  prefix: string,
+  pullMode: boolean,
+  initialNotes: number,
+): Promise<NoteCreateGraph> {
+  const env = createSchedulerBenchEnv(pullMode);
+  const { runtime } = env;
+  const { commonfabric } = createTrustedBuilder(runtime);
+  const { lift, pattern } = commonfabric;
+
+  const tx = runtime.edit();
+  const itemsCell = runtime.getCell<Note[]>(
+    benchSpace,
+    `${prefix}:items`,
+    noteListSchema,
+    tx,
+  );
+  itemsCell.set([]);
+
+  // Seed the initial notes as separate linked docs, like pieces in a space.
+  for (let i = 0; i < initialNotes; i++) {
+    const note = runtime.getCell<Note>(
+      benchSpace,
+      `${prefix}:note:${causeCounter++}`,
+      noteSchema,
+      tx,
+    );
+    note.set(noteValue(i));
+    itemsCell.push(note);
+  }
+
+  // Derived home view: reads (and therefore resolves + traverses) every note.
+  const titlesOf = lift(
+    noteListSchema,
+    { type: "array", items: { type: "string" } } as const satisfies JSONSchema,
+    (items: Note[]) =>
+      items.map((note) => `${note.title} (${note.tags?.length ?? 0})`),
+  );
+  const homeView = pattern<{ items: Note[] }, unknown>(
+    ({ items }) => ({ titles: titlesOf(items) }),
+    homeArgumentSchema,
+    homeResultSchema,
+  );
+
+  const resultCell = runtime.getCell<{ titles: string[] }>(
+    benchSpace,
+    `${prefix}:result`,
+    homeResultSchema,
+    tx,
+  );
+  const result = runtime.run(
+    tx,
+    homeView,
+    { items: itemsCell },
+    resultCell,
+  ) as Cell<{ titles: string[] }>;
+
+  const eventStream = runtime.getCell<unknown>(
+    benchSpace,
+    `${prefix}:events`,
+    { asCell: ["stream"] },
+    tx,
+  );
+
+  await tx.commit();
+  await runtime.idle();
+
+  // Live subscription, like the home UI rendering the list.
+  const cancels: Array<() => void> = [];
+  cancels.push(result.sink(() => {}));
+  await runtime.idle();
+
+  // "New Note" / "Remove Note" handler.
+  const linkItems = itemsCell.asSchema(noteLinkListSchema);
+  const handler = Object.assign(
+    ((handlerTx: IExtendedStorageTransaction, event: { kind: string }) => {
+      if (event.kind === "create") {
+        const note = runtime.getCell<Note>(
+          benchSpace,
+          `${prefix}:note:${causeCounter++}`,
+          noteSchema,
+          handlerTx,
+        );
+        note.set(noteValue(causeCounter));
+        itemsCell.withTx(handlerTx).push(note);
+      } else {
+        const links = linkItems.withTx(handlerTx).get() ?? [];
+        linkItems.withTx(handlerTx).set(links.slice(0, -1));
+      }
+    }) as EventHandler,
+    {
+      reads: [],
+      writes: [itemsCell.getAsNormalizedFullLink()],
+      module: { type: "javascript" as const },
+      pattern: {} as never,
+    },
+  );
+  cancels.push(
+    runtime.scheduler.addEventHandler(
+      handler,
+      eventStream.getAsNormalizedFullLink(),
+    ),
+  );
+
+  return { env, itemsCell, eventStream, result, cancels };
+}
+
+function noteCreateCycle(graph: NoteCreateGraph): Promise<void> {
+  const { env, eventStream } = graph;
+  const link = eventStream.getAsNormalizedFullLink();
+  env.runtime.scheduler.queueEvent(link, { kind: "create" });
+  return env.runtime.idle().then(() => {
+    env.runtime.scheduler.queueEvent(link, { kind: "remove" });
+    return env.runtime.idle();
+  });
+}
+
+for (const pullMode of [true, false]) {
+  const mode = pullMode ? "pull" : "push";
+  for (const size of [0, 32, 128]) {
+    const graphPromise = setupNoteCreateGraph(
+      `default-app:${mode}:${size}`,
+      pullMode,
+      size,
+    );
+    Deno.bench({
+      name: `note create+remove cycle @${size} notes (${mode})`,
+      group: `note create (${mode})`,
+      baseline: size === 0,
+    }, async () => {
+      const graph = await graphPromise;
+      await noteCreateCycle(graph);
+    });
+  }
+}
+
+// Note: graphs are deliberately kept alive for the whole bench process (the
+// emulated storage holds no external state); the process exit cleans up.


### PR DESCRIPTION
## What

First end-to-end measurement of a real user flow for the [Performance Program](docs/development/PERFORMANCE_PROGRAM.md): steady-state note creation in the default-app shell integration test. Compile time is explicitly out of scope.

Three pieces:

1. **CDP worker CPU profiler** (`packages/integration/cdp-profiler.ts`): attaches a second CDP client to the Astral browser, auto-attaches to the page's dedicated workers via flattened sessions, and drives the V8 sampling profiler on the `worker-runtime` target. The default-app test gains `CF_CAPTURE_NOTE_CREATE_CPUPROFILE_SERIES=N` / `CF_CPUPROFILE_DIR` to write `.cpuprofile` files + ranked self-time reports for notes 2..N+1 (note 1 is compile-dominated and oversized for the CDP websocket message limit).

2. **Benchmarks** reproducing each measured hotspot in-process:
   - `packages/runner/test/default-app-note-create.bench.ts` — macro event→preflight→handler→commit→settle cycle with a linked note list: 14.3ms @0 → 24.1ms @32 → 59.7ms @128 notes (~0.36ms per existing note, the O(n)-per-create seam)
   - `packages/html/bench/worker-reconciler-mount.bench.ts` — the top phase (37% of busy worker CPU): ~2.7ms **per cell child** to mount; re-mounting an unchanged tree pays full price; single-child update under a live mount is 6.7ms
   - `packages/data-model/bench/value-identity-shapes.bench.ts` — the identity-cache gap behind hashing (29%) and deep-freeze (12%): 10ns cached vs **2.1ms** per hash of a fresh-identity 128-note home doc

3. **Findings doc** (`docs/development/performance/default-app-note-create.md`): logger + CPU-profile breakdown, growth seams (traverse +41 calls / dirty-visits +28 per existing note per create), reproduction instructions, and seven ranked optimization candidates, each guarded by one of the benches.

## Key numbers (worker busy CPU, steady-state note create)

| Phase / subsystem | Share |
|---|---|
| `handleVDomMount` (home view re-mount on nav-back) | 37% |
| settle-loop action runs | 21% |
| value hashing (cross-cutting) | 29% |
| deep-freeze walks (cross-cutting) | 12% |

Note: the integration test's own wall numbers (~1.15s/note) are quantized by the harness's 500ms `waitFor` poll; real runtime cost is ~150–300ms/note.

## Test plan

- [x] `deno check` / `deno lint` / `deno fmt` on all new/changed files
- [x] default-app integration test passes with and without the new capture env vars (5-note series, profiles written for notes 2–4)
- [x] all three bench files run green with the baselines quoted above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Profiles the runtime web‑worker during default‑app note creation and adds targeted benchmarks, giving us end‑to‑end performance data and a reproducible baseline for optimizations. Docs capture the findings and rank the next fixes.

- **New Features**
  - CDP worker CPU profiler in `packages/integration/cdp-profiler.ts` that attaches a second CDP client and drives V8 sampling on the runtime worker; exposed via `ShellIntegration.wsEndpoint()`/`Browser.wsEndpoint()`.
  - Default‑app test can capture worker profiles with `CF_CAPTURE_NOTE_CREATE_CPUPROFILE_SERIES` and `CF_CPUPROFILE_DIR`, writing `.cpuprofile` + ranked self‑time reports for notes 2..N+1.
  - Benchmarks:
    - `packages/runner/test/default-app-note-create.bench.ts` — macro event→preflight→handler→commit→settle; shows O(n) per existing note.
    - `packages/html/bench/worker-reconciler-mount.bench.ts` — `WorkerReconciler` mount/remount; ~2.7 ms per child, re‑mount pays full price, single‑child update is still multi‑ms.
    - `packages/data-model/bench/value-identity-shapes.bench.ts` — hashing/deep‑freeze identity‑cache gap on fresh values.
  - Findings doc `docs/development/performance/default-app-note-create.md` with phase/subsystem breakdown and ranked optimization candidates; linked from `docs/development/PERFORMANCE_PROGRAM.md`. `packages/html/deno.json` adds a `bench` task.

- **Migration**
  - Optional: set `CF_CAPTURE_NOTE_CREATE_CPUPROFILE_SERIES=N` and `CF_CPUPROFILE_DIR=/path` to capture worker CPU profiles in the default‑app test (note 1 is skipped). Run new benches with `deno bench` in the added paths.

<sup>Written for commit 346ae34c2ec669240e394122ea4bc88f443d93e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



## Perf check note

The "Build application" step metric reads 20–24s on every attempt across two independent workflow runs of this PR, while main runs measure 11–14s in the same window — and warm `deno task build-binaries` is byte-identical on this branch vs main locally (12.0–12.2s vs 12.1–12.5s, same machine). Nothing in this PR is in the binaries' module graphs (benches/test/docs/harness only). Treating as a CI-environment artifact per the override mechanism:

The same cross-population skew (PR runs vs main-run baselines) tripped other untouched jobs on subsequent attempts, so those are overridden too:

NEW_PERF_BASELINE: step: Build application = 24s
NEW_PERF_BASELINE: job: Build Binaries = 64s
NEW_PERF_BASELINE: job: Generated Patterns Integration Tests (3/4) = 90s
NEW_PERF_BASELINE: job: Generated Patterns Integration Tests = 90s

