### PR TITLE
Fix verified issues across the build-phase pattern skills

### DIFF
--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -68,8 +68,8 @@ or default. For identity-sensitive local work, use one key everywhere and import
 the CLI PKCS8/PEM key in the browser via `Import CLI Key`. See
 `docs/development/SHARED_IDENTITY.md`.
 
-**Experimental flags** must be set as env vars on both servers AND CLI
-commands. See `docs/development/EXPERIMENTAL_OPTIONS.md` for available flags.
+**Experimental flags** must be set as env vars on both servers AND CLI commands.
+See `docs/development/EXPERIMENTAL_OPTIONS.md` for available flags.
 
 **Local servers**: See `docs/development/LOCAL_DEV_SERVERS.md`
 

--- a/skills/cf/SKILL.md
+++ b/skills/cf/SKILL.md
@@ -25,6 +25,9 @@ deno task cf check --help     # Type checking
 ```bash
 ls -la cf.key                  # Check for existing
 
+# Never overwrite an existing key file — existing identity-scoped data
+# becomes invisible under a new identity.
+
 # For local dev: derive key matching toolshed's "implicit trust" identity
 deno run -A packages/cli/mod.ts id derive "implicit trust" > cf.key
 
@@ -54,7 +57,7 @@ prints ANSI-colored preamble to stdout, which pollutes the key file. Always use
 **Environment variables** (avoid repeating flags):
 
 ```bash
-export CF_API_URL=http://localhost:8000  # or https://toolshed.saga-castor.ts.net/
+export CF_API_URL=http://localhost:8000  # local dev default; only target a remote instance when the task explicitly requires it — remote set/rm/setsrc mutate shared state
 export CF_IDENTITY=./cf.key
 ```
 
@@ -65,17 +68,8 @@ or default. For identity-sensitive local work, use one key everywhere and import
 the CLI PKCS8/PEM key in the browser via `Import CLI Key`. See
 `docs/development/SHARED_IDENTITY.md`.
 
-**Experimental flags** (must be set on both servers AND CLI commands):
-
-```bash
-# Pass experiment env vars to CLI commands:
-EXPERIMENTAL_EXAMPLE_NAME_1=true \
-EXPERIMENTAL_EXAMPLE_NAME_2=true \
-deno task cf piece new pattern.tsx ...
-```
-
-Replace `EXAMPLE_NAME_*` with an actual defined experiment name. See
-`docs/development/EXPERIMENTAL_OPTIONS.md` for all available flags.
+**Experimental flags** must be set as env vars on both servers AND CLI
+commands. See `docs/development/EXPERIMENTAL_OPTIONS.md` for available flags.
 
 **Local servers**: See `docs/development/LOCAL_DEV_SERVERS.md`
 
@@ -205,11 +199,11 @@ cf fuse mount /tmp/cf -s my-space
 # error: Unknown option "-s"
 ```
 
