### PR TITLE
feat(memory): space ACL on the v2 server — sessions need owner/member/ACL grants (S1/A1)

### DIFF
--- a/packages/memory/acl.ts
+++ b/packages/memory/acl.ts
@@ -67,7 +67,7 @@ const CapabilityMap: Record<Capability, number> = {
   OWNER: 2,
 };
 
-function isCapable(
+export function isCapable(
   capability: Capability,
   requirement: Capability,
 ): boolean {

--- a/packages/memory/test/v2-server-acl-test.ts
+++ b/packages/memory/test/v2-server-acl-test.ts
@@ -466,7 +466,9 @@ Deno.test("acl enforce: owner removing their own access still gets the commit re
       "writer must not be revoked before its own response",
     );
 
-    // The next message from Alice's now-unauthorized session is denied.
+    // The writer's session was still dropped from the registry (so it receives
+    // no further pushes without READ): its next message fails closed as an
+    // unknown session.
     const after = await transactSet(
       alice,
       space,
@@ -475,7 +477,7 @@ Deno.test("acl enforce: owner removing their own access still gets the commit re
       { n: 1 },
       2,
     );
-    assertEquals(after.error?.name, "AuthorizationError");
+    assertEquals(after.error?.name, "SessionError");
   } finally {
     await server.close();
   }

--- a/packages/memory/test/v2-server-acl-test.ts
+++ b/packages/memory/test/v2-server-acl-test.ts
@@ -432,6 +432,55 @@ Deno.test("acl enforce: revoking a grant takes effect for subsequent messages", 
   }
 });
 
