### PR TITLE
Migrate example patterns from free-text name joins to the shared-profile wish flow

### DIFF
--- a/docs/common/ai/pattern-testing-guide.md
+++ b/docs/common/ai/pattern-testing-guide.md
@@ -157,9 +157,26 @@ Key points:
   state may still be propagating from another runtime — don't assert
   "other user does NOT see X yet" right after the other user acted; assert
   stable invariants instead.
+- Pattern outputs a participant asserts on must be computed snapshots that
+  always yield a REAL, STABLE value. In a runtime that didn't write the
+  underlying scoped cell, the cell reads as `undefined` — and a computed that
+  returns `undefined` (or a fresh `[]` per recompute) is indistinguishable
+  from "not yet computed" for cross-runtime readers, so the assertion never
+  settles. Normalize inside the computed (`trimmedName(name.get())`,
+  `cell.get() ?? EMPTY_LIST` with a module-level constant).
+- Read another runtime's arrays with INLINE literal indexing in the assertion
+  computed (`users?.[0]?.name === "Alice"`). `.map()`, loop-variable
+  indexing, and module-level helper calls over the array resolve in the
+  runtime that wrote it but NOT cross-runtime before a local write.
+- A participant cannot read their own never-written `PerUser` array (e.g. an
+  empty rack before joining); assert pre-join isolation via normalized
+  primitives (`myName === ""`) instead.
 - The example to copy:
-  `packages/patterns/cfc-group-chat-demo/multi-user.test.tsx`. The scope
-  model background: `docs/common/patterns/multi-user-patterns.md` and
+  `packages/patterns/cfc-group-chat-demo/multi-user.test.tsx`; for the
+  output-snapshot and inline-read idioms see
+  `packages/patterns/scrabble/multi-user.test.tsx` and
+  `packages/patterns/lunch-poll/multi-user.test.tsx`. The scope model
+  background: `docs/common/patterns/multi-user-patterns.md` and
   `docs/development/debugging/gotchas/scoped-cell-pitfalls.md`.
 
 ## Testing Time and Randomness

--- a/docs/common/patterns/multi-user-patterns.md
+++ b/docs/common/patterns/multi-user-patterns.md
@@ -196,6 +196,17 @@ remember which entry is theirs. For simpler demos where names are immutable and
 unique enough for the domain, a `PerUser<string>` display name plus shared
 records that carry that name can also be acceptable.
 
+Source the display name and avatar from the viewer's **shared profile** rather
+than a free-text field: `wish({ query: "#profile" })` resolves the current
+viewer's profile, and its built-in `[UI]` covers the whole lifecycle (create
+surface when the user has no profile, a picker with inline create when they
+have several). Snapshot the resolved `#profileName` / `#profileAvatar` strings
+into the shared entry on join. See `docs/specs/shared-profile-rosters.md`;
+worked examples: `packages/patterns/profile-group-chat/main.tsx`,
+`packages/patterns/scrabble/scrabble.tsx`,
+`packages/patterns/battleship/multiplayer/lobby.tsx`,
+`packages/patterns/lunch-poll/main.tsx`.
+
 Do not store user DIDs, session ids, or generated ids only to simulate scoped
 visibility. Let `PerUser<T>` and `PerSession<T>` select the right storage
 instance. When comparing object or cell identity, use `equals()` instead of

