### PR TITLE
perf(runner): make reconciler mount/remount ~5× cheaper for all complex UIs + fix test poll quantization

### DIFF
--- a/docs/development/performance/default-app-note-create.md
+++ b/docs/development/performance/default-app-note-create.md
@@ -231,3 +231,58 @@ lever exists.
 - Skip sink re-subscription bookkeeping when the read set is unchanged.
 - Value-graph identity reuse (freeze + reuse query results) — the remaining
   big hashing/freeze lever.
+
+## Optimization round 2 (June 2026): remount hashing + poll fix
+
+Branch `perf/reconciler-remount` (stacked on round 1). Two changes from the
+follow-up session:
+
+**Test poll quantization fixed.** `waitFor`'s default poll interval dropped
+500ms → 50ms (`CF_WAITFOR_DELAY_MS` to override). The timing series now
+measures reality: per-note totals reported ~1147ms before, **~409ms** after
+(createToView ~294ms, returnToHome ~116ms) on the optimized stack.
+
+**Remount made ~5× cheaper for all complex UIs** (investigated per the
+"don't keep mounts alive, make mounting fast" directive). Profiling 100
+mount/unmount rounds @32 children showed **58% of busy CPU was content
+hashing**: five seams rebuilt fresh-but-structurally-equal schema/selector
+objects per mount, and `hashOf`/`internSchema` caches key on object identity
+at entry only — a fresh wrapper re-walks the whole embedded vdom schema.
+The seams (each now memoized/canonicalized, gated on deep-frozen inputs):
+
+1. `asCellCompoundSchemaForValue` rebuilt + interned every anyOf branch per
+   read of every vdom node → candidate list cached per schema identity.
+2. Created child cells got a fresh stripped-`asCell` schema per
+   materialization (re-hashed at `resolveLink`'s exit intern on every
+   `isStream`) → `unwrapAsCellSchema` memoized + interned.
+3. `internPathSelector` canonicalized the schema but not the selector
+   wrapper → now returns a canonical selector instance per (schema, path).
+4. `pull`'s sync dedup key hashed a fresh wrapper embedding the selector
+   schema → key composed from per-part cached hashes.
+5. `cfc.schemaAtPath`'s cache was per-instance while pull/watch/traversal
+   create a fresh `ContextualFlowControl` per call (permanently cold) →
+   module-level, results interned. Plus `checkAnyOf`'s per-item comparison
+   hashes cached per frozen identity.
+
+Numbers:
+
+| Gauge | Baseline | Round 1 | Round 2 |
+|---|---|---|---|
+| 100 mount/unmount rounds @32 children (in-process) | 7511ms* | — | **1828ms** |
+| Reconciler bench: mount+unmount @128 | 344.7ms | 265.0ms | **69.3ms** |
+| Reconciler bench: re-mount unchanged @32 | 171.5ms | 117.7ms | **33.8ms** |
+| Reconciler bench: single-child update @32 | 6.7ms | 5.1ms | **3.7ms** |
+| Integration: worker busy CPU, notes 2–4 | 1446ms | 1182ms | **742ms (−49%)** |
+| Integration: `handleVDomMount` phase | 540ms (37%, #1) | 406ms | **110ms (15%, #5)** |
+
+*measured at round-1 state; the profile target didn't exist at baseline.
+
+Diagnosis method worth keeping: when profile attribution plateaued,
+temporarily instrumenting `internSchemaReturningSchemaAndHash` misses with
+sampled stacks (`__internMiss` counter) found the exact fresh-object seams in
+minutes — profiles alone couldn't separate "hash of what, built where".
+
+Remaining (smaller) hash consumers in the settle phase: `resolveLink` under
+query-proxy reads and `resolveSchema` under `validateAndTransform` — both
+downstream of read-path value materialization (the value-graph identity reuse
+lever), plus the schema-interning-at-getCell seam for caller literals.

--- a/packages/data-model/src/schema-utils.ts
+++ b/packages/data-model/src/schema-utils.ts
@@ -361,6 +361,16 @@ const selectorPathKey = (path: readonly string[]): string => {
   return key;
 };
 
+/**
+ * Sweep threshold for a per-schema path map: schemas that never die (interned
+ * canonical schemas, the boolean/no-schema sentinels) would otherwise
+ * accumulate `pathKey -> dead WeakRef` entries forever, since the lazy
+ * cleanup below only fires when the exact same path is looked up again.
+ * Sweeping on insert once the map is large bounds growth to live selectors
+ * (plus the threshold).
+ */
+const SELECTOR_CACHE_SWEEP_THRESHOLD = 2048;
+
 export function internPathSelector(
   selector: SchemaPathSelector,
 ): SchemaPathSelector {
@@ -388,6 +398,12 @@ export function internPathSelector(
       return existing;
     }
     byPath.delete(pathK);
+  }
+
+  if (byPath.size >= SELECTOR_CACHE_SWEEP_THRESHOLD) {
+    for (const [k, ref] of byPath) {
+      if (ref.deref() === undefined) byPath.delete(k);
+    }
   }
 
   // First instance with this content becomes the canonical one. Keep the

--- a/packages/data-model/src/schema-utils.ts
+++ b/packages/data-model/src/schema-utils.ts
@@ -327,31 +327,88 @@ export function emptySchemaObject() {
  * guard internal to `hashOf()` and lets its `WeakMap` cache retain its hash
  * across repeat calls.
  */
+/**
+ * Canonical selector instances per (interned schema identity, path content).
+ * A `SchemaPathSelector` is just `{ path, schema? }`, so structurally-equal
+ * selectors can safely collapse to ONE frozen instance. That makes the
+ * selector WRAPPER identity stable across repeat constructions — without it,
+ * every freshly built selector misses entry-level identity caches
+ * (`hashOf()`'s frozen-object WeakMap, `MapSetStringToPathSelectors`'s
+ * hashing key fn, cycle trackers) and re-walks the embedded schema, which CPU
+ * profiles showed as a dominant remount cost.
+ *
+ * Inner values are `WeakRef`s: a selector held strongly here would strongly
+ * reference its schema — the outer `WeakMap` key — pinning both forever.
+ * Dead refs are dropped lazily on lookup.
+ */
+const canonicalSelectorsBySchema = new WeakMap<
+  object,
+  Map<string, WeakRef<SchemaPathSelector>>
+>();
+// `WeakMap` keys must be objects; sentinels stand in for non-object schemas.
+const NO_SCHEMA_KEY: Record<never, never> = {};
+const TRUE_SCHEMA_KEY: Record<never, never> = {};
+const FALSE_SCHEMA_KEY: Record<never, never> = {};
+
+/**
+ * Injective string key for a path: each component is length-prefixed, so a
+ * component containing the separator cannot collide with a differently-split
+ * path.
+ */
+const selectorPathKey = (path: readonly string[]): string => {
+  let key = "";
+  for (const part of path) key += `${part.length}:${part}`;
+  return key;
+};
+
 export function internPathSelector(
   selector: SchemaPathSelector,
 ): SchemaPathSelector {
   const { path, schema } = selector;
 
-  if (schema !== undefined) {
-    const interned = internSchema(schema);
-    if (interned !== schema) {
-      // Canonical schema differs from what the selector holds. Swap it in place
-      // if the selector is mutable; if it's frozen, we can't, so allocate a new
-      // deep-frozen selector carrying the canonical schema (sharing the now-
-      // frozen `path` array).
-      if (Object.isFrozen(selector)) {
-        return Object.freeze({
-          path: Object.freeze(path),
-          schema: interned,
-        }) as SchemaPathSelector;
-      }
-      selector.schema = interned;
+  const interned = schema === undefined ? undefined : internSchema(schema);
+  const schemaKey = interned === undefined
+    ? NO_SCHEMA_KEY
+    : interned === true
+    ? TRUE_SCHEMA_KEY
+    : interned === false
+    ? FALSE_SCHEMA_KEY
+    : (interned as object);
+
+  let byPath = canonicalSelectorsBySchema.get(schemaKey);
+  if (byPath === undefined) {
+    byPath = new Map();
+    canonicalSelectorsBySchema.set(schemaKey, byPath);
+  }
+  const pathK = selectorPathKey(path);
+  const existingRef = byPath.get(pathK);
+  if (existingRef !== undefined) {
+    const existing = existingRef.deref();
+    if (existing !== undefined) {
+      return existing;
     }
+    byPath.delete(pathK);
   }
 
-  Object.freeze(path);
-  Object.freeze(selector);
-  return selector;
+  // First instance with this content becomes the canonical one. Keep the
+  // pre-existing in-place behavior: swap in the canonical schema and freeze
+  // when the input is mutable; allocate only when the input is frozen with a
+  // non-canonical schema.
+  let canonical: SchemaPathSelector;
+  if (interned !== schema && Object.isFrozen(selector)) {
+    canonical = Object.freeze({
+      path: Object.freeze(path),
+      schema: interned,
+    }) as SchemaPathSelector;
+  } else {
+    if (interned !== schema) {
+      selector.schema = interned;
+    }
+    Object.freeze(path);
+    canonical = Object.freeze(selector);
+  }
+  byPath.set(pathK, new WeakRef(canonical));
+  return canonical;
 }
 
 /**

--- a/packages/integration/utils.ts
+++ b/packages/integration/utils.ts
@@ -1,5 +1,19 @@
 import { sleep } from "@commonfabric/utils/sleep";
 
+// Default poll interval between predicate calls. Polls are cheap (a CDP
+// evaluate round-trip), and a coarse interval quantizes every wall-clock
+// measurement taken around a waitFor up to its multiple — the old 500ms
+// default made the default-app timing series report ~520ms for phases whose
+// real latency was far lower. Override per run with CF_WAITFOR_DELAY_MS.
+const DEFAULT_DELAY_MS = (() => {
+  try {
+    const raw = Number(Deno.env.get("CF_WAITFOR_DELAY_MS"));
+    return Number.isFinite(raw) && raw > 0 ? raw : 50;
+  } catch {
+    return 50;
+  }
+})();
+
 /**
  * Receives an async predicate function to executed repeatedly
  * until either the predicate returns `true`, or throws once
@@ -7,7 +21,8 @@ import { sleep } from "@commonfabric/utils/sleep";
  *
  * @param predicate - The predicate callback.
  * @param config.timeout - The number of milliseconds to wait before throwing. [60000]
- * @param config.delay - The number of milliseconds to wait between predicate calls. [500]
+ * @param config.delay - The number of milliseconds to wait between predicate
+ *   calls. [50, or CF_WAITFOR_DELAY_MS]
  */
 export const waitFor = async (
   predicate: () => Promise<boolean>,
@@ -15,7 +30,7 @@ export const waitFor = async (
     {},
 ): Promise<void> => {
   const timeout = _timeout ?? 60_000;
-  const delay = _delay ?? 500;
+  const delay = _delay ?? DEFAULT_DELAY_MS;
   const end = Date.now() + timeout;
   while (Date.now() < end) {
     if ((await predicate())) {

--- a/packages/runner/src/cfc.ts
+++ b/packages/runner/src/cfc.ts
@@ -34,6 +34,17 @@ export {
 
 type IFCAtom = ImmutableJSONValue;
 
+// schemaAtPath derivations per deep-frozen schema identity. The derivation is
+// pure given (schema, path, boolean default flags) when no extra
+// confidentiality is passed — instance state never enters it (`lub` delegates
+// to a static and has no subclasses) — and it runs per array element / object
+// property on read and write-diff paths, so identical lookups repeat
+// constantly. Module-level rather than per-instance: several hot paths create
+// a fresh ContextualFlowControl per call (storage pull/watch, traversal
+// contexts), which would leave a per-instance cache permanently cold.
+// Mutable schemas are never cached (in-place edits must be observed).
+const schemaAtPathCache = new WeakMap<object, Map<string, JSONSchema>>();
+
 // Class for handling cfc rules.
 // The spec's confidentiality model is based on structured atoms.
 export class ContextualFlowControl {
@@ -311,14 +322,6 @@ export class ContextualFlowControl {
    * While we will handle $ref links as needed while getting to the schema,
    * the returned object will retain those $ref links.
    */
-  // schemaAtPath derivations per deep-frozen schema identity. The derivation
-  // is pure given (schema, path, boolean default flags) when no extra
-  // confidentiality is passed, and it runs per array element / object
-  // property on the write-diff path, so identical lookups repeat constantly.
-  // Mutable schemas are never cached (in-place edits must be observed).
-  // Per-instance because `lub` is an overridable instance method.
-  #schemaAtPathCache = new WeakMap<object, Map<string, JSONSchema>>();
-
   schemaAtPath(
     schema: JSONSchema,
     path: readonly string[],
@@ -342,10 +345,10 @@ export class ContextualFlowControl {
         defaultMissingProperty,
       );
     }
-    let byKey = this.#schemaAtPathCache.get(schema);
+    let byKey = schemaAtPathCache.get(schema);
     if (byKey === undefined) {
       byKey = new Map();
-      this.#schemaAtPathCache.set(schema, byKey);
+      schemaAtPathCache.set(schema, byKey);
     }
     // Length-prefix each segment so a segment containing the separator (a
     // NUL-bearing property name) cannot collide with a differently-split
@@ -356,14 +359,17 @@ export class ContextualFlowControl {
     }
     let result = byKey.get(key);
     if (result === undefined) {
-      result = this.schemaAtPathInternal(
+      // Intern the derivation so the cached result is the canonical frozen
+      // instance: downstream identity-keyed caches (standardization, value
+      // hashing) hit instead of re-walking a fresh anyOf rebuild every time.
+      result = internSchema(this.schemaAtPathInternal(
         schema,
         path,
         defs,
         undefined,
         defaultEmptyProperties,
         defaultMissingProperty,
-      );
+      ));
       byKey.set(key, result);
     }
     return result;

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -80,29 +80,62 @@ const linkWithAsCellScope = (
   return isCellScope(scope) ? { ...link, scope } : link;
 };
 
-const asCellCompoundSchemaForValue = (
+// Value-independent part of asCellCompoundSchemaForValue: the merged
+// candidate schemas (those that carry asCell entries) for each anyOf/oneOf
+// branch. Building them spreads the base schema and resolves + combines +
+// interns every branch — and that repeats on EVERY read of a cell with a
+// compound schema (e.g. every vdom node under rendererVDOMSchema), which
+// CPU profiles showed as the dominant hashing seam of reconciler mounts.
+// Cache per deep-frozen schema identity; mutable schemas recompute per call.
+// The cached candidates are interned (combineSchema interns its results), so
+// downstream identity-keyed memos see stable references too.
+const compoundAsCellCandidatesCache = new WeakMap<
+  JSONSchemaObj,
+  readonly JSONSchemaObj[]
+>();
+
+const asCellCompoundCandidates = (
   schema: JSONSchemaObj,
-  value: unknown,
-): JSONSchemaObj | undefined => {
+): readonly JSONSchemaObj[] => {
+  const cacheable = isDeepFrozen(schema);
+  if (cacheable) {
+    const cached = compoundAsCellCandidatesCache.get(schema);
+    if (cached !== undefined) return cached;
+  }
   const branches = [
     ...(Array.isArray(schema.anyOf) ? schema.anyOf : []),
     ...(Array.isArray(schema.oneOf) ? schema.oneOf : []),
   ];
-  if (branches.length === 0) {
+  const candidates: JSONSchemaObj[] = [];
+  if (branches.length > 0) {
+    const { anyOf: _anyOf, oneOf: _oneOf, ...baseSchema } = schema;
+    for (const branch of branches) {
+      const branchWithDefs = branchWithParentDefs(schema, branch);
+      const resolved = resolveSchema(branchWithDefs) ?? branchWithDefs;
+      const merged = combineSchema(baseSchema as JSONSchemaObj, resolved);
+      if (
+        isRecord(merged) &&
+        ContextualFlowControl.getAsCellValues(merged).length > 0
+      ) {
+        candidates.push(merged as JSONSchemaObj);
+      }
+    }
+  }
+  if (cacheable) {
+    compoundAsCellCandidatesCache.set(schema, candidates);
+  }
+  return candidates;
+};
+
+const asCellCompoundSchemaForValue = (
+  schema: JSONSchemaObj,
+  value: unknown,
+): JSONSchemaObj | undefined => {
+  if (value === undefined) {
     return undefined;
   }
-
-  const { anyOf: _anyOf, oneOf: _oneOf, ...baseSchema } = schema;
-  for (const branch of branches) {
-    const branchWithDefs = branchWithParentDefs(schema, branch);
-    const resolved = resolveSchema(branchWithDefs) ?? branchWithDefs;
-    const merged = combineSchema(baseSchema as JSONSchemaObj, resolved);
-    if (
-      isRecord(merged) &&
-      ContextualFlowControl.getAsCellValues(merged).length > 0 &&
-      value !== undefined &&
-      matchesConcreteValue(merged, value)
-    ) {
+  for (const merged of asCellCompoundCandidates(schema)) {
+    if (matchesConcreteValue(merged, value)) {
       return merged;
     }
   }
@@ -1171,7 +1204,6 @@ class TransformObjectCreator
     } else if (isRecord(link.schema)) {
       const schema = asCellCompoundSchemaForValue(link.schema, value) ??
         link.schema;
-      const { asCell: _c, ...restSchema } = schema;
       const asCellValues = ContextualFlowControl.getAsCellValues(schema);
       if (asCellValues.length > 0) {
         // We'll use the first asCell for the outermost, and pass the rest
@@ -1190,10 +1222,7 @@ class TransformObjectCreator
           this.runtime,
           {
             ...link,
-            schema: {
-              ...restSchema,
-              ...(asCellValues.length > 1) && { asCell: asCellValues.slice(1) },
-            },
+            schema: unwrapAsCellSchema(schema as JSONSchemaObj),
           },
           getTransactionForChildCells(this.tx),
           this.synced,
@@ -1319,13 +1348,32 @@ export function generateHandlerSchema(
   });
 }
 
+// unwrapAsCellSchema results per deep-frozen schema identity. The unwrapped
+// schema rides on every created child cell's link, where downstream identity
+// caches (link-resolution interning, schemaAtPath, value hashing) key on it —
+// a fresh spread per cell creation re-hashed the whole schema each time.
+const unwrappedAsCellSchemaCache = new WeakMap<JSONSchemaObj, JSONSchemaObj>();
+
 function unwrapAsCellSchema(schema: JSONSchemaObj): JSONSchemaObj {
+  const cacheable = isDeepFrozen(schema);
+  if (cacheable) {
+    const cached = unwrappedAsCellSchemaCache.get(schema);
+    if (cached !== undefined) {
+      return cached;
+    }
+  }
   const { asCell: _c, ...restSchema } = schema;
   const asCellValues = ContextualFlowControl.getAsCellValues(schema);
-  return {
+  // Intern so the result is the canonical frozen instance: child cell links
+  // then carry an identity-stable schema across repeat materializations.
+  const result = internSchema({
     ...restSchema,
     ...(asCellValues.length > 1 && { asCell: asCellValues.slice(1) }),
-  };
+  }) as JSONSchemaObj;
+  if (cacheable) {
+    unwrappedAsCellSchemaCache.set(schema, result);
+  }
+  return result;
 }
 
 function removeAsCellFromSchema(schema: JSONSchema): JSONSchema {

--- a/packages/runner/src/storage/selector-tracker.ts
+++ b/packages/runner/src/storage/selector-tracker.ts
@@ -249,27 +249,67 @@ export class SelectorTracker<T = Result<Unit, Error>> {
     schemaHash: string | false,
   ): boolean {
     return isRecord(schema) && Array.isArray(schema.anyOf) &&
-      (schema.anyOf.some((item) => {
-        item = SelectorTracker.getStandardSchema(item);
-        if (hashSchema(item) === schemaHash) {
-          return true;
-        }
-        if (schema.$defs !== undefined) {
-          item = schemaWithProperties(item, {
-            $defs: schema.$defs,
-          });
-          item = SelectorTracker.getStandardSchema(item);
-          if (hashSchema(item) === schemaHash) {
-            return true;
-          }
-        }
-        if (item.$ref !== undefined) {
-          item = ContextualFlowControl.resolveSchemaRefs(item, schema);
-          item = SelectorTracker.getStandardSchema(item);
-          return hashSchema(item) === schemaHash;
-        }
-        return false;
-      }));
+      (schema.anyOf.some((item) =>
+        SelectorTracker.#anyOfItemHashes(schema, item).includes(
+          schemaHash as string,
+        )
+      ));
+  }
+
+  /**
+   * The standardized hashes an anyOf item can match under: its plain form,
+   * its `$defs`-grafted form, and its `$ref`-resolved form. Computing these
+   * builds fresh schema objects and re-hashes them, so cache the resulting
+   * hash strings per (parent schema, item) identity when the parent is
+   * deep-frozen (its items then are too).
+   */
+  static #anyOfItemHashesCache = new WeakMap<
+    object,
+    Map<JSONSchema, readonly string[]>
+  >();
+
+  static #anyOfItemHashes(
+    schema: JSONSchema & object,
+    item: JSONSchema,
+  ): readonly string[] {
+    const cacheable = isDeepFrozen(schema);
+    let byItem: Map<JSONSchema, readonly string[]> | undefined;
+    if (cacheable) {
+      byItem = SelectorTracker.#anyOfItemHashesCache.get(schema);
+      const cached = byItem?.get(item);
+      if (cached !== undefined) {
+        return cached;
+      }
+    }
+    const hashes: string[] = [];
+    let current = SelectorTracker.getStandardSchema(item);
+    hashes.push(hashSchema(current));
+    if (schema.$defs !== undefined) {
+      current = SelectorTracker.getStandardSchema(
+        schemaWithProperties(current, { $defs: schema.$defs }),
+      );
+      hashes.push(hashSchema(current));
+    }
+    if (isRecord(current) && current.$ref !== undefined) {
+      hashes.push(
+        hashSchema(
+          SelectorTracker.getStandardSchema(
+            ContextualFlowControl.resolveSchemaRefs(
+              current,
+              schema,
+            ) as JSONSchema,
+          ),
+        ),
+      );
+    }
+    if (cacheable) {
+      if (byItem === undefined) {
+        byItem = new Map();
+        SelectorTracker.#anyOfItemHashesCache.set(schema, byItem);
+      }
+      byItem.set(item, hashes);
+    }
+    return hashes;
   }
 
   static getStandardSchema(schema: JSONSchema): JSONSchema {

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -1166,16 +1166,16 @@ class SpaceReplica implements ISpaceReplica {
     // level, so embedding the (large, already canonical) selector schema in a
     // fresh wrapper re-walked it on every pull. hashStringOf(schema) hits the
     // identity cache for frozen schemas and costs one walk for mutable ones.
-    const key = normalizedEntries.map(([address, selector]) => {
-      const schema = selector?.schema;
-      const schemaPart = schema === undefined ? "u" : hashStringOf(schema);
-      const pathPart = selector === undefined
-        ? "u"
-        : selector.path.map((part) => `${part.length}:${part}`).join("");
-      return `${address.id}|${
-        normalizeCellScope(address.scope) ?? ""
-      }|${pathPart}|${schemaPart}`;
-    }).join("\n");
+    // JSON.stringify escapes every field, so ids/scopes/path segments
+    // containing delimiter characters cannot produce ambiguous keys.
+    const key = JSON.stringify(
+      normalizedEntries.map(([address, selector]) => [
+        address.id,
+        normalizeCellScope(address.scope) ?? null,
+        selector === undefined ? null : selector.path,
+        selector?.schema === undefined ? null : hashStringOf(selector.schema),
+      ]),
+    );
     const existing = this.#syncTasks.get(key);
     if (existing) {
       return await existing.promise;

--- a/packages/runner/src/storage/v2.ts
+++ b/packages/runner/src/storage/v2.ts
@@ -1161,11 +1161,21 @@ class SpaceReplica implements ISpaceReplica {
     }
 
     const normalizedEntries = normalizeSyncEntries(entries);
-    const key = hashStringOf(normalizedEntries.map(([address, selector]) => ({
-      id: address.id,
-      scope: normalizeCellScope(address.scope),
-      selector,
-    })));
+    // Compose the dedup key from per-part hashes instead of hashing a fresh
+    // wrapper object: hashOf's frozen-object cache is only consulted at entry
+    // level, so embedding the (large, already canonical) selector schema in a
+    // fresh wrapper re-walked it on every pull. hashStringOf(schema) hits the
+    // identity cache for frozen schemas and costs one walk for mutable ones.
+    const key = normalizedEntries.map(([address, selector]) => {
+      const schema = selector?.schema;
+      const schemaPart = schema === undefined ? "u" : hashStringOf(schema);
+      const pathPart = selector === undefined
+        ? "u"
+        : selector.path.map((part) => `${part.length}:${part}`).join("");
+      return `${address.id}|${
+        normalizeCellScope(address.scope) ?? ""
+      }|${pathPart}|${schemaPart}`;
+    }).join("\n");
     const existing = this.#syncTasks.get(key);
     if (existing) {
       return await existing.promise;


### PR DESCRIPTION
## What

Round 2 of the default-app optimization work (stacked on [#3965](https://github.com/commontoolsinc/labs/pull/3965); [#3959](https://github.com/commontoolsinc/labs/pull/3959) is merged — retarget to `main` once #3965 merges). Two requested changes:

### 1. Test poll quantization fixed

`waitFor`'s default poll interval drops 500ms → 50ms (`CF_WAITFOR_DELAY_MS` to override). The default-app timing series previously reported ~520ms for phases whose real latency was far lower; per-note totals now read ~409ms (real) instead of ~1147ms (poll-quantized), and the test completes faster.

### 2. Remount made fundamentally cheaper (no mount-keeping)

Why did re-mounting an UNCHANGED tree cost as much as first mount (~2.7ms per cell child)? Profiling 100 mount/unmount rounds @32 children answered it: **58% of busy CPU was content hashing**. Five seams rebuilt fresh-but-structurally-equal schema/selector objects on every mount, and `hashOf`/`internSchema` caches key on object identity at entry only — every fresh wrapper re-walked the entire embedded vdom schema. Fixed each seam (all gated on deep-frozen inputs; mutable inputs keep per-call semantics):

- `asCellCompoundSchemaForValue`: memoize the value-independent anyOf candidate list per schema identity (was: spread + resolve + combine + intern per branch per read of every vdom node)
- `unwrapAsCellSchema`: memoize + intern; created child cell links now carry an identity-stable schema (was: fresh stripped schema per materialization, re-hashed at `resolveLink`'s exit on every `isStream`/sink)
- `internPathSelector`: return a **canonical selector instance** per (interned schema, path) — fresh wrapper identities defeated entry-level hash caches in every selector tracker
- `pull`: compose the sync dedup key from per-part cached hashes instead of hashing a fresh wrapper embedding the selector schema
- `cfc.schemaAtPath`: cache moved to module level (pull/watch/traversal construct a fresh `ContextualFlowControl` per call → per-instance cache was permanently cold) + results interned; `checkAnyOf` comparison hashes cached per frozen identity

Misses were pinpointed by temporarily instrumenting `internSchema` misses with sampled stacks after profile attribution plateaued — that found the exact construction sites in minutes.

## Numbers

| Gauge | Baseline | After round 1 | This PR |
|---|---|---|---|
| Reconciler bench: mount+unmount @128 children | 344.7ms | 265.0ms | **69.3ms** |
| Reconciler bench: re-mount unchanged @32 | 171.5ms | 117.7ms | **33.8ms** |
| Reconciler bench: single-child update @32 | 6.7ms | 5.1ms | **3.7ms** |
| In-process 100×(mount+unmount) @32 | — | 7511ms | **1828ms** |
| Integration: worker busy CPU, notes 2–4 | 1446ms | 1182ms | **742ms (−49%)** |
| Integration: `handleVDomMount` phase | 540ms (37%, #1 phase) | 406ms | **110ms (15%, #5 phase)** |

Macro note-create bench and selector-tracker bench show no regressions.

## Test plan

- [x] runner: cell-core/as-cell/links/arrays, schema-anyof/basic/defaults, query, query-result-proxy-enumeration, selector-tracker, memory-v2 subscription/pull-reactivity, cfc + cfc-schema-merge, traverse — green
- [x] html suite (28 tests) and data-model suite (37 tests) — green
- [x] default-app integration test passes on the rebuilt stack (5-note series, CPU profiles captured)
- [x] `deno check` / `lint` / `fmt` on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts reconciler mount/remount cost by ~5× for complex UIs via canonical selectors and schema caches, and fixes test timing quantization by lowering the default `waitFor` poll interval.

- **Performance**
  - Canonical selector instance per (interned schema, path) via `WeakRef` cache with sweep to bound growth.
  - Memoize `asCell` compound candidates; memoize+intern `unwrapAsCellSchema` and use it for child links.
  - Module-level `cfc.schemaAtPath` cache with interned results; cache comparable hashes for `anyOf` items.
  - Compose injective sync dedup keys from per-part hashes (JSON.stringify) instead of hashing fresh selector wrappers.
  - Results: mount+unmount @128 → 344.7ms → 69.3ms; remount @32 → 171.5ms → 33.8ms; single-child update @32 → 6.7ms → 3.7ms; worker busy CPU (notes 2–4) → 1446ms → 742ms (−49%).

- **Bug Fixes**
  - `waitFor` default poll: 500ms → 50ms (override via `CF_WAITFOR_DELAY_MS`) to remove timing quantization and speed up tests.

<sup>Written for commit 998346f70557140f07b9ba3e8d5fb3c63abc1077. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

