### PR TITLE
fix(ts-transformers): emit negative numeric schema defaults as unary minus

### DIFF
--- a/packages/ts-transformers/src/transformers/schema-generator.ts
+++ b/packages/ts-transformers/src/transformers/schema-generator.ts
@@ -176,7 +176,7 @@ function createSchemaAst(
   }
   if (schema === null) return factory.createNull();
   if (typeof schema === "string") return factory.createStringLiteral(schema);
-  if (typeof schema === "number") return factory.createNumericLiteral(schema);
+  if (typeof schema === "number") return createNumericAst(schema, factory);
   if (typeof schema === "boolean") {
     return schema ? factory.createTrue() : factory.createFalse();
   }
@@ -201,6 +201,30 @@ function createSchemaAst(
     return factory.createObjectLiteralExpression(properties, true);
   }
   return factory.createIdentifier("undefined");
+}
+
+// The TS factory rejects negative numbers in createNumericLiteral; they must
+// be emitted as a unary minus wrapping a positive literal. Non-finite values
+// have no literal form at all, so emit them as global identifiers.
+function createNumericAst(
+  value: number,
+  factory: ts.NodeFactory,
+): ts.Expression {
+  if (Number.isNaN(value)) return factory.createIdentifier("NaN");
+  if (value === Infinity) return factory.createIdentifier("Infinity");
+  if (value === -Infinity) {
+    return factory.createPrefixUnaryExpression(
+      ts.SyntaxKind.MinusToken,
+      factory.createIdentifier("Infinity"),
+    );
+  }
+  if (value < 0 || Object.is(value, -0)) {
+    return factory.createPrefixUnaryExpression(
+      ts.SyntaxKind.MinusToken,
+      factory.createNumericLiteral(-value),
+    );
+  }
+  return factory.createNumericLiteral(value);
 }
 
 function attachWriteAuthorizedByMarker(

--- a/packages/ts-transformers/test/fixtures/schema-transform/negative-number-default.expected.jsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/negative-number-default.expected.jsx
@@ -1,0 +1,74 @@
+function __cfHardenFn(fn: Function) {
+    Object.freeze(fn);
+    const prototype = fn.prototype;
+    if (prototype && typeof prototype === "object") {
+        Object.freeze(prototype);
+    }
+    return fn;
+}
+import { __cfHelpers } from "commonfabric";
+import { Default, NAME, pattern, toSchema } from "commonfabric";
+import "commonfabric/schema";
+const define = undefined;
+const runtimeDeps = undefined;
+const __cfAmdHooks = undefined;
+interface Input {
+    selectedIndex: number | Default<number, -1>;
+    threshold: number | Default<number, -0.5>;
+}
+const inputSchema = __cfHelpers.__cf_data({
+    type: "object",
+    properties: {
+        selectedIndex: {
+            type: "number",
+            "default": -1
+        },
+        threshold: {
+            type: "number",
+            "default": -0.5
+        }
+    },
+    required: ["selectedIndex", "threshold"]
+} as const satisfies __cfHelpers.JSONSchema);
+// FIXTURE: negative-number-default
+// Verifies: negative numeric defaults are emitted as unary minus expressions
+// (the TS factory rejects negative numbers in createNumericLiteral)
+export default pattern((__cf_pattern_input) => {
+    const selectedIndex = __cf_pattern_input.key("selectedIndex");
+    const threshold = __cf_pattern_input.key("threshold");
+    return ({
+        [NAME]: "Negative defaults",
+        selectedIndex,
+        threshold,
+    });
+}, {
+    type: "object",
+    properties: {
+        selectedIndex: {
+            type: "number",
+            "default": -1
+        },
+        threshold: {
+            type: "number",
+            "default": -0.5
+        }
+    },
+    required: ["selectedIndex", "threshold"]
+} as const satisfies __cfHelpers.JSONSchema, {
+    type: "object",
+    properties: {
+        $NAME: {
+            type: "string"
+        },
+        selectedIndex: {
+            type: "number"
+        },
+        threshold: {
+            type: "number"
+        }
+    },
+    required: ["$NAME", "selectedIndex", "threshold"]
+} as const satisfies __cfHelpers.JSONSchema);
+// @ts-ignore: Internals
+function h(...args: any[]) { return __cfHelpers.h.apply(null, args); }
+__cfHardenFn(h);

--- a/packages/ts-transformers/test/fixtures/schema-transform/negative-number-default.input.tsx
+++ b/packages/ts-transformers/test/fixtures/schema-transform/negative-number-default.input.tsx
@@ -1,0 +1,18 @@
+import { Default, NAME, pattern, toSchema } from "commonfabric";
+import "commonfabric/schema";
+
+interface Input {
+  selectedIndex: number | Default<number, -1>;
+  threshold: number | Default<number, -0.5>;
+}
+
+const inputSchema = toSchema<Input>();
+
+// FIXTURE: negative-number-default
+// Verifies: negative numeric defaults are emitted as unary minus expressions
+// (the TS factory rejects negative numbers in createNumericLiteral)
+export default pattern<Input>(({ selectedIndex, threshold }) => ({
+  [NAME]: "Negative defaults",
+  selectedIndex,
+  threshold,
+}), inputSchema);


### PR DESCRIPTION
## Problem

The CTS schema generator crashed on any pattern input with a negative numeric default, e.g. `selectedIndex: number | Default<number, -1>`:

```
Error: Debug Failure. False expression: Negative numbers should be created in combination with createPrefixUnaryExpression
    at Object.createNumericLiteral (typescript.js:25546)
    at createSchemaAst (packages/ts-transformers/src/transformers/schema-generator.ts:179)
```

`createSchemaAst` passed schema numbers straight to `ts.factory.createNumericLiteral`, which asserts on negative values — the TS factory requires negatives to be emitted as a unary minus wrapping a positive literal.

## Fix

Route numbers through a `createNumericAst` helper:
- negative values (incl. `-0`) → `createPrefixUnaryExpression(MinusToken, createNumericLiteral(-value))`
- `NaN` / `Infinity` / `-Infinity` (no literal form at all) → global identifiers

The other `createNumericLiteral` call sites in the package (destructuring-lowering, dataflow, reactive-keys) pass `.text` from existing numeric literal nodes, whose source text never includes the minus sign (it's a separate unary token), so they are not affected.

## Test

Regression fixture `negative-number-default` in `test/fixtures/schema-transform/` covering `Default<number, -1>` and fractional `-0.5`. Verified red→green: the fixture fails with the original Debug Failure assertion without the fix, and the full ts-transformers suite (292 tests) passes with it. Also verified the original repro pattern passes `deno task cf check --no-run`, with `--show-transformed` showing `"default": -1` in the emitted schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in `ts-transformers` schema generation when a pattern uses a negative numeric default. Negative numbers now emit with a unary minus; `NaN`/`±Infinity` are handled safely.

- **Bug Fixes**
  - Route numeric schema values through a helper to emit negatives (incl. `-0`) as `PrefixUnary(Minus, NumericLiteral)`.
  - Map `NaN` and `±Infinity` to global identifiers; added `negative-number-default` regression fixture.

<sup>Written for commit 2f02697cb1b345012fefe2f7319d16af9eeae83c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