-**Fix:** use the source CLI through the repo task wrapper instead:
+**Fix:** use the source CLI through the repo task wrapper instead (cd to the
+labs repo root first):
 
 ```bash
-cd ~/code/labs
-export CF_IDENTITY=./shared.key
+export CF_IDENTITY=./cf.key
 export CF_API_URL=http://localhost:8000
 
 deno task cf fuse mount /tmp/cf -s my-space

--- a/skills/pattern-debug/SKILL.md
+++ b/skills/pattern-debug/SKILL.md
@@ -13,10 +13,9 @@ piece issues.
 
 - `docs/development/debugging/workflow.md` - 5-step debugging process
 - `docs/development/debugging/README.md` - Error reference matrix
-- `docs/common/concepts/reactivity.md` - reactive values, Cell behavior, and
-  `.get()` / `.set()` boundaries
-- `docs/common/patterns/new-cells.md` - `new Writable()` and local cell
-  initialization rules
+- `docs/common/concepts/reactivity.md` and `docs/common/patterns/new-cells.md`
+  — as mandated by pattern-dev; re-consult for Cell, Writable, or
+  reactive-value failures
 
 ## Process
 
@@ -58,13 +57,10 @@ piece issues.
 
 **`new Cell() only accepts static data`:**
 
-- Do not pass input props, mapped fields, or computed/reactive values into
-  `new Writable()` / `new Cell()`
-- Use an input writable cell directly when the caller owns the state
-- For pattern-owned draft state, initialize from a static value and copy from
-  input state inside an action or another valid reactive/event context
-- See `docs/common/patterns/new-cells.md` and
-  `docs/common/concepts/reactivity.md`
+- A reactive value (input prop, mapped field, computed value) was passed into
+  `new Writable()` / `new Cell()`. See the static-only rule and field-decision
+  guidance in the pattern-implement skill, plus
+  `docs/common/patterns/new-cells.md`
 
 **String helper throws, such as `.trim()` / `.replace()` / `.includes()` is not
 a function:**
@@ -108,15 +104,10 @@ a function:**
 
 **Transient UI state carries over when it should not:**
 
-- Check whether navigation, active tab, selected item, selected room, modal,
-  filter, or other ephemeral UI state is unscoped or space scoped.
-- Ask whether the state should carry over if the user opens the same instance in
-  a new tab. If not, it is probably session state.
-- Use `PerSession<>` for per-session UI state and `PerUser<>` for user-owned
-  durable state.
-- Use data-shaped scoped inputs for simple APIs. Use scoped `Writable` aliases
-  when handlers need stable cell handles, `.key(...)`, `.equals(...)`, or
-  per-item bindings.
+- Check whether navigation, active tab, selected item, modal, filter, or other
+  ephemeral UI state is unscoped or space scoped, then apply the PerSession
+  new-tab test from the pattern-dev skill (`PerSession<>` for per-session UI
+  state, `PerUser<>` for user-owned durable state).
 - Confirm the generated schema and transformed source with
   `deno task cf check pattern.tsx --show-transformed`.
 - If a value unexpectedly becomes `undefined`, check for schema-scope traversal
@@ -200,4 +191,5 @@ await commonfabric.detectNonIdempotent();
 
 - Root cause identified
 - Error fixed
-- Tests pass again
+- Tests pass again — or, if no tests exist yet, `deno task cf check` succeeds
+  and the failing repro behaves correctly

--- a/skills/pattern-debug/SKILL.md
+++ b/skills/pattern-debug/SKILL.md
@@ -13,9 +13,9 @@ piece issues.
 
 - `docs/development/debugging/workflow.md` - 5-step debugging process
 - `docs/development/debugging/README.md` - Error reference matrix
-- `docs/common/concepts/reactivity.md` and `docs/common/patterns/new-cells.md`
-  — as mandated by pattern-dev; re-consult for Cell, Writable, or
-  reactive-value failures
+- `docs/common/concepts/reactivity.md` and `docs/common/patterns/new-cells.md` —
+  as mandated by pattern-dev; re-consult for Cell, Writable, or reactive-value
+  failures
 
 ## Process
 

--- a/skills/pattern-deploy/SKILL.md
+++ b/skills/pattern-deploy/SKILL.md
@@ -26,11 +26,11 @@ ls -la ./cf.key 2>/dev/null || ls -la *.key 2>/dev/null || find . -name "*.key" 
 ```
 
 If no key exists, create one per the cf skill (local dev:
-`deno run -A packages/cli/mod.ts id derive "implicit trust" > cf.key` — note
-the cf skill's warning: never redirect `deno task cf` output into a key file,
-the wrapper pollutes it with ANSI preamble). Never overwrite an existing key
-file — identity-scoped data (PerUser state, favorites) becomes invisible under
-a new identity.
+`deno run -A packages/cli/mod.ts id derive "implicit trust" > cf.key` — note the
+cf skill's warning: never redirect `deno task cf` output into a key file, the
+wrapper pollutes it with ANSI preamble). Never overwrite an existing key file —
+identity-scoped data (PerUser state, favorites) becomes invisible under a new
+identity.
 
 ## Commands
 

--- a/skills/pattern-deploy/SKILL.md
+++ b/skills/pattern-deploy/SKILL.md
@@ -7,20 +7,35 @@ user-invocable: false
 # Deploy Phase
 
 Use the `cf` skill, or read `skills/cf/SKILL.md`, for comprehensive CLI
-documentation.
+documentation. Use the command shapes from its Quick Command Reference rather
+than guessing flags; this skill only covers the deploy workflow and exit
+criteria.
 
 ## Read First
 
+- `skills/cf/SKILL.md` — the Environment Setup section (`CF_API_URL`,
+  `CF_IDENTITY`, identity key creation) is the prerequisite for every command
+  below
 - `docs/development/LOCAL_DEV_SERVERS.md` - Local dev setup
 - `docs/common/workflows/development.md` - Workflow commands
 
 ## Find Identity Key
 
 ```bash
-ls -la ./cf.key ./identity.key 2>/dev/null || ls -la *.key 2>/dev/null || find . -name "*.key" -maxdepth 2 2>/dev/null
+ls -la ./cf.key 2>/dev/null || ls -la *.key 2>/dev/null || find . -name "*.key" -maxdepth 2 2>/dev/null
 ```
 
