### PR TITLE
Fix multi-user cf test worker after memoryHost storage-option rename (#3947 × #3969 semantic conflict)

### DIFF
--- a/packages/cli/lib/multi-user-test-worker.ts
+++ b/packages/cli/lib/multi-user-test-worker.ts
@@ -131,7 +131,9 @@ const handlers: Record<
     storageManager = StorageManager.open({
       as: session.as,
       spaceIdentity: session.spaceIdentity,
-      address: new URL("/api/storage/memory", args.apiUrl as string),
+      // Host only — the storage path (/api/storage/memory) is joined
+      // internally (see createStorageAddressResolver).
+      memoryHost: new URL(args.apiUrl as string),
     });
     runtime = new Runtime({
       storageManager: storageManager as never,


### PR DESCRIPTION
#3947 (per-space host resolution) renamed `StorageManager.open`'s `address` option (full storage URL) to `memoryHost` (host only; `/api/storage/memory` joined internally) and migrated all callers — but #3969 added a new caller (the multi-user test worker) in parallel, so main broke with `Invalid URL: '/api/storage/memory'` in Pattern Unit Tests (1/5).

One-line fix: pass `memoryHost: new URL(apiUrl)`.

Verified locally: multi-user group-chat test 12/12 via `deno task cf test` **and** via the freshly compiled `cf` binary (the path CI uses); patterns multi-runtime integration suite green. The `Check` failure in the same main run is an unrelated esm.sh 522 fetch flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)