### PR TITLE
fix(cfc): Wave 2 — verifier semantics

### DIFF
--- a/packages/runner/src/builtins/sqlite-builtins.ts
+++ b/packages/runner/src/builtins/sqlite-builtins.ts
@@ -172,8 +172,14 @@ function deriveNullOriginIfc(tables: LabelTables): IFCLabel | undefined {
       if (ifc && typeof ifc === "object") merged = mergeLabel(merged, ifc);
     }
   }
-  return (merged.confidentiality?.length || merged.integrity?.length)
-    ? merged
+  // Confidentiality unions across contributors (a sound over-approximation: the
+  // aggregate could depend on any column). Integrity does NOT: an aggregate /
+  // expression / literal is a new computed value and inherits no integrity
+  // evidence. Unioning integrity would let it falsely claim an atom held by a
+  // single column (§8.17.1: class-aware meet, never union; propagation classes
+  // pending, so conservatively empty). [CT-1668]
+  return merged.confidentiality?.length
+    ? { confidentiality: merged.confidentiality }
     : undefined;
 }
 

--- a/packages/runner/src/cfc.ts
+++ b/packages/runner/src/cfc.ts
@@ -109,6 +109,42 @@ export class ContextualFlowControl {
     if (schema.ifc) {
       ContextualFlowControl.addIfcAtoms(joined, schema.ifc.confidentiality);
     }
+    // A value validates against one (anyOf/oneOf) or all (allOf) branches, so the
+    // confidentiality LUB must union every branch's atoms; otherwise branch-local
+    // confidentiality is silently dropped (under-tainting fail-open, audit 1.6).
+    for (const key of ["anyOf", "oneOf", "allOf"] as const) {
+      const branches = (schema as Record<string, unknown>)[key];
+      if (Array.isArray(branches)) {
+        for (const branch of branches) {
+          if (branch !== undefined && typeof branch === "object") {
+            ContextualFlowControl.joinSchema(
+              joined,
+              branch as JSONSchema,
+              ContextualFlowControl.childFullSchema(
+                branch as JSONSchema,
+                fullSchema,
+              ),
+              cycleTracker,
+            );
+          }
+        }
+      }
+    }
+    // Tuple element schemas carry their own confidentiality too.
+    if (Array.isArray((schema as Record<string, unknown>).prefixItems)) {
+      for (
+        const item of (schema as { prefixItems: JSONSchema[] }).prefixItems
+      ) {
+        if (item !== undefined && typeof item === "object") {
+          ContextualFlowControl.joinSchema(
+            joined,
+            item,
+            ContextualFlowControl.childFullSchema(item, fullSchema),
+            cycleTracker,
+          );
+        }
+      }
+    }
     if (schema.properties && typeof schema.properties === "object") {
       for (const value of Object.values(schema.properties)) {
         ContextualFlowControl.joinSchema(

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -2355,14 +2355,12 @@ export const prepareBoundaryCommit = (
         entry.schema,
       ]),
     );
-    const existingConfidentialityByPath = new Map<string, readonly unknown[]>(
-      (existing?.labelMap.entries ?? [])
-        .filter((e) => (e.label.confidentiality?.length ?? 0) > 0)
-        .map((e) => [
-          pathKey(canonicalizeLogicalPath(e.path)),
-          e.label.confidentiality as readonly unknown[],
-        ]),
-    );
+    const existingConfidentiality = (existing?.labelMap.entries ?? [])
+      .filter((e) => (e.label.confidentiality?.length ?? 0) > 0)
+      .map((e) => ({
+        path: canonicalizeLogicalPath(e.path),
+        confidentiality: e.label.confidentiality as readonly unknown[],
+      }));
     const persistedLabelEntries = mergedSchemaEntries.flatMap((entry) => {
       if (
         !ifcEntryAppliesToAttemptedWrite(tx, target, entry.path, entry.schema)
@@ -2380,11 +2378,15 @@ export const prepareBoundaryCommit = (
       );
       // Store confidentiality is grow-only (§8.12.1): a re-write of a path must
       // not drop confidentiality the labelMap already carried beyond the schema
-      // (e.g. link-derived or carried-view atoms). Merge the prior stored
-      // confidentiality into the freshly derived label. Integrity is left as
-      // derived (freshly gated) — it must not regrow (audit S9).
-      const prior = existingConfidentialityByPath.get(pathKey(entry.path));
-      const label = prior !== undefined
+      // (e.g. link-derived or carried-view atoms). Reads use longest-prefix
+      // matching, so a new child entry shadows an ancestor — merge prior
+      // confidentiality from this path AND every ancestor of it, not just an
+      // exact-path match (audit S9, review follow-up). Integrity is left as
+      // derived (freshly gated) — it must not regrow.
+      const prior = existingConfidentiality
+        .filter((e) => isPrefix(e.path, entry.path))
+        .flatMap((e) => e.confidentiality);
+      const label = prior.length > 0
         ? {
           ...derived,
           confidentiality: mergeLabelValues(derived.confidentiality, prior),

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -1851,6 +1851,23 @@ const verifyExactCopyRequirements = (
     if (sourcePath === undefined) {
       continue;
     }
+    // Only verify a claim whose target path the transaction actually wrote.
+    // Without this gate an untouched entry compares undefined to undefined and
+    // passes vacuously, accepting the claim (and copying its label) unverified.
+    if (
+      !ifcEntryAppliesToAttemptedWrite(tx, target, entry.path, entry.schema)
+    ) {
+      continue;
+    }
+    // Array-item (wildcard) exactCopyOf is unsupported: the per-path value
+    // reconstruction matches segments literally, so "*" never resolves against a
+    // concrete write and the comparison would pass vacuously. Fail closed
+    // (audit W2.15).
+    if (entry.path.includes("*") || sourcePath.includes("*")) {
+      return `exactCopyOf under an array wildcard is unsupported at /${
+        entry.path.join("/")
+      }`;
+    }
     const targetValue = writeValueForTarget(tx, {
       ...target,
       path: entry.path,

--- a/packages/runner/src/cfc/prepare.ts
+++ b/packages/runner/src/cfc/prepare.ts
@@ -2355,13 +2355,21 @@ export const prepareBoundaryCommit = (
         entry.schema,
       ]),
     );
+    const existingConfidentialityByPath = new Map<string, readonly unknown[]>(
+      (existing?.labelMap.entries ?? [])
+        .filter((e) => (e.label.confidentiality?.length ?? 0) > 0)
+        .map((e) => [
+          pathKey(canonicalizeLogicalPath(e.path)),
+          e.label.confidentiality as readonly unknown[],
+        ]),
+    );
     const persistedLabelEntries = mergedSchemaEntries.flatMap((entry) => {
       if (
         !ifcEntryAppliesToAttemptedWrite(tx, target, entry.path, entry.schema)
       ) {
         return [];
       }
-      const label = gateRuntimeMintedIntegrity(
+      const derived = gateRuntimeMintedIntegrity(
         derivePersistedLabel(
           tx,
           entry.schema,
@@ -2370,6 +2378,18 @@ export const prepareBoundaryCommit = (
         ),
         identityForSchemaPath(writeAuthorIdentities.get(key), entry.path),
       );
+      // Store confidentiality is grow-only (§8.12.1): a re-write of a path must
+      // not drop confidentiality the labelMap already carried beyond the schema
+      // (e.g. link-derived or carried-view atoms). Merge the prior stored
+      // confidentiality into the freshly derived label. Integrity is left as
+      // derived (freshly gated) — it must not regrow (audit S9).
+      const prior = existingConfidentialityByPath.get(pathKey(entry.path));
+      const label = prior !== undefined
+        ? {
+          ...derived,
+          confidentiality: mergeLabelValues(derived.confidentiality, prior),
+        }
+        : derived;
       return hasLabelValues(label) || hasPersistedPolicyClaim(entry.schema)
         ? [{
           path: entry.path,

--- a/packages/runner/test/cfc-exact-copy-wildcard.test.ts
+++ b/packages/runner/test/cfc-exact-copy-wildcard.test.ts
@@ -1,0 +1,57 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-exact-copy-wildcard");
+
+// Regression guard for exactCopyOf under array wildcards (audit W2.15).
+//
+// walkIfcSchema emits "*" for array items, but the write-value reconstruction
+// matches path segments literally, so a wildcard exactCopyOf claim never matched
+// a concrete write and deepEqual(undefined, undefined) passed vacuously — the
+// claim was accepted (and its label copied) with no verification. A wildcard
+// exactCopyOf must fail closed.
+describe("CFC exactCopyOf array wildcard", () => {
+  it("rejects an exactCopyOf claim on an array-item (wildcard) path", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    try {
+      const tx = runtime.edit();
+      const cell = runtime.getCell(
+        signer.did(),
+        "cfc-exact-copy-wildcard",
+        {
+          type: "object",
+          properties: {
+            items: {
+              type: "array",
+              items: { type: "string", ifc: { confidentiality: ["secret"] } },
+            },
+            copies: {
+              type: "array",
+              items: { type: "string", ifc: { exactCopyOf: ["items", "*"] } },
+            },
+          },
+          required: ["items", "copies"],
+        } as const satisfies JSONSchema,
+        tx,
+      );
+      cell.set({ items: ["a"], copies: ["a"] });
+
+      const digest = tx.prepareCfc();
+      expect(digest).toBe("");
+      const result = await tx.commit();
+      expect(result.error?.message).toContain("exactCopyOf");
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+});

--- a/packages/runner/test/cfc-joinschema-combinators.test.ts
+++ b/packages/runner/test/cfc-joinschema-combinators.test.ts
@@ -1,0 +1,42 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { ContextualFlowControl } from "../src/cfc.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+
+// Regression guard for joinSchema combinator descent (audit 1.6 / W2.16).
+//
+// lubSchema (confidentiality tainting) descended into properties/items/$ref but
+// not anyOf/oneOf/allOf or prefixItems, so branch-local confidentiality was
+// silently dropped — an under-tainting fail-open in the core algebra. The LUB
+// must union the confidentiality of every branch a value could match.
+describe("ContextualFlowControl.lubSchema combinator descent", () => {
+  const cfc = new ContextualFlowControl();
+  const atomsOf = (schema: JSONSchema) =>
+    (cfc.lubSchema(schema) ?? []).map((a) => a).sort();
+
+  it("unions confidentiality across anyOf branches", () => {
+    expect(atomsOf({
+      anyOf: [
+        { type: "string", ifc: { confidentiality: ["a"] } },
+        { type: "number", ifc: { confidentiality: ["b"] } },
+      ],
+    } as JSONSchema)).toEqual(["a", "b"]);
+  });
+
+  it("unions confidentiality across oneOf and allOf branches", () => {
+    expect(atomsOf({
+      oneOf: [{ type: "string", ifc: { confidentiality: ["x"] } }],
+      allOf: [{ type: "object", ifc: { confidentiality: ["y"] } }],
+    } as JSONSchema)).toEqual(["x", "y"]);
+  });
+
+  it("descends into prefixItems (tuple) branches", () => {
+    expect(atomsOf({
+      type: "array",
+      prefixItems: [
+        { type: "string", ifc: { confidentiality: ["t0"] } },
+        { type: "number", ifc: { confidentiality: ["t1"] } },
+      ],
+    } as JSONSchema)).toEqual(["t0", "t1"]);
+  });
+});

--- a/packages/runner/test/cfc-labelmap-monotone.test.ts
+++ b/packages/runner/test/cfc-labelmap-monotone.test.ts
@@ -108,4 +108,106 @@ describe("CFC labelMap confidentiality monotonicity", () => {
       await storageManager.close();
     }
   });
+
+  it("preserves ancestor confidentiality when re-writing a child path", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    try {
+      const guarded = internSchema(
+        {
+          type: "object",
+          properties: {
+            obj: {
+              type: "object",
+              properties: {
+                field: { type: "string", ifc: { confidentiality: ["base"] } },
+              },
+              required: ["field"],
+            },
+          },
+          required: ["obj"],
+        } satisfies JSONSchema,
+        true,
+      );
+
+      // Seed an ANCESTOR-path labelMap entry (at ["obj"]) carrying extra
+      // confidentiality beyond the schema.
+      const seed = runtime.edit();
+      const target = runtime.getCell(
+        signer.did(),
+        "cfc-labelmap-monotone-ancestor",
+        undefined,
+        seed,
+      );
+      const targetId = target.getAsNormalizedFullLink().id;
+      seed.writeOrThrow({
+        space: signer.did(),
+        scope: "space",
+        id: targetId,
+        path: [],
+      }, {
+        value: { obj: { field: "seeded" } },
+        cfc: {
+          version: 1,
+          schemaHash: guarded.taggedHashString,
+          labelMap: {
+            version: 1,
+            entries: [{
+              path: ["obj"],
+              label: { confidentiality: ["ancestor-secret"] },
+            }],
+          },
+        },
+      });
+      seed.writeOrThrow({
+        space: signer.did(),
+        scope: "space",
+        id: `cid:${guarded.taggedHashString}`,
+        path: [],
+      }, { value: guarded.schema });
+      expect((await seed.commit()).ok).toBeDefined();
+
+      // Re-write the CHILD path; its new entry must not shadow (drop) the
+      // ancestor's confidentiality under longest-prefix reads.
+      const tx = runtime.edit();
+      const cell = runtime.getCell(
+        signer.did(),
+        "cfc-labelmap-monotone-ancestor",
+        guarded.schema,
+        tx,
+      );
+      cell.set({ obj: { field: "updated" } });
+      tx.prepareCfc();
+      expect((await tx.commit()).ok).toBeDefined();
+
+      const persistedId = parseLink(cell.getAsLink()).id!;
+      const replica = storageManager.open(signer.did()).replica as unknown as {
+        getDocument(id: string): {
+          cfc?: {
+            labelMap?: {
+              entries: Array<
+                { path: string[]; label: { confidentiality?: string[] } }
+              >;
+            };
+          };
+        } | undefined;
+      };
+      const entries = replica.getDocument(persistedId)?.cfc?.labelMap?.entries ??
+        [];
+      const child = entries.find((e) =>
+        e.path.length === 2 && e.path[0] === "obj" && e.path[1] === "field"
+      );
+      expect(child).toBeDefined();
+      expect([...(child!.label.confidentiality ?? [])].sort()).toEqual(
+        ["ancestor-secret", "base"],
+      );
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
 });

--- a/packages/runner/test/cfc-labelmap-monotone.test.ts
+++ b/packages/runner/test/cfc-labelmap-monotone.test.ts
@@ -196,8 +196,9 @@ describe("CFC labelMap confidentiality monotonicity", () => {
           };
         } | undefined;
       };
-      const entries = replica.getDocument(persistedId)?.cfc?.labelMap?.entries ??
-        [];
+      const entries =
+        replica.getDocument(persistedId)?.cfc?.labelMap?.entries ??
+          [];
       const child = entries.find((e) =>
         e.path.length === 2 && e.path[0] === "obj" && e.path[1] === "field"
       );

--- a/packages/runner/test/cfc-labelmap-monotone.test.ts
+++ b/packages/runner/test/cfc-labelmap-monotone.test.ts
@@ -1,0 +1,111 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { Identity } from "@commonfabric/identity";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
+import { StorageManager } from "../src/storage/cache.deno.ts";
+import { Runtime } from "../src/runtime.ts";
+import { parseLink } from "../src/link-utils.ts";
+import type { JSONSchema } from "../src/builder/types.ts";
+
+const signer = await Identity.fromPassphrase("runner-cfc-labelmap-monotone");
+
+// Regression guard for labelMap store-confidentiality monotonicity (audit S9).
+//
+// A persisted path can carry confidentiality beyond what its schema declares
+// (link-derived or carried-view atoms). The persist path re-derived the label
+// from the schema alone and replaced the stored entry, dropping that extra
+// confidentiality — a non-monotone downgrade (§8.12.1: store confidentiality is
+// grow-only). A re-write must preserve it.
+describe("CFC labelMap confidentiality monotonicity", () => {
+  it("preserves stored confidentiality beyond the schema on a re-write", async () => {
+    const storageManager = StorageManager.emulate({ as: signer });
+    const runtime = new Runtime({
+      apiUrl: new URL("https://example.com"),
+      storageManager,
+      cfcEnforcementMode: "enforce-explicit",
+    });
+    try {
+      const guarded = internSchema(
+        {
+          type: "object",
+          properties: {
+            secret: { type: "string", ifc: { confidentiality: ["base"] } },
+          },
+          required: ["secret"],
+        } satisfies JSONSchema,
+        true,
+      );
+
+      // Seed a stored state whose labelMap carries an extra confidentiality atom
+      // ("link-derived") beyond the schema's declared ["base"].
+      const seed = runtime.edit();
+      const target = runtime.getCell(
+        signer.did(),
+        "cfc-labelmap-monotone",
+        undefined,
+        seed,
+      );
+      const targetId = target.getAsNormalizedFullLink().id;
+      seed.writeOrThrow({
+        space: signer.did(),
+        scope: "space",
+        id: targetId,
+        path: [],
+      }, {
+        value: { secret: "seeded" },
+        cfc: {
+          version: 1,
+          schemaHash: guarded.taggedHashString,
+          labelMap: {
+            version: 1,
+            entries: [{
+              path: ["secret"],
+              label: { confidentiality: ["base", "link-derived"] },
+            }],
+          },
+        },
+      });
+      seed.writeOrThrow({
+        space: signer.did(),
+        scope: "space",
+        id: `cid:${guarded.taggedHashString}`,
+        path: [],
+      }, { value: guarded.schema });
+      expect((await seed.commit()).ok).toBeDefined();
+
+      // Re-write the path through its schema (which declares only ["base"]).
+      const tx = runtime.edit();
+      const cell = runtime.getCell(
+        signer.did(),
+        "cfc-labelmap-monotone",
+        guarded.schema,
+        tx,
+      );
+      cell.set({ secret: "updated" });
+      tx.prepareCfc();
+      expect((await tx.commit()).ok).toBeDefined();
+
+      const persistedId = parseLink(cell.getAsLink()).id!;
+      const replica = storageManager.open(signer.did()).replica as unknown as {
+        getDocument(id: string): {
+          cfc?: {
+            labelMap?: {
+              entries: Array<
+                { path: string[]; label: { confidentiality?: string[] } }
+              >;
+            };
+          };
+        } | undefined;
+      };
+      const entry = replica.getDocument(persistedId)?.cfc?.labelMap?.entries
+        .find((e) => e.path.length === 1 && e.path[0] === "secret");
+      expect(entry).toBeDefined();
+      expect([...(entry!.label.confidentiality ?? [])].sort()).toEqual(
+        ["base", "link-derived"],
+      );
+    } finally {
+      await runtime.dispose();
+      await storageManager.close();
+    }
+  });
+});

--- a/packages/runner/test/cfc-sqlite-aggregate-integrity.test.ts
+++ b/packages/runner/test/cfc-sqlite-aggregate-integrity.test.ts
@@ -1,0 +1,36 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { labelResultSchema } from "../src/builtins/sqlite-builtins.ts";
+
+// Regression guard for aggregate/null-origin column integrity (CT-1668 / W2.17).
+//
+// A null-origin result column (aggregate, expression, literal) inherited the
+// runtime's mergeLabel union over every labeled db column — for confidentiality
+// that is a sound over-approximation, but for INTEGRITY it over-claims: a
+// COUNT(*) would claim an integrity atom held by a single column. §8.17.1
+// requires a class-aware meet (never union) for integrity; with propagation
+// classes still pending, the conservative result is empty integrity (an
+// aggregate is a new computed value with no inherited evidence).
+describe("CFC sqlite aggregate column integrity", () => {
+  it("gives a null-origin column the confidentiality union but no integrity", () => {
+    // deno-lint-ignore no-explicit-any
+    const tables: any = {
+      notes: {
+        properties: {
+          body: {
+            ifc: { confidentiality: ["secret-body"], integrity: ["trusted-body"] },
+          },
+        },
+      },
+    };
+    // deno-lint-ignore no-explicit-any
+    const columns: any = [{ output: "cnt", table: null, column: null }];
+
+    const { schema } = labelResultSchema(columns, tables);
+    const ifc = (schema as any)?.properties?.result?.items?.properties?.cnt?.ifc;
+
+    expect(ifc).toBeDefined();
+    expect(ifc.confidentiality).toEqual(["secret-body"]);
+    expect(ifc.integrity ?? []).toEqual([]);
+  });
+});

--- a/packages/runner/test/cfc-sqlite-aggregate-integrity.test.ts
+++ b/packages/runner/test/cfc-sqlite-aggregate-integrity.test.ts
@@ -18,7 +18,10 @@ describe("CFC sqlite aggregate column integrity", () => {
       notes: {
         properties: {
           body: {
-            ifc: { confidentiality: ["secret-body"], integrity: ["trusted-body"] },
+            ifc: {
+              confidentiality: ["secret-body"],
+              integrity: ["trusted-body"],
+            },
           },
         },
       },
@@ -27,7 +30,8 @@ describe("CFC sqlite aggregate column integrity", () => {
     const columns: any = [{ output: "cnt", table: null, column: null }];
 
     const { schema } = labelResultSchema(columns, tables);
-    const ifc = (schema as any)?.properties?.result?.items?.properties?.cnt?.ifc;
+    const ifc = (schema as any)?.properties?.result?.items?.properties?.cnt
+      ?.ifc;
 
     expect(ifc).toBeDefined();
     expect(ifc.confidentiality).toEqual(["secret-body"]);

--- a/packages/runner/test/sqlite-read-labeling.test.ts
+++ b/packages/runner/test/sqlite-read-labeling.test.ts
@@ -56,11 +56,13 @@ describe("labelResultSchema (pure)", () => {
     expect(schema).toBeUndefined();
   });
 
-  it("null-origin column carries the merged label of the db's sources", () => {
-    // An expression / aggregate (COUNT(*), upper(x)) has no single origin. We
-    // can't cheaply know which columns it derives from, so it conservatively
-    // inherits the combined label (the runtime's mergeLabel: union of BOTH
-    // confidentiality and integrity) across every declared labeled column.
+  it("null-origin column unions confidentiality but carries no integrity", () => {
+    // An expression / aggregate (COUNT(*), upper(x)) has no single origin. It
+    // conservatively unions the confidentiality of every declared labeled column
+    // (a sound over-approximation). It carries NO integrity: an aggregate is a
+    // new computed value and inherits no integrity evidence — unioning would let
+    // it falsely claim an atom held by a single column (§8.17.1: meet, never
+    // union; propagation classes pending, conservatively empty). [CT-1668]
     const t = {
       emails: {
         properties: {
@@ -82,7 +84,7 @@ describe("labelResultSchema (pure)", () => {
     const ifc = (schema as Record<string, any>).properties.result.items
       .properties.n.ifc;
     expect([...ifc.confidentiality].sort()).toEqual(["body-secret", "sender"]);
-    expect([...ifc.integrity].sort()).toEqual(["a", "b", "c"]); // union {a,b}∪{b,c}
+    expect(ifc.integrity ?? []).toEqual([]);
   });
 
   it("refuses a query with duplicate output column names (ambiguous label)", () => {


### PR DESCRIPTION
## Summary

Wave 2 of the CFC spec-audit remediation (stacked on [#3972](https://github.com/commontoolsinc/labs/pull/3972)). Tightens verifier *semantics* — over- and under-approximations in label derivation and claim verification.

## Fixes

1. **exactCopyOf applicability gating + reject array wildcards (W2.15)** — `verifyExactCopyRequirements` ran for every claim regardless of whether the target was written, so an untouched entry compared `undefined`/`undefined` and passed vacuously (accepting the claim and copying its label unverified); a wildcard claim could never match a concrete write. Now gated on `ifcEntryAppliesToAttemptedWrite`, and array-wildcard exactCopyOf fails closed.

2. **Aggregate columns carry no integrity (CT-1668)** — a null-origin sqlite result column (`COUNT(*)`, expression, literal) inherited the union of every labeled column's integrity, so it could falsely claim an atom held by a single column (§8.17.1: meet, never union). It now keeps the confidentiality union (sound over-approximation) but drops integrity.

3. **labelMap store confidentiality is grow-only on re-write (S9)** — a path can carry confidentiality beyond its schema (link-derived / carried-view atoms); re-deriving from the schema alone replaced the stored entry and dropped it (§8.12.1: store confidentiality is grow-only). The re-write now unions the prior stored confidentiality.

4. **joinSchema descends anyOf/oneOf/allOf + prefixItems (W2.16)** — the confidentiality-tainting LUB skipped combinator branches and tuple elements, silently dropping branch-local confidentiality (under-tainting fail-open) and tainting differently than the verifier's `walkIfcSchema`. Now unions every branch.

## Testing

- New focused tests per fix (unit + boundary), red-green verified (incl. revert-checks for the labelMap and joinSchema fixes).
- Full `packages/runner` unit suite: 568 passed, 0 failed.
- `deno task integration runner`: 12 passed, 0 failed.

## Deferred from this wave (flagged for review)

- **S7 vacuous-pass + ancestor reads** — the audit's explicitly *observe-first* item. `requiredIntegrity` is used by 0 real patterns, but the fix can't cleanly distinguish handler-input reads from runtime-plumbing reads (both unlabeled — failing plumbing reads would fail everything), and the ancestor-read half shifts `maxConfidentiality` for the 3 patterns that use it. Needs an observe-mode rollout with telemetry + read-provenance design rather than a blind autonomous landing.
- Smaller residual: `coalesceLabelEntries` still unions integrity for two *distinct* writes at one path in a single transaction (load-bearing for legitimate link/endorsement refresh; needs combination-vs-refresh provenance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wave 2 CFC verifier semantics hardening. Prevents vacuous exactCopyOf passes, drops over-claimed integrity on SQLite aggregates, preserves stored and ancestor confidentiality on rewrite, and unions confidentiality across schema combinators.

- **Bug Fixes**
  - Gate `exactCopyOf` checks to paths actually written; reject array wildcards to avoid vacuous passes (W2.15).
  - For null-origin SQLite result columns (aggregates/expressions), keep confidentiality union and drop integrity (CT-1668).
  - Make `labelMap` confidentiality grow-only on rewrite by unioning prior atoms from the path and its ancestors; integrity stays freshly derived (S9).
  - In `joinSchema`, descend `anyOf`/`oneOf`/`allOf` and `prefixItems`, unioning confidentiality across all branches (W2.16).

<sup>Written for commit 1c5073f697a1ea88c02fb378ec44f3906f27b99a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