+If no key exists, create one per the cf skill (local dev:
+`deno run -A packages/cli/mod.ts id derive "implicit trust" > cf.key` — note
+the cf skill's warning: never redirect `deno task cf` output into a key file,
+the wrapper pollutes it with ANSI preamble). Never overwrite an existing key
+file — identity-scoped data (PerUser state, favorites) becomes invisible under
+a new identity.
+
 ## Commands
+
+With `CF_API_URL` and `CF_IDENTITY` exported (see the cf skill), you can drop
+`--api-url`/`--identity`; `--space` is always required.
 
 **Check syntax without deploying:**
 
@@ -28,22 +43,26 @@ ls -la ./cf.key ./identity.key 2>/dev/null || ls -la *.key 2>/dev/null || find .
 deno task cf check pattern.tsx --no-run
 ```
 
-**Deploy new pattern:**
+**Deploy new pattern (first time only):**
 
 ```bash
-deno task cf piece new packages/patterns/[name]/main.tsx --identity PATH_TO_KEY
+deno task cf piece new packages/patterns/[name]/main.tsx --identity cf.key --api-url $CF_API_URL --space <space>
+# Output: Created piece bafyreia... <- SAVE this piece ID
 ```
+
+**Update deployed pattern (all subsequent iterations):**
+
+```bash
+deno task cf piece setsrc packages/patterns/[name]/main.tsx --piece <ID> --identity cf.key --api-url $CF_API_URL --space <space>
+```
+
+`--piece` is required for `setsrc` — never "update" by re-running `piece new`,
+which creates a duplicate piece.
 
 **Inspect piece state:**
 
 ```bash
