### PR TITLE
perf(runner): intern cell schemas at the getCell/asSchema seam (round 3)

### DIFF
--- a/docs/development/performance/default-app-note-create.md
+++ b/docs/development/performance/default-app-note-create.md
@@ -286,3 +286,48 @@ Remaining (smaller) hash consumers in the settle phase: `resolveLink` under
 query-proxy reads and `resolveSchema` under `validateAndTransform` — both
 downstream of read-path value materialization (the value-graph identity reuse
 lever), plus the schema-interning-at-getCell seam for caller literals.
+
+## Optimization round 3 (June 2026): schema interning at the cell seam
+
+The "schema-interning-at-getCell" lever from round 2's remaining list.
+Schemas attached to cell links via `runtime.getCell` / `getCellFromLink` /
+`getImmutableCell` and `cell.asSchema` are now interned
+(`internCellLinkSchema` in cell.ts): deep-frozen in place and collapsed to
+one canonical instance per structure, so every identity-keyed schema cache
+(`cfc.schemaAtPath`, schema-ref memos, selector standardization, value-hash)
+keys off the canonical instance from cell creation onward — including
+`key()` subschema derivation, which hits the `schemaAtPath` memo from the
+first access. In-place freezing is the same contract `resolveSchema()`
+already applies to cell schemas on every read/write-policy path; a caller
+sweep found no code mutating a schema after passing it to these APIs.
+
+Two carve-outs surfaced during implementation:
+
+1. **Query-result-proxy schemas must not be frozen in place.** The wish
+   builtin's `schema` argument is read through a query-result proxy;
+   `Object.freeze` forwards through the proxy and freezes the underlying
+   stored value, violating the proxy's object invariants (caught by the
+   pattern-scope wish-scope test as an `ownKeys` invariant TypeError).
+   `internCellLinkSchema` JSON-round-trips proxy-containing schemas first,
+   per the existing convention for proxy-wrapped schemas.
+2. **`TransformObjectCreator.mergeMatches` rebuilt its combined anyOf/allOf
+   cell schema fresh per matched cell** (the round-2 instrumentation
+   technique attributed 100% of intern misses during re-mount to this one
+   site). Each fresh build paid a full content hash at the new `asSchema`
+   seam: interning alone regressed re-mount @32 from ~34ms to ~46ms (+32%).
+   Memoized per frozen compound-schema identity × the match's `asCell`
+   values (module-level, mutable schemas never cached — same shape as the
+   round-2 seam memos), which recovers it fully and makes the output
+   identity-stable.
+
+**Bench effect (interleaved A/B vs the round-2 base): neutral to slightly
+positive.** Note-create @32 pull 24.4→22.7ms, selector subset path
+623→598µs, reconciler mount/re-mount/update all within run noise. The
+steady-state benches reuse stable module-level schema literals that
+`resolveSchema()` already interned in place on first use, so their identity
+caches were warm either way. The seam change is coverage and determinism
+groundwork: canonical link schemas from creation (not from first
+resolveSchema encounter), and structurally-equal-but-distinct schema objects
+(fresh pattern-JSON parses, cross-module duplicate literals, derived
+schemas) collapsing to one instance. Whether it moves the browser
+integration profile still needs a CDP pass.

--- a/docs/development/performance/default-app-note-create.md
+++ b/docs/development/performance/default-app-note-create.md
@@ -329,5 +329,6 @@ caches were warm either way. The seam change is coverage and determinism
 groundwork: canonical link schemas from creation (not from first
 resolveSchema encounter), and structurally-equal-but-distinct schema objects
 (fresh pattern-JSON parses, cross-module duplicate literals, derived
-schemas) collapsing to one instance. Whether it moves the browser
-integration profile still needs a CDP pass.
+schemas) collapsing to one instance. The browser CDP pass confirms
+neutrality: worker busy CPU for notes 2–4 measured 741ms on this branch vs
+742ms on main (post-round-2), test green, per-note wall within noise.

--- a/packages/runner/src/cell.ts
+++ b/packages/runner/src/cell.ts
@@ -13,7 +13,10 @@ import {
 } from "@commonfabric/data-model/fabric-value";
 import { codecOf } from "@commonfabric/data-model/codec-common";
 import { isArrayIndexPropertyName } from "@commonfabric/utils/arrays";
-import { internSchema } from "@commonfabric/data-model/schema-hash";
+import {
+  internSchema,
+  isInternedSchema,
+} from "@commonfabric/data-model/schema-hash";
 import type { MemorySpace } from "@commonfabric/memory/interface";
 import type { SqliteParamsWire } from "@commonfabric/memory/v2";
 import { isCfLinkColumn } from "@commonfabric/memory/sqlite/columns";
