### PR TITLE
perf(runner): optimization round 4 — read-path hashing eliminated, trigger-index/seeding skips, wish send halved

### DIFF
--- a/docs/development/performance/default-app-note-create.md
+++ b/docs/development/performance/default-app-note-create.md
@@ -332,3 +332,51 @@ resolveSchema encounter), and structurally-equal-but-distinct schema objects
 schemas) collapsing to one instance. The browser CDP pass confirms
 neutrality: worker busy CPU for notes 2–4 measured 741ms on this branch vs
 742ms on main (post-round-2), test green, per-note wall within noise.
+
+## Optimization round 4 (June 2026): the remaining candidates, in order
+
+Branch `perf/read-path-identity`. All four remaining candidates from the
+round-2/3 lists, tackled in priority order:
+
+**4a — read-path hashing eliminated.** Post-round-3 profiles showed ONE seam
+holding ~97% of remaining hash time: `resolveCfcSchemaRefs` (the plural
+follow-the-chain resolver; round 1 only memoized the singular) rebuilds a
+fresh `{...resolved, ...rest, $defs}` spread whenever a `$ref` schema carries
+extra keys — every `validateAndTransform` read of a vdom node. Memoized per
+(frozen schemaObj, frozen fullSchema) pair with interned results. Also:
+`selectorPathKey` ran on every `internPathSelector` call (>100ms self time)
+— now cached per frozen path-array identity. Remount loop: 1888 → 1045ms;
+hashing no longer appears in the remount profile's top frames at all.
+
+**4b — trigger-index rebuild skipped on unchanged reads.**
+`replaceActionTriggerPaths` cleared + re-added the per-entity trigger index
+on every action re-run; now it remembers the last-registered (reads,
+shallowReads) per action and returns the existing registration when equal.
+Update loop A/B: ~4%; removes O(read-entities) churn from every steady-state
+settle re-run.
+
+**4c — verified-load-id seeding memoized.** `seedVerifiedLoadIds` re-walked
+the full frozen pattern graph on every by-identity cache hit (every
+map/filter op resolve; ~24% of the commit-callback phase in the original
+profile). Seeded (root, loadId) pairs now skip.
+
+**4d — shared-hashtag wish send halved.** The ~17ms per `#notebook` query
+was `schemaAsCell` JSON-round-tripping the schema through its query-result
+proxy — every property access pays full cell-read machinery — and being
+called TWICE with identical input. Single materialization + content-keyed
+parse/intern cache: **16.9 → 7.8ms avg** in the browser integration. The
+remaining ~8ms is the one unavoidable stringify-through-proxy walk; reading
+the schema slot without proxying (a concrete recursive JSON schema instead
+of `schema: true` in TARGET_SCHEMA, or raw reads with link detection) is the
+documented next step if it matters.
+
+| Gauge | Round 3 / main | Round 4 |
+|---|---|---|
+| Remount loop, 100×(mount+unmount) @32 (in-process) | 1888ms | **1045ms** |
+| Reconciler bench: mount+unmount @128 | 69.3ms | **47.6ms** |
+| Integration: worker busy CPU, notes 2–4 | 742ms | **726ms** (pre-4d) |
+| Integration: `#notebook` wish send | 16.9ms avg | **7.8ms avg** |
+| Macro note-create @128 (pull) | 52.0ms | **49.8ms** |
+
+Observed for a future round: `getCfcState` (~139ms self in the remount loop)
+is now the largest single JS frame after GC.

--- a/packages/data-model/src/schema-utils.ts
+++ b/packages/data-model/src/schema-utils.ts
@@ -355,9 +355,22 @@ const FALSE_SCHEMA_KEY: Record<never, never> = {};
  * component containing the separator cannot collide with a differently-split
  * path.
  */
+// Path-key strings per (frozen) path array identity. internPathSelector
+// computes the key on EVERY call — including idempotent re-interning of an
+// already-canonical selector, the common repeat case — and that string
+// build showed up with >100ms self time in remount profiles. Canonical
+// selectors carry frozen, identity-stable path arrays, so a WeakMap hits.
+const selectorPathKeyCache = new WeakMap<readonly string[], string>();
+
 const selectorPathKey = (path: readonly string[]): string => {
+  if (path.length === 0) return "";
+  const cached = selectorPathKeyCache.get(path);
+  if (cached !== undefined) return cached;
   let key = "";
   for (const part of path) key += `${part.length}:${part}`;
+  if (Object.isFrozen(path)) {
+    selectorPathKeyCache.set(path, key);
+  }
   return key;
 };
 

