### PR TITLE
feat(runner): fold parent slot's declared scope into serialized sub-pattern binding aliases

### DIFF
--- a/packages/runner/src/pattern-binding.ts
+++ b/packages/runner/src/pattern-binding.ts
@@ -40,6 +40,73 @@ type SendValueToBindingOptions = {
 type UnwrapOneLevelOptions = {
   targetSchema?: JSONSchema;
   derivedInternalCells?: readonly DerivedInternalCellDescriptor[];
+  /**
+   * The containing pattern's authored argument schema, used as the source of
+   * declared cell scopes when serializing binding aliases (see
+   * `foldDeclaredScopeIntoLinkSchema`). The argument cell LINK only carries a
+   * sanitized schema (`sanitizeSchemaForLinks` strips `asCell` entries,
+   * taking their scope annotation with them), so a `PerUser<Cell<>>`
+   * declaration is invisible on the link by the time aliases are bound. The
+   * authored pattern schema keeps `asCell` (`keepAsCell: true` in
+   * builder/pattern.ts) and is the ground truth for what each slot declared.
+   * (Internal cells don't need this: each derived internal cell carries its
+   * declared scope on its descriptor, realized directly on its link.)
+   */
+  sourceSchemas?: {
+    argument?: JSONSchema;
+  };
+};
+
+/**
+ * Folds the source slot's declared cell scope into the serialized alias link's
+ * schema, making the stored link self-describing.
+ *
+ * A binding alias serialized into a sub-piece's argument doc carries the
+ * sub-pattern's (typically scope-silent) input schema, not the parent slot's
+ * schema — so the parent's `PerUser`/`PerSession` declaration (emitted as
+ * `asCell: [{kind, scope}]`) is dropped, and any consumer of the stored link
+ * must rely on the stored base-slot redirect existing to land reads and writes
+ * in the scoped instance. Folding the declared scope into the link's schema
+ * (as a top-level `scope`, which survives link-schema sanitization where
+ * `asCell` entries do not) keeps the serialized graph self-describing: writes
+ * through the link take the scope-narrowing branch and reads get the follow
+ * cap, per "scope lives in the schema, realized at read/write".
+ *
+ * The scope is deliberately NOT stamped onto the link's own `scope`: the link
+ * addresses the base-scope slot, where passed-in cell references legitimately
+ * live (see "lift can read session-scoped cell passed from pattern input" in
+ * pattern-scope.test.ts, and the matching guidance on
+ * ContextualFlowControl.getSchemaScopeCap).
+ *
+ * Folding applies exactly when the write-path narrowing branch would fire for
+ * the slot (declared scope narrower than the slot's link scope) and the
+ * emitted schema does not declare a scope of its own (a local declaration
+ * wins). Slots whose emitted link carries no schema at all are left alone so
+ * they keep inheriting the reader's schema during link resolution.
+ */
+const foldDeclaredScopeIntoLinkSchema = (
+  cfc: ContextualFlowControl,
+  link: NormalizedFullLink,
+  authoredRootSchema: JSONSchema | undefined,
+  path: readonly string[],
+): NormalizedFullLink => {
+  if (authoredRootSchema === undefined || !isRecord(link.schema)) return link;
+  if (ContextualFlowControl.getSchemaScopeCap(link.schema) !== undefined) {
+    return link;
+  }
+  const authoredSlotSchema = path.length > 0
+    ? cfc.getSchemaAtPath(authoredRootSchema, [...path])
+    : authoredRootSchema;
+  const declaredCap = ContextualFlowControl.getSchemaScopeCap(
+    authoredSlotSchema,
+  );
+  if (
+    !isCellScope(declaredCap) ||
+    scopeRank(declaredCap) <= scopeRank(link.scope)
+  ) {
+    return link;
+  }
+  return { ...link, schema: { ...link.schema, scope: declaredCap } };
 };
 
 const scopedLinkForPath = (
@@ -359,8 +426,16 @@ export function unwrapOneLevelAndBindtoDoc<T, U>(
           : link.schema !== undefined
           ? cfc.schemaAtPath(link.schema, path)
           : undefined;
+        const authoredRootSchema = alias.cell === "argument"
+          ? options?.sourceSchemas?.argument
+          : undefined;
         return createSigilLinkFromParsedLink(
-          scopedLinkForPath(cfc, link, path, targetSchema ?? sourceSchema),
+          foldDeclaredScopeIntoLinkSchema(
+            cfc,
+            scopedLinkForPath(cfc, link, path, targetSchema ?? sourceSchema),
+            authoredRootSchema,
+            path,
+          ),
           { includeSchema: true, overwrite: "redirect" },
         );
       }

--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -4133,6 +4133,11 @@ export class Runner {
       {
         targetSchema: patternImpl.argumentSchema,
         derivedInternalCells: pattern.derivedInternalCells,
+        // The links serialized into the sub-piece's argument doc must keep the
+        // containing pattern's declared slot scopes; the authored schema is
+        // the only place those declarations still exist (the meta link
+        // carries a sanitized schema). See foldDeclaredScopeIntoLinkSchema.
+        sourceSchemas: { argument: pattern.argumentSchema },
       },
     );
     const outputs = unwrapOneLevelAndBindtoDoc(

--- a/packages/runner/test/pattern-scope.test.ts
+++ b/packages/runner/test/pattern-scope.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../src/link-utils.ts";
 import { createTrustedBuilder } from "./support/trusted-builder.ts";
 import { type Cell, createCell } from "../src/cell.ts";
+import { ContextualFlowControl } from "../src/cfc.ts";
 import { type Opaque } from "../src/builder/types.ts";
 
 const signer = await Identity.fromPassphrase("test operator");
@@ -2950,6 +2951,131 @@ Deno.test("schema-less write AT a scoped slot follows the stored redirect", asyn
       { ...baseLink, schema: undefined, scope: "user" },
     );
     assertEquals(userInstance.getRaw(), "Alice");
+  } finally {
+    await runtime.dispose();
+    await storageManager.close();
+  }
+});
+
+Deno.test("sub-pattern binding alias carries the parent slot's declared scope on its serialized schema", async () => {
+  const storageManager = StorageManager.emulate({ as: signer });
+  const runtime = new Runtime({
+    apiUrl: new URL(import.meta.url),
+    storageManager,
+  });
+  const tx = runtime.edit();
+
+  try {
+    const { pattern } = createTrustedBuilder(runtime).commonfabric;
+
+    // A reusable sub-pattern whose input schema is scope-silent: it does not
+    // know its caller stores the value per-user.
+    const Child = pattern<{ profile: { name: string } }>(
+      ({ profile }) => ({ out: profile }),
+      {
+        type: "object",
+        properties: {
+          profile: {
+            type: "object",
+            properties: { name: { type: "string" } },
+            asCell: ["cell"],
+          },
+        },
+        required: ["profile"],
+      },
+    );
+
+    const Root = pattern<{ myProfile: { name: string } }>(
+      ({ myProfile }) => ({ child: Child({ profile: myProfile }) }),
+      {
+        type: "object",
+        properties: {
+          myProfile: {
+            type: "object",
+            properties: { name: { type: "string" } },
+            default: { name: "" },
+            asCell: [{ kind: "cell", scope: "user" }],
+          },
+        },
+        required: ["myProfile"],
+      },
+    );
+
+    const resultCell = runtime.getCell(
+      space,
+      "sub-pattern binding alias scope folding",
+      undefined,
+      tx,
+    );
+    const result = runtime.run(tx, Root, {}, resultCell);
+    runtime.prepareTxForCommit(tx);
+    await tx.commit();
+    await runtime.idle();
+    await runtime.storageManager.synced();
+    await result.pull();
+
+    const childResult = result.key("child").resolveAsCell();
+    const childArgument = runtime.getCellFromLink(
+      getMetaLink(childResult, "argument")!,
+    );
+    const storedAliasRaw = createCell<{ profile: unknown }>(
+      runtime,
+      { ...childArgument.getAsNormalizedFullLink(), schema: undefined },
+    ).key("profile").getRaw();
+    const storedAlias = parseLink(
+      storedAliasRaw,
+      childArgument.key("profile"),
+    )!;
+
+    // The alias targets the parent's base-scope slot (which holds the
+    // scoped-instance redirect), so the link itself stays at the inherited
+    // space scope...
+    assertEquals(storedAlias.scope, "space");
+    // ...and the parent's PerUser annotation is folded into the serialized
+    // schema, making the stored link self-describing: a consumer realizes the
+    // scope at read (follow cap) / write (narrowing branch) from the link
+    // alone, without relying on the stored base-slot redirect existing.
+    assertEquals(
+      ContextualFlowControl.getSchemaScopeCap(storedAlias.schema),
+      "user",
+    );
+
+    // End to end: a consumer writing through the stored alias — armed with
+    // nothing but the link's own serialized schema — lands the content in the
+    // user-scoped instance and leaves the base slot holding the redirect.
+    const writeTx = runtime.edit();
+    const consumer = runtime.getCellFromLink(
+      { ...storedAlias, overwrite: undefined },
+      storedAlias.schema,
+      writeTx,
+    );
+    consumer.set({ name: "Ada" });
+    runtime.prepareTxForCommit(writeTx);
+    await writeTx.commit();
+    await runtime.idle();
+
+    const parentArgument = runtime.getCellFromLink(
+      getMetaLink(result, "argument")!,
+    );
+    const parentSlot = createCell<{ myProfile: unknown }>(
+      runtime,
+      { ...parentArgument.getAsNormalizedFullLink(), schema: undefined },
+    ).key("myProfile");
+    assertEquals(
+      parseLink(parentSlot.getRaw(), parentSlot)?.scope,
+      "user",
+      "base-scope slot must keep the scoped-instance redirect",
+    );
+    const userInstance = createCell<{ name: string }>(
+      runtime,
+      {
+        ...parentArgument.getAsNormalizedFullLink(),
+        path: ["myProfile"],
+        schema: undefined,
+        scope: "user",
+      },
+    );
+    assertEquals(userInstance.getRaw(), { name: "Ada" });
   } finally {
     await runtime.dispose();
     await storageManager.close();


### PR DESCRIPTION
Follow-up to #3958.

## Problem

Binding aliases serialized into a sub-piece's argument doc drop the parent argument schema's declared cell scope: the stored alias pins `scope:"space"` and carries the sub-pattern's scope-silent input schema instead of the parent's `PerUser`/`PerSession` annotation (emitted as `asCell: [{kind:"cell", scope:"user"}]`). The two write-path fixes in #3958 (`2833c6042`, `4227d4abe`) make this harmless at write time — but only by way of the stored base-slot redirect. The serialized graph itself was not self-describing: any new consumer of those links had to rely on that redirect existing.

## Decision: fold onto the serialized **schema**, not the link's `scope` field

The codebase states the doctrine in three places (`ContextualFlowControl.getSchemaScopeCap` doc, `link-resolution.ts`, the `key()`-stamping test): **scope is a schema-level declaration realized at read (follow cap) and write (narrowing branch); it must never be stamped onto a navigated link's own scope.** Stamping the link's scope field re-addresses the parent's base-scope slot to a narrower instance — which breaks passed-in cell references, which legitimately live at the base slot ("lift can read session-scoped cell passed from pattern input" in pattern-scope.test.ts; this is exactly how a naive fix failed).

This is also spec-compliant: per `docs/specs/scoped-cell-instances.md`, a serialized link carries `scope` only when its target is *not* at the inherited scope. The alias targets the parent's base-scope slot (inherited scope), so the link's scope field stays omitted; the slot's narrower *content* scope is the schema's to declare.

## Mechanics

- The annotation was being lost because the argument/internal meta links carry **sanitized** schemas (`sanitizeSchemaForLinks` strips `asCell` entries, taking their scope with them). The authored pattern schemas keep `asCell` (`keepAsCell: true`), so `instantiatePatternNode` now threads them into `unwrapOneLevelAndBindtoDoc` as `options.sourceSchemas`.
- `foldDeclaredScopeIntoLinkSchema` folds the authored slot's scope cap into the emitted link schema as a top-level `scope` (which survives link-schema sanitization), exactly when the write-path narrowing branch would fire for the slot (declared scope narrower than the slot's link scope) and the emitted schema declares no scope of its own.
- The fold result is deterministic (derived from authored schemas), so re-instantiation across sessions serializes identically — no reload churn.
- With the folded schema, a write through the stored alias takes the scope-narrowing branch on its own; #3958's stored-redirect-following write fix remains as belt-and-braces for truly schema-less handles.

Known limitation (follow-up candidates): aliases that point *below* a scoped slot, slots whose emitted link carries no schema at all, and raw-node input bindings (the immutable inputs cell) still rely on the stored redirect.

## Verification

- New red→green test: the stored alias in the sub-piece's argument doc keeps `scope:"space"` on the link and carries cap `"user"` on its schema; end-to-end, a consumer writing through the stored alias with only its serialized schema lands content in the user instance, base slot keeps the redirect.
- `packages/runner` full suite: 554 passed, 0 failed.
- `packages/runner/test/pattern-scope.test.ts`: 39 passed (incl. the passed-in-reference test the naive fix broke, and #3958's redirect tests).
- `cfc-group-chat-demo-multi-runtime.test.ts` (headless): passed (re-run on the rebased branch).
- `cfc-group-chat-demo-two-browsers.test.ts` against local dev servers running this change: passed.
- `cfc-group-chat-demo.test.ts` (single-runtime) fails identically on plain `main` ("No data at cell" during `startPiece`) — pre-existing, unrelated; flagged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fold the parent slot’s declared cell scope into the serialized schema of sub-pattern binding aliases so stored links are self‑describing and don’t rely on base-slot redirects. `link.scope` stays inherited; scope is declared on the alias schema per design.

- **New Features**
  - Add `foldDeclaredScopeIntoLinkSchema` to write the parent’s `PerUser`/`PerSession` scope into the alias link’s schema when the emitted schema is scope‑silent and the parent’s scope is narrower than the link’s.
  - Pass authored `pattern.argumentSchema` into `unwrapOneLevelAndBindtoDoc` via `sourceSchemas` in `Runner.run` to recover `asCell` scope lost by `sanitizeSchemaForLinks`.
  - Keep `link.scope` unchanged; reads/writes realize scope from the schema.

<sup>Written for commit d0d15b454aee6e723c4317db483da02a153404ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

NEW_PERF_BASELINE: step: Build application = 25s
NEW_PERF_BASELINE: subtest: pattern-unit-4/pattern-unit-tests > packages/patterns/lunch-poll/main.test.tsx = 22s