### PR TITLE
Fix verified issues in pattern-ui, lit-component, pattern-critic, and agent-browser skills

### DIFF
--- a/docs/common/ai/pattern-critique-guide.md
+++ b/docs/common/ai/pattern-critique-guide.md
@@ -169,7 +169,28 @@ When to use `handler()`:
 | empty and first-run states | zero-data flows are understandable and actionable |
 | theme/styling stance | theme hooks, custom properties, or parts are used intentionally when relevant |
 
-### 13. Regression Check
+### 13. Scoped State (PerSession / PerUser / PerSpace)
+
+Review whether each state field has the right sharing boundary. A useful test
+for UI state: if the user opens the same instance in a new tab, should this
+state carry over? If not, it is probably `PerSession<>`.
+
+| State | Expected scope |
+|-------|----------------|
+| shared records, rooms, documents, canonical task lists | `PerSpace<>` |
+| display name, user preference, personal draft, account-local setting | `PerUser<>` |
+| navigation, selected tab/item/room, modal state, local filter text, focused item | `PerSession<>` |
+
+| Violation | Fix |
+|-----------|-----|
+| transient UI state stored as unscoped or shared space state | Use `PerSession<>` |
+| user-owned state stored as shared space state | Use `PerUser<>` |
+| shared canonical content stored per-session | Use `PerSpace<>` unless isolation is intentional |
+| user ids or session ids embedded in data to simulate isolation | Use scope wrappers |
+| `PerAny<>` used where the inner scope is known | Replace with the known scope |
+| scope used as an authorization boundary | Keep CFC/IFC/security policy separate |
+
+### 14. Regression Check
 
 | Check | What to verify |
 |-------|----------------|
@@ -214,10 +235,16 @@ calls, for example:
 
 Use the shared severity taxonomy from the factory protocol:
 
-- `critical`
-- `major`
-- `minor`
-- `info`
+- `critical` - breaks correctness or reactivity, or loses data. Examples: a
+  reactive loop, `.get()` on a computed during render, `new Writable(reactiveValue)`,
+  a handler that never fires.
+- `major` - violates a documented rule with a user-visible effect. Examples:
+  wrong binding so edits don't persist, wrong state scope leaking per-user
+  state, SES/determinism violations.
+- `minor` - convention or maintainability issue with no user-visible effect.
+  Examples: `handler()` where `action()` suffices, helper defined inside the
+  pattern body that happens to work.
+- `info` - observation, no change required.
 
 For modify-mode pre-build reviews, findings should also be easy for an
 orchestrator to triage into:

--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -30,6 +30,12 @@ profile. The default allowlisted skill scripts are limited to
 workflows such as `scripts/authenticated-session.sh` require a separate,
 explicit credential grant and origin-binding design.
 
+Under the cf-harness profile, the manual-testing-guide's screenshots,
+`--session` workflows, state save/load, console reading, and the Import-CLI-Key
+identity flow are unavailable. Substitute `snapshot` + `get text` for
+screenshots; skip multi-identity checks and record them as not-runnable in the
+report.
+
 ## Core Workflow
 
 Every browser automation follows this pattern:
@@ -118,7 +124,10 @@ agent-browser state load auth.json
 agent-browser open https://app.example.com/dashboard
 ```
 
-### Common Fabric identity checks
+### Common Fabric identity checks (host/interactive runs only)
+
+This recipe needs `--session`, `upload`, and `console`, which the cf-harness
+profile does not allow — run it only in host or interactive sessions.
 
 For Common Fabric tests that touch `PerUser`, `PerSession`, favorites, drafts,
 or home-space state, import the same CLI key used by `deno task cf` into the
@@ -204,6 +213,24 @@ agent-browser snapshot -i
 agent-browser click @e1
 ```
 
