### PR TITLE
fix(cli): drain in-flight syncs before dispatching piece handler events

### DIFF
--- a/packages/cli/lib/callable.ts
+++ b/packages/cli/lib/callable.ts
@@ -294,6 +294,15 @@ export async function executeResolvedCallable(
   if (resolved.callableKind === "handler") {
     const send = resolved.callableCell.send;
     if (typeof send === "function") {
+      // Drain in-flight storage syncs BEFORE dispatching the event: piece
+      // load issues watch batches that may still be in flight, and a handler
+      // reads its asCell inputs (e.g. a SqliteDb handle) synchronously from
+      // the local replica — dispatching early races the doc-carrying response
+      // and the handler sees an empty doc ("invalid database handle" on
+      // db.exec). The awaits AFTER send cover the handler's own writes, not
+      // its inputs.
+      await resolved.manager.runtime.idle();
+      await resolved.manager.synced();
       const runtimeErrors = runtimeErrorLog(resolved.manager.runtime);
       const errorCountBefore = runtimeErrors.length;
       const tx = await new Promise<CallableTransactionLike>(
@@ -322,6 +331,10 @@ export async function executeResolvedCallable(
       return {};
     }
 
+    // Same pre-send drain as above: don't trigger the handler while piece
+    // load syncs are still in flight.
+    await resolved.manager.runtime.idle();
+    await resolved.manager.synced();
     await resolved.piece[resolved.cellProp].set(input, [resolved.cellKey]);
     await resolved.manager.runtime.idle();
     await resolved.manager.synced();

--- a/packages/cli/test/piece-call.test.ts
+++ b/packages/cli/test/piece-call.test.ts
@@ -44,6 +44,46 @@ describe("executePieceCallable", () => {
     ]);
   });
 
+  it("drains idle+synced BEFORE dispatching a handler event", async () => {
+    // A handler reads its asCell inputs (e.g. a SqliteDb handle) synchronously
+    // from the local replica, so piece-load watch syncs must be drained before
+    // the event is dispatched — not only after (the post-send awaits cover the
+    // handler's writes, not its inputs).
+    const harness = createPieceCallableHarness({
+      callableKind: "handler",
+      cellKey: "recordMessage",
+      inputSchema: {
+        type: "object",
+        properties: {
+          message: { type: "string" },
+        },
+        required: ["message"],
+      },
+    });
+
+    await executePieceCallable(
+      {
+        apiUrl: "http://localhost:8000",
+        identity: "/tmp/test-identity.pem",
+        piece: "fid1:piece-123",
+        space: "home",
+      },
+      "recordMessage",
+      ["--message", "milk"],
+      {
+        loadManager: () => Promise.resolve(harness.manager),
+        loadPiece: () => Promise.resolve(harness.piece),
+      },
+    );
+
+    const events = harness.tracker.events;
+    const sendIndex = events.indexOf("send");
+    expect(sendIndex).toBeGreaterThan(-1);
+    const beforeSend = events.slice(0, sendIndex);
+    expect(beforeSend).toContain("idle");
+    expect(beforeSend).toContain("synced");
+  });
+
   it("runs tools from schema-derived flags and returns JSON output", async () => {
     const toolPattern: {
       nodes: Array<{ module: string }>;
@@ -598,6 +638,8 @@ function createPieceCallableHarness(options: {
     toolRunPattern: undefined as unknown,
     toolRunInput: undefined as unknown,
     toolResultScope: undefined as string | undefined,
+    // Ordered trace of idle/synced/send calls, for dispatch-ordering tests.
+    events: [] as string[],
   };
 
   const callableSchema: JSONSchema = options.callableKind === "tool"
@@ -635,6 +677,7 @@ function createPieceCallableHarness(options: {
               tx: { status: () => { status: string; error?: Error } },
             ) => void,
           ) => {
+            tracker.events.push("send");
             tracker.handlerWrites.push({
               cellProp: "result",
               path: [options.cellKey],
@@ -706,7 +749,10 @@ function createPieceCallableHarness(options: {
 
   const manager = {
     getSpace: () => "home",
-    synced: async () => {},
+    synced: () => {
+      tracker.events.push("synced");
+      return Promise.resolve();
+    },
     runtime: {
       [CF_RUNTIME_ERROR_LOG]: runtimeErrors,
       storageManager: {
@@ -738,7 +784,10 @@ function createPieceCallableHarness(options: {
           sink: () => () => {},
         };
       },
-      idle: async () => {},
+      idle: () => {
+        tracker.events.push("idle");
+        return Promise.resolve();
+      },
     },
   };
 


### PR DESCRIPTION
## What

`cf piece call` dispatched the handler event while the watch batches issued during piece load were still in flight. This PR awaits `runtime.idle()` + `manager.synced()` **before** dispatching (both the `send()` path and the `.set()` fallback in `executeResolvedCallable`), and adds an ordering test. The pre-existing awaits after `send` cover the handler's *writes*, not its *inputs*.

## Why — the lunch-poll "invalid database handle" bug, root-caused

This resolves the deployed-piece `db.exec` failure documented in `packages/patterns/lunch-poll/SQLITE-DEPLOY-BUG.md` (on `gideon/lunch-poll-sqlite-migration`): every sqlite-mutating handler on a deployed lunch-poll threw `TypeError: .exec() is only available on a SqliteDb cell (invalid database handle)`, while `db.query` reads and the emulated `cf test` runner were fine.

The mechanism, verified by tracing the handle doc id through both sides of the sync boundary (session-attributed logging, client and server):

1. A handler reads its asCell inputs (e.g. the `SqliteDb` handle) **synchronously** from the local replica — `.exec()` does `getRaw({ lastNode: "value" })`, and `getRaw` only *kicks off* a sync without awaiting (cell.ts). The delivered cell even reports `synced: true`, inherited from its parent during `validateAndTransform` materialization.
2. The server behaves correctly: the CLI session's own piece-load watch traversal reaches the handle doc and returns it in that batch's response; the later explicit watch for the handle is correctly `sameSnapshot`-skipped because the doc was already sent in-session.
3. But per-session watch batches are answered serially, so on a bulky pattern the doc-carrying response **arrives after `send()` has already run the handler**. The handler reads an empty doc and throws.

This also dissolves the "emergent (query-count × pattern bulk)" trigger from the earlier bisection effort: each `db.query` node adds watch entries, so bulk deterministically pushes the doc-carrying response past the dispatch. Minimal patterns (the P1–P8 build-ups) win the race; the full lunch-poll and the `lph-k`/`lph-d` skeletons lose it, every time. No SQL construct was ever involved. The emulated runner never fails because loopback storage always wins the race. Unrelated to (and on top of) the #3896 scope fix, which addressed a real but different bug.

## Verification

- Full unmodified lunch-poll deployed against a local toolshed: `clearHistory` / `logVisit` / `addOption` all succeed across repeated fresh CLI sessions; rows verifiably land in (and are deleted from) the per-piece sqlite file. Without this change the failure reproduces 100%.
- `cf test packages/patterns/lunch-poll/main.test.tsx` 17/17; `packages/cli` suite green; fmt/lint/check clean.

## What this does NOT fix (runtime follow-up)

The underlying invariant — *a handler's asCell input docs are locally synced before the handler body runs* — is still unguarded in the scheduler/event dispatch itself. The CLI was the only cold-start surface poking handlers immediately after load, but other surfaces (e.g. bg-piece-service delivering a queued event right after starting a piece) could in principle hit the same race, and `.exec()` is a sync API that cannot recover mid-handler. A principled fix belongs in event dispatch; we're exploring that separately and will bring a proposal — this PR is the narrow, verified unblock and a worked example of the failure mode.

Full investigation log: `session_outputs/2026-06-09_lunch-poll-sqlite-fresh-eyes/` (local), summarized in `SQLITE-DEPLOY-BUG.md` on the lunch-poll branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drain in-flight storage syncs before dispatching handler events in the CLI to prevent handlers from reading unsynced asCell inputs. Fixes the deterministic "invalid database handle" errors on deployed lunch-poll writes by awaiting `runtime.idle()` and `manager.synced()` before dispatch.

- **Bug Fixes**
  - Await `runtime.idle()` and `manager.synced()` before calling `send()` and before the `.set()` fallback in `executeResolvedCallable`.
  - Add an ordering test that asserts `idle` and `synced` occur before `send`.

<sup>Written for commit e1ab0a6496ac4c97e23ab45d11f053a9375ab464. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