--- a/packages/runner/src/builtins/wish.ts
+++ b/packages/runner/src/builtins/wish.ts
@@ -1,3 +1,4 @@
+import { LRUCache } from "@commonfabric/utils/cache";
 import {
   type VNode,
   type WishParams,
@@ -1258,20 +1259,36 @@ function createWishCandidatesCell(
   return runtime.getImmutableCell(space, values, undefined, tx);
 }
 
+// asCell-wrapped schemas per serialized content. The stringify itself is one
+// unavoidable walk (through the query-result proxy when the input is one),
+// but parse + intern repeat for the same content on every wish send.
+const schemaAsCellCache = new LRUCache<string, JSONSchema>({ capacity: 256 });
+
 function schemaAsCell(schema: unknown): JSONSchema {
   if (schema && typeof schema === "object") {
-    return {
-      ...(JSON.parse(JSON.stringify(schema)) as Record<string, unknown>),
-      asCell: ["cell"],
-    };
+    const json = JSON.stringify(schema);
+    let result = schemaAsCellCache.get(json);
+    if (result === undefined) {
+      result = internSchema({
+        ...(JSON.parse(json) as Record<string, unknown>),
+        asCell: ["cell"],
+      });
+      schemaAsCellCache.put(json, result);
+    }
+    return result;
   }
   return { asCell: ["cell"] };
 }
 
 function wishStateSchemaForResult(schema: unknown): JSONSchema | undefined {
   if (schema === undefined) return undefined;
+  // schemaAsCell JSON-round-trips its input, and `schema` is typically a
+  // query-result proxy where every property access during stringify pays the
+  // full cell-read machinery (~7ms for a large search schema in profiles).
+  // Materialize once and share the instance for both slots — internSchema
+  // canonicalizes the wrapper, so the duplicate reference is fine.
   const resultSchema = schemaAsCell(schema);
-  const candidateSchema = schemaAsCell(schema);
+  const candidateSchema = resultSchema;
   return internSchema({
     type: "object",
     properties: {

--- a/packages/runner/src/cfc/schema-refs.ts
+++ b/packages/runner/src/cfc/schema-refs.ts
@@ -2,6 +2,7 @@ import type { JSONSchema, JSONSchemaObj } from "@commonfabric/api";
 import { isRecord } from "@commonfabric/utils/types";
 import { getLogger } from "@commonfabric/utils/logger";
 import { isDeepFrozen } from "@commonfabric/data-model/deep-freeze";
+import { internSchema } from "@commonfabric/data-model/schema-hash";
 import { toCompactDebugString } from "@commonfabric/data-model/value-debug";
 import { rendererVDOMSchema, vnodeSchema } from "@commonfabric/runner/schemas";
 import { decodeJsonPointer } from "../link-types.ts";
@@ -197,7 +198,50 @@ const resolveCfcSchemaRefUncached = (
   return schemaCursor as JSONSchema;
 };
 
+// resolveCfcSchemaRefs results per (frozen schemaObj, frozen fullSchema)
+// identity pair. The loop body builds a fresh `{...resolved, ...rest, $defs}`
+// spread whenever a $ref schema carries extra keys (e.g. `{$ref, $defs}` —
+// the rendererVDOMSchema read path), and that fresh object then re-paid a
+// full content hash at downstream interning on every read. A sentinel marks
+// `undefined` results so failed resolutions are memoized too.
+const RESOLVED_UNDEFINED = Symbol("resolved-undefined");
+const resolvedRefsCache = new WeakMap<
+  object,
+  WeakMap<object, JSONSchema | typeof RESOLVED_UNDEFINED>
+>();
+
 export const resolveCfcSchemaRefs = (
+  schemaObj: JSONSchemaObj,
+  fullSchema: JSONSchema = schemaObj,
+): JSONSchema | undefined => {
+  const cacheable = isDeepFrozen(schemaObj) &&
+    (fullSchema === schemaObj ||
+      (isRecord(fullSchema) && isDeepFrozen(fullSchema)));
+  let byFull: WeakMap<object, JSONSchema | typeof RESOLVED_UNDEFINED>;
+  if (cacheable) {
+    const fullKey = fullSchema as object;
+    let existing = resolvedRefsCache.get(schemaObj);
+    if (existing === undefined) {
+      existing = new WeakMap();
+      resolvedRefsCache.set(schemaObj, existing);
+    }
+    byFull = existing;
+    const cached = byFull.get(fullKey);
+    if (cached !== undefined) {
+      return cached === RESOLVED_UNDEFINED ? undefined : cached;
+    }
+    // Intern record results so the cached instance is canonical and frozen —
+    // downstream identity-keyed caches then hit, and sharing it across
+    // callers is safe.
+    const raw = resolveCfcSchemaRefsUncached(schemaObj, fullSchema);
+    const result = raw !== undefined && isRecord(raw) ? internSchema(raw) : raw;
+    byFull.set(fullKey, result === undefined ? RESOLVED_UNDEFINED : result);
+    return result;
+  }
+  return resolveCfcSchemaRefsUncached(schemaObj, fullSchema);
+};
+
+const resolveCfcSchemaRefsUncached = (
   schemaObj: JSONSchemaObj,
   fullSchema: JSONSchema = schemaObj,
 ): JSONSchema | undefined => {

--- a/packages/runner/src/pattern-manager.ts
+++ b/packages/runner/src/pattern-manager.ts
@@ -249,15 +249,29 @@ export class PatternManager {
     return pattern;
   }
 
+  // Roots already fully seeded per verifiedLoadId. The walk is idempotent
+  // and pattern graphs are frozen after load, but it re-ran on every
+  // by-identity cache hit (i.e. every map/filter op resolve), paying a full
+  // Reflect.ownKeys recursion over the pattern graph each time — ~24% of the
+  // commit-callback phase in the default-app profile.
+  #seededVerifiedRoots = new WeakMap<object, Set<string>>();
+
   private seedVerifiedLoadIds(
     value: unknown,
     verifiedLoadId: string,
-    seen = new Map<unknown, boolean>(),
+    seen?: Map<unknown, boolean>,
     trusted = false,
   ): void {
     if (!value || (typeof value !== "object" && typeof value !== "function")) {
       return;
     }
+    const isRoot = seen === undefined;
+    if (
+      isRoot && this.#seededVerifiedRoots.get(value)?.has(verifiedLoadId)
+    ) {
+      return;
+    }
+    seen ??= new Map<unknown, boolean>();
 
     // Trust is rooted at a builder-produced (`isTrustedPattern`) value; nested
     // subpatterns within a trusted pattern's serialized node graph are legit
@@ -299,6 +313,15 @@ export class PatternManager {
         seen,
         subtreeTrusted,
       );
+    }
+
+    if (isRoot) {
+      let ids = this.#seededVerifiedRoots.get(value as object);
+      if (ids === undefined) {
+        ids = new Set();
+        this.#seededVerifiedRoots.set(value as object, ids);
+      }
+      ids.add(verifiedLoadId);
     }
   }
 

--- a/packages/runner/src/scheduler/trigger-index.ts
+++ b/packages/runner/src/scheduler/trigger-index.ts
@@ -369,7 +369,7 @@ const addressesEqual = (
     const x = a[i], y = b[i];
     if (
       x.space !== y.space || x.id !== y.id || x.type !== y.type ||
-      x.path.length !== y.path.length
+      x.scope !== y.scope || x.path.length !== y.path.length
     ) {
       return false;
     }

--- a/packages/runner/src/scheduler/trigger-index.ts
+++ b/packages/runner/src/scheduler/trigger-index.ts
@@ -342,6 +342,44 @@ export function addTriggerPathsToIndex(
   return state.addActionReads(action, reads, shallowReads);
 }
 
+// Last-registered reads per (subscription state, action), so a re-run whose
+// read set is unchanged — the overwhelmingly common case for steady-state
+// sinks and settle re-runs — skips the O(read-entities) clear + re-add of
+// the trigger index. Keyed by the state's `cancels` map (stable identity per
+// scheduler) so actions never cross-contaminate between runtimes.
+const lastTriggerReadsByState = new WeakMap<
+  object,
+  WeakMap<Action, {
+    reads: IMemorySpaceAddress[];
+    shallowReads: IMemorySpaceAddress[];
+    result: {
+      entities: Set<SpaceScopeAndURI>;
+      triggerPathsByEntity: Map<SpaceScopeAndURI, SortedAndCompactPaths>;
+    };
+  }>
+>();
+
+const addressesEqual = (
+  a: readonly IMemorySpaceAddress[],
+  b: readonly IMemorySpaceAddress[],
+): boolean => {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i], y = b[i];
+    if (
+      x.space !== y.space || x.id !== y.id || x.type !== y.type ||
+      x.path.length !== y.path.length
+    ) {
+      return false;
+    }
+    for (let j = 0; j < x.path.length; j++) {
+      if (x.path[j] !== y.path[j]) return false;
+    }
+  }
+  return true;
+};
+
 export function replaceActionTriggerPaths(
   state: TriggerSubscriptionState,
   action: Action,
@@ -351,8 +389,26 @@ export function replaceActionTriggerPaths(
   entities: Set<SpaceScopeAndURI>;
   triggerPathsByEntity: Map<SpaceScopeAndURI, SortedAndCompactPaths>;
 } {
+  let byAction = lastTriggerReadsByState.get(state.cancels);
+  // Only skip while the action is still registered: an unsubscribe runs the
+  // cancel (removing the action from the entity index), so a later
+  // re-subscribe must re-add even with identical reads.
+  const prev = state.cancels.has(action) ? byAction?.get(action) : undefined;
+  if (
+    prev !== undefined &&
+    addressesEqual(prev.reads, reads) &&
+    addressesEqual(prev.shallowReads, shallowReads)
+  ) {
+    return prev.result;
+  }
   clearActionTriggers(state, action);
-  return addTriggerPathsToIndex(state, action, reads, shallowReads);
+  const result = addTriggerPathsToIndex(state, action, reads, shallowReads);
+  if (byAction === undefined) {
+    byAction = new WeakMap();
+    lastTriggerReadsByState.set(state.cancels, byAction);
+  }
+  byAction.set(action, { reads, shallowReads, result });
+  return result;
 }
 
 export function clearActionTriggers(

--- a/packages/runner/test/scheduler-trigger-index.test.ts
+++ b/packages/runner/test/scheduler-trigger-index.test.ts
@@ -50,3 +50,41 @@ describe("SchedulerTriggerIndex", () => {
     expect(triggerIndex.hasRegisteredTriggers()).toBe(true);
   });
 });
+
+describe("replaceActionTriggerPaths unchanged-reads skip", () => {
+  it("re-registers triggers when only the read scope changes", async () => {
+    const { replaceActionTriggerPaths, setCancelForTriggerEntities } =
+      await import("../src/scheduler/trigger-index.ts");
+    const { SchedulerTriggerSubscriptions } = await import(
+      "../src/scheduler/trigger-index.ts"
+    );
+    const triggerIndex = new SchedulerTriggerIndex();
+    const state = new SchedulerTriggerSubscriptions({
+      triggerIndex,
+      cancels: new WeakMap(),
+      getActionId: () => "test-action",
+    });
+    const action: Action = () => {};
+    const base = {
+      space: "did:key:trigger-index-test",
+      id: "of:cell",
+      path: ["value"],
+    } as const;
+    const spaceRead = { ...base, scope: "space" } as IMemorySpaceAddress;
+    const userRead = { ...base, scope: "user" } as IMemorySpaceAddress;
+
+    const first = replaceActionTriggerPaths(state, action, [spaceRead], []);
+    setCancelForTriggerEntities(state, action, first.entities);
+
+    // Same space/id/path, different scope: must NOT be treated as unchanged.
+    const second = replaceActionTriggerPaths(state, action, [userRead], []);
+    setCancelForTriggerEntities(state, action, second.entities);
+
+    expect(triggerIndex.collectReadersForWrite(userRead).has(action)).toBe(
+      true,
+    );
+    expect(triggerIndex.collectReadersForWrite(spaceRead).has(action)).toBe(
+      false,
+    );
+  });
+});


### PR DESCRIPTION
## What

Round 4 of the default-app optimization series ([#3965](https://github.com/commontoolsinc/labs/pull/3965), [#3981](https://github.com/commontoolsinc/labs/pull/3981), [#3982](https://github.com/commontoolsinc/labs/pull/3982)): the four remaining documented candidates, in priority order. Full details in `docs/development/performance/default-app-note-create.md` ("round 4").

1. **Read-path hashing eliminated (4a).** One seam held ~97% of remaining hash time: `resolveCfcSchemaRefs` (plural; round 1 only memoized the singular) rebuilds a fresh `$defs`-grafted spread on every vdom-node read. Memoized per (frozen schemaObj, frozen fullSchema) identity pair, results interned. Plus `selectorPathKey` cached per frozen path-array (it ran on every `internPathSelector` call, >100ms self time).
2. **Trigger-index rebuild skipped on unchanged reads (4b).** `replaceActionTriggerPaths` cleared + re-added the per-entity index on every action re-run; it now remembers the last-registered reads per (state, action) and returns the existing registration when equal. Unsubscribe still forces a full re-add.
3. **Verified-load-id seeding memoized (4c).** `seedVerifiedLoadIds` re-walked the full frozen pattern graph on every by-identity cache hit (every map/filter op resolve). Seeded (root, loadId) pairs skip.
4. **Shared-hashtag wish send halved (4d).** ~17ms per `#notebook` query was `schemaAsCell` JSON-round-tripping the schema through its query-result proxy — twice, with identical input. Single materialization + content-keyed parse/intern cache.

## Numbers

| Gauge | Before (main) | After |
|---|---|---|
| Remount loop, 100×(mount+unmount) @32, in-process | 1888ms | **1045ms** |
| Reconciler bench: mount+unmount @128 | 69.3ms | **47.6ms** |
| Integration: `#notebook` wish send (browser) | 16.9ms avg | **7.8ms avg** |
| Update loop, 300 single-child updates @32 | ~1151ms | ~1108ms |
| Macro note-create @128 (pull) | 52.0ms | 49.8ms |

Hashing no longer appears in the remount profile's top frames at all (was 532ms attributable). Browser-validated against a stack built from this branch (integration test green; worker busy CPU 726ms pre-4d vs 742ms on main).

## Test plan

- [x] runner: scheduler suites (core/effects/events/convergence/ordering/pull-*/observations), cfc + cfc-schema-merge + boundary + ui-contract, selector-tracker, traverse, cell suites, query, pattern-manager/scope/provenance/binding, identity suites (by-identity-handler-exec, cfreg-builder-identity, cfc-*-identity), wish/wish-scope/wish-shared-hashtag, memory-v2 subscription/pull-reactivity — green
- [x] data-model + html suites green
- [x] default-app integration test green on this branch (twice: pre- and post-4d stacks)
- [x] `deno check`/`lint`/`fmt` on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Round 4 of runner performance work: removed read-path hashing hot spots, skipped trigger-index rebuilds on unchanged reads, memoized verified-load-id seeding, and halved shared-hashtag wish send. Results: remount loop 1888ms → 1045ms (-45%); `#notebook` wish send 16.9ms → 7.8ms.

- **Performance**
  - Memoized `resolveCfcSchemaRefs` per (frozen `schemaObj`, `fullSchema`) and interned results; cached `selectorPathKey` per frozen path array.
  - Skipped `replaceActionTriggerPaths` when an action’s `reads`/`shallowReads` are unchanged; equality now includes `scope` to avoid stale registrations.
  - Memoized `seedVerifiedLoadIds` per (pattern root, `loadId`) to avoid repeating full graph walks.
  - Cached `schemaAsCell` by serialized content and reused a single materialization for result/candidate schemas (`LRUCache`), cutting shared-hashtag wish send time roughly in half.

<sup>Written for commit a5befdab64288caa997fa61c3ea8dc4189fdeb93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Perf check note

The failing metrics (pattern-unit test shards) are the same PR-run-vs-main-baseline infra skew documented on #3959/#3965: the identical pattern tests run *faster* on this branch than on main locally (3.55s vs 3.75s for the cfc-render-policy + shopping-list pair, same machine/cache). Overrides for the tripped metrics:

NEW_PERF_BASELINE: job: Package Integration Tests (runner) = 108s
NEW_PERF_BASELINE: test: pattern-unit-1/pattern-unit-tests = 160s
NEW_PERF_BASELINE: test: pattern-unit-4/pattern-unit-tests = 230s
NEW_PERF_BASELINE: step: Build application = 24s
NEW_PERF_BASELINE: job: Build Binaries = 64s