+## When Things Break
+
+- **CDP endpoint unreachable**: verify with `agent-browser get url`. If
+  connection errors persist, record the failure in your notes/report and stop
+  rather than retrying blindly.
+- **A `wait` that never resolves**: bound every wait with a `wait <ms>`
+  fallback. Prefer `wait "<selector>" --state hidden` or `wait --fn "<expr>"`
+  for spinners and loading text.
+- **Element missing from snapshot**: `agent-browser scroll down 500` and
+  re-snapshot; then `agent-browser snapshot -s "<container-selector>"`; then
+  fall back to `find` semantic locators.
+- **Screenshot unavailable (restricted profiles)**: substitute
+  `agent-browser snapshot -i` + `agent-browser get text` and record evidence
+  textually.
+
+Verify each command against `agent-browser --help` (or
+`agent-browser <command> --help`) before writing it.
+
 ## Semantic Locators
 
 When refs are unavailable or unreliable, use semantic locators:
@@ -259,7 +286,9 @@ the `agent-browser` CLI to be available on `PATH` in the script execution
 environment.
 
 For cf-harness runs, pass a local CDP origin with `--cdp` or set
-`AGENT_BROWSER_CDP`. The scripts intentionally avoid browser state, screenshots,
+`AGENT_BROWSER_CDP`. Note that `AGENT_BROWSER_CDP` is honored by these bundled
+scripts (as the fallback when their `--cdp` flag is omitted), not by the
+`agent-browser` CLI itself. The scripts intentionally avoid browser state, screenshots,
 PDFs, uploads, downloads, and local file output; they print snapshots and
 extracted content to stdout for harness capture.
 

--- a/skills/agent-browser/SKILL.md
+++ b/skills/agent-browser/SKILL.md
@@ -288,9 +288,9 @@ environment.
 For cf-harness runs, pass a local CDP origin with `--cdp` or set
 `AGENT_BROWSER_CDP`. Note that `AGENT_BROWSER_CDP` is honored by these bundled
 scripts (as the fallback when their `--cdp` flag is omitted), not by the
-`agent-browser` CLI itself. The scripts intentionally avoid browser state, screenshots,
-PDFs, uploads, downloads, and local file output; they print snapshots and
-extracted content to stdout for harness capture.
+`agent-browser` CLI itself. The scripts intentionally avoid browser state,
+screenshots, PDFs, uploads, downloads, and local file output; they print
+snapshots and extracted content to stdout for harness capture.
 
 | Script                                                               | Description                                      |
 | -------------------------------------------------------------------- | ------------------------------------------------ |

--- a/skills/agent-browser/references/authentication.md
+++ b/skills/agent-browser/references/authentication.md
@@ -103,7 +103,7 @@ Handle 2FA with manual intervention:
 
 ```bash
 # Login with credentials
-agent-browser open https://app.example.com/login --headed  # Show browser
+agent-browser --headed open https://app.example.com/login  # Show browser
 agent-browser snapshot -i
 agent-browser fill @e1 "user@example.com"
 agent-browser fill @e2 "password123"
@@ -111,7 +111,7 @@ agent-browser click @e3
 
 # Wait for user to complete 2FA manually
 echo "Complete 2FA in the browser window..."
-agent-browser wait --url "**/dashboard" --timeout 120000
+agent-browser wait --url "**/dashboard"
 
 # Save state after 2FA
 agent-browser state save ./2fa-state.json

--- a/skills/agent-browser/references/commands.md
+++ b/skills/agent-browser/references/commands.md
@@ -1,7 +1,10 @@
 # Command Reference
 
-Complete reference for all agent-browser commands. For quick start and common
-patterns, see SKILL.md.
+Reference for agent-browser commands. For quick start and common patterns, see
+SKILL.md.
+
+This is a curated subset; for the full, version-matched reference run
+`agent-browser skills get core --full`.
 
 ## Navigation
 
@@ -98,6 +101,8 @@ agent-browser wait --text "Success"        # Wait for text (or -t)
 agent-browser wait --url "**/dashboard"    # Wait for URL pattern (or -u)
 agent-browser wait --load networkidle      # Wait for network idle (or -l)
 agent-browser wait --fn "window.ready"     # Wait for JS condition (or -f)
+agent-browser wait "#spinner" --state hidden   # Wait for element to disappear
+agent-browser wait @e5 --state detached    # Wait for element removal from DOM
 ```
 
 ## Mouse Control
