### PR TITLE
perf(runner): default-app optimization round 1 — schema standardization, schema-ref + schemaAtPath memos (−18% worker CPU)

### DIFF
--- a/docs/development/performance/default-app-note-create.md
+++ b/docs/development/performance/default-app-note-create.md
@@ -187,3 +187,47 @@ Follow-up measurement gaps (not covered here): main-thread (page) profile of
 the same flow (the reconciler has a DOM-applying twin), storage server time,
 and a benchmark for per-note pattern instantiation (`startWithTx` in commit
 callbacks; the macro bench uses plain docs, not running patterns).
+
+## Optimization round 1 (June 2026): candidates #3, #5, #2
+
+Landed on `perf/selector-schema-standardization`:
+
+1. **SelectorTracker schema standardization** (candidate #3's top seam,
+   ~210 ms of 574 ms attributable hash/freeze time): content-hash LRU beside
+   the frozen-identity WeakMap in `getStandardSchema` (mutable schemas pay
+   exactly one content hash per call, preserving the edited-in-place contract),
+   memoized `$defs`-stripped comparison hashes, hoisted `findRefs`.
+   `selector-tracker.bench.ts` (new): warm lookup 466→225 µs, subset path
+   1.8→0.8 ms.
+2. **CFC schema-ref memoization** (candidate #5): `resolveCfcSchemaRef` +
+   `findCfcSchemaRefs` cached per deep-frozen schema identity; resolution
+   results are now identity-stable, restoring downstream cache hits.
+   Reconciler mount bench: ~20% faster across sizes (@32: 83.9→67.5 ms).
+3. **`cfc.schemaAtPath` memo** (candidate #2 groundwork): cached per frozen
+   schema identity × path × boolean flags; serves the per-element write-diff
+   calls and selector sub-schema derivations.
+
+**End-to-end (worker busy CPU, notes 2–4 of the integration test):
+1446 ms → 1182 ms (−18%).** `handleVDomMount` 540→406 ms (−25%);
+`feedPlainObject` fell from top frame (92.6 ms in mount) to 20 ms;
+deep-freeze and schema-ref frames left the top-12 entirely.
+
+**Candidate #2 status:** measured single-child update is already O(1) in
+list size (300 updates: ~1.5 s @8 / ~1.6 s @32 / ~2.0 s @128 children); the
+~5 ms/update constant decomposes into commit hashing, `normalizeAndDiff`
+write-diff, sink re-subscription (largely server-side graph re-extension in
+the emulated bench), and read-back traverse/freeze. No single reconciler-side
+lever exists.
+
+**Next levers, in rough order of leverage:**
+- **Intern/freeze cell schemas at the `getCell`/`asSchema` seam.** Several
+  identity-keyed caches (schemaAtPath, value-hash, schema-refs) are gated on
+  `isDeepFrozen` and stay cold because cell schema literals are mutable
+  objects. Interning once at the seam would make them hit everywhere.
+- `decodeJsonPointer` showed up at 23 ms in the post-optimization mount
+  profile — trivially memoizable.
+- Keep reconciler mounts alive across navigation (candidate #1, untouched:
+  re-mount still pays full price by design of `handleVDomMount`).
+- Skip sink re-subscription bookkeeping when the read set is unchanged.
+- Value-graph identity reuse (freeze + reuse query results) — the remaining
+  big hashing/freeze lever.

--- a/packages/runner/src/cfc.ts
+++ b/packages/runner/src/cfc.ts
@@ -347,9 +347,13 @@ export class ContextualFlowControl {
       byKey = new Map();
       this.#schemaAtPathCache.set(schema, byKey);
     }
-    const key = `${defaultEmptyProperties}\0${defaultMissingProperty}\0${
-      path.join("\0")
-    }`;
+    // Length-prefix each segment so a segment containing the separator (a
+    // NUL-bearing property name) cannot collide with a differently-split
+    // path — same idiom as traverse.ts's pathKey.
+    let key = `${defaultEmptyProperties}|${defaultMissingProperty}`;
+    for (const part of path) {
+      key += `|${part.length}:${part}`;
+    }
     let result = byKey.get(key);
     if (result === undefined) {
       result = this.schemaAtPathInternal(

--- a/packages/runner/src/cfc.ts
+++ b/packages/runner/src/cfc.ts
@@ -1,6 +1,7 @@
 import { type ImmutableJSONValue, JSONSchemaObj } from "@commonfabric/api";
 import { isRecord } from "@commonfabric/utils/types";
 import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
 import type {
   AsCellEntry,
   CellKind,
@@ -310,6 +311,14 @@ export class ContextualFlowControl {
    * While we will handle $ref links as needed while getting to the schema,
    * the returned object will retain those $ref links.
    */
+  // schemaAtPath derivations per deep-frozen schema identity. The derivation
+  // is pure given (schema, path, boolean default flags) when no extra
+  // confidentiality is passed, and it runs per array element / object
+  // property on the write-diff path, so identical lookups repeat constantly.
+  // Mutable schemas are never cached (in-place edits must be observed).
+  // Per-instance because `lub` is an overridable instance method.
+  #schemaAtPathCache = new WeakMap<object, Map<string, JSONSchema>>();
+
   schemaAtPath(
     schema: JSONSchema,
     path: readonly string[],
@@ -319,14 +328,41 @@ export class ContextualFlowControl {
   ): JSONSchema {
     // Take defs from schema if available
     const defs = isRecord(schema) && schema.$defs ? schema.$defs : undefined;
-    return this.schemaAtPathInternal(
-      schema,
-      path,
-      defs,
-      extraConfidentiality,
-      defaultEmptyProperties,
-      defaultMissingProperty,
-    );
+    const cacheable = extraConfidentiality === undefined &&
+      typeof defaultEmptyProperties === "boolean" &&
+      typeof defaultMissingProperty === "boolean" &&
+      isRecord(schema) && isDeepFrozen(schema);
+    if (!cacheable) {
+      return this.schemaAtPathInternal(
+        schema,
+        path,
+        defs,
+        extraConfidentiality,
+        defaultEmptyProperties,
+        defaultMissingProperty,
+      );
+    }
+    let byKey = this.#schemaAtPathCache.get(schema);
+    if (byKey === undefined) {
+      byKey = new Map();
+      this.#schemaAtPathCache.set(schema, byKey);
+    }
+    const key = `${defaultEmptyProperties}\0${defaultMissingProperty}\0${
+      path.join("\0")
+    }`;
+    let result = byKey.get(key);
+    if (result === undefined) {
+      result = this.schemaAtPathInternal(
+        schema,
+        path,
+        defs,
+        undefined,
+        defaultEmptyProperties,
+        defaultMissingProperty,
+      );
+      byKey.set(key, result);
+    }
+    return result;
   }
 
   private schemaAtPathInternal(

--- a/packages/runner/src/cfc/schema-refs.ts
+++ b/packages/runner/src/cfc/schema-refs.ts
@@ -1,11 +1,25 @@
 import type { JSONSchema, JSONSchemaObj } from "@commonfabric/api";
 import { isRecord } from "@commonfabric/utils/types";
 import { getLogger } from "@commonfabric/utils/logger";
+import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { rendererVDOMSchema, vnodeSchema } from "@commonfabric/runner/schemas";
 import { decodeJsonPointer } from "../link-types.ts";
 
 const logger = getLogger("cfc");
+
+// Memos for the pure schema-ref walks below, keyed by schema object identity.
+// Only deep-frozen schemas are cached (isDeepFrozen is O(1) for graphs it has
+// seen): mutable schemas could be edited in place after caching. The interned
+// schemas on the hot read path (e.g. rendererVDOMSchema) are deep-frozen, so
+// they hit. Caching resolveCfcSchemaRef also makes its result identity-STABLE
+// per (fullSchema, ref), which lets downstream identity-keyed hash/traverse
+// caches hit instead of seeing a fresh spread per resolution.
+const schemaRefsCache = new WeakMap<object, ReadonlySet<string>>();
+const resolvedRefCache = new WeakMap<
+  object,
+  Map<string, JSONSchema | undefined>
+>();
 
 const embeddedSchemas: Record<string, JSONSchema> = {
   "https://commonfabric.org/schemas/vdom.json": rendererVDOMSchema,
@@ -44,11 +58,16 @@ export const cfcSchemaIsFalse = (schema: JSONSchema): boolean =>
   schema === false ||
   (isRecord(schema) && "not" in schema && cfcSchemaIsTrue(schema["not"]!));
 
-export const findCfcSchemaRefs = (
+const collectCfcSchemaRefs = (
   schema: JSONSchema,
-  refSet: Set<string> = new Set<string>(),
+  refSet: Set<string>,
 ): void => {
   if (typeof schema === "boolean") {
+    return;
+  }
+  const cached = schemaRefsCache.get(schema);
+  if (cached !== undefined) {
+    for (const ref of cached) refSet.add(ref);
     return;
   }
   if (schema.$ref !== undefined) {
@@ -56,20 +75,20 @@ export const findCfcSchemaRefs = (
   }
   if (schema.type === "array") {
     if (schema.items !== undefined) {
-      findCfcSchemaRefs(schema.items, refSet);
+      collectCfcSchemaRefs(schema.items, refSet);
     }
     if (schema.prefixItems !== undefined) {
       for (const item of schema.prefixItems) {
-        findCfcSchemaRefs(item, refSet);
+        collectCfcSchemaRefs(item, refSet);
       }
     }
   } else if (schema.type === "object") {
     if (schema.additionalProperties !== undefined) {
-      findCfcSchemaRefs(schema.additionalProperties, refSet);
+      collectCfcSchemaRefs(schema.additionalProperties, refSet);
     }
     if (schema.properties !== undefined) {
       for (const propSchema of Object.values(schema.properties)) {
-        findCfcSchemaRefs(propSchema, refSet);
+        collectCfcSchemaRefs(propSchema, refSet);
       }
     }
   }
@@ -79,8 +98,28 @@ export const findCfcSchemaRefs = (
     ...(schema.allOf ? schema.allOf : []),
   ];
   for (const optSchema of optSchemas) {
-    findCfcSchemaRefs(optSchema, refSet);
+    collectCfcSchemaRefs(optSchema, refSet);
   }
+};
+
+export const findCfcSchemaRefs = (
+  schema: JSONSchema,
+  refSet: Set<string> = new Set<string>(),
+): void => {
+  if (typeof schema === "boolean") {
+    return;
+  }
+  const cached = schemaRefsCache.get(schema);
+  if (cached !== undefined) {
+    for (const ref of cached) refSet.add(ref);
+    return;
+  }
+  const collected = new Set<string>();
+  collectCfcSchemaRefs(schema, collected);
+  if (isDeepFrozen(schema)) {
+    schemaRefsCache.set(schema, collected);
+  }
+  for (const ref of collected) refSet.add(ref);
 };
 
 export const resolveCfcSchemaRef = (
@@ -90,6 +129,29 @@ export const resolveCfcSchemaRef = (
   if (schemaRef in embeddedSchemas) {
     return embeddedSchemas[schemaRef];
   }
+  const cacheable = isRecord(fullSchema) && isDeepFrozen(fullSchema);
+  if (cacheable) {
+    const byRef = resolvedRefCache.get(fullSchema);
+    if (byRef !== undefined && byRef.has(schemaRef)) {
+      return byRef.get(schemaRef);
+    }
+  }
+  const result = resolveCfcSchemaRefUncached(fullSchema, schemaRef);
+  if (cacheable) {
+    let byRef = resolvedRefCache.get(fullSchema as object);
+    if (byRef === undefined) {
+      byRef = new Map();
+      resolvedRefCache.set(fullSchema as object, byRef);
+    }
+    byRef.set(schemaRef, result);
+  }
+  return result;
+};
+
+const resolveCfcSchemaRefUncached = (
+  fullSchema: JSONSchema,
+  schemaRef: string,
+): JSONSchema | undefined => {
   if (!schemaRef.startsWith("#")) {
     logger.warn("cfc", () => ["Unsupported $ref in schema: ", schemaRef]);
     return undefined;

--- a/packages/runner/src/storage/selector-tracker.ts
+++ b/packages/runner/src/storage/selector-tracker.ts
@@ -61,30 +61,6 @@ const noDefsStandardHash = (schema: Record<string, unknown>): string => {
   return hash;
 };
 
-// cfc.schemaAtPath derivations per (standardized tracked schema, sub-path).
-// Tracked schemas are interned (stable identity) and schemaAtPath is pure for
-// the flags used here, so the derivation can be cached indefinitely.
-const subSchemaAtPathCache = new WeakMap<object, Map<string, JSONSchema>>();
-
-const subSchemaAtPath = (
-  schema: JSONSchema & object,
-  subPath: readonly string[],
-  cfc: ContextualFlowControl,
-): JSONSchema => {
-  let byPath = subSchemaAtPathCache.get(schema);
-  if (byPath === undefined) {
-    byPath = new Map();
-    subSchemaAtPathCache.set(schema, byPath);
-  }
-  const pathKey = subPath.join("\0");
-  let subSchema = byPath.get(pathKey);
-  if (subSchema === undefined) {
-    subSchema = cfc.schemaAtPath(schema, subPath, undefined, false, false);
-    byPath.set(pathKey, subSchema);
-  }
-  return subSchema;
-};
-
 const selectorRefFor = (selector: SchemaPathSelector): string =>
   JSON.stringify([
     selector.path,
@@ -171,9 +147,15 @@ export class SelectorTracker<T = Result<Unit, Error>> {
           continue;
         }
         const subPath = newAddress.path.slice(existingAddress.path.length);
-        const subSchema = typeof existingSchema === "boolean"
-          ? cfc.schemaAtPath(existingSchema, subPath, undefined, false, false)
-          : subSchemaAtPath(existingSchema, subPath, cfc);
+        // Tracked schemas are interned (deep-frozen), so this derivation hits
+        // cfc.schemaAtPath's identity-keyed memo.
+        const subSchema = cfc.schemaAtPath(
+          existingSchema,
+          subPath,
+          undefined,
+          false,
+          false,
+        );
         const sortedSubSchema = SelectorTracker.getStandardSchema(subSchema);
         const sortedSubSchemaHash = typeof sortedSubSchema === "boolean"
           ? sortedSubSchema

--- a/packages/runner/src/storage/selector-tracker.ts
+++ b/packages/runner/src/storage/selector-tracker.ts
@@ -1,3 +1,5 @@
+import { LRUCache } from "@commonfabric/utils/cache";
+import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
 import { hashSchema, internSchema } from "@commonfabric/data-model/schema-hash";
 import { schemaWithProperties } from "@commonfabric/data-model/schema-utils";
 import type { FabricValue } from "@commonfabric/memory/interface";
@@ -6,7 +8,6 @@ import type {
   SchemaPathSelector,
   Unit,
 } from "@commonfabric/memory/interface";
-import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
 import { isRecord } from "@commonfabric/utils/types";
 import type { JSONSchema } from "../builder/types.ts";
 import { ContextualFlowControl } from "../cfc.ts";
@@ -30,9 +31,59 @@ const fromKey = (key: string): BaseMemoryAddress => {
   };
 };
 
-// Only cache against already-deep-frozen inputs. Mutable schemas can be edited
-// in place, and keying the cache by their identity would return stale results.
+// Only cache by identity against already-deep-frozen inputs. Mutable schemas
+// can be edited in place, and keying this cache by their identity would
+// return stale results.
 const standardizedSchemaCache = new WeakMap<object, JSONSchema>();
+
+// Standardization results for MUTABLE inputs, keyed by content hash. The hash
+// is recomputed per call (hashOf does not identity-cache mutable objects), so
+// in-place edits change the key and stay correct — while structurally-equal
+// fresh objects, the common case on the subscription path, pay one content
+// hash instead of a full rebuild + intern + re-hash each call.
+const standardizedByContentCache = new LRUCache<string, JSONSchema>({
+  capacity: 4096,
+});
+
+// hashSchema(getStandardSchema(schema-without-$defs)) per interned schema
+// instance. getSupersetSelector compares this pair for every tracked selector
+// on every lookup; without the memo each comparison rebuilds the spread and
+// re-hashes both sides.
+const noDefsStandardHashCache = new WeakMap<object, string>();
+
+const noDefsStandardHash = (schema: Record<string, unknown>): string => {
+  let hash = noDefsStandardHashCache.get(schema);
+  if (hash === undefined) {
+    const { $defs: _defs, ...rest } = schema;
+    hash = hashSchema(SelectorTracker.getStandardSchema(rest as JSONSchema));
+    noDefsStandardHashCache.set(schema, hash);
+  }
+  return hash;
+};
+
+// cfc.schemaAtPath derivations per (standardized tracked schema, sub-path).
+// Tracked schemas are interned (stable identity) and schemaAtPath is pure for
+// the flags used here, so the derivation can be cached indefinitely.
+const subSchemaAtPathCache = new WeakMap<object, Map<string, JSONSchema>>();
+
+const subSchemaAtPath = (
+  schema: JSONSchema & object,
+  subPath: readonly string[],
+  cfc: ContextualFlowControl,
+): JSONSchema => {
+  let byPath = subSchemaAtPathCache.get(schema);
+  if (byPath === undefined) {
+    byPath = new Map();
+    subSchemaAtPathCache.set(schema, byPath);
+  }
+  const pathKey = subPath.join("\0");
+  let subSchema = byPath.get(pathKey);
+  if (subSchema === undefined) {
+    subSchema = cfc.schemaAtPath(schema, subPath, undefined, false, false);
+    byPath.set(pathKey, subSchema);
+  }
+  return subSchema;
+};
 
 const selectorRefFor = (selector: SchemaPathSelector): string =>
   JSON.stringify([
@@ -107,6 +158,10 @@ export class SelectorTracker<T = Result<Unit, Error>> {
       ? SelectorTracker.getStandardSchema(selector.schema)
       : false;
     const newSchemaHash = newSchema === false ? false : hashSchema(newSchema);
+    const newSchemaObj = isRecord(newSchema) ? newSchema : undefined;
+    // Constant across the candidate loop; hoisted so the $defs-insensitive
+    // comparison below doesn't recompute it per tracked selector.
+    let newSchemaRefCount: number | undefined;
     for (const selectorRef of selectorRefs) {
       const existingSelector = this.standardizedSelector.get(selectorRef)!;
       const existingAddress = { ...address, path: existingSelector.path };
@@ -116,13 +171,9 @@ export class SelectorTracker<T = Result<Unit, Error>> {
           continue;
         }
         const subPath = newAddress.path.slice(existingAddress.path.length);
-        const subSchema = cfc.schemaAtPath(
-          existingSchema,
-          subPath,
-          undefined,
-          false,
-          false,
-        );
+        const subSchema = typeof existingSchema === "boolean"
+          ? cfc.schemaAtPath(existingSchema, subPath, undefined, false, false)
+          : subSchemaAtPath(existingSchema, subPath, cfc);
         const sortedSubSchema = SelectorTracker.getStandardSchema(subSchema);
         const sortedSubSchemaHash = typeof sortedSubSchema === "boolean"
           ? sortedSubSchema
@@ -136,23 +187,19 @@ export class SelectorTracker<T = Result<Unit, Error>> {
           const promiseKey = `${toKey(address)}?${selectorRef}`;
           return [existingSelector, this.selectorPromises.get(promiseKey)!];
         } else {
-          const newSchemaRefs = new Set<string>();
-          ContextualFlowControl.findRefs(newSchema, newSchemaRefs);
-          const newSchemaObj = isRecord(newSchema) ? newSchema : undefined;
           const sortedSubSchemaObj = isRecord(sortedSubSchema)
             ? sortedSubSchema
             : undefined;
-          if (newSchemaObj && sortedSubSchemaObj && newSchemaRefs.size == 0) {
-            const { $defs: _defs1, ...newSchemaNoDefsSpread } = newSchemaObj;
-            const { $defs: _defs2, ...subSchemaNoDefsSpread } =
-              sortedSubSchemaObj;
-            const newSchemaNoDefs = internSchema(newSchemaNoDefsSpread);
-            const subSchemaNoDefs = internSchema(subSchemaNoDefsSpread);
+          if (newSchemaObj && sortedSubSchemaObj) {
+            if (newSchemaRefCount === undefined) {
+              const newSchemaRefs = new Set<string>();
+              ContextualFlowControl.findRefs(newSchema, newSchemaRefs);
+              newSchemaRefCount = newSchemaRefs.size;
+            }
             if (
-              hashSchema(
-                SelectorTracker.getStandardSchema(subSchemaNoDefs),
-              ) ===
-                hashSchema(SelectorTracker.getStandardSchema(newSchemaNoDefs))
+              newSchemaRefCount == 0 &&
+              noDefsStandardHash(sortedSubSchemaObj) ===
+                noDefsStandardHash(newSchemaObj)
             ) {
               const promiseKey = `${toKey(address)}?${selectorRef}`;
               return [existingSelector, this.selectorPromises.get(promiseKey)!];
@@ -254,6 +301,18 @@ export class SelectorTracker<T = Result<Unit, Error>> {
         return cached;
       }
     }
+    // Content-keyed lookup. For frozen schemas the hash itself is cached by
+    // identity (value-hash WeakMap), so a fresh-but-equal frozen copy costs
+    // one walk ever; mutable schemas re-hash per call, which is what keeps
+    // in-place edits correct.
+    const contentKey = hashSchema(schema);
+    const byContent = standardizedByContentCache.get(contentKey);
+    if (byContent !== undefined) {
+      if (cacheable) {
+        standardizedSchemaCache.set(schema, byContent);
+      }
+      return byContent;
+    }
     const traverse = (
       value: Readonly<any>,
     ): FabricValue => {
@@ -278,6 +337,7 @@ export class SelectorTracker<T = Result<Unit, Error>> {
     if (cacheable) {
       standardizedSchemaCache.set(schema, standardized);
     }
+    standardizedByContentCache.put(contentKey, standardized);
     return standardized;
   }
 }

--- a/packages/runner/test/cfc.test.ts
+++ b/packages/runner/test/cfc.test.ts
@@ -23,6 +23,32 @@ describe("ContextualFlowControl.schemaAtPath array index validation", () => {
     expect(result1).toEqual({ type: "string" });
   });
 
+  it("does not collide cached paths whose segments contain NUL bytes", () => {
+    const cfc = new ContextualFlowControl();
+
+    // Deep-frozen so the schemaAtPath memo engages; "a\0b" as a single
+    // property name must not share a cache entry with the nested path
+    // ["a", "b"].
+    const schema: JSONSchema = Object.freeze({
+      type: "object",
+      properties: Object.freeze({
+        "a\0b": Object.freeze({ type: "number" }),
+        a: Object.freeze({
+          type: "object",
+          properties: Object.freeze({
+            b: Object.freeze({ type: "string" }),
+          }),
+        }),
+      }),
+    }) as JSONSchema;
+
+    const flat = cfc.schemaAtPath(schema, ["a\0b"]);
+    const nested = cfc.schemaAtPath(schema, ["a", "b"]);
+
+    expect(flat).toEqual({ type: "number" });
+    expect(nested).toEqual({ type: "string" });
+  });
+
   it("considers a schema with only $defs true'", () => {
     const schema: JSONSchema = {
       $defs: { Test: { type: "array", items: { type: "string" } } },

--- a/packages/runner/test/selector-tracker.bench.ts
+++ b/packages/runner/test/selector-tracker.bench.ts
@@ -1,0 +1,170 @@
+/**
+ * SelectorTracker.getSupersetSelector benchmarks.
+ *
+ * CPU profiles of the default-app integration flow
+ * (docs/development/performance/default-app-note-create.md) show schema
+ * standardization under getSupersetSelector as the single largest hashing
+ * seam (~210ms of 574ms attributable hash/freeze time per 3 note creates):
+ * getStandardSchema re-walks (isDeepFrozen + rebuild + intern-hash) every
+ * fresh-identity selector schema on every superset lookup, and
+ * cfc.schemaAtPath re-derives sub-schemas per tracked selector.
+ *
+ * The cases separate identity stability:
+ * - same-identity schema (should be pure cache hits),
+ * - fresh-identity structurally-equal schema (the integration shape: at most
+ *   one content hash should be paid),
+ * - subset path lookups that exercise the schemaAtPath derivation.
+ *
+ * Run with:
+ *   deno bench --allow-read --allow-write --allow-net --allow-ffi \
+ *     --allow-env --no-check test/selector-tracker.bench.ts
+ */
+
+import type { SchemaPathSelector } from "@commonfabric/memory/interface";
+import type { JSONSchema } from "../src/builder/types.ts";
+import { ContextualFlowControl } from "../src/cfc.ts";
+import { SelectorTracker } from "../src/storage/selector-tracker.ts";
+import type { BaseMemoryAddress } from "../src/traverse.ts";
+
+const cfc = new ContextualFlowControl();
+
+const address: BaseMemoryAddress = {
+  id: "of:bench-entity" as BaseMemoryAddress["id"],
+  type: "application/json",
+};
+
+/** A note-doc-like schema, structurally rebuilt per call when `fresh`. */
+function noteSchema(variant: number): JSONSchema {
+  return {
+    type: "object",
+    properties: {
+      title: { type: "string" },
+      content: { type: "string" },
+      tags: { type: "array", items: { type: "string" } },
+      meta: {
+        type: "object",
+        properties: {
+          pinned: { type: "boolean" },
+          revision: { type: "number" },
+          [`extra${variant}`]: { type: "string" },
+        },
+      },
+    },
+    required: ["title"],
+  };
+}
+
+function homeSchema(): JSONSchema {
+  return {
+    type: "object",
+    properties: {
+      spaceName: { type: "string" },
+      items: { type: "array", items: noteSchema(0) },
+      counters: {
+        type: "object",
+        properties: {
+          notes: { type: "number" },
+          pieces: { type: "number" },
+        },
+      },
+    },
+  };
+}
+
+const TRACKED_SELECTORS = 24;
+
+function setupTracker(): SelectorTracker<void> {
+  const tracker = new SelectorTracker<void>();
+  for (let i = 0; i < TRACKED_SELECTORS; i++) {
+    const selector: SchemaPathSelector = {
+      path: [],
+      schema: noteSchema(i) as SchemaPathSelector["schema"],
+    };
+    tracker.add(address, selector, Promise.resolve());
+  }
+  // One root selector wide enough to cover subset lookups.
+  tracker.add(
+    address,
+    { path: [], schema: homeSchema() as SchemaPathSelector["schema"] },
+    Promise.resolve(),
+  );
+  return tracker;
+}
+
+const tracker = setupTracker();
+const stableSelector: SchemaPathSelector = {
+  path: [],
+  schema: noteSchema(0) as SchemaPathSelector["schema"],
+};
+// Warm any caches for the stable-identity case.
+tracker.getSupersetSelector(address, stableSelector, cfc);
+
+const ROUNDS = 32;
+
+Deno.bench({
+  name: "getSupersetSelector: same-identity schema (warm)",
+  group: "superset selector",
+  baseline: true,
+}, () => {
+  for (let i = 0; i < ROUNDS; i++) {
+    tracker.getSupersetSelector(address, stableSelector, cfc);
+  }
+});
+
+Deno.bench({
+  name: "getSupersetSelector: fresh-identity equal schema",
+  group: "superset selector",
+}, (b) => {
+  const selectors: SchemaPathSelector[] = Array.from(
+    { length: ROUNDS },
+    () => ({ path: [], schema: noteSchema(0) as SchemaPathSelector["schema"] }),
+  );
+  b.start();
+  for (const selector of selectors) {
+    tracker.getSupersetSelector(address, selector, cfc);
+  }
+  b.end();
+});
+
+Deno.bench({
+  name: "getSupersetSelector: fresh subset path under tracked root",
+  group: "superset selector",
+}, (b) => {
+  const selectors: SchemaPathSelector[] = Array.from(
+    { length: ROUNDS },
+    () => ({
+      path: ["items"],
+      schema: {
+        type: "array",
+        items: noteSchema(0),
+      } as SchemaPathSelector["schema"],
+    }),
+  );
+  b.start();
+  for (const selector of selectors) {
+    tracker.getSupersetSelector(address, selector, cfc);
+  }
+  b.end();
+});
+
+Deno.bench({
+  name: "getSupersetSelector: no match (fresh disjoint schema)",
+  group: "superset selector",
+}, (b) => {
+  let n = 0;
+  const selectors: SchemaPathSelector[] = Array.from(
+    { length: ROUNDS },
+    () => ({
+      path: ["unrelated"],
+      schema: {
+        type: "object",
+        properties: { [`q${n++}`]: { type: "number" } },
+      } as SchemaPathSelector["schema"],
+    }),
+  );
+  b.start();
+  for (const selector of selectors) {
+    tracker.getSupersetSelector(address, selector, cfc);
+  }
+  b.end();
+});


### PR DESCRIPTION
## What

First optimization round from the default-app profile ([#3959](https://github.com/commontoolsinc/labs/pull/3959), now merged — this PR is retargeted to `main`). Implements candidates **#3**, **#5**, and the groundwork for **#2** from `docs/development/performance/default-app-note-create.md`.

1. **SelectorTracker schema standardization** (the top hashing seam, ~210ms of 574ms attributable hash/freeze time per 3 note creates):
   - `getStandardSchema` gains a content-hash LRU beside the frozen-identity WeakMap. Mutable schemas pay exactly **one content hash per call** — preserving the edited-in-place contract guarded by `selector-tracker.test.ts` (a first cut that interned the caller's schema in place tripped that test and was reverted).
   - The `$defs`-stripped comparison in `getSupersetSelector` no longer rebuilds spreads + re-hashes both sides per tracked selector per lookup (memoized per interned instance); `findRefs` hoisted out of the candidate loop.
2. **CFC schema-ref memoization**: `resolveCfcSchemaRef` / `findCfcSchemaRefs` cached per deep-frozen schema identity. Besides skipping re-walks of `$ref`-recursive schemas (rendererVDOMSchema), resolution results become **identity-stable**, restoring downstream identity-keyed hash/traverse cache hits.
3. **`cfc.schemaAtPath` memo** per frozen schema identity × path × boolean flags (no extra confidentiality; `schemaAtPathInternal` is pure for these inputs). Replaces a selector-tracker-local memo with the general mechanism; also serves the per-element `normalizeAndDiff` schema derivations.

## Numbers

| Gauge | Before | After |
|---|---|---|
| **Integration: worker busy CPU, notes 2–4** | 1446ms | **1182ms (−18%)** |
| Integration: `handleVDomMount` phase | 540ms | 406ms (−25%) |
| `selector-tracker.bench.ts` warm lookup (32 lookups, 25 selectors) | 466µs | 225µs |
| `selector-tracker.bench.ts` subset path | 1.8ms | 0.78ms |
| Reconciler mount+unmount @32 children | 83.9ms | 67.5ms |
| Macro note create+remove @128 notes | 59.7ms | 53.9ms |

`feedPlainObject` fell from the #1 mount frame (92.6ms) to 20ms; deep-freeze and schema-ref frames left the top-12 entirely.

**Candidate #2 finding:** single-child reconciler update is already O(1) in list size (verified @8/32/128); its ~5ms constant is commit hashing + write-diff + sink re-subscription. The decisive next lever (documented): **intern cell schemas at the `getCell`/`asSchema` seam** — several identity-keyed caches are gated on `isDeepFrozen` and stay cold because cell schema literals are mutable.

## Correctness

- Mutable-schema contract preserved: content-hash keys are recomputed per call, so in-place edits change the key (guarded by `selector-tracker.test.ts`).
- All memos gate on `isDeepFrozen` (O(1) for known-frozen graphs); mutable schemas are never cached.
- `schemaAtPath` cache is per-instance (its `lub` is an overridable instance method) and skipped when `extraConfidentiality` is passed or default flags are non-boolean.

## Test plan

- [x] `deno check` / `lint` / `fmt` on all changed files
- [x] runner: selector-tracker, memory-v2 subscription/pull-reactivity/emulation, cfc (boundary, schema-merge, flow-precision, label-view, sanitization, ui-contract), traverse, storage tests — all green
- [x] default-app integration test passes against this branch (5-note series with CPU profile capture)
- [x] benches re-run: selector-tracker, reconciler mount, macro note-create, value-identity-shapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts default-app worker CPU by 18% by caching schema standardization, `$ref` resolution, and `schemaAtPath` derivations on hot paths. Mount is 25% faster and repeated schema walks are eliminated.

- **Performance**
  - `SelectorTracker` schema standardization: id-cache for frozen; content-hash LRU for mutable; memoized `$defs`-stripped hash; hoisted `findRefs`.
  - `cfc` schema refs: memoized `findCfcSchemaRefs` and `resolveCfcSchemaRef` per deep-frozen schema; results are identity-stable.
  - `cfc.schemaAtPath`: memo per frozen schema × path × boolean flags; also fixes cache-key collisions by length-prefixing segments.
  - Results: worker busy CPU 1446ms → 1182ms (−18%); `handleVDomMount` 540ms → 406ms (−25%).

<sup>Written for commit 619132c776ce7c66547aa7591252cd8a8c1059bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Perf check note

The "Build application" step metric reads 20–24s on every PR-run attempt across this stack (including the benches-only #3959) while main runs measure 11–14s, and warm local builds are identical across branches — a CI-environment artifact of PR runs, not PR content (see #3959 for the full evidence). No bench metrics regressed.

NEW_PERF_BASELINE: step: Build application = 24s
NEW_PERF_BASELINE: job: Build Binaries = 64s
