### PR TITLE
fix(runner): sync handler asCell input docs before dispatching events

### DIFF
--- a/packages/runner/src/runner.ts
+++ b/packages/runner/src/runner.ts
@@ -3083,11 +3083,65 @@ export class Runner {
       setRunnableName(handler, `handler:${name}`, { setSrc: true });
     }
 
+    // Ensure the handler's input docs are locally available before the body
+    // runs: materialize the argument the same way the handler will (asCell
+    // fields surface as Cells WITHOUT reading their backing docs), then await
+    // sync() on each collected Cell. The scheduler awaits this before
+    // dispatching the event. Without it, a synchronous in-handler read of an
+    // asCell input (e.g. SqliteDb.exec reading the handle doc) races the
+    // doc-carrying storage response on a cold replica — piece-start sync
+    // (syncCellsForRunningPattern) covers node binding docs, not the docs
+    // behind link VALUES like a builtin's result handle. Steady-state this is
+    // ~free: covered selectors resolve without a server round trip.
+    const presyncInputs = module.argumentSchema !== undefined
+      ? async (event: any): Promise<void> => {
+        const eventInputs = {
+          ...(inputs as Record<string, any>),
+          $event: event,
+        };
+        const inputsCell = this.runtime.getImmutableCell(
+          processCell.space,
+          eventInputs,
+          undefined,
+        );
+        const argument = inputsCell.asSchema(module.argumentSchema!).get();
+        const promises: Promise<unknown>[] = [];
+        const seen = new Set<unknown>();
+        const collect = (value: unknown, depth: number): void => {
+          if (depth > 16) return;
+          if (isCell(value)) {
+            const maybePromise = value.sync();
+            if (maybePromise instanceof Promise) promises.push(maybePromise);
+            return;
+          }
+          // NOTE: materialized records all carry the back-to-cell symbol, so
+          // there is no cheap way to tell a lazy query-result proxy from an
+          // annotated plain object — descend both. Property access on a proxy
+          // is an ambient local read (it may kick off, but never await, a
+          // sync); guard each access so one lazy read failing doesn't abort
+          // the rest of the presync.
+          if (!isRecord(value)) return;
+          if (seen.has(value)) return;
+          seen.add(value);
+          for (const key of Object.keys(value)) {
+            try {
+              collect((value as Record<string, unknown>)[key], depth + 1);
+            } catch {
+              // A lazy read through a not-yet-synced link may throw; skip.
+            }
+          }
+        };
+        collect(argument, 0);
+        await Promise.all(promises);
+      }
+      : undefined;
+
     const wrappedHandler = Object.assign(handler, {
       reads,
       writes,
       module,
       pattern,
+      ...(presyncInputs !== undefined && { presyncInputs }),
     });
 
     const schedulerReads = this.collectArgumentSchedulerReadLinks(

--- a/packages/runner/src/scheduler/events.ts
+++ b/packages/runner/src/scheduler/events.ts
@@ -426,6 +426,21 @@ export async function dispatchQueuedEvent(state: {
   });
   state.eventQueue.shift();
 
+  // Ensure the handler's input docs are locally available before the body
+  // runs (see EventHandler.presyncInputs). Fail open: a presync error should
+  // surface as the handler's own read failure, not silently drop the event.
+  if (typeof handler.presyncInputs === "function") {
+    try {
+      await handler.presyncInputs(eventValue);
+    } catch (error) {
+      logger.warn(
+        "scheduler",
+        "handler input presync failed; dispatching anyway",
+        { error, handlerId },
+      );
+    }
+  }
+
   const tx = state.runtime.edit();
   tx.tx.immediate = true;
   const actionId = state.getActionId(action);

--- a/packages/runner/src/scheduler/types.ts
+++ b/packages/runner/src/scheduler/types.ts
@@ -44,6 +44,15 @@ export type EventHandler =
       tx: IExtendedStorageTransaction,
       event: any,
     ) => void;
+    /**
+     * Optional callback to ensure the handler's input docs are locally
+     * available before the handler body runs. A handler reads its asCell
+     * inputs (e.g. a SqliteDb handle) synchronously from the local replica;
+     * the scheduler awaits this before dispatching the event so those reads
+     * don't race the doc-carrying storage responses. The event is passed so
+     * inputs reachable only through the event can be covered too.
+     */
+    presyncInputs?: (event: any) => Promise<void>;
   };
 export type AnnotatedEventHandler = EventHandler & TelemetryAnnotations;
 

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -1176,21 +1176,37 @@ class SpaceReplica implements ISpaceReplica {
       promise: Promise.resolve({ ok: {} } as Result<Unit, PullError>),
     };
     const cfc = new ContextualFlowControl();