@@ -238,7 +243,9 @@ agent-browser --session <name> ...    # Isolated browser session
 agent-browser --json ...              # JSON output for parsing
 agent-browser --headed ...            # Show browser window (not headless)
 agent-browser --full ...              # Full page screenshot (-f)
-agent-browser --cdp <port> ...        # Connect via Chrome DevTools Protocol
+agent-browser --cdp <port|origin> ... # Connect via Chrome DevTools Protocol;
+                                      # accepts a port (9222) or an HTTP origin
+                                      # (http://host.docker.internal:9222)
 agent-browser -p <provider> ...       # Cloud browser provider (--provider)
 agent-browser --proxy <url> ...       # Use proxy server
 agent-browser --headers <json> ...    # HTTP headers scoped to URL's origin

--- a/skills/agent-browser/references/snapshot-refs.md
+++ b/skills/agent-browser/references/snapshot-refs.md
@@ -135,7 +135,7 @@ For complex pages, snapshot specific areas:
 
 ```bash
 # Snapshot just the form
-agent-browser snapshot @e9
+agent-browser snapshot -s "#signup-form"
 ```
 
 ## Ref Notation Details
@@ -178,7 +178,7 @@ agent-browser snapshot -i
 
 ```bash
 # Scroll to reveal element
-agent-browser scroll --bottom
+agent-browser scroll down 1000   # or: agent-browser press End
 agent-browser snapshot -i
 
 # Or wait for dynamic content
@@ -190,7 +190,7 @@ agent-browser snapshot -i
 
 ```bash
 # Snapshot specific container
-agent-browser snapshot @e5
+agent-browser snapshot -s "#results"
 
 # Or use get text for content-only extraction
 agent-browser get text @e5

--- a/skills/lit-component/SKILL.md
+++ b/skills/lit-component/SKILL.md
@@ -148,10 +148,11 @@ variables, and helper functions.
 ## Cell Integration
 
 For components that work with reactive runtime data, declare the cell as
-`@property({ attribute: false })`, subscribe with `cell.sink(() =>
-this.requestUpdate())` when the `cell` property changes, and read with
-`cell.get()` in `render()` (guarding the no-cell case). The pitfalls that
-matter:
+`@property({ attribute: false })`, subscribe with
+`cell.sink(() =>
+this.requestUpdate())` when the `cell` property changes, and
+read with `cell.get()` in `render()` (guarding the no-cell case). The pitfalls
+that matter:
 
 - Clean up the previous subscription before subscribing to a new cell, and
   unsubscribe in `disconnectedCallback()` (memory leaks)

--- a/skills/lit-component/SKILL.md
+++ b/skills/lit-component/SKILL.md
@@ -19,6 +19,10 @@ Use this skill when:
 - Building reactive components for pattern UIs
 - Debugging component lifecycle or reactivity issues
 
+Do NOT use this skill when authoring or styling pattern UIs that consume `cf-`
+components — that's `pattern-ui`'s job. Patterns must never touch component
+internals, and pattern JSX uses `theme={...}`, not Lit's `.theme=${...}`.
+
 ## Core Philosophy
 
 Common UI is inspired by SwiftUI and emphasizes:
@@ -123,130 +127,41 @@ export { CFComponentName };
 export type {}; /* exported types */
 ```
 
+Both registrations are the codebase convention, not a contradiction: the
+component file registers unconditionally when it is imported, and the index
+file's guarded define is a safe no-op in that case — it only registers when the
+component module didn't (and prevents duplicate-registration errors during hot
+module replacement). Keep both.
+
 ## Theme Integration
 
-Most components should use `var(--cf-theme-*)` CSS variables with fallbacks.
-Consume `cfThemeContext` only when JavaScript needs the theme object for runtime
-logic, derived values, or applying theme variables to dynamically created
-elements:
+Most components should use `var(--cf-theme-*)` CSS variables with fallbacks
+(`--cf-theme-*` first, then `--cf-*` base token, then a literal). Consume
+`cfThemeContext` (with `applyThemeToElement`) only when JavaScript needs the
+theme object for runtime logic, derived values, or applying theme variables to
+dynamically created elements.
 
-```typescript
-import { consume } from "@lit/context";
-import { property } from "lit/decorators.js";
-import {
-  applyThemeToElement,
-  type CFTheme,
-  cfThemeContext,
-  defaultTheme,
-} from "../theme-context.ts";
-
-export class MyComponent extends BaseElement {
-  @consume({ context: cfThemeContext, subscribe: true })
-  @property({ attribute: false })
-  declare theme?: CFTheme;
-
-  override firstUpdated(changed: Map<string | number | symbol, unknown>) {
-    super.firstUpdated(changed);
-    this._updateThemeProperties();
-  }
-
-  override updated(changed: Map<string | number | symbol, unknown>) {
-    super.updated(changed);
-    if (changed.has("theme")) {
-      this._updateThemeProperties();
-    }
-  }
-
-  private _updateThemeProperties() {
-    const currentTheme = this.theme || defaultTheme;
-    applyThemeToElement(this, currentTheme);
-  }
-}
-```
-
-Then use theme CSS variables with fallbacks:
-
-```css
-.button {
-  background-color: var(
-    --cf-theme-color-primary,
-    var(--cf-colors-primary-500, #3b82f6)
-  );
-  border-radius: var(
-    --cf-theme-border-radius,
-    var(--cf-border-radius-md, 0.375rem)
-  );
-  font-family: var(--cf-theme-font-family, inherit);
-}
-```
-
-**Complete theme reference:** See `references/theme-system.md` for all available
-CSS variables and helper functions.
+**Theme consumption code and complete reference:** See
+`references/theme-system.md` for the `@consume` boilerplate, all available CSS
+variables, and helper functions.
 
 ## Cell Integration
 
-For components that work with reactive runtime data:
+For components that work with reactive runtime data, declare the cell as
+`@property({ attribute: false })`, subscribe with `cell.sink(() =>
+this.requestUpdate())` when the `cell` property changes, and read with
+`cell.get()` in `render()` (guarding the no-cell case). The pitfalls that
+matter:
 
-```typescript
-import { property } from "lit/decorators.js";
-import type { Cell } from "@commonfabric/runner";
-import { isCell } from "@commonfabric/runner";
+- Clean up the previous subscription before subscribing to a new cell, and
+  unsubscribe in `disconnectedCallback()` (memory leaks)
+- Check `isCell(this.cell)` before subscribing
+- Mutate cells through transactions, never directly
 
-export class MyComponent extends BaseElement {
-  @property({ attribute: false })
-  declare cell: Cell<MyDataType>;
-
-  private _unsubscribe: (() => void) | null = null;
-
-  override updated(changedProperties: Map<string, any>) {
-    super.updated(changedProperties);
-
-    if (changedProperties.has("cell")) {
-      // Clean up previous subscription
-      if (this._unsubscribe) {
-        this._unsubscribe();
-        this._unsubscribe = null;
-      }
-
-      // Subscribe to new Cell
-      if (this.cell && isCell(this.cell)) {
-        this._unsubscribe = this.cell.sink(() => {
-          this.requestUpdate();
-        });
-      }
-    }
-  }
-
-  override disconnectedCallback() {
-    super.disconnectedCallback();
-    if (this._unsubscribe) {
-      this._unsubscribe();
-      this._unsubscribe = null;
-    }
-  }
-
-  override render() {
-    if (!this.cell) {
-      return html`
-
-      `;
-    }
-
-    const value = this.cell.get();
-    return html`
-      <div>${value}</div>
-    `;
-  }
-}
-```
-
-**Complete Cell patterns:** See `references/cell-integration.md` for:
-
-- Subscription management
-- Nested property access with `.key()`
-- Array cell manipulation
-- Transaction-based mutations
-- Finding cells by equality
+**Subscription boilerplate and complete Cell patterns:** See
+`references/cell-integration.md` for subscription management, nested property
+access with `.key()`, array cell manipulation, transaction-based mutations, and
+finding cells by equality.
 
 ## Reactive Controllers
 

--- a/skills/lit-component/references/cell-integration.md
+++ b/skills/lit-component/references/cell-integration.md
@@ -280,12 +280,15 @@ mutateCell(this.cell, (cell) => cell.set(newValue));
 repeat(items, (_, index) => index, ...)
 ```
 
-### ✅ Do: Use stable identifiers or composite keys
+### ✅ Do: Use stable identifiers
 
 ```typescript
 // GOOD
-repeat(items, (item, index) => `${index}-${item.title}`, ...)
+repeat(items, (item) => item.id, ...)
 ```
+
+If no stable id exists, add one at creation time; composite keys containing the
+index still break on reorder.
 
 ## Real-World Examples
 

--- a/skills/lit-component/references/component-patterns.md
+++ b/skills/lit-component/references/component-patterns.md
@@ -224,8 +224,11 @@ export { CFButton };
 export type { ButtonVariant };
 ```
 
-Note: The conditional check prevents duplicate registration errors during hot
-module replacement.
+Note: Both registrations are intentional. The component file registers
+unconditionally on import (the dominant convention in
+`packages/ui/src/v2/components/`); the index file's conditional check is then a
+safe no-op, and prevents duplicate registration errors during hot module
+replacement or alternate import paths. Keep both.
 
 ## Type Safety
 

--- a/skills/pattern-critic/SKILL.md
+++ b/skills/pattern-critic/SKILL.md
@@ -11,20 +11,19 @@ Read that guide first. It is the canonical reference. Severity definitions
 (`critical`/`major`/`minor`/`info`) live in the guide; use them as defined
 there.
 
-Whatever else happens, honor the output contract: emit the guide's
-[PASS]/[FAIL] categorized checklist and end with the Summary counts and the
-Priority Fixes list. If nothing fails, say so explicitly in two lines. Write
-the review to the output path you were given (in the factory:
-`reviews/critic-NN.md`).
+Whatever else happens, honor the output contract: emit the guide's [PASS]/[FAIL]
+categorized checklist and end with the Summary counts and the Priority Fixes
+list. If nothing fails, say so explicitly in two lines. Write the review to the
+output path you were given (in the factory: `reviews/critic-NN.md`).
 
 Be explicit about SES and determinism issues. Flag direct `Date.now()` or
 `Math.random()`, authored timers, and any call — including `safeDateNow()` /
 `nonPrivateRandom()` — made inside a re-running `computed()`/`lift()` without
-clear intent (non-idempotent use). Also flag
-bound-control self-feedback: if a `cf-*` form control is already bound to a
-cell, usually via `$value` or `$checked`, treat an event handler that writes the
-same value back into that same cell as a reactive-loop hazard unless it is
-clearly necessary and idempotent.
+clear intent (non-idempotent use). Also flag bound-control self-feedback: if a
+`cf-*` form control is already bound to a cell, usually via `$value` or
+`$checked`, treat an event handler that writes the same value back into that
+same cell as a reactive-loop hazard unless it is clearly necessary and
+idempotent.
 
 Then use the detailed references already maintained in the repo for:
 

--- a/skills/pattern-critic/SKILL.md
+++ b/skills/pattern-critic/SKILL.md
@@ -7,11 +7,20 @@ Start with the shared critique guidance in:
 
 - `docs/common/ai/pattern-critique-guide.md`
 
-Read that guide first. It is the canonical reference.
+Read that guide first. It is the canonical reference. Severity definitions
+(`critical`/`major`/`minor`/`info`) live in the guide; use them as defined
+there.
 
-Be explicit about SES and determinism issues: direct `Date.now()` or
-`Math.random()`, authored timers, and non-idempotent `computed()` use of
-`safeDateNow()` or `nonPrivateRandom()` should all be flagged. Also flag
+Whatever else happens, honor the output contract: emit the guide's
+[PASS]/[FAIL] categorized checklist and end with the Summary counts and the
+Priority Fixes list. If nothing fails, say so explicitly in two lines. Write
+the review to the output path you were given (in the factory:
+`reviews/critic-NN.md`).
+
+Be explicit about SES and determinism issues. Flag direct `Date.now()` or
+`Math.random()`, authored timers, and any call — including `safeDateNow()` /
+`nonPrivateRandom()` — made inside a re-running `computed()`/`lift()` without
+clear intent (non-idempotent use). Also flag
 bound-control self-feedback: if a `cf-*` form control is already bound to a
 cell, usually via `$value` or `$checked`, treat an event handler that writes the
 same value back into that same cell as a reactive-loop hazard unless it is

--- a/skills/pattern-ui/SKILL.md
+++ b/skills/pattern-ui/SKILL.md
@@ -1,27 +1,36 @@
 ---
 name: pattern-ui
-description: Add UI polish with layout and styling
+description: Design and polish pattern UIs with cf- components - theme-first styling via cf-theme, layout with cf-screen/cf-vstack, two-way binding ($value/$checked), and PerSession/PerUser/PerSpace UI-state scoping. Use when styling pattern JSX or writing a UI design doc.
 user-invocable: false
 ---
 
 # UI Polish Phase
 
-Only do this AFTER all logic is verified and tests pass.
+In a build/polish pass, apply this only after logic is verified and tests pass.
+In a design phase (e.g. Pattern Factory ui_design), use this guidance to write
+the UI design document — specify theme, layout composition, and state scoping;
+do not write implementation code.
 
 ## Read First, In Order
 
-- `docs/common/patterns/style.md` - Theme-first UI guidance and design process
+- `docs/common/components/COMPONENTS.md` - Full component reference; consult on
+  demand before assuming a component does or does not exist
+- one vignette story for the closest tone:
+  `packages/patterns/catalog/stories/vignette-recipe-story.tsx` (warm,
+  editorial light) or
+  `packages/patterns/catalog/stories/vignette-finance-story.tsx` (dark,
+  dashboard-style)
+- `docs/common/patterns/style.md` - for deeper rationale behind the theme-first
+  guidance this skill already digests
+
+If needed:
+
 - `docs/common/patterns/ui-cookbook.md` - Themed layout scaffolds and vignette
   references
-- `docs/common/components/COMPONENTS.md` - Full component reference
 - `docs/common/patterns/two-way-binding.md` - $value, $checked bindings
 - `packages/ui/README.md` - Current notes on CSS custom properties and parts
 - `packages/ui/LLM-COMPONENT-INSTRUCTIONS.md` - Agent-oriented component and
   theme system notes
-- `packages/patterns/catalog/stories/vignette-recipe-story.tsx` - warm,
-  editorial light vignette
-- `packages/patterns/catalog/stories/vignette-finance-story.tsx` - dark,
-  dashboard-style vignette
 
 ## Visual Priorities
 
@@ -36,7 +45,8 @@ Aim for:
 
 ## Design Brief Before Coding
 
-Before touching JSX, decide all of the following:
+Before touching JSX (or, in a design phase, as the core of the design doc),
+decide all of the following:
 
 - **Purpose**: What is this interface helping the user do?
 - **Tone**: Pick a concrete direction such as editorial, playful, luxurious,
@@ -85,12 +95,23 @@ Otherwise, prefer it over scattered ad hoc overrides.
   worth naming or an `iframe` / artifact case, not an excuse to guess at
   unsupported structure.
 
-## Available Components
+## Core Layout & Form Set (not exhaustive)
 
 Layout: `cf-theme`, `cf-screen`, `cf-vstack`, `cf-hstack`, `cf-vgroup`,
 `cf-hgroup`, `cf-card`, `cf-vscroll`, `cf-hscroll` Input: `cf-input`,
 `cf-textarea`, `cf-checkbox`, `cf-select` Action: `cf-button`, `cf-chip`
 Display: `cf-label`, `cf-heading`, `cf-badge`, `cf-alert`
+
+Many more exist — `cf-modal`, `cf-tabs`, `cf-table`, `cf-switch`,
+`cf-radio-group`, `cf-slider`, `cf-progress`, `cf-toast`, `cf-avatar`,
+`cf-accordion`, ... — check `docs/common/components/COMPONENTS.md` before
+concluding a component doesn't exist.
+
+If a needed component doesn't exist, name the design-system gap in your output;
+do not create Lit components or use component internals
+(`applyThemeToElement`, `@consume`, shadow selectors) — component authoring is
+the `lit-component` skill's domain, for `packages/ui` work only. In pattern JSX
+the theme is passed as `theme={...}`, not Lit's `.theme=${...}`.
 
 ## Aesthetic Guidance
 
@@ -191,6 +212,10 @@ Use existing production patterns only when you specifically need to understand a
 domain flow, not as the first place to copy styling from.
 
 ## Done When
+
+In a design phase, the artifact is the design doc (`ui-design.md` in the
+factory), not a rendering UI: done when the doc commits to a theme, layout
+composition, and explicit UI-state scoping. In a build/polish pass:
 
 - UI renders correctly
 - Bindings work (typing updates state)

--- a/skills/pattern-ui/SKILL.md
+++ b/skills/pattern-ui/SKILL.md
@@ -16,10 +16,9 @@ do not write implementation code.
 - `docs/common/components/COMPONENTS.md` - Full component reference; consult on
   demand before assuming a component does or does not exist
 - one vignette story for the closest tone:
-  `packages/patterns/catalog/stories/vignette-recipe-story.tsx` (warm,
-  editorial light) or
-  `packages/patterns/catalog/stories/vignette-finance-story.tsx` (dark,
-  dashboard-style)
+  `packages/patterns/catalog/stories/vignette-recipe-story.tsx` (warm, editorial
+  light) or `packages/patterns/catalog/stories/vignette-finance-story.tsx`
+  (dark, dashboard-style)
 - `docs/common/patterns/style.md` - for deeper rationale behind the theme-first
   guidance this skill already digests
 
@@ -108,10 +107,10 @@ Many more exist — `cf-modal`, `cf-tabs`, `cf-table`, `cf-switch`,
 concluding a component doesn't exist.
 
 If a needed component doesn't exist, name the design-system gap in your output;
-do not create Lit components or use component internals
-(`applyThemeToElement`, `@consume`, shadow selectors) — component authoring is
-the `lit-component` skill's domain, for `packages/ui` work only. In pattern JSX
-the theme is passed as `theme={...}`, not Lit's `.theme=${...}`.
+do not create Lit components or use component internals (`applyThemeToElement`,
+`@consume`, shadow selectors) — component authoring is the `lit-component`
+skill's domain, for `packages/ui` work only. In pattern JSX the theme is passed
+as `theme={...}`, not Lit's `.theme=${...}`.
 
 ## Aesthetic Guidance
 


### PR DESCRIPTION
Companion to #3963, covering the skills the Pattern Factory loads into its ui_design, critic, and manual_test phases. Every fix was re-verified against the file, the component source, or the installed agent-browser CLI (v0.26.0) before editing.

## Highlights

**pattern-ui**: the skill opened with "Only do this AFTER all logic is verified and tests pass" — but the factory loads it in **ui_design**, which runs before any code exists and produces only a design doc. Now mode-aware, with a design-phase exit criterion. The "Available Components" list of 19 read as exhaustive while 100+ exist (cf-modal, cf-tabs, cf-table, …) — retitled "not exhaustive" with more components (all verified to exist) and a pointer to COMPONENTS.md. Frontmatter description rewritten for triggering; the 8-doc mandatory read list cut to a prioritized 3; scope guard added against authoring Lit components or touching component internals from pattern code (`theme={...}` vs Lit's `.theme=${...}`).

**lit-component**: "When to Use" invited pattern-building agents to author Lit components — explicit "Do NOT use" guidance now steers pattern-UI work to pattern-ui. The apparent unconditional-vs-guarded `customElements.define` contradiction turned out to be the real codebase convention (91/106 component files define unconditionally AND 78/103 index files carry a guarded define) — now documented as intentional rather than "fixed". ~115 always-loaded lines that duplicated references/ byte-for-byte replaced with short rules + pointers (this also removed a broken empty `html`` snippet). `references/cell-integration.md` recommended `(item, index) => \`${index}-${item.title}\`` as a GOOD repeat() key two lines after banning index keys — now a genuinely stable `item.id` with guidance to add ids at creation time.

