### PR TITLE
fix(runner): resolve wish sidecar pattern URLs lazily, not at module load

### DIFF
--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -31,12 +31,18 @@ import { setRunnableName } from "../runner-utils.ts";
 import { isCellScope, narrowestScope } from "../scope.ts";
 import { scopedCell } from "./scope-policy.ts";
 
-const SUGGESTION_TSX_PATH = getPatternEnvironment().apiUrl +
-  "api/patterns/system/suggestion.tsx";
-const PROFILE_CREATE_TSX_PATH = getPatternEnvironment().apiUrl +
-  "api/patterns/system/profile-create.tsx";
-const PROFILE_PICKER_TSX_PATH = getPatternEnvironment().apiUrl +
-  "api/patterns/system/profile-picker.tsx";
+// Resolved lazily (not at module load): in the browser worker this module is
+// imported before the runtime calls `setPatternEnvironment` with the real API
+// URL, so a module-level const would capture the default — the worker's own
+// origin, i.e. the frontend server. That is only correct when the shell is
+// served by the API host (as in CI); against a separate frontend the fetch
+// gets the SPA index.html fallback and pattern compilation fails.
+const suggestionTsxPath = () =>
+  getPatternEnvironment().apiUrl + "api/patterns/system/suggestion.tsx";
+const profileCreateTsxPath = () =>
+  getPatternEnvironment().apiUrl + "api/patterns/system/profile-create.tsx";
+const profilePickerTsxPath = () =>
+  getPatternEnvironment().apiUrl + "api/patterns/system/profile-picker.tsx";
 const wishFlowLogger = getLogger("runner.wish-flow", {
   enabled: true,
   level: "warn",
@@ -1140,7 +1146,7 @@ async function fetchSuggestionPattern(
 ): Promise<Pattern | undefined> {
   try {
     const program = await runtime.harness.resolve(
-      new HttpProgramResolver(SUGGESTION_TSX_PATH),
+      new HttpProgramResolver(suggestionTsxPath()),
     );
 
     if (!program) {
@@ -1166,7 +1172,7 @@ async function fetchProfileCreatePattern(
 ): Promise<Pattern | undefined> {
   try {
     const program = await runtime.harness.resolve(
-      new HttpProgramResolver(PROFILE_CREATE_TSX_PATH),
+      new HttpProgramResolver(profileCreateTsxPath()),
     );
 
     if (!program) {
@@ -1192,7 +1198,7 @@ async function fetchProfilePickerPattern(
 ): Promise<Pattern | undefined> {
   try {
     const program = await runtime.harness.resolve(
-      new HttpProgramResolver(PROFILE_PICKER_TSX_PATH),
+      new HttpProgramResolver(profilePickerTsxPath()),
     );
 
     if (!program) {

--- a/packages/runner/test/wish.test.ts
+++ b/packages/runner/test/wish.test.ts
@@ -9,6 +9,10 @@ import { Runtime } from "../src/runtime.ts";
 import { ALL_PIECES_ID } from "../src/builtins/well-known.ts";
 import { NAME, UI } from "../src/builder/types.ts";
 import { parseWishTarget, tagMatchesHashtag } from "../src/builtins/wish.ts";
+import {
+  getPatternEnvironment,
+  setPatternEnvironment,
+} from "../src/builder/env.ts";
 
 const signer = await Identity.fromPassphrase("wish built-in tests");
 const space = signer.did();
@@ -2477,6 +2481,70 @@ describe("wish built-in", () => {
           .resolveAsCell()
           .getRaw(),
       ).toBeUndefined();
+    });
+
+    it("fetches the profile-create pattern from the pattern environment apiUrl set after module load", async () => {
+      // Regression test: the sidecar pattern URLs (profile-create / picker /
+      // suggestion) must be resolved when the fetch happens, not at module
+      // import. In the browser worker, wish.ts is imported before the runtime
+      // calls setPatternEnvironment with the real API URL; a module-load-time
+      // const captures the default (the worker's own origin, i.e. the frontend
+      // server), whose SPA fallback serves index.html instead of the pattern.
+      const homeSpaceCell = runtime.getHomeSpaceCell(tx);
+      const homeDefaultCell = runtime.getCell(
+        userIdentity.did(),
+        "home-default-profile-create-fetch-url",
+        undefined,
+        tx,
+      );
+      (homeSpaceCell as any).key("defaultPattern").set(homeDefaultCell);
+
+      await tx.commit();
+      await runtime.idle();
+      tx = runtime.edit();
+
+      const recordedUrls: string[] = [];
+      const originalFetch = globalThis.fetch;
+      const originalEnvironment = getPatternEnvironment();
+      setPatternEnvironment({ apiUrl: new URL("https://pattern-env.test/") });
+      globalThis.fetch = ((input: Request | URL | string) => {
+        recordedUrls.push(
+          input instanceof Request ? input.url : String(input),
+        );
+        return Promise.resolve(new Response("not found", { status: 404 }));
+      }) as typeof fetch;
+
+      try {
+        const wishPattern = pattern(() => ({
+          profile: wish({ query: "#profile" }),
+        }));
+        const resultCell = runtime.getCell<Record<string, any>>(
+          patternSpace.did(),
+          "wish-profile-create-fetch-url-result",
+          undefined,
+          tx,
+        );
+        const result = runtime.run(tx, wishPattern, {}, resultCell);
+        await tx.commit();
+        tx = runtime.edit();
+
+        await result.pull();
+
+        // The missing-profile UI kicks off a deferred profile-create fetch.
+        const expectedUrl =
+          "https://pattern-env.test/api/patterns/system/profile-create.tsx";
+        const deadline = Date.now() + 5_000;
+        while (
+          !recordedUrls.includes(expectedUrl) && Date.now() < deadline
+        ) {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+        }
+        expect(recordedUrls).toContain(expectedUrl);
+      } finally {
+        globalThis.fetch = originalFetch;
+        setPatternEnvironment(originalEnvironment);
+        await runtime.idle();
+      }
     });
 
     it("searches home default profile elements for hashtag wishes with profile scope", async () => {


### PR DESCRIPTION
## Problem

`packages/patterns/integration/shared-profile.test.ts` fails on a fresh local dev stack (`scripts/start-local-dev.sh`, then `API_URL=… FRONTEND_URL=… deno test …`) with 'Unable to find profile create input "cf-input"' — the wish-rendered profile-create UI never renders, with the piece stuck at "No profile". The failure is pre-existing on `main`, while the same test is green in CI.

## Root cause

The suggestion / profile-create / profile-picker pattern URLs in `packages/runner/src/builtins/wish.ts` were module-level consts built from `getPatternEnvironment()` at import time:

```ts
const PROFILE_CREATE_TSX_PATH = getPatternEnvironment().apiUrl +
  "api/patterns/system/profile-create.tsx";
```

In the browser web worker this module is imported **before** the runtime calls `setPatternEnvironment({ apiUrl })` (`runtime-processor.ts`), so the consts capture the default environment — `location.origin`, i.e. the **frontend** server, not the API.

- **CI**: the pattern-integration job starts only the toolshed binary and sets `API_URL=http://localhost:8000/`; `FRONTEND_URL` falls back to `API_URL`, so shell origin == API origin and the wrong-origin fetch happens to hit the right server. Bug masked.
- **Local dev** (and any split shell/API deployment): the felt dev server's SPA fallback (`redirectToIndex` in `packages/shell/felt.config.ts` matches `/api/…`) serves **index.html with HTTP 200** for the pattern URL. The compiler then fails with `CompilerError: … Cannot find name 'DOCTYPE'` (confirmed via worker-side `runner.wish-flow` logger flags over the `commonfabric.rt` IPC), `fetchProfileCreatePattern` swallows the error, and the wish `cf-render` stays empty forever.

## Fix

Resolve the three URLs inside the fetch functions (call time), after the pattern environment has been configured — matching how `fetch-data.ts` already reads `getPatternEnvironment()`.

## Verification

- New unit regression test in `packages/runner/test/wish.test.ts`: stubs `fetch`, sets a sentinel `apiUrl` after module load, and asserts the deferred profile-create fetch targets the sentinel API origin. **Red** without the fix (fetches the stale module-load-time origin), **green** with it.
- `integration/shared-profile.test.ts` against a split-origin local stack (`FRONTEND_URL` ≠ `API_URL`): failed in 33s before, **passes in 10s** after.
- `integration/home-profile.test.ts` (profile-picker path, same mechanism): passes.
- `deno check` clean on both changed files; full `wish.test.ts` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve wish sidecar pattern URLs at fetch time so the worker uses the configured API origin. Fixes the stuck profile-create UI in split frontend/API setups and restores passing local integration tests.

- **Bug Fixes**
  - Resolve `suggestion`, `profile-create`, and `profile-picker` URLs lazily via `getPatternEnvironment().apiUrl` inside fetch calls in `packages/runner/src/builtins/wish.ts`.
  - Prevent wrong-origin fetches when `FRONTEND_URL` != `API_URL`, avoiding SPA index fallback and compilation errors.
  - Add a regression test in `packages/runner/test/wish.test.ts` that sets `apiUrl` after import and asserts the fetch targets the correct origin.

<sup>Written for commit b157112a859086ddc6695cf725f1d5aeb69b383c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