+    // Entries covered by an already-registered selector are not re-fetched,
+    // but the covering watch may still be IN FLIGHT. A sync's contract is
+    // "resolved means the data is locally available", so collect the covering
+    // promises and await them — returning early here would let a caller (e.g.
+    // handler-input presync) proceed before the doc-carrying response lands.
+    // For coverage registered by a long-settled watch the promise is already
+    // resolved and the await is a no-op.
+    const coveredInFlight: Promise<Result<Unit, PullError>>[] = [];
     const newEntries = normalizedEntries.filter(([address, selector]) => {
       const baseAddress = {
         id: address.id,
         type: DOCUMENT_MIME,
         scope: normalizeCellScope(address.scope),
       };
-      const [superset] = this.#watchSelectorTracker.getSupersetSelector(
-        baseAddress,
-        selector,
-        cfc,
-      );
+      const [superset, supersetPromise] = this.#watchSelectorTracker
+        .getSupersetSelector(
+          baseAddress,
+          selector,
+          cfc,
+        );
+      if (superset !== undefined && supersetPromise !== undefined) {
+        coveredInFlight.push(supersetPromise);
+      }
       return superset === undefined;
     });
     if (newEntries.length === 0) {
-      return { ok: {} };
+      if (coveredInFlight.length === 0) {
+        return { ok: {} };
+      }
+      const results = await Promise.all(coveredInFlight);
+      return results.find((result) => result.error) ?? { ok: {} };
     }
     task.entries = newEntries;
     this.#syncTasks.set(key, task);
@@ -1210,7 +1226,14 @@ class SpaceReplica implements ISpaceReplica {
     }
     this.#syncPromises.add(promise);
     try {
-      return await promise;
+      const result = await promise;
+      if (result.error || coveredInFlight.length === 0) {
+        return result;
+      }
+      // Mixed batch: some entries fetched here, others covered by in-flight
+      // watches. Resolve only when ALL requested docs are locally available.
+      const covered = await Promise.all(coveredInFlight);
+      return covered.find((coveredResult) => coveredResult.error) ?? result;
     } finally {
       this.#syncTasks.delete(key);
       this.#syncPromises.delete(promise);

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -1210,34 +1210,48 @@ class SpaceReplica implements ISpaceReplica {
     }
     task.entries = newEntries;
     this.#syncTasks.set(key, task);
-    const promise = this.enqueueWatchRefresh("pull", newEntries);
-    task.promise = promise;
+    const fetchPromise = this.enqueueWatchRefresh("pull", newEntries);
+    // Mixed batch: some entries fetched here, others covered by in-flight
+    // watches. The pull resolves only when ALL requested docs are locally
+    // available, and concurrent same-key callers dedupe onto this COMBINED
+    // wait (joining only `fetchPromise` would let them resolve before the
+    // covered docs land).
+    const combinedPromise = coveredInFlight.length === 0
+      ? fetchPromise
+      : (async (): Promise<Result<Unit, PullError>> => {
+        const result = await fetchPromise;
+        if (result.error) {
+          return result;
+        }
+        const covered = await Promise.all(coveredInFlight);
+        return covered.find((coveredResult) => coveredResult.error) ?? result;
+      })();
+    task.promise = combinedPromise;
     for (const [address, selector] of newEntries) {
       const baseAddress = {
         id: address.id,
         type: DOCUMENT_MIME,
         scope: normalizeCellScope(address.scope),
       };
+      // The tracker promise is what FUTURE pulls covered by these selectors
+      // await: their data is available once THIS fetch lands, independent of
+      // this batch's own covered set — so register the raw fetch promise.
       this.#watchSelectorTracker.add(
         baseAddress,
         selector,
-        promise,
+        fetchPromise,
       );
     }
