### PR TITLE
fix(cfc): Wave 3 — egress relabeling

### DIFF
--- a/packages/runner/src/builtins/sqlite/write-ceiling.ts
+++ b/packages/runner/src/builtins/sqlite/write-ceiling.ts
@@ -17,11 +17,85 @@ import {
 
 interface ColumnIfc {
   maxConfidentiality?: readonly unknown[];
+  confidentiality?: readonly unknown[];
 }
 type Tables = Record<
   string,
   { properties?: Record<string, { ifc?: ColumnIfc }> } | undefined
 >;
+
+/** Any column anywhere declares a read-label or a write-ceiling. */
+function dbDeclaresAnyLabel(tables: Tables): boolean {
+  return Object.values(tables).some((t) =>
+    Object.values(t?.properties ?? {}).some((c) =>
+      (c?.ifc?.maxConfidentiality !== undefined) ||
+      ((c?.ifc?.confidentiality?.length ?? 0) > 0)
+    )
+  );
+}
+
+/** A bound-paramless RHS token that stores no column-derived data. */
+function rhsIsLiteral(rhs: string): boolean {
+  const t = rhs.replace(/;\s*$/, "").trim();
+  return t === "" ||
+    /^''$/.test(t) || // blanked string literal
+    /^[-+]?\d+(\.\d+)?$/.test(t) || // numeric literal
+    /^(null|true|false)$/i.test(t) || // keyword literal
+    t === "?"; // positional param (handled by the param path)
+}
+
+/**
+ * Whether a write with no bound params moves column-derived data into a stored
+ * position — `INSERT…SELECT`, or `UPDATE col = <column expr>`. Such a write
+ * relabels data past a destination column's declared label and cannot be
+ * attributed without bound params, so a labeled db must fail closed on it
+ * (audit S6). Literal-only INSERT/UPDATE and DELETE store no column data.
+ * Sound over-approximation: any non-literal RHS counts as a column reference.
+ */
+function paramlessRelabelRisk(blanked: string): boolean {
+  const kw = /^\s*(\w+)/.exec(blanked)?.[1]?.toUpperCase();
+  if (kw === "DELETE") return false;
+  if (kw === "INSERT" || kw === "REPLACE") {
+    return /\bselect\b/i.test(blanked);
+  }
+  if (kw === "UPDATE") {
+    const setIdx = blanked.search(/\bset\b/i);
+    if (setIdx === -1) return true; // unparseable → fail closed
+    let depth = 0;
+    let region = "";
+    for (let i = setIdx + 3; i < blanked.length; i++) {
+      const c = blanked[i];
+      if (c === "(") depth++;
+      else if (c === ")") depth--;
+      if (
+        depth === 0 &&
+        /^\s*\b(where|returning|from)\b/i.test(blanked.slice(i))
+      ) break;
+      region += c;
+    }
+    if (depth !== 0) return true; // unbalanced → fail closed
+    // Split top-level assignments and inspect each RHS.
+    let d = 0;
+    let current = "";
+    const parts: string[] = [];
+    for (const c of region) {
+      if (c === "(") d++;
+      else if (c === ")") d--;
+      if (c === "," && d === 0) {
+        parts.push(current);
+        current = "";
+      } else current += c;
+    }
+    parts.push(current);
+    for (const part of parts) {
+      const eq = part.indexOf("=");
+      if (eq === -1) continue;
+      if (!rhsIsLiteral(part.slice(eq + 1))) return true;
+    }
+    return false;
+  }
+  return true; // unknown shape → fail closed
+}
 
 /** Returns a violation message, or undefined if the write is within ceiling. */
 export function checkSqliteWriteCeiling(
@@ -31,10 +105,26 @@ export function checkSqliteWriteCeiling(
   /** The confidentiality atoms carried by a bound value ([] if unlabeled). */
   confidentialityOf: (value: unknown) => readonly unknown[],
 ): string | undefined {
-  if (!tables || params === undefined) return undefined;
+  if (!tables) return undefined;
   // Blank string-literals/comments once; both parsers read the same SQL.
   const blanked = blankWriteSql(sql);
   const table = parseWriteTable(sql, blanked);
+
+  // Paramless writes carry no bound values to attribute, so the per-value ceiling
+  // check below has nothing to inspect. A column-to-column flow (INSERT…SELECT,
+  // UPDATE col = col) would still relabel data past a destination column's
+  // declared label. On a labeled db, fail closed for such shapes (audit S6).
+  if (params === undefined) {
+    if (dbDeclaresAnyLabel(tables) && paramlessRelabelRisk(blanked)) {
+      return (
+        "sqlite: a paramless write moves column data on a labeled database " +
+        "(e.g. INSERT…SELECT or UPDATE col = col); its labels cannot be " +
+        "attributed, so it is refused — use positional ? params with an " +
+        "explicit column list, or literal values"
+      );
+    }
+    return undefined;
+  }
 
   const UNRESOLVED =
     "sqlite: a labeled value is bound in a write whose target column cannot be " +

--- a/packages/runner/src/builtins/sqlite/write-ceiling.ts
+++ b/packages/runner/src/builtins/sqlite/write-ceiling.ts
@@ -39,7 +39,9 @@ function rhsIsLiteral(rhs: string): boolean {
   const t = rhs.replace(/;\s*$/, "").trim();
   return t === "" ||
     /^''$/.test(t) || // blanked string literal
-    /^[-+]?\d+(\.\d+)?$/.test(t) || // numeric literal
+    // numeric literal incl. floats, exponents (1e3), and hex (0x1)
+    /^(?:[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?|0[xX][0-9A-Fa-f]+)$/
+      .test(t) ||
     /^(null|true|false)$/i.test(t) || // keyword literal
     t === "?"; // positional param (handled by the param path)
 }
@@ -56,7 +58,10 @@ function paramlessRelabelRisk(blanked: string): boolean {
   const kw = /^\s*(\w+)/.exec(blanked)?.[1]?.toUpperCase();
   if (kw === "DELETE") return false;
   if (kw === "INSERT" || kw === "REPLACE") {
-    return /\bselect\b/i.test(blanked);
+    // INSERT…SELECT copies column data; an ON CONFLICT … DO UPDATE clause can
+    // also relabel via `SET col = other_col`, so treat any upsert DO UPDATE as
+    // risky (the bound-param parser likewise fails closed on upserts).
+    return /\bselect\b/i.test(blanked) || /\bdo\s+update\b/i.test(blanked);
   }
   if (kw === "UPDATE") {
     const setIdx = blanked.search(/\bset\b/i);
@@ -114,7 +119,8 @@ export function checkSqliteWriteCeiling(
   // check below has nothing to inspect. A column-to-column flow (INSERT…SELECT,
   // UPDATE col = col) would still relabel data past a destination column's
   // declared label. On a labeled db, fail closed for such shapes (audit S6).
-  if (params === undefined) {
+  // An empty bound-param array is the same no-bound-value flow as `undefined`.
+  if (params === undefined || (Array.isArray(params) && params.length === 0)) {
     if (dbDeclaresAnyLabel(tables) && paramlessRelabelRisk(blanked)) {
       return (
         "sqlite: a paramless write moves column data on a labeled database " +

--- a/packages/runner/src/cfc/sink-request.ts
+++ b/packages/runner/src/cfc/sink-request.ts
@@ -107,12 +107,24 @@ export function enqueueSinkRequestPostCommitEffect(
         policyInput,
       );
       if (reason !== undefined) {
-        console.warn("[CFC sink-request]", {
-          ruleId: "sink-request-release",
-          sink,
-          effectId,
-          detail: reason,
-        });
+        // Fail closed: the effect is not sent. Surface the reject to the
+        // transaction (CFC stats + diagnostics) rather than only console.warn,
+        // so a systematically failing release check is observable (audit W3.23).
+        const noteable = committedTx as {
+          noteCfcSinkReleaseReject?: (
+            info: { sink: string; effectId: string; detail: string },
+          ) => void;
+        };
+        if (typeof noteable.noteCfcSinkReleaseReject === "function") {
+          noteable.noteCfcSinkReleaseReject({ sink, effectId, detail: reason });
+        } else {
+          console.warn("[CFC sink-request]", {
+            ruleId: "sink-request-release",
+            sink,
+            effectId,
+            detail: reason,
+          });
+        }
         return;
       }
       await flush(committedTx as IExtendedStorageTransaction);

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -220,6 +220,7 @@ export interface CfcRuntimeStats {
   cfcDigestInvalidations: number;
   cfcOutboxFlushes: number;
   sinkDedupHits: number;
+  sinkReleaseRejects: number;
 }
 
 const initialCfcRuntimeStats = (): CfcRuntimeStats => ({
@@ -229,6 +230,7 @@ const initialCfcRuntimeStats = (): CfcRuntimeStats => ({
   cfcDigestInvalidations: 0,
   cfcOutboxFlushes: 0,
   sinkDedupHits: 0,
+  sinkReleaseRejects: 0,
 });
 
 /**
@@ -589,6 +591,9 @@ export class Runtime {
       },
       onSinkDedupHit: () => {
         this.cfcStats.sinkDedupHits += 1;
+      },
+      onSinkReleaseReject: () => {
+        this.cfcStats.sinkReleaseRejects += 1;
       },
     });
     wrapped.setCfcEnforcementMode(this.cfcEnforcementMode);

--- a/packages/runner/src/storage/extended-storage-transaction.ts
+++ b/packages/runner/src/storage/extended-storage-transaction.ts
@@ -79,6 +79,9 @@ type CfcInstrumentationHooks = {
   onDigestInvalidation?(reason: string): void;
   onOutboxFlush?(effect: PostCommitSideEffect): void;
   onSinkDedupHit?(key: string): void;
+  onSinkReleaseReject?(
+    info: { sink: string; effectId: string; detail: string },
+  ): void;
 };
 
 export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
@@ -119,6 +122,15 @@ export class ExtendedStorageTransaction implements IExtendedStorageTransaction {
     public tx: IStorageTransaction,
     private cfcInstrumentation: CfcInstrumentationHooks = {},
   ) {}
+
+  noteCfcSinkReleaseReject(
+    info: { sink: string; effectId: string; detail: string },
+  ): void {
+    this.cfcState.diagnostics.push(
+      `sink-request release rejected for ${info.sink} (${info.effectId}): ${info.detail}`,
+    );
+    this.cfcInstrumentation.onSinkReleaseReject?.(info);
+  }
 
   getCfcState(): Readonly<CfcTxState> {
     return this.cfcState;
@@ -846,6 +858,12 @@ export class TransactionWrapper implements IExtendedStorageTransaction {
 
   recordCfcWritePolicyInput(input: WritePolicyInput): void {
     this.wrapped.recordCfcWritePolicyInput(input);
+  }
+
+  noteCfcSinkReleaseReject(
+    info: { sink: string; effectId: string; detail: string },
+  ): void {
+    this.wrapped.noteCfcSinkReleaseReject(info);
   }
 
   enqueuePostCommitEffect(effect: PostCommitSideEffect): void {

--- a/packages/runner/src/storage/interface.ts
+++ b/packages/runner/src/storage/interface.ts
@@ -775,6 +775,15 @@ export interface IExtendedStorageTransaction
   recordCfcWritePolicyInput(input: WritePolicyInput): void;
 
   /**
+   * Surfaces a post-commit sink-request release rejection (the effect is fail-
+   * closed and not sent) to CFC diagnostics and runtime stats, instead of only
+   * logging it (audit W3.23).
+   */
+  noteCfcSinkReleaseReject(
+    info: { sink: string; effectId: string; detail: string },
+  ): void;
+
+  /**
    * Enqueues a side effect to run from the CFC outbox after a successful
    * commit. See ownership note above.
    */

--- a/packages/runner/test/cfc-runtime-stats.test.ts
+++ b/packages/runner/test/cfc-runtime-stats.test.ts
@@ -37,6 +37,7 @@ describe("CFC runtime stats", () => {
       cfcDigestInvalidations: 0,
       cfcOutboxFlushes: 0,
       sinkDedupHits: 0,
+      sinkReleaseRejects: 0,
     });
 
     const preparedTx = runtime.edit();
@@ -161,6 +162,7 @@ describe("CFC runtime stats", () => {
       cfcDigestInvalidations: 1,
       cfcOutboxFlushes: 2,
       sinkDedupHits: 1,
+      sinkReleaseRejects: 0,
     });
   });
 });

--- a/packages/runner/test/cfc-sink-release-reject-surfaced.test.ts
+++ b/packages/runner/test/cfc-sink-release-reject-surfaced.test.ts
@@ -1,0 +1,78 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { createFrozenRequestSnapshot } from "../src/cfc/request-snapshot.ts";
+import {
+  createSinkRequestPolicyInput,
+  enqueueSinkRequestPostCommitEffect,
+} from "../src/cfc/sink-request.ts";
+import type { PostCommitSideEffect } from "../src/cfc/types.ts";
+import type { IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+// Regression guard for sink-release reject observability (audit W3.23).
+//
+// A post-commit sink release that fails verification is fail-closed (the effect
+// is skipped), but it was only console.warn'd — invisible to CFC stats and
+// diagnostics. The reject must now be surfaced to the transaction so the runtime
+// can count it. The effect is still not sent.
+describe("CFC sink-release reject surfacing", () => {
+  it("notes a release reject on the transaction and skips the send", async () => {
+    const request = createFrozenRequestSnapshot({
+      url: "https://example.com/release-reject",
+    });
+
+    let captured: PostCommitSideEffect | undefined;
+    const enqueueTx = {
+      enqueuePostCommitEffect: (e: PostCommitSideEffect) => {
+        captured = e;
+      },
+      recordCfcWritePolicyInput: () => {},
+    } as unknown as IExtendedStorageTransaction;
+
+    let flushed = false;
+    enqueueSinkRequestPostCommitEffect(
+      enqueueTx,
+      "fetchData",
+      "fetchData:release-reject",
+      request,
+      "fetchData-start",
+      () => {
+        flushed = true;
+      },
+    );
+    expect(captured).toBeDefined();
+
+    // Commit-time policy input carries a DIFFERENT request than the prepared
+    // snapshot, so release verification fails.
+    const noted: Array<{ sink: string; effectId: string; detail: string }> = [];
+    const mismatchingInputs = [
+      createSinkRequestPolicyInput(
+        "fetchData",
+        "fetchData:release-reject",
+        createFrozenRequestSnapshot({ url: "https://evil.example.com" }),
+      ),
+    ];
+    const committedTx = {
+      getCfcState: () => ({
+        writePolicyInputs: mismatchingInputs,
+        prepare: {
+          status: "prepared",
+          digest: "x",
+          input: { writePolicyInputs: mismatchingInputs },
+        },
+      }),
+      noteCfcSinkReleaseReject: (
+        info: { sink: string; effectId: string; detail: string },
+      ) => {
+        noted.push(info);
+      },
+    } as unknown as IExtendedStorageTransaction;
+
+    await captured!.flush!(committedTx);
+
+    expect(flushed).toBe(false); // fail-closed: send skipped
+    expect(noted.length).toBe(1);
+    expect(noted[0].sink).toBe("fetchData");
+    expect(noted[0].effectId).toBe("fetchData:release-reject");
+    expect(noted[0].detail).toContain("mismatch");
+  });
+});

--- a/packages/runner/test/cfc-sqlite-paramless-relabel.test.ts
+++ b/packages/runner/test/cfc-sqlite-paramless-relabel.test.ts
@@ -1,0 +1,89 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { checkSqliteWriteCeiling } from "../src/builtins/sqlite/write-ceiling.ts";
+
+// Regression guard for paramless intra-db relabeling (audit S6 / W3.19).
+//
+// checkSqliteWriteCeiling skipped entirely when params === undefined, so a
+// paramless column-to-column flow (INSERT…SELECT, UPDATE col = col) on a labeled
+// db copied a labeled column's data into a column whose declared label is weaker
+// — the data re-emerged under the destination column's (weaker) read-label. A
+// labeled db must fail closed on these unverifiable relabeling shapes.
+const labeledTables = {
+  notes: {
+    properties: {
+      secret_col: { ifc: { confidentiality: ["secret"] } },
+      pub: {},
+    },
+  },
+  plain: { properties: { body: {} } },
+} as unknown as Parameters<typeof checkSqliteWriteCeiling>[2];
+
+const unlabeledTables = {
+  plain: { properties: { body: {}, other: {} } },
+} as unknown as Parameters<typeof checkSqliteWriteCeiling>[2];
+
+const noConf = () => [];
+
+describe("CFC sqlite paramless relabeling", () => {
+  it("rejects a paramless INSERT…SELECT on a labeled db", () => {
+    const v = checkSqliteWriteCeiling(
+      "INSERT INTO plain(body) SELECT secret_col FROM notes",
+      undefined,
+      labeledTables,
+      noConf,
+    );
+    expect(v).toBeDefined();
+  });
+
+  it("rejects a paramless UPDATE col = col on a labeled db", () => {
+    const v = checkSqliteWriteCeiling(
+      "UPDATE notes SET pub = secret_col",
+      undefined,
+      labeledTables,
+      noConf,
+    );
+    expect(v).toBeDefined();
+  });
+
+  it("allows a paramless literal-only INSERT on a labeled db", () => {
+    const v = checkSqliteWriteCeiling(
+      "INSERT INTO plain(body) VALUES ('hello')",
+      undefined,
+      labeledTables,
+      noConf,
+    );
+    expect(v).toBeUndefined();
+  });
+
+  it("allows a paramless literal-only UPDATE on a labeled db", () => {
+    const v = checkSqliteWriteCeiling(
+      "UPDATE notes SET pub = 'done'",
+      undefined,
+      labeledTables,
+      noConf,
+    );
+    expect(v).toBeUndefined();
+  });
+
+  it("allows a paramless DELETE on a labeled db", () => {
+    const v = checkSqliteWriteCeiling(
+      "DELETE FROM notes WHERE pub = 'x'",
+      undefined,
+      labeledTables,
+      noConf,
+    );
+    expect(v).toBeUndefined();
+  });
+
+  it("does not affect an unlabeled db (no ceilings/labels)", () => {
+    expect(
+      checkSqliteWriteCeiling(
+        "INSERT INTO plain(body) SELECT other FROM plain",
+        undefined,
+        unlabeledTables,
+        noConf,
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/packages/runner/test/cfc-sqlite-paramless-relabel.test.ts
+++ b/packages/runner/test/cfc-sqlite-paramless-relabel.test.ts
@@ -86,4 +86,38 @@ describe("CFC sqlite paramless relabeling", () => {
       ),
     ).toBeUndefined();
   });
+
+  it("treats an empty bound-param array as a paramless write (F7)", () => {
+    expect(
+      checkSqliteWriteCeiling(
+        "INSERT INTO plain(body) SELECT secret_col FROM notes",
+        [],
+        labeledTables,
+        noConf,
+      ),
+    ).toBeDefined();
+  });
+
+  it("rejects a paramless ON CONFLICT DO UPDATE col = col upsert (F6)", () => {
+    expect(
+      checkSqliteWriteCeiling(
+        "INSERT INTO notes(secret_col) VALUES ('x') " +
+          "ON CONFLICT(secret_col) DO UPDATE SET pub = secret_col",
+        undefined,
+        labeledTables,
+        noConf,
+      ),
+    ).toBeDefined();
+  });
+
+  it("allows paramless literal UPDATEs with exponent/hex numerals (F8)", () => {
+    expect(
+      checkSqliteWriteCeiling(
+        "UPDATE notes SET pub = 1e3, secret_col = 0xFF",
+        undefined,
+        labeledTables,
+        noConf,
+      ),
+    ).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

Wave 3 of the CFC spec-audit remediation (stacked on [#3973](https://github.com/commontoolsinc/labs/pull/3973)). Closes an egress/relabeling fail-open and adds observability for sink-release rejects.

## Fixes

1. **Refuse paramless intra-db relabeling on a labeled db (S6)** — `checkSqliteWriteCeiling` skipped entirely when `params === undefined`, so a paramless column-to-column flow (`INSERT…SELECT`, `UPDATE col = col`) copied a labeled column's data into a column whose declared label is weaker — the data re-emerged under the destination column's (weaker) read-label, laundering its confidentiality. On a labeled db (any column declares confidentiality or `maxConfidentiality`), a paramless write that moves column-derived data into a stored position now fails closed. Literal-only INSERT/UPDATE, DELETE, and every write to an unlabeled db are unaffected (sound over-approximation: any non-literal RHS counts as a column reference).

2. **Surface sink-request release rejects (W3.23)** — a post-commit sink-request release that fails verification is fail-closed (the effect is skipped) but was only `console.warn`'d. It now records a CFC diagnostic, fires an `onSinkReleaseReject` instrumentation hook, and increments a `sinkReleaseRejects` runtime stat. The effect is still not sent.

## Testing

- New unit tests per fix, red-green verified (`checkSqliteWriteCeiling` exploit/allow cases; sink-release reject surfacing + skip).
- Full `packages/runner` unit suite: 570 passed, 0 failed.
- `deno task integration runner` (incl. `sqlite-cfc-label*`): 12 passed, 0 failed.

## Deferred from this wave (flagged for review)

The remaining Wave 3 items are the largest/riskiest in the audit's plan and need design review rather than an autonomous landing:

- **S12 trusted-event hardening** — nonce-unique event ids, consume-on-use (session-scoped single use), verifying provenance against the runtime-serialized envelope rather than candidate-embedded data, and stopping WeakSet trust-mark propagation through handler re-dispatch.
- **Label-aware sink ceiling** — `sink-inventory.ts` currently declares no per-sink ceilings; activating it needs adding ceilings plus request-confidentiality tracing.
- **LLM observation fail-open** — low-exploitability (only rare genuine metadata read errors; `NotFound` is already `undefined`); the swallow sites are shared between display (treats `undefined` as *blocked* = fail-closed) and observation (treats it as *public* = fail-open), so the fix needs cross-package renderer validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)