**pattern-critic + pattern-critique-guide**: the severity taxonomy was four bare labels with no definitions — the main source of inter-critic variance. The guide now defines critical/major/minor/info with concrete examples, and gains the scoped-state (PerSession/PerUser/PerSpace) review category that previously existed only in the skill (inverting the "guide is canonical" claim). The skill restates its output contract so it survives a skipped guide read, and the garbled sentence that read as "flag uses of safeDateNow()" now correctly flags only non-idempotent computed/lift use.

**agent-browser**: new "When Things Break" section (CDP unreachable, never-resolving waits, element missing from snapshot, screenshot unavailable under restricted profiles) — every command verified against CLI help. The canonical manual-testing guide mandates screenshots/--session/console that the cf-harness profile forbids; a mapping paragraph now says what to substitute, and the identity-check recipe is marked host/interactive-only. Stale commands fixed: `scroll --bottom` doesn't exist, `snapshot @ref` is undocumented, `--headed` after the subcommand, `wait --url --timeout` undocumented. commands.md gains `wait --state hidden|detached`, documents `--cdp` accepting port or origin (verified empirically), and is marked as a curated subset with `agent-browser skills get core --full` as the version-matched reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes and clarifies the `pattern-ui`, `lit-component`, `pattern-critic`, and `agent-browser` skills to reduce variance, improve docs, and make UI/design/manual test workflows more reliable.