-    this.#syncPromises.add(promise);
+    this.#syncPromises.add(combinedPromise);
     try {
-      const result = await promise;
-      if (result.error || coveredInFlight.length === 0) {
-        return result;
-      }
-      // Mixed batch: some entries fetched here, others covered by in-flight
-      // watches. Resolve only when ALL requested docs are locally available.
-      const covered = await Promise.all(coveredInFlight);
-      return covered.find((coveredResult) => coveredResult.error) ?? result;
+      return await combinedPromise;
     } finally {
       this.#syncTasks.delete(key);
-      this.#syncPromises.delete(promise);
-      const result = await Promise.resolve(task.promise);
+      this.#syncPromises.delete(combinedPromise);
+      // Tracker cleanup is keyed on THIS batch's fetch result alone: a
+      // failure in a covered watch belongs to the pull that registered it,
+      // and must not invalidate selectors whose fetch succeeded here.
+      const result = await fetchPromise;
       if (result.error) {
         for (const [address, selector] of newEntries) {
           const baseAddress = {

--- a/packages/runner/test/scheduler-events.test.ts
+++ b/packages/runner/test/scheduler-events.test.ts
@@ -100,6 +100,90 @@ describe("event handling", () => {
     expect(eventResultCell.get()).toBe(2);
   });
 
+  it("awaits presyncInputs before running the handler body", async () => {
+    const eventCell = runtime.getCell<number>(
+      space,
+      "presync before handler 1",
+      undefined,
+      tx,
+    );
+    eventCell.set(0);
+    const eventResultCell = runtime.getCell<number>(
+      space,
+      "presync before handler 2",
+      undefined,
+      tx,
+    );
+    eventResultCell.set(0);
+    tx.commit();
+
+    const order: string[] = [];
+    let releasePresync!: () => void;
+    const presyncDone = new Promise<void>((resolve) => {
+      releasePresync = resolve;
+    });
+
+    const eventHandler: EventHandler = (tx, event) => {
+      order.push("handler");
+      eventResultCell.withTx(tx).send(event);
+    };
+    eventHandler.presyncInputs = async (event) => {
+      order.push(`presync:${event}`);
+      await presyncDone;
+      order.push("presync-resolved");
+    };
+
+    runtime.scheduler.addEventHandler(
+      eventHandler,
+      eventCell.getAsNormalizedFullLink(),
+    );
+    runtime.scheduler.queueEvent(eventCell.getAsNormalizedFullLink(), 7);
+
+    // Give the scheduler a chance to dispatch; the handler must not run while
+    // presync is pending.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(order).toEqual(["presync:7"]);
+
+    releasePresync();
+    await eventResultCell.pull();
+
+    expect(order).toEqual(["presync:7", "presync-resolved", "handler"]);
+    expect(eventResultCell.get()).toBe(7);
+  });
+
+  it("dispatches the handler even when presyncInputs rejects (fail open)", async () => {
+    const eventCell = runtime.getCell<number>(
+      space,
+      "presync fail open 1",
+      undefined,
+      tx,
+    );
+    eventCell.set(0);
+    const eventResultCell = runtime.getCell<number>(
+      space,
+      "presync fail open 2",
+      undefined,
+      tx,
+    );
+    eventResultCell.set(0);
+    tx.commit();
+
+    const eventHandler: EventHandler = (tx, event) => {
+      eventResultCell.withTx(tx).send(event);
+    };
+    eventHandler.presyncInputs = () =>
+      Promise.reject(new Error("presync boom"));
+
+    runtime.scheduler.addEventHandler(
+      eventHandler,
+      eventCell.getAsNormalizedFullLink(),
+    );
+    runtime.scheduler.queueEvent(eventCell.getAsNormalizedFullLink(), 3);
+
+    await eventResultCell.pull();
+    expect(eventResultCell.get()).toBe(3);
+  });
+
   it("should remove event handlers", async () => {
     const eventCell = runtime.getCell<number>(
       space,


### PR DESCRIPTION
**For Robin & Berni** — this is a worked exemplar of a runtime-level fix for an invariant gap we root-caused while debugging the lunch-poll SQLite deploy bug, offered to kickstart a design discussion. It is fully functional and verified, but the design choice deserves your eyes before it's a real candidate. Companion PR #3962 (CLI-side narrow unblock) describes the original bug; this PR addresses the underlying invariant.

## The invariant gap

A handler reads its asCell inputs (e.g. a `SqliteDb` handle) **synchronously** from the local replica, but nothing in the system guarantees those docs are locally available when the handler body runs:

- Piece-start sync (`syncCellsForRunningPattern`) covers node **binding** docs, not the docs behind link **values** — e.g. a builtin's result handle stored at its output spot. Instrumented on the failing pattern: 396 node cells synced, the handle doc never among them.
- The pulls kicked off during input materialization (`getRaw`/`get`'s non-awaited `this.sync()`) are connected to nothing.
- `pull()` had a second, subtler hole: an entry covered by an already-registered selector resolved **immediately**, even when the covering watch was still in flight — so even a caller that diligently awaited `cell.sync()` could proceed before the doc arrived.

On a cold client (`cf piece call`), the doc-carrying watch response loses the race against dispatch *deterministically on bulky patterns* (serialized watch batches delay it past `send()`): timing trace showed dispatch at T+20ms and the doc landing at T+152ms, after the scheduler had already burned its retry. Result: `db.exec` → "invalid database handle", 100% reproducible, only on deploy (the emulated runner's loopback storage always wins the race).

## Two candidate designs we considered

**A — pre-sync at dispatch (this PR, proactive).** Ensure inputs are present *before* the handler body runs:
1. `pull()` now awaits covering in-flight watch promises — restoring `sync()`'s contract that *resolved ⇒ data locally available*. No-op for settled coverage.
2. `EventHandler.presyncInputs` (built in `instantiateJavaScriptHandlerNode`): materialize the argument with the existing machinery — asCell fields surface as `Cell`s *without* reading their backing docs — walk the materialized structure, await `sync()` on each collected Cell.
3. `dispatchQueuedEvent` awaits `presyncInputs` before invoking, fail-open (a presync error surfaces as the handler's own read failure, not a dropped event).

**B — retry on unsynced read (reactive, not implemented).** Follow the `frame.pendingSpaceNames` → `resolvePendingSpaceNamesAndRetry` precedent: when a read like `.exec()` finds a doc that was *never received* (distinguishable in storage: no confirmed record, sync in flight), record it on the frame; abort, await the sync, requeue via the existing `RetryImmediately` machinery.

**Why we lean A:** it installs the invariant at the right anchor — "inputs synced at dispatch" — once, rather than teaching individual read sites to recover; B must be wired read-site by read-site (`.exec` first, then whatever's next) and re-runs cold handlers twice by design. B remains attractive as a *backstop* for anything A's enumeration misses (e.g. reads through lazy query-result proxies, which this presync deliberately treats as best-effort), and the two compose cleanly.

## Costs / open questions for you

- **Event latency:** dispatch now awaits presync. Steady-state it's ~free (covered selectors resolve in a microtask — measured single-dispatch, no retry, on the testbed), but a cold-replica event pays the sync round trip up front. Is that acceptable as a universal rule, or should it be opt-in per surface?
- **Proxy subtrees:** materialized records all carry the back-to-cell symbol, so the walk can't distinguish a lazy query-result proxy from an annotated plain object; it descends both with guarded property access. A cheap `isQueryResultProxy` predicate would make this exact.
- **`synced`-flag inheritance:** `validateAndTransform` propagates the parent's `synced` flag onto asCell children whose docs were never fetched — a white lie that also suppresses `getRaw`'s fallback re-sync. Harmless once dispatch presyncs, but worth tightening?
- Is the `pull()` covered-in-flight await (change 1) something you'd want **regardless** of A-vs-B? We believe yes — it's a contract fix on its own.

## Verification

- Testbed = main + lunch-poll SQLite pattern, **no** CLI workaround: `clearHistory`/`logVisit` go from 100% "invalid database handle" to passing; timing trace shows presync issuing the pull, awaiting it (61ms), then a single successful dispatch; rows verifiably land in (and are deleted from) the per-piece sqlite file across repeated fresh CLI sessions.
- Runner suite 553/553 (+2 new tests: presync-ordering, fail-open), `cf test` lunch-poll 17/17, CLI suite 43/43, fmt/lint/check clean.

Full investigation log: `session_outputs/2026-06-09_lunch-poll-sqlite-fresh-eyes/` (local to Gideon's machine); bug history in `SQLITE-DEPLOY-BUG.md` on `gideon/lunch-poll-sqlite-migration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pre-sync handler `asCell` inputs before dispatch so required docs are local, fixing cold-replica races (e.g. "invalid database handle"). Also make `sync()` reliable by awaiting in-flight coverage in storage `pull()` and deduping concurrent pulls on the full wait.

- **Bug Fixes**
  - Added optional `presyncInputs` on event handlers. It materializes the argument, collects `Cell`s, and awaits `sync()`. The scheduler awaits this before invoking, and fails open if it errors.
  - Updated storage `pull()` to enforce "resolved ⇒ data local." It awaits covering in-flight watches, waits for both fetched and covered entries in mixed batches, and dedupes concurrent same-key pulls onto that combined wait.
  - Added tests for presync ordering and fail-open behavior.

<sup>Written for commit de6e2078d7bf2b122d70e1aefa84ef8e78cd06e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---BEGIN COPY-PASTE---
NEW_PERF_BASELINE: step: Type check = 88s
NEW_PERF_BASELINE: job: Check = 115s
---END COPY-PASTE---