+Deno.test("acl enforce: owner removing their own access still gets the commit response", async () => {
+  // The writing session must receive its transact response before any
+  // revocation — otherwise the client treats session/revoked as terminal and
+  // reports the successful self-removal as a failure. The access change still
+  // takes effect on the owner's next message.
+  const server = createAclServer("memory://acl-enforce-self-remove", {
+    mode: "enforce",
+  });
+  const space = "did:key:z6Mk-acl-space-self";
+  const alice = await connect(server);
+  try {
+    const aliceSession = await openSession(alice, space, ALICE);
+    assertExists(aliceSession.ok);
+
+    // Alice rewrites the ACL to drop herself entirely (someone else owns now).
+    const selfRemove = await transactSet(
+      alice,
+      space,
+      aliceSession.ok.sessionId,
+      `of:${space}`,
+      { [BOB]: "OWNER" },
+      1,
+    );
+    assertExists(
+      selfRemove.ok,
+      "self-removal commit must succeed and report ok, not a revocation",
+    );
+    // No session/revoked was pushed to the writing connection for its own tx.
+    assertEquals(
+      alice.messages.length,
+      0,
+      "writer must not be revoked before its own response",
+    );
+
+    // The next message from Alice's now-unauthorized session is denied.
+    const after = await transactSet(
+      alice,
+      space,
+      aliceSession.ok.sessionId,
+      "of:doc:after",
+      { n: 1 },
+      2,
+    );
+    assertEquals(after.error?.name, "AuthorizationError");
+  } finally {
+    await server.close();
+  }
+});
+
 Deno.test("acl observe: stranger is allowed but the would-deny is counted", async () => {
   const server = createAclServer("memory://acl-observe", { mode: "observe" });
   const space = "did:key:z6Mk-acl-space-8";

--- a/packages/memory/test/v2-server-acl-test.ts
+++ b/packages/memory/test/v2-server-acl-test.ts
@@ -135,7 +135,12 @@ Deno.test("acl enforce: creator is seeded as OWNER and a stranger is denied", as
     assertExists(opened.ok, "creator open should succeed");
 
     // The seed is a real commit: the ACL doc is readable and names the creator.
-    const acl = await graphQuery(alice, space, opened.ok.sessionId, `of:${space}`);
+    const acl = await graphQuery(
+      alice,
+      space,
+      opened.ok.sessionId,
+      `of:${space}`,
+    );
     assertExists(acl.ok);
     const aclDoc = JSON.stringify(acl.ok);
     assert(
@@ -465,7 +470,12 @@ Deno.test("acl observe: creator seeding still happens (migration path)", async (
   try {
     const opened = await openSession(alice, space, ALICE);
     assertExists(opened.ok);
-    const acl = await graphQuery(alice, space, opened.ok.sessionId, `of:${space}`);
+    const acl = await graphQuery(
+      alice,
+      space,
+      opened.ok.sessionId,
+      `of:${space}`,
+    );
     const aclDoc = JSON.stringify(acl.ok ?? {});
     assert(
       aclDoc.includes(ALICE) && aclDoc.includes("OWNER"),

--- a/packages/memory/test/v2-server-acl-test.ts
+++ b/packages/memory/test/v2-server-acl-test.ts
@@ -385,7 +385,8 @@ Deno.test("acl enforce: revoking a grant takes effect for subsequent messages", 
     );
     assertExists(first.ok, "grant should allow Bob's first write");
 
-    // Owner revokes Bob.
+    // Owner revokes Bob. Bob's live session is torn down (gating alone
+    // would still let his existing subscriptions receive pushes).
     const revoke = await transactSet(
       alice,
       space,
@@ -395,6 +396,14 @@ Deno.test("acl enforce: revoking a grant takes effect for subsequent messages", 
       2,
     );
     assertExists(revoke.ok);
+
+    const revoked = shiftMessage(bob.messages);
+    assertEquals(revoked, {
+      type: "session/revoked",
+      space,
+      sessionId: bobSession.ok.sessionId,
+      reason: "unauthorized",
+    });
 
     const second = await transactSet(
       bob,
@@ -406,9 +415,13 @@ Deno.test("acl enforce: revoking a grant takes effect for subsequent messages", 
     );
     assertEquals(
       second.error?.name,
-      "AuthorizationError",
-      "revocation must invalidate the cached capability",
+      "SessionError",
+      "the revoked session must be gone",
     );
+
+    // And Bob cannot just open a new one.
+    const reopen = await openSession(bob, space, BOB);
+    assertEquals(reopen.error?.name, "AuthorizationError");
   } finally {
     await server.close();
   }

--- a/packages/memory/test/v2-server-acl-test.ts
+++ b/packages/memory/test/v2-server-acl-test.ts
@@ -1,0 +1,503 @@
+import { assert, assertEquals, assertExists } from "@std/assert";
+import { Server } from "../v2/server.ts";
+import {
+  encodeMemoryBoundary,
+  getMemoryProtocolFlags,
+  type GraphQueryResult,
+  MEMORY_PROTOCOL,
+  type ResponseMessage,
+  type ServerMessage,
+} from "../v2.ts";
+
+const HELLO_FLAGS = getMemoryProtocolFlags();
+const HELLO = {
+  type: "hello",
+  protocol: MEMORY_PROTOCOL,
+  flags: HELLO_FLAGS,
+} as const;
+
+const ALICE = "did:key:z6Mk-acl-alice";
+const BOB = "did:key:z6Mk-acl-bob";
+const CAROL = "did:key:z6Mk-acl-carol";
+const SERVICE = "did:key:z6Mk-acl-service";
+
+const shiftMessage = (messages: ServerMessage[]): ServerMessage => {
+  const message = messages.shift();
+  assertExists(message, "expected a server message");
+  return message;
+};
+
+const assertResponse = <Result>(
+  message: ServerMessage,
+): ResponseMessage<Result> => {
+  assertEquals(message.type, "response");
+  return message as ResponseMessage<Result>;
+};
+
+/** Server whose session principal is taken (untested-crypto, test-only) from
+ *  `invocation.iss`, mirroring the toolshed hook's result. */
+const createAclServer = (
+  store: string,
+  acl?: {
+    mode: "off" | "observe" | "enforce";
+    serviceDids?: readonly string[];
+  },
+) =>
+  new Server({
+    store: new URL(store),
+    subscriptionRefreshDelayMs: 0,
+    authorizeSessionOpen: (message) => {
+      const iss = message.invocation?.iss;
+      return typeof iss === "string" ? iss : undefined;
+    },
+    acl,
+  });
+
+type Harness = {
+  messages: ServerMessage[];
+  connection: ReturnType<Server["connect"]>;
+};
+
+const connect = async (server: Server): Promise<Harness> => {
+  const messages: ServerMessage[] = [];
+  const connection = server.connect((message) => messages.push(message));
+  await connection.receive(encodeMemoryBoundary(HELLO));
+  shiftMessage(messages); // hello.ok
+  return { messages, connection };
+};
+
+let requestCounter = 0;
+const nextRequestId = (label: string): string => `${label}-${++requestCounter}`;
+
+const openSession = async (
+  { connection, messages }: Harness,
+  space: string,
+  principal?: string,
+): Promise<ResponseMessage<{ sessionId: string; serverSeq: number }>> => {
+  await connection.receive(encodeMemoryBoundary({
+    type: "session.open",
+    requestId: nextRequestId("open"),
+    space,
+    session: {},
+    ...(principal === undefined ? {} : { invocation: { iss: principal } }),
+  }));
+  return assertResponse<{ sessionId: string; serverSeq: number }>(
+    shiftMessage(messages),
+  );
+};
+
+const transactSet = async (
+  { connection, messages }: Harness,
+  space: string,
+  sessionId: string,
+  id: string,
+  value: unknown,
+  localSeq: number,
+): Promise<ResponseMessage<{ seq: number }>> => {
+  await connection.receive(encodeMemoryBoundary({
+    type: "transact",
+    requestId: nextRequestId("tx"),
+    space,
+    sessionId,
+    commit: {
+      localSeq,
+      reads: { confirmed: [], pending: [] },
+      operations: [{ op: "set", id, value: { value } }],
+    },
+  }));
+  return assertResponse<{ seq: number }>(shiftMessage(messages));
+};
+
+const graphQuery = async (
+  { connection, messages }: Harness,
+  space: string,
+  sessionId: string,
+  id: string,
+): Promise<ResponseMessage<GraphQueryResult>> => {
+  await connection.receive(encodeMemoryBoundary({
+    type: "graph.query",
+    requestId: nextRequestId("query"),
+    space,
+    sessionId,
+    query: { roots: [{ id, selector: { path: [], schema: false } }] },
+  }));
+  return assertResponse<GraphQueryResult>(shiftMessage(messages));
+};
+
+Deno.test("acl enforce: creator is seeded as OWNER and a stranger is denied", async () => {
+  const server = createAclServer("memory://acl-enforce-stranger", {
+    mode: "enforce",
+  });
+  const space = "did:key:z6Mk-acl-space-1";
+  const alice = await connect(server);
+  try {
+    const opened = await openSession(alice, space, ALICE);
+    assertExists(opened.ok, "creator open should succeed");
+
+    // The seed is a real commit: the ACL doc is readable and names the creator.
+    const acl = await graphQuery(alice, space, opened.ok.sessionId, `of:${space}`);
+    assertExists(acl.ok);
+    const aclDoc = JSON.stringify(acl.ok);
+    assert(
+      aclDoc.includes(ALICE) && aclDoc.includes("OWNER"),
+      `seeded ACL doc should grant creator OWNER, got: ${aclDoc}`,
+    );
+
+    // Creator can write.
+    const write = await transactSet(
+      alice,
+      space,
+      opened.ok.sessionId,
+      "of:doc:1",
+      { hello: "world" },
+      1,
+    );
+    assertExists(write.ok, "creator write should succeed");
+
+    // A stranger cannot even open a session.
+    const bob = await connect(server);
+    const denied = await openSession(bob, space, BOB);
+    assertEquals(denied.error?.name, "AuthorizationError");
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("acl enforce: WRITE grant allows transact but not ACL-doc writes", async () => {
+  const server = createAclServer("memory://acl-enforce-write-grant", {
+    mode: "enforce",
+  });
+  const space = "did:key:z6Mk-acl-space-2";
+  const alice = await connect(server);
+  const bob = await connect(server);
+  try {
+    const aliceSession = await openSession(alice, space, ALICE);
+    assertExists(aliceSession.ok);
+
+    // Owner grants Bob WRITE (owner may write the ACL doc).
+    const grant = await transactSet(
+      alice,
+      space,
+      aliceSession.ok.sessionId,
+      `of:${space}`,
+      { [ALICE]: "OWNER", [BOB]: "WRITE" },
+      1,
+    );
+    assertExists(grant.ok, "owner should be able to write the ACL doc");
+
+    const bobSession = await openSession(bob, space, BOB);
+    assertExists(bobSession.ok, "WRITE grant should allow session open");
+
+    const write = await transactSet(
+      bob,
+      space,
+      bobSession.ok.sessionId,
+      "of:doc:bob",
+      { from: "bob" },
+      1,
+    );
+    assertExists(write.ok, "WRITE grant should allow transact");
+
+    // ...but Bob cannot self-promote: ACL-doc writes need OWNER.
+    const escalate = await transactSet(
+      bob,
+      space,
+      bobSession.ok.sessionId,
+      `of:${space}`,
+      { [BOB]: "OWNER" },
+      2,
+    );
+    assertEquals(escalate.error?.name, "AuthorizationError");
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("acl enforce: READ grant allows queries but not writes", async () => {
+  const server = createAclServer("memory://acl-enforce-read-grant", {
+    mode: "enforce",
+  });
+  const space = "did:key:z6Mk-acl-space-3";
+  const alice = await connect(server);
+  const carol = await connect(server);
+  try {
+    const aliceSession = await openSession(alice, space, ALICE);
+    assertExists(aliceSession.ok);
+    await transactSet(
+      alice,
+      space,
+      aliceSession.ok.sessionId,
+      `of:${space}`,
+      { [ALICE]: "OWNER", [CAROL]: "READ" },
+      1,
+    );
+    await transactSet(
+      alice,
+      space,
+      aliceSession.ok.sessionId,
+      "of:doc:shared",
+      { shared: true },
+      2,
+    );
+
+    const carolSession = await openSession(carol, space, CAROL);
+    assertExists(carolSession.ok, "READ grant should allow session open");
+
+    const query = await graphQuery(
+      carol,
+      space,
+      carolSession.ok.sessionId,
+      "of:doc:shared",
+    );
+    assertExists(query.ok, "READ grant should allow graph queries");
+
+    const write = await transactSet(
+      carol,
+      space,
+      carolSession.ok.sessionId,
+      "of:doc:carol",
+      { from: "carol" },
+      1,
+    );
+    assertEquals(write.error?.name, "AuthorizationError");
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("acl enforce: '*' READ opens the space to any principal read-only", async () => {
+  const server = createAclServer("memory://acl-enforce-anyone", {
+    mode: "enforce",
+  });
+  const space = "did:key:z6Mk-acl-space-4";
+  const alice = await connect(server);
+  const bob = await connect(server);
+  try {
+    const aliceSession = await openSession(alice, space, ALICE);
+    assertExists(aliceSession.ok);
+    await transactSet(
+      alice,
+      space,
+      aliceSession.ok.sessionId,
+      `of:${space}`,
+      { [ALICE]: "OWNER", "*": "READ" },
+      1,
+    );
+
+    const bobSession = await openSession(bob, space, BOB);
+    assertExists(bobSession.ok, "'*' READ should allow any principal to open");
+    const write = await transactSet(
+      bob,
+      space,
+      bobSession.ok.sessionId,
+      "of:doc:bob",
+      { from: "bob" },
+      1,
+    );
+    assertEquals(write.error?.name, "AuthorizationError");
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("acl enforce: service DIDs have implicit OWNER and do not claim spaces", async () => {
+  const server = createAclServer("memory://acl-enforce-service", {
+    mode: "enforce",
+    serviceDids: [SERVICE],
+  });
+  const space = "did:key:z6Mk-acl-space-5";
+  const service = await connect(server);
+  const alice = await connect(server);
+  try {
+    // Service touches (and effectively creates) the space first...
+    const serviceSession = await openSession(service, space, SERVICE);
+    assertExists(serviceSession.ok, "service DID should open any space");
+    const write = await transactSet(
+      service,
+      space,
+      serviceSession.ok.sessionId,
+      "of:doc:svc",
+      { from: "service" },
+      1,
+    );
+    assertExists(write.ok, "service DID should write any space");
+
+    // ...but must NOT have claimed ownership: the space now has data and no
+    // ACL doc, so a later regular principal is denied (not silently second).
+    const denied = await openSession(alice, space, ALICE);
+    assertEquals(denied.error?.name, "AuthorizationError");
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("acl enforce: principal equal to the space DID has implicit OWNER", async () => {
+  const server = createAclServer("memory://acl-enforce-space-key", {
+    mode: "enforce",
+  });
+  const space = "did:key:z6Mk-acl-space-6";
+  const holder = await connect(server);
+  try {
+    const session = await openSession(holder, space, space);
+    assertExists(session.ok, "space-key principal should open its own space");
+    const write = await transactSet(
+      holder,
+      space,
+      session.ok.sessionId,
+      "of:doc:self",
+      { self: true },
+      1,
+    );
+    assertExists(write.ok);
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("acl enforce: revoking a grant takes effect for subsequent messages", async () => {
+  const server = createAclServer("memory://acl-enforce-revoke", {
+    mode: "enforce",
+  });
+  const space = "did:key:z6Mk-acl-space-7";
+  const alice = await connect(server);
+  const bob = await connect(server);
+  try {
+    const aliceSession = await openSession(alice, space, ALICE);
+    assertExists(aliceSession.ok);
+    await transactSet(
+      alice,
+      space,
+      aliceSession.ok.sessionId,
+      `of:${space}`,
+      { [ALICE]: "OWNER", [BOB]: "WRITE" },
+      1,
+    );
+
+    const bobSession = await openSession(bob, space, BOB);
+    assertExists(bobSession.ok);
+    const first = await transactSet(
+      bob,
+      space,
+      bobSession.ok.sessionId,
+      "of:doc:bob",
+      { n: 1 },
+      1,
+    );
+    assertExists(first.ok, "grant should allow Bob's first write");
+
+    // Owner revokes Bob.
+    const revoke = await transactSet(
+      alice,
+      space,
+      aliceSession.ok.sessionId,
+      `of:${space}`,
+      { [ALICE]: "OWNER" },
+      2,
+    );
+    assertExists(revoke.ok);
+
+    const second = await transactSet(
+      bob,
+      space,
+      bobSession.ok.sessionId,
+      "of:doc:bob",
+      { n: 2 },
+      2,
+    );
+    assertEquals(
+      second.error?.name,
+      "AuthorizationError",
+      "revocation must invalidate the cached capability",
+    );
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("acl observe: stranger is allowed but the would-deny is counted", async () => {
+  const server = createAclServer("memory://acl-observe", { mode: "observe" });
+  const space = "did:key:z6Mk-acl-space-8";
+  const alice = await connect(server);
+  const bob = await connect(server);
+  try {
+    const aliceSession = await openSession(alice, space, ALICE);
+    assertExists(aliceSession.ok);
+
+    const bobSession = await openSession(bob, space, BOB);
+    assertExists(bobSession.ok, "observe mode must not deny");
+    const write = await transactSet(
+      bob,
+      space,
+      bobSession.ok.sessionId,
+      "of:doc:bob",
+      { from: "bob" },
+      1,
+    );
+    assertExists(write.ok, "observe mode must not deny writes");
+    assert(
+      server.aclStats.wouldDeny > 0,
+      "observe mode should count would-denies",
+    );
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("acl observe: creator seeding still happens (migration path)", async () => {
+  const server = createAclServer("memory://acl-observe-seed", {
+    mode: "observe",
+  });
+  const space = "did:key:z6Mk-acl-space-9";
+  const alice = await connect(server);
+  try {
+    const opened = await openSession(alice, space, ALICE);
+    assertExists(opened.ok);
+    const acl = await graphQuery(alice, space, opened.ok.sessionId, `of:${space}`);
+    const aclDoc = JSON.stringify(acl.ok ?? {});
+    assert(
+      aclDoc.includes(ALICE) && aclDoc.includes("OWNER"),
+      `observe mode should seed creator OWNER, got: ${aclDoc}`,
+    );
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("acl off: no seeding, no gating", async () => {
+  const server = createAclServer("memory://acl-off", { mode: "off" });
+  const space = "did:key:z6Mk-acl-space-10";
+  const alice = await connect(server);
+  const bob = await connect(server);
+  try {
+    const opened = await openSession(alice, space, ALICE);
+    assertExists(opened.ok);
+    assertEquals(opened.ok.serverSeq, 0, "off mode must not seed a commit");
+
+    const bobSession = await openSession(bob, space, BOB);
+    assertExists(bobSession.ok);
+    const write = await transactSet(
+      bob,
+      space,
+      bobSession.ok.sessionId,
+      "of:doc:bob",
+      { from: "bob" },
+      1,
+    );
+    assertExists(write.ok);
+  } finally {
+    await server.close();
+  }
+});
+
+Deno.test("acl default: absent acl option behaves like off", async () => {
+  const server = createAclServer("memory://acl-default");
+  const space = "did:key:z6Mk-acl-space-11";
+  const bob = await connect(server);
+  try {
+    const opened = await openSession(bob, space, BOB);
+    assertExists(opened.ok);
+    assertEquals(opened.ok.serverSeq, 0);
+  } finally {
+    await server.close();
+  }
+});

--- a/packages/memory/v2.ts
+++ b/packages/memory/v2.ts
@@ -463,7 +463,7 @@ export interface SessionRevokedMessage {
   type: "session/revoked";
   space: string;
   sessionId: SessionId;
-  reason: "taken-over";
+  reason: "taken-over" | "unauthorized";
 }
 
 export interface V2Error {

--- a/packages/memory/v2/client.ts
+++ b/packages/memory/v2/client.ts
@@ -1186,11 +1186,17 @@ const isSessionEffect = (
 const isSessionRevoked = (
   message: unknown,
 ): message is SessionRevokedMessage => {
-  return typeof message === "object" && message !== null &&
-    (message as { type?: string }).type === "session/revoked" &&
-    typeof (message as { space?: string }).space === "string" &&
-    typeof (message as { sessionId?: string }).sessionId === "string" &&
-    (message as { reason?: string }).reason === "taken-over";
+  if (typeof message !== "object" || message === null) return false;
+  const { type, space, sessionId, reason } = message as {
+    type?: string;
+    space?: string;
+    sessionId?: string;
+    reason?: string;
+  };
+  return type === "session/revoked" &&
+    typeof space === "string" &&
+    typeof sessionId === "string" &&
+    (reason === "taken-over" || reason === "unauthorized");
 };
 
 const isResponse = (message: unknown): message is ResponseMessage<unknown> => {

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -769,20 +769,32 @@ export class Server {
    *  let their already-registered subscriptions receive pushes. The owning
    *  connection gets a session/revoked("unauthorized"), which the client
    *  treats as a terminal session close (no reopen loop — a reopen attempt
-   *  is denied at session.open). `skipSessionId` excludes the session that
-   *  made the triggering ACL write, so it gets that transact's response
-   *  before any revocation (a self-removal otherwise reads as a failure). */
+   *  is denied at session.open). The session that made the triggering ACL
+   *  write (`writerSessionId`) is still dropped from the registry — so it
+   *  receives no further pushes — but is NOT sent the terminal revocation, so
+   *  it gets this transact's response first (a self-removal otherwise reads as
+   *  a failure). Its next message fails closed as an unknown session. */
   #revokeDeauthorizedSessions(
     engine: Engine.Engine,
     space: string,
-    skipSessionId?: string,
+    writerSessionId?: string,
   ): void {
     if (this.#aclMode() !== "enforce") return;
     for (const session of this.#sessions.sessionsForSpace(space)) {
-      if (session.id === skipSessionId) continue;
       const capability = this.#capabilityFor(engine, space, session.principal);
       if (capability !== null && isCapable(capability, "READ")) continue;
+      // Drop the de-authorized session from the registry: the refresh loop
+      // iterates registered sessions, so removal stops all further watch
+      // pushes, and its next message fails closed (Unknown session).
       this.#sessions.remove(space, session.id);
+      if (session.id === writerSessionId) {
+        // The writer's own session — it just removed its own access. Removal
+        // already stopped its pushes and denies its next message; do NOT also
+        // send the terminal session/revoked, which the client treats as
+        // terminal and would turn this transact's successful self-removal into
+        // a reported failure.
+        continue;
+      }
       if (session.ownerConnectionId !== null) {
         this.#connections.get(session.ownerConnectionId)?.revokeSession(
           space,
@@ -1496,10 +1508,10 @@ export class Server {
       }
       if (aclTouched) {
         this.#invalidateAclCapabilities(message.space);
-        // Skip the writing session: it must receive this transact's response
-        // first (the client treats session/revoked as terminal and would
-        // report a successful self-removal as a failure). If the owner removed
-        // their own access, the per-message gate denies their next message.
+        // Pass the writing session so it isn't sent the terminal revocation
+        // before its own transact response (the client treats session/revoked
+        // as terminal). It's still dropped from the registry, so a
+        // self-deauthorized writer receives no further pushes.
         this.#revokeDeauthorizedSessions(
           engine,
           message.space,

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -769,10 +769,17 @@ export class Server {
    *  let their already-registered subscriptions receive pushes. The owning
    *  connection gets a session/revoked("unauthorized"), which the client
    *  treats as a terminal session close (no reopen loop — a reopen attempt
-   *  is denied at session.open). */
-  #revokeDeauthorizedSessions(engine: Engine.Engine, space: string): void {
+   *  is denied at session.open). `skipSessionId` excludes the session that
+   *  made the triggering ACL write, so it gets that transact's response
+   *  before any revocation (a self-removal otherwise reads as a failure). */
+  #revokeDeauthorizedSessions(
+    engine: Engine.Engine,
+    space: string,
+    skipSessionId?: string,
+  ): void {
     if (this.#aclMode() !== "enforce") return;
     for (const session of this.#sessions.sessionsForSpace(space)) {
+      if (session.id === skipSessionId) continue;
       const capability = this.#capabilityFor(engine, space, session.principal);
       if (capability !== null && isCapable(capability, "READ")) continue;
       this.#sessions.remove(space, session.id);
@@ -1489,7 +1496,15 @@ export class Server {
       }
       if (aclTouched) {
         this.#invalidateAclCapabilities(message.space);
-        this.#revokeDeauthorizedSessions(engine, message.space);
+        // Skip the writing session: it must receive this transact's response
+        // first (the client treats session/revoked as terminal and would
+        // report a successful self-removal as a failure). If the owner removed
+        // their own access, the per-message gate denies their next message.
+        this.#revokeDeauthorizedSessions(
+          engine,
+          message.space,
+          message.sessionId,
+        );
       }
       await this.runPostCommitSchedulerSideEffects(
         message.space,

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -43,12 +43,7 @@ import {
   type WireMemoryProtocolFlags,
 } from "../v2.ts";
 import * as Engine from "./engine.ts";
-import {
-  ANYONE_USER,
-  type Capability,
-  isACL,
-  isCapable,
-} from "../acl.ts";
+import { ANYONE_USER, type Capability, isACL, isCapable } from "../acl.ts";
 import {
   aliasForDbId,
   attachDatabase,

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -44,6 +44,12 @@ import {
 } from "../v2.ts";
 import * as Engine from "./engine.ts";
 import {
+  ANYONE_USER,
+  type Capability,
+  isACL,
+  isCapable,
+} from "../acl.ts";
+import {
   aliasForDbId,
   attachDatabase,
   detachDatabase,
@@ -190,6 +196,23 @@ const toError = (name: string, message: string): V2Error => ({
   name,
   message,
 });
+
+export type MemoryAclMode = "off" | "observe" | "enforce";
+
+/** Engine doc id of a space's ACL document: the doc whose entity id is the
+ *  space DID itself, as managed by the runner's `ACLManager` / `cf acl`
+ *  (runner `toURI` prefixes bare ids with `of:`). */
+const aclDocId = (space: string): string => `of:${space}`;
+
+const commitTouchesAclDoc = (
+  operations: readonly Operation[],
+  space: string,
+): boolean => {
+  const id = aclDocId(space);
+  return operations.some((operation) =>
+    "id" in operation && operation.id === id
+  );
+};
 
 /** Deterministic, collision-resistant-enough token for a filename component
  *  (FNV-1a 32-bit + length). Used to derive cell-db file names from (space,id). */
@@ -624,10 +647,158 @@ export class Server {
       authorizeSessionOpen?: (
         message: SessionOpenRequest,
       ) => Promise<string | undefined> | string | undefined;
+      /**
+       * Space access control. `off` (default) preserves the historical
+       * any-authenticated-session-may-do-anything behavior. `observe`
+       * evaluates the policy, counts and logs would-denies, but allows.
+       * `enforce` denies.
+       *
+       * Policy: a session principal has implicit OWNER on a space when it
+       * IS the space DID or is listed in `serviceDids`; otherwise the
+       * space's ACL document (entity id == the space DID, as managed by the
+       * runner's `ACLManager` / `cf acl`) grants per-DID or `"*"`
+       * capabilities. On the first-ever open of a commit-less space by a
+       * regular principal, the server seeds that document with
+       * `{ [principal]: "OWNER" }` (creator ownership) in observe and
+       * enforce modes.
+       *
+       * Requirements: session.open, queries, and watches need READ;
+       * transact needs WRITE; ACL-document writes and disk-source
+       * registration need OWNER. Enforcement is only meaningful when
+       * `authorizeSessionOpen` is configured — without it sessions carry no
+       * principal and only `"*"` grants can apply.
+       */
+      acl?: {
+        mode: MemoryAclMode;
+        serviceDids?: readonly string[];
+      };
     } = {},
   ) {
     this.#sessions = options.sessions ?? new SessionRegistry();
     this.#store = options.store;
+  }
+
+  /** Counters for ACL decisions; `wouldDeny` is the observe-mode rollout
+   *  signal (a nonzero value on a deployment means flipping to `enforce`
+   *  would break that traffic). */
+  readonly aclStats = { seeded: 0, wouldDeny: 0, denied: 0 };
+
+  /** space → (principal key → capability). Invalidated whenever a commit
+   *  touches the space's ACL document. */
+  #aclCapabilities = new Map<string, Map<string, Capability | null>>();
+
+  #aclMode(): MemoryAclMode {
+    return this.options.acl?.mode ?? "off";
+  }
+
+  #isServicePrincipal(principal: string): boolean {
+    return this.options.acl?.serviceDids?.includes(principal) ?? false;
+  }
+
+  #invalidateAclCapabilities(space: string): void {
+    this.#aclCapabilities.delete(space);
+  }
+
+  #resolveCapability(
+    engine: Engine.Engine,
+    space: string,
+    principal: string | undefined,
+  ): Capability | null {
+    if (
+      principal !== undefined &&
+      (principal === space || this.#isServicePrincipal(principal))
+    ) {
+      return "OWNER";
+    }
+    const document = Engine.read(engine, { id: aclDocId(space) });
+    const acl = document?.value;
+    // Missing or malformed ACL document grants nothing (fail closed); the
+    // implicit owners above are unaffected.
+    if (!isACL(acl)) return null;
+    const byPrincipal = acl as Record<string, Capability | undefined>;
+    return (principal !== undefined ? byPrincipal[principal] : undefined) ??
+      byPrincipal[ANYONE_USER] ?? null;
+  }
+
+  #capabilityFor(
+    engine: Engine.Engine,
+    space: string,
+    principal: string | undefined,
+  ): Capability | null {
+    const key = principal ?? "";
+    let bySpace = this.#aclCapabilities.get(space);
+    if (bySpace !== undefined && bySpace.has(key)) {
+      return bySpace.get(key) ?? null;
+    }
+    const capability = this.#resolveCapability(engine, space, principal);
+    if (bySpace === undefined) {
+      bySpace = new Map();
+      this.#aclCapabilities.set(space, bySpace);
+    }
+    bySpace.set(key, capability);
+    return capability;
+  }
+
+  /** Evaluate the ACL policy for a message. Returns `null` when the message
+   *  may proceed and a typed error when it must be rejected; in `observe`
+   *  mode a shortfall is counted and logged but never rejected. */
+  async #authorizeMessage(
+    space: string,
+    principal: string | undefined,
+    requirement: Capability,
+  ): Promise<V2Error | null> {
+    if (this.#aclMode() === "off") return null;
+    const engine = await this.openEngine(space);
+    const capability = this.#capabilityFor(engine, space, principal);
+    if (capability !== null && isCapable(capability, requirement)) {
+      return null;
+    }
+    const principalLabel = principal ?? "<anonymous>";
+    if (this.#aclMode() === "observe") {
+      this.aclStats.wouldDeny += 1;
+      console.warn(
+        `[memory-acl] would deny ${requirement} on ${space} for ` +
+          `${principalLabel} (capability: ${capability ?? "none"})`,
+      );
+      return null;
+    }
+    this.aclStats.denied += 1;
+    return toError(
+      "AuthorizationError",
+      `Principal ${principalLabel} lacks ${requirement} on space ${space}`,
+    );
+  }
+
+  /** On the first-ever open of a commit-less space by a regular principal,
+   *  seed the ACL document with creator ownership. Skipped for service
+   *  principals and the space's own key: they hold implicit OWNER, and
+   *  seeding would wrongly claim the space for them (e.g. the background
+   *  service touching a user's not-yet-created space). */
+  #ensureCreatorSeeded(
+    engine: Engine.Engine,
+    space: string,
+    principal: string | undefined,
+  ): void {
+    if (this.#aclMode() === "off") return;
+    if (principal === undefined) return;
+    if (principal === space || this.#isServicePrincipal(principal)) return;
+    if (Engine.serverSeq(engine) !== 0) return;
+    Engine.applyCommit(engine, {
+      sessionId: "memory-acl-seed",
+      space,
+      principal,
+      commit: {
+        localSeq: 1,
+        reads: { confirmed: [], pending: [] },
+        operations: [{
+          op: "set",
+          id: aclDocId(space),
+          value: { value: { [principal]: "OWNER" } },
+        }],
+      },
+    });
+    this.aclStats.seeded += 1;
+    this.#invalidateAclCapabilities(space);
   }
 
   connect(send: Send): Connection {
@@ -1003,6 +1174,16 @@ export class Server {
         toError("SessionError", "Unknown session for space"),
       );
     }
+    {
+      const deny = await this.#authorizeMessage(
+        message.space,
+        session.principal,
+        "READ",
+      );
+      if (deny) {
+        return respondTypedError<SqliteQueryResult>(message.requestId, deny);
+      }
+    }
     try {
       // All reads run unattached on a pooled read-only connection (no ATTACH,
       // real read-only, each file its own `main` namespace). The only
@@ -1075,11 +1256,26 @@ export class Server {
   async sqliteRegisterDiskSource(
     message: SqliteRegisterDiskSourceRequest,
   ): Promise<ResponseMessage<SqliteRegisterDiskSourceResult>> {
-    if (this.#sessions.get(message.space, message.sessionId) === null) {
+    const session = this.#sessions.get(message.space, message.sessionId);
+    if (session === null) {
       return respondTypedError<SqliteRegisterDiskSourceResult>(
         message.requestId,
         toError("SessionError", "Unknown session for space"),
       );
+    }
+    {
+      // Maps a server filesystem path into the space — operator surface.
+      const deny = await this.#authorizeMessage(
+        message.space,
+        session.principal,
+        "OWNER",
+      );
+      if (deny) {
+        return respondTypedError<SqliteRegisterDiskSourceResult>(
+          message.requestId,
+          deny,
+        );
+      }
     }
     try {
       await this.registerDiskSource(message.space, message.id, message.path);
@@ -1106,6 +1302,15 @@ export class Server {
     try {
       const engine = await this.openEngine(message.space);
       const principal = await this.options.authorizeSessionOpen?.(message);
+      this.#ensureCreatorSeeded(engine, message.space, principal);
+      const deny = await this.#authorizeMessage(
+        message.space,
+        principal,
+        "READ",
+      );
+      if (deny) {
+        return respondTypedError<SessionOpenResult>(message.requestId, deny);
+      }
       const opened = this.#sessions.open(
         message.space,
         message.session,
@@ -1199,6 +1404,19 @@ export class Server {
 
     try {
       const engine = await this.openEngine(message.space);
+      // ACL-document writes change who may access the space — OWNER only.
+      const aclTouched = commitTouchesAclDoc(
+        message.commit.operations,
+        message.space,
+      );
+      const deny = await this.#authorizeMessage(
+        message.space,
+        session.principal,
+        aclTouched ? "OWNER" : "WRITE",
+      );
+      if (deny) {
+        return respondTypedError<Engine.AppliedCommit>(message.requestId, deny);
+      }
       const schedulerStateEnabled = getPersistentSchedulerStateConfig();
       const commitPayload = schedulerStateEnabled ? message.commit : {
         ...message.commit,
@@ -1251,6 +1469,9 @@ export class Server {
         for (const alias of sqliteAttachments.values()) {
           detachDatabase(engine.database, alias);
         }
+      }
+      if (aclTouched) {
+        this.#invalidateAclCapabilities(message.space);
       }
       await this.runPostCommitSchedulerSideEffects(
         message.space,
@@ -1305,6 +1526,16 @@ export class Server {
         toError("SessionError", "Unknown session for space"),
       );
     }
+    {
+      const deny = await this.#authorizeMessage(
+        message.space,
+        session.principal,
+        "READ",
+      );
+      if (deny) {
+        return respondTypedError<GraphQueryResult>(message.requestId, deny);
+      }
+    }
     if ((message.query as GraphQuery & { subscribe?: boolean }).subscribe) {
       return respondTypedError<GraphQueryResult>(
         message.requestId,
@@ -1350,6 +1581,19 @@ export class Server {
         message.requestId,
         toError("SessionError", "Unknown session for space"),
       );
+    }
+    {
+      const deny = await this.#authorizeMessage(
+        message.space,
+        session.principal,
+        "READ",
+      );
+      if (deny) {
+        return respondTypedError<SchedulerSnapshotListResult>(
+          message.requestId,
+          deny,
+        );
+      }
     }
 
     try {
@@ -1413,6 +1657,16 @@ export class Server {
         toError("SessionError", "Unknown session for space"),
       );
     }
+    {
+      const deny = await this.#authorizeMessage(
+        message.space,
+        session.principal,
+        "READ",
+      );
+      if (deny) {
+        return respondTypedError<WatchSetResult>(message.requestId, deny);
+      }
+    }
 
     try {
       const { serverSeq, graphs, entities } = await this.evaluateWatchSet(
@@ -1463,6 +1717,16 @@ export class Server {
         message.requestId,
         toError("SessionError", "Unknown session for space"),
       );
+    }
+    {
+      const deny = await this.#authorizeMessage(
+        message.space,
+        session.principal,
+        "READ",
+      );
+      if (deny) {
+        return respondTypedError<WatchAddResult>(message.requestId, deny);
+      }
     }
 
     try {

--- a/packages/memory/v2/server.ts
+++ b/packages/memory/v2/server.ts
@@ -769,6 +769,28 @@ export class Server {
     );
   }
 
+  /** After an ACL change, drop live sessions whose principal no longer
+   *  holds READ (enforce mode only): per-message gating alone would still
+   *  let their already-registered subscriptions receive pushes. The owning
+   *  connection gets a session/revoked("unauthorized"), which the client
+   *  treats as a terminal session close (no reopen loop — a reopen attempt
+   *  is denied at session.open). */
+  #revokeDeauthorizedSessions(engine: Engine.Engine, space: string): void {
+    if (this.#aclMode() !== "enforce") return;
+    for (const session of this.#sessions.sessionsForSpace(space)) {
+      const capability = this.#capabilityFor(engine, space, session.principal);
+      if (capability !== null && isCapable(capability, "READ")) continue;
+      this.#sessions.remove(space, session.id);
+      if (session.ownerConnectionId !== null) {
+        this.#connections.get(session.ownerConnectionId)?.revokeSession(
+          space,
+          session.id,
+          "unauthorized",
+        );
+      }
+    }
+  }
+
   /** On the first-ever open of a commit-less space by a regular principal,
    *  seed the ACL document with creator ownership. Skipped for service
    *  principals and the space's own key: they hold implicit OWNER, and
@@ -1472,6 +1494,7 @@ export class Server {
       }
       if (aclTouched) {
         this.#invalidateAclCapabilities(message.space);
+        this.#revokeDeauthorizedSessions(engine, message.space);
       }
       await this.runPostCommitSchedulerSideEffects(
         message.space,

--- a/packages/memory/v2/session-registry.ts
+++ b/packages/memory/v2/session-registry.ts
@@ -137,6 +137,22 @@ export class SessionRegistry {
     return false;
   }
 
+  sessionsForSpace(space: string): SessionState[] {
+    this.#prune();
+    const sessions: SessionState[] = [];
+    for (const session of this.#sessions.values()) {
+      if (session.space === space) {
+        sessions.push(session);
+      }
+    }
+    return sessions;
+  }
+
+  /** Remove a session outright (e.g. its principal lost access). */
+  remove(space: string, sessionId: string): void {
+    this.#sessions.delete(sessionKey(space, sessionId));
+  }
+
   updateSeenSeq(
     space: string,
     sessionId: string,

--- a/packages/memory/v2/standalone.ts
+++ b/packages/memory/v2/standalone.ts
@@ -102,7 +102,10 @@ export class StandaloneMemoryServer {
     options: {
       /** Space ACL config, passed through to the memory server. Default:
        *  off (the historical wide-open behavior in-process tests expect). */
-      acl?: { mode: MemoryServer.MemoryAclMode; serviceDids?: readonly string[] };
+      acl?: {
+        mode: MemoryServer.MemoryAclMode;
+        serviceDids?: readonly string[];
+      };
     } = {},
   ): StandaloneMemoryServer {
     const memory = new MemoryServer.Server({

--- a/packages/memory/v2/standalone.ts
+++ b/packages/memory/v2/standalone.ts
@@ -98,8 +98,17 @@ export class StandaloneMemoryServer {
     this.url = new URL(`http://127.0.0.1:${address.port}/`);
   }
 
-  static start(): StandaloneMemoryServer {
-    const memory = new MemoryServer.Server({ authorizeSessionOpen });
+  static start(
+    options: {
+      /** Space ACL config, passed through to the memory server. Default:
+       *  off (the historical wide-open behavior in-process tests expect). */
+      acl?: { mode: MemoryServer.MemoryAclMode; serviceDids?: readonly string[] };
+    } = {},
+  ): StandaloneMemoryServer {
+    const memory = new MemoryServer.Server({
+      authorizeSessionOpen,
+      acl: options.acl,
+    });
     const http = Deno.serve({
       hostname: "127.0.0.1",
       port: 0,

--- a/packages/toolshed/env.ts
+++ b/packages/toolshed/env.ts
@@ -195,6 +195,16 @@ const EnvSchema = z.object({
   // Path to an identity key.
   IDENTITY: z.string().default(""),
 
+  // Space ACL enforcement on the memory v2 server: off | observe | enforce.
+  // `observe` evaluates the policy and counts/logs would-denies without
+  // blocking (the rollout signal); `enforce` denies. See the `acl` option in
+  // packages/memory/v2/server.ts for the policy.
+  MEMORY_ACL_MODE: z.enum(["off", "observe", "enforce"]).default("off"),
+
+  // Comma-separated DIDs with implicit OWNER on every space (e.g. the
+  // background service operator identity).
+  MEMORY_SERVICE_DIDS: z.string().default(""),
+
   // In development, you can optionally proxy the upstream SHELL
   SHELL_URL: z.string().optional(),
 

--- a/packages/toolshed/routes/storage/memory.ts
+++ b/packages/toolshed/routes/storage/memory.ts
@@ -94,6 +94,13 @@ await FS.ensureDir(memoryEngineStoreUrl);
 export const memoryServer = new MemoryServer.Server({
   store: memoryEngineStoreUrl,
   authorizeSessionOpen,
+  acl: {
+    mode: env.MEMORY_ACL_MODE,
+    serviceDids: env.MEMORY_SERVICE_DIDS
+      .split(",")
+      .map((did) => did.trim())
+      .filter((did) => did.length > 0),
+  },
 });
 export const memory = {
   async close(): Promise<


### PR DESCRIPTION
## Summary

Track A1 of the CFC spec-audit remediation, soundness finding **S1** (the audit's highest-severity hole): the memory v2 server verified only that a `session.open` invocation was self-signed and named the space — it never checked the principal's relationship to the space. Any DID that could reach the websocket could read/write any space, voiding the §9 threat-model rows for network adversaries and other users and making every client-side CFC label guarantee advisory.

## Design

`Server` gains an `acl` option: `{ mode: "off" | "observe" | "enforce", serviceDids?: string[] }` (default **off** — zero behavior change unless configured).

**Capability resolution** (READ < WRITE < OWNER):
- implicit OWNER when the session principal IS the space DID, or is a configured service DID (e.g. the background service operator)
- otherwise the space's **ACL document** — the doc whose entity id is the space DID itself, which `ACLManager` / `cf acl` already manage — grants per-DID or `"*"` capabilities (same semantics as the legacy `checkACL`, which was wired only to the long-gone v1 consumer)

**Gates** (sessions are the auth unit; per-commit invocations are deliberately ignored by the parser):
- `session.open`, graph/sqlite queries, watches, scheduler snapshot lists → READ
- `transact` → WRITE
- ACL-document writes and disk-source registration → OWNER (so a WRITE grantee can't self-promote)

**Creator seeding:** the first open of a commit-less space by a regular principal seeds `{ [principal]: "OWNER" }` so ownership persists from day one. Service principals and space-key principals never claim spaces they touch (the bg service opening a user's not-yet-created space must not own it).

**Revocation is live:** an ACL-doc commit invalidates the per-space capability cache **and tears down de-authorized live sessions** with `session/revoked("unauthorized")` — without this, gating alone would let already-registered subscriptions keep receiving pushes. The client treats it as a terminal session close (no reopen loop; reopen is denied at `session.open`).

**Observe mode** allows everything but counts (`aclStats.wouldDeny`) and logs shortfalls — the rollout signal.

## Wiring

- toolshed: `MEMORY_ACL_MODE` (default off) + `MEMORY_SERVICE_DIDS` (csv)
- `StandaloneMemoryServer.start({ acl })` — explicit option so in-process harnesses opt in deliberately

## Rollout plan

1. land (default off; nothing changes)
2. set `MEMORY_ACL_MODE=observe` in a deployment; watch `aclStats.wouldDeny` + `[memory-acl]` logs while creator seeding populates ACL docs organically
3. seed any remaining grants via `cf acl` (the observe logs name exactly which (space, principal) pairs need them)
4. flip `enforce`

## Testing

- 11 new server tests (`v2-server-acl-test.ts`), red-green: stranger denied / creator seeded / WRITE-not-OWNER escalation blocked / READ-only grants / `"*"` public read / service-DID bypass without claiming / space-key implicit owner / live-session revocation incl. the `session/revoked` push / observe counts + seeds / off & default unchanged
- full `packages/memory` suite: 176 passed, 0 failed
- runner storage type-checks clean against the widened `SessionRevokedMessage.reason`

## Deferred / follow-ups

- end-to-end runner↔server exercise of the seeded ACL doc via `cf acl` (wire-level contract is pinned by the server tests)
- shell UX for `AuthorizationError` at session open
- **A2** (server-side acceptance of `["cfc"]`/`cid:` writes — the `cell-cache.ts` "server becomes the sole acceptor" end-state) stays next-phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds space ACLs to the v2 memory server with `off | observe | enforce` modes to restrict access by principal. Default is `off`, so nothing changes unless configured.

- **New Features**
  - `Server` accepts `acl` options: `{ mode, serviceDids? }`.
  - Capability model: implicit OWNER for the space DID and configured service DIDs; otherwise the space’s ACL doc (entity id == space DID) grants per-DID or `"*"` READ/WRITE/OWNER.
  - Gates: `session.open`/queries/watches/scheduler snapshot lists require READ; `transact` requires WRITE; ACL-doc writes and disk-source registration require OWNER.
  - Creator seeding: first open of a commit-less space by a regular principal seeds `{ [principal]: "OWNER" }`. Service and space-key principals never claim spaces.
  - Live revocation: ACL commits invalidate the capability cache and remove de-authorized live sessions; revoked connections get `session/revoked("unauthorized")`. The writing session is dropped from the registry but not sent a terminal revoke until after its own commit response; its next message fails closed. Client guard accepts the new reason.

- **Migration**
  - Configure via `MEMORY_ACL_MODE` and `MEMORY_SERVICE_DIDS` in `packages/toolshed`; `StandaloneMemoryServer.start({ acl })` passes options through.
  - Rollout: set `observe`, watch `aclStats.wouldDeny` and `[memory-acl]` logs, grant missing access via `cf acl`, then flip to `enforce`.

<sup>Written for commit 799cd52db82b8b31067a70dc424bdff4bba64bf1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