- **New Features**
  - `pattern-critic`: define severities with examples; add scoped-state review (PerSession/PerUser/PerSpace); enforce checklist+summary output; clarify SES/determinism (flag only non-idempotent `computed()`/`lift()` use, incl. `safeDateNow()`/`nonPrivateRandom()`).
  - `pattern-ui`: make the skill mode-aware (design vs build) with a clear design-doc exit; mark the component list non-exhaustive and point to `COMPONENTS.md`; add guardrails against authoring Lit or touching component internals (`theme={...}` vs `.theme=${...}`).
  - `agent-browser`: add a “When Things Break” section; document `wait --state hidden|detached`, `--cdp <port|origin>`, and that the command reference is curated with `agent-browser skills get core --full` for the full spec.
  - `lit-component`: explain the dual `customElements.define` pattern as intentional; replace long theme/cell blocks with concise rules and references.

- **Bug Fixes**
  - `agent-browser`: correct examples (`--headed` before subcommand; drop undocumented `--timeout`; replace `scroll --bottom`; prefer `snapshot -s`); clarify `AGENT_BROWSER_CDP` is honored by bundled scripts (not the CLI); mark identity checks as host/interactive-only and map cf-harness restrictions with snapshot/text substitutes.
  - `lit-component`: fix `repeat()` guidance to use a stable `item.id`; steer pattern UI work to `pattern-ui`.
  - `pattern-ui`: strengthen frontmatter for better triggering; prioritize the “Read First” list; add a design-phase “Done” criterion.

<sup>Written for commit 76b6316bcf60ffb45e5809f7d150cdca92249d2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