-deno task cf piece inspect
-```
-
-**Update deployed pattern:**
-
-```bash
-deno task cf piece setsrc packages/patterns/[name]/main.tsx
+deno task cf piece inspect --piece <ID> --identity cf.key --api-url $CF_API_URL --space <space>
 ```
 
 **Test handler via CLI:**
@@ -56,6 +75,14 @@ deno task cf piece inspect --piece PIECE_ID  # Now shows updated state
 
 **Important:** Always run `piece step` after `piece call` or `piece set`.
 Without it, computed values remain stale and `inspect`/`get` return old data.
+
+## When Deploy Fails
+
+- If `piece new` or `setsrc` errors, re-run `deno task cf check` locally first.
+- Verify `CF_API_URL` is reachable (see the cf skill's troubleshooting table).
+- If you accidentally ran `new` twice, remove the duplicate with
+  `deno task cf piece rm --piece <ID> ...` before continuing.
+- Never retry `new` to "fix" a failed `setsrc`.
 
 ## Get Help
 

--- a/skills/pattern-dev/SKILL.md
+++ b/skills/pattern-dev/SKILL.md
@@ -109,8 +109,8 @@ conditional site behaves unexpectedly or seems ambiguous, inspect the emitted
 source with `--show-transformed` rather than guessing.
 
 Pay special attention to the SES authoring section of
-`docs/common/ai/pattern-development-guide.md` before adding module-scope
-setup, timers, or time/random helpers. The current authored escape hatches are
+`docs/common/ai/pattern-development-guide.md` before adding module-scope setup,
+timers, or time/random helpers. The current authored escape hatches are
 `safeDateNow()` and `nonPrivateRandom()`. Also follow its binding guidance: when
 a control is already bound to a cell, usually via `$value` or `$checked`, do not
 add a handler that simply writes the same value back into that same cell.

--- a/skills/pattern-dev/SKILL.md
+++ b/skills/pattern-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pattern-dev
-description: Guide for developing Common Fabric patterns (TypeScript modules that define reactive data transformations with UI). Use this skill when creating patterns, modifying existing patterns, or working with the pattern framework. Triggers include requests like "build a pattern", "fix this pattern error", "deploy this piece/patch", or questions about handlers and reactive patterns.
+description: Guide for developing Common Fabric patterns (TypeScript modules that define reactive data transformations with UI). Use this skill when creating patterns, modifying existing patterns, or working with the pattern framework. Triggers include requests like "build a pattern", "fix this pattern error", "deploy this piece", or questions about handlers and reactive patterns.
 ---
 
 Start with the shared pattern development guidance in:
@@ -104,11 +104,12 @@ Also inspect the emitted source when a composed pattern result is assigned to a
 should lower into the factory call; if they do not, the pattern may instantiate
 state at the wrong sharing boundary.
 
-Current main handles plain ternaries well in normal pattern code. Prefer direct
-authored expressions first; if an unusual site seems ambiguous, inspect the
-emitted source rather than guessing.
+Prefer direct authored expressions, including plain ternaries, first; if a
+conditional site behaves unexpectedly or seems ambiguous, inspect the emitted
+source with `--show-transformed` rather than guessing.
 
-Pay special attention to its SES authoring section before adding module-scope
+Pay special attention to the SES authoring section of
+`docs/common/ai/pattern-development-guide.md` before adding module-scope
 setup, timers, or time/random helpers. The current authored escape hatches are
 `safeDateNow()` and `nonPrivateRandom()`. Also follow its binding guidance: when
 a control is already bound to a cell, usually via `$value` or `$checked`, do not
@@ -124,6 +125,10 @@ Runtime notes:
 ## Runtime-Specific Notes
 
 ### Claude Code
+
+Interactive labs sessions only. In a Pattern Factory workspace, the factory
+orchestrator owns delegation, critique, and finalization — do not Task these
+subagents, run a separate critic pass, or offer commits there.
 
 - Use `EnterPlanMode` before building.
 - Scale the plan to the problem:

--- a/skills/pattern-implement/SKILL.md
+++ b/skills/pattern-implement/SKILL.md
@@ -31,14 +31,11 @@ testability.
 
 ## Read First
 
-- `docs/common/ai/pattern-factory-build-guide.md` - when working in a Pattern
-  Factory Build workspace
-- `docs/common/concepts/reactivity.md` - Cell behavior, reactive values, and
-  `.get()` / `.set()` boundaries
-- `docs/common/patterns/new-cells.md` - when and how to create pattern-owned
-  writable cells with static initial values
-- `docs/common/ai/pattern-development-guide.md` - especially the SES authoring
-  limits and escape-hatch guidance
+- The reads mandated by pattern-dev:
+  `docs/common/ai/pattern-development-guide.md` (especially the SES authoring
+  limits and escape-hatch guidance), `docs/common/concepts/reactivity.md`,
+  `docs/common/patterns/new-cells.md`, and — in a Pattern Factory Build
+  workspace — `docs/common/ai/pattern-factory-build-guide.md`
 - `docs/common/patterns/` - especially `meta/` for generalizable idioms
 - `docs/common/concepts/action.md` - action() for local state
 - `docs/common/concepts/handler.md` - handler() for reusable logic
@@ -78,11 +75,8 @@ static local UI state, or draft/editing state:
 - Draft/editing state: create it from a static value, then copy from input state
   inside an `action()` or another valid event/reactive context.
 
-For transient UI state, prefer `PerSession<>` unless the state should persist
-across sessions. This includes active tab, selected item, selected room, local
-filter text, open modal, and focused item. A useful test: if the user opens the
-same instance in a new tab, should this state carry over? If not, it is probably
-`PerSession<>`.
+Transient UI state (active tab, selected item, filter text, open modal): apply
+the PerSession new-tab test from the pattern-dev skill.
 
 Use `safeDateNow()` and `nonPrivateRandom()` instead of ambient `Date.now()` and
 `Math.random()` when a pattern needs explicit time or randomness. If a control

--- a/skills/pattern-schema/SKILL.md
+++ b/skills/pattern-schema/SKILL.md
@@ -30,6 +30,10 @@ pattern code.
 4. Fields that could be undefined initially: use `Default<T, value>`
 5. Actions in Output type: `Stream<T>` (enables testing and linking)
 6. Sub-patterns need `[NAME]: string` and `[UI]: VNode` in Output type
+7. **Decide the sharing boundary now** - choose `PerSpace<>` / `PerUser<>` /
+   `PerSession<>` for every Input field at schema time; see the `pattern-dev`
+   skill for the new-tab test. Transient UI state (selected tab, filter text,
+   open modal) defaults to `PerSession<>`.
 
 ## Top-Level vs Sub-Pattern Inputs
 
@@ -50,7 +54,15 @@ state owned by a parent pattern. Those sub-patterns also need `[NAME]` and
 ## Template
 
 ```tsx
