### PR TITLE
perf(ts-transformers): memoize capability analyses in schema-injection

### DIFF
--- a/packages/ts-transformers/src/transformers/schema-injection.ts
+++ b/packages/ts-transformers/src/transformers/schema-injection.ts
@@ -31,6 +31,7 @@ import {
 import { unwrapExpression } from "../utils/expression.ts";
 import {
   type CapabilityParamSummary,
+  type FunctionCapabilitySummary,
   HelpersOnlyTransformer,
   type SchemaHint,
   type SchemaHints,
@@ -193,6 +194,40 @@ function getSymbolTypeAtSource(
   return checker.getTypeOfSymbolAtLocation(symbol, declaration);
 }
 
+// Per-context memo for the capability analyses this transformer runs.
+// `analyzeFunctionCapabilities` consults `options.summaryCache` before
+// traversing, but defaults it to a fresh WeakMap per call — so without a
+// persistent cache every lookup re-walks the callback body (a single handler
+// site queries the same callback three times: event param, state param,
+// identity hints). Keyed by TransformationContext so entries live exactly one
+// (stage, source file) pass and can't leak across programs. The two analysis
+// variants used below produce different summaries, hence separate maps. No
+// invalidation wiring is needed: the analysis is a pure function of the
+// callback AST and checker (it reads no cross-stage registries), and
+// transformed nodes have fresh identities, so entries can't go stale.
+interface CapabilitySummaryMemo {
+  /** `{ checker, includeNestedCallbacks: true }` analyses. */
+  readonly nested: WeakMap<ts.Node, FunctionCapabilitySummary>;
+  /** Checker-less analyses (fallback after a recorded-summary miss). */
+  readonly bare: WeakMap<ts.Node, FunctionCapabilitySummary>;
+}
+
+const capabilitySummaryMemos = new WeakMap<
+  TransformationContext,
+  CapabilitySummaryMemo
+>();
+
+function capabilitySummaryMemoFor(
+  context: TransformationContext,
+): CapabilitySummaryMemo {
+  let memo = capabilitySummaryMemos.get(context);
+  if (!memo) {
+    memo = { nested: new WeakMap(), bare: new WeakMap() };
+    capabilitySummaryMemos.set(context, memo);
+  }
+  return memo;
+}
+
 function findCapabilitySummaryForParameter(
   fn: ts.ArrowFunction | ts.FunctionExpression,
   index: number,
@@ -206,9 +241,15 @@ function findCapabilitySummaryForParameter(
     ? analyzeFunctionCapabilities(fn, {
       checker: options.checker,
       includeNestedCallbacks: true,
+      summaryCache: context
+        ? capabilitySummaryMemoFor(context).nested
+        : undefined,
     })
     : context
-    ? (context.lookupCapabilitySummary(fn) ?? analyzeFunctionCapabilities(fn))
+    ? (context.lookupCapabilitySummary(fn) ??
+      analyzeFunctionCapabilities(fn, {
+        summaryCache: capabilitySummaryMemoFor(context).bare,
+      }))
     : analyzeFunctionCapabilities(fn, {
       checker: options?.checker,
     });


### PR DESCRIPTION
## Summary

`findCapabilitySummaryForParameter` re-ran `analyzeFunctionCapabilities` from scratch on every lookup:

- The `includeNestedCallbacks: true` path never consulted any cache. `analyzeFunctionCapabilities` checks `options.summaryCache` before traversing, but defaults it to a **fresh WeakMap per call** (`capability-analysis.ts:1075`), so the cache only ever served interprocedural recursion within one run.
- The recorded-summary fallback (`context.lookupCapabilitySummary(fn) ?? analyzeFunctionCapabilities(fn)`) computed a summary on a miss and threw it away.

Concretely, a single handler site walked the same callback body three times — event param, state param, identity-hint lookup — each a full traversal plus interprocedural fixpoint.

## Fix

Keep a pair of WeakMap caches keyed by `TransformationContext` (one per analysis variant — `{checker, includeNestedCallbacks: true}` vs. the checker-less fallback, whose summaries differ) and pass them as `summaryCache`. This buys top-level memoization *and* cross-call reuse of interprocedural sub-summaries with no new API surface and no signature changes.

Safety:
- Entries live exactly one (stage, source file) pass — nothing can leak across programs or stages.
- Capability analysis reads no cross-stage registries (it is a pure function of the callback AST + checker), so the `invalidateReactiveAnalysisCaches` contract in `core/mod.ts` doesn't apply; transformed nodes get fresh identities, so entries can't go stale.
- The deliberately context-less call sites (e.g. the 1-arg handler event param, which omits `context` to avoid double-validation) keep their existing uncached behavior — no behavior change there.

## Verification

- Full package suite: 292 passed (618 steps), 0 failed — golden output byte-identical, so emitted schemas are unchanged.
- Measured with a temporary analysis counter over the fixture suite: **3,881 → 3,401** body analyses (480 redundant analyses eliminated, ~12% of all capability analyses; the residual is the legitimate once-per-callback recording pass in pattern-callback-lowering plus the context-less sites). Handler-heavy files benefit proportionally more.
- `deno fmt --check`, `deno lint`, `deno check` clean on the edited file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Memoizes capability analyses in `packages/ts-transformers` schema-injection to avoid re-running `analyzeFunctionCapabilities` on repeated lookups. Adds per-`TransformationContext` WeakMap caches for nested and bare variants (passed via `summaryCache`), removing ~480 redundant body analyses (~12%) with no emitted schema changes; context-less call sites remain uncached.

<sup>Written for commit 06a6b15f1db6e9f86344adedc7d3fcc693020940. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/commontoolsinc/labs/pull/3991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

