### PR TITLE
Multi-user pattern tests in cf test: participant patterns in isolated runtimes with marker coordination

### DIFF
--- a/docs/common/ai/pattern-testing-guide.md
+++ b/docs/common/ai/pattern-testing-guide.md
@@ -113,7 +113,11 @@ against one shared space on an in-process storage server.
 
 ```tsx
 import { action, computed, multiUserTest, pattern } from "commonfabric";
-import Chat from "./pattern.tsx";
+import Chat, { type ChatOutput } from "./pattern.tsx";
+
+interface Setup {
+  chat: ChatOutput;
+}
 
 // Instantiates the shared state ONCE; every participant runtime runs this
 // same instance (like every browser tab does) and receives its result as

--- a/docs/common/ai/pattern-testing-guide.md
+++ b/docs/common/ai/pattern-testing-guide.md
@@ -102,6 +102,62 @@ export default pattern(() => {
 - test a sub-pattern before building the next dependent layer when that helps
   isolate failures
 
+## Multi-User Tests
+
+A single-runtime test cannot exercise `PerUser`/`PerSession` scoping or
+cross-client propagation — one runtime is one user and one session. For
+patterns with multi-user behavior, export a `multiUserTest` descriptor as the
+default export instead of a single test pattern. `cf test` then runs each
+participant pattern in its own isolated runtime (own identity, own realm)
+against one shared space on an in-process storage server.
+
+```tsx
+import { action, computed, multiUserTest, pattern } from "commonfabric";
+import Chat from "./pattern.tsx";
+
+// Instantiates the shared state ONCE; every participant runtime runs this
+// same instance (like every browser tab does) and receives its result as
+// the `setup` input.
+export const setup = pattern(() => ({ chat: Chat({}) }));
+
+export const alice = pattern<{ setup: Setup }>(({ setup }) => {
+  const save = action(() => setup.chat.saveProfile.send());
+  const sees_bob = computed(() => /* ... */);
+  return {
+    tests: [
+      { action: save },
+      { label: "alice-saved" }, //  announce a marker
+      { await: "bob-saved" }, //    park until bob announces
+      { assertion: sees_bob },
+    ],
+  };
+});
+
+export const bob = pattern<{ setup: Setup }>(({ setup }) => {
+  /* ... */
+});
+
+export default multiUserTest({ setup, participants: { alice, bob } });
+```
+
+Key points:
+
+- A participant's steps run in order; cross-participant ordering happens
+  ONLY at `{ label: "name" }` / `{ await: "name" }` markers. If every
+  remaining participant is parked on an unannounced marker, the test fails
+  with a deadlock report.
+- Each participant gets its own identity. Use
+  `{ pattern: aliceTab2, user: "alice" }` for a second session of an
+  existing user (PerUser state shared, PerSession state isolated).
+- Assertions retry (with settling) until the step timeout, since asserted
+  state may still be propagating from another runtime — don't assert
+  "other user does NOT see X yet" right after the other user acted; assert
+  stable invariants instead.
+- The example to copy:
+  `packages/patterns/cfc-group-chat-demo/multi-user.test.tsx`. The scope
+  model background: `docs/common/patterns/multi-user-patterns.md` and
+  `docs/development/debugging/gotchas/scoped-cell-pitfalls.md`.
+
 ## Testing Time and Randomness
 
 If a pattern uses `safeDateNow()` or `nonPrivateRandom()`, keep the assertions

--- a/docs/common/patterns/multi-user-patterns.md
+++ b/docs/common/patterns/multi-user-patterns.md
@@ -306,19 +306,25 @@ inside the child pattern or handler.
 ## Testing Multi-User Behavior
 
 Use pattern tests for deterministic state transitions and browser/integration
-tests for identity behavior.
+tests for identity behavior. A single runtime (or one page that switches
+identities) cannot catch cross-user leaks or fails-to-propagate bugs.
 
-For headless multi-user coverage, use the multi-runtime harness
-(`packages/patterns/integration/multi-runtime-harness.ts`): it opens the same
-piece in several worker-isolated runtimes (distinct identities, or one
-identity in two sessions) against one shared in-process storage server, so
-`PerUser`/`PerSession` partitioning and cross-client propagation are actually
-exercised — no toolshed or browser needed. See
-`cfc-group-chat-demo-multi-runtime.test.ts` for usage, and
-`cfc-group-chat-demo-two-browsers.test.ts` for the two-simultaneous-browser
-variant that guards the real DOM/event stack. A single runtime (or one page
-that switches identities) cannot catch cross-user leaks or
-fails-to-propagate bugs.
+Three escalating options:
+
+1. **Multi-user pattern tests (`cf test`)** — the default for pattern
+   authors. Export a `multiUserTest({ setup, participants })` descriptor;
+   each participant pattern runs in its own isolated runtime against one
+   shared space, coordinating via `{ label }` / `{ await }` markers. See the
+   "Multi-User Tests" section of `docs/common/ai/pattern-testing-guide.md`
+   and the example `packages/patterns/cfc-group-chat-demo/multi-user.test.tsx`.
+2. **Multi-runtime integration harness**
+   (`packages/patterns/integration/multi-runtime-harness.ts`): opens an
+   existing piece in several worker-isolated runtimes (distinct identities,
+   or one identity in two sessions); supports trusted-surface CFC events
+   headlessly. See `cfc-group-chat-demo-multi-runtime.test.ts`.
+3. **Two simultaneous browsers**
+   (`cfc-group-chat-demo-two-browsers.test.ts`): guards the real DOM input
+   binding / event-provenance / login stack.
 
 Expected visibility:
 

--- a/packages/api/index.ts
+++ b/packages/api/index.ts
@@ -2498,6 +2498,25 @@ export type EqualsFunction = (
   b: AnyCell<any> | object | undefined,
 ) => boolean;
 
+/**
+ * Multi-user pattern test descriptor (`cf test`). Export it as the test
+ * file's default export to run each participant pattern in its own isolated
+ * runtime (own identity) against one shared space. The optional `setup`
+ * pattern instantiates shared state once; each participant pattern receives
+ * its result as the `setup` input. Participants coordinate through
+ * `{ label: "name" }` / `{ await: "name" }` entries in their `tests` arrays.
+ * Use `{ pattern, user: "other" }` to run a second session of an existing
+ * user's identity.
+ */
+export interface MultiUserTestDescriptor {
+  setup?: (...args: never[]) => unknown;
+  participants: Record<
+    string,
+    | ((...args: never[]) => unknown)
+    | { pattern: (...args: never[]) => unknown; user?: string }
+  >;
+}
+
 // Re-export all function types as values for destructuring imports
 // These will be implemented by the factory
 export declare const pattern: PatternFunction;
@@ -2525,6 +2544,14 @@ export declare const table: SqliteTableFunction;
 export declare const cfLink: SqliteCfLinkFunction;
 export declare const navigateTo: NavigateToFunction;
 export declare const wish: WishFunction;
+/**
+ * Tag a multi-user test descriptor for `cf test` (identity at runtime; a
+ * call expression keeps the descriptor's pattern factories out of the
+ * plain-data hardening that module-level data literals receive).
+ */
+export declare const multiUserTest: <T extends MultiUserTestDescriptor>(
+  descriptor: T,
+) => T;
 export declare const createNodeFactory: CreateNodeFactoryFunction;
 /** @deprecated Use Cell.of(defaultValue?) instead */
 export declare const cell: CellTypeConstructor<AsCell>["of"];

--- a/packages/cli/lib/multi-user-test-runner.ts
+++ b/packages/cli/lib/multi-user-test-runner.ts
@@ -1,0 +1,422 @@
+/**
+ * Multi-user mode for `cf test`.
+ *
+ * A multi-user test file exports a descriptor as its default export:
+ *
+ * ```tsx
+ * export const setup = pattern(() => ({ chat: GroupChatDemo({}) }));
+ * export const alice = pattern<{ setup: Setup }>(({ setup }) => ({
+ *   tests: [
+ *     { action: action_save_alice },
+ *     { label: "alice-saved" },
+ *     { await: "bob-saved" },
+ *     { assertion: assert_sees_bob },
+ *   ],
+ * }));
+ * export const bob = pattern<{ setup: Setup }>(({ setup }) => ({
+ *   tests: [
+ *     { await: "alice-saved" },
+ *     { assertion: assert_sees_alice },
+ *     { action: action_save_bob },
+ *     { label: "bob-saved" },
+ *   ],
+ * }));
+ * export default { setup, participants: { alice, bob } };
+ * ```
+ *
+ * Each participant runs in its own worker realm with its own identity
+ * (`{ pattern, user: "alice" }` shares an identity for a second session of
+ * the same user), all against one shared space on an in-process storage
+ * server. The `setup` pattern instantiates the shared piece once; every
+ * worker runs that same instance locally (like every browser tab does), so
+ * per-user scoped state behaves like production.
+ *
+ * Coordination: a participant's steps run in order until an
+ * `{ await: marker }` for a marker no other participant has announced via
+ * `{ label: marker }` yet; the orchestrator then switches to the next
+ * runnable participant. If every unfinished participant is parked, the test
+ * fails with a deadlock report. Assertions retry (with settling) until the
+ * step timeout, since asserted state may still be propagating from another
+ * runtime.
+ */
+
+import { Identity } from "@commonfabric/identity";
+import { StandaloneMemoryServer } from "@commonfabric/memory/v2/standalone";
+import type {
+  TestResult,
+  TestRunnerOptions,
+  TestRunResult,
+} from "./test-runner.ts";
+import type {
+  ParticipantInitResult,
+  StepMeta,
+  WorkerRequest,
+  WorkerResponse,
+} from "./multi-user-test-worker.ts";
+
+export interface MultiUserParticipantSpec {
+  name: string;
+  /** Identity seed; participants with the same `user` share an identity. */
+  user: string;
+}
+
+export interface MultiUserDescriptorMeta {
+  participants: MultiUserParticipantSpec[];
+}
+
+/**
+ * Recognize a multi-user descriptor (default export with a `participants`
+ * record of pattern factories or `{ pattern, user? }` entries). Returns the
+ * orchestration metadata, or undefined for ordinary single-runtime tests.
+ */
+export function multiUserDescriptorMeta(
+  defaultExport: unknown,
+): MultiUserDescriptorMeta | undefined {
+  if (
+    typeof defaultExport !== "object" || defaultExport === null ||
+    typeof (defaultExport as { participants?: unknown }).participants !==
+      "object"
+  ) {
+    return undefined;
+  }
+  const raw = (defaultExport as { participants: Record<string, unknown> })
+    .participants;
+  const participants: MultiUserParticipantSpec[] = [];
+  for (const [name, entry] of Object.entries(raw)) {
+    if (typeof entry === "function") {
+      participants.push({ name, user: name });
+    } else if (
+      typeof entry === "object" && entry !== null &&
+      typeof (entry as { pattern?: unknown }).pattern === "function"
+    ) {
+      const user = (entry as { user?: unknown }).user;
+      participants.push({
+        name,
+        user: typeof user === "string" ? user : name,
+      });
+    } else {
+      return undefined;
+    }
+  }
+  return participants.length > 0 ? { participants } : undefined;
+}
+
+const RPC_TIMEOUT_MS = 120_000;
+const ASSERTION_RETRY_DELAY_MS = 100;
+
+class ParticipantWorker {
+  readonly name: string;
+  #worker: Worker;
+  #nextId = 1;
+  #pending = new Map<
+    number,
+    { resolve: (value: unknown) => void; reject: (error: Error) => void }
+  >();
+
+  constructor(name: string) {
+    this.name = name;
+    this.#worker = new Worker(
+      new URL("./multi-user-test-worker.ts", import.meta.url),
+      { type: "module", name: `cf-test:${name}` },
+    );
+    this.#worker.onmessage = (event: MessageEvent<WorkerResponse>) => {
+      const pending = this.#pending.get(event.data.id);
+      if (!pending) return;
+      this.#pending.delete(event.data.id);
+      if ("error" in event.data) {
+        pending.reject(new Error(`[${this.name}] ${event.data.error}`));
+      } else {
+        pending.resolve(event.data.ok);
+      }
+    };
+    this.#worker.onerror = (event) => {
+      const error = new Error(`[${this.name}] worker error: ${event.message}`);
+      for (const pending of this.#pending.values()) pending.reject(error);
+      this.#pending.clear();
+    };
+  }
+
+  call(cmd: string, args: Record<string, unknown> = {}): Promise<unknown> {
+    const id = this.#nextId++;
+    const request: WorkerRequest = { id, cmd, args };
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.#pending.delete(id);
+        reject(
+          new Error(
+            `[${this.name}] ${cmd} timed out after ${RPC_TIMEOUT_MS}ms`,
+          ),
+        );
+      }, RPC_TIMEOUT_MS);
+      this.#pending.set(id, {
+        resolve: (value) => {
+          clearTimeout(timer);
+          resolve(value);
+        },
+        reject: (error) => {
+          clearTimeout(timer);
+          reject(error);
+        },
+      });
+      this.#worker.postMessage(request);
+    });
+  }
+
+  terminate(): void {
+    this.#worker.terminate();
+    for (const pending of this.#pending.values()) {
+      pending.reject(new Error(`[${this.name}] worker terminated`));
+    }
+    this.#pending.clear();
+  }
+}
+
+interface ParticipantState {
+  spec: MultiUserParticipantSpec;
+  worker: ParticipantWorker;
+  steps: StepMeta[];
+  cursor: number;
+  actionCount: number;
+  assertionCount: number;
+  lastActionName: string | null;
+  allowRuntimeErrors: boolean;
+  expectNonIdempotent: boolean;
+}
+
+export async function runMultiUserTestPattern(
+  testPath: string,
+  meta: MultiUserDescriptorMeta,
+  options: TestRunnerOptions = {},
+): Promise<TestRunResult> {
+  const startTime = performance.now();
+  const stepTimeout = options.timeout ?? 5000;
+  const results: TestResult[] = [];
+  const runtimeErrors: string[] = [];
+  const nonIdempotent: string[] = [];
+  let allowRuntimeErrors = false;
+  let expectNonIdempotent = false;
+
+  const server = StandaloneMemoryServer.start();
+  const spaceName = crypto.randomUUID();
+  const participants: ParticipantState[] = [];
+
+  try {
+    const identities = new Map<string, Identity>();
+    for (const spec of meta.participants) {
+      if (!identities.has(spec.user)) {
+        identities.set(
+          spec.user,
+          await Identity.fromPassphrase(`test-runner ${spec.user}`, {
+            implementation: "noble",
+          }),
+        );
+      }
+    }
+
+    // Sequential init: the first worker materializes the shared setup
+    // instance (and the wish("#default") seed); the rest resume it.
+    for (const [index, spec] of meta.participants.entries()) {
+      const worker = new ParticipantWorker(spec.name);
+      try {
+        const init = await worker.call("init", {
+          rawIdentity: identities.get(spec.user)!.serialize(),
+          spaceName,
+          apiUrl: server.url.href,
+          testPath,
+          root: options.root,
+          participant: spec.name,
+          seedDefaults: index === 0,
+        }) as ParticipantInitResult;
+        participants.push({
+          spec,
+          worker,
+          steps: init.steps,
+          cursor: 0,
+          actionCount: 0,
+          assertionCount: 0,
+          lastActionName: null,
+          allowRuntimeErrors: init.allowRuntimeErrors,
+          expectNonIdempotent: init.expectNonIdempotent,
+        });
+        allowRuntimeErrors ||= init.allowRuntimeErrors;
+        expectNonIdempotent ||= init.expectNonIdempotent;
+        if (options.verbose) {
+          console.log(
+            `  [${spec.name}] ${init.steps.length} step(s), user "${spec.user}"`,
+          );
+        }
+      } catch (error) {
+        worker.terminate();
+        throw error;
+      }
+    }
+
+    // Marker scheduler: round-robin in declaration order; each turn runs a
+    // participant's steps until it parks on an unannounced marker or ends.
+    const announced = new Set<string>();
+    while (participants.some((p) => p.cursor < p.steps.length)) {
+      let progressed = false;
+      for (const participant of participants) {
+        while (participant.cursor < participant.steps.length) {
+          const index = participant.cursor;
+          const step = participant.steps[index];
+          if (step.kind === "await" && !step.skip) {
+            if (!announced.has(step.marker!)) break; // parked
+            participant.cursor++;
+            progressed = true;
+            if (options.verbose) {
+              console.log(`  [${participant.spec.name}] ⇣ ${step.marker}`);
+            }
+            continue;
+          }
+          participant.cursor++;
+          progressed = true;
+          if (step.skip) {
+            recordSkip(participant, step, results, options);
+            continue;
+          }
+          if (step.kind === "label") {
+            announced.add(step.marker!);
+            if (options.verbose) {
+              console.log(`  [${participant.spec.name}] ⇡ ${step.marker}`);
+            }
+            continue;
+          }
+          if (step.kind === "action") {
+            participant.actionCount++;
+            participant.lastActionName = `action_${participant.actionCount}`;
+            const stepStart = performance.now();
+            await participant.worker.call("action", { index });
+            if (options.verbose) {
+              console.log(
+                `  [${participant.spec.name}] ${participant.lastActionName} (${
+                  Math.round(performance.now() - stepStart)
+                }ms)`,
+              );
+            }
+            continue;
+          }
+          // Assertion: retry with settling until the step timeout — the
+          // asserted state may still be propagating from another runtime.
+          participant.assertionCount++;
+          const name =
+            `${participant.spec.name}/assertion_${participant.assertionCount}`;
+          const stepStart = performance.now();
+          let passed = false;
+          let error: string | undefined;
+          while (true) {
+            try {
+              const outcome = await participant.worker.call("assertion", {
+                index,
+              }) as { passed: boolean };
+              passed = outcome.passed;
+              error = undefined;
+            } catch (assertionError) {
+              passed = false;
+              error = String(
+                (assertionError as Error).message ?? assertionError,
+              );
+            }
+            if (passed || performance.now() - stepStart >= stepTimeout) break;
+            await participant.worker.call("settle");
+            await new Promise((resolve) =>
+              setTimeout(resolve, ASSERTION_RETRY_DELAY_MS)
+            );
+          }
+          const durationMs = performance.now() - stepStart;
+          // runTests prints each result; no per-step echo here.
+          results.push({
+            name,
+            passed,
+            afterAction: participant.lastActionName === null
+              ? null
+              : `${participant.spec.name}/${participant.lastActionName}`,
+            ...(error !== undefined ? { error } : {}),
+            durationMs,
+          });
+        }
+      }
+      if (!progressed) {
+        const parked = participants
+          .filter((p) => p.cursor < p.steps.length)
+          .map((p) => `${p.spec.name} awaits "${p.steps[p.cursor].marker}"`)
+          .join("; ");
+        throw new Error(
+          `Deadlock: every remaining participant is parked (${parked}). ` +
+            `Check {label}/{await} markers for a cycle or a missing label.`,
+        );
+      }
+    }
+
+    for (const participant of participants) {
+      const health = await participant.worker.call("health") as {
+        runtimeErrors: string[];
+        nonIdempotent: string[];
+      };
+      runtimeErrors.push(
+        ...health.runtimeErrors.map((e) => `[${participant.spec.name}] ${e}`),
+      );
+      nonIdempotent.push(
+        ...health.nonIdempotent.map((e) => `[${participant.spec.name}] ${e}`),
+      );
+    }
+
+    return {
+      path: testPath,
+      results,
+      totalDurationMs: performance.now() - startTime,
+      navigations: [],
+      runtimeErrors,
+      allowRuntimeErrors,
+      nonIdempotent,
+      expectNonIdempotent,
+    };
+  } catch (error) {
+    return {
+      path: testPath,
+      results,
+      totalDurationMs: performance.now() - startTime,
+      navigations: [],
+      runtimeErrors,
+      allowRuntimeErrors,
+      nonIdempotent,
+      expectNonIdempotent,
+      error: error instanceof Error
+        ? `${error.message}\n${error.stack ?? ""}`
+        : String(error),
+    };
+  } finally {
+    for (const participant of participants) {
+      await participant.worker.call("dispose").catch(() => {});
+      participant.worker.terminate();
+    }
+    await server.close().catch(() => {});
+  }
+}
+
+function recordSkip(
+  participant: ParticipantState,
+  step: StepMeta,
+  results: TestResult[],
+  options: TestRunnerOptions,
+): void {
+  if (step.kind === "assertion") {
+    participant.assertionCount++;
+    const name =
+      `${participant.spec.name}/assertion_${participant.assertionCount}`;
+    results.push({
+      name,
+      passed: true,
+      skipped: true,
+      afterAction: null,
+      durationMs: 0,
+    });
+  } else if (step.kind === "action") {
+    participant.actionCount++;
+    if (options.verbose) {
+      console.log(
+        `  [${participant.spec.name}] ⊘ action_${participant.actionCount} (skipped)`,
+      );
+    }
+  }
+}

--- a/packages/cli/lib/multi-user-test-runner.ts
+++ b/packages/cli/lib/multi-user-test-runner.ts
@@ -136,7 +136,11 @@ class ParticipantWorker {
     };
   }
 
-  call(cmd: string, args: Record<string, unknown> = {}): Promise<unknown> {
+  call(
+    cmd: string,
+    args: Record<string, unknown> = {},
+    timeoutMs = RPC_TIMEOUT_MS,
+  ): Promise<unknown> {
     const id = this.#nextId++;
     const request: WorkerRequest = { id, cmd, args };
     return new Promise((resolve, reject) => {
@@ -144,10 +148,10 @@ class ParticipantWorker {
         this.#pending.delete(id);
         reject(
           new Error(
-            `[${this.name}] ${cmd} timed out after ${RPC_TIMEOUT_MS}ms`,
+            `[${this.name}] ${cmd} timed out after ${timeoutMs}ms`,
           ),
         );
-      }, RPC_TIMEOUT_MS);
+      }, timeoutMs);
       this.#pending.set(id, {
         resolve: (value) => {
           clearTimeout(timer);
@@ -193,8 +197,6 @@ export async function runMultiUserTestPattern(
   const results: TestResult[] = [];
   const runtimeErrors: string[] = [];
   const nonIdempotent: string[] = [];
-  let allowRuntimeErrors = false;
-  let expectNonIdempotent = false;
 
   const server = StandaloneMemoryServer.start();
   const spaceName = crypto.randomUUID();
@@ -238,8 +240,6 @@ export async function runMultiUserTestPattern(
           allowRuntimeErrors: init.allowRuntimeErrors,
           expectNonIdempotent: init.expectNonIdempotent,
         });
-        allowRuntimeErrors ||= init.allowRuntimeErrors;
-        expectNonIdempotent ||= init.expectNonIdempotent;
         if (options.verbose) {
           console.log(
             `  [${spec.name}] ${init.steps.length} step(s), user "${spec.user}"`,
@@ -286,7 +286,10 @@ export async function runMultiUserTestPattern(
             participant.actionCount++;
             participant.lastActionName = `action_${participant.actionCount}`;
             const stepStart = performance.now();
-            await participant.worker.call("action", { index });
+            // Per-action deadline, matching the single-runtime runner's use
+            // of --timeout (an action is a local send + settle; a slow one is
+            // a bug, not propagation latency).
+            await participant.worker.call("action", { index }, stepTimeout);
             if (options.verbose) {
               console.log(
                 `  [${participant.spec.name}] ${participant.lastActionName} (${
@@ -348,17 +351,25 @@ export async function runMultiUserTestPattern(
       }
     }
 
+    // Apply allowRuntimeErrors / expectNonIdempotent PER participant — one
+    // participant opting out must not mask another participant's failures —
+    // so the aggregate result reports only unallowed entries with the flags
+    // left off.
     for (const participant of participants) {
       const health = await participant.worker.call("health") as {
         runtimeErrors: string[];
         nonIdempotent: string[];
       };
-      runtimeErrors.push(
-        ...health.runtimeErrors.map((e) => `[${participant.spec.name}] ${e}`),
-      );
-      nonIdempotent.push(
-        ...health.nonIdempotent.map((e) => `[${participant.spec.name}] ${e}`),
-      );
+      if (!participant.allowRuntimeErrors) {
+        runtimeErrors.push(
+          ...health.runtimeErrors.map((e) => `[${participant.spec.name}] ${e}`),
+        );
+      }
+      if (!participant.expectNonIdempotent) {
+        nonIdempotent.push(
+          ...health.nonIdempotent.map((e) => `[${participant.spec.name}] ${e}`),
+        );
+      }
     }
 
     return {
@@ -367,9 +378,7 @@ export async function runMultiUserTestPattern(
       totalDurationMs: performance.now() - startTime,
       navigations: [],
       runtimeErrors,
-      allowRuntimeErrors,
       nonIdempotent,
-      expectNonIdempotent,
     };
   } catch (error) {
     return {
@@ -378,9 +387,7 @@ export async function runMultiUserTestPattern(
       totalDurationMs: performance.now() - startTime,
       navigations: [],
       runtimeErrors,
-      allowRuntimeErrors,
       nonIdempotent,
-      expectNonIdempotent,
       error: error instanceof Error
         ? `${error.message}\n${error.stack ?? ""}`
         : String(error),

--- a/packages/cli/lib/multi-user-test-worker.ts
+++ b/packages/cli/lib/multi-user-test-worker.ts
@@ -1,0 +1,324 @@
+/**
+ * Worker-side runtime host for multi-user pattern tests (`cf test`).
+ *
+ * Each worker owns one full client stack — Identity, StorageManager,
+ * Runtime, Engine — in its own JS realm, exactly like one browser tab or
+ * CLI process. All workers of a test share one storage server and one
+ * space; each runs the test file's `setup` pattern on the SAME result cell
+ * (local-first: every client runs the shared instance, so per-user scoped
+ * outputs are computed under this worker's principal) and then its own
+ * participant pattern, whose `tests` steps the orchestrator drives via a
+ * small request/response protocol.
+ *
+ * Realm isolation is required, not an optimization: two runtimes in one
+ * realm cross-talk through module-level state (verified-load registries,
+ * frame stack).
+ */
+
+import { type Cell, Engine, type Pattern, Runtime } from "@commonfabric/runner";
+import { FileSystemProgramResolver } from "@commonfabric/js-compiler";
+import {
+  createSession,
+  Identity,
+  type KeyPairRaw,
+} from "@commonfabric/identity";
+
+export interface WorkerRequest {
+  id: number;
+  cmd: string;
+  args: Record<string, unknown>;
+}
+
+export type WorkerResponse =
+  | { id: number; ok: unknown }
+  | { id: number; error: string };
+
+export type StepKind = "action" | "assertion" | "label" | "await";
+
+export interface StepMeta {
+  kind: StepKind;
+  /** Marker name for label/await steps. */
+  marker?: string;
+  skip?: boolean;
+}
+
+export interface ParticipantInitResult {
+  steps: StepMeta[];
+  allowRuntimeErrors: boolean;
+  expectNonIdempotent: boolean;
+}
+
+const SETUP_CAUSE = "multi-user-test-setup";
+const SETTLE_FAST_MS = 2;
+
+let runtime: Runtime | undefined;
+let storageManager:
+  | { synced(): Promise<void>; close(): Promise<void> }
+  | undefined;
+let engine: Engine | undefined;
+let stepCells: Cell<unknown>[] = [];
+const runtimeErrors: string[] = [];
+
+function rt(): Runtime {
+  if (!runtime) throw new Error("worker not initialized");
+  return runtime;
+}
+
+async function settle(maxIterations = 20): Promise<void> {
+  for (let i = 0; i < maxIterations; i++) {
+    const start = performance.now();
+    await rt().idle();
+    await storageManager!.synced();
+    if (performance.now() - start < SETTLE_FAST_MS) return;
+  }
+}
+
+const stepPeekSchema = {
+  type: "object",
+  properties: {
+    action: { type: "unknown" },
+    assertion: { type: "unknown" },
+    label: { type: "string" },
+    await: { type: "string" },
+    skip: { type: "boolean" },
+  },
+} as const;
+
+function classifyStep(stepCell: Cell<unknown>, index: number): StepMeta {
+  const peek = stepCell.asSchema(stepPeekSchema).get() as {
+    action?: unknown;
+    assertion?: unknown;
+    label?: string;
+    await?: string;
+    skip?: boolean;
+  };
+  const skip = peek?.skip === true ? { skip: true } : {};
+  if (typeof peek?.label === "string") {
+    return { kind: "label", marker: peek.label, ...skip };
+  }
+  if (typeof peek?.await === "string") {
+    return { kind: "await", marker: peek.await, ...skip };
+  }
+  // Streams/computeds peek as present-but-opaque; key presence is the signal.
+  if (Object.hasOwn(peek ?? {}, "action")) return { kind: "action", ...skip };
+  if (Object.hasOwn(peek ?? {}, "assertion")) {
+    return { kind: "assertion", ...skip };
+  }
+  throw new Error(
+    `Test step ${index} has none of action/assertion/label/await ` +
+      `(keys: ${Object.keys(peek ?? {}).join(",") || "none"})`,
+  );
+}
+
+const handlers: Record<
+  string,
+  (args: Record<string, unknown>) => Promise<unknown>
+> = {
+  /**
+   * Boot the stack, run the shared `setup` pattern, run this worker's
+   * participant pattern, and return the classified step list.
+   */
+  async init(args) {
+    const identity = await Identity.deserialize(args.rawIdentity as KeyPairRaw);
+    const session = await createSession({
+      identity,
+      spaceName: args.spaceName as string,
+    });
+    const space = session.space;
+    const { StorageManager } = await import(
+      "@commonfabric/runner/storage/cache.deno"
+    );
+    storageManager = StorageManager.open({
+      as: session.as,
+      spaceIdentity: session.spaceIdentity,
+      address: new URL("/api/storage/memory", args.apiUrl as string),
+    });
+    runtime = new Runtime({
+      storageManager: storageManager as never,
+      // Same default as single-runtime pattern tests: actions are invoked
+      // directly rather than through the trusted renderer event path.
+      cfcEnforcementMode: "observe",
+      apiUrl: new URL(import.meta.url),
+      errorHandlers: [(error: Error) => runtimeErrors.push(String(error))],
+    });
+    runtime.enableIdempotencyCheck();
+    engine = new Engine(runtime);
+
+    const program = await engine.resolve(
+      new FileSystemProgramResolver(
+        args.testPath as string,
+        args.root as string | undefined,
+      ),
+    );
+    const { jsScript, id } = await engine.compile(program);
+    const { main } = await engine.evaluate(id, jsScript, program.files);
+    const descriptor = (main?.default ?? {}) as {
+      setup?: Pattern;
+      participants?: Record<string, Pattern | { pattern: Pattern }>;
+    };
+    const entry = descriptor.participants?.[args.participant as string];
+    const participantFactory = typeof entry === "function"
+      ? entry
+      : (entry as { pattern?: Pattern } | undefined)?.pattern;
+    if (typeof participantFactory !== "function") {
+      throw new Error(
+        `No participant pattern "${args.participant}" in test descriptor`,
+      );
+    }
+
+    // Minimal wish("#default") environment, seeded once by the first worker.
+    if (args.seedDefaults === true) {
+      const setupTx = rt().edit();
+      const spaceCell = rt().getCell(space, space, undefined, setupTx);
+      const defaultPatternCell = rt().getCell(
+        space,
+        "default-pattern",
+        undefined,
+        setupTx,
+      );
+      (defaultPatternCell as any).key("allPieces").set([]);
+      (defaultPatternCell as any).key("recentPieces").set([]);
+      (defaultPatternCell as any).key("backlinksIndex").set({
+        mentionable: [],
+      });
+      (spaceCell as any).key("defaultPattern").set(defaultPatternCell);
+      rt().prepareTxForCommit?.(setupTx);
+      await setupTx.commit();
+      await rt().idle();
+    }
+
+    // Run the shared setup pattern on a cause-derived result cell: every
+    // worker runs the SAME instance (the first materializes it, the rest
+    // resume it from storage and compute their own per-user partitions).
+    let setupCell: Cell<Record<string, unknown>> | undefined;
+    if (typeof descriptor.setup === "function") {
+      const tx = rt().edit();
+      setupCell = rt().getCell<Record<string, unknown>>(
+        space,
+        SETUP_CAUSE,
+        undefined,
+        tx,
+      );
+      await setupCell.sync();
+      rt().run(tx, descriptor.setup, {}, setupCell);
+      rt().prepareTxForCommit?.(tx);
+      await tx.commit();
+      await settle();
+    }
+
+    const tx = rt().edit();
+    const resultCell = rt().getCell<Record<string, unknown>>(
+      space,
+      `multi-user-test-${args.participant}`,
+      undefined,
+      tx,
+    );
+    rt().run(
+      tx,
+      participantFactory,
+      setupCell !== undefined ? { setup: setupCell } : {},
+      resultCell,
+    );
+    rt().prepareTxForCommit?.(tx);
+    await tx.commit();
+    await settle();
+
+    const stepsValue = resultCell.key("tests").asSchema(
+      {
+        type: "array",
+        items: { type: "object", asCell: ["cell"] },
+        default: [],
+      } as const,
+    ).get();
+    if (!Array.isArray(stepsValue)) {
+      throw new Error(
+        `Participant "${args.participant}" must return { tests: TestStep[] }`,
+      );
+    }
+    stepCells = stepsValue as Cell<unknown>[];
+
+    const result: ParticipantInitResult = {
+      steps: stepCells.map((cell, index) => classifyStep(cell, index)),
+      allowRuntimeErrors:
+        await (resultCell.key("allowRuntimeErrors") as Cell<unknown>)
+          .pull() === true,
+      expectNonIdempotent:
+        await (resultCell.key("expectNonIdempotent") as Cell<unknown>)
+          .pull() === true,
+    };
+    return result;
+  },
+
+  /** Invoke an action step's stream and settle. */
+  async action({ index }) {
+    const stepCell = stepCells[index as number];
+    const stream = stepCell.key("action" as never) as unknown as {
+      send?: (value: unknown) => void;
+    };
+    if (typeof stream?.send !== "function") {
+      throw new Error(`Test step ${index} action is not a stream`);
+    }
+    stream.send(undefined);
+    await settle();
+    return {};
+  },
+
+  /** Pull an assertion step's value; the orchestrator handles retries. */
+  async assertion({ index }) {
+    const stepCell = stepCells[index as number];
+    const value = await (stepCell.key("assertion" as never) as Cell<unknown>)
+      .pull();
+    return { passed: value === true };
+  },
+
+  /** Let in-flight work and incoming subscription pushes land. */
+  async settle() {
+    await settle(6);
+    return {};
+  },
+
+  /** Runtime health for end-of-run reporting. */
+  async health() {
+    return {
+      runtimeErrors: [...runtimeErrors],
+      nonIdempotent:
+        rt().getIdempotencyViolations?.()?.map((violation) =>
+          String(
+            (violation as { actionId?: string }).actionId ?? violation,
+          )
+        ) ?? [],
+    };
+  },
+
+  async dispose() {
+    stepCells = [];
+    engine?.dispose();
+    await runtime?.dispose();
+    await storageManager?.close();
+    runtime = undefined;
+    storageManager = undefined;
+    engine = undefined;
+    return {};
+  },
+};
+
+self.onmessage = (event: MessageEvent<WorkerRequest>) => {
+  const { id, cmd, args } = event.data;
+  const handler = handlers[cmd];
+  const respond = (response: WorkerResponse) =>
+    (self as unknown as Worker).postMessage(response);
+  if (!handler) {
+    respond({ id, error: `unknown command "${cmd}"` });
+    return;
+  }
+  handler(args).then(
+    (ok) => respond({ id, ok }),
+    (error: unknown) =>
+      respond({
+        id,
+        error: error instanceof Error
+          ? `${error.message}\n${error.stack ?? ""}`
+          : String(error),
+      }),
+  );
+};

--- a/packages/cli/lib/multi-user-test-worker.ts
+++ b/packages/cli/lib/multi-user-test-worker.ts
@@ -278,8 +278,8 @@ const handlers: Record<
   },
 
   /** Runtime health for end-of-run reporting. */
-  async health() {
-    return {
+  health() {
+    return Promise.resolve({
       runtimeErrors: [...runtimeErrors],
       nonIdempotent:
         rt().getIdempotencyViolations?.()?.map((violation) =>
@@ -287,7 +287,7 @@ const handlers: Record<
             (violation as { actionId?: string }).actionId ?? violation,
           )
         ) ?? [],
-    };
+    });
   },
 
   async dispose() {

--- a/packages/cli/lib/multi-user-test-worker.ts
+++ b/packages/cli/lib/multi-user-test-worker.ts
@@ -281,12 +281,11 @@ const handlers: Record<
   health() {
     return Promise.resolve({
       runtimeErrors: [...runtimeErrors],
-      nonIdempotent:
-        rt().getIdempotencyViolations?.()?.map((violation) =>
-          String(
-            (violation as { actionId?: string }).actionId ?? violation,
-          )
-        ) ?? [],
+      nonIdempotent: rt().getIdempotencyViolations?.()?.map((violation) =>
+        String(
+          (violation as { actionId?: string }).actionId ?? violation,
+        )
+      ) ?? [],
     });
   },
 

--- a/packages/cli/lib/test-runner.ts
+++ b/packages/cli/lib/test-runner.ts
@@ -43,6 +43,10 @@ import { basename } from "@std/path";
 import { timeout } from "@commonfabric/utils/sleep";
 import { experimentalOptionsFromEnv } from "./utils.ts";
 import {
+  multiUserDescriptorMeta,
+  runMultiUserTestPattern,
+} from "./multi-user-test-runner.ts";
+import {
   type CDFPoint,
   getLogger,
   getLoggerCountsBreakdown,
@@ -884,6 +888,18 @@ export async function runTestPattern(
     if (!main?.default) {
       throw new Error(
         `Test pattern must export a pattern function as default`,
+      );
+    }
+
+    // Multi-user tests export a descriptor ({ setup?, participants }) as the
+    // default export. They run in worker-isolated runtimes against a shared
+    // storage server — hand off to the multi-user orchestrator (this local
+    // runtime is only used for detection; the try/finally below disposes it).
+    const multiUserMeta = multiUserDescriptorMeta(main.default);
+    if (multiUserMeta) {
+      return await withPhase(
+        ["runTestPattern", "multiUser"],
+        () => runMultiUserTestPattern(testPath, multiUserMeta, options),
       );
     }
 

--- a/packages/memory/deno.json
+++ b/packages/memory/deno.json
@@ -36,6 +36,7 @@
     "./v2/client": "./v2/client.ts",
     "./v2/engine": "./v2/engine.ts",
     "./v2/server": "./v2/server.ts",
+    "./v2/standalone": "./v2/standalone.ts",
     "./v2/storage-path": "./v2/storage-path.ts",
     "./commit": "./commit.ts",
     "./codec": "./codec.ts",

--- a/packages/memory/v2/standalone.ts
+++ b/packages/memory/v2/standalone.ts
@@ -1,18 +1,22 @@
 /**
- * Standalone in-memory storage server for multi-runtime tests.
+ * Standalone in-process memory v2 server.
  *
- * Serves the same memory v2 websocket protocol (and session.open signature
- * verification) as toolshed's `/api/storage/memory` route, but in-process on
- * an ephemeral port with a non-persistent store. This lets several runtimes —
- * including ones in Deno Workers — share one storage backend without a
- * toolshed process.
+ * Serves the same websocket protocol (and `session.open` signature
+ * verification) as toolshed's `/api/storage/memory` route, on an ephemeral
+ * localhost port with a non-persistent store. Several runtimes — including
+ * ones in Deno Workers or subprocesses — can share one storage backend
+ * without a toolshed process. Used by multi-runtime test harnesses
+ * (`cf test` multi-user mode, packages/patterns integration tests).
+ *
+ * Deno-only (uses `Deno.serve`); keep this export path out of browser
+ * bundles.
  */
 
-import { encodeMemoryBoundary, MEMORY_PROTOCOL } from "@commonfabric/memory/v2";
-import * as MemoryServer from "@commonfabric/memory/v2/server";
+import { encodeMemoryBoundary, MEMORY_PROTOCOL } from "../v2.ts";
+import * as MemoryServer from "./server.ts";
 import { hashOf } from "@commonfabric/data-model/value-hash";
 import { FabricBytes } from "@commonfabric/data-model/fabric-primitives";
-import { VerifierIdentity } from "@commonfabric/identity";
+import { fromDID } from "../util.ts";
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === "object" && !Array.isArray(value);
@@ -31,7 +35,7 @@ const sameSessionDescriptor = (
 
 // Same verification as toolshed's memory route: the session principal is the
 // verified issuer of the signed session.open invocation. User/session scoped
-// storage partitioning keys off this principal, so the tests exercise real
+// storage partitioning keys off this principal, so clients exercise real
 // authentication, not a trusted-client shortcut.
 const authorizeSessionOpen = async (
   message: {
@@ -64,10 +68,12 @@ const authorizeSessionOpen = async (
     throw authorizationError("memory session.open authorization mismatch");
   }
 
-  const issuer = await VerifierIdentity.fromDid(
-    invocation.iss as `did:key:${string}`,
-  );
-  const verified = await issuer.verify({
+  const issuer = await fromDID(invocation.iss);
+  if (issuer.error) {
+    throw issuer.error;
+  }
+
+  const verified = await issuer.ok.verify({
     payload: hashOf(invocation).bytes,
     signature,
   });
@@ -117,38 +123,7 @@ export class StandaloneMemoryServer {
           return;
         }
         if (debugWrites) {
-          try {
-            const parsed = MemoryServer.parseClientMessage(
-              event.data,
-            ) as unknown as {
-              commit?: { operations?: unknown[] };
-            };
-            const operations = parsed?.commit?.operations as
-              | Array<Record<string, any>>
-              | undefined;
-            if (Array.isArray(operations)) {
-              for (const op of operations) {
-                const detail = op?.op === "patch"
-                  ? ` paths=${
-                    JSON.stringify(
-                      (op.patches ?? []).map((p: { path?: string }) => p?.path),
-                    )
-                  }`
-                  : op?.op === "set"
-                  ? ` keys=${
-                    JSON.stringify(Object.keys(op.value?.value ?? {}))
-                  }`
-                  : "";
-                console.error(
-                  `[memwrite conn=${connectionTag}] op=${op?.op} id=${
-                    String(op?.id).slice(0, 24)
-                  } scope=${op?.scope ?? "(space)"}${detail}`,
-                );
-              }
-            }
-          } catch {
-            // Best-effort logging only.
-          }
+          logCommitOperations(connectionTag, event.data);
         }
         connection.receive(event.data).catch(() => {
           if (socket.readyState === WebSocket.OPEN) {
@@ -167,5 +142,36 @@ export class StandaloneMemoryServer {
   async close(): Promise<void> {
     await this.#http.shutdown();
     await this.#memory.close();
+  }
+}
+
+// Best-effort per-commit write tracing (CF_DEBUG_MEMORY_WRITES=1): one line
+// per operation with id + scope, the fastest way to see which scope partition
+// a client's writes actually land in.
+function logCommitOperations(connectionTag: number, payload: string): void {
+  try {
+    const parsed = MemoryServer.parseClientMessage(payload) as unknown as {
+      commit?: { operations?: Array<Record<string, any>> };
+    };
+    const operations = parsed?.commit?.operations;
+    if (!Array.isArray(operations)) return;
+    for (const op of operations) {
+      const detail = op?.op === "patch"
+        ? ` paths=${
+          JSON.stringify(
+            (op.patches ?? []).map((p: { path?: string }) => p?.path),
+          )
+        }`
+        : op?.op === "set"
+        ? ` keys=${JSON.stringify(Object.keys(op.value?.value ?? {}))}`
+        : "";
+      console.error(
+        `[memwrite conn=${connectionTag}] op=${op?.op} id=${
+          String(op?.id).slice(0, 24)
+        } scope=${op?.scope ?? "(space)"}${detail}`,
+      );
+    }
+  } catch {
+    // Logging only.
   }
 }

--- a/packages/patterns/cfc-group-chat-demo/multi-user.test.tsx
+++ b/packages/patterns/cfc-group-chat-demo/multi-user.test.tsx
@@ -21,7 +21,6 @@ import {
 } from "commonfabric";
 import {
   messagesValue,
-  type MyProfileCell,
   profilesValue,
   type SharedMessagesCell,
   type SharedProfilesCell,

--- a/packages/patterns/cfc-group-chat-demo/multi-user.test.tsx
+++ b/packages/patterns/cfc-group-chat-demo/multi-user.test.tsx
@@ -1,0 +1,167 @@
+/// <cts-enable />
+/**
+ * Multi-user pattern test for the CFC group chat demo.
+ *
+ * Unlike main.test.tsx (one runtime, two GroupChatDemo instances wired to
+ * separate cells), this runs ONE shared instance across two worker-isolated
+ * runtimes with distinct identities — so PerUser/PerSession scope
+ * partitioning and cross-runtime propagation are actually exercised.
+ *
+ * Each participant's steps run in order; cross-user ordering happens only at
+ * `{ label }` / `{ await }` markers. See the multi-user section of
+ * docs/common/patterns/multi-user-patterns.md.
+ */
+import {
+  action,
+  computed,
+  type Default,
+  multiUserTest,
+  pattern,
+  type Writable,
+} from "commonfabric";
+import {
+  messagesValue,
+  type MyProfileCell,
+  profilesValue,
+  type SharedMessagesCell,
+  type SharedProfilesCell,
+} from "./trusted.tsx";
+import { GroupChatDemo, type GroupChatDemoOutput } from "./main.tsx";
+
+type GroupChatDemoInputArg = Parameters<typeof GroupChatDemo>[0];
+
+interface Setup {
+  chat: GroupChatDemoOutput;
+}
+
+export const setup = pattern(() => ({
+  chat: GroupChatDemo({} as GroupChatDemoInputArg),
+}));
+
+const profileNames = (chat: GroupChatDemoOutput): string[] =>
+  profilesValue(chat.profiles as SharedProfilesCell)
+    .map((profile) => profile.get()?.name ?? "")
+    .filter((name) => name.length > 0)
+    .toSorted();
+
+const messageBodies = (chat: GroupChatDemoOutput): string[] =>
+  messagesValue(chat.messages as SharedMessagesCell).map((m) => m.body);
+
+export const alice = pattern<{ setup: Setup }>(({ setup }) => {
+  const chat = setup.chat;
+  const action_set_name = action(() => {
+    chat.setProfileDraft.send("Alice");
+  });
+  const action_save = action(() => {
+    chat.saveProfile.send();
+  });
+  const action_set_message = action(() => {
+    chat.setMessageDraft.send("Hello from Alice");
+  });
+  const action_send = action(() => {
+    chat.sendTrustedMessage.send();
+  });
+  const action_lockdown = action(() => {
+    chat.toggleEveryoneAdmin.send({ everyoneIsAdmin: false });
+  });
+
+  const assert_named_alice = computed(() =>
+    chat.currentProfileName === "Alice"
+  );
+  const assert_sees_both_profiles = computed(() =>
+    profileNames(chat).join(",") === "Alice,Bob"
+  );
+  const assert_sees_bobs_message = computed(() =>
+    messageBodies(chat).includes("Hi from Bob")
+  );
+  const assert_sees_bobs_lockdown_message = computed(() =>
+    messageBodies(chat).includes("Bob posts after lockdown")
+  );
+  const assert_is_admin = computed(() => chat.currentUserIsAdmin === true);
+
+  return {
+    tests: [
+      { action: action_set_name },
+      { action: action_save },
+      { assertion: assert_named_alice },
+      { label: "alice-saved" },
+      { await: "bob-saved" },
+      // Bob saving must not clobber Alice's PerUser profile, and the shared
+      // registry must resolve BOTH names in Alice's runtime.
+      { assertion: assert_named_alice },
+      { assertion: assert_sees_both_profiles },
+      { action: action_set_message },
+      { action: action_send },
+      { label: "alice-posted" },
+      { await: "bob-posted" },
+      { assertion: assert_sees_bobs_message },
+      // Admin lockdown: Alice becomes the bootstrap admin; posting stays
+      // open for everyone (the original regression disabled it).
+      { action: action_lockdown },
+      { assertion: assert_is_admin },
+      { label: "alice-locked-down" },
+      { await: "bob-posted-after-lockdown" },
+      { assertion: assert_sees_bobs_lockdown_message },
+    ],
+  };
+});
+
+export const bob = pattern<{ setup: Setup }>(({ setup }) => {
+  const chat = setup.chat;
+  const action_set_name = action(() => {
+    chat.setProfileDraft.send("Bob");
+  });
+  const action_save = action(() => {
+    chat.saveProfile.send();
+  });
+  const action_set_message = action(() => {
+    chat.setMessageDraft.send("Hi from Bob");
+  });
+  const action_set_lockdown_message = action(() => {
+    chat.setMessageDraft.send("Bob posts after lockdown");
+  });
+  const action_send = action(() => {
+    chat.sendTrustedMessage.send();
+  });
+
+  // PerUser draft: Alice's typing must never show up in Bob's runtime.
+  const assert_draft_empty = computed(() =>
+    ((chat.profileDraft as Writable<string | Default<"">>).get() ?? "") === ""
+  );
+  const assert_unnamed = computed(() =>
+    chat.currentProfileName === "Name not set"
+  );
+  const assert_named_bob = computed(() => chat.currentProfileName === "Bob");
+  const assert_sees_alice_profile = computed(() =>
+    profileNames(chat).includes("Alice")
+  );
+  const assert_sees_alices_message = computed(() =>
+    messageBodies(chat).includes("Hello from Alice")
+  );
+  const assert_not_admin = computed(() => chat.currentUserIsAdmin === false);
+
+  return {
+    tests: [
+      { await: "alice-saved" },
+      { assertion: assert_draft_empty },
+      { assertion: assert_unnamed },
+      { assertion: assert_sees_alice_profile },
+      { action: action_set_name },
+      { action: action_save },
+      { assertion: assert_named_bob },
+      { label: "bob-saved" },
+      { await: "alice-posted" },
+      { assertion: assert_sees_alices_message },
+      { action: action_set_message },
+      { action: action_send },
+      { label: "bob-posted" },
+      { await: "alice-locked-down" },
+      { assertion: assert_not_admin },
+      { action: action_set_lockdown_message },
+      { action: action_send },
+      { label: "bob-posted-after-lockdown" },
+    ],
+  };
+});
+
+export default multiUserTest({ setup, participants: { alice, bob } });

--- a/packages/patterns/integration/multi-runtime-harness.ts
+++ b/packages/patterns/integration/multi-runtime-harness.ts
@@ -16,12 +16,12 @@
  * runtimes (verified-load registries, frame stacks and similar module-level
  * state cross-talk), and production never does — every browser tab or CLI
  * process is its own realm. The storage server is self-hosted in-process
- * (see multi-runtime-memory-server.ts), so no toolshed is needed; pass
+ * (@commonfabric/memory/v2/standalone), so no toolshed is needed; pass
  * `apiUrl` to target a running toolshed instead.
  */
 
 import { Identity } from "@commonfabric/identity";
-import { StandaloneMemoryServer } from "./multi-runtime-memory-server.ts";
+import { StandaloneMemoryServer } from "@commonfabric/memory/v2/standalone";
 import type {
   TrustedUiDescriptor,
   WorkerRequest,

--- a/packages/runner/src/builder/factory.ts
+++ b/packages/runner/src/builder/factory.ts
@@ -170,6 +170,11 @@ export const createBuilder = (options: CreateBuilderOptions = {}): {
     navigateTo,
     wish,
 
+    // Multi-user test descriptor tag (see api MultiUserTestDescriptor):
+    // identity at runtime; the call expression keeps the descriptor's pattern
+    // factories out of module-level plain-data hardening.
+    multiUserTest: <T>(descriptor: T): T => descriptor,
+
     // Cell creation
     cell: cellConstructorFactory<AsCell>("cell").of,
     equals: cellConstructorFactory<AsCell>("cell").equals,

--- a/packages/runner/src/sandbox/compiled-bundle-verifier.ts
+++ b/packages/runner/src/sandbox/compiled-bundle-verifier.ts
@@ -1102,6 +1102,21 @@ function verifyTrustedBuilderCall(
 ): void {
   const measureStart = performance.now();
   try {
+    // multiUserTest is the one builder without a callback: it tags a
+    // descriptor object whose leaves are other trusted-builder results, so
+    // its arguments verify as trusted value expressions.
+    if (builderName === "multiUserTest") {
+      for (const argument of args) {
+        verifyTrustedValueExpression(
+          source,
+          filename,
+          argument.start,
+          argument.end,
+          env,
+        );
+      }
+      return;
+    }
     const callbackIndexes = callbackIndexesForBuilder(
       source,
       builderName,

--- a/packages/utils/src/sandbox-contract.ts
+++ b/packages/utils/src/sandbox-contract.ts
@@ -11,6 +11,9 @@ export const TRUSTED_BUILDERS = Object.freeze(
     "derive",
     "handler",
     "lift",
+    // Identity tag for multi-user test descriptors (`cf test`); its
+    // arguments are trusted-builder results, never event-carrying closures.
+    "multiUserTest",
     "pattern",
   ] as const,
 );

--- a/packages/utils/test/sandbox-contract.test.ts
+++ b/packages/utils/test/sandbox-contract.test.ts
@@ -15,6 +15,7 @@ describe("sandbox-contract", () => {
       "derive",
       "handler",
       "lift",
+      "multiUserTest",
       "pattern",
     ]);
   });

--- a/tasks/build-binaries.ts
+++ b/tasks/build-binaries.ts
@@ -100,6 +100,10 @@ class BuildConfig {
     return this.path("packages", "cli", "mod.ts");
   }
 
+  cliMultiUserTestWorkerPath() {
+    return this.path("packages", "cli", "lib", "multi-user-test-worker.ts");
+  }
+
   fusePackagePath() {
     return this.path("packages", "fuse");
   }
@@ -300,6 +304,10 @@ async function buildCli(config: BuildConfig): Promise<void> {
       config.docsCommonPath(),
       "--include",
       config.fusePackagePath(),
+      // Worker module spawned by cf test's multi-user mode — workers are not
+      // followed by compile's static analysis, so include it explicitly.
+      "--include",
+      config.cliMultiUserTestWorkerPath(),
       config.cliEntryPath(),
     ],
     cwd: config.root,


### PR DESCRIPTION
## Why

PR #3958 proved that multi-user pattern bugs (PerUser/PerSession scoping, cross-client propagation) only manifest across genuinely isolated runtimes — but that harness lives in integration-test land. Pattern authors write `cf test` pattern tests. This generalizes the infrastructure into `cf test` itself: tests are still patterns, split into N participant patterns that each run in a different runtime instance, coordinating via synchronization markers.

## Authoring model

```tsx
export const setup = pattern(() => ({ chat: GroupChatDemo({}) }));

export const alice = pattern<{ setup: Setup }>(({ setup }) => ({
  tests: [
    { action: action_save_alice },
    { label: "alice-saved" },      // announce a marker
    { await: "bob-saved" },        // park until bob announces
    { assertion: assert_sees_bob },
  ],
}));
export const bob = pattern<{ setup: Setup }>(({ setup }) => ({ tests: [/* … */] }));

export default multiUserTest({ setup, participants: { alice, bob } });
```

- Each participant runs in its own **Deno Worker realm** with its own identity (`{ pattern, user: "alice" }` = second session of the same user), all against one shared space on the in-process standalone memory server (promoted to `@commonfabric/memory/v2/standalone`).
- The `setup` pattern instantiates shared state once on a cause-derived cell; **every worker runs that same instance locally** (like every browser tab does), so per-user scoped outputs are computed under each participant's principal.
- Coordination is orchestrator-side: a participant's steps run in order until an `{ await }` whose marker nobody has `{ label }`-ed; all-parked → deadlock failure naming each waiter. Assertions retry with settling until the step timeout (cross-runtime propagation).
- `multiUserTest` is an identity tag in the pattern environment, registered as a (callback-less) trusted builder so the descriptor survives SES module-scope verification and plain-data hardening.

## Example + docs

[multi-user.test.tsx](packages/patterns/cfc-group-chat-demo/multi-user.test.tsx) tests ONE shared GroupChatDemo across two runtimes — draft isolation, profile propagation without clobbering, bidirectional messages, admin lockdown never gating posting: **12 assertions in ~5s**, `deno task cf test --root packages/patterns packages/patterns/cfc-group-chat-demo/multi-user.test.tsx`. (Contrast main.test.tsx, which simulates two users as two instances inside one runtime and cannot catch scoping bugs.) Docs: pattern-testing guide multi-user section + multi-user-patterns testing options.

## Verification

- Multi-user example: 12/12 in ~5s; both group-chat test files together: 36/36.
- Failure paths exercised manually: failing assertion reports per-step; deadlock reports each parked participant + marker.
- Regressions: runner 553/0, utils 85/0 (TRUSTED_BUILDERS expectation updated), cli 43/0, ts-transformers 292/0, verifier/engine suites green, single-runtime cf tests (main.test.tsx, shopping-list) 46/0, patterns multi-runtime integration suite green after the memory-server move.

## Notes / risks

- The cf compiled binary spawns the worker via a static `new URL(...)` module reference; Build Binaries + CLI integration CI will confirm `deno compile` includes it.
- `cfcEnforcementMode` stays "observe" in workers (same as single-runtime pattern tests); trusted-surface enforcement coverage remains with the integration harness, which can synthesize trusted UI events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds multi-user mode to `cf test`, running participant patterns in isolated Deno Worker runtimes against a shared in‑process memory server. This exposes `PerUser`/`PerSession` and cross-client propagation bugs; the compiled `cf` binary bundles the worker so multi-user tests run there too.

- New Features
  - Added `multiUserTest({ setup, participants })`; each participant runs in its own worker/identity. Use `{ pattern, user: "alice" }` for a second session of the same user.
  - Orchestrator coordinates `{ label }` / `{ await }` markers with deadlock detection; assertions auto‑retry until the step timeout; results are participant‑prefixed to match single‑runtime reporting.
  - `cf test` detects a multi-user descriptor default export and hands off to the new orchestrator; the compiled CLI includes `packages/cli/lib/multi-user-test-worker.ts`.
  - Promoted the in‑process memory server to `@commonfabric/memory/v2/standalone` (optional write‑debug logging).
  - Exposed `MultiUserTestDescriptor`/`multiUserTest` in `@commonfabric/api`, registered the builder in trusted surface + SES verifier; example and docs added.

- Bug Fixes
  - Actions now honor the per‑step `--timeout` (matching single‑runtime tests).
  - `allowRuntimeErrors` / `expectNonIdempotent` flags apply per participant, so one participant’s opt‑out doesn’t hide another’s failures.

<sup>Written for commit 7dc7cffa949b5359f1bad8c127e1a9bb6a90e640. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



## Perf baselines

Build Binaries grows ~9s (the cf binary now bundles the multi-user test worker's module graph); pattern-unit shard 1 grows ~30s (the new multi-user test spins 2 worker runtimes + a storage server). main.test.tsx shows no local regression (~4s) — the subtest bump is shard contention.

NEW_PERF_BASELINE: step: Build application = 21s
NEW_PERF_BASELINE: test: pattern-unit-1/pattern-unit-tests = 143s
NEW_PERF_BASELINE: subtest: pattern-unit-1/pattern-unit-tests > packages/patterns/cfc-group-chat-demo/main.test.tsx = 23s
NEW_PERF_BASELINE: job: Build Binaries = 60s