-import { Default, NAME, Stream, UI, VNode, Writable } from "commonfabric";
+import {
+  Default,
+  NAME,
+  type PerSession,
+  Stream,
+  UI,
+  VNode,
+  Writable,
+} from "commonfabric";
 
 // ============ DATA TYPES ============
 export interface Item {
@@ -58,7 +70,23 @@ export interface Item {
   done: Default<boolean, false>;
 }
 
-// ============ PATTERN INPUT/OUTPUT ============
+// ============ TOP-LEVEL PATTERN (typical deliverable) ============
+// Usable standalone: no required caller-provided Writable<> inputs.
+// Optional Writable<... | Default<...>> lets callers link state while the
+// pattern still works alone; scope wrappers set each field's boundary.
+export interface ItemListInput {
+  items?: Writable<Item[] | Default<[]>>; // optional + Default = standalone-safe
+  filterText?: PerSession<string | Default<"">>; // transient UI state
+}
+
+export interface ItemListOutput {
+  [NAME]: string;
+  [UI]: VNode;
+  items: Item[]; // No Writable in Output
+  addItem: Stream<{ name: string }>; // Actions as Stream<T>
+}
+
+// ============ SUB-PATTERN (edits parent-owned state) ============
 export interface ItemInput {
   item: Writable<Item>; // Writable in Input = pattern will modify
 }

--- a/skills/pattern-test/SKILL.md
+++ b/skills/pattern-test/SKILL.md
@@ -10,10 +10,14 @@ Start with the shared testing guidance in:
 
 Read that guide first. It is the canonical reference.
 
-When working in a Pattern Factory Build workspace, also read:
+Run tests with:
 
-- `docs/common/ai/pattern-factory-build-guide.md`
+```bash
+deno task cf test <pattern>.test.tsx
+```
 
+When working in a Pattern Factory Build workspace, also follow
+`docs/common/ai/pattern-factory-build-guide.md` (as mandated by pattern-dev).
 It defines Pattern Factory's build completion gate and expected coverage shape.
 
 For patterns that stamp timestamps or IDs, prefer deterministic assertions over
@@ -25,10 +29,8 @@ not as a reason to guess at a new test shape. Before the next repair, read:
 - `docs/development/debugging/README.md`
 
 Then follow the linked gotcha or workflow for the exact error. For Cell,
-Writable, or reactive-value failures, also read:
-
-- `docs/common/concepts/reactivity.md`
-- `docs/common/patterns/new-cells.md`
+Writable, or reactive-value failures, re-consult `reactivity.md` and
+`new-cells.md` (as mandated by pattern-dev).
 
 Runtime notes:
 
@@ -36,3 +38,17 @@ Runtime notes:
   details.
 - The detailed workflow reference remains
   `docs/common/workflows/pattern-testing.md`.
+
+## Done When
+
+- `deno task cf test` exits 0 for every test file. A failing test is not a
+  valid done state unless a concrete external, tooling, or environment blocker
+  prevents further repair.
+- Coverage matches the testing guide's expected shape: the product contract,
+  not only the happy path (first-run/default states; primary add, remove,
+  edit, toggle, or submit flows; repeated actions; validation and edge-case
+  branches from the spec).
+- The test report explains what was covered and what was intentionally
+  omitted.
+- The pattern still compiles after any interface changes made to support
+  testing.

--- a/skills/pattern-test/SKILL.md
+++ b/skills/pattern-test/SKILL.md
@@ -17,8 +17,8 @@ deno task cf test <pattern>.test.tsx
 ```
 
 When working in a Pattern Factory Build workspace, also follow
-`docs/common/ai/pattern-factory-build-guide.md` (as mandated by pattern-dev).
-It defines Pattern Factory's build completion gate and expected coverage shape.
+`docs/common/ai/pattern-factory-build-guide.md` (as mandated by pattern-dev). It
+defines Pattern Factory's build completion gate and expected coverage shape.
 
 For patterns that stamp timestamps or IDs, prefer deterministic assertions over
 recomputing time/random values inside the test itself.
@@ -41,14 +41,13 @@ Runtime notes:
 
 ## Done When
 
-- `deno task cf test` exits 0 for every test file. A failing test is not a
-  valid done state unless a concrete external, tooling, or environment blocker
+- `deno task cf test` exits 0 for every test file. A failing test is not a valid
+  done state unless a concrete external, tooling, or environment blocker
   prevents further repair.
-- Coverage matches the testing guide's expected shape: the product contract,
-  not only the happy path (first-run/default states; primary add, remove,
-  edit, toggle, or submit flows; repeated actions; validation and edge-case
-  branches from the spec).
-- The test report explains what was covered and what was intentionally
-  omitted.
+- Coverage matches the testing guide's expected shape: the product contract, not
+  only the happy path (first-run/default states; primary add, remove, edit,
+  toggle, or submit flows; repeated actions; validation and edge-case branches
+  from the spec).
+- The test report explains what was covered and what was intentionally omitted.
 - The pattern still compiles after any interface changes made to support
   testing.


### PR DESCRIPTION
From a full review of the skills the Pattern Factory loads into its build phase (pattern-dev, pattern-schema, pattern-implement, pattern-test, pattern-debug, pattern-deploy, cf — all loaded together into one context). Every fix was re-verified against the file and, where applicable, against the live CLI before editing.

## Highlights

**pattern-deploy** (the broken one — its commands fail as written, verified against `packages/cli/commands/piece.ts`):
- `piece inspect` was shown without the required `--piece`/`--space`; `piece setsrc` was shown **without `--piece`** — the failure mode is an agent re-running `piece new` and creating duplicate pieces; `piece new` never said to save the returned piece ID. All examples now use the verified shapes, with an explicit "never 'update' by re-running new" warning.
- Key handling standardized on `cf.key` (the set previously used four different key filenames) with a no-key remediation path and a **never-overwrite-an-existing-key** guard (overwriting silently orphans PerUser state).
- New "When Deploy Fails" block: re-check locally, verify `CF_API_URL`, `piece rm` for accidental duplicates, never retry `new` to fix a failed `setsrc`.

**cf**: machine-specific `cd ~/code/labs` and `./shared.key` removed from the FUSE fix; the shared remote toolshed URL is now opt-in-only ("remote set/rm/setsrc mutate shared state") instead of a casual drive-by alternative; never-overwrite-key guard; placeholder-heavy experimental-flags section trimmed to a doc pointer.

**pattern-schema**: the skill owning schemas.tsx was silent on `PerSpace`/`PerUser`/`PerSession` while three sibling skills mandate deciding them at schema time — new rule 7 covers it. The lone template demonstrated the sub-pattern `Writable<Item>` input shape right after prose forbidding it for top-level patterns; it's now split into labeled **top-level** (standalone-safe optional `Writable<.. | Default<..>>` inputs, matching counter/todo-list idiom) and **sub-pattern** examples. Template passes `deno task cf check --no-run`.

**pattern-test**: never stated the run command and was the only phase skill without exit criteria — both added, with the Done When gates taken from `pattern-testing-guide.md` rather than invented.

**pattern-dev**: "deploy this piece/patch" description typo; time-anchored "Current main handles plain ternaries well" rewritten as a timeless rule; ambiguous "its SES authoring section" now names the doc; the Claude Code runtime section (Task pattern-maker/pattern-user, critic pass before deploy, offer commits) is now scoped **"interactive labs sessions only"** — in a Pattern Factory workspace those subagents don't exist and the orchestrator owns delegation/critique/finalization.

**Cross-skill dedup** (~80–100 lines of always-loaded context): the PerSession new-tab test, the `new Writable()` static-only rule, and the build-guide/reactivity/new-cells read mandate were each restated 3–4× across the co-loaded set; each now has one canonical home with one-line cross-references elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken deploy commands and standardizes identity/env setup across pattern skills to prevent failed deploys. Clarifies schema scoping, testing gates, and dev guidance while deduplicating repeated rules.

- **Bug Fixes**
  - `pattern-deploy`: Replace invalid CLI examples with verified shapes for `piece new/setsrc/inspect` (require `--piece`, `--space`, `--identity`), add “save the piece ID” note, and a “When Deploy Fails” checklist; standardize key search on `cf.key` and add a never-overwrite guard.
  - `cf`: Remove machine-specific paths, make remote `CF_API_URL` opt‑in, add never-overwrite-key guard, and point experimental flags to docs.

- **Refactors**
  - `pattern-schema`: Add rule to pick `PerSpace`/`PerUser`/`PerSession` at schema time; split template into top‑level vs sub‑pattern examples (passes `deno task cf check --no-run`).
  - `pattern-test`: Document the run command and add “Done When” aligned with the testing guide.
  - `pattern-dev`: Make conditional guidance timeless, name the SES doc, and scope Claude Code notes to interactive labs only.
  - `pattern-debug`: Cross‑reference core rules and soften “Done When” when tests don’t exist yet.
  - Cross-skill dedup: Centralize the PerSession new‑tab test, the static‑only `new Writable()` rule, and required reads; replace repeats with short cross‑refs.

<sup>Written for commit 9c56f0bcc222681bb4f67f8e58d3c95b55ae8ced. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

