### PR TITLE
fix(cfc): Wave 0 — close enforcement bypasses & fail-open holes

### DIFF
--- a/cfc-spec-audit.md
+++ b/cfc-spec-audit.md
@@ -1,0 +1,545 @@
+# CFC Spec Audit — packages/runner vs ~/src/specs/cfc
+
+Date: 2026-06-09. Spec bar: sections marked "Status: Normative"; ch. 14 (open problems),
+08-14 and 08-16 (redirect stubs to ch. 14) treated as non-normative. Produced by seven
+parallel audit passes (one per spec slice plus one code-first sweep); the highest-impact
+soundness claims were independently re-verified against source.
+
+## How the implementation relates to the spec
+
+The runner implements a deliberate **phase-1 subset**: flat conjunctive labels (atom
+arrays, no CNF clauses), schema-declared `ifc` annotations verified at **commit time**
+(`prepareBoundaryCommit`, `packages/runner/src/cfc/prepare.ts:2077`) with a prepared-digest
+recheck at commit (`extended-storage-transaction.ts:656-673`), persisted per-path label
+maps bound to content-addressed schema hashes, link/reference label pass-through, write
+authority, UI-contract trusted events, sink-request replay fidelity, and InjectionSafe
+schema sanitization. Default mode is `enforce-explicit` (`runtime.ts:391`); the bare
+transaction default is `disabled` (`cfc/types.ts:31`).
+
+Terminology: spec `Label{confidentiality: Clause[], integrity: Atom[]}` ↔ impl
+`IFCLabel{confidentiality?: unknown[], integrity?: unknown[]}` (`label-view-core.ts:4`);
+spec boundary loop ↔ impl prepare/digest two-phase; spec `CodeHash` write authority ↔ impl
+builtin-id strings or `__ctWriterIdentityOf{bundleId,file,path}` bindings; spec
+`$actingUser` ↔ impl `{__ctCurrentPrincipal: true}` placeholders.
+
+The single largest architectural distance: **the spec derives output labels from input
+labels (default transition §8.9.3 + PC propagation §8.9.2/§8.11); the implementation never
+does** — it persists only schema-declared labels and verifies declared constraints. Every
+"value-copy laundering" finding below is downstream of that one posture.
+
+---
+
+## 1a. Gaps in existing features (implemented, but incomplete or divergent)
+
+**Input requirement checks (`requiredIntegrity` / `maxConfidentiality`), §8.10.3:**
+- Consumed set is **transaction-global**, not scoped to the annotated input path
+  (`prepare.ts:1694-1709`) — spec uses `collectConsumedLabelsAtOrBelow(path)`. Over-strict
+  in one direction (unrelated labeled read can fail an unrelated write), under-strict in
+  the other (see soundness S7).
+- Satisfaction is whole-atom `deepEqual` membership (`prepare.ts:1747-1759`), not the
+  spec's pattern matching with **shared-witness-key coherence** — two leaves matching via
+  different witnesses both pass where the spec requires one shared witness.
+- Ceiling checks are flat atom membership (`prepare.ts:1761-1771`), not clause-aware
+  "every clause contains an allowed alternative". Fail-closed for opaque `anyOf` objects,
+  but authored OR-clauses can never be satisfied.
+- `labelAtPath` (`prepare.ts:65-87`) matches only ancestor-or-equal entries: a read of a
+  **parent object** of a labeled field resolves to no label and is filtered out of the
+  consumed set entirely (see soundness S7). The label-view machinery handles the same case
+  correctly in the other direction (`rebaseCfcLabelView`), so this looks like an oversight.
+
+**`exactCopyOf` (§8.4):**
+- Compares two paths **within the same target document** by `deepEqual`
+  (`prepare.ts:1819-1847`); spec compares handler-input→output via `refer()` identity.
+  Cross-document/handler-input sources inexpressible; reference-form copies spuriously
+  reject.
+- **Wildcard (`items`) claim paths are silently unverified**: `walkIfcSchema` emits `"*"`
+  segments (`prepare.ts:971-973`) but `writeDetailValueForTarget` matches literally, so a
+  write at `["list","0"]` never matches `["list","*"]` and `deepEqual(undefined,
+  undefined)` passes vacuously — while the label copy still happens (`prepare.ts:1857-1859`).
+- Source label copied from the *schema-declared* sibling entry only, not the stored/runtime
+  label of the source; not transitive across copy chains.
+- No `ifcEntryAppliesToAttemptedWrite` gating (unlike sibling checks): writing only the
+  source while the target is untouched spuriously rejects; touching neither passes
+  vacuously.
+
+**Integrity combination — union everywhere, never meet (§8.6.2, §8.17.1):**
+- `mergeLabel`/`mergeLabels` union integrity (`label-view-core.ts:68-92`,
+  `prepare.ts:1906-1915`). Fine for link refresh/endorsement merges; wrong when two
+  *different* writes land at one path in one tx (`coalesceLabelEntries`,
+  `prepare.ts:2012-2033`) — the surviving value claims integrity only the overwritten value
+  had.
+- SQLite null-origin (aggregate) columns inherit the **union** of all labeled columns'
+  integrity (`deriveNullOriginIfc`, `sqlite-builtins.ts:167-178`) where §8.17.1 says
+  "class-aware meet … never union". A `COUNT(*)` can claim a provenance atom held by one
+  column. (Acknowledged in-repo as CT-1668.)
+- Computation outputs get **no** integrity at all (`applyInputIfcToOutput` propagates only
+  confidentiality, `builder/node-utils.ts:70-88`) — under-claim, fail-safe, but it means
+  hereditary atoms (`PolicyCertified`-class) don't survive as §3.1.6.1/§15.1.1 require.
+
+**Two inconsistent schema-IFC walkers (§4.2.1.1):**
+`walkIfcSchema` (`prepare.ts:916-978`) descends into `anyOf`/`oneOf`/`allOf` and
+flatten-merges branch-local `ifc` (spec says reject); `ContextualFlowControl.joinSchema`
+(`cfc.ts:75-149`) doesn't descend at all, so branch-local confidentiality is silently
+dropped from `lubSchema`-based tainting (the one **under-tainting fail-open** in the core
+algebra). Same schema taints differently on the propagation path vs the verification path.
+`joinSchema` also skips `prefixItems` and skips `items` when `additionalProperties` is
+present (acknowledged TODO, `cfc.ts:124`).
+
+**Flow-precision claims (§8.5.4, §8.9.1):**
+- Claims are minted and trust-gated at the builtin runtime path but **nothing consumes
+  them** (`ifc.flowPrecisionClaim` has no reader) — currently inert.
+- Claims are attached **regardless of op argument usage** (`map.ts:122-127` ignores
+  `inferListOpArgumentUsage`) — a pre-staged unsound `PointwiseWriteDependency` for ops
+  that read the whole array/params, armed for whenever a consumer lands.
+- Trust gate is a compiled-in builtin allowlist (`flow-precision.ts:98-107`), not the
+  user-scoped trust closure §4.8.7 requires; `CodeHash` claims for user modules unsupported.
+- `filter`/`flatMap` have no structural-confidentiality counterpart: element labels pass
+  through by reference (good), but membership/order/length carry **no** label — the
+  §8.5.6.1 secret-search example (private query filtering public items) is unrepresentable,
+  and the implemented default is *permissive*, not conservative.
+
+**Sink gating (§5.2.1, §7.3-7.5):**
+- The "sink gate" is request **immutability** only: `verifySinkRequestRelease` deep-equals
+  the post-commit request against the prepared snapshot (`sink-request.ts:51-82`). No label
+  is consulted, nothing is stripped, no `AuthorizedRequest` integrity fact is emitted.
+  Today the only enforced sink property is replay fidelity, not information flow.
+- No attempt/commit distinction, no durable consumed-intent record, no retries/`exp`/
+  `maxAttempts`; failed flushes are warn-and-drop (`sink-request.ts:109-117` — at least
+  fail-closed) and invisible to CFC instrumentation.
+
+**Trusted events / UI contracts (§6.2-6.3, §8.15.9):**
+- Event identity `trusted-event:${type}:${id}:${path}` (`ui-contract.ts:609-615`) — no
+  nonce/timestamp/payload digest; not unique, not single-use (dedup is per-transaction
+  only).
+- No payload binding: `verifyTrustedEventRequirements` (`prepare.ts:1776-1817`) checks a
+  matching gesture exists for the path; the handler may write **any value** (spec §7.3.4
+  requires payloadDigest binding).
+- No render binding: `EventProvenance` carries no `renderRef`/`snapshotDigest`/`targetPath`
+  (§6.3.1's "primary evidence handle").
+- `requiredEventIntegrity` are untyped strings scraped from pattern-authored `data-*`
+  attributes (see soundness S12).
+
+**Write authority (§8.15):**
+- Verified-handler claims accept exactly **one** `__ctWriterIdentityOf` binding
+  (`prepare.ts:307-328`); the spec's per-field union of handler identities (§8.15.2,
+  §8.15.8 cross-pattern reuse) is only expressible for legacy builtin-string arrays.
+
+**CAS / dual addressing (§17):**
+- Causal path matches §17.1's envelope sketch. The CAS path is vestigial: `cid:<schemaHash>`
+  docs are written with the **caller-claimed** hash, unverified on write
+  (`ensureSchemaDocument`, `prepare.ts:2041-2054`) and trusted on read
+  (`loadSchemaDocument`, `prepare.ts:2057-2075`). No `labelBindings`, no `expectedLabel`
+  read API, no miss normalization. The compile cache (`compilation-cache/cell-cache.ts:369-401`)
+  is the one spec-faithful CAS implementation. See soundness S5.
+
+**Schema-evolution monotonicity (§4.2.2.1):** directions correct
+(`schema-merge.ts:55-120`), but missing the normalized-profile eligibility gate,
+`preservesStructuralMeaning` checks, and `labelHistory`.
+
+**Persisted envelope layout (§4.6.4):** label paths are value-relative where the spec says
+newly persisted envelopes MUST key under `/value`; no `PathLabelTemplate` observation
+classes (`shape`/`iterate`/`children`...), and read ops aren't captured per §8.10.1.1
+(`ConsumedRead` has no `op`).
+
+**Profiles (§18.3/§18.4):**
+- AgentHarness: `PromptSlotBinding` has the right fields but they're optional,
+  caller-supplied, and **never verified**; `evaluateHarnessWriteFileAuthorization` trusts a
+  bare `role === "direct-command"` field (`harness-write-policy.ts:25-27`). No registry
+  snapshots, no descriptor digests, no labeled descriptor fields. Opaque-handle
+  pass-through is the one fully met item.
+- TrustedRender: authored-by boundaries, blocked placeholders, and literal-text blocking
+  are real and fail-closed (`packages/html/src/worker/reconciler.ts:384-421,643-708`);
+  trusted-component registry has exactly one entry; no `RenderRef`/`snapshotDigest`
+  machinery at all.
+- Harness digests use `sha256(JSON.stringify(x))` (`packages/cf-harness/src/structured-result.ts:43`)
+  — key-order-sensitive, no NFC; the runner's own digest is properly canonical
+  (`data-model/src/value-hash.ts`). Inconsistent c14n across the TCB.
+
+## 1b. Unimplemented areas (no code counterpart)
+
+- **The entire generic policy calculus (spec layer 2)**: policy records, context
+  principals, exchange-rule syntax/matching/binding, clause-local rewrite, fixpoint
+  evaluation, declassification as guarded release, multi-party consent, response
+  translation, error exchange rules / `SanitizedError`, `PolicyCertified` certification.
+  Zero hits for any of it in the runner. Consequently every declassification-shaped
+  behavior is either hard-coded into the evaluator or absent.
+- **CNF label algebra**: flat atom lists; disjunctive clauses, clause subsumption,
+  clause-local authority, §8.17.4 common-alternative property all unrepresentable.
+  (§8.12.1's note blesses the degenerate all-singleton case, which the impl matches.)
+- **The intent lifecycle (ch. 6-7)**: no `IntentEvent`/`IntentOnce`/refinement chain/
+  consumption cells/attempt cells/`commitIntent`/atomic claims. Single-use semantics —
+  the central mechanism of ch. 6 — exist nowhere. §11's developer guidance references
+  `commitIntent`, which doesn't exist.
+- **Trust lattice (§2.2, §4.8)**: no `TrustStatement`/`VerifierDelegation`/concept
+  reachability; `TrustSnapshot` is `{id, actingPrincipal, revision}` used only for
+  `$currentPrincipal` resolution and owner checks.
+- **Trusted derived identifiers (§2.4)**: no `TrustedDerivedId`/`DerivedByTrustedHash`
+  anywhere; all coordination identifiers are raw strings (see soundness S14).
+- **Access semantics (§3.1.4)**: no `canAccess`, no read-time checks at all; enforcement is
+  write/commit-side plus sink snapshots.
+- **Expiry/TTL (§3.2, §8.12.6)**: no `Expires` atoms, no cascade.
+- **Projection (§8.3) and collection (§8.5) schema claims**: authorable, rejected
+  fail-closed (`unsupportedTrustSensitiveReason`, `prepare.ts:1028-1046`) — correct posture.
+  But `recomposeProjections`, `passThrough`, `combinedFrom`/`combinationType`,
+  `transformation`, and spec-spelled `addedIntegrity` are **silently ignored** (not in
+  `IFC_KEYS`, not in the reject list, dropped on merge) — an author writing spec-conformant
+  annotations gets no enforcement and no error.
+- **`OpaqueInput` (§8.13)**: authorable, lowered to `ifc.opaque` by the transformer, never
+  read by the runner, and **silently dropped by schema-merge** — the one fail-open
+  exception to the otherwise fail-closed treatment of unimplemented claims.
+- **Per-output label derivation + PC propagation (§8.9.2/§8.9.3, §8.11)**: see
+  architecture note; the router attack worked example in ch. 10 is not blocked.
+- **§17.2-17.5 CAS structures**; **§11.2 static analysis**; **§11.1.3 inference rules**
+  (no space-based confidentiality inheritance, no automatic `CodeHash` stamping).
+- Chapter-10 invariants with no enforcement anywhere: #2 (default propagation), #3
+  (guarded exchange), #5 (authority-only secrets), #7 (robust declassification), #8
+  (transparent endorsement), #11 (user-scoped trust closure), #12 (label-metadata
+  confidentiality).
+
+---
+
+## 2. Differences from spec pseudocode
+
+1. **Boundary loop vs prepare/digest.** Spec (§8.10.1): per-attempt verify→propagate→
+   commit loop. Impl: verify once in `prepareCfc()`, then a canonical-digest recheck at
+   commit with invalidation on any post-prepare activity. Materially different but
+   defensible factoring of the same fail-closed contract — except the digest covers
+   *activity*, not *that verification ran* (see S2).
+2. **Input requirements attached to write-target schemas, not handler-input schemas.**
+   Spec walks the handler's input schema; impl walks the write target's and gates on
+   write-applicability (`prepare.ts:1711+`). A structural inversion: requirements fire when
+   a protected output is written, not when a protected input is consumed.
+3. **`refer(ptr)` vs `deepEqual`.** Everywhere the spec compares content addresses, the
+   impl deep-equals reconstructed values (`exactCopyOf` `prepare.ts:1842`, sink snapshots
+   `sink-request.ts:77`). Equivalent for canonical JSON in-process; produces no auditable
+   digest artifact and exhibits the `undefined/undefined` vacuous edge.
+4. **Event processing: claim-before-handle vs at-least-once.** Spec (§6.2.2):
+   `atomicClaimCell` then handle. Impl (`scheduler/events.ts:518-588`): queue, run, retry
+   on conflict — exactly-once replaced by at-least-once with tx-conflict gating.
+5. **Write authority: `CodeHash` atom membership vs source-binding identity.** Spec
+   compares atoms; impl compares builtin-id strings or `{bundleId,file,path}` structures,
+   with silent bundleId rebinding of authored claims (`prepare.ts:771-833`). `codeHash`
+   exists only as a fallback and hashes `Function.prototype.toString`, not a shipped
+   artifact.
+6. **`AttemptedWrite`**: spec `{path, changed}` ordered sequence; impl bare addresses with
+   changed-ness recomputed ad hoc in wildcard matching and final values reconstructed
+   granularity-independently (`prepare.ts:1159-1270`) — equivalent in effect.
+7. **Key drift**: spec `addedIntegrity` vs impl `addIntegrity`; spec `classification`
+   shorthand dropped; impl adds `addIntegrity`, `ownerPrincipal`, `exactCopyOf`,
+   `projection`, `collection`, `flowPrecisionClaim`, `uiContract` under `ifc`.
+8. **Gesture integrity**: spec mints `UIRuntime`/`GestureProvenance` atoms; impl uses a
+   realm-local WeakSet mark plus DOM dataset dictionaries — trust is a JS object-identity
+   property that cannot persist, transfer, or be inspected by policy.
+9. **Developer surface**: §11's branded types / JSDoc annotations / `$actingUser` /
+   `$eventIntegrity` / `$now` are realized as ts-transformer type aliases
+   (`packages/api/cfc.ts:195-387`) and `{__ctCurrentPrincipal:true}` placeholders with a
+   stricter unspecced rule (literal `did:` subjects rejected).
+
+---
+
+## 3. In the code, not in the spec (should probably be specified)
+
+1. **Enforcement-mode ladder + relevance predicate.** `disabled|observe|enforce-explicit|
+   enforce-strict` and the `markCfcRelevant` criterion decide *whether CFC runs at all* —
+   the spec assumes verification at every boundary. Also: `enforce-strict` is currently
+   **indistinguishable** from `enforce-explicit` in the commit gate.
+2. **The prepared-digest two-phase commit** (digest contents, canonicalization/freeze
+   rules, invalidation triggers, and the `prepareCfc(input)` contract).
+3. **Setup-projection structural provenance** (`CFC_STRUCTURAL_PROVENANCE_SETUP_PROJECTION`,
+   `prepare.ts:380-492`) — the load-bearing write-authority carve-out for pattern
+   instantiation; §8.15.4 covers it in one sentence.
+4. **The implementation-identity scheme** (`bundleId`+`sourceFile`+`bindingPath` bindings,
+   bundleId rebinding, bundleId-insensitive schema equality) — the root of trust for write
+   authority, zero spec text.
+5. **`ownerPrincipal` + `__ctCurrentPrincipal`** placeholder semantics and the mandatory
+   companion-claim chain (trust snapshot + `represents-principal` + `writeAuthorizedBy` +
+   `uiContract`).
+6. **`addIntegrity`** annotation (used by sanitizer and label persistence; zero spec hits).
+7. **Claim-only labelMap entries** (entry presence = "policy applies here") and the
+   value-relative path layout — the mechanism that makes later unlabeled writes to
+   protected docs CFC-relevant.
+8. **Carried label views + dereference-trace merging + the minted `LinkReference` atom** —
+   the runtime's main label-transport mechanism; `LinkReference` (and
+   `PromptSlotInfluence`) are absent from the §15 atom registry.
+9. **The uiContract trusted-event system** (helper taxonomy, WeakSet renderer mark,
+   provenance/dataset matching) — only ch. 14 *proposals* mention `uiContracts`; this is
+   the implementation's primary UI-evidence mechanism and should be normative.
+10. **The schema-merge per-key direction table** (grow-only vs shrink-only vs frozen) —
+    the actual store-label-monotonicity enforcement rules live only in code.
+11. **Post-commit outbox + sink-release re-verification contract** (idempotency keys,
+    flush-once, verify-against-prepared-snapshot).
+12. **Schema-sanitization / contamination scoping** is *ahead* of the normative spec
+    (08-14 redirects to non-normative ch. 14): instruction-inertness analysis,
+    caveat-kind aliases, the InjectionSafe discharge — implemented, tested, unspecced.
+
+---
+
+## 4. Soundness findings
+
+Ordered by severity. Tagged **[hole]** = looks unintended, **[phase-1]** = consistent with
+the staged-rollout posture but worth recording as the load-bearing assumption.
+
+- **S1 [hole] Memory v2 server has no ACL/ownership check.** `authorizeSessionOpen`
+  verifies only that the `session.open` invocation is self-signed and names the space
+  (`packages/toolshed/routes/storage/memory.ts:26-74`); the v2 server then accepts
+  `transact`/`query` from any open session, using the principal only for scope addressing.
+  Legacy `checkACL` (`packages/memory/access.ts`, `acl.ts`) is wired only to the legacy
+  consumer; `ACLManager` writes ACL docs nothing on v2 reads. Net: any DID that can reach
+  the websocket can read/write any space — which voids the §9 threat-model rows for
+  network adversaries and other users, and makes every client-side label guarantee
+  advisory. (No tracking comment found, unlike S4's seam.)
+- **S2 [hole] `prepareCfc(input)` is a verification bypass on a public interface.**
+  Supplying an input skips `prepareBoundaryCommit` entirely
+  (`extended-storage-transaction.ts:311-323` — verified); the commit digest only confirms
+  the input matches actual activity, not that policy ran. Combined with the next item this
+  is reachable, and even alone it's an unguarded TCB edge (`storage/interface.ts:746`).
+- **S3 [hole] The live transaction is exposed to anything holding a Cell.**
+  `CellImpl.tx` is `public readonly` (`cell.ts:610` — verified), and
+  `setCfcEnforcementMode` / `prepareCfc` are on the public tx interface
+  (`interface.ts:700,746`). Unless a membrane strips it (none found; `security.test.ts`
+  has no assertion for it), handler code can disable enforcement for its own transaction
+  or pre-prepare with a self-assembled digest input. Needs either a membrane test pinning
+  unreachability or moving these to an internal surface.
+- **S4 [hole] Schema-authored integrity minting is unguarded for non-principal atoms.**
+  `derivePersistedLabel` persists `ifc.integrity`/`addIntegrity` from pattern-authorable
+  schemas (`prepare.ts:1849-1877`); only `authored-by`/`represents-principal` kinds are
+  gated. Anyone who authors a schema can mint `InjectionSafe` — the exact atom the
+  prompt-injection screen and `requiredIntegrity` consumers trust. Trusted minting
+  (compile cache) and forgery share one channel. The client-asserted-label seam is
+  acknowledged for compiled-code atoms (`cell-cache.ts:405-417`) but applies, uncommented,
+  to every label in the system (server never inspects `cfc` metadata).
+- **S5 [hole] `cid:` schema-document poisoning.** Caller-claimed hash, no write-side
+  verification, no read-side re-hash (`prepare.ts:2035-2075`). The loaded schema drives
+  label derivation for *other* principals' writes, so a same-space writer can alter what
+  labels everyone else persists. Violates §17.6 ("neither path may silently bypass the
+  other path's access rules"). The compile cache shows the correct pattern.
+- **S6 [hole] Paramless SQL writes bypass the write ceiling.** `checkSqliteWriteCeiling`
+  returns immediately when `params === undefined` (`builtins/sqlite/write-ceiling.ts:34`),
+  and the guard allows `INSERT … SELECT` / `UPDATE t SET public_col = secret_col` —
+  intra-database relabeling that re-emerges under the destination column's (weaker) label.
+  Not covered by the documented "source A" deferral in docs/specs/sqlite-builtin/06-cfc.md.
+- **S7 [hole] Vacuous pass of `requiredIntegrity`/`maxConfidentiality`.** Consumed reads
+  are filtered to those with **persisted stored labels** (`prepare.ts:1694-1709` —
+  verified) and the checks skip when none remain. A handler consuming only unlabeled (or
+  in-flight-schema-labeled, or **parent-of-labeled**) inputs writes into a protected slot
+  unchecked. The spec's own pseudocode skips on empty consumed sets, but its consumed set
+  includes unlabeled inputs as empty-label reads that then *fail* integrity floors — the
+  impl inverts "all inputs endorsed" into "all labeled inputs endorsed". Three audit
+  passes found this independently.
+- **S8 [hole] SQLite label declarations live in mutable cell data.** Per-column
+  `ifc` (read labels *and* write ceilings) is a plain field of the db-handle cell's value
+  (`sqlite-builtins.ts:295,424`); nothing prevents weakening/deleting it, and
+  schema-envelope monotonicity never sees it. A store's effective label can go down —
+  exactly what §8.12.1 exists to prevent.
+- **S9 [hole] labelMap replace-on-write loses accumulated atoms.** A path holding
+  link-derived or carried-view confidentiality beyond the schema loses those atoms when a
+  later schema-covered write re-derives the label from the schema alone
+  (`prepare.ts:2253-2295`); no `canUpdateStoreLabel`-style restrictiveness check, no
+  regression test.
+- **S10 [hole] `ifc.opaque` silently dropped** by schema-merge (`schema-merge.ts:6-19`) —
+  authored opacity claims don't even survive metadata persistence. Add to the fail-closed
+  reject list with the other ignored keys (`recomposeProjections`, `passThrough`,
+  `combinedFrom`, `transformation`, `addedIntegrity`).
+- **S11 [hole] Authoring-layer `setSchema` strips the conservative confidentiality join
+  without a trust gate.** `mapWithPattern`/`filterWithPattern`/`flatMapWithPattern` call
+  the *untrusted* `flowPrecisionSchemaForBuiltin` variant and `setSchema` replaces the
+  link schema wholesale (`cell.ts:1988,2081,2124`, `cell.ts:1773-1781`), discarding the
+  input-confidentiality join `applyInputIfcToOutput` just attached. Exactly the §8.9.1
+  forbidden shape (less-restrictive labeling without verified trust); muted today because
+  enforcement rides persisted labelMaps, not declared schemas.
+- **S12 [hole] Forgeable recognizer evidence + trusted-event replay.**
+  `uiContractDataset`/`eventIntegrity` come from pattern-authored `data-*` attributes
+  (`packages/html/src/event-provenance.ts:66-95`) — any real click on an element the
+  pattern decorates satisfies any contract the same pattern declares. And the WeakSet
+  trust mark propagates through `Cell.set` re-emission (`cell.ts:1094`,
+  `ui-contract.ts:406-439`) with nothing consumed: one gesture can authorize unboundedly
+  many protected writes over time. The anti-synthetic half (unmarked events rejected) is
+  solid and tested.
+- **S13 [hole] Identity fallback can misattribute writes.** `identityForInput` falls back
+  to the transaction's *current* identity for inputs recorded before any identity was set
+  (`prepare.ts:2082-2085`, same in `writeAuthorizedByReason`) — partially reopening the
+  cross-context borrowing the per-input capture comment says it exists to prevent.
+- **S14 [phase-1→hole] `createRef` vs §2.4.** Raw digests with no label/integrity
+  envelope; lossy untyped canonicalization (functions → `toString`, cycles → null);
+  **fail-open `crypto.randomUUID()` fallbacks** on missing cause (`create-ref.ts:25-31,
+  66-90`) where the spec requires fail-closed; deterministic IDs + open sync = existence
+  probing (§17.1 MUST NOT). `fetchData`'s `inputHash` additionally writes a content-
+  equality oracle for possibly-confidential inputs into a shared doc.
+- **S15 [hole, adjacent pkg] Render declassification minted by untrusted markup.**
+  `declassifyConfidentiality` is read from static VDOM props and accumulated down the tree
+  (`packages/html/src/worker/reconciler.ts:360-381`); default render policy has no ceiling
+  (every atom renders unless a pattern opts into a boundary). Any pattern can wrap a
+  secret in a boundary that declassifies it — the unguarded-release shape ch. 5 forbids,
+  currently pinned by tests as intended.
+- **S16 [phase-1] Value-copy laundering.** Read labeled data, write a derived plain value
+  to an unlabeled cell, commit unlabeled, fetch it out (no label-gated egress). The
+  default-transition absence; the single biggest spec/impl distance. Named here because
+  every other mitigation composes with it.
+- **S17 [hole] Policy applicability steered by author-controlled link schemas.**
+  `wildcardPolicyMatchesValue` falls back to the *written link's embedded schema* when the
+  target is unreadable (`prepare.ts:1509-1535`); a mismatching embedded schema makes the
+  policy entry not apply, skipping `writeAuthorizedBy`/`requiredIntegrity`/`uiContract`
+  for that write. Should fail closed.
+- **S18 [phase-1] Enforcement perimeter.** Raw `IStorageTransaction.write` never marks
+  relevance; `["cfc"]`/`cid:`/`source` path writes are excluded from verification by
+  address pattern (`prepare.ts:887-895`); bare-tx default mode is `disabled`; pattern
+  tests default to `observe` (`packages/cli/lib/test-runner.ts:835`). All rest on
+  "sandbox keeps raw tx away from untrusted code" — which S3 currently undermines.
+- **Minor**: empty `maxConfidentiality` array means "no ceiling" not "public only"
+  (`observation.ts:76-81`); label-view/display reads swallow errors as "no label"
+  (`label-view-state.ts:54-66` — renderer treats undefined as blocked, but the LLM
+  observed-confidentiality path treats it as unconfidential, stacking with the opt-in
+  ceiling); label metadata at `["cfc"]` is freely introspectable incl. `Caveat.source`
+  identities (inv. 12); `sink-inventory.ts`/`INITIAL_SINK_ROLLOUT_GATE` and
+  `StorageValue.labels` are dormant security-looking code; harness digest c14n
+  inconsistent with runner c14n.
+
+## What is implemented well (don't "fix" these away)
+
+Commit gate fails closed in enforce modes incl. digest-drift rejection and
+read/write-after-prepare invalidation; sink release verifies against the **prepared**
+snapshot and skips on mismatch; projection/collection claims rejected fail-closed;
+schema-merge monotonicity directions match the spec and are tested; link-write label
+derivation merges source metadata + link schema and mints provenance, failing closed on
+missing source metadata; exact-copy happy path with granularity-independent value
+reconstruction; rendered-text authorship boundary (blocked placeholder, literal-text
+blocking) is the most spec-faithful piece of ch. 6; SES/cfreg sandbox surface is credible
+(modulo S3); sqlite write-ceiling parser is genuinely fail-closed for the bound-param
+shapes it covers; InjectionSafe sanitizer matches §8.10.5 including the
+stricter-than-JSON-Schema closed-object rule.
+
+---
+
+## Suggested fix order (everything except next-phase work)
+
+Ordering logic: close the bypasses first (a gate that can be switched off isn't a gate),
+then make the verifier's inputs trustworthy (checks over forgeable labels are theater),
+then fix check semantics (false passes), then harden event/egress surfaces, then profiles
+and hygiene. Sizes: S = hours-to-a-day, M = days, L = a week+.
+
+Cross-cutting discipline: failing test first for every item (red-green); small commits;
+every semantic *tightening* lands in observe mode and rides the diagnostics channel
+before flipping to enforce; the "implemented well" list above is the do-not-regress set.
+
+### Wave 0 — close the bypasses (all small, independent)
+
+1. **`prepareCfc(input)` bypass (S2)** — always run `prepareBoundaryCommit`; the input
+   param only feeds digest computation (or move it to an internal/test-only surface).
+   Test: a caller-supplied input cannot skip a policy reject. (S)
+2. **Tx control surface off the public interface (S3)** — `setCfcEnforcementMode` /
+   `prepareCfc` off `IExtendedStorageTransaction` (internal interface), plus a
+   security.test.ts case pinning that sandboxed handler code can't reach `cell.tx`
+   controls. (S–M)
+3. **Identity fallback (S13)** — drop `?? state.implementationIdentity`; unattributed
+   write-policy inputs fail closed in enforce modes. (S)
+4. **Author-steered applicability (S17)** — `wildcardPolicyMatchesValue`: unresolvable
+   link target under a value-conditioned entry ⇒ entry *applies* (fail closed). (S)
+5. **Reject unsupported `ifc.*` keys (S10 + key drift)** — `opaque`,
+   `recomposeProjections`, `passThrough`, `combinedFrom`/`combinationType`,
+   `transformation`, spec-spelled `addedIntegrity`: prepare-reject + schema-merge
+   preserves-or-rejects instead of silently dropping. (S)
+6. **Defuse the flow-precision time bomb** — condition claim attachment on
+   `inferListOpArgumentUsage` (no pointwise claim when the op reads `array`/`params`). (S)
+7. **Empty `maxConfidentiality` semantics** — declared-empty = deny-all (or reject empty
+   arrays at authoring); pick one and pin it. (S)
+8. **`createRef` fail-open fallbacks (S14-minimal)** — replace `randomUUID()` fallbacks
+   with throws; survey call sites first, stage warn→throw if needed. Full
+   TrustedDerivedId envelope stays phase work. (S code, M fallout risk)
+
+### Wave 1 — make the verifier's inputs trustworthy
+
+9. **`cid:` schema-doc verification (S5)** — read-side re-hash à la
+   `verifySourceDocs`/compile-cache; assert hash on write. (S–M)
+10. **Integrity-mint gating (S4)** — split author-mintable *claims* from runtime-only
+    *evidence* families (`InjectionSafe`, compiled-code, provenance); deny evidence
+    families in plain schema `integrity`/`addIntegrity`; sanitizer + compile cache mint
+    via a privileged channel. Needs a short design note — subtlest item in the wave. (M)
+11. **Chokepoint guard for `["cfc"]`/`cid:`/`source` writes (S18-partial)** — explicit
+    privileged-writer assertion at the extended-tx layer instead of address-pattern
+    exclusion in `valueWriteTargets`. (S–M)
+12. **SQLite column `ifc` out of mutable cell data (S8)** — move into the schema envelope
+    or guard handle-cell writes with monotone merge over `tables[].ifc`. (M)
+13. **Default-mode hardening** — bare-tx default `disabled` → runtime-inherited (or
+    `observe`); cli pattern-test default `observe` → `enforce-explicit` (do the test flip
+    *after* Wave 2 lands to avoid churn against the old semantics). (S each, M fallout)
+
+### Wave 2 — verifier semantics: the false-pass cluster (observe-first rollout)
+
+14. **Vacuous pass + ancestor reads (S7)** — unlabeled consumed reads enter the consumed
+    set with empty labels (so `requiredIntegrity` fails without witnesses); `labelAtPath`
+    aggregates descendant labelMap entries for ancestor reads (subtree join). The biggest
+    behavioral change in the plan; expect false-fail fallout — observe, watch
+    diagnostics, then enforce. (M–L)
+15. **`exactCopyOf` repairs** — immediate: reject wildcard (`*`) claim paths fail-closed;
+    then wildcard expansion if patterns need it; add `ifcEntryAppliesToAttemptedWrite`
+    gating; copy the source's *stored* label (not just schema-declared); kill the
+    `undefined`/`undefined` vacuous pass. (M)
+16. **One shared schema-IFC walker** — `joinSchema` gains `anyOf`/`oneOf`/`allOf` descent
+    (+ `prefixItems`, `items`+`additionalProperties` TODO), or both paths extract a
+    common walker; conflicting branch-local `ifc` rejected consistently per §4.2.1.1. (M)
+17. **Integrity meet where combination happens** — same-path distinct-write coalescing
+    stops unioning integrity (last verified write wins, or intersect); sqlite null-origin
+    integrity → empty pending propagation classes (closes CT-1668). Keep union only for
+    link/endorsement *refresh* merges and document the distinction. (M)
+18. **labelMap monotone update (S9)** — merge persisted entries with grow-only
+    confidentiality instead of replace; regression test: link-derived atoms survive a
+    later schema-covered write. (S–M)
+
+### Wave 3 — events and egress
+
+19. **Paramless SQL ceiling bypass (S6)** — writes against ceiling-bearing dbs require
+    attributable shapes; `INSERT…SELECT`/`UPDATE col=col` verify source-column labels fit
+    the destination ceiling, else reject. (M)
+20. **Trusted-event hardening (S12)** — nonce-unique event ids; consume-on-use
+    (session-scoped) so one gesture authorizes one matching write; verify provenance
+    against the runtime-serialized envelope, not candidate-embedded data; runtime-mint or
+    remove the `eventIntegrity` string channel; stop WeakSet-mark propagation through
+    handler re-dispatch. Biggest design item of the wave. Full §7.3 payload-digest
+    binding stays phase work. (M–L)
+21. **Minimal label-aware sink ceiling** — join request-input confidentiality (carried
+    views + stored labels reachable from request cells) against per-sink
+    `maxConfidentiality` from `sink-inventory.ts` (activates the dormant module). Limited
+    until the default transition (phase) closes laundering, but gates direct flows. (M)
+22. **LLM observation path fail-closed** — metadata read errors are errors, not "no
+    label" (`label-view-state.ts:54-66` consumer side). (S)
+23. **Sink-flush failures surfaced** — `cfcInstrumentation` + diagnostics instead of
+    `console.warn`-and-drop. (S)
+
+### Wave 4 — profiles, authority, hygiene
+
+24. **`writeAuthorizedBy` union composition** — accept arrays of verified
+    `__ctWriterIdentityOf` bindings; transformer emit support (§8.15.2/§8.15.8). (M)
+25. **Harness fixes** — canonical digests via `value-hash` (not
+    `JSON.stringify`); verify `PromptSlotBinding` digests/eventId when present; enforce
+    modes require a verified eventId for `direct-command`. Registry snapshots stay phase
+    work. (M)
+26. **Render declassification (S15)** — `declassifyConfidentiality` requires verified
+    authority (interim: trusted-chrome components only, or remove the prop); revisit the
+    default-allow render policy. Product decision involved. (M)
+27. **`enforce-strict` gets real semantics or is removed** — e.g. strict = explicit +
+    reject unknown sink names + no observe escape hatches; decide after Wave 2. (S)
+28. **Hygiene** — delete `StorageValue.labels`; redact `Caveat.source` in label-view
+    introspection (full inv-12 labeling stays phase); `/value` prefix wire-format
+    decision (fix or document equivalence); spec §15 registry sync (`LinkReference`,
+    `PromptSlotInfluence`, caveat alias kind strings). (S each)
+
+### Track A — server (parallel from day 1)
+
+- **A1. Session ACL (S1)** — ownership/membership check in `authorizeSessionOpen` / v2
+  server (port legacy `checkACL` semantics or a space-owner check). Everything
+  client-side assumes this boundary exists. (M–L)
+- **A2. Server-side acceptance of `["cfc"]`/`cid:` writes** — the stated end-state in
+  `cell-cache.ts:405-417` ("server becomes the sole acceptor"). Borders on phase-2 scope,
+  but A1 alone restores the space boundary. (L)
+
+### Explicitly excluded as next-phase work
+
+Policy calculus (records, exchange rules, declassification, fixpoint), CNF clause
+algebra, the intent lifecycle (incl. full §7.3 request binding), trust
+lattice/delegations, the TrustedDerivedId envelope, read-time access checks, expiry,
+projection/collection claim *support* (they stay fail-closed), default transition + PC
+propagation (S16 value-copy laundering), §17 CAS `labelBindings`/`expectedLabel`,
+observation op classes, per-row sqlite labels, `RenderRef`/`snapshotDigest`, harness
+registry snapshots, §11.2 static analysis. Waves 0–2 convert these from "silently absent"
+to "visibly rejected or fail-closed", which is the correct resting state until each phase
+lands.

--- a/cfc-spec-audit.md
+++ b/cfc-spec-audit.md
@@ -1,545 +1,639 @@
 # CFC Spec Audit — packages/runner vs ~/src/specs/cfc
 
-Date: 2026-06-09. Spec bar: sections marked "Status: Normative"; ch. 14 (open problems),
-08-14 and 08-16 (redirect stubs to ch. 14) treated as non-normative. Produced by seven
-parallel audit passes (one per spec slice plus one code-first sweep); the highest-impact
-soundness claims were independently re-verified against source.
+Date: 2026-06-09. Spec bar: sections marked "Status: Normative"; ch. 14 (open
+problems), 08-14 and 08-16 (redirect stubs to ch. 14) treated as non-normative.
+Produced by seven parallel audit passes (one per spec slice plus one code-first
+sweep); the highest-impact soundness claims were independently re-verified
+against source.
 
 ## How the implementation relates to the spec
 
-The runner implements a deliberate **phase-1 subset**: flat conjunctive labels (atom
-arrays, no CNF clauses), schema-declared `ifc` annotations verified at **commit time**
-(`prepareBoundaryCommit`, `packages/runner/src/cfc/prepare.ts:2077`) with a prepared-digest
-recheck at commit (`extended-storage-transaction.ts:656-673`), persisted per-path label
-maps bound to content-addressed schema hashes, link/reference label pass-through, write
-authority, UI-contract trusted events, sink-request replay fidelity, and InjectionSafe
-schema sanitization. Default mode is `enforce-explicit` (`runtime.ts:391`); the bare
-transaction default is `disabled` (`cfc/types.ts:31`).
+The runner implements a deliberate **phase-1 subset**: flat conjunctive labels
+(atom arrays, no CNF clauses), schema-declared `ifc` annotations verified at
+**commit time** (`prepareBoundaryCommit`,
+`packages/runner/src/cfc/prepare.ts:2077`) with a prepared-digest recheck at
+commit (`extended-storage-transaction.ts:656-673`), persisted per-path label
+maps bound to content-addressed schema hashes, link/reference label
+pass-through, write authority, UI-contract trusted events, sink-request replay
+fidelity, and InjectionSafe schema sanitization. Default mode is
+`enforce-explicit` (`runtime.ts:391`); the bare transaction default is
+`disabled` (`cfc/types.ts:31`).
 
 Terminology: spec `Label{confidentiality: Clause[], integrity: Atom[]}` ↔ impl
-`IFCLabel{confidentiality?: unknown[], integrity?: unknown[]}` (`label-view-core.ts:4`);
-spec boundary loop ↔ impl prepare/digest two-phase; spec `CodeHash` write authority ↔ impl
-builtin-id strings or `__ctWriterIdentityOf{bundleId,file,path}` bindings; spec
-`$actingUser` ↔ impl `{__ctCurrentPrincipal: true}` placeholders.
+`IFCLabel{confidentiality?: unknown[], integrity?: unknown[]}`
+(`label-view-core.ts:4`); spec boundary loop ↔ impl prepare/digest two-phase;
+spec `CodeHash` write authority ↔ impl builtin-id strings or
+`__ctWriterIdentityOf{bundleId,file,path}` bindings; spec `$actingUser` ↔ impl
+`{__ctCurrentPrincipal: true}` placeholders.
 
-The single largest architectural distance: **the spec derives output labels from input
-labels (default transition §8.9.3 + PC propagation §8.9.2/§8.11); the implementation never
-does** — it persists only schema-declared labels and verifies declared constraints. Every
-"value-copy laundering" finding below is downstream of that one posture.
+The single largest architectural distance: **the spec derives output labels from
+input labels (default transition §8.9.3 + PC propagation §8.9.2/§8.11); the
+implementation never does** — it persists only schema-declared labels and
+verifies declared constraints. Every "value-copy laundering" finding below is
+downstream of that one posture.
 
 ---
 
 ## 1a. Gaps in existing features (implemented, but incomplete or divergent)
 
-**Input requirement checks (`requiredIntegrity` / `maxConfidentiality`), §8.10.3:**
+**Input requirement checks (`requiredIntegrity` / `maxConfidentiality`),
+§8.10.3:**
+
 - Consumed set is **transaction-global**, not scoped to the annotated input path
-  (`prepare.ts:1694-1709`) — spec uses `collectConsumedLabelsAtOrBelow(path)`. Over-strict
-  in one direction (unrelated labeled read can fail an unrelated write), under-strict in
-  the other (see soundness S7).
-- Satisfaction is whole-atom `deepEqual` membership (`prepare.ts:1747-1759`), not the
-  spec's pattern matching with **shared-witness-key coherence** — two leaves matching via
-  different witnesses both pass where the spec requires one shared witness.
-- Ceiling checks are flat atom membership (`prepare.ts:1761-1771`), not clause-aware
-  "every clause contains an allowed alternative". Fail-closed for opaque `anyOf` objects,
-  but authored OR-clauses can never be satisfied.
-- `labelAtPath` (`prepare.ts:65-87`) matches only ancestor-or-equal entries: a read of a
-  **parent object** of a labeled field resolves to no label and is filtered out of the
-  consumed set entirely (see soundness S7). The label-view machinery handles the same case
-  correctly in the other direction (`rebaseCfcLabelView`), so this looks like an oversight.
+  (`prepare.ts:1694-1709`) — spec uses `collectConsumedLabelsAtOrBelow(path)`.
+  Over-strict in one direction (unrelated labeled read can fail an unrelated
+  write), under-strict in the other (see soundness S7).
+- Satisfaction is whole-atom `deepEqual` membership (`prepare.ts:1747-1759`),
+  not the spec's pattern matching with **shared-witness-key coherence** — two
+  leaves matching via different witnesses both pass where the spec requires one
+  shared witness.
+- Ceiling checks are flat atom membership (`prepare.ts:1761-1771`), not
+  clause-aware "every clause contains an allowed alternative". Fail-closed for
+  opaque `anyOf` objects, but authored OR-clauses can never be satisfied.
+- `labelAtPath` (`prepare.ts:65-87`) matches only ancestor-or-equal entries: a
+  read of a **parent object** of a labeled field resolves to no label and is
+  filtered out of the consumed set entirely (see soundness S7). The label-view
+  machinery handles the same case correctly in the other direction
+  (`rebaseCfcLabelView`), so this looks like an oversight.
 
 **`exactCopyOf` (§8.4):**
+
 - Compares two paths **within the same target document** by `deepEqual`
-  (`prepare.ts:1819-1847`); spec compares handler-input→output via `refer()` identity.
-  Cross-document/handler-input sources inexpressible; reference-form copies spuriously
-  reject.
-- **Wildcard (`items`) claim paths are silently unverified**: `walkIfcSchema` emits `"*"`
-  segments (`prepare.ts:971-973`) but `writeDetailValueForTarget` matches literally, so a
-  write at `["list","0"]` never matches `["list","*"]` and `deepEqual(undefined,
-  undefined)` passes vacuously — while the label copy still happens (`prepare.ts:1857-1859`).
-- Source label copied from the *schema-declared* sibling entry only, not the stored/runtime
-  label of the source; not transitive across copy chains.
-- No `ifcEntryAppliesToAttemptedWrite` gating (unlike sibling checks): writing only the
-  source while the target is untouched spuriously rejects; touching neither passes
-  vacuously.
+  (`prepare.ts:1819-1847`); spec compares handler-input→output via `refer()`
+  identity. Cross-document/handler-input sources inexpressible; reference-form
+  copies spuriously reject.
+- **Wildcard (`items`) claim paths are silently unverified**: `walkIfcSchema`
+  emits `"*"` segments (`prepare.ts:971-973`) but `writeDetailValueForTarget`
+  matches literally, so a write at `["list","0"]` never matches `["list","*"]`
+  and `deepEqual(undefined,
+  undefined)` passes vacuously — while the label
+  copy still happens (`prepare.ts:1857-1859`).
+- Source label copied from the _schema-declared_ sibling entry only, not the
+  stored/runtime label of the source; not transitive across copy chains.
+- No `ifcEntryAppliesToAttemptedWrite` gating (unlike sibling checks): writing
+  only the source while the target is untouched spuriously rejects; touching
+  neither passes vacuously.
 
 **Integrity combination — union everywhere, never meet (§8.6.2, §8.17.1):**
-- `mergeLabel`/`mergeLabels` union integrity (`label-view-core.ts:68-92`,
-  `prepare.ts:1906-1915`). Fine for link refresh/endorsement merges; wrong when two
-  *different* writes land at one path in one tx (`coalesceLabelEntries`,
-  `prepare.ts:2012-2033`) — the surviving value claims integrity only the overwritten value
-  had.
-- SQLite null-origin (aggregate) columns inherit the **union** of all labeled columns'
-  integrity (`deriveNullOriginIfc`, `sqlite-builtins.ts:167-178`) where §8.17.1 says
-  "class-aware meet … never union". A `COUNT(*)` can claim a provenance atom held by one
-  column. (Acknowledged in-repo as CT-1668.)
-- Computation outputs get **no** integrity at all (`applyInputIfcToOutput` propagates only
-  confidentiality, `builder/node-utils.ts:70-88`) — under-claim, fail-safe, but it means
-  hereditary atoms (`PolicyCertified`-class) don't survive as §3.1.6.1/§15.1.1 require.
 
-**Two inconsistent schema-IFC walkers (§4.2.1.1):**
-`walkIfcSchema` (`prepare.ts:916-978`) descends into `anyOf`/`oneOf`/`allOf` and
-flatten-merges branch-local `ifc` (spec says reject); `ContextualFlowControl.joinSchema`
-(`cfc.ts:75-149`) doesn't descend at all, so branch-local confidentiality is silently
-dropped from `lubSchema`-based tainting (the one **under-tainting fail-open** in the core
-algebra). Same schema taints differently on the propagation path vs the verification path.
-`joinSchema` also skips `prefixItems` and skips `items` when `additionalProperties` is
-present (acknowledged TODO, `cfc.ts:124`).
+- `mergeLabel`/`mergeLabels` union integrity (`label-view-core.ts:68-92`,
+  `prepare.ts:1906-1915`). Fine for link refresh/endorsement merges; wrong when
+  two _different_ writes land at one path in one tx (`coalesceLabelEntries`,
+  `prepare.ts:2012-2033`) — the surviving value claims integrity only the
+  overwritten value had.
+- SQLite null-origin (aggregate) columns inherit the **union** of all labeled
+  columns' integrity (`deriveNullOriginIfc`, `sqlite-builtins.ts:167-178`) where
+  §8.17.1 says "class-aware meet … never union". A `COUNT(*)` can claim a
+  provenance atom held by one column. (Acknowledged in-repo as CT-1668.)
+- Computation outputs get **no** integrity at all (`applyInputIfcToOutput`
+  propagates only confidentiality, `builder/node-utils.ts:70-88`) — under-claim,
+  fail-safe, but it means hereditary atoms (`PolicyCertified`-class) don't
+  survive as §3.1.6.1/§15.1.1 require.
+
+**Two inconsistent schema-IFC walkers (§4.2.1.1):** `walkIfcSchema`
+(`prepare.ts:916-978`) descends into `anyOf`/`oneOf`/`allOf` and flatten-merges
+branch-local `ifc` (spec says reject); `ContextualFlowControl.joinSchema`
+(`cfc.ts:75-149`) doesn't descend at all, so branch-local confidentiality is
+silently dropped from `lubSchema`-based tainting (the one **under-tainting
+fail-open** in the core algebra). Same schema taints differently on the
+propagation path vs the verification path. `joinSchema` also skips `prefixItems`
+and skips `items` when `additionalProperties` is present (acknowledged TODO,
+`cfc.ts:124`).
 
 **Flow-precision claims (§8.5.4, §8.9.1):**
-- Claims are minted and trust-gated at the builtin runtime path but **nothing consumes
-  them** (`ifc.flowPrecisionClaim` has no reader) — currently inert.
-- Claims are attached **regardless of op argument usage** (`map.ts:122-127` ignores
-  `inferListOpArgumentUsage`) — a pre-staged unsound `PointwiseWriteDependency` for ops
-  that read the whole array/params, armed for whenever a consumer lands.
-- Trust gate is a compiled-in builtin allowlist (`flow-precision.ts:98-107`), not the
-  user-scoped trust closure §4.8.7 requires; `CodeHash` claims for user modules unsupported.
-- `filter`/`flatMap` have no structural-confidentiality counterpart: element labels pass
-  through by reference (good), but membership/order/length carry **no** label — the
-  §8.5.6.1 secret-search example (private query filtering public items) is unrepresentable,
-  and the implemented default is *permissive*, not conservative.
+
+- Claims are minted and trust-gated at the builtin runtime path but **nothing
+  consumes them** (`ifc.flowPrecisionClaim` has no reader) — currently inert.
+- Claims are attached **regardless of op argument usage** (`map.ts:122-127`
+  ignores `inferListOpArgumentUsage`) — a pre-staged unsound
+  `PointwiseWriteDependency` for ops that read the whole array/params, armed for
+  whenever a consumer lands.
+- Trust gate is a compiled-in builtin allowlist (`flow-precision.ts:98-107`),
+  not the user-scoped trust closure §4.8.7 requires; `CodeHash` claims for user
+  modules unsupported.
+- `filter`/`flatMap` have no structural-confidentiality counterpart: element
+  labels pass through by reference (good), but membership/order/length carry
+  **no** label — the §8.5.6.1 secret-search example (private query filtering
+  public items) is unrepresentable, and the implemented default is _permissive_,
+  not conservative.
 
 **Sink gating (§5.2.1, §7.3-7.5):**
-- The "sink gate" is request **immutability** only: `verifySinkRequestRelease` deep-equals
-  the post-commit request against the prepared snapshot (`sink-request.ts:51-82`). No label
-  is consulted, nothing is stripped, no `AuthorizedRequest` integrity fact is emitted.
-  Today the only enforced sink property is replay fidelity, not information flow.
-- No attempt/commit distinction, no durable consumed-intent record, no retries/`exp`/
-  `maxAttempts`; failed flushes are warn-and-drop (`sink-request.ts:109-117` — at least
-  fail-closed) and invisible to CFC instrumentation.
+
+- The "sink gate" is request **immutability** only: `verifySinkRequestRelease`
+  deep-equals the post-commit request against the prepared snapshot
+  (`sink-request.ts:51-82`). No label is consulted, nothing is stripped, no
+  `AuthorizedRequest` integrity fact is emitted. Today the only enforced sink
+  property is replay fidelity, not information flow.
+- No attempt/commit distinction, no durable consumed-intent record, no
+  retries/`exp`/ `maxAttempts`; failed flushes are warn-and-drop
+  (`sink-request.ts:109-117` — at least fail-closed) and invisible to CFC
+  instrumentation.
 
 **Trusted events / UI contracts (§6.2-6.3, §8.15.9):**
-- Event identity `trusted-event:${type}:${id}:${path}` (`ui-contract.ts:609-615`) — no
-  nonce/timestamp/payload digest; not unique, not single-use (dedup is per-transaction
-  only).
-- No payload binding: `verifyTrustedEventRequirements` (`prepare.ts:1776-1817`) checks a
-  matching gesture exists for the path; the handler may write **any value** (spec §7.3.4
-  requires payloadDigest binding).
-- No render binding: `EventProvenance` carries no `renderRef`/`snapshotDigest`/`targetPath`
-  (§6.3.1's "primary evidence handle").
-- `requiredEventIntegrity` are untyped strings scraped from pattern-authored `data-*`
-  attributes (see soundness S12).
+
+- Event identity `trusted-event:${type}:${id}:${path}`
+  (`ui-contract.ts:609-615`) — no nonce/timestamp/payload digest; not unique,
+  not single-use (dedup is per-transaction only).
+- No payload binding: `verifyTrustedEventRequirements` (`prepare.ts:1776-1817`)
+  checks a matching gesture exists for the path; the handler may write **any
+  value** (spec §7.3.4 requires payloadDigest binding).
+- No render binding: `EventProvenance` carries no
+  `renderRef`/`snapshotDigest`/`targetPath` (§6.3.1's "primary evidence
+  handle").
+- `requiredEventIntegrity` are untyped strings scraped from pattern-authored
+  `data-*` attributes (see soundness S12).
 
 **Write authority (§8.15):**
+
 - Verified-handler claims accept exactly **one** `__ctWriterIdentityOf` binding
-  (`prepare.ts:307-328`); the spec's per-field union of handler identities (§8.15.2,
-  §8.15.8 cross-pattern reuse) is only expressible for legacy builtin-string arrays.
+  (`prepare.ts:307-328`); the spec's per-field union of handler identities
+  (§8.15.2, §8.15.8 cross-pattern reuse) is only expressible for legacy
+  builtin-string arrays.
 
 **CAS / dual addressing (§17):**
-- Causal path matches §17.1's envelope sketch. The CAS path is vestigial: `cid:<schemaHash>`
-  docs are written with the **caller-claimed** hash, unverified on write
-  (`ensureSchemaDocument`, `prepare.ts:2041-2054`) and trusted on read
-  (`loadSchemaDocument`, `prepare.ts:2057-2075`). No `labelBindings`, no `expectedLabel`
-  read API, no miss normalization. The compile cache (`compilation-cache/cell-cache.ts:369-401`)
-  is the one spec-faithful CAS implementation. See soundness S5.
+
+- Causal path matches §17.1's envelope sketch. The CAS path is vestigial:
+  `cid:<schemaHash>` docs are written with the **caller-claimed** hash,
+  unverified on write (`ensureSchemaDocument`, `prepare.ts:2041-2054`) and
+  trusted on read (`loadSchemaDocument`, `prepare.ts:2057-2075`). No
+  `labelBindings`, no `expectedLabel` read API, no miss normalization. The
+  compile cache (`compilation-cache/cell-cache.ts:369-401`) is the one
+  spec-faithful CAS implementation. See soundness S5.
 
 **Schema-evolution monotonicity (§4.2.2.1):** directions correct
 (`schema-merge.ts:55-120`), but missing the normalized-profile eligibility gate,
 `preservesStructuralMeaning` checks, and `labelHistory`.
 
-**Persisted envelope layout (§4.6.4):** label paths are value-relative where the spec says
-newly persisted envelopes MUST key under `/value`; no `PathLabelTemplate` observation
-classes (`shape`/`iterate`/`children`...), and read ops aren't captured per §8.10.1.1
-(`ConsumedRead` has no `op`).
+**Persisted envelope layout (§4.6.4):** label paths are value-relative where the
+spec says newly persisted envelopes MUST key under `/value`; no
+`PathLabelTemplate` observation classes (`shape`/`iterate`/`children`...), and
+read ops aren't captured per §8.10.1.1 (`ConsumedRead` has no `op`).
 
 **Profiles (§18.3/§18.4):**
+
 - AgentHarness: `PromptSlotBinding` has the right fields but they're optional,
-  caller-supplied, and **never verified**; `evaluateHarnessWriteFileAuthorization` trusts a
-  bare `role === "direct-command"` field (`harness-write-policy.ts:25-27`). No registry
-  snapshots, no descriptor digests, no labeled descriptor fields. Opaque-handle
-  pass-through is the one fully met item.
-- TrustedRender: authored-by boundaries, blocked placeholders, and literal-text blocking
-  are real and fail-closed (`packages/html/src/worker/reconciler.ts:384-421,643-708`);
-  trusted-component registry has exactly one entry; no `RenderRef`/`snapshotDigest`
-  machinery at all.
-- Harness digests use `sha256(JSON.stringify(x))` (`packages/cf-harness/src/structured-result.ts:43`)
-  — key-order-sensitive, no NFC; the runner's own digest is properly canonical
+  caller-supplied, and **never verified**;
+  `evaluateHarnessWriteFileAuthorization` trusts a bare
+  `role === "direct-command"` field (`harness-write-policy.ts:25-27`). No
+  registry snapshots, no descriptor digests, no labeled descriptor fields.
+  Opaque-handle pass-through is the one fully met item.
+- TrustedRender: authored-by boundaries, blocked placeholders, and literal-text
+  blocking are real and fail-closed
+  (`packages/html/src/worker/reconciler.ts:384-421,643-708`); trusted-component
+  registry has exactly one entry; no `RenderRef`/`snapshotDigest` machinery at
+  all.
+- Harness digests use `sha256(JSON.stringify(x))`
+  (`packages/cf-harness/src/structured-result.ts:43`) — key-order-sensitive, no
+  NFC; the runner's own digest is properly canonical
   (`data-model/src/value-hash.ts`). Inconsistent c14n across the TCB.
 
 ## 1b. Unimplemented areas (no code counterpart)
 
 - **The entire generic policy calculus (spec layer 2)**: policy records, context
-  principals, exchange-rule syntax/matching/binding, clause-local rewrite, fixpoint
-  evaluation, declassification as guarded release, multi-party consent, response
-  translation, error exchange rules / `SanitizedError`, `PolicyCertified` certification.
-  Zero hits for any of it in the runner. Consequently every declassification-shaped
-  behavior is either hard-coded into the evaluator or absent.
-- **CNF label algebra**: flat atom lists; disjunctive clauses, clause subsumption,
-  clause-local authority, §8.17.4 common-alternative property all unrepresentable.
-  (§8.12.1's note blesses the degenerate all-singleton case, which the impl matches.)
-- **The intent lifecycle (ch. 6-7)**: no `IntentEvent`/`IntentOnce`/refinement chain/
-  consumption cells/attempt cells/`commitIntent`/atomic claims. Single-use semantics —
-  the central mechanism of ch. 6 — exist nowhere. §11's developer guidance references
-  `commitIntent`, which doesn't exist.
-- **Trust lattice (§2.2, §4.8)**: no `TrustStatement`/`VerifierDelegation`/concept
-  reachability; `TrustSnapshot` is `{id, actingPrincipal, revision}` used only for
-  `$currentPrincipal` resolution and owner checks.
-- **Trusted derived identifiers (§2.4)**: no `TrustedDerivedId`/`DerivedByTrustedHash`
-  anywhere; all coordination identifiers are raw strings (see soundness S14).
-- **Access semantics (§3.1.4)**: no `canAccess`, no read-time checks at all; enforcement is
-  write/commit-side plus sink snapshots.
+  principals, exchange-rule syntax/matching/binding, clause-local rewrite,
+  fixpoint evaluation, declassification as guarded release, multi-party consent,
+  response translation, error exchange rules / `SanitizedError`,
+  `PolicyCertified` certification. Zero hits for any of it in the runner.
+  Consequently every declassification-shaped behavior is either hard-coded into
+  the evaluator or absent.
+- **CNF label algebra**: flat atom lists; disjunctive clauses, clause
+  subsumption, clause-local authority, §8.17.4 common-alternative property all
+  unrepresentable. (§8.12.1's note blesses the degenerate all-singleton case,
+  which the impl matches.)
+- **The intent lifecycle (ch. 6-7)**: no `IntentEvent`/`IntentOnce`/refinement
+  chain/ consumption cells/attempt cells/`commitIntent`/atomic claims.
+  Single-use semantics — the central mechanism of ch. 6 — exist nowhere. §11's
+  developer guidance references `commitIntent`, which doesn't exist.
+- **Trust lattice (§2.2, §4.8)**: no
+  `TrustStatement`/`VerifierDelegation`/concept reachability; `TrustSnapshot` is
+  `{id, actingPrincipal, revision}` used only for `$currentPrincipal` resolution
+  and owner checks.
+- **Trusted derived identifiers (§2.4)**: no
+  `TrustedDerivedId`/`DerivedByTrustedHash` anywhere; all coordination
+  identifiers are raw strings (see soundness S14).
+- **Access semantics (§3.1.4)**: no `canAccess`, no read-time checks at all;
+  enforcement is write/commit-side plus sink snapshots.
 - **Expiry/TTL (§3.2, §8.12.6)**: no `Expires` atoms, no cascade.
-- **Projection (§8.3) and collection (§8.5) schema claims**: authorable, rejected
-  fail-closed (`unsupportedTrustSensitiveReason`, `prepare.ts:1028-1046`) — correct posture.
-  But `recomposeProjections`, `passThrough`, `combinedFrom`/`combinationType`,
-  `transformation`, and spec-spelled `addedIntegrity` are **silently ignored** (not in
-  `IFC_KEYS`, not in the reject list, dropped on merge) — an author writing spec-conformant
+- **Projection (§8.3) and collection (§8.5) schema claims**: authorable,
+  rejected fail-closed (`unsupportedTrustSensitiveReason`,
+  `prepare.ts:1028-1046`) — correct posture. But `recomposeProjections`,
+  `passThrough`, `combinedFrom`/`combinationType`, `transformation`, and
+  spec-spelled `addedIntegrity` are **silently ignored** (not in `IFC_KEYS`, not
+  in the reject list, dropped on merge) — an author writing spec-conformant
   annotations gets no enforcement and no error.
-- **`OpaqueInput` (§8.13)**: authorable, lowered to `ifc.opaque` by the transformer, never
-  read by the runner, and **silently dropped by schema-merge** — the one fail-open
-  exception to the otherwise fail-closed treatment of unimplemented claims.
+- **`OpaqueInput` (§8.13)**: authorable, lowered to `ifc.opaque` by the
+  transformer, never read by the runner, and **silently dropped by
+  schema-merge** — the one fail-open exception to the otherwise fail-closed
+  treatment of unimplemented claims.
 - **Per-output label derivation + PC propagation (§8.9.2/§8.9.3, §8.11)**: see
   architecture note; the router attack worked example in ch. 10 is not blocked.
-- **§17.2-17.5 CAS structures**; **§11.2 static analysis**; **§11.1.3 inference rules**
-  (no space-based confidentiality inheritance, no automatic `CodeHash` stamping).
-- Chapter-10 invariants with no enforcement anywhere: #2 (default propagation), #3
-  (guarded exchange), #5 (authority-only secrets), #7 (robust declassification), #8
-  (transparent endorsement), #11 (user-scoped trust closure), #12 (label-metadata
-  confidentiality).
+- **§17.2-17.5 CAS structures**; **§11.2 static analysis**; **§11.1.3 inference
+  rules** (no space-based confidentiality inheritance, no automatic `CodeHash`
+  stamping).
+- Chapter-10 invariants with no enforcement anywhere: #2 (default propagation),
+  #3 (guarded exchange), #5 (authority-only secrets), #7 (robust
+  declassification), #8 (transparent endorsement), #11 (user-scoped trust
+  closure), #12 (label-metadata confidentiality).
 
 ---
 
 ## 2. Differences from spec pseudocode
 
-1. **Boundary loop vs prepare/digest.** Spec (§8.10.1): per-attempt verify→propagate→
-   commit loop. Impl: verify once in `prepareCfc()`, then a canonical-digest recheck at
-   commit with invalidation on any post-prepare activity. Materially different but
-   defensible factoring of the same fail-closed contract — except the digest covers
-   *activity*, not *that verification ran* (see S2).
-2. **Input requirements attached to write-target schemas, not handler-input schemas.**
-   Spec walks the handler's input schema; impl walks the write target's and gates on
-   write-applicability (`prepare.ts:1711+`). A structural inversion: requirements fire when
-   a protected output is written, not when a protected input is consumed.
-3. **`refer(ptr)` vs `deepEqual`.** Everywhere the spec compares content addresses, the
-   impl deep-equals reconstructed values (`exactCopyOf` `prepare.ts:1842`, sink snapshots
-   `sink-request.ts:77`). Equivalent for canonical JSON in-process; produces no auditable
-   digest artifact and exhibits the `undefined/undefined` vacuous edge.
+1. **Boundary loop vs prepare/digest.** Spec (§8.10.1): per-attempt
+   verify→propagate→ commit loop. Impl: verify once in `prepareCfc()`, then a
+   canonical-digest recheck at commit with invalidation on any post-prepare
+   activity. Materially different but defensible factoring of the same
+   fail-closed contract — except the digest covers _activity_, not _that
+   verification ran_ (see S2).
+2. **Input requirements attached to write-target schemas, not handler-input
+   schemas.** Spec walks the handler's input schema; impl walks the write
+   target's and gates on write-applicability (`prepare.ts:1711+`). A structural
+   inversion: requirements fire when a protected output is written, not when a
+   protected input is consumed.
+3. **`refer(ptr)` vs `deepEqual`.** Everywhere the spec compares content
+   addresses, the impl deep-equals reconstructed values (`exactCopyOf`
+   `prepare.ts:1842`, sink snapshots `sink-request.ts:77`). Equivalent for
+   canonical JSON in-process; produces no auditable digest artifact and exhibits
+   the `undefined/undefined` vacuous edge.
 4. **Event processing: claim-before-handle vs at-least-once.** Spec (§6.2.2):
-   `atomicClaimCell` then handle. Impl (`scheduler/events.ts:518-588`): queue, run, retry
-   on conflict — exactly-once replaced by at-least-once with tx-conflict gating.
-5. **Write authority: `CodeHash` atom membership vs source-binding identity.** Spec
-   compares atoms; impl compares builtin-id strings or `{bundleId,file,path}` structures,
-   with silent bundleId rebinding of authored claims (`prepare.ts:771-833`). `codeHash`
-   exists only as a fallback and hashes `Function.prototype.toString`, not a shipped
-   artifact.
-6. **`AttemptedWrite`**: spec `{path, changed}` ordered sequence; impl bare addresses with
-   changed-ness recomputed ad hoc in wildcard matching and final values reconstructed
-   granularity-independently (`prepare.ts:1159-1270`) — equivalent in effect.
-7. **Key drift**: spec `addedIntegrity` vs impl `addIntegrity`; spec `classification`
-   shorthand dropped; impl adds `addIntegrity`, `ownerPrincipal`, `exactCopyOf`,
-   `projection`, `collection`, `flowPrecisionClaim`, `uiContract` under `ifc`.
-8. **Gesture integrity**: spec mints `UIRuntime`/`GestureProvenance` atoms; impl uses a
-   realm-local WeakSet mark plus DOM dataset dictionaries — trust is a JS object-identity
-   property that cannot persist, transfer, or be inspected by policy.
-9. **Developer surface**: §11's branded types / JSDoc annotations / `$actingUser` /
-   `$eventIntegrity` / `$now` are realized as ts-transformer type aliases
-   (`packages/api/cfc.ts:195-387`) and `{__ctCurrentPrincipal:true}` placeholders with a
-   stricter unspecced rule (literal `did:` subjects rejected).
+   `atomicClaimCell` then handle. Impl (`scheduler/events.ts:518-588`): queue,
+   run, retry on conflict — exactly-once replaced by at-least-once with
+   tx-conflict gating.
+5. **Write authority: `CodeHash` atom membership vs source-binding identity.**
+   Spec compares atoms; impl compares builtin-id strings or
+   `{bundleId,file,path}` structures, with silent bundleId rebinding of authored
+   claims (`prepare.ts:771-833`). `codeHash` exists only as a fallback and
+   hashes `Function.prototype.toString`, not a shipped artifact.
+6. **`AttemptedWrite`**: spec `{path, changed}` ordered sequence; impl bare
+   addresses with changed-ness recomputed ad hoc in wildcard matching and final
+   values reconstructed granularity-independently (`prepare.ts:1159-1270`) —
+   equivalent in effect.
+7. **Key drift**: spec `addedIntegrity` vs impl `addIntegrity`; spec
+   `classification` shorthand dropped; impl adds `addIntegrity`,
+   `ownerPrincipal`, `exactCopyOf`, `projection`, `collection`,
+   `flowPrecisionClaim`, `uiContract` under `ifc`.
+8. **Gesture integrity**: spec mints `UIRuntime`/`GestureProvenance` atoms; impl
+   uses a realm-local WeakSet mark plus DOM dataset dictionaries — trust is a JS
+   object-identity property that cannot persist, transfer, or be inspected by
+   policy.
+9. **Developer surface**: §11's branded types / JSDoc annotations /
+   `$actingUser` / `$eventIntegrity` / `$now` are realized as ts-transformer
+   type aliases (`packages/api/cfc.ts:195-387`) and
+   `{__ctCurrentPrincipal:true}` placeholders with a stricter unspecced rule
+   (literal `did:` subjects rejected).
 
 ---
 
 ## 3. In the code, not in the spec (should probably be specified)
 
-1. **Enforcement-mode ladder + relevance predicate.** `disabled|observe|enforce-explicit|
-   enforce-strict` and the `markCfcRelevant` criterion decide *whether CFC runs at all* —
-   the spec assumes verification at every boundary. Also: `enforce-strict` is currently
+1. **Enforcement-mode ladder + relevance predicate.**
+   `disabled|observe|enforce-explicit|
+   enforce-strict` and the
+   `markCfcRelevant` criterion decide _whether CFC runs at all_ — the spec
+   assumes verification at every boundary. Also: `enforce-strict` is currently
    **indistinguishable** from `enforce-explicit` in the commit gate.
-2. **The prepared-digest two-phase commit** (digest contents, canonicalization/freeze
-   rules, invalidation triggers, and the `prepareCfc(input)` contract).
-3. **Setup-projection structural provenance** (`CFC_STRUCTURAL_PROVENANCE_SETUP_PROJECTION`,
-   `prepare.ts:380-492`) — the load-bearing write-authority carve-out for pattern
-   instantiation; §8.15.4 covers it in one sentence.
-4. **The implementation-identity scheme** (`bundleId`+`sourceFile`+`bindingPath` bindings,
-   bundleId rebinding, bundleId-insensitive schema equality) — the root of trust for write
-   authority, zero spec text.
-5. **`ownerPrincipal` + `__ctCurrentPrincipal`** placeholder semantics and the mandatory
-   companion-claim chain (trust snapshot + `represents-principal` + `writeAuthorizedBy` +
-   `uiContract`).
-6. **`addIntegrity`** annotation (used by sanitizer and label persistence; zero spec hits).
-7. **Claim-only labelMap entries** (entry presence = "policy applies here") and the
-   value-relative path layout — the mechanism that makes later unlabeled writes to
-   protected docs CFC-relevant.
-8. **Carried label views + dereference-trace merging + the minted `LinkReference` atom** —
-   the runtime's main label-transport mechanism; `LinkReference` (and
-   `PromptSlotInfluence`) are absent from the §15 atom registry.
-9. **The uiContract trusted-event system** (helper taxonomy, WeakSet renderer mark,
-   provenance/dataset matching) — only ch. 14 *proposals* mention `uiContracts`; this is
-   the implementation's primary UI-evidence mechanism and should be normative.
-10. **The schema-merge per-key direction table** (grow-only vs shrink-only vs frozen) —
-    the actual store-label-monotonicity enforcement rules live only in code.
-11. **Post-commit outbox + sink-release re-verification contract** (idempotency keys,
-    flush-once, verify-against-prepared-snapshot).
-12. **Schema-sanitization / contamination scoping** is *ahead* of the normative spec
-    (08-14 redirects to non-normative ch. 14): instruction-inertness analysis,
-    caveat-kind aliases, the InjectionSafe discharge — implemented, tested, unspecced.
+2. **The prepared-digest two-phase commit** (digest contents,
+   canonicalization/freeze rules, invalidation triggers, and the
+   `prepareCfc(input)` contract).
+3. **Setup-projection structural provenance**
+   (`CFC_STRUCTURAL_PROVENANCE_SETUP_PROJECTION`, `prepare.ts:380-492`) — the
+   load-bearing write-authority carve-out for pattern instantiation; §8.15.4
+   covers it in one sentence.
+4. **The implementation-identity scheme** (`bundleId`+`sourceFile`+`bindingPath`
+   bindings, bundleId rebinding, bundleId-insensitive schema equality) — the
+   root of trust for write authority, zero spec text.
+5. **`ownerPrincipal` + `__ctCurrentPrincipal`** placeholder semantics and the
+   mandatory companion-claim chain (trust snapshot + `represents-principal` +
+   `writeAuthorizedBy` + `uiContract`).
+6. **`addIntegrity`** annotation (used by sanitizer and label persistence; zero
+   spec hits).
+7. **Claim-only labelMap entries** (entry presence = "policy applies here") and
+   the value-relative path layout — the mechanism that makes later unlabeled
+   writes to protected docs CFC-relevant.
+8. **Carried label views + dereference-trace merging + the minted
+   `LinkReference` atom** — the runtime's main label-transport mechanism;
+   `LinkReference` (and `PromptSlotInfluence`) are absent from the §15 atom
+   registry.
+9. **The uiContract trusted-event system** (helper taxonomy, WeakSet renderer
+   mark, provenance/dataset matching) — only ch. 14 _proposals_ mention
+   `uiContracts`; this is the implementation's primary UI-evidence mechanism and
+   should be normative.
+10. **The schema-merge per-key direction table** (grow-only vs shrink-only vs
+    frozen) — the actual store-label-monotonicity enforcement rules live only in
+    code.
+11. **Post-commit outbox + sink-release re-verification contract** (idempotency
+    keys, flush-once, verify-against-prepared-snapshot).
+12. **Schema-sanitization / contamination scoping** is _ahead_ of the normative
+    spec (08-14 redirects to non-normative ch. 14): instruction-inertness
+    analysis, caveat-kind aliases, the InjectionSafe discharge — implemented,
+    tested, unspecced.
 
 ---
 
 ## 4. Soundness findings
 
-Ordered by severity. Tagged **[hole]** = looks unintended, **[phase-1]** = consistent with
-the staged-rollout posture but worth recording as the load-bearing assumption.
+Ordered by severity. Tagged **[hole]** = looks unintended, **[phase-1]** =
+consistent with the staged-rollout posture but worth recording as the
+load-bearing assumption.
 
-- **S1 [hole] Memory v2 server has no ACL/ownership check.** `authorizeSessionOpen`
-  verifies only that the `session.open` invocation is self-signed and names the space
-  (`packages/toolshed/routes/storage/memory.ts:26-74`); the v2 server then accepts
-  `transact`/`query` from any open session, using the principal only for scope addressing.
-  Legacy `checkACL` (`packages/memory/access.ts`, `acl.ts`) is wired only to the legacy
-  consumer; `ACLManager` writes ACL docs nothing on v2 reads. Net: any DID that can reach
-  the websocket can read/write any space — which voids the §9 threat-model rows for
-  network adversaries and other users, and makes every client-side label guarantee
-  advisory. (No tracking comment found, unlike S4's seam.)
-- **S2 [hole] `prepareCfc(input)` is a verification bypass on a public interface.**
-  Supplying an input skips `prepareBoundaryCommit` entirely
-  (`extended-storage-transaction.ts:311-323` — verified); the commit digest only confirms
-  the input matches actual activity, not that policy ran. Combined with the next item this
-  is reachable, and even alone it's an unguarded TCB edge (`storage/interface.ts:746`).
+- **S1 [hole] Memory v2 server has no ACL/ownership check.**
+  `authorizeSessionOpen` verifies only that the `session.open` invocation is
+  self-signed and names the space
+  (`packages/toolshed/routes/storage/memory.ts:26-74`); the v2 server then
+  accepts `transact`/`query` from any open session, using the principal only for
+  scope addressing. Legacy `checkACL` (`packages/memory/access.ts`, `acl.ts`) is
+  wired only to the legacy consumer; `ACLManager` writes ACL docs nothing on v2
+  reads. Net: any DID that can reach the websocket can read/write any space —
+  which voids the §9 threat-model rows for network adversaries and other users,
+  and makes every client-side label guarantee advisory. (No tracking comment
+  found, unlike S4's seam.)
+- **S2 [hole] `prepareCfc(input)` is a verification bypass on a public
+  interface.** Supplying an input skips `prepareBoundaryCommit` entirely
+  (`extended-storage-transaction.ts:311-323` — verified); the commit digest only
+  confirms the input matches actual activity, not that policy ran. Combined with
+  the next item this is reachable, and even alone it's an unguarded TCB edge
+  (`storage/interface.ts:746`).
 - **S3 [hole] The live transaction is exposed to anything holding a Cell.**
   `CellImpl.tx` is `public readonly` (`cell.ts:610` — verified), and
   `setCfcEnforcementMode` / `prepareCfc` are on the public tx interface
-  (`interface.ts:700,746`). Unless a membrane strips it (none found; `security.test.ts`
-  has no assertion for it), handler code can disable enforcement for its own transaction
-  or pre-prepare with a self-assembled digest input. Needs either a membrane test pinning
-  unreachability or moving these to an internal surface.
-- **S4 [hole] Schema-authored integrity minting is unguarded for non-principal atoms.**
-  `derivePersistedLabel` persists `ifc.integrity`/`addIntegrity` from pattern-authorable
-  schemas (`prepare.ts:1849-1877`); only `authored-by`/`represents-principal` kinds are
-  gated. Anyone who authors a schema can mint `InjectionSafe` — the exact atom the
-  prompt-injection screen and `requiredIntegrity` consumers trust. Trusted minting
-  (compile cache) and forgery share one channel. The client-asserted-label seam is
-  acknowledged for compiled-code atoms (`cell-cache.ts:405-417`) but applies, uncommented,
-  to every label in the system (server never inspects `cfc` metadata).
-- **S5 [hole] `cid:` schema-document poisoning.** Caller-claimed hash, no write-side
-  verification, no read-side re-hash (`prepare.ts:2035-2075`). The loaded schema drives
-  label derivation for *other* principals' writes, so a same-space writer can alter what
-  labels everyone else persists. Violates §17.6 ("neither path may silently bypass the
-  other path's access rules"). The compile cache shows the correct pattern.
-- **S6 [hole] Paramless SQL writes bypass the write ceiling.** `checkSqliteWriteCeiling`
-  returns immediately when `params === undefined` (`builtins/sqlite/write-ceiling.ts:34`),
-  and the guard allows `INSERT … SELECT` / `UPDATE t SET public_col = secret_col` —
-  intra-database relabeling that re-emerges under the destination column's (weaker) label.
-  Not covered by the documented "source A" deferral in docs/specs/sqlite-builtin/06-cfc.md.
-- **S7 [hole] Vacuous pass of `requiredIntegrity`/`maxConfidentiality`.** Consumed reads
-  are filtered to those with **persisted stored labels** (`prepare.ts:1694-1709` —
-  verified) and the checks skip when none remain. A handler consuming only unlabeled (or
-  in-flight-schema-labeled, or **parent-of-labeled**) inputs writes into a protected slot
-  unchecked. The spec's own pseudocode skips on empty consumed sets, but its consumed set
-  includes unlabeled inputs as empty-label reads that then *fail* integrity floors — the
-  impl inverts "all inputs endorsed" into "all labeled inputs endorsed". Three audit
-  passes found this independently.
+  (`interface.ts:700,746`). Unless a membrane strips it (none found;
+  `security.test.ts` has no assertion for it), handler code can disable
+  enforcement for its own transaction or pre-prepare with a self-assembled
+  digest input. Needs either a membrane test pinning unreachability or moving
+  these to an internal surface.
+- **S4 [hole] Schema-authored integrity minting is unguarded for non-principal
+  atoms.** `derivePersistedLabel` persists `ifc.integrity`/`addIntegrity` from
+  pattern-authorable schemas (`prepare.ts:1849-1877`); only
+  `authored-by`/`represents-principal` kinds are gated. Anyone who authors a
+  schema can mint `InjectionSafe` — the exact atom the prompt-injection screen
+  and `requiredIntegrity` consumers trust. Trusted minting (compile cache) and
+  forgery share one channel. The client-asserted-label seam is acknowledged for
+  compiled-code atoms (`cell-cache.ts:405-417`) but applies, uncommented, to
+  every label in the system (server never inspects `cfc` metadata).
+- **S5 [hole] `cid:` schema-document poisoning.** Caller-claimed hash, no
+  write-side verification, no read-side re-hash (`prepare.ts:2035-2075`). The
+  loaded schema drives label derivation for _other_ principals' writes, so a
+  same-space writer can alter what labels everyone else persists. Violates §17.6
+  ("neither path may silently bypass the other path's access rules"). The
+  compile cache shows the correct pattern.
+- **S6 [hole] Paramless SQL writes bypass the write ceiling.**
+  `checkSqliteWriteCeiling` returns immediately when `params === undefined`
+  (`builtins/sqlite/write-ceiling.ts:34`), and the guard allows
+  `INSERT … SELECT` / `UPDATE t SET public_col = secret_col` — intra-database
+  relabeling that re-emerges under the destination column's (weaker) label. Not
+  covered by the documented "source A" deferral in
+  docs/specs/sqlite-builtin/06-cfc.md.
+- **S7 [hole] Vacuous pass of `requiredIntegrity`/`maxConfidentiality`.**
+  Consumed reads are filtered to those with **persisted stored labels**
+  (`prepare.ts:1694-1709` — verified) and the checks skip when none remain. A
+  handler consuming only unlabeled (or in-flight-schema-labeled, or
+  **parent-of-labeled**) inputs writes into a protected slot unchecked. The
+  spec's own pseudocode skips on empty consumed sets, but its consumed set
+  includes unlabeled inputs as empty-label reads that then _fail_ integrity
+  floors — the impl inverts "all inputs endorsed" into "all labeled inputs
+  endorsed". Three audit passes found this independently.
 - **S8 [hole] SQLite label declarations live in mutable cell data.** Per-column
-  `ifc` (read labels *and* write ceilings) is a plain field of the db-handle cell's value
-  (`sqlite-builtins.ts:295,424`); nothing prevents weakening/deleting it, and
-  schema-envelope monotonicity never sees it. A store's effective label can go down —
-  exactly what §8.12.1 exists to prevent.
-- **S9 [hole] labelMap replace-on-write loses accumulated atoms.** A path holding
-  link-derived or carried-view confidentiality beyond the schema loses those atoms when a
-  later schema-covered write re-derives the label from the schema alone
-  (`prepare.ts:2253-2295`); no `canUpdateStoreLabel`-style restrictiveness check, no
-  regression test.
-- **S10 [hole] `ifc.opaque` silently dropped** by schema-merge (`schema-merge.ts:6-19`) —
-  authored opacity claims don't even survive metadata persistence. Add to the fail-closed
-  reject list with the other ignored keys (`recomposeProjections`, `passThrough`,
-  `combinedFrom`, `transformation`, `addedIntegrity`).
-- **S11 [hole] Authoring-layer `setSchema` strips the conservative confidentiality join
-  without a trust gate.** `mapWithPattern`/`filterWithPattern`/`flatMapWithPattern` call
-  the *untrusted* `flowPrecisionSchemaForBuiltin` variant and `setSchema` replaces the
-  link schema wholesale (`cell.ts:1988,2081,2124`, `cell.ts:1773-1781`), discarding the
-  input-confidentiality join `applyInputIfcToOutput` just attached. Exactly the §8.9.1
-  forbidden shape (less-restrictive labeling without verified trust); muted today because
-  enforcement rides persisted labelMaps, not declared schemas.
+  `ifc` (read labels _and_ write ceilings) is a plain field of the db-handle
+  cell's value (`sqlite-builtins.ts:295,424`); nothing prevents
+  weakening/deleting it, and schema-envelope monotonicity never sees it. A
+  store's effective label can go down — exactly what §8.12.1 exists to prevent.
+- **S9 [hole] labelMap replace-on-write loses accumulated atoms.** A path
+  holding link-derived or carried-view confidentiality beyond the schema loses
+  those atoms when a later schema-covered write re-derives the label from the
+  schema alone (`prepare.ts:2253-2295`); no `canUpdateStoreLabel`-style
+  restrictiveness check, no regression test.
+- **S10 [hole] `ifc.opaque` silently dropped** by schema-merge
+  (`schema-merge.ts:6-19`) — authored opacity claims don't even survive metadata
+  persistence. Add to the fail-closed reject list with the other ignored keys
+  (`recomposeProjections`, `passThrough`, `combinedFrom`, `transformation`,
+  `addedIntegrity`).
+- **S11 [hole] Authoring-layer `setSchema` strips the conservative
+  confidentiality join without a trust gate.**
+  `mapWithPattern`/`filterWithPattern`/`flatMapWithPattern` call the _untrusted_
+  `flowPrecisionSchemaForBuiltin` variant and `setSchema` replaces the link
+  schema wholesale (`cell.ts:1988,2081,2124`, `cell.ts:1773-1781`), discarding
+  the input-confidentiality join `applyInputIfcToOutput` just attached. Exactly
+  the §8.9.1 forbidden shape (less-restrictive labeling without verified trust);
+  muted today because enforcement rides persisted labelMaps, not declared
+  schemas.
 - **S12 [hole] Forgeable recognizer evidence + trusted-event replay.**
-  `uiContractDataset`/`eventIntegrity` come from pattern-authored `data-*` attributes
-  (`packages/html/src/event-provenance.ts:66-95`) — any real click on an element the
-  pattern decorates satisfies any contract the same pattern declares. And the WeakSet
-  trust mark propagates through `Cell.set` re-emission (`cell.ts:1094`,
-  `ui-contract.ts:406-439`) with nothing consumed: one gesture can authorize unboundedly
-  many protected writes over time. The anti-synthetic half (unmarked events rejected) is
-  solid and tested.
-- **S13 [hole] Identity fallback can misattribute writes.** `identityForInput` falls back
-  to the transaction's *current* identity for inputs recorded before any identity was set
-  (`prepare.ts:2082-2085`, same in `writeAuthorizedByReason`) — partially reopening the
-  cross-context borrowing the per-input capture comment says it exists to prevent.
-- **S14 [phase-1→hole] `createRef` vs §2.4.** Raw digests with no label/integrity
-  envelope; lossy untyped canonicalization (functions → `toString`, cycles → null);
-  **fail-open `crypto.randomUUID()` fallbacks** on missing cause (`create-ref.ts:25-31,
-  66-90`) where the spec requires fail-closed; deterministic IDs + open sync = existence
-  probing (§17.1 MUST NOT). `fetchData`'s `inputHash` additionally writes a content-
-  equality oracle for possibly-confidential inputs into a shared doc.
-- **S15 [hole, adjacent pkg] Render declassification minted by untrusted markup.**
-  `declassifyConfidentiality` is read from static VDOM props and accumulated down the tree
-  (`packages/html/src/worker/reconciler.ts:360-381`); default render policy has no ceiling
-  (every atom renders unless a pattern opts into a boundary). Any pattern can wrap a
-  secret in a boundary that declassifies it — the unguarded-release shape ch. 5 forbids,
-  currently pinned by tests as intended.
-- **S16 [phase-1] Value-copy laundering.** Read labeled data, write a derived plain value
-  to an unlabeled cell, commit unlabeled, fetch it out (no label-gated egress). The
-  default-transition absence; the single biggest spec/impl distance. Named here because
-  every other mitigation composes with it.
+  `uiContractDataset`/`eventIntegrity` come from pattern-authored `data-*`
+  attributes (`packages/html/src/event-provenance.ts:66-95`) — any real click on
+  an element the pattern decorates satisfies any contract the same pattern
+  declares. And the WeakSet trust mark propagates through `Cell.set` re-emission
+  (`cell.ts:1094`, `ui-contract.ts:406-439`) with nothing consumed: one gesture
+  can authorize unboundedly many protected writes over time. The anti-synthetic
+  half (unmarked events rejected) is solid and tested.
+- **S13 [hole] Identity fallback can misattribute writes.** `identityForInput`
+  falls back to the transaction's _current_ identity for inputs recorded before
+  any identity was set (`prepare.ts:2082-2085`, same in
+  `writeAuthorizedByReason`) — partially reopening the cross-context borrowing
+  the per-input capture comment says it exists to prevent.
+- **S14 [phase-1→hole] `createRef` vs §2.4.** Raw digests with no
+  label/integrity envelope; lossy untyped canonicalization (functions →
+  `toString`, cycles → null); **fail-open `crypto.randomUUID()` fallbacks** on
+  missing cause (`create-ref.ts:25-31,
+  66-90`) where the spec requires
+  fail-closed; deterministic IDs + open sync = existence probing (§17.1 MUST
+  NOT). `fetchData`'s `inputHash` additionally writes a content- equality oracle
+  for possibly-confidential inputs into a shared doc.
+- **S15 [hole, adjacent pkg] Render declassification minted by untrusted
+  markup.** `declassifyConfidentiality` is read from static VDOM props and
+  accumulated down the tree (`packages/html/src/worker/reconciler.ts:360-381`);
+  default render policy has no ceiling (every atom renders unless a pattern opts
+  into a boundary). Any pattern can wrap a secret in a boundary that
+  declassifies it — the unguarded-release shape ch. 5 forbids, currently pinned
+  by tests as intended.
+- **S16 [phase-1] Value-copy laundering.** Read labeled data, write a derived
+  plain value to an unlabeled cell, commit unlabeled, fetch it out (no
+  label-gated egress). The default-transition absence; the single biggest
+  spec/impl distance. Named here because every other mitigation composes with
+  it.
 - **S17 [hole] Policy applicability steered by author-controlled link schemas.**
-  `wildcardPolicyMatchesValue` falls back to the *written link's embedded schema* when the
-  target is unreadable (`prepare.ts:1509-1535`); a mismatching embedded schema makes the
-  policy entry not apply, skipping `writeAuthorizedBy`/`requiredIntegrity`/`uiContract`
-  for that write. Should fail closed.
-- **S18 [phase-1] Enforcement perimeter.** Raw `IStorageTransaction.write` never marks
-  relevance; `["cfc"]`/`cid:`/`source` path writes are excluded from verification by
-  address pattern (`prepare.ts:887-895`); bare-tx default mode is `disabled`; pattern
-  tests default to `observe` (`packages/cli/lib/test-runner.ts:835`). All rest on
-  "sandbox keeps raw tx away from untrusted code" — which S3 currently undermines.
-- **Minor**: empty `maxConfidentiality` array means "no ceiling" not "public only"
-  (`observation.ts:76-81`); label-view/display reads swallow errors as "no label"
-  (`label-view-state.ts:54-66` — renderer treats undefined as blocked, but the LLM
-  observed-confidentiality path treats it as unconfidential, stacking with the opt-in
-  ceiling); label metadata at `["cfc"]` is freely introspectable incl. `Caveat.source`
-  identities (inv. 12); `sink-inventory.ts`/`INITIAL_SINK_ROLLOUT_GATE` and
-  `StorageValue.labels` are dormant security-looking code; harness digest c14n
-  inconsistent with runner c14n.
+  `wildcardPolicyMatchesValue` falls back to the _written link's embedded
+  schema_ when the target is unreadable (`prepare.ts:1509-1535`); a mismatching
+  embedded schema makes the policy entry not apply, skipping
+  `writeAuthorizedBy`/`requiredIntegrity`/`uiContract` for that write. Should
+  fail closed.
+- **S18 [phase-1] Enforcement perimeter.** Raw `IStorageTransaction.write` never
+  marks relevance; `["cfc"]`/`cid:`/`source` path writes are excluded from
+  verification by address pattern (`prepare.ts:887-895`); bare-tx default mode
+  is `disabled`; pattern tests default to `observe`
+  (`packages/cli/lib/test-runner.ts:835`). All rest on "sandbox keeps raw tx
+  away from untrusted code" — which S3 currently undermines.
+- **Minor**: empty `maxConfidentiality` array means "no ceiling" not "public
+  only" (`observation.ts:76-81`); label-view/display reads swallow errors as "no
+  label" (`label-view-state.ts:54-66` — renderer treats undefined as blocked,
+  but the LLM observed-confidentiality path treats it as unconfidential,
+  stacking with the opt-in ceiling); label metadata at `["cfc"]` is freely
+  introspectable incl. `Caveat.source` identities (inv. 12);
+  `sink-inventory.ts`/`INITIAL_SINK_ROLLOUT_GATE` and `StorageValue.labels` are
+  dormant security-looking code; harness digest c14n inconsistent with runner
+  c14n.
 
 ## What is implemented well (don't "fix" these away)
 
 Commit gate fails closed in enforce modes incl. digest-drift rejection and
-read/write-after-prepare invalidation; sink release verifies against the **prepared**
-snapshot and skips on mismatch; projection/collection claims rejected fail-closed;
-schema-merge monotonicity directions match the spec and are tested; link-write label
-derivation merges source metadata + link schema and mints provenance, failing closed on
-missing source metadata; exact-copy happy path with granularity-independent value
-reconstruction; rendered-text authorship boundary (blocked placeholder, literal-text
-blocking) is the most spec-faithful piece of ch. 6; SES/cfreg sandbox surface is credible
-(modulo S3); sqlite write-ceiling parser is genuinely fail-closed for the bound-param
-shapes it covers; InjectionSafe sanitizer matches §8.10.5 including the
+read/write-after-prepare invalidation; sink release verifies against the
+**prepared** snapshot and skips on mismatch; projection/collection claims
+rejected fail-closed; schema-merge monotonicity directions match the spec and
+are tested; link-write label derivation merges source metadata + link schema and
+mints provenance, failing closed on missing source metadata; exact-copy happy
+path with granularity-independent value reconstruction; rendered-text authorship
+boundary (blocked placeholder, literal-text blocking) is the most spec-faithful
+piece of ch. 6; SES/cfreg sandbox surface is credible (modulo S3); sqlite
+write-ceiling parser is genuinely fail-closed for the bound-param shapes it
+covers; InjectionSafe sanitizer matches §8.10.5 including the
 stricter-than-JSON-Schema closed-object rule.
 
 ---
 
 ## Suggested fix order (everything except next-phase work)
 
-Ordering logic: close the bypasses first (a gate that can be switched off isn't a gate),
-then make the verifier's inputs trustworthy (checks over forgeable labels are theater),
-then fix check semantics (false passes), then harden event/egress surfaces, then profiles
-and hygiene. Sizes: S = hours-to-a-day, M = days, L = a week+.
+Ordering logic: close the bypasses first (a gate that can be switched off isn't
+a gate), then make the verifier's inputs trustworthy (checks over forgeable
+labels are theater), then fix check semantics (false passes), then harden
+event/egress surfaces, then profiles and hygiene. Sizes: S = hours-to-a-day, M =
+days, L = a week+.
 
-Cross-cutting discipline: failing test first for every item (red-green); small commits;
-every semantic *tightening* lands in observe mode and rides the diagnostics channel
-before flipping to enforce; the "implemented well" list above is the do-not-regress set.
+Cross-cutting discipline: failing test first for every item (red-green); small
+commits; every semantic _tightening_ lands in observe mode and rides the
+diagnostics channel before flipping to enforce; the "implemented well" list
+above is the do-not-regress set.
 
 ### Wave 0 — close the bypasses (all small, independent)
 
-1. **`prepareCfc(input)` bypass (S2)** — always run `prepareBoundaryCommit`; the input
-   param only feeds digest computation (or move it to an internal/test-only surface).
-   Test: a caller-supplied input cannot skip a policy reject. (S)
-2. **Tx control surface off the public interface (S3)** — `setCfcEnforcementMode` /
-   `prepareCfc` off `IExtendedStorageTransaction` (internal interface), plus a
-   security.test.ts case pinning that sandboxed handler code can't reach `cell.tx`
-   controls. (S–M)
-3. **Identity fallback (S13)** — drop `?? state.implementationIdentity`; unattributed
-   write-policy inputs fail closed in enforce modes. (S)
-4. **Author-steered applicability (S17)** — `wildcardPolicyMatchesValue`: unresolvable
-   link target under a value-conditioned entry ⇒ entry *applies* (fail closed). (S)
+1. **`prepareCfc(input)` bypass (S2)** — always run `prepareBoundaryCommit`; the
+   input param only feeds digest computation (or move it to an
+   internal/test-only surface). Test: a caller-supplied input cannot skip a
+   policy reject. (S)
+2. **Tx control surface off the public interface (S3)** —
+   `setCfcEnforcementMode` / `prepareCfc` off `IExtendedStorageTransaction`
+   (internal interface), plus a security.test.ts case pinning that sandboxed
+   handler code can't reach `cell.tx` controls. (S–M)
+3. **Identity fallback (S13)** — drop `?? state.implementationIdentity`;
+   unattributed write-policy inputs fail closed in enforce modes. (S)
+4. **Author-steered applicability (S17)** — `wildcardPolicyMatchesValue`:
+   unresolvable link target under a value-conditioned entry ⇒ entry _applies_
+   (fail closed). (S)
 5. **Reject unsupported `ifc.*` keys (S10 + key drift)** — `opaque`,
    `recomposeProjections`, `passThrough`, `combinedFrom`/`combinationType`,
-   `transformation`, spec-spelled `addedIntegrity`: prepare-reject + schema-merge
-   preserves-or-rejects instead of silently dropping. (S)
+   `transformation`, spec-spelled `addedIntegrity`: prepare-reject +
+   schema-merge preserves-or-rejects instead of silently dropping. (S)
 6. **Defuse the flow-precision time bomb** — condition claim attachment on
-   `inferListOpArgumentUsage` (no pointwise claim when the op reads `array`/`params`). (S)
-7. **Empty `maxConfidentiality` semantics** — declared-empty = deny-all (or reject empty
-   arrays at authoring); pick one and pin it. (S)
-8. **`createRef` fail-open fallbacks (S14-minimal)** — replace `randomUUID()` fallbacks
-   with throws; survey call sites first, stage warn→throw if needed. Full
-   TrustedDerivedId envelope stays phase work. (S code, M fallout risk)
+   `inferListOpArgumentUsage` (no pointwise claim when the op reads
+   `array`/`params`). (S)
+7. **Empty `maxConfidentiality` semantics** — declared-empty = deny-all (or
+   reject empty arrays at authoring); pick one and pin it. (S)
+8. **`createRef` fail-open fallbacks (S14-minimal)** — replace `randomUUID()`
+   fallbacks with throws; survey call sites first, stage warn→throw if needed.
+   Full TrustedDerivedId envelope stays phase work. (S code, M fallout risk)
 
 ### Wave 1 — make the verifier's inputs trustworthy
 
 9. **`cid:` schema-doc verification (S5)** — read-side re-hash à la
    `verifySourceDocs`/compile-cache; assert hash on write. (S–M)
-10. **Integrity-mint gating (S4)** — split author-mintable *claims* from runtime-only
-    *evidence* families (`InjectionSafe`, compiled-code, provenance); deny evidence
-    families in plain schema `integrity`/`addIntegrity`; sanitizer + compile cache mint
-    via a privileged channel. Needs a short design note — subtlest item in the wave. (M)
-11. **Chokepoint guard for `["cfc"]`/`cid:`/`source` writes (S18-partial)** — explicit
-    privileged-writer assertion at the extended-tx layer instead of address-pattern
-    exclusion in `valueWriteTargets`. (S–M)
-12. **SQLite column `ifc` out of mutable cell data (S8)** — move into the schema envelope
-    or guard handle-cell writes with monotone merge over `tables[].ifc`. (M)
-13. **Default-mode hardening** — bare-tx default `disabled` → runtime-inherited (or
-    `observe`); cli pattern-test default `observe` → `enforce-explicit` (do the test flip
-    *after* Wave 2 lands to avoid churn against the old semantics). (S each, M fallout)
+10. **Integrity-mint gating (S4)** — split author-mintable _claims_ from
+    runtime-only _evidence_ families (`InjectionSafe`, compiled-code,
+    provenance); deny evidence families in plain schema
+    `integrity`/`addIntegrity`; sanitizer + compile cache mint via a privileged
+    channel. Needs a short design note — subtlest item in the wave. (M)
+11. **Chokepoint guard for `["cfc"]`/`cid:`/`source` writes (S18-partial)** —
+    explicit privileged-writer assertion at the extended-tx layer instead of
+    address-pattern exclusion in `valueWriteTargets`. (S–M)
+12. **SQLite column `ifc` out of mutable cell data (S8)** — move into the schema
+    envelope or guard handle-cell writes with monotone merge over
+    `tables[].ifc`. (M)
+13. **Default-mode hardening** — bare-tx default `disabled` → runtime-inherited
+    (or `observe`); cli pattern-test default `observe` → `enforce-explicit` (do
+    the test flip _after_ Wave 2 lands to avoid churn against the old
+    semantics). (S each, M fallout)
 
 ### Wave 2 — verifier semantics: the false-pass cluster (observe-first rollout)
 
-14. **Vacuous pass + ancestor reads (S7)** — unlabeled consumed reads enter the consumed
-    set with empty labels (so `requiredIntegrity` fails without witnesses); `labelAtPath`
-    aggregates descendant labelMap entries for ancestor reads (subtree join). The biggest
-    behavioral change in the plan; expect false-fail fallout — observe, watch
-    diagnostics, then enforce. (M–L)
-15. **`exactCopyOf` repairs** — immediate: reject wildcard (`*`) claim paths fail-closed;
-    then wildcard expansion if patterns need it; add `ifcEntryAppliesToAttemptedWrite`
-    gating; copy the source's *stored* label (not just schema-declared); kill the
-    `undefined`/`undefined` vacuous pass. (M)
-16. **One shared schema-IFC walker** — `joinSchema` gains `anyOf`/`oneOf`/`allOf` descent
-    (+ `prefixItems`, `items`+`additionalProperties` TODO), or both paths extract a
-    common walker; conflicting branch-local `ifc` rejected consistently per §4.2.1.1. (M)
-17. **Integrity meet where combination happens** — same-path distinct-write coalescing
-    stops unioning integrity (last verified write wins, or intersect); sqlite null-origin
-    integrity → empty pending propagation classes (closes CT-1668). Keep union only for
-    link/endorsement *refresh* merges and document the distinction. (M)
+14. **Vacuous pass + ancestor reads (S7)** — unlabeled consumed reads enter the
+    consumed set with empty labels (so `requiredIntegrity` fails without
+    witnesses); `labelAtPath` aggregates descendant labelMap entries for
+    ancestor reads (subtree join). The biggest behavioral change in the plan;
+    expect false-fail fallout — observe, watch diagnostics, then enforce. (M–L)
+15. **`exactCopyOf` repairs** — immediate: reject wildcard (`*`) claim paths
+    fail-closed; then wildcard expansion if patterns need it; add
+    `ifcEntryAppliesToAttemptedWrite` gating; copy the source's _stored_ label
+    (not just schema-declared); kill the `undefined`/`undefined` vacuous pass.
+    (M)
+16. **One shared schema-IFC walker** — `joinSchema` gains
+    `anyOf`/`oneOf`/`allOf` descent (+ `prefixItems`,
+    `items`+`additionalProperties` TODO), or both paths extract a common walker;
+    conflicting branch-local `ifc` rejected consistently per §4.2.1.1. (M)
+17. **Integrity meet where combination happens** — same-path distinct-write
+    coalescing stops unioning integrity (last verified write wins, or
+    intersect); sqlite null-origin integrity → empty pending propagation classes
+    (closes CT-1668). Keep union only for link/endorsement _refresh_ merges and
+    document the distinction. (M)
 18. **labelMap monotone update (S9)** — merge persisted entries with grow-only
-    confidentiality instead of replace; regression test: link-derived atoms survive a
-    later schema-covered write. (S–M)
+    confidentiality instead of replace; regression test: link-derived atoms
+    survive a later schema-covered write. (S–M)
 
 ### Wave 3 — events and egress
 
-19. **Paramless SQL ceiling bypass (S6)** — writes against ceiling-bearing dbs require
-    attributable shapes; `INSERT…SELECT`/`UPDATE col=col` verify source-column labels fit
-    the destination ceiling, else reject. (M)
+19. **Paramless SQL ceiling bypass (S6)** — writes against ceiling-bearing dbs
+    require attributable shapes; `INSERT…SELECT`/`UPDATE col=col` verify
+    source-column labels fit the destination ceiling, else reject. (M)
 20. **Trusted-event hardening (S12)** — nonce-unique event ids; consume-on-use
-    (session-scoped) so one gesture authorizes one matching write; verify provenance
-    against the runtime-serialized envelope, not candidate-embedded data; runtime-mint or
-    remove the `eventIntegrity` string channel; stop WeakSet-mark propagation through
-    handler re-dispatch. Biggest design item of the wave. Full §7.3 payload-digest
-    binding stays phase work. (M–L)
-21. **Minimal label-aware sink ceiling** — join request-input confidentiality (carried
-    views + stored labels reachable from request cells) against per-sink
-    `maxConfidentiality` from `sink-inventory.ts` (activates the dormant module). Limited
-    until the default transition (phase) closes laundering, but gates direct flows. (M)
-22. **LLM observation path fail-closed** — metadata read errors are errors, not "no
-    label" (`label-view-state.ts:54-66` consumer side). (S)
-23. **Sink-flush failures surfaced** — `cfcInstrumentation` + diagnostics instead of
-    `console.warn`-and-drop. (S)
+    (session-scoped) so one gesture authorizes one matching write; verify
+    provenance against the runtime-serialized envelope, not candidate-embedded
+    data; runtime-mint or remove the `eventIntegrity` string channel; stop
+    WeakSet-mark propagation through handler re-dispatch. Biggest design item of
+    the wave. Full §7.3 payload-digest binding stays phase work. (M–L)
+21. **Minimal label-aware sink ceiling** — join request-input confidentiality
+    (carried views + stored labels reachable from request cells) against
+    per-sink `maxConfidentiality` from `sink-inventory.ts` (activates the
+    dormant module). Limited until the default transition (phase) closes
+    laundering, but gates direct flows. (M)
+22. **LLM observation path fail-closed** — metadata read errors are errors, not
+    "no label" (`label-view-state.ts:54-66` consumer side). (S)
+23. **Sink-flush failures surfaced** — `cfcInstrumentation` + diagnostics
+    instead of `console.warn`-and-drop. (S)
 
 ### Wave 4 — profiles, authority, hygiene
 
 24. **`writeAuthorizedBy` union composition** — accept arrays of verified
-    `__ctWriterIdentityOf` bindings; transformer emit support (§8.15.2/§8.15.8). (M)
+    `__ctWriterIdentityOf` bindings; transformer emit support (§8.15.2/§8.15.8).
+    (M)
 25. **Harness fixes** — canonical digests via `value-hash` (not
-    `JSON.stringify`); verify `PromptSlotBinding` digests/eventId when present; enforce
-    modes require a verified eventId for `direct-command`. Registry snapshots stay phase
-    work. (M)
-26. **Render declassification (S15)** — `declassifyConfidentiality` requires verified
-    authority (interim: trusted-chrome components only, or remove the prop); revisit the
-    default-allow render policy. Product decision involved. (M)
-27. **`enforce-strict` gets real semantics or is removed** — e.g. strict = explicit +
-    reject unknown sink names + no observe escape hatches; decide after Wave 2. (S)
-28. **Hygiene** — delete `StorageValue.labels`; redact `Caveat.source` in label-view
-    introspection (full inv-12 labeling stays phase); `/value` prefix wire-format
-    decision (fix or document equivalence); spec §15 registry sync (`LinkReference`,
-    `PromptSlotInfluence`, caveat alias kind strings). (S each)
+    `JSON.stringify`); verify `PromptSlotBinding` digests/eventId when present;
+    enforce modes require a verified eventId for `direct-command`. Registry
+    snapshots stay phase work. (M)
+26. **Render declassification (S15)** — `declassifyConfidentiality` requires
+    verified authority (interim: trusted-chrome components only, or remove the
+    prop); revisit the default-allow render policy. Product decision involved.
+    (M)
+27. **`enforce-strict` gets real semantics or is removed** — e.g. strict =
+    explicit + reject unknown sink names + no observe escape hatches; decide
+    after Wave 2. (S)
+28. **Hygiene** — delete `StorageValue.labels`; redact `Caveat.source` in
+    label-view introspection (full inv-12 labeling stays phase); `/value` prefix
+    wire-format decision (fix or document equivalence); spec §15 registry sync
+    (`LinkReference`, `PromptSlotInfluence`, caveat alias kind strings). (S
+    each)
 
 ### Track A — server (parallel from day 1)
 
-- **A1. Session ACL (S1)** — ownership/membership check in `authorizeSessionOpen` / v2
-  server (port legacy `checkACL` semantics or a space-owner check). Everything
-  client-side assumes this boundary exists. (M–L)
-- **A2. Server-side acceptance of `["cfc"]`/`cid:` writes** — the stated end-state in
-  `cell-cache.ts:405-417` ("server becomes the sole acceptor"). Borders on phase-2 scope,
-  but A1 alone restores the space boundary. (L)
+- **A1. Session ACL (S1)** — ownership/membership check in
+  `authorizeSessionOpen` / v2 server (port legacy `checkACL` semantics or a
+  space-owner check). Everything client-side assumes this boundary exists. (M–L)
+- **A2. Server-side acceptance of `["cfc"]`/`cid:` writes** — the stated
+  end-state in `cell-cache.ts:405-417` ("server becomes the sole acceptor").
+  Borders on phase-2 scope, but A1 alone restores the space boundary. (L)
 
 ### Explicitly excluded as next-phase work
 
-Policy calculus (records, exchange rules, declassification, fixpoint), CNF clause
-algebra, the intent lifecycle (incl. full §7.3 request binding), trust
-lattice/delegations, the TrustedDerivedId envelope, read-time access checks, expiry,
-projection/collection claim *support* (they stay fail-closed), default transition + PC
-propagation (S16 value-copy laundering), §17 CAS `labelBindings`/`expectedLabel`,
-observation op classes, per-row sqlite labels, `RenderRef`/`snapshotDigest`, harness
-registry snapshots, §11.2 static analysis. Waves 0–2 convert these from "silently absent"
-to "visibly rejected or fail-closed", which is the correct resting state until each phase
-lands.
+Policy calculus (records, exchange rules, declassification, fixpoint), CNF
+clause algebra, the intent lifecycle (incl. full §7.3 request binding), trust
+lattice/delegations, the TrustedDerivedId envelope, read-time access checks,
+expiry, projection/collection claim _support_ (they stay fail-closed), default
+transition + PC propagation (S16 value-copy laundering), §17 CAS
+`labelBindings`/`expectedLabel`, observation op classes, per-row sqlite labels,
+`RenderRef`/`snapshotDigest`, harness registry snapshots, §11.2 static analysis.
+Waves 0–2 convert these from "silently absent" to "visibly rejected or
+fail-closed", which is the correct resting state until each phase lands.

--- a/packages/runner/src/builtins/filter.ts
+++ b/packages/runner/src/builtins/filter.ts
@@ -91,6 +91,8 @@ export function filter(
       const resultSchema = trustedFlowPrecisionSchemaForBuiltin(
         tx.getCfcState().implementationIdentity,
         "filter",
+        undefined,
+        argumentUsage,
       );
       // CT-1623: identify the result container by the reserved output spot
       // (stable, program-independent). See map.ts for rationale.

--- a/packages/runner/src/builtins/flatmap.ts
+++ b/packages/runner/src/builtins/flatmap.ts
@@ -93,6 +93,8 @@ export function flatMap(
       const resultSchema = trustedFlowPrecisionSchemaForBuiltin(
         tx.getCfcState().implementationIdentity,
         "flatMap",
+        undefined,
+        argumentUsage,
       );
       // CT-1623: identify the result container by the reserved output spot
       // (stable, program-independent). See map.ts for rationale.

--- a/packages/runner/src/builtins/llm-dialog.ts
+++ b/packages/runner/src/builtins/llm-dialog.ts
@@ -1870,7 +1870,11 @@ function toolAllowsObservedConfidentiality(
   const maxConfidentiality = isRecord(toolSchema) && isRecord(toolSchema.ifc)
     ? toolSchema.ifc.maxConfidentiality
     : undefined;
-  if (!Array.isArray(maxConfidentiality) || maxConfidentiality.length === 0) {
+  // A non-array ceiling means none was declared. A declared (even empty) ceiling
+  // is enforced: an empty array is "public only". Delegate to
+  // cfcObservationFitsCeiling rather than special-casing empty as allow-all,
+  // which would skip the empty-ceiling protection (review follow-up to W0.7).
+  if (!Array.isArray(maxConfidentiality)) {
     return true;
   }
 

--- a/packages/runner/src/builtins/map.ts
+++ b/packages/runner/src/builtins/map.ts
@@ -117,12 +117,14 @@ export function map(
     // `{ $patternRef }` sentinel (resolved to the live canonical pattern by
     // identity) or, on the legacy path, the embedded pattern graph itself.
     const opPattern = resolveOpPattern(runtime, op.getRaw(), "map");
+    const argumentUsage = inferListOpArgumentUsage(runtime.cfc, opPattern);
 
     if (!result || result.getAsNormalizedFullLink().scope !== listScope) {
       const resultSchema = trustedFlowPrecisionSchemaForBuiltin(
         tx.getCfcState().implementationIdentity,
         "map",
         opPattern.resultSchema,
+        argumentUsage,
       );
       // CT-1623: identify the result container by the reserved output spot —
       // the fully-resolved write-redirect target the runner supplies as the
@@ -152,7 +154,6 @@ export function map(
     }
     const resultWithLog = result.withTx(tx);
 
-    const argumentUsage = inferListOpArgumentUsage(runtime.cfc, opPattern);
     const createRunInput = (element: Cell<any>, index: number) => ({
       ...(argumentUsage.usesElement ? { element } : {}),
       ...(argumentUsage.usesIndex ? { index } : {}),

--- a/packages/runner/src/cfc/flow-precision.ts
+++ b/packages/runner/src/cfc/flow-precision.ts
@@ -1,5 +1,6 @@
 import { internSchema } from "@commonfabric/data-model/schema-hash";
 import type { JSONSchema } from "../builder/types.ts";
+import type { ListOpArgumentUsage } from "../builtins/list-op-argument-usage.ts";
 import type { ImplementationIdentity } from "./types.ts";
 
 export const FLOW_TAINT_PRECISION_CONCEPT =
@@ -19,60 +20,72 @@ type FlowPrecisionClaim = {
 const BUILTIN_IDS = ["map", "filter", "flatMap"] as const;
 type BuiltinId = (typeof BUILTIN_IDS)[number];
 
-const claimForBuiltin = (
+// Claims asserting that each output position derives only from the corresponding
+// input element. They are unsound when the op reads the whole `array` or
+// data-bearing `params` (a cross-key dependency), so they are dropped in that
+// case. The remaining claims (PointwisePresencePreserved, StableRelativeOrder)
+// are purely structural and hold regardless of what the op reads.
+const ELEMENT_LOCAL_CLAIMS: ReadonlySet<FlowPrecisionClaimType> = new Set([
+  "PointwiseWriteDependency",
+  "ElementLocalExpansion",
+]);
+
+const allClaimsForBuiltin = (
   builtinId: BuiltinId,
-): FlowPrecisionClaim | undefined => {
+): FlowPrecisionClaimType[] => {
   switch (builtinId) {
     case "map":
-      return {
-        concept: FLOW_TAINT_PRECISION_CONCEPT,
-        claims: [
-          { type: "PointwisePresencePreserved" },
-          { type: "PointwiseWriteDependency" },
-        ],
-      };
+      return ["PointwisePresencePreserved", "PointwiseWriteDependency"];
     case "filter":
-      return {
-        concept: FLOW_TAINT_PRECISION_CONCEPT,
-        claims: [
-          { type: "ElementLocalExpansion" },
-          { type: "StableRelativeOrder" },
-        ],
-      };
     case "flatMap":
-      return {
-        concept: FLOW_TAINT_PRECISION_CONCEPT,
-        claims: [
-          { type: "ElementLocalExpansion" },
-          { type: "StableRelativeOrder" },
-        ],
-      };
+      return ["ElementLocalExpansion", "StableRelativeOrder"];
   }
 };
 
-const internFlowPrecisionSchema = (builtinId: BuiltinId): JSONSchema => {
-  const claim = claimForBuiltin(builtinId);
+const claimForBuiltin = (
+  builtinId: BuiltinId,
+  argumentUsage?: ListOpArgumentUsage,
+): FlowPrecisionClaim | undefined => {
+  // A cross-key dependency exists when the callback reads the whole input list
+  // or potentially-data-bearing params. `params` may be config-only, but we
+  // cannot tell, so we drop the element-local claims conservatively.
+  const crossKey = argumentUsage !== undefined &&
+    (argumentUsage.usesArray || argumentUsage.usesParams);
+  const claims = allClaimsForBuiltin(builtinId)
+    .filter((type) => !crossKey || !ELEMENT_LOCAL_CLAIMS.has(type))
+    .map((type) => ({ type }));
+  if (claims.length === 0) {
+    return undefined;
+  }
+  return { concept: FLOW_TAINT_PRECISION_CONCEPT, claims };
+};
 
+const buildFlowPrecisionSchema = (
+  builtinId: BuiltinId,
+  argumentUsage?: ListOpArgumentUsage,
+): JSONSchema => {
+  const claim = claimForBuiltin(builtinId, argumentUsage);
   // Note: `as JSONSchema` required since `ifc.flowPrecisionClaim` is not
   // defined as a property of `JSONSchema`.
   return internSchema({
     type: "array",
-    ifc: {
-      flowPrecisionClaim: claim,
-    },
+    ...(claim !== undefined && { ifc: { flowPrecisionClaim: claim } }),
   } as JSONSchema);
 };
 
-const FLOW_PRECISION_SCHEMAS = new Map<string, JSONSchema>(
-  BUILTIN_IDS.map((id) => [id, internFlowPrecisionSchema(id)]),
-);
+const isBuiltinId = (builtinId: string): builtinId is BuiltinId =>
+  (BUILTIN_IDS as readonly string[]).includes(builtinId);
 
 export const flowPrecisionSchemaForBuiltin = (
   builtinId: string,
   itemSchema?: JSONSchema,
+  argumentUsage?: ListOpArgumentUsage,
 ): JSONSchema | undefined => {
-  const schema = FLOW_PRECISION_SCHEMAS.get(builtinId);
-  if (schema === undefined || itemSchema === undefined) {
+  if (!isBuiltinId(builtinId)) {
+    return undefined;
+  }
+  const schema = buildFlowPrecisionSchema(builtinId, argumentUsage);
+  if (itemSchema === undefined) {
     return schema;
   }
   if (typeof schema === "boolean") return schema;
@@ -99,9 +112,10 @@ export const trustedFlowPrecisionSchemaForBuiltin = (
   identity: ImplementationIdentity | undefined,
   builtinId: string,
   itemSchema?: JSONSchema,
+  argumentUsage?: ListOpArgumentUsage,
 ): JSONSchema | undefined => {
   if (identity?.kind !== "builtin" || identity.builtinId !== builtinId) {
     return undefined;
   }
-  return flowPrecisionSchemaForBuiltin(builtinId, itemSchema);
+  return flowPrecisionSchemaForBuiltin(builtinId, itemSchema, argumentUsage);
 };

--- a/packages/runner/src/cfc/mod.ts
+++ b/packages/runner/src/cfc/mod.ts
@@ -36,6 +36,8 @@ export type {
 } from "./types.ts";
 export {
   CFC_ENFORCEMENT_MODES,
+  CFC_ENFORCING_STRICTNESS,
+  cfcEnforcementStrictness,
   DEFAULT_CFC_ENFORCEMENT_MODE,
   isCfcEnforcementMode,
 } from "./types.ts";

--- a/packages/runner/src/cfc/observation.ts
+++ b/packages/runner/src/cfc/observation.ts
@@ -73,11 +73,10 @@ export const cfcObservationFitsCeiling = (
   confidentiality: readonly unknown[],
   observationMaxConfidentiality: CfcObservationMaxConfidentiality,
 ): boolean => {
-  if (
-    observationMaxConfidentiality === undefined ||
-    observationMaxConfidentiality.length === 0 ||
-    confidentiality.length === 0
-  ) {
+  // undefined means no ceiling. A declared but empty ceiling means "public
+  // only": no confidential atom is permitted. Public data (no confidentiality
+  // atoms) fits any ceiling, including the empty one.
+  if (observationMaxConfidentiality === undefined) {
     return true;
   }
 

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1034,13 +1034,23 @@ const unsupportedTrustSensitiveReason = (
   if (!isRecord(schema) || !isRecord(schema.ifc)) {
     return undefined;
   }
+  // Claims the runner does not implement. A write to a path declaring one must
+  // fail closed rather than be silently ignored (and dropped by schema-merge),
+  // which would give an author no enforcement and no error (audit S10).
   const unsupportedKeys = [
     "projection",
     "collection",
+    "opaque",
+    "passThrough",
+    "recomposeProjections",
+    "combinedFrom",
+    "combinationType",
+    "transformation",
+    "addedIntegrity",
   ] as const;
+  const ifc = schema.ifc as Record<string, unknown>;
   for (const key of unsupportedKeys) {
-    const value = schema.ifc[key];
-    if (value !== undefined) {
+    if (ifc[key] !== undefined) {
       return `unsupported trust-sensitive claim ${key} at /${path.join("/")}`;
     }
   }

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -287,9 +287,11 @@ const writeAuthorizedByReason = (
     return `writeAuthorizedBy requires a trust snapshot at /${path.join("/")}`;
   }
 
-  // Verify against the identity that authored this target's writes, falling
-  // back to the transaction's current identity for writes recorded without one.
-  const identity = targetIdentity ?? tx.getCfcState().implementationIdentity;
+  // Verify against the identity that authored this target's writes. A write
+  // recorded without an active identity stays unattributed (undefined) and
+  // fails closed below; it must not borrow the transaction's current identity
+  // (audit S13).
+  const identity = targetIdentity;
   if (
     Array.isArray(claim) && claim.every((entry) => typeof entry === "string")
   ) {
@@ -2082,7 +2084,13 @@ export const prepareBoundaryCommit = (
   const identityForInput = (
     input: WritePolicyInput,
   ): ImplementationIdentity | undefined =>
-    state.writePolicyInputIdentities.get(input) ?? state.implementationIdentity;
+    // Honor the identity captured when the input was recorded, even when that
+    // is undefined. Falling back to the transaction's current identity would
+    // let a write recorded before any identity was set borrow a trusted
+    // identity established later in the same transaction (audit S13). Every
+    // recorded input is registered in this map, so a missing key cannot occur
+    // for a real input; an unattributed write must fail closed.
+    state.writePolicyInputIdentities.get(input);
   const candidates = candidateSchemasByTarget(
     state.writePolicyInputs,
     identityForInput,

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1508,7 +1508,9 @@ const policySchemaMatchesValue = (
   return true;
 };
 
-const wildcardPolicyMatchesValue = (
+// Exported for unit testing of the unresolvable-link fail-closed branch (S17).
+// Not part of the public CFC surface.
+export const wildcardPolicyMatchesValue = (
   tx: IExtendedStorageTransaction,
   target: {
     space: MemorySpace;
@@ -1531,9 +1533,11 @@ const wildcardPolicyMatchesValue = (
     return policySchemaMatchesValue(schema, linkedValue);
   }
 
-  const link = parseLink(value, { ...target, path: [] });
-  return link?.schema === undefined ||
-    schemasEqualIgnoringWriterBundleIds(schema, link.schema);
+  // The link's target value is unresolvable, so the policy's value condition
+  // cannot be evaluated against real data. The link's embedded schema is
+  // author-controlled and must not be trusted to exclude the policy (audit
+  // S17): fail closed by treating the entry as applying.
+  return true;
 };
 
 const ifcEntryAppliesToAttemptedWrite = (

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1774,8 +1774,10 @@ const verifyInputRequirements = (
       }
     }
 
-    const maxConfidentiality = ifc?.maxConfidentiality ?? [];
-    if (maxConfidentiality.length > 0 && consumed.length > 0) {
+    // undefined means no ceiling; a declared (even empty) ceiling is enforced.
+    // An empty ceiling is "public only": any consumed confidential atom fails.
+    const maxConfidentiality = ifc?.maxConfidentiality;
+    if (maxConfidentiality !== undefined && consumed.length > 0) {
       const ok = consumed.every((read) =>
         (read.label?.confidentiality ?? []).every((value) =>
           maxConfidentiality.some((allowed) => deepEqual(allowed, value))

--- a/packages/runner/src/cfc/types.ts
+++ b/packages/runner/src/cfc/types.ts
@@ -30,6 +30,31 @@ export const isCfcEnforcementMode = (
 
 export const DEFAULT_CFC_ENFORCEMENT_MODE: CfcEnforcementMode = "disabled";
 
+/**
+ * Strictness ranking used to forbid weakening a transaction's enforcement mode
+ * after it has been raised (audit S3). Higher = stricter. `disabled`/`observe`
+ * impose no enforcement floor; the two `enforce-*` levels do.
+ */
+export const cfcEnforcementStrictness = (
+  mode: CfcEnforcementMode,
+): number => {
+  switch (mode) {
+    case "disabled":
+      return 0;
+    case "observe":
+      return 1;
+    case "enforce-explicit":
+      return 2;
+    case "enforce-strict":
+      return 3;
+  }
+};
+
+/** Lowest strictness considered "enforcing" (establishes a non-lowerable floor). */
+export const CFC_ENFORCING_STRICTNESS = cfcEnforcementStrictness(
+  "enforce-explicit",
+);
+
 export type CfcSandboxJsonValue =
   | null
   | boolean

--- a/packages/runner/src/create-ref.ts
+++ b/packages/runner/src/create-ref.ts
@@ -17,8 +17,13 @@ export type EntityId = {
 /**
  * Generates an entity ID.
  *
+ * Derivation inputs must resolve: a Cell with no entityId or an OpaqueRef with
+ * no value throws rather than minting a random substitute, so a derived id never
+ * silently becomes non-deterministic (audit S14). A missing `cause`, by
+ * contrast, deliberately mints a fresh random id.
+ *
  * @param source - The source object.
- * @param cause - Optional causal source. Otherwise a random n is used.
+ * @param cause - Optional causal source. If omitted, a random id is minted.
  */
 export function createRef(
   source: Record<string | number | symbol, any> = {},

--- a/packages/runner/src/create-ref.ts
+++ b/packages/runner/src/create-ref.ts
@@ -64,11 +64,11 @@ export function createRef(
     if (isOpaqueRef(obj)) {
       const val = obj.export().value;
       if (val == null) {
-        console.error(
-          "[createRef] OpaqueRef has no value — falling back to randomUUID",
-          new Error().stack,
+        // An OpaqueRef feeding a derived id must carry a value; otherwise the
+        // id would silently become non-deterministic (audit S14). Fail closed.
+        throw new Error(
+          "[createRef] OpaqueRef has no value; cannot derive a stable id",
         );
-        return crypto.randomUUID();
       }
       return val;
     }
@@ -82,11 +82,12 @@ export function createRef(
     if (isCell(obj)) {
       const id = obj.entityId;
       if (id == null) {
-        console.error(
-          "[createRef] Cell has no entityId — falling back to randomUUID",
-          new Error().stack,
+        // A Cell referenced from a derived id must have an entityId; otherwise
+        // the id would silently become non-deterministic (audit S14). Fail
+        // closed rather than mint a random substitute.
+        throw new Error(
+          "[createRef] Cell has no entityId; cannot derive a stable id",
         );
-        return crypto.randomUUID();
       }
       return id;
     } else if (Array.isArray(obj)) return obj.map(traverse);

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -308,20 +308,23 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     };
   }
 
-  prepareCfc(input?: PreparedDigestInput): string {
-    if (input === undefined) {
-      const reasons = prepareBoundaryCommit(this);
-      if (reasons.length > 0) {
-        this.cfcInstrumentation.onPrepareReject?.(reasons);
-        this.cfcState.prepare = {
-          status: "invalidated",
-          reasons,
-        };
-        this.cfcState.diagnostics.push(...reasons);
-        return "";
-      }
+  prepareCfc(): string {
+    // Verification always runs. There is deliberately no caller-supplied input
+    // override: the commit-time digest recheck only confirms the prepared input
+    // matches real activity, so accepting an external input here would let a
+    // caller skip prepareBoundaryCommit while still passing the recheck (audit
+    // S2 — verification bypass).
+    const reasons = prepareBoundaryCommit(this);
+    if (reasons.length > 0) {
+      this.cfcInstrumentation.onPrepareReject?.(reasons);
+      this.cfcState.prepare = {
+        status: "invalidated",
+        reasons,
+      };
+      this.cfcState.diagnostics.push(...reasons);
+      return "";
     }
-    const preparedInput = input ?? this.buildPreparedDigestInput();
+    const preparedInput = this.buildPreparedDigestInput();
     const digest = preparedDigestFor(preparedInput);
     this.cfcState.prepare = {
       status: "prepared",
@@ -805,8 +808,8 @@ export class TransactionWrapper implements IExtendedStorageTransaction {
     this.wrapped.recordCfcDereferenceTrace(trace);
   }
 
-  prepareCfc(input?: PreparedDigestInput): string {
-    return this.wrapped.prepareCfc(input);
+  prepareCfc(): string {
+    return this.wrapped.prepareCfc();
   }
 
   setCfcTrustSnapshot(snapshot: TrustSnapshot | undefined): void {

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -53,6 +53,8 @@ import {
   canonicalizeLogicalPath,
   type CfcDereferenceTrace,
   type CfcEnforcementMode,
+  CFC_ENFORCING_STRICTNESS,
+  cfcEnforcementStrictness,
   type CfcTxState,
   type ConsumedRead,
   DEFAULT_CFC_ENFORCEMENT_MODE,
@@ -103,6 +105,8 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   };
   private reportedCfcRelevant = false;
   private reportedCfcPrepared = false;
+  // Highest enforcing strictness ever set on this tx; mode cannot drop below it.
+  private cfcEnforcementFloor = 0;
   // Per-transaction cache of `Cell.get()` results, keyed by cell link identity.
   // Replaced wholesale on any write (see `invalidateReadResultCache`), so a hit
   // is only ever served when nothing has been written since the cached read.
@@ -121,7 +125,25 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
   }
 
   setCfcEnforcementMode(mode: CfcEnforcementMode): void {
+    // Enforcement may be raised but never weakened below the highest enforcing
+    // level set on this transaction (audit S3). The control surface is on the
+    // public transaction interface and cell.tx is reachable, so this prevents
+    // code holding a Cell from disabling enforcement mid-transaction to commit a
+    // policy violation. `disabled`/`observe` impose no floor (neither enforces),
+    // so they may still be juggled before any enforcing mode is set.
+    if (cfcEnforcementStrictness(mode) < this.cfcEnforcementFloor) {
+      throw new Error(
+        `CFC enforcement mode cannot be weakened to "${mode}": transaction is ` +
+          `pinned at strictness ${this.cfcEnforcementFloor} or higher`,
+      );
+    }
     this.cfcState.enforcementMode = mode;
+    if (cfcEnforcementStrictness(mode) >= CFC_ENFORCING_STRICTNESS) {
+      this.cfcEnforcementFloor = Math.max(
+        this.cfcEnforcementFloor,
+        cfcEnforcementStrictness(mode),
+      );
+    }
   }
 
   markCfcRelevant(reason?: string): void {

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -51,9 +51,9 @@ import { ignoreReadForScheduling } from "../scheduler.ts";
 import {
   type AttemptedWrite,
   canonicalizeLogicalPath,
+  CFC_ENFORCING_STRICTNESS,
   type CfcDereferenceTrace,
   type CfcEnforcementMode,
-  CFC_ENFORCING_STRICTNESS,
   cfcEnforcementStrictness,
   type CfcTxState,
   type ConsumedRead,

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -41,7 +41,6 @@ import type {
   CfcTxState,
   ImplementationIdentity,
   PostCommitSideEffect,
-  PreparedDigestInput,
   TrustSnapshot,
   WritePolicyInput,
 } from "../cfc/mod.ts";
@@ -743,7 +742,14 @@ export interface IExtendedStorageTransaction
    */
   recordCfcDereferenceTrace(trace: CfcDereferenceTrace): void;
 
-  prepareCfc(input?: PreparedDigestInput): string;
+  /**
+   * Runs CFC boundary verification for this transaction and records the
+   * prepared digest. Takes no caller-supplied input: the commit-time digest
+   * recheck only confirms the prepared input matches real activity, so an
+   * external input override would let a caller skip verification while still
+   * passing the recheck (audit S2).
+   */
+  prepareCfc(): string;
 
   /**
    * Sets (or clears) the CFC trust snapshot for this transaction. See

--- a/packages/runner/test/cfc-authoring-observe.test.ts
+++ b/packages/runner/test/cfc-authoring-observe.test.ts
@@ -3,6 +3,7 @@ import { expect } from "@std/expect";
 import { Identity } from "@commonfabric/identity";
 import { StorageManager } from "../src/storage/cache.deno.ts";
 import { Runtime } from "../src/runtime.ts";
+import type { CfcEnforcementMode } from "../src/cfc/mod.ts";
 import { createSchemaTransformerV2 } from "../../schema-generator/src/plugin.ts";
 import {
   asObjectSchema,
@@ -14,13 +15,14 @@ const signer = await Identity.fromPassphrase(
 );
 
 describe("CFC authoring surface trust-sensitive claims", () => {
-  const createRuntime = () => {
+  const createRuntime = (cfcEnforcementMode?: CfcEnforcementMode) => {
     const storageManager = StorageManager.emulate({
       as: signer,
     });
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
+      ...(cfcEnforcementMode ? { cfcEnforcementMode } : {}),
     });
     return { runtime, storageManager };
   };
@@ -48,10 +50,9 @@ describe("CFC authoring surface trust-sensitive claims", () => {
       },
     });
 
-    const { runtime, storageManager } = createRuntime();
+    const { runtime, storageManager } = createRuntime("observe");
     try {
       const observeTx = runtime.edit();
-      observeTx.setCfcEnforcementMode("observe");
 
       const observeCell = runtime.getCell(
         signer.did(),

--- a/packages/runner/test/cfc-boundary.test.ts
+++ b/packages/runner/test/cfc-boundary.test.ts
@@ -23,7 +23,10 @@ import {
   logicalPathToPointer,
 } from "../src/cfc/mod.ts";
 import { flowPrecisionSchemaForBuiltin } from "../src/cfc/flow-precision.ts";
-import { CFC_STRUCTURAL_PROVENANCE_SETUP_PROJECTION } from "../src/cfc/types.ts";
+import {
+  CFC_STRUCTURAL_PROVENANCE_SETUP_PROJECTION,
+  type CfcEnforcementMode,
+} from "../src/cfc/types.ts";
 import type { JSONSchema, Pattern } from "../src/builder/types.ts";
 import { LINK_V1_TAG } from "../src/sigil-types.ts";
 import { ignoreReadForScheduling } from "../src/scheduler.ts";
@@ -172,13 +175,14 @@ describe("CFC canonicalization helpers", () => {
 });
 
 describe("ExtendedStorageTransaction CFC gate", () => {
-  const createRuntime = () => {
+  const createRuntime = (cfcEnforcementMode?: CfcEnforcementMode) => {
     const storageManager = StorageManager.emulate({
       as: signer,
     });
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
       storageManager,
+      ...(cfcEnforcementMode ? { cfcEnforcementMode } : {}),
     });
     return { runtime, storageManager };
   };
@@ -782,10 +786,9 @@ describe("ExtendedStorageTransaction CFC gate", () => {
   });
 
   it("allows relevant unprepared commits when enforcement is disabled", async () => {
-    const { runtime, storageManager } = createRuntime();
+    const { runtime, storageManager } = createRuntime("disabled");
     try {
       const tx = runtime.edit();
-      tx.setCfcEnforcementMode("disabled");
       tx.markCfcRelevant("test");
       tx.writeValueOrThrow({
         space: signer.did(),
@@ -804,10 +807,9 @@ describe("ExtendedStorageTransaction CFC gate", () => {
   });
 
   it("allows observe-mode commits without blocking", async () => {
-    const { runtime, storageManager } = createRuntime();
+    const { runtime, storageManager } = createRuntime("observe");
     try {
       const tx = runtime.edit();
-      tx.setCfcEnforcementMode("observe");
       tx.markCfcRelevant("test");
       tx.writeValueOrThrow({
         space: signer.did(),
@@ -2952,10 +2954,9 @@ describe("ExtendedStorageTransaction CFC gate", () => {
   });
 
   it("does not record link-write provenance when a link is collapsed to a snapshot", async () => {
-    const { runtime, storageManager } = createRuntime();
+    const { runtime, storageManager } = createRuntime("observe");
     try {
       const tx = runtime.edit();
-      tx.setCfcEnforcementMode("observe");
       const cell = runtime.getCell(
         signer.did(),
         "cfc-collapsed-link-provenance",
@@ -5441,10 +5442,9 @@ describe("ExtendedStorageTransaction CFC gate", () => {
   });
 
   it("records diagnostics for unsupported trust-sensitive claims in observe mode", async () => {
-    const { runtime, storageManager } = createRuntime();
+    const { runtime, storageManager } = createRuntime("observe");
     try {
       const tx = runtime.edit();
-      tx.setCfcEnforcementMode("observe");
 
       const cell = runtime.getCell(
         signer.did(),

--- a/packages/runner/test/cfc-ceiling-empty.test.ts
+++ b/packages/runner/test/cfc-ceiling-empty.test.ts
@@ -1,0 +1,89 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+import { cfcObservationFitsCeiling } from "../src/cfc/observation.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-ceiling-empty");
+
+// Regression guard for empty-ceiling semantics (audit minor / W0.7).
+//
+// A declared but empty maxConfidentiality means "public only" — no confidential
+// atom is permitted. It was conflated with undefined ("no ceiling"), so an empty
+// ceiling let confidential data through. undefined stays no-ceiling; public data
+// (no confidentiality atoms) still fits any ceiling, including the empty one.
+describe("cfcObservationFitsCeiling empty ceiling", () => {
+  it("treats undefined ceiling as no ceiling", () => {
+    expect(cfcObservationFitsCeiling(["secret"], undefined)).toBe(true);
+  });
+
+  it("denies confidential data under an empty (public-only) ceiling", () => {
+    expect(cfcObservationFitsCeiling(["secret"], [])).toBe(false);
+  });
+
+  it("permits public data under an empty ceiling", () => {
+    expect(cfcObservationFitsCeiling([], [])).toBe(true);
+  });
+
+  it("permits atoms within a populated ceiling", () => {
+    expect(cfcObservationFitsCeiling(["a"], ["a", "b"])).toBe(true);
+    expect(cfcObservationFitsCeiling(["c"], ["a", "b"])).toBe(false);
+  });
+});
+
+describe("prepare maxConfidentiality empty ceiling", () => {
+  it("rejects a write to an empty-ceiling path that consumes confidential input", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    try {
+      // Seed and persist a confidential source.
+      const seed = runtime.edit();
+      const srcSchema = {
+        type: "string",
+        ifc: { confidentiality: ["secret"] },
+      } as const satisfies JSONSchema;
+      const src = runtime.getCell(signer.did(), "ceiling-src", srcSchema, seed);
+      src.set("classified");
+      seed.prepareCfc();
+      expect((await seed.commit()).ok).toBeDefined();
+
+      // In an enforcing tx, consume the confidential read and write to a path
+      // declaring an empty (public-only) maxConfidentiality ceiling.
+      const tx = runtime.edit();
+      const srcRead = runtime.getCell(
+        signer.did(),
+        "ceiling-src",
+        srcSchema,
+        tx,
+      );
+      srcRead.get();
+      const target = runtime.getCell(
+        signer.did(),
+        "ceiling-target",
+        {
+          type: "object",
+          properties: {
+            out: { type: "string", ifc: { maxConfidentiality: [] } },
+          },
+          required: ["out"],
+        } as const satisfies JSONSchema,
+        tx,
+      );
+      target.set({ out: "derived" });
+
+      const digest = tx.prepareCfc();
+      expect(digest).toBe("");
+      const result = await tx.commit();
+      expect(result.error?.message).toContain("maxConfidentiality failed");
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+});

--- a/packages/runner/test/cfc-flow-precision-argument-usage.test.ts
+++ b/packages/runner/test/cfc-flow-precision-argument-usage.test.ts
@@ -1,0 +1,81 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { flowPrecisionSchemaForBuiltin } from "../src/cfc/flow-precision.ts";
+import type { ListOpArgumentUsage } from "../src/builtins/list-op-argument-usage.ts";
+
+// Regression guard for flow-precision claims vs op argument usage (audit, W0.6).
+//
+// PointwiseWriteDependency (map) and ElementLocalExpansion (filter/flatMap)
+// assert that each output position derives only from the corresponding input
+// element. That is false when the op reads the whole `array` or data-bearing
+// `params` — a cross-key dependency. These element-local claims must be dropped
+// in that case; the purely structural claims (PointwisePresencePreserved,
+// StableRelativeOrder) stay.
+
+const claimTypes = (schema: unknown): string[] => {
+  const ifc = (schema as { ifc?: { flowPrecisionClaim?: { claims?: Array<{ type: string }> } } })
+    .ifc;
+  return (ifc?.flowPrecisionClaim?.claims ?? []).map((c) => c.type);
+};
+
+const usage = (over: Partial<ListOpArgumentUsage>): ListOpArgumentUsage => ({
+  usesElement: true,
+  usesIndex: false,
+  usesArray: false,
+  usesParams: false,
+  ...over,
+});
+
+describe("flow-precision claims vs op argument usage", () => {
+  it("keeps all map claims when the op is element-local", () => {
+    const schema = flowPrecisionSchemaForBuiltin("map", undefined, usage({}));
+    expect(claimTypes(schema).sort()).toEqual(
+      ["PointwisePresencePreserved", "PointwiseWriteDependency"].sort(),
+    );
+  });
+
+  it("drops PointwiseWriteDependency when a map op reads the array", () => {
+    const schema = flowPrecisionSchemaForBuiltin(
+      "map",
+      undefined,
+      usage({ usesArray: true }),
+    );
+    expect(claimTypes(schema)).toEqual(["PointwisePresencePreserved"]);
+  });
+
+  it("drops PointwiseWriteDependency when a map op reads params", () => {
+    const schema = flowPrecisionSchemaForBuiltin(
+      "map",
+      undefined,
+      usage({ usesParams: true }),
+    );
+    expect(claimTypes(schema)).toEqual(["PointwisePresencePreserved"]);
+  });
+
+  it("drops ElementLocalExpansion for filter/flatMap reading the array", () => {
+    for (const builtin of ["filter", "flatMap"]) {
+      const schema = flowPrecisionSchemaForBuiltin(
+        builtin,
+        undefined,
+        usage({ usesArray: true }),
+      );
+      expect(claimTypes(schema)).toEqual(["StableRelativeOrder"]);
+    }
+  });
+
+  it("keeps all filter/flatMap claims when element-local", () => {
+    for (const builtin of ["filter", "flatMap"]) {
+      const schema = flowPrecisionSchemaForBuiltin(builtin, undefined, usage({}));
+      expect(claimTypes(schema).sort()).toEqual(
+        ["ElementLocalExpansion", "StableRelativeOrder"].sort(),
+      );
+    }
+  });
+
+  it("keeps all claims when argument usage is unknown (backward compatible)", () => {
+    const schema = flowPrecisionSchemaForBuiltin("map");
+    expect(claimTypes(schema).sort()).toEqual(
+      ["PointwisePresencePreserved", "PointwiseWriteDependency"].sort(),
+    );
+  });
+});

--- a/packages/runner/test/cfc-flow-precision-argument-usage.test.ts
+++ b/packages/runner/test/cfc-flow-precision-argument-usage.test.ts
@@ -13,7 +13,9 @@ import type { ListOpArgumentUsage } from "../src/builtins/list-op-argument-usage
 // StableRelativeOrder) stay.
 
 const claimTypes = (schema: unknown): string[] => {
-  const ifc = (schema as { ifc?: { flowPrecisionClaim?: { claims?: Array<{ type: string }> } } })
+  const ifc = (schema as {
+    ifc?: { flowPrecisionClaim?: { claims?: Array<{ type: string }> } };
+  })
     .ifc;
   return (ifc?.flowPrecisionClaim?.claims ?? []).map((c) => c.type);
 };
@@ -65,7 +67,11 @@ describe("flow-precision claims vs op argument usage", () => {
 
   it("keeps all filter/flatMap claims when element-local", () => {
     for (const builtin of ["filter", "flatMap"]) {
-      const schema = flowPrecisionSchemaForBuiltin(builtin, undefined, usage({}));
+      const schema = flowPrecisionSchemaForBuiltin(
+        builtin,
+        undefined,
+        usage({}),
+      );
       expect(claimTypes(schema).sort()).toEqual(
         ["ElementLocalExpansion", "StableRelativeOrder"].sort(),
       );

--- a/packages/runner/test/cfc-identity-borrowing.test.ts
+++ b/packages/runner/test/cfc-identity-borrowing.test.ts
@@ -1,0 +1,73 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-identity-borrowing");
+
+// Regression guard for the write-policy identity fallback (audit S13).
+//
+// writeAuthorizedBy is verified against the implementation identity captured
+// when the write-policy input was recorded. The pre-fix code fell back to the
+// transaction's *current* identity (state.implementationIdentity) for inputs
+// recorded before any identity was set, so an unattributed write into a
+// protected field could borrow a trusted identity set later in the same
+// transaction and pass verification. Unattributed writes must fail closed.
+describe("CFC write-policy identity borrowing", () => {
+  it("does not attribute an unattributed write to a later-set identity", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+      trustSnapshotProvider: () => ({
+        id: "trust-snapshot-identity-borrowing",
+        actingPrincipal: signer.did(),
+      }),
+    });
+    try {
+      const tx = runtime.edit();
+      const schema = {
+        type: "object",
+        properties: {
+          counter: {
+            type: "number",
+            ifc: {
+              // Builtin write-authority claim: only the named builtin may write.
+              writeAuthorizedBy: ["trustedIncrement"],
+            },
+          },
+        },
+        required: ["counter"],
+      } as const satisfies JSONSchema;
+      const cell = runtime.getCell(
+        signer.did(),
+        "cfc-identity-borrowing",
+        schema,
+        tx,
+      );
+
+      // The write is recorded now, while no implementation identity is active —
+      // so this write is unattributed.
+      cell.set({ counter: 1 });
+
+      // Later in the same transaction a trusted builtin identity becomes active
+      // (e.g. an unrelated builtin runs). The earlier unattributed write must
+      // NOT borrow it to satisfy writeAuthorizedBy.
+      tx.setCfcImplementationIdentity({
+        kind: "builtin",
+        builtinId: "trustedIncrement",
+      });
+
+      const digest = tx.prepareCfc();
+      expect(digest).toBe("");
+      const result = await tx.commit();
+      expect(result.error).toBeDefined();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+});

--- a/packages/runner/test/cfc-prepare-bypass.test.ts
+++ b/packages/runner/test/cfc-prepare-bypass.test.ts
@@ -1,0 +1,83 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-prepare-bypass-tests");
+
+// Regression guard for the prepareCfc verification-bypass (audit S2).
+//
+// The hole: prepareCfc(input) skipped prepareBoundaryCommit whenever an input
+// was supplied, and the commit-time digest recheck only confirms the input
+// matches real activity — not that policy verification ran. Untrusted code
+// holding the transaction could reconstruct the genuine prepared-digest input
+// from the public read/write getters, hand it to prepareCfc, and commit a
+// policy-violating transaction cleanly.
+//
+// The fix removes the input parameter entirely so verification always runs.
+// This test pins the behavioural contract: a relevant, policy-violating
+// transaction can never reach a committed state through prepareCfc.
+describe("CFC prepareCfc verification bypass", () => {
+  it("rejects a writeAuthorizedBy violation even when prepareCfc is driven directly", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+      trustSnapshotProvider: () => ({
+        id: "trust-snapshot-prepare-bypass",
+        actingPrincipal: signer.did(),
+      }),
+    });
+    try {
+      const tx = runtime.edit();
+      const schema = {
+        type: "object",
+        properties: {
+          savedTitle: {
+            type: "string",
+            ifc: {
+              writeAuthorizedBy: {
+                __ctWriterIdentityOf: {
+                  file: "/main.tsx",
+                  path: ["commitTrustedSaveTitle"],
+                },
+              },
+            },
+          },
+        },
+        required: ["savedTitle"],
+      } as const satisfies JSONSchema;
+      const cell = runtime.getCell(
+        signer.did(),
+        "cfc-prepare-bypass",
+        schema,
+        tx,
+      );
+      // Unauthorized write into a writeAuthorizedBy-protected field.
+      cell.set({ savedTitle: "not user authorized" });
+
+      // Even if a caller reconstructs the genuine prepared-digest input from the
+      // public transaction surfaces, there is no way to feed it to prepareCfc:
+      // the parameter was removed (audit S2) so verification always runs. Pin
+      // that prepareCfc accepts no argument and still rejects the violation.
+      // deno-lint-ignore no-explicit-any
+      const attackerInput = (tx as any).buildPreparedDigestInput?.();
+      expect(attackerInput).toBeDefined();
+      // deno-lint-ignore no-explicit-any
+      expect(() => (tx as any).prepareCfc(attackerInput)).not.toThrow();
+
+      // Verification must have run and invalidated the transaction regardless of
+      // the ignored extra argument.
+      expect(tx.getCfcState().prepare.status).toBe("invalidated");
+
+      const result = await tx.commit();
+      expect(result.error).toBeDefined();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+});

--- a/packages/runner/test/cfc-runtime-stats.test.ts
+++ b/packages/runner/test/cfc-runtime-stats.test.ts
@@ -125,7 +125,6 @@ describe("CFC runtime stats", () => {
     );
 
     const sinkTx = runtime.edit();
-    sinkTx.setCfcEnforcementMode("disabled");
     sinkTx.markCfcRelevant("stats-sink");
     const request = createFrozenRequestSnapshot({
       url: "https://example.com/cfc-runtime-stats",
@@ -151,12 +150,13 @@ describe("CFC runtime stats", () => {
         flushCount++;
       },
     );
+    sinkTx.prepareCfc();
     expect((await sinkTx.commit()).ok).toBeDefined();
     expect(flushCount).toBe(1);
 
     expect(runtime.getCfcStats()).toEqual({
       cfcRelevantTx: 4,
-      cfcPreparedTx: 2,
+      cfcPreparedTx: 3,
       cfcPrepareRejects: 1,
       cfcDigestInvalidations: 1,
       cfcOutboxFlushes: 2,

--- a/packages/runner/test/cfc-sink-request-policy.test.ts
+++ b/packages/runner/test/cfc-sink-request-policy.test.ts
@@ -107,6 +107,7 @@ describe("CFC sink request policy", () => {
     const runtime = new Runtime({
       apiUrl: new URL(import.meta.url),
       storageManager,
+      cfcEnforcementMode: "observe",
     });
     const tx = runtime.edit();
 
@@ -115,7 +116,6 @@ describe("CFC sink request policy", () => {
     });
 
     let flushCount = 0;
-    tx.setCfcEnforcementMode("observe");
     enqueueSinkRequestPostCommitEffect(
       tx,
       "fetchData",

--- a/packages/runner/test/cfc-tool-ceiling-empty.test.ts
+++ b/packages/runner/test/cfc-tool-ceiling-empty.test.ts
@@ -1,0 +1,67 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { llmDialogTestHelpers } from "../src/builtins/llm-dialog.ts";
+
+const { toolAllowsObservedConfidentiality } = llmDialogTestHelpers;
+
+// Regression guard for empty tool-ceiling semantics (review follow-up to W0.7).
+//
+// W0.7 made an empty maxConfidentiality "public only" in cfcObservationFitsCeiling,
+// but the LLM tool-call gate kept special-casing an empty ceiling as allow-all,
+// so a tool declaring ifc.maxConfidentiality: [] still received confidential
+// observations. A declared (even empty) ceiling must be enforced.
+describe("CFC tool ceiling empty", () => {
+  const catalogWithToolCeiling = (
+    maxConfidentiality: unknown,
+  ): Parameters<typeof toolAllowsObservedConfidentiality>[0] =>
+    ({
+      llmTools: {
+        mytool: {
+          inputSchema: { type: "object", ifc: { maxConfidentiality } },
+        },
+      },
+    }) as unknown as Parameters<typeof toolAllowsObservedConfidentiality>[0];
+
+  it("denies confidential observations under an empty tool ceiling", () => {
+    expect(
+      toolAllowsObservedConfidentiality(
+        catalogWithToolCeiling([]),
+        "mytool",
+        ["secret"],
+      ),
+    ).toBe(false);
+  });
+
+  it("allows public observations under an empty tool ceiling", () => {
+    expect(
+      toolAllowsObservedConfidentiality(catalogWithToolCeiling([]), "mytool", []),
+    ).toBe(true);
+  });
+
+  it("allows when no ceiling is declared (non-array)", () => {
+    expect(
+      toolAllowsObservedConfidentiality(
+        catalogWithToolCeiling(undefined),
+        "mytool",
+        ["secret"],
+      ),
+    ).toBe(true);
+  });
+
+  it("enforces a populated tool ceiling", () => {
+    expect(
+      toolAllowsObservedConfidentiality(
+        catalogWithToolCeiling(["a"]),
+        "mytool",
+        ["a"],
+      ),
+    ).toBe(true);
+    expect(
+      toolAllowsObservedConfidentiality(
+        catalogWithToolCeiling(["a"]),
+        "mytool",
+        ["b"],
+      ),
+    ).toBe(false);
+  });
+});

--- a/packages/runner/test/cfc-tool-ceiling-empty.test.ts
+++ b/packages/runner/test/cfc-tool-ceiling-empty.test.ts
@@ -34,7 +34,11 @@ describe("CFC tool ceiling empty", () => {
 
   it("allows public observations under an empty tool ceiling", () => {
     expect(
-      toolAllowsObservedConfidentiality(catalogWithToolCeiling([]), "mytool", []),
+      toolAllowsObservedConfidentiality(
+        catalogWithToolCeiling([]),
+        "mytool",
+        [],
+      ),
     ).toBe(true);
   });
 

--- a/packages/runner/test/cfc-tx-control-guard.test.ts
+++ b/packages/runner/test/cfc-tx-control-guard.test.ts
@@ -15,7 +15,7 @@ const signer = await Identity.fromPassphrase("runner-cfc-tx-control-guard");
 // setCfcEnforcementMode lowering an enforcing transaction back to disabled/observe.
 // The mode must not be lowerable below the highest enforcing level set on a tx.
 describe("CFC transaction control guard", () => {
-  it("refuses to weaken an enforcing transaction's mode", () => {
+  it("refuses to weaken an enforcing transaction's mode", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
@@ -40,12 +40,12 @@ describe("CFC transaction control guard", () => {
       // ...and cannot then be lowered back to a weaker enforcing level.
       expect(() => tx.setCfcEnforcementMode("enforce-explicit")).toThrow();
     } finally {
-      runtime.dispose();
-      storageManager.close();
+      await runtime.dispose();
+      await storageManager.close();
     }
   });
 
-  it("allows juggling non-enforcing modes before any enforcement", () => {
+  it("allows juggling non-enforcing modes before any enforcement", async () => {
     const storageManager = StorageManager.emulate({ as: signer });
     const runtime = new Runtime({
       apiUrl: new URL("https://example.com"),
@@ -61,8 +61,8 @@ describe("CFC transaction control guard", () => {
       // Now the floor is set.
       expect(() => tx.setCfcEnforcementMode("observe")).toThrow();
     } finally {
-      runtime.dispose();
-      storageManager.close();
+      await runtime.dispose();
+      await storageManager.close();
     }
   });
 

--- a/packages/runner/test/cfc-tx-control-guard.test.ts
+++ b/packages/runner/test/cfc-tx-control-guard.test.ts
@@ -1,0 +1,117 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-tx-control-guard");
+
+// Regression guard for the transaction control surface (audit S3).
+//
+// setCfcEnforcementMode / prepareCfc are on the public IExtendedStorageTransaction
+// and cell.tx is public, so code holding a Cell can reach them. prepareCfc was
+// fixed to always verify (S2); the remaining weakening lever is
+// setCfcEnforcementMode lowering an enforcing transaction back to disabled/observe.
+// The mode must not be lowerable below the highest enforcing level set on a tx.
+describe("CFC transaction control guard", () => {
+  it("refuses to weaken an enforcing transaction's mode", () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    try {
+      const tx = runtime.edit();
+      expect(tx.getCfcState().enforcementMode).toBe("enforce-explicit");
+
+      // Downgrades to weaker modes must throw.
+      expect(() => tx.setCfcEnforcementMode("disabled")).toThrow();
+      expect(() => tx.setCfcEnforcementMode("observe")).toThrow();
+
+      // Mode is unchanged after the rejected downgrades.
+      expect(tx.getCfcState().enforcementMode).toBe("enforce-explicit");
+
+      // Raising strictness is still allowed.
+      expect(() => tx.setCfcEnforcementMode("enforce-strict")).not.toThrow();
+      expect(tx.getCfcState().enforcementMode).toBe("enforce-strict");
+
+      // ...and cannot then be lowered back to a weaker enforcing level.
+      expect(() => tx.setCfcEnforcementMode("enforce-explicit")).toThrow();
+    } finally {
+      runtime.dispose();
+      storageManager.close();
+    }
+  });
+
+  it("allows juggling non-enforcing modes before any enforcement", () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "disabled",
+    });
+    try {
+      const tx = runtime.edit();
+      // disabled <-> observe impose no floor (neither enforces).
+      expect(() => tx.setCfcEnforcementMode("observe")).not.toThrow();
+      expect(() => tx.setCfcEnforcementMode("disabled")).not.toThrow();
+      expect(() => tx.setCfcEnforcementMode("enforce-explicit")).not.toThrow();
+      // Now the floor is set.
+      expect(() => tx.setCfcEnforcementMode("observe")).toThrow();
+    } finally {
+      runtime.dispose();
+      storageManager.close();
+    }
+  });
+
+  it("still rejects a violation after a blocked downgrade attempt", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+      trustSnapshotProvider: () => ({
+        id: "trust-snapshot-tx-control-guard",
+        actingPrincipal: signer.did(),
+      }),
+    });
+    try {
+      const tx = runtime.edit();
+      const schema = {
+        type: "object",
+        properties: {
+          savedTitle: {
+            type: "string",
+            ifc: {
+              writeAuthorizedBy: {
+                __ctWriterIdentityOf: {
+                  file: "/main.tsx",
+                  path: ["commitTrustedSaveTitle"],
+                },
+              },
+            },
+          },
+        },
+        required: ["savedTitle"],
+      } as const satisfies JSONSchema;
+      const cell = runtime.getCell(
+        signer.did(),
+        "cfc-tx-control-guard",
+        schema,
+        tx,
+      );
+      cell.set({ savedTitle: "not user authorized" });
+
+      // Attacker tries to disable enforcement, then commit the violation.
+      expect(() => tx.setCfcEnforcementMode("disabled")).toThrow();
+      tx.prepareCfc();
+      const result = await tx.commit();
+      expect(result.error).toBeDefined();
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+});

--- a/packages/runner/test/cfc-unsupported-ifc-keys.test.ts
+++ b/packages/runner/test/cfc-unsupported-ifc-keys.test.ts
@@ -1,0 +1,72 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-unsupported-ifc-keys");
+
+// Regression guard for unimplemented ifc.* claims (audit S10).
+//
+// Several ifc keys are defined by the spec / authoring surface but unimplemented
+// in the runner. They were silently ignored (and dropped by schema-merge), so an
+// author declaring them got no enforcement and no error — a fail-open trap. A
+// write to a path declaring an unsupported claim must fail closed, the same way
+// projection/collection already do.
+describe("CFC unsupported ifc claims fail closed", () => {
+  const unsupportedClaims: Array<[string, unknown]> = [
+    ["opaque", true],
+    ["passThrough", true],
+    ["recomposeProjections", [{ scope: "x" }]],
+    ["combinedFrom", ["/a", "/b"]],
+    ["combinationType", "join"],
+    ["transformation", { kind: "trusted" }],
+    ["addedIntegrity", [{ type: "https://example.com/x" }]],
+  ];
+
+  for (const [claimKey, claimValue] of unsupportedClaims) {
+    it(`rejects a write to a path declaring ifc.${claimKey}`, async () => {
+      const storageManager = StorageManager.emulate({ as: signer });
+      const runtime = new Runtime({
+        apiUrl: new URL("https://example.com"),
+        storageManager,
+        cfcEnforcementMode: "enforce-explicit",
+        trustSnapshotProvider: () => ({
+          id: `trust-snapshot-unsupported-${claimKey}`,
+          actingPrincipal: signer.did(),
+        }),
+      });
+      try {
+        const tx = runtime.edit();
+        const schema = {
+          type: "object",
+          properties: {
+            value: {
+              type: "string",
+              ifc: { [claimKey]: claimValue },
+            },
+          },
+          required: ["value"],
+        } as unknown as JSONSchema;
+        const cell = runtime.getCell(
+          signer.did(),
+          `cfc-unsupported-${claimKey}`,
+          schema,
+          tx,
+        );
+        cell.set({ value: "written" });
+
+        const digest = tx.prepareCfc();
+        expect(digest).toBe("");
+        const result = await tx.commit();
+        expect(result.error?.message).toContain(
+          `unsupported trust-sensitive claim ${claimKey}`,
+        );
+      } finally {
+        await runtime.dispose();
+        await storageManager.close();
+      }
+    });
+  }
+});

--- a/packages/runner/test/cfc-wildcard-link-applicability.test.ts
+++ b/packages/runner/test/cfc-wildcard-link-applicability.test.ts
@@ -1,0 +1,76 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { wildcardPolicyMatchesValue } from "../src/cfc/prepare.ts";
+import { LINK_V1_TAG } from "../src/sigil-types.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+// Regression guard for wildcard policy applicability on unresolvable links
+// (audit S17).
+//
+// When a written value is a link whose target value cannot be resolved, the
+// policy's value condition cannot be evaluated against real data. The pre-fix
+// code fell back to comparing the policy schema against the link's
+// author-embedded schema, so an attacker could embed a mismatching schema to
+// make the policy entry "not apply" and skip its writeAuthorizedBy /
+// requiredIntegrity / uiContract checks. Unresolvable links must fail closed:
+// the entry applies.
+//
+// Driving through a full write is impractical because the Cell write path
+// collapses an unresolvable link before it reaches the verifier, so the link
+// only reaches this matcher when verifying a pre-existing stored link whose
+// target is not present in the transaction. This exercises that branch directly.
+describe("CFC wildcard policy applicability on unresolvable links", () => {
+  const space = "did:key:wildcard-link" as const;
+  const policySchema = {
+    type: "object",
+    ifc: { writeAuthorizedBy: ["trusted-handler"] },
+  } as const satisfies JSONSchema;
+  const target = { space, id: "of:guarded" as const, scope: "space" as const };
+
+  // A link whose embedded schema (string) deliberately mismatches the object
+  // policy schema, pointing at a target the transaction cannot resolve.
+  const linkValue = {
+    "/": {
+      [LINK_V1_TAG]: {
+        id: "of:unresolvable-target",
+        path: [] as string[],
+        space,
+        scope: "space",
+        schema: { type: "string" },
+      },
+    },
+  };
+
+  it("applies (fail-closed) when the linked target cannot be resolved", () => {
+    const tx = {
+      getWriteDetails: () => [],
+      readValueOrThrow: () => undefined,
+    } as unknown as IExtendedStorageTransaction;
+
+    expect(wildcardPolicyMatchesValue(tx, target, policySchema, linkValue))
+      .toBe(true);
+  });
+
+  it("still value-conditions when the linked target resolves to a non-matching value", () => {
+    // The link resolves to a string; the policy schema requires an object, so
+    // the entry legitimately does not apply (the value-condition is real data,
+    // not an author-controlled schema).
+    const tx = {
+      getWriteDetails: () => [
+        {
+          address: {
+            id: "of:unresolvable-target",
+            scope: "space",
+            path: ["value"],
+          },
+          value: "a string, not an object",
+        },
+      ],
+      readValueOrThrow: () => undefined,
+    } as unknown as IExtendedStorageTransaction;
+
+    expect(wildcardPolicyMatchesValue(tx, target, policySchema, linkValue))
+      .toBe(false);
+  });
+});

--- a/packages/runner/test/create-ref-fail-closed.test.ts
+++ b/packages/runner/test/create-ref-fail-closed.test.ts
@@ -1,0 +1,34 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { createRef } from "../src/create-ref.ts";
+import { isOpaqueRefMarker } from "../src/builder/types.ts";
+
+// Regression guard for createRef fail-closed behavior (audit S14).
+//
+// When a derivation input is an OpaqueRef with no value (or a Cell with no
+// entityId), the id can no longer be derived from real inputs. The pre-fix code
+// substituted a random UUID, silently producing a non-deterministic id where a
+// stable, content-derived one was expected. createRef must fail closed instead.
+describe("createRef fail-closed", () => {
+  it("throws when an OpaqueRef derivation input has no value", () => {
+    const opaqueRefNoValue = {
+      [isOpaqueRefMarker]: true,
+      export: () => ({ value: null }),
+    };
+    expect(() => createRef({ ref: opaqueRefNoValue }, "cause")).toThrow(
+      /cannot derive a stable id/,
+    );
+  });
+
+  it("derives a stable id from concrete inputs (unchanged)", () => {
+    const a = createRef({ x: 1, y: "z" }, "cause");
+    const b = createRef({ x: 1, y: "z" }, "cause");
+    expect(a.toJSON!()).toEqual(b.toJSON!());
+  });
+
+  it("still mints a fresh id when no cause is given (documented behavior)", () => {
+    const a = createRef({ x: 1 });
+    const b = createRef({ x: 1 });
+    expect(a.toJSON!()).not.toEqual(b.toJSON!());
+  });
+});


### PR DESCRIPTION
## Summary

Wave 0 of the CFC spec-audit remediation: close the **enforcement bypasses** and **fail-open holes** in `packages/runner` that let untrusted code skip or weaken information-flow checks, or that silently dropped/ignored security-relevant claims. These are the highest-priority items from a spec audit of `packages/runner` against `~/src/specs/cfc` — a gate that can be switched off isn't a gate, so these land first.

Each fix is red-green (failing test first) and scoped to a single concern. Audit IDs (Sn) reference the audit's soundness findings.

## Fixes

1. **`prepareCfc` always verifies (S2)** — removed the `input` parameter that let a caller skip `prepareBoundaryCommit` while still passing the commit-time digest recheck. Bypass closed at the type level.
2. **Enforcement mode can't be weakened (S3)** — `setCfcEnforcementMode` may be raised but never lowered below the highest enforcing level set on a transaction, so code holding a `Cell` can't disable enforcement mid-transaction. Tests that exercised weaker modes now construct the runtime at that mode.
3. **Unattributed writes fail closed (S13)** — `writeAuthorizedBy` no longer falls back to the transaction's *current* identity for a write recorded before any identity was set; an unattributed write can't borrow a trusted identity established later in the same tx.
4. **Wildcard policy applies to unresolvable links (S17)** — when a written link's target is unresolvable, applicability no longer trusts the link's author-embedded schema to exclude the policy; it fails closed (the entry applies).
5. **Unsupported `ifc.*` claims fail closed (S10)** — `opaque`, `passThrough`, `recomposeProjections`, `combinedFrom`, `combinationType`, `transformation`, `addedIntegrity` join `projection`/`collection` as rejected-on-write, instead of being silently ignored and dropped by schema-merge.
6. **Flow-precision claims conditioned on op argument usage** — the element-local claims (`PointwiseWriteDependency`, `ElementLocalExpansion`) are dropped when a map/filter/flatMap op reads the whole `array` or data-bearing `params` (a cross-key dependency); structural claims stay. Closes a latent unsoundness before any consumer relies on them.
7. **Empty `maxConfidentiality` = public-only (not no-ceiling)** — a declared but empty ceiling now denies confidential atoms; only `undefined` means no ceiling. Both the observation path and the prepare-time check.
8. **`createRef` fails closed on underivable ids (S14)** — throws instead of substituting a random UUID when a derivation input is an OpaqueRef with no value or a Cell with no entityId. The documented no-cause "mint fresh entity" path is preserved.

## Testing

- New focused tests for each fix (unit + boundary), red-green verified.
- Full `packages/runner` unit suite: green.
- `deno task integration runner` (incl. the `sqlite-cfc-label*` CFC integration tests): 12 passed, 0 failed.

## Scope

Deliberately **not** in this wave: the generic policy calculus, CNF labels, the intent lifecycle, trust lattice, the typed `TrustedDerivedId` envelope, default label transition + PC propagation, and other next-phase items. Waves 1–3 (verifier-input integrity, verifier semantics, events/egress) build on this branch. Server-side ACL (Track A) is deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes CFC enforcement bypasses and fail-open edges in `packages/runner` so untrusted code can’t skip checks and unsupported claims fail closed. Tightens APIs and defaults; also enforces empty ceilings on the LLM tool-call path.

- **Bug Fixes**
  - `prepareCfc()` always verifies; removed the input parameter that allowed skipping verification (S2).
  - Enforcement mode can be raised but not lowered below the highest enforcing level set on a transaction (S3).
  - Unattributed writes no longer borrow the transaction’s current identity; they fail closed (S13).
  - Wildcard policy entries apply to unresolvable links (fail-closed) instead of trusting author-embedded link schemas (S17).
  - Reject unsupported `ifc.*` claims on write: `opaque`, `passThrough`, `recomposeProjections`, `combinedFrom`, `combinationType`, `transformation`, `addedIntegrity` (S10).
  - Flow-precision claims now depend on op argument usage; drop element-local claims when the callback reads `array` or data-bearing `params`. Updated `map`/`filter`/`flatMap`.
  - Empty `maxConfidentiality` means public-only; `undefined` means no ceiling. Applies to observation, prepare-time checks, and the LLM tool-call gate.
  - `createRef` throws on underivable inputs (OpaqueRef without value, Cell without entityId); the no-cause “mint fresh id” path is unchanged.

- **Migration**
  - Remove any argument to `prepareCfc()`; it no longer accepts input.
  - Don’t downgrade enforcement mid-transaction. Set the desired `cfcEnforcementMode` when creating `Runtime`.
  - If you relied on empty ceilings allowing confidential data, use `undefined` for “no ceiling” or list allowed atoms explicitly.
  - If you relied on `createRef` falling back to random IDs, supply real inputs or avoid cause-based derivation; it now throws instead.

<sup>Written for commit c762d3a565ebf7c7cd91ca12a528451be94a6901. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

---

NEW_PERF_BASELINE: subtest: pattern-unit-1/pattern-unit-tests > packages/patterns/cfc-authorized-save/main.test.tsx = 13s

> **Perf note:** the `cfc-authorized-save` pattern shows ~+20% (median unchanged at 10.0s; the comparison metric caught a 12.0s run). It is the only regressed metric — every other pattern is flat — which points to the small per-write overhead the W0 CFC verification checks add on the most CFC-intensive pattern (authorized saves), not generic runner drift. Accepting the baseline as an expected cost of the security hardening; revert this line if you'd rather investigate.