--- a/docs/development/debugging/gotchas/closure-capture-in-nested-map.md
+++ b/docs/development/debugging/gotchas/closure-capture-in-nested-map.md
@@ -109,9 +109,10 @@ const peopleNames = computed(() =>
 ```
 
 The receiver is now an OpaqueRef again; the transformer rewrites the inner
-`.map`. Shipping example:
-`packages/patterns/factory-outputs/lot-watch/main.tsx:1443-1447`
-(definition) consumed at `:2110-2118`.
+`.map`. Shipping example: `packages/patterns/factory-outputs/lot-watch/main.tsx`
+— the hoisted `people` receiver, consumed inside the sightings rows by the
+quick-pick chips
+(`people.map((p) => … setAssignPersonName.send({ name: p.name }))`).
 
 ### C — Local `computed()` bridge inside the row callback
 

--- a/docs/specs/shared-profile-rosters.md
+++ b/docs/specs/shared-profile-rosters.md
@@ -39,11 +39,12 @@ contribute their own entry when they join**:
 - Every other user renders names and avatars straight from `participants`. No
   cross-user profile enumeration is ever required.
 
-This is the same shape already used by `packages/patterns/scrabble/scrabble.tsx`
+This is the same shape used by `packages/patterns/scrabble/scrabble.tsx`
 (a `PerSpace` `players` roster + a join handler that `push`es the current
-player) and `packages/patterns/scoped-user-directory/main.tsx` (a `PerSpace`
-`directory` + a `PerUser` `me` pointer). The only addition here is sourcing the
-display name/avatar from the shared profile instead of a free-text field.
+player — its join now sources name/avatar from the shared profile this way) and
+`packages/patterns/scoped-user-directory/main.tsx` (a `PerSpace` `directory` +
+a `PerUser` `me` pointer). The only addition here is sourcing the display
+name/avatar from the shared profile instead of a free-text field.
 
 ## Why links vs snapshots
 

--- a/docs/specs/shared-profile-rosters.md
+++ b/docs/specs/shared-profile-rosters.md
@@ -118,8 +118,10 @@ reachable. Every API used below is exercised elsewhere in the repo:
   `packages/patterns/scoped-group-chat/main-plain-inputs.tsx`.
 - `safeDateNow()` for timestamps in handlers —
   `packages/patterns/scoped-group-chat/main-plain-inputs.tsx`.
-- `<img src={...}>` avatar rendering —
-  `packages/patterns/group-chat-room.tsx`.
+- avatar rendering from snapshot strings — `<img src={...}>` here for
+  self-containment; production patterns use `<cf-avatar src name>`
+  (`packages/patterns/group-chat-room.tsx`,
+  `packages/patterns/profile-group-chat/main.tsx`).
 
 ```tsx
 import {

--- a/packages/patterns/battleship/multiplayer/lobby.tsx
+++ b/packages/patterns/battleship/multiplayer/lobby.tsx
@@ -41,7 +41,7 @@ import {
   trimmedName,
 } from "./schemas.tsx";
 
-interface LobbyOutput {
+export interface LobbyOutput {
   [UI]: PerSession<VNode>;
   gameName: string;
   player1: PlayerData | null;
@@ -428,7 +428,11 @@ const BattleshipLobby = pattern<LobbyState, LobbyOutput>(
       player2: player2Data,
       shots: computed(() => shots.get()),
       gameState: computed(() => gameState.get()),
-      myName: computed(() => myName.get()),
+      // Normalize like myPlayerNumber below: an unwritten PerUser cell reads
+      // as undefined in runtimes that didn't create the instance, and a
+      // computed that RETURNS undefined is indistinguishable from "not yet
+      // computed" for cross-runtime readers.
+      myName: computed(() => trimmedName(myName.get())),
       myPlayerNumber: computed(() =>
         normalizePlayerNumber(myPlayerNumber.get())
       ),

--- a/packages/patterns/battleship/multiplayer/lobby.tsx
+++ b/packages/patterns/battleship/multiplayer/lobby.tsx
@@ -1,8 +1,12 @@
 /**
  * Battleship Multiplayer
  *
- * A single shared game surface. Shared match state is scoped to the space, while
- * each viewer's name and assigned player slot are scoped per user.
+ * A single shared game surface. Shared match state is scoped to the space,
+ * while each viewer's assigned player slot is scoped per user. The viewer's
+ * name and avatar come from their shared profile
+ * (`wish({ query: "#profile" })`): the wish's built-in UI lets them pick an
+ * existing profile or create a new one, and joining snapshots the resolved
+ * values into the shared player slot.
  */
 
 import {
@@ -15,6 +19,7 @@ import {
   Stream,
   UI,
   type VNode,
+  wish,
 } from "commonfabric";
 
 import BattleshipRoom from "./room.tsx";
@@ -73,6 +78,7 @@ const startIfReady = (
 const joinSlot = (
   slot: 1 | 2,
   name: string,
+  avatar: string,
   player1: PlayerCell,
   player2: PlayerCell,
   shots: ShotsCell,
@@ -80,6 +86,7 @@ const joinSlot = (
 ) => {
   const playerData: PlayerData = {
     name,
+    avatar,
     ships: generateRandomShips(),
     color: getRandomColor(slot - 1),
     joinedAt: safeDateNow(),
@@ -96,6 +103,7 @@ const joinSlot = (
 
 const joinAvailableSlot = (
   name: string,
+  avatar: string,
   myName: PlayerNameCell,
   myPlayerNumber: PlayerNumberCell,
   player1: PlayerCell,
@@ -116,16 +124,19 @@ const joinAvailableSlot = (
   const slot = !player1.get() ? 1 : !player2.get() ? 2 : null;
   if (slot === null) return false;
 
-  joinSlot(slot, name, player1, player2, shots, gameState);
+  joinSlot(slot, name, avatar, player1, player2, shots, gameState);
   myName.set(name);
   myPlayerNumber.set(slot);
   return true;
 };
 
+// Join with the viewer's resolved profile. `name`/`avatar` arrive as plain
+// strings (named `computed` values auto-unwrap as handler state).
 const joinGame = handler<
   void,
   {
-    joinName: PlayerNameCell;
+    name: string;
+    avatar: string;
     myName: PlayerNameCell;
     myPlayerNumber: PlayerNumberCell;
     player1: PlayerCell;
@@ -135,24 +146,21 @@ const joinGame = handler<
   }
 >((
   _event,
-  { joinName, myName, myPlayerNumber, player1, player2, shots, gameState },
+  { name, avatar, myName, myPlayerNumber, player1, player2, shots, gameState },
 ) => {
-  const name = trimmedName(joinName.get());
-  if (!name) return;
+  const trimmed = trimmedName(name);
+  if (!trimmed) return; // No resolved profile name yet.
 
-  if (
-    joinAvailableSlot(
-      name,
-      myName,
-      myPlayerNumber,
-      player1,
-      player2,
-      shots,
-      gameState,
-    )
-  ) {
-    joinName.set("");
-  }
+  joinAvailableSlot(
+    trimmed,
+    (avatar ?? "").trim(),
+    myName,
+    myPlayerNumber,
+    player1,
+    player2,
+    shots,
+    gameState,
+  );
 });
 
 const joinWithName = handler<
@@ -173,6 +181,7 @@ const joinWithName = handler<
   if (!trimmed) return;
   joinAvailableSlot(
     trimmed,
+    "",
     myName,
     myPlayerNumber,
     player1,
@@ -194,7 +203,7 @@ const joinPlayer = handler<
 >(({ name }, { slot, player1, player2, shots, gameState }) => {
   const trimmed = trimmedName(name);
   if (!trimmed) return;
-  joinSlot(slot, trimmed, player1, player2, shots, gameState);
+  joinSlot(slot, trimmed, "", player1, player2, shots, gameState);
 });
 
 const resetGame = handler<
@@ -206,11 +215,10 @@ const resetGame = handler<
     gameState: GameStateCell;
     myName: PlayerNameCell;
     myPlayerNumber: PlayerNumberCell;
-    joinName: PlayerNameCell;
   }
 >((
   _event,
-  { player1, player2, shots, gameState, myName, myPlayerNumber, joinName },
+  { player1, player2, shots, gameState, myName, myPlayerNumber },
 ) => {
   player1.set(null);
   player2.set(null);
@@ -218,7 +226,6 @@ const resetGame = handler<
   gameState.set(INITIAL_GAME_STATE);
   myName.set("");
   myPlayerNumber.set(null);
-  joinName.set("");
 });
 
 const BattleshipLobby = pattern<LobbyState, LobbyOutput>(
@@ -231,12 +238,31 @@ const BattleshipLobby = pattern<LobbyState, LobbyOutput>(
       gameState,
       myName,
       myPlayerNumber,
-      joinName,
     },
   ) => {
+    // Resolve THIS viewer's shared profile. The `#profile` wish's built-in UI
+    // covers the whole lifecycle: a create surface when the viewer has no
+    // profile, a link when they have one, and a picker (with inline create)
+    // when they have several. The field targets give the snapshot strings.
+    const profileWish = wish<{ name?: string; avatar?: string }>({
+      query: "#profile",
+    });
+    const profileNameWish = wish<string>({ query: "#profileName" });
+    const profileAvatarWish = wish<string>({ query: "#profileAvatar" });
+
+    const profileName = computed(() => profileNameWish.result ?? "");
+    const profileAvatar = computed(() => profileAvatarWish.result ?? "");
+    const hasProfile = computed(() =>
+      (profileNameWish.result ?? "").trim() !== ""
+    );
+    const joinLabel = computed(() =>
+      hasProfile ? `Join as ${profileName}` : "Create a profile to join"
+    );
+
     const sharedCells = { player1, player2, shots, gameState };
     const join = joinGame({
-      joinName,
+      name: profileName,
+      avatar: profileAvatar,
       myName,
       myPlayerNumber,
       ...sharedCells,
@@ -258,7 +284,6 @@ const BattleshipLobby = pattern<LobbyState, LobbyOutput>(
       ...sharedCells,
       myName,
       myPlayerNumber,
-      joinName,
     } as any);
 
     const room = BattleshipRoom({
@@ -329,10 +354,32 @@ const BattleshipLobby = pattern<LobbyState, LobbyOutput>(
                     marginBottom: "20px",
                   }}
                 >
-                  <div>
+                  <div
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: "8px",
+                    }}
+                  >
+                    <cf-avatar
+                      src={player1Data?.avatar}
+                      name={player1Data?.name ?? "?"}
+                      size="xs"
+                    />
                     Player 1: {player1Data?.name ?? "Open"}
                   </div>
-                  <div>
+                  <div
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: "8px",
+                    }}
+                  >
+                    <cf-avatar
+                      src={player2Data?.avatar}
+                      name={player2Data?.name ?? "?"}
+                      size="xs"
+                    />
                     Player 2: {player2Data?.name ?? "Open"}
                   </div>
                 </div>
@@ -346,18 +393,21 @@ const BattleshipLobby = pattern<LobbyState, LobbyOutput>(
                   : (
                     <div
                       style={{
-                        display: "flex",
+                        display: "grid",
                         gap: "10px",
-                        alignItems: "center",
                       }}
                     >
-                      <cf-input
-                        $value={joinName}
-                        placeholder="Your name"
-                        timing-strategy="immediate"
-                        style="flex: 1;"
-                      />
-                      <cf-button onClick={join}>Join</cf-button>
+                      {
+                        /* Built-in profile UI: create a profile when there is
+                          none, pick between existing profiles otherwise. */
+                      }
+                      <div>{profileWish[UI]}</div>
+                      <cf-button
+                        onClick={join}
+                        disabled={computed(() => !hasProfile)}
+                      >
+                        {joinLabel}
+                      </cf-button>
                     </div>
                   )}
 

--- a/packages/patterns/battleship/multiplayer/multi-user.test.tsx
+++ b/packages/patterns/battleship/multiplayer/multi-user.test.tsx
@@ -1,0 +1,95 @@
+/// <cts-enable />
+/**
+ * Multi-user pattern test for the battleship multiplayer lobby.
+ *
+ * Unlike lobby.test.tsx (one runtime driving both slots from a single
+ * identity), this runs ONE shared lobby instance across two worker-isolated
+ * runtimes — so the PerUser slot assignment (`myName` / `myPlayerNumber`)
+ * and cross-runtime propagation of the shared match state are actually
+ * exercised: two real users land in two different slots.
+ *
+ * Joins go through the programmatic `joinWithName` stream (the headless seam
+ * kept by the profile migration); the profile-wish UI path needs a browser.
+ */
+import { action, computed, multiUserTest, pattern } from "commonfabric";
+import BattleshipLobby, { type LobbyOutput } from "./lobby.tsx";
+
+interface Setup {
+  lobby: LobbyOutput;
+}
+
+export const setup = pattern(() => ({
+  lobby: BattleshipLobby({}),
+}));
+
+export const alice = pattern<{ setup: Setup }>(({ setup }) => {
+  const lobby = setup.lobby;
+
+  const action_join = action(() => {
+    lobby.joinWithName.send("Alice");
+  });
+
+  const assert_joined_slot_1 = computed(() =>
+    lobby.myName === "Alice" &&
+    lobby.myPlayerNumber === 1 &&
+    lobby.player1?.name === "Alice"
+  );
+  const assert_game_started = computed(() =>
+    lobby.player2?.name === "Bob" &&
+    lobby.gameState.phase === "playing" &&
+    lobby.gameState.currentTurn === 1
+  );
+  // Bob joining must not clobber Alice's PerUser slot assignment.
+  const assert_slot_unchanged = computed(() =>
+    lobby.myName === "Alice" && lobby.myPlayerNumber === 1
+  );
+
+  return {
+    tests: [
+      { action: action_join },
+      { assertion: assert_joined_slot_1 },
+      { label: "alice-joined" },
+      { await: "bob-joined" },
+      { assertion: assert_game_started },
+      { assertion: assert_slot_unchanged },
+    ],
+  };
+});
+
+export const bob = pattern<{ setup: Setup }>(({ setup }) => {
+  const lobby = setup.lobby;
+
+  const action_join = action(() => {
+    lobby.joinWithName.send("Bob");
+  });
+
+  // Shared slot propagated from Alice's runtime.
+  const assert_sees_alice = computed(() => lobby.player1?.name === "Alice");
+  // PerUser isolation: Alice's join must not leak into Bob's identity cells
+  // (unwritten PerUser cells may read as undefined in a fresh runtime).
+  const assert_not_joined_yet = computed(() =>
+    (lobby.myName ?? "") === "" && (lobby.myPlayerNumber ?? null) === null
+  );
+  const assert_joined_slot_2 = computed(() =>
+    lobby.myName === "Bob" &&
+    lobby.myPlayerNumber === 2 &&
+    lobby.player2?.name === "Bob"
+  );
+  const assert_game_started = computed(() =>
+    lobby.gameState.phase === "playing" && lobby.gameState.currentTurn === 1
+  );
+
+  return {
+    tests: [
+      { await: "alice-joined" },
+      { assertion: assert_sees_alice },
+      { assertion: assert_not_joined_yet },
+      { action: action_join },
+      { assertion: assert_joined_slot_2 },
+      { assertion: assert_game_started },
+      { label: "bob-joined" },
+    ],
+  };
+});
+
+export default multiUserTest({ setup, participants: { alice, bob } });

--- a/packages/patterns/battleship/multiplayer/schemas.tsx
+++ b/packages/patterns/battleship/multiplayer/schemas.tsx
@@ -61,6 +61,8 @@ import { createEmptyGrid } from "../shared/index.tsx";
 
 export interface PlayerData {
   name: string;
+  /** Avatar URL or glyph, snapshotted from the joiner's shared profile. */
+  avatar?: string;
   ships: Ship[];
   color: string;
   joinedAt: number;
@@ -126,8 +128,9 @@ export function trimmedName(value: string | undefined): string {
 // ============ PATTERN INPUT/OUTPUT TYPES ============
 
 /**
- * Shared match state is per-space; viewer identity and join-form text are
- * scoped separately so the entry pattern does not need a navigation lobby.
+ * Shared match state is per-space; viewer identity is scoped per user. The
+ * join name/avatar come from the viewer's shared profile (resolved via
+ * `wish({ query: "#profile" })` in the lobby), so there is no join-form text.
  */
 export interface LobbyState {
   gameName?: PerSpace<string | Default<"Battleship">>;
@@ -137,7 +140,6 @@ export interface LobbyState {
   gameState?: PerSpace<GameStateCell>;
   myName?: PerUser<PlayerNameCell>;
   myPlayerNumber?: PerUser<PlayerNumberCell>;
-  joinName?: PerSession<PlayerNameCell>;
 }
 
 /**

--- a/packages/patterns/cozy-poll/main.test.tsx
+++ b/packages/patterns/cozy-poll/main.test.tsx
@@ -4,10 +4,11 @@
  * Exercises the scope idioms (per-space directory, per-user identity,
  * derived admin) and the core voting flows.
  *
- * Single-identity caveat (CT-1598): the test framework dispatches every
- * action from one identity, so we cannot simulate a second user. Admin
- * gating is exercised by attempting admin actions *before* any join
- * (myName empty → handler bails).
+ * Single-identity caveat (CT-1598): this file runs in one runtime with one
+ * identity, so admin gating is exercised by attempting admin actions *before*
+ * any join (myName empty → handler bails). The real second-user cases —
+ * gating against a non-host user, host takeover, cross-runtime visibility —
+ * are covered by multi-user.test.tsx.
  */
 
 import { action, computed, pattern } from "commonfabric";
@@ -75,8 +76,8 @@ export default pattern(() => {
     if (first) poll.removeOption.send({ optionId: first.id });
   });
 
-  // Single-identity caveat (CT-1598): we can't simulate a *second* user, so
-  // host *takeover* can't be exercised. This just confirms claimHost is wired
+  // Single-identity caveat (CT-1598): host *takeover* needs a second user and
+  // is covered by multi-user.test.tsx. This just confirms claimHost is wired
   // and is a harmless no-op when the caller already holds the role.
   const action_claim_host = action(() => {
     poll.claimHost.send({});

--- a/packages/patterns/cozy-poll/main.tsx
+++ b/packages/patterns/cozy-poll/main.tsx
@@ -357,6 +357,12 @@ export interface CozyPollOutput {
   resetVotes: Stream<ResetVotesEvent>;
 }
 
+// Stable empty fallbacks for the output snapshots below — fresh `[]` per
+// recompute would make the computed results non-idempotent.
+const EMPTY_OPTIONS: Option[] = [];
+const EMPTY_VOTES: Vote[] = [];
+const EMPTY_USERS: User[] = [];
+
 export default pattern<CozyPollInput, CozyPollOutput>(
   (
     {
@@ -1165,11 +1171,17 @@ export default pattern<CozyPollInput, CozyPollOutput>(
         </cf-theme>
       ),
       question,
-      options,
-      votes,
-      users,
-      adminName,
-      myName,
+      // Output snapshots readable from OTHER runtimes (multi-user tests,
+      // remote viewers): raw scoped values read as undefined in runtimes that
+      // didn't write them, and a computed that RETURNS undefined is
+      // indistinguishable from "not yet computed" for cross-runtime readers —
+      // so every snapshot yields a real, stable value (the shared EMPTY
+      // constants keep the fallback idempotent across recomputes).
+      options: computed(() => options ?? EMPTY_OPTIONS),
+      votes: computed(() => votes ?? EMPTY_VOTES),
+      users: computed(() => users ?? EMPTY_USERS),
+      adminName: computed(() => trimmedName(adminName)),
+      myName: computed(() => trimmedName(myName)),
       userCount,
       optionCount,
       voteCount,

--- a/packages/patterns/cozy-poll/main.tsx
+++ b/packages/patterns/cozy-poll/main.tsx
@@ -9,7 +9,10 @@
  * Identity follows the scrabble idiom:
  * - `users` is a per-space directory of joined participants.
  * - Each viewer's `myName` is per-user; it is set once on join and treated as
- *   immutable thereafter.
+ *   immutable thereafter. The join name/avatar come from the viewer's shared
+ *   profile (`wish({ query: "#profile" })` — its built-in UI covers profile
+ *   create/pick); programmatic callers can still pass an explicit name in the
+ *   `joinAs` event.
  * - The first joiner's name is captured into `adminName` (per-space). They can
  *   add/remove options and reset votes. `isAdmin` is derived, not stored.
  * - Open host takeover: any joined participant can `claimHost`, transferring
@@ -30,11 +33,14 @@ import {
   Stream,
   UI,
   type VNode,
+  wish,
   Writable,
 } from "commonfabric";
 
 export interface User {
   name: string;
+  /** Avatar URL or glyph, snapshotted from the joiner's shared profile. */
+  avatar?: string;
   color: string;
   joinedAt: number;
 }
@@ -142,13 +148,19 @@ const getInitials = (name: string): string => {
   );
 };
 
+// `profileName`/`profileAvatar` arrive as plain strings resolved from the
+// viewer's shared profile (named `computed` values auto-unwrap as handler
+// state). An explicit `name` in the event (tests, headless drivers) overrides
+// the profile name — and then deliberately skips the profile avatar.
 const joinAs = handler<JoinEvent, {
   users: UsersCell;
   myName: NameCell;
   adminName: NameCell;
-  joinName: NameCell;
-}>(({ name }, { users, myName, adminName, joinName }) => {
-  const trimmed = trimmedName(name ?? joinName.get());
+  profileName: string;
+  profileAvatar: string;
+}>(({ name }, { users, myName, adminName, profileName, profileAvatar }) => {
+  const override = trimmedName(name);
+  const trimmed = override || trimmedName(profileName);
   if (!trimmed) return;
   const current = trimmedName(myName.get());
   if (current) return;
@@ -156,12 +168,12 @@ const joinAs = handler<JoinEvent, {
   if (existing.some((u) => u.name === trimmed)) return;
   const user: User = {
     name: trimmed,
+    avatar: override ? "" : (profileAvatar ?? "").trim(),
     color: colorForIndex(existing.length),
     joinedAt: safeDateNow(),
   };
   users.push(user);
   myName.set(trimmed);
-  joinName.set("");
   if (trimmedName(adminName.get()) === "") {
     adminName.set(trimmed);
   }
@@ -318,7 +330,7 @@ export interface CozyPollInput {
   users?: PerSpace<User[] | Default<[]>>;
   adminName?: PerSpace<string | Default<"">>;
   myName?: PerUser<string | Default<"">>;
-  // joinName + optionDraft are internal form drafts, declared as local
+  // optionDraft etc. are internal form drafts, declared as local
   // per-session cells in the pattern body (parking-coordinator idiom).
 }
 
@@ -359,7 +371,6 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     // Internal per-session form drafts — local to each browser session,
     // not exposed as pattern inputs. Uses the scoped-constructor idiom
     // introduced by parking-coordinator (PR #3610).
-    const joinName = Writable.perSession.of<string>("");
     const optionDraft = Writable.perSession.of<string>("");
     // Two-step confirmation for destructive actions. Stores the optionId
     // pending remove-confirm (null = nothing pending). Same idiom as
@@ -370,7 +381,32 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     // way until a non-host clicks the "Hosted by …" label.
     const claimHostRevealed = Writable.perSession.of<boolean>(false);
 
-    const boundJoin = joinAs({ users, myName, adminName, joinName });
+    // Resolve THIS viewer's shared profile. The `#profile` wish's built-in UI
+    // covers the whole lifecycle: a create surface when the viewer has no
+    // profile, a link when they have one, and a picker (with inline create)
+    // when they have several. The field targets give the snapshot strings.
+    const profileWish = wish<{ name?: string; avatar?: string }>({
+      query: "#profile",
+    });
+    const profileNameWish = wish<string>({ query: "#profileName" });
+    const profileAvatarWish = wish<string>({ query: "#profileAvatar" });
+
+    const profileName = computed(() => profileNameWish.result ?? "");
+    const profileAvatar = computed(() => profileAvatarWish.result ?? "");
+    const hasProfile = computed(() =>
+      (profileNameWish.result ?? "").trim() !== ""
+    );
+    const joinLabel = computed(() =>
+      hasProfile ? `Join as ${profileName}` : "Create a profile to join"
+    );
+
+    const boundJoin = joinAs({
+      users,
+      myName,
+      adminName,
+      profileName,
+      profileAvatar,
+    });
     const boundClaimHost = claimHost({ myName, adminName });
     const boundAddOption = addOption({
       options,
@@ -577,18 +613,21 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                     <div
                       style={{
                         display: "flex",
+                        flexDirection: "column",
                         gap: "8px",
-                        alignItems: "center",
                       }}
                     >
-                      <cf-input
-                        $value={joinName}
-                        placeholder="Your name"
-                        aria-label="Your name"
-                        timing-strategy="immediate"
-                        style="flex:1"
-                      />
-                      <cf-button onClick={boundJoin}>Join</cf-button>
+                      {
+                        /* Built-in profile UI: create a profile when there is
+                          none, pick between existing profiles otherwise. */
+                      }
+                      <div>{profileWish[UI]}</div>
+                      <cf-button
+                        onClick={boundJoin}
+                        disabled={computed(() => !hasProfile)}
+                      >
+                        {joinLabel}
+                      </cf-button>
                     </div>
                   </div>
                 )}

--- a/packages/patterns/cozy-poll/multi-user.test.tsx
+++ b/packages/patterns/cozy-poll/multi-user.test.tsx
@@ -1,0 +1,143 @@
+/// <cts-enable />
+/**
+ * Multi-user pattern test for cozy poll.
+ *
+ * main.test.tsx documents the single-identity caveat (CT-1598): one runtime
+ * cannot simulate a second user. This runs ONE shared poll across two
+ * worker-isolated runtimes and covers that gap: second-user join isolation,
+ * the host gate rejecting a real non-host user, cross-runtime vote
+ * visibility, and open host takeover. The deeper voting flows stay in
+ * main.test.tsx; lunch-poll/multi-user.test.tsx covers the richer variant.
+ *
+ * Joins go through the `joinAs` event-name override (the headless seam kept
+ * by the profile migration); the profile-wish UI path needs a browser.
+ * Cross-runtime reads use INLINE literal accesses — see
+ * scrabble/multi-user.test.tsx.
+ */
+import { action, computed, multiUserTest, pattern } from "commonfabric";
+import CozyPoll, { type CozyPollOutput } from "./main.tsx";
+
+interface Setup {
+  poll: CozyPollOutput;
+}
+
+export const setup = pattern(() => ({
+  poll: CozyPoll({}),
+}));
+
+export const alice = pattern<{ setup: Setup }>(({ setup }) => {
+  const poll = setup.poll;
+
+  const action_join = action(() => {
+    poll.joinAs.send({ name: "Alice" });
+  });
+  const action_add_ramen = action(() => {
+    poll.addOption.send({ title: "Ramen" });
+  });
+
+  const assert_joined_as_host = computed(() =>
+    poll.myName === "Alice" &&
+    poll.adminName === "Alice" &&
+    poll.isAdmin === true &&
+    (poll.users ?? []).length === 1 &&
+    poll.users?.[0]?.name === "Alice"
+  );
+  const assert_option_added = computed(() =>
+    (poll.options ?? []).length === 1 &&
+    poll.options?.[0]?.title === "Ramen"
+  );
+  // Bob joined and voted; his gated addOption attempt left no trace.
+  const assert_sees_bobs_vote = computed(() =>
+    (poll.users ?? []).length === 2 &&
+    poll.users?.[1]?.name === "Bob" &&
+    (poll.votes ?? []).length === 1 &&
+    poll.votes?.[0]?.voterName === "Bob" &&
+    poll.votes?.[0]?.voteType === "red" &&
+    (poll.options ?? []).length === 1 &&
+    poll.myName === "Alice"
+  );
+  // Host takeover observed from the deposed host's runtime.
+  const assert_deposed = computed(() =>
+    poll.adminName === "Bob" && poll.isAdmin === false
+  );
+
+  return {
+    tests: [
+      { action: action_join },
+      { assertion: assert_joined_as_host },
+      { action: action_add_ramen },
+      { assertion: assert_option_added },
+      { label: "alice-set-up" },
+      { await: "bob-voted" },
+      { assertion: assert_sees_bobs_vote },
+      { await: "bob-claimed-host" },
+      { assertion: assert_deposed },
+    ],
+  };
+});
+
+export const bob = pattern<{ setup: Setup }>(({ setup }) => {
+  const poll = setup.poll;
+
+  const action_join = action(() => {
+    poll.joinAs.send({ name: "Bob" });
+  });
+  const action_try_add_as_non_host = action(() => {
+    poll.addOption.send({ title: "Should not appear" });
+  });
+  const action_vote_red = action(() => {
+    const first = poll.options?.[0];
+    if (first) poll.castVote.send({ optionId: first.id, voteType: "red" });
+  });
+  const action_claim_host = action(() => {
+    poll.claimHost.send({});
+  });
+
+  const assert_sees_alice_setup = computed(() =>
+    (poll.users ?? []).length === 1 &&
+    poll.users?.[0]?.name === "Alice" &&
+    poll.adminName === "Alice" &&
+    (poll.options ?? []).length === 1 &&
+    poll.options?.[0]?.title === "Ramen"
+  );
+  // PerUser isolation: Alice's join must not leak into Bob's identity.
+  const assert_not_joined_yet = computed(() =>
+    poll.myName === "" && poll.isJoined === false
+  );
+  const assert_joined_not_host = computed(() =>
+    poll.myName === "Bob" &&
+    poll.isAdmin === false &&
+    (poll.users ?? []).length === 2 &&
+    poll.users?.[1]?.name === "Bob"
+  );
+  // The host gate rejected a real second user (the CT-1598 gap).
+  const assert_gating_held = computed(() => (poll.options ?? []).length === 1);
+  const assert_own_vote = computed(() =>
+    (poll.votes ?? []).length === 1 &&
+    poll.votes?.[0]?.voterName === "Bob" &&
+    poll.votes?.[0]?.voteType === "red"
+  );
+  const assert_is_host_now = computed(() =>
+    poll.adminName === "Bob" && poll.isAdmin === true
+  );
+
+  return {
+    tests: [
+      { await: "alice-set-up" },
+      { assertion: assert_sees_alice_setup },
+      { assertion: assert_not_joined_yet },
+      { action: action_join },
+      { assertion: assert_joined_not_host },
+      { action: action_try_add_as_non_host },
+      { assertion: assert_gating_held },
+      { action: action_vote_red },
+      { assertion: assert_own_vote },
+      { label: "bob-voted" },
+      { action: action_claim_host },
+      { assertion: assert_is_host_now },
+      { label: "bob-claimed-host" },
+    ],
+  };
+});
+
+export default multiUserTest({ setup, participants: { alice, bob } });

--- a/packages/patterns/factory-outputs/lot-watch/main.tsx
+++ b/packages/patterns/factory-outputs/lot-watch/main.tsx
@@ -16,6 +16,7 @@ import {
   Stream,
   UI,
   type VNode,
+  wish,
   Writable,
 } from "commonfabric";
 import {
@@ -480,8 +481,30 @@ export default pattern<LotWatchInput, LotWatchOutput>(
       LotWatchAdminManagerCredential | null
     >(null);
 
-    // PerUser: who is reporting
+    // PerUser: who is reporting. Set from the viewer's shared profile (the
+    // `#profile` wish's built-in UI covers profile create/pick); tests and
+    // headless callers set it via the `setReporterName` stream.
     const reporterName = new Writable.perUser("");
+
+    const profileWish = wish<{ name?: string; avatar?: string }>({
+      query: "#profile",
+    });
+    const profileNameWish = wish<string>({ query: "#profileName" });
+    const profileAvatarWish = wish<string>({ query: "#profileAvatar" });
+    const profileName = computed(() => (profileNameWish.result ?? "").trim());
+    const profileAvatar = computed(() =>
+      (profileAvatarWish.result ?? "").trim()
+    );
+    const hasProfile = computed(() =>
+      (profileNameWish.result ?? "").trim() !== ""
+    );
+    const reporterLabel = computed(() => (reporterName.get() || "").trim());
+    const hasReporter = computed(() => reporterLabel !== "");
+    // Show the profile avatar only while the reporter IS the profile (an
+    // explicit setReporterName override keeps initials-only rendering).
+    const reporterAvatar = computed(() =>
+      reporterLabel !== "" && reporterLabel === profileName ? profileAvatar : ""
+    );
 
     // PerSession: tab navigation
     const selectedTab = new Writable.perSession<
@@ -683,10 +706,17 @@ export default pattern<LotWatchInput, LotWatchOutput>(
       captureStep.set("review");
     });
 
-    // Programmatic setter for the perUser `reporterName`. The UI binds the
-    // capture tab's "Your name" cf-input directly via `$value={reporterName}`,
-    // but tests (and any non-UI caller) need a Stream seam to set it.
+    // Programmatic setter for the perUser `reporterName`. The capture tab's
+    // "Report as <profile>" button adopts the resolved profile name; tests
+    // (and any non-UI caller) use this Stream seam to set an explicit name.
     const setReporterName = action<{ name: string }>(({ name }) => {
+      reporterName.set(name);
+    });
+
+    // Adopt the viewer's resolved shared-profile name as the reporter name.
+    const adoptProfileName = action(() => {
+      const name = (profileNameWish.result ?? "").trim();
+      if (!name) return;
       reporterName.set(name);
     });
 
@@ -1477,7 +1507,12 @@ export default pattern<LotWatchInput, LotWatchOutput>(
               {isCaptureTab
                 ? (
                   <cf-vstack gap="3">
-                    {/* Persistent reporter banner (always visible, small) */}
+                    {
+                      /* Persistent reporter banner (always visible, small).
+                        Identity comes from the viewer's shared profile: the
+                        wish UI handles create/pick, then one click adopts the
+                        resolved name as the reporter. */
+                    }
                     <cf-card style="padding: 0.5rem 0.75rem;">
                       <cf-hstack
                         justify="between"
@@ -1488,11 +1523,33 @@ export default pattern<LotWatchInput, LotWatchOutput>(
                         <span style="font-size: 0.75rem; color: var(--cf-color-gray-500); white-space: nowrap;">
                           Reporting as
                         </span>
-                        <cf-input
-                          $value={reporterName}
-                          placeholder="your name"
-                          style="flex: 1; min-width: 120px;"
-                        />
+                        {hasReporter
+                          ? (
+                            <cf-hstack gap="2" align="center">
+                              <cf-avatar
+                                src={reporterAvatar}
+                                name={reporterLabel}
+                                size="xs"
+                              />
+                              <span style="font-size: 0.875rem;">
+                                {reporterLabel}
+                              </span>
+                            </cf-hstack>
+                          )
+                          : hasProfile
+                          ? (
+                            <cf-button
+                              size="sm"
+                              onClick={() => adoptProfileName.send()}
+                            >
+                              Report as {profileName}
+                            </cf-button>
+                          )
+                          : (
+                            <div style="flex: 1; min-width: 160px;">
+                              {profileWish[UI]}
+                            </div>
+                          )}
                       </cf-hstack>
                     </cf-card>
 

--- a/packages/patterns/group-chat-lobby.tsx
+++ b/packages/patterns/group-chat-lobby.tsx
@@ -1,6 +1,7 @@
 import {
   computed,
   Default,
+  equals,
   handler,
   ifElse,
   NAME,
@@ -12,7 +13,11 @@ import {
   wish,
   Writable,
 } from "commonfabric";
-import GroupChatRoom, { Message, User } from "./group-chat-room.tsx";
+import GroupChatRoom, {
+  Message,
+  ParticipantProfileCell,
+  User,
+} from "./group-chat-room.tsx";
 
 /**
  * Group Chat Lobby Pattern
@@ -63,20 +68,25 @@ const resetLobby = handler<
 
 // Handler for joining the chat. `name`/`avatar` arrive as plain strings
 // resolved from the viewer's shared profile (named `computed` values
-// auto-unwrap as handler state).
+// auto-unwrap as handler state); `profile` is the live profile cell — the
+// STABLE identity key. Display names are mutable and not unique across users
+// (two profiles can both be "Alex"), so re-join detection compares profile
+// cells with `equals()`, never names.
 const joinChat = handler<
   unknown,
   {
     messages: Writable<Message[]>;
     users: Writable<User[]>;
     sessionId: Writable<string>;
+    // May be undefined until the viewer's `#profile` wish resolves.
+    profile: ParticipantProfileCell | undefined;
     name: string;
     avatar: string;
   }
->((_event, { messages, users, sessionId, name, avatar }) => {
+>((_event, { messages, users, sessionId, profile, name, avatar }) => {
   const trimmed = (name ?? "").trim();
-  if (!trimmed) {
-    console.log("[joinChat] No profile name resolved yet, returning");
+  if (!trimmed || !profile) {
+    console.log("[joinChat] No resolved profile yet, returning");
     return;
   }
   console.log("[joinChat] Name:", trimmed);
@@ -91,34 +101,40 @@ const joinChat = handler<
     console.log("[joinChat] Initialized new session:", currentSessionId);
   }
 
-  // Get existing users
+  // Re-join check by profile-cell identity: the same user (even after a
+  // rename) navigates back in under their previously claimed display name.
   const existingUsers = users.get() || [];
-
-  // Check if user already exists
-  const existingUser = existingUsers.find((u) => u.name === trimmed);
-  if (!existingUser) {
-    // Create new user with a profile snapshot and add to list
-    const newUser: User = {
-      name: trimmed,
+  const mine = existingUsers.find(
+    (u) => u.profile && equals(u.profile, profile),
+  );
+  let displayName = trimmed;
+  if (mine) {
+    displayName = mine.name;
+  } else {
+    // The room keys messages/reactions on the display name, so it must stay
+    // unique within this roster — disambiguate when a DIFFERENT profile
+    // already claimed the same name.
+    let suffix = 2;
+    while (existingUsers.some((u) => u.name === displayName)) {
+      displayName = `${trimmed} ${suffix++}`;
+    }
+    users.push({
+      name: displayName,
       joinedAt: safeDateNow(),
       avatar: (avatar ?? "").trim(),
-    };
-    users.set([...existingUsers, newUser]);
-    console.log("[joinChat] User added:", trimmed);
+      profile,
+    });
+    console.log("[joinChat] User added:", displayName);
 
     // Add system message for join
-    const existingMessages = messages.get() || [];
-    messages.set([
-      ...existingMessages,
-      {
-        id: `msg-${safeDateNow()}-${nonPrivateRandom().toString(36).slice(2)}`,
-        author: "System",
-        content: `${trimmed} joined the chat`,
-        timestamp: safeDateNow(),
-        type: "system",
-        reactions: [],
-      },
-    ]);
+    messages.push({
+      id: `msg-${safeDateNow()}-${nonPrivateRandom().toString(36).slice(2)}`,
+      author: "System",
+      content: `${displayName} joined the chat`,
+      timestamp: safeDateNow(),
+      type: "system",
+      reactions: [],
+    });
   }
 
   // Create chat room instance and navigate
@@ -127,13 +143,15 @@ const joinChat = handler<
     "[joinChat] Navigating to chat room with session:",
     currentSessionId,
   );
+  // `as any`: the cell-link `profile` inside `User` defeats the Opaque<>
+  // input mapping (same workaround as battleship's lobby bindings).
   const roomInstance = GroupChatRoom({
     messages,
     users,
-    myName: trimmed,
+    myName: displayName,
     mySessionId: currentSessionId,
     currentSessionId: sessionId,
-  });
+  } as any);
 
   return navigateTo(roomInstance);
 });
@@ -161,13 +179,16 @@ export default pattern<LobbyInput, LobbyOutput>(
 
     const userCount = computed(() => users.get().length);
 
+    // `as any`: the cell-link `profile` inside `User` defeats the Opaque<>
+    // state mapping (same workaround as battleship's lobby bindings).
     const join = joinChat({
       messages,
       users,
       sessionId,
+      profile: profileWish.result,
       name: myName,
       avatar: myAvatar,
-    });
+    } as any);
 
     return {
       [NAME]: computed(() => `${chatName} - Lobby`),
@@ -333,7 +354,7 @@ export default pattern<LobbyInput, LobbyOutput>(
                 border: "none",
                 cursor: "pointer",
               }}
-              onClick={resetLobby({ messages, users, sessionId })}
+              onClick={resetLobby({ messages, users, sessionId } as any)}
             >
               Reset
             </button>

--- a/packages/patterns/group-chat-lobby.tsx
+++ b/packages/patterns/group-chat-lobby.tsx
@@ -9,6 +9,7 @@ import {
   pattern,
   safeDateNow,
   UI,
+  wish,
   Writable,
 } from "commonfabric";
 import GroupChatRoom, { Message, User } from "./group-chat-room.tsx";
@@ -16,8 +17,11 @@ import GroupChatRoom, { Message, User } from "./group-chat-room.tsx";
 /**
  * Group Chat Lobby Pattern
  *
- * Apple iOS-style lobby where unlimited users can join.
- * Shows all joined users and a form for new users.
+ * Apple iOS-style lobby where unlimited users can join. Identity comes from
+ * the viewer's shared profile (`wish({ query: "#profile" })`): the wish's
+ * built-in UI lets the viewer pick one of their existing profiles or create a
+ * new one, and joining snapshots the resolved name/avatar into the shared
+ * user roster (see docs/specs/shared-profile-rosters.md).
  */
 
 interface LobbyInput {
@@ -32,33 +36,6 @@ interface LobbyOutput {
   messages: Writable<Message[] | Default<[]>>;
   users: Writable<User[] | Default<[]>>;
   sessionId: Writable<string | Default<"">>;
-}
-
-// Random color selection from a pool of distinct colors
-function getRandomColor(): string {
-  const colors = [
-    "#007AFF", // Apple blue
-    "#34C759", // Apple green
-    "#FF9500", // Apple orange
-    "#AF52DE", // Apple purple
-    "#FF3B30", // Apple red
-    "#5856D6", // Apple indigo
-    "#FF2D55", // Apple pink
-    "#00C7BE", // Apple teal
-  ];
-  return colors[Math.floor(nonPrivateRandom() * colors.length)];
-}
-
-// Get initials from name
-function getInitials(name: string): string {
-  if (!name || typeof name !== "string") return "?";
-  return name
-    .trim()
-    .split(/\s+/)
-    .map((word) => word[0])
-    .join("")
-    .toUpperCase()
-    .slice(0, 2);
 }
 
 // Handler to reset the lobby (clear all state and generate new session)
@@ -84,23 +61,25 @@ const resetLobby = handler<
   );
 });
 
-// Handler for joining the chat
+// Handler for joining the chat. `name`/`avatar` arrive as plain strings
+// resolved from the viewer's shared profile (named `computed` values
+// auto-unwrap as handler state).
 const joinChat = handler<
   unknown,
   {
-    chatName: string;
     messages: Writable<Message[]>;
     users: Writable<User[]>;
     sessionId: Writable<string>;
-    nameInput: Writable<string>;
+    name: string;
+    avatar: string;
   }
->((_event, { messages, users, sessionId, nameInput }) => {
-  const name = nameInput.get().trim();
-  if (!name) {
-    console.log("[joinChat] No name entered, returning");
+>((_event, { messages, users, sessionId, name, avatar }) => {
+  const trimmed = (name ?? "").trim();
+  if (!trimmed) {
+    console.log("[joinChat] No profile name resolved yet, returning");
     return;
   }
-  console.log("[joinChat] Name:", name);
+  console.log("[joinChat] Name:", trimmed);
 
   // Initialize session ID if not set (first user joining)
   let currentSessionId = sessionId.get();
@@ -116,16 +95,16 @@ const joinChat = handler<
   const existingUsers = users.get() || [];
 
   // Check if user already exists
-  const existingUser = existingUsers.find((u) => u.name === name);
+  const existingUser = existingUsers.find((u) => u.name === trimmed);
   if (!existingUser) {
-    // Create new user and add to list
+    // Create new user with a profile snapshot and add to list
     const newUser: User = {
-      name,
+      name: trimmed,
       joinedAt: safeDateNow(),
-      color: getRandomColor(),
+      avatar: (avatar ?? "").trim(),
     };
     users.set([...existingUsers, newUser]);
-    console.log("[joinChat] User added:", name);
+    console.log("[joinChat] User added:", trimmed);
 
     // Add system message for join
     const existingMessages = messages.get() || [];
@@ -134,16 +113,13 @@ const joinChat = handler<
       {
         id: `msg-${safeDateNow()}-${nonPrivateRandom().toString(36).slice(2)}`,
         author: "System",
-        content: `${name} joined the chat`,
+        content: `${trimmed} joined the chat`,
         timestamp: safeDateNow(),
         type: "system",
         reactions: [],
       },
     ]);
   }
-
-  // Clear the name input
-  nameInput.set("");
 
   // Create chat room instance and navigate
   // Pass both the session ID at join time (mySessionId) and the Cell reference to check against (currentSessionId)
@@ -154,7 +130,7 @@ const joinChat = handler<
   const roomInstance = GroupChatRoom({
     messages,
     users,
-    myName: name,
+    myName: trimmed,
     mySessionId: currentSessionId,
     currentSessionId: sessionId,
   });
@@ -164,10 +140,34 @@ const joinChat = handler<
 
 export default pattern<LobbyInput, LobbyOutput>(
   ({ chatName, messages, users, sessionId }) => {
-    // Name input for new users
-    const nameInput = new Writable("");
+    // Resolve THIS viewer's shared profile. The `#profile` wish's built-in UI
+    // covers the whole lifecycle: a create surface when the viewer has no
+    // profile, a link when they have one, and a picker (with inline create)
+    // when they have several. The field targets give the snapshot strings.
+    const profileWish = wish<{ name?: string; avatar?: string }>({
+      query: "#profile",
+    });
+    const profileNameWish = wish<string>({ query: "#profileName" });
+    const profileAvatarWish = wish<string>({ query: "#profileAvatar" });
+
+    const myName = computed(() => profileNameWish.result ?? "");
+    const myAvatar = computed(() => profileAvatarWish.result ?? "");
+    const hasProfile = computed(() =>
+      (profileNameWish.result ?? "").trim() !== ""
+    );
+    const joinLabel = computed(() =>
+      hasProfile ? `Join as ${myName}` : "Create a profile to join"
+    );
 
     const userCount = computed(() => users.get().length);
+
+    const join = joinChat({
+      messages,
+      users,
+      sessionId,
+      name: myName,
+      avatar: myAvatar,
+    });
 
     return {
       [NAME]: computed(() => `${chatName} - Lobby`),
@@ -208,7 +208,7 @@ export default pattern<LobbyInput, LobbyOutput>(
                 fontSize: "1.1rem",
               }}
             >
-              Enter your name to join the conversation
+              Join the conversation with your profile
             </p>
 
             {/* Join Form Card */}
@@ -232,43 +232,32 @@ export default pattern<LobbyInput, LobbyOutput>(
                   letterSpacing: "0.05em",
                 }}
               >
-                Join as
+                Your profile
               </div>
-              <cf-input
-                $value={nameInput}
-                placeholder="Your name"
-                style="width: 100%; margin-bottom: 1rem;"
-                timingStrategy="immediate"
-                oncf-submit={joinChat({
-                  chatName,
-                  messages,
-                  users,
-                  sessionId,
-                  nameInput,
-                })}
-              />
+              {
+                /* Built-in profile UI: create a profile when there is none,
+                  pick between (or add to) existing profiles otherwise. */
+              }
+              <div style={{ marginBottom: "1rem" }}>{profileWish[UI]}</div>
               <button
                 type="button"
+                disabled={computed(() => !hasProfile)}
                 style={{
                   width: "100%",
                   padding: "0.75rem 1.5rem",
                   fontSize: "1rem",
-                  backgroundColor: "#007AFF",
+                  backgroundColor: computed(() =>
+                    hasProfile ? "#007AFF" : "#b9b9c0"
+                  ),
                   color: "white",
                   fontWeight: "600",
                   border: "none",
                   borderRadius: "8px",
-                  cursor: "pointer",
+                  cursor: computed(() => hasProfile ? "pointer" : "default"),
                 }}
-                onClick={joinChat({
-                  chatName,
-                  messages,
-                  users,
-                  sessionId,
-                  nameInput,
-                })}
+                onClick={join}
               >
-                Join Chat
+                {joinLabel}
               </button>
             </div>
 
@@ -314,22 +303,7 @@ export default pattern<LobbyInput, LobbyOutput>(
                         borderRadius: "20px",
                       }}
                     >
-                      <div
-                        style={{
-                          width: "28px",
-                          height: "28px",
-                          borderRadius: "50%",
-                          backgroundColor: user.color,
-                          color: "white",
-                          display: "flex",
-                          alignItems: "center",
-                          justifyContent: "center",
-                          fontWeight: "600",
-                          fontSize: "11px",
-                        }}
-                      >
-                        {computed(() => user ? getInitials(user.name) : "?")}
-                      </div>
+                      <cf-avatar src={user.avatar} name={user.name} size="xs" />
                       <span
                         style={{
                           fontSize: "0.875rem",

--- a/packages/patterns/group-chat-room.tsx
+++ b/packages/patterns/group-chat-room.tsx
@@ -1,4 +1,5 @@
 import {
+  type Cell,
   computed,
   Default,
   handler,
@@ -38,11 +39,28 @@ export interface Message {
   reactions: Reaction[];
 }
 
+/**
+ * Stable identity for a user: the joiner's own `#profile` cell. Display names
+ * are mutable and not unique across users, so they must not be the identity
+ * key — compare profile cells with `equals()` instead (see
+ * `docs/specs/shared-profile-rosters.md`).
+ */
+export type ParticipantProfileCell = Cell<{ name?: string; avatar?: string }>;
+
 export interface User {
+  /**
+   * Display name shown in the room. Unique within this roster (the lobby
+   * disambiguates collisions) because messages/reactions key on it.
+   */
   name: string;
   joinedAt: number;
   /** Avatar URL or glyph, snapshotted from the joiner's shared profile. */
   avatar?: string;
+  /**
+   * Link to the joiner's profile cell — the stable identity key (optional so
+   * rosters written before the profile migration still load).
+   */
+  profile?: ParticipantProfileCell;
 }
 
 interface RoomInput {

--- a/packages/patterns/group-chat-room.tsx
+++ b/packages/patterns/group-chat-room.tsx
@@ -15,8 +15,9 @@ import {
 /**
  * Group Chat Room Pattern v9
  *
- * New features:
- * 1. Click avatar to set/change avatar
+ * Features:
+ * 1. Avatars come from each user's shared profile (snapshotted on join in the
+ *    lobby) and render via cf-avatar
  * 2. Camera icon sends images to chat
  * 3. Emoji reactions on messages with hover UI
  */
@@ -40,8 +41,8 @@ export interface Message {
 export interface User {
   name: string;
   joinedAt: number;
-  color: string;
-  avatarImage?: { url: string };
+  /** Avatar URL or glyph, snapshotted from the joiner's shared profile. */
+  avatar?: string;
 }
 
 interface RoomInput {
@@ -58,18 +59,6 @@ interface RoomOutput {
 
 // Common reaction emojis
 const REACTION_EMOJIS = ["👍", "❤️", "😂", "😮", "😢", "😡"];
-
-// Utility function to get initials from a name
-function getInitials(name: string): string {
-  if (!name || typeof name !== "string") return "?";
-  return name
-    .trim()
-    .split(/\s+/)
-    .map((word) => word[0])
-    .join("")
-    .toUpperCase()
-    .slice(0, 2);
-}
 
 // Handler to send a text message
 const sendMessage = handler<
@@ -121,37 +110,12 @@ const sendImageMessage = handler<
   chatImages.set([]);
 });
 
-// Handler to confirm and save the avatar from avatarImages cell
-const confirmAvatar = handler<
+// Handler to clear pending images
+const clearImages = handler<
   unknown,
-  {
-    users: Writable<User[]>;
-    myName: string;
-    avatarImages: Writable<ImageData[]>;
-  }
->((_event, { users, myName, avatarImages }) => {
-  const images = avatarImages.get() || [];
-  if (images.length === 0) return;
-
-  const newImage = images[0];
-  const currentUsers = users.get() || [];
-  const myUser = currentUsers.find((usr: User) => usr.name === myName);
-
-  if (!myUser) return;
-
-  const updatedUsers = currentUsers.map((usr: User) =>
-    usr.name === myName ? { ...usr, avatarImage: { url: newImage.url } } : usr
-  );
-  users.set(updatedUsers);
-  avatarImages.set([]);
-});
-
-// Handler to cancel pending avatar
-const cancelAvatar = handler<
-  unknown,
-  { avatarImages: Writable<ImageData[]> }
->((_event, { avatarImages }) => {
-  avatarImages.set([]);
+  { images: Writable<ImageData[]> }
+>((_event, { images }) => {
+  images.set([]);
 });
 
 type ImageUploadEvent = {
@@ -230,7 +194,6 @@ const toggleReaction = handler<
 export default pattern<RoomInput, RoomOutput>(
   ({ messages, users, myName, mySessionId, currentSessionId }) => {
     const contentInput = new Writable("");
-    const avatarImages = new Writable<ImageData[]>([]);
     const chatImages = new Writable<ImageData[]>([]);
     const emojiPickerMessageId = new Writable<string>("");
 
@@ -238,17 +201,6 @@ export default pattern<RoomInput, RoomOutput>(
       () => (users.get() || []).filter((user: User) => user && user.name),
     );
     const myNameResolved = computed(() => myName || "");
-
-    const hasPendingAvatar = computed(
-      () => avatarImages.get() && avatarImages.get().length > 0,
-    );
-    const pendingAvatarUrl = computed(() => {
-      const imgs = avatarImages.get();
-      if (!imgs || imgs.length === 0) {
-        return "";
-      }
-      return imgs[0].url || "";
-    });
 
     const hasPendingChatImage = computed(
       () => chatImages.get() && chatImages.get().length > 0,
@@ -272,8 +224,7 @@ export default pattern<RoomInput, RoomOutput>(
       return (users.get() || []).find((user: User) => user.name === resolved);
     });
 
-    const myAvatarUrl = computed(() => myUser?.avatarImage?.url || "");
-    const myColor = computed(() => myUser?.color || "#007AFF");
+    const myAvatar = computed(() => myUser?.avatar || "");
 
     return {
       [NAME]: computed(() => `Chat: ${myName}`),
@@ -327,63 +278,33 @@ export default pattern<RoomInput, RoomOutput>(
                       borderBottom: "1px solid #e5e5ea",
                     }}
                   >
-                    {userList.map((user) => {
-                      const hasAvatar = computed(() =>
-                        user && !!user.avatarImage?.url
-                      );
-                      return (
-                        <div
+                    {userList.map((user) => (
+                      <div
+                        style={{
+                          display: "flex",
+                          alignItems: "center",
+                          gap: "0.5rem",
+                          padding: "0.5rem 0.75rem",
+                          backgroundColor: "#f2f2f7",
+                          borderRadius: "20px",
+                        }}
+                      >
+                        <cf-avatar
+                          src={user.avatar}
+                          name={user.name}
+                          size="xs"
+                        />
+                        <span
                           style={{
-                            display: "flex",
-                            alignItems: "center",
-                            gap: "0.5rem",
-                            padding: "0.5rem 0.75rem",
-                            backgroundColor: "#f2f2f7",
-                            borderRadius: "20px",
+                            fontSize: "0.875rem",
+                            fontWeight: "500",
+                            color: "#1c1c1e",
                           }}
                         >
-                          {ifElse(
-                            hasAvatar,
-                            <img
-                              src={user.avatarImage?.url}
-                              style={{
-                                width: "28px",
-                                height: "28px",
-                                borderRadius: "50%",
-                                objectFit: "cover",
-                              }}
-                            />,
-                            <div
-                              style={{
-                                width: "28px",
-                                height: "28px",
-                                borderRadius: "50%",
-                                backgroundColor: user.color,
-                                color: "white",
-                                display: "flex",
-                                alignItems: "center",
-                                justifyContent: "center",
-                                fontWeight: "600",
-                                fontSize: "11px",
-                              }}
-                            >
-                              {computed(() =>
-                                user ? getInitials(user.name) : "?"
-                              )}
-                            </div>,
-                          )}
-                          <span
-                            style={{
-                              fontSize: "0.875rem",
-                              fontWeight: "500",
-                              color: "#1c1c1e",
-                            }}
-                          >
-                            {user.name}
-                          </span>
-                        </div>
-                      );
-                    })}
+                          {user.name}
+                        </span>
+                      </div>
+                    ))}
                   </div>
                 </div>
 
@@ -410,19 +331,12 @@ export default pattern<RoomInput, RoomOutput>(
                     const isImageMessage = computed(() =>
                       msg && msg.type === "image"
                     );
-                    const authorColor = computed(() => {
-                      if (!msg) return "#6b7280";
-                      const user = (users.get() || []).find((usr: User) =>
-                        usr && usr.name === msg.author
-                      );
-                      return user?.color || "#6b7280";
-                    });
-                    const authorAvatarUrl = computed(() => {
+                    const authorAvatar = computed(() => {
                       if (!msg) return "";
                       const user = (users.get() || []).find((usr: User) =>
                         usr && usr.name === msg.author
                       );
-                      return user?.avatarImage?.url || "";
+                      return user?.avatar || "";
                     });
                     const isFirstInAuthorBlock = computed(() => {
                       if (!msg) return true;
@@ -508,38 +422,12 @@ export default pattern<RoomInput, RoomOutput>(
                               null,
                               ifElse(
                                 shouldShowAvatar,
-                                ifElse(
-                                  authorAvatarUrl,
-                                  <img
-                                    src={authorAvatarUrl}
-                                    style={{
-                                      width: "32px",
-                                      height: "32px",
-                                      borderRadius: "50%",
-                                      objectFit: "cover",
-                                      flexShrink: "0",
-                                    }}
-                                  />,
-                                  <div
-                                    style={{
-                                      width: "32px",
-                                      height: "32px",
-                                      borderRadius: "50%",
-                                      backgroundColor: authorColor,
-                                      color: "white",
-                                      display: "flex",
-                                      alignItems: "center",
-                                      justifyContent: "center",
-                                      fontWeight: "600",
-                                      fontSize: "12px",
-                                      flexShrink: "0",
-                                    }}
-                                  >
-                                    {computed(() =>
-                                      msg ? getInitials(msg.author) : "?"
-                                    )}
-                                  </div>,
-                                ),
+                                <cf-avatar
+                                  src={authorAvatar}
+                                  name={msg.author}
+                                  size="sm"
+                                  style={{ flexShrink: "0" }}
+                                />,
                                 <div
                                   style={{ width: "32px", flexShrink: "0" }}
                                 />,
@@ -757,51 +645,15 @@ export default pattern<RoomInput, RoomOutput>(
                       marginBottom: "0.5rem",
                     }}
                   >
-                    {/* Clickable Avatar - click to change */}
-                    <div style={{ position: "relative", cursor: "pointer" }}>
-                      {ifElse(
-                        myAvatarUrl,
-                        <img
-                          src={myAvatarUrl}
-                          style={{
-                            width: "40px",
-                            height: "40px",
-                            borderRadius: "50%",
-                            objectFit: "cover",
-                            border: "2px solid #bae6fd",
-                          }}
-                        />,
-                        <div
-                          style={{
-                            width: "40px",
-                            height: "40px",
-                            borderRadius: "50%",
-                            backgroundColor: myColor,
-                            color: "white",
-                            display: "flex",
-                            alignItems: "center",
-                            justifyContent: "center",
-                            fontWeight: "600",
-                            fontSize: "14px",
-                            border: "2px solid #bae6fd",
-                          }}
-                        >
-                          {computed(() => getInitials(myNameResolved))}
-                        </div>,
-                      )}
-                      {/* Hidden cf-image-input overlaid on avatar */}
-                      <cf-image-input
-                        maxImages={1}
-                        showPreview={false}
-                        buttonText=""
-                        variant="ghost"
-                        size="sm"
-                        style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; opacity: 0; cursor: pointer;"
-                        oncf-change={setUploadedImage({
-                          images: avatarImages,
-                        })}
-                      />
-                    </div>
+                    {
+                      /* Profile avatar (snapshotted from the shared profile
+                        when the user joined in the lobby) */
+                    }
+                    <cf-avatar
+                      src={myAvatar}
+                      name={myNameResolved}
+                      size="md"
+                    />
 
                     <div style={{ flex: 1 }}>
                       <div
@@ -825,66 +677,6 @@ export default pattern<RoomInput, RoomOutput>(
                       size="sm"
                       oncf-change={setUploadedImage({ images: chatImages })}
                     />
-
-                    {/* Pending avatar preview */}
-                    {ifElse(
-                      hasPendingAvatar,
-                      <div
-                        style={{
-                          display: "flex",
-                          alignItems: "center",
-                          gap: "0.5rem",
-                        }}
-                      >
-                        <img
-                          src={pendingAvatarUrl}
-                          style={{
-                            width: "40px",
-                            height: "40px",
-                            borderRadius: "50%",
-                            objectFit: "cover",
-                            border: "2px solid #34C759",
-                          }}
-                        />
-                        <button
-                          type="button"
-                          style={{
-                            padding: "0.25rem 0.5rem",
-                            fontSize: "0.75rem",
-                            backgroundColor: "#34C759",
-                            color: "white",
-                            fontWeight: "600",
-                            border: "none",
-                            borderRadius: "4px",
-                            cursor: "pointer",
-                          }}
-                          onClick={confirmAvatar({
-                            users,
-                            myName,
-                            avatarImages,
-                          })}
-                        >
-                          ✓
-                        </button>
-                        <button
-                          type="button"
-                          style={{
-                            padding: "0.25rem 0.5rem",
-                            fontSize: "0.75rem",
-                            backgroundColor: "#FF3B30",
-                            color: "white",
-                            fontWeight: "600",
-                            border: "none",
-                            borderRadius: "4px",
-                            cursor: "pointer",
-                          }}
-                          onClick={cancelAvatar({ avatarImages })}
-                        >
-                          ✗
-                        </button>
-                      </div>,
-                      null,
-                    )}
 
                     {/* Pending chat image preview */}
                     {ifElse(
@@ -938,7 +730,7 @@ export default pattern<RoomInput, RoomOutput>(
                             borderRadius: "4px",
                             cursor: "pointer",
                           }}
-                          onClick={cancelAvatar({ avatarImages: chatImages })}
+                          onClick={clearImages({ images: chatImages })}
                         >
                           ✗
                         </button>

--- a/packages/patterns/index.md
+++ b/packages/patterns/index.md
@@ -767,10 +767,12 @@ type ChatOutput = {
 
 ## `group-chat-lobby.tsx`
 
-Multiplayer group chat lobby where users join, pick colors, and enter a shared
-chat room. Uses `navigateTo()` to transition into `group-chat-room.tsx`.
+Multiplayer group chat lobby where users join with their shared profile
+(`wish({ query: "#profile" })` — the wish UI covers profile create/pick) and
+enter a shared chat room. Uses `navigateTo()` to transition into
+`group-chat-room.tsx`.
 
-**Keywords:** multiplayer, chat, lobby, navigateTo
+**Keywords:** multiplayer, chat, lobby, navigateTo, profile, wish
 
 ### Input Schema
 
@@ -788,8 +790,8 @@ interface Message {
 interface User {
   name: string;
   joinedAt: number;
-  color: string;
-  avatarImage?: { url: string };
+  /** Avatar URL or glyph, snapshotted from the joiner's shared profile. */
+  avatar?: string;
 }
 
 interface LobbyInput {

--- a/packages/patterns/lunch-poll/main.test.tsx
+++ b/packages/patterns/lunch-poll/main.test.tsx
@@ -4,10 +4,11 @@
  * Exercises the scope idioms (per-space directory, per-user identity,
  * derived admin) and the core voting flows.
  *
- * Single-identity caveat (CT-1598): the test framework dispatches every
- * action from one identity, so we cannot simulate a second user. Admin
- * gating is exercised by attempting admin actions *before* any join
- * (myName empty → handler bails).
+ * Single-identity caveat (CT-1598): this file runs in one runtime with one
+ * identity, so admin gating is exercised by attempting admin actions *before*
+ * any join (myName empty → handler bails). The real second-user cases —
+ * gating against a non-host user, host takeover, cross-runtime visibility —
+ * are covered by multi-user.test.tsx.
  */
 
 import { action, computed, pattern } from "commonfabric";
@@ -99,8 +100,8 @@ export default pattern(() => {
     poll.clearHistory.send({});
   });
 
-  // Single-identity caveat (CT-1598): we can't simulate a *second* user, so
-  // host *takeover* can't be exercised. This just confirms claimHost is wired
+  // Single-identity caveat (CT-1598): host *takeover* needs a second user and
+  // is covered by multi-user.test.tsx. This just confirms claimHost is wired
   // and is a harmless no-op when the caller already holds the role.
   const action_claim_host = action(() => {
     poll.claimHost.send({});

--- a/packages/patterns/lunch-poll/main.tsx
+++ b/packages/patterns/lunch-poll/main.tsx
@@ -9,7 +9,10 @@
  * Identity follows the scrabble idiom:
  * - `users` is a per-space directory of joined participants.
  * - Each viewer's `myName` is per-user; it is set once on join and treated as
- *   immutable thereafter.
+ *   immutable thereafter. The join name/avatar come from the viewer's shared
+ *   profile (`wish({ query: "#profile" })` — its built-in UI covers profile
+ *   create/pick); programmatic callers can still pass an explicit name in the
+ *   `joinAs` event.
  * - The first joiner's name is captured into `adminName` (per-space). They can
  *   add/remove options and reset votes. `isAdmin` is derived, not stored.
  * - Open host takeover: any joined participant can `claimHost`, transferring
@@ -41,11 +44,14 @@ import {
   Stream,
   UI,
   type VNode,
+  wish,
   Writable,
 } from "commonfabric";
 
 export interface User {
   name: string;
+  /** Avatar URL or glyph, snapshotted from the joiner's shared profile. */
+  avatar?: string;
   color: string;
   joinedAt: number;
 }
@@ -294,13 +300,19 @@ const visitLabel = (wentAt: number): string => {
   }`;
 };
 
+// `profileName`/`profileAvatar` arrive as plain strings resolved from the
+// viewer's shared profile (named `computed` values auto-unwrap as handler
+// state). An explicit `name` in the event (tests, headless drivers) overrides
+// the profile name — and then deliberately skips the profile avatar.
 const joinAs = handler<JoinEvent, {
   users: UsersCell;
   myName: NameCell;
   adminName: NameCell;
-  joinName: NameCell;
-}>(({ name }, { users, myName, adminName, joinName }) => {
-  const trimmed = trimmedName(name ?? joinName.get());
+  profileName: string;
+  profileAvatar: string;
+}>(({ name }, { users, myName, adminName, profileName, profileAvatar }) => {
+  const override = trimmedName(name);
+  const trimmed = override || trimmedName(profileName);
   if (!trimmed) return;
   const current = trimmedName(myName.get());
   if (current) return;
@@ -308,12 +320,12 @@ const joinAs = handler<JoinEvent, {
   if (existing.some((u) => u.name === trimmed)) return;
   const user: User = {
     name: trimmed,
+    avatar: override ? "" : (profileAvatar ?? "").trim(),
     color: colorForIndex(existing.length),
     joinedAt: safeDateNow(),
   };
   users.push(user);
   myName.set(trimmed);
-  joinName.set("");
   if (trimmedName(adminName.get()) === "") {
     adminName.set(trimmed);
   }
@@ -701,7 +713,7 @@ export interface CozyPollInput {
   history?: PerSpace<HistoryEntry[] | Default<[]>>;
   adminName?: PerSpace<string | Default<"">>;
   myName?: PerUser<string | Default<"">>;
-  // joinName + optionDraft are internal form drafts, declared as local
+  // optionDraft etc. are internal form drafts, declared as local
   // per-session cells in the pattern body (parking-coordinator idiom).
 }
 
@@ -753,7 +765,6 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     // Internal per-session form drafts — local to each browser session,
     // not exposed as pattern inputs. Uses the scoped-constructor idiom
     // introduced by parking-coordinator (PR #3610).
-    const joinName = Writable.perSession.of<string>("");
     const optionDraft = Writable.perSession.of<string>("");
     // Host's draft for the poll's city (scopes the menu web search).
     const cityDraft = Writable.perSession.of<string>("");
@@ -774,7 +785,32 @@ export default pattern<CozyPollInput, CozyPollOutput>(
     // way until a non-host clicks the "Hosted by …" label.
     const claimHostRevealed = Writable.perSession.of<boolean>(false);
 
-    const boundJoin = joinAs({ users, myName, adminName, joinName });
+    // Resolve THIS viewer's shared profile. The `#profile` wish's built-in UI
+    // covers the whole lifecycle: a create surface when the viewer has no
+    // profile, a link when they have one, and a picker (with inline create)
+    // when they have several. The field targets give the snapshot strings.
+    const profileWish = wish<{ name?: string; avatar?: string }>({
+      query: "#profile",
+    });
+    const profileNameWish = wish<string>({ query: "#profileName" });
+    const profileAvatarWish = wish<string>({ query: "#profileAvatar" });
+
+    const profileName = computed(() => profileNameWish.result ?? "");
+    const profileAvatar = computed(() => profileAvatarWish.result ?? "");
+    const hasProfile = computed(() =>
+      (profileNameWish.result ?? "").trim() !== ""
+    );
+    const joinLabel = computed(() =>
+      hasProfile ? `Join as ${profileName}` : "Create a profile to join"
+    );
+
+    const boundJoin = joinAs({
+      users,
+      myName,
+      adminName,
+      profileName,
+      profileAvatar,
+    });
     const boundClaimHost = claimHost({ myName, adminName });
     const boundAddOption = addOption({
       options,
@@ -1031,18 +1067,21 @@ export default pattern<CozyPollInput, CozyPollOutput>(
                     <div
                       style={{
                         display: "flex",
+                        flexDirection: "column",
                         gap: "8px",
-                        alignItems: "center",
                       }}
                     >
-                      <cf-input
-                        $value={joinName}
-                        placeholder="Your name"
-                        aria-label="Your name"
-                        timing-strategy="immediate"
-                        style="flex:1"
-                      />
-                      <cf-button onClick={boundJoin}>Join</cf-button>
+                      {
+                        /* Built-in profile UI: create a profile when there is
+                          none, pick between existing profiles otherwise. */
+                      }
+                      <div>{profileWish[UI]}</div>
+                      <cf-button
+                        onClick={boundJoin}
+                        disabled={computed(() => !hasProfile)}
+                      >
+                        {joinLabel}
+                      </cf-button>
                     </div>
                   </div>
                 )}

--- a/packages/patterns/lunch-poll/main.tsx
+++ b/packages/patterns/lunch-poll/main.tsx
@@ -749,6 +749,13 @@ export interface CozyPollOutput {
   setOptionUrl: Stream<SetOptionUrlEvent>;
 }
 
+// Stable empty fallbacks for the output snapshots below — fresh `[]` per
+// recompute would make the computed results non-idempotent.
+const EMPTY_OPTIONS: Option[] = [];
+const EMPTY_VOTES: Vote[] = [];
+const EMPTY_USERS: User[] = [];
+const EMPTY_HISTORY: HistoryEntry[] = [];
+
 export default pattern<CozyPollInput, CozyPollOutput>(
   (
     {
@@ -2048,12 +2055,18 @@ export default pattern<CozyPollInput, CozyPollOutput>(
       ),
       question,
       city: cityLabel,
-      options,
-      votes,
-      users,
-      history,
-      adminName,
-      myName,
+      // Output snapshots readable from OTHER runtimes (multi-user tests,
+      // remote viewers): raw scoped values read as undefined in runtimes that
+      // didn't write them, and a computed that RETURNS undefined is
+      // indistinguishable from "not yet computed" for cross-runtime readers —
+      // so every snapshot yields a real, stable value (the shared EMPTY
+      // constants keep the fallback idempotent across recomputes).
+      options: computed(() => options ?? EMPTY_OPTIONS),
+      votes: computed(() => votes ?? EMPTY_VOTES),
+      users: computed(() => users ?? EMPTY_USERS),
+      history: computed(() => history ?? EMPTY_HISTORY),
+      adminName: computed(() => trimmedName(adminName)),
+      myName: computed(() => trimmedName(myName)),
       userCount,
       optionCount,
       voteCount,

--- a/packages/patterns/lunch-poll/multi-user.test.tsx
+++ b/packages/patterns/lunch-poll/multi-user.test.tsx
@@ -1,0 +1,167 @@
+/// <cts-enable />
+/**
+ * Multi-user pattern test for the lunch poll.
+ *
+ * main.test.tsx documents the single-identity caveat (CT-1598): one runtime
+ * cannot simulate a second user, so admin gating against a real non-host and
+ * host takeover were untestable. This runs ONE shared poll across two
+ * worker-isolated runtimes and covers exactly that gap:
+ * - second user join (PerUser identity isolation),
+ * - admin gating rejecting a genuinely different non-host user,
+ * - votes from two users tallied and visible cross-runtime,
+ * - open host takeover (claimHost) observed from the deposed host's runtime.
+ *
+ * Joins go through the `joinAs` event-name override (the headless seam kept
+ * by the profile migration); the profile-wish UI path needs a browser.
+ *
+ * Cross-runtime reads use INLINE literal accesses (users[0].name) — `.map()`,
+ * loop-variable indexing, and helper calls over another runtime's arrays do
+ * not resolve before a local write (see scrabble/multi-user.test.tsx).
+ */
+import { action, computed, multiUserTest, pattern } from "commonfabric";
+import LunchPoll, { type CozyPollOutput } from "./main.tsx";
+
+interface Setup {
+  poll: CozyPollOutput;
+}
+
+export const setup = pattern(() => ({
+  poll: LunchPoll({}),
+}));
+
+export const alice = pattern<{ setup: Setup }>(({ setup }) => {
+  const poll = setup.poll;
+
+  const action_join = action(() => {
+    poll.joinAs.send({ name: "Alice" });
+  });
+  const action_add_sushi = action(() => {
+    poll.addOption.send({ title: "Sushi" });
+  });
+  const action_vote_green = action(() => {
+    const first = poll.options?.[0];
+    if (first) poll.castVote.send({ optionId: first.id, voteType: "green" });
+  });
+
+  // First joiner becomes the host.
+  const assert_joined_as_host = computed(() =>
+    poll.myName === "Alice" &&
+    poll.adminName === "Alice" &&
+    poll.isJoined === true &&
+    poll.isAdmin === true &&
+    (poll.users ?? []).length === 1 &&
+    poll.users?.[0]?.name === "Alice"
+  );
+  const assert_option_added = computed(() =>
+    (poll.options ?? []).length === 1 &&
+    poll.options?.[0]?.title === "Sushi"
+  );
+  const assert_own_vote = computed(() =>
+    (poll.votes ?? []).length === 1 &&
+    poll.votes?.[0]?.voterName === "Alice" &&
+    poll.votes?.[0]?.voteType === "green"
+  );
+  // Bob joined and voted; his two gated addOption attempts left no trace.
+  const assert_sees_bob = computed(() =>
+    (poll.users ?? []).length === 2 &&
+    poll.users?.[1]?.name === "Bob" &&
+    (poll.votes ?? []).length === 2 &&
+    poll.votes?.[1]?.voterName === "Bob" &&
+    (poll.options ?? []).length === 1 &&
+    poll.myName === "Alice"
+  );
+  // Host takeover observed from the deposed host's runtime.
+  const assert_deposed = computed(() =>
+    poll.adminName === "Bob" && poll.isAdmin === false
+  );
+
+  return {
+    tests: [
+      { action: action_join },
+      { assertion: assert_joined_as_host },
+      { action: action_add_sushi },
+      { assertion: assert_option_added },
+      { action: action_vote_green },
+      { assertion: assert_own_vote },
+      { label: "alice-set-up" },
+      { await: "bob-voted" },
+      { assertion: assert_sees_bob },
+      { await: "bob-claimed-host" },
+      { assertion: assert_deposed },
+    ],
+  };
+});
+
+export const bob = pattern<{ setup: Setup }>(({ setup }) => {
+  const poll = setup.poll;
+
+  const action_try_add_before_join = action(() => {
+    poll.addOption.send({ title: "Pizza" });
+  });
+  const action_join = action(() => {
+    poll.joinAs.send({ name: "Bob" });
+  });
+  const action_try_add_as_non_host = action(() => {
+    poll.addOption.send({ title: "Pizza" });
+  });
+  const action_vote_green = action(() => {
+    const first = poll.options?.[0];
+    if (first) poll.castVote.send({ optionId: first.id, voteType: "green" });
+  });
+  const action_claim_host = action(() => {
+    poll.claimHost.send({});
+  });
+
+  // Alice's setup propagated from her runtime.
+  const assert_sees_alice_setup = computed(() =>
+    (poll.users ?? []).length === 1 &&
+    poll.users?.[0]?.name === "Alice" &&
+    poll.adminName === "Alice" &&
+    (poll.options ?? []).length === 1 &&
+    poll.options?.[0]?.title === "Sushi" &&
+    (poll.votes ?? []).length === 1
+  );
+  // PerUser isolation: Alice's join must not leak into Bob's identity.
+  const assert_not_joined_yet = computed(() =>
+    poll.myName === "" && poll.isJoined === false
+  );
+  const assert_joined_not_host = computed(() =>
+    poll.myName === "Bob" &&
+    poll.isJoined === true &&
+    poll.isAdmin === false &&
+    (poll.users ?? []).length === 2 &&
+    poll.users?.[1]?.name === "Bob"
+  );
+  // Both gated attempts (pre-join AND joined-but-not-host) left no trace —
+  // the CT-1598 gap: a real second user is rejected by the host gate.
+  const assert_gating_held = computed(() => (poll.options ?? []).length === 1);
+  const assert_both_votes = computed(() =>
+    (poll.votes ?? []).length === 2 &&
+    poll.votes?.[0]?.voterName === "Alice" &&
+    poll.votes?.[1]?.voterName === "Bob"
+  );
+  const assert_is_host_now = computed(() =>
+    poll.adminName === "Bob" && poll.isAdmin === true
+  );
+
+  return {
+    tests: [
+      { await: "alice-set-up" },
+      { assertion: assert_sees_alice_setup },
+      { assertion: assert_not_joined_yet },
+      { action: action_try_add_before_join },
+      { action: action_join },
+      { assertion: assert_joined_not_host },
+      { action: action_try_add_as_non_host },
+      { assertion: assert_gating_held },
+      { action: action_vote_green },
+      { assertion: assert_both_votes },
+      { label: "bob-voted" },
+      { action: action_claim_host },
+      { assertion: assert_is_host_now },
+      { label: "bob-claimed-host" },
+    ],
+  };
+});
+
+export default multiUserTest({ setup, participants: { alice, bob } });

--- a/packages/patterns/scrabble/multi-user.test.tsx
+++ b/packages/patterns/scrabble/multi-user.test.tsx
@@ -1,0 +1,118 @@
+/// <cts-enable />
+/**
+ * Multi-user pattern test for scrabble.
+ *
+ * Unlike scrabble.test.tsx (one runtime, one identity), this runs ONE shared
+ * game across two worker-isolated runtimes — exercising what a single runtime
+ * cannot: each user draws into their OWN PerUser rack from the shared bag,
+ * the shared player roster propagates across runtimes, and the "name already
+ * taken" guard rejects a join from a genuinely different user.
+ *
+ * Joins go through the programmatic `joinWithName` stream (the headless seam
+ * kept by the profile migration); the profile-wish UI path needs a browser.
+ *
+ * Cross-runtime read caveats baked into this test (reads of state another
+ * runtime wrote, before this runtime's first own write):
+ * - roster reads are INLINE literal accesses (players[0].name) in the
+ *   assertion computed — `.map()`, loop-variable indexing, and module-level
+ *   helper calls over the shared array do not resolve cross-runtime.
+ * - a participant cannot read their own UNWRITTEN PerUser array (bob's rack
+ *   before joining), so pre-join isolation is asserted via `myName` and via
+ *   Alice's rack surviving Bob's join.
+ *
+ * Join order is deterministic (markers): Alice first, then Bob.
+ */
+import { action, computed, multiUserTest, pattern } from "commonfabric";
+import Scrabble, { type GameOutput } from "./scrabble.tsx";
+
+interface Setup {
+  game: GameOutput;
+}
+
+export const setup = pattern(() => ({
+  game: Scrabble({ gameName: "Multi-user Scrabble" }),
+}));
+
+export const alice = pattern<{ setup: Setup }>(({ setup }) => {
+  const game = setup.game;
+
+  const action_join = action(() => {
+    game.joinWithName.send("Alice");
+  });
+
+  const assert_joined = computed(() =>
+    game.myName === "Alice" &&
+    (game.rack ?? []).length === 7 &&
+    (game.players ?? []).length === 1 &&
+    game.players?.[0]?.name === "Alice"
+  );
+  // Bob joining must not clobber Alice's PerUser identity or rack, and the
+  // shared roster must resolve BOTH players in Alice's runtime.
+  const assert_sees_both = computed(() =>
+    (game.players ?? []).length === 2 &&
+    game.players?.[0]?.name === "Alice" &&
+    game.players?.[1]?.name === "Bob" &&
+    game.myName === "Alice" &&
+    (game.rack ?? []).length === 7
+  );
+  // Two players drew 7 tiles each from the one shared bag.
+  const assert_bag_consumed = computed(() => game.bagIndex === 14);
+
+  return {
+    tests: [
+      { action: action_join },
+      { assertion: assert_joined },
+      { label: "alice-joined" },
+      { await: "bob-joined" },
+      { assertion: assert_sees_both },
+      { assertion: assert_bag_consumed },
+    ],
+  };
+});
+
+export const bob = pattern<{ setup: Setup }>(({ setup }) => {
+  const game = setup.game;
+
+  const action_join_as_alice = action(() => {
+    game.joinWithName.send("Alice");
+  });
+  const action_join = action(() => {
+    game.joinWithName.send("Bob");
+  });
+
+  // Shared roster propagated from Alice's runtime.
+  const assert_sees_alice = computed(() =>
+    (game.players ?? []).length === 1 &&
+    game.players?.[0]?.name === "Alice"
+  );
+  // PerUser isolation: Alice's join must not leak into Bob's identity.
+  const assert_not_joined_yet = computed(() => game.myName === "");
+  // A DIFFERENT user trying to take Alice's name is rejected with a message
+  // (PerSession) and stays unjoined.
+  const assert_name_taken = computed(() =>
+    game.message === "Name Alice is already taken." &&
+    game.myName === ""
+  );
+  const assert_joined = computed(() =>
+    game.myName === "Bob" &&
+    (game.rack ?? []).length === 7 &&
+    (game.players ?? []).length === 2 &&
+    game.players?.[0]?.name === "Alice" &&
+    game.players?.[1]?.name === "Bob"
+  );
+
+  return {
+    tests: [
+      { await: "alice-joined" },
+      { assertion: assert_sees_alice },
+      { assertion: assert_not_joined_yet },
+      { action: action_join_as_alice },
+      { assertion: assert_name_taken },
+      { action: action_join },
+      { assertion: assert_joined },
+      { label: "bob-joined" },
+    ],
+  };
+});
+
+export default multiUserTest({ setup, participants: { alice, bob } });

--- a/packages/patterns/scrabble/scrabble.tsx
+++ b/packages/patterns/scrabble/scrabble.tsx
@@ -1104,6 +1104,13 @@ const submitTurn = handler<
   );
 });
 
+// Stable empty fallbacks for the output snapshots below — fresh `[]` per
+// recompute would make the computed results non-idempotent.
+const EMPTY_TILES: PlacedTile[] = [];
+const EMPTY_LETTERS: Letter[] = [];
+const EMPTY_PLAYERS: Player[] = [];
+const EMPTY_EVENTS: GameEvent[] = [];
+
 const ScrabbleGame = pattern<GameInput, GameOutput>(
   (
     {
@@ -1581,15 +1588,21 @@ const ScrabbleGame = pattern<GameInput, GameOutput>(
           </aside>
         </div>
       ),
-      myName,
-      board,
-      bag,
-      bagIndex,
-      players,
-      gameEvents,
-      rack,
-      placed,
-      message,
+      // Output snapshots readable from OTHER runtimes (multi-user tests,
+      // remote viewers): raw scoped cells read as undefined in runtimes that
+      // didn't write them, and a computed that RETURNS undefined is
+      // indistinguishable from "not yet computed" for cross-runtime readers —
+      // so every snapshot yields a real, stable value (the shared EMPTY
+      // constants keep the fallback idempotent across recomputes).
+      myName: computed(() => trimmedName(myName.get())),
+      board: computed(() => board.get() ?? EMPTY_TILES),
+      bag: computed(() => bag.get() ?? EMPTY_LETTERS),
+      bagIndex: computed(() => bagIndex.get() ?? 0),
+      players: computed(() => players.get() ?? EMPTY_PLAYERS),
+      gameEvents: computed(() => gameEvents.get() ?? EMPTY_EVENTS),
+      rack: computed(() => rack.get() ?? EMPTY_LETTERS),
+      placed: computed(() => placed.get() ?? EMPTY_TILES),
+      message: computed(() => message.get() ?? ""),
       joinGame,
       joinWithName,
       placeTile,

--- a/packages/patterns/scrabble/scrabble.tsx
+++ b/packages/patterns/scrabble/scrabble.tsx
@@ -2,7 +2,11 @@
  * Multiplayer Free-for-All Scrabble
  *
  * Shared board, bag, scoreboard, and event log are scoped to the space. Each
- * user's name, rack, and unsubmitted board tiles are scoped per user.
+ * user's name, rack, and unsubmitted board tiles are scoped per user. The
+ * viewer's name and avatar come from their shared profile
+ * (`wish({ query: "#profile" })`): the wish's built-in UI lets them pick an
+ * existing profile or create a new one, and joining snapshots the resolved
+ * values into the shared player roster.
  */
 
 import {
@@ -18,6 +22,7 @@ import {
   safeDateNow,
   Stream,
   UI,
+  wish,
   Writable,
 } from "commonfabric";
 
@@ -36,6 +41,8 @@ export interface PlacedTile {
 
 export interface Player {
   name: string;
+  /** Avatar URL or glyph, snapshotted from the joiner's shared profile. */
+  avatar?: string;
   color: string;
   score: number;
   joinedAt: number;
@@ -318,7 +325,6 @@ export interface GameInput {
   rack?: PerUser<RackCell>;
   placed?: PerUser<PlacedCell>;
   myName?: PerUser<NameCell>;
-  joinName?: PerSession<NameCell>;
   message?: PerSession<MessageCell>;
 }
 
@@ -609,6 +615,7 @@ function returnedLetters(tiles: readonly PlacedTile[]): Letter[] {
 
 function joinPlayerByName(
   nameInput: string | undefined,
+  avatar: string,
   myName: NameCell,
   rack: RackCell,
   placed: PlacedCell,
@@ -621,7 +628,7 @@ function joinPlayerByName(
 ): boolean {
   const name = trimmedName(nameInput);
   if (!name) {
-    message.set("Enter your name to join.");
+    message.set("Set up a profile to join.");
     return false;
   }
 
@@ -661,6 +668,7 @@ function joinPlayerByName(
   const drawn = drawTilesFromBag(currentBag, currentIndex, 7);
   const player: Player = {
     name,
+    avatar: (avatar ?? "").trim(),
     color: getRandomColor(existingPlayers.length),
     score: 0,
     joinedAt: safeDateNow(),
@@ -681,10 +689,13 @@ function joinPlayerByName(
   return true;
 }
 
+// Join with the viewer's resolved profile. `name`/`avatar` arrive as plain
+// strings (named `computed` values auto-unwrap as handler state).
 const joinGameHandler = handler<
   void,
   {
-    joinName: NameCell;
+    name: string;
+    avatar: string;
     myName: NameCell;
     rack: RackCell;
     placed: PlacedCell;
@@ -698,7 +709,8 @@ const joinGameHandler = handler<
 >((
   _event,
   {
-    joinName,
+    name,
+    avatar,
     myName,
     rack,
     placed,
@@ -710,8 +722,9 @@ const joinGameHandler = handler<
     message,
   },
 ) => {
-  const joined = joinPlayerByName(
-    joinName.get(),
+  joinPlayerByName(
+    name,
+    avatar,
     myName,
     rack,
     placed,
@@ -722,7 +735,6 @@ const joinGameHandler = handler<
     gameEvents,
     message,
   );
-  if (joined) joinName.set("");
 });
 
 const joinWithNameHandler = handler<
@@ -744,6 +756,7 @@ const joinWithNameHandler = handler<
 ) => {
   joinPlayerByName(
     name,
+    "",
     myName,
     rack,
     placed,
@@ -1103,11 +1116,30 @@ const ScrabbleGame = pattern<GameInput, GameOutput>(
       rack,
       placed,
       myName,
-      joinName,
       message,
     },
   ) => {
     const cellWithGap = CELL_SIZE + 2;
+
+    // Resolve THIS viewer's shared profile. The `#profile` wish's built-in UI
+    // covers the whole lifecycle: a create surface when the viewer has no
+    // profile, a link when they have one, and a picker (with inline create)
+    // when they have several. The field targets give the snapshot strings.
+    const profileWish = wish<{ name?: string; avatar?: string }>({
+      query: "#profile",
+    });
+    const profileNameWish = wish<string>({ query: "#profileName" });
+    const profileAvatarWish = wish<string>({ query: "#profileAvatar" });
+
+    const profileName = computed(() => profileNameWish.result ?? "");
+    const profileAvatar = computed(() => profileAvatarWish.result ?? "");
+    const hasProfile = computed(() =>
+      (profileNameWish.result ?? "").trim() !== ""
+    );
+    const joinLabel = computed(() =>
+      hasProfile ? `Join as ${profileName}` : "Create a profile to join"
+    );
+
     const joined = computed(() =>
       players.get().some((player) => player.name === trimmedName(myName.get()))
     );
@@ -1117,7 +1149,8 @@ const ScrabbleGame = pattern<GameInput, GameOutput>(
       rack.get().map((letter, index) => ({ ...letter, index }))
     );
     const joinGame = joinGameHandler({
-      joinName,
+      name: profileName,
+      avatar: profileAvatar,
       myName,
       rack,
       placed,
@@ -1210,13 +1243,17 @@ const ScrabbleGame = pattern<GameInput, GameOutput>(
                       width: "min(420px, 100%)",
                     }}
                   >
-                    <cf-input
-                      $value={joinName}
-                      placeholder="Your name"
-                      timing-strategy="immediate"
-                      style="flex: 1;"
-                    />
-                    <cf-button onClick={joinGame}>Join</cf-button>
+                    {
+                      /* Built-in profile UI: create a profile when there is
+                        none, pick between existing profiles otherwise. */
+                    }
+                    <div style={{ flex: 1 }}>{profileWish[UI]}</div>
+                    <cf-button
+                      onClick={joinGame}
+                      disabled={computed(() => !hasProfile)}
+                    >
+                      {joinLabel}
+                    </cf-button>
                   </div>
                 )}
             </div>
@@ -1503,8 +1540,12 @@ const ScrabbleGame = pattern<GameInput, GameOutput>(
                     : "3px solid transparent",
                 }}
               >
-                <div style={{ fontWeight: 700 }}>
-                  {getInitials(player.name)}
+                <div style={{ display: "flex", justifyContent: "center" }}>
+                  <cf-avatar
+                    src={player.avatar}
+                    name={player.name}
+                    size="sm"
+                  />
                 </div>
                 <div
                   style={{


### PR DESCRIPTION
## Summary

Many examples still established user identity with a local free-text "Your name" field. This migrates them to the wish-based profile flow: `wish({ query: "#profile" })` (+ `#profileName` / `#profileAvatar`), with the wish's built-in `[UI]` embedded in each join card — so users get the trusted **create surface** when they have no profile, and the **profile picker with inline create** when they have several. Joining snapshots the resolved name/avatar into the shared roster entry, per `docs/specs/shared-profile-rosters.md`.

**Migrated patterns**
- `group-chat-lobby.tsx` + `group-chat-room.tsx` — profile join; room renders profile-snapshot avatars via `cf-avatar` and drops the local avatar-upload machinery (the profile owns the avatar now)
- `battleship/multiplayer` — profile join; avatars on player slots
- `scrabble` — profile join; player cards render `cf-avatar` instead of hand-rolled initials
- `lunch-poll`, `cozy-poll` — profile join (same join-by-name idiom)
- `factory-outputs/lot-watch` — "Reporting as" free-text becomes one-click "Report as ⟨profile⟩" backed by the wish UI

**Kept working:** the programmatic join streams (`joinWithName`, `joinPlayer1/2`, `joinAs({name})`, `setReporterName`) still accept plain names — tests and headless drivers use them. An explicit event name overrides the profile and deliberately skips the profile avatar.

**Deliberately not migrated:** `scoped-group-chat` (the documented free-text baseline that `profile-group-chat` contrasts with), `cfc-group-chat-demo` (own CFC trusted-identity architecture), `scoped-user-directory` (stream-driven scope demo, no name UI), `parking-coordinator` (admin-curated Person registry, not viewer identity).

**Docs:** `multi-user-patterns.md` now points identity sourcing at the profile wish; pattern index + roster spec citations refreshed; rotted line-number citations into lot-watch replaced with symbol anchors.

## Test plan

- `cf test`: battleship lobby (22) + room (9), scrabble (5), lunch-poll (16), cozy-poll (12), lot-watch (31) — all green
- `deno check` on all touched patterns (pre-commit hook)
- Not browser-verified; the `{profileWish[UI]}` embed follows the `arbitrary-wish-example` / `create-auth-manager` precedent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates example patterns from free‑text joins to the shared‑profile wish flow and adds multi‑user tests. Outputs now expose stable computed snapshots so cross‑runtime reads work in the new tests.

- New Features
  - Join via `wish({ query: "#profile" })` with inline UI; snapshot `#profileName`/`#profileAvatar`; join buttons disable until a profile resolves and label “Join as {name}”.
  - Migrated: `group-chat-lobby`/room, `battleship/multiplayer`, `scrabble`, `lunch-poll`, `cozy-poll`, `factory-outputs/lot-watch` (“Report as {profile}”).
  - Multi-user tests added for `battleship`, `scrabble`, `lunch-poll`, `cozy-poll` to cover real second-user joins, gating, and host takeover.
  - Programmatic overrides kept for tests: `joinWithName`, `joinPlayer1/2`, `joinAs({ name })`, `setReporterName` (explicit name overrides profile and skips avatar).

- Refactors
  - Group chat: roster identity uses the `#profile` cell (`equals()`), display-name collisions auto-disambiguated; avatars render via `cf-avatar`; local avatar upload removed.
  - Patterns expose read-surface outputs as computed snapshots with stable fallbacks (arrays/strings) for cross‑runtime visibility in tests.
  - Schemas/handlers accept `name`/`avatar` strings and snapshot on join; UIs render avatars via `cf-avatar`.
  - Docs updated to point identity sourcing at the profile wish and to reference `cf-avatar` (multi-user guide, roster spec, pattern index).

<sup>Written for commit f3211ecf9a03c750e0964ed18d3ea4f643057b36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



## Performance baselines

New baselines accepted for this PR, understood as follows:
- `pattern-unit-3/4` shards + `Generated Patterns Integration (3/4)`: four new multi-user pattern tests (battleship, scrabble, lunch-poll, cozy-poll), each booting an in-process memory server plus two worker-isolated runtimes — intended added coverage.
- `lot-watch/main.test.tsx` subtest (45.8s vs 45.7s threshold): the pattern now resolves three #profile wishes per instantiation; marginal real cost of the profile flow.
- `Package Integration Tests (shell)`: not touched by this PR — the run sits on freshly-rebased main (incl. the Deno 2.8.1 toolchain upgrade) while the baseline median is mostly pre-upgrade runs.

NEW_PERF_BASELINE: job: Generated Patterns Integration Tests (3/4) = 72s
NEW_PERF_BASELINE: job: Package Integration Tests = 128s
NEW_PERF_BASELINE: job: Package Integration Tests (shell) = 128s
NEW_PERF_BASELINE: test: pattern-unit-4/pattern-unit-tests = 234s
NEW_PERF_BASELINE: test: pattern-unit-3/pattern-unit-tests = 279s
NEW_PERF_BASELINE: subtest: pattern-unit-3/pattern-unit-tests > packages/patterns/factory-outputs/lot-watch/main.test.tsx = 46s

NEW_PERF_BASELINE: test: pattern-unit-1/pattern-unit-tests = 160s
