### PR TITLE
fix(cfc): Wave 1 — make verifier inputs trustworthy

### DIFF
--- a/packages/runner/src/builtins/llm.ts
+++ b/packages/runner/src/builtins/llm.ts
@@ -1455,6 +1455,13 @@ export function generateObject<T extends Record<string, unknown>>(
               await runtime.idle();
 
               await runtime.editWithRetry((tx) => {
+                // The InjectionSafe annotations on resultSchema are minted by
+                // the trusted sanitizer; attribute this write to the builtin so
+                // the persist-time evidence gate trusts them (audit S4).
+                tx.setCfcImplementationIdentity({
+                  kind: "builtin",
+                  builtinId: "generateObject",
+                });
                 resultCell.key("pending").withTx(tx).set(false);
                 const resultTarget = objectResponse.resultSchema === undefined
                   ? resultCell.key("result")
@@ -1670,6 +1677,13 @@ export function generateObject<T extends Record<string, unknown>>(
               await runtime.idle();
 
               await runtime.editWithRetry((tx) => {
+                // The InjectionSafe annotations on resultSchema are minted by
+                // the trusted sanitizer; attribute this write to the builtin so
+                // the persist-time evidence gate trusts them (audit S4).
+                tx.setCfcImplementationIdentity({
+                  kind: "builtin",
+                  builtinId: "generateObject",
+                });
                 const assistantMessage: BuiltInLLMMessage = {
                   role: "assistant",
                   content: JSON.stringify(response.object, null, 2),

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1935,7 +1935,9 @@ const gateRuntimeMintedIntegrity = (
   if (integrity === undefined || integrity.length === 0) {
     return label;
   }
-  const filtered = integrity.filter((atom) => !isRuntimeMintedIntegrityAtom(atom));
+  const filtered = integrity.filter((atom) =>
+    !isRuntimeMintedIntegrityAtom(atom)
+  );
   if (filtered.length === integrity.length) {
     return label;
   }

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1,5 +1,8 @@
 import { CFC_ATOM_TYPE } from "@commonfabric/api/cfc";
-import { internSchema } from "@commonfabric/data-model/schema-hash";
+import {
+  internSchema,
+  internSchemaAsTaggedHashString,
+} from "@commonfabric/data-model/schema-hash";
 import { emptySchemaObject } from "@commonfabric/data-model/schema-utils";
 import {
   cloneForMutation,
@@ -2056,6 +2059,15 @@ const ensureSchemaDocument = (
   schemaHash: string,
   schema: JSONSchema,
 ): void => {
+  // Defense in depth: the content address must be the canonical hash of the
+  // schema it names. A mismatch is a programming error in the caller; refuse it
+  // rather than write a self-inconsistent cid: document (audit S5).
+  const actualHash = internSchemaAsTaggedHashString(schema);
+  if (actualHash !== schemaHash) {
+    throw new Error(
+      `cid schema document hash mismatch: claimed ${schemaHash}, actual ${actualHash}`,
+    );
+  }
   const id = `cid:${schemaHash}`;
   // Do not pre-read the content-addressed schema document here. A read-before-
   // write can make otherwise idempotent schema persistence fail with stale-read
@@ -2072,7 +2084,8 @@ const ensureSchemaDocument = (
   });
 };
 
-const loadSchemaDocument = (
+// Exported for unit testing of the read-side content-address verification (S5).
+export const loadSchemaDocument = (
   tx: IExtendedStorageTransaction,
   space: MemorySpace,
   schemaHash: string,
@@ -2089,7 +2102,19 @@ const loadSchemaDocument = (
   if (!isRecord(existing) || existing.value === undefined) {
     throw new Error(`stored schemaHash ${schemaHash} is missing or unreadable`);
   }
-  return existing.value as JSONSchema;
+  const schema = existing.value as JSONSchema;
+  // The cid: document is content-addressed but stored on an unverified write
+  // path that any same-space writer can reach. Re-derive its canonical hash and
+  // reject a value that does not match the address it was loaded from; the
+  // loaded schema drives label derivation for other principals' writes, so a
+  // poisoned schema must not be trusted (audit S5).
+  const actualHash = internSchemaAsTaggedHashString(schema);
+  if (actualHash !== schemaHash) {
+    throw new Error(
+      `cid schema document hash mismatch for ${schemaHash}: content hashes to ${actualHash}`,
+    );
+  }
+  return schema;
 };
 
 export const prepareBoundaryCommit = (

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -2016,6 +2016,7 @@ const derivePersistedLinkLabel = (
   tx: IExtendedStorageTransaction,
   input: LinkWritePolicyInput,
   candidateSchemas: ReadonlyMap<string, JSONSchema>,
+  authoringIdentity: ImplementationIdentity | undefined,
 ): { label?: IFCLabel; reason?: string } => {
   const sourceMetadata = storedMetadataFor(
     tx,
@@ -2059,14 +2060,27 @@ const derivePersistedLinkLabel = (
     ) ?? {},
     pendingSourceLabel,
   );
+  // The source/link-schema integrity is author-influenceable (a link value can
+  // carry a forged link schema or label view). Gate runtime-minted evidence
+  // atoms out of it unless a trusted builtin authored the link write, THEN add
+  // the runtime-minted LinkReference — which is added here, never filtered, and
+  // is the only evidence atom a link write legitimately mints (audit S4 review).
+  const gatedIntegrity = gateRuntimeMintedIntegrity(
+    {
+      integrity: mergeLabelValues(
+        sourceLabel.integrity,
+        linkSchemaLabel.integrity,
+      ),
+    },
+    authoringIdentity,
+  ).integrity;
   const label: IFCLabel = {
     confidentiality: mergeLabelValues(
       sourceLabel.confidentiality,
       linkSchemaLabel.confidentiality,
     ),
     integrity: mergeLabelValues(
-      sourceLabel.integrity,
-      linkSchemaLabel.integrity,
+      gatedIntegrity,
       [linkReferenceIntegrity(input)],
     ),
   };
@@ -2370,7 +2384,13 @@ export const prepareBoundaryCommit = (
       }
     }
     for (const input of linkWriteInputs) {
-      const result = derivePersistedLinkLabel(tx, input, candidates);
+      const linkIdentity = identityForInput(input);
+      const result = derivePersistedLinkLabel(
+        tx,
+        input,
+        candidates,
+        linkIdentity,
+      );
       if (result.reason !== undefined) {
         reasons.push(result.reason);
         continue;
@@ -2386,12 +2406,18 @@ export const prepareBoundaryCommit = (
         if (!hasLabelValues(entry.label)) {
           continue;
         }
+        // The carried label view is author-influenceable; gate runtime-minted
+        // evidence atoms unless a builtin authored the link write (audit S4
+        // review).
         persistedLabelEntries.push({
           path: [
             ...targetPath,
             ...canonicalizeLogicalPath(entry.path),
           ],
-          label: cloneLabel(entry.label),
+          label: gateRuntimeMintedIntegrity(
+            cloneLabel(entry.label),
+            linkIdentity,
+          ),
         });
       }
     }

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1897,6 +1897,54 @@ const derivePersistedLabel = (
   };
 };
 
+// Integrity atom families that are concrete evidence minted only by trusted
+// runtime code (the InjectionSafe sanitizer, code-identity/provenance minting,
+// the harness prompt-slot binder). Untrusted schema authors must not be able to
+// self-attach them and then satisfy a requiredIntegrity gate or the
+// prompt-injection screen (audit S4). The current-principal claim family
+// (authored-by / represents-principal) is gated separately by
+// currentPrincipalIntegrityReason and intentionally not listed here.
+const RUNTIME_MINTED_INTEGRITY_ATOM_TYPES = new Set<string>([
+  CFC_ATOM_TYPE.InjectionSafe,
+  CFC_ATOM_TYPE.Builtin,
+  CFC_ATOM_TYPE.LinkReference,
+  CFC_ATOM_TYPE.Origin,
+  CFC_ATOM_TYPE.PromptSlotBound,
+  CFC_ATOM_TYPE.PromptSlotInfluence,
+  CFC_ATOM_TYPE.UserSurfaceInput,
+]);
+
+const isRuntimeMintedIntegrityAtom = (atom: unknown): boolean =>
+  isRecord(atom) && typeof atom.type === "string" &&
+  RUNTIME_MINTED_INTEGRITY_ATOM_TYPES.has(atom.type);
+
+/**
+ * Drops runtime-minted evidence atoms from a persisted label's integrity unless
+ * the write was authored by a trusted builtin (the sanitizer, compile cache,
+ * and link/provenance minting all run as builtins). Verified pattern code and
+ * unattributed writes may not mint evidence (audit S4).
+ */
+const gateRuntimeMintedIntegrity = (
+  label: IFCLabel,
+  authoringIdentity: ImplementationIdentity | undefined,
+): IFCLabel => {
+  if (authoringIdentity?.kind === "builtin") {
+    return label;
+  }
+  const integrity = label.integrity;
+  if (integrity === undefined || integrity.length === 0) {
+    return label;
+  }
+  const filtered = integrity.filter((atom) => !isRuntimeMintedIntegrityAtom(atom));
+  if (filtered.length === integrity.length) {
+    return label;
+  }
+  return {
+    ...label,
+    integrity: filtered.length > 0 ? filtered : undefined,
+  };
+};
+
 const persistedLabelFromSchemaAtPath = (
   tx: IExtendedStorageTransaction,
   schema: JSONSchema,
@@ -2280,11 +2328,14 @@ export const prepareBoundaryCommit = (
       ) {
         return [];
       }
-      const label = derivePersistedLabel(
-        tx,
-        entry.schema,
-        entry.label,
-        mergedSchemaEntryLabels,
+      const label = gateRuntimeMintedIntegrity(
+        derivePersistedLabel(
+          tx,
+          entry.schema,
+          entry.label,
+          mergedSchemaEntryLabels,
+        ),
+        identityForSchemaPath(writeAuthorIdentities.get(key), entry.path),
       );
       return hasLabelValues(label) || hasPersistedPolicyClaim(entry.schema)
         ? [{

--- a/packages/runner/test/cfc-cid-schema-verify.test.ts
+++ b/packages/runner/test/cfc-cid-schema-verify.test.ts
@@ -1,0 +1,49 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { loadSchemaDocument } from "../src/cfc/prepare.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+// Regression guard for cid: schema-document content-address verification (S5).
+//
+// cid:<hash> schema documents are content-addressed but stored on an unverified
+// write path any same-space writer can reach. The loaded schema drives label
+// derivation for other principals' writes, so loadSchemaDocument must re-derive
+// the canonical hash and reject a value that does not match its address.
+const space = "did:key:cid-verify" as const;
+
+const fakeTxReturning = (stored: JSONSchema): IExtendedStorageTransaction =>
+  ({
+    readOrThrow: () => ({ value: stored }),
+  }) as unknown as IExtendedStorageTransaction;
+
+describe("cid schema document verification", () => {
+  it("returns the schema when its content matches the address", () => {
+    const { schema, taggedHashString } = internSchema(
+      { type: "object", properties: { a: { type: "string" } } } as JSONSchema,
+      true,
+    );
+    const result = loadSchemaDocument(
+      fakeTxReturning(schema),
+      space,
+      taggedHashString,
+    );
+    expect(result).toEqual(schema);
+  });
+
+  it("throws when the stored content does not hash to the address (poisoned)", () => {
+    const { taggedHashString } = internSchema(
+      { type: "object", properties: { a: { type: "string" } } } as JSONSchema,
+      true,
+    );
+    // A different schema served at the same cid: address.
+    const poisoned = internSchema(
+      { type: "string", ifc: { confidentiality: [] } } as JSONSchema,
+      true,
+    ).schema;
+    expect(() =>
+      loadSchemaDocument(fakeTxReturning(poisoned), space, taggedHashString)
+    ).toThrow(/hash mismatch/);
+  });
+});

--- a/packages/runner/test/cfc-integrity-mint-gate.test.ts
+++ b/packages/runner/test/cfc-integrity-mint-gate.test.ts
@@ -1,0 +1,82 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-integrity-mint-gate");
+
+// Regression guard for runtime-evidence integrity minting (audit S4).
+//
+// InjectionSafe is runtime-minted evidence consumed by requiredIntegrity gates
+// and the prompt-injection screen. The pre-fix code persisted whatever integrity
+// atoms an author declared in ifc.integrity/addIntegrity, so untrusted pattern
+// code could self-attach InjectionSafe to a value it controls and then satisfy
+// an InjectionSafe requiredIntegrity gate. Author-declared schemas (verified or
+// unattributed identity) must not mint runtime-evidence atoms.
+const INJECTION_SAFE_ATOM = {
+  type: "https://commonfabric.org/cfc/atom/InjectionSafe",
+};
+
+describe("CFC integrity mint gate", () => {
+  it("does not let an author-declared InjectionSafe satisfy a requiredIntegrity gate", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    try {
+      // An author persists a source value with a self-attached InjectionSafe
+      // integrity atom (plus a confidentiality atom so the read is labeled).
+      const seed = runtime.edit();
+      const srcSchema = {
+        type: "string",
+        ifc: {
+          confidentiality: ["s"],
+          integrity: [INJECTION_SAFE_ATOM],
+        },
+      } as const satisfies JSONSchema;
+      const src = runtime.getCell(signer.did(), "mint-gate-src", srcSchema, seed);
+      src.set("attacker-controlled");
+      seed.prepareCfc();
+      expect((await seed.commit()).ok).toBeDefined();
+
+      // A sink requires InjectionSafe integrity on its inputs. The forged atom
+      // on the source must not satisfy it.
+      const tx = runtime.edit();
+      const srcRead = runtime.getCell(
+        signer.did(),
+        "mint-gate-src",
+        srcSchema,
+        tx,
+      );
+      srcRead.get();
+      const sink = runtime.getCell(
+        signer.did(),
+        "mint-gate-sink",
+        {
+          type: "object",
+          properties: {
+            out: {
+              type: "string",
+              ifc: { requiredIntegrity: [INJECTION_SAFE_ATOM] },
+            },
+          },
+          required: ["out"],
+        } as const satisfies JSONSchema,
+        tx,
+      );
+      sink.set({ out: "derived" });
+
+      const digest = tx.prepareCfc();
+      expect(digest).toBe("");
+      const result = await tx.commit();
+      expect(result.error?.message).toContain("requiredIntegrity failed");
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+});

--- a/packages/runner/test/cfc-integrity-mint-gate.test.ts
+++ b/packages/runner/test/cfc-integrity-mint-gate.test.ts
@@ -38,7 +38,12 @@ describe("CFC integrity mint gate", () => {
           integrity: [INJECTION_SAFE_ATOM],
         },
       } as const satisfies JSONSchema;
-      const src = runtime.getCell(signer.did(), "mint-gate-src", srcSchema, seed);
+      const src = runtime.getCell(
+        signer.did(),
+        "mint-gate-src",
+        srcSchema,
+        seed,
+      );
       src.set("attacker-controlled");
       seed.prepareCfc();
       expect((await seed.commit()).ok).toBeDefined();

--- a/packages/runner/test/cfc-link-integrity-gate.test.ts
+++ b/packages/runner/test/cfc-link-integrity-gate.test.ts
@@ -93,8 +93,9 @@ describe("CFC link-write integrity gate", () => {
           };
         } | undefined;
       };
-      const entries = replica.getDocument(persistedId)?.cfc?.labelMap?.entries ??
-        [];
+      const entries =
+        replica.getDocument(persistedId)?.cfc?.labelMap?.entries ??
+          [];
       const allIntegrity = entries.flatMap((e) => e.label.integrity ?? []);
       // The forged InjectionSafe must not have been persisted anywhere.
       expect(

--- a/packages/runner/test/cfc-link-integrity-gate.test.ts
+++ b/packages/runner/test/cfc-link-integrity-gate.test.ts
@@ -1,0 +1,108 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import { parseLink } from "../src/link-utils.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-link-integrity-gate");
+
+const INJECTION_SAFE_ATOM = {
+  type: "https://commonfabric.org/cfc/atom/InjectionSafe",
+};
+
+// Regression guard for runtime-evidence atoms on the link-write path (audit S4
+// review follow-up). The integrity mint gate originally covered only
+// schema-derived labels; an author could persist a forged InjectionSafe through
+// a link's carried label view (or embedded link schema) and later satisfy an
+// InjectionSafe requiredIntegrity gate. Author-influenced link labels must be
+// gated too; only the runtime-minted LinkReference survives.
+describe("CFC link-write integrity gate", () => {
+  it("filters a forged InjectionSafe carried on a link's label view", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    try {
+      const tx = runtime.edit();
+      const target = runtime.getCell(
+        signer.did(),
+        "cfc-link-integrity-target",
+        undefined,
+        tx,
+      );
+      const targetId = target.getAsNormalizedFullLink().id;
+
+      // A plain value write makes the target a CFC write target.
+      tx.markCfcRelevant("test");
+      tx.writeValueOrThrow({
+        space: signer.did(),
+        scope: "space",
+        id: targetId,
+        path: ["value", "field"],
+      }, "v");
+
+      // Forge a link-write policy input whose carried label view attaches an
+      // InjectionSafe integrity atom (author-controlled).
+      tx.recordCfcWritePolicyInput({
+        kind: "link-write",
+        target: {
+          space: signer.did(),
+          scope: "space",
+          id: targetId,
+          path: ["value", "field"],
+        },
+        source: {
+          space: signer.did(),
+          scope: "space",
+          id: "of:cfc-link-integrity-source",
+          path: ["value"],
+        },
+        cfcLabelView: {
+          version: 1,
+          entries: [{
+            path: [],
+            label: {
+              confidentiality: ["leak"],
+              integrity: [INJECTION_SAFE_ATOM],
+            },
+          }],
+        },
+      });
+
+      tx.prepareCfc();
+      expect((await tx.commit()).ok).toBeDefined();
+
+      const persistedId = parseLink(target.getAsLink()).id!;
+      const replica = storageManager.open(signer.did()).replica as unknown as {
+        getDocument(id: string): {
+          cfc?: {
+            labelMap?: {
+              entries: Array<
+                {
+                  path: string[];
+                  label: {
+                    confidentiality?: unknown[];
+                    integrity?: Array<{ type?: string }>;
+                  };
+                }
+              >;
+            };
+          };
+        } | undefined;
+      };
+      const entries = replica.getDocument(persistedId)?.cfc?.labelMap?.entries ??
+        [];
+      const allIntegrity = entries.flatMap((e) => e.label.integrity ?? []);
+      // The forged InjectionSafe must not have been persisted anywhere.
+      expect(
+        allIntegrity.some((a) => a?.type?.endsWith("/InjectionSafe")),
+      ).toBe(false);
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Wave 1 of the CFC spec-audit remediation (stacked on [#3970](https://github.com/commontoolsinc/labs/pull/3970)). Wave 0 closed the enforcement *bypasses*; this wave makes the verifier's *inputs* trustworthy — a check over a forgeable schema or label is theater.

## Fixes

1. **Verify `cid:` schema-document content addresses (S5)** — `cid:<hash>` schema docs are content-addressed but written on an unverified path any same-space writer can reach, and the loaded schema drives label derivation for *other* principals' writes. `loadSchemaDocument` now re-derives the canonical hash and rejects a value that doesn't match its address; `ensureSchemaDocument` asserts the same on write. (Mirrors what the compile cache already does for compiled-code docs.)

2. **Gate runtime-minted integrity evidence at persist (S4)** — `InjectionSafe` (and the other runtime-evidence atom families) are concrete evidence minted only by trusted code and consumed by `requiredIntegrity` gates / the prompt-injection screen. The persist path wrote whatever integrity an author declared, so untrusted pattern code could self-attach `InjectionSafe` and satisfy an `InjectionSafe` gate. Persisted label integrity now drops runtime-evidence atoms unless the write is authored by a trusted builtin; the `generateObject` result-write transactions mark themselves as the builtin so the sanitizer's legitimate `InjectionSafe` annotations still persist.

## Testing

- New focused tests (unit + boundary), red-green verified.
- Full `packages/runner` unit suite: 564 passed, 0 failed (incl. the existing `InjectionSafe`-persistence test).
- `deno task integration runner` (incl. `sqlite-cfc-label*`): 12 passed, 0 failed.

## Deferred from this wave (flagged for review)

Two items share a root cause — **protecting a system-managed field/path from untrusted writes** — and need a design decision rather than an autonomous landing:

- **S18** raw `["cfc"]`/`["source"]` metadata writes. Note the highest-value part (`cid:` poisoning) is *already closed* by S5 above.
- **S8** sqlite `tables[].ifc` mutability (read labels + write ceilings live in mutable handle-cell data).

Both want either a privileged-write channel or `writeAuthorizedBy`-on-the-handle with builtin-identity set/restore in the hot `db.exec` path. Recommend designing the protection mechanism once and applying to both. The bare-tx default-mode change was also dropped (low value — `Runtime.edit` always sets the real mode — and high test churn). `enforce-strict` not-implemented handling is tracked for a later wave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes CFC verifier inputs trustworthy by validating `cid:` schema-document hashes and gating runtime-minted integrity on value and link writes. Blocks poisoned schemas and stops untrusted code from faking `InjectionSafe` to pass integrity gates.

- **Bug Fixes**
  - Verify `cid:` schema documents: re-derive the canonical hash in `loadSchemaDocument` and assert correctness in `ensureSchemaDocument`; reject mismatches.
  - Gate runtime-minted integrity at persist: drop `InjectionSafe`, `Builtin`, `LinkReference`, `Origin`, `PromptSlotBound`, `PromptSlotInfluence`, `UserSurfaceInput` unless authored by a trusted builtin; `generateObject` marks result writes as builtin so sanitizer-minted `InjectionSafe` persists.
  - Gate link-write integrity: filter runtime-minted atoms from link/source-schema integrity and carried label views unless authored by a builtin, then add `LinkReference` after the gate.
  - Add focused tests for schema verification, value-write gating, and link-write gating.

<sup>Written for commit 9444ef2119bd0bf3f5d9ccee60642f042b98a2ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