@@ -1455,11 +1458,12 @@ export class CellImpl<T extends FabricValue>
     schema?: JSONSchema,
   ): Cell<T>;
   asSchema(schema?: JSONSchema): Cell<any> {
-    // asSchema creates a sibling with same identity but different schema
-    // Create a new link with modified schema
+    // asSchema creates a sibling with same identity but different schema.
+    // Create a new link with the modified schema, interned so downstream
+    // identity-keyed schema caches hit (see `internCellLinkSchema`).
     const siblingLink: NormalizedLink = {
       ...this._link,
-      schema: schema,
+      schema: internCellLinkSchema(schema),
     };
 
     return new CellImpl(
@@ -2795,6 +2799,54 @@ export function schemaCellScope(
   return isRecord(schema) && isCellScope(schema.scope)
     ? schema.scope
     : undefined;
+}
+
+/**
+ * Returns `true` if the value is, or transitively contains, a query-result
+ * proxy. Schemas are plain JSON, so the walk is acyclic; visiting plain
+ * objects is trap-free, and a proxy is detected before recursing into it.
+ */
+function containsCellResult(value: unknown): boolean {
+  if (value === null || typeof value !== "object") return false;
+  if (isCellResultForDereferencing(value)) return true;
+  for (const v of Object.values(value)) {
+    if (containsCellResult(v)) return true;
+  }
+  return false;
+}
+
+/**
+ * Interns a schema for attachment to a cell link, so the link carries the
+ * canonical deep-frozen instance and the downstream identity-keyed schema
+ * caches (cfc.schemaAtPath, schema-ref memos, selector standardization,
+ * value-hash) hit instead of staying cold for mutable schema literals.
+ *
+ * Interning deep-freezes the caller's schema object in place — the same
+ * contract `resolveSchema()` already applies to cell schemas on every
+ * read/write-policy path.
+ *
+ * Exception: schemas read through a query-result proxy (e.g. the wish
+ * builtin's `schema` argument) must NOT be frozen in place — `Object.freeze`
+ * forwards through the proxy and would freeze the underlying stored value,
+ * breaking the proxy's object invariants (and any later `JSON.stringify` of
+ * it). Those are round-tripped to a plain value first, the documented
+ * convention for proxy-wrapped schemas (see `cloneSchemaMutable`'s note in
+ * data-model's schema-utils).
+ */
+export function internCellLinkSchema(schema: JSONSchema): JSONSchema;
+export function internCellLinkSchema(
+  schema?: JSONSchema,
+): JSONSchema | undefined;
+export function internCellLinkSchema(
+  schema?: JSONSchema,
+): JSONSchema | undefined {
+  if (schema === undefined) return undefined;
+  // Already canonical (covers boolean schemas): skip the proxy scan.
+  if (isInternedSchema(schema)) return schema;
+  if (containsCellResult(schema)) {
+    return internSchema(JSON.parse(JSON.stringify(schema)) as JSONSchema);
+  }
+  return internSchema(schema);
 }
 
 /**

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -892,11 +892,15 @@ export class Runtime {
     // Intern the schema so the link carries the canonical deep-frozen
     // instance: all downstream identity-keyed schema caches (schemaAtPath,
     // schema-ref memos, SelectorTracker standardization, value-hash) key off
-    // deep-frozen identity and stay cold for mutable schema literals. Note
-    // that this deep-freezes the caller's schema object in place — see
-    // `internCellLinkSchema` for the contract and the proxy exception.
-    if (schema !== undefined) {
-      link = { ...link, schema: internCellLinkSchema(schema) };
+    // deep-frozen identity and stay cold for mutable schema literals. The
+    // explicit parameter takes precedence; a schema already embedded in the
+    // link (sigil links preserve them through parseLink) is interned too, so
+    // schema-bearing links don't bypass the seam. Note that this deep-freezes
+    // the schema object in place — see `internCellLinkSchema` for the
+    // contract and the proxy exception.
+    const effectiveSchema = schema !== undefined ? schema : link.schema;
+    if (effectiveSchema !== undefined) {
+      link = { ...link, schema: internCellLinkSchema(effectiveSchema) };
     }
     return createCell(
       this,

--- a/packages/runner/src/runtime.ts
+++ b/packages/runner/src/runtime.ts
@@ -40,7 +40,12 @@ import type {
   IStorageProvider,
   MemorySpace,
 } from "./storage/interface.ts";
-import { type Cell, createCell, schemaCellScope } from "./cell.ts";
+import {
+  type Cell,
+  createCell,
+  internCellLinkSchema,
+  schemaCellScope,
+} from "./cell.ts";
 import { createRef, EntityId } from "./create-ref.ts";
 import { createSession, Identity } from "@commonfabric/identity";
 import { Action, Scheduler } from "./scheduler.ts";
@@ -884,7 +889,15 @@ export class Runtime {
         & { cfcLabelView?: CfcLabelView };
       link = cleanLink;
     }
-    if (schema !== undefined) link = { ...link, schema };
+    // Intern the schema so the link carries the canonical deep-frozen
+    // instance: all downstream identity-keyed schema caches (schemaAtPath,
+    // schema-ref memos, SelectorTracker standardization, value-hash) key off
+    // deep-frozen identity and stay cold for mutable schema literals. Note
+    // that this deep-freezes the caller's schema object in place — see
+    // `internCellLinkSchema` for the contract and the proxy exception.
+    if (schema !== undefined) {
+      link = { ...link, schema: internCellLinkSchema(schema) };
+    }
     return createCell(
       this,
       link as NormalizedFullLink,
@@ -925,7 +938,7 @@ export class Runtime {
         space,
         path: [],
         id: asDataURI,
-        schema,
+        schema: internCellLinkSchema(schema),
       },
       tx,
       false,

--- a/packages/runner/src/schema.ts
+++ b/packages/runner/src/schema.ts
@@ -1078,6 +1078,21 @@ export function validateAndTransform(
   return val;
 }
 
+/**
+ * Memo for `TransformObjectCreator.mergeMatches`' combined anyOf/allOf cell
+ * schema, keyed per deep-frozen compound schema identity × the cell match's
+ * (tiny) `asCell` values. `mergeMatches` runs once per matched anyOf cell on
+ * the traverse path and the combined schema is deterministic from these two
+ * inputs; without the memo every call rebuilds the (large) combined schema
+ * and pays a full content hash to intern it onto the cell link. Mutable
+ * compound schemas are never cached (in-place edits must be observed).
+ * Module-level so the memo survives across traverser instances.
+ */
+const combinedCellSchemaCache = new WeakMap<
+  JSONSchemaObj,
+  Map<string, JSONSchema>
+>();
+
 class TransformObjectCreator
   implements IObjectCreator<AnyCellWrapping<FabricValue>> {
   constructor(
@@ -1138,17 +1153,34 @@ class TransformObjectCreator
           // wouldn't have a cell. We will use the asCell used for creating
           // this cell, but change the rest of the schema to be the logical
           // combination schema.
-          const allOfItems = (schema.allOf ?? []).map(removeAsCellFromSchema);
-          const anyOfItems = (schema.anyOf ?? []).map(removeAsCellFromSchema);
           const asCellValues = ContextualFlowControl.getAsCellValues(
             cellMatch.schema,
           );
-          const combinedSchema = {
+          const cacheKey = isDeepFrozen(schema)
+            ? JSON.stringify(asCellValues)
+            : undefined;
+          if (cacheKey !== undefined) {
+            const cached = combinedCellSchemaCache.get(schema)?.get(cacheKey);
+            if (cached !== undefined) return cellMatch.asSchema(cached) as any;
+          }
+          const allOfItems = (schema.allOf ?? []).map(removeAsCellFromSchema);
+          const anyOfItems = (schema.anyOf ?? []).map(removeAsCellFromSchema);
+          // Intern here so the memo holds the canonical instance and the
+          // `asSchema` interning below is an identity cache hit.
+          const combinedSchema = internSchema({
             ...schema,
             ...(allOfItems.length > 0) && { allOf: allOfItems },
             ...(anyOfItems.length > 0) && { anyOf: anyOfItems },
             ...(asCellValues.length > 0) && { asCell: asCellValues },
-          };
+          });
+          if (cacheKey !== undefined) {
+            let byKey = combinedCellSchemaCache.get(schema);
+            if (byKey === undefined) {
+              byKey = new Map();
+              combinedCellSchemaCache.set(schema, byKey);
+            }
+            byKey.set(cacheKey, combinedSchema);
+          }
           return cellMatch.asSchema(combinedSchema) as any;
         }
       }

--- a/packages/runner/test/cell-schema-interning.test.ts
+++ b/packages/runner/test/cell-schema-interning.test.ts
@@ -1,0 +1,102 @@
+// Cell schema interning tests: schemas attached to cell links via
+// runtime.getCell / cell.asSchema / runtime.getImmutableCell are interned —
+// deep-frozen and collapsed to one canonical instance per structure — so the
+// identity-keyed schema caches downstream (cfc.schemaAtPath, schema-ref
+// memos, selector standardization, value-hash) hit instead of staying cold
+// for mutable schema literals.
+
+import { afterEach, beforeEach, describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+
+import { Identity } from "@commonfabric/identity";
+import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
+import { isInternedSchema } from "@commonfabric/data-model/schema-hash";
+import { StorageManager } from "@commonfabric/runner/storage/cache.deno";
+import { JSONSchema } from "../src/builder/types.ts";
+import { Runtime } from "../src/runtime.ts";
+import { type IExtendedStorageTransaction } from "../src/storage/interface.ts";
+
+const signer = await Identity.fromPassphrase("test operator");
+const space = signer.did();
+
+// A fresh mutable copy per call: structurally equal, never the same object.
+const makeSchema = () =>
+  ({
+    type: "object",
+    properties: { title: { type: "string" }, count: { type: "number" } },
+  }) as JSONSchema;
+
+describe("cell link schema interning", () => {
+  let runtime: Runtime;
+  let storageManager: ReturnType<typeof StorageManager.emulate>;
+  let tx: IExtendedStorageTransaction;
+
+  beforeEach(() => {
+    storageManager = StorageManager.emulate({ as: signer });
+    runtime = new Runtime({
+      apiUrl: new URL(import.meta.url),
+      storageManager,
+    });
+    tx = runtime.edit();
+  });
+
+  afterEach(async () => {
+    await tx.commit();
+    await runtime?.dispose();
+    await storageManager?.close();
+  });
+
+  it("getCell interns the schema onto the link", () => {
+    const a = runtime.getCell(space, "intern-a", makeSchema(), tx);
+    const b = runtime.getCell(space, "intern-b", makeSchema(), tx);
+
+    const schemaA = a.getAsNormalizedFullLink().schema;
+    const schemaB = b.getAsNormalizedFullLink().schema;
+    expect(isInternedSchema(schemaA!)).toBe(true);
+    expect(isDeepFrozen(schemaA)).toBe(true);
+    // Structurally-equal literals collapse to one canonical instance.
+    expect(schemaA).toBe(schemaB);
+  });
+
+  it("asSchema interns the schema onto the sibling link", () => {
+    const cell = runtime.getCell(space, "intern-as-schema", undefined, tx);
+    const sibling = cell.asSchema(makeSchema());
+    const viaGetCell = runtime.getCell(space, "intern-c", makeSchema(), tx);
+
+    const schema = sibling.getAsNormalizedFullLink().schema;
+    expect(isInternedSchema(schema!)).toBe(true);
+    // Canonical across the asSchema and getCell seams.
+    expect(schema).toBe(viaGetCell.getAsNormalizedFullLink().schema);
+  });
+
+  it("getImmutableCell interns the schema onto the link", () => {
+    const cell = runtime.getImmutableCell(space, { title: "x" }, makeSchema());
+    expect(isInternedSchema(cell.getAsNormalizedFullLink().schema!)).toBe(true);
+  });
+
+  it("asSchema does not freeze through a query-result proxy schema", () => {
+    // A schema stored as a cell VALUE and read back via .get() is a
+    // query-result proxy. Freezing it in place would freeze the underlying
+    // stored value and violate the proxy's object invariants (this is the
+    // wish builtin's schema-argument shape; see pattern-scope.test.ts "wish
+    // result schema scope overrides query-derived scope").
+    const holder = runtime.getCell<{ schema: unknown }>(
+      space,
+      "intern-proxy-holder",
+      undefined,
+      tx,
+    );
+    holder.set({ schema: makeSchema() });
+    const proxySchema = holder.key("schema").get();
+
+    const target = runtime.getCell(space, "intern-proxy-target", undefined, tx);
+    const sibling = target.asSchema(proxySchema as JSONSchema);
+
+    const linkSchema = sibling.getAsNormalizedFullLink().schema;
+    expect(isInternedSchema(linkSchema!)).toBe(true);
+    expect(linkSchema).not.toBe(proxySchema);
+    // The proxy must remain stringifiable (its target stays extensible).
+    expect(() => JSON.stringify(proxySchema)).not.toThrow();
+    expect(JSON.parse(JSON.stringify(proxySchema))).toEqual(makeSchema());
+  });
+});

--- a/packages/runner/test/cell-schema-interning.test.ts
+++ b/packages/runner/test/cell-schema-interning.test.ts
@@ -69,6 +69,29 @@ describe("cell link schema interning", () => {
     expect(schema).toBe(viaGetCell.getAsNormalizedFullLink().schema);
   });
 
+  it("getCellFromLink interns a schema already embedded in the link", () => {
+    // Sigil/normalized links can carry schemas through parseLink; without an
+    // explicit schema argument the embedded one must be interned too, or
+    // schema-bearing links bypass the seam (review finding on #3982).
+    const base = runtime.getCell(space, "intern-link-embed", undefined, tx);
+    const link = { ...base.getAsNormalizedFullLink(), schema: makeSchema() };
+
+    const cell = runtime.getCellFromLink(link, undefined, tx);
+
+    const schema = cell.getAsNormalizedFullLink().schema;
+    expect(isInternedSchema(schema!)).toBe(true);
+    // Explicit parameter still takes precedence over the embedded schema.
+    const override = { type: "object" } as JSONSchema;
+    const cellWithOverride = runtime.getCellFromLink(
+      { ...base.getAsNormalizedFullLink(), schema: makeSchema() },
+      override,
+      tx,
+    );
+    const overrideSchema = cellWithOverride.getAsNormalizedFullLink().schema;
+    expect(isInternedSchema(overrideSchema!)).toBe(true);
+    expect(overrideSchema).not.toBe(schema);
+  });
+
   it("getImmutableCell interns the schema onto the link", () => {
     const cell = runtime.getImmutableCell(space, { title: "x" }, makeSchema());
     expect(isInternedSchema(cell.getAsNormalizedFullLink().schema!)).toBe(true);


### PR DESCRIPTION
## What

Round 3 of the default-app optimization series (rounds 1–2: [#3965](https://github.com/commontoolsinc/labs/pull/3965), [#3981](https://github.com/commontoolsinc/labs/pull/3981)) — the "intern cell schemas at the seam" lever those rounds documented. Work originated in a spawned follow-up session; taken over, rebased onto main, and browser-validated here.

Schemas attached to cell links via `runtime.getCell` / `getCellFromLink` / `getImmutableCell` and `cell.asSchema` are now interned (`internCellLinkSchema`): deep-frozen and collapsed to one canonical instance per structure, so every identity-keyed schema cache (`cfc.schemaAtPath`, schema-ref memos, selector standardization, value-hash's frozen-object cache) keys off the canonical instance from creation onward. In-place freezing is the same contract `resolveSchema()` already applies on every read; a caller sweep found no post-call schema mutation.

Two carve-outs found during implementation (details in the doc):

1. **Query-result-proxy schemas are JSON-round-tripped, not frozen in place** — `Object.freeze` forwards through the proxy onto the stored value and violates proxy invariants (caught by the pattern-scope wish-scope test).
2. **`TransformObjectCreator.mergeMatches` rebuilt its combined cell schema fresh per matched cell** — interning alone regressed re-mount @32 by +32%; a per-frozen-identity memo recovers it fully and makes the output identity-stable.

## Numbers

Bench effect neutral-to-slightly-positive (note-create @32 pull 24.4→22.7ms; reconciler mount/re-mount/update within noise — the steady-state benches use stable literals that `resolveSchema` already interned on first use). Browser CDP validation on the integration test: worker busy CPU 741ms vs 742ms on main — neutral, as expected for coverage/determinism groundwork: canonical link schemas from creation, and structurally-equal-but-distinct schema objects (fresh pattern-JSON parses, cross-module duplicates, derived schemas) now collapse to one instance.

## Test plan

- [x] new `cell-schema-interning.test.ts` suite
- [x] runner: cell-core/as-cell, schema-anyof, query, selector-tracker, memory-v2 subscription, cfc, traverse, pattern-scope — green
- [x] html suite green; reconciler + macro + selector benches no regression
- [x] default-app integration test green against a stack built from this branch (CPU profiles captured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Interns cell schemas at `runtime.getCell`/`getCellFromLink`/`getImmutableCell`/`cell.asSchema` so links carry a canonical, deep-frozen instance and identity-keyed caches hit consistently. Adds a targeted memo for combined schemas to avoid a re-mount regression; slight perf win with no behavior changes.

- **Refactors**
  - Added `internCellLinkSchema` to deep-freeze and intern schemas; detects query-result proxies and JSON round-trips before interning to preserve proxy invariants.
  - Applied interning in `Runtime.getCell`, `Runtime.getCellFromLink` (including schemas embedded in links), `Runtime.getImmutableCell`, and `Cell.asSchema` so schema identity is stable from creation.
  - Memoized `TransformObjectCreator.mergeMatches` combined anyOf/allOf schema per frozen schema identity × `asCell` values.
  - Added `cell-schema-interning.test.ts`; updated default-app perf doc with round 3 results.
  - Perf: note-create @32 24.4→22.7ms; reconciler mount/re-mount/update neutral.

<sup>Written for commit acff106758c3681c31d80f30b9cf3b9ec3471c7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

